### PR TITLE
[TRTLLM-12955][fix] use get_free_port_in_ci to avoid binding to a port in use

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -477,7 +477,6 @@ unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py::TestWanI2VTP::test_wan_i2v_
 unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py::TestWanI2VTP::test_wan_i2v_tp_vs_single_gpu SKIP (https://nvbugs/6384633)
 unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py::TestWanT2VTP::test_wan_t2v_tp_forward SKIP (https://nvbugs/6384633)
 unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py::TestWanT2VTP::test_wan_t2v_tp_vs_single_gpu SKIP (https://nvbugs/6384633)
-unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py::TestWanTransformerParallel::test_parallel_all_combinations_vs_single_gpu_8gpu[attn2d_1x4_ul2] SKIP (https://nvbugs/6385134)
 unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_self_attention[fp8-2-1560] SKIP (https://nvbugs/6198760)
 unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_self_attention[int8-2-1560] SKIP (https://nvbugs/6198760)
 unittest/bindings/test_transfer_agent_bindings.py::TestNixlFunctionalTransfer::test_nixl_wait_in_progress_on_zero_timeout SKIP (https://nvbugs/6260897)

--- a/tests/unittest/_torch/visual_gen/multi_gpu/_visual_gen_dist_utils.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/_visual_gen_dist_utils.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared helpers for visual_gen multi-GPU (mp.spawn) tests.
+
+Provides :func:`spawn_with_retry`, which allocates a fresh master port and
+retries the spawn when the c10d rendezvous ``TCPStore`` loses the bind race and
+fails with ``EADDRINUSE``.
+
+Why the retry is needed: the CI-aware port allocator (``get_free_port_in_ci``)
+binds a probe socket, *closes* it, and returns the port number. ``mp.spawn``
+then launches fresh worker processes and rank 0's ``TCPStore`` re-binds that
+port. Anything on the host (including ephemeral outbound sockets or a parallel
+test) can grab the port in the gap between the probe close and the re-bind, so a
+single allocation is not enough on busy nodes -- we must re-allocate and retry.
+"""
+
+import sys
+from pathlib import Path
+
+import torch.multiprocessing as mp
+
+# The CI-aware allocator lives in tests/integration/defs/common.py. Adding that
+# directory to sys.path lets us reuse it (it tracks allocated ports per-process
+# so sequential tests don't collide, and honors CONTAINER_PORT_START/NUM).
+_INTEGRATION_DIR = Path(__file__).resolve().parents[4] / "integration"
+if str(_INTEGRATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_INTEGRATION_DIR))
+from defs.common import get_free_port_in_ci  # noqa: E402
+
+_ADDR_IN_USE_MARKERS = ("EADDRINUSE", "address already in use")
+
+
+def _is_addr_in_use(exc: BaseException) -> bool:
+    msg = str(exc)
+    return any(marker in msg for marker in _ADDR_IN_USE_MARKERS)
+
+
+def spawn_with_retry(spawn_fn, max_retries: int = 10):
+    """Run ``spawn_fn(port)`` with a fresh free port, retrying on EADDRINUSE.
+
+    ``spawn_fn`` receives a master port and is expected to call ``mp.spawn``
+    (passing the port through to the workers). If the rendezvous TCPStore fails
+    to bind because the port was grabbed after allocation, a new port is chosen
+    and the spawn is retried up to ``max_retries`` times. Any other failure
+    (e.g. a real assertion inside the test) propagates immediately.
+    """
+    last_exc: BaseException | None = None
+    for _ in range(max_retries):
+        port = get_free_port_in_ci()
+        try:
+            spawn_fn(port)
+            return
+        except mp.ProcessRaisedException as exc:
+            if _is_addr_in_use(exc):
+                last_exc = exc
+                continue
+            raise
+        except OSError as exc:
+            if _is_addr_in_use(exc):
+                last_exc = exc
+                continue
+            raise
+    assert last_exc is not None
+    raise last_exc

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_attn2d_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_attn2d_attention.py
@@ -34,6 +34,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.attention_backend.interface import PredefinedAttentionMask
     from tensorrt_llm._torch.visual_gen.attention_backend import Attention2DAttention
     from tensorrt_llm._torch.visual_gen.attention_backend.flash_attn4 import FlashAttn4Attention
@@ -41,7 +44,14 @@ try:
         _flash_attn_fwd as _fa4_fwd,
     )
     from tensorrt_llm._torch.visual_gen.attention_backend.interface import AttentionTensorLayout
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -161,7 +171,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker,
         args=(world_size, backend, test_fn, port),

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_attn2d_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_attn2d_attention.py
@@ -45,13 +45,10 @@ try:
     )
     from tensorrt_llm._torch.visual_gen.attention_backend.interface import AttentionTensorLayout
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -171,12 +168,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker,
-        args=(world_size, backend, test_fn, port),
-        nprocs=world_size,
-        join=True,
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, backend, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_cosmos3_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_cosmos3_transformer_parallel.py
@@ -37,13 +37,10 @@ try:
         Cosmos3VFMTransformer,
     )
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.models.modeling_utils import QuantConfig
 
@@ -173,9 +170,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
     if use_cuda and torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker, args=(world_size, backend, test_fn, port), nprocs=world_size, join=True
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, backend, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_cosmos3_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_cosmos3_transformer_parallel.py
@@ -24,6 +24,9 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.config import (
         AttentionConfig,
         DiffusionModelConfig,
@@ -33,7 +36,15 @@ try:
     from tensorrt_llm._torch.visual_gen.models.cosmos3.transformer_cosmos3 import (
         Cosmos3VFMTransformer,
     )
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.models.modeling_utils import QuantConfig
 
     MODULES_AVAILABLE = True
@@ -162,7 +173,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
     if use_cuda and torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker, args=(world_size, backend, test_fn, port), nprocs=world_size, join=True
     )

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_flux2_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_flux2_transformer_parallel.py
@@ -35,13 +35,23 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.config import (
         AttentionConfig,
         DiffusionModelConfig,
         TorchCompileConfig,
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -99,7 +109,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
     if use_cuda and torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker,
         args=(world_size, backend, test_fn, port, kwargs),

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_flux2_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_flux2_transformer_parallel.py
@@ -45,13 +45,10 @@ try:
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -109,12 +106,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
     if use_cuda and torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker,
-        args=(world_size, backend, test_fn, port, kwargs),
-        nprocs=world_size,
-        join=True,
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, backend, test_fn, port, kwargs),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_tp.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_tp.py
@@ -35,6 +35,9 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.config import (
         AttentionConfig,
         DiffusionModelConfig,
@@ -46,7 +49,15 @@ try:
         FluxJointAttnMLPProj,
         FluxJointQKVMLPProj,
     )
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.models.modeling_utils import QuantConfig
 
     MODULES_AVAILABLE = True
@@ -104,7 +115,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port()
+    port = get_free_port_in_ci()
 
     mp.spawn(
         _distributed_worker, args=(world_size, backend, test_fn, port), nprocs=world_size, join=True

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_tp.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_tp.py
@@ -50,13 +50,10 @@ try:
         FluxJointQKVMLPProj,
     )
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.models.modeling_utils import QuantConfig
 
@@ -115,10 +112,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port_in_ci()
-
-    mp.spawn(
-        _distributed_worker, args=(world_size, backend, test_fn, port), nprocs=world_size, join=True
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, backend, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
@@ -32,13 +32,10 @@ try:
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.models.modeling_utils import QuantConfig
     from tensorrt_llm.visual_gen.args import AttentionConfig, TorchCompileConfig
@@ -98,10 +95,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port_in_ci()
-
-    mp.spawn(
-        _distributed_worker, args=(world_size, backend, test_fn, port), nprocs=world_size, join=True
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, backend, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
@@ -23,12 +23,23 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.config import (
         DiffusionModelConfig,
         create_attention_metadata_state,
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.models.modeling_utils import QuantConfig
     from tensorrt_llm.visual_gen.args import AttentionConfig, TorchCompileConfig
 
@@ -87,7 +98,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port()
+    port = get_free_port_in_ci()
 
     mp.spawn(
         _distributed_worker, args=(world_size, backend, test_fn, port), nprocs=world_size, join=True

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_async_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_async_ulysses.py
@@ -36,12 +36,23 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.config import (
         DiffusionModelConfig,
         create_attention_metadata_state,
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.models.modeling_utils import QuantConfig
     from tensorrt_llm.visual_gen.args import AttentionConfig, ParallelConfig, TorchCompileConfig
 
@@ -91,7 +102,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, *fn_args):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker,
         args=(world_size, "nccl", test_fn, port, fn_args),

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_async_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_async_ulysses.py
@@ -45,13 +45,10 @@ try:
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.models.modeling_utils import QuantConfig
     from tensorrt_llm.visual_gen.args import AttentionConfig, ParallelConfig, TorchCompileConfig
@@ -102,12 +99,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, *fn_args):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker,
-        args=(world_size, "nccl", test_fn, port, fn_args),
-        nprocs=world_size,
-        join=True,
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, "nccl", test_fn, port, fn_args),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py
@@ -34,13 +34,10 @@ try:
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
     from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.rope import LTXRopeType
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.models.modeling_utils import QuantConfig
     from tensorrt_llm.visual_gen.args import AttentionConfig, ParallelConfig, TorchCompileConfig
@@ -91,12 +88,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, *fn_args):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker,
-        args=(world_size, "nccl", test_fn, port, fn_args),
-        nprocs=world_size,
-        join=True,
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, "nccl", test_fn, port, fn_args),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py
@@ -24,13 +24,24 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.config import (
         DiffusionModelConfig,
         create_attention_metadata_state,
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
     from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.rope import LTXRopeType
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.models.modeling_utils import QuantConfig
     from tensorrt_llm.visual_gen.args import AttentionConfig, ParallelConfig, TorchCompileConfig
 
@@ -80,7 +91,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, *fn_args):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker,
         args=(world_size, "nccl", test_fn, port, fn_args),

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_attention.py
@@ -19,10 +19,20 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from diffusers.models.autoencoders.autoencoder_kl_wan import WanAttentionBlock
 
     from tensorrt_llm._torch.visual_gen.modules.vae import ParallelVaeAttentionBlock
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -70,7 +80,7 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(_distributed_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_attention.py
@@ -26,13 +26,10 @@ try:
 
     from tensorrt_llm._torch.visual_gen.modules.vae import ParallelVaeAttentionBlock
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -80,8 +77,14 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port_in_ci()
-    mp.spawn(_distributed_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
+    )
 
 
 def _broadcast_params(module):

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
@@ -31,13 +31,10 @@ try:
         HaloExchangeConv2dStride2,
     )
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -85,8 +82,14 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port_in_ci()
-    mp.spawn(_distributed_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
@@ -20,6 +20,9 @@ import torch.multiprocessing as mp
 import torch.nn as nn
 
 try:
+    import sys
+    from pathlib import Path
+
     from diffusers.models.autoencoders.autoencoder_kl_wan import WanCausalConv3d
 
     from tensorrt_llm._torch.visual_gen.models.wan.parallel_vae import WanCausalConvHalo
@@ -27,7 +30,14 @@ try:
         HaloExchangeConv,
         HaloExchangeConv2dStride2,
     )
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -75,7 +85,7 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(_distributed_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_group_norm.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_group_norm.py
@@ -25,13 +25,10 @@ try:
 
     from tensorrt_llm._torch.visual_gen.modules.vae import GroupNormParallel
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -74,8 +71,14 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port_in_ci()
-    mp.spawn(_distributed_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
+    )
 
 
 # ===========================================================================

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_group_norm.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_group_norm.py
@@ -20,8 +20,18 @@ import torch.multiprocessing as mp
 import torch.nn as nn
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.modules.vae import GroupNormParallel
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -64,7 +74,7 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(_distributed_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
@@ -21,10 +21,20 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from diffusers.models.autoencoders.autoencoder_kl_wan import AutoencoderKLWan
 
     from tensorrt_llm._torch.visual_gen.models.wan.parallel_vae import ParallelVAE_Wan
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -72,7 +82,7 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(_distributed_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
@@ -28,13 +28,10 @@ try:
 
     from tensorrt_llm._torch.visual_gen.models.wan.parallel_vae import ParallelVAE_Wan
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -82,8 +79,14 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port_in_ci()
-    mp.spawn(_distributed_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ring_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ring_attention.py
@@ -53,13 +53,10 @@ try:
     )
     from tensorrt_llm._torch.visual_gen.attention_backend.interface import AttentionTensorLayout
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -158,12 +155,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker,
-        args=(world_size, backend, test_fn, port),
-        nprocs=world_size,
-        join=True,
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, backend, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ring_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ring_attention.py
@@ -42,6 +42,9 @@ import torch.nn.functional as F
 from torch.distributed.device_mesh import init_device_mesh
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.attention_backend.interface import PredefinedAttentionMask
     from tensorrt_llm._torch.visual_gen.attention_backend import RingAttention, UlyssesAttention
     from tensorrt_llm._torch.visual_gen.attention_backend.flash_attn4 import FlashAttn4Attention
@@ -49,7 +52,14 @@ try:
         _flash_attn_fwd as _fa4_fwd,
     )
     from tensorrt_llm._torch.visual_gen.attention_backend.interface import AttentionTensorLayout
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -148,7 +158,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker,
         args=(world_size, backend, test_fn, port),

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_tp_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_tp_attention.py
@@ -47,13 +47,10 @@ try:
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
     from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.mapping import Mapping
     from tensorrt_llm.visual_gen.args import AttentionConfig
@@ -104,9 +101,13 @@ def _run(world_size: int, test_fn: Callable, *args):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker, args=(world_size, test_fn, port, *args), nprocs=world_size, join=True
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, test_fn, port, *args),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_tp_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_tp_attention.py
@@ -39,11 +39,22 @@ import torch.multiprocessing as mp
 import torch.nn.functional as F
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.device_mesh import DeviceMeshTopologyImpl
     from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
     from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.mapping import Mapping
     from tensorrt_llm.visual_gen.args import AttentionConfig
 
@@ -93,7 +104,7 @@ def _run(world_size: int, test_fn: Callable, *args):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker, args=(world_size, test_fn, port, *args), nprocs=world_size, join=True
     )

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_async.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_async.py
@@ -30,8 +30,18 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.distributed import all_to_all_4d
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -262,7 +272,7 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(test_fn, args=(world_size, port), nprocs=world_size, join=True)
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_async.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_async.py
@@ -35,13 +35,10 @@ try:
 
     from tensorrt_llm._torch.distributed import all_to_all_4d
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -272,8 +269,14 @@ def _run(world_size: int, test_fn: Callable):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port_in_ci()
-    mp.spawn(test_fn, args=(world_size, port), nprocs=world_size, join=True)
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            test_fn,
+            args=(world_size, port),
+            nprocs=world_size,
+            join=True,
+        )
+    )
 
 
 def test_slot_ring_wraparound():

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_attention.py
@@ -20,6 +20,9 @@ import torch.nn.functional as F
 
 # Try to import the modules - skip tests if not available
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.attention_backend.interface import PredefinedAttentionMask
     from tensorrt_llm._torch.distributed import all_to_all_4d, all_to_all_5d
     from tensorrt_llm._torch.visual_gen.attention_backend import UlyssesAttention, VanillaAttention
@@ -27,7 +30,14 @@ try:
         AttentionBackend,
         AttentionTensorLayout,
     )
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -91,7 +101,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
 
     backend = "nccl" if use_cuda else "gloo"
 
-    port = get_free_port()
+    port = get_free_port_in_ci()
 
     # Spawn processes
     mp.spawn(

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_attention.py
@@ -31,13 +31,10 @@ try:
         AttentionTensorLayout,
     )
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -101,11 +98,14 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
 
     backend = "nccl" if use_cuda else "gloo"
 
-    port = get_free_port_in_ci()
-
     # Spawn processes
-    mp.spawn(
-        _distributed_worker, args=(world_size, backend, test_fn, port), nprocs=world_size, join=True
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, backend, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_sage_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_sage_attention.py
@@ -37,10 +37,21 @@ import torch.multiprocessing as mp
 import torch.nn.functional as F
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.attention_backend import UlyssesAttention
     from tensorrt_llm._torch.visual_gen.attention_backend.trtllm import TrtllmAttention
     from tensorrt_llm._torch.visual_gen.config import create_attention_metadata_state
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.visual_gen.args import QuantAttentionConfig
 
     MODULES_AVAILABLE = True
@@ -104,7 +115,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable):
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker,
         args=(world_size, "nccl", test_fn, port),

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_sage_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_sage_attention.py
@@ -44,13 +44,10 @@ try:
     from tensorrt_llm._torch.visual_gen.attention_backend.trtllm import TrtllmAttention
     from tensorrt_llm._torch.visual_gen.config import create_attention_metadata_state
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.visual_gen.args import QuantAttentionConfig
 
@@ -115,12 +112,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable):
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker,
-        args=(world_size, "nccl", test_fn, port),
-        nprocs=world_size,
-        join=True,
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, "nccl", test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
@@ -13,8 +13,18 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -55,7 +65,7 @@ def _run_multi_gpu(world_size, test_fn):
         pytest.skip("Required modules not available")
     if not torch.cuda.is_available() or torch.cuda.device_count() < world_size:
         pytest.skip(f"Requires {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
@@ -18,13 +18,10 @@ try:
 
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -65,8 +62,14 @@ def _run_multi_gpu(world_size, test_fn):
         pytest.skip("Required modules not available")
     if not torch.cuda.is_available() or torch.cuda.device_count() < world_size:
         pytest.skip(f"Requires {world_size} GPUs, have {torch.cuda.device_count()}")
-    port = get_free_port_in_ci()
-    mp.spawn(_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True)
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _worker,
+            args=(world_size, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
+    )
 
 
 # =============================================================================

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_async_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_async_ulysses.py
@@ -32,9 +32,20 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.models.modeling_utils import QuantConfig
     from tensorrt_llm.visual_gen.args import (
         AttentionConfig,
@@ -89,7 +100,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, *fn_args):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker,
         args=(world_size, "nccl", test_fn, port, fn_args),

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_async_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_async_ulysses.py
@@ -38,13 +38,10 @@ try:
     from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.models.modeling_utils import QuantConfig
     from tensorrt_llm.visual_gen.args import (
@@ -100,12 +97,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, *fn_args):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker,
-        args=(world_size, "nccl", test_fn, port, fn_args),
-        nprocs=world_size,
-        join=True,
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, "nccl", test_fn, port, fn_args),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_pipeline_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_pipeline_parallel.py
@@ -37,10 +37,21 @@ import torch.multiprocessing as mp
 import torch.nn.functional as F
 
 try:
+    import sys
+    from pathlib import Path
+
     from diffusers import DiffusionPipeline
 
     from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.visual_gen.args import (
         AttentionConfig,
         ParallelConfig,
@@ -149,7 +160,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, **kwargs):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker,
         args=(world_size, "nccl", test_fn, port, kwargs),

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_pipeline_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_pipeline_parallel.py
@@ -44,13 +44,10 @@ try:
 
     from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.visual_gen.args import (
         AttentionConfig,
@@ -160,12 +157,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, **kwargs):
         pytest.skip("Required modules not available")
     if torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker,
-        args=(world_size, "nccl", test_fn, port, kwargs),
-        nprocs=world_size,
-        join=True,
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, "nccl", test_fn, port, kwargs),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py
@@ -46,13 +46,10 @@ try:
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.models.modeling_utils import QuantConfig
 
@@ -121,10 +118,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port_in_ci()
-
-    mp.spawn(
-        _distributed_worker, args=(world_size, backend, test_fn, port), nprocs=world_size, join=True
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, backend, test_fn, port),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py
@@ -35,6 +35,9 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.config import (
         AttentionConfig,
         DiffusionModelConfig,
@@ -42,7 +45,15 @@ try:
         create_attention_metadata_state,
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
+
     from tensorrt_llm.models.modeling_utils import QuantConfig
 
     MODULES_AVAILABLE = True
@@ -110,7 +121,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
 
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port()
+    port = get_free_port_in_ci()
 
     mp.spawn(
         _distributed_worker, args=(world_size, backend, test_fn, port), nprocs=world_size, join=True

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py
@@ -36,13 +36,23 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 try:
+    import sys
+    from pathlib import Path
+
     from tensorrt_llm._torch.visual_gen.config import (
         AttentionConfig,
         DiffusionModelConfig,
         TorchCompileConfig,
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
-    from tensorrt_llm._utils import get_free_port
+
+    # Reuse the CI-aware free-port allocator from tests/integration so that
+    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
+    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
+    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
+    if str(_integration_dir) not in sys.path:
+        sys.path.insert(0, str(_integration_dir))
+    from defs.common import get_free_port_in_ci
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -105,7 +115,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
     if use_cuda and torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port()
+    port = get_free_port_in_ci()
     mp.spawn(
         _distributed_worker,
         args=(world_size, backend, test_fn, port, kwargs),

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py
@@ -46,13 +46,10 @@ try:
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
 
-    # Reuse the CI-aware free-port allocator from tests/integration so that
-    # sequentially spawned distributed workers get disjoint MASTER_PORTs and
-    # don't collide with ports still in TIME_WAIT (EADDRINUSE).
-    _integration_dir = Path(__file__).resolve().parents[4] / "integration"
-    if str(_integration_dir) not in sys.path:
-        sys.path.insert(0, str(_integration_dir))
-    from defs.common import get_free_port_in_ci
+    # Spawn distributed workers via a helper that retries with a fresh master
+    # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _visual_gen_dist_utils import spawn_with_retry
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -115,12 +112,13 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
     if use_cuda and torch.cuda.device_count() < world_size:
         pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
     backend = "nccl" if use_cuda else "gloo"
-    port = get_free_port_in_ci()
-    mp.spawn(
-        _distributed_worker,
-        args=(world_size, backend, test_fn, port, kwargs),
-        nprocs=world_size,
-        join=True,
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker,
+            args=(world_size, backend, test_fn, port, kwargs),
+            nprocs=world_size,
+            join=True,
+        )
     )
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated multiple multi-GPU distributed test runs to use CI-aware free-port selection.
  * Reduced the risk of `MASTER_PORT` collisions when tests spawn workers sequentially in CI.
  * Improved stability for distributed visual generation test runs across several attention, transformer, and parallel execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
