### PR TITLE
[TRTLLM-13553][feat] Add WideEP rank health telemetry (1d.3)

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/ep_group_health.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/ep_group_health.py
@@ -30,7 +30,13 @@ telemetry consumers must not mutate this object to drive recovery.
 """
 
 import threading
-from typing import NamedTuple
+import uuid
+from typing import Any, NamedTuple
+
+# Canonical ModelConfig.extra_attrs key for coordinator-committed data-plane
+# membership. The object is not a detector or a physical-liveness tracker.
+EP_GROUP_HEALTH_EXTRA_ATTR = "wide_ep_ft_ep_group_health"
+EP_GROUP_HEALTH_LEGACY_EXTRA_ATTR = "ep_group_health"
 
 # Default number of uint64 words for EPGroupHealth.get_mask_words().
 # Matches the active_rank_mask ABI of the NVLink AlltoAll kernels
@@ -49,24 +55,29 @@ class EPGroupHealthSnapshot(NamedTuple):
     if a mutator runs between calls).
     """
 
-    # Active-rank bitmask (bit i set iff rank i is active).
+    # Committed-rank bitmask (bit i set iff rank i is included).
     mask: int
-    # Number of ranks currently marked active.
+    # Number of ranks included in committed data-plane membership.
     active_count: int
-    # Immutable snapshot of failed ranks.
+    # Immutable snapshot of ranks excluded from committed membership.
     failed_ranks: frozenset[int]
-    # Monotonic counter; bumps only on effective state changes.
+    # Monotonic committed-membership version.
     generation: int
 
 
 class EPGroupHealth:
-    """Thread-safe health tracker for the ranks of an EP group.
+    """Thread-safe committed-membership tracker for an EP group.
 
     Internally backed by an arbitrary-precision Python ``int`` bitmask
-    (bit ``i`` set iff rank ``i`` is currently active). The kernel-side
-    representation as a fixed-width array of ``uint64`` words is exposed via
-    :meth:`get_mask_words`; this matches the ``active_rank_mask`` parameter
-    expected by the NVLink AlltoAll kernels.
+    (bit ``i`` set iff rank ``i`` is included in the committed data plane).
+    The kernel-side representation as a fixed-width array of ``uint64`` words
+    is exposed via :meth:`get_mask_words`; this matches the
+    ``active_rank_mask`` parameter expected by the NVLink AlltoAll kernels.
+
+    This object does not represent uncommitted detector observations or
+    suspected physical liveness. A higher-level recovery coordinator owns
+    membership transitions; passive consumers such as telemetry must only
+    read coherent snapshots.
 
     All read and write operations take an internal lock. Read operations that
     return collection types return defensive snapshots so the caller cannot
@@ -98,6 +109,10 @@ class EPGroupHealth:
         self._active_count: int = moe_world_size
         self._failed_ranks: set[int] = set()
         self._generation: int = 0
+        # A generation is monotonic only within one producer lifetime.  The
+        # immutable epoch lets serving distinguish a restarted producer from a
+        # stale snapshot emitted by the current one.
+        self._source_epoch = uuid.uuid4().hex
         self._lock = threading.Lock()
 
     @property
@@ -107,7 +122,7 @@ class EPGroupHealth:
 
     @property
     def generation(self) -> int:
-        """Monotonic counter incremented on every effective state change.
+        """Monotonic counter incremented on each committed membership change.
 
         Idempotent calls (e.g. marking an already-failed rank as failed) do not
         bump the counter. Consumers that need to react to mask changes can
@@ -120,13 +135,22 @@ class EPGroupHealth:
         with self._lock:
             return self._generation
 
+    @property
+    def source_epoch(self) -> str:
+        """Unique identifier for this producer lifetime."""
+        return self._source_epoch
+
     def _validate_rank(self, rank: int) -> None:
         """Raise if ``rank`` is outside the MoE world."""
         if not 0 <= rank < self._moe_world_size:
             raise ValueError(f"rank must be in [0, {self._moe_world_size}), got {rank}")
 
     def mark_failed(self, rank: int) -> bool:
-        """Mark ``rank`` as failed. Idempotent.
+        """Exclude ``rank`` from committed data-plane membership. Idempotent.
+
+        A higher-level recovery coordinator owns calls to this mutator after
+        reconciling detector evidence; detection and telemetry must not call it
+        directly.
 
         Args:
             rank: Index of the rank to mark, in ``[0, moe_world_size)``.
@@ -150,7 +174,7 @@ class EPGroupHealth:
             return True
 
     def mark_active(self, rank: int) -> bool:
