### PR TITLE
[TRTLLM-13548][feat] Add MPI FT subcommunicator and broadcast thread (1c.3)

### DIFF
--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -1,6 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import math
 import pickle  # nosec B403
+import threading
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import IntEnum
 from functools import lru_cache, wraps
 from typing import Any, Callable, List, Optional, Tuple
@@ -71,6 +88,448 @@ _reduce_op_to_mpi_dict = {
 
 def reduce_op_to_mpi(op: ReduceOp) -> MPI.Op:
     return _reduce_op_to_mpi_dict[op]
+
+
+@dataclass(frozen=True)
+class MpiFtSubcommSetup:
+    """Collectively validated WideEP FT communicator startup state."""
+
+    comm: Any
+    local_rank: int
+    ep_size: int
+    ulfm_available: bool
+
+
+_MPI_FT_PROCESS_LIFETIME_REFS: list[Any] = []
+_MPI_FT_PROCESS_LIFETIME_REFS_LOCK = threading.Lock()
+
+
+def _retain_mpi_ft_comm(comm: Any) -> None:
+    """Keep a communicator with unsafe cleanup reachable until process exit."""
+    with _MPI_FT_PROCESS_LIFETIME_REFS_LOCK:
+        _MPI_FT_PROCESS_LIFETIME_REFS.append(comm)
+
+
+def _is_mpi_ft_int(value: Any) -> bool:
+    """Reject bool/float values that compare equal to MPI integer fields."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _mpi_ft_local_topology(mapping: Mapping, parent_rank: int, parent_size: int,
+                           provided_thread_level: int,
+                           health_size: Optional[int]) -> dict[str, Any]:
+    """Build a serializable startup record without raising locally."""
+    world_size = None
+    mapping_rank = None
+    ep_group = None
+    ep_size = None
+    ep_rank = None
+    mapping_error = None
+    try:
+        world_size = mapping.world_size
+        mapping_rank = mapping.rank
+        ep_group = tuple(mapping.moe_ep_group)
+        ep_size = mapping.moe_ep_size
+        ep_rank = mapping.moe_ep_rank
+    except Exception as error:
+        mapping_error = ("invalid WideEP FT mapping topology: "
+                         f"{type(error).__name__}: {error}")
+
+    error_kind = None
+    error_message = None
+    if provided_thread_level < MPI.THREAD_MULTIPLE:
+        error_kind = "runtime"
+        error_message = (
+            "WideEP FT requires MPI.THREAD_MULTIPLE because its control-plane "
+            "thread overlaps other MPI traffic "
+            f"(provided={provided_thread_level}, required={MPI.THREAD_MULTIPLE})"
+        )
+    elif mapping_error is not None:
+        error_kind = "value"
+        error_message = mapping_error
+    elif not ep_group:
+        error_kind = "value"
+        error_message = "mapping.moe_ep_group must not be empty"
+    elif len(ep_group) != ep_size:
+        error_kind = "value"
+        error_message = (
+            "mapping.moe_ep_group size must match mapping.moe_ep_size, "
+            f"got {len(ep_group)} and {ep_size}")
+    else:
+        try:
+            has_duplicate_ranks = len(set(ep_group)) != len(ep_group)
+            has_invalid_rank = any(
+                not isinstance(rank, int) or rank < 0 or rank >= parent_size
+                for rank in ep_group)
+        except TypeError as error:
+            error_kind = "value"
+            error_message = f"mapping.moe_ep_group contains invalid ranks: {error}"
+        else:
+            if has_duplicate_ranks:
+                error_kind = "value"
+                error_message = (
+                    "mapping.moe_ep_group contains duplicate ranks: "
+                    f"{ep_group}")
+            elif parent_size != world_size:
+                error_kind = "runtime"
+                error_message = (
+                    "WideEP FT parent communicator size must match "
+                    f"mapping.world_size, got {parent_size} and {world_size}")
+            elif parent_rank != mapping_rank:
+                error_kind = "runtime"
+                error_message = (
+                    "WideEP FT parent communicator rank must match mapping.rank, "
+                    f"got {parent_rank} and {mapping_rank}")
+            elif has_invalid_rank:
+                error_kind = "value"
+                error_message = (
+                    "mapping.moe_ep_group contains a rank outside the parent "
+                    f"communicator: {ep_group}")
+            elif ep_size != world_size or set(ep_group) != set(
+                    range(parent_size)):
+                error_kind = "value"
+                error_message = (
+                    "WideEP FT MVP requires one MoE EP group spanning the "
+                    "full MPI world; "
+                    f"got world_size={world_size}, moe_ep_group={ep_group}")
+            elif health_size is not None and health_size != ep_size:
+                error_kind = "value"
+                error_message = (
+                    "EPGroupHealth size must match mapping.moe_ep_size, "
+                    f"got {health_size} and {ep_size}")
+            elif parent_rank not in ep_group:
+                error_kind = "value"
+                error_message = (
+                    f"local rank {parent_rank} is not in its MoE EP group "
+                    f"{ep_group}")
+            elif ep_group.index(parent_rank) != ep_rank:
+                error_kind = "value"
+                error_message = (
+                    "mapping.moe_ep_group order must match mapping.moe_ep_rank, "
+                    f"got group index {ep_group.index(parent_rank)} and EP rank "
+                    f"{ep_rank}")
+
+    return {
+        "parent_rank": parent_rank,
+        "parent_size": parent_size,
+        "world_size": world_size,
+        "mapping_rank": mapping_rank,
+        "ep_group": ep_group,
+        "ep_size": ep_size,
+        "ep_rank": ep_rank,
+        "health_size": health_size,
+        "error_kind": error_kind,
+        "error_message": error_message,
+    }
+
+
+def _validate_mpi_ft_topologies(topologies: List[Any],
+                                parent_size: int) -> None:
+    """Raise the same validation error on every parent-communicator rank."""
+    if len(topologies) != parent_size:
+        raise RuntimeError(
+            "WideEP FT startup allgather returned an unexpected number of "
+            f"topologies: got {len(topologies)}, expected {parent_size}")
+
+    for gather_rank, topology in enumerate(topologies):
+        if not isinstance(topology, dict):
+            raise RuntimeError(
+                "WideEP FT startup allgather returned an invalid topology for "
+                f"parent rank {gather_rank}: {topology!r}")
+
+    # Object allgather returns records in communicator-rank order. Selecting the
+    # first error makes every rank raise the same exception before Split.
+    for gather_rank, topology in enumerate(topologies):
+        error_message = topology.get("error_message")
+        if error_message is None:
+            continue
+        reporting_rank = topology.get("parent_rank", gather_rank)
+        message = ("WideEP FT startup validation failed on parent rank "
+                   f"{reporting_rank}: {error_message}")
+        if topology.get("error_kind") == "value":
+            raise ValueError(message)
+        raise RuntimeError(message)
+
+    for gather_rank, topology in enumerate(topologies):
+        reported_parent_rank = topology.get("parent_rank")
+        if (not _is_mpi_ft_int(reported_parent_rank)
+                or reported_parent_rank != gather_rank):
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: allgather slot "
+                f"{gather_rank} reports parent rank "
+                f"{reported_parent_rank!r}")
+        reported_parent_size = topology.get("parent_size")
+        if (not _is_mpi_ft_int(reported_parent_size)
+                or reported_parent_size != parent_size):
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports communicator size "
+                f"{reported_parent_size!r}, expected {parent_size}")
+
+        ep_group = topology.get("ep_group")
+        if not isinstance(ep_group, (list, tuple)):
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports invalid EP group {ep_group!r}")
+        if len(ep_group) != parent_size:
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports EP group size {len(ep_group)}, "
+                f"expected {parent_size}")
+        if any(
+                isinstance(peer_rank, bool) or not _is_mpi_ft_int(peer_rank)
+                or peer_rank < 0 or peer_rank >= parent_size
+                for peer_rank in ep_group):
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports invalid EP group ranks {ep_group!r}")
+        if len(set(ep_group)) != parent_size:
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports duplicate EP group ranks {ep_group!r}")
+        world_size = topology.get("world_size")
+        if not _is_mpi_ft_int(world_size) or world_size != parent_size:
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports world size "
+                f"{world_size!r}, expected {parent_size}")
+        mapping_rank = topology.get("mapping_rank")
+        if not _is_mpi_ft_int(mapping_rank) or mapping_rank != gather_rank:
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports mapping rank "
+                f"{mapping_rank!r}")
+        ep_size = topology.get("ep_size")
+        if not _is_mpi_ft_int(ep_size) or ep_size != parent_size:
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports EP size {ep_size!r}, "
+                f"expected {parent_size}")
+        ep_rank = topology.get("ep_rank")
+        if (not _is_mpi_ft_int(ep_rank) or ep_rank < 0 or ep_rank >= parent_size
+                or ep_group[ep_rank] != gather_rank):
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports invalid EP rank {ep_rank!r} for "
+                f"group {ep_group!r}")
+        health_size = topology.get("health_size")
+        if health_size is not None and (not _is_mpi_ft_int(health_size)
+                                        or health_size != parent_size):
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports health size {health_size}, "
+                f"expected {parent_size}")
+    # Only dereference peer groups after every gathered record has passed the
+    # schema/range checks above. This keeps malformed records rank-attributed and
+    # prevents a valid earlier record from indexing into unchecked peer data.
+    for gather_rank, topology in enumerate(topologies):
+        ep_group = topology["ep_group"]
+        for peer_rank in ep_group:
+            peer_group = topologies[peer_rank].get("ep_group")
+            if peer_group != ep_group:
+                raise RuntimeError(
+                    "WideEP FT startup topology is inconsistent: parent rank "
+                    f"{gather_rank} reports EP group {ep_group}, but member "
+                    f"rank {peer_rank} reports {peer_group}")
+
+
+def _mpi_ft_post_split_status(ft_comm: Any, parent_rank: int, ep_rank: int,
+                              ep_size: int) -> dict[str, Any]:
+    """Configure a derived communicator without raising before reconciliation."""
+    error_message = None
+    ulfm_available = False
+    try:
+        # Install the non-fatal handler before any other operation on the new
+        # communicator. In particular, do not inspect a possibly broken handle
+        # while it still inherits the parent's fatal error policy.
+        ft_comm.Set_errhandler(MPI.ERRORS_RETURN)
+        actual_rank = ft_comm.Get_rank()
+        actual_size = ft_comm.Get_size()
+        if actual_size != ep_size or actual_rank != ep_rank:
+            error_message = (
+                "MPI_Comm_split created an unexpected WideEP FT communicator: "
+                f"rank={actual_rank}, size={actual_size}, "
+                f"expected rank={ep_rank}, size={ep_size}")
+    except Exception as error:
+        error_message = ("WideEP FT communicator setup raised "
+                         f"{type(error).__name__}: {error}")
+
+    if error_message is None and callable(getattr(
+            ft_comm, "Is_revoked", None)) and callable(
+                getattr(ft_comm, "Revoke", None)):
+        try:
+            already_revoked = ft_comm.Is_revoked()
+        except Exception as error:
+            if not _is_unsupported_mpi_ulfm_error(error):
+                error_message = ("WideEP FT ULFM probe raised "
+                                 f"{type(error).__name__}: {error}")
+        else:
+            if already_revoked:
+                error_message = (
+                    "WideEP FT communicator is already revoked at construction")
+            else:
+                ulfm_available = True
+    return {
+        "parent_rank": parent_rank,
+        "error_message": error_message,
+        "ulfm_available": ulfm_available,
+    }
+
+
+def _is_unsupported_mpi_ulfm_error(error: BaseException) -> bool:
+    if isinstance(error, NotImplementedError):
+        return True
+    mpi_exception = getattr(MPI, "Exception", None)
+    if not isinstance(mpi_exception, type) or not isinstance(
+            error, mpi_exception):
+        return False
+    get_error_class = getattr(error, "Get_error_class", None)
+    if not callable(get_error_class):
+        return False
+    unsupported_classes = {
+        value
+        for value in (
+            getattr(MPI, "ERR_NOT_SUPPORTED", None),
+            getattr(MPI, "ERR_UNSUPPORTED_OPERATION", None),
+        ) if value is not None
+    }
+    try:
+        error_class = get_error_class()
+    except Exception:
+        # This helper runs while building a rank-local status that must reach
+        # the parent allgather. A broken exception classifier is not evidence of
+        # an unsupported operation, but it must not strand peer ranks either.
+        return False
+    return error_class in unsupported_classes
+
+
+def _mpi_ft_post_split_result(
+    statuses: List[Any],
+    parent_size: int,
+) -> tuple[Optional[str], bool]:
+    """Reconcile setup errors and the global ULFM capability."""
+    if len(statuses) != parent_size:
+        return (
+            "WideEP FT post-split allgather returned an unexpected number of "
+            f"statuses: got {len(statuses)}, expected {parent_size}",
+            False,
+        )
+    for gather_rank, status in enumerate(statuses):
+        if not isinstance(status, dict):
+            return (
+                "WideEP FT post-split allgather returned an invalid status for "
+                f"parent rank {gather_rank}: {status!r}",
+                False,
+            )
+        if status.get("parent_rank") != gather_rank:
+            return (
+                "WideEP FT post-split status is inconsistent: allgather slot "
+                f"{gather_rank} reports parent rank "
+                f"{status.get('parent_rank')}",
+                False,
+            )
+        if not isinstance(status.get("ulfm_available"), bool):
+            return (
+                "WideEP FT post-split allgather returned incomplete capability "
+                f"state for parent rank {gather_rank}: {status!r}",
+                False,
+            )
+
+    ulfm_available = all(status["ulfm_available"] for status in statuses)
+    for gather_rank, status in enumerate(statuses):
+        error_message = status.get("error_message")
+        if error_message is not None:
+            return (
+                "WideEP FT communicator setup failed on parent rank "
+                f"{gather_rank}: {error_message}",
+                False,
+            )
+    return None, ulfm_available
+
+
+def create_mpi_ft_subcomm(
+        mapping: Mapping,
+        parent_comm: Optional[Any] = None,
+        health_size: Optional[int] = None) -> MpiFtSubcommSetup:
+    """Create the dedicated MPI control-plane communicator for WideEP FT.
+
+    This operation is collective across ``parent_comm`` and must run on every
+    rank during startup, before any background failure-broadcast threads are
+    launched. The MVP requires one MoE EP group spanning the parent world,
+    ordered by the EP-local rank used by :class:`EPGroupHealth`.
+
+    Before splitting, ranks exchange their local validation outcome and EP
+    topology on the healthy parent communicator. This prevents one rank from
+    raising locally while its peers block forever inside ``MPI_Comm_split``.
+
+    Args:
+        mapping: Distributed topology for the local rank.
+        parent_comm: Parent MPI communicator. Defaults to TRT-LLM's active
+            ``mpi_comm()``, which wraps ``MPI.COMM_WORLD`` in the standard
+            launch path and preserves custom communicator sessions.
+        health_size: Optional local ``EPGroupHealth`` size to validate
+            collectively before splitting.
+
+    Returns:
+        The world-spanning EP MPI communicator and its collectively validated
+        rank, size, and ULFM capability.
+
+    Raises:
+        RuntimeError: If MPI is unavailable, does not provide
+            ``MPI.THREAD_MULTIPLE``, or creates an unexpected communicator.
+        ValueError: If the mapping's EP group is inconsistent.
+    """
+    if MPI is None:
+        raise RuntimeError(
+            "mpi4py is required to create the WideEP FT communicator")
+
+    parent_comm = mpi_comm() if parent_comm is None else parent_comm
+    parent_rank = parent_comm.Get_rank()
+    parent_size = parent_comm.Get_size()
+    local_topology = _mpi_ft_local_topology(mapping, parent_rank, parent_size,
+                                            MPI.Query_thread(), health_size)
+    topologies = parent_comm.allgather(local_topology)
+    _validate_mpi_ft_topologies(topologies, parent_size)
+
+    ep_group = local_topology["ep_group"]
+    ep_rank = local_topology["ep_rank"]
+    ep_size = local_topology["ep_size"]
+
+    # The MVP topology gate above makes the world-spanning group's first rank
+    # a stable color shared by every process.
+    ft_comm = parent_comm.Split(color=ep_group[0], key=ep_rank)
+    try:
+        setup_status = _mpi_ft_post_split_status(ft_comm, parent_rank, ep_rank,
+                                                 ep_size)
+        setup_statuses = parent_comm.allgather(setup_status)
+        setup_error, ulfm_available = _mpi_ft_post_split_result(
+            setup_statuses, parent_size)
+        if setup_error is None:
+            setup = MpiFtSubcommSetup(
+                comm=ft_comm,
+                local_rank=ep_rank,
+                ep_size=ep_size,
+                ulfm_available=ulfm_available,
+            )
+            # Enforce process-lifetime ownership at the creation boundary. A
+            # direct or future caller must not be able to drop the last Python
+            # reference and trigger rank-local collective MPI_Comm_free.
+            _retain_mpi_ft_comm(ft_comm)
+            return setup
+    except Exception:
+        # Once Split succeeds, never let an unexpected post-Split exception
+        # drop the last reference and trigger rank-local communicator cleanup.
+        _retain_mpi_ft_comm(ft_comm)
+        raise
+
+    # MPI_Comm_free is collective. Once setup has reported any communicator
+    # invariant failure, attempting collective cleanup on that same handle is
+    # not provably bounded, even with MPI_ERRORS_RETURN installed. Keep the
+    # handle reachable and let MPI reclaim it at process teardown.
+    _retain_mpi_ft_comm(ft_comm)
+    logger.warning("WideEP FT retained a communicator after startup failure: "
+                   f"{setup_error}")
+    raise RuntimeError(setup_error)
 
 
 class Distributed(ABC):

--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -115,9 +115,10 @@ def _is_mpi_ft_int(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def _mpi_ft_local_topology(mapping: Mapping, parent_rank: int, parent_size: int,
-                           provided_thread_level: int,
-                           health_size: Optional[int]) -> dict[str, Any]:
+def _mpi_ft_local_topology(
+        mapping: Mapping, parent_rank: int, parent_size: int,
+        provided_thread_level: int,
+        failure_evidence_size: Optional[int]) -> dict[str, Any]:
     """Build a serializable startup record without raising locally."""
     world_size = None
     mapping_rank = None
@@ -192,11 +193,12 @@ def _mpi_ft_local_topology(mapping: Mapping, parent_rank: int, parent_size: int,
                     "WideEP FT MVP requires one MoE EP group spanning the "
                     "full MPI world; "
                     f"got world_size={world_size}, moe_ep_group={ep_group}")
-            elif health_size is not None and health_size != ep_size:
+            elif (failure_evidence_size is not None
+                  and failure_evidence_size != ep_size):
                 error_kind = "value"
                 error_message = (
-                    "EPGroupHealth size must match mapping.moe_ep_size, "
-                    f"got {health_size} and {ep_size}")
+                    "Failure-evidence state size must match mapping.moe_ep_size, "
+                    f"got {failure_evidence_size} and {ep_size}")
             elif parent_rank not in ep_group:
                 error_kind = "value"
                 error_message = (
@@ -217,7 +219,7 @@ def _mpi_ft_local_topology(mapping: Mapping, parent_rank: int, parent_size: int,
         "ep_group": ep_group,
         "ep_size": ep_size,
         "ep_rank": ep_rank,
-        "health_size": health_size,
+        "failure_evidence_size": failure_evidence_size,
         "error_kind": error_kind,
         "error_message": error_message,
     }
@@ -312,12 +314,13 @@ def _validate_mpi_ft_topologies(topologies: List[Any],
                 "WideEP FT startup topology is inconsistent: parent rank "
                 f"{gather_rank} reports invalid EP rank {ep_rank!r} for "
                 f"group {ep_group!r}")
-        health_size = topology.get("health_size")
-        if health_size is not None and (not _is_mpi_ft_int(health_size)
-                                        or health_size != parent_size):
+        failure_evidence_size = topology.get("failure_evidence_size")
+        if (failure_evidence_size is not None
+                and (not _is_mpi_ft_int(failure_evidence_size)
+                     or failure_evidence_size != parent_size)):
             raise RuntimeError(
                 "WideEP FT startup topology is inconsistent: parent rank "
-                f"{gather_rank} reports health size {health_size}, "
+                f"{gather_rank} reports failure-evidence size {failure_evidence_size}, "
                 f"expected {parent_size}")
     # Only dereference peer groups after every gathered record has passed the
     # schema/range checks above. This keeps malformed records rank-attributed and
@@ -450,13 +453,13 @@ def _mpi_ft_post_split_result(
 def create_mpi_ft_subcomm(
         mapping: Mapping,
         parent_comm: Optional[Any] = None,
-        health_size: Optional[int] = None) -> MpiFtSubcommSetup:
+        failure_evidence_size: Optional[int] = None) -> MpiFtSubcommSetup:
     """Create the dedicated MPI control-plane communicator for WideEP FT.
 
     This operation is collective across ``parent_comm`` and must run on every
     rank during startup, before any background failure-broadcast threads are
     launched. The MVP requires one MoE EP group spanning the parent world,
-    ordered by the EP-local rank used by the caller's detected-rank state.
+    ordered by the EP-local rank used by the caller's failure-evidence state.
 
     Before splitting, ranks exchange their local validation outcome and EP
     topology on the healthy parent communicator. This prevents one rank from
@@ -467,7 +470,7 @@ def create_mpi_ft_subcomm(
         parent_comm: Parent MPI communicator. Defaults to TRT-LLM's active
             ``mpi_comm()``, which wraps ``MPI.COMM_WORLD`` in the standard
             launch path and preserves custom communicator sessions.
-        health_size: Optional local detected-rank-state size to validate
+        failure_evidence_size: Optional local failure-evidence state size to validate
             collectively before splitting.
 
     Returns:
@@ -487,7 +490,8 @@ def create_mpi_ft_subcomm(
     parent_rank = parent_comm.Get_rank()
     parent_size = parent_comm.Get_size()
     local_topology = _mpi_ft_local_topology(mapping, parent_rank, parent_size,
-                                            MPI.Query_thread(), health_size)
+                                            MPI.Query_thread(),
+                                            failure_evidence_size)
     topologies = parent_comm.allgather(local_topology)
     _validate_mpi_ft_topologies(topologies, parent_size)
 

--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -456,7 +456,7 @@ def create_mpi_ft_subcomm(
     This operation is collective across ``parent_comm`` and must run on every
     rank during startup, before any background failure-broadcast threads are
     launched. The MVP requires one MoE EP group spanning the parent world,
-    ordered by the EP-local rank used by :class:`EPGroupHealth`.
+    ordered by the EP-local rank used by the caller's detected-rank state.
 
     Before splitting, ranks exchange their local validation outcome and EP
     topology on the healthy parent communicator. This prevents one rank from
@@ -467,7 +467,7 @@ def create_mpi_ft_subcomm(
         parent_comm: Parent MPI communicator. Defaults to TRT-LLM's active
             ``mpi_comm()``, which wraps ``MPI.COMM_WORLD`` in the standard
             launch path and preserves custom communicator sessions.
-        health_size: Optional local ``EPGroupHealth`` size to validate
+        health_size: Optional local detected-rank-state size to validate
             collectively before splitting.
 
     Returns:

--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -102,17 +102,35 @@ class MpiFtSubcommSetup:
 
 _MPI_FT_PROCESS_LIFETIME_REFS: list[Any] = []
 _MPI_FT_PROCESS_LIFETIME_REFS_LOCK = threading.Lock()
+_MPI_FT_CREATION_LOCK = threading.Lock()
+_MPI_FT_PROCESS_LIFETIME_PARENT: Optional[Any] = None
+
+
+def _is_mpi_ft_int(value: Any) -> bool:
+    """Reject bool/float values that compare equal to MPI integer fields."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _mpi_ft_process_lifetime_parent_is_reserved() -> bool:
+    with _MPI_FT_PROCESS_LIFETIME_REFS_LOCK:
+        return _MPI_FT_PROCESS_LIFETIME_PARENT is not None
+
+
+def _reserve_mpi_ft_process_lifetime_parent(parent_comm: Any) -> None:
+    """Strongly retain the one MVP parent before `MPI_Comm_split`."""
+    global _MPI_FT_PROCESS_LIFETIME_PARENT
+    with _MPI_FT_PROCESS_LIFETIME_REFS_LOCK:
+        if _MPI_FT_PROCESS_LIFETIME_PARENT is not None:
+            raise RuntimeError(
+                "WideEP FT process-lifetime communicator was reserved concurrently"
+            )
+        _MPI_FT_PROCESS_LIFETIME_PARENT = parent_comm
 
 
 def _retain_mpi_ft_comm(comm: Any) -> None:
     """Keep a communicator with unsafe cleanup reachable until process exit."""
     with _MPI_FT_PROCESS_LIFETIME_REFS_LOCK:
         _MPI_FT_PROCESS_LIFETIME_REFS.append(comm)
-
-
-def _is_mpi_ft_int(value: Any) -> bool:
-    """Reject bool/float values that compare equal to MPI integer fields."""
-    return isinstance(value, int) and not isinstance(value, bool)
 
 
 def _mpi_ft_local_topology(
@@ -141,7 +159,8 @@ def _mpi_ft_local_topology(
     if provided_thread_level < MPI.THREAD_MULTIPLE:
         error_kind = "runtime"
         error_message = (
-            "WideEP FT requires MPI.THREAD_MULTIPLE because its control-plane "
+            "WideEP FT requires MPI.THREAD_MULTIPLE because its "
+            "failure-notification "
             "thread overlaps other MPI traffic "
             f"(provided={provided_thread_level}, required={MPI.THREAD_MULTIPLE})"
         )
@@ -220,6 +239,7 @@ def _mpi_ft_local_topology(
         "ep_size": ep_size,
         "ep_rank": ep_rank,
         "failure_evidence_size": failure_evidence_size,
+        "ft_comm_reserved": False,
         "error_kind": error_kind,
         "error_message": error_message,
     }
@@ -322,6 +342,11 @@ def _validate_mpi_ft_topologies(topologies: List[Any],
                 "WideEP FT startup topology is inconsistent: parent rank "
                 f"{gather_rank} reports failure-evidence size {failure_evidence_size}, "
                 f"expected {parent_size}")
+        if not isinstance(topology.get("ft_comm_reserved"), bool):
+            raise RuntimeError(
+                "WideEP FT startup topology is inconsistent: parent rank "
+                f"{gather_rank} reports invalid communicator-lifecycle state "
+                f"{topology.get('ft_comm_reserved')!r}")
     # Only dereference peer groups after every gathered record has passed the
     # schema/range checks above. This keeps malformed records rank-attributed and
     # prevents a valid earlier record from indexing into unchecked peer data.
@@ -334,6 +359,20 @@ def _validate_mpi_ft_topologies(topologies: List[Any],
                     "WideEP FT startup topology is inconsistent: parent rank "
                     f"{gather_rank} reports EP group {ep_group}, but member "
                     f"rank {peer_rank} reports {peer_group}")
+
+    reserved_ranks = [
+        gather_rank for gather_rank, topology in enumerate(topologies)
+        if topology["ft_comm_reserved"]
+    ]
+    if reserved_ranks:
+        if len(reserved_ranks) != parent_size:
+            raise RuntimeError(
+                "WideEP FT communicator lifecycle is inconsistent across the "
+                f"parent communicator: reserved ranks={reserved_ranks}, "
+                f"expected either none or all {parent_size} ranks")
+        raise RuntimeError(
+            "WideEP FT MVP supports at most one process-lifetime communicator "
+            "per process")
 
 
 def _mpi_ft_post_split_status(ft_comm: Any, parent_rank: int, ep_rank: int,
@@ -454,21 +493,21 @@ def create_mpi_ft_subcomm(
         mapping: Mapping,
         parent_comm: Optional[Any] = None,
         failure_evidence_size: Optional[int] = None) -> MpiFtSubcommSetup:
-    """Create the dedicated MPI control-plane communicator for WideEP FT.
+    """Create the dedicated MPI failure-notification communicator for WideEP FT.
 
-    This operation is collective across ``parent_comm`` and must run on every
+    This operation is collective across `parent_comm` and must run on every
     rank during startup, before any background failure-broadcast threads are
     launched. The MVP requires one MoE EP group spanning the parent world,
     ordered by the EP-local rank used by the caller's failure-evidence state.
 
     Before splitting, ranks exchange their local validation outcome and EP
     topology on the healthy parent communicator. This prevents one rank from
-    raising locally while its peers block forever inside ``MPI_Comm_split``.
+    raising locally while its peers block forever inside `MPI_Comm_split`.
 
     Args:
         mapping: Distributed topology for the local rank.
         parent_comm: Parent MPI communicator. Defaults to TRT-LLM's active
-            ``mpi_comm()``, which wraps ``MPI.COMM_WORLD`` in the standard
+            `mpi_comm()`, which wraps `MPI.COMM_WORLD` in the standard
             launch path and preserves custom communicator sessions.
         failure_evidence_size: Optional local failure-evidence state size to validate
             collectively before splitting.
@@ -479,7 +518,8 @@ def create_mpi_ft_subcomm(
 
     Raises:
         RuntimeError: If MPI is unavailable, does not provide
-            ``MPI.THREAD_MULTIPLE``, or creates an unexpected communicator.
+            `MPI.THREAD_MULTIPLE`, creates an unexpected communicator, or a
+            process-lifetime FT communicator was already created.
         ValueError: If the mapping's EP group is inconsistent.
     """
     if MPI is None:
@@ -487,11 +527,23 @@ def create_mpi_ft_subcomm(
             "mpi4py is required to create the WideEP FT communicator")
 
     parent_comm = mpi_comm() if parent_comm is None else parent_comm
+    # The MVP topology is world-spanning, so only one FT channel may own this
+    # process. Serialization keeps its reservation atomic for local callers.
+    with _MPI_FT_CREATION_LOCK:
+        return _create_mpi_ft_subcomm(mapping, parent_comm,
+                                      failure_evidence_size)
+
+
+def _create_mpi_ft_subcomm(
+        mapping: Mapping, parent_comm: Any,
+        failure_evidence_size: Optional[int]) -> MpiFtSubcommSetup:
     parent_rank = parent_comm.Get_rank()
     parent_size = parent_comm.Get_size()
     local_topology = _mpi_ft_local_topology(mapping, parent_rank, parent_size,
                                             MPI.Query_thread(),
                                             failure_evidence_size)
+    local_topology[
+        "ft_comm_reserved"] = _mpi_ft_process_lifetime_parent_is_reserved()
     topologies = parent_comm.allgather(local_topology)
     _validate_mpi_ft_topologies(topologies, parent_size)
 
@@ -501,36 +553,29 @@ def create_mpi_ft_subcomm(
 
     # The MVP topology gate above makes the world-spanning group's first rank
     # a stable color shared by every process.
-    ft_comm = parent_comm.Split(color=ep_group[0], key=ep_rank)
-    try:
-        setup_status = _mpi_ft_post_split_status(ft_comm, parent_rank, ep_rank,
-                                                 ep_size)
-        setup_statuses = parent_comm.allgather(setup_status)
-        setup_error, ulfm_available = _mpi_ft_post_split_result(
-            setup_statuses, parent_size)
-        if setup_error is None:
-            setup = MpiFtSubcommSetup(
-                comm=ft_comm,
-                local_rank=ep_rank,
-                ep_size=ep_size,
-                ulfm_available=ulfm_available,
-            )
-            # Enforce process-lifetime ownership at the creation boundary. A
-            # direct or future caller must not be able to drop the last Python
-            # reference and trigger rank-local collective MPI_Comm_free.
-            _retain_mpi_ft_comm(ft_comm)
-            return setup
-    except Exception:
-        # Once Split succeeds, never let an unexpected post-Split exception
-        # drop the last reference and trigger rank-local communicator cleanup.
-        _retain_mpi_ft_comm(ft_comm)
-        raise
+    split = parent_comm.Split
+    _reserve_mpi_ft_process_lifetime_parent(parent_comm)
+    ft_comm = split(color=ep_group[0], key=ep_rank)
+    # Retain immediately after Split. Every later setup failure keeps the same
+    # handle and reservation alive instead of risking rank-local Comm_free.
+    _retain_mpi_ft_comm(ft_comm)
+    setup_status = _mpi_ft_post_split_status(ft_comm, parent_rank, ep_rank,
+                                             ep_size)
+    setup_statuses = parent_comm.allgather(setup_status)
+    setup_error, ulfm_available = _mpi_ft_post_split_result(
+        setup_statuses, parent_size)
+    if setup_error is None:
+        return MpiFtSubcommSetup(
+            comm=ft_comm,
+            local_rank=ep_rank,
+            ep_size=ep_size,
+            ulfm_available=ulfm_available,
+        )
 
     # MPI_Comm_free is collective. Once setup has reported any communicator
     # invariant failure, attempting collective cleanup on that same handle is
     # not provably bounded, even with MPI_ERRORS_RETURN installed. Keep the
     # handle reachable and let MPI reclaim it at process teardown.
-    _retain_mpi_ft_comm(ft_comm)
     logger.warning("WideEP FT retained a communicator after startup failure: "
                    f"{setup_error}")
     raise RuntimeError(setup_error)

--- a/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
+++ b/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
@@ -21,10 +21,10 @@ dedicated EP-scoped MPI communicator and progresses only nonblocking
 point-to-point requests on an independent CPU thread.
 
 The component propagates one rank-failure detection and updates only the
-process-local *detected* :class:`EPGroupHealth`. It never updates the committed
-execution mask. Multi-rank suspect/confirm consensus, commit authorization,
-and communicator reconstruction are intentionally left to later WideEP FT
-phases.
+process-local :class:`DetectedRankState`. It never receives or updates the
+committed ``EPGroupHealth`` execution mask. Multi-rank suspect/confirm
+consensus, commit authorization, and communicator reconstruction are
+intentionally left to later WideEP FT phases.
 
 Every survivor echoes a newly observed failure. Receiving one echo from every
 active survivor proves only that they propagated the same detection. Detection
@@ -57,10 +57,6 @@ try:
 except ImportError:
     MPI = None
 
-from tensorrt_llm._torch.modules.fused_moe.ep_group_health import (
-    EPGroupHealth,
-    EPGroupHealthSnapshot,
-)
 from tensorrt_llm.logger import logger
 
 if TYPE_CHECKING:
@@ -131,6 +127,97 @@ FailureDetectedCallback = Callable[[int, int, float], None]
 # should use ``FailureDetectedCallback`` because this callback carries detected,
 # never committed, state.
 FailureReceivedCallback = FailureDetectedCallback
+
+
+@dataclass(frozen=True)
+class DetectedRankStateSnapshot:
+    """Atomic snapshot of rank-failure evidence for one communicator epoch."""
+
+    mask: int
+    failed_ranks: frozenset[int]
+    generation: int
+
+
+class DetectedRankState:
+    """Thread-safe, process-local rank-failure evidence.
+
+    This state is deliberately distinct from ``EPGroupHealth``. It is an
+    observation owned by :class:`MpiFtSubcomm`, not a committed execution mask,
+    and it is monotonic for the lifetime of one FT communicator epoch.
+
+    Args:
+        ep_size: Number of EP-local ranks represented by this state.
+
+    Raises:
+        ValueError: If ``ep_size`` is not positive.
+    """
+
+    def __init__(self, ep_size: int) -> None:
+        if ep_size <= 0:
+            raise ValueError(f"ep_size must be > 0, got {ep_size}")
+        self._ep_size = ep_size
+        self._all_active_mask = (1 << ep_size) - 1
+        self._active_mask = self._all_active_mask
+        self._failed_ranks: set[int] = set()
+        self._generation = 0
+        self._lock = threading.Lock()
+
+    @property
+    def ep_size(self) -> int:
+        """Number of ranks represented by this immutable communicator epoch."""
+        return self._ep_size
+
+    @property
+    def generation(self) -> int:
+        """Number of effective detected-failure transitions."""
+        with self._lock:
+            return self._generation
+
+    def record_failure(self, rank: int) -> bool:
+        """Record one failed rank, returning whether evidence changed."""
+        self._validate_rank(rank)
+        bit = 1 << rank
+        with self._lock:
+            if not self._active_mask & bit:
+                return False
+            self._active_mask &= ~bit
+            self._failed_ranks.add(rank)
+            self._generation += 1
+            return True
+
+    def is_active(self, rank: int) -> bool:
+        """Return whether no failure has been recorded for ``rank``."""
+        self._validate_rank(rank)
+        with self._lock:
+            return bool(self._active_mask & (1 << rank))
+
+    def get_mask(self) -> int:
+        """Return the active-rank mask derived from detected evidence."""
+        with self._lock:
+            return self._active_mask
+
+    def get_failed_ranks(self) -> frozenset[int]:
+        """Return an immutable snapshot of ranks with failure evidence."""
+        with self._lock:
+            return frozenset(self._failed_ranks)
+
+    def all_active(self) -> bool:
+        """Return whether no rank failure has been detected."""
+        with self._lock:
+            return self._active_mask == self._all_active_mask
+
+    def snapshot(self) -> DetectedRankStateSnapshot:
+        """Return one coherent mask, failure-set, and generation snapshot."""
+        with self._lock:
+            return DetectedRankStateSnapshot(
+                mask=self._active_mask,
+                failed_ranks=frozenset(self._failed_ranks),
+                generation=self._generation,
+            )
+
+    def _validate_rank(self, rank: int) -> None:
+        if not 0 <= rank < self._ep_size:
+            raise ValueError(f"rank must be in [0, {self._ep_size}), got {rank}")
 
 
 @dataclass(frozen=True)
@@ -214,8 +301,8 @@ class MpiFtSubcomm:
     thread. Call :meth:`start` only after every rank has constructed the
     component. During normal operation, the progress thread owns MPI calls on
     this communicator; :meth:`report_detected_failure` updates only local
-    detected health and enqueues a report, so it never waits for a peer or MPI
-    progress. The watchdog must call this method instead of pre-marking health.
+    detected state and enqueues a report, so it never waits for a peer or MPI
+    progress. The watchdog must call this method instead of pre-recording evidence.
     Because ``MPI.THREAD_MULTIPLE`` is required, a caller whose start/stop
     deadline proves that thread is wedged may issue the terminal Revoke/Abort
     fallback.
@@ -223,13 +310,14 @@ class MpiFtSubcomm:
     Args:
         mapping: Distributed mapping whose ``moe_ep_group`` defines the FT
             communicator and whose ``moe_ep_rank`` defines the local rank.
-        detected_health: Process-local EP detection state updated by sent and
-            received failure reports. This must be separate from the committed
-            execution-mask state owned by the recovery coordinator.
+        detected_state: Process-local EP detection evidence updated by sent and
+            received failure reports. ``EPGroupHealth`` is rejected because it
+            is the committed execution-mask state owned by the recovery
+            coordinator.
         config: Progress-loop timing configuration.
         on_failure_detected: Optional callback invoked as
             ``(failed_rank, source_rank, monotonic_time)`` when a local or
-            received report first changes detected health. This is the handoff
+            received report first changes detected state. This is the handoff
             to the future 1c.4b recovery coordinator; it is detection evidence,
             not commit authorization. Delivery runs on a dedicated daemon
             thread so callback latency cannot block MPI progress.
@@ -240,14 +328,15 @@ class MpiFtSubcomm:
     Raises:
         RuntimeError: If MPI support or thread support is insufficient, or if
             the communicator does not match ``mapping``.
-        ValueError: If ``detected_health`` and ``mapping`` describe different
+        TypeError: If ``detected_state`` is not a :class:`DetectedRankState`.
+        ValueError: If ``detected_state`` and ``mapping`` describe different
             EP groups, or if both callback keyword names are provided.
     """
 
     def __init__(
         self,
         mapping: Mapping,
-        detected_health: EPGroupHealth,
+        detected_state: DetectedRankState,
         config: MpiFtSubcommConfig | None = None,
         on_failure_detected: FailureDetectedCallback | None = None,
         *,
@@ -255,6 +344,11 @@ class MpiFtSubcomm:
         mpi_module: _MpiModule | None = None,
         on_failure_received: FailureReceivedCallback | None = None,
     ) -> None:
+        if not isinstance(detected_state, DetectedRankState):
+            raise TypeError(
+                "detected_state must be a DetectedRankState; committed "
+                "EPGroupHealth cannot be used as failure-detection evidence"
+            )
         if on_failure_detected is not None and on_failure_received is not None:
             raise ValueError(
                 "Specify only on_failure_detected; on_failure_received is a compatibility alias"
@@ -279,7 +373,7 @@ class MpiFtSubcomm:
 
             collective_setup = create_mpi_ft_subcomm(
                 mapping,
-                health_size=detected_health.moe_world_size,
+                health_size=detected_state.ep_size,
             )
             comm = cast(_MpiComm, collective_setup.comm)
 
@@ -312,10 +406,10 @@ class MpiFtSubcomm:
                     "WideEP FT MVP requires one MoE EP group spanning the full MPI world; "
                     f"got world_size={mapping.world_size}, moe_ep_group={ep_group}"
                 )
-            if detected_health.moe_world_size != mapping.moe_ep_size:
+            if detected_state.ep_size != mapping.moe_ep_size:
                 raise ValueError(
-                    "EPGroupHealth size must match mapping.moe_ep_size, "
-                    f"got {detected_health.moe_world_size} and {mapping.moe_ep_size}"
+                    "DetectedRankState size must match mapping.moe_ep_size, "
+                    f"got {detected_state.ep_size} and {mapping.moe_ep_size}"
                 )
             self._local_rank = mapping.moe_ep_rank
             self._ep_size = mapping.moe_ep_size
@@ -331,7 +425,7 @@ class MpiFtSubcomm:
                     f"expected rank={self._local_rank}, size={self._ep_size}"
                 )
 
-        self._detected_health = detected_health
+        self._detected_state = detected_state
         self._on_failure_detected = on_failure_detected
         self._outbound_reports: queue.SimpleQueue[_OutboundMessage] = queue.SimpleQueue()
         self._announced_failures: set[int] = set()
@@ -610,8 +704,8 @@ class MpiFtSubcomm:
         """Record and asynchronously announce one detected EP-rank failure.
 
         This is the nonblocking seam invoked by the host watchdog. The
-        broadcaster owns the detected-health transition; callers must not mark
-        ``detected_health`` before invoking it. This method performs no MPI
+        broadcaster owns the detected-state transition; callers must not record
+        the failure before invoking it. This method performs no MPI
         calls and never waits for the progress thread. Repeated reports for the
         same rank are coalesced after the first local announcement.
 
@@ -619,7 +713,7 @@ class MpiFtSubcomm:
             failed_rank: EP-local rank in ``[0, ep_size)``.
 
         Returns:
-            ``True`` if this call changed local detected health, else ``False``.
+            ``True`` if this call changed local detected state, else ``False``.
         """
         self._validate_rank(failed_rank)
         with self._lifecycle_lock:
@@ -634,7 +728,7 @@ class MpiFtSubcomm:
                 self._lifecycle = _Lifecycle.FAILED
                 self._request_terminal_abort(error, failed_rank, self._local_rank)
                 raise
-            changed = self._detected_health.mark_failed(failed_rank)
+            changed = self._detected_state.record_failure(failed_rank)
             enqueued = self._observe_failure(failed_rank, self._local_rank)
         detected_time = time.monotonic()
         logger.warning(
@@ -649,7 +743,7 @@ class MpiFtSubcomm:
         """Compatibility alias for :meth:`report_detected_failure`.
 
         Despite the historical name, this method does not commit failover and
-        callers must not pre-mark detected health.
+        callers must not pre-record detected evidence.
         """
         return self.report_detected_failure(failed_rank)
 
@@ -662,7 +756,7 @@ class MpiFtSubcomm:
         return (
             self._transport_poisoned.is_set()
             or self._accepted_failure_rank() is not None
-            or not self._detected_health.all_active()
+            or not self._detected_state.all_active()
         )
 
     def failure_detection_is_reconciled(self, failed_rank: int) -> bool:
@@ -680,7 +774,7 @@ class MpiFtSubcomm:
                 return False
             if self.last_error is not None or self._progress_failed.is_set():
                 return False
-            snapshot = self._detected_health.snapshot()
+            snapshot = self._detected_state.snapshot()
             if failed_rank not in snapshot.failed_ranks:
                 return False
             accepted_failure, accepted_generation = self._accepted_failure_state()
@@ -691,7 +785,7 @@ class MpiFtSubcomm:
                     return False
                 return self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask)
 
-    def detected_health_is_reconciled(self) -> bool:
+    def detected_state_is_reconciled(self) -> bool:
         """Return whether survivors propagated every local failure detection.
 
         This is not a commit gate. A ``True`` result does not authorize request
@@ -703,7 +797,7 @@ class MpiFtSubcomm:
                 return False
             if self.last_error is not None or self._progress_failed.is_set():
                 return False
-            snapshot = self._detected_health.snapshot()
+            snapshot = self._detected_state.snapshot()
             accepted_failure, accepted_generation = self._accepted_failure_state()
             if not snapshot.failed_ranks:
                 return accepted_failure is None and not self._transport_poisoned.is_set()
@@ -717,13 +811,17 @@ class MpiFtSubcomm:
                     for failed_rank in snapshot.failed_ranks
                 )
 
+    def detected_health_is_reconciled(self) -> bool:
+        """Compatibility alias for :meth:`detected_state_is_reconciled`."""
+        return self.detected_state_is_reconciled()
+
     def failure_is_reconciled(self, failed_rank: int) -> bool:
         """Compatibility alias for :meth:`failure_detection_is_reconciled`."""
         return self.failure_detection_is_reconciled(failed_rank)
 
     def health_is_reconciled(self) -> bool:
-        """Compatibility alias for :meth:`detected_health_is_reconciled`."""
-        return self.detected_health_is_reconciled()
+        """Compatibility alias for :meth:`detected_state_is_reconciled`."""
+        return self.detected_state_is_reconciled()
 
     def _validate_rank(self, rank: int) -> None:
         if not 0 <= rank < self._ep_size:
@@ -732,14 +830,14 @@ class MpiFtSubcomm:
     def _claim_failure(self, failed_rank: int) -> None:
         """Atomically enforce the single-distinct-failure MVP contract."""
         with self._failure_claim_lock:
-            snapshot = self._detected_health.snapshot()
+            snapshot = self._detected_state.snapshot()
             known_failures = snapshot.failed_ranks
-            conflicting_health = known_failures - {failed_rank}
+            conflicting_evidence = known_failures - {failed_rank}
             accepted = self._accepted_failed_rank
-            if (accepted is not None and accepted != failed_rank) or conflicting_health:
+            if (accepted is not None and accepted != failed_rank) or conflicting_evidence:
                 first_failure = accepted
                 if first_failure is None:
-                    first_failure = min(conflicting_health)
+                    first_failure = min(conflicting_evidence)
                 raise RuntimeError(
                     "WideEP FT MVP supports exactly one distinct failed rank; "
                     f"already accepted rank {first_failure}, received rank {failed_rank}"
@@ -747,15 +845,15 @@ class MpiFtSubcomm:
             if accepted is None:
                 if failed_rank in known_failures:
                     raise RuntimeError(
-                        "WideEP FT detected health was mutated before the failure "
+                        "WideEP FT detected state was mutated before the failure "
                         "broadcaster accepted the report; the watchdog must call "
-                        "report_detected_failure() without pre-marking health"
+                        "report_detected_failure() without pre-recording evidence"
                     )
                 self._accepted_failed_rank = failed_rank
-                # Exactly one effective mark_failed() must be the next detected
-                # health transition. Capturing that generation here prevents an
-                # independent mutation in the claim-to-observe window from
-                # becoming the accepted epoch baseline.
+                # Exactly one effective record_failure() must be the next
+                # detected-state transition. Capturing that generation here
+                # prevents an independent mutation in the claim-to-observe
+                # window from becoming the accepted epoch baseline.
                 self._accepted_failure_generation = snapshot.generation + 1
 
     def _accepted_failure_rank(self) -> int | None:
@@ -769,7 +867,7 @@ class MpiFtSubcomm:
     def _observe_failure(self, failed_rank: int, reporter: int) -> bool:
         """Record one detection report and enqueue this rank's echo once."""
         now = time.monotonic()
-        snapshot = self._detected_health.snapshot()
+        snapshot = self._detected_state.snapshot()
         message: _OutboundMessage | None = None
         with self._protocol_lock:
             unattributed_deadline = self._unattributed_error_deadlines.get(failed_rank)
@@ -794,7 +892,7 @@ class MpiFtSubcomm:
 
     def _detection_reconciliation_state_is_valid_locked(
         self,
-        snapshot: EPGroupHealthSnapshot,
+        snapshot: DetectedRankStateSnapshot,
         accepted_failure: int | None,
         accepted_generation: int | None,
     ) -> bool:
@@ -822,7 +920,7 @@ class MpiFtSubcomm:
         ``MPI_Abort``. This method performs no MPI calls.
         """
         self._record_error(error)
-        snapshot = self._detected_health.snapshot()
+        snapshot = self._detected_state.snapshot()
         enqueue_abort = False
         now = time.monotonic()
         with self._protocol_lock:
@@ -977,7 +1075,7 @@ class MpiFtSubcomm:
                 return
 
             failed_rank = message.failed_rank
-            snapshot = self._detected_health.snapshot()
+            snapshot = self._detected_state.snapshot()
             if message.kind is _MessageKind.ABORT:
                 # Terminal state must reach every rank still believed active.
                 # If one of them is actually the second failed rank, send
@@ -1095,7 +1193,7 @@ class MpiFtSubcomm:
                         f"{failed_rank} from EP rank {source}"
                     )
 
-            if self._detected_health.is_active(source) and not self._stop_event.is_set():
+            if self._detected_state.is_active(source) and not self._stop_event.is_set():
                 try:
                     pending_receives[source] = self._post_receive(source)
                 except Exception as error:
@@ -1158,7 +1256,7 @@ class MpiFtSubcomm:
                 self._lifecycle = _Lifecycle.FAILED
                 claim_error = error
             else:
-                changed = self._detected_health.mark_failed(failed_rank)
+                changed = self._detected_state.record_failure(failed_rank)
                 if transport_poisoned:
                     self._transport_poisoned.set()
                 self._observe_failure(failed_rank, reporter)
@@ -1304,21 +1402,21 @@ class MpiFtSubcomm:
         self._deadline_monitor_wake_event.set()
 
     def _check_accepted_failure_epoch(self) -> None:
-        """Fail closed when detected health leaves the accepted failure epoch."""
+        """Fail closed when detected state leaves the accepted failure epoch."""
         error: RuntimeError | None = None
         accepted_failure: int | None = None
         with self._lifecycle_lock:
             if self._lifecycle not in (_Lifecycle.RUNNING, _Lifecycle.STOPPING):
                 return
-            snapshot = self._detected_health.snapshot()
+            snapshot = self._detected_state.snapshot()
             accepted_failure, accepted_generation = self._accepted_failure_state()
             if accepted_failure is None:
                 if not snapshot.failed_ranks:
                     return
                 error = RuntimeError(
-                    "WideEP FT detected health changed outside the failure "
+                    "WideEP FT detected state changed outside the failure "
                     "broadcaster; the watchdog must call "
-                    "report_detected_failure() without pre-marking health "
+                    "report_detected_failure() without pre-recording evidence "
                     f"(snapshot={snapshot})"
                 )
             elif (
@@ -1375,7 +1473,7 @@ class MpiFtSubcomm:
         with self._lifecycle_lock:
             if self._lifecycle not in (_Lifecycle.RUNNING, _Lifecycle.STOPPING):
                 return
-            snapshot = self._detected_health.snapshot()
+            snapshot = self._detected_state.snapshot()
             with self._protocol_lock:
                 for failed_rank, deadline in list(self._reconcile_deadlines.items()):
                     if self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask):
@@ -1392,7 +1490,7 @@ class MpiFtSubcomm:
 
     def _stop_reconciliation_state(self) -> tuple[bool, BaseException | None]:
         """Return whether shutdown can stop MPI progress without splitting ranks."""
-        snapshot = self._detected_health.snapshot()
+        snapshot = self._detected_state.snapshot()
         failed_ranks = snapshot.failed_ranks
         accepted_failure, accepted_generation = self._accepted_failure_state()
         with self._protocol_lock:

--- a/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
+++ b/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
@@ -13,26 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Out-of-band MPI failure propagation for WideEP fault tolerance.
+"""Out-of-band MPI failure-detection propagation for WideEP fault tolerance.
 
 The model-forward thread can be stuck in an AlltoAll kernel when a peer fails,
 so it cannot participate in recovery consensus. :class:`MpiFtSubcomm` owns a
 dedicated EP-scoped MPI communicator and progresses only nonblocking
 point-to-point requests on an independent CPU thread.
 
-The component implements authoritative single-failure propagation. Multi-rank
-suspect/confirm consensus and communicator reconstruction are intentionally
-left to the later WideEP FT phases.
+The component propagates one rank-failure detection and updates only the
+process-local *detected* :class:`EPGroupHealth`. It never updates the committed
+execution mask. Multi-rank suspect/confirm consensus, commit authorization,
+and communicator reconstruction are intentionally left to later WideEP FT
+phases.
 
 Every survivor echoes a newly observed failure. Receiving one echo from every
-active survivor proves that all of them updated their local health. This remains
-an asynchronous protocol, not an iteration barrier: the model-engine hook polls
-:meth:`health_is_reconciled` at safe iteration boundaries, and the later
-barrier-piggyback phase integrates the same state directly into the iteration
-barrier. ULFM revoke is reserved for terminal control-plane aborts because MPI
-does not carry enough information to distinguish a successful commit revoke
-from an emergency abort at remote ranks. Without ULFM, terminal state is echoed
-to every survivor; failure to confirm that echo within a bounded interval uses
+active survivor proves only that they propagated the same detection. Detection
+reconciliation does **not** authorize request resume, EPLB changes, NCCL
+reconfiguration or use, or committed-mask mutation. The future 1c.4b recovery
+coordinator consumes the detection callback and owns that authorization.
+
+ULFM revoke is reserved for terminal control-plane aborts because MPI does not
+carry enough information to distinguish a successful commit revoke from an
+emergency abort at remote ranks. Without ULFM, terminal state is echoed to every
+survivor; failure to confirm that echo within a bounded interval uses
 ``MPI_Abort`` on the world-spanning FT communicator as a fail-stop fallback.
 """
 
@@ -123,7 +126,11 @@ class _MpiModule(Protocol):
     def Query_thread(self) -> int: ...
 
 
-FailureReceivedCallback = Callable[[int, int, float], None]
+FailureDetectedCallback = Callable[[int, int, float], None]
+# Compatibility name for callers of the original draft API. New integrations
+# should use ``FailureDetectedCallback`` because this callback carries detected,
+# never committed, state.
+FailureReceivedCallback = FailureDetectedCallback
 
 
 @dataclass(frozen=True)
@@ -201,25 +208,30 @@ class _Lifecycle(Enum):
 
 
 class MpiFtSubcomm:
-    """Broadcast EP-rank failures on a dedicated MPI control plane.
+    """Broadcast EP-rank failure detections on a dedicated MPI control plane.
 
     Construction creates the FT communicator collectively on the caller's
     thread. Call :meth:`start` only after every rank has constructed the
     component. During normal operation, the progress thread owns MPI calls on
-    this communicator; :meth:`broadcast_failure` only updates local health and
-    enqueues a report, so it never waits for a peer or MPI progress. Because
-    ``MPI.THREAD_MULTIPLE`` is required, a caller whose start/stop deadline
-    proves that thread is wedged may issue the terminal Revoke/Abort fallback.
+    this communicator; :meth:`report_detected_failure` updates only local
+    detected health and enqueues a report, so it never waits for a peer or MPI
+    progress. The watchdog must call this method instead of pre-marking health.
+    Because ``MPI.THREAD_MULTIPLE`` is required, a caller whose start/stop
+    deadline proves that thread is wedged may issue the terminal Revoke/Abort
+    fallback.
 
     Args:
         mapping: Distributed mapping whose ``moe_ep_group`` defines the FT
             communicator and whose ``moe_ep_rank`` defines the local rank.
-        health: Process-local EP health state updated by sent and received
-            failure reports.
+        detected_health: Process-local EP detection state updated by sent and
+            received failure reports. This must be separate from the committed
+            execution-mask state owned by the recovery coordinator.
         config: Progress-loop timing configuration.
-        on_failure_received: Optional callback invoked as
-            ``(failed_rank, source_rank, monotonic_time)`` only when a received
-            report changes local health. Delivery runs on a dedicated daemon
+        on_failure_detected: Optional callback invoked as
+            ``(failed_rank, source_rank, monotonic_time)`` when a local or
+            received report first changes detected health. This is the handoff
+            to the future 1c.4b recovery coordinator; it is detection evidence,
+            not commit authorization. Delivery runs on a dedicated daemon
             thread so callback latency cannot block MPI progress.
         comm: Pre-created FT communicator. Intended for tests; production
             callers should let the component create it from ``mapping``.
@@ -228,19 +240,27 @@ class MpiFtSubcomm:
     Raises:
         RuntimeError: If MPI support or thread support is insufficient, or if
             the communicator does not match ``mapping``.
-        ValueError: If ``health`` and ``mapping`` describe different EP groups.
+        ValueError: If ``detected_health`` and ``mapping`` describe different
+            EP groups, or if both callback keyword names are provided.
     """
 
     def __init__(
         self,
         mapping: Mapping,
-        health: EPGroupHealth,
+        detected_health: EPGroupHealth,
         config: MpiFtSubcommConfig | None = None,
-        on_failure_received: FailureReceivedCallback | None = None,
+        on_failure_detected: FailureDetectedCallback | None = None,
         *,
         comm: _MpiComm | None = None,
         mpi_module: _MpiModule | None = None,
+        on_failure_received: FailureReceivedCallback | None = None,
     ) -> None:
+        if on_failure_detected is not None and on_failure_received is not None:
+            raise ValueError(
+                "Specify only on_failure_detected; on_failure_received is a compatibility alias"
+            )
+        if on_failure_detected is None:
+            on_failure_detected = on_failure_received
         if mpi_module is None:
             if MPI is None:
                 raise RuntimeError("mpi4py is required for WideEP failure propagation")
@@ -259,7 +279,7 @@ class MpiFtSubcomm:
 
             collective_setup = create_mpi_ft_subcomm(
                 mapping,
-                health_size=health.moe_world_size,
+                health_size=detected_health.moe_world_size,
             )
             comm = cast(_MpiComm, collective_setup.comm)
 
@@ -292,10 +312,10 @@ class MpiFtSubcomm:
                     "WideEP FT MVP requires one MoE EP group spanning the full MPI world; "
                     f"got world_size={mapping.world_size}, moe_ep_group={ep_group}"
                 )
-            if health.moe_world_size != mapping.moe_ep_size:
+            if detected_health.moe_world_size != mapping.moe_ep_size:
                 raise ValueError(
                     "EPGroupHealth size must match mapping.moe_ep_size, "
-                    f"got {health.moe_world_size} and {mapping.moe_ep_size}"
+                    f"got {detected_health.moe_world_size} and {mapping.moe_ep_size}"
                 )
             self._local_rank = mapping.moe_ep_rank
             self._ep_size = mapping.moe_ep_size
@@ -311,8 +331,8 @@ class MpiFtSubcomm:
                     f"expected rank={self._local_rank}, size={self._ep_size}"
                 )
 
-        self._health = health
-        self._on_failure_received = on_failure_received
+        self._detected_health = detected_health
+        self._on_failure_detected = on_failure_detected
         self._outbound_reports: queue.SimpleQueue[_OutboundMessage] = queue.SimpleQueue()
         self._announced_failures: set[int] = set()
         self._failure_reporters: dict[int, set[int]] = {}
@@ -391,7 +411,7 @@ class MpiFtSubcomm:
                 )
             self._lifecycle = _Lifecycle.STARTING
             try:
-                if self._on_failure_received is not None:
+                if self._on_failure_detected is not None:
                     callback_thread = threading.Thread(
                         target=self._callback_loop,
                         name="wide-ep-ft-callback",
@@ -452,7 +472,7 @@ class MpiFtSubcomm:
             )
             with self._lifecycle_lock:
                 self._lifecycle = _Lifecycle.FAILED
-            # Stop telemetry before the terminal MPI action. Real MPI_Abort
+            # Stop callback delivery before the terminal MPI action. Real MPI_Abort
             # does not return, while test doubles and Revoke do; either way no
             # callback worker should be left waiting for progress-thread cleanup.
             self._request_deadline_monitor_stop()
@@ -464,7 +484,7 @@ class MpiFtSubcomm:
             self._fail_closed_immediately(timeout_error)
             # The progress thread may be stuck inside the first MPI Irecv and
             # therefore unable to reach its ``finally`` block. Do not leave the
-            # independent telemetry worker alive after start() has failed.
+            # independent callback worker alive after start() has failed.
             callback_thread = self._callback_thread
             if callback_thread is not None and callback_thread is not threading.current_thread():
                 callback_thread.join(self._config.stop_timeout_sec)
@@ -576,37 +596,30 @@ class MpiFtSubcomm:
                 timeout_error = TimeoutError(
                     "WideEP FT callback thread did not stop before the timeout"
                 )
-                # Callbacks are telemetry only. A stuck callback may make this
-                # stop call time out, but it must not poison MPI state or make
-                # one rank take the poisoned-world process-exit path.
+                # The detection handoff does not own MPI state. A stuck future
+                # coordinator callback may make this stop call time out, but it
+                # must not make one rank take the poisoned-world process-exit
+                # path.
                 raise timeout_error
 
         with self._lifecycle_lock:
             if self._lifecycle is not _Lifecycle.FAILED:
                 self._lifecycle = _Lifecycle.STOPPED
 
-    def pre_failover(self, failed_rank: int) -> bool:
-        """Mark and asynchronously announce one failed EP rank.
+    def report_detected_failure(self, failed_rank: int) -> bool:
+        """Record and asynchronously announce one detected EP-rank failure.
 
-        This is the nonblocking seam used by failure detectors. The report is
-        queued even when ``health`` was already updated by the caller, because
-        the host watchdog normally marks local health before invoking the
-        broadcaster.
+        This is the nonblocking seam invoked by the host watchdog. The
+        broadcaster owns the detected-health transition; callers must not mark
+        ``detected_health`` before invoking it. This method performs no MPI
+        calls and never waits for the progress thread. Repeated reports for the
+        same rank are coalesced after the first local announcement.
 
         Args:
             failed_rank: EP-local rank in ``[0, ep_size)``.
 
         Returns:
-            ``True`` if this call changed local health, else ``False``.
-        """
-        return self.broadcast_failure(failed_rank)
-
-    def broadcast_failure(self, failed_rank: int) -> bool:
-        """Mark and asynchronously broadcast one failed EP rank.
-
-        This method performs no MPI calls and never waits for the progress
-        thread. Repeated calls for the same rank are coalesced after the first
-        local announcement.
+            ``True`` if this call changed local detected health, else ``False``.
         """
         self._validate_rank(failed_rank)
         with self._lifecycle_lock:
@@ -621,27 +634,45 @@ class MpiFtSubcomm:
                 self._lifecycle = _Lifecycle.FAILED
                 self._request_terminal_abort(error, failed_rank, self._local_rank)
                 raise
-            changed = self._health.mark_failed(failed_rank)
+            changed = self._detected_health.mark_failed(failed_rank)
             enqueued = self._observe_failure(failed_rank, self._local_rank)
+        detected_time = time.monotonic()
         logger.warning(
             f"WideEP FT local failure rank={failed_rank} changed={changed} "
-            f"enqueued={enqueued} elapsed_ms={(time.monotonic() - start_time) * 1000.0:.3f}"
+            f"enqueued={enqueued} elapsed_ms={(detected_time - start_time) * 1000.0:.3f}"
         )
+        if changed:
+            self._invoke_detection_callback(failed_rank, self._local_rank, detected_time)
         return changed
+
+    def pre_failover(self, failed_rank: int) -> bool:
+        """Compatibility alias for :meth:`report_detected_failure`.
+
+        Despite the historical name, this method does not commit failover and
+        callers must not pre-mark detected health.
+        """
+        return self.report_detected_failure(failed_rank)
+
+    def broadcast_failure(self, failed_rank: int) -> bool:
+        """Compatibility alias for :meth:`report_detected_failure`."""
+        return self.report_detected_failure(failed_rank)
 
     def world_is_poisoned(self) -> bool:
         """Return whether this communicator epoch has ever observed failure."""
         return (
             self._transport_poisoned.is_set()
             or self._accepted_failure_rank() is not None
-            or not self._health.all_active()
+            or not self._detected_health.all_active()
         )
 
-    def failure_is_reconciled(self, failed_rank: int) -> bool:
-        """Return whether every active survivor has announced ``failed_rank``.
+    def failure_detection_is_reconciled(self, failed_rank: int) -> bool:
+        """Return whether every active survivor announced the same detection.
 
-        This method performs no MPI calls and is safe to poll from an iteration
-        boundary. A terminal progress error always fails closed.
+        This is detection-plane evidence only. A ``True`` result does not
+        authorize request resume, EPLB changes, NCCL reconfiguration or use, or
+        committed-mask mutation. The future 1c.4b recovery coordinator owns
+        those decisions. This method performs no MPI calls, and a terminal
+        progress error always fails closed.
         """
         self._validate_rank(failed_rank)
         with self._lifecycle_lock:
@@ -649,37 +680,50 @@ class MpiFtSubcomm:
                 return False
             if self.last_error is not None or self._progress_failed.is_set():
                 return False
-            snapshot = self._health.snapshot()
+            snapshot = self._detected_health.snapshot()
             if failed_rank not in snapshot.failed_ranks:
                 return False
             accepted_failure, accepted_generation = self._accepted_failure_state()
             with self._protocol_lock:
-                if not self._reconciliation_state_is_valid_locked(
+                if not self._detection_reconciliation_state_is_valid_locked(
                     snapshot, accepted_failure, accepted_generation
                 ):
                     return False
-                return self._failure_is_reconciled_locked(failed_rank, snapshot.mask)
+                return self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask)
 
-    def health_is_reconciled(self) -> bool:
-        """Return whether all locally known failures are agreed by survivors."""
+    def detected_health_is_reconciled(self) -> bool:
+        """Return whether survivors propagated every local failure detection.
+
+        This is not a commit gate. A ``True`` result does not authorize request
+        resume, EPLB changes, NCCL reconfiguration or use, or committed-mask
+        mutation. The future 1c.4b recovery coordinator owns those decisions.
+        """
         with self._lifecycle_lock:
             if self._lifecycle is not _Lifecycle.RUNNING:
                 return False
             if self.last_error is not None or self._progress_failed.is_set():
                 return False
-            snapshot = self._health.snapshot()
+            snapshot = self._detected_health.snapshot()
             accepted_failure, accepted_generation = self._accepted_failure_state()
             if not snapshot.failed_ranks:
                 return accepted_failure is None and not self._transport_poisoned.is_set()
             with self._protocol_lock:
-                if not self._reconciliation_state_is_valid_locked(
+                if not self._detection_reconciliation_state_is_valid_locked(
                     snapshot, accepted_failure, accepted_generation
                 ):
                     return False
                 return all(
-                    self._failure_is_reconciled_locked(failed_rank, snapshot.mask)
+                    self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask)
                     for failed_rank in snapshot.failed_ranks
                 )
+
+    def failure_is_reconciled(self, failed_rank: int) -> bool:
+        """Compatibility alias for :meth:`failure_detection_is_reconciled`."""
+        return self.failure_detection_is_reconciled(failed_rank)
+
+    def health_is_reconciled(self) -> bool:
+        """Compatibility alias for :meth:`detected_health_is_reconciled`."""
+        return self.detected_health_is_reconciled()
 
     def _validate_rank(self, rank: int) -> None:
         if not 0 <= rank < self._ep_size:
@@ -688,7 +732,7 @@ class MpiFtSubcomm:
     def _claim_failure(self, failed_rank: int) -> None:
         """Atomically enforce the single-distinct-failure MVP contract."""
         with self._failure_claim_lock:
-            snapshot = self._health.snapshot()
+            snapshot = self._detected_health.snapshot()
             known_failures = snapshot.failed_ranks
             conflicting_health = known_failures - {failed_rank}
             accepted = self._accepted_failed_rank
@@ -701,15 +745,18 @@ class MpiFtSubcomm:
                     f"already accepted rank {first_failure}, received rank {failed_rank}"
                 )
             if accepted is None:
+                if failed_rank in known_failures:
+                    raise RuntimeError(
+                        "WideEP FT detected health was mutated before the failure "
+                        "broadcaster accepted the report; the watchdog must call "
+                        "report_detected_failure() without pre-marking health"
+                    )
                 self._accepted_failed_rank = failed_rank
-                # The watchdog may have marked the rank before calling us. If
-                # not, exactly one effective mark_failed() must be the next
-                # health transition. Capturing that expected generation here
-                # prevents an independent mutation in the claim-to-observe
-                # window from becoming the accepted epoch baseline.
-                self._accepted_failure_generation = snapshot.generation + (
-                    0 if failed_rank in known_failures else 1
-                )
+                # Exactly one effective mark_failed() must be the next detected
+                # health transition. Capturing that generation here prevents an
+                # independent mutation in the claim-to-observe window from
+                # becoming the accepted epoch baseline.
+                self._accepted_failure_generation = snapshot.generation + 1
 
     def _accepted_failure_rank(self) -> int | None:
         with self._failure_claim_lock:
@@ -720,9 +767,9 @@ class MpiFtSubcomm:
             return self._accepted_failed_rank, self._accepted_failure_generation
 
     def _observe_failure(self, failed_rank: int, reporter: int) -> bool:
-        """Record one authoritative report and enqueue this rank's echo once."""
+        """Record one detection report and enqueue this rank's echo once."""
         now = time.monotonic()
-        snapshot = self._health.snapshot()
+        snapshot = self._detected_health.snapshot()
         message: _OutboundMessage | None = None
         with self._protocol_lock:
             unattributed_deadline = self._unattributed_error_deadlines.get(failed_rank)
@@ -737,7 +784,7 @@ class MpiFtSubcomm:
             if failure_enqueued:
                 self._announced_failures.add(failed_rank)
                 message = _OutboundMessage(_MessageKind.FAILURE, failed_rank)
-            if self._failure_is_reconciled_locked(failed_rank, snapshot.mask):
+            if self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask):
                 self._reconcile_deadlines.pop(failed_rank, None)
         if message is not None:
             self._outbound_reports.put(message)
@@ -745,7 +792,7 @@ class MpiFtSubcomm:
         self._deadline_monitor_wake_event.set()
         return failure_enqueued
 
-    def _reconciliation_state_is_valid_locked(
+    def _detection_reconciliation_state_is_valid_locked(
         self,
         snapshot: EPGroupHealthSnapshot,
         accepted_failure: int | None,
@@ -775,7 +822,7 @@ class MpiFtSubcomm:
         ``MPI_Abort``. This method performs no MPI calls.
         """
         self._record_error(error)
-        snapshot = self._health.snapshot()
+        snapshot = self._detected_health.snapshot()
         enqueue_abort = False
         now = time.monotonic()
         with self._protocol_lock:
@@ -795,12 +842,12 @@ class MpiFtSubcomm:
         self._wake_event.set()
         self._deadline_monitor_wake_event.set()
 
-    def _failure_is_reconciled_locked(self, failed_rank: int, active_mask: int) -> bool:
+    def _failure_detection_is_reconciled_locked(self, failed_rank: int, active_mask: int) -> bool:
         required_reporters = {rank for rank in range(self._ep_size) if active_mask & (1 << rank)}
         if not required_reporters:
-            # There is nobody left who can safely execute the next collective.
-            # Do not let the usual ``empty set is a subset`` rule open the
-            # iteration gate in this terminal boundary case.
+            # There is no survivor that can participate in later recovery.
+            # Do not let the usual ``empty set is a subset`` rule claim
+            # detection propagation completed in this terminal case.
             return False
         reporters = self._failure_reporters.get(failed_rank, set())
         return failed_rank in self._failure_fanout_complete and required_reporters.issubset(
@@ -930,7 +977,7 @@ class MpiFtSubcomm:
                 return
 
             failed_rank = message.failed_rank
-            snapshot = self._health.snapshot()
+            snapshot = self._detected_health.snapshot()
             if message.kind is _MessageKind.ABORT:
                 # Terminal state must reach every rank still believed active.
                 # If one of them is actually the second failed rank, send
@@ -1016,7 +1063,7 @@ class MpiFtSubcomm:
                     # Without ULFM, MPI implementations may surface the dead
                     # source as a generic error. Do not guess the failed rank;
                     # drop only this fixed-source receive and keep polling the
-                    # other survivors for an authoritative watchdog report.
+                    # other survivors for a rank-attributed detection report.
                     del pending_receives[source]
                     self._track_unattributed_transport_error(source)
                     logger.warning(
@@ -1048,7 +1095,7 @@ class MpiFtSubcomm:
                         f"{failed_rank} from EP rank {source}"
                     )
 
-            if self._health.is_active(source) and not self._stop_event.is_set():
+            if self._detected_health.is_active(source) and not self._stop_event.is_set():
                 try:
                     pending_receives[source] = self._post_receive(source)
                 except Exception as error:
@@ -1078,7 +1125,7 @@ class MpiFtSubcomm:
             f"WideEP FT received failure rank={failed_rank} source={source} "
             f"elapsed_ms={(received_time - start_time) * 1000.0:.3f}"
         )
-        self._invoke_callback(failed_rank, source, received_time)
+        self._invoke_detection_callback(failed_rank, source, received_time)
 
     def _handle_failed_peer(self, failed_rank: int, source: int) -> None:
         changed = self._accept_received_failure(
@@ -1093,7 +1140,7 @@ class MpiFtSubcomm:
             logger.warning(
                 f"WideEP FT observed failed EP rank {failed_rank} through the FT communicator"
             )
-            self._invoke_callback(failed_rank, source, detected_time)
+            self._invoke_detection_callback(failed_rank, source, detected_time)
 
     def _accept_received_failure(
         self,
@@ -1111,7 +1158,7 @@ class MpiFtSubcomm:
                 self._lifecycle = _Lifecycle.FAILED
                 claim_error = error
             else:
-                changed = self._health.mark_failed(failed_rank)
+                changed = self._detected_health.mark_failed(failed_rank)
                 if transport_poisoned:
                     self._transport_poisoned.set()
                 self._observe_failure(failed_rank, reporter)
@@ -1133,24 +1180,25 @@ class MpiFtSubcomm:
             self._lifecycle = _Lifecycle.FAILED
             self._request_terminal_abort(error, payload, source)
 
-    def _invoke_callback(self, failed_rank: int, source: int, event_time: float) -> None:
-        if self._on_failure_received is None or self._callback_stop_event.is_set():
+    def _invoke_detection_callback(self, failed_rank: int, source: int, event_time: float) -> None:
+        if self._on_failure_detected is None or self._callback_stop_event.is_set():
             return
         self._callback_queue.put((failed_rank, source, event_time))
 
     def _callback_loop(self) -> None:
-        """Deliver telemetry callbacks without blocking MPI progress."""
+        """Deliver detection handoffs without blocking MPI progress."""
         while True:
             event = self._callback_queue.get()
             if event is None:
                 return
             failed_rank, source, event_time = event
             try:
-                callback = self._on_failure_received
+                callback = self._on_failure_detected
                 if callback is not None:
                     callback(failed_rank, source, event_time)
             except Exception as error:
-                # Telemetry must never terminate either control-plane thread.
+                # A coordinator callback must never terminate either
+                # control-plane thread.
                 logger.warning(f"WideEP FT failure callback raised: {error}")
 
     def _request_callback_stop(self) -> None:
@@ -1256,35 +1304,40 @@ class MpiFtSubcomm:
         self._deadline_monitor_wake_event.set()
 
     def _check_accepted_failure_epoch(self) -> None:
-        """Fail closed when health leaves the accepted single-failure epoch."""
+        """Fail closed when detected health leaves the accepted failure epoch."""
         error: RuntimeError | None = None
         accepted_failure: int | None = None
         with self._lifecycle_lock:
             if self._lifecycle not in (_Lifecycle.RUNNING, _Lifecycle.STOPPING):
                 return
-            snapshot = self._health.snapshot()
+            snapshot = self._detected_health.snapshot()
             accepted_failure, accepted_generation = self._accepted_failure_state()
-            # A watchdog may mark health immediately before calling
-            # pre_failover(). Until that call claims a rank, do not mistake the
-            # documented pre-mark seam for an epoch violation.
             if accepted_failure is None:
-                return
-            if (
+                if not snapshot.failed_ranks:
+                    return
+                error = RuntimeError(
+                    "WideEP FT detected health changed outside the failure "
+                    "broadcaster; the watchdog must call "
+                    "report_detected_failure() without pre-marking health "
+                    f"(snapshot={snapshot})"
+                )
+            elif (
                 snapshot.failed_ranks == frozenset({accepted_failure})
                 and snapshot.generation == accepted_generation
             ):
                 return
-            error = RuntimeError(
-                "WideEP FT accepted failure epoch changed before communicator "
-                "reconstruction "
-                f"(accepted_rank={accepted_failure}, "
-                f"expected_generation={accepted_generation}, snapshot={snapshot})"
-            )
+            else:
+                error = RuntimeError(
+                    "WideEP FT accepted failure epoch changed before communicator "
+                    "reconstruction "
+                    f"(accepted_rank={accepted_failure}, "
+                    f"expected_generation={accepted_generation}, snapshot={snapshot})"
+                )
             self._lifecycle = _Lifecycle.FAILED
 
         assert error is not None
-        assert accepted_failure is not None
-        self._request_terminal_abort(error, accepted_failure, self._local_rank)
+        payload = accepted_failure if accepted_failure is not None else -1
+        self._request_terminal_abort(error, payload, self._local_rank)
 
     def _check_unattributed_transport_deadlines(self) -> None:
         now = time.monotonic()
@@ -1322,10 +1375,10 @@ class MpiFtSubcomm:
         with self._lifecycle_lock:
             if self._lifecycle not in (_Lifecycle.RUNNING, _Lifecycle.STOPPING):
                 return
-            snapshot = self._health.snapshot()
+            snapshot = self._detected_health.snapshot()
             with self._protocol_lock:
                 for failed_rank, deadline in list(self._reconcile_deadlines.items()):
-                    if self._failure_is_reconciled_locked(failed_rank, snapshot.mask):
+                    if self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask):
                         del self._reconcile_deadlines[failed_rank]
                     elif now >= deadline:
                         expired.append(failed_rank)
@@ -1339,11 +1392,11 @@ class MpiFtSubcomm:
 
     def _stop_reconciliation_state(self) -> tuple[bool, BaseException | None]:
         """Return whether shutdown can stop MPI progress without splitting ranks."""
-        snapshot = self._health.snapshot()
+        snapshot = self._detected_health.snapshot()
         failed_ranks = snapshot.failed_ranks
         accepted_failure, accepted_generation = self._accepted_failure_state()
         with self._protocol_lock:
-            reconciliation_state_is_valid = self._reconciliation_state_is_valid_locked(
+            reconciliation_state_is_valid = self._detection_reconciliation_state_is_valid_locked(
                 snapshot,
                 accepted_failure,
                 accepted_generation,
@@ -1366,7 +1419,7 @@ class MpiFtSubcomm:
             unreconciled = [
                 failed_rank
                 for failed_rank in failed_ranks
-                if not self._failure_is_reconciled_locked(failed_rank, snapshot.mask)
+                if not self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask)
             ]
             untracked = [
                 failed_rank

--- a/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
+++ b/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
@@ -1,0 +1,1564 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Out-of-band MPI failure propagation for WideEP fault tolerance.
+
+The model-forward thread can be stuck in an AlltoAll kernel when a peer fails,
+so it cannot participate in recovery consensus. :class:`MpiFtSubcomm` owns a
+dedicated EP-scoped MPI communicator and progresses only nonblocking
+point-to-point requests on an independent CPU thread.
+
+The component implements authoritative single-failure propagation. Multi-rank
+suspect/confirm consensus and communicator reconstruction are intentionally
+left to the later WideEP FT phases.
+
+Every survivor echoes a newly observed failure. Receiving one echo from every
+active survivor proves that all of them updated their local health. This remains
+an asynchronous protocol, not an iteration barrier: the model-engine hook polls
+:meth:`health_is_reconciled` at safe iteration boundaries, and the later
+barrier-piggyback phase integrates the same state directly into the iteration
+barrier. ULFM revoke is reserved for terminal control-plane aborts because MPI
+does not carry enough information to distinguish a successful commit revoke
+from an emergency abort at remote ranks. Without ULFM, terminal state is echoed
+to every survivor; failure to confirm that echo within a bounded interval uses
+``MPI_Abort`` on the world-spanning FT communicator as a fail-stop fallback.
+"""
+
+from __future__ import annotations
+
+import math
+import queue
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum, IntEnum, auto
+from typing import TYPE_CHECKING, Protocol, cast
+
+import numpy as np
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    MPI = None
+
+from tensorrt_llm._torch.modules.fused_moe.ep_group_health import (
+    EPGroupHealth,
+    EPGroupHealthSnapshot,
+)
+from tensorrt_llm.logger import logger
+
+if TYPE_CHECKING:
+    from tensorrt_llm.mapping import Mapping
+
+
+_FAILURE_TAG = 0
+_MESSAGE_WORDS = 2
+
+
+class _MessageKind(IntEnum):
+    FAILURE = 1
+    ABORT = 2
+
+
+_PROCESS_LIFETIME_REFS: list[object] = []
+_PROCESS_LIFETIME_REFS_LOCK = threading.Lock()
+
+
+def _retain_for_process_lifetime(*references: object) -> None:
+    """Keep active MPI objects reachable until interpreter teardown."""
+    with _PROCESS_LIFETIME_REFS_LOCK:
+        _PROCESS_LIFETIME_REFS.extend(references)
+
+
+class _MpiRequest(Protocol):
+    """Subset of mpi4py request operations used by the progress loop."""
+
+    def Cancel(self) -> None: ...
+
+    def Test(self) -> bool: ...
+
+
+class _MpiComm(Protocol):
+    """Subset of mpi4py communicator operations used by this component."""
+
+    def Get_rank(self) -> int: ...
+
+    def Get_size(self) -> int: ...
+
+    def Irecv(self, buffer: np.ndarray, source: int, tag: int) -> _MpiRequest: ...
+
+    def Isend(self, buffer: np.ndarray, dest: int, tag: int) -> _MpiRequest: ...
+
+    def Is_revoked(self) -> bool: ...
+
+    def Revoke(self) -> None: ...
+
+    def Abort(self, errorcode: int) -> None: ...
+
+    def Set_errhandler(self, errhandler: object) -> None: ...
+
+
+class _MpiModule(Protocol):
+    """Subset of the mpi4py ``MPI`` module used by this component."""
+
+    ERRORS_RETURN: object
+    ERR_PROC_FAILED: int
+    ERR_UNKNOWN: int
+    THREAD_MULTIPLE: int
+    Exception: type[BaseException]
+
+    def Query_thread(self) -> int: ...
+
+
+FailureReceivedCallback = Callable[[int, int, float], None]
+
+
+@dataclass(frozen=True)
+class MpiFtSubcommConfig:
+    """Runtime-independent tuning for the FT progress thread.
+
+    Args:
+        poll_interval_sec: Maximum delay between MPI progress passes. The
+            default leaves margin below the 100 ms agreement budget.
+        startup_timeout_sec: Maximum time to wait for receive requests to be
+            posted when :meth:`MpiFtSubcomm.start` is called.
+        stop_timeout_sec: Default bounded join timeout used by
+            :meth:`MpiFtSubcomm.stop`.
+        reconcile_timeout_sec: Maximum time for every active survivor to
+            announce the same failure before the control plane fails closed.
+        unattributed_error_timeout_sec: Maximum time to wait for the host
+            watchdog to identify a rank after non-ULFM MPI reports a generic
+            transport error. The default leaves margin for the design's
+            five-second watchdog bound while keeping terminal escalation
+            inside the ten-second recovery budget.
+        abort_timeout_sec: Maximum time to reconcile a relayed terminal ABORT
+            before falling back to communicator-wide ``MPI_Abort`` when ULFM
+            is unavailable.
+    """
+
+    poll_interval_sec: float = 0.01
+    startup_timeout_sec: float = 2.0
+    stop_timeout_sec: float = 2.0
+    reconcile_timeout_sec: float = 1.0
+    unattributed_error_timeout_sec: float = 6.0
+    abort_timeout_sec: float = 0.1
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("poll_interval_sec", self.poll_interval_sec),
+            ("startup_timeout_sec", self.startup_timeout_sec),
+            ("stop_timeout_sec", self.stop_timeout_sec),
+            ("reconcile_timeout_sec", self.reconcile_timeout_sec),
+            ("unattributed_error_timeout_sec", self.unattributed_error_timeout_sec),
+            ("abort_timeout_sec", self.abort_timeout_sec),
+        ):
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be finite and > 0, got {value}")
+
+
+@dataclass
+class _PendingSend:
+    request: _MpiRequest
+    buffer: np.ndarray
+    destination: int
+    failed_rank: int
+    kind: _MessageKind
+
+
+@dataclass
+class _PendingReceive:
+    request: _MpiRequest
+    buffer: np.ndarray
+    source: int
+
+
+@dataclass(frozen=True)
+class _OutboundMessage:
+    kind: _MessageKind
+    failed_rank: int
+
+
+class _Lifecycle(Enum):
+    CREATED = auto()
+    STARTING = auto()
+    RUNNING = auto()
+    STOPPING = auto()
+    STOPPED = auto()
+    FAILED = auto()
+
+
+class MpiFtSubcomm:
+    """Broadcast EP-rank failures on a dedicated MPI control plane.
+
+    Construction creates the FT communicator collectively on the caller's
+    thread. Call :meth:`start` only after every rank has constructed the
+    component. During normal operation, the progress thread owns MPI calls on
+    this communicator; :meth:`broadcast_failure` only updates local health and
+    enqueues a report, so it never waits for a peer or MPI progress. Because
+    ``MPI.THREAD_MULTIPLE`` is required, a caller whose start/stop deadline
+    proves that thread is wedged may issue the terminal Revoke/Abort fallback.
+
+    Args:
+        mapping: Distributed mapping whose ``moe_ep_group`` defines the FT
+            communicator and whose ``moe_ep_rank`` defines the local rank.
+        health: Process-local EP health state updated by sent and received
+            failure reports.
+        config: Progress-loop timing configuration.
+        on_failure_received: Optional callback invoked as
+            ``(failed_rank, source_rank, monotonic_time)`` only when a received
+            report changes local health. Delivery runs on a dedicated daemon
+            thread so callback latency cannot block MPI progress.
+        comm: Pre-created FT communicator. Intended for tests; production
+            callers should let the component create it from ``mapping``.
+        mpi_module: MPI module paired with ``comm``. Intended for tests.
+
+    Raises:
+        RuntimeError: If MPI support or thread support is insufficient, or if
+            the communicator does not match ``mapping``.
+        ValueError: If ``health`` and ``mapping`` describe different EP groups.
+    """
+
+    def __init__(
+        self,
+        mapping: Mapping,
+        health: EPGroupHealth,
+        config: MpiFtSubcommConfig | None = None,
+        on_failure_received: FailureReceivedCallback | None = None,
+        *,
+        comm: _MpiComm | None = None,
+        mpi_module: _MpiModule | None = None,
+    ) -> None:
+        if mpi_module is None:
+            if MPI is None:
+                raise RuntimeError("mpi4py is required for WideEP failure propagation")
+            mpi_module = cast(_MpiModule, MPI)
+        self._mpi = mpi_module
+
+        self._config = config or MpiFtSubcommConfig()
+        comm_created_collectively = comm is None
+        collective_setup = None
+        if comm_created_collectively:
+            # Keep the collective startup validation and Split on the
+            # constructing thread. In particular, do not raise a rank-local
+            # mapping error before peers have entered the same collective
+            # validation path.
+            from tensorrt_llm._torch.distributed.communicator import create_mpi_ft_subcomm
+
+            collective_setup = create_mpi_ft_subcomm(
+                mapping,
+                health_size=health.moe_world_size,
+            )
+            comm = cast(_MpiComm, collective_setup.comm)
+
+        assert comm is not None
+        self._comm = comm
+        if comm_created_collectively:
+            # create_mpi_ft_subcomm already reconciled thread support, mapping,
+            # health size, communicator rank/size, and ERRORS_RETURN across the
+            # parent communicator. Repeating any of those MPI operations here
+            # would reintroduce a rank-local failure after collective startup.
+            assert collective_setup is not None
+            self._local_rank = collective_setup.local_rank
+            self._ep_size = collective_setup.ep_size
+        else:
+            if self._mpi.Query_thread() < self._mpi.THREAD_MULTIPLE:
+                raise RuntimeError(
+                    "WideEP FT requires MPI.THREAD_MULTIPLE because its control-plane "
+                    "thread overlaps other MPI traffic"
+                )
+
+            ep_group = tuple(mapping.moe_ep_group)
+            if len(ep_group) != mapping.moe_ep_size:
+                raise ValueError(
+                    "mapping.moe_ep_group size must match mapping.moe_ep_size, "
+                    f"got {len(ep_group)} and {mapping.moe_ep_size}"
+                )
+            expected_world = set(range(mapping.world_size))
+            if mapping.moe_ep_size != mapping.world_size or set(ep_group) != expected_world:
+                raise ValueError(
+                    "WideEP FT MVP requires one MoE EP group spanning the full MPI world; "
+                    f"got world_size={mapping.world_size}, moe_ep_group={ep_group}"
+                )
+            if health.moe_world_size != mapping.moe_ep_size:
+                raise ValueError(
+                    "EPGroupHealth size must match mapping.moe_ep_size, "
+                    f"got {health.moe_world_size} and {mapping.moe_ep_size}"
+                )
+            self._local_rank = mapping.moe_ep_rank
+            self._ep_size = mapping.moe_ep_size
+            # Install the non-fatal handler before inspecting the injected
+            # communicator so even validation errors are returned to Python.
+            self._comm.Set_errhandler(self._mpi.ERRORS_RETURN)
+            actual_rank = self._comm.Get_rank()
+            actual_size = self._comm.Get_size()
+            if actual_rank != self._local_rank or actual_size != self._ep_size:
+                raise RuntimeError(
+                    "WideEP FT communicator does not match the mapping: "
+                    f"rank={actual_rank}, size={actual_size}, "
+                    f"expected rank={self._local_rank}, size={self._ep_size}"
+                )
+
+        self._health = health
+        self._on_failure_received = on_failure_received
+        self._outbound_reports: queue.SimpleQueue[_OutboundMessage] = queue.SimpleQueue()
+        self._announced_failures: set[int] = set()
+        self._failure_reporters: dict[int, set[int]] = {}
+        self._reconcile_deadlines: dict[int, float] = {}
+        self._unattributed_error_deadlines: dict[int, float] = {}
+        self._failure_fanout_posted: set[int] = set()
+        self._failure_fanout_complete: set[int] = set()
+        self._abort_reporters: set[int] = set()
+        self._abort_expected_reporters: frozenset[int] = frozenset()
+        self._abort_deadline: float | None = None
+        self._abort_payload = -1
+        self._abort_announced = False
+        self._abort_fanout_posted = False
+        self._abort_fanout_complete = False
+        self._protocol_lock = threading.Lock()
+        self._failure_claim_lock = threading.Lock()
+        self._accepted_failed_rank: int | None = None
+        self._accepted_failure_generation: int | None = None
+        self._stop_event = threading.Event()
+        self._abort_requested = threading.Event()
+        self._wake_event = threading.Event()
+        self._ready_event = threading.Event()
+        self._deadline_monitor_stop_event = threading.Event()
+        self._deadline_monitor_wake_event = threading.Event()
+        self._deadline_monitor_ready_event = threading.Event()
+        self._transport_poisoned = threading.Event()
+        self._progress_failed = threading.Event()
+        self._lifecycle = _Lifecycle.CREATED
+        self._lifecycle_lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._deadline_monitor_thread: threading.Thread | None = None
+        self._last_error: BaseException | None = None
+        self._error_lock = threading.Lock()
+        self._retained_requests: list[_PendingSend | _PendingReceive] = []
+        self._process_lifetime_retained = comm_created_collectively
+        if comm_created_collectively:
+            # The FT communicator is a process-lifetime control-plane
+            # resource. Letting mpi4py destroy it when one broadcaster is
+            # garbage-collected would call a collective Free at rank-local
+            # and nondeterministic times.
+            _retain_for_process_lifetime(self._comm)
+        self._shutdown_deadline: float | None = None
+        self._callback_queue: queue.SimpleQueue[tuple[int, int, float] | None] = queue.SimpleQueue()
+        self._callback_stop_event = threading.Event()
+        self._callback_thread: threading.Thread | None = None
+        self._terminal_action_lock = threading.Lock()
+        self._revoke_attempted = False
+        self._world_abort_attempted = False
+        self._ulfm_available = (
+            collective_setup.ulfm_available if collective_setup is not None else self._probe_ulfm()
+        )
+
+    @property
+    def ulfm_available(self) -> bool:
+        """Whether this MPI build implements the ULFM communicator methods."""
+        with self._terminal_action_lock:
+            return self._ulfm_available
+
+    @property
+    def last_error(self) -> BaseException | None:
+        """First terminal control-plane error, if any."""
+        with self._error_lock:
+            return self._last_error
+
+    def start(self) -> None:
+        """Start the dedicated MPI progress thread.
+
+        This method is not restartable. A second call, including one after
+        :meth:`stop`, raises ``RuntimeError``.
+        """
+        thread_start_error: BaseException | None = None
+        with self._lifecycle_lock:
+            if self._lifecycle is not _Lifecycle.CREATED:
+                raise RuntimeError(
+                    f"WideEP FT broadcaster cannot start from {self._lifecycle.name.lower()} state"
+                )
+            self._lifecycle = _Lifecycle.STARTING
+            try:
+                if self._on_failure_received is not None:
+                    callback_thread = threading.Thread(
+                        target=self._callback_loop,
+                        name="wide-ep-ft-callback",
+                        daemon=True,
+                    )
+                    callback_thread.start()
+                    # Store only a successfully started thread. stop() may join
+                    # every stored thread and joining an unstarted Thread raises.
+                    self._callback_thread = callback_thread
+                deadline_monitor_thread = threading.Thread(
+                    target=self._deadline_monitor_loop,
+                    name="wide-ep-ft-deadline-monitor",
+                    daemon=True,
+                )
+                deadline_monitor_thread.start()
+                self._deadline_monitor_thread = deadline_monitor_thread
+                progress_thread = threading.Thread(
+                    target=self._progress_loop,
+                    name="wide-ep-ft-broadcast",
+                    daemon=True,
+                )
+                progress_thread.start()
+                self._thread = progress_thread
+            except Exception as error:
+                # Publish the error before FAILED so concurrent observers never
+                # see a terminal lifecycle without its cause.
+                self._record_error(error)
+                self._progress_failed.set()
+                self._lifecycle = _Lifecycle.FAILED
+                thread_start_error = error
+
+        if thread_start_error is not None:
+            self._request_deadline_monitor_stop()
+            self._request_callback_stop()
+            self._retain_requests([])
+            # There is no progress thread to relay ABORT, so fail closed on the
+            # caller thread. This is the only thread that can own the FT comm
+            # after progress-thread creation itself failed.
+            self._fail_closed_immediately(thread_start_error)
+            callback_thread = self._callback_thread
+            if callback_thread is not None and callback_thread.is_alive():
+                callback_thread.join(self._config.stop_timeout_sec)
+            deadline_monitor_thread = self._deadline_monitor_thread
+            if deadline_monitor_thread is not None and deadline_monitor_thread.is_alive():
+                deadline_monitor_thread.join(self._config.stop_timeout_sec)
+            raise RuntimeError(
+                "WideEP FT control-plane thread failed to start"
+            ) from thread_start_error
+
+        startup_deadline = time.monotonic() + self._config.startup_timeout_sec
+        progress_ready = self._ready_event.wait(max(0.0, startup_deadline - time.monotonic()))
+        deadline_monitor_ready = self._deadline_monitor_ready_event.wait(
+            max(0.0, startup_deadline - time.monotonic())
+        )
+        if not progress_ready or not deadline_monitor_ready:
+            timeout_error = TimeoutError(
+                "WideEP FT control-plane threads did not start before the timeout"
+            )
+            with self._lifecycle_lock:
+                self._lifecycle = _Lifecycle.FAILED
+            # Stop telemetry before the terminal MPI action. Real MPI_Abort
+            # does not return, while test doubles and Revoke do; either way no
+            # callback worker should be left waiting for progress-thread cleanup.
+            self._request_deadline_monitor_stop()
+            self._request_callback_stop()
+            # The progress thread may be wedged inside the MPI call whose
+            # startup deadline just expired, so it cannot execute the terminal
+            # action itself. MPI.THREAD_MULTIPLE is a construction invariant;
+            # use the caller thread to issue the terminal communicator action.
+            self._fail_closed_immediately(timeout_error)
+            # The progress thread may be stuck inside the first MPI Irecv and
+            # therefore unable to reach its ``finally`` block. Do not leave the
+            # independent telemetry worker alive after start() has failed.
+            callback_thread = self._callback_thread
+            if callback_thread is not None and callback_thread is not threading.current_thread():
+                callback_thread.join(self._config.stop_timeout_sec)
+            deadline_monitor_thread = self._deadline_monitor_thread
+            if (
+                deadline_monitor_thread is not None
+                and deadline_monitor_thread is not threading.current_thread()
+            ):
+                deadline_monitor_thread.join(self._config.stop_timeout_sec)
+            raise timeout_error
+        with self._lifecycle_lock:
+            startup_error = self.last_error
+            lifecycle = self._lifecycle
+            if startup_error is not None:
+                self._lifecycle = _Lifecycle.FAILED
+            elif lifecycle is not _Lifecycle.RUNNING:
+                raise RuntimeError(
+                    "WideEP FT broadcaster did not reach running state during startup "
+                    f"(state={lifecycle.name.lower()})"
+                )
+        if startup_error is not None:
+            self._request_deadline_monitor_stop()
+            deadline_monitor_thread = self._deadline_monitor_thread
+            if (
+                deadline_monitor_thread is not None
+                and deadline_monitor_thread is not threading.current_thread()
+            ):
+                deadline_monitor_thread.join(self._config.stop_timeout_sec)
+            raise RuntimeError("WideEP FT progress thread failed during startup") from startup_error
+
+    def stop(self, timeout: float | None = None) -> None:
+        """Stop progress without blocking on MPI requests or freeing the comm.
+
+        Healthy requests are cancelled and polled within the same bounded
+        timeout. After a peer or transport failure, requests and their NumPy
+        buffers are retained until process teardown because cancelling,
+        waiting for, or freeing them can hang inside MPI.
+
+        If a known failure is not yet reconciled, the progress thread keeps
+        running until agreement or the existing reconciliation deadline drives
+        the terminal fail-stop path.
+
+        Args:
+            timeout: Maximum join time. Defaults to
+                :attr:`MpiFtSubcommConfig.stop_timeout_sec`.
+
+        Raises:
+            ValueError: If ``timeout`` is not finite and positive.
+            TimeoutError: If the progress thread does not exit in time.
+        """
+        timeout = self._config.stop_timeout_sec if timeout is None else timeout
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError(f"timeout must be finite and > 0, got {timeout}")
+
+        stop_deadline = time.monotonic() + timeout
+        with self._lifecycle_lock:
+            if self._lifecycle is _Lifecycle.CREATED:
+                self._lifecycle = _Lifecycle.STOPPED
+                self._request_deadline_monitor_stop()
+                self._request_callback_stop()
+                return
+            callback_thread = self._callback_thread
+            deadline_monitor_thread = self._deadline_monitor_thread
+            if (
+                self._lifecycle is _Lifecycle.STOPPED
+                and (callback_thread is None or not callback_thread.is_alive())
+                and (deadline_monitor_thread is None or not deadline_monitor_thread.is_alive())
+            ):
+                return
+            thread = self._thread
+            if self._lifecycle in (_Lifecycle.STARTING, _Lifecycle.RUNNING):
+                self._lifecycle = _Lifecycle.STOPPING
+            join_grace = min(0.01, timeout / 2)
+            self._shutdown_deadline = stop_deadline - join_grace
+            self._stop_event.set()
+            self._wake_event.set()
+            self._request_callback_stop()
+
+        if thread is not None:
+            thread.join(max(0.0, stop_deadline - time.monotonic()))
+            if thread.is_alive():
+                timeout_error = TimeoutError(
+                    "WideEP FT progress thread did not stop before the timeout"
+                )
+                with self._lifecycle_lock:
+                    self._lifecycle = _Lifecycle.FAILED
+                # Do not enqueue fail-stop work onto the thread that this
+                # timeout proves is not making MPI progress.
+                self._request_deadline_monitor_stop()
+                self._fail_closed_immediately(timeout_error)
+                raise timeout_error
+
+        self._request_deadline_monitor_stop()
+        if (
+            deadline_monitor_thread is not None
+            and deadline_monitor_thread is not threading.current_thread()
+        ):
+            deadline_monitor_thread.join(max(0.0, stop_deadline - time.monotonic()))
+            if deadline_monitor_thread.is_alive():
+                timeout_error = TimeoutError(
+                    "WideEP FT deadline monitor did not stop before the timeout"
+                )
+                self._fail_closed_immediately(timeout_error)
+                raise timeout_error
+
+        if callback_thread is not None and callback_thread is not threading.current_thread():
+            callback_thread.join(max(0.0, stop_deadline - time.monotonic()))
+            if callback_thread.is_alive():
+                timeout_error = TimeoutError(
+                    "WideEP FT callback thread did not stop before the timeout"
+                )
+                # Callbacks are telemetry only. A stuck callback may make this
+                # stop call time out, but it must not poison MPI state or make
+                # one rank take the poisoned-world process-exit path.
+                raise timeout_error
+
+        with self._lifecycle_lock:
+            if self._lifecycle is not _Lifecycle.FAILED:
+                self._lifecycle = _Lifecycle.STOPPED
+
+    def pre_failover(self, failed_rank: int) -> bool:
+        """Mark and asynchronously announce one failed EP rank.
+
+        This is the nonblocking seam used by failure detectors. The report is
+        queued even when ``health`` was already updated by the caller, because
+        the host watchdog normally marks local health before invoking the
+        broadcaster.
+
+        Args:
+            failed_rank: EP-local rank in ``[0, ep_size)``.
+
+        Returns:
+            ``True`` if this call changed local health, else ``False``.
+        """
+        return self.broadcast_failure(failed_rank)
+
+    def broadcast_failure(self, failed_rank: int) -> bool:
+        """Mark and asynchronously broadcast one failed EP rank.
+
+        This method performs no MPI calls and never waits for the progress
+        thread. Repeated calls for the same rank are coalesced after the first
+        local announcement.
+        """
+        self._validate_rank(failed_rank)
+        with self._lifecycle_lock:
+            if self._lifecycle is not _Lifecycle.RUNNING or self._progress_failed.is_set():
+                raise RuntimeError(
+                    f"WideEP FT broadcaster is not running (state={self._lifecycle.name.lower()})"
+                )
+            start_time = time.monotonic()
+            try:
+                self._claim_failure(failed_rank)
+            except RuntimeError as error:
+                self._lifecycle = _Lifecycle.FAILED
+                self._request_terminal_abort(error, failed_rank, self._local_rank)
+                raise
+            changed = self._health.mark_failed(failed_rank)
+            enqueued = self._observe_failure(failed_rank, self._local_rank)
+        logger.warning(
+            f"WideEP FT local failure rank={failed_rank} changed={changed} "
+            f"enqueued={enqueued} elapsed_ms={(time.monotonic() - start_time) * 1000.0:.3f}"
+        )
+        return changed
+
+    def world_is_poisoned(self) -> bool:
+        """Return whether this communicator epoch has ever observed failure."""
+        return (
+            self._transport_poisoned.is_set()
+            or self._accepted_failure_rank() is not None
+            or not self._health.all_active()
+        )
+
+    def failure_is_reconciled(self, failed_rank: int) -> bool:
+        """Return whether every active survivor has announced ``failed_rank``.
+
+        This method performs no MPI calls and is safe to poll from an iteration
+        boundary. A terminal progress error always fails closed.
+        """
+        self._validate_rank(failed_rank)
+        with self._lifecycle_lock:
+            if self._lifecycle is not _Lifecycle.RUNNING:
+                return False
+            if self.last_error is not None or self._progress_failed.is_set():
+                return False
+            snapshot = self._health.snapshot()
+            if failed_rank not in snapshot.failed_ranks:
+                return False
+            accepted_failure, accepted_generation = self._accepted_failure_state()
+            with self._protocol_lock:
+                if not self._reconciliation_state_is_valid_locked(
+                    snapshot, accepted_failure, accepted_generation
+                ):
+                    return False
+                return self._failure_is_reconciled_locked(failed_rank, snapshot.mask)
+
+    def health_is_reconciled(self) -> bool:
+        """Return whether all locally known failures are agreed by survivors."""
+        with self._lifecycle_lock:
+            if self._lifecycle is not _Lifecycle.RUNNING:
+                return False
+            if self.last_error is not None or self._progress_failed.is_set():
+                return False
+            snapshot = self._health.snapshot()
+            accepted_failure, accepted_generation = self._accepted_failure_state()
+            if not snapshot.failed_ranks:
+                return accepted_failure is None and not self._transport_poisoned.is_set()
+            with self._protocol_lock:
+                if not self._reconciliation_state_is_valid_locked(
+                    snapshot, accepted_failure, accepted_generation
+                ):
+                    return False
+                return all(
+                    self._failure_is_reconciled_locked(failed_rank, snapshot.mask)
+                    for failed_rank in snapshot.failed_ranks
+                )
+
+    def _validate_rank(self, rank: int) -> None:
+        if not 0 <= rank < self._ep_size:
+            raise ValueError(f"failed_rank must be in [0, {self._ep_size}), got {rank}")
+
+    def _claim_failure(self, failed_rank: int) -> None:
+        """Atomically enforce the single-distinct-failure MVP contract."""
+        with self._failure_claim_lock:
+            snapshot = self._health.snapshot()
+            known_failures = snapshot.failed_ranks
+            conflicting_health = known_failures - {failed_rank}
+            accepted = self._accepted_failed_rank
+            if (accepted is not None and accepted != failed_rank) or conflicting_health:
+                first_failure = accepted
+                if first_failure is None:
+                    first_failure = min(conflicting_health)
+                raise RuntimeError(
+                    "WideEP FT MVP supports exactly one distinct failed rank; "
+                    f"already accepted rank {first_failure}, received rank {failed_rank}"
+                )
+            if accepted is None:
+                self._accepted_failed_rank = failed_rank
+                # The watchdog may have marked the rank before calling us. If
+                # not, exactly one effective mark_failed() must be the next
+                # health transition. Capturing that expected generation here
+                # prevents an independent mutation in the claim-to-observe
+                # window from becoming the accepted epoch baseline.
+                self._accepted_failure_generation = snapshot.generation + (
+                    0 if failed_rank in known_failures else 1
+                )
+
+    def _accepted_failure_rank(self) -> int | None:
+        with self._failure_claim_lock:
+            return self._accepted_failed_rank
+
+    def _accepted_failure_state(self) -> tuple[int | None, int | None]:
+        with self._failure_claim_lock:
+            return self._accepted_failed_rank, self._accepted_failure_generation
+
+    def _observe_failure(self, failed_rank: int, reporter: int) -> bool:
+        """Record one authoritative report and enqueue this rank's echo once."""
+        now = time.monotonic()
+        snapshot = self._health.snapshot()
+        message: _OutboundMessage | None = None
+        with self._protocol_lock:
+            unattributed_deadline = self._unattributed_error_deadlines.get(failed_rank)
+            if unattributed_deadline != math.inf:
+                self._unattributed_error_deadlines.pop(failed_rank, None)
+            reporters = self._failure_reporters.setdefault(failed_rank, set())
+            reporters.update((reporter, self._local_rank))
+            self._reconcile_deadlines.setdefault(
+                failed_rank, now + self._config.reconcile_timeout_sec
+            )
+            failure_enqueued = failed_rank not in self._announced_failures
+            if failure_enqueued:
+                self._announced_failures.add(failed_rank)
+                message = _OutboundMessage(_MessageKind.FAILURE, failed_rank)
+            if self._failure_is_reconciled_locked(failed_rank, snapshot.mask):
+                self._reconcile_deadlines.pop(failed_rank, None)
+        if message is not None:
+            self._outbound_reports.put(message)
+            self._wake_event.set()
+        self._deadline_monitor_wake_event.set()
+        return failure_enqueued
+
+    def _reconciliation_state_is_valid_locked(
+        self,
+        snapshot: EPGroupHealthSnapshot,
+        accepted_failure: int | None,
+        accepted_generation: int | None,
+    ) -> bool:
+        """Reject unresolved transport errors and same-epoch rank restoration."""
+        if self._unattributed_error_deadlines:
+            return False
+        if accepted_failure is None:
+            return not snapshot.failed_ranks and accepted_generation is None
+        return (
+            snapshot.failed_ranks == frozenset({accepted_failure})
+            and accepted_generation == snapshot.generation
+        )
+
+    def _request_terminal_abort(
+        self,
+        error: BaseException,
+        payload: int,
+        reporter: int,
+    ) -> None:
+        """Relay terminal state before the progress thread fails closed.
+
+        The relay is best effort because it uses the same FT communicator. If
+        survivor echoes do not converge before the bounded deadline, the
+        progress thread escalates to ULFM revoke or communicator-wide
+        ``MPI_Abort``. This method performs no MPI calls.
+        """
+        self._record_error(error)
+        snapshot = self._health.snapshot()
+        enqueue_abort = False
+        now = time.monotonic()
+        with self._protocol_lock:
+            if self._abort_deadline is None:
+                self._abort_payload = payload
+                self._abort_expected_reporters = frozenset(
+                    rank for rank in range(self._ep_size) if snapshot.mask & (1 << rank)
+                )
+                self._abort_deadline = now + self._config.abort_timeout_sec
+            self._abort_reporters.update((reporter, self._local_rank))
+            if not self._abort_announced:
+                self._abort_announced = True
+                enqueue_abort = True
+        self._abort_requested.set()
+        if enqueue_abort:
+            self._outbound_reports.put(_OutboundMessage(_MessageKind.ABORT, self._abort_payload))
+        self._wake_event.set()
+        self._deadline_monitor_wake_event.set()
+
+    def _failure_is_reconciled_locked(self, failed_rank: int, active_mask: int) -> bool:
+        required_reporters = {rank for rank in range(self._ep_size) if active_mask & (1 << rank)}
+        if not required_reporters:
+            # There is nobody left who can safely execute the next collective.
+            # Do not let the usual ``empty set is a subset`` rule open the
+            # iteration gate in this terminal boundary case.
+            return False
+        reporters = self._failure_reporters.get(failed_rank, set())
+        return failed_rank in self._failure_fanout_complete and required_reporters.issubset(
+            reporters
+        )
+
+    def _probe_ulfm(self) -> bool:
+        if not callable(getattr(self._comm, "Is_revoked", None)) or not callable(
+            getattr(self._comm, "Revoke", None)
+        ):
+            return False
+        try:
+            already_revoked = self._comm.Is_revoked()
+        except Exception as error:
+            if isinstance(error, NotImplementedError) or self._is_unsupported_ulfm_error(error):
+                logger.debug(f"WideEP FT ULFM is unavailable: {error}")
+                return False
+            self._record_error(error)
+            self._retain_requests([])
+            raise
+        if already_revoked:
+            error = RuntimeError("WideEP FT communicator is already revoked at construction")
+            self._record_error(error)
+            self._retain_requests([])
+            raise error
+        return True
+
+    def _is_unsupported_ulfm_error(self, error: BaseException) -> bool:
+        if not isinstance(error, self._mpi.Exception):
+            return False
+        get_error_class = getattr(error, "Get_error_class", None)
+        if not callable(get_error_class):
+            return False
+        unsupported_classes = {
+            value
+            for value in (
+                getattr(self._mpi, "ERR_NOT_SUPPORTED", None),
+                getattr(self._mpi, "ERR_UNSUPPORTED_OPERATION", None),
+            )
+            if value is not None
+        }
+        try:
+            error_class = get_error_class()
+        except Exception:
+            # Error inspection is advisory. Preserve the original probe error
+            # as the construction failure when the runtime cannot classify it.
+            return False
+        return error_class in unsupported_classes
+
+    def _progress_loop(self) -> None:
+        pending_sends: list[_PendingSend] = []
+        pending_receives: dict[int, _PendingReceive] = {}
+        try:
+            for peer in range(self._ep_size):
+                if peer != self._local_rank:
+                    pending_receives[peer] = self._post_receive(peer)
+            with self._lifecycle_lock:
+                if self._lifecycle is _Lifecycle.STARTING:
+                    self._lifecycle = _Lifecycle.RUNNING
+            self._ready_event.set()
+
+            while True:
+                if self._progress_failed.is_set():
+                    terminal_error = self.last_error
+                    if terminal_error is None:
+                        terminal_error = RuntimeError("WideEP FT progress was asked to fail closed")
+                    raise terminal_error
+                self._wake_event.clear()
+                self._drain_outbound_reports(pending_sends)
+                self._progress_sends(pending_sends)
+                self._progress_receives(pending_receives)
+                self._check_accepted_failure_epoch()
+                self._check_unattributed_transport_deadlines()
+                self._check_reconciliation_deadlines()
+                with self._lifecycle_lock:
+                    terminal_pending = (
+                        self._abort_requested.is_set() or self._lifecycle is _Lifecycle.FAILED
+                    )
+                    stop_requested = self._stop_event.is_set() and not terminal_pending
+                if terminal_pending:
+                    if self._progress_terminal_abort():
+                        break
+                    self._wake_event.wait(self._config.poll_interval_sec)
+                    continue
+                if stop_requested:
+                    safe_to_stop, stop_error = self._stop_reconciliation_state()
+                    if stop_error is not None:
+                        with self._lifecycle_lock:
+                            self._lifecycle = _Lifecycle.FAILED
+                        self._request_terminal_abort(
+                            stop_error,
+                            -1,
+                            self._local_rank,
+                        )
+                    elif safe_to_stop:
+                        break
+                self._wake_event.wait(self._config.poll_interval_sec)
+        except Exception as error:
+            self._fail_closed_immediately(error)
+            logger.error(f"WideEP FT progress thread failed: {error}")
+        finally:
+            self._ready_event.set()
+            self._request_deadline_monitor_stop()
+            self._request_callback_stop()
+            try:
+                self._cleanup_requests(pending_sends, pending_receives)
+            except Exception as error:
+                self._retain_requests([*pending_sends, *pending_receives.values()])
+                logger.error(f"WideEP FT request cleanup failed: {error}")
+                self._fail_closed_after_cleanup(error)
+            with self._lifecycle_lock:
+                if self._last_error is not None:
+                    self._lifecycle = _Lifecycle.FAILED
+                elif self._stop_event.is_set():
+                    self._lifecycle = _Lifecycle.STOPPED
+
+    def _post_receive(self, source: int) -> _PendingReceive:
+        buffer = np.empty(_MESSAGE_WORDS, dtype=np.int64)
+        request = self._comm.Irecv(buffer, source=source, tag=_FAILURE_TAG)
+        return _PendingReceive(request=request, buffer=buffer, source=source)
+
+    def _drain_outbound_reports(self, pending_sends: list[_PendingSend]) -> None:
+        while True:
+            try:
+                message = self._outbound_reports.get_nowait()
+            except queue.Empty:
+                return
+
+            failed_rank = message.failed_rank
+            snapshot = self._health.snapshot()
+            if message.kind is _MessageKind.ABORT:
+                # Terminal state must reach every rank still believed active.
+                # If one of them is actually the second failed rank, send
+                # failure falls through to the fail-stop MPI_Abort fallback.
+                peers = [
+                    peer
+                    for peer in range(self._ep_size)
+                    if peer != self._local_rank and snapshot.mask & (1 << peer)
+                ]
+            else:
+                peers = [
+                    peer
+                    for peer in range(self._ep_size)
+                    if peer != self._local_rank
+                    and peer != failed_rank
+                    and snapshot.mask & (1 << peer)
+                ]
+            if not peers:
+                with self._protocol_lock:
+                    if message.kind is _MessageKind.ABORT:
+                        self._abort_fanout_posted = True
+                        self._abort_fanout_complete = True
+                    else:
+                        self._failure_fanout_posted.add(failed_rank)
+                        self._failure_fanout_complete.add(failed_rank)
+                continue
+            for peer in peers:
+                buffer = np.asarray([int(message.kind), failed_rank], dtype=np.int64)
+                request = self._comm.Isend(buffer, dest=peer, tag=_FAILURE_TAG)
+                pending_sends.append(
+                    _PendingSend(
+                        request=request,
+                        buffer=buffer,
+                        destination=peer,
+                        failed_rank=failed_rank,
+                        kind=message.kind,
+                    )
+                )
+            with self._protocol_lock:
+                if message.kind is _MessageKind.ABORT:
+                    # Posting is not completion: rendezvous sends can still
+                    # require this thread to call Test before peers can receive
+                    # the relay.
+                    self._abort_fanout_posted = True
+                else:
+                    self._failure_fanout_posted.add(failed_rank)
+
+    def _progress_sends(self, pending_sends: list[_PendingSend]) -> None:
+        incomplete: list[_PendingSend] = []
+        for pending in pending_sends:
+            completed = pending.request.Test()
+            if not completed:
+                incomplete.append(pending)
+        pending_sends[:] = incomplete
+        incomplete_failure_ranks = {
+            pending.failed_rank for pending in incomplete if pending.kind is _MessageKind.FAILURE
+        }
+        abort_incomplete = any(pending.kind is _MessageKind.ABORT for pending in incomplete)
+        with self._protocol_lock:
+            self._failure_fanout_complete.update(
+                self._failure_fanout_posted - incomplete_failure_ranks
+            )
+            if self._abort_fanout_posted and not abort_incomplete:
+                self._abort_fanout_complete = True
+
+    def _progress_receives(self, pending_receives: dict[int, _PendingReceive]) -> None:
+        for source, pending in list(pending_receives.items()):
+            try:
+                completed = pending.request.Test()
+            except Exception as error:
+                if not isinstance(error, self._mpi.Exception):
+                    raise
+                self._transport_poisoned.set()
+                # A request that raised may still own its receive buffer. Keep
+                # both alive until process teardown instead of assuming the
+                # implementation completed it while returning the error.
+                self._retain_requests([pending])
+                if self._is_failed_peer_error(error):
+                    del pending_receives[source]
+                    self._handle_failed_peer(source, source)
+                    continue
+                if not self.ulfm_available:
+                    # Without ULFM, MPI implementations may surface the dead
+                    # source as a generic error. Do not guess the failed rank;
+                    # drop only this fixed-source receive and keep polling the
+                    # other survivors for an authoritative watchdog report.
+                    del pending_receives[source]
+                    self._track_unattributed_transport_error(source)
+                    logger.warning(
+                        f"WideEP FT receive from EP rank {source} failed without ULFM: {error}"
+                    )
+                    continue
+                raise
+            if not completed:
+                continue
+
+            del pending_receives[source]
+            message_kind_value = int(pending.buffer[0])
+            failed_rank = int(pending.buffer[1])
+            try:
+                message_kind = _MessageKind(message_kind_value)
+            except ValueError:
+                logger.warning(
+                    f"WideEP FT ignored invalid message kind {message_kind_value} "
+                    f"from EP rank {source}"
+                )
+            else:
+                if message_kind is _MessageKind.ABORT and -1 <= failed_rank < self._ep_size:
+                    self._handle_received_abort(failed_rank, source)
+                elif message_kind is _MessageKind.FAILURE and 0 <= failed_rank < self._ep_size:
+                    self._handle_received_report(failed_rank, source)
+                else:
+                    logger.warning(
+                        f"WideEP FT ignored invalid {message_kind.name.lower()} payload "
+                        f"{failed_rank} from EP rank {source}"
+                    )
+
+            if self._health.is_active(source) and not self._stop_event.is_set():
+                try:
+                    pending_receives[source] = self._post_receive(source)
+                except Exception as error:
+                    if isinstance(error, self._mpi.Exception) and not self.ulfm_available:
+                        self._transport_poisoned.set()
+                        self._track_unattributed_transport_error(source)
+                        logger.warning(
+                            f"WideEP FT could not repost receive from EP rank {source} "
+                            f"without ULFM: {error}"
+                        )
+                    else:
+                        raise
+
+    def _handle_received_report(self, failed_rank: int, source: int) -> None:
+        start_time = time.monotonic()
+        changed = self._accept_received_failure(
+            failed_rank,
+            reporter=source,
+            transport_poisoned=False,
+        )
+        if changed is None:
+            return
+        if not changed:
+            return
+        received_time = time.monotonic()
+        logger.warning(
+            f"WideEP FT received failure rank={failed_rank} source={source} "
+            f"elapsed_ms={(received_time - start_time) * 1000.0:.3f}"
+        )
+        self._invoke_callback(failed_rank, source, received_time)
+
+    def _handle_failed_peer(self, failed_rank: int, source: int) -> None:
+        changed = self._accept_received_failure(
+            failed_rank,
+            reporter=self._local_rank,
+            transport_poisoned=True,
+        )
+        if changed is None:
+            return
+        if changed:
+            detected_time = time.monotonic()
+            logger.warning(
+                f"WideEP FT observed failed EP rank {failed_rank} through the FT communicator"
+            )
+            self._invoke_callback(failed_rank, source, detected_time)
+
+    def _accept_received_failure(
+        self,
+        failed_rank: int,
+        *,
+        reporter: int,
+        transport_poisoned: bool,
+    ) -> bool | None:
+        """Atomically claim, mark, and observe one progress-thread failure."""
+        claim_error: RuntimeError | None = None
+        with self._lifecycle_lock:
+            try:
+                self._claim_failure(failed_rank)
+            except RuntimeError as error:
+                self._lifecycle = _Lifecycle.FAILED
+                claim_error = error
+            else:
+                changed = self._health.mark_failed(failed_rank)
+                if transport_poisoned:
+                    self._transport_poisoned.set()
+                self._observe_failure(failed_rank, reporter)
+                return changed
+
+        assert claim_error is not None
+        self._request_terminal_abort(
+            claim_error,
+            failed_rank,
+            self._local_rank,
+        )
+        return None
+
+    def _handle_received_abort(self, payload: int, source: int) -> None:
+        error = RuntimeError(
+            f"WideEP FT received terminal ABORT from EP rank {source} (payload={payload})"
+        )
+        with self._lifecycle_lock:
+            self._lifecycle = _Lifecycle.FAILED
+            self._request_terminal_abort(error, payload, source)
+
+    def _invoke_callback(self, failed_rank: int, source: int, event_time: float) -> None:
+        if self._on_failure_received is None or self._callback_stop_event.is_set():
+            return
+        self._callback_queue.put((failed_rank, source, event_time))
+
+    def _callback_loop(self) -> None:
+        """Deliver telemetry callbacks without blocking MPI progress."""
+        while True:
+            event = self._callback_queue.get()
+            if event is None:
+                return
+            failed_rank, source, event_time = event
+            try:
+                callback = self._on_failure_received
+                if callback is not None:
+                    callback(failed_rank, source, event_time)
+            except Exception as error:
+                # Telemetry must never terminate either control-plane thread.
+                logger.warning(f"WideEP FT failure callback raised: {error}")
+
+    def _request_callback_stop(self) -> None:
+        if self._callback_stop_event.is_set():
+            return
+        self._callback_stop_event.set()
+        self._callback_queue.put(None)
+
+    def _request_deadline_monitor_stop(self) -> None:
+        self._deadline_monitor_stop_event.set()
+        self._deadline_monitor_wake_event.set()
+
+    def _deadline_monitor_loop(self) -> None:
+        """Enforce Python-side deadlines even when an MPI call is wedged.
+
+        Normal communicator traffic remains owned by the progress thread. This
+        monitor only observes protected protocol state. If a terminal relay
+        itself reaches its deadline, ``MPI.THREAD_MULTIPLE`` permits this thread
+        to issue the existing one-shot Revoke/Abort fail-stop action.
+        """
+        self._deadline_monitor_ready_event.set()
+        try:
+            while True:
+                # Clear before checking stop/deadline state so a concurrent
+                # setter cannot be erased between the check and wait below.
+                self._deadline_monitor_wake_event.clear()
+                if self._deadline_monitor_stop_event.is_set():
+                    return
+                if self._progress_failed.is_set():
+                    return
+
+                self._check_accepted_failure_epoch()
+                self._check_unattributed_transport_deadlines()
+                self._check_reconciliation_deadlines()
+
+                if self._progress_failed.is_set():
+                    return
+                now = time.monotonic()
+                with self._protocol_lock:
+                    abort_deadline = self._abort_deadline
+                    abort_reconciled = (
+                        self._abort_fanout_complete
+                        and self._abort_expected_reporters.issubset(self._abort_reporters)
+                    )
+                if self._abort_requested.is_set() and abort_deadline is not None:
+                    if abort_reconciled:
+                        # The relay reached every expected survivor. The progress
+                        # thread will break cleanly when it resumes. Do not mark
+                        # progress failed here: its exception path would otherwise
+                        # escalate a reconciled non-ULFM terminal relay to
+                        # MPI_Abort.
+                        self._wake_event.set()
+                        return
+                    if now >= abort_deadline:
+                        self._fail_closed_immediately(
+                            TimeoutError(
+                                "WideEP FT terminal relay did not complete before "
+                                "the abort deadline"
+                            )
+                        )
+                        self._wake_event.set()
+                        return
+
+                self._deadline_monitor_wake_event.wait(self._config.poll_interval_sec)
+        except Exception as error:
+            self._fail_closed_immediately(error)
+            self._wake_event.set()
+        finally:
+            # start() also uses this event to distinguish a scheduled monitor
+            # from a thread that failed before its loop became observable.
+            self._deadline_monitor_ready_event.set()
+
+    def _is_failed_peer_error(self, error: BaseException) -> bool:
+        get_error_class = getattr(error, "Get_error_class", None)
+        if not callable(get_error_class):
+            return False
+        try:
+            error_class = get_error_class()
+        except Exception:
+            # Preserve the original transport failure as the terminal cause (or
+            # let the non-ULFM watchdog identify the source) when an MPI runtime
+            # cannot even classify its own exception.
+            return False
+        unknown = getattr(self._mpi, "ERR_UNKNOWN", None)
+        failure_classes = {
+            value
+            for value in (getattr(self._mpi, "ERR_PROC_FAILED", None),)
+            if value is not None and value != unknown
+        }
+        return error_class in failure_classes
+
+    def _track_unattributed_transport_error(self, source: int) -> None:
+        """Bound how long a generic non-ULFM peer error can remain unresolved."""
+        # The watchdog report and the MPI error race independently. If this
+        # source is already the accepted failed rank, the transport error is
+        # explained and must not arm a stale deadline after _observe_failure()
+        # has already cleared the error-first ordering.
+        deadline = time.monotonic() + self._config.unattributed_error_timeout_sec
+        with self._protocol_lock:
+            if self._accepted_failure_rank() == source:
+                return
+            self._unattributed_error_deadlines.setdefault(source, deadline)
+        self._deadline_monitor_wake_event.set()
+
+    def _check_accepted_failure_epoch(self) -> None:
+        """Fail closed when health leaves the accepted single-failure epoch."""
+        error: RuntimeError | None = None
+        accepted_failure: int | None = None
+        with self._lifecycle_lock:
+            if self._lifecycle not in (_Lifecycle.RUNNING, _Lifecycle.STOPPING):
+                return
+            snapshot = self._health.snapshot()
+            accepted_failure, accepted_generation = self._accepted_failure_state()
+            # A watchdog may mark health immediately before calling
+            # pre_failover(). Until that call claims a rank, do not mistake the
+            # documented pre-mark seam for an epoch violation.
+            if accepted_failure is None:
+                return
+            if (
+                snapshot.failed_ranks == frozenset({accepted_failure})
+                and snapshot.generation == accepted_generation
+            ):
+                return
+            error = RuntimeError(
+                "WideEP FT accepted failure epoch changed before communicator "
+                "reconstruction "
+                f"(accepted_rank={accepted_failure}, "
+                f"expected_generation={accepted_generation}, snapshot={snapshot})"
+            )
+            self._lifecycle = _Lifecycle.FAILED
+
+        assert error is not None
+        assert accepted_failure is not None
+        self._request_terminal_abort(error, accepted_failure, self._local_rank)
+
+    def _check_unattributed_transport_deadlines(self) -> None:
+        now = time.monotonic()
+        # Match the public reconciliation gate's lifecycle -> protocol lock
+        # order. Publish FAILED while both locks exclude a concurrent gate or
+        # local broadcast, then latch the expired poison before either can run.
+        with self._lifecycle_lock:
+            if self._lifecycle not in (_Lifecycle.RUNNING, _Lifecycle.STOPPING):
+                return
+            with self._protocol_lock:
+                expired_sources = [
+                    source
+                    for source, deadline in self._unattributed_error_deadlines.items()
+                    if now >= deadline
+                ]
+                if expired_sources:
+                    self._lifecycle = _Lifecycle.FAILED
+                    # Retaining these few per-source entries for this
+                    # communicator epoch is harmless and permanently keeps the
+                    # protocol gate closed. The infinity latch also prevents
+                    # repeated terminal requests on later progress passes.
+                    for source in expired_sources:
+                        self._unattributed_error_deadlines[source] = math.inf
+        if not expired_sources:
+            return
+        error = TimeoutError(
+            "WideEP FT could not attribute non-ULFM transport errors before "
+            f"the watchdog deadline: {expired_sources}"
+        )
+        self._request_terminal_abort(error, -1, self._local_rank)
+
+    def _check_reconciliation_deadlines(self) -> None:
+        now = time.monotonic()
+        expired: list[int] = []
+        with self._lifecycle_lock:
+            if self._lifecycle not in (_Lifecycle.RUNNING, _Lifecycle.STOPPING):
+                return
+            snapshot = self._health.snapshot()
+            with self._protocol_lock:
+                for failed_rank, deadline in list(self._reconcile_deadlines.items()):
+                    if self._failure_is_reconciled_locked(failed_rank, snapshot.mask):
+                        del self._reconcile_deadlines[failed_rank]
+                    elif now >= deadline:
+                        expired.append(failed_rank)
+            if expired:
+                self._lifecycle = _Lifecycle.FAILED
+        if expired:
+            error = TimeoutError(
+                f"WideEP FT did not reconcile failed EP ranks before the timeout: {expired}"
+            )
+            self._request_terminal_abort(error, expired[0], self._local_rank)
+
+    def _stop_reconciliation_state(self) -> tuple[bool, BaseException | None]:
+        """Return whether shutdown can stop MPI progress without splitting ranks."""
+        snapshot = self._health.snapshot()
+        failed_ranks = snapshot.failed_ranks
+        accepted_failure, accepted_generation = self._accepted_failure_state()
+        with self._protocol_lock:
+            reconciliation_state_is_valid = self._reconciliation_state_is_valid_locked(
+                snapshot,
+                accepted_failure,
+                accepted_generation,
+            )
+        if not reconciliation_state_is_valid:
+            return False, RuntimeError(
+                "WideEP FT cannot stop after the accepted failure epoch changed "
+                f"(accepted_rank={accepted_failure}, "
+                f"expected_generation={accepted_generation}, "
+                f"snapshot={snapshot})"
+            )
+        if not failed_ranks:
+            if self._transport_poisoned.is_set():
+                return False, RuntimeError(
+                    "WideEP FT cannot stop safely after an unattributed transport error"
+                )
+            return True, None
+
+        with self._protocol_lock:
+            unreconciled = [
+                failed_rank
+                for failed_rank in failed_ranks
+                if not self._failure_is_reconciled_locked(failed_rank, snapshot.mask)
+            ]
+            untracked = [
+                failed_rank
+                for failed_rank in unreconciled
+                if failed_rank not in self._reconcile_deadlines
+            ]
+        if not unreconciled:
+            return True, None
+        if untracked:
+            return False, RuntimeError(
+                "WideEP FT cannot stop with locally failed ranks that were never announced: "
+                f"{untracked}"
+            )
+        # Their existing reconciliation deadlines bound how long stop keeps
+        # progressing. Expiry enters the normal terminal ABORT path.
+        return False, None
+
+    def _progress_terminal_abort(self) -> bool:
+        """Return ``True`` after terminal state is globally safe to stop."""
+        if self.ulfm_available:
+            # Revoke is itself a communicator-wide terminal notification; it
+            # does not depend on rendezvous Isends reaching completion.
+            self._progress_failed.set()
+            with self._lifecycle_lock:
+                self._lifecycle = _Lifecycle.FAILED
+            try:
+                self._try_revoke()
+            except Exception as error:
+                logger.warning(f"WideEP FT terminal revoke failed: {error}")
+                self._try_world_abort()
+                return True
+            if self.ulfm_available:
+                return True
+            # A runtime unsupported result disables ULFM and falls through to
+            # the relayed-ABORT protocol. Clear the flag so the next loop pass
+            # can continue progressing those requests.
+            self._progress_failed.clear()
+
+        now = time.monotonic()
+        with self._protocol_lock:
+            reconciled = self._abort_fanout_complete and self._abort_expected_reporters.issubset(
+                self._abort_reporters
+            )
+            deadline = self._abort_deadline
+        expired = deadline is not None and now >= deadline
+        if not reconciled and not expired:
+            return False
+
+        self._progress_failed.set()
+        with self._lifecycle_lock:
+            self._lifecycle = _Lifecycle.FAILED
+        # A final echo can race the deadline check. Once every expected
+        # survivor has acknowledged ABORT, fail-stop escalation is no longer
+        # needed even if the wall-clock deadline has just elapsed.
+        if expired and not reconciled:
+            self._try_world_abort()
+        return True
+
+    def _fail_closed_immediately(self, error: BaseException) -> None:
+        """Abort globally after an error makes bounded relay unsafe."""
+        with self._lifecycle_lock:
+            self._record_error(error)
+            self._progress_failed.set()
+            self._lifecycle = _Lifecycle.FAILED
+        if self.ulfm_available:
+            try:
+                self._try_revoke()
+                if self.ulfm_available:
+                    return
+            except Exception as revoke_error:
+                logger.warning(f"WideEP FT could not revoke after terminal error: {revoke_error}")
+        self._try_world_abort()
+
+    def _fail_closed_after_cleanup(self, error: BaseException) -> None:
+        """Terminate the world when healthy MPI requests cannot be quiesced.
+
+        At this point the progress loop has already stopped, so a relayed ABORT
+        cannot be made reliable and ULFM revoke alone would not update peers'
+        process-local shutdown state. Communicator-wide abort is the only
+        deterministic way to prevent rank-asymmetric MPI_Finalize behavior.
+        """
+        self._record_error(error)
+        self._progress_failed.set()
+        with self._lifecycle_lock:
+            self._lifecycle = _Lifecycle.FAILED
+        self._try_world_abort()
+
+    def _try_world_abort(self) -> None:
+        """Last-resort fail-stop when terminal state cannot be reconciled."""
+        with self._terminal_action_lock:
+            if self._world_abort_attempted:
+                return
+            # MPI_Abort normally never returns. Mark the attempt before calling
+            # it so test doubles, broken runtimes, or a later-resuming progress
+            # thread cannot issue the communicator-wide action twice.
+            self._world_abort_attempted = True
+        abort = getattr(self._comm, "Abort", None)
+        if not callable(abort):
+            logger.error(
+                "WideEP FT communicator has no MPI_Abort fallback; "
+                "survivors must terminate through the poisoned-world shutdown hook"
+            )
+            return
+        try:
+            abort(1)
+        except Exception as error:
+            # Real MPI_Abort does not return. Test doubles and broken runtimes
+            # may do so or raise; the local process remains terminal either way.
+            logger.error(f"WideEP FT communicator-wide abort failed: {error}")
+
+    def _retain_requests(self, requests: list[_PendingSend | _PendingReceive]) -> None:
+        self._retained_requests.extend(requests)
+        references: list[object] = list(requests)
+        if not self._process_lifetime_retained:
+            self._process_lifetime_retained = True
+            references.append(self._comm)
+        _retain_for_process_lifetime(*references)
+
+    def _cleanup_requests(
+        self,
+        pending_sends: list[_PendingSend],
+        pending_receives: dict[int, _PendingReceive],
+    ) -> None:
+        requests: list[_PendingSend | _PendingReceive] = [
+            *pending_sends,
+            *pending_receives.values(),
+        ]
+        # Never cancel, wait for, or free MPI operations after a peer or the
+        # communicator has failed. Keeping each request together with its
+        # NumPy buffer is the only bounded shutdown behavior in that state;
+        # the later model-engine shutdown hook skips MPI_Finalize entirely.
+        if self.last_error is not None or self.world_is_poisoned():
+            self._retain_requests(requests)
+            return
+
+        if not requests:
+            return
+
+        # Healthy shutdown can locally cancel the preposted receives/sends.
+        # Poll Test rather than calling Wait so stop() remains bounded even on
+        # an MPI implementation with surprising cancellation behavior.
+        for pending in requests:
+            try:
+                pending.request.Cancel()
+            except Exception as error:
+                if not isinstance(error, self._mpi.Exception):
+                    raise
+                logger.warning(f"WideEP FT could not cancel a healthy MPI request: {error}")
+
+        remaining = requests
+        deadline = self._shutdown_deadline or time.monotonic()
+        while remaining and time.monotonic() < deadline:
+            next_remaining: list[_PendingSend | _PendingReceive] = []
+            for pending in remaining:
+                try:
+                    if not pending.request.Test():
+                        next_remaining.append(pending)
+                except Exception as error:
+                    if not isinstance(error, self._mpi.Exception):
+                        raise
+                    next_remaining.append(pending)
+            remaining = next_remaining
+            if remaining:
+                time.sleep(min(0.001, max(0.0, deadline - time.monotonic())))
+
+        if remaining:
+            raise TimeoutError(
+                f"{len(remaining)} WideEP FT MPI requests remained active after "
+                "the healthy shutdown timeout"
+            )
+
+    def _record_error(self, error: BaseException) -> None:
+        self._transport_poisoned.set()
+        with self._error_lock:
+            if self._last_error is None:
+                self._last_error = error
+
+    def _try_revoke(self) -> None:
+        # Claim the one permitted Revoke attempt, but never hold a Python lock
+        # across MPI. A caller-thread timeout and a later-resuming progress
+        # thread may enter terminal handling concurrently; the claimant owns
+        # any unsupported/error fallback.
+        with self._terminal_action_lock:
+            if not self._ulfm_available or self._revoke_attempted:
+                return
+            self._revoke_attempted = True
+        try:
+            self._comm.Revoke()
+        except Exception as error:
+            if isinstance(error, NotImplementedError) or self._is_unsupported_ulfm_error(error):
+                with self._terminal_action_lock:
+                    self._ulfm_available = False
+                logger.warning(f"WideEP FT revoke is unavailable at runtime: {error}")
+                return
+            raise

--- a/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
+++ b/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
@@ -21,13 +21,13 @@ dedicated EP-scoped MPI communicator and progresses only nonblocking
 point-to-point requests on an independent CPU thread.
 
 The component propagates one rank-failure detection and updates only the
-process-local :class:`DetectedRankState`. It never receives or updates the
+process-local :class:`FailureEvidenceState`. It never receives or updates the
 committed ``EPGroupHealth`` execution mask. Multi-rank suspect/confirm
 consensus, commit authorization, and communicator reconstruction are
 intentionally left to later WideEP FT phases.
 
 Every survivor echoes a newly observed failure. Receiving one echo from every
-active survivor proves only that they propagated the same detection. Detection
+candidate survivor proves only that they propagated the same detection. Detection
 reconciliation does **not** authorize request resume, EPLB changes, NCCL
 reconfiguration or use, or committed-mask mutation. The future 1c.4b recovery
 coordinator consumes the detection callback and owns that authorization.
@@ -42,6 +42,7 @@ survivor; failure to confirm that echo within a bounded interval uses
 from __future__ import annotations
 
 import math
+import operator
 import queue
 import threading
 import time
@@ -123,43 +124,49 @@ class _MpiModule(Protocol):
 
 
 FailureDetectedCallback = Callable[[int, int, float], None]
-# Compatibility name for callers of the original draft API. New integrations
-# should use ``FailureDetectedCallback`` because this callback carries detected,
-# never committed, state.
-FailureReceivedCallback = FailureDetectedCallback
+
+
+def _require_integer(value: object, name: str) -> int:
+    """Normalize one integer-like value while rejecting booleans."""
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer, got bool")
+    try:
+        return operator.index(value)
+    except TypeError as error:
+        raise TypeError(f"{name} must be an integer, got {type(value).__name__}") from error
 
 
 @dataclass(frozen=True)
-class DetectedRankStateSnapshot:
+class FailureEvidenceSnapshot:
     """Atomic snapshot of rank-failure evidence for one communicator epoch."""
 
-    mask: int
     failed_ranks: frozenset[int]
-    generation: int
+    evidence_epoch: int
 
 
-class DetectedRankState:
+class FailureEvidenceState:
     """Thread-safe, process-local rank-failure evidence.
 
-    This state is deliberately distinct from ``EPGroupHealth``. It is an
-    observation owned by :class:`MpiFtSubcomm`, not a committed execution mask,
-    and it is monotonic for the lifetime of one FT communicator epoch.
+    This state is deliberately distinct from ``EPGroupHealth``. It is evidence
+    exclusively mutated by :class:`MpiFtSubcomm`, not a committed execution
+    mask, and it is monotonic for one FT communicator epoch. Callers may retain
+    and inspect the state, but must not mutate it.
 
     Args:
         ep_size: Number of EP-local ranks represented by this state.
 
     Raises:
+        TypeError: If ``ep_size`` is not an integer.
         ValueError: If ``ep_size`` is not positive.
     """
 
     def __init__(self, ep_size: int) -> None:
+        ep_size = _require_integer(ep_size, "ep_size")
         if ep_size <= 0:
             raise ValueError(f"ep_size must be > 0, got {ep_size}")
         self._ep_size = ep_size
-        self._all_active_mask = (1 << ep_size) - 1
-        self._active_mask = self._all_active_mask
         self._failed_ranks: set[int] = set()
-        self._generation = 0
+        self._evidence_epoch = 0
         self._lock = threading.Lock()
 
     @property
@@ -167,57 +174,40 @@ class DetectedRankState:
         """Number of ranks represented by this immutable communicator epoch."""
         return self._ep_size
 
-    @property
-    def generation(self) -> int:
-        """Number of effective detected-failure transitions."""
-        with self._lock:
-            return self._generation
-
-    def record_failure(self, rank: int) -> bool:
+    def _record_failure(self, rank: int) -> bool:
         """Record one failed rank, returning whether evidence changed."""
-        self._validate_rank(rank)
-        bit = 1 << rank
+        rank = self._validate_rank(rank)
         with self._lock:
-            if not self._active_mask & bit:
+            if rank in self._failed_ranks:
                 return False
-            self._active_mask &= ~bit
             self._failed_ranks.add(rank)
-            self._generation += 1
+            self._evidence_epoch += 1
             return True
 
-    def is_active(self, rank: int) -> bool:
-        """Return whether no failure has been recorded for ``rank``."""
-        self._validate_rank(rank)
+    def has_failure(self, rank: int) -> bool:
+        """Return whether failure evidence has been recorded for ``rank``."""
+        rank = self._validate_rank(rank)
         with self._lock:
-            return bool(self._active_mask & (1 << rank))
+            return rank in self._failed_ranks
 
-    def get_mask(self) -> int:
-        """Return the active-rank mask derived from detected evidence."""
+    def has_failures(self) -> bool:
+        """Return whether this communicator epoch contains failure evidence."""
         with self._lock:
-            return self._active_mask
+            return bool(self._failed_ranks)
 
-    def get_failed_ranks(self) -> frozenset[int]:
-        """Return an immutable snapshot of ranks with failure evidence."""
+    def snapshot(self) -> FailureEvidenceSnapshot:
+        """Return one coherent failed-rank set and evidence-epoch snapshot."""
         with self._lock:
-            return frozenset(self._failed_ranks)
-
-    def all_active(self) -> bool:
-        """Return whether no rank failure has been detected."""
-        with self._lock:
-            return self._active_mask == self._all_active_mask
-
-    def snapshot(self) -> DetectedRankStateSnapshot:
-        """Return one coherent mask, failure-set, and generation snapshot."""
-        with self._lock:
-            return DetectedRankStateSnapshot(
-                mask=self._active_mask,
+            return FailureEvidenceSnapshot(
                 failed_ranks=frozenset(self._failed_ranks),
-                generation=self._generation,
+                evidence_epoch=self._evidence_epoch,
             )
 
-    def _validate_rank(self, rank: int) -> None:
+    def _validate_rank(self, rank: int) -> int:
+        rank = _require_integer(rank, "rank")
         if not 0 <= rank < self._ep_size:
             raise ValueError(f"rank must be in [0, {self._ep_size}), got {rank}")
+        return rank
 
 
 @dataclass(frozen=True)
@@ -231,7 +221,7 @@ class MpiFtSubcommConfig:
             posted when :meth:`MpiFtSubcomm.start` is called.
         stop_timeout_sec: Default bounded join timeout used by
             :meth:`MpiFtSubcomm.stop`.
-        reconcile_timeout_sec: Maximum time for every active survivor to
+        reconcile_timeout_sec: Maximum time for every candidate survivor to
             announce the same failure before the control plane fails closed.
         unattributed_error_timeout_sec: Maximum time to wait for the host
             watchdog to identify a rank after non-ULFM MPI reports a generic
@@ -301,7 +291,7 @@ class MpiFtSubcomm:
     thread. Call :meth:`start` only after every rank has constructed the
     component. During normal operation, the progress thread owns MPI calls on
     this communicator; :meth:`report_detected_failure` updates only local
-    detected state and enqueues a report, so it never waits for a peer or MPI
+    failure evidence and enqueues a report, so it never waits for a peer or MPI
     progress. The watchdog must call this method instead of pre-recording evidence.
     Because ``MPI.THREAD_MULTIPLE`` is required, a caller whose start/stop
     deadline proves that thread is wedged may issue the terminal Revoke/Abort
@@ -310,14 +300,14 @@ class MpiFtSubcomm:
     Args:
         mapping: Distributed mapping whose ``moe_ep_group`` defines the FT
             communicator and whose ``moe_ep_rank`` defines the local rank.
-        detected_state: Process-local EP detection evidence updated by sent and
+        failure_evidence: Process-local EP detection evidence updated by sent and
             received failure reports. ``EPGroupHealth`` is rejected because it
             is the committed execution-mask state owned by the recovery
             coordinator.
         config: Progress-loop timing configuration.
         on_failure_detected: Optional callback invoked as
             ``(failed_rank, source_rank, monotonic_time)`` when a local or
-            received report first changes detected state. This is the handoff
+            received report first changes failure evidence. This is the handoff
             to the future 1c.4b recovery coordinator; it is detection evidence,
             not commit authorization. Delivery runs on a dedicated daemon
             thread so callback latency cannot block MPI progress.
@@ -328,33 +318,26 @@ class MpiFtSubcomm:
     Raises:
         RuntimeError: If MPI support or thread support is insufficient, or if
             the communicator does not match ``mapping``.
-        TypeError: If ``detected_state`` is not a :class:`DetectedRankState`.
-        ValueError: If ``detected_state`` and ``mapping`` describe different
-            EP groups, or if both callback keyword names are provided.
+        TypeError: If ``failure_evidence`` is not a :class:`FailureEvidenceState`.
+        ValueError: If ``failure_evidence`` and ``mapping`` describe different
+            EP groups.
     """
 
     def __init__(
         self,
         mapping: Mapping,
-        detected_state: DetectedRankState,
+        failure_evidence: FailureEvidenceState,
         config: MpiFtSubcommConfig | None = None,
         on_failure_detected: FailureDetectedCallback | None = None,
         *,
         comm: _MpiComm | None = None,
         mpi_module: _MpiModule | None = None,
-        on_failure_received: FailureReceivedCallback | None = None,
     ) -> None:
-        if not isinstance(detected_state, DetectedRankState):
+        if not isinstance(failure_evidence, FailureEvidenceState):
             raise TypeError(
-                "detected_state must be a DetectedRankState; committed "
+                "failure_evidence must be a FailureEvidenceState; committed "
                 "EPGroupHealth cannot be used as failure-detection evidence"
             )
-        if on_failure_detected is not None and on_failure_received is not None:
-            raise ValueError(
-                "Specify only on_failure_detected; on_failure_received is a compatibility alias"
-            )
-        if on_failure_detected is None:
-            on_failure_detected = on_failure_received
         if mpi_module is None:
             if MPI is None:
                 raise RuntimeError("mpi4py is required for WideEP failure propagation")
@@ -373,7 +356,7 @@ class MpiFtSubcomm:
 
             collective_setup = create_mpi_ft_subcomm(
                 mapping,
-                health_size=detected_state.ep_size,
+                failure_evidence_size=failure_evidence.ep_size,
             )
             comm = cast(_MpiComm, collective_setup.comm)
 
@@ -381,9 +364,10 @@ class MpiFtSubcomm:
         self._comm = comm
         if comm_created_collectively:
             # create_mpi_ft_subcomm already reconciled thread support, mapping,
-            # health size, communicator rank/size, and ERRORS_RETURN across the
-            # parent communicator. Repeating any of those MPI operations here
-            # would reintroduce a rank-local failure after collective startup.
+            # failure-evidence size, communicator rank/size, and ERRORS_RETURN
+            # across the parent communicator. Repeating any of those MPI
+            # operations here would reintroduce a rank-local failure after
+            # collective startup.
             assert collective_setup is not None
             self._local_rank = collective_setup.local_rank
             self._ep_size = collective_setup.ep_size
@@ -406,10 +390,10 @@ class MpiFtSubcomm:
                     "WideEP FT MVP requires one MoE EP group spanning the full MPI world; "
                     f"got world_size={mapping.world_size}, moe_ep_group={ep_group}"
                 )
-            if detected_state.ep_size != mapping.moe_ep_size:
+            if failure_evidence.ep_size != mapping.moe_ep_size:
                 raise ValueError(
-                    "DetectedRankState size must match mapping.moe_ep_size, "
-                    f"got {detected_state.ep_size} and {mapping.moe_ep_size}"
+                    "FailureEvidenceState size must match mapping.moe_ep_size, "
+                    f"got {failure_evidence.ep_size} and {mapping.moe_ep_size}"
                 )
             self._local_rank = mapping.moe_ep_rank
             self._ep_size = mapping.moe_ep_size
@@ -425,7 +409,7 @@ class MpiFtSubcomm:
                     f"expected rank={self._local_rank}, size={self._ep_size}"
                 )
 
-        self._detected_state = detected_state
+        self._failure_evidence = failure_evidence
         self._on_failure_detected = on_failure_detected
         self._outbound_reports: queue.SimpleQueue[_OutboundMessage] = queue.SimpleQueue()
         self._announced_failures: set[int] = set()
@@ -444,7 +428,7 @@ class MpiFtSubcomm:
         self._protocol_lock = threading.Lock()
         self._failure_claim_lock = threading.Lock()
         self._accepted_failed_rank: int | None = None
-        self._accepted_failure_generation: int | None = None
+        self._accepted_evidence_epoch: int | None = None
         self._stop_event = threading.Event()
         self._abort_requested = threading.Event()
         self._wake_event = threading.Event()
@@ -704,7 +688,7 @@ class MpiFtSubcomm:
         """Record and asynchronously announce one detected EP-rank failure.
 
         This is the nonblocking seam invoked by the host watchdog. The
-        broadcaster owns the detected-state transition; callers must not record
+        broadcaster owns the failure-evidence transition; callers must not record
         the failure before invoking it. This method performs no MPI
         calls and never waits for the progress thread. Repeated reports for the
         same rank are coalesced after the first local announcement.
@@ -713,9 +697,9 @@ class MpiFtSubcomm:
             failed_rank: EP-local rank in ``[0, ep_size)``.
 
         Returns:
-            ``True`` if this call changed local detected state, else ``False``.
+            ``True`` if this call changed local failure evidence, else ``False``.
         """
-        self._validate_rank(failed_rank)
+        failed_rank = self._validate_rank(failed_rank)
         with self._lifecycle_lock:
             if self._lifecycle is not _Lifecycle.RUNNING or self._progress_failed.is_set():
                 raise RuntimeError(
@@ -728,7 +712,7 @@ class MpiFtSubcomm:
                 self._lifecycle = _Lifecycle.FAILED
                 self._request_terminal_abort(error, failed_rank, self._local_rank)
                 raise
-            changed = self._detected_state.record_failure(failed_rank)
+            changed = self._failure_evidence._record_failure(failed_rank)
             enqueued = self._observe_failure(failed_rank, self._local_rank)
         detected_time = time.monotonic()
         logger.warning(
@@ -739,28 +723,16 @@ class MpiFtSubcomm:
             self._invoke_detection_callback(failed_rank, self._local_rank, detected_time)
         return changed
 
-    def pre_failover(self, failed_rank: int) -> bool:
-        """Compatibility alias for :meth:`report_detected_failure`.
-
-        Despite the historical name, this method does not commit failover and
-        callers must not pre-record detected evidence.
-        """
-        return self.report_detected_failure(failed_rank)
-
-    def broadcast_failure(self, failed_rank: int) -> bool:
-        """Compatibility alias for :meth:`report_detected_failure`."""
-        return self.report_detected_failure(failed_rank)
-
     def world_is_poisoned(self) -> bool:
         """Return whether this communicator epoch has ever observed failure."""
         return (
             self._transport_poisoned.is_set()
             or self._accepted_failure_rank() is not None
-            or not self._detected_state.all_active()
+            or self._failure_evidence.has_failures()
         )
 
     def failure_detection_is_reconciled(self, failed_rank: int) -> bool:
-        """Return whether every active survivor announced the same detection.
+        """Return whether every candidate survivor announced the same detection.
 
         This is detection-plane evidence only. A ``True`` result does not
         authorize request resume, EPLB changes, NCCL reconfiguration or use, or
@@ -768,24 +740,26 @@ class MpiFtSubcomm:
         those decisions. This method performs no MPI calls, and a terminal
         progress error always fails closed.
         """
-        self._validate_rank(failed_rank)
+        failed_rank = self._validate_rank(failed_rank)
         with self._lifecycle_lock:
             if self._lifecycle is not _Lifecycle.RUNNING:
                 return False
             if self.last_error is not None or self._progress_failed.is_set():
                 return False
-            snapshot = self._detected_state.snapshot()
+            snapshot = self._failure_evidence.snapshot()
             if failed_rank not in snapshot.failed_ranks:
                 return False
-            accepted_failure, accepted_generation = self._accepted_failure_state()
+            accepted_failure, accepted_evidence_epoch = self._accepted_failure_state()
             with self._protocol_lock:
                 if not self._detection_reconciliation_state_is_valid_locked(
-                    snapshot, accepted_failure, accepted_generation
+                    snapshot, accepted_failure, accepted_evidence_epoch
                 ):
                     return False
-                return self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask)
+                return self._failure_detection_is_reconciled_locked(
+                    failed_rank, snapshot.failed_ranks
+                )
 
-    def detected_state_is_reconciled(self) -> bool:
+    def failure_evidence_is_reconciled(self) -> bool:
         """Return whether survivors propagated every local failure detection.
 
         This is not a commit gate. A ``True`` result does not authorize request
@@ -797,40 +771,30 @@ class MpiFtSubcomm:
                 return False
             if self.last_error is not None or self._progress_failed.is_set():
                 return False
-            snapshot = self._detected_state.snapshot()
-            accepted_failure, accepted_generation = self._accepted_failure_state()
+            snapshot = self._failure_evidence.snapshot()
+            accepted_failure, accepted_evidence_epoch = self._accepted_failure_state()
             if not snapshot.failed_ranks:
                 return accepted_failure is None and not self._transport_poisoned.is_set()
             with self._protocol_lock:
                 if not self._detection_reconciliation_state_is_valid_locked(
-                    snapshot, accepted_failure, accepted_generation
+                    snapshot, accepted_failure, accepted_evidence_epoch
                 ):
                     return False
                 return all(
-                    self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask)
+                    self._failure_detection_is_reconciled_locked(failed_rank, snapshot.failed_ranks)
                     for failed_rank in snapshot.failed_ranks
                 )
 
-    def detected_health_is_reconciled(self) -> bool:
-        """Compatibility alias for :meth:`detected_state_is_reconciled`."""
-        return self.detected_state_is_reconciled()
-
-    def failure_is_reconciled(self, failed_rank: int) -> bool:
-        """Compatibility alias for :meth:`failure_detection_is_reconciled`."""
-        return self.failure_detection_is_reconciled(failed_rank)
-
-    def health_is_reconciled(self) -> bool:
-        """Compatibility alias for :meth:`detected_state_is_reconciled`."""
-        return self.detected_state_is_reconciled()
-
-    def _validate_rank(self, rank: int) -> None:
+    def _validate_rank(self, rank: int) -> int:
+        rank = _require_integer(rank, "failed_rank")
         if not 0 <= rank < self._ep_size:
             raise ValueError(f"failed_rank must be in [0, {self._ep_size}), got {rank}")
+        return rank
 
     def _claim_failure(self, failed_rank: int) -> None:
         """Atomically enforce the single-distinct-failure MVP contract."""
         with self._failure_claim_lock:
-            snapshot = self._detected_state.snapshot()
+            snapshot = self._failure_evidence.snapshot()
             known_failures = snapshot.failed_ranks
             conflicting_evidence = known_failures - {failed_rank}
             accepted = self._accepted_failed_rank
@@ -845,16 +809,16 @@ class MpiFtSubcomm:
             if accepted is None:
                 if failed_rank in known_failures:
                     raise RuntimeError(
-                        "WideEP FT detected state was mutated before the failure "
+                        "WideEP FT failure evidence was mutated before the failure "
                         "broadcaster accepted the report; the watchdog must call "
                         "report_detected_failure() without pre-recording evidence"
                     )
                 self._accepted_failed_rank = failed_rank
-                # Exactly one effective record_failure() must be the next
-                # detected-state transition. Capturing that generation here
+                # Exactly one effective _record_failure() must be the next
+                # failure-evidence transition. Capturing that evidence epoch here
                 # prevents an independent mutation in the claim-to-observe
                 # window from becoming the accepted epoch baseline.
-                self._accepted_failure_generation = snapshot.generation + 1
+                self._accepted_evidence_epoch = snapshot.evidence_epoch + 1
 
     def _accepted_failure_rank(self) -> int | None:
         with self._failure_claim_lock:
@@ -862,12 +826,12 @@ class MpiFtSubcomm:
 
     def _accepted_failure_state(self) -> tuple[int | None, int | None]:
         with self._failure_claim_lock:
-            return self._accepted_failed_rank, self._accepted_failure_generation
+            return self._accepted_failed_rank, self._accepted_evidence_epoch
 
     def _observe_failure(self, failed_rank: int, reporter: int) -> bool:
         """Record one detection report and enqueue this rank's echo once."""
         now = time.monotonic()
-        snapshot = self._detected_state.snapshot()
+        snapshot = self._failure_evidence.snapshot()
         message: _OutboundMessage | None = None
         with self._protocol_lock:
             unattributed_deadline = self._unattributed_error_deadlines.get(failed_rank)
@@ -882,7 +846,7 @@ class MpiFtSubcomm:
             if failure_enqueued:
                 self._announced_failures.add(failed_rank)
                 message = _OutboundMessage(_MessageKind.FAILURE, failed_rank)
-            if self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask):
+            if self._failure_detection_is_reconciled_locked(failed_rank, snapshot.failed_ranks):
                 self._reconcile_deadlines.pop(failed_rank, None)
         if message is not None:
             self._outbound_reports.put(message)
@@ -892,18 +856,18 @@ class MpiFtSubcomm:
 
     def _detection_reconciliation_state_is_valid_locked(
         self,
-        snapshot: DetectedRankStateSnapshot,
+        snapshot: FailureEvidenceSnapshot,
         accepted_failure: int | None,
-        accepted_generation: int | None,
+        accepted_evidence_epoch: int | None,
     ) -> bool:
-        """Reject unresolved transport errors and same-epoch rank restoration."""
+        """Reject unresolved errors or evidence outside the accepted epoch."""
         if self._unattributed_error_deadlines:
             return False
         if accepted_failure is None:
-            return not snapshot.failed_ranks and accepted_generation is None
+            return not snapshot.failed_ranks and accepted_evidence_epoch is None
         return (
             snapshot.failed_ranks == frozenset({accepted_failure})
-            and accepted_generation == snapshot.generation
+            and accepted_evidence_epoch == snapshot.evidence_epoch
         )
 
     def _request_terminal_abort(
@@ -920,14 +884,14 @@ class MpiFtSubcomm:
         ``MPI_Abort``. This method performs no MPI calls.
         """
         self._record_error(error)
-        snapshot = self._detected_state.snapshot()
+        snapshot = self._failure_evidence.snapshot()
         enqueue_abort = False
         now = time.monotonic()
         with self._protocol_lock:
             if self._abort_deadline is None:
                 self._abort_payload = payload
                 self._abort_expected_reporters = frozenset(
-                    rank for rank in range(self._ep_size) if snapshot.mask & (1 << rank)
+                    self._candidate_survivor_ranks(snapshot.failed_ranks)
                 )
                 self._abort_deadline = now + self._config.abort_timeout_sec
             self._abort_reporters.update((reporter, self._local_rank))
@@ -940,8 +904,16 @@ class MpiFtSubcomm:
         self._wake_event.set()
         self._deadline_monitor_wake_event.set()
 
-    def _failure_detection_is_reconciled_locked(self, failed_rank: int, active_mask: int) -> bool:
-        required_reporters = {rank for rank in range(self._ep_size) if active_mask & (1 << rank)}
+    def _candidate_survivor_ranks(self, failed_ranks: frozenset[int]) -> tuple[int, ...]:
+        """Derive the ranks still eligible for detection-plane participation."""
+        return tuple(rank for rank in range(self._ep_size) if rank not in failed_ranks)
+
+    def _failure_detection_is_reconciled_locked(
+        self,
+        failed_rank: int,
+        failed_ranks: frozenset[int],
+    ) -> bool:
+        required_reporters = set(self._candidate_survivor_ranks(failed_ranks))
         if not required_reporters:
             # There is no survivor that can participate in later recovery.
             # Do not let the usual ``empty set is a subset`` rule claim
@@ -1075,23 +1047,18 @@ class MpiFtSubcomm:
                 return
 
             failed_rank = message.failed_rank
-            snapshot = self._detected_state.snapshot()
+            snapshot = self._failure_evidence.snapshot()
+            candidate_survivors = self._candidate_survivor_ranks(snapshot.failed_ranks)
             if message.kind is _MessageKind.ABORT:
-                # Terminal state must reach every rank still believed active.
+                # Terminal state must reach every candidate survivor.
                 # If one of them is actually the second failed rank, send
                 # failure falls through to the fail-stop MPI_Abort fallback.
-                peers = [
-                    peer
-                    for peer in range(self._ep_size)
-                    if peer != self._local_rank and snapshot.mask & (1 << peer)
-                ]
+                peers = [peer for peer in candidate_survivors if peer != self._local_rank]
             else:
                 peers = [
                     peer
-                    for peer in range(self._ep_size)
-                    if peer != self._local_rank
-                    and peer != failed_rank
-                    and snapshot.mask & (1 << peer)
+                    for peer in candidate_survivors
+                    if peer != self._local_rank and peer != failed_rank
                 ]
             if not peers:
                 with self._protocol_lock:
@@ -1193,7 +1160,7 @@ class MpiFtSubcomm:
                         f"{failed_rank} from EP rank {source}"
                     )
 
-            if self._detected_state.is_active(source) and not self._stop_event.is_set():
+            if not self._failure_evidence.has_failure(source) and not self._stop_event.is_set():
                 try:
                     pending_receives[source] = self._post_receive(source)
                 except Exception as error:
@@ -1256,7 +1223,7 @@ class MpiFtSubcomm:
                 self._lifecycle = _Lifecycle.FAILED
                 claim_error = error
             else:
-                changed = self._detected_state.record_failure(failed_rank)
+                changed = self._failure_evidence._record_failure(failed_rank)
                 if transport_poisoned:
                     self._transport_poisoned.set()
                 self._observe_failure(failed_rank, reporter)
@@ -1402,26 +1369,26 @@ class MpiFtSubcomm:
         self._deadline_monitor_wake_event.set()
 
     def _check_accepted_failure_epoch(self) -> None:
-        """Fail closed when detected state leaves the accepted failure epoch."""
+        """Fail closed when failure evidence leaves the accepted failure epoch."""
         error: RuntimeError | None = None
         accepted_failure: int | None = None
         with self._lifecycle_lock:
             if self._lifecycle not in (_Lifecycle.RUNNING, _Lifecycle.STOPPING):
                 return
-            snapshot = self._detected_state.snapshot()
-            accepted_failure, accepted_generation = self._accepted_failure_state()
+            snapshot = self._failure_evidence.snapshot()
+            accepted_failure, accepted_evidence_epoch = self._accepted_failure_state()
             if accepted_failure is None:
                 if not snapshot.failed_ranks:
                     return
                 error = RuntimeError(
-                    "WideEP FT detected state changed outside the failure "
+                    "WideEP FT failure evidence changed outside the failure "
                     "broadcaster; the watchdog must call "
                     "report_detected_failure() without pre-recording evidence "
                     f"(snapshot={snapshot})"
                 )
             elif (
                 snapshot.failed_ranks == frozenset({accepted_failure})
-                and snapshot.generation == accepted_generation
+                and snapshot.evidence_epoch == accepted_evidence_epoch
             ):
                 return
             else:
@@ -1429,7 +1396,7 @@ class MpiFtSubcomm:
                     "WideEP FT accepted failure epoch changed before communicator "
                     "reconstruction "
                     f"(accepted_rank={accepted_failure}, "
-                    f"expected_generation={accepted_generation}, snapshot={snapshot})"
+                    f"expected_evidence_epoch={accepted_evidence_epoch}, snapshot={snapshot})"
                 )
             self._lifecycle = _Lifecycle.FAILED
 
@@ -1473,10 +1440,12 @@ class MpiFtSubcomm:
         with self._lifecycle_lock:
             if self._lifecycle not in (_Lifecycle.RUNNING, _Lifecycle.STOPPING):
                 return
-            snapshot = self._detected_state.snapshot()
+            snapshot = self._failure_evidence.snapshot()
             with self._protocol_lock:
                 for failed_rank, deadline in list(self._reconcile_deadlines.items()):
-                    if self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask):
+                    if self._failure_detection_is_reconciled_locked(
+                        failed_rank, snapshot.failed_ranks
+                    ):
                         del self._reconcile_deadlines[failed_rank]
                     elif now >= deadline:
                         expired.append(failed_rank)
@@ -1490,20 +1459,20 @@ class MpiFtSubcomm:
 
     def _stop_reconciliation_state(self) -> tuple[bool, BaseException | None]:
         """Return whether shutdown can stop MPI progress without splitting ranks."""
-        snapshot = self._detected_state.snapshot()
+        snapshot = self._failure_evidence.snapshot()
         failed_ranks = snapshot.failed_ranks
-        accepted_failure, accepted_generation = self._accepted_failure_state()
+        accepted_failure, accepted_evidence_epoch = self._accepted_failure_state()
         with self._protocol_lock:
             reconciliation_state_is_valid = self._detection_reconciliation_state_is_valid_locked(
                 snapshot,
                 accepted_failure,
-                accepted_generation,
+                accepted_evidence_epoch,
             )
         if not reconciliation_state_is_valid:
             return False, RuntimeError(
                 "WideEP FT cannot stop after the accepted failure epoch changed "
                 f"(accepted_rank={accepted_failure}, "
-                f"expected_generation={accepted_generation}, "
+                f"expected_evidence_epoch={accepted_evidence_epoch}, "
                 f"snapshot={snapshot})"
             )
         if not failed_ranks:
@@ -1517,7 +1486,9 @@ class MpiFtSubcomm:
             unreconciled = [
                 failed_rank
                 for failed_rank in failed_ranks
-                if not self._failure_detection_is_reconciled_locked(failed_rank, snapshot.mask)
+                if not self._failure_detection_is_reconciled_locked(
+                    failed_rank, snapshot.failed_ranks
+                )
             ]
             untracked = [
                 failed_rank

--- a/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
+++ b/tensorrt_llm/_torch/pyexecutor/ep_failure_broadcast.py
@@ -22,7 +22,7 @@ point-to-point requests on an independent CPU thread.
 
 The component propagates one rank-failure detection and updates only the
 process-local :class:`FailureEvidenceState`. It never receives or updates the
-committed ``EPGroupHealth`` execution mask. Multi-rank suspect/confirm
+committed `EPGroupHealth` execution mask. Multi-rank suspect/confirm
 consensus, commit authorization, and communicator reconstruction are
 intentionally left to later WideEP FT phases.
 
@@ -32,11 +32,11 @@ reconciliation does **not** authorize request resume, EPLB changes, NCCL
 reconfiguration or use, or committed-mask mutation. The future 1c.4b recovery
 coordinator consumes the detection callback and owns that authorization.
 
-ULFM revoke is reserved for terminal control-plane aborts because MPI does not
+ULFM revoke is reserved for terminal detection-plane aborts because MPI does not
 carry enough information to distinguish a successful commit revoke from an
 emergency abort at remote ranks. Without ULFM, terminal state is echoed to every
 survivor; failure to confirm that echo within a bounded interval uses
-``MPI_Abort`` on the world-spanning FT communicator as a fail-stop fallback.
+`MPI_Abort` on the world-spanning FT communicator as a fail-stop fallback.
 """
 
 from __future__ import annotations
@@ -112,7 +112,7 @@ class _MpiComm(Protocol):
 
 
 class _MpiModule(Protocol):
-    """Subset of the mpi4py ``MPI`` module used by this component."""
+    """Subset of the mpi4py `MPI` module used by this component."""
 
     ERRORS_RETURN: object
     ERR_PROC_FAILED: int
@@ -147,7 +147,7 @@ class FailureEvidenceSnapshot:
 class FailureEvidenceState:
     """Thread-safe, process-local rank-failure evidence.
 
-    This state is deliberately distinct from ``EPGroupHealth``. It is evidence
+    This state is deliberately distinct from `EPGroupHealth`. It is evidence
     exclusively mutated by :class:`MpiFtSubcomm`, not a committed execution
     mask, and it is monotonic for one FT communicator epoch. Callers may retain
     and inspect the state, but must not mutate it.
@@ -156,8 +156,8 @@ class FailureEvidenceState:
         ep_size: Number of EP-local ranks represented by this state.
 
     Raises:
-        TypeError: If ``ep_size`` is not an integer.
-        ValueError: If ``ep_size`` is not positive.
+        TypeError: If `ep_size` is not an integer.
+        ValueError: If `ep_size` is not positive.
     """
 
     def __init__(self, ep_size: int) -> None:
@@ -185,7 +185,7 @@ class FailureEvidenceState:
             return True
 
     def has_failure(self, rank: int) -> bool:
-        """Return whether failure evidence has been recorded for ``rank``."""
+        """Return whether failure evidence has been recorded for `rank`."""
         rank = self._validate_rank(rank)
         with self._lock:
             return rank in self._failed_ranks
@@ -215,21 +215,22 @@ class MpiFtSubcommConfig:
     """Runtime-independent tuning for the FT progress thread.
 
     Args:
-        poll_interval_sec: Maximum delay between MPI progress passes. The
-            default leaves margin below the 100 ms agreement budget.
+        poll_interval_sec: Maximum delay between MPI progress passes.
         startup_timeout_sec: Maximum time to wait for receive requests to be
             posted when :meth:`MpiFtSubcomm.start` is called.
         stop_timeout_sec: Default bounded join timeout used by
-            :meth:`MpiFtSubcomm.stop`.
+            :meth:`MpiFtSubcomm.stop`, maximum time for Revoke to complete, and
+            maximum time for the progress thread to exit after a terminal
+            relay reconciles.
         reconcile_timeout_sec: Maximum time for every candidate survivor to
-            announce the same failure before the control plane fails closed.
+            announce the same failure before the detection plane fails closed.
         unattributed_error_timeout_sec: Maximum time to wait for the host
             watchdog to identify a rank after non-ULFM MPI reports a generic
-            transport error. The default leaves margin for the design's
-            five-second watchdog bound while keeping terminal escalation
-            inside the ten-second recovery budget.
+            transport error. This fail-closed bound is independent of the
+            watchdog's configurable detection policy, which later physical
+            tests must measure.
         abort_timeout_sec: Maximum time to reconcile a relayed terminal ABORT
-            before falling back to communicator-wide ``MPI_Abort`` when ULFM
+            before falling back to communicator-wide `MPI_Abort` when ULFM
             is unavailable.
     """
 
@@ -285,7 +286,7 @@ class _Lifecycle(Enum):
 
 
 class MpiFtSubcomm:
-    """Broadcast EP-rank failure detections on a dedicated MPI control plane.
+    """Broadcast EP-rank failure detections over a dedicated MPI communicator.
 
     Construction creates the FT communicator collectively on the caller's
     thread. Call :meth:`start` only after every rank has constructed the
@@ -293,33 +294,33 @@ class MpiFtSubcomm:
     this communicator; :meth:`report_detected_failure` updates only local
     failure evidence and enqueues a report, so it never waits for a peer or MPI
     progress. The watchdog must call this method instead of pre-recording evidence.
-    Because ``MPI.THREAD_MULTIPLE`` is required, a caller whose start/stop
+    Because `MPI.THREAD_MULTIPLE` is required, a caller whose start/stop
     deadline proves that thread is wedged may issue the terminal Revoke/Abort
     fallback.
 
     Args:
-        mapping: Distributed mapping whose ``moe_ep_group`` defines the FT
-            communicator and whose ``moe_ep_rank`` defines the local rank.
+        mapping: Distributed mapping whose `moe_ep_group` defines the FT
+            communicator and whose `moe_ep_rank` defines the local rank.
         failure_evidence: Process-local EP detection evidence updated by sent and
-            received failure reports. ``EPGroupHealth`` is rejected because it
+            received failure reports. `EPGroupHealth` is rejected because it
             is the committed execution-mask state owned by the recovery
             coordinator.
         config: Progress-loop timing configuration.
         on_failure_detected: Optional callback invoked as
-            ``(failed_rank, source_rank, monotonic_time)`` when a local or
+            `(failed_rank, source_rank, monotonic_time)` when a local or
             received report first changes failure evidence. This is the handoff
             to the future 1c.4b recovery coordinator; it is detection evidence,
             not commit authorization. Delivery runs on a dedicated daemon
             thread so callback latency cannot block MPI progress.
         comm: Pre-created FT communicator. Intended for tests; production
-            callers should let the component create it from ``mapping``.
-        mpi_module: MPI module paired with ``comm``. Intended for tests.
+            callers should let the component create it from `mapping`.
+        mpi_module: MPI module paired with `comm`. Intended for tests.
 
     Raises:
         RuntimeError: If MPI support or thread support is insufficient, or if
-            the communicator does not match ``mapping``.
-        TypeError: If ``failure_evidence`` is not a :class:`FailureEvidenceState`.
-        ValueError: If ``failure_evidence`` and ``mapping`` describe different
+            the communicator does not match `mapping`.
+        TypeError: If `failure_evidence` is not a :class:`FailureEvidenceState`.
+        ValueError: If `failure_evidence` and `mapping` describe different
             EP groups.
     """
 
@@ -374,7 +375,8 @@ class MpiFtSubcomm:
         else:
             if self._mpi.Query_thread() < self._mpi.THREAD_MULTIPLE:
                 raise RuntimeError(
-                    "WideEP FT requires MPI.THREAD_MULTIPLE because its control-plane "
+                    "WideEP FT requires MPI.THREAD_MULTIPLE because its "
+                    "failure-notification "
                     "thread overlaps other MPI traffic"
                 )
 
@@ -447,7 +449,7 @@ class MpiFtSubcomm:
         self._retained_requests: list[_PendingSend | _PendingReceive] = []
         self._process_lifetime_retained = comm_created_collectively
         if comm_created_collectively:
-            # The FT communicator is a process-lifetime control-plane
+            # The FT communicator is a process-lifetime failure-notification
             # resource. Letting mpi4py destroy it when one broadcaster is
             # garbage-collected would call a collective Free at rank-local
             # and nondeterministic times.
@@ -458,6 +460,8 @@ class MpiFtSubcomm:
         self._callback_thread: threading.Thread | None = None
         self._terminal_action_lock = threading.Lock()
         self._revoke_attempted = False
+        self._revoke_completed = False
+        self._revoke_deadline: float | None = None
         self._world_abort_attempted = False
         self._ulfm_available = (
             collective_setup.ulfm_available if collective_setup is not None else self._probe_ulfm()
@@ -471,7 +475,7 @@ class MpiFtSubcomm:
 
     @property
     def last_error(self) -> BaseException | None:
-        """First terminal control-plane error, if any."""
+        """First terminal failure-notification error, if any."""
         with self._error_lock:
             return self._last_error
 
@@ -479,7 +483,7 @@ class MpiFtSubcomm:
         """Start the dedicated MPI progress thread.
 
         This method is not restartable. A second call, including one after
-        :meth:`stop`, raises ``RuntimeError``.
+        :meth:`stop`, raises `RuntimeError`.
         """
         thread_start_error: BaseException | None = None
         with self._lifecycle_lock:
@@ -528,7 +532,7 @@ class MpiFtSubcomm:
             # There is no progress thread to relay ABORT, so fail closed on the
             # caller thread. This is the only thread that can own the FT comm
             # after progress-thread creation itself failed.
-            self._fail_closed_immediately(thread_start_error)
+            self._fail_closed_immediately(thread_start_error, try_revoke=False)
             callback_thread = self._callback_thread
             if callback_thread is not None and callback_thread.is_alive():
                 callback_thread.join(self._config.stop_timeout_sec)
@@ -536,7 +540,7 @@ class MpiFtSubcomm:
             if deadline_monitor_thread is not None and deadline_monitor_thread.is_alive():
                 deadline_monitor_thread.join(self._config.stop_timeout_sec)
             raise RuntimeError(
-                "WideEP FT control-plane thread failed to start"
+                "WideEP FT failure-notification thread failed to start"
             ) from thread_start_error
 
         startup_deadline = time.monotonic() + self._config.startup_timeout_sec
@@ -546,7 +550,7 @@ class MpiFtSubcomm:
         )
         if not progress_ready or not deadline_monitor_ready:
             timeout_error = TimeoutError(
-                "WideEP FT control-plane threads did not start before the timeout"
+                "WideEP FT failure-notification threads did not start before the timeout"
             )
             with self._lifecycle_lock:
                 self._lifecycle = _Lifecycle.FAILED
@@ -559,9 +563,9 @@ class MpiFtSubcomm:
             # startup deadline just expired, so it cannot execute the terminal
             # action itself. MPI.THREAD_MULTIPLE is a construction invariant;
             # use the caller thread to issue the terminal communicator action.
-            self._fail_closed_immediately(timeout_error)
+            self._fail_closed_immediately(timeout_error, try_revoke=False)
             # The progress thread may be stuck inside the first MPI Irecv and
-            # therefore unable to reach its ``finally`` block. Do not leave the
+            # therefore unable to reach its `finally` block. Do not leave the
             # independent callback worker alive after start() has failed.
             callback_thread = self._callback_thread
             if callback_thread is not None and callback_thread is not threading.current_thread():
@@ -584,6 +588,16 @@ class MpiFtSubcomm:
                     f"(state={lifecycle.name.lower()})"
                 )
         if startup_error is not None:
+            # Progress may be blocked in its terminal MPI action and unable to
+            # reach `finally`, so stop the independent callback worker before
+            # issuing an action that does not return in production.
+            self._request_callback_stop()
+            revoke_completed, _, _ = self._revoke_state()
+            if not self._progress_failed.is_set() and not revoke_completed:
+                # The error is published before Revoke or the non-ULFM relay
+                # completes. Do not retire the only deadline monitor while the
+                # progress thread may still be blocked in its terminal action.
+                self._fail_closed_immediately(startup_error, try_revoke=False)
             self._request_deadline_monitor_stop()
             deadline_monitor_thread = self._deadline_monitor_thread
             if (
@@ -591,6 +605,9 @@ class MpiFtSubcomm:
                 and deadline_monitor_thread is not threading.current_thread()
             ):
                 deadline_monitor_thread.join(self._config.stop_timeout_sec)
+            callback_thread = self._callback_thread
+            if callback_thread is not None and callback_thread is not threading.current_thread():
+                callback_thread.join(self._config.stop_timeout_sec)
             raise RuntimeError("WideEP FT progress thread failed during startup") from startup_error
 
     def stop(self, timeout: float | None = None) -> None:
@@ -610,7 +627,7 @@ class MpiFtSubcomm:
                 :attr:`MpiFtSubcommConfig.stop_timeout_sec`.
 
         Raises:
-            ValueError: If ``timeout`` is not finite and positive.
+            ValueError: If `timeout` is not finite and positive.
             TimeoutError: If the progress thread does not exit in time.
         """
         timeout = self._config.stop_timeout_sec if timeout is None else timeout
@@ -652,7 +669,7 @@ class MpiFtSubcomm:
                 # Do not enqueue fail-stop work onto the thread that this
                 # timeout proves is not making MPI progress.
                 self._request_deadline_monitor_stop()
-                self._fail_closed_immediately(timeout_error)
+                self._fail_closed_immediately(timeout_error, try_revoke=False)
                 raise timeout_error
 
         self._request_deadline_monitor_stop()
@@ -665,7 +682,7 @@ class MpiFtSubcomm:
                 timeout_error = TimeoutError(
                     "WideEP FT deadline monitor did not stop before the timeout"
                 )
-                self._fail_closed_immediately(timeout_error)
+                self._fail_closed_immediately(timeout_error, try_revoke=False)
                 raise timeout_error
 
         if callback_thread is not None and callback_thread is not threading.current_thread():
@@ -676,7 +693,7 @@ class MpiFtSubcomm:
                 )
                 # The detection handoff does not own MPI state. A stuck future
                 # coordinator callback may make this stop call time out, but it
-                # must not make one rank take the poisoned-world process-exit
+                # must not make one rank take the failed-epoch process-exit
                 # path.
                 raise timeout_error
 
@@ -694,10 +711,10 @@ class MpiFtSubcomm:
         same rank are coalesced after the first local announcement.
 
         Args:
-            failed_rank: EP-local rank in ``[0, ep_size)``.
+            failed_rank: EP-local rank in `[0, ep_size)`.
 
         Returns:
-            ``True`` if this call changed local failure evidence, else ``False``.
+            `True` if this call changed local failure evidence, else `False`.
         """
         failed_rank = self._validate_rank(failed_rank)
         with self._lifecycle_lock:
@@ -723,7 +740,7 @@ class MpiFtSubcomm:
             self._invoke_detection_callback(failed_rank, self._local_rank, detected_time)
         return changed
 
-    def world_is_poisoned(self) -> bool:
+    def communicator_epoch_is_failed(self) -> bool:
         """Return whether this communicator epoch has ever observed failure."""
         return (
             self._transport_poisoned.is_set()
@@ -734,7 +751,7 @@ class MpiFtSubcomm:
     def failure_detection_is_reconciled(self, failed_rank: int) -> bool:
         """Return whether every candidate survivor announced the same detection.
 
-        This is detection-plane evidence only. A ``True`` result does not
+        This is detection-plane evidence only. A `True` result does not
         authorize request resume, EPLB changes, NCCL reconfiguration or use, or
         committed-mask mutation. The future 1c.4b recovery coordinator owns
         those decisions. This method performs no MPI calls, and a terminal
@@ -762,7 +779,7 @@ class MpiFtSubcomm:
     def failure_evidence_is_reconciled(self) -> bool:
         """Return whether survivors propagated every local failure detection.
 
-        This is not a commit gate. A ``True`` result does not authorize request
+        This is not a commit gate. A `True` result does not authorize request
         resume, EPLB changes, NCCL reconfiguration or use, or committed-mask
         mutation. The future 1c.4b recovery coordinator owns those decisions.
         """
@@ -881,7 +898,7 @@ class MpiFtSubcomm:
         The relay is best effort because it uses the same FT communicator. If
         survivor echoes do not converge before the bounded deadline, the
         progress thread escalates to ULFM revoke or communicator-wide
-        ``MPI_Abort``. This method performs no MPI calls.
+        `MPI_Abort`. This method performs no MPI calls.
         """
         self._record_error(error)
         snapshot = self._failure_evidence.snapshot()
@@ -916,7 +933,7 @@ class MpiFtSubcomm:
         required_reporters = set(self._candidate_survivor_ranks(failed_ranks))
         if not required_reporters:
             # There is no survivor that can participate in later recovery.
-            # Do not let the usual ``empty set is a subset`` rule claim
+            # Do not let the usual `empty set is a subset` rule claim
             # detection propagation completed in this terminal case.
             return False
         reporters = self._failure_reporters.get(failed_rank, set())
@@ -1263,7 +1280,7 @@ class MpiFtSubcomm:
                     callback(failed_rank, source, event_time)
             except Exception as error:
                 # A coordinator callback must never terminate either
-                # control-plane thread.
+                # failure-notification thread.
                 logger.warning(f"WideEP FT failure callback raised: {error}")
 
     def _request_callback_stop(self) -> None:
@@ -1281,10 +1298,11 @@ class MpiFtSubcomm:
 
         Normal communicator traffic remains owned by the progress thread. This
         monitor only observes protected protocol state. If a terminal relay
-        itself reaches its deadline, ``MPI.THREAD_MULTIPLE`` permits this thread
+        itself reaches its deadline, `MPI.THREAD_MULTIPLE` permits this thread
         to issue the existing one-shot Revoke/Abort fail-stop action.
         """
         self._deadline_monitor_ready_event.set()
+        reconciled_exit_deadline: float | None = None
         try:
             while True:
                 # Clear before checking stop/deadline state so a concurrent
@@ -1292,16 +1310,61 @@ class MpiFtSubcomm:
                 self._deadline_monitor_wake_event.clear()
                 if self._deadline_monitor_stop_event.is_set():
                     return
-                if self._progress_failed.is_set():
+                revoke_completed, revoke_in_flight, revoke_deadline = self._revoke_state()
+                if revoke_completed:
                     return
+                if self._progress_failed.is_set() and not revoke_in_flight:
+                    return
+                now = time.monotonic()
+                if revoke_in_flight:
+                    if revoke_deadline is not None and now >= revoke_deadline:
+                        self._fail_closed_immediately(
+                            TimeoutError(
+                                "WideEP FT communicator revoke did not complete before the timeout"
+                            ),
+                            try_revoke=False,
+                        )
+                        self._wake_event.set()
+                        return
+                    self._deadline_monitor_wake_event.wait(
+                        min(
+                            self._config.poll_interval_sec,
+                            max(0.0, revoke_deadline - now)
+                            if revoke_deadline is not None
+                            else self._config.poll_interval_sec,
+                        )
+                    )
+                    continue
 
                 self._check_accepted_failure_epoch()
                 self._check_unattributed_transport_deadlines()
                 self._check_reconciliation_deadlines()
 
-                if self._progress_failed.is_set():
+                revoke_completed, revoke_in_flight, revoke_deadline = self._revoke_state()
+                if revoke_completed:
+                    return
+                if self._progress_failed.is_set() and not revoke_in_flight:
                     return
                 now = time.monotonic()
+                if revoke_in_flight:
+                    if revoke_deadline is not None and now >= revoke_deadline:
+                        self._fail_closed_immediately(
+                            TimeoutError(
+                                "WideEP FT communicator revoke did not complete before the timeout"
+                            ),
+                            try_revoke=False,
+                        )
+                        self._wake_event.set()
+                        return
+                    self._deadline_monitor_wake_event.wait(
+                        min(
+                            self._config.poll_interval_sec,
+                            max(0.0, revoke_deadline - now)
+                            if revoke_deadline is not None
+                            else self._config.poll_interval_sec,
+                        )
+                    )
+                    continue
                 with self._protocol_lock:
                     abort_deadline = self._abort_deadline
                     abort_reconciled = (
@@ -1311,25 +1374,45 @@ class MpiFtSubcomm:
                 if self._abort_requested.is_set() and abort_deadline is not None:
                     if abort_reconciled:
                         # The relay reached every expected survivor. The progress
-                        # thread will break cleanly when it resumes. Do not mark
-                        # progress failed here: its exception path would otherwise
-                        # escalate a reconciled non-ULFM terminal relay to
-                        # MPI_Abort.
+                        # thread should break cleanly when it resumes. Keep this
+                        # independent monitor alive until that happens so a wedged
+                        # MPI call still has a bounded fail-stop fallback.
+                        if reconciled_exit_deadline is None:
+                            reconciled_exit_deadline = now + self._config.stop_timeout_sec
                         self._wake_event.set()
-                        return
-                    if now >= abort_deadline:
+                        if now >= reconciled_exit_deadline:
+                            self._fail_closed_immediately(
+                                TimeoutError(
+                                    "WideEP FT progress thread did not stop after "
+                                    "terminal relay reconciliation"
+                                ),
+                                try_revoke=False,
+                            )
+                            self._wake_event.set()
+                            return
+                    elif now >= abort_deadline:
                         self._fail_closed_immediately(
                             TimeoutError(
                                 "WideEP FT terminal relay did not complete before "
                                 "the abort deadline"
-                            )
+                            ),
+                            try_revoke=False,
                         )
                         self._wake_event.set()
                         return
 
-                self._deadline_monitor_wake_event.wait(self._config.poll_interval_sec)
+                monitor_wait = self._config.poll_interval_sec
+                revoke_completed, revoke_in_flight, revoke_deadline = self._revoke_state()
+                if revoke_completed:
+                    return
+                if revoke_in_flight and revoke_deadline is not None:
+                    monitor_wait = min(
+                        monitor_wait,
+                        max(0.0, revoke_deadline - time.monotonic()),
+                    )
+                self._deadline_monitor_wake_event.wait(monitor_wait)
         except Exception as error:
-            self._fail_closed_immediately(error)
+            self._fail_closed_immediately(error, try_revoke=False)
             self._wake_event.set()
         finally:
             # start() also uses this event to distinguish a scheduled monitor
@@ -1507,25 +1590,31 @@ class MpiFtSubcomm:
         return False, None
 
     def _progress_terminal_abort(self) -> bool:
-        """Return ``True`` after terminal state is globally safe to stop."""
+        """Return `True` after terminal state is globally safe to stop."""
         if self.ulfm_available:
             # Revoke is itself a communicator-wide terminal notification; it
             # does not depend on rendezvous Isends reaching completion.
-            self._progress_failed.set()
             with self._lifecycle_lock:
                 self._lifecycle = _Lifecycle.FAILED
             try:
-                self._try_revoke()
+                revoke_completed = self._try_revoke()
             except Exception as error:
                 logger.warning(f"WideEP FT terminal revoke failed: {error}")
+                self._progress_failed.set()
                 self._try_world_abort()
                 return True
+            if revoke_completed:
+                self._progress_failed.set()
+                return True
             if self.ulfm_available:
+                # Another caller owns an in-flight Revoke, or its earlier
+                # attempt failed without proving ULFM unsupported. Do not
+                # mistake the attempted state for a completed fail-stop action.
+                self._progress_failed.set()
+                self._try_world_abort()
                 return True
             # A runtime unsupported result disables ULFM and falls through to
-            # the relayed-ABORT protocol. Clear the flag so the next loop pass
-            # can continue progressing those requests.
-            self._progress_failed.clear()
+            # the relayed-ABORT protocol.
 
         now = time.monotonic()
         with self._protocol_lock:
@@ -1547,19 +1636,24 @@ class MpiFtSubcomm:
             self._try_world_abort()
         return True
 
-    def _fail_closed_immediately(self, error: BaseException) -> None:
+    def _fail_closed_immediately(
+        self,
+        error: BaseException,
+        *,
+        try_revoke: bool = True,
+    ) -> None:
         """Abort globally after an error makes bounded relay unsafe."""
         with self._lifecycle_lock:
             self._record_error(error)
-            self._progress_failed.set()
             self._lifecycle = _Lifecycle.FAILED
-        if self.ulfm_available:
+        if try_revoke and self.ulfm_available:
             try:
-                self._try_revoke()
-                if self.ulfm_available:
+                if self._try_revoke():
+                    self._progress_failed.set()
                     return
             except Exception as revoke_error:
                 logger.warning(f"WideEP FT could not revoke after terminal error: {revoke_error}")
+        self._progress_failed.set()
         self._try_world_abort()
 
     def _fail_closed_after_cleanup(self, error: BaseException) -> None:
@@ -1589,7 +1683,7 @@ class MpiFtSubcomm:
         if not callable(abort):
             logger.error(
                 "WideEP FT communicator has no MPI_Abort fallback; "
-                "survivors must terminate through the poisoned-world shutdown hook"
+                "survivors must terminate through the failed-epoch shutdown hook"
             )
             return
         try:
@@ -1620,7 +1714,7 @@ class MpiFtSubcomm:
         # communicator has failed. Keeping each request together with its
         # NumPy buffer is the only bounded shutdown behavior in that state;
         # the later model-engine shutdown hook skips MPI_Finalize entirely.
-        if self.last_error is not None or self.world_is_poisoned():
+        if self.last_error is not None or self.communicator_epoch_is_failed():
             self._retain_requests(requests)
             return
 
@@ -1666,21 +1760,47 @@ class MpiFtSubcomm:
             if self._last_error is None:
                 self._last_error = error
 
-    def _try_revoke(self) -> None:
+    def _revoke_state(self) -> tuple[bool, bool, float | None]:
+        """Return completed, in-flight, and deadline state for Revoke."""
+        with self._terminal_action_lock:
+            in_flight = (
+                self._revoke_attempted
+                and not self._revoke_completed
+                and self._revoke_deadline is not None
+            )
+            return self._revoke_completed, in_flight, self._revoke_deadline
+
+    def _try_revoke(self) -> bool:
         # Claim the one permitted Revoke attempt, but never hold a Python lock
         # across MPI. A caller-thread timeout and a later-resuming progress
-        # thread may enter terminal handling concurrently; the claimant owns
-        # any unsupported/error fallback.
+        # thread may enter terminal handling concurrently. Only a returned
+        # `True` proves that the communicator-wide action completed.
         with self._terminal_action_lock:
+            if self._world_abort_attempted:
+                return False
+            if self._revoke_completed:
+                return True
             if not self._ulfm_available or self._revoke_attempted:
-                return
+                return False
             self._revoke_attempted = True
+            self._revoke_deadline = time.monotonic() + self._config.stop_timeout_sec
+        self._deadline_monitor_wake_event.set()
         try:
             self._comm.Revoke()
         except Exception as error:
             if isinstance(error, NotImplementedError) or self._is_unsupported_ulfm_error(error):
                 with self._terminal_action_lock:
                     self._ulfm_available = False
+                    self._revoke_deadline = None
+                self._deadline_monitor_wake_event.set()
                 logger.warning(f"WideEP FT revoke is unavailable at runtime: {error}")
-                return
+                return False
+            with self._terminal_action_lock:
+                self._revoke_deadline = None
+            self._deadline_monitor_wake_event.set()
             raise
+        with self._terminal_action_lock:
+            self._revoke_completed = True
+            self._revoke_deadline = None
+        self._deadline_monitor_wake_event.set()
+        return True

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -37,6 +37,12 @@ l0_a10:
   - unittest/_torch/executor/test_kv_cache_budget_split.py
   - unittest/_torch/executor/test_kv_pool_rebalance.py
   - unittest/_torch/executor/test_disagg_index_mapper_early_release.py
+  - unittest/_torch/distributed/test_communicator.py
+  - unittest/_torch/executor/test_ep_failure_broadcast.py
+  # MPI prerequisites are required by default. Local environments can opt out
+  # with TLLM_ALLOW_MPI_FT_SMOKE_SKIP=1. The three-minute outer timeout covers
+  # four 30-second launcher modes plus bounded cleanup.
+  - unittest/_torch/executor/test_ep_failure_broadcast_mpi.py TIMEOUT (3) ISOLATION
   - unittest/_torch/executor/test_kv_cache_compression_manager.py
   - unittest/_torch/executor/test_kv_cache_v2_capacity_only.py
   - unittest/_torch/executor/test_error_classification.py

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -40,8 +40,8 @@ l0_a10:
   - unittest/_torch/distributed/test_communicator.py
   - unittest/_torch/executor/test_ep_failure_broadcast.py
   # MPI prerequisites are required by default. Local environments can opt out
-  # with TLLM_ALLOW_MPI_FT_SMOKE_SKIP=1. The three-minute outer timeout covers
-  # four 30-second launcher modes plus bounded cleanup.
+  # with TLLM_ALLOW_MPI_FT_SMOKE_SKIP=1. The three-minute outer timeout wraps
+  # six launcher processes with 30-second inner timeouts and bounded cleanup.
   - unittest/_torch/executor/test_ep_failure_broadcast_mpi.py TIMEOUT (3) ISOLATION
   - unittest/_torch/executor/test_kv_cache_compression_manager.py
   - unittest/_torch/executor/test_kv_cache_v2_capacity_only.py

--- a/tests/unittest/_torch/distributed/test_communicator.py
+++ b/tests/unittest/_torch/distributed/test_communicator.py
@@ -1,0 +1,681 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tensorrt_llm._torch.distributed import communicator
+
+
+def _mapping(**overrides: object) -> SimpleNamespace:
+    values = {
+        "world_size": 8,
+        "rank": 5,
+        "moe_ep_group": list(range(8)),
+        "moe_ep_size": 8,
+        "moe_ep_rank": 5,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _valid_topologies(parent_size: int = 8) -> list[dict[str, object]]:
+    topologies = []
+    for rank in range(parent_size):
+        ep_group = tuple(range(parent_size))
+        topologies.append(
+            {
+                "parent_rank": rank,
+                "parent_size": parent_size,
+                "world_size": parent_size,
+                "mapping_rank": rank,
+                "ep_group": ep_group,
+                "ep_size": len(ep_group),
+                "ep_rank": ep_group.index(rank),
+                "health_size": None,
+                "error_kind": None,
+                "error_message": None,
+            }
+        )
+    return topologies
+
+
+def _valid_setup_statuses(parent_size: int = 8) -> list[dict[str, object]]:
+    return [
+        {
+            "parent_rank": rank,
+            "error_message": None,
+            "ulfm_available": True,
+        }
+        for rank in range(parent_size)
+    ]
+
+
+def _communicators(*, parent_rank: int = 5, parent_size: int = 8) -> tuple[Mock, Mock]:
+    ft_comm = Mock()
+    ft_comm.Get_rank.return_value = 5
+    ft_comm.Get_size.return_value = 8
+    ft_comm.Is_revoked.return_value = False
+
+    parent_comm = Mock()
+    parent_comm.Get_rank.return_value = parent_rank
+    parent_comm.Get_size.return_value = parent_size
+    parent_comm.Split.return_value = ft_comm
+
+    def _allgather(local_record: dict[str, object]) -> list[dict[str, object]]:
+        if "ep_group" in local_record:
+            records = _valid_topologies(parent_size)
+        else:
+            records = _valid_setup_statuses(parent_size)
+        records[parent_rank] = local_record
+        return records
+
+    parent_comm.allgather.side_effect = _allgather
+    return parent_comm, ft_comm
+
+
+def _fake_mpi(parent_comm: Mock, *, thread_level: int = 3) -> SimpleNamespace:
+    return SimpleNamespace(
+        COMM_WORLD=parent_comm,
+        ERRORS_RETURN=object(),
+        THREAD_MULTIPLE=3,
+        Exception=Exception,
+        Query_thread=Mock(return_value=thread_level),
+    )
+
+
+def test_create_mpi_ft_subcomm_splits_ep_group_and_sets_error_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    fake_mpi = _fake_mpi(parent_comm)
+    monkeypatch.setattr(communicator, "MPI", fake_mpi)
+    active_comm = Mock(return_value=parent_comm)
+    monkeypatch.setattr(communicator, "mpi_comm", active_comm)
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+
+    try:
+        result = communicator.create_mpi_ft_subcomm(_mapping())
+
+        assert result.comm is ft_comm
+        assert result.local_rank == 5
+        assert result.ep_size == 8
+        assert result.ulfm_available is True
+        active_comm.assert_called_once_with()
+        assert parent_comm.allgather.call_count == 2
+        parent_comm.Split.assert_called_once_with(color=0, key=5)
+        ft_comm.Set_errhandler.assert_called_once_with(fake_mpi.ERRORS_RETURN)
+        ft_comm.Free.assert_not_called()
+        assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
+    finally:
+        del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+
+
+def test_create_mpi_ft_subcomm_requires_thread_multiple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, _ = _communicators()
+    fake_mpi = _fake_mpi(parent_comm, thread_level=2)
+    monkeypatch.setattr(communicator, "MPI", fake_mpi)
+
+    with pytest.raises(RuntimeError, match=r"requires MPI\.THREAD_MULTIPLE"):
+        communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    parent_comm.allgather.assert_called_once()
+    parent_comm.Split.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("mapping_overrides", "error_match"),
+    [
+        ({"moe_ep_group": []}, "must not be empty"),
+        ({"moe_ep_group": list(range(7))}, "size must match mapping.moe_ep_size"),
+        ({"moe_ep_group": [0, 1, 2, 3, 4, 5, 6, 6]}, "contains duplicate ranks"),
+        ({"moe_ep_group": [0, 1, 2, 3, 4, 5, 6, 8]}, "outside the parent communicator"),
+        (
+            {"moe_ep_group": [0, 1, 2, 3], "moe_ep_size": 4},
+            "spanning the full MPI world",
+        ),
+        (
+            {"moe_ep_group": [5, 0, 1, 2, 3, 4, 6, 7]},
+            "group order must match mapping.moe_ep_rank",
+        ),
+    ],
+)
+def test_create_mpi_ft_subcomm_validates_ep_group(
+    monkeypatch: pytest.MonkeyPatch,
+    mapping_overrides: dict[str, object],
+    error_match: str,
+) -> None:
+    parent_comm, _ = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+
+    with pytest.raises(ValueError, match=error_match):
+        communicator.create_mpi_ft_subcomm(_mapping(**mapping_overrides), parent_comm)
+
+    parent_comm.allgather.assert_called_once()
+    parent_comm.Split.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("parent_rank", "parent_size", "error_match"),
+    [
+        (5, 7, "size must match mapping.world_size"),
+        (6, 8, "rank must match mapping.rank"),
+    ],
+)
+def test_create_mpi_ft_subcomm_validates_parent_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+    parent_rank: int,
+    parent_size: int,
+    error_match: str,
+) -> None:
+    parent_comm, _ = _communicators(parent_rank=parent_rank, parent_size=parent_size)
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+
+    with pytest.raises(RuntimeError, match=error_match):
+        communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    parent_comm.allgather.assert_called_once()
+    parent_comm.Split.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("mapping_error", "error_match"),
+    [
+        (IndexError("missing EP group"), "IndexError: missing EP group"),
+        (ValueError("invalid EP group"), "ValueError: invalid EP group"),
+    ],
+    ids=["index-error", "value-error"],
+)
+def test_create_mpi_ft_subcomm_collectively_reports_mapping_accessor_error(
+    monkeypatch: pytest.MonkeyPatch,
+    mapping_error: Exception,
+    error_match: str,
+) -> None:
+    class FailingMapping:
+        world_size = 8
+        rank = 5
+        moe_ep_size = 8
+        moe_ep_rank = 5
+
+        @property
+        def moe_ep_group(self) -> list[int]:
+            raise mapping_error
+
+    parent_comm, _ = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+
+    with pytest.raises(ValueError, match=error_match):
+        communicator.create_mpi_ft_subcomm(FailingMapping(), parent_comm)
+
+    parent_comm.allgather.assert_called_once()
+    parent_comm.Split.assert_not_called()
+
+
+def test_create_mpi_ft_subcomm_uses_collectively_validated_ep_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SingleReadMapping:
+        world_size = 8
+        rank = 5
+        moe_ep_group = list(range(8))
+
+        def __init__(self) -> None:
+            self.ep_size_reads = 0
+            self.ep_rank_reads = 0
+
+        @property
+        def moe_ep_size(self) -> int:
+            self.ep_size_reads += 1
+            if self.ep_size_reads > 1:
+                raise ValueError("moe_ep_size was read after collective validation")
+            return 8
+
+        @property
+        def moe_ep_rank(self) -> int:
+            self.ep_rank_reads += 1
+            if self.ep_rank_reads > 1:
+                raise ValueError("moe_ep_rank was read after collective validation")
+            return 5
+
+    parent_comm, ft_comm = _communicators()
+    fake_mpi = _fake_mpi(parent_comm)
+    monkeypatch.setattr(communicator, "MPI", fake_mpi)
+    mapping = SingleReadMapping()
+
+    result = communicator.create_mpi_ft_subcomm(mapping, parent_comm)
+
+    assert result.comm is ft_comm
+    assert result.local_rank == 5
+    assert result.ep_size == 8
+    assert result.ulfm_available is True
+    assert mapping.ep_size_reads == 1
+    assert mapping.ep_rank_reads == 1
+    assert parent_comm.allgather.call_count == 2
+    ft_comm.Set_errhandler.assert_called_once_with(fake_mpi.ERRORS_RETURN)
+
+
+@pytest.mark.parametrize(
+    ("failure_kind", "error_match"),
+    [
+        ("rank-mismatch", "unexpected WideEP FT communicator"),
+        ("size-mismatch", "unexpected WideEP FT communicator"),
+        ("get-rank-error", "RuntimeError: cannot inspect rank"),
+        ("get-size-error", "RuntimeError: cannot inspect size"),
+        ("errhandler", "RuntimeError: cannot set error handler"),
+    ],
+)
+def test_create_mpi_ft_subcomm_retains_comm_after_post_split_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+    error_match: str,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+    if failure_kind == "rank-mismatch":
+        ft_comm.Get_rank.return_value = 4
+    elif failure_kind == "size-mismatch":
+        ft_comm.Get_size.return_value = 7
+    elif failure_kind == "get-rank-error":
+        ft_comm.Get_rank.side_effect = RuntimeError("cannot inspect rank")
+    elif failure_kind == "get-size-error":
+        ft_comm.Get_size.side_effect = RuntimeError("cannot inspect size")
+    else:
+        ft_comm.Set_errhandler.side_effect = RuntimeError("cannot set error handler")
+
+    try:
+        with pytest.raises(RuntimeError, match=error_match):
+            communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+        assert parent_comm.allgather.call_count == 2
+        ft_comm.Free.assert_not_called()
+        assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
+    finally:
+        del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+
+
+def test_create_mpi_ft_subcomm_installs_error_handler_before_inspection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    fake_mpi = _fake_mpi(parent_comm)
+    monkeypatch.setattr(communicator, "MPI", fake_mpi)
+    calls = []
+    ft_comm.Set_errhandler.side_effect = lambda _handler: calls.append("errhandler")
+    ft_comm.Get_rank.side_effect = lambda: calls.append("rank") or 5
+    ft_comm.Get_size.side_effect = lambda: calls.append("size") or 8
+
+    communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    assert calls[:3] == ["errhandler", "rank", "size"]
+
+
+def test_create_mpi_ft_subcomm_collectively_disables_ulfm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    default_allgather = parent_comm.allgather.side_effect
+
+    def _allgather(local_record: dict[str, object]) -> list[dict[str, object]]:
+        records = default_allgather(local_record)
+        if "ep_group" not in local_record:
+            records[2]["ulfm_available"] = False
+        return records
+
+    parent_comm.allgather.side_effect = _allgather
+
+    result = communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    assert result.comm is ft_comm
+    assert result.ulfm_available is False
+
+
+def test_create_mpi_ft_subcomm_collectively_reports_ulfm_probe_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    ft_comm.Is_revoked.side_effect = RuntimeError("probe failed")
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="setup failed on parent rank 5.*ULFM probe raised.*probe failed",
+        ):
+            communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+        ft_comm.Free.assert_not_called()
+        assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
+    finally:
+        del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+
+
+def test_create_mpi_ft_subcomm_reconciles_ulfm_error_classifier_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ClassifierFailureMpiException(Exception):
+        def Get_error_class(self) -> int:
+            raise RuntimeError("cannot classify MPI error")
+
+    parent_comm, ft_comm = _communicators()
+    fake_mpi = _fake_mpi(parent_comm)
+    fake_mpi.Exception = ClassifierFailureMpiException
+    monkeypatch.setattr(communicator, "MPI", fake_mpi)
+    ft_comm.Is_revoked.side_effect = ClassifierFailureMpiException("probe failed")
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="setup failed on parent rank 5.*ULFM probe raised.*probe failed",
+        ):
+            communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+        assert parent_comm.allgather.call_count == 2
+        ft_comm.Free.assert_not_called()
+        assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
+    finally:
+        del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+
+
+def test_create_mpi_ft_subcomm_treats_unsupported_ulfm_probe_as_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    ft_comm.Is_revoked.side_effect = NotImplementedError("ULFM is not compiled")
+
+    result = communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    assert result.ulfm_available is False
+    ft_comm.Free.assert_not_called()
+
+
+def test_create_mpi_ft_subcomm_collectively_rejects_revoked_comm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    ft_comm.Is_revoked.return_value = True
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+
+    try:
+        with pytest.raises(RuntimeError, match="already revoked at construction"):
+            communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+        ft_comm.Free.assert_not_called()
+        assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
+    finally:
+        del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+
+
+def test_create_mpi_ft_subcomm_retains_comm_after_remote_post_split_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    default_allgather = parent_comm.allgather.side_effect
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+
+    def _allgather(local_record: dict[str, object]) -> list[dict[str, object]]:
+        records = default_allgather(local_record)
+        if "ep_group" not in local_record:
+            records[2]["error_message"] = "remote communicator setup failed"
+        return records
+
+    parent_comm.allgather.side_effect = _allgather
+
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="setup failed on parent rank 2: remote communicator setup failed",
+        ):
+            communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+        ft_comm.Set_errhandler.assert_called_once()
+        ft_comm.Free.assert_not_called()
+        assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
+    finally:
+        del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+
+
+def test_create_mpi_ft_subcomm_retains_comm_when_post_split_allgather_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    default_allgather = parent_comm.allgather.side_effect
+    allgather_error = RuntimeError("post-split allgather failed")
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+
+    def _allgather(local_record: dict[str, object]) -> list[dict[str, object]]:
+        if "ep_group" in local_record:
+            return default_allgather(local_record)
+        raise allgather_error
+
+    parent_comm.allgather.side_effect = _allgather
+
+    try:
+        with pytest.raises(RuntimeError, match="post-split allgather failed") as raised:
+            communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+        assert raised.value is allgather_error
+        assert parent_comm.allgather.call_count == 2
+        ft_comm.Free.assert_not_called()
+        assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
+    finally:
+        del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+
+
+def test_create_mpi_ft_subcomm_retains_comm_after_malformed_post_split_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    default_allgather = parent_comm.allgather.side_effect
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+
+    def _allgather(local_record: dict[str, object]) -> list[object]:
+        records = default_allgather(local_record)
+        if "ep_group" not in local_record:
+            records[2] = None
+        return records
+
+    parent_comm.allgather.side_effect = _allgather
+
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="invalid status for parent rank 2: None",
+        ):
+            communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+        ft_comm.Free.assert_not_called()
+        assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
+    finally:
+        del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+
+
+def test_create_mpi_ft_subcomm_propagates_remote_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, _ = _communicators()
+    topologies = _valid_topologies()
+    topologies[2]["error_kind"] = "value"
+    topologies[2]["error_message"] = "mapping.moe_ep_group must not be empty"
+    parent_comm.allgather.side_effect = None
+    parent_comm.allgather.return_value = topologies
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+
+    with pytest.raises(
+        ValueError, match="startup validation failed on parent rank 2.*must not be empty"
+    ):
+        communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    parent_comm.Split.assert_not_called()
+
+
+def test_create_mpi_ft_subcomm_collectively_validates_health_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, _ = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+
+    with pytest.raises(ValueError, match="EPGroupHealth size must match"):
+        communicator.create_mpi_ft_subcomm(
+            _mapping(),
+            parent_comm,
+            health_size=7,
+        )
+
+    parent_comm.allgather.assert_called_once()
+    parent_comm.Split.assert_not_called()
+
+
+def test_create_mpi_ft_subcomm_rejects_inconsistent_remote_ep_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, _ = _communicators()
+    topologies = _valid_topologies()
+    topologies[6]["ep_group"] = (6, 0, 1, 2, 3, 4, 5, 7)
+    parent_comm.allgather.side_effect = None
+    parent_comm.allgather.return_value = topologies
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+
+    with pytest.raises(RuntimeError, match="startup topology is inconsistent"):
+        communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    parent_comm.Split.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error_match"),
+    [
+        ("ep_group", None, "invalid EP group"),
+        ("ep_group", "01234567", "invalid EP group"),
+        ("ep_group", (0, 1, True, 3, 4, 5, 6, 7), "invalid EP group ranks"),
+        ("ep_group", (0, 1, 2, 3, 4, 5, 6, 8), "invalid EP group ranks"),
+        ("ep_group", (0, 1, 2, 3, 4, 5, 6, 6), "duplicate EP group ranks"),
+        ("ep_size", None, "reports EP size"),
+        ("parent_rank", 2.0, "reports parent rank"),
+        ("parent_size", 8.0, "reports communicator size"),
+        ("world_size", 8.0, "reports world size"),
+        ("mapping_rank", 2.0, "reports mapping rank"),
+        ("ep_size", 8.0, "reports EP size"),
+        ("ep_rank", 2.0, "reports invalid EP rank"),
+        ("health_size", 8.0, "reports health size"),
+    ],
+    ids=[
+        "missing-group",
+        "string-group",
+        "bool-rank",
+        "out-of-range-rank",
+        "duplicate-rank",
+        "missing-ep-size",
+        "float-parent-rank",
+        "float-parent-size",
+        "float-world-size",
+        "float-mapping-rank",
+        "float-ep-size",
+        "float-ep-rank",
+        "float-health-size",
+    ],
+)
+def test_create_mpi_ft_subcomm_rejects_malformed_remote_topology_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: object,
+    error_match: str,
+) -> None:
+    parent_comm, _ = _communicators()
+    topologies = _valid_topologies()
+    topologies[2][field] = value
+    parent_comm.allgather.side_effect = None
+    parent_comm.allgather.return_value = topologies
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+
+    with pytest.raises(RuntimeError, match=error_match):
+        communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    parent_comm.Split.assert_not_called()
+
+
+def test_create_mpi_ft_subcomm_rejects_float_local_ep_size_before_split(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, _ = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+
+    with pytest.raises(RuntimeError, match=r"reports EP size 8\.0"):
+        communicator.create_mpi_ft_subcomm(
+            _mapping(moe_ep_size=8.0),
+            parent_comm,
+        )
+
+    parent_comm.allgather.assert_called_once()
+    parent_comm.Split.assert_not_called()
+
+
+def test_create_mpi_ft_subcomm_uses_pkl5_compatible_object_allgather(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ft_comm = Mock()
+    ft_comm.Get_rank.return_value = 5
+    ft_comm.Get_size.return_value = 8
+    ft_comm.Is_revoked.return_value = False
+
+    class Pkl5LikeParent:
+        def __init__(self) -> None:
+            self.gathered_records = []
+            self.split_args = None
+
+        def Get_rank(self) -> int:
+            return 5
+
+        def Get_size(self) -> int:
+            return 8
+
+        def allgather(self, local_record: dict[str, object]) -> list[dict[str, object]]:
+            self.gathered_records.append(local_record)
+            if "ep_group" in local_record:
+                records = _valid_topologies()
+            else:
+                records = _valid_setup_statuses()
+            records[5] = local_record
+            return records
+
+        def Split(self, *, color: int, key: int) -> Mock:
+            self.split_args = (color, key)
+            return ft_comm
+
+    parent_comm = Pkl5LikeParent()
+    fake_mpi = _fake_mpi(Mock())
+    monkeypatch.setattr(communicator, "MPI", fake_mpi)
+
+    result = communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    assert result.comm is ft_comm
+    assert result.local_rank == 5
+    assert result.ep_size == 8
+    assert result.ulfm_available is True
+    assert len(parent_comm.gathered_records) == 2
+    assert parent_comm.split_args == (0, 5)
+    ft_comm.Set_errhandler.assert_called_once_with(fake_mpi.ERRORS_RETURN)

--- a/tests/unittest/_torch/distributed/test_communicator.py
+++ b/tests/unittest/_torch/distributed/test_communicator.py
@@ -46,7 +46,7 @@ def _valid_topologies(parent_size: int = 8) -> list[dict[str, object]]:
                 "ep_group": ep_group,
                 "ep_size": len(ep_group),
                 "ep_rank": ep_group.index(rank),
-                "health_size": None,
+                "failure_evidence_size": None,
                 "error_kind": None,
                 "error_message": None,
             }
@@ -533,17 +533,17 @@ def test_create_mpi_ft_subcomm_propagates_remote_validation_error(
     parent_comm.Split.assert_not_called()
 
 
-def test_create_mpi_ft_subcomm_collectively_validates_health_size(
+def test_create_mpi_ft_subcomm_collectively_validates_failure_evidence_size(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     parent_comm, _ = _communicators()
     monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
 
-    with pytest.raises(ValueError, match="EPGroupHealth size must match"):
+    with pytest.raises(ValueError, match="Failure-evidence state size must match"):
         communicator.create_mpi_ft_subcomm(
             _mapping(),
             parent_comm,
-            health_size=7,
+            failure_evidence_size=7,
         )
 
     parent_comm.allgather.assert_called_once()
@@ -581,7 +581,7 @@ def test_create_mpi_ft_subcomm_rejects_inconsistent_remote_ep_group(
         ("mapping_rank", 2.0, "reports mapping rank"),
         ("ep_size", 8.0, "reports EP size"),
         ("ep_rank", 2.0, "reports invalid EP rank"),
-        ("health_size", 8.0, "reports health size"),
+        ("failure_evidence_size", 8.0, "reports failure-evidence size"),
     ],
     ids=[
         "missing-group",
@@ -596,7 +596,7 @@ def test_create_mpi_ft_subcomm_rejects_inconsistent_remote_ep_group(
         "float-mapping-rank",
         "float-ep-size",
         "float-ep-rank",
-        "float-health-size",
+        "float-failure-evidence-size",
     ],
 )
 def test_create_mpi_ft_subcomm_rejects_malformed_remote_topology_schema(

--- a/tests/unittest/_torch/distributed/test_communicator.py
+++ b/tests/unittest/_torch/distributed/test_communicator.py
@@ -13,12 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 
 from tensorrt_llm._torch.distributed import communicator
+
+
+@pytest.fixture(autouse=True)
+def _restore_mpi_ft_process_lifetime_state() -> Iterator[None]:
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+    initial_parent = communicator._MPI_FT_PROCESS_LIFETIME_PARENT
+    yield
+    del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+    communicator._MPI_FT_PROCESS_LIFETIME_PARENT = initial_parent
 
 
 def _mapping(**overrides: object) -> SimpleNamespace:
@@ -33,7 +43,11 @@ def _mapping(**overrides: object) -> SimpleNamespace:
     return SimpleNamespace(**values)
 
 
-def _valid_topologies(parent_size: int = 8) -> list[dict[str, object]]:
+def _valid_topologies(
+    parent_size: int = 8,
+    *,
+    ft_comm_reserved: bool = False,
+) -> list[dict[str, object]]:
     topologies = []
     for rank in range(parent_size):
         ep_group = tuple(range(parent_size))
@@ -47,6 +61,7 @@ def _valid_topologies(parent_size: int = 8) -> list[dict[str, object]]:
                 "ep_size": len(ep_group),
                 "ep_rank": ep_group.index(rank),
                 "failure_evidence_size": None,
+                "ft_comm_reserved": ft_comm_reserved,
                 "error_kind": None,
                 "error_message": None,
             }
@@ -78,7 +93,10 @@ def _communicators(*, parent_rank: int = 5, parent_size: int = 8) -> tuple[Mock,
 
     def _allgather(local_record: dict[str, object]) -> list[dict[str, object]]:
         if "ep_group" in local_record:
-            records = _valid_topologies(parent_size)
+            records = _valid_topologies(
+                parent_size,
+                ft_comm_reserved=bool(local_record["ft_comm_reserved"]),
+            )
         else:
             records = _valid_setup_statuses(parent_size)
         records[parent_rank] = local_record
@@ -108,21 +126,85 @@ def test_create_mpi_ft_subcomm_splits_ep_group_and_sets_error_handler(
     monkeypatch.setattr(communicator, "mpi_comm", active_comm)
     initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
 
-    try:
-        result = communicator.create_mpi_ft_subcomm(_mapping())
+    result = communicator.create_mpi_ft_subcomm(_mapping())
 
-        assert result.comm is ft_comm
-        assert result.local_rank == 5
-        assert result.ep_size == 8
-        assert result.ulfm_available is True
-        active_comm.assert_called_once_with()
-        assert parent_comm.allgather.call_count == 2
-        parent_comm.Split.assert_called_once_with(color=0, key=5)
-        ft_comm.Set_errhandler.assert_called_once_with(fake_mpi.ERRORS_RETURN)
-        ft_comm.Free.assert_not_called()
-        assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
-    finally:
-        del communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:]
+    assert result.comm is ft_comm
+    assert result.local_rank == 5
+    assert result.ep_size == 8
+    assert result.ulfm_available is True
+    active_comm.assert_called_once_with()
+    assert parent_comm.allgather.call_count == 2
+    parent_comm.Split.assert_called_once_with(color=0, key=5)
+    ft_comm.Set_errhandler.assert_called_once_with(fake_mpi.ERRORS_RETURN)
+    ft_comm.Free.assert_not_called()
+    assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
+
+
+def test_create_mpi_ft_subcomm_collectively_rejects_second_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, _ = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+
+    communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    with pytest.raises(
+        RuntimeError,
+        match="at most one process-lifetime communicator per process",
+    ):
+        communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    parent_comm.Split.assert_called_once()
+    assert parent_comm.allgather.call_count == 3
+    assert communicator._MPI_FT_PROCESS_LIFETIME_PARENT is parent_comm
+
+
+def test_create_mpi_ft_subcomm_rejects_mixed_remote_lifecycle_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, _ = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    default_allgather = parent_comm.allgather.side_effect
+    initial_parent = communicator._MPI_FT_PROCESS_LIFETIME_PARENT
+
+    def _allgather(local_record: dict[str, object]) -> list[dict[str, object]]:
+        records = default_allgather(local_record)
+        if "ep_group" in local_record:
+            records[2]["ft_comm_reserved"] = True
+        return records
+
+    parent_comm.allgather.side_effect = _allgather
+
+    with pytest.raises(
+        RuntimeError,
+        match="communicator lifecycle is inconsistent.*reserved ranks=\\[2\\]",
+    ):
+        communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    parent_comm.Split.assert_not_called()
+    assert communicator._MPI_FT_PROCESS_LIFETIME_PARENT is initial_parent
+
+
+def test_create_mpi_ft_subcomm_burns_reservation_after_post_split_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent_comm, ft_comm = _communicators()
+    monkeypatch.setattr(communicator, "MPI", _fake_mpi(parent_comm))
+    ft_comm.Set_errhandler.side_effect = RuntimeError("cannot set error handler")
+    initial_refs = len(communicator._MPI_FT_PROCESS_LIFETIME_REFS)
+
+    with pytest.raises(RuntimeError, match="cannot set error handler"):
+        communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    with pytest.raises(
+        RuntimeError,
+        match="at most one process-lifetime communicator per process",
+    ):
+        communicator.create_mpi_ft_subcomm(_mapping(), parent_comm)
+
+    parent_comm.Split.assert_called_once()
+    assert communicator._MPI_FT_PROCESS_LIFETIME_PARENT is parent_comm
+    assert communicator._MPI_FT_PROCESS_LIFETIME_REFS[initial_refs:] == [ft_comm]
 
 
 def test_create_mpi_ft_subcomm_requires_thread_multiple(
@@ -582,6 +664,7 @@ def test_create_mpi_ft_subcomm_rejects_inconsistent_remote_ep_group(
         ("ep_size", 8.0, "reports EP size"),
         ("ep_rank", 2.0, "reports invalid EP rank"),
         ("failure_evidence_size", 8.0, "reports failure-evidence size"),
+        ("ft_comm_reserved", 0, "invalid communicator-lifecycle state"),
     ],
     ids=[
         "missing-group",
@@ -597,6 +680,7 @@ def test_create_mpi_ft_subcomm_rejects_inconsistent_remote_ep_group(
         "float-ep-size",
         "float-ep-rank",
         "float-failure-evidence-size",
+        "invalid-communicator-lifecycle-state",
     ],
 )
 def test_create_mpi_ft_subcomm_rejects_malformed_remote_topology_schema(

--- a/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
+++ b/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
@@ -273,7 +273,7 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
             propagation_start = time.monotonic()
             try:
                 assert broadcaster is not None
-                broadcaster.pre_failover(failure_rank)
+                broadcaster.report_detected_failure(failure_rank)
             except Exception:
                 trigger_error = traceback.format_exc()
 
@@ -281,12 +281,13 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
         try:
             # The victim process remains alive only so the smoke can coordinate
             # its result on COMM_WORLD. Survivors exclude its logical rank and
-            # exercise the same failure/reconciliation fanout as production.
+            # exercise the same detection/reconciliation fanout as production.
+            # This smoke does not model recovery commit or request resumption.
             assert broadcaster is not None
             deadline = time.monotonic() + _CONVERGENCE_TIMEOUT_SEC
             while not phase_errors and rank != failure_rank and time.monotonic() < deadline:
                 failure_observed = not health.is_active(failure_rank)
-                failure_reconciled = broadcaster.failure_is_reconciled(failure_rank)
+                failure_reconciled = broadcaster.failure_detection_is_reconciled(failure_rank)
                 if failure_observed and failure_reconciled:
                     if rank == detector_rank:
                         assert propagation_start is not None
@@ -295,8 +296,8 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
                 time.sleep(0.005)
             local_converged = rank == failure_rank or (
                 not health.is_active(failure_rank)
-                and broadcaster.failure_is_reconciled(failure_rank)
-                and broadcaster.health_is_reconciled()
+                and broadcaster.failure_detection_is_reconciled(failure_rank)
+                and broadcaster.detected_health_is_reconciled()
                 and broadcaster.world_is_poisoned()
             )
         except Exception:

--- a/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
+++ b/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
@@ -30,8 +30,11 @@ from types import SimpleNamespace
 import numpy as np
 from mpi4py import MPI
 
-from tensorrt_llm._torch.modules.fused_moe.ep_group_health import EPGroupHealth
-from tensorrt_llm._torch.pyexecutor.ep_failure_broadcast import MpiFtSubcomm, MpiFtSubcommConfig
+from tensorrt_llm._torch.pyexecutor.ep_failure_broadcast import (
+    DetectedRankState,
+    MpiFtSubcomm,
+    MpiFtSubcommConfig,
+)
 from tensorrt_llm.mapping import MpiTopology
 
 _SKIP_MARKER = "WIDEEP_MPI_SMOKE_SKIP:"
@@ -135,7 +138,7 @@ def _run_invalid_topology_smoke(world: MPI.Intracomm) -> str | None:
     try:
         unexpected_broadcaster = MpiFtSubcomm(
             mapping,
-            EPGroupHealth(world_size),
+            DetectedRankState(world_size),
             MpiFtSubcommConfig(startup_timeout_sec=5.0, stop_timeout_sec=5.0),
         )
     except Exception as error:
@@ -176,7 +179,7 @@ def _run_healthy_lifecycle_smoke(world: MPI.Intracomm) -> str | None:
         # collective validation and Split, and owns MPI progress directly.
         broadcaster = MpiFtSubcomm(
             mapping,
-            EPGroupHealth(world_size),
+            DetectedRankState(world_size),
             config,
         )
         ft_comm = broadcaster._comm
@@ -220,7 +223,7 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
     rank = world.Get_rank()
     world_size = world.Get_size()
     mapping = _mapping(world_size, rank)
-    health = EPGroupHealth(world_size)
+    health = DetectedRankState(world_size)
     owner: MpiFtSubcomm | None = None
     broadcaster: MpiFtSubcomm | None = None
     detector_rank = 0
@@ -239,7 +242,7 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
         # view so this smoke deterministically exercises typed Isend/Irecv+Test.
         owner = MpiFtSubcomm(
             mapping,
-            EPGroupHealth(world_size),
+            DetectedRankState(world_size),
             config,
         )
         ft_comm = owner._comm
@@ -297,7 +300,7 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
             local_converged = rank == failure_rank or (
                 not health.is_active(failure_rank)
                 and broadcaster.failure_detection_is_reconciled(failure_rank)
-                and broadcaster.detected_health_is_reconciled()
+                and broadcaster.detected_state_is_reconciled()
                 and broadcaster.world_is_poisoned()
             )
         except Exception:
@@ -404,7 +407,7 @@ def _run_terminal_abort_smoke(world: MPI.Intracomm) -> str | None:
         # scenario specifically validates the bounded ABORT echo fallback.
         owner = MpiFtSubcomm(
             mapping,
-            EPGroupHealth(world_size),
+            DetectedRankState(world_size),
             MpiFtSubcommConfig(startup_timeout_sec=5.0, stop_timeout_sec=5.0),
         )
         ft_comm = owner._comm
@@ -412,7 +415,7 @@ def _run_terminal_abort_smoke(world: MPI.Intracomm) -> str | None:
         wrapped_comm = _NonUlfmComm(ft_comm)
         broadcaster = MpiFtSubcomm(
             mapping,
-            EPGroupHealth(world_size),
+            DetectedRankState(world_size),
             MpiFtSubcommConfig(
                 startup_timeout_sec=5.0,
                 stop_timeout_sec=5.0,

--- a/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
+++ b/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
@@ -1,0 +1,622 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Logical WideEP failure-injection worker using a real MPI transport.
+
+The smoke keeps every process alive so ``COMM_WORLD`` can coordinate portable
+results. Actual peer death and MPI runtime error classification are outside its
+scope because common launchers terminate the whole job when a worker exits
+without ``MPI_Finalize``.
+"""
+
+import atexit
+import os
+import sys
+import time
+import traceback
+from types import SimpleNamespace
+
+import numpy as np
+from mpi4py import MPI
+
+from tensorrt_llm._torch.modules.fused_moe.ep_group_health import EPGroupHealth
+from tensorrt_llm._torch.pyexecutor.ep_failure_broadcast import MpiFtSubcomm, MpiFtSubcommConfig
+from tensorrt_llm.mapping import MpiTopology
+
+_SKIP_MARKER = "WIDEEP_MPI_SMOKE_SKIP:"
+_PROPAGATION_MARKER = "WIDEEP_MPI_PROPAGATION"
+_INVALID_TOPOLOGY_MARKER = "WIDEEP_MPI_INVALID_TOPOLOGY_OK"
+_HEALTHY_LIFECYCLE_MARKER = "WIDEEP_MPI_HEALTHY_LIFECYCLE_OK"
+_ABORT_WORLD_MARKER = "WIDEEP_MPI_ABORT_WORLD_OK"
+_TERMINAL_READY_MARKER = "WIDEEP_MPI_TERMINAL_READY"
+_TERMINAL_COMPLETE_MARKER = "WIDEEP_MPI_TERMINAL_COMPLETE"
+_TERMINAL_DONE_MARKER = "WIDEEP_MPI_TERMINAL_DONE"
+_TERMINAL_ERROR_MARKER = "WIDEEP_MPI_TERMINAL_ERROR"
+_TERMINAL_ATEXIT_MARKER = "WIDEEP_MPI_TERMINAL_ATEXIT_RAN"
+_PROPAGATION_TARGET_SEC = 0.1
+_CONVERGENCE_TIMEOUT_SEC = 2.0
+_ALLOW_SKIP_ENV = "TLLM_ALLOW_MPI_FT_SMOKE_SKIP"
+_HEALTHY_MODE = "healthy"
+_TERMINAL_MODE = "terminal"
+_WORKER_SKIPPED = False
+
+
+class _NonUlfmComm:
+    """Typed MPI communicator view that makes smoke behavior independent of ULFM."""
+
+    def __init__(self, comm: MPI.Intracomm) -> None:
+        self._comm = comm
+        self.abort_calls = 0
+
+    def Get_rank(self) -> int:
+        return self._comm.Get_rank()
+
+    def Get_size(self) -> int:
+        return self._comm.Get_size()
+
+    def Set_errhandler(self, errhandler: MPI.Errhandler) -> None:
+        self._comm.Set_errhandler(errhandler)
+
+    def Irecv(self, buffer: np.ndarray, source: int, tag: int) -> MPI.Request:
+        return self._comm.Irecv(buffer, source=source, tag=tag)
+
+    def Isend(self, buffer: np.ndarray, dest: int, tag: int) -> MPI.Request:
+        return self._comm.Isend(buffer, dest=dest, tag=tag)
+
+    def Abort(self, errorcode: int) -> None:
+        self.abort_calls += 1
+        self._comm.Abort(errorcode)
+
+
+def _mapping(world_size: int, rank: int) -> MpiTopology:
+    return MpiTopology(
+        world_size=world_size,
+        rank=rank,
+        tp_size=world_size,
+        moe_tp_size=1,
+        moe_ep_size=world_size,
+    )
+
+
+def _unsupported_environment(message: str, *, rank: int) -> int:
+    """Skip optional local runs, but fail a designated required smoke run."""
+    global _WORKER_SKIPPED
+    _WORKER_SKIPPED = True
+    required = os.environ.get(_ALLOW_SKIP_ENV) != "1"
+    if rank == 0:
+        if required:
+            print(f"WideEP MPI FT smoke requirement failed: {message}", file=sys.stderr)
+        else:
+            print(f"{_SKIP_MARKER} {message}")
+    return 2 if required else 0
+
+
+def _synchronize_phase_error(
+    world: MPI.Intracomm,
+    phase: str,
+    local_error: str | None,
+) -> str | None:
+    """Return the same rank-attributed phase failure before the next collective."""
+    errors = world.allgather(local_error)
+    failures = [(rank, error) for rank, error in enumerate(errors) if error is not None]
+    if not failures:
+        return None
+    details = "\n".join(f"rank {rank}:\n{error}" for rank, error in failures)
+    return f"{phase} failed before the next MPI phase:\n{details}"
+
+
+def _run_invalid_topology_smoke(world: MPI.Intracomm) -> str | None:
+    """Prove a rank-local topology error is reconciled before ``Split``."""
+    rank = world.Get_rank()
+    world_size = world.Get_size()
+    ep_group = tuple(range(world_size))
+    if rank == 0:
+        ep_group = ep_group[:-1]
+    mapping = SimpleNamespace(
+        world_size=world_size,
+        rank=rank,
+        moe_ep_size=world_size,
+        moe_ep_rank=rank,
+        moe_ep_group=ep_group,
+    )
+    caught_error: str | None = None
+    unexpected_broadcaster: MpiFtSubcomm | None = None
+    try:
+        unexpected_broadcaster = MpiFtSubcomm(
+            mapping,
+            EPGroupHealth(world_size),
+            MpiFtSubcommConfig(startup_timeout_sec=5.0, stop_timeout_sec=5.0),
+        )
+    except Exception as error:
+        caught_error = f"{type(error).__name__}: {error}"
+
+    caught_errors = world.allgather(caught_error)
+    expected_fragment = "startup validation failed on parent rank 0"
+    if any(error is None for error in caught_errors):
+        return f"invalid topology unexpectedly constructed on some ranks: {caught_errors}"
+    if len(set(caught_errors)) != 1 or expected_fragment not in caught_errors[0]:
+        return f"invalid topology errors were not identical across ranks: {caught_errors}"
+
+    # This barrier is intentionally after the failed constructor. It proves the
+    # parent communicator did not strand any rank in MPI_Comm_split.
+    world.Barrier()
+    if rank == 0:
+        print(_INVALID_TOPOLOGY_MARKER, flush=True)
+    if unexpected_broadcaster is not None:
+        return "invalid topology unexpectedly returned a broadcaster"
+    return None
+
+
+def _run_healthy_lifecycle_smoke(world: MPI.Intracomm) -> str | None:
+    """Exercise production construction, progress startup, and clean shutdown."""
+    rank = world.Get_rank()
+    world_size = world.Get_size()
+    mapping = _mapping(world_size, rank)
+    broadcaster: MpiFtSubcomm | None = None
+    error: str | None = None
+
+    try:
+        config = MpiFtSubcommConfig(
+            startup_timeout_sec=5.0,
+            stop_timeout_sec=5.0,
+            reconcile_timeout_sec=5.0,
+        )
+        # This path obtains TRT-LLM's pkl5 parent through mpi_comm(), performs
+        # collective validation and Split, and owns MPI progress directly.
+        broadcaster = MpiFtSubcomm(
+            mapping,
+            EPGroupHealth(world_size),
+            config,
+        )
+        ft_comm = broadcaster._comm
+        if ft_comm.Get_rank() != rank or ft_comm.Get_size() != world_size:
+            raise AssertionError(
+                "MPI_Comm_split returned an unexpected FT communicator: "
+                f"rank={ft_comm.Get_rank()}, size={ft_comm.Get_size()}"
+            )
+        if ft_comm.Get_errhandler() != MPI.ERRORS_RETURN:
+            raise AssertionError("FT communicator does not use MPI.ERRORS_RETURN")
+        broadcaster.start()
+        broadcaster.stop()
+        if broadcaster.last_error is not None:
+            raise AssertionError(
+                "Production-construction progress failed during healthy shutdown: "
+                f"{broadcaster.last_error}"
+            )
+    except Exception:
+        error = traceback.format_exc()
+    finally:
+        if broadcaster is not None:
+            try:
+                broadcaster.stop(timeout=5.0)
+                if broadcaster.last_error is not None:
+                    raise AssertionError(
+                        "MPI progress failed during healthy lifecycle smoke: "
+                        f"{broadcaster.last_error}"
+                    )
+            except Exception:
+                cleanup_error = traceback.format_exc()
+                error = f"{error or ''}\ncleanup failure:\n{cleanup_error}"
+        # Production-created FT communicators are intentionally retained for
+        # process lifetime. Freeing one here would violate the same ownership
+        # contract this smoke is meant to exercise.
+
+    return error
+
+
+def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
+    """Exercise logical failure fanout and sticky state over real MPI traffic."""
+    rank = world.Get_rank()
+    world_size = world.Get_size()
+    mapping = _mapping(world_size, rank)
+    health = EPGroupHealth(world_size)
+    owner: MpiFtSubcomm | None = None
+    broadcaster: MpiFtSubcomm | None = None
+    detector_rank = 0
+    failure_rank = world_size - 1
+    error: str | None = None
+    propagation_converged = False
+
+    setup_error: str | None = None
+    try:
+        config = MpiFtSubcommConfig(
+            startup_timeout_sec=5.0,
+            stop_timeout_sec=5.0,
+            reconcile_timeout_sec=5.0,
+        )
+        # Create the real FT communicator collectively, then inject a non-ULFM
+        # view so this smoke deterministically exercises typed Isend/Irecv+Test.
+        owner = MpiFtSubcomm(
+            mapping,
+            EPGroupHealth(world_size),
+            config,
+        )
+        ft_comm = owner._comm
+        owner.stop()
+        broadcaster = MpiFtSubcomm(
+            mapping,
+            health,
+            config,
+            comm=_NonUlfmComm(ft_comm),
+        )
+        broadcaster.start()
+    except Exception:
+        setup_error = traceback.format_exc()
+    error = _synchronize_phase_error(world, "failure-propagation setup", setup_error)
+
+    detector_elapsed_sec: float | None = None
+    local_converged = False
+    if error is None:
+        phase_errors: list[str] = []
+        try:
+            # Every broadcaster is running before rank 0 starts the latency
+            # clock. This synchronization is deliberately outside the measured
+            # interval.
+            world.Barrier()
+        except Exception:
+            phase_errors.append(f"readiness:\n{traceback.format_exc()}")
+
+        trigger_error: str | None = None
+        propagation_start: float | None = None
+        if not phase_errors and rank == detector_rank:
+            propagation_start = time.monotonic()
+            try:
+                assert broadcaster is not None
+                broadcaster.pre_failover(failure_rank)
+            except Exception:
+                trigger_error = traceback.format_exc()
+
+        observation_error: str | None = None
+        try:
+            # The victim process remains alive only so the smoke can coordinate
+            # its result on COMM_WORLD. Survivors exclude its logical rank and
+            # exercise the same failure/reconciliation fanout as production.
+            assert broadcaster is not None
+            deadline = time.monotonic() + _CONVERGENCE_TIMEOUT_SEC
+            while not phase_errors and rank != failure_rank and time.monotonic() < deadline:
+                failure_observed = not health.is_active(failure_rank)
+                failure_reconciled = broadcaster.failure_is_reconciled(failure_rank)
+                if failure_observed and failure_reconciled:
+                    if rank == detector_rank:
+                        assert propagation_start is not None
+                        detector_elapsed_sec = time.monotonic() - propagation_start
+                    break
+                time.sleep(0.005)
+            local_converged = rank == failure_rank or (
+                not health.is_active(failure_rank)
+                and broadcaster.failure_is_reconciled(failure_rank)
+                and broadcaster.health_is_reconciled()
+                and broadcaster.world_is_poisoned()
+            )
+        except Exception:
+            observation_error = traceback.format_exc()
+
+        if trigger_error is not None:
+            phase_errors.append(f"trigger:\n{trigger_error}")
+        if observation_error is not None:
+            phase_errors.append(f"observation:\n{observation_error}")
+        error = _synchronize_phase_error(
+            world,
+            "failure-propagation trigger/observation",
+            "\n".join(phase_errors) or None,
+        )
+
+    if error is None:
+        all_converged = world.allreduce(local_converged, op=MPI.LAND)
+        # Share only rank 0's completed duration after the timed interval; raw
+        # monotonic timestamps never cross rank or host boundaries.
+        detector_elapsed_sec = world.bcast(detector_elapsed_sec, root=detector_rank)
+        if all_converged and detector_elapsed_sec is not None:
+            propagation_converged = True
+        else:
+            error = (
+                f"failure rank {failure_rank} did not converge within "
+                f"{_CONVERGENCE_TIMEOUT_SEC:.0f}s"
+            )
+        if rank == detector_rank and detector_elapsed_sec is not None:
+            elapsed_ms = detector_elapsed_sec * 1000.0
+            target_ms = _PROPAGATION_TARGET_SEC * 1000.0
+            print(
+                f"{_PROPAGATION_MARKER} world_size={world_size} "
+                f"elapsed_ms={elapsed_ms!r} target_ms={target_ms!r} "
+                f"target_met={elapsed_ms < target_ms}",
+                flush=True,
+            )
+
+    stop_succeeded = False
+    if broadcaster is not None:
+        # Deliberately do not reactivate failure_rank. Survivors must take the
+        # poisoned shutdown path and retain their unmatched receive requests.
+        try:
+            broadcaster.stop(timeout=5.0)
+            if broadcaster.last_error is not None:
+                raise AssertionError(
+                    f"MPI progress failed during propagation smoke: {broadcaster.last_error}"
+                )
+            stop_succeeded = True
+        except Exception:
+            cleanup_error = traceback.format_exc()
+            error = f"{error or ''}\ncleanup failure:\n{cleanup_error}"
+    if propagation_converged and stop_succeeded:
+        try:
+            if rank == failure_rank:
+                if broadcaster.world_is_poisoned():
+                    raise AssertionError("logical victim unexpectedly entered poisoned state")
+                if broadcaster._retained_requests:
+                    raise AssertionError("logical victim retained healthy MPI requests")
+            else:
+                if not broadcaster.world_is_poisoned():
+                    raise AssertionError("survivor lost sticky poisoned state during stop")
+                if not broadcaster._retained_requests:
+                    raise AssertionError("survivor did not retain poisoned MPI requests")
+        except Exception:
+            sticky_error = traceback.format_exc()
+            error = f"{error or ''}\nsticky-poison failure:\n{sticky_error}"
+    if owner is not None:
+        try:
+            owner.stop(timeout=5.0)
+        except Exception:
+            cleanup_error = traceback.format_exc()
+            error = f"{error or ''}\nowner cleanup failure:\n{cleanup_error}"
+
+    return error
+
+
+def _write_terminal_manifest(lines: list[str]) -> None:
+    """Emit canonical rank evidence from the single rank-0 output stream."""
+    sys.stdout.write("".join(f"{line}\n" for line in lines))
+    sys.stdout.flush()
+
+
+def _terminal_atexit_sentinel() -> None:
+    """Negative evidence: this must not run in intentional no-Finalize mode."""
+    marker = f"{_TERMINAL_ATEXIT_MARKER} pid={os.getpid()}\n".encode()
+    try:
+        os.write(sys.stderr.fileno(), marker)
+    except BaseException:
+        pass
+
+
+def _run_terminal_abort_smoke(world: MPI.Intracomm) -> str | None:
+    """Exercise terminal ABORT relay while keeping ``COMM_WORLD`` healthy."""
+    rank = world.Get_rank()
+    world_size = world.Get_size()
+    mapping = _mapping(world_size, rank)
+    broadcaster: MpiFtSubcomm | None = None
+    wrapped_comm: _NonUlfmComm | None = None
+    error: str | None = None
+
+    setup_error: str | None = None
+    try:
+        # Construct a fresh production communicator, then hide ULFM so this
+        # scenario specifically validates the bounded ABORT echo fallback.
+        owner = MpiFtSubcomm(
+            mapping,
+            EPGroupHealth(world_size),
+            MpiFtSubcommConfig(startup_timeout_sec=5.0, stop_timeout_sec=5.0),
+        )
+        ft_comm = owner._comm
+        owner.stop()
+        wrapped_comm = _NonUlfmComm(ft_comm)
+        broadcaster = MpiFtSubcomm(
+            mapping,
+            EPGroupHealth(world_size),
+            MpiFtSubcommConfig(
+                startup_timeout_sec=5.0,
+                stop_timeout_sec=5.0,
+                reconcile_timeout_sec=5.0,
+                abort_timeout_sec=3.0,
+            ),
+            comm=wrapped_comm,
+        )
+        broadcaster.start()
+    except Exception:
+        setup_error = traceback.format_exc()
+    error = _synchronize_phase_error(world, "terminal-ABORT setup", setup_error)
+
+    if error is None:
+        trigger_error: str | None = None
+        try:
+            world.Barrier()
+            if rank == 0:
+                # A transport-independent terminal request is the protocol seam
+                # used by local second-failure and timeout paths.
+                assert broadcaster is not None
+                broadcaster._request_terminal_abort(
+                    RuntimeError("real-MPI terminal smoke"), -1, rank
+                )
+        except Exception:
+            trigger_error = traceback.format_exc()
+        error = _synchronize_phase_error(
+            world,
+            "terminal-ABORT trigger",
+            trigger_error,
+        )
+
+    local_converged = False
+    if error is None:
+        observation_error: str | None = None
+        try:
+            assert broadcaster is not None
+            assert wrapped_comm is not None
+            deadline = time.monotonic() + _CONVERGENCE_TIMEOUT_SEC
+            while time.monotonic() < deadline:
+                if broadcaster._progress_failed.is_set():
+                    break
+                time.sleep(0.005)
+            local_converged = (
+                broadcaster._progress_failed.is_set()
+                and broadcaster.last_error is not None
+                and broadcaster.world_is_poisoned()
+                and wrapped_comm.abort_calls == 0
+            )
+        except Exception:
+            observation_error = traceback.format_exc()
+        error = _synchronize_phase_error(
+            world,
+            "terminal-ABORT observation",
+            observation_error,
+        )
+
+    if error is None:
+        if not world.allreduce(local_converged, op=MPI.LAND):
+            error = "terminal ABORT did not converge on every MPI rank"
+        else:
+            # The ABORT protocol is confined to the FT subcommunicator. A
+            # parent barrier after convergence proves COMM_WORLD remains usable.
+            world.Barrier()
+            if rank == 0:
+                print(_ABORT_WORLD_MARKER, flush=True)
+    if broadcaster is not None:
+        try:
+            broadcaster.stop(timeout=5.0)
+            if not broadcaster.world_is_poisoned():
+                raise AssertionError("terminal FT state lost its poisoned-world latch")
+        except Exception:
+            cleanup_error = traceback.format_exc()
+            error = f"{error or ''}\nterminal cleanup failure:\n{cleanup_error}"
+
+    # Do not free the terminal communicator. Its component intentionally
+    # retains potentially active requests until process teardown.
+    return error
+
+
+def _report_scenario_errors(
+    world: MPI.Intracomm,
+    scenario: str,
+    local_error: str | None,
+) -> bool:
+    rank = world.Get_rank()
+    errors = world.gather(local_error, root=0)
+    failed = None
+    if rank == 0:
+        failed = any(error is not None for error in errors)
+        if failed:
+            for error_rank, error in enumerate(errors):
+                if error is not None:
+                    print(
+                        f"{scenario} failed on rank {error_rank}:\n{error}",
+                        file=sys.stderr,
+                    )
+    return world.bcast(failed, root=0)
+
+
+def main() -> int:
+    world = MPI.COMM_WORLD
+    expected_world_size = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+    mode = sys.argv[2] if len(sys.argv) > 2 else ""
+    world_size = world.Get_size()
+    rank = world.Get_rank()
+    if world_size < 2 or world_size != expected_world_size:
+        return _unsupported_environment(
+            f"expected {expected_world_size} MPI ranks, got {world_size}",
+            rank=rank,
+        )
+    if MPI.Query_thread() < MPI.THREAD_MULTIPLE:
+        return _unsupported_environment(
+            f"MPI.THREAD_MULTIPLE is unavailable (provided={MPI.Query_thread()})",
+            rank=rank,
+        )
+
+    if mode == _HEALTHY_MODE:
+        scenarios = (
+            ("invalid-topology", _run_invalid_topology_smoke),
+            ("healthy-lifecycle", _run_healthy_lifecycle_smoke),
+        )
+    elif mode == _TERMINAL_MODE:
+        scenarios = (
+            ("failure-broadcast", _run_failure_propagation_smoke),
+            ("terminal-abort", _run_terminal_abort_smoke),
+        )
+    else:
+        if rank == 0:
+            print(f"unknown WideEP MPI smoke mode: {mode!r}", file=sys.stderr)
+        return 2
+    for scenario, run_scenario in scenarios:
+        if _report_scenario_errors(world, scenario, run_scenario(world)):
+            return 1
+    if mode == _HEALTHY_MODE and rank == 0:
+        print(_HEALTHY_LIFECYCLE_MARKER, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    worker_mode = sys.argv[2] if len(sys.argv) > 2 else ""
+    if worker_mode == _TERMINAL_MODE:
+        # A normal interpreter shutdown would run mpi4py's Finalize hook. The
+        # launcher rejects this sentinel, so the smoke independently proves that
+        # the terminal path below bypassed Python atexit via os._exit().
+        atexit.register(_terminal_atexit_sentinel)
+    exit_code = main()
+    if worker_mode == _TERMINAL_MODE and not _WORKER_SKIPPED:
+        # This mode deliberately leaves the FT control plane terminal and
+        # retains its requests. Skip mpi4py's collective MPI_Finalize just as
+        # the production poisoned-world shutdown hook will do.
+        sys.stdout.flush()
+        sys.stderr.flush()
+        if exit_code == 0:
+            world = MPI.COMM_WORLD
+            rank = world.Get_rank()
+            world_size = world.Get_size()
+            try:
+                # Gather evidence first, then let rank 0 emit a canonical
+                # manifest. MPI launchers forward separate per-rank pipes and do
+                # not preserve cross-rank write atomicity in the merged stream.
+                ready_ranks = world.gather(rank, root=0)
+                if rank == 0:
+                    if sorted(ready_ranks) != list(range(world_size)):
+                        raise AssertionError(f"invalid terminal READY ranks: {ready_ranks}")
+                    _write_terminal_manifest(
+                        [
+                            f"{_TERMINAL_READY_MARKER} rank={ready_rank} world_size={world_size}"
+                            for ready_rank in ready_ranks
+                        ]
+                    )
+                world.Barrier()
+                done_ranks = world.gather(rank, root=0)
+                if rank == 0:
+                    if sorted(done_ranks) != list(range(world_size)):
+                        raise AssertionError(f"invalid terminal DONE ranks: {done_ranks}")
+                    _write_terminal_manifest(
+                        [
+                            f"{_TERMINAL_COMPLETE_MARKER} world_size={world_size}",
+                            *(
+                                f"{_TERMINAL_DONE_MARKER} rank={done_rank} world_size={world_size}"
+                                for done_rank in done_ranks
+                            ),
+                        ]
+                    )
+                # No rank can trigger launcher fail-fast until rank 0 has copied
+                # the complete gathered manifest to stdout.
+                world.Barrier()
+            except BaseException:
+                try:
+                    _write_terminal_manifest([f"{_TERMINAL_ERROR_MARKER} rank={rank} exit_code=1"])
+                except BaseException:
+                    pass
+                traceback.print_exc()
+                sys.stderr.flush()
+                exit_code = 1
+        else:
+            rank = MPI.COMM_WORLD.Get_rank()
+            try:
+                _write_terminal_manifest(
+                    [f"{_TERMINAL_ERROR_MARKER} rank={rank} exit_code={exit_code}"]
+                )
+            except BaseException:
+                pass
+        os._exit(exit_code)
+    # Healthy mode returns normally so mpi4py's MPI_Finalize path remains part
+    # of the smoke test.
+    sys.exit(exit_code)

--- a/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
+++ b/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
@@ -45,6 +45,7 @@ _ABORT_WORLD_MARKER = "WIDEEP_MPI_ABORT_WORLD_OK"
 _TERMINAL_READY_MARKER = "WIDEEP_MPI_TERMINAL_READY"
 _TERMINAL_COMPLETE_MARKER = "WIDEEP_MPI_TERMINAL_COMPLETE"
 _TERMINAL_DONE_MARKER = "WIDEEP_MPI_TERMINAL_DONE"
+_TERMINAL_EXITING_MARKER = "WIDEEP_MPI_TERMINAL_EXITING"
 _TERMINAL_ERROR_MARKER = "WIDEEP_MPI_TERMINAL_ERROR"
 _TERMINAL_ATEXIT_MARKER = "WIDEEP_MPI_TERMINAL_ATEXIT_RAN"
 _PROPAGATION_TARGET_SEC = 0.1
@@ -604,6 +605,13 @@ if __name__ == "__main__":
                 # No rank can trigger launcher fail-fast until rank 0 has copied
                 # the complete gathered manifest to stdout.
                 world.Barrier()
+                # Emit direct per-rank evidence after the final synchronization
+                # and immediately before the intentional no-Finalize exit. Keep
+                # this to one small os.write() so Python buffering cannot lose it.
+                os.write(
+                    sys.stdout.fileno(),
+                    (f"{_TERMINAL_EXITING_MARKER} rank={rank} world_size={world_size}\n").encode(),
+                )
             except BaseException:
                 try:
                     _write_terminal_manifest([f"{_TERMINAL_ERROR_MARKER} rank={rank} exit_code=1"])

--- a/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
+++ b/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
@@ -31,7 +31,7 @@ import numpy as np
 from mpi4py import MPI
 
 from tensorrt_llm._torch.pyexecutor.ep_failure_broadcast import (
-    DetectedRankState,
+    FailureEvidenceState,
     MpiFtSubcomm,
     MpiFtSubcommConfig,
 )
@@ -139,7 +139,7 @@ def _run_invalid_topology_smoke(world: MPI.Intracomm) -> str | None:
     try:
         unexpected_broadcaster = MpiFtSubcomm(
             mapping,
-            DetectedRankState(world_size),
+            FailureEvidenceState(world_size),
             MpiFtSubcommConfig(startup_timeout_sec=5.0, stop_timeout_sec=5.0),
         )
     except Exception as error:
@@ -180,7 +180,7 @@ def _run_healthy_lifecycle_smoke(world: MPI.Intracomm) -> str | None:
         # collective validation and Split, and owns MPI progress directly.
         broadcaster = MpiFtSubcomm(
             mapping,
-            DetectedRankState(world_size),
+            FailureEvidenceState(world_size),
             config,
         )
         ft_comm = broadcaster._comm
@@ -224,7 +224,7 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
     rank = world.Get_rank()
     world_size = world.Get_size()
     mapping = _mapping(world_size, rank)
-    health = DetectedRankState(world_size)
+    failure_evidence = FailureEvidenceState(world_size)
     owner: MpiFtSubcomm | None = None
     broadcaster: MpiFtSubcomm | None = None
     detector_rank = 0
@@ -243,14 +243,14 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
         # view so this smoke deterministically exercises typed Isend/Irecv+Test.
         owner = MpiFtSubcomm(
             mapping,
-            DetectedRankState(world_size),
+            FailureEvidenceState(world_size),
             config,
         )
         ft_comm = owner._comm
         owner.stop()
         broadcaster = MpiFtSubcomm(
             mapping,
-            health,
+            failure_evidence,
             config,
             comm=_NonUlfmComm(ft_comm),
         )
@@ -290,7 +290,7 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
             assert broadcaster is not None
             deadline = time.monotonic() + _CONVERGENCE_TIMEOUT_SEC
             while not phase_errors and rank != failure_rank and time.monotonic() < deadline:
-                failure_observed = not health.is_active(failure_rank)
+                failure_observed = failure_evidence.has_failure(failure_rank)
                 failure_reconciled = broadcaster.failure_detection_is_reconciled(failure_rank)
                 if failure_observed and failure_reconciled:
                     if rank == detector_rank:
@@ -299,9 +299,9 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
                     break
                 time.sleep(0.005)
             local_converged = rank == failure_rank or (
-                not health.is_active(failure_rank)
+                failure_evidence.has_failure(failure_rank)
                 and broadcaster.failure_detection_is_reconciled(failure_rank)
-                and broadcaster.detected_state_is_reconciled()
+                and broadcaster.failure_evidence_is_reconciled()
                 and broadcaster.world_is_poisoned()
             )
         except Exception:
@@ -408,7 +408,7 @@ def _run_terminal_abort_smoke(world: MPI.Intracomm) -> str | None:
         # scenario specifically validates the bounded ABORT echo fallback.
         owner = MpiFtSubcomm(
             mapping,
-            DetectedRankState(world_size),
+            FailureEvidenceState(world_size),
             MpiFtSubcommConfig(startup_timeout_sec=5.0, stop_timeout_sec=5.0),
         )
         ft_comm = owner._comm
@@ -416,7 +416,7 @@ def _run_terminal_abort_smoke(world: MPI.Intracomm) -> str | None:
         wrapped_comm = _NonUlfmComm(ft_comm)
         broadcaster = MpiFtSubcomm(
             mapping,
-            DetectedRankState(world_size),
+            FailureEvidenceState(world_size),
             MpiFtSubcommConfig(
                 startup_timeout_sec=5.0,
                 stop_timeout_sec=5.0,

--- a/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
+++ b/tests/unittest/_torch/executor/_ep_failure_broadcast_mpi_worker.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 """Logical WideEP failure-injection worker using a real MPI transport.
 
-The smoke keeps every process alive so ``COMM_WORLD`` can coordinate portable
+The smoke keeps every process alive so `COMM_WORLD` can coordinate portable
 results. Actual peer death and MPI runtime error classification are outside its
 scope because common launchers terminate the whole job when a worker exits
-without ``MPI_Finalize``.
+without `MPI_Finalize`.
 """
 
 import atexit
@@ -48,10 +48,10 @@ _TERMINAL_DONE_MARKER = "WIDEEP_MPI_TERMINAL_DONE"
 _TERMINAL_EXITING_MARKER = "WIDEEP_MPI_TERMINAL_EXITING"
 _TERMINAL_ERROR_MARKER = "WIDEEP_MPI_TERMINAL_ERROR"
 _TERMINAL_ATEXIT_MARKER = "WIDEEP_MPI_TERMINAL_ATEXIT_RAN"
-_PROPAGATION_TARGET_SEC = 0.1
 _CONVERGENCE_TIMEOUT_SEC = 2.0
 _ALLOW_SKIP_ENV = "TLLM_ALLOW_MPI_FT_SMOKE_SKIP"
 _HEALTHY_MODE = "healthy"
+_PROPAGATION_MODE = "propagation"
 _TERMINAL_MODE = "terminal"
 _WORKER_SKIPPED = False
 
@@ -121,7 +121,7 @@ def _synchronize_phase_error(
 
 
 def _run_invalid_topology_smoke(world: MPI.Intracomm) -> str | None:
-    """Prove a rank-local topology error is reconciled before ``Split``."""
+    """Prove a rank-local topology error is reconciled before `Split`."""
     rank = world.Get_rank()
     world_size = world.Get_size()
     ep_group = tuple(range(world_size))
@@ -198,6 +198,27 @@ def _run_healthy_lifecycle_smoke(world: MPI.Intracomm) -> str | None:
                 "Production-construction progress failed during healthy shutdown: "
                 f"{broadcaster.last_error}"
             )
+        second_error: str | None = None
+        try:
+            MpiFtSubcomm(
+                mapping,
+                FailureEvidenceState(world_size),
+                config,
+            )
+        except RuntimeError as creation_error:
+            second_error = str(creation_error)
+        second_errors = world.allgather(second_error)
+        expected_fragment = "at most one process-lifetime communicator per process"
+        if (
+            any(message is None for message in second_errors)
+            or len(set(second_errors)) != 1
+            or expected_fragment not in second_errors[0]
+        ):
+            raise AssertionError(
+                "second FT communicator construction was not rejected "
+                f"collectively: {second_errors}"
+            )
+        world.Barrier()
     except Exception:
         error = traceback.format_exc()
     finally:
@@ -302,7 +323,7 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
                 failure_evidence.has_failure(failure_rank)
                 and broadcaster.failure_detection_is_reconciled(failure_rank)
                 and broadcaster.failure_evidence_is_reconciled()
-                and broadcaster.world_is_poisoned()
+                and broadcaster.communicator_epoch_is_failed()
             )
         except Exception:
             observation_error = traceback.format_exc()
@@ -331,18 +352,15 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
             )
         if rank == detector_rank and detector_elapsed_sec is not None:
             elapsed_ms = detector_elapsed_sec * 1000.0
-            target_ms = _PROPAGATION_TARGET_SEC * 1000.0
             print(
-                f"{_PROPAGATION_MARKER} world_size={world_size} "
-                f"elapsed_ms={elapsed_ms!r} target_ms={target_ms!r} "
-                f"target_met={elapsed_ms < target_ms}",
+                f"{_PROPAGATION_MARKER} world_size={world_size} elapsed_ms={elapsed_ms!r}",
                 flush=True,
             )
 
     stop_succeeded = False
     if broadcaster is not None:
         # Deliberately do not reactivate failure_rank. Survivors must take the
-        # poisoned shutdown path and retain their unmatched receive requests.
+        # failed-epoch shutdown path and retain their unmatched receive requests.
         try:
             broadcaster.stop(timeout=5.0)
             if broadcaster.last_error is not None:
@@ -356,15 +374,15 @@ def _run_failure_propagation_smoke(world: MPI.Intracomm) -> str | None:
     if propagation_converged and stop_succeeded:
         try:
             if rank == failure_rank:
-                if broadcaster.world_is_poisoned():
-                    raise AssertionError("logical victim unexpectedly entered poisoned state")
+                if broadcaster.communicator_epoch_is_failed():
+                    raise AssertionError("logical victim unexpectedly entered a failed epoch")
                 if broadcaster._retained_requests:
                     raise AssertionError("logical victim retained healthy MPI requests")
             else:
-                if not broadcaster.world_is_poisoned():
-                    raise AssertionError("survivor lost sticky poisoned state during stop")
+                if not broadcaster.communicator_epoch_is_failed():
+                    raise AssertionError("survivor lost sticky failed-epoch state during stop")
                 if not broadcaster._retained_requests:
-                    raise AssertionError("survivor did not retain poisoned MPI requests")
+                    raise AssertionError("survivor did not retain failed-epoch MPI requests")
         except Exception:
             sticky_error = traceback.format_exc()
             error = f"{error or ''}\nsticky-poison failure:\n{sticky_error}"
@@ -394,7 +412,7 @@ def _terminal_atexit_sentinel() -> None:
 
 
 def _run_terminal_abort_smoke(world: MPI.Intracomm) -> str | None:
-    """Exercise terminal ABORT relay while keeping ``COMM_WORLD`` healthy."""
+    """Exercise terminal ABORT relay while keeping `COMM_WORLD` healthy."""
     rank = world.Get_rank()
     world_size = world.Get_size()
     mapping = _mapping(world_size, rank)
@@ -404,8 +422,9 @@ def _run_terminal_abort_smoke(world: MPI.Intracomm) -> str | None:
 
     setup_error: str | None = None
     try:
-        # Construct a fresh production communicator, then hide ULFM so this
-        # scenario specifically validates the bounded ABORT echo fallback.
+        # Construct this process's one production communicator, then hide ULFM
+        # so this scenario specifically validates the bounded ABORT echo
+        # fallback.
         owner = MpiFtSubcomm(
             mapping,
             FailureEvidenceState(world_size),
@@ -463,7 +482,7 @@ def _run_terminal_abort_smoke(world: MPI.Intracomm) -> str | None:
             local_converged = (
                 broadcaster._progress_failed.is_set()
                 and broadcaster.last_error is not None
-                and broadcaster.world_is_poisoned()
+                and broadcaster.communicator_epoch_is_failed()
                 and wrapped_comm.abort_calls == 0
             )
         except Exception:
@@ -486,8 +505,8 @@ def _run_terminal_abort_smoke(world: MPI.Intracomm) -> str | None:
     if broadcaster is not None:
         try:
             broadcaster.stop(timeout=5.0)
-            if not broadcaster.world_is_poisoned():
-                raise AssertionError("terminal FT state lost its poisoned-world latch")
+            if not broadcaster.communicator_epoch_is_failed():
+                raise AssertionError("terminal FT state lost its failed-epoch latch")
         except Exception:
             cleanup_error = traceback.format_exc()
             error = f"{error or ''}\nterminal cleanup failure:\n{cleanup_error}"
@@ -539,11 +558,10 @@ def main() -> int:
             ("invalid-topology", _run_invalid_topology_smoke),
             ("healthy-lifecycle", _run_healthy_lifecycle_smoke),
         )
+    elif mode == _PROPAGATION_MODE:
+        scenarios = (("failure-broadcast", _run_failure_propagation_smoke),)
     elif mode == _TERMINAL_MODE:
-        scenarios = (
-            ("failure-broadcast", _run_failure_propagation_smoke),
-            ("terminal-abort", _run_terminal_abort_smoke),
-        )
+        scenarios = (("terminal-abort", _run_terminal_abort_smoke),)
     else:
         if rank == 0:
             print(f"unknown WideEP MPI smoke mode: {mode!r}", file=sys.stderr)
@@ -558,16 +576,16 @@ def main() -> int:
 
 if __name__ == "__main__":
     worker_mode = sys.argv[2] if len(sys.argv) > 2 else ""
-    if worker_mode == _TERMINAL_MODE:
+    if worker_mode in (_PROPAGATION_MODE, _TERMINAL_MODE):
         # A normal interpreter shutdown would run mpi4py's Finalize hook. The
         # launcher rejects this sentinel, so the smoke independently proves that
         # the terminal path below bypassed Python atexit via os._exit().
         atexit.register(_terminal_atexit_sentinel)
     exit_code = main()
-    if worker_mode == _TERMINAL_MODE and not _WORKER_SKIPPED:
-        # This mode deliberately leaves the FT control plane terminal and
+    if worker_mode in (_PROPAGATION_MODE, _TERMINAL_MODE) and not _WORKER_SKIPPED:
+        # This mode deliberately leaves the FT detection plane terminal and
         # retains its requests. Skip mpi4py's collective MPI_Finalize just as
-        # the production poisoned-world shutdown hook will do.
+        # the production failed-epoch shutdown hook will do.
         sys.stdout.flush()
         sys.stderr.flush()
         if exit_code == 0:

--- a/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
+++ b/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
@@ -1,0 +1,2107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the WideEP MPI failure-broadcast control plane.
+
+The tests use in-memory MPI, communicator, and request doubles. They exercise
+the real progress thread without requiring mpi4py, GPUs, or a multi-rank
+launcher.
+"""
+
+from __future__ import annotations
+
+import gc
+import sys
+import threading
+import time
+import types
+import weakref
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from tensorrt_llm._torch.modules.fused_moe.ep_group_health import EPGroupHealth
+from tensorrt_llm._torch.pyexecutor import ep_failure_broadcast
+from tensorrt_llm._torch.pyexecutor.ep_failure_broadcast import MpiFtSubcomm, MpiFtSubcommConfig
+
+_TEST_CONFIG = MpiFtSubcommConfig(
+    poll_interval_sec=0.001,
+    startup_timeout_sec=0.5,
+    stop_timeout_sec=0.5,
+    reconcile_timeout_sec=2.0,
+    unattributed_error_timeout_sec=2.0,
+    abort_timeout_sec=2.0,
+)
+
+_FAILURE_MESSAGE = int(ep_failure_broadcast._MessageKind.FAILURE)
+_ABORT_MESSAGE = int(ep_failure_broadcast._MessageKind.ABORT)
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, float("nan"), float("inf"), float("-inf")])
+def test_config_requires_positive_finite_timeouts(value: float) -> None:
+    with pytest.raises(ValueError, match="must be finite and > 0"):
+        MpiFtSubcommConfig(poll_interval_sec=value)
+    with pytest.raises(ValueError, match="must be finite and > 0"):
+        MpiFtSubcommConfig(unattributed_error_timeout_sec=value)
+    with pytest.raises(ValueError, match="must be finite and > 0"):
+        MpiFtSubcommConfig(abort_timeout_sec=value)
+
+
+def test_default_poll_interval_leaves_margin_below_agreement_budget() -> None:
+    assert MpiFtSubcommConfig().poll_interval_sec == 0.01
+
+
+@dataclass(frozen=True)
+class _FakeMapping:
+    world_size: int
+    rank: int
+    moe_ep_size: int
+    moe_ep_rank: int
+    moe_ep_group: tuple[int, ...]
+
+    @classmethod
+    def ep_world(cls, size: int, rank: int = 0) -> "_FakeMapping":
+        return cls(
+            world_size=size,
+            rank=rank,
+            moe_ep_size=size,
+            moe_ep_rank=rank,
+            moe_ep_group=tuple(range(size)),
+        )
+
+
+class _FakeMpiException(RuntimeError):
+    def __init__(self, error_class: int, message: str = "fake MPI failure") -> None:
+        super().__init__(message)
+        self._error_class = error_class
+
+    def Get_error_class(self) -> int:
+        return self._error_class
+
+
+class _FakeMPI:
+    ERRORS_RETURN = object()
+    ERR_PROC_FAILED = 101
+    ERR_REVOKED = 102
+    ERR_UNSUPPORTED_OPERATION = 103
+    ERR_UNKNOWN = -1
+    THREAD_MULTIPLE = 3
+    Exception = _FakeMpiException
+
+    def __init__(self, thread_level: int = THREAD_MULTIPLE) -> None:
+        self._thread_level = thread_level
+
+    def Query_thread(self) -> int:
+        return self._thread_level
+
+
+class _FakeRequest:
+    """Controllable nonblocking request that never owns its MPI buffer."""
+
+    def __init__(self, *, completed: bool = False) -> None:
+        self._completed = threading.Event()
+        if completed:
+            self._completed.set()
+        self._error: BaseException | None = None
+        self._lock = threading.Lock()
+        self.cancel_calls = 0
+        self.test_calls = 0
+
+    def Cancel(self) -> None:
+        with self._lock:
+            self.cancel_calls += 1
+        self._completed.set()
+
+    def Test(self) -> bool:
+        with self._lock:
+            self.test_calls += 1
+            error = self._error
+        if error is not None:
+            raise error
+        return self._completed.is_set()
+
+    def complete(self) -> None:
+        self._completed.set()
+
+    def fail(self, error: BaseException) -> None:
+        with self._lock:
+            self._error = error
+
+
+class _BlockingRequest(_FakeRequest):
+    """Request whose Test call can hold the progress thread for stop tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.entered_test = threading.Event()
+        self.release_test = threading.Event()
+
+    def Test(self) -> bool:
+        self.entered_test.set()
+        self.release_test.wait()
+        return super().Test()
+
+
+class _NonCompletingCancelRequest(_FakeRequest):
+    """Cancellation request that remains incomplete until explicitly released."""
+
+    def Cancel(self) -> None:
+        with self._lock:
+            self.cancel_calls += 1
+
+
+@dataclass(frozen=True)
+class _ReceiveRecord:
+    request: _FakeRequest
+    buffer: np.ndarray
+    thread_id: int
+
+
+@dataclass(frozen=True)
+class _SendRecord:
+    request: _FakeRequest
+    buffer_ref: weakref.ReferenceType[np.ndarray]
+    destination: int
+    message_kind: int
+    payload: int
+    tag: int
+    thread_id: int
+
+
+class _FakeComm:
+    def __init__(
+        self,
+        *,
+        size: int,
+        rank: int = 0,
+        receive_factory: Callable[[int], _FakeRequest] | None = None,
+        send_factory: Callable[[int], _FakeRequest] | None = None,
+        ulfm_probe_error: BaseException | None = None,
+        ulfm_revoked: bool = False,
+        revoke_error: BaseException | None = None,
+        abort_error: BaseException | None = None,
+    ) -> None:
+        self._size = size
+        self._rank = rank
+        self._receive_factory = receive_factory or (lambda _source: _FakeRequest())
+        self._send_factory = send_factory or (lambda _destination: _FakeRequest())
+        self._ulfm_probe_error = ulfm_probe_error
+        self._ulfm_revoked = ulfm_revoked
+        self._revoke_error = revoke_error
+        self._abort_error = abort_error
+        self._lock = threading.Lock()
+        self._receives: dict[int, list[_ReceiveRecord]] = defaultdict(list)
+        self._sends: list[_SendRecord] = []
+        self.errhandler: object | None = None
+        self.errhandler_calls = 0
+        self.is_revoked_calls = 0
+        self.revoke_calls = 0
+        self.abort_calls = 0
+
+    def Get_rank(self) -> int:
+        return self._rank
+
+    def Get_size(self) -> int:
+        return self._size
+
+    def Set_errhandler(self, errhandler: object) -> None:
+        self.errhandler_calls += 1
+        self.errhandler = errhandler
+
+    def Is_revoked(self) -> bool:
+        self.is_revoked_calls += 1
+        if self._ulfm_probe_error is not None:
+            raise self._ulfm_probe_error
+        return self._ulfm_revoked
+
+    def Revoke(self) -> None:
+        self.revoke_calls += 1
+        if self._revoke_error is not None:
+            raise self._revoke_error
+
+    def Abort(self, _errorcode: int) -> None:
+        self.abort_calls += 1
+        if self._abort_error is not None:
+            raise self._abort_error
+
+    def Irecv(self, buffer: np.ndarray, source: int, tag: int) -> _FakeRequest:
+        del tag
+        request = self._receive_factory(source)
+        record = _ReceiveRecord(
+            request=request,
+            buffer=buffer,
+            thread_id=threading.get_ident(),
+        )
+        with self._lock:
+            self._receives[source].append(record)
+        return request
+
+    def Isend(self, buffer: np.ndarray, dest: int, tag: int) -> _FakeRequest:
+        request = self._send_factory(dest)
+        record = _SendRecord(
+            request=request,
+            buffer_ref=weakref.ref(buffer),
+            destination=dest,
+            message_kind=int(buffer[0]),
+            payload=int(buffer[1]),
+            tag=tag,
+            thread_id=threading.get_ident(),
+        )
+        with self._lock:
+            self._sends.append(record)
+        return request
+
+    def receive_count(self, source: int) -> int:
+        with self._lock:
+            return len(self._receives[source])
+
+    def latest_receive(self, source: int) -> _ReceiveRecord:
+        with self._lock:
+            return self._receives[source][-1]
+
+    def deliver(
+        self,
+        source: int,
+        failed_rank: int,
+        *,
+        message_kind: int = _FAILURE_MESSAGE,
+    ) -> None:
+        record = self.latest_receive(source)
+        record.buffer[:] = (message_kind, failed_rank)
+        record.request.complete()
+
+    @property
+    def sends(self) -> tuple[_SendRecord, ...]:
+        with self._lock:
+            return tuple(self._sends)
+
+
+def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 1.0,
+    description: str = "condition",
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.001)
+    raise AssertionError(f"timed out waiting for {description}")
+
+
+def _make_broadcaster(
+    *,
+    size: int = 4,
+    rank: int = 0,
+    health: EPGroupHealth | None = None,
+    comm: _FakeComm | None = None,
+    mpi: _FakeMPI | None = None,
+    callback: Callable[[int, int, float], None] | None = None,
+) -> tuple[MpiFtSubcomm, EPGroupHealth, _FakeComm, _FakeMPI]:
+    health = health or EPGroupHealth(size)
+    comm = comm or _FakeComm(size=size, rank=rank)
+    mpi = mpi or _FakeMPI()
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(size, rank),
+        health,
+        _TEST_CONFIG,
+        callback,
+        comm=comm,
+        mpi_module=mpi,
+    )
+    return broadcaster, health, comm, mpi
+
+
+def test_nonblocking_fanout_announces_externally_premarked_rank() -> None:
+    """The watchdog's prior local mark must not suppress cross-rank fanout."""
+    health = EPGroupHealth(4)
+    assert health.mark_failed(2) is True
+    broadcaster, _, comm, _ = _make_broadcaster(health=health)
+    broadcaster.start()
+    caller_thread = threading.get_ident()
+    try:
+        assert broadcaster.broadcast_failure(2) is False
+        _wait_until(lambda: len(comm.sends) == 2, description="failure fanout")
+        _wait_until(
+            lambda: all(record.request.test_calls > 0 for record in comm.sends),
+            description="send request polling",
+        )
+
+        assert {record.destination for record in comm.sends} == {1, 3}
+        assert {record.payload for record in comm.sends} == {2}
+        assert all(record.thread_id != caller_thread for record in comm.sends)
+        assert all(record.request.test_calls > 0 for record in comm.sends)
+        assert all(record.buffer_ref() is not None for record in comm.sends)
+
+        # A repeated detector report is locally coalesced.
+        assert broadcaster.pre_failover(2) is False
+        time.sleep(2 * _TEST_CONFIG.poll_interval_sec)
+        assert len(comm.sends) == 2
+
+        for send in comm.sends:
+            send.request.complete()
+        comm.deliver(source=1, failed_rank=2)
+        comm.deliver(source=3, failed_rank=2)
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+    finally:
+        broadcaster.stop()
+
+
+def test_survivor_echoes_reconcile_failure_before_next_collective() -> None:
+    broadcaster, _, comm, _ = _make_broadcaster(size=4)
+    broadcaster.start()
+    try:
+        assert broadcaster.pre_failover(2) is True
+        assert broadcaster.failure_is_reconciled(2) is False
+        _wait_until(lambda: len(comm.sends) == 2, description="initial failure fanout")
+
+        comm.deliver(source=1, failed_rank=2)
+        _wait_until(
+            lambda: comm.receive_count(1) == 2,
+            description="source 1 receive repost",
+        )
+        assert broadcaster.failure_is_reconciled(2) is False
+
+        comm.deliver(source=3, failed_rank=2)
+        for send in comm.sends:
+            send.request.complete()
+        _wait_until(
+            lambda: broadcaster.failure_is_reconciled(2),
+            description="all survivor echoes",
+        )
+        time.sleep(2 * _TEST_CONFIG.poll_interval_sec)
+        assert len(comm.sends) == 2
+        assert {send.destination for send in comm.sends} == {1, 3}
+        assert all(send.message_kind == _FAILURE_MESSAGE for send in comm.sends)
+        assert broadcaster.health_is_reconciled() is True
+        assert comm.revoke_calls == 0
+    finally:
+        broadcaster.stop()
+
+
+def test_rank_reactivation_cannot_reopen_reconciliation_for_same_comm_epoch() -> None:
+    broadcaster, health, comm, _ = _make_broadcaster(size=3)
+    broadcaster.start()
+    try:
+        assert broadcaster.pre_failover(2) is True
+        _wait_until(lambda: len(comm.sends) == 1, description="failure fanout")
+        comm.sends[0].request.complete()
+        comm.deliver(source=1, failed_rank=2)
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+
+        assert health.mark_active(2) is True
+        _wait_until(
+            lambda: isinstance(broadcaster.last_error, RuntimeError),
+            description="reactivated-rank terminal handling",
+        )
+        _wait_until(lambda: comm.revoke_calls == 1, description="epoch-violation revoke")
+        assert broadcaster.world_is_poisoned() is True
+        assert broadcaster.failure_is_reconciled(2) is False
+        assert broadcaster.health_is_reconciled() is False
+
+        # Even restoring the failed bit cannot restore the old consensus: the
+        # intervening generation change belongs to a future communicator epoch.
+        assert health.mark_failed(2) is True
+        assert broadcaster.world_is_poisoned() is True
+        assert broadcaster.failure_is_reconciled(2) is False
+        assert broadcaster.health_is_reconciled() is False
+    finally:
+        broadcaster.stop()
+
+
+def test_reactivation_between_failure_claim_and_observe_cannot_become_epoch_baseline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    health = EPGroupHealth(2)
+    assert health.mark_failed(1) is True
+    broadcaster, _, _, _ = _make_broadcaster(size=2, health=health)
+    original_claim = broadcaster._claim_failure
+    mutated = False
+
+    def claim_then_turn_over_epoch(failed_rank: int) -> None:
+        nonlocal mutated
+        original_claim(failed_rank)
+        if not mutated:
+            mutated = True
+            assert health.mark_active(failed_rank) is True
+            assert health.mark_failed(failed_rank) is True
+
+    monkeypatch.setattr(broadcaster, "_claim_failure", claim_then_turn_over_epoch)
+    broadcaster.start()
+    try:
+        assert broadcaster.broadcast_failure(1) is False
+        _wait_until(
+            lambda: 1 in broadcaster._failure_fanout_complete,
+            description="single-survivor fanout completion",
+        )
+        assert health.generation == 3
+        _wait_until(
+            lambda: isinstance(broadcaster.last_error, RuntimeError),
+            description="turnover terminal handling",
+        )
+        assert broadcaster.failure_is_reconciled(1) is False
+        assert broadcaster.health_is_reconciled() is False
+    finally:
+        broadcaster.stop()
+
+
+def test_second_failure_between_claim_and_observe_cannot_open_single_failure_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    health = EPGroupHealth(3)
+    broadcaster, _, _, _ = _make_broadcaster(size=3, health=health)
+    original_claim = broadcaster._claim_failure
+    mutated = False
+
+    def claim_then_add_second_failure(failed_rank: int) -> None:
+        nonlocal mutated
+        original_claim(failed_rank)
+        if not mutated:
+            mutated = True
+            assert health.mark_failed(1) is True
+
+    monkeypatch.setattr(broadcaster, "_claim_failure", claim_then_add_second_failure)
+    broadcaster.start()
+    try:
+        assert broadcaster.broadcast_failure(2) is True
+        _wait_until(
+            lambda: 2 in broadcaster._failure_fanout_complete,
+            description="single-survivor fanout completion",
+        )
+        assert health.get_failed_ranks() == frozenset({1, 2})
+        _wait_until(
+            lambda: isinstance(broadcaster.last_error, RuntimeError),
+            description="second-health-failure terminal handling",
+        )
+        assert broadcaster.failure_is_reconciled(2) is False
+        assert broadcaster.health_is_reconciled() is False
+    finally:
+        broadcaster.stop()
+
+
+def test_reconciliation_timeout_fails_closed_while_mpi_test_is_wedged() -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.02,
+    )
+    blocking_request = _BlockingRequest()
+    comm = _FakeComm(
+        size=3,
+        receive_factory=lambda source: blocking_request if source == 1 else _FakeRequest(),
+    )
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(3),
+        EPGroupHealth(3),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    _wait_until(blocking_request.entered_test.is_set, description="blocked MPI progress")
+    assert broadcaster.pre_failover(2) is True
+    assert blocking_request.release_test.is_set() is False
+    assert broadcaster._outbound_reports.empty() is False
+
+    _wait_until(
+        lambda: isinstance(broadcaster.last_error, TimeoutError),
+        description="terminal reconciliation timeout",
+    )
+    _wait_until(lambda: comm.revoke_calls == 1, description="deadline-monitor revoke")
+    assert blocking_request.release_test.is_set() is False
+    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.world_is_poisoned() is True
+    with pytest.raises(RuntimeError, match="not running"):
+        broadcaster.pre_failover(1)
+    blocking_request.release_test.set()
+    broadcaster.stop()
+
+
+def test_reconciliation_timeout_world_aborts_when_mpi_test_is_wedged_without_ulfm() -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.01,
+        abort_timeout_sec=0.01,
+    )
+    blocking_request = _BlockingRequest()
+    comm = _FakeComm(
+        size=3,
+        receive_factory=lambda source: blocking_request if source == 1 else _FakeRequest(),
+        ulfm_probe_error=NotImplementedError(),
+    )
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(3),
+        EPGroupHealth(3),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    _wait_until(blocking_request.entered_test.is_set, description="blocked MPI progress")
+    assert broadcaster.pre_failover(2) is True
+
+    _wait_until(lambda: comm.abort_calls == 1, description="deadline-monitor MPI_Abort")
+    assert blocking_request.release_test.is_set() is False
+    assert isinstance(broadcaster.last_error, TimeoutError)
+    assert broadcaster.world_is_poisoned() is True
+
+    blocking_request.release_test.set()
+    broadcaster.stop()
+
+
+def test_second_distinct_local_failure_fails_closed_before_health_mutation() -> None:
+    broadcaster, health, comm, _ = _make_broadcaster(size=4)
+    broadcaster.start()
+    assert broadcaster.pre_failover(3) is True
+
+    with pytest.raises(RuntimeError, match="exactly one distinct failed rank") as raised:
+        broadcaster.pre_failover(2)
+
+    assert health.get_failed_ranks() == frozenset({3})
+    _wait_until(lambda: broadcaster.last_error is raised.value, description="terminal failure")
+    _wait_until(lambda: comm.revoke_calls == 1, description="progress-thread abort revoke")
+    assert broadcaster.health_is_reconciled() is False
+    with pytest.raises(RuntimeError, match="not running"):
+        broadcaster.pre_failover(1)
+    broadcaster.stop()
+
+
+def test_no_ulfm_terminal_abort_relays_and_converges_without_world_abort() -> None:
+    comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
+    broadcaster, health, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster.start()
+    assert broadcaster.pre_failover(2) is True
+    with pytest.raises(RuntimeError, match="exactly one distinct failed rank"):
+        broadcaster.pre_failover(1)
+
+    _wait_until(
+        lambda: any(send.message_kind == _ABORT_MESSAGE for send in comm.sends),
+        description="terminal ABORT relay",
+    )
+    for send in comm.sends:
+        if send.message_kind == _ABORT_MESSAGE:
+            send.request.complete()
+    comm.deliver(source=1, failed_rank=1, message_kind=_ABORT_MESSAGE)
+    _wait_until(broadcaster._progress_failed.is_set, description="ABORT convergence")
+
+    assert health.get_failed_ranks() == frozenset({2})
+    assert comm.abort_calls == 0
+    assert comm.revoke_calls == 0
+    broadcaster.stop()
+
+
+def test_remote_conflicting_failure_relays_abort_before_world_abort() -> None:
+    comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
+    broadcaster, health, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster.start()
+    assert broadcaster.pre_failover(2) is True
+    _wait_until(
+        lambda: any(send.message_kind == _FAILURE_MESSAGE for send in comm.sends),
+        description="first failure fanout",
+    )
+    _wait_until(lambda: comm.receive_count(1) == 1, description="conflicting report receive")
+    comm.deliver(source=1, failed_rank=1)
+
+    _wait_until(
+        lambda: any(send.message_kind == _ABORT_MESSAGE for send in comm.sends),
+        description="remote-conflict ABORT relay",
+    )
+    assert comm.abort_calls == 0
+    for send in comm.sends:
+        if send.message_kind == _ABORT_MESSAGE:
+            send.request.complete()
+    _wait_until(lambda: comm.receive_count(1) == 2, description="survivor ABORT receive")
+    comm.deliver(source=1, failed_rank=1, message_kind=_ABORT_MESSAGE)
+    _wait_until(broadcaster._progress_failed.is_set, description="remote-conflict convergence")
+
+    assert health.get_failed_ranks() == frozenset({2})
+    assert isinstance(broadcaster.last_error, RuntimeError)
+    assert "exactly one distinct failed rank" in str(broadcaster.last_error)
+    assert comm.abort_calls == 0
+    broadcaster.stop()
+
+
+def test_reconciled_terminal_abort_at_deadline_does_not_world_abort() -> None:
+    comm = _FakeComm(size=1, ulfm_probe_error=NotImplementedError())
+    broadcaster, _, _, _ = _make_broadcaster(size=1, comm=comm)
+    broadcaster._request_terminal_abort(RuntimeError("terminal"), -1, 0)
+    broadcaster._drain_outbound_reports([])
+    with broadcaster._protocol_lock:
+        broadcaster._abort_deadline = time.monotonic() - 1.0
+
+    assert broadcaster._progress_terminal_abort() is True
+    assert comm.abort_calls == 0
+    broadcaster.stop()
+
+
+def test_monitor_does_not_world_abort_reconciled_relay_when_mpi_test_resumes() -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.2,
+        abort_timeout_sec=0.2,
+    )
+    blocking_request = _BlockingRequest()
+    comm = _FakeComm(
+        size=2,
+        receive_factory=lambda _source: blocking_request,
+        ulfm_probe_error=NotImplementedError(),
+    )
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(2),
+        EPGroupHealth(2),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    _wait_until(blocking_request.entered_test.is_set, description="blocked MPI progress")
+    broadcaster._request_terminal_abort(RuntimeError("terminal"), -1, 0)
+    with broadcaster._protocol_lock:
+        broadcaster._abort_reporters.add(1)
+        broadcaster._abort_fanout_posted = True
+        broadcaster._abort_fanout_complete = True
+    broadcaster._deadline_monitor_wake_event.set()
+
+    _wait_until(
+        lambda: broadcaster._deadline_monitor_thread is not None
+        and not broadcaster._deadline_monitor_thread.is_alive(),
+        description="monitor-observed terminal reconciliation",
+    )
+    assert broadcaster._progress_failed.is_set() is False
+    assert comm.abort_calls == 0
+
+    blocking_request.release_test.set()
+    _wait_until(broadcaster._progress_failed.is_set, description="clean terminal progress stop")
+    broadcaster.stop()
+    assert comm.abort_calls == 0
+
+
+def test_terminal_abort_waits_until_its_relay_completes() -> None:
+    comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
+    broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster._handle_received_abort(-1, 1)
+    broadcaster._handle_received_abort(-1, 2)
+
+    assert broadcaster._progress_terminal_abort() is False
+    pending_sends: list[ep_failure_broadcast._PendingSend] = []
+    broadcaster._drain_outbound_reports(pending_sends)
+    assert {send.destination for send in comm.sends} == {1, 2}
+    broadcaster._progress_sends(pending_sends)
+    assert broadcaster._progress_terminal_abort() is False
+
+    for send in comm.sends:
+        send.request.complete()
+    broadcaster._progress_sends(pending_sends)
+    assert pending_sends == []
+    assert broadcaster._progress_terminal_abort() is True
+    assert comm.abort_calls == 0
+    broadcaster.stop()
+
+
+def test_received_terminal_abort_is_relayed_without_mutating_health() -> None:
+    comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
+    broadcaster, health, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster.start()
+    _wait_until(lambda: comm.receive_count(1) == 1, description="source 1 receive")
+    comm.deliver(source=1, failed_rank=2, message_kind=_ABORT_MESSAGE)
+
+    _wait_until(
+        lambda: len([send for send in comm.sends if send.message_kind == _ABORT_MESSAGE]) == 2,
+        description="relayed terminal ABORT",
+    )
+    for send in comm.sends:
+        if send.message_kind == _ABORT_MESSAGE:
+            send.request.complete()
+    _wait_until(lambda: comm.receive_count(2) == 1, description="source 2 receive")
+    comm.deliver(source=2, failed_rank=2, message_kind=_ABORT_MESSAGE)
+    _wait_until(broadcaster._progress_failed.is_set, description="peer ABORT convergence")
+
+    assert health.all_active() is True
+    assert isinstance(broadcaster.last_error, RuntimeError)
+    assert broadcaster.world_is_poisoned() is True
+    assert comm.abort_calls == 0
+    broadcaster.stop()
+    assert broadcaster.world_is_poisoned() is True
+
+
+def test_no_ulfm_abort_timeout_uses_world_abort_before_stop_completes() -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.2,
+        abort_timeout_sec=0.02,
+    )
+    comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(3),
+        EPGroupHealth(3),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    assert broadcaster.pre_failover(2) is True
+    with pytest.raises(RuntimeError, match="exactly one distinct failed rank"):
+        broadcaster.pre_failover(1)
+
+    # stop_event must not let the progress loop skip the pending ABORT fallback.
+    broadcaster.stop(timeout=0.5)
+    assert comm.abort_calls == 1
+    assert comm.revoke_calls == 0
+
+
+def test_stop_cannot_bypass_abort_requested_during_blocked_drain() -> None:
+    send_entered = threading.Event()
+    release_send = threading.Event()
+
+    def blocking_send(_destination: int) -> _FakeRequest:
+        send_entered.set()
+        release_send.wait()
+        return _FakeRequest()
+
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.2,
+        abort_timeout_sec=0.02,
+    )
+    comm = _FakeComm(
+        size=3,
+        send_factory=blocking_send,
+        ulfm_probe_error=NotImplementedError(),
+    )
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(3),
+        EPGroupHealth(3),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    _wait_until(lambda: comm.receive_count(1) == 1, description="terminal receive")
+    comm.deliver(source=1, failed_rank=-1, message_kind=_ABORT_MESSAGE)
+    _wait_until(send_entered.is_set, description="blocked ABORT drain")
+
+    stop_errors: list[BaseException] = []
+
+    def stop_broadcaster() -> None:
+        try:
+            broadcaster.stop(timeout=0.5)
+        except BaseException as error:
+            stop_errors.append(error)
+
+    stop_thread = threading.Thread(target=stop_broadcaster)
+    stop_thread.start()
+    _wait_until(broadcaster._stop_event.is_set, description="stop during ABORT drain")
+    release_send.set()
+    stop_thread.join(timeout=1.0)
+
+    assert stop_thread.is_alive() is False
+    assert stop_errors == []
+    assert comm.abort_calls == 1
+    assert broadcaster._progress_failed.is_set()
+
+
+def test_concurrent_local_and_remote_distinct_failures_accept_only_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broadcaster, health, comm, _ = _make_broadcaster(size=4)
+    broadcaster.start()
+    _wait_until(lambda: comm.receive_count(1) == 1, description="remote receive")
+
+    original_claim = broadcaster._claim_failure
+    local_claimed = threading.Event()
+    release_local_claim = threading.Event()
+
+    def racing_claim(failed_rank: int) -> None:
+        original_claim(failed_rank)
+        if failed_rank == 2:
+            local_claimed.set()
+            release_local_claim.wait()
+
+    monkeypatch.setattr(broadcaster, "_claim_failure", racing_claim)
+    local_errors: list[BaseException] = []
+
+    def report_local_failure() -> None:
+        try:
+            broadcaster.pre_failover(2)
+        except BaseException as error:
+            local_errors.append(error)
+
+    local_thread = threading.Thread(target=report_local_failure)
+    local_thread.start()
+    _wait_until(local_claimed.is_set, description="local failure claim")
+    comm.deliver(source=1, failed_rank=3)
+    # The remote handler must wait for the local lifecycle transaction to commit
+    # its accepted rank and health generation atomically.
+    time.sleep(2 * _TEST_CONFIG.poll_interval_sec)
+    assert health.all_active() is True
+    release_local_claim.set()
+    local_thread.join(timeout=1.0)
+    assert local_thread.is_alive() is False
+
+    _wait_until(lambda: broadcaster.last_error is not None, description="second-failure rejection")
+    _wait_until(lambda: comm.revoke_calls == 1, description="terminal abort revoke")
+    assert len(health.get_failed_ranks()) == 1
+    assert health.get_failed_ranks() == frozenset({2})
+    assert "exactly one distinct failed rank" in str(broadcaster.last_error)
+    assert local_errors == []
+    broadcaster.stop()
+
+
+def test_isend_post_error_to_survivor_is_terminal_without_ulfm() -> None:
+    error = _FakeMpiException(999, "send post failed")
+
+    def fail_send(_destination: int) -> _FakeRequest:
+        raise error
+
+    comm = _FakeComm(
+        size=3,
+        send_factory=fail_send,
+        ulfm_probe_error=NotImplementedError(),
+    )
+    broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster.start()
+    assert broadcaster.pre_failover(2) is True
+
+    _wait_until(lambda: broadcaster.last_error is error, description="terminal Isend error")
+    assert broadcaster.health_is_reconciled() is False
+    assert comm.revoke_calls == 0
+    assert comm.sends == ()
+    broadcaster.stop()
+
+
+def test_send_test_error_is_terminal_and_revokes_with_ulfm() -> None:
+    error = _FakeMpiException(999, "send Test failed")
+    failed_request = _FakeRequest()
+    failed_request.fail(error)
+    comm = _FakeComm(size=3, send_factory=lambda _destination: failed_request)
+    broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster.start()
+    assert broadcaster.pre_failover(2) is True
+
+    _wait_until(lambda: broadcaster.last_error is error, description="terminal send Test error")
+    _wait_until(lambda: comm.revoke_calls == 1, description="ULFM emergency revoke")
+    assert broadcaster.health_is_reconciled() is False
+    assert failed_request.cancel_calls == 0
+    assert broadcaster._retained_requests
+    broadcaster.stop()
+
+
+def test_received_report_is_idempotent_and_callback_runs_once() -> None:
+    callbacks: list[tuple[int, int, float]] = []
+    broadcaster, health, comm, _ = _make_broadcaster(
+        size=3,
+        callback=lambda failed, source, when: callbacks.append((failed, source, when)),
+    )
+    broadcaster.start()
+    try:
+        _wait_until(lambda: comm.receive_count(1) == 1, description="initial receive")
+        comm.deliver(source=1, failed_rank=2)
+        _wait_until(lambda: health.is_active(2) is False, description="received failure")
+        _wait_until(lambda: comm.receive_count(1) == 2, description="reposted receive")
+
+        comm.deliver(source=1, failed_rank=2)
+        _wait_until(lambda: comm.receive_count(1) == 3, description="duplicate receive progress")
+        _wait_until(lambda: len(callbacks) == 1, description="failure callback")
+
+        assert health.generation == 1
+        assert len(callbacks) == 1
+        failed_rank, source, event_time = callbacks[0]
+        assert (failed_rank, source) == (2, 1)
+        assert isinstance(event_time, float)
+        _wait_until(lambda: len(comm.sends) == 1, description="failure relay")
+        comm.sends[0].request.complete()
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+    finally:
+        broadcaster.stop()
+
+
+def test_monitor_cannot_observe_remote_claim_before_health_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broadcaster, health, comm, _ = _make_broadcaster(size=3)
+    original_claim = broadcaster._claim_failure
+    claim_entered = threading.Event()
+    release_claim = threading.Event()
+
+    def claim_then_pause(failed_rank: int) -> None:
+        original_claim(failed_rank)
+        claim_entered.set()
+        release_claim.wait()
+
+    monkeypatch.setattr(broadcaster, "_claim_failure", claim_then_pause)
+    broadcaster.start()
+    try:
+        comm.deliver(source=1, failed_rank=2)
+        _wait_until(claim_entered.is_set, description="paused remote failure claim")
+        time.sleep(3 * _TEST_CONFIG.poll_interval_sec)
+
+        assert health.is_active(2) is True
+        assert broadcaster.last_error is None
+        assert comm.revoke_calls == 0
+
+        release_claim.set()
+        _wait_until(lambda: not health.is_active(2), description="committed remote failure")
+        _wait_until(lambda: len(comm.sends) == 1, description="remote failure echo")
+        comm.sends[0].request.complete()
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+    finally:
+        release_claim.set()
+        broadcaster.stop()
+
+
+def test_blocking_callback_does_not_block_mpi_progress_and_stop_is_bounded() -> None:
+    callback_entered = threading.Event()
+    release_callback = threading.Event()
+
+    def blocking_callback(_failed: int, _source: int, _when: float) -> None:
+        callback_entered.set()
+        release_callback.wait()
+
+    broadcaster, health, comm, _ = _make_broadcaster(
+        size=3,
+        callback=blocking_callback,
+    )
+    broadcaster.start()
+    _wait_until(lambda: comm.receive_count(1) == 1, description="initial receive")
+    comm.deliver(source=1, failed_rank=2)
+    _wait_until(callback_entered.is_set, description="blocking callback")
+    _wait_until(lambda: len(comm.sends) == 1, description="failure relay")
+    comm.sends[0].request.complete()
+
+    # The MPI thread must repost and continue polling while user telemetry is blocked.
+    _wait_until(lambda: comm.receive_count(1) == 2, description="receive repost")
+    comm.deliver(source=1, failed_rank=2)
+    _wait_until(lambda: comm.receive_count(1) == 3, description="duplicate receive progress")
+    assert health.get_failed_ranks() == frozenset({2})
+
+    start = time.monotonic()
+    with pytest.raises(TimeoutError, match="callback thread did not stop"):
+        broadcaster.stop(timeout=0.02)
+    assert time.monotonic() - start < 0.2
+    assert broadcaster.last_error is None
+    assert broadcaster.world_is_poisoned() is True
+
+    release_callback.set()
+    broadcaster.stop(timeout=0.5)
+
+
+def test_invalid_received_rank_is_ignored_and_receive_is_reposted() -> None:
+    callbacks: list[tuple[int, int, float]] = []
+    broadcaster, health, comm, _ = _make_broadcaster(
+        size=3,
+        callback=lambda failed, source, when: callbacks.append((failed, source, when)),
+    )
+    broadcaster.start()
+    try:
+        _wait_until(lambda: comm.receive_count(1) == 1, description="initial receive")
+        comm.deliver(source=1, failed_rank=99)
+        _wait_until(lambda: comm.receive_count(1) == 2, description="receive after invalid payload")
+
+        assert health.all_active() is True
+        assert callbacks == []
+        assert broadcaster.last_error is None
+    finally:
+        broadcaster.stop()
+
+
+def test_single_rank_group_has_no_peer_requests_or_sends() -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.02,
+        abort_timeout_sec=0.02,
+    )
+    comm = _FakeComm(size=1, ulfm_probe_error=NotImplementedError())
+    health = EPGroupHealth(1)
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(1),
+        health,
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    try:
+        assert broadcaster.broadcast_failure(0) is True
+        _wait_until(broadcaster._outbound_reports.empty, description="empty single-rank report")
+        assert health.get_failed_ranks() == frozenset({0})
+        assert broadcaster.world_is_poisoned() is True
+        assert broadcaster.failure_is_reconciled(0) is False
+        assert broadcaster.health_is_reconciled() is False
+        assert comm.sends == ()
+        assert comm.receive_count(0) == 0
+        _wait_until(
+            lambda: isinstance(broadcaster.last_error, TimeoutError),
+            description="empty-survivor terminal handling",
+        )
+    finally:
+        broadcaster.stop()
+
+
+def test_lifecycle_is_not_restartable_and_stop_before_start_is_terminal() -> None:
+    stopped, _, _, _ = _make_broadcaster(size=1)
+    stopped.stop()
+    stopped.stop()
+    with pytest.raises(RuntimeError, match="cannot start from stopped"):
+        stopped.start()
+
+    running, _, _, _ = _make_broadcaster(size=1)
+    running.start()
+    try:
+        with pytest.raises(RuntimeError, match="cannot start from running"):
+            running.start()
+    finally:
+        running.stop()
+    with pytest.raises(RuntimeError, match="cannot start from stopped"):
+        running.start()
+
+
+@pytest.mark.parametrize(
+    "failing_thread_name",
+    [
+        "wide-ep-ft-callback",
+        "wide-ep-ft-deadline-monitor",
+        "wide-ep-ft-broadcast",
+    ],
+    ids=["callback", "deadline-monitor", "progress"],
+)
+def test_thread_start_failure_is_terminal_and_stoppable(
+    monkeypatch: pytest.MonkeyPatch,
+    failing_thread_name: str,
+) -> None:
+    registry = ep_failure_broadcast._PROCESS_LIFETIME_REFS
+    initial_registry_size = len(registry)
+    original_start = threading.Thread.start
+    start_error = OSError(f"cannot start {failing_thread_name}")
+
+    def failing_start(thread: threading.Thread) -> None:
+        if thread.name == failing_thread_name:
+            raise start_error
+        original_start(thread)
+
+    monkeypatch.setattr(threading.Thread, "start", failing_start)
+    comm = _FakeComm(size=2)
+    broadcaster, _, _, _ = _make_broadcaster(
+        size=2,
+        comm=comm,
+        callback=lambda _failed, _source, _when: None,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="thread failed to start") as raised:
+            broadcaster.start()
+
+        assert raised.value.__cause__ is start_error
+        assert broadcaster.last_error is start_error
+        assert broadcaster._progress_failed.is_set()
+        assert broadcaster._thread is None
+        assert comm.revoke_calls == 1
+        if failing_thread_name == "wide-ep-ft-callback":
+            assert broadcaster._callback_thread is None
+            assert broadcaster._deadline_monitor_thread is None
+        elif failing_thread_name == "wide-ep-ft-deadline-monitor":
+            assert broadcaster._callback_thread is not None
+            assert broadcaster._callback_thread.is_alive() is False
+            assert broadcaster._deadline_monitor_thread is None
+        else:
+            assert broadcaster._callback_thread is not None
+            assert broadcaster._callback_thread.is_alive() is False
+            assert broadcaster._deadline_monitor_thread is not None
+            assert broadcaster._deadline_monitor_thread.is_alive() is False
+
+        # A failed start must not leave an unstarted Thread object that stop()
+        # later attempts to join.
+        broadcaster.stop()
+    finally:
+        del registry[initial_registry_size:]
+
+
+def test_concurrent_stop_prevents_start_from_publishing_running() -> None:
+    receive_entered = threading.Event()
+    release_receive = threading.Event()
+
+    def blocking_receive(_source: int) -> _FakeRequest:
+        receive_entered.set()
+        release_receive.wait()
+        return _FakeRequest()
+
+    comm = _FakeComm(size=2, receive_factory=blocking_receive)
+    broadcaster, _, _, _ = _make_broadcaster(size=2, comm=comm)
+    start_errors: list[BaseException] = []
+    stop_errors: list[BaseException] = []
+
+    def start_broadcaster() -> None:
+        try:
+            broadcaster.start()
+        except BaseException as error:
+            start_errors.append(error)
+
+    def stop_broadcaster() -> None:
+        try:
+            broadcaster.stop(timeout=0.5)
+        except BaseException as error:
+            stop_errors.append(error)
+
+    start_thread = threading.Thread(target=start_broadcaster)
+    start_thread.start()
+    _wait_until(receive_entered.is_set, description="blocked startup receive")
+    stop_thread = threading.Thread(target=stop_broadcaster)
+    stop_thread.start()
+    _wait_until(broadcaster._stop_event.is_set, description="concurrent stop")
+    release_receive.set()
+
+    start_thread.join(timeout=1.0)
+    stop_thread.join(timeout=1.0)
+    assert start_thread.is_alive() is False
+    assert stop_thread.is_alive() is False
+    assert len(start_errors) == 1
+    assert "did not reach running state" in str(start_errors[0])
+    assert stop_errors == []
+    assert broadcaster.health_is_reconciled() is False
+
+
+def test_startup_failure_publishes_error_before_failed_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    comm = _FakeComm(size=1)
+    broadcaster, _, _, _ = _make_broadcaster(size=1, comm=comm)
+    error = _FakeMpiException(999, "forced startup failure")
+    record_entered = threading.Event()
+    release_record = threading.Event()
+    original_record_error = broadcaster._record_error
+
+    def blocked_record_error(recorded_error: BaseException) -> None:
+        record_entered.set()
+        release_record.wait()
+        original_record_error(recorded_error)
+
+    def failing_progress_loop() -> None:
+        broadcaster._fail_closed_immediately(error)
+        broadcaster._ready_event.set()
+
+    monkeypatch.setattr(broadcaster, "_record_error", blocked_record_error)
+    monkeypatch.setattr(broadcaster, "_progress_loop", failing_progress_loop)
+    start_errors: list[BaseException] = []
+
+    def start_broadcaster() -> None:
+        try:
+            broadcaster.start()
+        except BaseException as start_error:
+            start_errors.append(start_error)
+
+    start_thread = threading.Thread(target=start_broadcaster)
+    start_thread.start()
+    _wait_until(record_entered.is_set, description="blocked terminal publication")
+    assert broadcaster._progress_failed.is_set() is False
+    assert broadcaster.last_error is None
+    release_record.set()
+    start_thread.join(timeout=1.0)
+
+    assert start_thread.is_alive() is False
+    assert len(start_errors) == 1
+    assert "failed during startup" in str(start_errors[0])
+    assert broadcaster.last_error is error
+    assert broadcaster._progress_failed.is_set()
+    assert comm.revoke_calls == 1
+
+
+def test_startup_timeout_fails_closed_before_progress_resumes() -> None:
+    receive_entered = threading.Event()
+    release_receive = threading.Event()
+
+    def blocking_receive(_source: int) -> _FakeRequest:
+        receive_entered.set()
+        release_receive.wait()
+        return _FakeRequest()
+
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.02,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.2,
+        abort_timeout_sec=0.02,
+    )
+    comm = _FakeComm(
+        size=2,
+        receive_factory=blocking_receive,
+        ulfm_probe_error=NotImplementedError(),
+    )
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(2),
+        EPGroupHealth(2),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    start_errors: list[BaseException] = []
+
+    def start_broadcaster() -> None:
+        try:
+            broadcaster.start()
+        except BaseException as error:
+            start_errors.append(error)
+
+    start_thread = threading.Thread(target=start_broadcaster)
+    start_thread.start()
+    _wait_until(receive_entered.is_set, description="blocked startup")
+    start_thread.join(timeout=1.0)
+
+    assert start_thread.is_alive() is False
+    assert len(start_errors) == 1
+    assert isinstance(start_errors[0], TimeoutError)
+    assert "did not start" in str(start_errors[0])
+    assert broadcaster._abort_requested.is_set() is False
+    assert isinstance(broadcaster.last_error, TimeoutError)
+    # The progress thread is still blocked in Irecv, so the caller thread must
+    # execute the no-ULFM fail-stop fallback before start() returns.
+    assert release_receive.is_set() is False
+    assert comm.abort_calls == 1
+    release_receive.set()
+    broadcaster.stop(timeout=0.5)
+    assert comm.abort_calls == 1
+
+
+def test_startup_timeout_stops_callback_before_blocked_receive_is_released() -> None:
+    receive_entered = threading.Event()
+    release_receive = threading.Event()
+
+    def blocking_receive(_source: int) -> _FakeRequest:
+        receive_entered.set()
+        release_receive.wait()
+        return _FakeRequest()
+
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.02,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.2,
+        unattributed_error_timeout_sec=0.2,
+        abort_timeout_sec=0.02,
+    )
+    comm = _FakeComm(
+        size=2,
+        receive_factory=blocking_receive,
+        ulfm_probe_error=NotImplementedError(),
+    )
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(2),
+        EPGroupHealth(2),
+        config,
+        lambda _failed, _source, _when: None,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+
+    try:
+        with pytest.raises(TimeoutError, match="did not start"):
+            broadcaster.start()
+        assert receive_entered.is_set()
+        assert release_receive.is_set() is False
+        assert broadcaster._callback_thread is not None
+        assert broadcaster._callback_thread.is_alive() is False
+        assert comm.abort_calls == 1
+    finally:
+        release_receive.set()
+        broadcaster.stop(timeout=0.5)
+    assert comm.abort_calls == 1
+
+
+def test_reconciliation_gates_fail_closed_outside_running_lifecycle() -> None:
+    broadcaster, _, _, _ = _make_broadcaster(size=2)
+    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_is_reconciled(1) is False
+
+    broadcaster.start()
+    assert broadcaster.pre_failover(1) is True
+    _wait_until(
+        lambda: broadcaster.failure_is_reconciled(1),
+        description="single-survivor reconciliation",
+    )
+    assert broadcaster.health_is_reconciled() is True
+
+    broadcaster.stop()
+    assert broadcaster.failure_is_reconciled(1) is False
+    assert broadcaster.health_is_reconciled() is False
+
+
+@pytest.mark.parametrize("timeout", [0.0, -1.0, float("nan"), float("inf"), float("-inf")])
+def test_stop_requires_positive_finite_timeout(timeout: float) -> None:
+    broadcaster, _, _, _ = _make_broadcaster(size=1)
+    with pytest.raises(ValueError, match="finite and > 0"):
+        broadcaster.stop(timeout)
+    broadcaster.start()
+    broadcaster.stop()
+
+
+def test_stop_is_bounded_when_mpi_test_is_stuck() -> None:
+    blocking_request = _BlockingRequest()
+    comm = _FakeComm(size=2, receive_factory=lambda _source: blocking_request)
+    broadcaster, _, _, _ = _make_broadcaster(size=2, comm=comm)
+    broadcaster.start()
+    _wait_until(blocking_request.entered_test.is_set, description="blocked MPI Test")
+
+    start = time.monotonic()
+    with pytest.raises(TimeoutError, match="did not stop"):
+        broadcaster.stop(timeout=0.01)
+    assert time.monotonic() - start < 0.2
+    assert blocking_request.release_test.is_set() is False
+    assert comm.revoke_calls == 1
+    assert comm.abort_calls == 0
+
+    blocking_request.release_test.set()
+    broadcaster.stop(timeout=0.5)
+    assert comm.revoke_calls == 1
+    assert comm.abort_calls == 0
+
+
+def test_broadcast_rejects_report_after_stop_begins() -> None:
+    blocking_request = _BlockingRequest()
+    comm = _FakeComm(size=2, receive_factory=lambda _source: blocking_request)
+    broadcaster, health, _, _ = _make_broadcaster(size=2, comm=comm)
+    broadcaster.start()
+    _wait_until(blocking_request.entered_test.is_set, description="blocked MPI Test")
+
+    stop_errors: list[BaseException] = []
+
+    def stop_broadcaster() -> None:
+        try:
+            broadcaster.stop(timeout=0.5)
+        except BaseException as error:
+            stop_errors.append(error)
+
+    stop_thread = threading.Thread(target=stop_broadcaster)
+    stop_thread.start()
+    _wait_until(broadcaster._stop_event.is_set, description="stop transition")
+
+    with pytest.raises(RuntimeError, match="state=stopping"):
+        broadcaster.broadcast_failure(1)
+    assert health.all_active() is True
+
+    blocking_request.release_test.set()
+    stop_thread.join(timeout=1.0)
+    assert stop_thread.is_alive() is False
+    assert stop_errors == []
+
+
+def test_healthy_stop_cancels_preposted_receives() -> None:
+    broadcaster, health, comm, _ = _make_broadcaster(size=3)
+    broadcaster.start()
+    _wait_until(
+        lambda: comm.receive_count(1) == 1 and comm.receive_count(2) == 1,
+        description="preposted receives",
+    )
+    receives = [comm.latest_receive(source).request for source in (1, 2)]
+
+    assert health.all_active() is True
+    broadcaster.stop()
+
+    assert [request.cancel_calls for request in receives] == [1, 1]
+    assert all(request.Test() is True for request in receives)
+    assert broadcaster._retained_requests == []
+
+
+def test_healthy_stop_cleanup_timeout_aborts_world_and_retains_request() -> None:
+    request = _NonCompletingCancelRequest()
+    comm = _FakeComm(size=2, receive_factory=lambda _source: request)
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.05,
+        reconcile_timeout_sec=0.2,
+    )
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(2),
+        EPGroupHealth(2),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    _wait_until(lambda: comm.receive_count(1) == 1, description="preposted receive")
+
+    start = time.monotonic()
+    broadcaster.stop()
+    assert time.monotonic() - start < 0.2
+    assert request.cancel_calls == 1
+    assert isinstance(broadcaster.last_error, TimeoutError)
+    assert broadcaster._retained_requests
+    assert comm.abort_calls == 1
+    assert comm.revoke_calls == 0
+
+
+def test_poisoned_stop_keeps_progressing_until_failure_is_reconciled() -> None:
+    broadcaster, health, comm, _ = _make_broadcaster(size=3)
+    broadcaster.start()
+    _wait_until(
+        lambda: comm.receive_count(1) == 1 and comm.receive_count(2) == 1,
+        description="preposted receives",
+    )
+    receives = [comm.latest_receive(source).request for source in (1, 2)]
+    assert broadcaster.broadcast_failure(2) is True
+    _wait_until(lambda: len(comm.sends) == 1, description="pending failure send")
+    send = comm.sends[0]
+
+    assert health.get_failed_ranks() == frozenset({2})
+    initial_test_calls = send.request.test_calls
+    stop_errors: list[BaseException] = []
+
+    def stop_broadcaster() -> None:
+        try:
+            broadcaster.stop()
+        except BaseException as error:
+            stop_errors.append(error)
+
+    stop_thread = threading.Thread(target=stop_broadcaster)
+    stop_thread.start()
+    _wait_until(broadcaster._stop_event.is_set, description="stop request")
+    _wait_until(
+        lambda: send.request.test_calls > initial_test_calls,
+        description="continued send progress during stop",
+    )
+    assert stop_thread.is_alive() is True
+
+    send.request.complete()
+    comm.deliver(source=1, failed_rank=2)
+    stop_thread.join(timeout=1.0)
+
+    assert stop_thread.is_alive() is False
+    assert stop_errors == []
+    assert [request.cancel_calls for request in receives] == [0, 0]
+    assert send.request.cancel_calls == 0
+    assert broadcaster.last_error is None
+    assert broadcaster._retained_requests
+
+
+def test_poisoned_resources_outlive_broadcaster_object() -> None:
+    registry = ep_failure_broadcast._PROCESS_LIFETIME_REFS
+    initial_registry_size = len(registry)
+
+    def retain_then_drop_owner() -> tuple[
+        weakref.ReferenceType[_FakeRequest],
+        weakref.ReferenceType[np.ndarray],
+        weakref.ReferenceType[_FakeComm],
+    ]:
+        broadcaster, _, comm, _ = _make_broadcaster(size=3)
+        broadcaster.start()
+        _wait_until(
+            lambda: comm.receive_count(1) == 1 and comm.receive_count(2) == 1,
+            description="preposted receives",
+        )
+        assert broadcaster.pre_failover(2) is True
+        _wait_until(lambda: len(comm.sends) == 1, description="pending send")
+        send = comm.sends[0]
+        send.request.complete()
+        comm.deliver(source=1, failed_rank=2)
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        retained_receive = comm.latest_receive(2)
+        references = (
+            weakref.ref(retained_receive.request),
+            weakref.ref(retained_receive.buffer),
+            weakref.ref(comm),
+        )
+        broadcaster.stop()
+        # The fake communicator owns test bookkeeping references that a real
+        # MPI communicator does not. Drop those so only the process-lifetime
+        # registry can keep the poisoned request and buffer reachable.
+        comm._receives.clear()
+        return references
+
+    request_ref, buffer_ref, comm_ref = retain_then_drop_owner()
+    gc.collect()
+    try:
+        assert request_ref() is not None
+        assert buffer_ref() is not None
+        assert comm_ref() is not None
+        assert len(registry) > initial_registry_size
+    finally:
+        del registry[initial_registry_size:]
+
+
+def test_startup_failure_retains_poisoned_comm_without_pending_requests() -> None:
+    registry = ep_failure_broadcast._PROCESS_LIFETIME_REFS
+    initial_registry_size = len(registry)
+
+    def fail_first_receive(_source: int) -> _FakeRequest:
+        raise _FakeMpiException(999, "first Irecv failed")
+
+    def start_then_drop_owner() -> weakref.ReferenceType[_FakeComm]:
+        comm = _FakeComm(size=2, receive_factory=fail_first_receive)
+        comm_ref = weakref.ref(comm)
+        broadcaster, _, _, _ = _make_broadcaster(size=2, comm=comm)
+        with pytest.raises(RuntimeError, match="failed during startup"):
+            broadcaster.start()
+        assert broadcaster._retained_requests == []
+        assert isinstance(broadcaster.last_error, _FakeMpiException)
+        return comm_ref
+
+    comm_ref = start_then_drop_owner()
+    gc.collect()
+    try:
+        assert comm_ref() is not None
+        assert len(registry) > initial_registry_size
+        assert any(reference is comm_ref() for reference in registry[initial_registry_size:])
+    finally:
+        del registry[initial_registry_size:]
+
+
+def test_constructor_requires_mpi_thread_multiple() -> None:
+    mpi = _FakeMPI(thread_level=_FakeMPI.THREAD_MULTIPLE - 1)
+    comm = _FakeComm(size=2)
+    with pytest.raises(RuntimeError, match="MPI.THREAD_MULTIPLE"):
+        MpiFtSubcomm(
+            _FakeMapping.ep_world(2),
+            EPGroupHealth(2),
+            _TEST_CONFIG,
+            comm=comm,
+            mpi_module=mpi,
+        )
+    assert comm.errhandler is None
+
+
+def test_collectively_created_comm_uses_frozen_setup_and_lives_for_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ep_failure_broadcast._PROCESS_LIFETIME_REFS
+    initial_registry_size = len(registry)
+    comm = _FakeComm(size=2)
+    mpi = _FakeMPI()
+
+    class SingleReadMapping:
+        def __init__(self) -> None:
+            self.rank_reads = 0
+
+        @property
+        def moe_ep_rank(self) -> int:
+            self.rank_reads += 1
+            if self.rank_reads > 1:
+                raise RuntimeError("mapping rank was read after collective validation")
+            return 0
+
+    mapping = SingleReadMapping()
+
+    def create_mpi_ft_subcomm(
+        setup_mapping: SingleReadMapping,
+        *,
+        health_size: int,
+    ) -> types.SimpleNamespace:
+        assert health_size == 2
+        local_rank = setup_mapping.moe_ep_rank
+        comm.Set_errhandler(mpi.ERRORS_RETURN)
+        return types.SimpleNamespace(
+            comm=comm,
+            local_rank=local_rank,
+            ep_size=2,
+            ulfm_available=False,
+        )
+
+    distributed = types.ModuleType("tensorrt_llm._torch.distributed")
+    distributed.__path__ = []
+    communicator = types.ModuleType("tensorrt_llm._torch.distributed.communicator")
+    communicator.create_mpi_ft_subcomm = create_mpi_ft_subcomm
+    distributed.communicator = communicator
+    monkeypatch.setitem(sys.modules, "tensorrt_llm._torch.distributed", distributed)
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_llm._torch.distributed.communicator",
+        communicator,
+    )
+
+    try:
+        broadcaster = MpiFtSubcomm(
+            mapping,
+            EPGroupHealth(2),
+            _TEST_CONFIG,
+            mpi_module=mpi,
+        )
+
+        assert broadcaster._comm is comm
+        assert broadcaster._local_rank == 0
+        assert broadcaster._ep_size == 2
+        assert mapping.rank_reads == 1
+        assert comm.errhandler_calls == 1
+        assert comm.is_revoked_calls == 0
+        assert any(reference is comm for reference in registry[initial_registry_size:])
+        broadcaster.stop()
+        del broadcaster
+        gc.collect()
+        assert any(reference is comm for reference in registry[initial_registry_size:])
+    finally:
+        del registry[initial_registry_size:]
+
+
+def test_constructor_rejects_non_world_spanning_ep_group_for_mvp() -> None:
+    mapping = _FakeMapping(
+        world_size=4,
+        rank=0,
+        moe_ep_size=2,
+        moe_ep_rank=0,
+        moe_ep_group=(0, 1),
+    )
+    comm = _FakeComm(size=2)
+    with pytest.raises(ValueError, match="spanning the full MPI world"):
+        MpiFtSubcomm(
+            mapping,
+            EPGroupHealth(2),
+            _TEST_CONFIG,
+            comm=comm,
+            mpi_module=_FakeMPI(),
+        )
+    assert comm.errhandler is None
+
+
+@pytest.mark.parametrize(
+    "probe_error",
+    [
+        NotImplementedError("ULFM not compiled"),
+        _FakeMpiException(_FakeMPI.ERR_UNSUPPORTED_OPERATION),
+    ],
+    ids=["not-implemented", "unsupported-operation"],
+)
+def test_ulfm_probe_falls_back_when_runtime_does_not_support_it(
+    probe_error: BaseException,
+) -> None:
+    comm = _FakeComm(size=2, ulfm_probe_error=probe_error)
+    broadcaster, _, _, _ = _make_broadcaster(size=2, comm=comm)
+    assert broadcaster.ulfm_available is False
+    assert comm.is_revoked_calls == 1
+    broadcaster.stop()
+
+
+def test_ulfm_probe_propagates_unrelated_mpi_error() -> None:
+    registry = ep_failure_broadcast._PROCESS_LIFETIME_REFS
+    initial_registry_size = len(registry)
+    error = _FakeMpiException(_FakeMPI.ERR_UNKNOWN, "corrupt communicator")
+    comm = _FakeComm(size=2, ulfm_probe_error=error)
+    try:
+        with pytest.raises(_FakeMpiException, match="corrupt communicator") as raised:
+            _make_broadcaster(size=2, comm=comm)
+        assert raised.value is error
+        assert any(reference is comm for reference in registry[initial_registry_size:])
+    finally:
+        del registry[initial_registry_size:]
+
+
+def test_ulfm_probe_retains_original_error_when_error_class_inspection_raises() -> None:
+    registry = ep_failure_broadcast._PROCESS_LIFETIME_REFS
+    initial_registry_size = len(registry)
+
+    class UnclassifiableMpiError(_FakeMpiException):
+        def Get_error_class(self) -> int:
+            raise RuntimeError("error-class lookup failed")
+
+    probe_error = UnclassifiableMpiError(
+        _FakeMPI.ERR_UNSUPPORTED_OPERATION,
+        "unclassifiable ULFM probe failure",
+    )
+    comm = _FakeComm(size=2, ulfm_probe_error=probe_error)
+    try:
+        with pytest.raises(UnclassifiableMpiError, match="unclassifiable") as raised:
+            _make_broadcaster(size=2, comm=comm)
+        assert raised.value is probe_error
+        assert any(reference is comm for reference in registry[initial_registry_size:])
+    finally:
+        del registry[initial_registry_size:]
+
+
+def test_constructor_rejects_and_retains_already_revoked_comm() -> None:
+    registry = ep_failure_broadcast._PROCESS_LIFETIME_REFS
+    initial_registry_size = len(registry)
+
+    def construct_then_drop_owner() -> weakref.ReferenceType[_FakeComm]:
+        comm = _FakeComm(size=2, ulfm_revoked=True)
+        comm_ref = weakref.ref(comm)
+        with pytest.raises(RuntimeError, match="already revoked"):
+            _make_broadcaster(size=2, comm=comm)
+        return comm_ref
+
+    comm_ref = construct_then_drop_owner()
+    gc.collect()
+    try:
+        assert comm_ref() is not None
+        assert len(registry) > initial_registry_size
+    finally:
+        del registry[initial_registry_size:]
+
+
+def test_peer_failure_reconciles_without_revoking_control_plane() -> None:
+    callbacks: list[tuple[int, int, float]] = []
+    broadcaster, health, comm, _ = _make_broadcaster(
+        size=3,
+        callback=lambda failed, source, when: callbacks.append((failed, source, when)),
+    )
+    assert broadcaster.ulfm_available is True
+    broadcaster.start()
+    try:
+        _wait_until(lambda: comm.receive_count(1) == 1, description="peer receive")
+        comm.latest_receive(1).request.fail(_FakeMpiException(_FakeMPI.ERR_PROC_FAILED))
+
+        _wait_until(lambda: health.is_active(1) is False, description="peer failure classification")
+        _wait_until(lambda: len(comm.sends) == 1, description="peer failure relay")
+
+        assert health.get_failed_ranks() == frozenset({1})
+        _wait_until(lambda: len(callbacks) == 1, description="failed-peer callback")
+        assert [(failed, source) for failed, source, _ in callbacks] == [(1, 1)]
+        assert comm.sends[0].destination == 2
+        assert comm.sends[0].message_kind == _FAILURE_MESSAGE
+        assert comm.sends[0].payload == 1
+        assert comm.revoke_calls == 0
+        assert broadcaster.last_error is None
+
+        comm.sends[0].request.complete()
+        comm.deliver(source=2, failed_rank=1)
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(lambda: comm.receive_count(2) == 2, description="reposted receive")
+        assert broadcaster.health_is_reconciled() is True
+        assert broadcaster.last_error is None
+        assert comm.revoke_calls == 0
+    finally:
+        broadcaster.stop()
+
+
+def test_remote_revoke_after_local_reconciliation_still_fails_closed() -> None:
+    error = _FakeMpiException(_FakeMPI.ERR_REVOKED, "remote revoke")
+    comm = _FakeComm(size=3)
+    broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster.start()
+    assert broadcaster.pre_failover(2) is True
+    _wait_until(lambda: len(comm.sends) == 1, description="failure relay")
+    comm.sends[0].request.complete()
+    _wait_until(lambda: comm.receive_count(1) == 1, description="initial peer receive")
+    comm.deliver(source=1, failed_rank=2)
+    _wait_until(broadcaster.health_is_reconciled, description="local reconciliation")
+    _wait_until(
+        lambda: comm.receive_count(1) == 2,
+        description="receive after failure report",
+    )
+
+    comm.latest_receive(1).request.fail(error)
+    _wait_until(lambda: broadcaster.last_error is error, description="terminal remote revoke")
+    assert broadcaster.health_is_reconciled() is False
+    assert comm.revoke_calls == 1
+    with pytest.raises(RuntimeError, match="not running"):
+        broadcaster.pre_failover(1)
+    assert broadcaster._health.get_failed_ranks() == frozenset({2})
+    broadcaster.stop()
+
+
+def test_premature_remote_revoke_fails_closed() -> None:
+    error = _FakeMpiException(_FakeMPI.ERR_REVOKED, "premature revoke")
+    comm = _FakeComm(size=3)
+    broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster.start()
+    assert broadcaster.pre_failover(2) is True
+    _wait_until(lambda: comm.receive_count(1) == 1, description="initial peer receive")
+
+    comm.latest_receive(1).request.fail(error)
+    _wait_until(lambda: broadcaster.last_error is error, description="terminal revoke")
+    assert broadcaster.health_is_reconciled() is False
+    assert comm.revoke_calls == 1
+    broadcaster.stop()
+
+
+def test_generic_mpi_error_is_terminal_and_revokes_once() -> None:
+    comm = _FakeComm(size=2)
+    broadcaster, health, _, _ = _make_broadcaster(size=2, comm=comm)
+    broadcaster.start()
+    try:
+        _wait_until(lambda: comm.receive_count(1) == 1, description="peer receive")
+        error = _FakeMpiException(999, "generic transport failure")
+        comm.latest_receive(1).request.fail(error)
+
+        _wait_until(lambda: broadcaster.last_error is error, description="terminal MPI error")
+        _wait_until(lambda: comm.revoke_calls == 1, description="communicator revoke")
+        assert health.all_active() is True
+        with pytest.raises(RuntimeError, match="broadcaster is not running"):
+            broadcaster.broadcast_failure(1)
+    finally:
+        broadcaster.stop()
+    assert comm.revoke_calls == 1
+
+
+def test_proc_failed_is_classified_without_full_ulfm_support() -> None:
+    comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
+    broadcaster, health, _, _ = _make_broadcaster(size=3, comm=comm)
+    assert broadcaster.ulfm_available is False
+    broadcaster.start()
+    try:
+        _wait_until(lambda: comm.receive_count(1) == 1, description="peer receive")
+        comm.latest_receive(1).request.fail(_FakeMpiException(_FakeMPI.ERR_PROC_FAILED))
+        _wait_until(lambda: health.is_active(1) is False, description="peer failure classification")
+        _wait_until(lambda: len(comm.sends) == 1, description="peer failure relay")
+
+        assert health.get_failed_ranks() == frozenset({1})
+        assert comm.sends[0].destination == 2
+        assert comm.sends[0].payload == 1
+        assert broadcaster.last_error is None
+        assert comm.revoke_calls == 0
+        comm.sends[0].request.complete()
+        comm.deliver(source=2, failed_rank=1)
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+    finally:
+        broadcaster.stop()
+
+
+def test_non_ulfm_generic_receive_error_keeps_other_sources_live() -> None:
+    callbacks: list[tuple[int, int, float]] = []
+    comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
+    broadcaster, health, _, _ = _make_broadcaster(
+        size=3,
+        comm=comm,
+        callback=lambda failed, source, when: callbacks.append((failed, source, when)),
+    )
+    broadcaster.start()
+    try:
+        _wait_until(
+            lambda: comm.receive_count(1) == 1 and comm.receive_count(2) == 1,
+            description="fixed-source receives",
+        )
+        failed_receive = comm.latest_receive(1).request
+        failed_receive.fail(_FakeMpiException(999, "implementation-specific peer error"))
+        _wait_until(
+            lambda: len(broadcaster._retained_requests) == 1,
+            description="retained failed receive",
+        )
+
+        assert health.all_active() is True
+        assert broadcaster.last_error is None
+        assert failed_receive.cancel_calls == 0
+
+        # Another survivor's watchdog report remains authoritative even when
+        # the dead source's fixed receive failed with a generic error.
+        comm.deliver(source=2, failed_rank=1)
+        _wait_until(lambda: health.is_active(1) is False, description="authoritative report")
+        _wait_until(lambda: len(comm.sends) == 1, description="failure relay")
+        comm.sends[0].request.complete()
+        _wait_until(lambda: comm.receive_count(2) == 2, description="live-source receive repost")
+        _wait_until(lambda: len(callbacks) == 1, description="authoritative callback")
+
+        assert [(failed, source) for failed, source, _ in callbacks] == [(1, 2)]
+        assert broadcaster.last_error is None
+        assert comm.revoke_calls == 0
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+    finally:
+        broadcaster.stop()
+
+
+def test_non_ulfm_generic_error_after_watchdog_report_does_not_arm_stale_deadline() -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.2,
+        unattributed_error_timeout_sec=0.01,
+        abort_timeout_sec=0.02,
+    )
+    comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(3),
+        EPGroupHealth(3),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    try:
+        _wait_until(
+            lambda: comm.receive_count(1) == 1 and comm.receive_count(2) == 1,
+            description="fixed-source receives",
+        )
+        comm.deliver(source=2, failed_rank=1)
+        _wait_until(lambda: len(comm.sends) == 1, description="failure relay")
+
+        # The transport notification can arrive after the watchdog report. It
+        # is already attributed to rank 1 and must not create a deadline that
+        # aborts an otherwise reconciled survivor set later.
+        failed_receive = comm.latest_receive(1).request
+        failed_receive.fail(_FakeMpiException(999, "late generic peer error"))
+        _wait_until(
+            lambda: failed_receive
+            in [pending.request for pending in broadcaster._retained_requests],
+            description="retained explained receive",
+        )
+        comm.sends[0].request.complete()
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        time.sleep(3 * config.unattributed_error_timeout_sec)
+
+        assert broadcaster.last_error is None
+        assert broadcaster.health_is_reconciled() is True
+        assert comm.abort_calls == 0
+    finally:
+        broadcaster.stop()
+
+
+def test_unattributed_error_from_other_source_keeps_reconciliation_gate_closed() -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.5,
+        unattributed_error_timeout_sec=0.05,
+        abort_timeout_sec=0.02,
+    )
+    comm = _FakeComm(size=4, ulfm_probe_error=NotImplementedError())
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(4),
+        EPGroupHealth(4),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    try:
+        _wait_until(
+            lambda: all(comm.receive_count(source) == 1 for source in (1, 2, 3)),
+            description="fixed-source receives",
+        )
+        comm.deliver(source=1, failed_rank=3)
+        _wait_until(lambda: comm.receive_count(1) == 2, description="source 1 receive repost")
+        _wait_until(lambda: len(comm.sends) == 2, description="failure fanout")
+
+        # Source 1 already reported rank 3, but a later generic error from
+        # source 1 is not explained by that different failed rank.
+        comm.latest_receive(1).request.fail(_FakeMpiException(999, "second transport error"))
+        _wait_until(
+            lambda: bool(broadcaster._unattributed_error_deadlines),
+            description="unattributed deadline",
+        )
+        comm.deliver(source=2, failed_rank=3)
+        for send in comm.sends:
+            send.request.complete()
+        _wait_until(lambda: comm.receive_count(2) == 2, description="source 2 report")
+        _wait_until(
+            lambda: 3 in broadcaster._failure_fanout_complete,
+            description="completed failure fanout",
+        )
+
+        assert broadcaster.failure_is_reconciled(3) is False
+        assert broadcaster.health_is_reconciled() is False
+        _wait_until(
+            lambda: isinstance(broadcaster.last_error, TimeoutError),
+            description="unattributed transport deadline",
+        )
+        _wait_until(lambda: comm.abort_calls == 1, description="terminal fallback")
+    finally:
+        broadcaster.stop()
+
+
+def test_non_ulfm_unattributed_receive_error_aborts_after_bounded_deadlines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.5,
+        reconcile_timeout_sec=0.2,
+        unattributed_error_timeout_sec=0.01,
+        abort_timeout_sec=0.05,
+    )
+    comm = _FakeComm(size=2, ulfm_probe_error=NotImplementedError())
+    health = EPGroupHealth(2)
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(2),
+        health,
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    terminal_request_entered = threading.Event()
+    release_terminal_request = threading.Event()
+    original_request_terminal_abort = broadcaster._request_terminal_abort
+
+    def blocking_terminal_request(
+        error: BaseException,
+        payload: int,
+        reporter: int,
+    ) -> None:
+        terminal_request_entered.set()
+        assert release_terminal_request.wait(timeout=1.0)
+        original_request_terminal_abort(error, payload, reporter)
+
+    monkeypatch.setattr(broadcaster, "_request_terminal_abort", blocking_terminal_request)
+    broadcaster.start()
+    _wait_until(lambda: comm.receive_count(1) == 1, description="fixed-source receive")
+    failed_receive = comm.latest_receive(1).request
+    failed_receive.fail(_FakeMpiException(999, "unattributed peer error"))
+
+    _wait_until(terminal_request_entered.is_set, description="blocked terminal publication")
+    # The request is deliberately blocked before last_error is recorded. The
+    # lifecycle and protocol poison must already make the public gate fail
+    # closed, with no lock held that prevents the iteration thread from polling.
+    try:
+        assert broadcaster.last_error is None
+        assert broadcaster._lifecycle is ep_failure_broadcast._Lifecycle.FAILED
+        assert broadcaster._unattributed_error_deadlines[1] == float("inf")
+        assert broadcaster.health_is_reconciled() is False
+    finally:
+        release_terminal_request.set()
+
+    _wait_until(
+        lambda: isinstance(broadcaster.last_error, TimeoutError),
+        description="unattributed transport deadline",
+    )
+    assert "could not attribute" in str(broadcaster.last_error)
+    # Expiry remains protocol-visible for the rest of this communicator epoch.
+    assert 1 in broadcaster._unattributed_error_deadlines
+    assert broadcaster.health_is_reconciled() is False
+    _wait_until(
+        lambda: any(send.message_kind == _ABORT_MESSAGE for send in comm.sends),
+        description="terminal ABORT relay",
+    )
+    _wait_until(lambda: comm.abort_calls == 1, description="bounded MPI_Abort fallback")
+
+    assert health.all_active() is True
+    assert failed_receive.cancel_calls == 0
+    assert comm.revoke_calls == 0
+    broadcaster.stop()
+
+
+def test_send_buffer_lives_until_request_test_completes() -> None:
+    comm = _FakeComm(size=3)
+    broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster.start()
+    try:
+        assert broadcaster.broadcast_failure(2) is True
+        _wait_until(lambda: len(comm.sends) == 1, description="pending send")
+        record = comm.sends[0]
+        _wait_until(lambda: record.request.test_calls > 0, description="send Test polling")
+
+        gc.collect()
+        assert record.buffer_ref() is not None
+
+        record.request.complete()
+
+        def buffer_released() -> bool:
+            gc.collect()
+            return record.buffer_ref() is None
+
+        _wait_until(buffer_released, description="completed send buffer release")
+        comm.deliver(source=1, failed_rank=2)
+        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+    finally:
+        broadcaster.stop()

--- a/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
+++ b/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
@@ -37,7 +37,11 @@ import pytest
 
 from tensorrt_llm._torch.modules.fused_moe.ep_group_health import EPGroupHealth
 from tensorrt_llm._torch.pyexecutor import ep_failure_broadcast
-from tensorrt_llm._torch.pyexecutor.ep_failure_broadcast import MpiFtSubcomm, MpiFtSubcommConfig
+from tensorrt_llm._torch.pyexecutor.ep_failure_broadcast import (
+    DetectedRankState,
+    MpiFtSubcomm,
+    MpiFtSubcommConfig,
+)
 
 _TEST_CONFIG = MpiFtSubcommConfig(
     poll_interval_sec=0.001,
@@ -309,34 +313,50 @@ def _make_broadcaster(
     *,
     size: int = 4,
     rank: int = 0,
-    detected_health: EPGroupHealth | None = None,
+    detected_state: DetectedRankState | None = None,
     comm: _FakeComm | None = None,
     mpi: _FakeMPI | None = None,
     callback: Callable[[int, int, float], None] | None = None,
-) -> tuple[MpiFtSubcomm, EPGroupHealth, _FakeComm, _FakeMPI]:
-    detected_health = detected_health or EPGroupHealth(size)
+) -> tuple[MpiFtSubcomm, DetectedRankState, _FakeComm, _FakeMPI]:
+    detected_state = detected_state or DetectedRankState(size)
     comm = comm or _FakeComm(size=size, rank=rank)
     mpi = mpi or _FakeMPI()
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(size, rank),
-        detected_health,
+        detected_state,
         _TEST_CONFIG,
         callback,
         comm=comm,
         mpi_module=mpi,
     )
-    return broadcaster, detected_health, comm, mpi
+    return broadcaster, detected_state, comm, mpi
+
+
+def test_committed_ep_group_health_is_rejected_before_mpi_setup() -> None:
+    comm = _FakeComm(size=2)
+
+    with pytest.raises(TypeError, match="committed EPGroupHealth cannot be used"):
+        MpiFtSubcomm(
+            _FakeMapping.ep_world(2),
+            EPGroupHealth(2),
+            _TEST_CONFIG,
+            comm=comm,
+            mpi_module=_FakeMPI(),
+        )
+
+    assert comm.errhandler_calls == 0
+    assert comm.is_revoked_calls == 0
 
 
 def test_watchdog_callback_records_and_fans_out_detected_failure() -> None:
-    detected_health = EPGroupHealth(4)
-    broadcaster, _, comm, _ = _make_broadcaster(detected_health=detected_health)
+    detected_state = DetectedRankState(4)
+    broadcaster, _, comm, _ = _make_broadcaster(detected_state=detected_state)
     broadcaster.start()
     caller_thread = threading.get_ident()
     try:
         watchdog_callback = broadcaster.report_detected_failure
         assert watchdog_callback(2) is True
-        assert detected_health.get_failed_ranks() == frozenset({2})
+        assert detected_state.get_failed_ranks() == frozenset({2})
         _wait_until(lambda: len(comm.sends) == 2, description="failure fanout")
         _wait_until(
             lambda: all(record.request.test_calls > 0 for record in comm.sends),
@@ -359,19 +379,19 @@ def test_watchdog_callback_records_and_fans_out_detected_failure() -> None:
         comm.deliver(source=1, failed_rank=2)
         comm.deliver(source=3, failed_rank=2)
         _wait_until(
-            broadcaster.detected_health_is_reconciled,
+            broadcaster.detected_state_is_reconciled,
             description="detection reconciliation",
         )
     finally:
         broadcaster.stop()
 
 
-def test_externally_premarked_detected_health_fails_closed() -> None:
-    detected_health = EPGroupHealth(2)
-    assert detected_health.mark_failed(1) is True
+def test_externally_premarked_detected_state_fails_closed() -> None:
+    detected_state = DetectedRankState(2)
+    assert detected_state.record_failure(1) is True
     broadcaster, _, comm, _ = _make_broadcaster(
         size=2,
-        detected_health=detected_health,
+        detected_state=detected_state,
     )
 
     try:
@@ -383,9 +403,9 @@ def test_externally_premarked_detected_health_fails_closed() -> None:
             pass
         _wait_until(
             lambda: isinstance(broadcaster.last_error, RuntimeError),
-            description="pre-marked detected-health rejection",
+            description="pre-recorded detected-state rejection",
         )
-        assert "without pre-marking health" in str(broadcaster.last_error)
+        assert "without pre-recording evidence" in str(broadcaster.last_error)
         _wait_until(lambda: comm.revoke_calls == 1, description="pre-mark fail-closed revoke")
     finally:
         broadcaster.stop()
@@ -393,12 +413,12 @@ def test_externally_premarked_detected_health_fails_closed() -> None:
 
 def test_detection_reconciliation_does_not_mutate_committed_health() -> None:
     callbacks: list[tuple[int, int, float]] = []
-    detected_health = EPGroupHealth(2)
+    detected_state = DetectedRankState(2)
     committed_health = EPGroupHealth(2)
     initial_committed_snapshot = committed_health.snapshot()
     broadcaster, _, _, _ = _make_broadcaster(
         size=2,
-        detected_health=detected_health,
+        detected_state=detected_state,
         callback=lambda failed, source, when: callbacks.append((failed, source, when)),
     )
     broadcaster.start()
@@ -409,12 +429,12 @@ def test_detection_reconciliation_does_not_mutate_committed_health() -> None:
             description="local detection coordinator handoff",
         )
         _wait_until(
-            broadcaster.detected_health_is_reconciled,
+            broadcaster.detected_state_is_reconciled,
             description="detection reconciliation",
         )
 
-        assert detected_health.get_failed_ranks() == frozenset({1})
-        assert detected_health.generation == 1
+        assert detected_state.get_failed_ranks() == frozenset({1})
+        assert detected_state.generation == 1
         assert committed_health.snapshot() == initial_committed_snapshot
         assert committed_health.all_active() is True
         assert callbacks[0][:2] == (1, 0)
@@ -454,77 +474,54 @@ def test_survivor_echoes_reconcile_failure_detection() -> None:
         broadcaster.stop()
 
 
-def test_rank_reactivation_cannot_reopen_reconciliation_for_same_comm_epoch() -> None:
-    broadcaster, health, comm, _ = _make_broadcaster(size=3)
-    broadcaster.start()
-    try:
-        assert broadcaster.pre_failover(2) is True
-        _wait_until(lambda: len(comm.sends) == 1, description="failure fanout")
-        comm.sends[0].request.complete()
-        comm.deliver(source=1, failed_rank=2)
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+def test_detected_state_is_monotonic_for_one_communicator_epoch() -> None:
+    state = DetectedRankState(3)
 
-        assert health.mark_active(2) is True
-        _wait_until(
-            lambda: isinstance(broadcaster.last_error, RuntimeError),
-            description="reactivated-rank terminal handling",
-        )
-        _wait_until(lambda: comm.revoke_calls == 1, description="epoch-violation revoke")
-        assert broadcaster.world_is_poisoned() is True
-        assert broadcaster.failure_is_reconciled(2) is False
-        assert broadcaster.health_is_reconciled() is False
-
-        # Even restoring the failed bit cannot restore the old consensus: the
-        # intervening generation change belongs to a future communicator epoch.
-        assert health.mark_failed(2) is True
-        assert broadcaster.world_is_poisoned() is True
-        assert broadcaster.failure_is_reconciled(2) is False
-        assert broadcaster.health_is_reconciled() is False
-    finally:
-        broadcaster.stop()
+    assert state.snapshot() == ep_failure_broadcast.DetectedRankStateSnapshot(
+        mask=0b111,
+        failed_ranks=frozenset(),
+        generation=0,
+    )
+    assert state.record_failure(2) is True
+    assert state.record_failure(2) is False
+    assert state.get_mask() == 0b011
+    assert state.get_failed_ranks() == frozenset({2})
+    assert state.generation == 1
+    assert not hasattr(state, "mark_active")
 
 
-def test_reactivation_between_failure_claim_and_observe_cannot_become_epoch_baseline(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    health = EPGroupHealth(2)
-    broadcaster, _, _, _ = _make_broadcaster(size=2, detected_health=health)
-    original_claim = broadcaster._claim_failure
-    mutated = False
+def test_detected_state_coalesces_concurrent_evidence() -> None:
+    state = DetectedRankState(4)
+    barrier = threading.Barrier(8)
+    results: list[bool] = []
+    results_lock = threading.Lock()
 
-    def claim_then_turn_over_epoch(failed_rank: int) -> None:
-        nonlocal mutated
-        original_claim(failed_rank)
-        if not mutated:
-            mutated = True
-            assert health.mark_failed(failed_rank) is True
-            assert health.mark_active(failed_rank) is True
-            assert health.mark_failed(failed_rank) is True
+    def record_same_failure() -> None:
+        barrier.wait()
+        changed = state.record_failure(2)
+        with results_lock:
+            results.append(changed)
 
-    monkeypatch.setattr(broadcaster, "_claim_failure", claim_then_turn_over_epoch)
-    broadcaster.start()
-    try:
-        assert broadcaster.broadcast_failure(1) is False
-        _wait_until(
-            lambda: 1 in broadcaster._failure_fanout_complete,
-            description="single-survivor fanout completion",
-        )
-        assert health.generation == 3
-        _wait_until(
-            lambda: isinstance(broadcaster.last_error, RuntimeError),
-            description="turnover terminal handling",
-        )
-        assert broadcaster.failure_is_reconciled(1) is False
-        assert broadcaster.health_is_reconciled() is False
-    finally:
-        broadcaster.stop()
+    threads = [threading.Thread(target=record_same_failure) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results.count(True) == 1
+    assert results.count(False) == 7
+    assert state.snapshot() == ep_failure_broadcast.DetectedRankStateSnapshot(
+        mask=0b1011,
+        failed_ranks=frozenset({2}),
+        generation=1,
+    )
 
 
 def test_second_failure_between_claim_and_observe_cannot_open_single_failure_gate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    health = EPGroupHealth(3)
-    broadcaster, _, _, _ = _make_broadcaster(size=3, detected_health=health)
+    health = DetectedRankState(3)
+    broadcaster, _, _, _ = _make_broadcaster(size=3, detected_state=health)
     original_claim = broadcaster._claim_failure
     mutated = False
 
@@ -533,7 +530,7 @@ def test_second_failure_between_claim_and_observe_cannot_open_single_failure_gat
         original_claim(failed_rank)
         if not mutated:
             mutated = True
-            assert health.mark_failed(1) is True
+            assert health.record_failure(1) is True
 
     monkeypatch.setattr(broadcaster, "_claim_failure", claim_then_add_second_failure)
     broadcaster.start()
@@ -546,7 +543,7 @@ def test_second_failure_between_claim_and_observe_cannot_open_single_failure_gat
         assert health.get_failed_ranks() == frozenset({1, 2})
         _wait_until(
             lambda: isinstance(broadcaster.last_error, RuntimeError),
-            description="second-health-failure terminal handling",
+            description="second-detected-failure terminal handling",
         )
         assert broadcaster.failure_is_reconciled(2) is False
         assert broadcaster.health_is_reconciled() is False
@@ -568,7 +565,7 @@ def test_reconciliation_timeout_fails_closed_while_mpi_test_is_wedged() -> None:
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        EPGroupHealth(3),
+        DetectedRankState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -609,7 +606,7 @@ def test_reconciliation_timeout_world_aborts_when_mpi_test_is_wedged_without_ulf
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        EPGroupHealth(3),
+        DetectedRankState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -728,7 +725,7 @@ def test_monitor_does_not_world_abort_reconciled_relay_when_mpi_test_resumes() -
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
-        EPGroupHealth(2),
+        DetectedRankState(2),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -817,7 +814,7 @@ def test_no_ulfm_abort_timeout_uses_world_abort_before_stop_completes() -> None:
     comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        EPGroupHealth(3),
+        DetectedRankState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -856,7 +853,7 @@ def test_stop_cannot_bypass_abort_requested_during_blocked_drain() -> None:
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        EPGroupHealth(3),
+        DetectedRankState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -1001,7 +998,7 @@ def test_received_report_is_idempotent_and_callback_runs_once() -> None:
         broadcaster.stop()
 
 
-def test_monitor_cannot_observe_remote_claim_before_detected_health_update(
+def test_monitor_cannot_observe_remote_claim_before_detected_state_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     broadcaster, health, comm, _ = _make_broadcaster(size=3)
@@ -1099,7 +1096,7 @@ def test_single_rank_group_has_no_peer_requests_or_sends() -> None:
         abort_timeout_sec=0.02,
     )
     comm = _FakeComm(size=1, ulfm_probe_error=NotImplementedError())
-    health = EPGroupHealth(1)
+    health = DetectedRankState(1)
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(1),
         health,
@@ -1315,7 +1312,7 @@ def test_startup_timeout_fails_closed_before_progress_resumes() -> None:
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
-        EPGroupHealth(2),
+        DetectedRankState(2),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -1372,7 +1369,7 @@ def test_startup_timeout_stops_callback_before_blocked_receive_is_released() -> 
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
-        EPGroupHealth(2),
+        DetectedRankState(2),
         config,
         lambda _failed, _source, _when: None,
         comm=comm,
@@ -1498,7 +1495,7 @@ def test_healthy_stop_cleanup_timeout_aborts_world_and_retains_request() -> None
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
-        EPGroupHealth(2),
+        DetectedRankState(2),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -1637,7 +1634,7 @@ def test_constructor_requires_mpi_thread_multiple() -> None:
     with pytest.raises(RuntimeError, match="MPI.THREAD_MULTIPLE"):
         MpiFtSubcomm(
             _FakeMapping.ep_world(2),
-            EPGroupHealth(2),
+            DetectedRankState(2),
             _TEST_CONFIG,
             comm=comm,
             mpi_module=mpi,
@@ -1696,7 +1693,7 @@ def test_collectively_created_comm_uses_frozen_setup_and_lives_for_process(
     try:
         broadcaster = MpiFtSubcomm(
             mapping,
-            EPGroupHealth(2),
+            DetectedRankState(2),
             _TEST_CONFIG,
             mpi_module=mpi,
         )
@@ -1728,7 +1725,7 @@ def test_constructor_rejects_non_world_spanning_ep_group_for_mvp() -> None:
     with pytest.raises(ValueError, match="spanning the full MPI world"):
         MpiFtSubcomm(
             mapping,
-            EPGroupHealth(2),
+            DetectedRankState(2),
             _TEST_CONFIG,
             comm=comm,
             mpi_module=_FakeMPI(),
@@ -1867,7 +1864,7 @@ def test_remote_revoke_after_local_reconciliation_still_fails_closed() -> None:
     assert comm.revoke_calls == 1
     with pytest.raises(RuntimeError, match="not running"):
         broadcaster.pre_failover(1)
-    assert broadcaster._detected_health.get_failed_ranks() == frozenset({2})
+    assert broadcaster._detected_state.get_failed_ranks() == frozenset({2})
     broadcaster.stop()
 
 
@@ -1982,7 +1979,7 @@ def test_non_ulfm_generic_error_after_watchdog_report_does_not_arm_stale_deadlin
     comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        EPGroupHealth(3),
+        DetectedRankState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -2030,7 +2027,7 @@ def test_unattributed_error_from_other_source_keeps_reconciliation_gate_closed()
     comm = _FakeComm(size=4, ulfm_probe_error=NotImplementedError())
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(4),
-        EPGroupHealth(4),
+        DetectedRankState(4),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -2084,7 +2081,7 @@ def test_non_ulfm_unattributed_receive_error_aborts_after_bounded_deadlines(
         abort_timeout_sec=0.05,
     )
     comm = _FakeComm(size=2, ulfm_probe_error=NotImplementedError())
-    health = EPGroupHealth(2)
+    health = DetectedRankState(2)
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
         health,

--- a/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
+++ b/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
@@ -309,34 +309,34 @@ def _make_broadcaster(
     *,
     size: int = 4,
     rank: int = 0,
-    health: EPGroupHealth | None = None,
+    detected_health: EPGroupHealth | None = None,
     comm: _FakeComm | None = None,
     mpi: _FakeMPI | None = None,
     callback: Callable[[int, int, float], None] | None = None,
 ) -> tuple[MpiFtSubcomm, EPGroupHealth, _FakeComm, _FakeMPI]:
-    health = health or EPGroupHealth(size)
+    detected_health = detected_health or EPGroupHealth(size)
     comm = comm or _FakeComm(size=size, rank=rank)
     mpi = mpi or _FakeMPI()
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(size, rank),
-        health,
+        detected_health,
         _TEST_CONFIG,
         callback,
         comm=comm,
         mpi_module=mpi,
     )
-    return broadcaster, health, comm, mpi
+    return broadcaster, detected_health, comm, mpi
 
 
-def test_nonblocking_fanout_announces_externally_premarked_rank() -> None:
-    """The watchdog's prior local mark must not suppress cross-rank fanout."""
-    health = EPGroupHealth(4)
-    assert health.mark_failed(2) is True
-    broadcaster, _, comm, _ = _make_broadcaster(health=health)
+def test_watchdog_callback_records_and_fans_out_detected_failure() -> None:
+    detected_health = EPGroupHealth(4)
+    broadcaster, _, comm, _ = _make_broadcaster(detected_health=detected_health)
     broadcaster.start()
     caller_thread = threading.get_ident()
     try:
-        assert broadcaster.broadcast_failure(2) is False
+        watchdog_callback = broadcaster.report_detected_failure
+        assert watchdog_callback(2) is True
+        assert detected_health.get_failed_ranks() == frozenset({2})
         _wait_until(lambda: len(comm.sends) == 2, description="failure fanout")
         _wait_until(
             lambda: all(record.request.test_calls > 0 for record in comm.sends),
@@ -350,7 +350,7 @@ def test_nonblocking_fanout_announces_externally_premarked_rank() -> None:
         assert all(record.buffer_ref() is not None for record in comm.sends)
 
         # A repeated detector report is locally coalesced.
-        assert broadcaster.pre_failover(2) is False
+        assert watchdog_callback(2) is False
         time.sleep(2 * _TEST_CONFIG.poll_interval_sec)
         assert len(comm.sends) == 2
 
@@ -358,17 +358,76 @@ def test_nonblocking_fanout_announces_externally_premarked_rank() -> None:
             send.request.complete()
         comm.deliver(source=1, failed_rank=2)
         comm.deliver(source=3, failed_rank=2)
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(
+            broadcaster.detected_health_is_reconciled,
+            description="detection reconciliation",
+        )
     finally:
         broadcaster.stop()
 
 
-def test_survivor_echoes_reconcile_failure_before_next_collective() -> None:
+def test_externally_premarked_detected_health_fails_closed() -> None:
+    detected_health = EPGroupHealth(2)
+    assert detected_health.mark_failed(1) is True
+    broadcaster, _, comm, _ = _make_broadcaster(
+        size=2,
+        detected_health=detected_health,
+    )
+
+    try:
+        try:
+            broadcaster.start()
+        except RuntimeError:
+            # The progress thread can detect the invalid initial state before
+            # start() observes RUNNING, or immediately after start() returns.
+            pass
+        _wait_until(
+            lambda: isinstance(broadcaster.last_error, RuntimeError),
+            description="pre-marked detected-health rejection",
+        )
+        assert "without pre-marking health" in str(broadcaster.last_error)
+        _wait_until(lambda: comm.revoke_calls == 1, description="pre-mark fail-closed revoke")
+    finally:
+        broadcaster.stop()
+
+
+def test_detection_reconciliation_does_not_mutate_committed_health() -> None:
+    callbacks: list[tuple[int, int, float]] = []
+    detected_health = EPGroupHealth(2)
+    committed_health = EPGroupHealth(2)
+    initial_committed_snapshot = committed_health.snapshot()
+    broadcaster, _, _, _ = _make_broadcaster(
+        size=2,
+        detected_health=detected_health,
+        callback=lambda failed, source, when: callbacks.append((failed, source, when)),
+    )
+    broadcaster.start()
+    try:
+        assert broadcaster.report_detected_failure(1) is True
+        _wait_until(
+            lambda: len(callbacks) == 1,
+            description="local detection coordinator handoff",
+        )
+        _wait_until(
+            broadcaster.detected_health_is_reconciled,
+            description="detection reconciliation",
+        )
+
+        assert detected_health.get_failed_ranks() == frozenset({1})
+        assert detected_health.generation == 1
+        assert committed_health.snapshot() == initial_committed_snapshot
+        assert committed_health.all_active() is True
+        assert callbacks[0][:2] == (1, 0)
+    finally:
+        broadcaster.stop()
+
+
+def test_survivor_echoes_reconcile_failure_detection() -> None:
     broadcaster, _, comm, _ = _make_broadcaster(size=4)
     broadcaster.start()
     try:
-        assert broadcaster.pre_failover(2) is True
-        assert broadcaster.failure_is_reconciled(2) is False
+        assert broadcaster.report_detected_failure(2) is True
+        assert broadcaster.failure_detection_is_reconciled(2) is False
         _wait_until(lambda: len(comm.sends) == 2, description="initial failure fanout")
 
         comm.deliver(source=1, failed_rank=2)
@@ -376,20 +435,20 @@ def test_survivor_echoes_reconcile_failure_before_next_collective() -> None:
             lambda: comm.receive_count(1) == 2,
             description="source 1 receive repost",
         )
-        assert broadcaster.failure_is_reconciled(2) is False
+        assert broadcaster.failure_detection_is_reconciled(2) is False
 
         comm.deliver(source=3, failed_rank=2)
         for send in comm.sends:
             send.request.complete()
         _wait_until(
-            lambda: broadcaster.failure_is_reconciled(2),
+            lambda: broadcaster.failure_detection_is_reconciled(2),
             description="all survivor echoes",
         )
         time.sleep(2 * _TEST_CONFIG.poll_interval_sec)
         assert len(comm.sends) == 2
         assert {send.destination for send in comm.sends} == {1, 3}
         assert all(send.message_kind == _FAILURE_MESSAGE for send in comm.sends)
-        assert broadcaster.health_is_reconciled() is True
+        assert broadcaster.detected_health_is_reconciled() is True
         assert comm.revoke_calls == 0
     finally:
         broadcaster.stop()
@@ -429,8 +488,7 @@ def test_reactivation_between_failure_claim_and_observe_cannot_become_epoch_base
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     health = EPGroupHealth(2)
-    assert health.mark_failed(1) is True
-    broadcaster, _, _, _ = _make_broadcaster(size=2, health=health)
+    broadcaster, _, _, _ = _make_broadcaster(size=2, detected_health=health)
     original_claim = broadcaster._claim_failure
     mutated = False
 
@@ -439,6 +497,7 @@ def test_reactivation_between_failure_claim_and_observe_cannot_become_epoch_base
         original_claim(failed_rank)
         if not mutated:
             mutated = True
+            assert health.mark_failed(failed_rank) is True
             assert health.mark_active(failed_rank) is True
             assert health.mark_failed(failed_rank) is True
 
@@ -465,7 +524,7 @@ def test_second_failure_between_claim_and_observe_cannot_open_single_failure_gat
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     health = EPGroupHealth(3)
-    broadcaster, _, _, _ = _make_broadcaster(size=3, health=health)
+    broadcaster, _, _, _ = _make_broadcaster(size=3, detected_health=health)
     original_claim = broadcaster._claim_failure
     mutated = False
 
@@ -684,8 +743,10 @@ def test_monitor_does_not_world_abort_reconciled_relay_when_mpi_test_resumes() -
     broadcaster._deadline_monitor_wake_event.set()
 
     _wait_until(
-        lambda: broadcaster._deadline_monitor_thread is not None
-        and not broadcaster._deadline_monitor_thread.is_alive(),
+        lambda: (
+            broadcaster._deadline_monitor_thread is not None
+            and not broadcaster._deadline_monitor_thread.is_alive()
+        ),
         description="monitor-observed terminal reconciliation",
     )
     assert broadcaster._progress_failed.is_set() is False
@@ -940,7 +1001,7 @@ def test_received_report_is_idempotent_and_callback_runs_once() -> None:
         broadcaster.stop()
 
 
-def test_monitor_cannot_observe_remote_claim_before_health_commit(
+def test_monitor_cannot_observe_remote_claim_before_detected_health_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     broadcaster, health, comm, _ = _make_broadcaster(size=3)
@@ -965,7 +1026,7 @@ def test_monitor_cannot_observe_remote_claim_before_health_commit(
         assert comm.revoke_calls == 0
 
         release_claim.set()
-        _wait_until(lambda: not health.is_active(2), description="committed remote failure")
+        _wait_until(lambda: not health.is_active(2), description="recorded remote detection")
         _wait_until(lambda: len(comm.sends) == 1, description="remote failure echo")
         comm.sends[0].request.complete()
         _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
@@ -1806,7 +1867,7 @@ def test_remote_revoke_after_local_reconciliation_still_fails_closed() -> None:
     assert comm.revoke_calls == 1
     with pytest.raises(RuntimeError, match="not running"):
         broadcaster.pre_failover(1)
-    assert broadcaster._health.get_failed_ranks() == frozenset({2})
+    assert broadcaster._detected_health.get_failed_ranks() == frozenset({2})
     broadcaster.stop()
 
 
@@ -1892,14 +1953,14 @@ def test_non_ulfm_generic_receive_error_keeps_other_sources_live() -> None:
         assert broadcaster.last_error is None
         assert failed_receive.cancel_calls == 0
 
-        # Another survivor's watchdog report remains authoritative even when
-        # the dead source's fixed receive failed with a generic error.
+        # Another survivor's rank-attributed detection remains usable even
+        # when the dead source's fixed receive failed with a generic error.
         comm.deliver(source=2, failed_rank=1)
-        _wait_until(lambda: health.is_active(1) is False, description="authoritative report")
+        _wait_until(lambda: health.is_active(1) is False, description="detection report")
         _wait_until(lambda: len(comm.sends) == 1, description="failure relay")
         comm.sends[0].request.complete()
         _wait_until(lambda: comm.receive_count(2) == 2, description="live-source receive repost")
-        _wait_until(lambda: len(callbacks) == 1, description="authoritative callback")
+        _wait_until(lambda: len(callbacks) == 1, description="detection callback")
 
         assert [(failed, source) for failed, source, _ in callbacks] == [(1, 2)]
         assert broadcaster.last_error is None
@@ -1941,8 +2002,9 @@ def test_non_ulfm_generic_error_after_watchdog_report_does_not_arm_stale_deadlin
         failed_receive = comm.latest_receive(1).request
         failed_receive.fail(_FakeMpiException(999, "late generic peer error"))
         _wait_until(
-            lambda: failed_receive
-            in [pending.request for pending in broadcaster._retained_requests],
+            lambda: (
+                failed_receive in [pending.request for pending in broadcaster._retained_requests]
+            ),
             description="retained explained receive",
         )
         comm.sends[0].request.complete()

--- a/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
+++ b/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
@@ -38,7 +38,7 @@ import pytest
 from tensorrt_llm._torch.modules.fused_moe.ep_group_health import EPGroupHealth
 from tensorrt_llm._torch.pyexecutor import ep_failure_broadcast
 from tensorrt_llm._torch.pyexecutor.ep_failure_broadcast import (
-    DetectedRankState,
+    FailureEvidenceState,
     MpiFtSubcomm,
     MpiFtSubcommConfig,
 )
@@ -313,23 +313,23 @@ def _make_broadcaster(
     *,
     size: int = 4,
     rank: int = 0,
-    detected_state: DetectedRankState | None = None,
+    failure_evidence: FailureEvidenceState | None = None,
     comm: _FakeComm | None = None,
     mpi: _FakeMPI | None = None,
     callback: Callable[[int, int, float], None] | None = None,
-) -> tuple[MpiFtSubcomm, DetectedRankState, _FakeComm, _FakeMPI]:
-    detected_state = detected_state or DetectedRankState(size)
+) -> tuple[MpiFtSubcomm, FailureEvidenceState, _FakeComm, _FakeMPI]:
+    failure_evidence = failure_evidence or FailureEvidenceState(size)
     comm = comm or _FakeComm(size=size, rank=rank)
     mpi = mpi or _FakeMPI()
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(size, rank),
-        detected_state,
+        failure_evidence,
         _TEST_CONFIG,
         callback,
         comm=comm,
         mpi_module=mpi,
     )
-    return broadcaster, detected_state, comm, mpi
+    return broadcaster, failure_evidence, comm, mpi
 
 
 def test_committed_ep_group_health_is_rejected_before_mpi_setup() -> None:
@@ -349,14 +349,14 @@ def test_committed_ep_group_health_is_rejected_before_mpi_setup() -> None:
 
 
 def test_watchdog_callback_records_and_fans_out_detected_failure() -> None:
-    detected_state = DetectedRankState(4)
-    broadcaster, _, comm, _ = _make_broadcaster(detected_state=detected_state)
+    failure_evidence = FailureEvidenceState(4)
+    broadcaster, _, comm, _ = _make_broadcaster(failure_evidence=failure_evidence)
     broadcaster.start()
     caller_thread = threading.get_ident()
     try:
         watchdog_callback = broadcaster.report_detected_failure
         assert watchdog_callback(2) is True
-        assert detected_state.get_failed_ranks() == frozenset({2})
+        assert failure_evidence.snapshot().failed_ranks == frozenset({2})
         _wait_until(lambda: len(comm.sends) == 2, description="failure fanout")
         _wait_until(
             lambda: all(record.request.test_calls > 0 for record in comm.sends),
@@ -379,19 +379,19 @@ def test_watchdog_callback_records_and_fans_out_detected_failure() -> None:
         comm.deliver(source=1, failed_rank=2)
         comm.deliver(source=3, failed_rank=2)
         _wait_until(
-            broadcaster.detected_state_is_reconciled,
+            broadcaster.failure_evidence_is_reconciled,
             description="detection reconciliation",
         )
     finally:
         broadcaster.stop()
 
 
-def test_externally_premarked_detected_state_fails_closed() -> None:
-    detected_state = DetectedRankState(2)
-    assert detected_state.record_failure(1) is True
+def test_externally_premarked_failure_evidence_fails_closed() -> None:
+    failure_evidence = FailureEvidenceState(2)
+    assert failure_evidence._record_failure(1) is True
     broadcaster, _, comm, _ = _make_broadcaster(
         size=2,
-        detected_state=detected_state,
+        failure_evidence=failure_evidence,
     )
 
     try:
@@ -403,7 +403,7 @@ def test_externally_premarked_detected_state_fails_closed() -> None:
             pass
         _wait_until(
             lambda: isinstance(broadcaster.last_error, RuntimeError),
-            description="pre-recorded detected-state rejection",
+            description="pre-recorded failure-evidence rejection",
         )
         assert "without pre-recording evidence" in str(broadcaster.last_error)
         _wait_until(lambda: comm.revoke_calls == 1, description="pre-mark fail-closed revoke")
@@ -413,12 +413,12 @@ def test_externally_premarked_detected_state_fails_closed() -> None:
 
 def test_detection_reconciliation_does_not_mutate_committed_health() -> None:
     callbacks: list[tuple[int, int, float]] = []
-    detected_state = DetectedRankState(2)
+    failure_evidence = FailureEvidenceState(2)
     committed_health = EPGroupHealth(2)
     initial_committed_snapshot = committed_health.snapshot()
     broadcaster, _, _, _ = _make_broadcaster(
         size=2,
-        detected_state=detected_state,
+        failure_evidence=failure_evidence,
         callback=lambda failed, source, when: callbacks.append((failed, source, when)),
     )
     broadcaster.start()
@@ -429,12 +429,12 @@ def test_detection_reconciliation_does_not_mutate_committed_health() -> None:
             description="local detection coordinator handoff",
         )
         _wait_until(
-            broadcaster.detected_state_is_reconciled,
+            broadcaster.failure_evidence_is_reconciled,
             description="detection reconciliation",
         )
 
-        assert detected_state.get_failed_ranks() == frozenset({1})
-        assert detected_state.generation == 1
+        assert failure_evidence.snapshot().failed_ranks == frozenset({1})
+        assert failure_evidence.snapshot().evidence_epoch == 1
         assert committed_health.snapshot() == initial_committed_snapshot
         assert committed_health.all_active() is True
         assert callbacks[0][:2] == (1, 0)
@@ -468,37 +468,64 @@ def test_survivor_echoes_reconcile_failure_detection() -> None:
         assert len(comm.sends) == 2
         assert {send.destination for send in comm.sends} == {1, 3}
         assert all(send.message_kind == _FAILURE_MESSAGE for send in comm.sends)
-        assert broadcaster.detected_health_is_reconciled() is True
+        assert broadcaster.failure_evidence_is_reconciled() is True
         assert comm.revoke_calls == 0
     finally:
         broadcaster.stop()
 
 
-def test_detected_state_is_monotonic_for_one_communicator_epoch() -> None:
-    state = DetectedRankState(3)
+def test_failure_evidence_is_monotonic_for_one_communicator_epoch() -> None:
+    state = FailureEvidenceState(3)
 
-    assert state.snapshot() == ep_failure_broadcast.DetectedRankStateSnapshot(
-        mask=0b111,
+    assert state.snapshot() == ep_failure_broadcast.FailureEvidenceSnapshot(
         failed_ranks=frozenset(),
-        generation=0,
+        evidence_epoch=0,
     )
-    assert state.record_failure(2) is True
-    assert state.record_failure(2) is False
-    assert state.get_mask() == 0b011
-    assert state.get_failed_ranks() == frozenset({2})
-    assert state.generation == 1
+    assert state._record_failure(2) is True
+    assert state._record_failure(2) is False
+    assert state.has_failure(2) is True
+    assert state.has_failure(1) is False
+    assert state.snapshot().failed_ranks == frozenset({2})
+    assert state.snapshot().evidence_epoch == 1
+    assert not hasattr(state, "get_mask")
+    assert not hasattr(state.snapshot(), "mask")
     assert not hasattr(state, "mark_active")
 
 
-def test_detected_state_coalesces_concurrent_evidence() -> None:
-    state = DetectedRankState(4)
+@pytest.mark.parametrize("ep_size", [1.5, True], ids=["fractional", "boolean"])
+def test_failure_evidence_rejects_non_integer_size(ep_size: object) -> None:
+    with pytest.raises(TypeError, match="ep_size must be an integer"):
+        FailureEvidenceState(ep_size)
+
+
+@pytest.mark.parametrize("rank", [0.5, True], ids=["fractional", "boolean"])
+def test_non_integer_failure_rank_is_rejected(rank: object) -> None:
+    failure_evidence = FailureEvidenceState(2)
+    with pytest.raises(TypeError, match="rank must be an integer"):
+        failure_evidence._record_failure(rank)
+
+    broadcaster, _, _, _ = _make_broadcaster(
+        size=2,
+        failure_evidence=failure_evidence,
+    )
+    broadcaster.start()
+    try:
+        with pytest.raises(TypeError, match="failed_rank must be an integer"):
+            broadcaster.report_detected_failure(rank)
+        assert failure_evidence.has_failures() is False
+    finally:
+        broadcaster.stop()
+
+
+def test_failure_evidence_coalesces_concurrent_evidence() -> None:
+    state = FailureEvidenceState(4)
     barrier = threading.Barrier(8)
     results: list[bool] = []
     results_lock = threading.Lock()
 
     def record_same_failure() -> None:
         barrier.wait()
-        changed = state.record_failure(2)
+        changed = state._record_failure(2)
         with results_lock:
             results.append(changed)
 
@@ -510,18 +537,17 @@ def test_detected_state_coalesces_concurrent_evidence() -> None:
 
     assert results.count(True) == 1
     assert results.count(False) == 7
-    assert state.snapshot() == ep_failure_broadcast.DetectedRankStateSnapshot(
-        mask=0b1011,
+    assert state.snapshot() == ep_failure_broadcast.FailureEvidenceSnapshot(
         failed_ranks=frozenset({2}),
-        generation=1,
+        evidence_epoch=1,
     )
 
 
 def test_second_failure_between_claim_and_observe_cannot_open_single_failure_gate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    health = DetectedRankState(3)
-    broadcaster, _, _, _ = _make_broadcaster(size=3, detected_state=health)
+    failure_evidence = FailureEvidenceState(3)
+    broadcaster, _, _, _ = _make_broadcaster(size=3, failure_evidence=failure_evidence)
     original_claim = broadcaster._claim_failure
     mutated = False
 
@@ -530,23 +556,23 @@ def test_second_failure_between_claim_and_observe_cannot_open_single_failure_gat
         original_claim(failed_rank)
         if not mutated:
             mutated = True
-            assert health.record_failure(1) is True
+            assert failure_evidence._record_failure(1) is True
 
     monkeypatch.setattr(broadcaster, "_claim_failure", claim_then_add_second_failure)
     broadcaster.start()
     try:
-        assert broadcaster.broadcast_failure(2) is True
+        assert broadcaster.report_detected_failure(2) is True
         _wait_until(
             lambda: 2 in broadcaster._failure_fanout_complete,
             description="single-survivor fanout completion",
         )
-        assert health.get_failed_ranks() == frozenset({1, 2})
+        assert failure_evidence.snapshot().failed_ranks == frozenset({1, 2})
         _wait_until(
             lambda: isinstance(broadcaster.last_error, RuntimeError),
             description="second-detected-failure terminal handling",
         )
-        assert broadcaster.failure_is_reconciled(2) is False
-        assert broadcaster.health_is_reconciled() is False
+        assert broadcaster.failure_detection_is_reconciled(2) is False
+        assert broadcaster.failure_evidence_is_reconciled() is False
     finally:
         broadcaster.stop()
 
@@ -565,14 +591,14 @@ def test_reconciliation_timeout_fails_closed_while_mpi_test_is_wedged() -> None:
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        DetectedRankState(3),
+        FailureEvidenceState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
     )
     broadcaster.start()
     _wait_until(blocking_request.entered_test.is_set, description="blocked MPI progress")
-    assert broadcaster.pre_failover(2) is True
+    assert broadcaster.report_detected_failure(2) is True
     assert blocking_request.release_test.is_set() is False
     assert broadcaster._outbound_reports.empty() is False
 
@@ -582,10 +608,10 @@ def test_reconciliation_timeout_fails_closed_while_mpi_test_is_wedged() -> None:
     )
     _wait_until(lambda: comm.revoke_calls == 1, description="deadline-monitor revoke")
     assert blocking_request.release_test.is_set() is False
-    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
     assert broadcaster.world_is_poisoned() is True
     with pytest.raises(RuntimeError, match="not running"):
-        broadcaster.pre_failover(1)
+        broadcaster.report_detected_failure(1)
     blocking_request.release_test.set()
     broadcaster.stop()
 
@@ -606,14 +632,14 @@ def test_reconciliation_timeout_world_aborts_when_mpi_test_is_wedged_without_ulf
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        DetectedRankState(3),
+        FailureEvidenceState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
     )
     broadcaster.start()
     _wait_until(blocking_request.entered_test.is_set, description="blocked MPI progress")
-    assert broadcaster.pre_failover(2) is True
+    assert broadcaster.report_detected_failure(2) is True
 
     _wait_until(lambda: comm.abort_calls == 1, description="deadline-monitor MPI_Abort")
     assert blocking_request.release_test.is_set() is False
@@ -624,30 +650,30 @@ def test_reconciliation_timeout_world_aborts_when_mpi_test_is_wedged_without_ulf
     broadcaster.stop()
 
 
-def test_second_distinct_local_failure_fails_closed_before_health_mutation() -> None:
-    broadcaster, health, comm, _ = _make_broadcaster(size=4)
+def test_second_distinct_local_failure_fails_closed_before_failure_evidence_mutation() -> None:
+    broadcaster, failure_evidence, comm, _ = _make_broadcaster(size=4)
     broadcaster.start()
-    assert broadcaster.pre_failover(3) is True
+    assert broadcaster.report_detected_failure(3) is True
 
     with pytest.raises(RuntimeError, match="exactly one distinct failed rank") as raised:
-        broadcaster.pre_failover(2)
+        broadcaster.report_detected_failure(2)
 
-    assert health.get_failed_ranks() == frozenset({3})
+    assert failure_evidence.snapshot().failed_ranks == frozenset({3})
     _wait_until(lambda: broadcaster.last_error is raised.value, description="terminal failure")
     _wait_until(lambda: comm.revoke_calls == 1, description="progress-thread abort revoke")
-    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
     with pytest.raises(RuntimeError, match="not running"):
-        broadcaster.pre_failover(1)
+        broadcaster.report_detected_failure(1)
     broadcaster.stop()
 
 
 def test_no_ulfm_terminal_abort_relays_and_converges_without_world_abort() -> None:
     comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
-    broadcaster, health, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster, failure_evidence, _, _ = _make_broadcaster(size=3, comm=comm)
     broadcaster.start()
-    assert broadcaster.pre_failover(2) is True
+    assert broadcaster.report_detected_failure(2) is True
     with pytest.raises(RuntimeError, match="exactly one distinct failed rank"):
-        broadcaster.pre_failover(1)
+        broadcaster.report_detected_failure(1)
 
     _wait_until(
         lambda: any(send.message_kind == _ABORT_MESSAGE for send in comm.sends),
@@ -659,7 +685,7 @@ def test_no_ulfm_terminal_abort_relays_and_converges_without_world_abort() -> No
     comm.deliver(source=1, failed_rank=1, message_kind=_ABORT_MESSAGE)
     _wait_until(broadcaster._progress_failed.is_set, description="ABORT convergence")
 
-    assert health.get_failed_ranks() == frozenset({2})
+    assert failure_evidence.snapshot().failed_ranks == frozenset({2})
     assert comm.abort_calls == 0
     assert comm.revoke_calls == 0
     broadcaster.stop()
@@ -667,9 +693,9 @@ def test_no_ulfm_terminal_abort_relays_and_converges_without_world_abort() -> No
 
 def test_remote_conflicting_failure_relays_abort_before_world_abort() -> None:
     comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
-    broadcaster, health, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster, failure_evidence, _, _ = _make_broadcaster(size=3, comm=comm)
     broadcaster.start()
-    assert broadcaster.pre_failover(2) is True
+    assert broadcaster.report_detected_failure(2) is True
     _wait_until(
         lambda: any(send.message_kind == _FAILURE_MESSAGE for send in comm.sends),
         description="first failure fanout",
@@ -689,7 +715,7 @@ def test_remote_conflicting_failure_relays_abort_before_world_abort() -> None:
     comm.deliver(source=1, failed_rank=1, message_kind=_ABORT_MESSAGE)
     _wait_until(broadcaster._progress_failed.is_set, description="remote-conflict convergence")
 
-    assert health.get_failed_ranks() == frozenset({2})
+    assert failure_evidence.snapshot().failed_ranks == frozenset({2})
     assert isinstance(broadcaster.last_error, RuntimeError)
     assert "exactly one distinct failed rank" in str(broadcaster.last_error)
     assert comm.abort_calls == 0
@@ -725,7 +751,7 @@ def test_monitor_does_not_world_abort_reconciled_relay_when_mpi_test_resumes() -
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
-        DetectedRankState(2),
+        FailureEvidenceState(2),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -777,9 +803,9 @@ def test_terminal_abort_waits_until_its_relay_completes() -> None:
     broadcaster.stop()
 
 
-def test_received_terminal_abort_is_relayed_without_mutating_health() -> None:
+def test_received_terminal_abort_is_relayed_without_mutating_failure_evidence() -> None:
     comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
-    broadcaster, health, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster, failure_evidence, _, _ = _make_broadcaster(size=3, comm=comm)
     broadcaster.start()
     _wait_until(lambda: comm.receive_count(1) == 1, description="source 1 receive")
     comm.deliver(source=1, failed_rank=2, message_kind=_ABORT_MESSAGE)
@@ -795,7 +821,7 @@ def test_received_terminal_abort_is_relayed_without_mutating_health() -> None:
     comm.deliver(source=2, failed_rank=2, message_kind=_ABORT_MESSAGE)
     _wait_until(broadcaster._progress_failed.is_set, description="peer ABORT convergence")
 
-    assert health.all_active() is True
+    assert failure_evidence.has_failures() is False
     assert isinstance(broadcaster.last_error, RuntimeError)
     assert broadcaster.world_is_poisoned() is True
     assert comm.abort_calls == 0
@@ -814,15 +840,15 @@ def test_no_ulfm_abort_timeout_uses_world_abort_before_stop_completes() -> None:
     comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        DetectedRankState(3),
+        FailureEvidenceState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
     )
     broadcaster.start()
-    assert broadcaster.pre_failover(2) is True
+    assert broadcaster.report_detected_failure(2) is True
     with pytest.raises(RuntimeError, match="exactly one distinct failed rank"):
-        broadcaster.pre_failover(1)
+        broadcaster.report_detected_failure(1)
 
     # stop_event must not let the progress loop skip the pending ABORT fallback.
     broadcaster.stop(timeout=0.5)
@@ -853,7 +879,7 @@ def test_stop_cannot_bypass_abort_requested_during_blocked_drain() -> None:
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        DetectedRankState(3),
+        FailureEvidenceState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -886,7 +912,7 @@ def test_stop_cannot_bypass_abort_requested_during_blocked_drain() -> None:
 def test_concurrent_local_and_remote_distinct_failures_accept_only_one(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    broadcaster, health, comm, _ = _make_broadcaster(size=4)
+    broadcaster, failure_evidence, comm, _ = _make_broadcaster(size=4)
     broadcaster.start()
     _wait_until(lambda: comm.receive_count(1) == 1, description="remote receive")
 
@@ -905,7 +931,7 @@ def test_concurrent_local_and_remote_distinct_failures_accept_only_one(
 
     def report_local_failure() -> None:
         try:
-            broadcaster.pre_failover(2)
+            broadcaster.report_detected_failure(2)
         except BaseException as error:
             local_errors.append(error)
 
@@ -914,17 +940,17 @@ def test_concurrent_local_and_remote_distinct_failures_accept_only_one(
     _wait_until(local_claimed.is_set, description="local failure claim")
     comm.deliver(source=1, failed_rank=3)
     # The remote handler must wait for the local lifecycle transaction to commit
-    # its accepted rank and health generation atomically.
+    # its accepted rank and evidence epoch atomically.
     time.sleep(2 * _TEST_CONFIG.poll_interval_sec)
-    assert health.all_active() is True
+    assert failure_evidence.has_failures() is False
     release_local_claim.set()
     local_thread.join(timeout=1.0)
     assert local_thread.is_alive() is False
 
     _wait_until(lambda: broadcaster.last_error is not None, description="second-failure rejection")
     _wait_until(lambda: comm.revoke_calls == 1, description="terminal abort revoke")
-    assert len(health.get_failed_ranks()) == 1
-    assert health.get_failed_ranks() == frozenset({2})
+    assert len(failure_evidence.snapshot().failed_ranks) == 1
+    assert failure_evidence.snapshot().failed_ranks == frozenset({2})
     assert "exactly one distinct failed rank" in str(broadcaster.last_error)
     assert local_errors == []
     broadcaster.stop()
@@ -943,10 +969,10 @@ def test_isend_post_error_to_survivor_is_terminal_without_ulfm() -> None:
     )
     broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
     broadcaster.start()
-    assert broadcaster.pre_failover(2) is True
+    assert broadcaster.report_detected_failure(2) is True
 
     _wait_until(lambda: broadcaster.last_error is error, description="terminal Isend error")
-    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
     assert comm.revoke_calls == 0
     assert comm.sends == ()
     broadcaster.stop()
@@ -959,11 +985,11 @@ def test_send_test_error_is_terminal_and_revokes_with_ulfm() -> None:
     comm = _FakeComm(size=3, send_factory=lambda _destination: failed_request)
     broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
     broadcaster.start()
-    assert broadcaster.pre_failover(2) is True
+    assert broadcaster.report_detected_failure(2) is True
 
     _wait_until(lambda: broadcaster.last_error is error, description="terminal send Test error")
     _wait_until(lambda: comm.revoke_calls == 1, description="ULFM emergency revoke")
-    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
     assert failed_request.cancel_calls == 0
     assert broadcaster._retained_requests
     broadcaster.stop()
@@ -971,7 +997,7 @@ def test_send_test_error_is_terminal_and_revokes_with_ulfm() -> None:
 
 def test_received_report_is_idempotent_and_callback_runs_once() -> None:
     callbacks: list[tuple[int, int, float]] = []
-    broadcaster, health, comm, _ = _make_broadcaster(
+    broadcaster, failure_evidence, comm, _ = _make_broadcaster(
         size=3,
         callback=lambda failed, source, when: callbacks.append((failed, source, when)),
     )
@@ -979,29 +1005,31 @@ def test_received_report_is_idempotent_and_callback_runs_once() -> None:
     try:
         _wait_until(lambda: comm.receive_count(1) == 1, description="initial receive")
         comm.deliver(source=1, failed_rank=2)
-        _wait_until(lambda: health.is_active(2) is False, description="received failure")
+        _wait_until(lambda: failure_evidence.has_failure(2) is True, description="received failure")
         _wait_until(lambda: comm.receive_count(1) == 2, description="reposted receive")
 
         comm.deliver(source=1, failed_rank=2)
         _wait_until(lambda: comm.receive_count(1) == 3, description="duplicate receive progress")
         _wait_until(lambda: len(callbacks) == 1, description="failure callback")
 
-        assert health.generation == 1
+        assert failure_evidence.snapshot().evidence_epoch == 1
         assert len(callbacks) == 1
         failed_rank, source, event_time = callbacks[0]
         assert (failed_rank, source) == (2, 1)
         assert isinstance(event_time, float)
         _wait_until(lambda: len(comm.sends) == 1, description="failure relay")
         comm.sends[0].request.complete()
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(
+            broadcaster.failure_evidence_is_reconciled, description="failure reconciliation"
+        )
     finally:
         broadcaster.stop()
 
 
-def test_monitor_cannot_observe_remote_claim_before_detected_state_update(
+def test_monitor_cannot_observe_remote_claim_before_failure_evidence_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    broadcaster, health, comm, _ = _make_broadcaster(size=3)
+    broadcaster, failure_evidence, comm, _ = _make_broadcaster(size=3)
     original_claim = broadcaster._claim_failure
     claim_entered = threading.Event()
     release_claim = threading.Event()
@@ -1018,15 +1046,19 @@ def test_monitor_cannot_observe_remote_claim_before_detected_state_update(
         _wait_until(claim_entered.is_set, description="paused remote failure claim")
         time.sleep(3 * _TEST_CONFIG.poll_interval_sec)
 
-        assert health.is_active(2) is True
+        assert failure_evidence.has_failure(2) is False
         assert broadcaster.last_error is None
         assert comm.revoke_calls == 0
 
         release_claim.set()
-        _wait_until(lambda: not health.is_active(2), description="recorded remote detection")
+        _wait_until(
+            lambda: failure_evidence.has_failure(2), description="recorded remote detection"
+        )
         _wait_until(lambda: len(comm.sends) == 1, description="remote failure echo")
         comm.sends[0].request.complete()
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(
+            broadcaster.failure_evidence_is_reconciled, description="failure reconciliation"
+        )
     finally:
         release_claim.set()
         broadcaster.stop()
@@ -1040,7 +1072,7 @@ def test_blocking_callback_does_not_block_mpi_progress_and_stop_is_bounded() -> 
         callback_entered.set()
         release_callback.wait()
 
-    broadcaster, health, comm, _ = _make_broadcaster(
+    broadcaster, failure_evidence, comm, _ = _make_broadcaster(
         size=3,
         callback=blocking_callback,
     )
@@ -1055,7 +1087,7 @@ def test_blocking_callback_does_not_block_mpi_progress_and_stop_is_bounded() -> 
     _wait_until(lambda: comm.receive_count(1) == 2, description="receive repost")
     comm.deliver(source=1, failed_rank=2)
     _wait_until(lambda: comm.receive_count(1) == 3, description="duplicate receive progress")
-    assert health.get_failed_ranks() == frozenset({2})
+    assert failure_evidence.snapshot().failed_ranks == frozenset({2})
 
     start = time.monotonic()
     with pytest.raises(TimeoutError, match="callback thread did not stop"):
@@ -1070,7 +1102,7 @@ def test_blocking_callback_does_not_block_mpi_progress_and_stop_is_bounded() -> 
 
 def test_invalid_received_rank_is_ignored_and_receive_is_reposted() -> None:
     callbacks: list[tuple[int, int, float]] = []
-    broadcaster, health, comm, _ = _make_broadcaster(
+    broadcaster, failure_evidence, comm, _ = _make_broadcaster(
         size=3,
         callback=lambda failed, source, when: callbacks.append((failed, source, when)),
     )
@@ -1080,7 +1112,7 @@ def test_invalid_received_rank_is_ignored_and_receive_is_reposted() -> None:
         comm.deliver(source=1, failed_rank=99)
         _wait_until(lambda: comm.receive_count(1) == 2, description="receive after invalid payload")
 
-        assert health.all_active() is True
+        assert failure_evidence.has_failures() is False
         assert callbacks == []
         assert broadcaster.last_error is None
     finally:
@@ -1096,22 +1128,22 @@ def test_single_rank_group_has_no_peer_requests_or_sends() -> None:
         abort_timeout_sec=0.02,
     )
     comm = _FakeComm(size=1, ulfm_probe_error=NotImplementedError())
-    health = DetectedRankState(1)
+    failure_evidence = FailureEvidenceState(1)
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(1),
-        health,
+        failure_evidence,
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
     )
     broadcaster.start()
     try:
-        assert broadcaster.broadcast_failure(0) is True
+        assert broadcaster.report_detected_failure(0) is True
         _wait_until(broadcaster._outbound_reports.empty, description="empty single-rank report")
-        assert health.get_failed_ranks() == frozenset({0})
+        assert failure_evidence.snapshot().failed_ranks == frozenset({0})
         assert broadcaster.world_is_poisoned() is True
-        assert broadcaster.failure_is_reconciled(0) is False
-        assert broadcaster.health_is_reconciled() is False
+        assert broadcaster.failure_detection_is_reconciled(0) is False
+        assert broadcaster.failure_evidence_is_reconciled() is False
         assert comm.sends == ()
         assert comm.receive_count(0) == 0
         _wait_until(
@@ -1241,7 +1273,7 @@ def test_concurrent_stop_prevents_start_from_publishing_running() -> None:
     assert len(start_errors) == 1
     assert "did not reach running state" in str(start_errors[0])
     assert stop_errors == []
-    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
 
 
 def test_startup_failure_publishes_error_before_failed_flag(
@@ -1312,7 +1344,7 @@ def test_startup_timeout_fails_closed_before_progress_resumes() -> None:
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
-        DetectedRankState(2),
+        FailureEvidenceState(2),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -1369,7 +1401,7 @@ def test_startup_timeout_stops_callback_before_blocked_receive_is_released() -> 
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
-        DetectedRankState(2),
+        FailureEvidenceState(2),
         config,
         lambda _failed, _source, _when: None,
         comm=comm,
@@ -1392,20 +1424,20 @@ def test_startup_timeout_stops_callback_before_blocked_receive_is_released() -> 
 
 def test_reconciliation_gates_fail_closed_outside_running_lifecycle() -> None:
     broadcaster, _, _, _ = _make_broadcaster(size=2)
-    assert broadcaster.health_is_reconciled() is False
-    assert broadcaster.failure_is_reconciled(1) is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
+    assert broadcaster.failure_detection_is_reconciled(1) is False
 
     broadcaster.start()
-    assert broadcaster.pre_failover(1) is True
+    assert broadcaster.report_detected_failure(1) is True
     _wait_until(
-        lambda: broadcaster.failure_is_reconciled(1),
+        lambda: broadcaster.failure_detection_is_reconciled(1),
         description="single-survivor reconciliation",
     )
-    assert broadcaster.health_is_reconciled() is True
+    assert broadcaster.failure_evidence_is_reconciled() is True
 
     broadcaster.stop()
-    assert broadcaster.failure_is_reconciled(1) is False
-    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_detection_is_reconciled(1) is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
 
 
 @pytest.mark.parametrize("timeout", [0.0, -1.0, float("nan"), float("inf"), float("-inf")])
@@ -1438,10 +1470,10 @@ def test_stop_is_bounded_when_mpi_test_is_stuck() -> None:
     assert comm.abort_calls == 0
 
 
-def test_broadcast_rejects_report_after_stop_begins() -> None:
+def test_failure_report_is_rejected_after_stop_begins() -> None:
     blocking_request = _BlockingRequest()
     comm = _FakeComm(size=2, receive_factory=lambda _source: blocking_request)
-    broadcaster, health, _, _ = _make_broadcaster(size=2, comm=comm)
+    broadcaster, failure_evidence, _, _ = _make_broadcaster(size=2, comm=comm)
     broadcaster.start()
     _wait_until(blocking_request.entered_test.is_set, description="blocked MPI Test")
 
@@ -1458,8 +1490,8 @@ def test_broadcast_rejects_report_after_stop_begins() -> None:
     _wait_until(broadcaster._stop_event.is_set, description="stop transition")
 
     with pytest.raises(RuntimeError, match="state=stopping"):
-        broadcaster.broadcast_failure(1)
-    assert health.all_active() is True
+        broadcaster.report_detected_failure(1)
+    assert failure_evidence.has_failures() is False
 
     blocking_request.release_test.set()
     stop_thread.join(timeout=1.0)
@@ -1468,7 +1500,7 @@ def test_broadcast_rejects_report_after_stop_begins() -> None:
 
 
 def test_healthy_stop_cancels_preposted_receives() -> None:
-    broadcaster, health, comm, _ = _make_broadcaster(size=3)
+    broadcaster, failure_evidence, comm, _ = _make_broadcaster(size=3)
     broadcaster.start()
     _wait_until(
         lambda: comm.receive_count(1) == 1 and comm.receive_count(2) == 1,
@@ -1476,7 +1508,7 @@ def test_healthy_stop_cancels_preposted_receives() -> None:
     )
     receives = [comm.latest_receive(source).request for source in (1, 2)]
 
-    assert health.all_active() is True
+    assert failure_evidence.has_failures() is False
     broadcaster.stop()
 
     assert [request.cancel_calls for request in receives] == [1, 1]
@@ -1495,7 +1527,7 @@ def test_healthy_stop_cleanup_timeout_aborts_world_and_retains_request() -> None
     )
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
-        DetectedRankState(2),
+        FailureEvidenceState(2),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -1513,19 +1545,19 @@ def test_healthy_stop_cleanup_timeout_aborts_world_and_retains_request() -> None
     assert comm.revoke_calls == 0
 
 
-def test_poisoned_stop_keeps_progressing_until_failure_is_reconciled() -> None:
-    broadcaster, health, comm, _ = _make_broadcaster(size=3)
+def test_poisoned_stop_keeps_progressing_until_failure_detection_is_reconciled() -> None:
+    broadcaster, failure_evidence, comm, _ = _make_broadcaster(size=3)
     broadcaster.start()
     _wait_until(
         lambda: comm.receive_count(1) == 1 and comm.receive_count(2) == 1,
         description="preposted receives",
     )
     receives = [comm.latest_receive(source).request for source in (1, 2)]
-    assert broadcaster.broadcast_failure(2) is True
+    assert broadcaster.report_detected_failure(2) is True
     _wait_until(lambda: len(comm.sends) == 1, description="pending failure send")
     send = comm.sends[0]
 
-    assert health.get_failed_ranks() == frozenset({2})
+    assert failure_evidence.snapshot().failed_ranks == frozenset({2})
     initial_test_calls = send.request.test_calls
     stop_errors: list[BaseException] = []
 
@@ -1571,12 +1603,14 @@ def test_poisoned_resources_outlive_broadcaster_object() -> None:
             lambda: comm.receive_count(1) == 1 and comm.receive_count(2) == 1,
             description="preposted receives",
         )
-        assert broadcaster.pre_failover(2) is True
+        assert broadcaster.report_detected_failure(2) is True
         _wait_until(lambda: len(comm.sends) == 1, description="pending send")
         send = comm.sends[0]
         send.request.complete()
         comm.deliver(source=1, failed_rank=2)
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(
+            broadcaster.failure_evidence_is_reconciled, description="failure reconciliation"
+        )
         retained_receive = comm.latest_receive(2)
         references = (
             weakref.ref(retained_receive.request),
@@ -1634,7 +1668,7 @@ def test_constructor_requires_mpi_thread_multiple() -> None:
     with pytest.raises(RuntimeError, match="MPI.THREAD_MULTIPLE"):
         MpiFtSubcomm(
             _FakeMapping.ep_world(2),
-            DetectedRankState(2),
+            FailureEvidenceState(2),
             _TEST_CONFIG,
             comm=comm,
             mpi_module=mpi,
@@ -1666,9 +1700,9 @@ def test_collectively_created_comm_uses_frozen_setup_and_lives_for_process(
     def create_mpi_ft_subcomm(
         setup_mapping: SingleReadMapping,
         *,
-        health_size: int,
+        failure_evidence_size: int,
     ) -> types.SimpleNamespace:
-        assert health_size == 2
+        assert failure_evidence_size == 2
         local_rank = setup_mapping.moe_ep_rank
         comm.Set_errhandler(mpi.ERRORS_RETURN)
         return types.SimpleNamespace(
@@ -1693,7 +1727,7 @@ def test_collectively_created_comm_uses_frozen_setup_and_lives_for_process(
     try:
         broadcaster = MpiFtSubcomm(
             mapping,
-            DetectedRankState(2),
+            FailureEvidenceState(2),
             _TEST_CONFIG,
             mpi_module=mpi,
         )
@@ -1725,7 +1759,7 @@ def test_constructor_rejects_non_world_spanning_ep_group_for_mvp() -> None:
     with pytest.raises(ValueError, match="spanning the full MPI world"):
         MpiFtSubcomm(
             mapping,
-            DetectedRankState(2),
+            FailureEvidenceState(2),
             _TEST_CONFIG,
             comm=comm,
             mpi_module=_FakeMPI(),
@@ -1809,7 +1843,7 @@ def test_constructor_rejects_and_retains_already_revoked_comm() -> None:
 
 def test_peer_failure_reconciles_without_revoking_control_plane() -> None:
     callbacks: list[tuple[int, int, float]] = []
-    broadcaster, health, comm, _ = _make_broadcaster(
+    broadcaster, failure_evidence, comm, _ = _make_broadcaster(
         size=3,
         callback=lambda failed, source, when: callbacks.append((failed, source, when)),
     )
@@ -1819,10 +1853,13 @@ def test_peer_failure_reconciles_without_revoking_control_plane() -> None:
         _wait_until(lambda: comm.receive_count(1) == 1, description="peer receive")
         comm.latest_receive(1).request.fail(_FakeMpiException(_FakeMPI.ERR_PROC_FAILED))
 
-        _wait_until(lambda: health.is_active(1) is False, description="peer failure classification")
+        _wait_until(
+            lambda: failure_evidence.has_failure(1) is True,
+            description="peer failure classification",
+        )
         _wait_until(lambda: len(comm.sends) == 1, description="peer failure relay")
 
-        assert health.get_failed_ranks() == frozenset({1})
+        assert failure_evidence.snapshot().failed_ranks == frozenset({1})
         _wait_until(lambda: len(callbacks) == 1, description="failed-peer callback")
         assert [(failed, source) for failed, source, _ in callbacks] == [(1, 1)]
         assert comm.sends[0].destination == 2
@@ -1833,9 +1870,11 @@ def test_peer_failure_reconciles_without_revoking_control_plane() -> None:
 
         comm.sends[0].request.complete()
         comm.deliver(source=2, failed_rank=1)
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(
+            broadcaster.failure_evidence_is_reconciled, description="failure reconciliation"
+        )
         _wait_until(lambda: comm.receive_count(2) == 2, description="reposted receive")
-        assert broadcaster.health_is_reconciled() is True
+        assert broadcaster.failure_evidence_is_reconciled() is True
         assert broadcaster.last_error is None
         assert comm.revoke_calls == 0
     finally:
@@ -1847,12 +1886,12 @@ def test_remote_revoke_after_local_reconciliation_still_fails_closed() -> None:
     comm = _FakeComm(size=3)
     broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
     broadcaster.start()
-    assert broadcaster.pre_failover(2) is True
+    assert broadcaster.report_detected_failure(2) is True
     _wait_until(lambda: len(comm.sends) == 1, description="failure relay")
     comm.sends[0].request.complete()
     _wait_until(lambda: comm.receive_count(1) == 1, description="initial peer receive")
     comm.deliver(source=1, failed_rank=2)
-    _wait_until(broadcaster.health_is_reconciled, description="local reconciliation")
+    _wait_until(broadcaster.failure_evidence_is_reconciled, description="local reconciliation")
     _wait_until(
         lambda: comm.receive_count(1) == 2,
         description="receive after failure report",
@@ -1860,11 +1899,11 @@ def test_remote_revoke_after_local_reconciliation_still_fails_closed() -> None:
 
     comm.latest_receive(1).request.fail(error)
     _wait_until(lambda: broadcaster.last_error is error, description="terminal remote revoke")
-    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
     assert comm.revoke_calls == 1
     with pytest.raises(RuntimeError, match="not running"):
-        broadcaster.pre_failover(1)
-    assert broadcaster._detected_state.get_failed_ranks() == frozenset({2})
+        broadcaster.report_detected_failure(1)
+    assert broadcaster._failure_evidence.snapshot().failed_ranks == frozenset({2})
     broadcaster.stop()
 
 
@@ -1873,19 +1912,19 @@ def test_premature_remote_revoke_fails_closed() -> None:
     comm = _FakeComm(size=3)
     broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
     broadcaster.start()
-    assert broadcaster.pre_failover(2) is True
+    assert broadcaster.report_detected_failure(2) is True
     _wait_until(lambda: comm.receive_count(1) == 1, description="initial peer receive")
 
     comm.latest_receive(1).request.fail(error)
     _wait_until(lambda: broadcaster.last_error is error, description="terminal revoke")
-    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
     assert comm.revoke_calls == 1
     broadcaster.stop()
 
 
 def test_generic_mpi_error_is_terminal_and_revokes_once() -> None:
     comm = _FakeComm(size=2)
-    broadcaster, health, _, _ = _make_broadcaster(size=2, comm=comm)
+    broadcaster, failure_evidence, _, _ = _make_broadcaster(size=2, comm=comm)
     broadcaster.start()
     try:
         _wait_until(lambda: comm.receive_count(1) == 1, description="peer receive")
@@ -1894,9 +1933,9 @@ def test_generic_mpi_error_is_terminal_and_revokes_once() -> None:
 
         _wait_until(lambda: broadcaster.last_error is error, description="terminal MPI error")
         _wait_until(lambda: comm.revoke_calls == 1, description="communicator revoke")
-        assert health.all_active() is True
+        assert failure_evidence.has_failures() is False
         with pytest.raises(RuntimeError, match="broadcaster is not running"):
-            broadcaster.broadcast_failure(1)
+            broadcaster.report_detected_failure(1)
     finally:
         broadcaster.stop()
     assert comm.revoke_calls == 1
@@ -1904,23 +1943,28 @@ def test_generic_mpi_error_is_terminal_and_revokes_once() -> None:
 
 def test_proc_failed_is_classified_without_full_ulfm_support() -> None:
     comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
-    broadcaster, health, _, _ = _make_broadcaster(size=3, comm=comm)
+    broadcaster, failure_evidence, _, _ = _make_broadcaster(size=3, comm=comm)
     assert broadcaster.ulfm_available is False
     broadcaster.start()
     try:
         _wait_until(lambda: comm.receive_count(1) == 1, description="peer receive")
         comm.latest_receive(1).request.fail(_FakeMpiException(_FakeMPI.ERR_PROC_FAILED))
-        _wait_until(lambda: health.is_active(1) is False, description="peer failure classification")
+        _wait_until(
+            lambda: failure_evidence.has_failure(1) is True,
+            description="peer failure classification",
+        )
         _wait_until(lambda: len(comm.sends) == 1, description="peer failure relay")
 
-        assert health.get_failed_ranks() == frozenset({1})
+        assert failure_evidence.snapshot().failed_ranks == frozenset({1})
         assert comm.sends[0].destination == 2
         assert comm.sends[0].payload == 1
         assert broadcaster.last_error is None
         assert comm.revoke_calls == 0
         comm.sends[0].request.complete()
         comm.deliver(source=2, failed_rank=1)
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(
+            broadcaster.failure_evidence_is_reconciled, description="failure reconciliation"
+        )
     finally:
         broadcaster.stop()
 
@@ -1928,7 +1972,7 @@ def test_proc_failed_is_classified_without_full_ulfm_support() -> None:
 def test_non_ulfm_generic_receive_error_keeps_other_sources_live() -> None:
     callbacks: list[tuple[int, int, float]] = []
     comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
-    broadcaster, health, _, _ = _make_broadcaster(
+    broadcaster, failure_evidence, _, _ = _make_broadcaster(
         size=3,
         comm=comm,
         callback=lambda failed, source, when: callbacks.append((failed, source, when)),
@@ -1946,14 +1990,14 @@ def test_non_ulfm_generic_receive_error_keeps_other_sources_live() -> None:
             description="retained failed receive",
         )
 
-        assert health.all_active() is True
+        assert failure_evidence.has_failures() is False
         assert broadcaster.last_error is None
         assert failed_receive.cancel_calls == 0
 
         # Another survivor's rank-attributed detection remains usable even
         # when the dead source's fixed receive failed with a generic error.
         comm.deliver(source=2, failed_rank=1)
-        _wait_until(lambda: health.is_active(1) is False, description="detection report")
+        _wait_until(lambda: failure_evidence.has_failure(1) is True, description="detection report")
         _wait_until(lambda: len(comm.sends) == 1, description="failure relay")
         comm.sends[0].request.complete()
         _wait_until(lambda: comm.receive_count(2) == 2, description="live-source receive repost")
@@ -1962,7 +2006,9 @@ def test_non_ulfm_generic_receive_error_keeps_other_sources_live() -> None:
         assert [(failed, source) for failed, source, _ in callbacks] == [(1, 2)]
         assert broadcaster.last_error is None
         assert comm.revoke_calls == 0
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(
+            broadcaster.failure_evidence_is_reconciled, description="failure reconciliation"
+        )
     finally:
         broadcaster.stop()
 
@@ -1979,7 +2025,7 @@ def test_non_ulfm_generic_error_after_watchdog_report_does_not_arm_stale_deadlin
     comm = _FakeComm(size=3, ulfm_probe_error=NotImplementedError())
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(3),
-        DetectedRankState(3),
+        FailureEvidenceState(3),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -2005,11 +2051,13 @@ def test_non_ulfm_generic_error_after_watchdog_report_does_not_arm_stale_deadlin
             description="retained explained receive",
         )
         comm.sends[0].request.complete()
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(
+            broadcaster.failure_evidence_is_reconciled, description="failure reconciliation"
+        )
         time.sleep(3 * config.unattributed_error_timeout_sec)
 
         assert broadcaster.last_error is None
-        assert broadcaster.health_is_reconciled() is True
+        assert broadcaster.failure_evidence_is_reconciled() is True
         assert comm.abort_calls == 0
     finally:
         broadcaster.stop()
@@ -2027,7 +2075,7 @@ def test_unattributed_error_from_other_source_keeps_reconciliation_gate_closed()
     comm = _FakeComm(size=4, ulfm_probe_error=NotImplementedError())
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(4),
-        DetectedRankState(4),
+        FailureEvidenceState(4),
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -2058,8 +2106,8 @@ def test_unattributed_error_from_other_source_keeps_reconciliation_gate_closed()
             description="completed failure fanout",
         )
 
-        assert broadcaster.failure_is_reconciled(3) is False
-        assert broadcaster.health_is_reconciled() is False
+        assert broadcaster.failure_detection_is_reconciled(3) is False
+        assert broadcaster.failure_evidence_is_reconciled() is False
         _wait_until(
             lambda: isinstance(broadcaster.last_error, TimeoutError),
             description="unattributed transport deadline",
@@ -2081,10 +2129,10 @@ def test_non_ulfm_unattributed_receive_error_aborts_after_bounded_deadlines(
         abort_timeout_sec=0.05,
     )
     comm = _FakeComm(size=2, ulfm_probe_error=NotImplementedError())
-    health = DetectedRankState(2)
+    failure_evidence = FailureEvidenceState(2)
     broadcaster = MpiFtSubcomm(
         _FakeMapping.ep_world(2),
-        health,
+        failure_evidence,
         config,
         comm=comm,
         mpi_module=_FakeMPI(),
@@ -2116,7 +2164,7 @@ def test_non_ulfm_unattributed_receive_error_aborts_after_bounded_deadlines(
         assert broadcaster.last_error is None
         assert broadcaster._lifecycle is ep_failure_broadcast._Lifecycle.FAILED
         assert broadcaster._unattributed_error_deadlines[1] == float("inf")
-        assert broadcaster.health_is_reconciled() is False
+        assert broadcaster.failure_evidence_is_reconciled() is False
     finally:
         release_terminal_request.set()
 
@@ -2127,14 +2175,14 @@ def test_non_ulfm_unattributed_receive_error_aborts_after_bounded_deadlines(
     assert "could not attribute" in str(broadcaster.last_error)
     # Expiry remains protocol-visible for the rest of this communicator epoch.
     assert 1 in broadcaster._unattributed_error_deadlines
-    assert broadcaster.health_is_reconciled() is False
+    assert broadcaster.failure_evidence_is_reconciled() is False
     _wait_until(
         lambda: any(send.message_kind == _ABORT_MESSAGE for send in comm.sends),
         description="terminal ABORT relay",
     )
     _wait_until(lambda: comm.abort_calls == 1, description="bounded MPI_Abort fallback")
 
-    assert health.all_active() is True
+    assert failure_evidence.has_failures() is False
     assert failed_receive.cancel_calls == 0
     assert comm.revoke_calls == 0
     broadcaster.stop()
@@ -2145,7 +2193,7 @@ def test_send_buffer_lives_until_request_test_completes() -> None:
     broadcaster, _, _, _ = _make_broadcaster(size=3, comm=comm)
     broadcaster.start()
     try:
-        assert broadcaster.broadcast_failure(2) is True
+        assert broadcaster.report_detected_failure(2) is True
         _wait_until(lambda: len(comm.sends) == 1, description="pending send")
         record = comm.sends[0]
         _wait_until(lambda: record.request.test_calls > 0, description="send Test polling")
@@ -2161,6 +2209,8 @@ def test_send_buffer_lives_until_request_test_completes() -> None:
 
         _wait_until(buffer_released, description="completed send buffer release")
         comm.deliver(source=1, failed_rank=2)
-        _wait_until(broadcaster.health_is_reconciled, description="failure reconciliation")
+        _wait_until(
+            broadcaster.failure_evidence_is_reconciled, description="failure reconciliation"
+        )
     finally:
         broadcaster.stop()

--- a/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
+++ b/tests/unittest/_torch/executor/test_ep_failure_broadcast.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the WideEP MPI failure-broadcast control plane.
+"""Unit tests for the WideEP MPI failure-notification plane.
 
 The tests use in-memory MPI, communicator, and request doubles. They exercise
 the real progress thread without requiring mpi4py, GPUs, or a multi-rank
@@ -66,7 +66,7 @@ def test_config_requires_positive_finite_timeouts(value: float) -> None:
         MpiFtSubcommConfig(abort_timeout_sec=value)
 
 
-def test_default_poll_interval_leaves_margin_below_agreement_budget() -> None:
+def test_default_poll_interval_is_ten_milliseconds() -> None:
     assert MpiFtSubcommConfig().poll_interval_sec == 0.01
 
 
@@ -293,6 +293,23 @@ class _FakeComm:
     def sends(self) -> tuple[_SendRecord, ...]:
         with self._lock:
             return tuple(self._sends)
+
+
+class _BlockingRevokeComm(_FakeComm):
+    """Communicator whose Revoke call remains in flight until released."""
+
+    def __init__(self, *, size: int, rank: int = 0) -> None:
+        super().__init__(size=size, rank=rank)
+        self.revoke_entered = threading.Event()
+        self.release_revoke = threading.Event()
+        self.on_revoke_entered: Callable[[], None] | None = None
+
+    def Revoke(self) -> None:
+        self.revoke_calls += 1
+        self.revoke_entered.set()
+        if self.on_revoke_entered is not None:
+            self.on_revoke_entered()
+        self.release_revoke.wait()
 
 
 def _wait_until(
@@ -606,10 +623,11 @@ def test_reconciliation_timeout_fails_closed_while_mpi_test_is_wedged() -> None:
         lambda: isinstance(broadcaster.last_error, TimeoutError),
         description="terminal reconciliation timeout",
     )
-    _wait_until(lambda: comm.revoke_calls == 1, description="deadline-monitor revoke")
+    _wait_until(lambda: comm.abort_calls == 1, description="deadline-monitor MPI_Abort")
     assert blocking_request.release_test.is_set() is False
+    assert comm.revoke_calls == 0
     assert broadcaster.failure_evidence_is_reconciled() is False
-    assert broadcaster.world_is_poisoned() is True
+    assert broadcaster.communicator_epoch_is_failed() is True
     with pytest.raises(RuntimeError, match="not running"):
         broadcaster.report_detected_failure(1)
     blocking_request.release_test.set()
@@ -644,7 +662,7 @@ def test_reconciliation_timeout_world_aborts_when_mpi_test_is_wedged_without_ulf
     _wait_until(lambda: comm.abort_calls == 1, description="deadline-monitor MPI_Abort")
     assert blocking_request.release_test.is_set() is False
     assert isinstance(broadcaster.last_error, TimeoutError)
-    assert broadcaster.world_is_poisoned() is True
+    assert broadcaster.communicator_epoch_is_failed() is True
 
     blocking_request.release_test.set()
     broadcaster.stop()
@@ -759,26 +777,127 @@ def test_monitor_does_not_world_abort_reconciled_relay_when_mpi_test_resumes() -
     broadcaster.start()
     _wait_until(blocking_request.entered_test.is_set, description="blocked MPI progress")
     broadcaster._request_terminal_abort(RuntimeError("terminal"), -1, 0)
+    broadcaster._wake_event.clear()
     with broadcaster._protocol_lock:
         broadcaster._abort_reporters.add(1)
         broadcaster._abort_fanout_posted = True
         broadcaster._abort_fanout_complete = True
     broadcaster._deadline_monitor_wake_event.set()
 
-    _wait_until(
-        lambda: (
-            broadcaster._deadline_monitor_thread is not None
-            and not broadcaster._deadline_monitor_thread.is_alive()
-        ),
-        description="monitor-observed terminal reconciliation",
-    )
+    _wait_until(broadcaster._wake_event.is_set, description="monitor-observed reconciliation")
+    assert broadcaster._deadline_monitor_thread is not None
+    assert broadcaster._deadline_monitor_thread.is_alive()
     assert broadcaster._progress_failed.is_set() is False
     assert comm.abort_calls == 0
 
     blocking_request.release_test.set()
     _wait_until(broadcaster._progress_failed.is_set, description="clean terminal progress stop")
+    _wait_until(
+        lambda: (
+            broadcaster._deadline_monitor_thread is not None
+            and not broadcaster._deadline_monitor_thread.is_alive()
+        ),
+        description="deadline monitor shutdown",
+    )
     broadcaster.stop()
     assert comm.abort_calls == 0
+
+
+def test_monitor_world_aborts_when_reconciled_relay_progress_never_resumes() -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.001,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.02,
+        reconcile_timeout_sec=0.2,
+        abort_timeout_sec=0.2,
+    )
+    blocking_request = _BlockingRequest()
+    comm = _FakeComm(
+        size=2,
+        receive_factory=lambda _source: blocking_request,
+    )
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(2),
+        FailureEvidenceState(2),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    try:
+        _wait_until(blocking_request.entered_test.is_set, description="blocked MPI progress")
+        broadcaster._request_terminal_abort(RuntimeError("terminal"), -1, 0)
+        with broadcaster._protocol_lock:
+            broadcaster._abort_reporters.add(1)
+            broadcaster._abort_fanout_posted = True
+            broadcaster._abort_fanout_complete = True
+        broadcaster._deadline_monitor_wake_event.set()
+
+        _wait_until(lambda: comm.abort_calls == 1, description="wedged progress fallback")
+        assert broadcaster._progress_failed.is_set()
+        assert blocking_request.release_test.is_set() is False
+        assert comm.revoke_calls == 0
+    finally:
+        blocking_request.release_test.set()
+        broadcaster.stop(timeout=0.5)
+    assert comm.abort_calls == 1
+    assert comm.revoke_calls == 0
+
+
+def test_monitor_world_aborts_when_ulfm_revoke_never_completes() -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.1,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.02,
+        reconcile_timeout_sec=0.2,
+        abort_timeout_sec=0.2,
+    )
+    comm = _BlockingRevokeComm(size=1)
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(1),
+        FailureEvidenceState(1),
+        config,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    broadcaster.start()
+    try:
+        broadcaster._request_terminal_abort(RuntimeError("terminal"), -1, 0)
+        _wait_until(comm.revoke_entered.is_set, description="in-flight communicator revoke")
+        assert comm.release_revoke.is_set() is False
+
+        _wait_until(lambda: comm.abort_calls == 1, description="wedged revoke MPI_Abort fallback")
+        assert broadcaster._progress_failed.is_set()
+        assert broadcaster._revoke_completed is False
+        assert comm.release_revoke.is_set() is False
+    finally:
+        comm.release_revoke.set()
+        broadcaster.stop(timeout=0.5)
+    assert comm.revoke_calls == 1
+    assert comm.abort_calls == 1
+
+
+@pytest.mark.parametrize(
+    "revoke_error",
+    [
+        NotImplementedError("ULFM not compiled"),
+        _FakeMpiException(_FakeMPI.ERR_UNSUPPORTED_OPERATION),
+    ],
+    ids=["not-implemented", "unsupported-operation"],
+)
+def test_runtime_unsupported_revoke_falls_back_to_terminal_relay(
+    revoke_error: BaseException,
+) -> None:
+    comm = _FakeComm(size=1, revoke_error=revoke_error)
+    broadcaster, _, _, _ = _make_broadcaster(size=1, comm=comm)
+    broadcaster.start()
+    broadcaster._request_terminal_abort(RuntimeError("terminal"), -1, 0)
+
+    _wait_until(broadcaster._progress_failed.is_set, description="terminal relay completion")
+    assert broadcaster.ulfm_available is False
+    assert comm.revoke_calls == 1
+    assert comm.abort_calls == 0
+    broadcaster.stop()
 
 
 def test_terminal_abort_waits_until_its_relay_completes() -> None:
@@ -823,10 +942,10 @@ def test_received_terminal_abort_is_relayed_without_mutating_failure_evidence() 
 
     assert failure_evidence.has_failures() is False
     assert isinstance(broadcaster.last_error, RuntimeError)
-    assert broadcaster.world_is_poisoned() is True
+    assert broadcaster.communicator_epoch_is_failed() is True
     assert comm.abort_calls == 0
     broadcaster.stop()
-    assert broadcaster.world_is_poisoned() is True
+    assert broadcaster.communicator_epoch_is_failed() is True
 
 
 def test_no_ulfm_abort_timeout_uses_world_abort_before_stop_completes() -> None:
@@ -939,7 +1058,7 @@ def test_concurrent_local_and_remote_distinct_failures_accept_only_one(
     local_thread.start()
     _wait_until(local_claimed.is_set, description="local failure claim")
     comm.deliver(source=1, failed_rank=3)
-    # The remote handler must wait for the local lifecycle transaction to commit
+    # The remote handler must wait for the local lifecycle transaction to publish
     # its accepted rank and evidence epoch atomically.
     time.sleep(2 * _TEST_CONFIG.poll_interval_sec)
     assert failure_evidence.has_failures() is False
@@ -989,6 +1108,7 @@ def test_send_test_error_is_terminal_and_revokes_with_ulfm() -> None:
 
     _wait_until(lambda: broadcaster.last_error is error, description="terminal send Test error")
     _wait_until(lambda: comm.revoke_calls == 1, description="ULFM emergency revoke")
+    assert comm.abort_calls == 0
     assert broadcaster.failure_evidence_is_reconciled() is False
     assert failed_request.cancel_calls == 0
     assert broadcaster._retained_requests
@@ -1094,7 +1214,7 @@ def test_blocking_callback_does_not_block_mpi_progress_and_stop_is_bounded() -> 
         broadcaster.stop(timeout=0.02)
     assert time.monotonic() - start < 0.2
     assert broadcaster.last_error is None
-    assert broadcaster.world_is_poisoned() is True
+    assert broadcaster.communicator_epoch_is_failed() is True
 
     release_callback.set()
     broadcaster.stop(timeout=0.5)
@@ -1141,7 +1261,7 @@ def test_single_rank_group_has_no_peer_requests_or_sends() -> None:
         assert broadcaster.report_detected_failure(0) is True
         _wait_until(broadcaster._outbound_reports.empty, description="empty single-rank report")
         assert failure_evidence.snapshot().failed_ranks == frozenset({0})
-        assert broadcaster.world_is_poisoned() is True
+        assert broadcaster.communicator_epoch_is_failed() is True
         assert broadcaster.failure_detection_is_reconciled(0) is False
         assert broadcaster.failure_evidence_is_reconciled() is False
         assert comm.sends == ()
@@ -1211,7 +1331,8 @@ def test_thread_start_failure_is_terminal_and_stoppable(
         assert broadcaster.last_error is start_error
         assert broadcaster._progress_failed.is_set()
         assert broadcaster._thread is None
-        assert comm.revoke_calls == 1
+        assert comm.revoke_calls == 0
+        assert comm.abort_calls == 1
         if failing_thread_name == "wide-ep-ft-callback":
             assert broadcaster._callback_thread is None
             assert broadcaster._deadline_monitor_thread is None
@@ -1319,6 +1440,55 @@ def test_startup_failure_publishes_error_before_failed_flag(
     assert broadcaster.last_error is error
     assert broadcaster._progress_failed.is_set()
     assert comm.revoke_calls == 1
+
+
+def test_startup_failure_aborts_before_retiring_monitor_with_revoke_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = MpiFtSubcommConfig(
+        poll_interval_sec=0.1,
+        startup_timeout_sec=0.5,
+        stop_timeout_sec=0.02,
+        reconcile_timeout_sec=0.2,
+        abort_timeout_sec=0.2,
+    )
+    comm = _BlockingRevokeComm(size=1)
+    broadcaster = MpiFtSubcomm(
+        _FakeMapping.ep_world(1),
+        FailureEvidenceState(1),
+        config,
+        lambda _failed, _source, _when: None,
+        comm=comm,
+        mpi_module=_FakeMPI(),
+    )
+    startup_error = _FakeMpiException(999, "failure after thread readiness")
+    comm.on_revoke_entered = broadcaster._ready_event.set
+
+    def fail_during_startup() -> None:
+        with broadcaster._lifecycle_lock:
+            broadcaster._lifecycle = ep_failure_broadcast._Lifecycle.RUNNING
+        broadcaster._fail_closed_immediately(startup_error)
+
+    monkeypatch.setattr(broadcaster, "_progress_loop", fail_during_startup)
+    try:
+        with pytest.raises(RuntimeError, match="failed during startup") as raised:
+            broadcaster.start()
+
+        assert raised.value.__cause__ is startup_error
+        assert comm.revoke_entered.is_set()
+        assert comm.release_revoke.is_set() is False
+        assert comm.revoke_calls == 1
+        assert comm.abort_calls == 1
+        assert broadcaster._progress_failed.is_set()
+        assert broadcaster._deadline_monitor_thread is not None
+        assert broadcaster._deadline_monitor_thread.is_alive() is False
+        assert broadcaster._callback_thread is not None
+        assert broadcaster._callback_thread.is_alive() is False
+    finally:
+        comm.release_revoke.set()
+        broadcaster.stop(timeout=0.5)
+    assert comm.revoke_calls == 1
+    assert comm.abort_calls == 1
 
 
 def test_startup_timeout_fails_closed_before_progress_resumes() -> None:
@@ -1461,13 +1631,13 @@ def test_stop_is_bounded_when_mpi_test_is_stuck() -> None:
         broadcaster.stop(timeout=0.01)
     assert time.monotonic() - start < 0.2
     assert blocking_request.release_test.is_set() is False
-    assert comm.revoke_calls == 1
-    assert comm.abort_calls == 0
+    assert comm.revoke_calls == 0
+    assert comm.abort_calls == 1
 
     blocking_request.release_test.set()
     broadcaster.stop(timeout=0.5)
-    assert comm.revoke_calls == 1
-    assert comm.abort_calls == 0
+    assert comm.revoke_calls == 0
+    assert comm.abort_calls == 1
 
 
 def test_failure_report_is_rejected_after_stop_begins() -> None:
@@ -1545,7 +1715,7 @@ def test_healthy_stop_cleanup_timeout_aborts_world_and_retains_request() -> None
     assert comm.revoke_calls == 0
 
 
-def test_poisoned_stop_keeps_progressing_until_failure_detection_is_reconciled() -> None:
+def test_failed_epoch_stop_keeps_progressing_until_detection_is_reconciled() -> None:
     broadcaster, failure_evidence, comm, _ = _make_broadcaster(size=3)
     broadcaster.start()
     _wait_until(
@@ -1588,7 +1758,7 @@ def test_poisoned_stop_keeps_progressing_until_failure_detection_is_reconciled()
     assert broadcaster._retained_requests
 
 
-def test_poisoned_resources_outlive_broadcaster_object() -> None:
+def test_failed_epoch_resources_outlive_broadcaster_object() -> None:
     registry = ep_failure_broadcast._PROCESS_LIFETIME_REFS
     initial_registry_size = len(registry)
 
@@ -1620,7 +1790,7 @@ def test_poisoned_resources_outlive_broadcaster_object() -> None:
         broadcaster.stop()
         # The fake communicator owns test bookkeeping references that a real
         # MPI communicator does not. Drop those so only the process-lifetime
-        # registry can keep the poisoned request and buffer reachable.
+        # registry can keep the failed-epoch request and buffer reachable.
         comm._receives.clear()
         return references
 
@@ -1635,7 +1805,7 @@ def test_poisoned_resources_outlive_broadcaster_object() -> None:
         del registry[initial_registry_size:]
 
 
-def test_startup_failure_retains_poisoned_comm_without_pending_requests() -> None:
+def test_startup_failure_retains_failed_comm_without_pending_requests() -> None:
     registry = ep_failure_broadcast._PROCESS_LIFETIME_REFS
     initial_registry_size = len(registry)
 
@@ -1841,7 +2011,7 @@ def test_constructor_rejects_and_retains_already_revoked_comm() -> None:
         del registry[initial_registry_size:]
 
 
-def test_peer_failure_reconciles_without_revoking_control_plane() -> None:
+def test_peer_failure_reconciles_without_revoking_failure_notification_comm() -> None:
     callbacks: list[tuple[int, int, float]] = []
     broadcaster, failure_evidence, comm, _ = _make_broadcaster(
         size=3,

--- a/tests/unittest/_torch/executor/test_ep_failure_broadcast_mpi.py
+++ b/tests/unittest/_torch/executor/test_ep_failure_broadcast_mpi.py
@@ -1,0 +1,687 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Launcher for logical WideEP failure injection over a real MPI transport."""
+
+import importlib.util
+import math
+import os
+import re
+import shutil
+import signal
+import subprocess  # nosec B404
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Protocol
+
+import pytest
+
+_SKIP_MARKER = "WIDEEP_MPI_SMOKE_SKIP:"
+_PROPAGATION_MARKER = "WIDEEP_MPI_PROPAGATION"
+_INVALID_TOPOLOGY_MARKER = "WIDEEP_MPI_INVALID_TOPOLOGY_OK"
+_HEALTHY_LIFECYCLE_MARKER = "WIDEEP_MPI_HEALTHY_LIFECYCLE_OK"
+_ABORT_WORLD_MARKER = "WIDEEP_MPI_ABORT_WORLD_OK"
+_TERMINAL_READY_MARKER = "WIDEEP_MPI_TERMINAL_READY"
+_TERMINAL_COMPLETE_MARKER = "WIDEEP_MPI_TERMINAL_COMPLETE"
+_TERMINAL_DONE_MARKER = "WIDEEP_MPI_TERMINAL_DONE"
+_TERMINAL_ERROR_MARKER = "WIDEEP_MPI_TERMINAL_ERROR"
+_TERMINAL_ATEXIT_MARKER = "WIDEEP_MPI_TERMINAL_ATEXIT_RAN"
+_WORKER_TIMEOUT_SEC = 30.0
+_REAP_TIMEOUT_SEC = 5.0
+_ALLOW_SKIP_ENV = "TLLM_ALLOW_MPI_FT_SMOKE_SKIP"
+_HEALTHY_MODE = "healthy"
+_TERMINAL_MODE = "terminal"
+_PROPAGATION_PATTERN = re.compile(
+    rf"^{_PROPAGATION_MARKER} world_size=(\d+) "
+    r"elapsed_ms=(\S+) target_ms=(\S+) target_met=(True|False)$",
+    re.MULTILINE,
+)
+_TERMINAL_READY_PATTERN = re.compile(rf"^{_TERMINAL_READY_MARKER} rank=(\d+) world_size=(\d+)$")
+_TERMINAL_COMPLETE_PATTERN = re.compile(rf"^{_TERMINAL_COMPLETE_MARKER} world_size=(\d+)$")
+_TERMINAL_DONE_PATTERN = re.compile(rf"^{_TERMINAL_DONE_MARKER} rank=(\d+) world_size=(\d+)$")
+
+
+class _ReapableProcess(Protocol):
+    def kill(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> int: ...
+
+
+def _mpi_launcher() -> str | None:
+    return shutil.which("mpiexec") or shutil.which("mpirun")
+
+
+def _smoke_is_required(environment: Mapping[str, str] | None = None) -> bool:
+    """Return whether missing MPI prerequisites must fail this invocation."""
+    environment = os.environ if environment is None else environment
+    return environment.get(_ALLOW_SKIP_ENV) != "1"
+
+
+def _handle_missing_prerequisite(reason: str, *, required: bool) -> None:
+    if required:
+        pytest.fail(
+            f"WideEP MPI FT smoke is required but cannot run: {reason}",
+            pytrace=False,
+        )
+    pytest.skip(reason)
+
+
+def _subprocess_output_text(output: str | bytes | None) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace")
+    return output
+
+
+def _merge_subprocess_output(*outputs: str | bytes | None) -> str:
+    """Preserve timeout output without duplicating communicate's cumulative data."""
+    merged = ""
+    for output in outputs:
+        text = _subprocess_output_text(output)
+        if not text or text in merged:
+            continue
+        if merged and merged in text:
+            merged = text
+        else:
+            merged += text
+    return merged
+
+
+def _validate_rank_marker_set(
+    output: str,
+    expected_world_size: int,
+    marker: str,
+    pattern: re.Pattern[str],
+) -> None:
+    """Require one exact structured marker from every expected rank."""
+    marker_lines = [line for line in output.splitlines() if marker in line]
+    # MPI launchers may prefix a forwarded rank-0 stdout line. The worker emits
+    # all success evidence from one canonical stream, so strip only the prefix
+    # and retain strict validation of the marker payload itself.
+    marker_payloads = [line[line.index(marker) :] for line in marker_lines]
+    matches = [pattern.fullmatch(payload) for payload in marker_payloads]
+    malformed = [line for line, match in zip(marker_lines, matches) if match is None]
+    reported = [
+        (int(match.group(1)), int(match.group(2))) for match in matches if match is not None
+    ]
+    expected_ranks = list(range(expected_world_size))
+    reported_ranks = sorted(rank for rank, _world_size in reported)
+    invalid_world_sizes = sorted(
+        {world_size for _rank, world_size in reported if world_size != expected_world_size}
+    )
+    if malformed or invalid_world_sizes or reported_ranks != expected_ranks:
+        pytest.fail(
+            f"expected exactly one {marker} from ranks "
+            f"{expected_ranks} with world_size={expected_world_size}, got "
+            f"markers={reported}, malformed={malformed}, "
+            f"invalid_world_sizes={invalid_world_sizes}:\n{output}",
+            pytrace=False,
+        )
+
+
+def _validate_terminal_completion(output: str, expected_world_size: int) -> None:
+    """Require exact READY/DONE sets around one global completion marker."""
+    if _TERMINAL_ERROR_MARKER in output:
+        pytest.fail(f"terminal MPI worker reported an error:\n{output}", pytrace=False)
+    if _TERMINAL_ATEXIT_MARKER in output:
+        pytest.fail(
+            "terminal MPI worker entered Python atexit/mpi4py Finalize instead "
+            f"of the intentional os._exit path:\n{output}",
+            pytrace=False,
+        )
+
+    _validate_rank_marker_set(
+        output,
+        expected_world_size,
+        _TERMINAL_READY_MARKER,
+        _TERMINAL_READY_PATTERN,
+    )
+
+    completion_lines = [line for line in output.splitlines() if _TERMINAL_COMPLETE_MARKER in line]
+    completion_payloads = [
+        line[line.index(_TERMINAL_COMPLETE_MARKER) :] for line in completion_lines
+    ]
+    completion_matches = [
+        _TERMINAL_COMPLETE_PATTERN.fullmatch(payload) for payload in completion_payloads
+    ]
+    if (
+        len(completion_matches) != 1
+        or completion_matches[0] is None
+        or int(completion_matches[0].group(1)) != expected_world_size
+    ):
+        pytest.fail(
+            f"expected exactly one valid {_TERMINAL_COMPLETE_MARKER} with "
+            f"world_size={expected_world_size}, got {completion_lines}:\n{output}",
+            pytrace=False,
+        )
+    _validate_rank_marker_set(
+        output,
+        expected_world_size,
+        _TERMINAL_DONE_MARKER,
+        _TERMINAL_DONE_PATTERN,
+    )
+
+
+def _validate_worker_result(
+    returncode: int,
+    output: str,
+    *,
+    required: bool,
+    mode: str = _HEALTHY_MODE,
+    expected_world_size: int | None = None,
+) -> None:
+    """Validate normal-finalize and intentional no-finalize launcher results."""
+    # A skip marker never excuses a launcher failure. Required workers return a
+    # nonzero status instead of printing this marker, but retain this ordering
+    # so a malformed optional worker cannot hide a launch error.
+    if returncode != 0 and (mode != _TERMINAL_MODE or _SKIP_MARKER in output):
+        pytest.fail(output or f"MPI smoke launcher exited with status {returncode}", pytrace=False)
+    if _SKIP_MARKER not in output:
+        if mode == _TERMINAL_MODE:
+            if expected_world_size is None:
+                raise ValueError("terminal MPI smoke validation requires expected_world_size")
+            # Open MPI reports a nonzero launcher status when workers
+            # intentionally bypass MPI_Finalize via os._exit(). Structured
+            # rank readiness plus global completion distinguishes that expected
+            # status from a real worker failure or MPI_Abort.
+            _validate_terminal_completion(output, expected_world_size)
+        return
+    if required:
+        pytest.fail(
+            f"WideEP MPI FT smoke is required but the worker skipped:\n{output.strip()}",
+            pytrace=False,
+        )
+    pytest.skip(output.strip())
+
+
+def _parse_propagation_metric(output: str, expected_world_size: int) -> tuple[float, bool]:
+    """Validate and return the functional smoke's structured latency metric."""
+    metric_lines = [line for line in output.splitlines() if _PROPAGATION_MARKER in line]
+    metric_payloads = [line[line.index(_PROPAGATION_MARKER) :] for line in metric_lines]
+    matches = [_PROPAGATION_PATTERN.fullmatch(payload) for payload in metric_payloads]
+    if len(matches) != 1 or matches[0] is None:
+        pytest.fail(
+            f"expected exactly one valid {_PROPAGATION_MARKER} line, got {metric_lines}:\n{output}",
+            pytrace=False,
+        )
+    match = matches[0]
+    assert match is not None
+    world_size = int(match.group(1))
+    try:
+        elapsed_ms = float(match.group(2))
+        target_ms = float(match.group(3))
+    except ValueError:
+        pytest.fail(f"invalid propagation metric:\n{match.group(0)}", pytrace=False)
+    target_met = match.group(4) == "True"
+    if world_size != expected_world_size:
+        pytest.fail(
+            f"propagation metric reported world_size={world_size}, expected {expected_world_size}",
+            pytrace=False,
+        )
+    if not math.isfinite(elapsed_ms) or elapsed_ms < 0:
+        pytest.fail(f"invalid elapsed_ms={elapsed_ms}", pytrace=False)
+    if not math.isfinite(target_ms) or target_ms != 100.0:
+        pytest.fail(f"unexpected target_ms={target_ms}, expected 100", pytrace=False)
+    if target_met is not (elapsed_ms < target_ms):
+        pytest.fail(
+            f"target_met={target_met} is inconsistent with "
+            f"elapsed_ms={elapsed_ms} and target_ms={target_ms}",
+            pytrace=False,
+        )
+    return elapsed_ms, target_met
+
+
+def _validate_propagation_budget(output: str, expected_world_size: int) -> float:
+    """Require the real-MPI logical-failure fanout to meet its 100 ms budget."""
+    elapsed_ms, target_met = _parse_propagation_metric(output, expected_world_size)
+    if not target_met:
+        pytest.fail(
+            f"WideEP MPI propagation exceeded the <100 ms budget: elapsed_ms={elapsed_ms}",
+            pytrace=False,
+        )
+    return elapsed_ms
+
+
+def _kill_and_reap_launcher(process: _ReapableProcess, timeout: float) -> bool:
+    """Kill the launcher and make one bounded attempt to reap it."""
+    try:
+        process.kill()
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return False
+    return True
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ({}, True),
+        ({_ALLOW_SKIP_ENV: "0"}, True),
+        ({_ALLOW_SKIP_ENV: "1"}, False),
+    ],
+)
+def test_mpi_ft_smoke_required_mode(environment: dict[str, str], expected: bool) -> None:
+    assert _smoke_is_required(environment) is expected
+
+
+def test_mpi_ft_smoke_missing_prerequisite_is_optional_locally() -> None:
+    with pytest.raises(pytest.skip.Exception, match="missing launcher"):
+        _handle_missing_prerequisite("missing launcher", required=False)
+
+
+def test_mpi_ft_smoke_missing_prerequisite_fails_when_required() -> None:
+    with pytest.raises(pytest.fail.Exception, match="required.*missing launcher"):
+        _handle_missing_prerequisite("missing launcher", required=True)
+
+
+def test_mpi_ft_smoke_launcher_failure_precedes_skip_marker() -> None:
+    with pytest.raises(pytest.fail.Exception, match="launcher failed"):
+        _validate_worker_result(
+            1,
+            f"launcher failed\n{_SKIP_MARKER} unsupported thread level",
+            required=False,
+        )
+
+
+def test_mpi_ft_smoke_worker_skip_fails_when_required() -> None:
+    with pytest.raises(pytest.fail.Exception, match="worker skipped"):
+        _validate_worker_result(
+            0,
+            f"{_SKIP_MARKER} unsupported thread level",
+            required=True,
+        )
+
+
+def test_mpi_ft_smoke_worker_skip_is_optional_when_opted_out() -> None:
+    with pytest.raises(pytest.skip.Exception, match="unsupported thread level"):
+        _validate_worker_result(
+            0,
+            f"{_SKIP_MARKER} unsupported thread level",
+            required=False,
+        )
+
+
+def _terminal_completion_output(world_size: int) -> str:
+    ready = [
+        f"{_TERMINAL_READY_MARKER} rank={rank} world_size={world_size}"
+        for rank in range(world_size)
+    ]
+    done = [
+        f"{_TERMINAL_DONE_MARKER} rank={rank} world_size={world_size}" for rank in range(world_size)
+    ]
+    return "\n".join([*ready, f"{_TERMINAL_COMPLETE_MARKER} world_size={world_size}", *done])
+
+
+@pytest.mark.parametrize("returncode", [0, 1, 137], ids=["zero", "open-mpi", "signal-style"])
+def test_mpi_ft_terminal_result_accepts_complete_evidence(returncode: int) -> None:
+    _validate_worker_result(
+        returncode,
+        _terminal_completion_output(4),
+        required=True,
+        mode=_TERMINAL_MODE,
+        expected_world_size=4,
+    )
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "",
+        "\n".join(
+            [
+                f"{_TERMINAL_READY_MARKER} rank=0 world_size=2",
+                f"{_TERMINAL_COMPLETE_MARKER} world_size=2",
+            ]
+        ),
+        "\n".join(
+            [
+                f"{_TERMINAL_READY_MARKER} rank=0 world_size=2",
+                f"{_TERMINAL_READY_MARKER} rank=0 world_size=2",
+                f"{_TERMINAL_READY_MARKER} rank=1 world_size=2",
+                f"{_TERMINAL_COMPLETE_MARKER} world_size=2",
+            ]
+        ),
+        "\n".join(
+            [
+                f"{_TERMINAL_READY_MARKER} rank=0 world_size=3",
+                f"{_TERMINAL_READY_MARKER} rank=1 world_size=3",
+                f"{_TERMINAL_COMPLETE_MARKER} world_size=3",
+            ]
+        ),
+    ],
+    ids=["missing", "incomplete", "duplicate", "wrong-world-size"],
+)
+def test_mpi_ft_terminal_result_rejects_incomplete_rank_set(output: str) -> None:
+    with pytest.raises(pytest.fail.Exception, match="expected exactly one"):
+        _validate_worker_result(
+            1,
+            output,
+            required=True,
+            mode=_TERMINAL_MODE,
+            expected_world_size=2,
+        )
+
+
+@pytest.mark.parametrize(
+    "completion_suffix",
+    [
+        "",
+        "\n".join(
+            [
+                f"{_TERMINAL_COMPLETE_MARKER} world_size=2",
+                f"{_TERMINAL_COMPLETE_MARKER} world_size=2",
+            ]
+        ),
+        f"{_TERMINAL_COMPLETE_MARKER} world_size=3",
+        f"{_TERMINAL_COMPLETE_MARKER} world_size=2 trailing-garbage",
+        f"{_TERMINAL_COMPLETE_MARKER} world_size=2\n{_TERMINAL_ERROR_MARKER} rank=0",
+    ],
+    ids=["missing", "duplicate", "wrong-world-size", "malformed", "worker-error"],
+)
+def test_mpi_ft_terminal_result_rejects_invalid_global_completion(
+    completion_suffix: str,
+) -> None:
+    ready = "\n".join(f"{_TERMINAL_READY_MARKER} rank={rank} world_size=2" for rank in range(2))
+    done = "\n".join(f"{_TERMINAL_DONE_MARKER} rank={rank} world_size=2" for rank in range(2))
+    output = "\n".join(part for part in (ready, completion_suffix, done) if part)
+    with pytest.raises(pytest.fail.Exception):
+        _validate_worker_result(
+            1,
+            output,
+            required=True,
+            mode=_TERMINAL_MODE,
+            expected_world_size=2,
+        )
+
+
+def test_mpi_ft_terminal_result_rejects_crash_before_done() -> None:
+    ready_and_complete = "\n".join(
+        [
+            *(f"{_TERMINAL_READY_MARKER} rank={rank} world_size=2" for rank in range(2)),
+            f"{_TERMINAL_COMPLETE_MARKER} world_size=2",
+        ]
+    )
+    with pytest.raises(pytest.fail.Exception, match=_TERMINAL_DONE_MARKER):
+        _validate_worker_result(
+            137,
+            ready_and_complete,
+            required=True,
+            mode=_TERMINAL_MODE,
+            expected_world_size=2,
+        )
+
+
+@pytest.mark.parametrize(
+    "done_suffix",
+    [
+        f"{_TERMINAL_DONE_MARKER} rank=0 world_size=2",
+        "\n".join(
+            [
+                f"{_TERMINAL_DONE_MARKER} rank=0 world_size=2",
+                f"{_TERMINAL_DONE_MARKER} rank=0 world_size=2",
+                f"{_TERMINAL_DONE_MARKER} rank=1 world_size=2",
+            ]
+        ),
+        "\n".join(
+            [
+                f"{_TERMINAL_DONE_MARKER} rank=0 world_size=3",
+                f"{_TERMINAL_DONE_MARKER} rank=1 world_size=3",
+            ]
+        ),
+        "\n".join(
+            [
+                f"{_TERMINAL_DONE_MARKER} rank=0 world_size=2",
+                f"{_TERMINAL_DONE_MARKER} rank=1 world_size=2 trailing-garbage",
+            ]
+        ),
+    ],
+    ids=["incomplete", "duplicate", "wrong-world-size", "malformed"],
+)
+def test_mpi_ft_terminal_result_rejects_invalid_done_set(done_suffix: str) -> None:
+    ready = "\n".join(f"{_TERMINAL_READY_MARKER} rank={rank} world_size=2" for rank in range(2))
+    output = "\n".join([ready, f"{_TERMINAL_COMPLETE_MARKER} world_size=2", done_suffix])
+    with pytest.raises(pytest.fail.Exception, match=_TERMINAL_DONE_MARKER):
+        _validate_worker_result(
+            1,
+            output,
+            required=True,
+            mode=_TERMINAL_MODE,
+            expected_world_size=2,
+        )
+
+
+def test_mpi_ft_terminal_result_accepts_launcher_prefixes_and_noise() -> None:
+    output = "\n".join(
+        [
+            "unrelated launcher diagnostic",
+            *(f"[rank0]<stdout>: {line}" for line in _terminal_completion_output(2).splitlines()),
+            "another unrelated diagnostic",
+        ]
+    )
+
+    _validate_worker_result(
+        1,
+        output,
+        required=True,
+        mode=_TERMINAL_MODE,
+        expected_world_size=2,
+    )
+
+
+def test_mpi_ft_terminal_result_rejects_python_atexit_evidence() -> None:
+    output = "\n".join(
+        [
+            _terminal_completion_output(2),
+            f"{_TERMINAL_ATEXIT_MARKER} pid=123",
+        ]
+    )
+
+    with pytest.raises(pytest.fail.Exception, match="atexit/mpi4py Finalize"):
+        _validate_worker_result(
+            0,
+            output,
+            required=True,
+            mode=_TERMINAL_MODE,
+            expected_world_size=2,
+        )
+
+
+def test_mpi_ft_terminal_launcher_failure_precedes_skip_marker() -> None:
+    with pytest.raises(pytest.fail.Exception, match="launcher failed"):
+        _validate_worker_result(
+            1,
+            f"launcher failed\n{_SKIP_MARKER} unsupported thread level",
+            required=False,
+            mode=_TERMINAL_MODE,
+            expected_world_size=2,
+        )
+
+
+@pytest.mark.parametrize(
+    ("outputs", "expected"),
+    [
+        ((None, "complete"), "complete"),
+        ((b"partial ", b"partial complete"), "partial complete"),
+        (("first\n", "second\n"), "first\nsecond\n"),
+        ((b"bad-\xff",), "bad-\ufffd"),
+    ],
+    ids=["none", "cumulative", "incremental", "bytes-replacement"],
+)
+def test_merge_subprocess_output_preserves_timeout_diagnostics(
+    outputs: tuple[str | bytes | None, ...], expected: str
+) -> None:
+    assert _merge_subprocess_output(*outputs) == expected
+
+
+def test_parse_propagation_metric_validates_target_without_requiring_it() -> None:
+    elapsed_ms, target_met = _parse_propagation_metric(
+        f"{_PROPAGATION_MARKER} world_size=4 elapsed_ms=125.5 target_ms=100.0 target_met=False",
+        4,
+    )
+
+    assert elapsed_ms == 125.5
+    assert target_met is False
+
+
+def test_parse_propagation_metric_accepts_launcher_prefix_and_noise() -> None:
+    metric = f"{_PROPAGATION_MARKER} world_size=4 elapsed_ms=25.5 target_ms=100.0 target_met=True"
+    output = f"launcher diagnostic\n[rank0]<stdout>: {metric}\nmore noise"
+
+    assert _parse_propagation_metric(output, 4) == (25.5, True)
+
+
+def test_validate_propagation_budget_rejects_semantically_valid_miss() -> None:
+    metric = f"{_PROPAGATION_MARKER} world_size=4 elapsed_ms=125.5 target_ms=100.0 target_met=False"
+    assert _parse_propagation_metric(metric, 4) == (125.5, False)
+
+    with pytest.raises(pytest.fail.Exception, match="exceeded the <100 ms budget"):
+        _validate_propagation_budget(metric, 4)
+
+
+@pytest.mark.parametrize("wait_times_out", [False, True], ids=["reaped", "still-running"])
+def test_kill_and_reap_launcher_is_bounded(wait_times_out: bool) -> None:
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.kill_calls = 0
+            self.wait_timeouts: list[float] = []
+
+        def kill(self) -> None:
+            self.kill_calls += 1
+
+        def wait(self, timeout: float | None = None) -> int:
+            assert timeout is not None
+            self.wait_timeouts.append(timeout)
+            if wait_times_out:
+                raise subprocess.TimeoutExpired("mpiexec", timeout)
+            return -signal.SIGKILL
+
+    process = FakeProcess()
+    assert _kill_and_reap_launcher(process, 0.25) is (not wait_times_out)
+    assert process.kill_calls == 1
+    assert process.wait_timeouts == [0.25]
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        "",
+        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=nan target_ms=100 target_met=False",
+        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=-1 target_ms=100 target_met=True",
+        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=1 target_ms=99 target_met=True",
+        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=101 target_ms=100 target_met=True",
+        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=1 target_ms=100 target_met=True trailing",
+    ],
+)
+def test_parse_propagation_metric_rejects_malformed_semantics(metric: str) -> None:
+    with pytest.raises(pytest.fail.Exception):
+        _parse_propagation_metric(metric, 2)
+
+
+@pytest.mark.parametrize("world_size", [2, 4], ids=["2-ranks", "4-ranks"])
+def test_ep_failure_broadcast_real_mpi(world_size: int) -> None:
+    """Exercise logical failure fanout and shutdown over a real MPI transport.
+
+    The victim remains alive for portable ``COMM_WORLD`` result coordination;
+    actual process death and MPI error classification are outside this smoke.
+    """
+    required = _smoke_is_required()
+    if importlib.util.find_spec("mpi4py") is None:
+        _handle_missing_prerequisite("mpi4py is not installed", required=required)
+    launcher = _mpi_launcher()
+    if launcher is None:
+        _handle_missing_prerequisite("mpiexec/mpirun is not installed", required=required)
+
+    worker = Path(__file__).with_name("_ep_failure_broadcast_mpi_worker.py")
+    environment = os.environ.copy()
+    # Open MPI requires explicit opt-in when CI runs inside a root container.
+    # Other MPI implementations ignore these variables.
+    environment["OMPI_ALLOW_RUN_AS_ROOT"] = "1"
+    environment["OMPI_ALLOW_RUN_AS_ROOT_CONFIRM"] = "1"
+    environment["OMPI_MCA_rmaps_base_oversubscribe"] = "1"
+    environment["PYTHONUNBUFFERED"] = "1"
+    if not required:
+        environment[_ALLOW_SKIP_ENV] = "1"
+
+    outputs: dict[str, str] = {}
+    for mode in (_HEALTHY_MODE, _TERMINAL_MODE):
+        command = [
+            launcher,
+            "-n",
+            str(world_size),
+            sys.executable,
+            str(worker),
+            str(world_size),
+            mode,
+        ]
+        process = subprocess.Popen(  # nosec B603
+            command,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            text=True,
+        )
+        try:
+            output, _ = process.communicate(timeout=_WORKER_TIMEOUT_SEC)
+        except subprocess.TimeoutExpired as timeout_error:
+            partial_output = _subprocess_output_text(timeout_error.output)
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                # mpiexec may exit between communicate() timing out and cleanup.
+                pass
+            try:
+                output, _ = process.communicate(timeout=_REAP_TIMEOUT_SEC)
+            except subprocess.TimeoutExpired as reap_error:
+                output = _merge_subprocess_output(partial_output, reap_error.output)
+                reaped_after_kill = _kill_and_reap_launcher(process, _REAP_TIMEOUT_SEC)
+                if process.stdout is not None:
+                    try:
+                        process.stdout.close()
+                    except OSError:
+                        pass
+                reap_status = (
+                    "launcher was reaped after direct SIGKILL"
+                    if reaped_after_kill
+                    else "launcher still could not be reaped after direct SIGKILL"
+                )
+                pytest.fail(
+                    f"{world_size}-rank WideEP MPI {mode} smoke timed out after "
+                    f"{_WORKER_TIMEOUT_SEC:.0f}s and could not be reaped within "
+                    f"{_REAP_TIMEOUT_SEC:.0f}s; {reap_status}\n{output}"
+                )
+            output = _merge_subprocess_output(partial_output, output)
+            pytest.fail(
+                f"{world_size}-rank WideEP MPI {mode} smoke timed out after "
+                f"{_WORKER_TIMEOUT_SEC:.0f}s\n{output}"
+            )
+
+        _validate_worker_result(
+            process.returncode,
+            output,
+            required=required,
+            mode=mode,
+            expected_world_size=world_size,
+        )
+        outputs[mode] = output
+
+    _validate_propagation_budget(outputs[_TERMINAL_MODE], world_size)
+    assert _INVALID_TOPOLOGY_MARKER in outputs[_HEALTHY_MODE]
+    assert _HEALTHY_LIFECYCLE_MARKER in outputs[_HEALTHY_MODE]
+    assert _ABORT_WORLD_MARKER in outputs[_TERMINAL_MODE]

--- a/tests/unittest/_torch/executor/test_ep_failure_broadcast_mpi.py
+++ b/tests/unittest/_torch/executor/test_ep_failure_broadcast_mpi.py
@@ -36,6 +36,7 @@ _ABORT_WORLD_MARKER = "WIDEEP_MPI_ABORT_WORLD_OK"
 _TERMINAL_READY_MARKER = "WIDEEP_MPI_TERMINAL_READY"
 _TERMINAL_COMPLETE_MARKER = "WIDEEP_MPI_TERMINAL_COMPLETE"
 _TERMINAL_DONE_MARKER = "WIDEEP_MPI_TERMINAL_DONE"
+_TERMINAL_EXITING_MARKER = "WIDEEP_MPI_TERMINAL_EXITING"
 _TERMINAL_ERROR_MARKER = "WIDEEP_MPI_TERMINAL_ERROR"
 _TERMINAL_ATEXIT_MARKER = "WIDEEP_MPI_TERMINAL_ATEXIT_RAN"
 _WORKER_TIMEOUT_SEC = 30.0
@@ -51,6 +52,7 @@ _PROPAGATION_PATTERN = re.compile(
 _TERMINAL_READY_PATTERN = re.compile(rf"^{_TERMINAL_READY_MARKER} rank=(\d+) world_size=(\d+)$")
 _TERMINAL_COMPLETE_PATTERN = re.compile(rf"^{_TERMINAL_COMPLETE_MARKER} world_size=(\d+)$")
 _TERMINAL_DONE_PATTERN = re.compile(rf"^{_TERMINAL_DONE_MARKER} rank=(\d+) world_size=(\d+)$")
+_TERMINAL_EXITING_PATTERN = re.compile(rf"^{_TERMINAL_EXITING_MARKER} rank=(\d+) world_size=(\d+)$")
 
 
 class _ReapableProcess(Protocol):
@@ -133,7 +135,7 @@ def _validate_rank_marker_set(
 
 
 def _validate_terminal_completion(output: str, expected_world_size: int) -> None:
-    """Require exact READY/DONE sets around one global completion marker."""
+    """Require exact READY/DONE/EXITING sets around one completion marker."""
     if _TERMINAL_ERROR_MARKER in output:
         pytest.fail(f"terminal MPI worker reported an error:\n{output}", pytrace=False)
     if _TERMINAL_ATEXIT_MARKER in output:
@@ -172,6 +174,12 @@ def _validate_terminal_completion(output: str, expected_world_size: int) -> None
         expected_world_size,
         _TERMINAL_DONE_MARKER,
         _TERMINAL_DONE_PATTERN,
+    )
+    _validate_rank_marker_set(
+        output,
+        expected_world_size,
+        _TERMINAL_EXITING_MARKER,
+        _TERMINAL_EXITING_PATTERN,
     )
 
 
@@ -268,6 +276,32 @@ def _kill_and_reap_launcher(process: _ReapableProcess, timeout: float) -> bool:
     return True
 
 
+def _accept_reaped_terminal_timeout(
+    output: str,
+    *,
+    mode: str,
+    required: bool,
+    expected_world_size: int,
+    launcher_reaped: bool,
+) -> bool:
+    """Accept bounded launcher cleanup after complete no-Finalize evidence."""
+    if mode != _TERMINAL_MODE or not launcher_reaped or _TERMINAL_COMPLETE_MARKER not in output:
+        return False
+
+    # Some MPI launchers wait indefinitely when every worker deliberately uses
+    # os._exit() instead of MPI_Finalize. The strict terminal validator still
+    # requires complete READY/DONE/EXITING rank sets and rejects worker or
+    # atexit errors.
+    _validate_worker_result(
+        -signal.SIGKILL,
+        output,
+        required=required,
+        mode=mode,
+        expected_world_size=expected_world_size,
+    )
+    return True
+
+
 @pytest.mark.parametrize(
     ("environment", "expected"),
     [
@@ -325,7 +359,13 @@ def _terminal_completion_output(world_size: int) -> str:
     done = [
         f"{_TERMINAL_DONE_MARKER} rank={rank} world_size={world_size}" for rank in range(world_size)
     ]
-    return "\n".join([*ready, f"{_TERMINAL_COMPLETE_MARKER} world_size={world_size}", *done])
+    exiting = [
+        f"{_TERMINAL_EXITING_MARKER} rank={rank} world_size={world_size}"
+        for rank in range(world_size)
+    ]
+    return "\n".join(
+        [*ready, f"{_TERMINAL_COMPLETE_MARKER} world_size={world_size}", *done, *exiting]
+    )
 
 
 @pytest.mark.parametrize("returncode", [0, 1, 137], ids=["zero", "open-mpi", "signal-style"])
@@ -337,6 +377,74 @@ def test_mpi_ft_terminal_result_accepts_complete_evidence(returncode: int) -> No
         mode=_TERMINAL_MODE,
         expected_world_size=4,
     )
+
+
+def test_mpi_ft_terminal_timeout_accepts_complete_evidence_after_reap() -> None:
+    assert _accept_reaped_terminal_timeout(
+        _terminal_completion_output(4),
+        mode=_TERMINAL_MODE,
+        required=True,
+        expected_world_size=4,
+        launcher_reaped=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "launcher_reaped"),
+    [
+        (_HEALTHY_MODE, True),
+        (_TERMINAL_MODE, False),
+    ],
+    ids=["healthy-mode", "unreaped-launcher"],
+)
+def test_mpi_ft_terminal_timeout_requires_terminal_mode_and_reap(
+    mode: str,
+    launcher_reaped: bool,
+) -> None:
+    assert not _accept_reaped_terminal_timeout(
+        _terminal_completion_output(2),
+        mode=mode,
+        required=True,
+        expected_world_size=2,
+        launcher_reaped=launcher_reaped,
+    )
+
+
+def test_mpi_ft_terminal_timeout_rejects_incomplete_evidence() -> None:
+    output = "\n".join(
+        [
+            *(f"{_TERMINAL_READY_MARKER} rank={rank} world_size=2" for rank in range(2)),
+            f"{_TERMINAL_COMPLETE_MARKER} world_size=2",
+            f"{_TERMINAL_DONE_MARKER} rank=0 world_size=2",
+        ]
+    )
+    with pytest.raises(pytest.fail.Exception, match=_TERMINAL_DONE_MARKER):
+        _accept_reaped_terminal_timeout(
+            output,
+            mode=_TERMINAL_MODE,
+            required=True,
+            expected_world_size=2,
+            launcher_reaped=True,
+        )
+
+
+def test_mpi_ft_terminal_result_rejects_incomplete_exiting_set() -> None:
+    output = "\n".join(
+        [
+            *(f"{_TERMINAL_READY_MARKER} rank={rank} world_size=2" for rank in range(2)),
+            f"{_TERMINAL_COMPLETE_MARKER} world_size=2",
+            *(f"{_TERMINAL_DONE_MARKER} rank={rank} world_size=2" for rank in range(2)),
+            f"{_TERMINAL_EXITING_MARKER} rank=0 world_size=2",
+        ]
+    )
+    with pytest.raises(pytest.fail.Exception, match=_TERMINAL_EXITING_MARKER):
+        _validate_worker_result(
+            -signal.SIGKILL,
+            output,
+            required=True,
+            mode=_TERMINAL_MODE,
+            expected_world_size=2,
+        )
 
 
 @pytest.mark.parametrize(
@@ -663,10 +771,19 @@ def test_ep_failure_broadcast_real_mpi(world_size: int) -> None:
                 )
                 pytest.fail(
                     f"{world_size}-rank WideEP MPI {mode} smoke timed out after "
-                    f"{_WORKER_TIMEOUT_SEC:.0f}s and could not be reaped within "
-                    f"{_REAP_TIMEOUT_SEC:.0f}s; {reap_status}\n{output}"
+                    f"{_WORKER_TIMEOUT_SEC:.0f}s and could not close its output "
+                    f"within {_REAP_TIMEOUT_SEC:.0f}s; {reap_status}\n{output}"
                 )
             output = _merge_subprocess_output(partial_output, output)
+            if _accept_reaped_terminal_timeout(
+                output,
+                mode=mode,
+                required=required,
+                expected_world_size=world_size,
+                launcher_reaped=True,
+            ):
+                outputs[mode] = output
+                continue
             pytest.fail(
                 f"{world_size}-rank WideEP MPI {mode} smoke timed out after "
                 f"{_WORKER_TIMEOUT_SEC:.0f}s\n{output}"

--- a/tests/unittest/_torch/executor/test_ep_failure_broadcast_mpi.py
+++ b/tests/unittest/_torch/executor/test_ep_failure_broadcast_mpi.py
@@ -43,10 +43,11 @@ _WORKER_TIMEOUT_SEC = 30.0
 _REAP_TIMEOUT_SEC = 5.0
 _ALLOW_SKIP_ENV = "TLLM_ALLOW_MPI_FT_SMOKE_SKIP"
 _HEALTHY_MODE = "healthy"
+_PROPAGATION_MODE = "propagation"
 _TERMINAL_MODE = "terminal"
+_FAILED_EPOCH_MODES = frozenset((_PROPAGATION_MODE, _TERMINAL_MODE))
 _PROPAGATION_PATTERN = re.compile(
-    rf"^{_PROPAGATION_MARKER} world_size=(\d+) "
-    r"elapsed_ms=(\S+) target_ms=(\S+) target_met=(True|False)$",
+    rf"^{_PROPAGATION_MARKER} world_size=(\d+) elapsed_ms=(\S+)$",
     re.MULTILINE,
 )
 _TERMINAL_READY_PATTERN = re.compile(rf"^{_TERMINAL_READY_MARKER} rank=(\d+) world_size=(\d+)$")
@@ -195,12 +196,12 @@ def _validate_worker_result(
     # A skip marker never excuses a launcher failure. Required workers return a
     # nonzero status instead of printing this marker, but retain this ordering
     # so a malformed optional worker cannot hide a launch error.
-    if returncode != 0 and (mode != _TERMINAL_MODE or _SKIP_MARKER in output):
+    if returncode != 0 and (mode not in _FAILED_EPOCH_MODES or _SKIP_MARKER in output):
         pytest.fail(output or f"MPI smoke launcher exited with status {returncode}", pytrace=False)
     if _SKIP_MARKER not in output:
-        if mode == _TERMINAL_MODE:
+        if mode in _FAILED_EPOCH_MODES:
             if expected_world_size is None:
-                raise ValueError("terminal MPI smoke validation requires expected_world_size")
+                raise ValueError("failed-epoch MPI smoke validation requires expected_world_size")
             # Open MPI reports a nonzero launcher status when workers
             # intentionally bypass MPI_Finalize via os._exit(). Structured
             # rank readiness plus global completion distinguishes that expected
@@ -215,7 +216,7 @@ def _validate_worker_result(
     pytest.skip(output.strip())
 
 
-def _parse_propagation_metric(output: str, expected_world_size: int) -> tuple[float, bool]:
+def _parse_propagation_metric(output: str, expected_world_size: int) -> float:
     """Validate and return the functional smoke's structured latency metric."""
     metric_lines = [line for line in output.splitlines() if _PROPAGATION_MARKER in line]
     metric_payloads = [line[line.index(_PROPAGATION_MARKER) :] for line in metric_lines]
@@ -230,10 +231,8 @@ def _parse_propagation_metric(output: str, expected_world_size: int) -> tuple[fl
     world_size = int(match.group(1))
     try:
         elapsed_ms = float(match.group(2))
-        target_ms = float(match.group(3))
     except ValueError:
         pytest.fail(f"invalid propagation metric:\n{match.group(0)}", pytrace=False)
-    target_met = match.group(4) == "True"
     if world_size != expected_world_size:
         pytest.fail(
             f"propagation metric reported world_size={world_size}, expected {expected_world_size}",
@@ -241,25 +240,6 @@ def _parse_propagation_metric(output: str, expected_world_size: int) -> tuple[fl
         )
     if not math.isfinite(elapsed_ms) or elapsed_ms < 0:
         pytest.fail(f"invalid elapsed_ms={elapsed_ms}", pytrace=False)
-    if not math.isfinite(target_ms) or target_ms != 100.0:
-        pytest.fail(f"unexpected target_ms={target_ms}, expected 100", pytrace=False)
-    if target_met is not (elapsed_ms < target_ms):
-        pytest.fail(
-            f"target_met={target_met} is inconsistent with "
-            f"elapsed_ms={elapsed_ms} and target_ms={target_ms}",
-            pytrace=False,
-        )
-    return elapsed_ms, target_met
-
-
-def _validate_propagation_budget(output: str, expected_world_size: int) -> float:
-    """Require the real-MPI logical-failure fanout to meet its 100 ms budget."""
-    elapsed_ms, target_met = _parse_propagation_metric(output, expected_world_size)
-    if not target_met:
-        pytest.fail(
-            f"WideEP MPI propagation exceeded the <100 ms budget: elapsed_ms={elapsed_ms}",
-            pytrace=False,
-        )
     return elapsed_ms
 
 
@@ -285,7 +265,11 @@ def _accept_reaped_terminal_timeout(
     launcher_reaped: bool,
 ) -> bool:
     """Accept bounded launcher cleanup after complete no-Finalize evidence."""
-    if mode != _TERMINAL_MODE or not launcher_reaped or _TERMINAL_COMPLETE_MARKER not in output:
+    if (
+        mode not in _FAILED_EPOCH_MODES
+        or not launcher_reaped
+        or _TERMINAL_COMPLETE_MARKER not in output
+    ):
         return False
 
     # Some MPI launchers wait indefinitely when every worker deliberately uses
@@ -368,21 +352,23 @@ def _terminal_completion_output(world_size: int) -> str:
     )
 
 
+@pytest.mark.parametrize("mode", [_PROPAGATION_MODE, _TERMINAL_MODE])
 @pytest.mark.parametrize("returncode", [0, 1, 137], ids=["zero", "open-mpi", "signal-style"])
-def test_mpi_ft_terminal_result_accepts_complete_evidence(returncode: int) -> None:
+def test_mpi_ft_failed_epoch_result_accepts_complete_evidence(returncode: int, mode: str) -> None:
     _validate_worker_result(
         returncode,
         _terminal_completion_output(4),
         required=True,
-        mode=_TERMINAL_MODE,
+        mode=mode,
         expected_world_size=4,
     )
 
 
-def test_mpi_ft_terminal_timeout_accepts_complete_evidence_after_reap() -> None:
+@pytest.mark.parametrize("mode", [_PROPAGATION_MODE, _TERMINAL_MODE])
+def test_mpi_ft_failed_epoch_timeout_accepts_complete_evidence_after_reap(mode: str) -> None:
     assert _accept_reaped_terminal_timeout(
         _terminal_completion_output(4),
-        mode=_TERMINAL_MODE,
+        mode=mode,
         required=True,
         expected_world_size=4,
         launcher_reaped=True,
@@ -637,29 +623,19 @@ def test_merge_subprocess_output_preserves_timeout_diagnostics(
     assert _merge_subprocess_output(*outputs) == expected
 
 
-def test_parse_propagation_metric_validates_target_without_requiring_it() -> None:
-    elapsed_ms, target_met = _parse_propagation_metric(
-        f"{_PROPAGATION_MARKER} world_size=4 elapsed_ms=125.5 target_ms=100.0 target_met=False",
-        4,
+def test_parse_propagation_metric_reports_unbudgeted_latency() -> None:
+    elapsed_ms = _parse_propagation_metric(
+        f"{_PROPAGATION_MARKER} world_size=4 elapsed_ms=125.5", 4
     )
 
     assert elapsed_ms == 125.5
-    assert target_met is False
 
 
 def test_parse_propagation_metric_accepts_launcher_prefix_and_noise() -> None:
-    metric = f"{_PROPAGATION_MARKER} world_size=4 elapsed_ms=25.5 target_ms=100.0 target_met=True"
+    metric = f"{_PROPAGATION_MARKER} world_size=4 elapsed_ms=25.5"
     output = f"launcher diagnostic\n[rank0]<stdout>: {metric}\nmore noise"
 
-    assert _parse_propagation_metric(output, 4) == (25.5, True)
-
-
-def test_validate_propagation_budget_rejects_semantically_valid_miss() -> None:
-    metric = f"{_PROPAGATION_MARKER} world_size=4 elapsed_ms=125.5 target_ms=100.0 target_met=False"
-    assert _parse_propagation_metric(metric, 4) == (125.5, False)
-
-    with pytest.raises(pytest.fail.Exception, match="exceeded the <100 ms budget"):
-        _validate_propagation_budget(metric, 4)
+    assert _parse_propagation_metric(output, 4) == 25.5
 
 
 @pytest.mark.parametrize("wait_times_out", [False, True], ids=["reaped", "still-running"])
@@ -689,11 +665,9 @@ def test_kill_and_reap_launcher_is_bounded(wait_times_out: bool) -> None:
     "metric",
     [
         "",
-        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=nan target_ms=100 target_met=False",
-        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=-1 target_ms=100 target_met=True",
-        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=1 target_ms=99 target_met=True",
-        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=101 target_ms=100 target_met=True",
-        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=1 target_ms=100 target_met=True trailing",
+        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=nan",
+        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=-1",
+        f"{_PROPAGATION_MARKER} world_size=2 elapsed_ms=1 trailing",
     ],
 )
 def test_parse_propagation_metric_rejects_malformed_semantics(metric: str) -> None:
@@ -705,7 +679,7 @@ def test_parse_propagation_metric_rejects_malformed_semantics(metric: str) -> No
 def test_ep_failure_broadcast_real_mpi(world_size: int) -> None:
     """Exercise logical failure fanout and shutdown over a real MPI transport.
 
-    The victim remains alive for portable ``COMM_WORLD`` result coordination;
+    The victim remains alive for portable `COMM_WORLD` result coordination;
     actual process death and MPI error classification are outside this smoke.
     """
     required = _smoke_is_required()
@@ -727,7 +701,7 @@ def test_ep_failure_broadcast_real_mpi(world_size: int) -> None:
         environment[_ALLOW_SKIP_ENV] = "1"
 
     outputs: dict[str, str] = {}
-    for mode in (_HEALTHY_MODE, _TERMINAL_MODE):
+    for mode in (_HEALTHY_MODE, _PROPAGATION_MODE, _TERMINAL_MODE):
         command = [
             launcher,
             "-n",
@@ -798,7 +772,7 @@ def test_ep_failure_broadcast_real_mpi(world_size: int) -> None:
         )
         outputs[mode] = output
 
-    _validate_propagation_budget(outputs[_TERMINAL_MODE], world_size)
+    _parse_propagation_metric(outputs[_PROPAGATION_MODE], world_size)
     assert _INVALID_TOPOLOGY_MARKER in outputs[_HEALTHY_MODE]
     assert _HEALTHY_LIFECYCLE_MARKER in outputs[_HEALTHY_MODE]
     assert _ABORT_WORLD_MARKER in outputs[_TERMINAL_MODE]


### PR DESCRIPTION
## Summary

- add a dedicated, process-lifetime MPI failure-notification communicator for the world-spanning MoE EP group
- propagate one authoritative EP-rank failure on an independent CPU thread using nonblocking `Isend`/`Irecv` plus `Test`
- keep monotonic detection evidence separate from committed `EPGroupHealth` state
- enforce bounded reconciliation and fail-stop behavior with optional ULFM `Revoke` and a non-ULFM terminal relay plus `MPI_Abort` fallback
- add deterministic protocol coverage and required 2-rank/4-rank real-MPI L0 smoke coverage

## Scope

This PR implements 1c.3 failure-detection propagation only. It does not independently enable end-to-end WideEP failover.

Owned here:

- collective construction and validation of the failure-notification communicator
- propagation and reconciliation of one authoritative failed EP rank
- monotonic `FailureEvidenceState` with `failed_ranks` and `evidence_epoch`
- detection callbacks and failed-communicator-epoch state for later integration
- bounded terminal behavior when progress, Revoke, or shutdown is wedged

Explicitly deferred:

- committed `EPGroupHealth` or execution-mask mutation
- request resume, EPLB changes, or NCCL use/reconstruction
- survivor-control communicator membership and reconstruction
- multi-failure suspect/confirm consensus
- destructive peer-death hardware validation

## Change size

This is a net-new, L-sized failure-notification component with `6,901` added lines:

| Category | Added lines | Share | Contents |
|:--|--:|--:|:--|
| Production | `2,314` | `33.5%` | `508` lines of communicator setup/lifetime handling and `1,806` lines of detection propagation, reconciliation, deadlines, lifecycle, and terminal behavior |
| Tests | `4,581` | `66.4%` | `3,151` lines of deterministic communicator/protocol unit coverage and `1,430` lines for the real-MPI worker, launcher, parser, and lifecycle harness |
| CI registration | `6` | `0.1%` | Required L0 entries with timeout and isolation configuration |

The test share is intentionally large because this code has concurrent MPI progress, callback, deadline-monitor, ULFM/non-ULFM, startup/shutdown, and failed-epoch resource-lifetime paths that require deterministic fault injection in addition to real-MPI smoke coverage.

## Implementation details

- collectively validate topology, rank ordering, `MPI.THREAD_MULTIPLE`, failure-evidence size, and process-lifetime ownership before `MPI_Comm_split`
- install `MPI.ERRORS_RETURN` before inspecting the derived communicator and reconcile post-split setup on the parent communicator
- negotiate ULFM capability across ranks: Revoke is enabled only when every rank reports compatible runtime support
- reject repeated or rank-inconsistent communicator construction before another collective split
- derive candidate survivors privately from failure evidence; no public generic mask API is exposed
- keep MPI progress, callback delivery, and deadline enforcement on independent threads
- distinguish Revoke attempted, in flight, completed, and timed out; use one-shot `MPI_Abort` when the enforcing thread or Revoke itself is wedged
- retain failed-epoch communicators, requests, and buffers for process lifetime instead of risking rank-local collective cleanup or blocking finalization

## Real-MPI smoke coverage

The L0 registration runs 2-rank and 4-rank launchers in three isolated modes:

- healthy lifecycle, including collective topology rejection and repeated-construction rejection
- logical failure propagation and survivor reconciliation
- terminal ABORT relay and intentional failed-epoch process exit without `MPI_Finalize`

The smoke keeps every worker alive for portable result coordination; actual peer death remains part of later hardware validation.

## Local validation

- `81 passed` — failure-notification protocol tests
- `49 passed` — communicator construction and validation tests
- `49 passed, 2 skipped` — MPI launcher/parser tests; the two real launcher cases were explicitly opted out because local MPI prerequisites are unavailable and remain required by default in L0
- Python compilation and `git diff --check`
- isort, Ruff lint/format, YAPF, YAML, whitespace, codespell, legacy lint, private-key, and merge-conflict hooks

## Impact

This PR provides the detection-plane primitive consumed by later recovery and shutdown integration. It does not publish committed membership, rebuild communicators, or authorize inference to resume.