-        """Mark ``rank`` as active. Idempotent.
+        """Include ``rank`` in committed data-plane membership. Idempotent.
 
         Used when a replacement rank rejoins the group after a failure.
         Higher layers may impose a "monotonic failure" policy (do not
@@ -179,7 +203,7 @@ class EPGroupHealth:
             return True
 
     def is_active(self, rank: int) -> bool:
-        """Return ``True`` iff ``rank`` is currently marked active.
+        """Return whether ``rank`` is included in committed membership.
 
         Raises:
             ValueError: If ``rank`` is outside ``[0, moe_world_size)``.
@@ -189,15 +213,15 @@ class EPGroupHealth:
             return bool(self._active_mask & (1 << rank))
 
     def get_mask(self) -> int:
-        """Return the active-rank bitmask as a Python ``int``.
+        """Return the committed active-rank bitmask as a Python ``int``.
 
-        Bit ``i`` is set iff rank ``i`` is currently active.
+        Bit ``i`` is set iff rank ``i`` is included in data-plane membership.
         """
         with self._lock:
             return self._active_mask
 
     def get_mask_words(self, num_words: int = EP_MASK_NUM_WORDS) -> tuple[int, ...]:
-        """Return the active-rank bitmask split into little-endian uint64 words.
+        """Return the committed rank mask as little-endian uint64 words.
 
         Suitable for passing to CUDA kernels that accept ``uint64_t[num_words]``.
         Word ``0`` covers ranks ``0..63``, word ``1`` covers ranks ``64..127``,
@@ -228,22 +252,22 @@ class EPGroupHealth:
         return tuple((mask >> (i * 64)) & word_mask for i in range(num_words))
 
     def get_active_count(self) -> int:
-        """Return the number of ranks currently marked active."""
+        """Return the number of ranks in committed data-plane membership."""
         with self._lock:
             return self._active_count
 
     def get_failed_ranks(self) -> frozenset[int]:
-        """Return an immutable snapshot of the set of failed ranks."""
+        """Return ranks excluded from committed data-plane membership."""
         with self._lock:
             return frozenset(self._failed_ranks)
 
     def all_active(self) -> bool:
-        """Return ``True`` iff every rank in the group is currently active."""
+        """Return whether committed membership includes every group rank."""
         with self._lock:
             return self._active_mask == self._all_active_mask
 
     def snapshot(self) -> EPGroupHealthSnapshot:
-        """Return an atomic snapshot of mask, active_count, failed_ranks, generation.
+        """Return an atomic committed-membership snapshot.
 
         All four fields reflect a single point in time (one lock acquisition).
         Prefer this over calling individual accessors back-to-back when the
@@ -261,13 +285,18 @@ class EPGroupHealth:
         """Return the MoE world size (``moe_world_size``), not the active count.
 
         Provided for compatibility with code that treats this object as a
-        sized container of ranks (alive or dead). Use :meth:`get_active_count`
-        when you specifically want the surviving-rank count.
+        sized container of included and excluded ranks. Use
+        :meth:`get_active_count` for the committed-membership count.
         """
         return self._moe_world_size
 
+    def __deepcopy__(self, memo: dict[int, Any]) -> "EPGroupHealth":
+        """Preserve producer identity when ``ModelConfig`` is deep-copied."""
+        memo[id(self)] = self
+        return self
+
     def __repr__(self) -> str:
-        """Return a concise debug representation of the current health state."""
+        """Return a concise representation of committed membership."""
         with self._lock:
             return (
                 f"EPGroupHealth(moe_world_size={self._moe_world_size}, "

--- a/tensorrt_llm/_torch/modules/fused_moe/ep_metrics.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/ep_metrics.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prometheus-independent serialization of committed EP membership.
+
+Workers serialize the recovery coordinator's committed data-plane membership
+for a dedicated serving RPC without importing the client before its
+multiprocess directory is configured. This module is a passive observer: it
+does not expose detected/suspected physical liveness and must not drive
+recovery.
+"""
+
+from typing import Any
+
+from .ep_group_health import (
+    EP_GROUP_HEALTH_EXTRA_ATTR,
+    EP_GROUP_HEALTH_LEGACY_EXTRA_ATTR,
+    EPGroupHealth,
+)
+
+_EP_HEALTH_METRICS_STATUS_KEY = "status"
+_EP_HEALTH_METRICS_PENDING_STATUS = "pending"
+
+
+def validate_ep_health_metrics_topology(model_config: Any) -> None:
+    """Reject topologies whose rank-0 endpoint cannot expose every EP group."""
+    mapping = getattr(model_config, "mapping", None)
+    if any(
+        getattr(mapping, axis, 1) > 1 for axis in ("moe_tp_size", "pp_size", "moe_cluster_size")
+    ):
+        raise NotImplementedError("EP health telemetry does not support multi-group MoE topologies")
+
+
+def get_ep_group_health(model_config: Any) -> EPGroupHealth | None:
+    """Return an already-configured coordinator-owned membership tracker.
+
+    ``ModelConfig.extra_attrs`` shares the committed data-plane membership
+    tracker with communication. It does not carry raw detector observations or
+    suspected physical liveness. This telemetry consumer never creates,
+    registers, enables, or mutates it. The legacy prototype key remains
+    readable during rollout; if both keys are populated they must reference the
+    same object.
+    """
+    extra_attrs = getattr(model_config, "extra_attrs", None)
+    if extra_attrs is None:
+        return None
+
+    health = extra_attrs.get(EP_GROUP_HEALTH_EXTRA_ATTR)
+    legacy_health = extra_attrs.get(EP_GROUP_HEALTH_LEGACY_EXTRA_ATTR)
+    if health is not None and legacy_health is not None and health is not legacy_health:
+        raise ValueError("configured EP group health keys reference different trackers")
+    health = health if health is not None else legacy_health
+    if health is None:
+        return None
+    if not isinstance(health, EPGroupHealth):
+        raise TypeError("configured EP group health must be an EPGroupHealth")
+
+    mapping = getattr(model_config, "mapping", None)
+    moe_world_size = getattr(mapping, "moe_ep_size", None)
+    if (
+        type(moe_world_size) is int
+        and moe_world_size > 0
+        and health.moe_world_size != moe_world_size
+    ):
+        raise ValueError("configured EP group health world size does not match model mapping")
+    return health
+
+
+def is_ep_group_health_registration_pending(model_config: Any) -> bool:
+    """Return whether a producer reserved a tracker slot for late attachment."""
+    extra_attrs = getattr(model_config, "extra_attrs", None)
+    if extra_attrs is None:
+        return False
+    return any(
+        key in extra_attrs and extra_attrs[key] is None
+        for key in (EP_GROUP_HEALTH_EXTRA_ATTR, EP_GROUP_HEALTH_LEGACY_EXTRA_ATTR)
+    )
+
+
+def pending_ep_health_metrics() -> dict[str, str]:
+    """Return the JSON-safe marker for an explicitly pending registration."""
+    return {_EP_HEALTH_METRICS_STATUS_KEY: _EP_HEALTH_METRICS_PENDING_STATUS}
+
+
+def is_pending_ep_health_metrics(ep_health_stats: dict[str, Any]) -> bool:
+    """Return whether a worker reported an explicitly pending registration."""
+    return ep_health_stats == pending_ep_health_metrics()
+
+
+def serialize_ep_health_metrics(ep_group_health: EPGroupHealth) -> dict[str, Any]:
+    """Serialize one coherent committed-membership snapshot.
+
+    ``failedRanks`` contains ranks excluded from the committed data-plane mask;
+    it is not a physical-liveness or suspicion signal. The per-rank gauge is
+    derived from ``worldSize`` and ``failedRanks`` without mutating recovery
+    state.
+    """
+    snapshot = ep_group_health.snapshot()
+    return {
+        "sourceEpoch": ep_group_health.source_epoch,
+        "worldSize": ep_group_health.moe_world_size,
+        "activeCount": snapshot.active_count,
+        "failedRanks": sorted(snapshot.failed_ranks),
+        "generation": snapshot.generation,
+    }

--- a/tensorrt_llm/_torch/modules/fused_moe/wide_ep_ft.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/wide_ep_ft.py
@@ -24,15 +24,16 @@ from tensorrt_llm._torch.alltoall_watchdog import (
     DEFAULT_ALLTOALL_WATCHDOG_TIMEOUT_S,
 )
 
-from .ep_group_health import EPGroupHealth
+from .ep_group_health import (
+    EP_GROUP_HEALTH_EXTRA_ATTR,
+    EP_GROUP_HEALTH_LEGACY_EXTRA_ATTR,
+    EPGroupHealth,
+)
 
 _ENABLE_ENV = "TLLM_FAULT_TOLERANCE_MODE"
 _TIMEOUT_ENV = "TRTLLM_ALLTOALL_WATCHDOG_TIMEOUT_S"
 _POLL_INTERVAL_ENV = "TRTLLM_ALLTOALL_WATCHDOG_POLL_INTERVAL_S"
 
-# This object contains membership committed by higher-layer recovery
-# coordination.  Detection threads must treat it as read-only.
-_HEALTH_KEY = "wide_ep_ft_ep_group_health"
 _TIMEOUT_KEY = "alltoall_watchdog_timeout_s"
 _POLL_INTERVAL_KEY = "alltoall_watchdog_poll_interval_s"
 
@@ -65,7 +66,9 @@ def get_wide_ep_ft_options(
     """
 
     extra_attrs = getattr(model_config, "extra_attrs", {})
-    health = extra_attrs.get(_HEALTH_KEY) or extra_attrs.get("ep_group_health")
+    health = extra_attrs.get(EP_GROUP_HEALTH_EXTRA_ATTR) or extra_attrs.get(
+        EP_GROUP_HEALTH_LEGACY_EXTRA_ATTR
+    )
     rank_mask_enabled = health is not None or _env_enabled()
     if rank_mask_enabled and getattr(model_config, "use_cuda_graph", False):
         raise ValueError(
@@ -74,7 +77,7 @@ def get_wide_ep_ft_options(
         )
     if health is None and rank_mask_enabled:
         health = EPGroupHealth(model_config.mapping.moe_ep_size)
-        extra_attrs[_HEALTH_KEY] = health
+        extra_attrs[EP_GROUP_HEALTH_EXTRA_ATTR] = health
 
     poll_interval_s = _float_option(
         extra_attrs,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -55,6 +55,10 @@ from ..models.modeling_multimodal_mixin import \
     maybe_prefetch_mm_encoder_for_next_iter
 from ..models.modeling_utils import DecoderModelForCausalLM
 from ..modules.decoder_layer import DecoderLayer
+from ..modules.fused_moe.ep_metrics import (
+    get_ep_group_health, is_ep_group_health_registration_pending,
+    pending_ep_health_metrics, serialize_ep_health_metrics,
+    validate_ep_health_metrics_topology)
 from ..speculative.drafter import Drafter
 from ..speculative.spec_sampler_base import SampleStateTensorsSpec
 from ..speculative.speculation_gate import SpeculationGate
@@ -568,6 +572,8 @@ class PyExecutor:
         self.model_engine = model_engine
         self._enable_dsv4_adp_dummy_fixes = getattr(
             model_engine, "_enable_dsv4_adp_dummy_fixes", False)
+        model = getattr(model_engine, "model", None)
+        self._ep_health_model_config = getattr(model, "model_config", None)
         self.enable_attention_dp = model_engine.enable_attention_dp
         self.dist = dist
         self.sampler = sampler
@@ -1515,6 +1521,19 @@ class PyExecutor:
         Indicates if the current process is allowed to enqueue requests
         """
         return self.executor_request_queue.can_enqueue_request()
+
+    def _get_ep_health_stats(self) -> Optional[dict]:
+        """Return committed EP membership for passive internal telemetry."""
+        ep_group_health = get_ep_group_health(self._ep_health_model_config)
+        if ep_group_health is None:
+            if is_ep_group_health_registration_pending(
+                    self._ep_health_model_config):
+                validate_ep_health_metrics_topology(
+                    self._ep_health_model_config)
+                return pending_ep_health_metrics()
+            return None
+        validate_ep_health_metrics_topology(self._ep_health_model_config)
+        return serialize_ep_health_metrics(ep_group_health)
 
     def get_latest_iteration_stats(self):
         """

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -246,6 +246,17 @@ class BaseWorker(GenerationExecutor):
 
         return {}
 
+    def _get_ep_health_stats(self, timeout: float = 1.0) -> Optional[dict]:
+        """Return committed EP membership when the backend supports it."""
+        health_reader = getattr(self.engine, "_get_ep_health_stats", None)
+        if health_reader is None:
+            return None
+        return health_reader()
+
+    def fetch_ep_health_stats(self) -> Optional[dict]:
+        """RPC entry point for passive committed-membership telemetry."""
+        return self._get_ep_health_stats()
+
     def fetch_kv_cache_events(self) -> list:
         return self.engine.get_latest_kv_cache_events()
 

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -421,6 +421,10 @@ class GenerationExecutor(ABC):
         """
         return {}
 
+    def _get_ep_health_stats(self, timeout: float = 1.0) -> Optional[dict]:
+        """Return passive committed EP membership telemetry when supported."""
+        return None
+
     def aget_stats(self, timeout: float) -> IterationResult:
         """Get iteration statistics from the runtime.
 

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -935,6 +935,19 @@ class GenerationExecutorProxy(GenerationExecutor):
             logger.debug(f"Error fetching kv cache capacity via RPC: {e}")
             return {}
 
+    def _get_ep_health_stats(self, timeout: float = 1.0) -> Optional[dict]:
+        """Fetch best-effort committed EP membership from the rank-0 worker.
+
+        The rank-0 RPC is the only MPI worker control endpoint today. Callers
+        must treat ``ep_health_available`` as the validity bit if that endpoint
+        is lost. The snapshot is not detected/suspected physical liveness, and
+        this passive metrics hook must not drive recovery. Survivor-side
+        observation belongs to the fault-tolerant control-plane work.
+        """
+        if self.rpc_client is None:
+            return None
+        return self.rpc_client.fetch_ep_health_stats().remote(timeout=timeout)
+
     def get_disaggregated_params(self) -> dict:
         """Get disaggregated params from worker runtime via RPC."""
         if self.rpc_client is None:

--- a/tensorrt_llm/executor/rpc_proxy_mixin.py
+++ b/tensorrt_llm/executor/rpc_proxy_mixin.py
@@ -165,6 +165,10 @@ class RpcExecutorMixin:
             method_name="_fetch_responses_loop_async",
         )
 
+    def _get_ep_health_stats(self, timeout: float = 1.0) -> Optional[dict]:
+        """Fetch passive committed EP membership from the rank-0 RPC worker."""
+        return self.rpc_client.fetch_ep_health_stats().remote(timeout=timeout)
+
     # NOTE: _fetch_stats_loop_async and _fetch_kv_cache_events_loop_async have been removed.
     # Stats and kv_events are now fetched on-demand via direct RPC calls
     # (get_stats, aget_stats, get_kv_events, aget_kv_events) instead of streaming loops.

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -1148,6 +1148,13 @@ class BaseLLM:
                 "Use llm.encode() for encoder-only models.")
         return self._executor.aget_stats(timeout=timeout)
 
+    def _get_ep_health_stats(self) -> Optional[dict]:
+        """Return committed EP membership for the passive metrics hook."""
+        executor = getattr(self, "_executor", None)
+        if executor is None:
+            return None
+        return executor._get_ep_health_stats()
+
     @set_api_status("beta")
     def get_kv_cache_events(self, timeout: Optional[float] = 2) -> List[dict]:
         """Get iteration KV events from the runtime.

--- a/tensorrt_llm/metrics/collector.py
+++ b/tensorrt_llm/metrics/collector.py
@@ -14,11 +14,130 @@
 # limitations under the License.
 """Utilities for Prometheus Metrics Collection."""
 
+import logging
 import math
+import threading
 import time
-from typing import Dict, List, Optional, Union
+from collections import deque
+from typing import Dict, List, NamedTuple, Optional, Union
 
 from .enums import MetricNames
+
+_LOGGER = logging.getLogger(__name__)
+
+# Phase-1 WideEP uses the two-word uint64 active-rank-mask ABI. Reject a
+# malformed payload before it can create unbounded Prometheus cardinality on
+# the serving event loop.
+_MAX_EP_HEALTH_RANKS = 128
+# Prometheus gauges are IEEE-754 doubles. Keep the monotonic generation exact
+# so stale/conflict comparisons have the same meaning before and after export.
+_MAX_EP_HEALTH_GENERATION = (1 << 53) - 1
+_MAX_EP_HEALTH_SOURCE_EPOCH_LENGTH = 128
+_MAX_RETIRED_EP_HEALTH_SOURCE_EPOCHS = 32
+
+
+class _EPHealthSnapshot(NamedTuple):
+    """One immutable snapshot exported by the local Prometheus collector."""
+
+    world_size: int
+    active_count: int
+    failed_ranks: frozenset[int]
+    generation: int
+
+
+class _EPHealthPrometheusCollector:
+    """Export a coherent EP snapshot without multiprocess gauge merging.
+
+    ``prometheus_client`` combines each multiprocess gauge independently.  A
+    rank vector, its aggregate counts, and its validity bit therefore cannot
+    form an atomic snapshot when more than one process writes the same label
+    set.  EP health is polled by the OpenAI server itself, so keep its latest
+    immutable value in that process and register this collector directly on
+    the server's scrape registry instead.
+    """
+
+    def __init__(self, labels: Dict[str, str], metric_prefix: str) -> None:
+        self._label_names = list(labels)
+        self._label_values = [labels[name] for name in self._label_names]
+        self._metric_prefix = metric_prefix
+        self._lock = threading.Lock()
+        self._snapshot: Optional[_EPHealthSnapshot] = None
+        self._available = False
+
+    def publish(self, snapshot: _EPHealthSnapshot) -> None:
+        """Atomically replace the snapshot and mark it available."""
+        with self._lock:
+            self._snapshot = snapshot
+            self._available = True
+
+    def mark_unavailable(self) -> None:
+        """Atomically invalidate the retained snapshot."""
+        with self._lock:
+            self._available = False
+
+    def collect(self) -> list:
+        """Build all metric families from one locked state read."""
+        with self._lock:
+            snapshot = self._snapshot
+            available = self._available
+
+        # Do not advertise EP health for non-EP or non-FT deployments. Once a
+        # producer has published a valid snapshot, retain its samples during an
+        # outage and use the availability family as their validity bit.
+        if snapshot is None:
+            return []
+
+        from prometheus_client.core import GaugeMetricFamily
+
+        metrics = []
+        rank_active = GaugeMetricFamily(
+            self._metric_prefix + "ep_rank_active",
+            "Whether an Expert Parallel rank is included in coordinator-committed "
+            "data-plane membership (1) or excluded (0); not physical liveness.",
+            labels=[*self._label_names, MetricsCollector.labelname_ep_rank],
+        )
+        for rank in range(snapshot.world_size):
+            rank_active.add_metric(
+                [*self._label_values, str(rank)],
+                int(rank not in snapshot.failed_ranks),
+            )
+        metrics.append(rank_active)
+
+        for name, documentation, value in (
+            (
+                "ep_active_ranks",
+                "Number of ranks in coordinator-committed EP data-plane membership.",
+                snapshot.active_count,
+            ),
+            (
+                "ep_failed_ranks",
+                "Number of ranks excluded from coordinator-committed EP data-plane "
+                "membership; not a physical-failure detector.",
+                snapshot.world_size - snapshot.active_count,
+            ),
+            (
+                "ep_health_generation",
+                "Committed EP membership version; increments on each effective transition.",
+                snapshot.generation,
+            ),
+        ):
+            metric = GaugeMetricFamily(
+                self._metric_prefix + name,
+                documentation,
+                labels=self._label_names,
+            )
+            metric.add_metric(self._label_values, value)
+            metrics.append(metric)
+
+        availability = GaugeMetricFamily(
+            self._metric_prefix + "ep_health_available",
+            "Whether rank-0 committed EP membership telemetry is available. "
+            "When 0, ignore all other trtllm_ep_* health samples.",
+            labels=self._label_names,
+        )
+        availability.add_metric(self._label_values, int(available))
+        metrics.append(availability)
+        return metrics
 
 
 # Adapted from https://github.com/vllm-project/vllm/blob/v0.10.0rc1/vllm/engine/metrics.py#L30
@@ -51,6 +170,13 @@ class MetricsCollector:
             trtllm_prefill_perplexity
             trtllm_generation_perplexity
             trtllm_request_error_total
+
+        Expert Parallel health metrics:
+            trtllm_ep_rank_active
+            trtllm_ep_active_ranks
+            trtllm_ep_failed_ranks
+            trtllm_ep_health_generation
+            trtllm_ep_health_available
 
         Iteration-level metrics:
             trtllm_kv_cache_hit_rate
@@ -102,6 +228,7 @@ class MetricsCollector:
             trtllm_kv_cache_config_info
     """
     labelname_finish_reason = "finished_reason"
+    labelname_ep_rank = "ep_rank"
 
     def __init__(
         self,
@@ -314,6 +441,17 @@ class MetricsCollector:
             name=self.metric_prefix + "max_num_active_requests",
             documentation="Maximum number of active requests",
             labelnames=self.labels.keys())
+
+        # Committed Expert Parallel membership is passively observed from the
+        # rank-0 worker through a dedicated internal RPC. Unlike independent
+        # multiprocess gauges, this local collector preserves the rank vector,
+        # aggregate counts, generation, and availability as one snapshot.
+        self._last_ep_health_state = None
+        self._last_ep_health_rejection = None
+        self._retired_ep_health_source_epochs = set()
+        self._retired_ep_health_source_epoch_order = deque()
+        self._ep_health_prometheus_collector = _EPHealthPrometheusCollector(
+            self.labels, self.metric_prefix)
 
         # Iteration latency
         self.iteration_latency_seconds = Gauge(
@@ -867,6 +1005,113 @@ class MetricsCollector:
             if total_intra_device_copy_bytes > 0:
                 self._log_counter(self.kv_cache_intra_device_copy_bytes_total,
                                   {}, total_intra_device_copy_bytes)
+
+    def _reject_ep_health_stats(self, message: str, *args: object) -> bool:
+        """Mark telemetry unavailable and warn once per repeated rejection."""
+        signature = (message, tuple(str(arg) for arg in args))
+        if signature != self._last_ep_health_rejection:
+            _LOGGER.warning(message, *args)
+            self._last_ep_health_rejection = signature
+        self.log_ep_health_unavailable()
+        return False
+
+    def log_ep_health_stats(self, ep_health_stats: dict) -> bool:
+        """Materialize committed ``EPGroupHealth`` membership as gauges.
+
+        Returns ``False`` when the payload is invalid, stale, or conflicts with
+        the last accepted snapshot. Callers may retry because a later generation
+        or a never-before-seen producer epoch can restore a coherent stream.
+        ``sourceEpoch`` is required so a producer restart cannot be confused
+        with delayed state from a retired producer. This passive consumer does
+        not interpret the snapshot as physical liveness or mutate recovery
+        state.
+        """
+        try:
+            world_size = ep_health_stats["worldSize"]
+            active_count = ep_health_stats["activeCount"]
+            generation = ep_health_stats["generation"]
+            failed_rank_list = ep_health_stats["failedRanks"]
+            source_epoch = ep_health_stats["sourceEpoch"]
+            scalar_values = (world_size, active_count, generation)
+            if any(type(value) is not int for value in scalar_values):
+                raise TypeError(
+                    "worldSize, activeCount, and generation must be integers")
+            if (world_size <= 0 or world_size > _MAX_EP_HEALTH_RANKS
+                    or not 0 <= active_count <= world_size or generation < 0
+                    or generation > _MAX_EP_HEALTH_GENERATION):
+                raise ValueError("EP health scalar values are out of range")
+            if not isinstance(failed_rank_list, list):
+                raise TypeError("failedRanks must be a list")
+            if (not isinstance(source_epoch, str) or not source_epoch
+                    or len(source_epoch) > _MAX_EP_HEALTH_SOURCE_EPOCH_LENGTH):
+                raise TypeError(
+                    "sourceEpoch must be a bounded non-empty string")
+            if len(failed_rank_list) > world_size:
+                raise ValueError("failedRanks contains too many ranks")
+            if any(
+                    type(rank) is not int or not 0 <= rank < world_size
+                    for rank in failed_rank_list):
+                raise ValueError("failedRanks contains an invalid rank")
+            failed_ranks = set(failed_rank_list)
+            if (len(failed_ranks) != len(failed_rank_list)
+                    or active_count != world_size - len(failed_ranks)):
+                raise ValueError("EP health counts are inconsistent")
+        except (KeyError, TypeError, ValueError) as error:
+            return self._reject_ep_health_stats(
+                "Ignoring invalid epHealthStats payload: %s", error)
+
+        state = (source_epoch, world_size, generation,
+                 tuple(sorted(failed_ranks)))
+        last_source_epoch = None
+        if self._last_ep_health_state is not None:
+            last_source_epoch, last_world_size, last_generation, last_failed_ranks = (
+                self._last_ep_health_state)
+            if world_size != last_world_size:
+                return self._reject_ep_health_stats(
+                    "Ignoring epHealthStats world-size change from %s to %s",
+                    last_world_size, world_size)
+            if source_epoch == last_source_epoch and generation < last_generation:
+                return self._reject_ep_health_stats(
+                    "Ignoring stale epHealthStats generation %s after %s",
+                    generation, last_generation)
+            if (source_epoch == last_source_epoch
+                    and generation == last_generation
+                    and state[3] != last_failed_ranks):
+                return self._reject_ep_health_stats(
+                    "Conflicting epHealthStats payloads at generation %s",
+                    generation)
+            if source_epoch != last_source_epoch:
+                if source_epoch in self._retired_ep_health_source_epochs:
+                    return self._reject_ep_health_stats(
+                        "Ignoring epHealthStats from retired source epoch %s",
+                        source_epoch)
+
+        if last_source_epoch is not None and source_epoch != last_source_epoch:
+            if (len(self._retired_ep_health_source_epoch_order) ==
+                    _MAX_RETIRED_EP_HEALTH_SOURCE_EPOCHS):
+                expired_epoch = self._retired_ep_health_source_epoch_order.popleft(
+                )
+                self._retired_ep_health_source_epochs.remove(expired_epoch)
+            self._retired_ep_health_source_epoch_order.append(last_source_epoch)
+            self._retired_ep_health_source_epochs.add(last_source_epoch)
+        self._last_ep_health_state = state
+        self._last_ep_health_rejection = None
+        self._ep_health_prometheus_collector.publish(
+            _EPHealthSnapshot(
+                world_size=world_size,
+                active_count=active_count,
+                failed_ranks=frozenset(failed_ranks),
+                generation=generation,
+            ))
+        return True
+
+    def log_ep_health_unavailable(self) -> None:
+        """Mark the last EP health telemetry read as unavailable."""
+        self._ep_health_prometheus_collector.mark_unavailable()
+
+    def register_ep_health_metrics(self, registry: object) -> None:
+        """Register coherent EP health metrics on a scrape registry."""
+        registry.register(self._ep_health_prometheus_collector)
 
     def log_request_error(self, http_code: Union[int, str] = "") -> None:
         """Increment the error counter, labeled by HTTP status code."""

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -11,6 +11,7 @@ import socket
 import time
 import traceback
 import uuid
+from builtins import anext
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
@@ -21,6 +22,7 @@ from typing import (Annotated, Any, AsyncGenerator, AsyncIterator, List,
                     Optional, Union)
 
 import uvicorn
+import zmq
 from fastapi import Body, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import (FileResponse, JSONResponse, Response,
@@ -31,10 +33,13 @@ from starlette.routing import Mount
 from transformers import AutoProcessor
 
 from tensorrt_llm._torch.async_llm import AsyncLLM
+from tensorrt_llm._torch.modules.fused_moe.ep_metrics import \
+    is_pending_ep_health_metrics
 from tensorrt_llm._utils import EnergyMonitor
 # yapf: disable
 from tensorrt_llm.executor import CppExecutorError
 from tensorrt_llm.executor.postproc_worker import PostprocParams
+from tensorrt_llm.executor.rpc import RPCCancelled, RPCError, RPCTimeout
 from tensorrt_llm.inputs import prompt_inputs
 from tensorrt_llm.inputs.data import TokensPrompt
 from tensorrt_llm.inputs.media_io import BaseMediaIO
@@ -154,6 +159,51 @@ if _MSGSPEC_ENABLED:
 
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
+
+
+def _is_transient_ep_health_error(error: Exception) -> bool:
+    """Return whether an EP health read can reasonably succeed on retry."""
+    if isinstance(
+            error,
+        (RPCCancelled, RPCTimeout, TimeoutError, OSError, zmq.ZMQError)):
+        return True
+    if isinstance(error, RPCError) and error.cause is not None:
+        return _is_transient_ep_health_error(error.cause)
+    return False
+
+
+async def _await_task_cancellation_safe(task: asyncio.Task) -> Any:
+    """Await ``task`` without forwarding repeated owner cancellation to it.
+
+    ``asyncio.shield`` protects a child only from the cancellation that reaches
+    that particular shield future.  After catching the first cancellation, an
+    unshielded ``await task`` lets a later ``Task.cancel()`` cancel the child.
+    That is especially unsafe for ``asyncio.to_thread``: cancelling its asyncio
+    wrapper does not stop the worker thread.  Drain through a separately
+    shielded task instead, retrying the shield after every owner cancellation,
+    then preserve the first cancellation request.
+    """
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError as cancellation:
+
+        async def drain_task() -> None:
+            try:
+                await task
+            except (Exception, asyncio.CancelledError):
+                pass
+
+        drain = asyncio.create_task(drain_task())
+        while not drain.done():
+            try:
+                await asyncio.shield(drain)
+            except asyncio.CancelledError:
+                continue
+        # Retrieve an unexpected BaseException from the drain before restoring
+        # cancellation. Ordinary task errors and child cancellation were
+        # consumed above to preserve the owner's cancellation semantics.
+        drain.result()
+        raise cancellation
 
 
 def _build_tool_strict_guided_decoding_params(tools, tool_parser_name):
@@ -318,6 +368,10 @@ class OpenAIServer(_VideoRoutesMixin):
         self.perf_metrics = None
         self.perf_metrics_lock = None
         self._iteration_stats_collector_task = None
+        self._ep_health_collector_task = None
+        self._ep_health_metrics_mounted = False
+        self._ep_health_stop_event = asyncio.Event()
+        self._ep_health_outage_logged = False
         self._iteration_stats_wakeup_event = asyncio.Event()
         # Bounded snapshot of iteration stats for the GET /metrics handler.
         # When the background Prometheus collector loop is active, it is the
@@ -368,75 +422,90 @@ class OpenAIServer(_VideoRoutesMixin):
                     self.server_role, self.host, self.port,
                     self.disagg_cluster_config, self.disagg_cluster_storage)
 
-            # VisualGen has no args
-            if not isinstance(self.generator, VisualGen):
-                # Start energy monitoring if enabled
-                if getattr(self.generator.args, "enable_energy_metrics", False):
-                    try:
-                        world_size = self.generator.args.parallel_config.world_size
-                        self.energy_monitor = EnergyMonitor(world_size)
-                        logger.info("Initialized GPU energy monitoring")
-                    except Exception as e:
-                        logger.warning(
-                            f"Failed to initialize GPU energy monitoring: {e}")
-                        self.energy_monitor = None
+            try:
+                # VisualGen has no args
+                if not isinstance(self.generator, VisualGen):
+                    # Start energy monitoring if enabled
+                    if getattr(self.generator.args, "enable_energy_metrics",
+                               False):
+                        try:
+                            world_size = self.generator.args.parallel_config.world_size
+                            self.energy_monitor = EnergyMonitor(world_size)
+                            logger.info("Initialized GPU energy monitoring")
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to initialize GPU energy monitoring: {e}"
+                            )
+                            self.energy_monitor = None
 
-                # Start background iteration stats collector if metrics are enabled
-                # The args for pytorch and autodeploy backend has attribute `enable_iter_perf_stats` while
-                # tensorrt backend does not have this attribute but it always has iter stats enabled.
-                if self.metrics_collector and getattr(
-                        self.generator.args, "enable_iter_perf_stats", True):
-                    # The background loop becomes the sole consumer of the
-                    # engine stats queue; /metrics reads from a tee buffer
-                    # bounded by iter_stats_max_iterations to avoid racing
-                    # the loop for the queue (nvbug 6102381).
-                    # One shared buffer is sufficient while this collector task
-                    # is the only consumer of the engine iteration-stats queue.
-                    # Other consumers can read it through get_iteration_stats(),
-                    # which clears the buffer. Adding another queue consumer
-                    # requires revisiting the buffering and clearing ownership.
-                    max_buf = self._iteration_stats_buffer_maxlen(
-                        getattr(self.generator.args,
-                                "iter_stats_max_iterations", 1000))
-                    self._iteration_stats_buffer = deque(maxlen=max_buf)
-                    self._iteration_stats_collector_task = asyncio.create_task(
-                        self._iteration_stats_collector_loop())
-                    # Wake up the collector immediately so it processes the
-                    # initial stats emitted by the executor at startup (e.g.
-                    # cache_config_info).
-                    self._iteration_stats_wakeup_event.set()
-                    logger.info(
-                        "Started background iteration stats collector task")
+                    # Start background iteration stats collector if metrics are enabled
+                    # The args for pytorch and autodeploy backend has attribute `enable_iter_perf_stats` while
+                    # tensorrt backend does not have this attribute but it always has iter stats enabled.
+                    if self.metrics_collector and getattr(
+                            self.generator.args, "enable_iter_perf_stats",
+                            True):
+                        # The background loop becomes the sole consumer of the
+                        # engine stats queue; /metrics reads from a tee buffer
+                        # bounded by iter_stats_max_iterations to avoid racing
+                        # the loop for the queue (nvbug 6102381).
+                        # One shared buffer is sufficient while this collector task
+                        # is the only consumer of the engine iteration-stats queue.
+                        # Other consumers can read it through get_iteration_stats(),
+                        # which clears the buffer. Adding another queue consumer
+                        # requires revisiting the buffering and clearing ownership.
+                        max_buf = self._iteration_stats_buffer_maxlen(
+                            getattr(self.generator.args,
+                                    "iter_stats_max_iterations", 1000))
+                        self._iteration_stats_buffer = deque(maxlen=max_buf)
+                        self._iteration_stats_collector_task = asyncio.create_task(
+                            self._iteration_stats_collector_loop())
+                        # Wake up the collector immediately so it processes the
+                        # initial stats emitted by the executor at startup (e.g.
+                        # cache_config_info).
+                        self._iteration_stats_wakeup_event.set()
+                        logger.info(
+                            "Started background iteration stats collector task")
 
-            # Start the encode dynamic batcher (embedding server only). It must be
-            # started inside the running event loop, hence here rather than __init__.
-            if self.embedding_batcher is not None:
-                await self.embedding_batcher.start()
-                logger.info("Started encode dynamic batcher")
+                    await self._start_ep_health_collector()
 
-            yield
+                # Start the encode dynamic batcher (embedding server only). It must be
+                # started inside the running event loop, hence here rather than __init__.
+                if self.embedding_batcher is not None:
+                    await self.embedding_batcher.start()
+                    logger.info("Started encode dynamic batcher")
 
-            if self.embedding_batcher is not None:
-                await self.embedding_batcher.shutdown()
-                logger.info("Stopped encode dynamic batcher")
-
-            # Stop background iteration stats collector
-            if self._iteration_stats_collector_task is not None:
-                self._iteration_stats_collector_task.cancel()
+                yield
+            finally:
                 try:
-                    await self._iteration_stats_collector_task
-                except asyncio.CancelledError:
-                    pass
-                logger.info("Stopped background iteration stats collector task")
+                    if self.embedding_batcher is not None:
+                        await self.embedding_batcher.shutdown()
+                        logger.info("Stopped encode dynamic batcher")
+                finally:
+                    try:
+                        await self._stop_ep_health_collector()
+                    finally:
+                        # Stop background iteration stats collector
+                        if self._iteration_stats_collector_task is not None:
+                            self._iteration_stats_collector_task.cancel()
+                            try:
+                                await self._iteration_stats_collector_task
+                            except asyncio.CancelledError:
+                                pass
+                            logger.info(
+                                "Stopped background iteration stats collector task"
+                            )
 
-            if self.metadata_server is not None:
-                self.metadata_server.remove(f"trtllm/{self.generator.llm_id}")
-                logger.info(f"trtllm/{self.generator.llm_id} is unregistered")
-            if self.disagg_cluster_worker:
-                await self.disagg_cluster_worker.deregister_worker()
-            if self.resource_governor is not None:
-                self.resource_governor.close()
-            self.generator.shutdown()
+                        if self.metadata_server is not None:
+                            self.metadata_server.remove(
+                                f"trtllm/{self.generator.llm_id}")
+                            logger.info(
+                                f"trtllm/{self.generator.llm_id} is unregistered"
+                            )
+                        if self.disagg_cluster_worker:
+                            await self.disagg_cluster_worker.deregister_worker()
+                        if self.resource_governor is not None:
+                            self.resource_governor.close()
+                        self.generator.shutdown()
 
         self.app = FastAPI(lifespan=lifespan)
         if _MSGSPEC_ENABLED:
@@ -901,6 +970,7 @@ class OpenAIServer(_VideoRoutesMixin):
         from prometheus_fastapi_instrumentator import Instrumentator
         registry = CollectorRegistry()
         multiprocess.MultiProcessCollector(registry)
+        self.metrics_collector.register_ep_health_metrics(registry)
         Instrumentator(
             should_group_status_codes=False,
             should_respect_env_var=True,
@@ -912,6 +982,7 @@ class OpenAIServer(_VideoRoutesMixin):
         metrics_route.path_regex = re.compile(
             "^/prometheus/metrics(?P<path>.*)$")
         self.app.routes.append(metrics_route)
+        self._ep_health_metrics_mounted = True
 
     def register_mm_encoder_routes(self):
         self.app.add_api_route("/health", self.health, methods=["GET"])
@@ -1468,6 +1539,114 @@ class OpenAIServer(_VideoRoutesMixin):
         except asyncio.CancelledError:
             logger.info("Iteration stats collector loop cancelled")
             raise
+
+    def _log_ep_health_outage_once(self,
+                                   message: str,
+                                   error: Optional[Exception] = None,
+                                   terminal: bool = False) -> None:
+        """Log one retry diagnostic, while always logging a terminal state."""
+        if (getattr(self, "_ep_health_outage_logged", False) and not terminal):
+            return
+        detail = f": {error}" if error is not None else ""
+        logger.warning(f"{message}{detail}")
+        self._ep_health_outage_logged = True
+
+    def _get_ep_health_stop_event(self) -> asyncio.Event:
+        """Return the lazily initialized health-collector stop event."""
+        stop_event = getattr(self, "_ep_health_stop_event", None)
+        if stop_event is None:
+            stop_event = asyncio.Event()
+            self._ep_health_stop_event = stop_event
+        return stop_event
+
+    async def _wait_for_ep_health_stop(self, timeout: float) -> bool:
+        """Wait up to ``timeout`` seconds for a collector stop request."""
+        stop_event = self._get_ep_health_stop_event()
+        if stop_event.is_set():
+            return True
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return False
+        return True
+
+    async def _read_ep_health_stats(self) -> Optional[dict]:
+        """Run one synchronous health read without abandoning its worker thread."""
+        read_task = asyncio.create_task(
+            asyncio.to_thread(self.generator._get_ep_health_stats))
+        # asyncio.to_thread cancellation does not stop the underlying thread.
+        # Drain it before allowing the owner to close the RPC client.
+        return await _await_task_cancellation_safe(read_task)
+
+    async def _stop_ep_health_collector(self) -> None:
+        """Cooperatively stop and cancellation-safely drain the collector."""
+        task = self._ep_health_collector_task
+        if task is None:
+            return
+        self._get_ep_health_stop_event().set()
+        try:
+            await _await_task_cancellation_safe(task)
+        finally:
+            self._ep_health_collector_task = None
+            logger.info("Stopped EP health metrics collector task")
+
+    async def _ep_health_collector_loop(self) -> None:
+        """Passively poll rank-0's committed EP membership for metrics.
+
+        This loop observes coordinator-committed state, not detected or
+        suspected physical liveness, and never drives recovery.
+        """
+        try:
+            while not self._get_ep_health_stop_event().is_set():
+                try:
+                    stats = await self._read_ep_health_stats()
+                    if stats is None:
+                        self.metrics_collector.log_ep_health_unavailable()
+                        logger.info(
+                            "EP health telemetry is unsupported; polling disabled"
+                        )
+                        return
+                    if is_pending_ep_health_metrics(stats):
+                        self.metrics_collector.log_ep_health_unavailable()
+                        self._log_ep_health_outage_once(
+                            "EP health telemetry registration is pending; will retry"
+                        )
+                    elif not self.metrics_collector.log_ep_health_stats(stats):
+                        self._log_ep_health_outage_once(
+                            "EP health telemetry returned an invalid, stale, or conflicting payload; will retry",
+                        )
+                    else:
+                        self._ep_health_outage_logged = False
+                except Exception as e:
+                    self.metrics_collector.log_ep_health_unavailable()
+                    if not _is_transient_ep_health_error(e):
+                        self._log_ep_health_outage_once(
+                            "EP health telemetry failed deterministically; stopping polling",
+                            e,
+                            terminal=True)
+                        return
+                    self._log_ep_health_outage_once(
+                        "Transient error collecting EP health telemetry; will retry",
+                        e)
+                if await self._wait_for_ep_health_stop(timeout=1.0):
+                    return
+        except asyncio.CancelledError:
+            logger.info("EP health metrics collector loop cancelled")
+            raise
+
+    async def _start_ep_health_collector(self) -> None:
+        """Start EP health polling without delaying server readiness."""
+        if (not self.metrics_collector
+                or not getattr(self, "_ep_health_metrics_mounted", False)):
+            return
+        if self._ep_health_collector_task is not None:
+            if not self._ep_health_collector_task.done():
+                return
+            self._ep_health_collector_task = None
+        self._get_ep_health_stop_event().clear()
+        self._ep_health_collector_task = asyncio.create_task(
+            self._ep_health_collector_loop())
+        logger.info("Started EP health metrics collector task")
 
     async def openai_chat(self, request: ChatCompletionRequest,
                           raw_request: Request) -> Response:

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -181,6 +181,8 @@ l0_b200:
   # ------------- KV Cache Iteration Stats ---------------
   - unittest/executor/test_stats_serializer.py
   - unittest/metrics/test_collector.py
+  - unittest/_torch/modules/test_ep_metrics.py
+  - unittest/_torch/executor/test_ep_metrics_stats.py
   - kv_cache/test_kv_cache_iteration_stats.py::TestKvCacheIterationStats::test_cold_start
   - kv_cache/test_kv_cache_iteration_stats.py::TestKvCacheIterationStats::test_partial_block_reuse
   - kv_cache/test_kv_cache_iteration_stats.py::TestKvCacheIterationStats::test_full_block_reuse

--- a/tests/unittest/_torch/executor/test_ep_metrics_stats.py
+++ b/tests/unittest/_torch/executor/test_ep_metrics_stats.py
@@ -1,0 +1,790 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the passive PyExecutor committed-membership metrics transport."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import zmq
+
+from tensorrt_llm._torch.modules.fused_moe.ep_group_health import (
+    EP_GROUP_HEALTH_EXTRA_ATTR,
+    EPGroupHealth,
+)
+from tensorrt_llm._torch.modules.fused_moe.ep_metrics import pending_ep_health_metrics
+from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+from tensorrt_llm.executor.base_worker import BaseWorker
+from tensorrt_llm.executor.proxy import GenerationExecutorProxy
+from tensorrt_llm.executor.rpc import RPCCancelled, RPCClient, RPCError, RPCServer, RPCTimeout
+from tensorrt_llm.executor.rpc.rpc_common import get_unique_ipc_addr
+from tensorrt_llm.executor.rpc_proxy import GenerationExecutorRpcProxy
+from tensorrt_llm.executor.rpc_proxy_mixin import RpcExecutorMixin
+from tensorrt_llm.llmapi.disagg_utils import ServerRole
+from tensorrt_llm.llmapi.llm import BaseLLM
+from tensorrt_llm.serve.openai_server import OpenAIServer
+
+EP_HEALTH_SOURCE_EPOCH = "source-a"
+
+
+def _mount_ep_health_metrics_for_test(server: OpenAIServer) -> None:
+    server._ep_health_metrics_mounted = True
+
+
+def _make_executor(health: EPGroupHealth) -> PyExecutor:
+    executor = PyExecutor.__new__(PyExecutor)
+    executor._ep_health_model_config = SimpleNamespace(
+        extra_attrs={EP_GROUP_HEALTH_EXTRA_ATTR: health}
+    )
+    executor.model_engine = SimpleNamespace(
+        model=SimpleNamespace(model_config=executor._ep_health_model_config)
+    )
+    return executor
+
+
+def test_pyexecutor_returns_committed_membership_snapshot() -> None:
+    health = EPGroupHealth(4)
+    health.mark_failed(2)
+    executor = _make_executor(health)
+
+    assert executor._get_ep_health_stats() == {
+        "sourceEpoch": health.source_epoch,
+        "worldSize": 4,
+        "activeCount": 3,
+        "failedRanks": [2],
+        "generation": 1,
+    }
+    executor.enable_iter_perf_stats = False
+    assert executor.get_latest_iteration_stats() == []
+
+
+def test_pyexecutor_discovers_tracker_attached_after_initialization() -> None:
+    executor = PyExecutor.__new__(PyExecutor)
+    executor._ep_health_model_config = SimpleNamespace(
+        extra_attrs={EP_GROUP_HEALTH_EXTRA_ATTR: None}
+    )
+    assert executor._get_ep_health_stats() == pending_ep_health_metrics()
+
+    health = EPGroupHealth(4)
+    health.mark_failed(1)
+    executor._ep_health_model_config.extra_attrs[EP_GROUP_HEALTH_EXTRA_ATTR] = health
+
+    stats = executor._get_ep_health_stats()
+    assert stats["sourceEpoch"] == health.source_epoch
+    assert stats["failedRanks"] == [1]
+
+
+def test_pyexecutor_rejects_unqualified_multi_group_metrics() -> None:
+    executor = _make_executor(EPGroupHealth(4))
+    executor._ep_health_model_config.mapping = SimpleNamespace(
+        moe_tp_size=1,
+        pp_size=2,
+        moe_cluster_size=1,
+    )
+
+    with pytest.raises(NotImplementedError, match="multi-group MoE topologies"):
+        executor._get_ep_health_stats()
+
+
+def test_base_worker_exposes_engine_health_snapshot() -> None:
+    health = EPGroupHealth(4)
+    health.mark_failed(1)
+    worker = BaseWorker.__new__(BaseWorker)
+    worker.engine = _make_executor(health)
+
+    assert worker.fetch_ep_health_stats()["failedRanks"] == [1]
+
+
+def test_base_worker_reports_unsupported_engine_without_rpc_failure() -> None:
+    worker = BaseWorker.__new__(BaseWorker)
+    worker.engine = SimpleNamespace()
+
+    assert worker.fetch_ep_health_stats() is None
+
+
+def test_proxy_fetches_health_over_dedicated_rpc() -> None:
+    expected = {
+        "sourceEpoch": EP_HEALTH_SOURCE_EPOCH,
+        "worldSize": 4,
+        "activeCount": 3,
+        "failedRanks": [1],
+        "generation": 1,
+    }
+    proxy = GenerationExecutorProxy.__new__(GenerationExecutorProxy)
+    proxy.rpc_client = MagicMock()
+    proxy.rpc_client.fetch_ep_health_stats.return_value.remote.return_value = expected
+
+    assert proxy._get_ep_health_stats() == expected
+    proxy.rpc_client.fetch_ep_health_stats.return_value.remote.assert_called_once_with(timeout=1.0)
+
+
+def test_proxy_propagates_transient_rpc_failure() -> None:
+    proxy = GenerationExecutorProxy.__new__(GenerationExecutorProxy)
+    proxy.rpc_client = MagicMock()
+    proxy.rpc_client.fetch_ep_health_stats.return_value.remote.side_effect = TimeoutError
+
+    with pytest.raises(TimeoutError):
+        proxy._get_ep_health_stats()
+
+
+def test_rpc_proxy_fetches_health_over_dedicated_rpc() -> None:
+    expected = {
+        "sourceEpoch": EP_HEALTH_SOURCE_EPOCH,
+        "worldSize": 4,
+        "activeCount": 4,
+        "failedRanks": [],
+        "generation": 0,
+    }
+    proxy = GenerationExecutorRpcProxy.__new__(GenerationExecutorRpcProxy)
+    proxy.rpc_client = MagicMock()
+    proxy.rpc_client.fetch_ep_health_stats.return_value.remote.return_value = expected
+
+    assert proxy._get_ep_health_stats(timeout=0.25) == expected
+    proxy.rpc_client.fetch_ep_health_stats.return_value.remote.assert_called_once_with(timeout=0.25)
+
+
+def test_rpc_executor_mixin_forwards_health_for_ray_and_rpc_executors() -> None:
+    """Every RpcExecutorMixin consumer, including RayExecutor, gets telemetry."""
+    expected = {
+        "sourceEpoch": EP_HEALTH_SOURCE_EPOCH,
+        "worldSize": 4,
+        "activeCount": 4,
+        "failedRanks": [],
+        "generation": 0,
+    }
+    executor = SimpleNamespace(rpc_client=MagicMock())
+    executor.rpc_client.fetch_ep_health_stats.return_value.remote.return_value = expected
+
+    assert RpcExecutorMixin._get_ep_health_stats(executor, timeout=0.5) == expected
+    executor.rpc_client.fetch_ep_health_stats.return_value.remote.assert_called_once_with(
+        timeout=0.5
+    )
+
+
+def test_ep_health_snapshot_crosses_real_rpc_and_llm_bridge() -> None:
+    """Exercise the passive committed-membership path without a model worker."""
+
+    class HealthRpcSurface:
+        _get_ep_health_stats = BaseWorker._get_ep_health_stats
+        fetch_ep_health_stats = BaseWorker.fetch_ep_health_stats
+
+    health = EPGroupHealth(4)
+    health.mark_failed(2)
+    worker = HealthRpcSurface()
+    worker.engine = _make_executor(health)
+    address = get_unique_ipc_addr()
+
+    with RPCServer(worker) as rpc_server:
+        rpc_server.bind(address)
+        rpc_server.start()
+        with RPCClient(address, hmac_key=rpc_server.hmac_key) as rpc_client:
+            proxy = GenerationExecutorProxy.__new__(GenerationExecutorProxy)
+            proxy.rpc_client = rpc_client
+            llm = BaseLLM.__new__(BaseLLM)
+            llm._executor = proxy
+
+            assert llm._get_ep_health_stats() == {
+                "sourceEpoch": health.source_epoch,
+                "worldSize": 4,
+                "activeCount": 3,
+                "failedRanks": [2],
+                "generation": 1,
+            }
+
+
+def test_encode_only_llm_reports_ep_health_as_unsupported() -> None:
+    llm = BaseLLM.__new__(BaseLLM)
+    llm._executor = None
+
+    assert llm._get_ep_health_stats() is None
+
+
+def test_server_mount_metrics_registers_local_ep_health_collector(monkeypatch) -> None:
+    """The Prometheus endpoint registry includes the coherent local snapshot."""
+    import prometheus_client
+    import prometheus_fastapi_instrumentator
+    from prometheus_client import multiprocess
+    from prometheus_client.core import GaugeMetricFamily
+
+    class SnapshotCollector:
+        def collect(self):
+            metric = GaugeMetricFamily(
+                "trtllm_ep_health_available",
+                "Whether EP health telemetry is available.",
+            )
+            metric.add_metric([], 1)
+            return [metric]
+
+    metrics_collector = MagicMock()
+    metrics_collector.register_ep_health_metrics.side_effect = lambda registry: registry.register(
+        SnapshotCollector()
+    )
+    monkeypatch.setattr(multiprocess, "MultiProcessCollector", MagicMock())
+    instrumentator = MagicMock()
+    instrumentator.add.return_value = instrumentator
+    instrumentator.instrument.return_value = instrumentator
+    instrumentator.expose.return_value = instrumentator
+    monkeypatch.setattr(
+        prometheus_fastapi_instrumentator, "Instrumentator", MagicMock(return_value=instrumentator)
+    )
+    monkeypatch.setattr(prometheus_client, "make_asgi_app", MagicMock(return_value=MagicMock()))
+
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.app = SimpleNamespace(routes=[])
+    server.metrics_collector = metrics_collector
+    server.mount_metrics()
+
+    registry = metrics_collector.register_ep_health_metrics.call_args.args[0]
+    output = prometheus_client.generate_latest(registry).decode()
+    assert "trtllm_ep_health_available 1.0" in output
+    assert server._ep_health_metrics_mounted
+    assert len(server.app.routes) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "server_role",
+    [ServerRole.EMBEDDING, ServerRole.MM_ENCODER],
+)
+async def test_server_does_not_poll_without_ep_metrics_endpoint(server_role) -> None:
+    """Encoder-only roles do not mount Prometheus, so polling is unobservable."""
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.server_role = server_role
+    server.metrics_collector = MagicMock()
+    server._ep_health_metrics_mounted = False
+    server._ep_health_collector_task = None
+    server.generator = SimpleNamespace(_get_ep_health_stats=MagicMock())
+
+    await server._start_ep_health_collector()
+
+    assert server._ep_health_collector_task is None
+    server.generator._get_ep_health_stats.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        TimeoutError("health read timed out"),
+        RPCTimeout("health RPC timed out"),
+        RPCCancelled("rank-0 worker is being replaced"),
+        RPCError("health transport failed", cause=ConnectionError("closed")),
+        zmq.ZMQError(zmq.ENOTCONN, "socket disconnected"),
+        RPCError(
+            "wrapped socket failure",
+            cause=zmq.ZMQError(zmq.ENOTCONN, "socket disconnected"),
+        ),
+    ],
+)
+async def test_server_retries_after_transient_first_read_failure(
+    transient_error: Exception,
+) -> None:
+    expected = {
+        "sourceEpoch": EP_HEALTH_SOURCE_EPOCH,
+        "worldSize": 4,
+        "activeCount": 3,
+        "failedRanks": [1],
+        "generation": 1,
+    }
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.metrics_collector = MagicMock()
+    server.metrics_collector.log_ep_health_stats.return_value = True
+    server._ep_health_collector_task = None
+    server._ep_health_stop_event = asyncio.Event()
+    _mount_ep_health_metrics_for_test(server)
+
+    results = iter((transient_error, expected))
+
+    def read_health():
+        result = next(results)
+        if isinstance(result, Exception):
+            raise result
+        server._ep_health_stop_event.set()
+        return result
+
+    health_reader = MagicMock(side_effect=read_health)
+    server.generator = SimpleNamespace(_get_ep_health_stats=health_reader)
+    server._wait_for_ep_health_stop = AsyncMock(side_effect=[False, True])
+
+    await server._start_ep_health_collector()
+    assert server._ep_health_collector_task is not None
+    await server._ep_health_collector_task
+
+    server.metrics_collector.log_ep_health_unavailable.assert_called_once_with()
+    server.metrics_collector.log_ep_health_stats.assert_called_once_with(expected)
+    assert health_reader.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        TimeoutError("timed out"),
+        RPCCancelled("rank-0 worker is being replaced"),
+        zmq.ZMQError(zmq.ENOTCONN, "socket disconnected"),
+        RPCError(
+            "wrapped socket failure",
+            cause=zmq.ZMQError(zmq.ENOTCONN, "socket disconnected"),
+        ),
+    ],
+)
+async def test_server_loop_retries_transient_rank0_loss_and_recovers(
+    transient_error: Exception,
+) -> None:
+    """Transient rank-0 loss clears availability, then accepts its replacement."""
+    before_restart = {
+        "sourceEpoch": "source-before-restart",
+        "worldSize": 4,
+        "activeCount": 3,
+        "failedRanks": [1],
+        "generation": 2,
+    }
+    after_restart = {
+        "sourceEpoch": "source-after-restart",
+        "worldSize": 4,
+        "activeCount": 4,
+        "failedRanks": [],
+        "generation": 0,
+    }
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.metrics_collector = MagicMock()
+    server.metrics_collector.log_ep_health_stats.return_value = True
+    server._ep_health_stop_event = asyncio.Event()
+
+    results = iter((before_restart, transient_error, after_restart))
+
+    def read_health():
+        result = next(results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    health_reader = MagicMock(side_effect=read_health)
+    server.generator = SimpleNamespace(_get_ep_health_stats=health_reader)
+    server._wait_for_ep_health_stop = AsyncMock(side_effect=[False, False, True])
+
+    await asyncio.wait_for(server._ep_health_collector_loop(), timeout=1.0)
+
+    assert health_reader.call_count == 3
+    server.metrics_collector.log_ep_health_unavailable.assert_called_once_with()
+    assert [
+        call.args[0] for call in server.metrics_collector.log_ep_health_stats.call_args_list
+    ] == [before_restart, after_restart]
+    assert server._wait_for_ep_health_stop.await_count == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "read_result",
+    [
+        None,
+        ValueError("invalid health configuration"),
+        RPCError("remote health configuration failed", cause=ValueError("invalid")),
+        RPCError(
+            "unsupported multi-group topology",
+            cause=NotImplementedError("multi-group"),
+        ),
+    ],
+)
+async def test_server_loop_stops_after_deterministic_health_loss(read_result) -> None:
+    """Unsupported and deterministic failures do not create a polling loop."""
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.metrics_collector = MagicMock()
+    if isinstance(read_result, Exception):
+        health_reader = MagicMock(side_effect=read_result)
+    else:
+        health_reader = MagicMock(return_value=read_result)
+    server.generator = SimpleNamespace(_get_ep_health_stats=health_reader)
+
+    await asyncio.wait_for(server._ep_health_collector_loop(), timeout=0.5)
+
+    health_reader.assert_called_once_with()
+    server.metrics_collector.log_ep_health_unavailable.assert_called_once_with()
+    server.metrics_collector.log_ep_health_stats.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "startup_error",
+    [
+        ValueError("invalid health configuration"),
+        RPCError("remote health configuration failed", cause=ValueError("invalid")),
+        RPCError("method unavailable"),
+    ],
+)
+async def test_server_stops_after_deterministic_first_read_failure(startup_error) -> None:
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.metrics_collector = MagicMock()
+    server._ep_health_collector_task = None
+    _mount_ep_health_metrics_for_test(server)
+    health_reader = MagicMock(side_effect=startup_error)
+    server.generator = SimpleNamespace(_get_ep_health_stats=health_reader)
+
+    await server._start_ep_health_collector()
+    task = server._ep_health_collector_task
+    assert task is not None
+    await task
+
+    health_reader.assert_called_once_with()
+    assert task.done()
+    server.metrics_collector.log_ep_health_unavailable.assert_called_once_with()
+    server.metrics_collector.log_ep_health_stats.assert_not_called()
+    await server._stop_ep_health_collector()
+    assert server._ep_health_collector_task is None
+
+
+@pytest.mark.asyncio
+async def test_server_retries_after_collector_rejects_payload() -> None:
+    snapshot = {
+        "sourceEpoch": EP_HEALTH_SOURCE_EPOCH,
+        "worldSize": 4,
+        "activeCount": 4,
+        "failedRanks": [],
+        "generation": 0,
+    }
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.metrics_collector = MagicMock()
+    server.metrics_collector.log_ep_health_stats.side_effect = [False, True]
+    server._ep_health_stop_event = asyncio.Event()
+
+    read_count = 0
+
+    def read_health():
+        nonlocal read_count
+        read_count += 1
+        if read_count == 2:
+            server._ep_health_stop_event.set()
+        return snapshot
+
+    server.generator = SimpleNamespace(_get_ep_health_stats=MagicMock(side_effect=read_health))
+    server._wait_for_ep_health_stop = AsyncMock(side_effect=[False, True])
+
+    await server._ep_health_collector_loop()
+
+    assert server.generator._get_ep_health_stats.call_count == 2
+    assert [
+        args.args[0] for args in server.metrics_collector.log_ep_health_stats.call_args_list
+    ] == [snapshot, snapshot]
+
+
+@pytest.mark.asyncio
+async def test_server_retries_after_initial_payload_rejection() -> None:
+    snapshot = {
+        "sourceEpoch": EP_HEALTH_SOURCE_EPOCH,
+        "worldSize": 4,
+        "activeCount": 4,
+        "failedRanks": [],
+        "generation": 0,
+    }
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.metrics_collector = MagicMock()
+    server.metrics_collector.log_ep_health_stats.side_effect = [False, True]
+    server._ep_health_collector_task = None
+    server._ep_health_stop_event = asyncio.Event()
+    _mount_ep_health_metrics_for_test(server)
+
+    read_count = 0
+
+    def read_health():
+        nonlocal read_count
+        read_count += 1
+        if read_count == 2:
+            server._ep_health_stop_event.set()
+        return snapshot
+
+    server.generator = SimpleNamespace(_get_ep_health_stats=MagicMock(side_effect=read_health))
+    server._wait_for_ep_health_stop = AsyncMock(side_effect=[False, True])
+
+    await server._start_ep_health_collector()
+
+    assert server._ep_health_collector_task is not None
+    await server._ep_health_collector_task
+    assert server.generator._get_ep_health_stats.call_count == 2
+    assert server.metrics_collector.log_ep_health_stats.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_server_does_not_poll_unsupported_backend() -> None:
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.metrics_collector = MagicMock()
+    server._ep_health_collector_task = None
+    _mount_ep_health_metrics_for_test(server)
+    server.generator = SimpleNamespace(_get_ep_health_stats=MagicMock(return_value=None))
+
+    await server._start_ep_health_collector()
+    task = server._ep_health_collector_task
+    assert task is not None
+    await task
+
+    assert task.done()
+    server.generator._get_ep_health_stats.assert_called_once_with()
+    server.metrics_collector.log_ep_health_stats.assert_not_called()
+    server.metrics_collector.log_ep_health_unavailable.assert_called_once_with()
+    await server._stop_ep_health_collector()
+    assert server._ep_health_collector_task is None
+
+
+@pytest.mark.asyncio
+async def test_server_retries_explicitly_pending_registration() -> None:
+    snapshot = {
+        "sourceEpoch": "source-after-attachment",
+        "worldSize": 4,
+        "activeCount": 4,
+        "failedRanks": [],
+        "generation": 0,
+    }
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.metrics_collector = MagicMock()
+    server.metrics_collector.log_ep_health_stats.return_value = True
+    server._ep_health_collector_task = None
+    server._ep_health_stop_event = asyncio.Event()
+    _mount_ep_health_metrics_for_test(server)
+    server.generator = SimpleNamespace(
+        _get_ep_health_stats=MagicMock(side_effect=[pending_ep_health_metrics(), snapshot])
+    )
+    server._wait_for_ep_health_stop = AsyncMock(side_effect=[False, True])
+
+    await server._start_ep_health_collector()
+    assert server._ep_health_collector_task is not None
+    await server._ep_health_collector_task
+
+    server.metrics_collector.log_ep_health_unavailable.assert_called_once_with()
+    server.metrics_collector.log_ep_health_stats.assert_called_once_with(snapshot)
+
+
+@pytest.mark.asyncio
+async def test_server_lifespan_starts_and_stops_health_collector(monkeypatch) -> None:
+    """The real server lifespan owns the health collector task."""
+    generator = SimpleNamespace(
+        args=SimpleNamespace(enable_energy_metrics=False, enable_iter_perf_stats=False),
+        _get_ep_health_stats=MagicMock(),
+        shutdown=MagicMock(),
+    )
+    monkeypatch.setattr(OpenAIServer, "_init_llm", lambda self, chat_template=None: None)
+    monkeypatch.setattr(OpenAIServer, "register_routes", lambda self: None)
+    server = OpenAIServer(
+        generator=generator,
+        model="test-model",
+        tool_parser=None,
+        server_role=None,
+        metadata_server_cfg=None,
+    )
+    server.metrics_collector = MagicMock()
+    server.metrics_collector.log_ep_health_stats.return_value = True
+    _mount_ep_health_metrics_for_test(server)
+    collector_started = asyncio.Event()
+
+    async def controlled_collector_loop() -> None:
+        collector_started.set()
+        await server._ep_health_stop_event.wait()
+
+    server._ep_health_collector_loop = controlled_collector_loop
+
+    async with server.app.router.lifespan_context(server.app):
+        await asyncio.wait_for(collector_started.wait(), timeout=1.0)
+        collector_task = server._ep_health_collector_task
+        assert collector_task is not None
+        assert not collector_task.done()
+
+    assert collector_task.done()
+    assert not collector_task.cancelled()
+    generator._get_ep_health_stats.assert_not_called()
+    generator.shutdown.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_server_lifespan_body_failure_still_shuts_down_once(monkeypatch) -> None:
+    """An exception thrown at the lifespan yield cannot bypass cleanup."""
+    generator = SimpleNamespace(
+        args=SimpleNamespace(enable_energy_metrics=False, enable_iter_perf_stats=False),
+        _get_ep_health_stats=MagicMock(return_value=None),
+        shutdown=MagicMock(),
+    )
+    monkeypatch.setattr(OpenAIServer, "_init_llm", lambda self, chat_template=None: None)
+    monkeypatch.setattr(OpenAIServer, "register_routes", lambda self: None)
+    server = OpenAIServer(
+        generator=generator,
+        model="test-model",
+        tool_parser=None,
+        server_role=None,
+        metadata_server_cfg=None,
+    )
+    server.metrics_collector = MagicMock()
+    _mount_ep_health_metrics_for_test(server)
+
+    with pytest.raises(RuntimeError, match="lifespan body failed"):
+        async with server.app.router.lifespan_context(server.app):
+            raise RuntimeError("lifespan body failed")
+
+    assert server._ep_health_collector_task is None
+    generator.shutdown.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_server_lifespan_startup_failure_stops_health_collector(monkeypatch) -> None:
+    """A later startup failure cannot leak telemetry or bypass engine shutdown."""
+    generator = SimpleNamespace(
+        args=SimpleNamespace(enable_energy_metrics=False, enable_iter_perf_stats=False),
+        _get_ep_health_stats=MagicMock(),
+        shutdown=MagicMock(),
+    )
+    monkeypatch.setattr(OpenAIServer, "_init_llm", lambda self, chat_template=None: None)
+    monkeypatch.setattr(OpenAIServer, "register_routes", lambda self: None)
+    server = OpenAIServer(
+        generator=generator,
+        model="test-model",
+        tool_parser=None,
+        server_role=None,
+        metadata_server_cfg=None,
+    )
+    server.metrics_collector = MagicMock()
+    _mount_ep_health_metrics_for_test(server)
+    collector_started = asyncio.Event()
+
+    async def controlled_collector_loop() -> None:
+        collector_started.set()
+        await server._ep_health_stop_event.wait()
+
+    server._ep_health_collector_loop = controlled_collector_loop
+    server.embedding_batcher = SimpleNamespace(
+        start=AsyncMock(side_effect=RuntimeError("batcher startup failed")),
+        shutdown=AsyncMock(),
+    )
+
+    with pytest.raises(RuntimeError, match="batcher startup failed"):
+        async with server.app.router.lifespan_context(server.app):
+            pytest.fail("lifespan body must not run after startup failure")
+
+    assert collector_started.is_set()
+    assert server._ep_health_collector_task is None
+    server.embedding_batcher.shutdown.assert_awaited_once_with()
+    generator.shutdown.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_server_lifespan_drains_inflight_health_poll_before_shutdown(monkeypatch) -> None:
+    """Startup stays non-blocking, while shutdown drains the health RPC."""
+    expected = {
+        "sourceEpoch": EP_HEALTH_SOURCE_EPOCH,
+        "worldSize": 4,
+        "activeCount": 4,
+        "failedRanks": [],
+        "generation": 0,
+    }
+    poll_started = threading.Event()
+    release_poll = threading.Event()
+
+    def read_health():
+        poll_started.set()
+        release_poll.wait(timeout=5.0)
+        return expected
+
+    health_reader = MagicMock(side_effect=read_health)
+    generator = SimpleNamespace(
+        args=SimpleNamespace(enable_energy_metrics=False, enable_iter_perf_stats=False),
+        _get_ep_health_stats=health_reader,
+        shutdown=MagicMock(),
+    )
+    monkeypatch.setattr(OpenAIServer, "_init_llm", lambda self, chat_template=None: None)
+    monkeypatch.setattr(OpenAIServer, "register_routes", lambda self: None)
+    server = OpenAIServer(
+        generator=generator,
+        model="test-model",
+        tool_parser=None,
+        server_role=None,
+        metadata_server_cfg=None,
+    )
+    server.metrics_collector = MagicMock()
+    server.metrics_collector.log_ep_health_stats.return_value = True
+    _mount_ep_health_metrics_for_test(server)
+
+    lifespan = server.app.router.lifespan_context(server.app)
+    await asyncio.wait_for(lifespan.__aenter__(), timeout=1.0)
+    exit_task = None
+    try:
+        assert await asyncio.wait_for(asyncio.to_thread(poll_started.wait, 1.0), timeout=2.0)
+        exit_task = asyncio.create_task(lifespan.__aexit__(None, None, None))
+        await asyncio.wait_for(server._ep_health_stop_event.wait(), timeout=1.0)
+
+        generator.shutdown.assert_not_called()
+        assert not exit_task.done()
+    finally:
+        release_poll.set()
+        if exit_task is None:
+            exit_task = asyncio.create_task(lifespan.__aexit__(None, None, None))
+        await asyncio.wait_for(exit_task, timeout=1.0)
+
+    health_reader.assert_called_once_with()
+    generator.shutdown.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_server_lifespan_cancellation_still_drains_health_poll(monkeypatch) -> None:
+    """Cancelling lifespan cleanup cannot abandon a running health RPC thread."""
+    snapshot = {
+        "sourceEpoch": EP_HEALTH_SOURCE_EPOCH,
+        "worldSize": 4,
+        "activeCount": 4,
+        "failedRanks": [],
+        "generation": 0,
+    }
+    poll_started = threading.Event()
+    release_poll = threading.Event()
+
+    def read_health():
+        poll_started.set()
+        release_poll.wait(timeout=5.0)
+        return snapshot
+
+    generator = SimpleNamespace(
+        args=SimpleNamespace(enable_energy_metrics=False, enable_iter_perf_stats=False),
+        _get_ep_health_stats=MagicMock(side_effect=read_health),
+        shutdown=MagicMock(),
+    )
+    monkeypatch.setattr(OpenAIServer, "_init_llm", lambda self, chat_template=None: None)
+    monkeypatch.setattr(OpenAIServer, "register_routes", lambda self: None)
+    server = OpenAIServer(
+        generator=generator,
+        model="test-model",
+        tool_parser=None,
+        server_role=None,
+        metadata_server_cfg=None,
+    )
+    server.metrics_collector = MagicMock()
+    server.metrics_collector.log_ep_health_stats.return_value = True
+    _mount_ep_health_metrics_for_test(server)
+
+    lifespan = server.app.router.lifespan_context(server.app)
+    await asyncio.wait_for(lifespan.__aenter__(), timeout=1.0)
+    exit_task = None
+    try:
+        assert await asyncio.wait_for(asyncio.to_thread(poll_started.wait, 1.0), timeout=2.0)
+        exit_task = asyncio.create_task(lifespan.__aexit__(None, None, None))
+        await asyncio.wait_for(server._ep_health_stop_event.wait(), timeout=1.0)
+        for _ in range(3):
+            exit_task.cancel()
+            await asyncio.sleep(0)
+            generator.shutdown.assert_not_called()
+            assert not exit_task.done()
+    finally:
+        release_poll.set()
+
+    assert exit_task is not None
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(exit_task, timeout=1.0)
+    generator._get_ep_health_stats.assert_called_once_with()
+    generator.shutdown.assert_called_once_with()

--- a/tests/unittest/_torch/modules/test_ep_metrics.py
+++ b/tests/unittest/_torch/modules/test_ep_metrics.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for passive committed WideEP membership serialization."""
+
+import copy
+import threading
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensorrt_llm._torch.modules.fused_moe.ep_group_health import (
+    EP_GROUP_HEALTH_EXTRA_ATTR,
+    EP_GROUP_HEALTH_LEGACY_EXTRA_ATTR,
+    EPGroupHealth,
+)
+from tensorrt_llm._torch.modules.fused_moe.ep_metrics import (
+    get_ep_group_health,
+    is_ep_group_health_registration_pending,
+    is_pending_ep_health_metrics,
+    pending_ep_health_metrics,
+    serialize_ep_health_metrics,
+    validate_ep_health_metrics_topology,
+)
+from tensorrt_llm._torch.modules.fused_moe.wide_ep_ft import get_wide_ep_ft_options
+
+
+def test_serialize_initial_health() -> None:
+    health = EPGroupHealth(4)
+
+    assert serialize_ep_health_metrics(health) == {
+        "sourceEpoch": health.source_epoch,
+        "worldSize": 4,
+        "activeCount": 4,
+        "failedRanks": [],
+        "generation": 0,
+    }
+
+
+def test_deepcopy_preserves_shared_producer_identity() -> None:
+    health = EPGroupHealth(4)
+
+    assert copy.deepcopy(health) is health
+
+
+def test_serialization_reads_one_coherent_snapshot() -> None:
+    health: Any = SimpleNamespace(
+        moe_world_size=4,
+        source_epoch="source-a",
+        snapshot=MagicMock(
+            return_value=SimpleNamespace(
+                active_count=3,
+                failed_ranks=frozenset({2}),
+                generation=1,
+            )
+        ),
+    )
+
+    assert serialize_ep_health_metrics(health) == {
+        "sourceEpoch": "source-a",
+        "worldSize": 4,
+        "activeCount": 3,
+        "failedRanks": [2],
+        "generation": 1,
+    }
+    health.snapshot.assert_called_once_with()
+
+
+def test_serialize_committed_exclusion_and_reinclusion() -> None:
+    health = EPGroupHealth(72)
+    health.mark_failed(70)
+    health.mark_failed(3)
+    health.mark_failed(3)
+
+    assert serialize_ep_health_metrics(health) == {
+        "sourceEpoch": health.source_epoch,
+        "worldSize": 72,
+        "activeCount": 70,
+        "failedRanks": [3, 70],
+        "generation": 2,
+    }
+
+    health.mark_active(3)
+    assert serialize_ep_health_metrics(health) == {
+        "sourceEpoch": health.source_epoch,
+        "worldSize": 72,
+        "activeCount": 71,
+        "failedRanks": [70],
+        "generation": 3,
+    }
+
+
+@pytest.mark.parametrize(
+    "key",
+    [EP_GROUP_HEALTH_EXTRA_ATTR, EP_GROUP_HEALTH_LEGACY_EXTRA_ATTR],
+)
+def test_get_ep_group_health_passively_reads_registered_tracker(key: str) -> None:
+    health = EPGroupHealth(4)
+    extra_attrs = {key: health}
+    model_config = SimpleNamespace(
+        extra_attrs=extra_attrs,
+        mapping=SimpleNamespace(moe_ep_size=4),
+    )
+
+    assert get_ep_group_health(model_config) is health
+    assert model_config.extra_attrs == extra_attrs
+
+
+def test_get_ep_group_health_does_not_create_or_enable_tracker(monkeypatch) -> None:
+    monkeypatch.setenv("TRTLLM_ENABLE_WIDE_EP_FT", "1")
+    model_config = SimpleNamespace(
+        extra_attrs={},
+        mapping=SimpleNamespace(moe_ep_size=8),
+    )
+
+    assert get_ep_group_health(model_config) is None
+    assert not is_ep_group_health_registration_pending(model_config)
+    assert model_config.extra_attrs == {}
+
+
+def test_wide_ep_ft_producer_uses_canonical_telemetry_seam(monkeypatch) -> None:
+    monkeypatch.setenv("TLLM_FAULT_TOLERANCE_MODE", "1")
+    model_config = SimpleNamespace(
+        extra_attrs={},
+        mapping=SimpleNamespace(moe_ep_size=4),
+        use_cuda_graph=False,
+    )
+
+    produced_health, _, _ = get_wide_ep_ft_options(model_config)
+    observed_health = get_ep_group_health(model_config)
+
+    assert produced_health is observed_health
+    assert model_config.extra_attrs[EP_GROUP_HEALTH_EXTRA_ATTR] is observed_health
+    assert serialize_ep_health_metrics(observed_health)["activeCount"] == 4
+
+
+def test_explicit_empty_registration_is_pending_without_mutation() -> None:
+    model_config = SimpleNamespace(extra_attrs={EP_GROUP_HEALTH_EXTRA_ATTR: None})
+
+    assert get_ep_group_health(model_config) is None
+    assert is_ep_group_health_registration_pending(model_config)
+    pending = pending_ep_health_metrics()
+    assert pending == {"status": "pending"}
+    assert is_pending_ep_health_metrics(pending)
+    assert not is_pending_ep_health_metrics({"status": "unsupported"})
+    assert model_config.extra_attrs == {EP_GROUP_HEALTH_EXTRA_ATTR: None}
+
+
+def test_get_ep_group_health_rejects_split_trackers() -> None:
+    model_config = SimpleNamespace(
+        extra_attrs={
+            EP_GROUP_HEALTH_EXTRA_ATTR: EPGroupHealth(4),
+            EP_GROUP_HEALTH_LEGACY_EXTRA_ATTR: EPGroupHealth(4),
+        },
+        mapping=SimpleNamespace(moe_ep_size=4),
+    )
+
+    with pytest.raises(ValueError, match="different trackers"):
+        get_ep_group_health(model_config)
+
+
+def test_get_ep_group_health_rejects_invalid_shared_object() -> None:
+    wrong_type = SimpleNamespace(
+        extra_attrs={EP_GROUP_HEALTH_EXTRA_ATTR: object()},
+        mapping=SimpleNamespace(moe_ep_size=8),
+    )
+    with pytest.raises(TypeError, match="must be an EPGroupHealth"):
+        get_ep_group_health(wrong_type)
+
+    wrong_size = SimpleNamespace(
+        extra_attrs={EP_GROUP_HEALTH_EXTRA_ATTR: EPGroupHealth(4)},
+        mapping=SimpleNamespace(moe_ep_size=8),
+    )
+    with pytest.raises(ValueError, match="world size does not match"):
+        get_ep_group_health(wrong_size)
+
+
+@pytest.mark.parametrize("unsupported_axis", ["moe_tp_size", "pp_size", "moe_cluster_size"])
+def test_topology_validation_is_deferred_to_metric_read(unsupported_axis: str) -> None:
+    health = EPGroupHealth(4)
+    topology = {
+        "moe_tp_size": 1,
+        "pp_size": 1,
+        "moe_cluster_size": 1,
+    }
+    topology[unsupported_axis] = 2
+    model_config = SimpleNamespace(
+        extra_attrs={EP_GROUP_HEALTH_EXTRA_ATTR: health},
+        mapping=SimpleNamespace(
+            moe_ep_size=4,
+            **topology,
+        ),
+    )
+
+    assert get_ep_group_health(model_config) is health
+    with pytest.raises(NotImplementedError, match="multi-group MoE topologies"):
+        validate_ep_health_metrics_topology(model_config)
+
+
+def test_concurrent_serialization_is_coherent() -> None:
+    health = EPGroupHealth(8)
+    start = threading.Barrier(2)
+    worker_errors: list[BaseException] = []
+
+    def toggle_rank() -> None:
+        try:
+            start.wait(timeout=10.0)
+            for _ in range(1_000):
+                health.mark_failed(3)
+                health.mark_active(3)
+        except BaseException as error:
+            worker_errors.append(error)
+
+    thread = threading.Thread(target=toggle_rank)
+    thread.start()
+    start.wait(timeout=10.0)
+
+    for _ in range(1_000):
+        stats = serialize_ep_health_metrics(health)
+        assert stats["activeCount"] == stats["worldSize"] - len(stats["failedRanks"])
+        assert stats["failedRanks"] in ([], [3])
+        assert bool(stats["generation"] % 2) is bool(stats["failedRanks"])
+
+    thread.join(timeout=10.0)
+    assert not thread.is_alive()
+    assert not worker_errors
+    assert health.generation == 2_000
+    assert health.get_failed_ranks() == frozenset()

--- a/tests/unittest/metrics/test_collector.py
+++ b/tests/unittest/metrics/test_collector.py
@@ -14,12 +14,14 @@
 # limitations under the License.
 """Unit tests for MetricsCollector and process_req_perf_metrics."""
 
+import threading
+import time
 from typing import Dict
 
 import pytest
-from prometheus_client import REGISTRY
+from prometheus_client import REGISTRY, CollectorRegistry, generate_latest, multiprocess
 
-from tensorrt_llm.metrics.collector import MetricsCollector
+from tensorrt_llm.metrics.collector import _MAX_RETIRED_EP_HEALTH_SOURCE_EPOCHS, MetricsCollector
 from tensorrt_llm.metrics.enums import MetricNames, RequestEventTiming
 from tensorrt_llm.metrics.perf_utils import process_req_perf_metrics
 
@@ -47,6 +49,13 @@ def collector():
 
 def _get_gauge_value(collector, metric_name: str):
     """Get the current value of a Prometheus gauge."""
+    if metric_name.startswith("ep_"):
+        sample_name = f"trtllm_{metric_name}"
+        for metric in collector._ep_health_prometheus_collector.collect():
+            for sample in metric.samples:
+                if sample.name == sample_name:
+                    return sample.value
+        raise AssertionError(f"Missing EP health sample {sample_name}")
     metric = getattr(collector, metric_name)
     return metric.labels(**collector.labels)._value.get()
 
@@ -55,6 +64,37 @@ def _get_counter_value(collector, metric_name: str):
     """Get the current value of a Prometheus counter."""
     metric = getattr(collector, metric_name)
     return metric.labels(**collector.labels)._value.get()
+
+
+def _get_ep_rank_gauge_value(collector, rank: int):
+    for metric in collector._ep_health_prometheus_collector.collect():
+        for sample in metric.samples:
+            if sample.name == "trtllm_ep_rank_active" and sample.labels[
+                collector.labelname_ep_rank
+            ] == str(rank):
+                return sample.value
+    raise AssertionError(f"Missing EP rank sample {rank}")
+
+
+def _get_ep_rank_samples(collector):
+    return [
+        sample
+        for metric in collector._ep_health_prometheus_collector.collect()
+        for sample in metric.samples
+        if sample.name == "trtllm_ep_rank_active"
+    ]
+
+
+def _get_ep_metric_samples(collector):
+    return [
+        sample
+        for metric in collector._ep_health_prometheus_collector.collect()
+        for sample in metric.samples
+    ]
+
+
+EP_HEALTH_SOURCE_A = "source-a"
+EP_HEALTH_SOURCE_B = "source-b"
 
 
 SAMPLE_ITERATION_STATS = {
@@ -91,6 +131,491 @@ SAMPLE_ITERATION_STATS = {
         "draftOverhead": 1.2,
     },
 }
+
+
+class TestEPHealthStats:
+    """Test committed EPGroupHealth membership is exposed as passive gauges."""
+
+    def test_no_snapshot_exports_no_ep_health_families(self, collector):
+        registry = CollectorRegistry()
+        collector.register_ep_health_metrics(registry)
+
+        assert _get_ep_metric_samples(collector) == []
+        assert "trtllm_ep_" not in generate_latest(registry).decode()
+
+        # ``None``/unsupported health is represented by marking a collector
+        # unavailable before any producer has published a valid snapshot.
+        collector.log_ep_health_unavailable()
+        assert _get_ep_metric_samples(collector) == []
+        assert "trtllm_ep_" not in generate_latest(registry).decode()
+
+    def test_per_rank_and_group_gauges(self, collector):
+        assert (
+            collector.log_ep_health_stats(
+                {
+                    "sourceEpoch": EP_HEALTH_SOURCE_A,
+                    "worldSize": 4,
+                    "activeCount": 3,
+                    "failedRanks": [2],
+                    "generation": 1,
+                }
+            )
+            is True
+        )
+
+        assert [_get_ep_rank_gauge_value(collector, rank) for rank in range(4)] == [
+            1,
+            1,
+            0,
+            1,
+        ]
+        assert _get_gauge_value(collector, "ep_active_ranks") == 3
+        assert _get_gauge_value(collector, "ep_failed_ranks") == 1
+        assert _get_gauge_value(collector, "ep_health_generation") == 1
+        assert _get_gauge_value(collector, "ep_health_available") == 1
+
+    def test_reactivation_updates_existing_rank_series(self, collector):
+        collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 2,
+                "activeCount": 1,
+                "failedRanks": [1],
+                "generation": 1,
+            }
+        )
+        collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 2,
+                "activeCount": 2,
+                "failedRanks": [],
+                "generation": 2,
+            }
+        )
+
+        assert _get_ep_rank_gauge_value(collector, 1) == 1
+        assert _get_gauge_value(collector, "ep_active_ranks") == 2
+        assert _get_gauge_value(collector, "ep_failed_ranks") == 0
+        assert _get_gauge_value(collector, "ep_health_generation") == 2
+
+    def test_conflicting_same_generation_warns_and_is_ignored(self, collector, caplog):
+        collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 2,
+                "activeCount": 1,
+                "failedRanks": [1],
+                "generation": 1,
+            }
+        )
+        assert (
+            collector.log_ep_health_stats(
+                {
+                    "sourceEpoch": EP_HEALTH_SOURCE_A,
+                    "worldSize": 2,
+                    "activeCount": 1,
+                    "failedRanks": [0],
+                    "generation": 1,
+                }
+            )
+            is False
+        )
+
+        assert "Conflicting epHealthStats payloads" in caplog.text
+        assert _get_ep_rank_gauge_value(collector, 0) == 1
+        assert _get_ep_rank_gauge_value(collector, 1) == 0
+        assert _get_gauge_value(collector, "ep_health_available") == 0
+
+    def test_stale_generation_warns_and_is_ignored(self, collector, caplog):
+        collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 2,
+                "activeCount": 1,
+                "failedRanks": [1],
+                "generation": 2,
+            }
+        )
+        assert (
+            collector.log_ep_health_stats(
+                {
+                    "sourceEpoch": EP_HEALTH_SOURCE_A,
+                    "worldSize": 2,
+                    "activeCount": 1,
+                    "failedRanks": [0],
+                    "generation": 1,
+                }
+            )
+            is False
+        )
+
+        assert "Ignoring stale epHealthStats generation" in caplog.text
+        assert _get_ep_rank_gauge_value(collector, 0) == 1
+        assert _get_ep_rank_gauge_value(collector, 1) == 0
+        assert _get_gauge_value(collector, "ep_health_available") == 0
+
+    def test_new_producer_epoch_can_restart_generation(self, collector):
+        assert collector.log_ep_health_stats(
+            {
+                "sourceEpoch": "producer-a",
+                "worldSize": 2,
+                "activeCount": 1,
+                "failedRanks": [1],
+                "generation": 5,
+            }
+        )
+        collector.log_ep_health_unavailable()
+
+        assert collector.log_ep_health_stats(
+            {
+                "sourceEpoch": "producer-b",
+                "worldSize": 2,
+                "activeCount": 2,
+                "failedRanks": [],
+                "generation": 0,
+            }
+        )
+        assert [_get_ep_rank_gauge_value(collector, rank) for rank in range(2)] == [1, 1]
+        assert _get_gauge_value(collector, "ep_active_ranks") == 2
+        assert _get_gauge_value(collector, "ep_health_generation") == 0
+        assert _get_gauge_value(collector, "ep_health_available") == 1
+
+    def test_retired_producer_epoch_cannot_become_current_again(self, collector, caplog):
+        assert collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 2,
+                "activeCount": 1,
+                "failedRanks": [1],
+                "generation": 9,
+            }
+        )
+        assert collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_B,
+                "worldSize": 2,
+                "activeCount": 2,
+                "failedRanks": [],
+                "generation": 0,
+            }
+        )
+
+        assert (
+            collector.log_ep_health_stats(
+                {
+                    "sourceEpoch": EP_HEALTH_SOURCE_A,
+                    "worldSize": 2,
+                    "activeCount": 1,
+                    "failedRanks": [1],
+                    "generation": 9,
+                }
+            )
+            is False
+        )
+        assert "retired source epoch" in caplog.text
+        assert [_get_ep_rank_gauge_value(collector, rank) for rank in range(2)] == [1, 1]
+        assert _get_gauge_value(collector, "ep_health_generation") == 0
+        assert _get_gauge_value(collector, "ep_health_available") == 0
+
+    def test_source_epoch_is_required_after_epoch_aware_payload(self, collector):
+        assert collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 1,
+                "activeCount": 1,
+                "failedRanks": [],
+                "generation": 0,
+            }
+        )
+
+        assert (
+            collector.log_ep_health_stats(
+                {
+                    "worldSize": 1,
+                    "activeCount": 1,
+                    "failedRanks": [],
+                    "generation": 1,
+                }
+            )
+            is False
+        )
+        assert collector._last_ep_health_state[0] == EP_HEALTH_SOURCE_A
+        assert _get_gauge_value(collector, "ep_health_available") == 0
+
+    def test_source_epoch_churn_keeps_recent_replay_window_bounded(self, collector):
+        transitions = _MAX_RETIRED_EP_HEALTH_SOURCE_EPOCHS + 10
+        for epoch in range(transitions):
+            assert collector.log_ep_health_stats(
+                {
+                    "sourceEpoch": f"source-{epoch}",
+                    "worldSize": 1,
+                    "activeCount": 1,
+                    "failedRanks": [],
+                    "generation": 0,
+                }
+            )
+
+        # Legitimate producer replacements continue after the bounded history
+        # fills, while recently retired producers are still rejected.
+        assert (
+            collector.log_ep_health_stats(
+                {
+                    "sourceEpoch": f"source-{transitions - 2}",
+                    "worldSize": 1,
+                    "activeCount": 1,
+                    "failedRanks": [],
+                    "generation": 0,
+                }
+            )
+            is False
+        )
+        assert (
+            len(collector._retired_ep_health_source_epochs) == _MAX_RETIRED_EP_HEALTH_SOURCE_EPOCHS
+        )
+        assert (
+            len(collector._retired_ep_health_source_epoch_order)
+            == _MAX_RETIRED_EP_HEALTH_SOURCE_EPOCHS
+        )
+        assert _get_gauge_value(collector, "ep_health_available") == 0
+
+        assert collector.log_ep_health_stats(
+            {
+                "sourceEpoch": "source-0",
+                "worldSize": 1,
+                "activeCount": 1,
+                "failedRanks": [],
+                "generation": 0,
+            }
+        )
+        assert _get_gauge_value(collector, "ep_health_available") == 1
+
+    def test_oversized_world_is_rejected_before_rank_series_creation(self, collector):
+        assert _get_ep_rank_samples(collector) == []
+
+        assert (
+            collector.log_ep_health_stats(
+                {
+                    "sourceEpoch": EP_HEALTH_SOURCE_A,
+                    "worldSize": 129,
+                    "activeCount": 129,
+                    "failedRanks": [],
+                    "generation": 0,
+                }
+            )
+            is False
+        )
+        assert _get_ep_metric_samples(collector) == []
+
+    def test_unrepresentable_generation_is_rejected_before_metric_writes(self, collector):
+        assert _get_ep_rank_samples(collector) == []
+
+        assert (
+            collector.log_ep_health_stats(
+                {
+                    "sourceEpoch": EP_HEALTH_SOURCE_A,
+                    "worldSize": 1,
+                    "activeCount": 1,
+                    "failedRanks": [],
+                    "generation": 10**1000,
+                }
+            )
+            is False
+        )
+        assert collector._last_ep_health_state is None
+        assert _get_ep_metric_samples(collector) == []
+
+    def test_world_size_change_warns_and_is_ignored(self, collector, caplog):
+        collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 4,
+                "activeCount": 3,
+                "failedRanks": [3],
+                "generation": 1,
+            }
+        )
+        assert (
+            collector.log_ep_health_stats(
+                {
+                    "sourceEpoch": EP_HEALTH_SOURCE_A,
+                    "worldSize": 2,
+                    "activeCount": 2,
+                    "failedRanks": [],
+                    "generation": 2,
+                }
+            )
+            is False
+        )
+
+        assert "Ignoring epHealthStats world-size change" in caplog.text
+        assert _get_ep_rank_gauge_value(collector, 3) == 0
+        assert _get_gauge_value(collector, "ep_active_ranks") == 3
+        assert _get_gauge_value(collector, "ep_failed_ranks") == 1
+        assert _get_gauge_value(collector, "ep_health_generation") == 1
+        assert _get_gauge_value(collector, "ep_health_available") == 0
+
+    def test_invalid_payload_is_ignored(self, collector, caplog):
+        invalid = {
+            "sourceEpoch": EP_HEALTH_SOURCE_A,
+            "worldSize": 4,
+            "activeCount": 4,
+            "failedRanks": [4],
+            "generation": 1,
+        }
+        assert collector.log_ep_health_stats(invalid) is False
+        assert collector.log_ep_health_stats(invalid) is False
+
+        assert "Ignoring invalid epHealthStats payload" in caplog.text
+        assert caplog.text.count("Ignoring invalid epHealthStats payload") == 1
+        assert collector._last_ep_health_state is None
+        assert _get_ep_metric_samples(collector) == []
+
+        assert collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 4,
+                "activeCount": 4,
+                "failedRanks": [],
+                "generation": 0,
+            }
+        )
+        assert collector.log_ep_health_stats(invalid) is False
+        assert caplog.text.count("Ignoring invalid epHealthStats payload") == 2
+
+    def test_rpc_outage_marks_snapshot_unavailable_and_duplicate_recovers(self, collector):
+        snapshot = {
+            "sourceEpoch": EP_HEALTH_SOURCE_A,
+            "worldSize": 2,
+            "activeCount": 2,
+            "failedRanks": [],
+            "generation": 0,
+        }
+        assert collector.log_ep_health_stats(snapshot) is True
+        collector.log_ep_health_unavailable()
+
+        assert _get_ep_rank_gauge_value(collector, 0) == 1
+        assert _get_gauge_value(collector, "ep_active_ranks") == 2
+        assert _get_gauge_value(collector, "ep_failed_ranks") == 0
+        assert _get_gauge_value(collector, "ep_health_generation") == 0
+        assert _get_gauge_value(collector, "ep_health_available") == 0
+
+        assert collector.log_ep_health_stats(snapshot) is True
+        assert _get_gauge_value(collector, "ep_health_available") == 1
+
+    def test_health_metrics_register_on_scrape_registry(self, collector):
+        collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 2,
+                "activeCount": 1,
+                "failedRanks": [1],
+                "generation": 3,
+            }
+        )
+        registry = CollectorRegistry()
+        collector.register_ep_health_metrics(registry)
+        output = generate_latest(registry).decode()
+
+        assert 'trtllm_ep_rank_active{ep_rank="0",model_name="test_model"} 1.0' in output
+        assert 'trtllm_ep_rank_active{ep_rank="1",model_name="test_model"} 0.0' in output
+        assert 'trtllm_ep_active_ranks{model_name="test_model"} 1.0' in output
+        assert 'trtllm_ep_failed_ranks{model_name="test_model"} 1.0' in output
+        assert 'trtllm_ep_health_generation{model_name="test_model"} 3.0' in output
+        assert 'trtllm_ep_health_available{model_name="test_model"} 1.0' in output
+
+    def test_multiprocess_registry_and_local_health_collector_do_not_duplicate(
+        self, collector, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+        collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 2,
+                "activeCount": 1,
+                "failedRanks": [1],
+                "generation": 4,
+            }
+        )
+
+        registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(registry)
+        collector.register_ep_health_metrics(registry)
+        output = generate_latest(registry).decode()
+
+        assert output.count("# HELP trtllm_ep_rank_active") == 1
+        assert output.count("trtllm_ep_rank_active{") == 2
+        assert output.count("trtllm_ep_health_available{") == 1
+        assert "pid=" not in "\n".join(
+            line for line in output.splitlines() if line.startswith("trtllm_ep_")
+        )
+
+    def test_concurrent_scrapes_observe_only_complete_health_snapshots(self, collector):
+        registry = CollectorRegistry()
+        collector.register_ep_health_metrics(registry)
+        assert collector.log_ep_health_stats(
+            {
+                "sourceEpoch": EP_HEALTH_SOURCE_A,
+                "worldSize": 4,
+                "activeCount": 3,
+                "failedRanks": [0],
+                "generation": 0,
+            }
+        )
+        writer_done = threading.Event()
+        start = threading.Barrier(2)
+        writer_errors = []
+
+        def writer():
+            try:
+                start.wait(timeout=10.0)
+                for generation in range(1, 501):
+                    failed_ranks = [generation % 4]
+                    assert collector.log_ep_health_stats(
+                        {
+                            "sourceEpoch": EP_HEALTH_SOURCE_A,
+                            "worldSize": 4,
+                            "activeCount": 3,
+                            "failedRanks": failed_ranks,
+                            "generation": generation,
+                        }
+                    )
+                    time.sleep(0)
+            except BaseException as error:
+                writer_errors.append(error)
+            finally:
+                writer_done.set()
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+        start.wait(timeout=10.0)
+        scrapes = 0
+        while not writer_done.is_set() or scrapes == 0:
+            families = {
+                metric.name: metric
+                for metric in collector._ep_health_prometheus_collector.collect()
+            }
+            availability = families["trtllm_ep_health_available"].samples[0].value
+            if availability:
+                ranks = families["trtllm_ep_rank_active"].samples
+                active_count = families["trtllm_ep_active_ranks"].samples[0].value
+                failed_count = families["trtllm_ep_failed_ranks"].samples[0].value
+                generation = families["trtllm_ep_health_generation"].samples[0].value
+                failed_ranks = [
+                    int(sample.labels[collector.labelname_ep_rank])
+                    for sample in ranks
+                    if not sample.value
+                ]
+                assert len(ranks) == 4
+                assert sum(sample.value for sample in ranks) == active_count
+                assert len(ranks) - active_count == failed_count
+                assert failed_ranks == [int(generation) % 4]
+            scrapes += 1
+        thread.join(timeout=10.0)
+
+        assert not thread.is_alive()
+        assert writer_errors == []
+        assert collector._last_ep_health_state[2] == 500
 
 
 class TestIterationStatsTopLevel:


### PR DESCRIPTION
## Summary

- add a passive `EPGroupHealth` metrics adapter for WideEP FT item 1d.3
- carry coherent per-rank health snapshots from the rank-0 PyExecutor through a dedicated internal RPC to `trtllm-serve`
- expose atomic Prometheus rank, active/failed-count, generation, and availability metrics
- cover producer replacement, pending registration, transient RPC loss, unsupported backends, mount gating, and cancellation-safe shutdown

## Why

`EPGroupHealth` is process-local, while Prometheus is served by the OpenAI server process. Existing multiprocess gauges also merge each metric independently, so they cannot guarantee that the rank vector, aggregate counts, generation, and validity bit come from one coherent health snapshot.

This change keeps telemetry observational: it reads the producer-owned tracker from the canonical `ModelConfig.extra_attrs` seam and never creates a separate always-healthy tracker or changes communication selection. The current-main WideEP producer and telemetry consumer now share the same canonical key constants. The adapter remains dormant until a communication producer registers a tracker; an explicit `key: None` reservation supports late attachment without polling ordinary unsupported backends.

## Behavior

- exports `trtllm_ep_rank_active{ep_rank=...}`, `trtllm_ep_active_ranks`, `trtllm_ep_failed_ranks`, `trtllm_ep_health_generation`, and `trtllm_ep_health_available`
- emits no EP metric families before the first valid producer snapshot
- retains the last coherent snapshot during an outage and sets availability to `0`
- uses a producer epoch so generation can safely restart after rank-0 replacement
- retries transport timeouts, ZeroMQ failures, and `RPCCancelled`; deterministic configuration/topology failures stop polling
- polls only when the Prometheus endpoint has mounted the coherent local collector, so embedding/MM-encoder roles remain dormant
- rejects multi-group PP / MoE-TP / MoE-cluster topologies until the serving endpoint can identify every EP group

## Validation

- 55 focused `EPGroupHealth` / producer / serialization tests
- 105 metrics collector tests with `prometheus_client` 0.23
- 105 metrics collector tests with `prometheus_client` 0.18
- focused exact-source checks for PyExecutor late attachment, RPC forwarding, pending registration, producer replacement, endpoint mount gating, and cancellation-safe drain
- Ruff format/lint, YAPF, isort, autoflake, legacy lint baseline, `py_compile`, Python 3.10 grammar, YAML parsing, and `git diff --check`

Full Torch/GPU execution was not available locally; the new unit files are added to B200 CI routing.

## Corrected telemetry contract

This PR is a **passive observer of coordinator-committed data-plane membership**:

- `active`, `failed`, and `generation` describe the committed EP mask, not raw physical liveness or suspicion;
- `failedRanks` and existing metric names remain unchanged for compatibility, while documentation and Prometheus HELP text clarify their meaning;
- telemetry never creates, enables, or mutates `EPGroupHealth`, and it cannot drive recovery;
- detected/suspected state and recovery-phase metrics remain separate follow-up work;
- the shared `EPGroupHealth` contract and key constants are aligned with the current-main WideEP communication producer.

Canonical plan: https://github.com/chienchunhung/TensorRT-LLM/blob/docs-and-plans/docs/design/wide-ep-fault-tolerance/pr-execution/08-implementation-plan.md
