### PR TITLE
[TRTLLM-12560][feat] Add NCCL fault-tolerance wrapper for WideEP (1a.7)

### DIFF
--- a/cpp/include/tensorrt_llm/runtime/utils/mpiTags.h
+++ b/cpp/include/tensorrt_llm/runtime/utils/mpiTags.h
@@ -75,7 +75,23 @@ enum class MpiTag : int
 
     // Asynchronous context-transfer coordination.
     kContextTransferEvent = 1028,
-    kContextTransferUpdate = 1029
+    kContextTransferUpdate = 1029,
+
+    // Fault-tolerant NCCL communicator rendezvous. Each ownership path and
+    // protocol phase has a distinct tag so stale or simultaneous messages
+    // cannot be decoded as another phase's payload.
+    kNcclCommReady = 1030,
+    kNcclCommUniqueId = 1031,
+    kNcclCommAck = 1032,
+    kNcclPpReady = 1033,
+    kNcclPpUniqueId = 1034,
+    kNcclPpAck = 1035,
+
+    // Seeds used with the canonical group to derive MPI_Comm_create_group
+    // tags for dedicated, pre-failure NCCL rendezvous channels. These are
+    // separate from message tags and distinguish raw-op and PP ownership.
+    kNcclCommControl = 1036,
+    kNcclPpControl = 1037
 };
 
 } // namespace tensorrt_llm::mpi

--- a/cpp/include/tensorrt_llm/runtime/utils/ncclHostApi.h
+++ b/cpp/include/tensorrt_llm/runtime/utils/ncclHostApi.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <mutex>
+
+namespace tensorrt_llm::runtime
+{
+
+// NCCL host APIs must not run concurrently from different threads for
+// communicators associated with the same CUDA device. TRT-LLM can own both a
+// PP communicator and several cached raw-op communicators, each with its own
+// watchdog, so a per-communicator mutex is insufficient. A process-wide gate
+// is deliberately stricter than a per-device gate and avoids relying on CUDA
+// thread-local device state in watchdog threads.
+//
+// Recursive locking lets low-level error paths abort a communicator while the
+// operation wrapper already owns the gate. A grouped operation keeps one lock
+// alive from ncclGroupStart through ncclGroupEnd.
+inline std::recursive_mutex& getNcclHostApiMutex()
+{
+    // Communicator registries and watchdogs are also process-lifetime
+    // singletons, with cross-translation-unit destruction order unspecified.
+    // Keep the gate alive until process exit so late communicator teardown can
+    // never touch an already-destroyed mutex.
+    static auto* mutex = new std::recursive_mutex;
+    return *mutex;
+}
+
+using NcclHostApiLock = std::unique_lock<std::recursive_mutex>;
+
+inline NcclHostApiLock acquireNcclHostApiLock()
+{
+    return NcclHostApiLock{getNcclHostApiMutex()};
+}
+
+} // namespace tensorrt_llm::runtime

--- a/cpp/include/tensorrt_llm/runtime/utils/ncclUniqueIdRendezvous.h
+++ b/cpp/include/tensorrt_llm/runtime/utils/ncclUniqueIdRendezvous.h
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/runtime/utils/mpiUtils.h"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#if ENABLE_MULTI_DEVICE
+#include <nccl.h>
+#endif
+
+namespace tensorrt_llm::runtime
+{
+
+#if ENABLE_MULTI_DEVICE
+
+struct NcclUniqueIdRendezvousTags
+{
+    mpi::MpiTag ready;
+    mpi::MpiTag id;
+    mpi::MpiTag ack;
+};
+
+//! An MPI control channel dedicated to NCCL unique-ID rendezvous.
+//!
+//! The channel is created collectively by the initial NCCL group while every
+//! member is healthy. It retains a process-lifetime MPI communicator whose
+//! error handler is MPI_ERRORS_RETURN, leaving the parent/session communicator unchanged. The
+//! original parent-communicator ranks are retained so a later survivor subset
+//! can keep using stable world-rank IDs even though MPI ranks in this channel
+//! are compact.
+//!
+//! This isolates rendezvous traffic and error handling, but it is not a ULFM
+//! communicator repair. Post-failure point-to-point progress still requires an
+//! MPI implementation and launcher configured to let survivors continue.
+class NcclUniqueIdRendezvousComm
+{
+public:
+    NcclUniqueIdRendezvousComm(mpi::MpiComm comm, std::vector<int> worldRanks, int worldRank);
+
+    NcclUniqueIdRendezvousComm(NcclUniqueIdRendezvousComm const&) = delete;
+    NcclUniqueIdRendezvousComm& operator=(NcclUniqueIdRendezvousComm const&) = delete;
+
+    [[nodiscard]] mpi::MpiComm const& mpiComm() const noexcept;
+    [[nodiscard]] std::vector<int> const& worldRanks() const noexcept;
+    [[nodiscard]] int worldRank() const noexcept;
+    [[nodiscard]] int commRank(int worldRank) const;
+    [[nodiscard]] int worldRank(int commRank) const;
+
+private:
+    mpi::MpiComm mComm;
+    std::vector<int> mWorldRanks;
+    int mWorldRank;
+};
+
+//! Create a dedicated control channel over initialRanks.
+//!
+//! Every member of initialRanks must call this before any process failure.
+//! Non-members must not call. creationTagSeed and the canonical group derive a
+//! bounded, deterministic MPI creation tag so concurrently-created overlapping
+//! groups do not normally cross-pair.
+std::shared_ptr<NcclUniqueIdRendezvousComm> createNcclUniqueIdRendezvousComm(
+    std::vector<int> const& initialRanks, int worldRank, mpi::MpiComm const& parentComm, int creationTagSeed);
+
+// Exchange a fresh NCCL unique ID among only activeRanks. READY/ID/ACK tokens
+// prevent delayed eager MPI messages from an earlier timed-out attempt from
+// pairing different IDs across ranks. rendezvousId is a coordinator-provided
+// logical attempt identity: all ranks in one attempt must pass the same value,
+// and retries for the same logical communicator must use strictly increasing
+// values. The protocol discards older same-communicator messages after seeing
+// a later value while retaining messages for future values and other groups.
+// All ranks use original/global rank IDs.
+// Callers must keep one logical communicator per (control channel, tag set,
+// active-rank set), or construct multiple instances in the same order on every
+// rank. Recovery reuses the pre-failure control channel and performs no MPI
+// collective.
+ncclUniqueId exchangeNcclUniqueId(std::vector<int> const& activeRanks, NcclUniqueIdRendezvousComm const& controlComm,
+    NcclUniqueIdRendezvousTags tags, std::uint64_t rendezvousId, std::chrono::steady_clock::time_point deadline);
+
+#endif // ENABLE_MULTI_DEVICE
+
+} // namespace tensorrt_llm::runtime

--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -35,6 +35,7 @@
 #include "tensorrt_llm/runtime/utils/debugUtils.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 
 using namespace tensorrt_llm::kernels;
@@ -372,20 +373,26 @@ int AttentionOp::ulyssesContextPreprocess(T const* input, T* output, T* buffer, 
 
     // Do all to all
 #if ENABLE_MULTI_DEVICE
-    ncclGroupStart();
-    for (int cpIdx = 0; cpIdx < mCpSize; cpIdx++)
     {
-        if (cpIdx != mCpRank)
+        auto commLease = acquireComm(mCpNcclComm);
+        auto const comm = commLease.get();
+        auto const watchdogToken = commLease.begin(stream, "NCCL send/recv(ulysses context preprocess)");
+        commLease.groupStart("ncclGroupStart(ulysses context preprocess)");
+        auto checkNcclEnqueue = [&](ncclResult_t result)
+        { commLease.checkEnqueue(result, "NCCL send/recv(ulysses context preprocess)"); };
+        for (int cpIdx = 0; cpIdx < mCpSize; cpIdx++)
         {
-            NCCLCHECK(ncclSend(output + cpIdx * (partialTokenNum * getHeadSize() * partialHeads),
-                (partialTokenNum * getHeadSize() * partialHeads), (*getDtypeMap())[mType], cpIdx, *mCpNcclComm,
-                stream));
-            NCCLCHECK(ncclRecv(buffer + cpIdx * (partialTokenNum * getHeadSize() * partialHeads),
-                (partialTokenNum * getHeadSize() * partialHeads), (*getDtypeMap())[mType], cpIdx, *mCpNcclComm,
-                stream));
+            if (cpIdx != mCpRank)
+            {
+                checkNcclEnqueue(ncclSend(output + cpIdx * (partialTokenNum * getHeadSize() * partialHeads),
+                    (partialTokenNum * getHeadSize() * partialHeads), (*getDtypeMap())[mType], cpIdx, comm, stream));
+                checkNcclEnqueue(ncclRecv(buffer + cpIdx * (partialTokenNum * getHeadSize() * partialHeads),
+                    (partialTokenNum * getHeadSize() * partialHeads), (*getDtypeMap())[mType], cpIdx, comm, stream));
+            }
         }
+        commLease.groupEnd("ncclGroupEnd(ulysses context preprocess)");
+        commLease.track(watchdogToken, stream);
     }
-    ncclGroupEnd();
     sync_check_cuda_error(stream);
 #endif // ENABLE_MULTI_DEVICE
 
@@ -431,28 +438,36 @@ int AttentionOp::ulyssesContextPostprocess(T* input, T* output, T* buffer, Enque
     // all-to-all
 #if ENABLE_MULTI_DEVICE
     size_t const elementNum = partialTokenNum * getHeadSize() * mNumAttnHeads;
-    ncclGroupStart();
-    for (int cpIdx = 0; cpIdx < mCpSize; cpIdx++)
     {
-        if (cpIdx != mCpRank)
+        auto commLease = acquireComm(mCpNcclComm);
+        auto const comm = commLease.get();
+        auto const watchdogToken = commLease.begin(stream, "NCCL send/recv(ulysses context postprocess)");
+        commLease.groupStart("ncclGroupStart(ulysses context postprocess)");
+        auto checkNcclEnqueue = [&](ncclResult_t result)
+        { commLease.checkEnqueue(result, "NCCL send/recv(ulysses context postprocess)"); };
+        for (int cpIdx = 0; cpIdx < mCpSize; cpIdx++)
         {
-            if (mFP8AttenOutput)
+            if (cpIdx != mCpRank)
             {
-                NCCLCHECK(ncclSend(reinterpret_cast<__nv_fp8_e4m3*>(buffer) + cpIdx * elementNum, elementNum, ncclInt8,
-                    cpIdx, *mCpNcclComm, stream));
-                NCCLCHECK(ncclRecv(reinterpret_cast<__nv_fp8_e4m3*>(input) + cpIdx * elementNum, elementNum, ncclInt8,
-                    cpIdx, *mCpNcclComm, stream));
-            }
-            else
-            {
-                NCCLCHECK(ncclSend(
-                    buffer + cpIdx * elementNum, elementNum, (*getDtypeMap())[mType], cpIdx, *mCpNcclComm, stream));
-                NCCLCHECK(ncclRecv(
-                    input + cpIdx * elementNum, elementNum, (*getDtypeMap())[mType], cpIdx, *mCpNcclComm, stream));
+                if (mFP8AttenOutput)
+                {
+                    checkNcclEnqueue(ncclSend(reinterpret_cast<__nv_fp8_e4m3*>(buffer) + cpIdx * elementNum, elementNum,
+                        ncclInt8, cpIdx, comm, stream));
+                    checkNcclEnqueue(ncclRecv(reinterpret_cast<__nv_fp8_e4m3*>(input) + cpIdx * elementNum, elementNum,
+                        ncclInt8, cpIdx, comm, stream));
+                }
+                else
+                {
+                    checkNcclEnqueue(ncclSend(
+                        buffer + cpIdx * elementNum, elementNum, (*getDtypeMap())[mType], cpIdx, comm, stream));
+                    checkNcclEnqueue(
+                        ncclRecv(input + cpIdx * elementNum, elementNum, (*getDtypeMap())[mType], cpIdx, comm, stream));
+                }
             }
         }
+        commLease.groupEnd("ncclGroupEnd(ulysses context postprocess)");
+        commLease.track(watchdogToken, stream);
     }
-    ncclGroupEnd();
 #endif // ENABLE_MULTI_DEVICE
 
     // transpose_1_reverse + view
@@ -498,20 +513,26 @@ int AttentionOp::ulyssesGenerationPreprocess(
 #if ENABLE_MULTI_DEVICE
     auto const partialHeads = mNumAttnHeads + 2 * mNumAttnKVHeads;
 
-    ncclGroupStart();
-    for (int cpIdx = 0; cpIdx < mCpSize; cpIdx++)
     {
-        if (cpIdx != mCpRank)
+        auto commLease = acquireComm(mCpNcclComm);
+        auto const comm = commLease.get();
+        auto const watchdogToken = commLease.begin(stream, "NCCL send/recv(ulysses generation preprocess)");
+        commLease.groupStart("ncclGroupStart(ulysses generation preprocess)");
+        auto checkNcclEnqueue = [&](ncclResult_t result)
+        { commLease.checkEnqueue(result, "NCCL send/recv(ulysses generation preprocess)"); };
+        for (int cpIdx = 0; cpIdx < mCpSize; cpIdx++)
         {
-            NCCLCHECK(ncclSend(buffer + cpIdx * (partialTokenNum * getHeadSize() * partialHeads),
-                (partialTokenNum * getHeadSize() * partialHeads), (*getDtypeMap())[mType], cpIdx, *mCpNcclComm,
-                stream));
-            NCCLCHECK(ncclRecv(output + cpIdx * (partialTokenNum * getHeadSize() * partialHeads),
-                (partialTokenNum * getHeadSize() * partialHeads), (*getDtypeMap())[mType], cpIdx, *mCpNcclComm,
-                stream));
+            if (cpIdx != mCpRank)
+            {
+                checkNcclEnqueue(ncclSend(buffer + cpIdx * (partialTokenNum * getHeadSize() * partialHeads),
+                    (partialTokenNum * getHeadSize() * partialHeads), (*getDtypeMap())[mType], cpIdx, comm, stream));
+                checkNcclEnqueue(ncclRecv(output + cpIdx * (partialTokenNum * getHeadSize() * partialHeads),
+                    (partialTokenNum * getHeadSize() * partialHeads), (*getDtypeMap())[mType], cpIdx, comm, stream));
+            }
         }
+        commLease.groupEnd("ncclGroupEnd(ulysses generation preprocess)");
+        commLease.track(watchdogToken, stream);
     }
-    ncclGroupEnd();
     sync_check_cuda_error(stream);
 #endif // ENABLE_MULTI_DEVICE
     return 0;
@@ -534,28 +555,36 @@ int AttentionOp::ulyssesGenerationPostprocess(T* input, T* output, T* buffer, in
     // do all-to-all
 #if ENABLE_MULTI_DEVICE
     size_t const elementNum = partialTokenNum * getHeadSize() * mNumAttnHeads;
-    ncclGroupStart();
-    for (int cpIdx = 0; cpIdx < mCpSize; cpIdx++)
     {
-        if (cpIdx != mCpRank)
+        auto commLease = acquireComm(mCpNcclComm);
+        auto const comm = commLease.get();
+        auto const watchdogToken = commLease.begin(stream, "NCCL send/recv(ulysses generation postprocess)");
+        commLease.groupStart("ncclGroupStart(ulysses generation postprocess)");
+        auto checkNcclEnqueue = [&](ncclResult_t result)
+        { commLease.checkEnqueue(result, "NCCL send/recv(ulysses generation postprocess)"); };
+        for (int cpIdx = 0; cpIdx < mCpSize; cpIdx++)
         {
-            if (mFP8AttenOutput)
+            if (cpIdx != mCpRank)
             {
-                NCCLCHECK(ncclSend(reinterpret_cast<__nv_fp8_e4m3*>(input) + cpIdx * elementNum, elementNum, ncclInt8,
-                    cpIdx, *mCpNcclComm, stream));
-                NCCLCHECK(ncclRecv(reinterpret_cast<__nv_fp8_e4m3*>(buffer) + cpIdx * elementNum, elementNum, ncclInt8,
-                    cpIdx, *mCpNcclComm, stream));
-            }
-            else
-            {
-                NCCLCHECK(ncclSend(
-                    input + cpIdx * elementNum, elementNum, (*getDtypeMap())[mType], cpIdx, *mCpNcclComm, stream));
-                NCCLCHECK(ncclRecv(
-                    buffer + cpIdx * elementNum, elementNum, (*getDtypeMap())[mType], cpIdx, *mCpNcclComm, stream));
+                if (mFP8AttenOutput)
+                {
+                    checkNcclEnqueue(ncclSend(reinterpret_cast<__nv_fp8_e4m3*>(input) + cpIdx * elementNum, elementNum,
+                        ncclInt8, cpIdx, comm, stream));
+                    checkNcclEnqueue(ncclRecv(reinterpret_cast<__nv_fp8_e4m3*>(buffer) + cpIdx * elementNum, elementNum,
+                        ncclInt8, cpIdx, comm, stream));
+                }
+                else
+                {
+                    checkNcclEnqueue(
+                        ncclSend(input + cpIdx * elementNum, elementNum, (*getDtypeMap())[mType], cpIdx, comm, stream));
+                    checkNcclEnqueue(ncclRecv(
+                        buffer + cpIdx * elementNum, elementNum, (*getDtypeMap())[mType], cpIdx, comm, stream));
+                }
             }
         }
+        commLease.groupEnd("ncclGroupEnd(ulysses generation postprocess)");
+        commLease.track(watchdogToken, stream);
     }
-    ncclGroupEnd();
 #endif // ENABLE_MULTI_DEVICE
 
     // do transpose_1_reverse
@@ -3261,11 +3290,13 @@ int AttentionOp::initialize() noexcept
     }
 
 #if ENABLE_MULTI_DEVICE
-    if (mCpSize > 1 && COMM_SESSION.getSize() > 1)
+    if (mCpSize > 1)
     {
-        TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, COMM_SESSION.getRank());
+        TLLM_CHECK_WITH_INFO(mCpGroup.size() == static_cast<std::size_t>(mCpSize),
+            "Context-parallel group size %zu does not match configured CP size %d", mCpGroup.size(), mCpSize);
+        TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
         mCpNcclComm = getComm(mCpGroup);
-        TLLM_LOG_TRACE("%s stop for rank %d", __PRETTY_FUNCTION__, COMM_SESSION.getRank());
+        TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
     }
 #endif // ENABLE_MULTI_DEVICE
     return 0;

--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -21,8 +21,13 @@
 #include "tensorrt_llm/common/assert.h"
 #include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/common/opUtils.h"
+#include "tensorrt_llm/runtime/utils/ncclHostApi.h"
+#include <chrono>
+#include <cstdlib>
 #include <limits>
 #include <stdexcept>
+#include <thread>
 
 namespace
 {
@@ -70,6 +75,7 @@ struct NcclMemGuard
     {
         if (ptr)
         {
+            auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
             TLLM_NCCL_CHECK_WARN(ncclMemFree(ptr));
         }
     }
@@ -87,7 +93,9 @@ struct NcclMemGuard
 
 } // namespace
 
-namespace tensorrt_llm::common::nccl_util
+TRTLLM_NAMESPACE_BEGIN
+
+namespace common::nccl_util
 {
 
 namespace
@@ -97,6 +105,62 @@ namespace
 constexpr int kNcclWindowMinRuntimeVersion = NCCL_VERSION(2, 28, 0);
 constexpr int kNcclGb10WindowFixedVersion = NCCL_VERSION(2, 30, 4);
 constexpr int kGb10RealSmVersion = 121;
+constexpr auto kRawNcclPollInterval = std::chrono::milliseconds{1};
+
+struct RawNcclCallCompletion
+{
+    ncclResult_t result;
+    bool completed;
+};
+
+std::chrono::milliseconds getRawNcclCallTimeout()
+{
+    constexpr int64_t defaultTimeoutMs = 5000;
+    auto const* value = std::getenv("TRTLLM_NCCL_NONBLOCKING_TIMEOUT_MS");
+    if (value != nullptr)
+    {
+        try
+        {
+            auto const parsed = std::stoll(value);
+            if (parsed > 0)
+            {
+                return std::chrono::milliseconds{parsed};
+            }
+        }
+        catch (...)
+        {
+        }
+    }
+    return std::chrono::milliseconds{defaultTimeoutMs};
+}
+
+// The caller must hold the process-wide NCCL host-API gate from the initial
+// call through this poll. NCCL permits only ncclCommGetAsyncError after a
+// nonblocking API returns ncclInProgress.
+RawNcclCallCompletion completeRawNcclCall(
+    ncclComm_t comm, ncclResult_t initialResult, std::chrono::steady_clock::time_point deadline) noexcept
+{
+    if (initialResult != ncclInProgress)
+    {
+        return {initialResult, true};
+    }
+
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        ncclResult_t asyncResult = ncclInProgress;
+        auto const queryResult = ncclCommGetAsyncError(comm, &asyncResult);
+        if (queryResult == ncclSuccess && asyncResult != ncclInProgress)
+        {
+            return {asyncResult, true};
+        }
+        if (queryResult != ncclSuccess && queryResult != ncclInProgress)
+        {
+            return {queryResult, true};
+        }
+        std::this_thread::sleep_for(kRawNcclPollInterval);
+    }
+    return {ncclInProgress, false};
+}
 
 bool isGb10Platform(int realSmVersion, bool isIntegrated)
 {
@@ -107,6 +171,7 @@ bool isGb10Platform(int realSmVersion, bool isIntegrated)
 bool queryNcclWindowSupported()
 {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+    auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
     int version = 0;
     if (ncclGetVersion(&version) != ncclSuccess)
     {
@@ -211,8 +276,11 @@ bool isNcclWindowSupported()
 
 NcclCommResourceManager& NcclCommResourceManager::getInstance() noexcept
 {
-    static NcclCommResourceManager instance;
-    return instance;
+    // Communicator registries and watchdogs are process-lifetime. Keep their
+    // resource owner alive until process exit instead of relying on undefined
+    // cross-translation-unit singleton destruction order.
+    static auto* instance = new NcclCommResourceManager;
+    return *instance;
 }
 
 NcclCommResourceManager::~NcclCommResourceManager()
@@ -271,18 +339,44 @@ void NcclCommResourceManager::registerResource(ncclComm_t comm, ResourceCleanupF
         debugName ? debugName : "unnamed", static_cast<void*>(comm), resources.size());
 }
 
-void NcclCommResourceManager::cleanupResources(ncclComm_t comm) noexcept
+void NcclCommResourceManager::beginAbortCleanup(ncclComm_t comm) noexcept
+{
+    if (comm == nullptr)
+    {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(mMutex);
+    mAbortCleanups.insert(comm);
+}
+
+void NcclCommResourceManager::waitForAbortCleanup(ncclComm_t comm) noexcept
+{
+    if (comm == nullptr)
+    {
+        return;
+    }
+    std::unique_lock<std::mutex> lock(mMutex);
+    mAbortCleanupComplete.wait(lock, [this, comm]() { return mAbortCleanups.find(comm) == mAbortCleanups.end(); });
+}
+
+bool NcclCommResourceManager::cleanupResources(ncclComm_t comm, bool communicatorAborted) noexcept
 {
     if (!comm)
     {
-        return;
+        return true;
     }
 
     // Check if we're in the process of being destroyed
     // If so, skip cleanup - the destructor will handle it proactively
     if (mIsDestroying.load(std::memory_order_acquire))
     {
-        return;
+        if (communicatorAborted)
+        {
+            std::lock_guard<std::mutex> lock(mMutex);
+            mAbortCleanups.erase(comm);
+            mAbortCleanupComplete.notify_all();
+        }
+        return false;
     }
 
     std::vector<ResourceEntry> resourcesToClean;
@@ -297,20 +391,42 @@ void NcclCommResourceManager::cleanupResources(ncclComm_t comm) noexcept
             // Double-check after acquiring lock (destruction may have started)
             if (mIsDestroying.load(std::memory_order_acquire))
             {
-                return;
+                if (communicatorAborted)
+                {
+                    mAbortCleanups.erase(comm);
+                    mAbortCleanupComplete.notify_all();
+                }
+                return false;
+            }
+
+            if (communicatorAborted)
+            {
+                mAbortCleanups.insert(comm);
+            }
+            if (mCleanupsInProgress.find(comm) != mCleanupsInProgress.end())
+            {
+                // Another thread already owns the callbacks. Its completion
+                // path rechecks the retirement marker, including one that was
+                // installed after that owner started, before waking handle
+                // reusers.
+                return true;
             }
 
             auto it = mCommResources.find(comm);
             if (it == mCommResources.end())
             {
                 // Nothing registered for this comm, nothing to clean up
-                return;
+                if (mAbortCleanups.erase(comm) != 0)
+                {
+                    mAbortCleanupComplete.notify_all();
+                }
+                return true;
             }
 
             // Move resources out (preserves order) and remove from map
             resourcesToClean = std::move(it->second);
             mCommResources.erase(it);
-
+            mCleanupsInProgress.insert(comm);
             // Logging may fail during static destruction, so wrap in try-catch
             try
             {
@@ -326,12 +442,13 @@ void NcclCommResourceManager::cleanupResources(ncclComm_t comm) noexcept
         {
             // If mutex access fails during static destruction, just return.
             // This prevents segfaults when the singleton is being destroyed.
-            return;
+            return false;
         }
     }
 
     // Clean up outside the lock to avoid deadlocks if cleanup functions try to access the manager
     // Order is preserved: resources are cleaned up in registration order
+    bool cleanupSucceeded = true;
     for (auto& [cleanup, name] : resourcesToClean)
     {
         try
@@ -346,10 +463,11 @@ void NcclCommResourceManager::cleanupResources(ncclComm_t comm) noexcept
             {
                 // Ignore logging failures during static destruction
             }
-            cleanup();
+            cleanupSucceeded = cleanup() && cleanupSucceeded;
         }
         catch (std::exception const& e)
         {
+            cleanupSucceeded = false;
             try
             {
                 TLLM_LOG_ERROR("[NCCLUtil] Exception during cleanup of resource '%s' for NCCL comm %p: %s",
@@ -362,6 +480,7 @@ void NcclCommResourceManager::cleanupResources(ncclComm_t comm) noexcept
         }
         catch (...)
         {
+            cleanupSucceeded = false;
             try
             {
                 TLLM_LOG_ERROR("[NCCLUtil] Unknown exception during cleanup of resource '%s' for NCCL comm %p",
@@ -373,6 +492,22 @@ void NcclCommResourceManager::cleanupResources(ncclComm_t comm) noexcept
             }
         }
     }
+
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        mCleanupsInProgress.erase(comm);
+        if (mAbortCleanups.erase(comm) != 0)
+        {
+            mAbortCleanupComplete.notify_all();
+        }
+    }
+    return cleanupSucceeded;
+}
+
+bool NcclCommResourceManager::isAbortCleanup(ncclComm_t comm) const noexcept
+{
+    std::lock_guard<std::mutex> lock(mMutex);
+    return mAbortCleanups.find(comm) != mAbortCleanups.end();
 }
 
 bool NcclCommResourceManager::hasResources(ncclComm_t comm) const noexcept
@@ -396,93 +531,171 @@ size_t NcclCommResourceManager::getResourceCount(ncclComm_t comm) const noexcept
 
 NCCLWindowAllocator& NCCLWindowAllocator::getInstance()
 {
-    static NCCLWindowAllocator instance;
-    return instance;
+    static auto* instance = new NCCLWindowAllocator;
+    return *instance;
 }
 
 NCCLWindowBuffer NCCLWindowAllocator::requestBuffer(ncclComm_t comm, size_t size)
+{
+    return requestBufferImpl(comm, size, nullptr, nullptr);
+}
+
+NCCLWindowBuffer NCCLWindowAllocator::requestBuffer(
+    std::shared_ptr<ncclComm_t> const& comm, size_t size, ncclComm_t* associatedComm)
+{
+    TLLM_CHECK_WITH_INFO(comm != nullptr, "NCCL communicator cannot be null");
+    if (associatedComm != nullptr)
+    {
+        *associatedComm = nullptr;
+    }
+    return requestBufferImpl(nullptr, size, &comm, associatedComm);
+}
+
+NCCLWindowBuffer NCCLWindowAllocator::requestBufferImpl(
+    ncclComm_t comm, size_t size, std::shared_ptr<ncclComm_t> const* managedComm, ncclComm_t* associatedComm)
 {
     if (!isNcclWindowSupported())
     {
         return NCCLWindowBuffer();
     }
 
-    TLLM_CHECK_WITH_INFO(comm != nullptr, "NCCL communicator cannot be null");
     TLLM_CHECK_WITH_INFO(size > 0, "Buffer size must be greater than 0");
 
-    std::lock_guard<std::mutex> lock(mMutex);
-
-    // Register cleanup callback for this communicator if not already registered
-    // This is cheap even if no buffers exist yet - cleanup will just return early
-    registerBufferCleanup(comm);
-
-    // Check if we have an available buffer of at least the requested size for this communicator
-    // Use best-fit: find the smallest buffer that's >= requested size
-    auto& commBuffers = mBufferPool[comm];
-    auto bestFit = commBuffers.end();
-    size_t bestFitSize = std::numeric_limits<size_t>::max();
-
-    for (auto it = commBuffers.begin(); it != commBuffers.end(); ++it)
+    bool const managedFaultTolerance = managedComm != nullptr && isNcclFaultToleranceEnabled();
+    if (managedComm == nullptr)
     {
-        if (!it->inUse && it->buffer.size >= size && it->buffer.size < bestFitSize)
+        TLLM_CHECK_WITH_INFO(comm != nullptr, "NCCL communicator cannot be null");
+        NcclCommResourceManager::getInstance().waitForAbortCleanup(comm);
+    }
+    // Pool hits need only mMutex. On a miss, release all communicator/pool
+    // locks, serialize allocation attempts, then recheck: another thread may
+    // have populated the pool while this thread waited. This preserves
+    // collective ordering without adding a second lock to the steady-state
+    // pooled-buffer path or inverting the host-gate -> pool-lock cleanup order.
+    std::unique_lock<std::mutex> allocationLock(mAllocationMutex, std::defer_lock);
+    int handle = 0;
+    while (true)
+    {
+        std::unique_ptr<NcclCommLease> validationLease;
+        if (managedComm != nullptr)
         {
-            bestFit = it;
-            bestFitSize = it->buffer.size;
+            if (managedFaultTolerance)
+            {
+                // Keep lock ordering consistent with abort cleanup:
+                // communicator state / NCCL host gate precede the pool mutex.
+                validationLease = std::make_unique<NcclCommLease>(acquireComm(*managedComm));
+                comm = validationLease->get();
+            }
+            else
+            {
+                TLLM_CHECK_WITH_INFO(*managedComm != nullptr, "NCCL communicator cannot be null");
+                comm = **managedComm;
+            }
         }
-    }
+        TLLM_CHECK_WITH_INFO(comm != nullptr, "NCCL communicator cannot be null");
+        if (associatedComm != nullptr)
+        {
+            *associatedComm = comm;
+        }
+        std::unique_lock<std::mutex> poolLock(mMutex);
 
-    if (bestFit != commBuffers.end())
-    {
-        bestFit->inUse = true;
+        // Register cleanup callback for this communicator if not already registered.
+        registerBufferCleanup(comm);
+        // Keep validationLease until poolLock releases. Lease destruction can
+        // drain abort cleanup, which re-enters this non-recursive pool mutex.
+
+        auto& commBuffers = mBufferPool[comm];
+        auto bestFit = commBuffers.end();
+        size_t bestFitSize = std::numeric_limits<size_t>::max();
+
+        for (auto it = commBuffers.begin(); it != commBuffers.end(); ++it)
+        {
+            if (!it->inUse && it->buffer.size >= size && it->buffer.size < bestFitSize)
+            {
+                bestFit = it;
+                bestFitSize = it->buffer.size;
+            }
+        }
+
+        if (bestFit != commBuffers.end())
+        {
+            bestFit->inUse = true;
+            TLLM_LOG_TRACE(
+                "[NCCLUtil] Reusing NCCL window buffer for comm %p: handle=%d, ptr=%p, size=%zu (requested: %zu)",
+                static_cast<void*>(comm), bestFit->buffer.handle, bestFit->buffer.ptr, bestFit->buffer.size, size);
+            return bestFit->buffer;
+        }
+
+        auto const failureIt = mMinSymmetricFailureSize.find(comm);
+        if (failureIt != mMinSymmetricFailureSize.end() && size >= failureIt->second)
+        {
+            TLLM_LOG_DEBUG(
+                "[NCCLUtil] Skipping NCCL window allocation for comm %p, size=%zu; known failure threshold=%zu",
+                static_cast<void*>(comm), size, failureIt->second);
+            return NCCLWindowBuffer();
+        }
+
+        auto stream = at::cuda::getCurrentCUDAStream();
+        cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+        auto const captureResult = cudaStreamIsCapturing(stream, &captureStatus);
+        if (captureResult != cudaSuccess)
+        {
+            TLLM_LOG_DEBUG("[NCCLUtil] cudaStreamIsCapturing failed: %s", cudaGetErrorString(captureResult));
+        }
+        if (captureResult == cudaSuccess && captureStatus != cudaStreamCaptureStatusNone)
+        {
+            TLLM_LOG_DEBUG("[NCCLUtil] Skipping NCCL window allocation during capture for comm %p (requested: %zu)",
+                static_cast<void*>(comm), size);
+            return NCCLWindowBuffer();
+        }
+
+        if (!allocationLock.owns_lock())
+        {
+            poolLock.unlock();
+            validationLease.reset();
+            allocationLock.lock();
+            continue;
+        }
+
         TLLM_LOG_TRACE(
-            "[NCCLUtil] Reusing NCCL window buffer for comm %p: handle=%d, ptr=%p, size=%zu (requested: %zu)",
-            static_cast<void*>(comm), bestFit->buffer.handle, bestFit->buffer.ptr, bestFit->buffer.size, size);
-        return bestFit->buffer;
+            "[NCCLUtil] Allocating new NCCL window buffer for comm %p, size=%zu", static_cast<void*>(comm), size);
+        handle = static_cast<int>(commBuffers.size());
+        poolLock.unlock();
+        validationLease.reset();
+        break;
     }
 
-    // If a previous allocateAndRegisterBuffer call collectively failed for this comm at a size
-    // no larger than this request, do not retry the known-failing new allocation path. Smaller
-    // requests and already-pooled buffers can still use NCCL windows.
-    auto const failureIt = mMinSymmetricFailureSize.find(comm);
-    if (failureIt != mMinSymmetricFailureSize.end() && size >= failureIt->second)
-    {
-        TLLM_LOG_DEBUG("[NCCLUtil] Skipping NCCL window allocation for comm %p, size=%zu; known failure threshold=%zu",
-            static_cast<void*>(comm), size, failureIt->second);
-        return NCCLWindowBuffer();
-    }
-
-    // No available buffer found, avoid registration during CUDA graph capture
-    auto stream = at::cuda::getCurrentCUDAStream();
-    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
-    auto capture_err = cudaStreamIsCapturing(stream, &capture_status);
-    if (capture_err != cudaSuccess)
-    {
-        TLLM_LOG_DEBUG("[NCCLUtil] cudaStreamIsCapturing failed: %s", cudaGetErrorString(capture_err));
-    }
-    if (capture_err == cudaSuccess && capture_status != cudaStreamCaptureStatusNone)
-    {
-        TLLM_LOG_DEBUG("[NCCLUtil] Skipping NCCL window allocation during capture for comm %p (requested: %zu)",
-            static_cast<void*>(comm), size);
-        return NCCLWindowBuffer();
-    }
-
-    // No available buffer found, allocate a new one
-    TLLM_LOG_TRACE(
-        "[NCCLUtil] Allocating new NCCL window buffer for comm %p, size=%zu", static_cast<void*>(comm), size);
-    int handle = static_cast<int>(commBuffers.size());
-    NCCLWindowBuffer buffer = allocateAndRegisterBuffer(comm, size, handle);
+    // CUDA allocation must not hold the communicator mutex or process-wide
+    // NCCL gate: a watchdog needs both in order to abort stalled work.
+    std::unique_ptr<NcclCommLease> completionLease;
+    NCCLWindowBuffer buffer = allocateAndRegisterBuffer(comm, size, handle, managedComm, &completionLease);
     // Only cache valid buffers. allocateAndRegisterBuffer returns an empty buffer when any rank
     // failed ncclMemAlloc (collective fallback to plain allreduce); caching it would leak a
     // permanently "in use" empty entry per request because releaseBuffer is a no-op for nullptr.
     if (buffer.isValid())
     {
-        commBuffers.push_back({buffer, true});
+        // The managed registration lease remains live until the buffer is in
+        // the pool. That closes the gap where the watchdog could abort and run
+        // cleanup after registration but before the resource became visible.
+        {
+            std::lock_guard<std::mutex> poolLock(mMutex);
+            mBufferPool[comm].push_back({buffer, true});
+        }
+        completionLease.reset();
     }
     else
     {
+        std::unique_ptr<NcclCommLease> healthyLease;
+        if (managedFaultTolerance)
+        {
+            healthyLease = std::make_unique<NcclCommLease>(acquireComm(*managedComm));
+            TLLM_CHECK_WITH_INFO(
+                healthyLease->get() == comm, "NCCL communicator changed while recording a window-allocation fallback");
+        }
         // The collective allreduce inside allocateAndRegisterBuffer agreed that this request
         // cannot use symmetric memory on at least one rank. Remember the smallest failing
         // request size so repeated too-large autotuner probes do not keep stressing this path.
+        std::lock_guard<std::mutex> poolLock(mMutex);
         recordSymmetricFailureLocked(comm, size);
     }
 
@@ -607,7 +820,8 @@ bool NCCLWindowAllocator::isCommValid(ncclComm_t comm) const noexcept
     return comm != nullptr;
 }
 
-NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm, size_t size, int handle)
+NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm, size_t size, int handle,
+    std::shared_ptr<ncclComm_t> const* managedComm, std::unique_ptr<NcclCommLease>* completionLease)
 {
     // Step 1: Pre-allocate the rank-sync flag before ncclMemAlloc. ncclMemAlloc can fail
     // asymmetrically with ncclUnhandledCudaError on configurations where the symmetric/VMM path
@@ -626,7 +840,10 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
     // the stream-ordered flag copy and collective fallback so the failing rank still reaches
     // ncclAllReduce with the other ranks.
     void* ncclPtr = nullptr;
-    TLLM_NCCL_CHECK_WARN(ncclMemAlloc(&ncclPtr, size));
+    {
+        auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+        TLLM_NCCL_CHECK_WARN(ncclMemAlloc(&ncclPtr, size));
+    }
     int const localAllocOk = (ncclPtr != nullptr) ? 1 : 0;
     NcclMemGuard ncclGuard{ncclPtr}; // frees ncclPtr on any early return or exception
     clearCudaErrorIfSymmetricAllocationFailed(localAllocOk);
@@ -640,8 +857,66 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
         TLLM_CUDA_CHECK_WARN(
             cudaMemcpyAsync(rankSyncFlag, &localAllocOk, sizeof(localAllocOk), cudaMemcpyHostToDevice, stream));
     }
-    TLLM_NCCL_CHECK(ncclAllReduce(rankSyncFlag, rankSyncFlag, 1, ncclInt32, ncclMin, comm, stream));
-    TLLM_CUDA_CHECK_WARN(cudaStreamSynchronize(stream));
+    if (managedComm != nullptr)
+    {
+        try
+        {
+            std::uint64_t watchdogToken = 0;
+            {
+                auto commLease = acquireComm(*managedComm);
+                auto const currentComm = commLease.get();
+                TLLM_CHECK_WITH_INFO(currentComm == comm,
+                    "NCCL communicator changed while allocating a window buffer; retry with the active communicator");
+                watchdogToken = commLease.begin(stream, "NCCL window allocation agreement");
+                auto const allocAgreementResult
+                    = ncclAllReduce(rankSyncFlag, rankSyncFlag, 1, ncclInt32, ncclMin, currentComm, stream);
+                commLease.check(allocAgreementResult, "ncclAllReduce(window allocation agreement)");
+                commLease.track(watchdogToken, stream);
+            }
+            if (isNcclFaultToleranceEnabled())
+            {
+                waitCommOperation(*managedComm, watchdogToken, "NCCL window allocation agreement");
+            }
+            else
+            {
+                TLLM_CUDA_CHECK_WARN(cudaStreamSynchronize(stream));
+            }
+        }
+        catch (...)
+        {
+            // A failed NCCL kernel may still hold the temporary flag even
+            // after communicator abort. Quarantine four bytes instead of
+            // letting cudaFree introduce a device-wide wait on recovery.
+            static_cast<void>(flagGuard.release());
+            throw;
+        }
+    }
+    else
+    {
+        RawNcclCallCompletion completion{ncclSuccess, true};
+        {
+            auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+            auto const allocAgreementResult
+                = ncclAllReduce(rankSyncFlag, rankSyncFlag, 1, ncclInt32, ncclMin, comm, stream);
+            completion = completeRawNcclCall(
+                comm, allocAgreementResult, std::chrono::steady_clock::now() + getRawNcclCallTimeout());
+        }
+        if (!completion.completed)
+        {
+            // The background enqueue may still acquire the flag after the
+            // local deadline. Keep its storage alive rather than racing it.
+            static_cast<void>(flagGuard.release());
+            TLLM_THROW("NCCL error: window allocation agreement timed out while the communicator was in progress");
+        }
+        if (completion.result != ncclSuccess)
+        {
+            // NCCL documents device work as indeterminate after an async
+            // communicator error. Quarantine the flag before surfacing it.
+            static_cast<void>(flagGuard.release());
+            TLLM_NCCL_CHECK(completion.result);
+        }
+        TLLM_CUDA_CHECK_WARN(cudaStreamSynchronize(stream));
+    }
 
     int allAllocOk = 0;
     TLLM_CUDA_CHECK(cudaMemcpy(&allAllocOk, rankSyncFlag, sizeof(int), cudaMemcpyDeviceToHost));
@@ -663,10 +938,60 @@ NCCLWindowBuffer NCCLWindowAllocator::allocateAndRegisterBuffer(ncclComm_t comm,
     // Failure here is non-fatal: warn and fall back to regular allreduce.
     // ncclGuard frees ncclPtr on return.
     ncclWindow_t window = nullptr;
-    ncclResult_t const regResult = ncclCommWindowRegister(comm, ncclPtr, size, &window, NCCL_WIN_COLL_SYMMETRIC);
-    TLLM_NCCL_CHECK_WARN(regResult);
+    ncclResult_t regResult = ncclSuccess;
+    if (managedComm != nullptr)
+    {
+        auto commLease = acquireComm(*managedComm);
+        auto const currentComm = commLease.get();
+        TLLM_CHECK_WITH_INFO(currentComm == comm,
+            "NCCL communicator changed while registering a window buffer; retry with the active communicator");
+        regResult = ncclCommWindowRegister(currentComm, ncclPtr, size, &window, NCCL_WIN_COLL_SYMMETRIC);
+        try
+        {
+            regResult = commLease.checkOptional(regResult, "ncclCommWindowRegister");
+        }
+        catch (...)
+        {
+            // Registration may still reference the allocation after an
+            // asynchronous communicator failure. Quarantine it instead
+            // of calling ncclMemFree on the recovery path.
+            static_cast<void>(ncclGuard.release());
+            throw;
+        }
+        if (regResult == ncclSuccess && completionLease != nullptr && isNcclFaultToleranceEnabled())
+        {
+            *completionLease = std::make_unique<NcclCommLease>(std::move(commLease));
+        }
+    }
+    else
+    {
+        ncclResult_t initialResult = ncclSuccess;
+        RawNcclCallCompletion completion{ncclSuccess, true};
+        auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+        initialResult = ncclCommWindowRegister(comm, ncclPtr, size, &window, NCCL_WIN_COLL_SYMMETRIC);
+        completion
+            = completeRawNcclCall(comm, initialResult, std::chrono::steady_clock::now() + getRawNcclCallTimeout());
+        if (!completion.completed)
+        {
+            // Registration can still complete in the background and retain
+            // ncclPtr. The unmanaged caller owns communicator recovery, so
+            // quarantine the allocation locally and surface the timeout.
+            static_cast<void>(ncclGuard.release());
+            TLLM_THROW("NCCL error: window registration timed out while the communicator was in progress");
+        }
+        regResult = completion.result;
+        if (initialResult == ncclInProgress && regResult != ncclSuccess)
+        {
+            // Once an asynchronous registration fails, NCCL does not promise
+            // that the allocation is no longer referenced.
+            static_cast<void>(ncclGuard.release());
+            TLLM_THROW("NCCL error: window registration failed asynchronously: %s", ncclGetErrorString(regResult));
+        }
+    }
     if (regResult != ncclSuccess)
     {
+        TLLM_LOG_WARNING("NCCL window registration failed for comm %p; falling back to regular allreduce: %s",
+            static_cast<void*>(comm), ncclGetErrorString(regResult));
         return NCCLWindowBuffer{};
     }
 
@@ -709,24 +1034,38 @@ void NCCLWindowAllocator::registerBufferCleanup(ncclComm_t comm)
 
     // Register cleanup with the resource manager
     NcclCommResourceManager::getInstance().registerResource(
-        comm, [this, comm]() { this->cleanupBuffersForComm(comm); }, "NCCLWindowAllocator");
+        comm, [this, comm]() { return this->cleanupBuffersForComm(comm); }, "NCCLWindowAllocator");
 }
 
-void NCCLWindowAllocator::cleanupBuffersForComm(ncclComm_t comm) noexcept
+bool NCCLWindowAllocator::cleanupBuffersForComm(ncclComm_t comm) noexcept
 {
     if (!comm)
     {
-        return;
+        return true;
     }
 
-    // Synchronize CUDA to ensure all operations using these buffers are complete
-    // before we deregister windows and free memory
-    cudaError_t cudaErr = cudaDeviceSynchronize();
-    if (cudaErr != cudaSuccess)
+    bool const communicatorAborted = NcclCommResourceManager::getInstance().isAbortCleanup(comm);
+    bool cudaSynchronized = true;
+
+    // Never hold the process-wide NCCL host gate across a CUDA synchronization:
+    // work from another failed communicator may be what the synchronization is
+    // waiting for, and that communicator's watchdog needs the gate to abort it.
+    tensorrt_llm::runtime::NcclHostApiLock hostApiLock;
+    if (!communicatorAborted)
     {
-        TLLM_LOG_WARNING("[NCCLUtil] cudaDeviceSynchronize failed with error: %d before cleanup for comm %p", cudaErr,
-            static_cast<void*>(comm));
-        // Continue anyway - the sync failure might be from a previous error
+        cudaError_t cudaErr = cudaDeviceSynchronize();
+        if (cudaErr != cudaSuccess)
+        {
+            cudaSynchronized = false;
+            TLLM_LOG_WARNING("[NCCLUtil] cudaDeviceSynchronize failed with error: %d before cleanup for comm %p",
+                cudaErr, static_cast<void*>(comm));
+        }
+        if (cudaSynchronized)
+        {
+            // Healthy cleanup uses NCCL deregistration/free below. Acquire the gate
+            // before mMutex to preserve the communicator -> allocator lock order.
+            hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+        }
     }
 
     std::lock_guard<std::mutex> lock(mMutex);
@@ -735,7 +1074,7 @@ void NCCLWindowAllocator::cleanupBuffersForComm(ncclComm_t comm) noexcept
     if (mRegisteredComms.find(comm) == mRegisteredComms.end())
     {
         // Already cleaned up or never registered
-        return;
+        return true;
     }
 
     auto commIt = mBufferPool.find(comm);
@@ -744,7 +1083,7 @@ void NCCLWindowAllocator::cleanupBuffersForComm(ncclComm_t comm) noexcept
         // No buffers to clean up, but mark as cleaned
         mRegisteredComms.erase(comm);
         mMinSymmetricFailureSize.erase(comm);
-        return;
+        return true;
     }
 
     TLLM_LOG_TRACE(
@@ -772,25 +1111,50 @@ void NCCLWindowAllocator::cleanupBuffersForComm(ncclComm_t comm) noexcept
     TLLM_LOG_DEBUG("[NCCLUtil] NCCL window allocator teardown for comm %p: %zu buffers, %zu bytes total",
         static_cast<void*>(comm), commIt->second.size(), totalBytes);
 
+    if (communicatorAborted || !cudaSynchronized)
+    {
+        // Tensor storages or non-NCCL CUDA work may still reference these
+        // allocations. There is no safe stream fence once the communicator
+        // has failed, so quarantine them for the remaining process lifetime
+        // instead of risking a UAF or another blocking CUDA call. Rank failure
+        // is rare and process restart ultimately reclaims the memory.
+        TLLM_LOG_WARNING("[NCCLUtil] Quarantining %zu NCCL window buffers (%zu bytes) after %s", commIt->second.size(),
+            totalBytes, communicatorAborted ? "communicator abort" : "failed CUDA synchronization");
+        mBufferPool.erase(commIt);
+        mRegisteredComms.erase(comm);
+        mMinSymmetricFailureSize.erase(comm);
+        return communicatorAborted;
+    }
+
+    bool quarantineRemainingBuffers = false;
     for (auto& entry : commIt->second)
     {
         if (entry.buffer.isValid())
         {
+            if (quarantineRemainingBuffers)
+            {
+                continue;
+            }
             // Deregister the window - the communicator is still valid at this point
             // (cleanup happens before ncclCommDestroy), but we need to be careful
             // if buffers are still in use by active operations
-            if (entry.buffer.window && comm)
+            if (entry.buffer.window && comm && !communicatorAborted)
             {
                 // Note: Even if buffer is marked inUse, we must deregister since
                 // the communicator is being destroyed. The communicator is valid,
                 // but we should handle potential errors gracefully.
-                ncclResult_t result = ncclCommWindowDeregister(comm, entry.buffer.window);
-                if (result != ncclSuccess)
+                auto const initialResult = ncclCommWindowDeregister(comm, entry.buffer.window);
+                auto const completion = completeRawNcclCall(
+                    comm, initialResult, std::chrono::steady_clock::now() + getRawNcclCallTimeout());
+                if (!completion.completed || completion.result != ncclSuccess)
                 {
                     TLLM_LOG_WARNING(
-                        "[NCCLUtil] ncclCommWindowDeregister failed with error: %d for comm %p, "
-                        "window %p (buffer inUse: %d)",
-                        result, static_cast<void*>(comm), static_cast<void*>(entry.buffer.window), entry.inUse);
+                        "[NCCLUtil] ncclCommWindowDeregister %s for comm %p, window %p "
+                        "(result: %s, buffer inUse: %d); quarantining this and remaining buffers",
+                        completion.completed ? "failed" : "timed out", static_cast<void*>(comm),
+                        static_cast<void*>(entry.buffer.window), ncclGetErrorString(completion.result), entry.inUse);
+                    quarantineRemainingBuffers = true;
+                    continue;
                 }
             }
 
@@ -820,10 +1184,13 @@ void NCCLWindowAllocator::cleanupBuffersForComm(ncclComm_t comm) noexcept
     mBufferPool.erase(commIt);
     mRegisteredComms.erase(comm);
     mMinSymmetricFailureSize.erase(comm);
+    return !quarantineRemainingBuffers;
 }
 
 #endif // NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
 
-} // namespace tensorrt_llm::common::nccl_util
+} // namespace common::nccl_util
+
+TRTLLM_NAMESPACE_END
 
 #endif // ENABLE_MULTI_DEVICE

--- a/cpp/tensorrt_llm/common/ncclUtils.h
+++ b/cpp/tensorrt_llm/common/ncclUtils.h
@@ -30,11 +30,13 @@
 
 #include <algorithm>
 #include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <mutex>
 #include <numeric>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -61,6 +63,10 @@
 
 TRTLLM_NAMESPACE_BEGIN
 
+class NcclCommLease;
+bool isNcclFaultToleranceEnabled();
+std::optional<std::string> getCommAsyncError(std::shared_ptr<ncclComm_t> const& comm);
+
 namespace common::nccl_util
 {
 
@@ -68,8 +74,10 @@ namespace common::nccl_util
 // NCCL Resource Management
 //==============================================================================
 
-// Resource cleanup function type. Called before the NCCL communicator is destroyed.
-using ResourceCleanupFunc = std::function<void()>;
+// Resource cleanup function type. Called before the NCCL communicator is
+// destroyed. False tells the owner that graceful communicator destruction is
+// unsafe and it must take the abort/quarantine path instead.
+using ResourceCleanupFunc = std::function<bool()>;
 
 // Manages resources associated with NCCL communicators. Thread-safe singleton that maintains
 // a pool of resources per NCCL comm. Resources are automatically cleaned up when the
@@ -88,7 +96,18 @@ public:
     // the shared_ptr deleter before ncclCommDestroy.
     // Thread-safe: Uses global mutex to serialize cleanup operations.
     // Order-preserving: Resources are cleaned up in registration order.
-    void cleanupResources(ncclComm_t comm) noexcept;
+    [[nodiscard]] bool cleanupResources(ncclComm_t comm, bool communicatorAborted = false) noexcept;
+
+    // Mark a successfully-aborted native handle as retired before releasing
+    // the NCCL host gate. A later communicator whose native pointer is reused
+    // waits for the old pointer-keyed cleanup before it can be published.
+    void beginAbortCleanup(ncclComm_t comm) noexcept;
+    void waitForAbortCleanup(ncclComm_t comm) noexcept;
+
+    // True only while abort-specific callbacks for comm are running. Resource
+    // owners use this to skip operations that require a live communicator or
+    // a device-wide synchronization (both can hang on a failed communicator).
+    bool isAbortCleanup(ncclComm_t comm) const noexcept;
 
     // Check if a communicator has registered resources.
     bool hasResources(ncclComm_t comm) const noexcept;
@@ -108,7 +127,13 @@ private:
     using ResourceEntry = std::pair<ResourceCleanupFunc, std::string>;
 
     mutable std::mutex mMutex;
+    std::condition_variable mAbortCleanupComplete;
     std::unordered_map<ncclComm_t, std::vector<ResourceEntry>> mCommResources;
+    std::unordered_set<ncclComm_t> mAbortCleanups;
+    // Track every callback owner, not just callers explicitly marked as
+    // aborted. A normal cleanup may already own the callbacks when another
+    // thread retires the same native handle.
+    std::unordered_set<ncclComm_t> mCleanupsInProgress;
     std::atomic<bool> mIsDestroying{false};
 };
 
@@ -134,6 +159,7 @@ public:
                 {
                     mCleanup(mResource);
                 }
+                return true;
             },
             debugName);
     }
@@ -223,7 +249,17 @@ public:
     // If an unused buffer of at least the requested size exists for this communicator, it will be reused.
     // Uses best-fit strategy: selects the smallest available buffer that meets the size requirement.
     // Otherwise, a new buffer is allocated and registered.
+    // Caller-owned/raw communicator overload. It supports a nonblocking call
+    // result by bounded polling, but it cannot coordinate with the TRT-LLM
+    // registry's abort/replacement lock. Registry-managed communicators must
+    // use the shared_ptr overload below.
     NCCLWindowBuffer requestBuffer(ncclComm_t comm, size_t size);
+
+    // Managed-communicator overload. CUDA allocation and tensor construction
+    // happen without an operation lease; the allocator acquires short leases
+    // only around NCCL calls so a watchdog can abort stalled work.
+    NCCLWindowBuffer requestBuffer(
+        std::shared_ptr<ncclComm_t> const& comm, size_t size, ncclComm_t* associatedComm = nullptr);
 
     // Search for a buffer by pointer. Returns an invalid buffer if not found.
     // This matches the UBManager.search_buffer() interface.
@@ -264,7 +300,10 @@ private:
     ~NCCLWindowAllocator() = default;
 
     // Allocate a new buffer and register it with NCCL as a window
-    NCCLWindowBuffer allocateAndRegisterBuffer(ncclComm_t comm, size_t size, int handle);
+    NCCLWindowBuffer requestBufferImpl(
+        ncclComm_t comm, size_t size, std::shared_ptr<ncclComm_t> const* managedComm, ncclComm_t* associatedComm);
+    NCCLWindowBuffer allocateAndRegisterBuffer(ncclComm_t comm, size_t size, int handle,
+        std::shared_ptr<ncclComm_t> const* managedComm, std::unique_ptr<NcclCommLease>* completionLease);
 
     // Record a failed new symmetric allocation (assumes mMutex is already locked).
     void recordSymmetricFailureLocked(ncclComm_t comm, size_t size);
@@ -282,7 +321,7 @@ private:
     void registerBufferCleanup(ncclComm_t comm);
 
     // Cleanup all buffers for a specific communicator
-    void cleanupBuffersForComm(ncclComm_t comm) noexcept;
+    [[nodiscard]] bool cleanupBuffersForComm(ncclComm_t comm) noexcept;
 
     struct BufferEntry
     {
@@ -291,6 +330,7 @@ private:
     };
 
     mutable std::mutex mMutex;
+    std::mutex mAllocationMutex;
     std::unordered_map<ncclComm_t, std::vector<BufferEntry>> mBufferPool;
     std::unordered_set<ncclComm_t> mRegisteredComms;
     // Smallest request size that is known to fail collectively for each communicator.
@@ -305,11 +345,12 @@ class ScopedNCCLWindowBuffer
 public:
     ScopedNCCLWindowBuffer(std::shared_ptr<ncclComm_t> comm, size_t size)
         : mComm(std::move(comm))
+        , mRawComm(nullptr)
         , mBuffer{}
     {
-        if (mComm && *mComm)
+        if (mComm)
         {
-            mBuffer = NCCLWindowAllocator::getInstance().requestBuffer(*mComm, size);
+            mBuffer = NCCLWindowAllocator::getInstance().requestBuffer(mComm, size, &mRawComm);
         }
     }
 
@@ -317,7 +358,7 @@ public:
     {
         if (mBuffer.isValid())
         {
-            NCCLWindowAllocator::getInstance().releaseBuffer(*mComm, mBuffer.ptr);
+            NCCLWindowAllocator::getInstance().releaseBuffer(mRawComm, mBuffer.ptr);
         }
     }
 
@@ -348,6 +389,7 @@ public:
 
 private:
     std::shared_ptr<ncclComm_t> mComm;
+    ncclComm_t mRawComm;
     NCCLWindowBuffer mBuffer;
 };
 
@@ -357,6 +399,7 @@ private:
 inline std::pair<torch::Tensor, NCCLWindowBuffer> createNCCLWindowTensor(
     std::shared_ptr<ncclComm_t> comm, at::IntArrayRef shape, torch::ScalarType dtype)
 {
+    ncclComm_t rawComm = nullptr;
     // Calculate buffer size
     int64_t buffer_size
         = std::accumulate(shape.begin(), shape.end(), 1LL, std::multiplies<int64_t>()) * torch::elementSize(dtype);
@@ -376,7 +419,7 @@ inline std::pair<torch::Tensor, NCCLWindowBuffer> createNCCLWindowTensor(
     auto& allocator = NCCLWindowAllocator::getInstance();
     NCCLWindowBuffer buffer;
 
-    if (!comm || !*comm)
+    if (!comm || (!isNcclFaultToleranceEnabled() && !*comm))
     {
         TLLM_LOG_DEBUG("[createNCCLWindowTensor] null comm; returning invalid buffer");
         return std::make_pair(torch::Tensor(), NCCLWindowBuffer());
@@ -384,10 +427,17 @@ inline std::pair<torch::Tensor, NCCLWindowBuffer> createNCCLWindowTensor(
 
     try
     {
-        buffer = allocator.requestBuffer(*comm, buffer_size);
+        buffer = allocator.requestBuffer(comm, buffer_size, &rawComm);
     }
     catch (std::exception const& e)
     {
+        // Local allocation failures may fall back to a regular CUDA tensor.
+        // Never hide a watchdog error: continuing would reuse an aborted
+        // communicator on the fallback collective.
+        if (isNcclFaultToleranceEnabled() && getCommAsyncError(comm).has_value())
+        {
+            throw;
+        }
         TLLM_LOG_DEBUG("[createNCCLWindowTensor] requestBuffer failed; returning invalid buffer: %s", e.what());
         return std::make_pair(torch::Tensor(), NCCLWindowBuffer());
     }
@@ -398,9 +448,16 @@ inline std::pair<torch::Tensor, NCCLWindowBuffer> createNCCLWindowTensor(
         TLLM_LOG_DEBUG("[createNCCLWindowTensor] invalid buffer returned from requestBuffer; returning invalid buffer");
         return std::make_pair(torch::Tensor(), NCCLWindowBuffer());
     }
+    TLLM_CHECK_WITH_INFO(rawComm != nullptr, "NCCL window allocator returned a buffer without its communicator");
 
     // Create custom deleter that releases the buffer
-    auto deleter = [comm, ptr = buffer.ptr](void*) { NCCLWindowAllocator::getInstance().releaseBuffer(*comm, ptr); };
+    auto deleter = [comm = std::move(comm), rawComm, ptr = buffer.ptr](void*)
+    {
+        // Keep a generic caller-owned communicator alive until its window
+        // tensor releases the buffer; rawComm remains the stable pool key.
+        static_cast<void>(comm);
+        NCCLWindowAllocator::getInstance().releaseBuffer(rawComm, ptr);
+    };
 
     // Create tensor from the buffer
     auto tensor = torch::from_blob(buffer.ptr, shape, strides_vec, deleter, torch::dtype(dtype).device(torch::kCUDA));

--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -21,15 +21,26 @@
 #include "tensorrt_llm/runtime/ipcNvlsMemory.h"
 #include "tensorrt_llm/runtime/utils/mpiTags.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
+#include "tensorrt_llm/runtime/utils/ncclHostApi.h"
+#include "tensorrt_llm/runtime/utils/ncclUniqueIdRendezvous.h"
 
 #include "cuda.h"
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
 
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
 #include <functional>
+#include <initializer_list>
+#include <iterator>
 #include <mutex>
+#include <sstream>
 #include <thread>
+#include <unordered_map>
+#include <utility>
 
 TRTLLM_NAMESPACE_BEGIN
 #if ENABLE_MULTI_DEVICE
@@ -53,16 +64,55 @@ std::unordered_map<tensorrt_llm::DataType, ncclDataType_t>* getDtypeMap()
 namespace
 {
 
-// Get NCCL unique ID for a group of ranks.
-ncclUniqueId getUniqueId(std::set<int> const& group)
+using Clock = std::chrono::steady_clock;
+
+std::chrono::milliseconds getPositiveDurationFromEnv(char const* name, int64_t defaultMs)
+{
+    auto const* value = std::getenv(name);
+    if (value == nullptr)
+    {
+        return std::chrono::milliseconds{defaultMs};
+    }
+    try
+    {
+        auto const parsed = std::stoll(value);
+        if (parsed > 0)
+        {
+            return std::chrono::milliseconds{parsed};
+        }
+    }
+    catch (...)
+    {
+    }
+    TLLM_LOG_WARNING("Ignoring invalid %s=%s; expected a positive integer in milliseconds", name, value);
+    return std::chrono::milliseconds{defaultMs};
+}
+
+std::string groupToString(std::set<int> const& group)
+{
+    std::ostringstream oss;
+    for (auto it = group.begin(); it != group.end(); ++it)
+    {
+        if (it != group.begin())
+        {
+            oss << ',';
+        }
+        oss << *it;
+    }
+    return oss.str();
+}
+
+ncclUniqueId getLegacyUniqueId(std::set<int> const& group)
 {
     auto const rank = COMM_SESSION.getRank();
-    TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, rank);
-    ncclUniqueId id;
+    ncclUniqueId id{};
     if (rank == *group.begin())
     {
-        NCCLCHECK_THROW(ncclGetUniqueId(&id));
-        for (auto it = std::next(std::begin(group), 1); it != group.end(); ++it)
+        {
+            auto hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+            NCCLCHECK_THROW(ncclGetUniqueId(&id));
+        }
+        for (auto it = std::next(group.begin()); it != group.end(); ++it)
         {
             COMM_SESSION.sendValue(id, *it, tensorrt_llm::mpi::MpiTag::kDefault);
         }
@@ -71,87 +121,11 @@ ncclUniqueId getUniqueId(std::set<int> const& group)
     {
         COMM_SESSION.recvValue(id, *group.begin(), tensorrt_llm::mpi::MpiTag::kDefault);
     }
-    TLLM_LOG_TRACE("%s stop for rank %d", __PRETTY_FUNCTION__, rank);
     return id;
 }
-} // namespace
 
-std::shared_ptr<ncclComm_t> getComm(std::set<int> const& group)
+void configureNcclEnvironment()
 {
-    auto const rank = COMM_SESSION.getRank();
-    TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, rank);
-    static std::map<std::set<int>, std::shared_ptr<ncclComm_t>> commMap;
-    static std::mutex mutex;
-    std::lock_guard<std::mutex> lock(mutex);
-    std::ostringstream oss;
-    int index = 0;
-    for (auto const& rank : group)
-    {
-        if (index != 0)
-        {
-            oss << ",";
-        }
-        oss << rank;
-        index++;
-    }
-    auto groupStr = oss.str();
-    auto it = commMap.find(group);
-    if (it != commMap.end())
-    {
-        auto ncclComm = it->second;
-        TLLM_LOG_TRACE("NCCL comm for group(%s) is cached for rank %d", groupStr.c_str(), rank);
-        return ncclComm;
-    }
-
-    TLLM_LOG_TRACE("Init NCCL comm for group(%s) for rank %d", groupStr.c_str(), rank);
-    ncclUniqueId id = getUniqueId(group);
-    int groupRank = 0;
-    for (auto const& currentRank : group)
-    {
-        if (rank == currentRank)
-            break;
-        ++groupRank;
-    }
-    TLLM_CHECK(static_cast<size_t>(groupRank) < group.size());
-    std::shared_ptr<ncclComm_t> ncclComm(new ncclComm_t,
-        [](ncclComm_t* comm)
-        {
-            if (!comm)
-            {
-                return;
-            }
-
-            // STEP 1: Clean up resources and destroy NCCL communicator if it's valid
-            if (*comm)
-            {
-                // Clean up all registered resources FIRST
-                // The cleanupResources function uses a destruction guard to safely handle
-                // static destruction order issues - it will return early if the singleton
-                // is being destroyed (in which case the destructor handles cleanup proactively)
-                tensorrt_llm::common::nccl_util::NcclCommResourceManager::getInstance().cleanupResources(*comm);
-
-                // Now destroy the NCCL communicator
-                ncclResult_t result = ncclCommDestroy(*comm);
-                if (result != ncclSuccess)
-                {
-                    // Logging may fail during static destruction, so wrap in try-catch
-                    try
-                    {
-                        TLLM_LOG_WARNING("ncclCommDestroy failed with error: %d", result);
-                    }
-                    catch (...)
-                    {
-                        // Ignore logging failures during static destruction
-                    }
-                }
-
-                // Clear the communicator value before freeing the pointer
-                *comm = nullptr;
-            }
-
-            // STEP 2: Always free the pointer memory (regardless of whether *comm was valid)
-            delete comm;
-        });
 #if defined(_WIN32)
     // Need static connection initialization for accurate KV cache size estimation
     if (getenv("NCCL_RUNTIME_CONNECT") == nullptr)
@@ -170,16 +144,1334 @@ std::shared_ptr<ncclComm_t> getComm(std::set<int> const& group)
         setenv("NCCL_NVLS_ENABLE", "0", 0);
     }
 #endif // _WIN32
+}
+
+class NcclCommState
+{
+public:
+    explicit NcclCommState(std::set<int> group,
+        std::shared_ptr<tensorrt_llm::runtime::NcclUniqueIdRendezvousComm> controlComm = nullptr, bool recovery = false,
+        std::uint64_t rendezvousId = 0)
+        : mGroup(std::move(group))
+        , mControlComm(std::move(controlComm))
+        , mWorldRank(mControlComm != nullptr ? mControlComm->worldRank() : COMM_SESSION.getRank())
+        , mFaultToleranceEnabled(tensorrt_llm::isNcclFaultToleranceEnabled())
+        , mPollInterval(mFaultToleranceEnabled
+                  ? getPositiveDurationFromEnv("TRTLLM_NCCL_WATCHDOG_POLL_INTERVAL_MS", 100)
+                  : std::chrono::milliseconds{100})
+        , mOperationTimeout(mFaultToleranceEnabled
+                  ? getPositiveDurationFromEnv("TRTLLM_NCCL_NONBLOCKING_TIMEOUT_MS", 5000)
+                  : std::chrono::milliseconds{5000})
+        , mInitTimeout(mFaultToleranceEnabled
+                  ? (recovery ? getPositiveDurationFromEnv("TRTLLM_NCCL_RECOVERY_TIMEOUT_MS", 5000)
+                              : getPositiveDurationFromEnv("TRTLLM_NCCL_INIT_TIMEOUT_MS", 120000))
+                  : std::chrono::milliseconds{120000})
+    {
+        TLLM_CHECK_WITH_INFO(!recovery || mFaultToleranceEnabled,
+            "NCCL error: recovery communicator construction requires TLLM_FAULT_TOLERANCE_MODE=1");
+        if (mFaultToleranceEnabled && mControlComm == nullptr)
+        {
+            std::vector<int> const initialRanks(mGroup.begin(), mGroup.end());
+            mControlComm = tensorrt_llm::runtime::createNcclUniqueIdRendezvousComm(
+                initialRanks, mWorldRank, COMM_SESSION, static_cast<int>(tensorrt_llm::mpi::MpiTag::kNcclCommControl));
+        }
+        initialize(rendezvousId);
+        if (!mFaultToleranceEnabled)
+        {
+            return;
+        }
+        try
+        {
+            mWatchdog = std::thread([this]() { watchdogLoop(); });
+        }
+        catch (...)
+        {
+            ncclComm_t abortedComm = nullptr;
+            if (mComm != nullptr)
+            {
+                auto const comm = mComm;
+                ncclResult_t abortResult;
+                {
+                    auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+                    abortResult = ncclCommAbort(comm);
+                    if (abortResult == ncclSuccess)
+                    {
+                        common::nccl_util::NcclCommResourceManager::getInstance().beginAbortCleanup(comm);
+                    }
+                }
+                if (abortResult == ncclSuccess)
+                {
+                    mComm = nullptr;
+                    abortedComm = comm;
+                }
+                else
+                {
+                    TLLM_LOG_ERROR("NCCL communicator leaked after watchdog thread creation and abort failed: %s",
+                        ncclGetErrorString(abortResult));
+                }
+            }
+            if (abortedComm != nullptr)
+            {
+                static_cast<void>(
+                    common::nccl_util::NcclCommResourceManager::getInstance().cleanupResources(abortedComm, true));
+            }
+            throw;
+        }
+    }
+
+    ~NcclCommState()
+    {
+        {
+            std::lock_guard<std::mutex> lock(mMutex);
+            mStop = true;
+        }
+        mWakeup.notify_all();
+        if (mWatchdog.joinable())
+        {
+            mWatchdog.join();
+        }
+
+        cleanupAbortedResources();
+
+        std::lock_guard<std::mutex> lock(mMutex);
+        if (mComm != nullptr)
+        {
+            auto const comm = mComm;
+            mComm = nullptr;
+            if (mError.has_value() || mFaultToleranceEnabled)
+            {
+                ncclResult_t abortResult;
+                {
+                    auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+                    abortResult = ncclCommAbort(comm);
+                    if (abortResult == ncclSuccess)
+                    {
+                        common::nccl_util::NcclCommResourceManager::getInstance().beginAbortCleanup(comm);
+                    }
+                }
+                if (abortResult == ncclSuccess)
+                {
+                    static_cast<void>(
+                        common::nccl_util::NcclCommResourceManager::getInstance().cleanupResources(comm, true));
+                    quarantinePendingOperationsLocked();
+                }
+                else
+                {
+                    // Do not release registered buffers while a failed abort
+                    // may have left kernels referencing them.
+                    try
+                    {
+                        TLLM_LOG_WARNING("Leaking failed NCCL communicator for group (%s) after abort error: %s",
+                            groupToString(mGroup).c_str(), ncclGetErrorString(abortResult));
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+                if (abortResult != ncclSuccess)
+                {
+                    quarantinePendingOperationsLocked();
+                }
+                destroyPooledEventsLocked();
+                return;
+            }
+            bool const resourcesCleaned
+                = common::nccl_util::NcclCommResourceManager::getInstance().cleanupResources(comm);
+            if (!resourcesCleaned)
+            {
+                ncclResult_t abortResult;
+                {
+                    auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+                    abortResult = ncclCommAbort(comm);
+                }
+                if (abortResult != ncclSuccess)
+                {
+                    try
+                    {
+                        TLLM_LOG_WARNING(
+                            "NCCL resource cleanup did not complete and ncclCommAbort failed for group (%s): %s",
+                            groupToString(mGroup).c_str(), ncclGetErrorString(abortResult));
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+                quarantinePendingOperationsLocked();
+                destroyPooledEventsLocked();
+                return;
+            }
+            ncclResult_t result;
+            {
+                auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+                ncclResult_t asyncResult = ncclInProgress;
+                auto const queryResult = ncclCommGetAsyncError(comm, &asyncResult);
+                if (queryResult != ncclSuccess || asyncResult != ncclSuccess)
+                {
+                    // The watcher is already stopped. Re-sample immediately
+                    // before destroy so a late asynchronous error cannot turn
+                    // ncclCommDestroy into an unbounded blocking call.
+                    result = ncclCommAbort(comm);
+                    if (result != ncclSuccess)
+                    {
+                        try
+                        {
+                            TLLM_LOG_WARNING("Final NCCL health check failed and abort failed for group (%s): %s",
+                                groupToString(mGroup).c_str(), ncclGetErrorString(result));
+                        }
+                        catch (...)
+                        {
+                        }
+                    }
+                    quarantinePendingOperationsLocked();
+                    destroyPooledEventsLocked();
+                    return;
+                }
+                result = ncclCommDestroy(comm);
+            }
+            if (result != ncclSuccess)
+            {
+                try
+                {
+                    TLLM_LOG_WARNING("ncclCommDestroy failed for group (%s): %s", groupToString(mGroup).c_str(),
+                        ncclGetErrorString(result));
+                }
+                catch (...)
+                {
+                }
+            }
+            if (result == ncclSuccess)
+            {
+                destroyCompletedWatchdogEventsLocked();
+            }
+            else
+            {
+                quarantinePendingOperationsLocked();
+                destroyPooledEventsLocked();
+            }
+            return;
+        }
+        destroyPooledEventsLocked();
+    }
+
+    NcclCommState(NcclCommState const&) = delete;
+    NcclCommState& operator=(NcclCommState const&) = delete;
+
+    ncclComm_t requireCommLocked() const
+    {
+        if (mError.has_value())
+        {
+            TLLM_THROW("NCCL error: communicator was aborted: %s", mError->c_str());
+        }
+        TLLM_CHECK_WITH_INFO(mComm != nullptr, "NCCL error: communicator was aborted");
+        return mComm;
+    }
+
+    void checkResultLocked(ncclResult_t result, char const* operation)
+    {
+        if (result == ncclSuccess)
+        {
+            return;
+        }
+
+        auto const deadline = Clock::now() + mOperationTimeout;
+        while (result == ncclInProgress && Clock::now() < deadline)
+        {
+            ncclResult_t asyncResult = ncclInProgress;
+            auto const queryResult = ncclCommGetAsyncError(requireCommLocked(), &asyncResult);
+            if (queryResult != ncclSuccess && queryResult != ncclInProgress)
+            {
+                result = queryResult;
+                break;
+            }
+            if (queryResult == ncclSuccess && asyncResult == ncclSuccess)
+            {
+                return;
+            }
+            if (queryResult == ncclSuccess && asyncResult != ncclInProgress)
+            {
+                result = asyncResult;
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds{1});
+        }
+
+        std::string message;
+        if (result == ncclInProgress)
+        {
+            message = std::string(operation) + " timed out while the NCCL communicator was in progress";
+        }
+        else
+        {
+            message = std::string(operation) + " failed with NCCL error: " + ncclGetErrorString(result);
+        }
+        setErrorAndAbortLocked(message);
+        TLLM_THROW("NCCL error: communicator was aborted: %s", message.c_str());
+    }
+
+    ncclResult_t checkOptionalResultLocked(ncclResult_t result, char const* operation)
+    {
+        if (result == ncclSuccess || result == ncclInvalidArgument)
+        {
+            return result;
+        }
+        if (result != ncclInProgress)
+        {
+            checkResultLocked(result, operation);
+        }
+
+        auto const deadline = Clock::now() + mOperationTimeout;
+        while (Clock::now() < deadline)
+        {
+            ncclResult_t asyncResult = ncclInProgress;
+            auto const queryResult = ncclCommGetAsyncError(requireCommLocked(), &asyncResult);
+            if (queryResult != ncclSuccess && queryResult != ncclInProgress)
+            {
+                checkResultLocked(queryResult, "ncclCommGetAsyncError(optional NCCL operation)");
+            }
+            if (queryResult == ncclSuccess)
+            {
+                if (asyncResult == ncclSuccess)
+                {
+                    return asyncResult;
+                }
+                if (asyncResult != ncclInProgress)
+                {
+                    // ncclInvalidArgument is a benign capability fallback only
+                    // when the optional API returns it synchronously. Once the
+                    // call reports ncclInProgress, every eventual non-success
+                    // result is an asynchronous communicator failure.
+                    checkResultLocked(asyncResult, operation);
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds{1});
+        }
+
+        auto const message = std::string(operation) + " timed out while the optional NCCL operation was in progress";
+        setErrorAndAbortLocked(message);
+        TLLM_THROW("NCCL error: communicator was aborted: %s", message.c_str());
+    }
+
+    void checkEnqueueResultLocked(ncclResult_t result, char const* operation)
+    {
+        if (result == ncclSuccess || result == ncclInProgress)
+        {
+            return;
+        }
+        auto const message = std::string(operation) + " failed with NCCL error: " + ncclGetErrorString(result);
+        setErrorAndAbortLocked(message);
+        TLLM_THROW("NCCL error: communicator was aborted: %s", message.c_str());
+    }
+
+    void waitOperation(std::uint64_t token, char const* operation)
+    {
+        TLLM_CHECK_WITH_INFO(token != 0, "NCCL error: watchdog operation token must not be zero in FT mode");
+
+        while (true)
+        {
+            std::string pendingError;
+            {
+                std::lock_guard<std::mutex> lock(mMutex);
+                if (mError.has_value())
+                {
+                    pendingError = *mError;
+                }
+                else
+                {
+                    TLLM_CHECK_WITH_INFO(token < mNextOperationToken,
+                        "NCCL error: unknown watchdog operation token %llu", static_cast<unsigned long long>(token));
+                    auto const pending = std::find_if(mPendingOperations.begin(), mPendingOperations.end(),
+                        [token](PendingOperation const& candidate) { return candidate.token == token; });
+                    // The watchdog may have observed and retired a fast
+                    // operation between track() releasing its lease and this
+                    // waiter acquiring the state mutex.
+                    if (pending == mPendingOperations.end())
+                    {
+                        return;
+                    }
+                    TLLM_CHECK_WITH_INFO(pending->completion != nullptr,
+                        "NCCL error: watchdog operation token %llu has not been tracked",
+                        static_cast<unsigned long long>(token));
+
+                    auto const now = Clock::now();
+                    if (pending->start != nullptr)
+                    {
+                        auto const startResult = cudaEventQuery(pending->start);
+                        if (startResult == cudaSuccess)
+                        {
+                            recycleEventLocked(pending->start);
+                            pending->start = nullptr;
+                            pending->deadline = now + mOperationTimeout;
+                            pending->armed = true;
+                        }
+                        else if (startResult != cudaErrorNotReady)
+                        {
+                            pendingError = pending->name + " start marker failed: " + cudaGetErrorString(startResult);
+                        }
+                    }
+
+                    bool completionReady = false;
+                    if (pendingError.empty() && pending->start == nullptr)
+                    {
+                        auto const completionResult = cudaEventQuery(pending->completion);
+                        if (completionResult == cudaSuccess)
+                        {
+                            completionReady = true;
+                        }
+                        else if (completionResult != cudaErrorNotReady)
+                        {
+                            pendingError
+                                = pending->name + " failed with CUDA error: " + cudaGetErrorString(completionResult);
+                        }
+                        else if (pending->armed && now >= pending->deadline)
+                        {
+                            pendingError = pending->name + " timed out before its CUDA completion marker";
+                        }
+                    }
+
+                    bool communicatorReady = false;
+                    if (pendingError.empty())
+                    {
+                        auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+                        ncclResult_t asyncResult = ncclInProgress;
+                        auto const queryResult = ncclCommGetAsyncError(requireCommLocked(), &asyncResult);
+                        if (queryResult != ncclSuccess && queryResult != ncclInProgress)
+                        {
+                            pendingError = std::string(operation)
+                                + " failed while querying NCCL: " + ncclGetErrorString(queryResult);
+                        }
+                        else if (queryResult == ncclSuccess && asyncResult != ncclSuccess
+                            && asyncResult != ncclInProgress)
+                        {
+                            pendingError = std::string(operation)
+                                + " failed with NCCL error: " + ncclGetErrorString(asyncResult);
+                        }
+                        else
+                        {
+                            communicatorReady = queryResult == ncclSuccess && asyncResult == ncclSuccess;
+                        }
+                    }
+
+                    if (pendingError.empty() && completionReady && communicatorReady)
+                    {
+                        recycleEventLocked(pending->completion);
+                        mPendingOperations.erase(pending);
+                        return;
+                    }
+                    if (!pendingError.empty())
+                    {
+                        setErrorAndAbortLocked(pendingError);
+                        pendingError = mError.value_or(pendingError);
+                    }
+                }
+            }
+
+            if (!pendingError.empty())
+            {
+                cleanupAbortedResources();
+                TLLM_THROW("NCCL error: communicator was aborted: %s", pendingError.c_str());
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds{1});
+        }
+    }
+
+    uint64_t beginOperationLocked(cudaStream_t stream, char const* operation)
+    {
+        requireCommLocked();
+        if (!mFaultToleranceEnabled)
+        {
+            return 0;
+        }
+
+        cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+        auto const captureResult = cudaStreamIsCapturing(stream, &captureStatus);
+        if (captureResult != cudaSuccess)
+        {
+            auto const message = std::string(operation)
+                + " failed to query CUDA stream capture state: " + cudaGetErrorString(captureResult);
+            setErrorAndAbortLocked(message);
+            TLLM_THROW("NCCL error: communicator was aborted: %s", message.c_str());
+        }
+        if (captureStatus != cudaStreamCaptureStatusNone)
+        {
+            TLLM_CHECK_WITH_INFO(!mFaultToleranceEnabled,
+                "NCCL error: CUDA graph capture of managed NCCL operations is disabled while "
+                "TLLM_FAULT_TOLERANCE_MODE=1; captured graph nodes retain the old communicator across recovery");
+            // An event recorded while capturing belongs to the graph and may
+            // not execute until long after capture ends. Arming a wall-clock
+            // deadline here would therefore report a false timeout before the
+            // graph is launched. Non-FT graph launches retain legacy async
+            // error monitoring; FT mode above requires eager launches so every
+            // operation receives the completion deadline below.
+            TLLM_LOG_DEBUG("Skipping eager NCCL completion deadline for %s during CUDA graph capture", operation);
+            return 0;
+        }
+
+        if (mPendingOperations.size() >= kMaxPendingOperations)
+        {
+            auto const message = std::string(operation) + " exceeded the bounded NCCL watchdog operation queue";
+            setErrorAndAbortLocked(message);
+            TLLM_THROW("NCCL error: communicator was aborted: %s", message.c_str());
+        }
+
+        auto const token = mNextOperationToken++;
+        cudaEvent_t start = acquireEventLocked();
+        mPendingOperations.push_back({token, start, nullptr, {}, false, operation});
+        auto const result = cudaEventRecord(start, stream);
+        if (result != cudaSuccess)
+        {
+            auto const message
+                = std::string(operation) + " failed to record its start marker: " + cudaGetErrorString(result);
+            setErrorAndAbortLocked(message);
+            TLLM_THROW("NCCL error: communicator was aborted: %s", message.c_str());
+        }
+
+        mWakeup.notify_all();
+        return token;
+    }
+
+    void finishOperationLocked(uint64_t token, cudaStream_t stream)
+    {
+        requireCommLocked();
+        if (token == 0)
+        {
+            return;
+        }
+
+        auto const operation = std::find_if(mPendingOperations.begin(), mPendingOperations.end(),
+            [token](PendingOperation const& pending) { return pending.token == token; });
+        TLLM_CHECK_WITH_INFO(operation != mPendingOperations.end(), "NCCL error: unknown watchdog operation token %llu",
+            static_cast<unsigned long long>(token));
+        TLLM_CHECK_WITH_INFO(operation->completion == nullptr,
+            "NCCL error: watchdog operation token %llu was already completed", static_cast<unsigned long long>(token));
+
+        operation->completion = acquireEventLocked();
+        auto const result = cudaEventRecord(operation->completion, stream);
+        if (result != cudaSuccess)
+        {
+            auto const message
+                = operation->name + " failed to record its completion marker: " + cudaGetErrorString(result);
+            setErrorAndAbortLocked(message);
+            TLLM_THROW("NCCL error: communicator was aborted: %s", message.c_str());
+        }
+        mWakeup.notify_all();
+    }
+
+    void abort(std::string const& reason)
+    {
+        {
+            std::lock_guard<std::mutex> lock(mMutex);
+            auto hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+            setErrorAndAbortLocked(reason);
+            TLLM_CHECK_WITH_INFO(mComm == nullptr,
+                "NCCL error: communicator abort failed; refusing to initialize a replacement while the old handle "
+                "is live");
+        }
+        cleanupAbortedResources();
+    }
+
+    std::optional<std::string> getError() const
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        return mError;
+    }
+
+    std::shared_ptr<tensorrt_llm::runtime::NcclUniqueIdRendezvousComm> const& controlComm() const noexcept
+    {
+        return mControlComm;
+    }
+
+    int worldRank() const noexcept
+    {
+        return mWorldRank;
+    }
+
+    ncclComm_t* slot() noexcept
+    {
+        return &mComm;
+    }
+
+    std::mutex& mutex() noexcept
+    {
+        return mMutex;
+    }
+
+    void cleanupAbortedResources() noexcept
+    {
+        std::vector<ncclComm_t> abortedComms;
+        {
+            std::lock_guard<std::mutex> lock(mMutex);
+            abortedComms.swap(mPendingAbortCleanup);
+        }
+        for (auto const comm : abortedComms)
+        {
+            static_cast<void>(common::nccl_util::NcclCommResourceManager::getInstance().cleanupResources(comm, true));
+        }
+    }
+
+private:
+    void initialize(std::uint64_t rendezvousId)
+    {
+        configureNcclEnvironment();
+        auto const rank = mWorldRank;
+        TLLM_CHECK_WITH_INFO(!mGroup.empty(), "NCCL communicator group must not be empty");
+        auto const rankIt = mGroup.find(rank);
+        TLLM_CHECK_WITH_INFO(rankIt != mGroup.end(), "Global rank %d is not in NCCL communicator group (%s)", rank,
+            groupToString(mGroup).c_str());
+
+        auto const groupRank = static_cast<int>(std::distance(mGroup.begin(), rankIt));
+        if (!mFaultToleranceEnabled)
+        {
+            auto const id = getLegacyUniqueId(mGroup);
+            auto hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+            ncclComm_t comm = nullptr;
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
-    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-    config.graphUsageMode = 1;
-    NCCLCHECK_THROW(ncclCommInitRankConfig(ncclComm.get(), group.size(), id, groupRank, &config));
+            ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+            config.graphUsageMode = 1;
+            auto const result = ncclCommInitRankConfig(&comm, static_cast<int>(mGroup.size()), id, groupRank, &config);
 #else
-    NCCLCHECK_THROW(ncclCommInitRank(ncclComm.get(), group.size(), id, groupRank));
+            auto const result = ncclCommInitRank(&comm, static_cast<int>(mGroup.size()), id, groupRank);
 #endif // NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
-    commMap[group] = ncclComm;
-    TLLM_LOG_TRACE("%s stop for rank %d", __PRETTY_FUNCTION__, rank);
-    return ncclComm;
+            if (result != ncclSuccess)
+            {
+                if (comm != nullptr)
+                {
+                    static_cast<void>(ncclCommAbort(comm));
+                }
+                TLLM_THROW("NCCL communicator initialization failed for group (%s) with NCCL error: %s",
+                    groupToString(mGroup).c_str(), ncclGetErrorString(result));
+            }
+            hostApiLock.unlock();
+            common::nccl_util::NcclCommResourceManager::getInstance().waitForAbortCleanup(comm);
+            mComm = comm;
+            return;
+        }
+
+        TLLM_CHECK_WITH_INFO(mControlComm != nullptr, "NCCL rendezvous control channel is not initialized");
+        TLLM_CHECK_WITH_INFO(rank == mControlComm->worldRank(),
+            "NCCL error: MPI rank %d does not match rendezvous world rank %d", rank, mControlComm->worldRank());
+        auto const deadline = Clock::now() + mInitTimeout;
+        std::vector<int> const group(mGroup.begin(), mGroup.end());
+        auto const id = tensorrt_llm::runtime::exchangeNcclUniqueId(group, *mControlComm,
+            {tensorrt_llm::mpi::MpiTag::kNcclCommReady, tensorrt_llm::mpi::MpiTag::kNcclCommUniqueId,
+                tensorrt_llm::mpi::MpiTag::kNcclCommAck},
+            rendezvousId, deadline);
+        ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+        config.blocking = 0;
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+        config.graphUsageMode = 1;
+#endif // NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+
+        auto hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+        ncclComm_t comm = nullptr;
+        auto result = ncclCommInitRankConfig(&comm, static_cast<int>(mGroup.size()), id, groupRank, &config);
+        while (result == ncclInProgress && Clock::now() < deadline)
+        {
+            ncclResult_t asyncResult = ncclInProgress;
+            auto const queryResult = ncclCommGetAsyncError(comm, &asyncResult);
+            if (queryResult != ncclSuccess && queryResult != ncclInProgress)
+            {
+                result = queryResult;
+                break;
+            }
+            if (queryResult == ncclSuccess && asyncResult == ncclSuccess)
+            {
+                result = ncclSuccess;
+                break;
+            }
+            if (queryResult == ncclSuccess && asyncResult != ncclInProgress)
+            {
+                result = asyncResult;
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds{1});
+        }
+
+        if (result != ncclSuccess)
+        {
+            if (comm != nullptr)
+            {
+                ncclCommAbort(comm);
+            }
+            if (result == ncclInProgress)
+            {
+                TLLM_THROW(
+                    "NCCL error: communicator initialization timed out for group (%s)", groupToString(mGroup).c_str());
+            }
+            TLLM_THROW("NCCL communicator initialization failed for group (%s) with NCCL error: %s",
+                groupToString(mGroup).c_str(), ncclGetErrorString(result));
+        }
+        hostApiLock.unlock();
+        common::nccl_util::NcclCommResourceManager::getInstance().waitForAbortCleanup(comm);
+        mComm = comm;
+    }
+
+    void setErrorAndAbortLocked(std::string const& reason)
+    {
+        auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+        if (!mError.has_value())
+        {
+            mError = reason;
+        }
+        if (mComm == nullptr)
+        {
+            return;
+        }
+
+        auto const comm = mComm;
+        // Abort first: graceful window cleanup synchronizes the entire device
+        // and can hang forever while a failed NCCL kernel is still resident.
+        auto const abortResult = ncclCommAbort(comm);
+        if (abortResult == ncclSuccess)
+        {
+            common::nccl_util::NcclCommResourceManager::getInstance().beginAbortCleanup(comm);
+            mComm = nullptr;
+            quarantinePendingOperationsLocked();
+            // Cleanup is deferred until the operation lease and any allocator
+            // lock have unwound. Running callbacks here can recursively enter
+            // NCCLWindowAllocator and deadlock its non-recursive mutex.
+            mPendingAbortCleanup.push_back(comm);
+        }
+        else
+        {
+            // Keep both the handle and registered buffers alive. Releasing
+            // them while NCCL kernels may still reference them is unsafe; a
+            // later control-path call can retry the idempotent abort.
+            TLLM_LOG_WARNING("ncclCommAbort failed for group (%s): %s", groupToString(mGroup).c_str(),
+                ncclGetErrorString(abortResult));
+        }
+    }
+
+    void quarantinePendingOperationsLocked() noexcept
+    {
+        if (!mPendingOperations.empty())
+        {
+            // cudaEventDestroy is asynchronous, but the event may still be
+            // referenced by work from the failed communicator. Keep the
+            // handles alive for the rest of the process instead of making
+            // assumptions about CUDA progress after abort.
+            TLLM_LOG_WARNING(
+                "Quarantining %zu NCCL completion events after communicator abort", mPendingOperations.size());
+        }
+        mPendingOperations.clear();
+    }
+
+    void destroyCompletedWatchdogEventsLocked() noexcept
+    {
+        size_t quarantined = 0;
+        for (auto const& operation : mPendingOperations)
+        {
+            for (auto const event : {operation.start, operation.completion})
+            {
+                if (event == nullptr)
+                {
+                    continue;
+                }
+                if (cudaEventQuery(event) == cudaSuccess)
+                {
+                    static_cast<void>(cudaEventDestroy(event));
+                }
+                else
+                {
+                    ++quarantined;
+                }
+            }
+        }
+        mPendingOperations.clear();
+        if (quarantined != 0)
+        {
+            TLLM_LOG_WARNING("Quarantining %zu incomplete NCCL watchdog events during healthy teardown", quarantined);
+        }
+        for (auto const event : mEventPool)
+        {
+            static_cast<void>(cudaEventDestroy(event));
+        }
+        mEventPool.clear();
+    }
+
+    void destroyPooledEventsLocked() noexcept
+    {
+        for (auto const event : mEventPool)
+        {
+            static_cast<void>(cudaEventDestroy(event));
+        }
+        mEventPool.clear();
+    }
+
+    cudaEvent_t acquireEventLocked()
+    {
+        if (!mEventPool.empty())
+        {
+            auto const event = mEventPool.back();
+            mEventPool.pop_back();
+            return event;
+        }
+
+        cudaEvent_t event = nullptr;
+        auto const result = cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+        if (result != cudaSuccess)
+        {
+            auto const message
+                = std::string("failed to allocate an NCCL watchdog event: ") + cudaGetErrorString(result);
+            setErrorAndAbortLocked(message);
+            TLLM_THROW("NCCL error: communicator was aborted: %s", message.c_str());
+        }
+        return event;
+    }
+
+    void recycleEventLocked(cudaEvent_t event) noexcept
+    {
+        if (event == nullptr)
+        {
+            return;
+        }
+        if (mEventPool.size() < kMaxPooledEvents)
+        {
+            mEventPool.push_back(event);
+        }
+        else
+        {
+            // The event has completed, so releasing pool overflow cannot race
+            // device work. Keeping the pool bounded avoids unbounded steady-
+            // state driver resources under bursty workloads.
+            static_cast<void>(cudaEventDestroy(event));
+        }
+    }
+
+    void watchdogLoop() noexcept
+    {
+        while (true)
+        {
+            std::unique_lock<std::mutex> lock(mMutex);
+            if (mWakeup.wait_for(lock, mPollInterval, [this]() { return mStop; }))
+            {
+                return;
+            }
+            if (mComm == nullptr)
+            {
+                if (mError.has_value())
+                {
+                    lock.unlock();
+                    cleanupAbortedResources();
+                    return;
+                }
+                continue;
+            }
+            if (mError.has_value())
+            {
+                {
+                    auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+                    setErrorAndAbortLocked(*mError);
+                }
+                lock.unlock();
+                cleanupAbortedResources();
+                continue;
+            }
+
+            std::string pendingError;
+            auto const now = Clock::now();
+            for (auto operation = mPendingOperations.begin(); operation != mPendingOperations.end();)
+            {
+                if (operation->start != nullptr)
+                {
+                    auto const startResult = cudaEventQuery(operation->start);
+                    if (startResult == cudaSuccess)
+                    {
+                        recycleEventLocked(operation->start);
+                        operation->start = nullptr;
+                        operation->deadline = now + mOperationTimeout;
+                        operation->armed = true;
+                    }
+                    else if (startResult != cudaErrorNotReady)
+                    {
+                        pendingError = operation->name + " start marker failed: " + cudaGetErrorString(startResult);
+                        break;
+                    }
+                    else
+                    {
+                        ++operation;
+                        continue;
+                    }
+                }
+
+                if (operation->completion == nullptr)
+                {
+                    if (operation->armed && now >= operation->deadline)
+                    {
+                        pendingError = operation->name + " timed out before its completion marker was recorded";
+                        break;
+                    }
+                    ++operation;
+                    continue;
+                }
+                auto const eventResult = cudaEventQuery(operation->completion);
+                if (eventResult == cudaSuccess)
+                {
+                    recycleEventLocked(operation->completion);
+                    operation = mPendingOperations.erase(operation);
+                    continue;
+                }
+                if (eventResult != cudaErrorNotReady)
+                {
+                    pendingError = operation->name + " failed with CUDA error: " + cudaGetErrorString(eventResult);
+                    break;
+                }
+                if (operation->armed && now >= operation->deadline)
+                {
+                    pendingError = operation->name + " timed out before its CUDA completion marker";
+                    break;
+                }
+                ++operation;
+            }
+
+            {
+                auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+                if (!pendingError.empty())
+                {
+                    setErrorAndAbortLocked(pendingError);
+                }
+                else
+                {
+                    ncclResult_t asyncResult = ncclSuccess;
+                    auto const queryResult = ncclCommGetAsyncError(mComm, &asyncResult);
+                    if (queryResult != ncclSuccess && queryResult != ncclInProgress)
+                    {
+                        setErrorAndAbortLocked(std::string("ncclCommGetAsyncError failed with NCCL error: ")
+                            + ncclGetErrorString(queryResult));
+                    }
+                    else if (asyncResult != ncclSuccess && asyncResult != ncclInProgress)
+                    {
+                        setErrorAndAbortLocked(std::string("NCCL watchdog observed asynchronous NCCL error: ")
+                            + ncclGetErrorString(asyncResult));
+                    }
+                }
+            }
+            lock.unlock();
+            cleanupAbortedResources();
+        }
+    }
+
+    std::set<int> mGroup;
+    std::shared_ptr<tensorrt_llm::runtime::NcclUniqueIdRendezvousComm> mControlComm;
+    int const mWorldRank;
+    bool mFaultToleranceEnabled;
+    ncclComm_t mComm{nullptr};
+    mutable std::mutex mMutex;
+    std::condition_variable mWakeup;
+    bool mStop{false};
+    std::optional<std::string> mError;
+    std::vector<ncclComm_t> mPendingAbortCleanup;
+
+    struct PendingOperation
+    {
+        uint64_t token;
+        cudaEvent_t start;
+        cudaEvent_t completion;
+        Clock::time_point deadline;
+        bool armed;
+        std::string name;
+    };
+
+    std::vector<PendingOperation> mPendingOperations;
+    std::vector<cudaEvent_t> mEventPool;
+    uint64_t mNextOperationToken{1};
+    static constexpr size_t kMaxPendingOperations = 4096;
+    static constexpr size_t kMaxPooledEvents = 256;
+    std::chrono::milliseconds mPollInterval;
+    std::chrono::milliseconds mOperationTimeout;
+    std::chrono::milliseconds mInitTimeout;
+    std::thread mWatchdog;
+};
+
+class NcclCommRegistry
+{
+public:
+    static NcclCommRegistry& instance()
+    {
+        // Raw communicators, watchdogs, and their CUDA/MPI dependencies are
+        // process-lifetime resources. Avoid cross-translation-unit static
+        // destruction where the resource manager or allocator could disappear
+        // before a live watchdog/state attempts final cleanup.
+        static auto* registry = new NcclCommRegistry;
+        return *registry;
+    }
+
+    std::shared_ptr<ncclComm_t> get(std::set<int> const& group)
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        auto it = mComms.find(group);
+        if (it == mComms.end())
+        {
+            auto state = std::make_shared<NcclCommState>(group);
+            mSlots[state->slot()] = state;
+            it = mComms.emplace(group, std::move(state)).first;
+        }
+        return std::shared_ptr<ncclComm_t>{it->second, it->second->slot()};
+    }
+
+    std::shared_ptr<NcclCommState> find(std::shared_ptr<ncclComm_t> const& comm)
+    {
+        TLLM_CHECK_WITH_INFO(comm != nullptr, "NCCL communicator holder is null");
+        std::lock_guard<std::mutex> lock(mMutex);
+        auto const it = mSlots.find(comm.get());
+        TLLM_CHECK_WITH_INFO(it != mSlots.end(), "NCCL communicator is not managed by the TRT-LLM registry");
+        auto state = it->second.lock();
+        TLLM_CHECK_WITH_INFO(state != nullptr, "NCCL communicator registry entry has expired");
+        return state;
+    }
+
+    std::shared_ptr<NcclCommState> find(std::set<int> const& group)
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        auto const it = mComms.find(group);
+        TLLM_CHECK_WITH_INFO(
+            it != mComms.end(), "No cached NCCL communicator exists for group (%s)", groupToString(group).c_str());
+        return it->second;
+    }
+
+    void abortAndReinit(std::set<int> const& oldGroup, std::set<int> const& activeGroup, std::uint64_t rendezvousId)
+    {
+        std::lock_guard<std::mutex> const recoveryLock(mRecoveryMutex);
+        TLLM_CHECK_WITH_INFO(rendezvousId != 0,
+            "NCCL error: recovery rendezvous ID must be nonzero; zero is reserved for initial bootstrap");
+        TLLM_CHECK_WITH_INFO(!activeGroup.empty(), "active NCCL rank group must not be empty");
+        TLLM_CHECK_WITH_INFO(std::includes(oldGroup.begin(), oldGroup.end(), activeGroup.begin(), activeGroup.end()),
+            "active NCCL rank group (%s) must be a subset of old group (%s)", groupToString(activeGroup).c_str(),
+            groupToString(oldGroup).c_str());
+        TLLM_CHECK_WITH_INFO(tensorrt_llm::isNcclFaultToleranceEnabled(),
+            "NCCL error: communicator reinitialization requires TLLM_FAULT_TOLERANCE_MODE=1; otherwise captured "
+            "CUDA graphs may retain the old communicator");
+        std::shared_ptr<NcclCommState> oldState;
+        std::shared_ptr<NcclCommState> existingTargetState;
+        {
+            std::lock_guard<std::mutex> lock(mMutex);
+            auto const old = mComms.find(oldGroup);
+            if (old != mComms.end())
+            {
+                oldState = old->second;
+            }
+            auto const existingTarget = mComms.find(activeGroup);
+            if (existingTarget != mComms.end())
+            {
+                existingTargetState = existingTarget->second;
+            }
+        }
+        TLLM_CHECK_WITH_INFO(
+            oldState != nullptr, "No cached NCCL communicator exists for group (%s)", groupToString(oldGroup).c_str());
+        auto const& controlComm = oldState->controlComm();
+        TLLM_CHECK_WITH_INFO(controlComm != nullptr, "NCCL rendezvous control channel is not initialized");
+        auto const worldRank = controlComm->worldRank();
+        TLLM_CHECK_WITH_INFO(
+            activeGroup.count(worldRank) != 0, "Failed rank %d must not call NCCL abort_and_reinit", worldRank);
+        oldState->abort("NCCL error: communicator was aborted for survivor reinitialization");
+        if (existingTargetState != nullptr && existingTargetState != oldState)
+        {
+            // Explicit recovery is a distributed generation change. Never let
+            // one rank reuse a locally healthy cached target communicator
+            // while another rank enters the fresh-ID rendezvous.
+            existingTargetState->abort("NCCL error: cached target communicator was retired for reinitialization");
+        }
+
+        // Do not mutate oldState: existing operations retain it and must fail
+        // immediately instead of silently switching rank numbering underneath
+        // an in-flight call. Subsequent operations request activeGroup.
+        std::lock_guard<std::mutex> lock(mMutex);
+        auto state = std::make_shared<NcclCommState>(activeGroup, controlComm, true, rendezvousId);
+        mSlots[state->slot()] = state;
+        mComms[activeGroup] = std::move(state);
+    }
+
+    std::optional<std::string> getError(std::set<int> const& group)
+    {
+        std::shared_ptr<NcclCommState> state;
+        {
+            std::lock_guard<std::mutex> lock(mMutex);
+            auto const it = mComms.find(group);
+            if (it == mComms.end())
+            {
+                return std::nullopt;
+            }
+            state = it->second;
+        }
+        return state->getError();
+    }
+
+private:
+    std::mutex mRecoveryMutex;
+    std::mutex mMutex;
+    std::map<std::set<int>, std::shared_ptr<NcclCommState>> mComms;
+    std::unordered_map<ncclComm_t*, std::weak_ptr<NcclCommState>> mSlots;
+};
+
+} // namespace
+
+struct NcclCommLease::Impl
+{
+    explicit Impl(std::shared_ptr<NcclCommState> state_)
+        : state(std::move(state_))
+        , lock(state->mutex())
+    {
+        // Complete the call_once-protected capability probe before taking the
+        // host gate. The probe itself briefly takes that gate for
+        // ncclGetVersion; reversing the order can deadlock with a concurrent
+        // first-time capability query.
+        static_cast<void>(common::nccl_util::isNcclWindowSupported());
+        hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+        state->requireCommLocked();
+    }
+
+    ~Impl()
+    {
+        if (groupActive)
+        {
+            auto const result = ncclGroupEnd();
+            groupActive = false;
+            try
+            {
+                state->checkResultLocked(result, "ncclGroupEnd(exception cleanup)");
+            }
+            catch (...)
+            {
+                // Destructors cannot propagate. checkResultLocked has already
+                // latched the classifier-friendly error and aborted the comm.
+            }
+        }
+        if (hostApiLock.owns_lock())
+        {
+            hostApiLock.unlock();
+        }
+        if (lock.owns_lock())
+        {
+            lock.unlock();
+        }
+        state->cleanupAbortedResources();
+    }
+
+    std::shared_ptr<NcclCommState> state;
+    std::unique_lock<std::mutex> lock;
+    tensorrt_llm::runtime::NcclHostApiLock hostApiLock;
+    bool groupActive{false};
+};
+
+NcclCommLease::NcclCommLease(std::unique_ptr<Impl> impl)
+    : mImpl(std::move(impl))
+{
+}
+
+NcclCommLease::NcclCommLease(ncclComm_t legacyComm)
+    : mLegacyComm(legacyComm)
+{
+}
+
+NcclCommLease::~NcclCommLease()
+{
+    if (mLegacyGroupActive)
+    {
+        auto const result = ncclGroupEnd();
+        mLegacyGroupActive = false;
+        if (result != ncclSuccess)
+        {
+            TLLM_LOG_WARNING(
+                "Failed to close legacy NCCL group during exception cleanup: %s", ncclGetErrorString(result));
+        }
+    }
+}
+
+NcclCommLease::NcclCommLease(NcclCommLease&& other) noexcept
+    : mImpl(std::move(other.mImpl))
+    , mLegacyComm(std::exchange(other.mLegacyComm, nullptr))
+    , mLegacyGroupActive(std::exchange(other.mLegacyGroupActive, false))
+{
+}
+
+NcclCommLease& NcclCommLease::operator=(NcclCommLease&& other) noexcept
+{
+    if (this != &other)
+    {
+        if (mLegacyGroupActive)
+        {
+            static_cast<void>(ncclGroupEnd());
+        }
+        mImpl = std::move(other.mImpl);
+        mLegacyComm = std::exchange(other.mLegacyComm, nullptr);
+        mLegacyGroupActive = std::exchange(other.mLegacyGroupActive, false);
+    }
+    return *this;
+}
+
+ncclComm_t NcclCommLease::get() const
+{
+    if (mImpl == nullptr)
+    {
+        TLLM_CHECK_WITH_INFO(mLegacyComm != nullptr, "NCCL communicator lease was moved from");
+        return mLegacyComm;
+    }
+    return mImpl->state->requireCommLocked();
+}
+
+void NcclCommLease::check(ncclResult_t result, char const* operation) const
+{
+    if (mImpl == nullptr)
+    {
+        (void) operation;
+        TLLM_CHECK_WITH_INFO(mLegacyComm != nullptr, "NCCL communicator lease was moved from");
+        NCCLCHECK_THROW(result);
+        return;
+    }
+    mImpl->state->checkResultLocked(result, operation);
+}
+
+ncclResult_t NcclCommLease::checkOptional(ncclResult_t result, char const* operation) const
+{
+    if (mImpl == nullptr)
+    {
+        (void) operation;
+        TLLM_CHECK_WITH_INFO(mLegacyComm != nullptr, "NCCL communicator lease was moved from");
+        if (result != ncclInvalidArgument)
+        {
+            NCCLCHECK_THROW(result);
+        }
+        return result;
+    }
+    return mImpl->state->checkOptionalResultLocked(result, operation);
+}
+
+void NcclCommLease::checkEnqueue(ncclResult_t result, char const* operation) const
+{
+    if (mImpl == nullptr)
+    {
+        check(result, operation);
+        return;
+    }
+    if (result != ncclSuccess && result != ncclInProgress && mImpl->groupActive)
+    {
+        // Close the thread-local group before aborting. Otherwise the first
+        // collective on a replacement communicator can be nested inside the
+        // failed group.
+        static_cast<void>(ncclGroupEnd());
+        mImpl->groupActive = false;
+    }
+    mImpl->state->checkEnqueueResultLocked(result, operation);
+}
+
+uint64_t NcclCommLease::begin(cudaStream_t stream, char const* operation) const
+{
+    if (mImpl == nullptr)
+    {
+        (void) stream;
+        (void) operation;
+        TLLM_CHECK_WITH_INFO(mLegacyComm != nullptr, "NCCL communicator lease was moved from");
+        return 0;
+    }
+    return mImpl->state->beginOperationLocked(stream, operation);
+}
+
+void NcclCommLease::track(uint64_t token, cudaStream_t stream) const
+{
+    if (mImpl == nullptr)
+    {
+        (void) token;
+        (void) stream;
+        TLLM_CHECK_WITH_INFO(mLegacyComm != nullptr, "NCCL communicator lease was moved from");
+        return;
+    }
+    mImpl->state->finishOperationLocked(token, stream);
+}
+
+void NcclCommLease::groupStart(char const* operation) const
+{
+    if (mImpl == nullptr)
+    {
+        TLLM_CHECK_WITH_INFO(mLegacyComm != nullptr, "NCCL communicator lease was moved from");
+        TLLM_CHECK_WITH_INFO(!mLegacyGroupActive, "NCCL error: nested NCCL groups are not supported by this lease");
+        (void) operation;
+        NCCLCHECK_THROW(ncclGroupStart());
+        mLegacyGroupActive = true;
+        return;
+    }
+    TLLM_CHECK_WITH_INFO(!mImpl->groupActive, "NCCL error: nested NCCL groups are not supported by this lease");
+    mImpl->state->checkResultLocked(ncclGroupStart(), operation);
+    mImpl->groupActive = true;
+}
+
+void NcclCommLease::groupEnd(char const* operation) const
+{
+    if (mImpl == nullptr)
+    {
+        TLLM_CHECK_WITH_INFO(mLegacyComm != nullptr, "NCCL communicator lease was moved from");
+        TLLM_CHECK_WITH_INFO(mLegacyGroupActive, "NCCL error: no NCCL group is active on this lease");
+        auto const result = ncclGroupEnd();
+        mLegacyGroupActive = false;
+        (void) operation;
+        NCCLCHECK_THROW(result);
+        return;
+    }
+    TLLM_CHECK_WITH_INFO(mImpl->groupActive, "NCCL error: no NCCL group is active on this lease");
+    auto const result = ncclGroupEnd();
+    mImpl->groupActive = false;
+    mImpl->state->checkResultLocked(result, operation);
+}
+
+std::shared_ptr<ncclComm_t> getComm(std::set<int> const& group)
+{
+    auto const groupString = groupToString(group);
+    // Do not query COMM_SESSION here: after survivor reinitialization that
+    // communicator may include a dead process and retain its fatal handler.
+    TLLM_LOG_TRACE("Get NCCL comm for group(%s)", groupString.c_str());
+    return NcclCommRegistry::instance().get(group);
+}
+
+int getCommWorldRank(std::shared_ptr<ncclComm_t> const& comm)
+{
+    return NcclCommRegistry::instance().find(comm)->worldRank();
+}
+
+bool isNcclFaultToleranceEnabled()
+{
+    // Communicator mode cannot change after the first managed communicator is
+    // used: its blocking configuration and watchdog ownership are fixed.
+    static bool const enabled = tensorrt_llm::mpi::isFaultToleranceModeEnabled();
+    return enabled;
+}
+
+NcclCommLease acquireComm(std::shared_ptr<ncclComm_t> const& comm)
+{
+    // FT mode is a startup-only process setting. Keep the default-off path
+    // equivalent to the legacy blocking communicator: no registry lookup,
+    // heap allocation, communicator mutex, or process-wide NCCL gate per op.
+    if (!isNcclFaultToleranceEnabled())
+    {
+        TLLM_CHECK_WITH_INFO(comm != nullptr && *comm != nullptr, "NCCL communicator is null");
+        return NcclCommLease{*comm};
+    }
+    auto state = NcclCommRegistry::instance().find(comm);
+    return NcclCommLease{std::make_unique<NcclCommLease::Impl>(std::move(state))};
+}
+
+void waitCommOperation(std::shared_ptr<ncclComm_t> const& comm, std::uint64_t token, char const* operation)
+{
+    if (!isNcclFaultToleranceEnabled())
+    {
+        TLLM_CHECK_WITH_INFO(token == 0, "NCCL error: legacy communicator received a watchdog operation token");
+        return;
+    }
+    auto state = NcclCommRegistry::instance().find(comm);
+    state->waitOperation(token, operation);
+}
+
+void abortAndReinitComm(std::set<int> const& oldGroup, std::set<int> const& activeGroup, std::uint64_t rendezvousId)
+{
+    NcclCommRegistry::instance().abortAndReinit(oldGroup, activeGroup, rendezvousId);
+}
+
+std::optional<std::string> getCommAsyncError(std::set<int> const& group)
+{
+    return NcclCommRegistry::instance().getError(group);
+}
+
+std::optional<std::string> getCommAsyncError(std::shared_ptr<ncclComm_t> const& comm)
+{
+    auto state = NcclCommRegistry::instance().find(comm);
+    return state->getError();
 }
 #endif // ENABLE_MULTI_DEVICE
 

--- a/cpp/tensorrt_llm/common/opUtils.h
+++ b/cpp/tensorrt_llm/common/opUtils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,8 @@
 #include <nccl.h>
 #endif // ENABLE_MULTI_DEVICE
 
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <map>
 #include <memory>
@@ -37,6 +39,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "tensorrt_llm/common/nvmlWrapper.h"
 
@@ -209,7 +212,99 @@ void const* getCommSessionHandle();
 
 std::unordered_map<tensorrt_llm::DataType, ncclDataType_t>* getDtypeMap();
 
+/// Access to a cached NCCL communicator.
+///
+/// NCCL communicators used by the raw TRT-LLM collectives are configured as
+/// nonblocking so that the fault-tolerance watchdog can abort them. NCCL does
+/// not allow host API calls and ncclCommAbort to race on the same communicator,
+/// so every FT raw collective must hold this serialized lease from its first
+/// communicator call through ncclGroupEnd (when a group is used). When FT is
+/// disabled the lease is an inline, non-locking wrapper around the legacy
+/// blocking communicator.
+class NcclCommLease
+{
+public:
+    ~NcclCommLease();
+
+    NcclCommLease(NcclCommLease const&) = delete;
+    NcclCommLease& operator=(NcclCommLease const&) = delete;
+    NcclCommLease(NcclCommLease&&) noexcept;
+    NcclCommLease& operator=(NcclCommLease&&) noexcept;
+
+    /// Return the native communicator, or throw a classifier-friendly error
+    /// when its watchdog has aborted it.
+    [[nodiscard]] ncclComm_t get() const;
+
+    /// Complete a nonblocking NCCL host call. ncclInProgress is polled via
+    /// ncclCommGetAsyncError before another host API is issued.
+    void check(ncclResult_t result, char const* operation) const;
+
+    /// Complete an optional NCCL capability call. An immediate
+    /// ncclInvalidArgument is returned as a documented, nonfatal unsupported
+    /// result. Once a call returns ncclInProgress, every eventual non-success
+    /// result is latched and aborted as an asynchronous communicator failure.
+    [[nodiscard]] ncclResult_t checkOptional(ncclResult_t result, char const* operation) const;
+
+    /// Validate an operation queued inside ncclGroupStart/ncclGroupEnd.
+    /// ncclInProgress is completed by the enclosing ncclGroupEnd call.
+    void checkEnqueue(ncclResult_t result, char const* operation) const;
+
+    /// Record a stream marker immediately before an asynchronous NCCL
+    /// operation. The timeout is armed only when this marker completes, so
+    /// unrelated work already queued on the stream cannot cause a false
+    /// timeout.
+    [[nodiscard]] uint64_t begin(cudaStream_t stream, char const* operation) const;
+
+    /// Record the matching completion marker after the NCCL operation has
+    /// been enqueued. The watchdog aborts if it does not complete by the
+    /// deadline armed by begin(). A zero token denotes the default-off legacy
+    /// path. FT mode rejects capture so a recovered communicator can never be
+    /// bypassed by stale graph nodes.
+    void track(uint64_t token, cudaStream_t stream) const;
+
+    /// Start/end an NCCL group tracked by this lease. If any intervening C++
+    /// operation throws, the lease destructor closes the group before
+    /// releasing the shared NCCL host-API gate.
+    void groupStart(char const* operation) const;
+    void groupEnd(char const* operation) const;
+
+private:
+    struct Impl;
+    explicit NcclCommLease(std::unique_ptr<Impl> impl);
+    explicit NcclCommLease(ncclComm_t legacyComm);
+    std::unique_ptr<Impl> mImpl;
+    ncclComm_t mLegacyComm{nullptr};
+    mutable bool mLegacyGroupActive{false};
+
+    friend NcclCommLease acquireComm(std::shared_ptr<ncclComm_t> const& comm);
+};
+
 std::shared_ptr<ncclComm_t> getComm(std::set<int> const& group);
+
+/// Return the immutable original/global MPI rank associated with a managed communicator.
+int getCommWorldRank(std::shared_ptr<ncclComm_t> const& comm);
+
+/// Return the startup-cached raw-NCCL fault-tolerance mode.
+bool isNcclFaultToleranceEnabled();
+
+/// Acquire exclusive host-API access to a cached NCCL communicator.
+NcclCommLease acquireComm(std::shared_ptr<ncclComm_t> const& comm);
+
+/// Abort the communicator for oldGroup and initialize a fresh communicator
+/// containing only activeGroup. Both groups contain global MPI ranks. Only
+/// ranks in activeGroup may call this function.
+void abortAndReinitComm(std::set<int> const& oldGroup, std::set<int> const& activeGroup, std::uint64_t rendezvousId);
+
+/// Wait for a begin()/track() operation without retaining its lease. The
+/// operation timeout is armed only after its start marker reaches the head of
+/// the stream, and other communicators remain free to enqueue or abort.
+void waitCommOperation(std::shared_ptr<ncclComm_t> const& comm, std::uint64_t token, char const* operation);
+
+/// Return the stable watchdog error for a cached communicator, if any.
+std::optional<std::string> getCommAsyncError(std::set<int> const& group);
+
+/// Return the stable watchdog error for the communicator referenced by comm.
+std::optional<std::string> getCommAsyncError(std::shared_ptr<ncclComm_t> const& comm);
 
 #endif // ENABLE_MULTI_DEVICE
 

--- a/cpp/tensorrt_llm/runtime/CMakeLists.txt
+++ b/cpp/tensorrt_llm/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION &
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION &
 # AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -16,6 +16,7 @@ include(FetchContent)
 
 set(SRCS
     utils/mpiUtils.cpp
+    utils/ncclUniqueIdRendezvous.cpp
     utils/numpyUtils.cpp
     utils/runtimeUtils.cpp
     utils/debugUtils.cu

--- a/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
+++ b/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
@@ -21,19 +21,37 @@
 #include "tensorrt_llm/common/tllmDataType.h"
 #include "tensorrt_llm/runtime/ipcNvlsMemory.h"
 #include "tensorrt_llm/runtime/utils/multiDeviceUtils.h"
+#include "tensorrt_llm/runtime/utils/ncclHostApi.h"
+#include "tensorrt_llm/runtime/utils/ncclUniqueIdRendezvous.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <exception>
+#include <initializer_list>
+#include <numeric>
+#include <set>
+#include <sstream>
+#include <thread>
+#include <utility>
 
 #if ENABLE_MULTI_DEVICE
 #include <nccl.h>
 #endif // ENABLE_MULTI_DEVICE
 
-#include <chrono>
-#include <cstdlib>
-#include <thread>
-
 using namespace tensorrt_llm::runtime;
 
 namespace
 {
+using namespace std::chrono_literals;
+
+constexpr auto kInitialReadyTimeout = 120s;
+#if ENABLE_MULTI_DEVICE
+constexpr auto kReadyPollInterval = 1ms;
+constexpr auto kRecoveryReadyTimeout = 5s;
+constexpr auto kWatcherPollInterval = 100ms;
+#endif
+
 #if ENABLE_MULTI_DEVICE
 constexpr int kDefaultNcclCommInitTimeoutSec = 60;
 constexpr int kNcclCommInitPollIntervalMs = 20;
@@ -48,6 +66,7 @@ int getNcclCommInitTimeoutSec()
 
 void initNcclCommProbeWithTimeout(ncclUniqueId const& id, int worldSize, int rank, int timeoutSec)
 {
+    auto const hostApiLock = acquireNcclHostApiLock();
     ncclComm_t comm{nullptr};
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
     config.blocking = 0;
@@ -95,7 +114,7 @@ void initNcclCommProbeWithTimeout(ncclUniqueId const& id, int worldSize, int ran
         {
             TLLM_THROW(
                 "NCCL communicator probe initialization timed out after %d seconds on rank %d of %d in "
-                "NcclCommunicator::createComm. This indicates NCCL init is hung. TensorRT-LLM will not retry "
+                "NcclCommunicator::createLegacyComm. This indicates NCCL init is hung. TensorRT-LLM will not retry "
                 "in-process. Set %s to adjust the timeout.",
                 timeoutSec, rank, worldSize, kNcclCommInitTimeoutEnv);
         }
@@ -117,19 +136,154 @@ ncclDataType_t toNcclType(tensorrt_llm::DataType dataType)
 #if ENABLE_BF16
     case tensorrt_llm::DataType::kBF16: return ncclBfloat16;
 #endif // ENABLE_BF16
-    default: TLLM_THROW("Unsupported data type: %d", static_cast<int>(dataType));
+    default: TLLM_THROW("NCCL error: unsupported data type: %d", static_cast<int>(dataType));
     }
 }
+
+std::string ncclErrorMessage(char const* operation, ncclResult_t result)
+{
+    std::ostringstream message;
+    message << "NCCL error during " << operation << ": " << ncclGetErrorString(result);
+    return message.str();
+}
+
+std::chrono::milliseconds getOperationTimeout()
+{
+    static auto const timeout = []
+    {
+        constexpr int64_t defaultTimeoutMs = 5000;
+        auto const* value = std::getenv("TRTLLM_NCCL_NONBLOCKING_TIMEOUT_MS");
+        if (value != nullptr)
+        {
+            try
+            {
+                auto const parsed = std::stoll(value);
+                if (parsed > 0)
+                {
+                    return std::chrono::milliseconds{parsed};
+                }
+            }
+            catch (...)
+            {
+            }
+            TLLM_LOG_WARNING(
+                "Ignoring invalid TRTLLM_NCCL_NONBLOCKING_TIMEOUT_MS=%s; expected positive milliseconds", value);
+        }
+        return std::chrono::milliseconds{defaultTimeoutMs};
+    }();
+    return timeout;
+}
+
 #endif // ENABLE_MULTI_DEVICE
 } // namespace
+
+NcclCommunicator::NcclCommunicator(ncclComm_t comm)
+    : mFaultToleranceEnabled{mpi::isFaultToleranceModeEnabled()}
+    , mComm{comm}
+{
+#if ENABLE_MULTI_DEVICE
+    TLLM_CHECK_WITH_INFO(mComm != nullptr, "NCCL error: cannot wrap a null communicator");
+
+    auto const hostApiLock = acquireNcclHostApiLock();
+    try
+    {
+        if (mFaultToleranceEnabled)
+        {
+            waitUntilReady(mComm, "wrapping communicator", std::chrono::steady_clock::now() + kInitialReadyTimeout);
+        }
+        TLLM_NCCL_CHECK(ncclCommCount(mComm, &mInitialWorldSize));
+        TLLM_NCCL_CHECK(ncclCommUserRank(mComm, &mWorldRank));
+        mActiveRanks.resize(mInitialWorldSize);
+        std::iota(mActiveRanks.begin(), mActiveRanks.end(), 0);
+    }
+    catch (...)
+    {
+        ncclCommAbort(mComm);
+        mComm = nullptr;
+        throw;
+    }
+    startWatcher();
+#else
+    (void) comm;
+#endif // ENABLE_MULTI_DEVICE
+}
+
+NcclCommunicator::NcclCommunicator(int worldSize, int rank, mpi::MpiComm const& mpiComm)
+    : mInitialWorldSize{worldSize}
+    , mWorldRank{rank}
+    , mFaultToleranceEnabled{mpi::isFaultToleranceModeEnabled()}
+{
+    TLLM_CHECK_WITH_INFO(worldSize > 0, "NCCL error: communicator world size must be positive, got %d", worldSize);
+    TLLM_CHECK_WITH_INFO(
+        rank >= 0 && rank < worldSize, "NCCL error: communicator rank must be in [0, %d), got %d", worldSize, rank);
+
+    mActiveRanks.resize(worldSize);
+    std::iota(mActiveRanks.begin(), mActiveRanks.end(), 0);
+#if ENABLE_MULTI_DEVICE
+    TLLM_CHECK_WITH_INFO(mpiComm.getRank() == rank, "NCCL error: world rank %d does not match MPI bootstrap rank %d",
+        rank, mpiComm.getRank());
+    TLLM_CHECK_WITH_INFO(mpiComm.getSize() >= worldSize, "NCCL error: world size %d exceeds MPI bootstrap size %d",
+        worldSize, mpiComm.getSize());
+    if (mFaultToleranceEnabled)
+    {
+        mControlComm = createNcclUniqueIdRendezvousComm(
+            mActiveRanks, rank, mpiComm, static_cast<int>(mpi::MpiTag::kNcclPpControl));
+        mComm = createComm(mActiveRanks, rank, *mControlComm, /*rendezvousId=*/0, kInitialReadyTimeout);
+    }
+    else
+    {
+        // Preserve the legacy blocking MPI-broadcast bootstrap when FT is
+        // disabled. It creates no control communicator or watcher thread.
+        mComm = createLegacyComm(worldSize, rank, mpiComm);
+    }
+#else
+    mComm = nullptr;
+#endif // ENABLE_MULTI_DEVICE
+    startWatcher();
+}
 
 void NcclCommunicator::send(
     void const* sendbuff, size_t count, tensorrt_llm::DataType dataType, int peer, CudaStream const& stream) const
 {
 #if ENABLE_MULTI_DEVICE
-    TLLM_NCCL_CHECK(ncclSend(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
+    if (!mFaultToleranceEnabled)
+    {
+        TLLM_NCCL_CHECK(ncclSend(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
+        return;
+    }
+    std::lock_guard<std::mutex> lock(mCommMutex);
+    auto const hostApiLock = acquireNcclHostApiLock();
+    checkUsableLocked();
+    int const commPeer = getCommPeerRankLocked(peer);
+    auto const watchdogToken = beginOperationLocked(stream.get(), "ncclSend");
+    ncclResult_t const result = ncclSend(sendbuff, count, toNcclType(dataType), commPeer, mComm, stream.get());
+    if (result == ncclInProgress)
+    {
+        try
+        {
+            waitUntilReady(mComm, "ncclSend enqueue", std::chrono::steady_clock::now() + kRecoveryReadyTimeout);
+        }
+        catch (std::exception const& error)
+        {
+            static_cast<void>(abortLocked(
+                std::string{"NCCL error: communicator was aborted after ncclSend failed: "} + error.what()));
+            TLLM_THROW("%s", mAsyncError.c_str());
+        }
+        catch (...)
+        {
+            static_cast<void>(abortLocked("NCCL error: communicator was aborted after ncclSend failed"));
+            TLLM_THROW("%s", mAsyncError.c_str());
+        }
+    }
+    else if (result != ncclSuccess)
+    {
+        static_cast<void>(
+            abortLocked("NCCL error: communicator was aborted after " + ncclErrorMessage("ncclSend", result)));
+        TLLM_THROW("%s", mAsyncError.c_str());
+    }
+    finishOperationLocked(watchdogToken, stream.get());
 #else
-    TLLM_THROW("Multi device support is disabled.");
+    TLLM_THROW("NCCL error: multi device support is disabled.");
 #endif // ENABLE_MULTI_DEVICE
 }
 
@@ -137,16 +291,67 @@ void NcclCommunicator::receive(
     void* sendbuff, size_t count, tensorrt_llm::DataType dataType, int peer, CudaStream const& stream) const
 {
 #if ENABLE_MULTI_DEVICE
-    TLLM_NCCL_CHECK(ncclRecv(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
+    if (!mFaultToleranceEnabled)
+    {
+        TLLM_NCCL_CHECK(ncclRecv(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
+        return;
+    }
+    std::lock_guard<std::mutex> lock(mCommMutex);
+    auto const hostApiLock = acquireNcclHostApiLock();
+    checkUsableLocked();
+    int const commPeer = getCommPeerRankLocked(peer);
+    auto const watchdogToken = beginOperationLocked(stream.get(), "ncclRecv");
+    ncclResult_t const result = ncclRecv(sendbuff, count, toNcclType(dataType), commPeer, mComm, stream.get());
+    if (result == ncclInProgress)
+    {
+        try
+        {
+            waitUntilReady(mComm, "ncclRecv enqueue", std::chrono::steady_clock::now() + kRecoveryReadyTimeout);
+        }
+        catch (std::exception const& error)
+        {
+            static_cast<void>(abortLocked(
+                std::string{"NCCL error: communicator was aborted after ncclRecv failed: "} + error.what()));
+            TLLM_THROW("%s", mAsyncError.c_str());
+        }
+        catch (...)
+        {
+            static_cast<void>(abortLocked("NCCL error: communicator was aborted after ncclRecv failed"));
+            TLLM_THROW("%s", mAsyncError.c_str());
+        }
+    }
+    else if (result != ncclSuccess)
+    {
+        static_cast<void>(
+            abortLocked("NCCL error: communicator was aborted after " + ncclErrorMessage("ncclRecv", result)));
+        TLLM_THROW("%s", mAsyncError.c_str());
+    }
+    finishOperationLocked(watchdogToken, stream.get());
 #else
-    TLLM_THROW("Multi device support is disabled.");
+    TLLM_THROW("NCCL error: multi device support is disabled.");
 #endif // ENABLE_MULTI_DEVICE
 }
 
-ncclComm_t NcclCommunicator::createComm(int worldSize, int rank, mpi::MpiComm const& mpiComm)
+ncclComm_t NcclCommunicator::createComm(std::vector<int> const& activeRanks, int worldRank,
+    NcclUniqueIdRendezvousComm const& controlComm, std::uint64_t rendezvousId, std::chrono::milliseconds readyTimeout)
 {
 #if ENABLE_MULTI_DEVICE
+    TLLM_CHECK_WITH_INFO(!activeRanks.empty(), "NCCL error: communicator active-rank set must not be empty");
+    auto const rankIt = std::find(activeRanks.begin(), activeRanks.end(), worldRank);
+    TLLM_CHECK_WITH_INFO(
+        rankIt != activeRanks.end(), "NCCL error: world rank %d is not present in the active-rank set", worldRank);
 
+    // Do not use an MPI collective here. During recovery, failed ranks remain
+    // members of the pre-failure control communicator. Only the survivors
+    // exchange the fresh NCCL ID point-to-point.
+    auto const deadline = std::chrono::steady_clock::now() + readyTimeout;
+    TLLM_CHECK_WITH_INFO(controlComm.worldRank() == worldRank,
+        "NCCL error: world rank %d does not match rendezvous control world rank %d", worldRank,
+        controlComm.worldRank());
+    ncclUniqueId const id = exchangeNcclUniqueId(activeRanks, controlComm,
+        {mpi::MpiTag::kNcclPpReady, mpi::MpiTag::kNcclPpUniqueId, mpi::MpiTag::kNcclPpAck}, rendezvousId, deadline);
+
+    ncclComm_t comm{nullptr};
 // Need static connection initialization for accurate KV cache size estimation.
 #if defined(_WIN32)
     if (getenv("NCCL_RUNTIME_CONNECT") == nullptr)
@@ -158,34 +363,647 @@ ncclComm_t NcclCommunicator::createComm(int worldSize, int rank, mpi::MpiComm co
         setenv("NCCL_NVLS_ENABLE", "0", 0);
     }
 #endif // _WIN32
-    ncclUniqueId id;
-    if (rank == 0)
+
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    config.blocking = 0;
+    int const commRank = static_cast<int>(std::distance(activeRanks.begin(), rankIt));
+    int const commSize = static_cast<int>(activeRanks.size());
+    auto const hostApiLock = acquireNcclHostApiLock();
+    ncclResult_t const result = ncclCommInitRankConfig(&comm, commSize, id, commRank, &config);
+    if (result != ncclSuccess && result != ncclInProgress)
     {
-        TLLM_NCCL_CHECK(ncclGetUniqueId(&id));
+        if (comm != nullptr)
+        {
+            ncclCommAbort(comm);
+        }
+        TLLM_THROW("%s", ncclErrorMessage("ncclCommInitRankConfig", result).c_str());
     }
-    mpiComm.bcastValue(id, 0);
-    initNcclCommProbeWithTimeout(id, worldSize, rank, getNcclCommInitTimeoutSec());
-    if (rank == 0)
+
+    try
     {
-        TLLM_NCCL_CHECK(ncclGetUniqueId(&id));
+        waitUntilReady(comm, "ncclCommInitRankConfig", deadline);
     }
-    mpiComm.bcastValue(id, 0);
-    ncclComm_t comm;
-    TLLM_NCCL_CHECK(ncclCommInitRank(&comm, worldSize, id, rank));
+    catch (...)
+    {
+        if (comm != nullptr)
+        {
+            ncclCommAbort(comm);
+        }
+        throw;
+    }
     return comm;
 #else
+    (void) activeRanks;
+    (void) worldRank;
+    (void) controlComm;
+    (void) rendezvousId;
+    (void) readyTimeout;
     // Python runtime requires instantiation of a communicator even though it may never be used to enable
     // pipeline parallel code-path. To enable this, have an empty communicator with uninitialized state.
     return nullptr;
 #endif // ENABLE_MULTI_DEVICE
 }
 
+ncclComm_t NcclCommunicator::createLegacyComm(int worldSize, int rank, mpi::MpiComm const& mpiComm)
+{
+#if ENABLE_MULTI_DEVICE
+// Need static connection initialization for accurate KV cache size estimation.
+#if defined(_WIN32)
+    if (getenv("NCCL_RUNTIME_CONNECT") == nullptr)
+        _putenv_s("NCCL_RUNTIME_CONNECT", "0");
+#else
+    setenv("NCCL_RUNTIME_CONNECT", "0", 0);
+    if (getenv("NCCL_NVLS_ENABLE") == nullptr && !ipcNvlsSupported())
+    {
+        setenv("NCCL_NVLS_ENABLE", "0", 0);
+    }
+#endif // _WIN32
+
+    ncclUniqueId id;
+    if (rank == 0)
+    {
+        auto const hostApiLock = acquireNcclHostApiLock();
+        TLLM_NCCL_CHECK(ncclGetUniqueId(&id));
+    }
+    mpiComm.bcastValue(id, 0);
+    initNcclCommProbeWithTimeout(id, worldSize, rank, getNcclCommInitTimeoutSec());
+    if (rank == 0)
+    {
+        auto const hostApiLock = acquireNcclHostApiLock();
+        TLLM_NCCL_CHECK(ncclGetUniqueId(&id));
+    }
+    mpiComm.bcastValue(id, 0);
+
+    ncclComm_t comm{nullptr};
+    auto const hostApiLock = acquireNcclHostApiLock();
+    TLLM_NCCL_CHECK(ncclCommInitRank(&comm, worldSize, id, rank));
+    return comm;
+#else
+    (void) worldSize;
+    (void) rank;
+    (void) mpiComm;
+    return nullptr;
+#endif // ENABLE_MULTI_DEVICE
+}
+
+void NcclCommunicator::waitUntilReady(
+    ncclComm_t comm, char const* operation, std::chrono::steady_clock::time_point deadline)
+{
+#if ENABLE_MULTI_DEVICE
+    auto const hostApiLock = acquireNcclHostApiLock();
+    TLLM_CHECK_WITH_INFO(comm != nullptr, "NCCL error: communicator was aborted while waiting for %s", operation);
+    while (true)
+    {
+        ncclResult_t asyncError = ncclInProgress;
+        ncclResult_t const queryResult = ncclCommGetAsyncError(comm, &asyncError);
+        if (queryResult != ncclSuccess && queryResult != ncclInProgress)
+        {
+            TLLM_THROW("%s", ncclErrorMessage("ncclCommGetAsyncError", queryResult).c_str());
+        }
+        if (queryResult == ncclSuccess && asyncError == ncclSuccess)
+        {
+            return;
+        }
+        if (queryResult == ncclSuccess && asyncError != ncclInProgress)
+        {
+            TLLM_THROW("%s", ncclErrorMessage(operation, asyncError).c_str());
+        }
+        if (std::chrono::steady_clock::now() >= deadline)
+        {
+            TLLM_THROW("NCCL error: timed out waiting for %s", operation);
+        }
+        std::this_thread::sleep_for(kReadyPollInterval);
+    }
+#else
+    (void) comm;
+    (void) operation;
+    (void) deadline;
+#endif // ENABLE_MULTI_DEVICE
+}
+
+void NcclCommunicator::checkUsableLocked() const
+{
+    TLLM_CHECK_WITH_INFO(mAsyncError.empty(), "%s", mAsyncError.c_str());
+    TLLM_CHECK_WITH_INFO(mComm != nullptr, "NCCL error: communicator was aborted");
+}
+
+bool NcclCommunicator::abortLocked(std::string reason) const noexcept
+{
+#if ENABLE_MULTI_DEVICE
+    auto const hostApiLock = acquireNcclHostApiLock();
+    if (mComm == nullptr)
+    {
+        if (mAsyncError.empty())
+        {
+            mAsyncError = std::move(reason);
+        }
+        return true;
+    }
+
+    ncclComm_t const comm = mComm;
+    ncclResult_t const result = ncclCommAbort(comm);
+    if (result == ncclSuccess)
+    {
+        mComm = nullptr;
+        mAsyncError = std::move(reason);
+        quarantinePendingOperationsLocked();
+        return true;
+    }
+
+    bool const firstAbortFailure = reason.find("ncclCommAbort failed") == std::string::npos;
+    mAsyncError = std::move(reason);
+    if (firstAbortFailure)
+    {
+        try
+        {
+            mAsyncError += "; ncclCommAbort failed: ";
+            mAsyncError += ncclGetErrorString(result);
+        }
+        catch (...)
+        {
+        }
+    }
+    if (firstAbortFailure)
+    {
+        TLLM_LOG_ERROR("Failed to abort NCCL communicator: %s", ncclGetErrorString(result));
+    }
+    return false;
+#else
+    (void) reason;
+    return true;
+#endif // ENABLE_MULTI_DEVICE
+}
+
+int NcclCommunicator::getCommPeerRankLocked(int worldRank) const
+{
+    auto const peer = std::find(mActiveRanks.begin(), mActiveRanks.end(), worldRank);
+    TLLM_CHECK_WITH_INFO(peer != mActiveRanks.end(),
+        "NCCL error: peer world rank %d is not active in the current communicator", worldRank);
+    return static_cast<int>(std::distance(mActiveRanks.begin(), peer));
+}
+
+uint64_t NcclCommunicator::beginOperationLocked(cudaStream_t stream, char const* operation) const
+{
+#if ENABLE_MULTI_DEVICE
+    checkUsableLocked();
+    if (!mFaultToleranceEnabled)
+    {
+        return 0;
+    }
+    cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+    auto const captureResult = cudaStreamIsCapturing(stream, &captureStatus);
+    if (captureResult != cudaSuccess)
+    {
+        static_cast<void>(abortLocked(std::string{"NCCL error: "} + operation
+            + " failed to query CUDA stream capture state: " + cudaGetErrorString(captureResult)));
+        TLLM_THROW("%s", mAsyncError.c_str());
+    }
+    if (captureStatus != cudaStreamCaptureStatusNone)
+    {
+        TLLM_CHECK_WITH_INFO(!mFaultToleranceEnabled,
+            "NCCL error: CUDA graph capture of PP NCCL operations is disabled while "
+            "TLLM_FAULT_TOLERANCE_MODE=1; captured graph nodes retain the old communicator across recovery");
+        TLLM_LOG_DEBUG("Skipping eager NCCL completion deadline for %s during CUDA graph capture", operation);
+        return 0;
+    }
+    if (mPendingOperations.size() >= kMaxPendingOperations)
+    {
+        static_cast<void>(abortLocked(
+            std::string{"NCCL error: "} + operation + " exceeded the bounded NCCL watchdog operation queue"));
+        TLLM_THROW("%s", mAsyncError.c_str());
+    }
+
+    auto const token = mNextOperationToken++;
+    auto const start = acquireEventLocked();
+    mPendingOperations.push_back({token, start, nullptr, {}, false, operation});
+    auto const result = cudaEventRecord(start, stream);
+    if (result != cudaSuccess)
+    {
+        static_cast<void>(abortLocked(std::string{"NCCL error: "} + operation
+            + " failed to record its start marker: " + cudaGetErrorString(result)));
+        TLLM_THROW("%s", mAsyncError.c_str());
+    }
+    mWatcherWakeup.notify_all();
+    return token;
+#else
+    (void) stream;
+    (void) operation;
+    return 0;
+#endif // ENABLE_MULTI_DEVICE
+}
+
+void NcclCommunicator::finishOperationLocked(uint64_t token, cudaStream_t stream) const
+{
+#if ENABLE_MULTI_DEVICE
+    checkUsableLocked();
+    if (token == 0)
+    {
+        return;
+    }
+    auto const operation = std::find_if(mPendingOperations.begin(), mPendingOperations.end(),
+        [token](PendingOperation const& pending) { return pending.token == token; });
+    TLLM_CHECK_WITH_INFO(operation != mPendingOperations.end(), "NCCL error: unknown watchdog operation token %llu",
+        static_cast<unsigned long long>(token));
+    TLLM_CHECK_WITH_INFO(operation->completion == nullptr,
+        "NCCL error: watchdog operation token %llu was already completed", static_cast<unsigned long long>(token));
+
+    operation->completion = acquireEventLocked();
+    auto const result = cudaEventRecord(operation->completion, stream);
+    if (result != cudaSuccess)
+    {
+        static_cast<void>(abortLocked(std::string{"NCCL error: "} + operation->name
+            + " failed to record its completion marker: " + cudaGetErrorString(result)));
+        TLLM_THROW("%s", mAsyncError.c_str());
+    }
+    mWatcherWakeup.notify_all();
+#else
+    (void) token;
+    (void) stream;
+#endif // ENABLE_MULTI_DEVICE
+}
+
+cudaEvent_t NcclCommunicator::acquireEventLocked() const
+{
+#if ENABLE_MULTI_DEVICE
+    if (!mEventPool.empty())
+    {
+        auto const event = mEventPool.back();
+        mEventPool.pop_back();
+        return event;
+    }
+    cudaEvent_t event = nullptr;
+    auto const result = cudaEventCreateWithFlags(&event, cudaEventDisableTiming);
+    if (result != cudaSuccess)
+    {
+        static_cast<void>(
+            abortLocked(std::string{"NCCL error: failed to allocate a watchdog event: "} + cudaGetErrorString(result)));
+        TLLM_THROW("%s", mAsyncError.c_str());
+    }
+    return event;
+#else
+    return nullptr;
+#endif // ENABLE_MULTI_DEVICE
+}
+
+void NcclCommunicator::recycleEventLocked(cudaEvent_t event) const noexcept
+{
+#if ENABLE_MULTI_DEVICE
+    if (event == nullptr)
+    {
+        return;
+    }
+    if (mEventPool.size() < kMaxPooledEvents)
+    {
+        mEventPool.push_back(event);
+    }
+    else
+    {
+        static_cast<void>(cudaEventDestroy(event));
+    }
+#else
+    (void) event;
+#endif // ENABLE_MULTI_DEVICE
+}
+
+void NcclCommunicator::quarantinePendingOperationsLocked() const noexcept
+{
+    if (!mPendingOperations.empty())
+    {
+        // The failed communicator may still have device work referencing
+        // these events. Drop host ownership without destroying their handles;
+        // process restart reclaims the deliberately quarantined resources.
+        TLLM_LOG_WARNING(
+            "Quarantining %zu PP NCCL completion markers after communicator abort", mPendingOperations.size());
+    }
+    mPendingOperations.clear();
+}
+
+void NcclCommunicator::destroyCompletedWatchdogEventsLocked() const noexcept
+{
+#if ENABLE_MULTI_DEVICE
+    size_t quarantined = 0;
+    for (auto const& operation : mPendingOperations)
+    {
+        for (auto const event : {operation.start, operation.completion})
+        {
+            if (event == nullptr)
+            {
+                continue;
+            }
+            if (cudaEventQuery(event) == cudaSuccess)
+            {
+                static_cast<void>(cudaEventDestroy(event));
+            }
+            else
+            {
+                ++quarantined;
+            }
+        }
+    }
+    mPendingOperations.clear();
+    if (quarantined != 0)
+    {
+        TLLM_LOG_WARNING("Quarantining %zu incomplete PP NCCL watchdog events during healthy teardown", quarantined);
+    }
+    destroyPooledEventsLocked();
+#endif // ENABLE_MULTI_DEVICE
+}
+
+void NcclCommunicator::destroyPooledEventsLocked() const noexcept
+{
+#if ENABLE_MULTI_DEVICE
+    for (auto const event : mEventPool)
+    {
+        static_cast<void>(cudaEventDestroy(event));
+    }
+    mEventPool.clear();
+#endif // ENABLE_MULTI_DEVICE
+}
+
+void NcclCommunicator::abort()
+{
+#if ENABLE_MULTI_DEVICE
+    std::lock_guard<std::mutex> lock(mCommMutex);
+    bool const abortSucceeded = abortLocked("NCCL error: communicator was aborted by the fault-tolerance control path");
+    TLLM_CHECK_WITH_INFO(abortSucceeded, "%s", mAsyncError.c_str());
+#endif // ENABLE_MULTI_DEVICE
+}
+
+void NcclCommunicator::abortAndReinit(std::vector<int> const& activeRanks, std::uint64_t rendezvousId)
+{
+#if ENABLE_MULTI_DEVICE
+    std::lock_guard<std::mutex> lock(mCommMutex);
+    TLLM_CHECK_WITH_INFO(mFaultToleranceEnabled,
+        "NCCL error: communicator reinitialization requires TLLM_FAULT_TOLERANCE_MODE=1; otherwise captured CUDA "
+        "graphs may retain the old communicator");
+    TLLM_CHECK_WITH_INFO(
+        rendezvousId != 0, "NCCL error: recovery rendezvous ID must be positive; zero is reserved for bootstrap");
+    TLLM_CHECK_WITH_INFO(mControlComm != nullptr,
+        "NCCL error: communicator created from a raw handle has no MPI bootstrap for reinitialization");
+    TLLM_CHECK_WITH_INFO(!activeRanks.empty(), "NCCL error: active-rank set must not be empty");
+    std::set<int> const requested(activeRanks.begin(), activeRanks.end());
+    TLLM_CHECK_WITH_INFO(requested.size() == activeRanks.size(), "NCCL error: active-rank set contains duplicates");
+    TLLM_CHECK_WITH_INFO(requested.find(mWorldRank) != requested.end(),
+        "NCCL error: survivor rank %d must be present in active_ranks", mWorldRank);
+
+    for (int const rank : requested)
+    {
+        TLLM_CHECK_WITH_INFO(rank >= 0 && rank < mInitialWorldSize,
+            "NCCL error: active world rank %d is outside [0, %d)", rank, mInitialWorldSize);
+        TLLM_CHECK_WITH_INFO(std::find(mActiveRanks.begin(), mActiveRanks.end(), rank) != mActiveRanks.end(),
+            "NCCL error: cannot re-add world rank %d after it was removed", rank);
+    }
+
+    std::vector<int> nextActiveRanks;
+    nextActiveRanks.reserve(requested.size());
+    for (int const worldRank : mActiveRanks)
+    {
+        if (requested.find(worldRank) != requested.end())
+        {
+            nextActiveRanks.push_back(worldRank);
+        }
+    }
+
+    TLLM_CHECK_WITH_INFO(mControlComm->worldRank() == mWorldRank,
+        "NCCL error: world rank %d does not match rendezvous control world rank %d", mWorldRank,
+        mControlComm->worldRank());
+    // This is deliberately a fresh-ID rebuild rather than ncclCommShrink. The
+    // watcher may already have destroyed the poisoned communicator, and the
+    // failed rank must not be required by any recovery collective.
+    bool const abortSucceeded
+        = abortLocked("NCCL error: communicator was aborted before survivor-only reinitialization");
+    TLLM_CHECK_WITH_INFO(abortSucceeded,
+        "NCCL error: communicator reinitialization refused because ncclCommAbort did not succeed: %s",
+        mAsyncError.c_str());
+
+    ncclComm_t nextComm{nullptr};
+    try
+    {
+        nextComm = createComm(nextActiveRanks, mWorldRank, *mControlComm, rendezvousId, kRecoveryReadyTimeout);
+    }
+    catch (std::exception const& error)
+    {
+        mAsyncError = std::string{"NCCL error: communicator reinitialization failed after abort: "} + error.what();
+        TLLM_THROW("%s", mAsyncError.c_str());
+    }
+    catch (...)
+    {
+        mAsyncError = "NCCL error: communicator reinitialization failed after abort";
+        TLLM_THROW("%s", mAsyncError.c_str());
+    }
+
+    mComm = nextComm;
+    mActiveRanks = std::move(nextActiveRanks);
+    mAsyncError.clear();
+#else
+    (void) activeRanks;
+    (void) rendezvousId;
+    TLLM_THROW("NCCL error: multi device support is disabled.");
+#endif // ENABLE_MULTI_DEVICE
+}
+
+std::string NcclCommunicator::getAsyncError() const
+{
+    std::lock_guard<std::mutex> lock(mCommMutex);
+    return mAsyncError;
+}
+
+std::vector<int> NcclCommunicator::getActiveRanks() const
+{
+    std::lock_guard<std::mutex> lock(mCommMutex);
+    return mActiveRanks;
+}
+
+void NcclCommunicator::startWatcher()
+{
+#if ENABLE_MULTI_DEVICE
+    if (mFaultToleranceEnabled && mComm != nullptr)
+    {
+        try
+        {
+            mWatcherThread = std::thread(&NcclCommunicator::watchAsyncErrors, this);
+        }
+        catch (...)
+        {
+            auto const hostApiLock = acquireNcclHostApiLock();
+            ncclCommAbort(mComm);
+            mComm = nullptr;
+            throw;
+        }
+    }
+#endif // ENABLE_MULTI_DEVICE
+}
+
+void NcclCommunicator::stopWatcher() noexcept
+{
+    mStopWatcher.store(true, std::memory_order_release);
+    mWatcherWakeup.notify_all();
+    if (mWatcherThread.joinable())
+    {
+        mWatcherThread.join();
+    }
+}
+
+void NcclCommunicator::watchAsyncErrors() noexcept
+{
+#if ENABLE_MULTI_DEVICE
+    try
+    {
+        while (!mStopWatcher.load(std::memory_order_acquire))
+        {
+            {
+                // NCCL communicators are not generally thread-safe. Serialize
+                // the monitor with send/receive, abort, and reinit host calls.
+                std::lock_guard<std::mutex> lock(mCommMutex);
+                if (mComm != nullptr && !mAsyncError.empty())
+                {
+                    // A previous abort attempt failed. Keep the handle so the
+                    // watcher can retry; a rebuild is forbidden until abort
+                    // succeeds.
+                    static_cast<void>(abortLocked(mAsyncError));
+                }
+                else if (mComm != nullptr)
+                {
+                    std::string error;
+                    auto const now = std::chrono::steady_clock::now();
+                    for (auto operation = mPendingOperations.begin(); operation != mPendingOperations.end();)
+                    {
+                        if (operation->start != nullptr)
+                        {
+                            auto const startResult = cudaEventQuery(operation->start);
+                            if (startResult == cudaSuccess)
+                            {
+                                recycleEventLocked(operation->start);
+                                operation->start = nullptr;
+                                operation->deadline = now + getOperationTimeout();
+                                operation->armed = true;
+                            }
+                            else if (startResult != cudaErrorNotReady)
+                            {
+                                error = operation->name + " start marker failed: " + cudaGetErrorString(startResult);
+                                break;
+                            }
+                            else
+                            {
+                                ++operation;
+                                continue;
+                            }
+                        }
+                        if (operation->completion == nullptr)
+                        {
+                            if (operation->armed && now >= operation->deadline)
+                            {
+                                error = operation->name + " timed out before its completion marker was recorded";
+                                break;
+                            }
+                            ++operation;
+                            continue;
+                        }
+
+                        auto const eventResult = cudaEventQuery(operation->completion);
+                        if (eventResult == cudaSuccess)
+                        {
+                            recycleEventLocked(operation->completion);
+                            operation = mPendingOperations.erase(operation);
+                            continue;
+                        }
+                        if (eventResult != cudaErrorNotReady)
+                        {
+                            error = operation->name + " completion marker failed: " + cudaGetErrorString(eventResult);
+                            break;
+                        }
+                        if (operation->armed && now >= operation->deadline)
+                        {
+                            error = operation->name + " timed out before its CUDA completion marker";
+                            break;
+                        }
+                        ++operation;
+                    }
+
+                    if (error.empty())
+                    {
+                        auto const hostApiLock = acquireNcclHostApiLock();
+                        ncclResult_t asyncError = ncclSuccess;
+                        ncclResult_t const queryResult = ncclCommGetAsyncError(mComm, &asyncError);
+                        if (queryResult != ncclSuccess && queryResult != ncclInProgress)
+                        {
+                            error = ncclErrorMessage("ncclCommGetAsyncError watcher", queryResult);
+                        }
+                        else if (queryResult == ncclSuccess && asyncError != ncclSuccess
+                            && asyncError != ncclInProgress)
+                        {
+                            error = ncclErrorMessage("asynchronous communicator operation", asyncError);
+                        }
+                    }
+
+                    if (!error.empty())
+                    {
+                        static_cast<void>(abortLocked(
+                            "NCCL error: communicator was aborted by the async-error watcher after " + error));
+                        TLLM_LOG_ERROR("%s", mAsyncError.c_str());
+                    }
+                }
+            }
+
+            std::unique_lock<std::mutex> waitLock(mWatcherWaitMutex);
+            mWatcherWakeup.wait_for(
+                waitLock, kWatcherPollInterval, [this]() { return mStopWatcher.load(std::memory_order_acquire); });
+        }
+    }
+    catch (...)
+    {
+        // Never allow a diagnostic side thread to terminate the process.
+    }
+#endif // ENABLE_MULTI_DEVICE
+}
+
 NcclCommunicator::~NcclCommunicator()
 {
 #if ENABLE_MULTI_DEVICE
-    if (mComm && ncclCommDestroy(mComm) != ncclSuccess)
+    if (!mFaultToleranceEnabled)
     {
-        TLLM_LOG_WARNING("Failed to destroy NCCL communicator.");
+        if (mComm != nullptr && ncclCommDestroy(mComm) != ncclSuccess)
+        {
+            TLLM_LOG_WARNING("Failed to destroy NCCL communicator.");
+        }
+        return;
+    }
+#endif // ENABLE_MULTI_DEVICE
+    stopWatcher();
+#if ENABLE_MULTI_DEVICE
+    std::lock_guard<std::mutex> lock(mCommMutex);
+    auto const hostApiLock = acquireNcclHostApiLock();
+    if (mComm != nullptr)
+    {
+        ncclResult_t asyncError = ncclSuccess;
+        ncclResult_t const queryResult = ncclCommGetAsyncError(mComm, &asyncError);
+        bool const healthy = mAsyncError.empty() && queryResult == ncclSuccess && asyncError == ncclSuccess;
+        // ncclCommDestroy is an intra-node collective. Python model-engine
+        // reference counts are process-local, so their final release is not a
+        // cross-rank teardown barrier; after a peer failure, the one healthy
+        // sample above is also inherently racy. In FT mode use the local abort
+        // path and never stop the watcher only to enter an unbounded graceful
+        // destroy while holding the process-wide NCCL gate.
+        bool const useAbort = !healthy || mFaultToleranceEnabled;
+        ncclResult_t const result = useAbort ? ncclCommAbort(mComm) : ncclCommDestroy(mComm);
+        if (result != ncclSuccess)
+        {
+            TLLM_LOG_WARNING("Failed to release NCCL communicator: %s", ncclGetErrorString(result));
+        }
+        mComm = nullptr;
+        if (!useAbort && result == ncclSuccess)
+        {
+            destroyCompletedWatchdogEventsLocked();
+        }
+        else
+        {
+            quarantinePendingOperationsLocked();
+            destroyPooledEventsLocked();
+        }
+    }
+    else
+    {
+        destroyPooledEventsLocked();
     }
 #endif // ENABLE_MULTI_DEVICE
 }

--- a/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
+++ b/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
@@ -413,7 +413,7 @@ ncclComm_t NcclCommunicator::createLegacyComm(int worldSize, int rank, mpi::MpiC
         _putenv_s("NCCL_RUNTIME_CONNECT", "0");
 #else
     setenv("NCCL_RUNTIME_CONNECT", "0", 0);
-    if (getenv("NCCL_NVLS_ENABLE") == nullptr && !ipcNvlsSupported())
+    if (getenv("NCCL_NVLS_ENABLE") == nullptr && !ipcNvlsFabricUsable())
     {
         setenv("NCCL_NVLS_ENABLE", "0", 0);
     }

--- a/cpp/tensorrt_llm/runtime/ncclCommunicator.h
+++ b/cpp/tensorrt_llm/runtime/ncclCommunicator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,20 +22,43 @@
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include "tensorrt_llm/runtime/worldConfig.h"
 
+#include <cuda_runtime_api.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
 struct ncclComm;
 typedef struct ncclComm* ncclComm_t;
 
 namespace tensorrt_llm::runtime
 {
 
+class NcclUniqueIdRendezvousComm;
+
 class NcclCommunicator
 {
 public:
-    explicit NcclCommunicator(ncclComm_t comm)
-        : mComm{comm} {};
+    //! Wrap an existing communicator.
+    //!
+    //! In fault-tolerance mode the caller is responsible for creating `comm`
+    //! in non-blocking mode. The default-off path preserves the legacy
+    //! blocking communicator contract.
+    explicit NcclCommunicator(ncclComm_t comm);
 
-    explicit NcclCommunicator(int worldSize, int rank, mpi::MpiComm const& mpiComm = COMM_SESSION)
-        : mComm{createComm(worldSize, rank, mpiComm)} {};
+    //! Create a communicator bootstrapped by `mpiComm`.
+    //!
+    //! Construction establishes and retains a dedicated MPI control channel while
+    //! the initial group is healthy. Recovery reuses that channel without an
+    //! MPI collective; `mpiComm` therefore need not outlive this object.
+    explicit NcclCommunicator(int worldSize, int rank, mpi::MpiComm const& mpiComm = COMM_SESSION);
 
     explicit NcclCommunicator(WorldConfig const& worldConfig, mpi::MpiComm const& mpiComm = COMM_SESSION)
         : NcclCommunicator{worldConfig.getSize(), worldConfig.getRank(), mpiComm} {};
@@ -56,6 +79,30 @@ public:
         receive(buf.data(), buf.getSize(), buf.getDataType(), peer, stream);
     }
 
+    //! Abort the current communicator. Idempotent.
+    void abort();
+
+    //! Abort and replace the current communicator with a fresh communicator
+    //! containing only `activeRanks`.
+    //!
+    //! Ranks are the original world-rank IDs supplied to the constructor. The
+    //! local rank must be present, and previously removed ranks cannot be added
+    //! again. Every survivor must call this method with the same rank set. The
+    //! positive `rendezvousId` must identify the same logical recovery attempt
+    //! on every survivor; zero is reserved for the initial bootstrap. The NCCL
+    //! unique ID is exchanged point-to-point over the dedicated control
+    //! channel, so failed ranks do not participate in recovery.
+    //!
+    //! Communicators created by the raw-handle constructor cannot be rebuilt
+    //! because that constructor has no MPI bootstrap communicator.
+    void abortAndReinit(std::vector<int> const& activeRanks, std::uint64_t rendezvousId);
+
+    //! Return the latched NCCL abort/error reason, or an empty string.
+    [[nodiscard]] std::string getAsyncError() const;
+
+    //! Return the original world-rank IDs in the current communicator.
+    [[nodiscard]] std::vector<int> getActiveRanks() const;
+
 private:
     void send(
         void const* sendbuff, size_t count, tensorrt_llm::DataType dataType, int peer, CudaStream const& stream) const;
@@ -63,9 +110,56 @@ private:
     void receive(
         void* sendbuff, size_t count, tensorrt_llm::DataType dataType, int peer, CudaStream const& stream) const;
 
-    static ncclComm_t createComm(int worldSize, int rank, mpi::MpiComm const& mpiComm);
+    static ncclComm_t createComm(std::vector<int> const& activeRanks, int worldRank,
+        NcclUniqueIdRendezvousComm const& controlComm, std::uint64_t rendezvousId,
+        std::chrono::milliseconds readyTimeout);
+    static ncclComm_t createLegacyComm(int worldSize, int rank, mpi::MpiComm const& mpiComm);
+    static void waitUntilReady(ncclComm_t comm, char const* operation, std::chrono::steady_clock::time_point deadline);
 
-    ncclComm_t mComm;
+    void startWatcher();
+    void stopWatcher() noexcept;
+    void watchAsyncErrors() noexcept;
+    [[nodiscard]] bool abortLocked(std::string reason) const noexcept;
+    void checkUsableLocked() const;
+    [[nodiscard]] int getCommPeerRankLocked(int worldRank) const;
+    [[nodiscard]] uint64_t beginOperationLocked(cudaStream_t stream, char const* operation) const;
+    void finishOperationLocked(uint64_t token, cudaStream_t stream) const;
+    [[nodiscard]] cudaEvent_t acquireEventLocked() const;
+    void recycleEventLocked(cudaEvent_t event) const noexcept;
+    void quarantinePendingOperationsLocked() const noexcept;
+    void destroyCompletedWatchdogEventsLocked() const noexcept;
+    void destroyPooledEventsLocked() const noexcept;
+
+    int mInitialWorldSize{0};
+    int mWorldRank{0};
+    bool mFaultToleranceEnabled{false};
+    std::vector<int> mActiveRanks;
+    std::shared_ptr<NcclUniqueIdRendezvousComm> mControlComm;
+
+    mutable std::mutex mCommMutex;
+    mutable ncclComm_t mComm{nullptr};
+    mutable std::string mAsyncError;
+
+    struct PendingOperation
+    {
+        uint64_t token;
+        cudaEvent_t start;
+        cudaEvent_t completion;
+        std::chrono::steady_clock::time_point deadline;
+        bool armed;
+        std::string name;
+    };
+
+    mutable std::vector<PendingOperation> mPendingOperations;
+    mutable std::vector<cudaEvent_t> mEventPool;
+    mutable uint64_t mNextOperationToken{1};
+    static constexpr size_t kMaxPendingOperations = 4096;
+    static constexpr size_t kMaxPooledEvents = 256;
+
+    std::atomic<bool> mStopWatcher{false};
+    std::mutex mWatcherWaitMutex;
+    mutable std::condition_variable mWatcherWakeup;
+    std::thread mWatcherThread;
 };
 
 } // namespace tensorrt_llm::runtime

--- a/cpp/tensorrt_llm/runtime/utils/ncclUniqueIdRendezvous.cpp
+++ b/cpp/tensorrt_llm/runtime/utils/ncclUniqueIdRendezvous.cpp
@@ -1,0 +1,787 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/runtime/utils/ncclUniqueIdRendezvous.h"
+
+#if ENABLE_MULTI_DEVICE
+
+#include "tensorrt_llm/common/assert.h"
+#include "tensorrt_llm/runtime/utils/ncclHostApi.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <exception>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace tensorrt_llm::runtime
+{
+namespace
+{
+
+using Clock = std::chrono::steady_clock;
+
+constexpr std::uint32_t kProtocolVersion = 2;
+constexpr auto kPollInterval = std::chrono::milliseconds{1};
+constexpr auto kReadyRefreshInterval = std::chrono::milliseconds{100};
+constexpr std::size_t kMaxTokensPerPeer = 1024;
+constexpr std::size_t kMaxPendingMessages = 4096;
+
+struct AttemptToken
+{
+    std::uint64_t incarnation;
+    std::uint64_t sequence;
+};
+
+bool operator==(AttemptToken const& lhs, AttemptToken const& rhs) noexcept
+{
+    return lhs.incarnation == rhs.incarnation && lhs.sequence == rhs.sequence;
+}
+
+struct ReadyMessage
+{
+    std::uint32_t version;
+    std::uint32_t reserved;
+    std::uint64_t communicatorKey;
+    std::uint64_t rendezvousId;
+    AttemptToken clientToken;
+};
+
+struct IdMessage
+{
+    std::uint32_t version;
+    std::uint32_t reserved;
+    std::uint64_t communicatorKey;
+    std::uint64_t rendezvousId;
+    AttemptToken clientToken;
+    AttemptToken serverToken;
+    std::uint64_t idDigest;
+    ncclUniqueId id;
+};
+
+struct AckMessage
+{
+    std::uint32_t version;
+    std::uint32_t reserved;
+    std::uint64_t communicatorKey;
+    std::uint64_t rendezvousId;
+    AttemptToken clientToken;
+    AttemptToken serverToken;
+    std::uint64_t idDigest;
+};
+
+template <typename Message>
+struct ReceivedMessage
+{
+    int source;
+    Message message;
+};
+
+struct RendezvousContext
+{
+    std::mutex exchangeMutex;
+    std::deque<ReceivedMessage<ReadyMessage>> pendingReady;
+    std::deque<ReceivedMessage<IdMessage>> pendingIds;
+    std::deque<ReceivedMessage<AckMessage>> pendingAcks;
+};
+
+struct ControlCommCacheEntry
+{
+    ControlCommCacheEntry(MPI_Group parentGroup_, std::vector<int> initialRanks_, int worldRank_, int creationTagSeed_)
+        : parentGroup(parentGroup_)
+        , initialRanks(std::move(initialRanks_))
+        , worldRank(worldRank_)
+        , creationTagSeed(creationTagSeed_)
+    {
+    }
+
+    std::mutex mutex;
+    MPI_Group parentGroup{MPI_GROUP_NULL};
+    std::vector<int> initialRanks;
+    int worldRank;
+    int creationTagSeed;
+    std::shared_ptr<NcclUniqueIdRendezvousComm> comm;
+    std::exception_ptr failure;
+};
+
+std::uint64_t groupIdentity(std::vector<int> const& ranks) noexcept
+{
+    std::uint64_t hash = 14695981039346656037ULL;
+    for (int const rank : ranks)
+    {
+        auto const* bytes = reinterpret_cast<unsigned char const*>(&rank);
+        for (std::size_t index = 0; index < sizeof(rank); ++index)
+        {
+            hash ^= bytes[index];
+            hash *= 1099511628211ULL;
+        }
+    }
+    return hash;
+}
+
+using ContextKey = std::tuple<MPI_Fint, std::uint64_t, int, int, int>;
+
+ContextKey getContextKey(NcclUniqueIdRendezvousTags const& tags, NcclUniqueIdRendezvousComm const& controlComm) noexcept
+{
+    return {MPI_Comm_c2f(static_cast<MPI_Comm>(controlComm.mpiComm())), groupIdentity(controlComm.worldRanks()),
+        static_cast<int>(tags.ready), static_cast<int>(tags.id), static_cast<int>(tags.ack)};
+}
+
+RendezvousContext& getRendezvousContext(
+    NcclUniqueIdRendezvousTags const& tags, NcclUniqueIdRendezvousComm const& controlComm)
+{
+    // Keep contexts immortal for the same reason as the NCCL host gate: a
+    // communicator may be torn down from another process-lifetime singleton.
+    static auto* registryMutex = new std::mutex;
+    static auto* contexts = new std::map<ContextKey, std::unique_ptr<RendezvousContext>>;
+    std::lock_guard<std::mutex> lock(*registryMutex);
+    auto& context = (*contexts)[getContextKey(tags, controlComm)];
+    if (context == nullptr)
+    {
+        context = std::make_unique<RendezvousContext>();
+    }
+    return *context;
+}
+
+std::shared_ptr<ControlCommCacheEntry> getControlCommCacheEntry(
+    std::vector<int> const& initialRanks, int worldRank, mpi::MpiComm const& parentComm, int creationTagSeed)
+{
+    // A control communicator cannot be freed safely after a member dies. Keep
+    // one channel per topology for the process lifetime and reuse it across PP
+    // engine teardown/recreation instead of leaking a new MPI context each
+    // time. Retain the parent's MPI group as a stable process-membership
+    // identity: MPI communicator handles may be recycled after a custom parent
+    // is freed. Per-entry locking permits unrelated groups to create
+    // concurrently.
+    static auto* registryMutex = new std::mutex;
+    static auto* entries = new std::vector<std::shared_ptr<ControlCommCacheEntry>>;
+
+    MPI_Group parentGroup = MPI_GROUP_NULL;
+    int result = MPI_Comm_group(static_cast<MPI_Comm>(parentComm), &parentGroup);
+    TLLM_CHECK_WITH_INFO(
+        result == MPI_SUCCESS, "NCCL error: failed to retain MPI parent group identity (code %d)", result);
+    try
+    {
+        std::lock_guard<std::mutex> lock(*registryMutex);
+        for (auto const& entry : *entries)
+        {
+            if (entry->initialRanks != initialRanks || entry->worldRank != worldRank
+                || entry->creationTagSeed != creationTagSeed)
+            {
+                continue;
+            }
+            int comparison = MPI_UNEQUAL;
+            result = MPI_Group_compare(entry->parentGroup, parentGroup, &comparison);
+            TLLM_CHECK_WITH_INFO(
+                result == MPI_SUCCESS, "NCCL error: failed to compare MPI parent group identity (code %d)", result);
+            if (comparison == MPI_IDENT)
+            {
+                MPI_Group_free(&parentGroup);
+                return entry;
+            }
+        }
+
+        auto entry = std::make_shared<ControlCommCacheEntry>(parentGroup, initialRanks, worldRank, creationTagSeed);
+        entries->push_back(entry);
+        parentGroup = MPI_GROUP_NULL;
+        return entry;
+    }
+    catch (...)
+    {
+        if (parentGroup != MPI_GROUP_NULL)
+        {
+            MPI_Group_free(&parentGroup);
+        }
+        throw;
+    }
+}
+
+template <typename Message>
+bool takePending(std::deque<ReceivedMessage<Message>>& pending, int source, std::uint64_t key,
+    std::uint64_t rendezvousId, ReceivedMessage<Message>& result)
+{
+    auto found = pending.begin();
+    for (; found != pending.end(); ++found)
+    {
+        if ((source == MPI_ANY_SOURCE || found->source == source) && found->message.communicatorKey == key
+            && found->message.rendezvousId == rendezvousId)
+        {
+            break;
+        }
+    }
+    if (found == pending.end())
+    {
+        return false;
+    }
+    result = *found;
+    pending.erase(found);
+    return true;
+}
+
+template <typename Message>
+void discardObsoletePending(
+    std::deque<ReceivedMessage<Message>>& pending, std::uint64_t key, std::uint64_t rendezvousId)
+{
+    pending.erase(std::remove_if(pending.begin(), pending.end(),
+                      [key, rendezvousId](auto const& received)
+                      {
+                          return received.message.version == kProtocolVersion && received.message.communicatorKey == key
+                              && received.message.rendezvousId < rendezvousId;
+                      }),
+        pending.end());
+}
+
+template <typename Message>
+bool isCurrentAttempt(Message const& message, std::uint64_t key, std::uint64_t rendezvousId) noexcept
+{
+    return message.communicatorKey == key && message.rendezvousId == rendezvousId;
+}
+
+template <typename Message>
+bool shouldStashForLater(Message const& message, std::uint64_t key, std::uint64_t rendezvousId) noexcept
+{
+    if (message.version != kProtocolVersion)
+    {
+        return false;
+    }
+    // Rendezvous IDs must increase for retries of one base communicator.
+    // Messages from an older retry can never be consumed again, while a peer
+    // may legitimately have entered a future retry or a different group first.
+    return message.communicatorKey != key || message.rendezvousId > rendezvousId;
+}
+
+template <typename Message>
+void stashPending(std::deque<ReceivedMessage<Message>>& pending, ReceivedMessage<Message> received)
+{
+    TLLM_CHECK_WITH_INFO(
+        pending.size() < kMaxPendingMessages, "NCCL error: communicator rendezvous pending-message limit exceeded");
+    pending.push_back(std::move(received));
+}
+
+std::uint64_t fnv1a(void const* data, std::size_t size, std::uint64_t hash = 14695981039346656037ULL) noexcept
+{
+    auto const* bytes = static_cast<unsigned char const*>(data);
+    for (std::size_t index = 0; index < size; ++index)
+    {
+        hash ^= bytes[index];
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
+
+std::uint64_t communicatorKey(std::vector<int> const& activeRanks, NcclUniqueIdRendezvousTags const& tags) noexcept
+{
+    std::uint64_t hash = fnv1a(activeRanks.data(), activeRanks.size() * sizeof(activeRanks.front()));
+    std::array<int, 3> const tagValues{
+        static_cast<int>(tags.ready), static_cast<int>(tags.id), static_cast<int>(tags.ack)};
+    return fnv1a(tagValues.data(), tagValues.size() * sizeof(tagValues.front()), hash);
+}
+
+std::uint64_t processIncarnation()
+{
+    static std::uint64_t const incarnation = []()
+    {
+        std::random_device random;
+        std::array<std::uint32_t, 4> entropy{random(), random(), random(), random()};
+        auto const wallClock = std::chrono::system_clock::now().time_since_epoch().count();
+        std::uint64_t hash = fnv1a(entropy.data(), entropy.size() * sizeof(entropy.front()));
+        hash = fnv1a(&wallClock, sizeof(wallClock), hash);
+        return hash == 0 ? std::uint64_t{1} : hash;
+    }();
+    return incarnation;
+}
+
+AttemptToken makeAttemptToken()
+{
+    static std::atomic<std::uint64_t> sequence{1};
+    auto const value = sequence.fetch_add(1, std::memory_order_relaxed);
+    TLLM_CHECK_WITH_INFO(value != 0, "NCCL error: communicator rendezvous token sequence overflow");
+    return AttemptToken{processIncarnation(), value};
+}
+
+int abandonRequest(MPI_Request& request) noexcept
+{
+    int firstError = MPI_SUCCESS;
+    if (request != MPI_REQUEST_NULL)
+    {
+        firstError = MPI_Cancel(&request);
+        // MPI_Wait can block forever after a peer failure, defeating the
+        // recovery deadline. Free the local request handle and let MPI retire
+        // it asynchronously; callers deliberately leak the tiny backing
+        // payload so the implementation can no longer access freed storage.
+        int const freeResult = MPI_Request_free(&request);
+        if (firstError == MPI_SUCCESS)
+        {
+            firstError = freeResult;
+        }
+    }
+    return firstError;
+}
+
+void waitForSend(MPI_Request& request, Clock::time_point deadline, char const* operation)
+{
+    while (true)
+    {
+        int complete = 0;
+        int const result = MPI_Test(&request, &complete, MPI_STATUS_IGNORE);
+        if (result != MPI_SUCCESS)
+        {
+            int const cleanupResult = abandonRequest(request);
+            TLLM_THROW(
+                "NCCL error: MPI_Test failed while %s (code %d, cleanup code %d)", operation, result, cleanupResult);
+        }
+        if (complete != 0)
+        {
+            return;
+        }
+        if (Clock::now() >= deadline)
+        {
+            int const cleanupResult = abandonRequest(request);
+            TLLM_THROW("NCCL error: timed out while %s (MPI cleanup code %d)", operation, cleanupResult);
+        }
+        std::this_thread::sleep_for(kPollInterval);
+    }
+}
+
+template <typename Message>
+void sendMessage(Message const& message, int destination, mpi::MpiTag tag, mpi::MpiComm const& mpiComm,
+    Clock::time_point deadline, char const* operation)
+{
+    auto payload = std::make_unique<Message>(message);
+    MPI_Request request = MPI_REQUEST_NULL;
+    int const result = MPI_Isend(payload.get(), static_cast<int>(sizeof(message)), MPI_BYTE, destination,
+        static_cast<int>(tag), static_cast<MPI_Comm>(mpiComm), &request);
+    if (result != MPI_SUCCESS)
+    {
+        int const cleanupResult = abandonRequest(request);
+        static_cast<void>(payload.release());
+        TLLM_THROW("NCCL error: MPI_Isend failed while %s to rank %d (code %d, cleanup code %d)", operation,
+            destination, result, cleanupResult);
+    }
+    try
+    {
+        waitForSend(request, deadline, operation);
+    }
+    catch (...)
+    {
+        static_cast<void>(payload.release());
+        throw;
+    }
+}
+
+bool probeMessage(int source, mpi::MpiTag tag, mpi::MpiComm const& mpiComm, MPI_Status& status)
+{
+    int available = 0;
+    int const result = MPI_Iprobe(source, static_cast<int>(tag), static_cast<MPI_Comm>(mpiComm), &available, &status);
+    TLLM_CHECK_WITH_INFO(result == MPI_SUCCESS, "NCCL error: MPI_Iprobe failed with code %d", result);
+    return available != 0;
+}
+
+template <typename Message>
+Message receiveMessage(MPI_Status const& probedStatus, mpi::MpiTag tag, mpi::MpiComm const& mpiComm,
+    Clock::time_point deadline, char const* operation)
+{
+    auto message = std::make_unique<Message>();
+    MPI_Request request = MPI_REQUEST_NULL;
+    int const result = MPI_Irecv(message.get(), static_cast<int>(sizeof(Message)), MPI_BYTE, probedStatus.MPI_SOURCE,
+        static_cast<int>(tag), static_cast<MPI_Comm>(mpiComm), &request);
+    if (result != MPI_SUCCESS)
+    {
+        int const cleanupResult = abandonRequest(request);
+        static_cast<void>(message.release());
+        TLLM_THROW("NCCL error: MPI_Irecv failed while %s from rank %d (code %d, cleanup code %d)", operation,
+            probedStatus.MPI_SOURCE, result, cleanupResult);
+    }
+
+    while (true)
+    {
+        int complete = 0;
+        MPI_Status status{};
+        int const testResult = MPI_Test(&request, &complete, &status);
+        if (testResult != MPI_SUCCESS)
+        {
+            int const cleanupResult = abandonRequest(request);
+            static_cast<void>(message.release());
+            TLLM_THROW("NCCL error: MPI_Test failed while %s (code %d, cleanup code %d)", operation, testResult,
+                cleanupResult);
+        }
+        if (complete != 0)
+        {
+            int count = 0;
+            int const countResult = MPI_Get_count(&status, MPI_BYTE, &count);
+            TLLM_CHECK_WITH_INFO(countResult == MPI_SUCCESS && count == static_cast<int>(sizeof(Message)),
+                "NCCL error: invalid MPI rendezvous payload while %s", operation);
+            return *message;
+        }
+        if (Clock::now() >= deadline)
+        {
+            int const cleanupResult = abandonRequest(request);
+            static_cast<void>(message.release());
+            TLLM_THROW("NCCL error: timed out while %s (MPI cleanup code %d)", operation, cleanupResult);
+        }
+        std::this_thread::sleep_for(kPollInterval);
+    }
+}
+
+bool isActivePeer(std::vector<int> const& activeRanks, int rank, int root)
+{
+    return rank != root && std::binary_search(activeRanks.begin(), activeRanks.end(), rank);
+}
+
+} // namespace
+
+NcclUniqueIdRendezvousComm::NcclUniqueIdRendezvousComm(mpi::MpiComm comm, std::vector<int> worldRanks, int worldRank)
+    : mComm(std::move(comm))
+    , mWorldRanks(std::move(worldRanks))
+    , mWorldRank(worldRank)
+{
+    TLLM_CHECK_WITH_INFO(!mWorldRanks.empty(), "NCCL error: rendezvous control group must not be empty");
+    TLLM_CHECK_WITH_INFO(std::is_sorted(mWorldRanks.begin(), mWorldRanks.end()),
+        "NCCL error: rendezvous control ranks must be in canonical order");
+    TLLM_CHECK_WITH_INFO(std::adjacent_find(mWorldRanks.begin(), mWorldRanks.end()) == mWorldRanks.end(),
+        "NCCL error: rendezvous control ranks contain duplicates");
+    TLLM_CHECK_WITH_INFO(mComm.getSize() == static_cast<int>(mWorldRanks.size()),
+        "NCCL error: rendezvous control communicator size %d does not match rank map size %zu", mComm.getSize(),
+        mWorldRanks.size());
+    TLLM_CHECK_WITH_INFO(worldRank == this->worldRank(mComm.getRank()),
+        "NCCL error: world rank %d does not match rendezvous control rank %d", worldRank, mComm.getRank());
+}
+
+mpi::MpiComm const& NcclUniqueIdRendezvousComm::mpiComm() const noexcept
+{
+    return mComm;
+}
+
+std::vector<int> const& NcclUniqueIdRendezvousComm::worldRanks() const noexcept
+{
+    return mWorldRanks;
+}
+
+int NcclUniqueIdRendezvousComm::worldRank() const noexcept
+{
+    return mWorldRank;
+}
+
+int NcclUniqueIdRendezvousComm::commRank(int worldRank) const
+{
+    auto const found = std::lower_bound(mWorldRanks.begin(), mWorldRanks.end(), worldRank);
+    TLLM_CHECK_WITH_INFO(found != mWorldRanks.end() && *found == worldRank,
+        "NCCL error: world rank %d is not present in the rendezvous control channel", worldRank);
+    return static_cast<int>(std::distance(mWorldRanks.begin(), found));
+}
+
+int NcclUniqueIdRendezvousComm::worldRank(int commRank) const
+{
+    TLLM_CHECK_WITH_INFO(commRank >= 0 && commRank < static_cast<int>(mWorldRanks.size()),
+        "NCCL error: rendezvous control rank %d is outside [0, %zu)", commRank, mWorldRanks.size());
+    return mWorldRanks[static_cast<std::size_t>(commRank)];
+}
+
+std::shared_ptr<NcclUniqueIdRendezvousComm> createNcclUniqueIdRendezvousComm(
+    std::vector<int> const& initialRanks, int worldRank, mpi::MpiComm const& parentComm, int creationTagSeed)
+{
+    TLLM_CHECK_WITH_INFO(!initialRanks.empty(), "NCCL error: rendezvous control group must not be empty");
+    TLLM_CHECK_WITH_INFO(std::is_sorted(initialRanks.begin(), initialRanks.end()),
+        "NCCL error: rendezvous control ranks must be in canonical order");
+    TLLM_CHECK_WITH_INFO(std::adjacent_find(initialRanks.begin(), initialRanks.end()) == initialRanks.end(),
+        "NCCL error: rendezvous control ranks contain duplicates");
+    TLLM_CHECK_WITH_INFO(std::binary_search(initialRanks.begin(), initialRanks.end(), worldRank),
+        "NCCL error: world rank %d is not a member of the rendezvous control group", worldRank);
+    TLLM_CHECK_WITH_INFO(parentComm.getRank() == worldRank,
+        "NCCL error: world rank %d does not match MPI parent rank %d", worldRank, parentComm.getRank());
+    TLLM_CHECK_WITH_INFO(initialRanks.front() >= 0 && initialRanks.back() < parentComm.getSize(),
+        "NCCL error: rendezvous control ranks must be within MPI parent size %d", parentComm.getSize());
+
+    auto cacheEntry = getControlCommCacheEntry(initialRanks, worldRank, parentComm, creationTagSeed);
+    std::lock_guard<std::mutex> const cacheLock(cacheEntry->mutex);
+    if (cacheEntry->comm != nullptr)
+    {
+        return cacheEntry->comm;
+    }
+    if (cacheEntry->failure != nullptr)
+    {
+        // Creation is collective over the initial group. Never let one rank
+        // retry that collective after a prior asymmetric local failure while
+        // peers may already have cached a successfully-created channel.
+        std::rethrow_exception(cacheEntry->failure);
+    }
+
+    void* tagUpperBoundValue = nullptr;
+    int hasTagUpperBound = 0;
+    int result
+        = MPI_Comm_get_attr(static_cast<MPI_Comm>(parentComm), MPI_TAG_UB, &tagUpperBoundValue, &hasTagUpperBound);
+    TLLM_CHECK_WITH_INFO(
+        result == MPI_SUCCESS, "NCCL error: failed to query MPI_TAG_UB for the control channel (code %d)", result);
+    TLLM_CHECK_WITH_INFO(hasTagUpperBound != 0 && tagUpperBoundValue != nullptr,
+        "NCCL error: MPI parent communicator does not expose MPI_TAG_UB");
+    int const tagUpperBound = *static_cast<int*>(tagUpperBoundValue);
+    constexpr int kFirstControlCreationTag = static_cast<int>(mpi::MpiTag::kNcclPpControl) + 1;
+    TLLM_CHECK_WITH_INFO(creationTagSeed >= 0, "NCCL error: rendezvous control creation-tag seed must be nonnegative");
+    int const tagParity = creationTagSeed & 1;
+    TLLM_CHECK_WITH_INFO(tagUpperBound >= kFirstControlCreationTag + tagParity,
+        "NCCL error: MPI_TAG_UB %d is too small for NCCL control-channel creation", tagUpperBound);
+    std::uint64_t tagHash = groupIdentity(initialRanks);
+    tagHash ^= static_cast<std::uint64_t>(creationTagSeed) + 0x9e3779b97f4a7c15ULL + (tagHash << 6) + (tagHash >> 2);
+    // Even/odd slots separate raw-op and PP seeds; the group hash makes lazy
+    // creation order-independent within each ownership path.
+    auto const tagSlots = static_cast<std::uint64_t>(tagUpperBound - kFirstControlCreationTag - tagParity) / 2 + 1;
+    int const creationTag = kFirstControlCreationTag + tagParity + static_cast<int>(2 * (tagHash % tagSlots));
+
+    MPI_Group parentGroup = MPI_GROUP_NULL;
+    MPI_Group controlGroup = MPI_GROUP_NULL;
+    MPI_Comm controlComm = MPI_COMM_NULL;
+    auto cleanup = [&]() noexcept
+    {
+        if (controlGroup != MPI_GROUP_NULL)
+        {
+            MPI_Group_free(&controlGroup);
+        }
+        if (parentGroup != MPI_GROUP_NULL)
+        {
+            MPI_Group_free(&parentGroup);
+        }
+        // Once MPI_Comm_create_group has returned a non-null communicator,
+        // never call collective MPI_Comm_free from an exception path. A
+        // local allocation or error-handler failure can be asymmetric, so
+        // peers may already have published their process-lifetime channel.
+        // Leaking that rare failed construction is safer than deadlocking.
+    };
+
+    try
+    {
+        result = MPI_Comm_group(static_cast<MPI_Comm>(parentComm), &parentGroup);
+        TLLM_CHECK_WITH_INFO(result == MPI_SUCCESS, "NCCL error: failed to inspect MPI parent group (code %d)", result);
+        result = MPI_Group_incl(parentGroup, static_cast<int>(initialRanks.size()), initialRanks.data(), &controlGroup);
+        TLLM_CHECK_WITH_INFO(result == MPI_SUCCESS, "NCCL error: failed to create MPI control group (code %d)", result);
+        // MPI_Comm_create_group is collective only over initialRanks. This is
+        // the sole control-channel collective and must happen before failure.
+        result = MPI_Comm_create_group(static_cast<MPI_Comm>(parentComm), controlGroup, creationTag, &controlComm);
+        TLLM_CHECK_WITH_INFO(
+            result == MPI_SUCCESS, "NCCL error: failed to create MPI control communicator (code %d)", result);
+        TLLM_CHECK_WITH_INFO(controlComm != MPI_COMM_NULL,
+            "NCCL error: MPI returned a null rendezvous control communicator for member rank %d", worldRank);
+        result = MPI_Comm_set_errhandler(controlComm, MPI_ERRORS_RETURN);
+        TLLM_CHECK_WITH_INFO(result == MPI_SUCCESS,
+            "NCCL error: failed to configure MPI_ERRORS_RETURN on the control channel (code %d)", result);
+
+        MPI_Group_free(&controlGroup);
+        controlGroup = MPI_GROUP_NULL;
+        MPI_Group_free(&parentGroup);
+        parentGroup = MPI_GROUP_NULL;
+        // Never call MPI_Comm_free on a successfully-published FT control
+        // channel: freeing after a member dies is not guaranteed to make
+        // progress. The communicator intentionally lives until process exit.
+        auto ownedComm = mpi::MpiComm{controlComm, false};
+        auto resultComm = std::make_shared<NcclUniqueIdRendezvousComm>(std::move(ownedComm), initialRanks, worldRank);
+        controlComm = MPI_COMM_NULL;
+        cacheEntry->comm = std::move(resultComm);
+        return cacheEntry->comm;
+    }
+    catch (...)
+    {
+        cacheEntry->failure = std::current_exception();
+        cleanup();
+        throw;
+    }
+}
+
+ncclUniqueId exchangeNcclUniqueId(std::vector<int> const& activeRanks, NcclUniqueIdRendezvousComm const& controlComm,
+    NcclUniqueIdRendezvousTags tags, std::uint64_t rendezvousId, Clock::time_point deadline)
+{
+    auto const worldRank = controlComm.worldRank();
+    auto const& mpiComm = controlComm.mpiComm();
+    TLLM_CHECK_WITH_INFO(!activeRanks.empty(), "NCCL error: communicator rendezvous group must not be empty");
+    TLLM_CHECK_WITH_INFO(std::is_sorted(activeRanks.begin(), activeRanks.end()),
+        "NCCL error: communicator rendezvous ranks must be in canonical order");
+    TLLM_CHECK_WITH_INFO(std::adjacent_find(activeRanks.begin(), activeRanks.end()) == activeRanks.end(),
+        "NCCL error: communicator rendezvous ranks contain duplicates");
+    TLLM_CHECK_WITH_INFO(std::binary_search(activeRanks.begin(), activeRanks.end(), worldRank),
+        "NCCL error: world rank %d is not active in communicator rendezvous", worldRank);
+    TLLM_CHECK_WITH_INFO(std::includes(controlComm.worldRanks().begin(), controlComm.worldRanks().end(),
+                             activeRanks.begin(), activeRanks.end()),
+        "NCCL error: communicator rendezvous group is not a subset of the pre-failure control group");
+
+    auto& context = getRendezvousContext(tags, controlComm);
+    std::unique_lock<std::mutex> const exchangeLock(context.exchangeMutex);
+    int const root = activeRanks.front();
+    std::uint64_t const key = communicatorKey(activeRanks, tags);
+    discardObsoletePending(context.pendingReady, key, rendezvousId);
+    discardObsoletePending(context.pendingIds, key, rendezvousId);
+    discardObsoletePending(context.pendingAcks, key, rendezvousId);
+    if (worldRank == root)
+    {
+        ncclUniqueId id{};
+        {
+            auto const hostApiLock = acquireNcclHostApiLock();
+            auto const result = ncclGetUniqueId(&id);
+            TLLM_CHECK_WITH_INFO(
+                result == ncclSuccess, "NCCL error: ncclGetUniqueId failed: %s", ncclGetErrorString(result));
+        }
+        if (activeRanks.size() == 1)
+        {
+            return id;
+        }
+
+        AttemptToken const serverToken = makeAttemptToken();
+        std::uint64_t const digest = fnv1a(&id, sizeof(id));
+        std::unordered_map<int, std::vector<AttemptToken>> issuedTokens;
+        std::unordered_set<int> acknowledged;
+        while (acknowledged.size() + 1 < activeRanks.size())
+        {
+            TLLM_CHECK_WITH_INFO(
+                Clock::now() < deadline, "NCCL error: timed out waiting for survivor communicator rendezvous");
+            bool progressed = false;
+            ReceivedMessage<ReadyMessage> receivedReady{};
+            bool haveReady = takePending(context.pendingReady, MPI_ANY_SOURCE, key, rendezvousId, receivedReady);
+            MPI_Status status{};
+            if (!haveReady && probeMessage(MPI_ANY_SOURCE, tags.ready, mpiComm, status))
+            {
+                progressed = true;
+                receivedReady = {controlComm.worldRank(status.MPI_SOURCE),
+                    receiveMessage<ReadyMessage>(status, tags.ready, mpiComm, deadline, "receiving NCCL READY")};
+                haveReady = isCurrentAttempt(receivedReady.message, key, rendezvousId);
+                if (!haveReady && shouldStashForLater(receivedReady.message, key, rendezvousId))
+                {
+                    stashPending(context.pendingReady, receivedReady);
+                }
+            }
+            if (haveReady)
+            {
+                progressed = true;
+                ReadyMessage const& ready = receivedReady.message;
+                int const source = receivedReady.source;
+                if (ready.version == kProtocolVersion && isCurrentAttempt(ready, key, rendezvousId)
+                    && isActivePeer(activeRanks, source, root))
+                {
+                    auto& tokens = issuedTokens[source];
+                    if (std::find(tokens.begin(), tokens.end(), ready.clientToken) == tokens.end())
+                    {
+                        TLLM_CHECK_WITH_INFO(tokens.size() < kMaxTokensPerPeer,
+                            "NCCL error: too many stale communicator rendezvous attempts from rank %d", source);
+                        tokens.push_back(ready.clientToken);
+                    }
+                    IdMessage const proposal{
+                        kProtocolVersion, 0, key, rendezvousId, ready.clientToken, serverToken, digest, id};
+                    sendMessage(
+                        proposal, controlComm.commRank(source), tags.id, mpiComm, deadline, "sending NCCL unique ID");
+                }
+            }
+
+            ReceivedMessage<AckMessage> receivedAck{};
+            bool haveAck = takePending(context.pendingAcks, MPI_ANY_SOURCE, key, rendezvousId, receivedAck);
+            if (!haveAck && probeMessage(MPI_ANY_SOURCE, tags.ack, mpiComm, status))
+            {
+                progressed = true;
+                receivedAck = {controlComm.worldRank(status.MPI_SOURCE),
+                    receiveMessage<AckMessage>(status, tags.ack, mpiComm, deadline, "receiving NCCL ACK")};
+                haveAck = isCurrentAttempt(receivedAck.message, key, rendezvousId);
+                if (!haveAck && shouldStashForLater(receivedAck.message, key, rendezvousId))
+                {
+                    stashPending(context.pendingAcks, receivedAck);
+                }
+            }
+            if (haveAck)
+            {
+                progressed = true;
+                AckMessage const& ack = receivedAck.message;
+                int const source = receivedAck.source;
+                auto const issued = issuedTokens.find(source);
+                if (ack.version == kProtocolVersion && isCurrentAttempt(ack, key, rendezvousId)
+                    && ack.serverToken == serverToken && ack.idDigest == digest && issued != issuedTokens.end()
+                    && std::find(issued->second.begin(), issued->second.end(), ack.clientToken) != issued->second.end())
+                {
+                    acknowledged.insert(source);
+                }
+            }
+
+            if (!progressed)
+            {
+                TLLM_CHECK_WITH_INFO(
+                    Clock::now() < deadline, "NCCL error: timed out waiting for survivor communicator rendezvous");
+                std::this_thread::sleep_for(kPollInterval);
+            }
+        }
+        return id;
+    }
+
+    AttemptToken const clientToken = makeAttemptToken();
+    ReadyMessage const ready{kProtocolVersion, 0, key, rendezvousId, clientToken};
+    int const rootCommRank = controlComm.commRank(root);
+    sendMessage(ready, rootCommRank, tags.ready, mpiComm, deadline, "sending NCCL READY");
+    auto nextReadyRefresh = Clock::now() + kReadyRefreshInterval;
+    while (true)
+    {
+        TLLM_CHECK_WITH_INFO(Clock::now() < deadline, "NCCL error: timed out waiting for survivor communicator ID");
+        if (Clock::now() >= nextReadyRefresh)
+        {
+            // A root attempt can consume READY and fail before accepting our
+            // ACK. Refresh the same idempotent client token so a subsequent
+            // root attempt can converge without waiting for this call to end.
+            sendMessage(ready, rootCommRank, tags.ready, mpiComm, deadline, "refreshing NCCL READY");
+            nextReadyRefresh = Clock::now() + kReadyRefreshInterval;
+        }
+        ReceivedMessage<IdMessage> receivedProposal{};
+        bool haveProposal = takePending(context.pendingIds, root, key, rendezvousId, receivedProposal);
+        MPI_Status status{};
+        if (!haveProposal && probeMessage(rootCommRank, tags.id, mpiComm, status))
+        {
+            receivedProposal = {controlComm.worldRank(status.MPI_SOURCE),
+                receiveMessage<IdMessage>(status, tags.id, mpiComm, deadline, "receiving NCCL unique ID")};
+            haveProposal = isCurrentAttempt(receivedProposal.message, key, rendezvousId);
+            if (!haveProposal && shouldStashForLater(receivedProposal.message, key, rendezvousId))
+            {
+                stashPending(context.pendingIds, receivedProposal);
+            }
+        }
+        if (!haveProposal)
+        {
+            TLLM_CHECK_WITH_INFO(Clock::now() < deadline, "NCCL error: timed out waiting for survivor communicator ID");
+            std::this_thread::sleep_for(kPollInterval);
+            continue;
+        }
+
+        IdMessage const& proposal = receivedProposal.message;
+        if (proposal.version != kProtocolVersion || !isCurrentAttempt(proposal, key, rendezvousId)
+            || !(proposal.clientToken == clientToken) || proposal.idDigest != fnv1a(&proposal.id, sizeof(proposal.id)))
+        {
+            sendMessage(ready, rootCommRank, tags.ready, mpiComm, deadline, "refreshing NCCL READY");
+            nextReadyRefresh = Clock::now() + kReadyRefreshInterval;
+            continue;
+        }
+
+        AckMessage const ack{
+            kProtocolVersion, 0, key, rendezvousId, clientToken, proposal.serverToken, proposal.idDigest};
+        sendMessage(ack, rootCommRank, tags.ack, mpiComm, deadline, "sending NCCL ACK");
+        return proposal.id;
+    }
+}
+
+} // namespace tensorrt_llm::runtime
+
+#endif // ENABLE_MULTI_DEVICE

--- a/cpp/tensorrt_llm/thop/allgatherOp.cpp
+++ b/cpp/tensorrt_llm/thop/allgatherOp.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,9 +55,9 @@ public:
 
     int initialize()
     {
-        TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, COMM_SESSION.getRank());
+        TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
         mNcclComm = getComm(mGroup);
-        TLLM_LOG_TRACE("%s stop for rank %d", __PRETTY_FUNCTION__, COMM_SESSION.getRank());
+        TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
         return 0;
     }
 
@@ -70,12 +70,11 @@ public:
         int64_t sum_sizes
             = sizes.has_value() ? std::accumulate(sizes.value().begin(), sizes.value().end(), 0, std::plus<>{}) : 0;
         std::vector<torch::Tensor> output_list;
+        std::vector<cudaStream_t> streams;
+        bool const trackOperations = isNcclFaultToleranceEnabled();
         output_list.reserve(input_list.size());
-        ncclGroupStart();
         for (auto const& input : input_list)
         {
-            auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
-            auto type = tensorrt_llm::runtime::TorchUtils::dataType(input.scalar_type());
             std::vector<int64_t> outputShape = input.sizes().vec();
             if (sizes.has_value())
             {
@@ -85,29 +84,68 @@ public:
             {
                 outputShape[0] *= mGroup.size();
             }
-            auto output = torch::empty(outputShape, input.options());
+            output_list.push_back(torch::empty(outputShape, input.options()));
+            if (trackOperations)
+            {
+                auto const stream = at::cuda::getCurrentCUDAStream(input.get_device());
+                if (std::find(streams.begin(), streams.end(), stream) == streams.end())
+                {
+                    streams.push_back(stream);
+                }
+            }
+        }
+
+        auto commLease = acquireComm(mNcclComm);
+        auto const comm = commLease.get();
+        std::vector<uint64_t> watchdogTokens;
+        if (trackOperations)
+        {
+            watchdogTokens.reserve(streams.size());
+            for (auto const stream : streams)
+            {
+                watchdogTokens.push_back(commLease.begin(stream, "ncclAllGather"));
+            }
+        }
+        commLease.groupStart("ncclGroupStart(allgather)");
+        for (size_t index = 0; index < input_list.size(); ++index)
+        {
+            auto const& input = input_list[index];
+            auto& output = output_list[index];
+            auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
+            auto type = tensorrt_llm::runtime::TorchUtils::dataType(input.scalar_type());
             if (use_nccl_allgather)
             {
-                ncclAllGather(input.data_ptr(), output.mutable_data_ptr(), input.numel(), (*getDtypeMap())[type],
-                    *mNcclComm, stream);
+                commLease.checkEnqueue(ncclAllGather(input.data_ptr(), output.mutable_data_ptr(), input.numel(),
+                                           (*getDtypeMap())[type], comm, stream),
+                    "ncclAllGather");
             }
             else
             {
+                auto const& outputShape = output.sizes();
                 size_t numel_base
                     = std::accumulate(outputShape.cbegin() + 1, outputShape.cend(), 1, std::multiplies<>{});
                 int64_t split_offset = 0;
                 for (int root = 0; root < static_cast<int>(mGroup.size()); ++root)
                 {
                     auto split_size = sizes.value()[root];
-                    ncclBroadcast(input.data_ptr(),
-                        output.index({torch::indexing::Slice(split_offset, torch::indexing::None)}).mutable_data_ptr(),
-                        numel_base * split_size, (*getDtypeMap())[type], root, *mNcclComm, stream);
+                    commLease.checkEnqueue(
+                        ncclBroadcast(input.data_ptr(),
+                            output.index({torch::indexing::Slice(split_offset, torch::indexing::None)})
+                                .mutable_data_ptr(),
+                            numel_base * split_size, (*getDtypeMap())[type], root, comm, stream),
+                        "ncclBroadcast(allgather)");
                     split_offset += split_size;
                 }
             }
-            output_list.push_back(output);
         }
-        NCCLCHECK_THROW(ncclGroupEnd());
+        commLease.groupEnd("ncclGroupEnd(allgather)");
+        if (trackOperations)
+        {
+            for (size_t index = 0; index < streams.size(); ++index)
+            {
+                commLease.track(watchdogTokens[index], streams[index]);
+            }
+        }
         return output_list;
     }
 

--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -265,9 +265,13 @@ public:
 
     int getRank() const
     {
-        return std::visit(
-            overloaded{[&](std::shared_ptr<ncclComm_t> const&) { return COMM_SESSION.getRank(); },
-                [&](c10::intrusive_ptr<c10d::ProcessGroup> const& torchPg) { return get_world_pg()->getRank(); }},
+        return std::visit(overloaded{[&](std::shared_ptr<ncclComm_t> const&)
+                              {
+                                  TLLM_CHECK_WITH_INFO(
+                                      mRank >= 0, "Raw AllreduceOp must be initialized before querying its rank");
+                                  return mRank;
+                              },
+                              [&](c10::intrusive_ptr<c10d::ProcessGroup> const&) { return get_world_pg()->getRank(); }},
             mNcclComm);
     }
 
@@ -283,6 +287,12 @@ public:
         TLLM_LOG_DEBUG("All reduce message size is %zu", size * bytes_per_element);
 
         AllReduceStrategyType runtime_strategy = selectImplementation(seq_len, hidden_size);
+
+        if (mNcclComm.index() == 0 && isNcclFaultToleranceEnabled())
+        {
+            TLLM_CHECK_WITH_INFO(runtime_strategy == AllReduceStrategyType::NCCL,
+                "NCCL error: TLLM_FAULT_TOLERANCE_MODE=1 requires a watchdog-managed NCCL allreduce strategy");
+        }
 
         // Log runtime strategy
         auto const rank = getRank();
@@ -308,10 +318,14 @@ public:
 
     int initialize()
     {
-        TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, getRank());
+        int const initialRank = mNcclComm.index() == 0 ? -1 : getRank();
+        TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, initialRank);
         if (mNcclComm.index() == 0)
         {
+            TLLM_CHECK_WITH_INFO(!isNcclFaultToleranceEnabled() || mStrategy == AllReduceStrategyType::NCCL,
+                "NCCL error: TLLM_FAULT_TOLERANCE_MODE=1 requires a watchdog-managed NCCL allreduce strategy");
             mNcclComm = getComm(mGroup);
+            mRank = getCommWorldRank(std::get<0>(mNcclComm));
         }
         if (mStrategy != AllReduceStrategyType::NCCL && mStrategy != AllReduceStrategyType::UB)
         {
@@ -415,8 +429,12 @@ private:
                            auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
                            int size = input.numel();
                            reduce_output = torch::empty_like(input);
-                           NCCLCHECK_THROW(ncclAllReduce(input.data_ptr(), reduce_output.mutable_data_ptr(), size,
-                               (*getDtypeMap())[mType], ncclSum, *rawComm, stream));
+                           auto commLease = acquireComm(rawComm);
+                           auto const watchdogToken = commLease.begin(stream, "ncclAllReduce");
+                           commLease.check(ncclAllReduce(input.data_ptr(), reduce_output.mutable_data_ptr(), size,
+                                               (*getDtypeMap())[mType], ncclSum, commLease.get(), stream),
+                               "ncclAllReduce");
+                           commLease.track(watchdogToken, stream);
                        },
                        [&](c10::intrusive_ptr<c10d::ProcessGroup>& torchPg)
                        {
@@ -462,8 +480,6 @@ private:
 
         // From here on, we have a raw NCCL comm - can proceed with window registration
         auto rawComm = std::get<0>(mNcclComm);
-        ncclComm_t comm = *rawComm;
-        TLLM_CHECK_WITH_INFO(comm != nullptr, "NCCL communicator is null");
         TLLM_LOG_DEBUG("[runNCCLAllReduceSymmetric] Using raw NCCL comm path (not ProcessGroup)");
 
         using tensorrt_llm::common::nccl_util::NCCLWindowAllocator;
@@ -486,7 +502,13 @@ private:
         double const a = -4986.43478503;
         double const b = 156716.52177552;
         int nRanks;
-        NCCLCHECK_THROW(ncclCommCount(comm, &nRanks));
+        ncclComm_t comm = nullptr;
+        {
+            auto commLease = acquireComm(rawComm);
+            comm = commLease.get();
+            TLLM_CHECK_WITH_INFO(comm != nullptr, "NCCL communicator is null");
+            commLease.check(ncclCommCount(comm, &nRanks), "ncclCommCount");
+        }
         size_t minRegistrationThreshold = static_cast<size_t>(std::max(0.0, a * nRanks + b)) * input.element_size();
         // Disable window registration if neither NVLink nor MNNVL is supported
         // TODO replace in NCCL 2.29 with comm query
@@ -566,7 +588,16 @@ private:
         }
 
         // Perform allreduce
-        NCCLCHECK_THROW(ncclAllReduce(inputPtr, outputPtr, size, (*getDtypeMap())[mType], ncclSum, comm, stream));
+        {
+            auto commLease = acquireComm(rawComm);
+            auto const activeComm = commLease.get();
+            TLLM_CHECK_WITH_INFO(activeComm == comm, "NCCL communicator changed while preparing a symmetric allreduce");
+            auto const watchdogToken = commLease.begin(stream, "ncclAllReduce(symmetric)");
+            commLease.check(
+                ncclAllReduce(inputPtr, outputPtr, size, (*getDtypeMap())[mType], ncclSum, activeComm, stream),
+                "ncclAllReduce(symmetric)");
+            commLease.track(watchdogToken, stream);
+        }
 
         if (mOp == AllReduceFusionOp::NONE)
         {
@@ -1466,6 +1497,7 @@ private:
     AllReduceFusionOp mOp;
     float mEps;
     std::variant<std::shared_ptr<ncclComm_t>, c10::intrusive_ptr<c10d::ProcessGroup>> mNcclComm;
+    int mRank{-1};
 };
 
 } // namespace
@@ -1488,7 +1520,7 @@ void preallocateNCCLWindowBuffer(
     }
 
     auto const commPtr = getComm(groupSet);
-    if (!commPtr || *commPtr == nullptr)
+    if (!commPtr)
     {
         TLLM_LOG_DEBUG("[preallocateNCCLWindowBuffers] NCCL comm is null; skipping preallocation");
         return;
@@ -1496,7 +1528,11 @@ void preallocateNCCLWindowBuffer(
 
     using tensorrt_llm::common::nccl_util::NCCLWindowAllocator;
     auto& allocator = NCCLWindowAllocator::getInstance();
-    ncclComm_t const comm = *commPtr;
+    ncclComm_t comm = nullptr;
+    {
+        auto commLease = acquireComm(commPtr);
+        comm = commLease.get();
+    }
 
     int64_t const numTokens = input.size(0);
     int64_t const elementsPerToken = input.numel() / numTokens;
@@ -1518,7 +1554,7 @@ void preallocateNCCLWindowBuffer(
     {
         for (int64_t i = 0; i < buffersPerSize; ++i)
         {
-            auto buffer = allocator.requestBuffer(comm, bufferSize);
+            auto buffer = allocator.requestBuffer(commPtr, bufferSize);
             if (!buffer.isValid())
             {
                 break;
@@ -1528,6 +1564,14 @@ void preallocateNCCLWindowBuffer(
     }
     catch (std::exception const& e)
     {
+        // A local allocation failure is a best-effort preallocation miss. A
+        // communicator failure is not: preserve the classifier-friendly NCCL
+        // exception so the executor enters recovery instead of continuing on
+        // the aborted native handle.
+        if (getCommAsyncError(commPtr).has_value())
+        {
+            throw;
+        }
         TLLM_LOG_DEBUG("[preallocateNCCLWindowBuffer] requestBuffer failed for %zu bytes: %s", bufferSize, e.what());
     }
 

--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -1610,14 +1610,15 @@ bool isNCCLWindowBuffer(torch::Tensor const& input, torch::List<int64_t> const& 
         return false;
     }
 
-    if (!commPtr || *commPtr == nullptr)
+    if (!commPtr)
     {
-        TLLM_LOG_DEBUG("[isNCCLWindowBuffer] NCCL comm is null");
+        TLLM_LOG_DEBUG("[isNCCLWindowBuffer] NCCL comm holder is null");
         return false;
     }
 
+    auto commLease = acquireComm(commPtr);
     using tensorrt_llm::common::nccl_util::NCCLWindowAllocator;
-    auto const buffer = NCCLWindowAllocator::getInstance().searchBuffer(*commPtr, input.data_ptr());
+    auto const buffer = NCCLWindowAllocator::getInstance().searchBuffer(commLease.get(), input.data_ptr());
     return buffer.isValid();
 #else
     (void) input;

--- a/cpp/tensorrt_llm/thop/alltoallOp.cpp
+++ b/cpp/tensorrt_llm/thop/alltoallOp.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,10 +44,10 @@ public:
 
     int initialize()
     {
-        TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, COMM_SESSION.getRank());
+        TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
         mNcclComm = getComm(mGroup);
         TLLM_CHECK_WITH_INFO(mGroup.size() > 0, "group size should be greater than 0");
-        TLLM_LOG_TRACE("%s stop for rank %d", __PRETTY_FUNCTION__, COMM_SESSION.getRank());
+        TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
         return 0;
     }
 
@@ -64,25 +64,37 @@ public:
             TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
         }
         std::vector<torch::Tensor> output_list(static_cast<size_t>(num_lists_));
+        for (int il = 0; il < num_lists_; ++il)
+        {
+            auto const off = il * num_ranks;
+            auto output_shape = input_list[off].sizes().vec();
+            output_shape.insert(output_shape.begin(), num_ranks);
+            output_list[il] = torch::empty(output_shape, input_list[off].options());
+        }
+
         auto stream = at::cuda::getCurrentCUDAStream(input_list[0].get_device());
-        ncclGroupStart();
+        auto commLease = acquireComm(mNcclComm);
+        auto const comm = commLease.get();
+        auto const watchdogToken = commLease.begin(stream, "ncclSend/ncclRecv(alltoall)");
+        commLease.groupStart("ncclGroupStart(alltoall)");
         for (int il = 0; il < num_lists_; ++il)
         {
             auto off = il * num_ranks;
-            auto output_shape = input_list[off].sizes().vec();
-            output_shape.insert(output_shape.begin(), num_ranks);
-            auto output = torch::empty(output_shape, input_list[off].options());
-            output_list[il] = output;
+            auto& output = output_list[il];
             auto type = tensorrt_llm::runtime::TorchUtils::dataType(input_list[off].scalar_type());
             auto nccl_type = (*getDtypeMap())[type];
             for (int r = 0; r < num_ranks; ++r)
             {
                 auto const& input = input_list[off + r];
-                ncclSend(input.data_ptr(), input.numel(), nccl_type, r, *mNcclComm, stream);
-                ncclRecv(output[r].mutable_data_ptr(), output[r].numel(), nccl_type, r, *mNcclComm, stream);
+                commLease.checkEnqueue(
+                    ncclSend(input.data_ptr(), input.numel(), nccl_type, r, comm, stream), "ncclSend(alltoall)");
+                commLease.checkEnqueue(
+                    ncclRecv(output[r].mutable_data_ptr(), output[r].numel(), nccl_type, r, comm, stream),
+                    "ncclRecv(alltoall)");
             }
         }
-        NCCLCHECK_THROW(ncclGroupEnd());
+        commLease.groupEnd("ncclGroupEnd(alltoall)");
+        commLease.track(watchdogToken, stream);
         return output_list;
     }
 

--- a/cpp/tensorrt_llm/thop/ncclCommunicatorOp.cpp
+++ b/cpp/tensorrt_llm/thop/ncclCommunicatorOp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,14 @@
 
 #include "tensorrt_llm/thop/ncclCommunicatorOp.h"
 
+#include "tensorrt_llm/common/opUtils.h"
 #include "tensorrt_llm/runtime/iBuffer.h"
+
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <utility>
 
 namespace tr = tensorrt_llm::runtime;
 
@@ -24,11 +31,70 @@ TRTLLM_NAMESPACE_BEGIN
 
 namespace torch_ext
 {
+namespace
+{
+
+std::mutex& pipelineCommunicatorMutex()
+{
+    static auto* mutex = new std::mutex;
+    return *mutex;
+}
+
+struct PipelineCommunicatorCache
+{
+    int64_t worldSize{-1};
+    int64_t rank{-1};
+    std::shared_ptr<tensorrt_llm::runtime::NcclCommunicator> communicator;
+};
+
+PipelineCommunicatorCache& pipelineCommunicatorCache()
+{
+    // Python model-engine reference counts are process-local and therefore
+    // cannot define a cross-rank NCCL teardown boundary. Keep the FT PP
+    // communicator alive for the process lifetime so rank-skewed wrapper churn
+    // never makes one rank reuse an old communicator while a peer enters a
+    // fresh-ID rendezvous. Coordinated teardown belongs to the Phase-2 owner.
+    static auto* cache = new PipelineCommunicatorCache;
+    return *cache;
+}
+
+} // namespace
 
 NcclCommunicatorOp::NcclCommunicatorOp(int64_t worldSize, int64_t rank)
     : mRank(static_cast<int32_t>(rank))
 {
-    mPipelineComm = std::make_shared<tensorrt_llm::runtime::NcclCommunicator>(worldSize, rank);
+    TLLM_CHECK_WITH_INFO(worldSize > 0 && worldSize <= std::numeric_limits<int32_t>::max(),
+        "NCCL error: world size is out of range: %lld", static_cast<long long>(worldSize));
+    TLLM_CHECK_WITH_INFO(rank >= 0 && rank < worldSize && rank <= std::numeric_limits<int32_t>::max(),
+        "NCCL error: rank is out of range: %lld", static_cast<long long>(rank));
+
+    if (!mpi::isFaultToleranceModeEnabled())
+    {
+        // The legacy MPI-broadcast bootstrap assigns independent NCCL IDs, so
+        // multiple PP communicators remain valid when fault tolerance is off.
+        mPipelineComm = std::make_shared<tensorrt_llm::runtime::NcclCommunicator>(
+            static_cast<int>(worldSize), static_cast<int>(rank));
+        return;
+    }
+
+    std::lock_guard<std::mutex> const lock(pipelineCommunicatorMutex());
+    auto& cache = pipelineCommunicatorCache();
+    if (cache.communicator == nullptr)
+    {
+        cache.communicator = std::make_shared<tensorrt_llm::runtime::NcclCommunicator>(
+            static_cast<int>(worldSize), static_cast<int>(rank));
+        cache.worldSize = worldSize;
+        cache.rank = rank;
+    }
+    else
+    {
+        TLLM_CHECK_WITH_INFO(cache.worldSize == worldSize && cache.rank == rank,
+            "NCCL error: the process-lifetime PP communicator was initialized for world size %lld rank %lld, "
+            "not world size %lld rank %lld",
+            static_cast<long long>(cache.worldSize), static_cast<long long>(cache.rank),
+            static_cast<long long>(worldSize), static_cast<long long>(rank));
+    }
+    mPipelineComm = cache.communicator;
 }
 
 void NcclCommunicatorOp::send(th::Tensor tensor, int64_t toRank) const
@@ -49,6 +115,91 @@ void NcclCommunicatorOp::recv(th::Tensor& tensor, int64_t fromRank) const
     mPipelineComm->receive(*tr::IBuffer::wrap(ptr, size), static_cast<int>(fromRank), cudaStream);
 }
 
+void NcclCommunicatorOp::abort()
+{
+    mPipelineComm->abort();
+}
+
+void NcclCommunicatorOp::abortAndReinit(std::vector<int64_t> const& activeRanks, int64_t rendezvousId)
+{
+    TLLM_CHECK_WITH_INFO(rendezvousId > 0, "NCCL error: recovery rendezvous ID must be positive, got %lld",
+        static_cast<long long>(rendezvousId));
+    std::vector<int> ranks;
+    ranks.reserve(activeRanks.size());
+    for (int64_t const rank : activeRanks)
+    {
+        TLLM_CHECK_WITH_INFO(rank >= 0 && rank <= std::numeric_limits<int>::max(),
+            "NCCL error: active rank is out of range: %lld", static_cast<long long>(rank));
+        ranks.push_back(static_cast<int>(rank));
+    }
+    mPipelineComm->abortAndReinit(ranks, static_cast<std::uint64_t>(rendezvousId));
+}
+
+std::string NcclCommunicatorOp::getAsyncError() const
+{
+    return mPipelineComm->getAsyncError();
+}
+
+std::vector<int64_t> NcclCommunicatorOp::getActiveRanks() const
+{
+    auto const ranks = mPipelineComm->getActiveRanks();
+    return std::vector<int64_t>(ranks.begin(), ranks.end());
+}
+
+void ncclCommAbortAndReinit(
+    std::vector<int64_t> const& oldGroup, std::vector<int64_t> const& activeGroup, int64_t rendezvousId)
+{
+#if ENABLE_MULTI_DEVICE
+    TLLM_CHECK_WITH_INFO(rendezvousId > 0, "NCCL error: recovery rendezvous ID must be positive, got %lld",
+        static_cast<long long>(rendezvousId));
+    std::set<int> oldRanks;
+    std::set<int> activeRanks;
+    for (auto const rank : oldGroup)
+    {
+        TLLM_CHECK_WITH_INFO(rank >= 0 && rank <= std::numeric_limits<int>::max(),
+            "NCCL error: old-group rank is out of range: %lld", static_cast<long long>(rank));
+        oldRanks.insert(static_cast<int>(rank));
+    }
+    for (auto const rank : activeGroup)
+    {
+        TLLM_CHECK_WITH_INFO(rank >= 0 && rank <= std::numeric_limits<int>::max(),
+            "NCCL error: active-group rank is out of range: %lld", static_cast<long long>(rank));
+        activeRanks.insert(static_cast<int>(rank));
+    }
+    TLLM_CHECK_WITH_INFO(oldRanks.size() == oldGroup.size(), "NCCL error: old group contains duplicate ranks");
+    TLLM_CHECK_WITH_INFO(activeRanks.size() == activeGroup.size(), "NCCL error: active group contains duplicate ranks");
+    abortAndReinitComm(oldRanks, activeRanks, static_cast<std::uint64_t>(rendezvousId));
+#else
+    (void) oldGroup;
+    (void) activeGroup;
+    (void) rendezvousId;
+    TLLM_THROW("NCCL error: multi device support is disabled.");
+#endif
+}
+
+c10::optional<std::string> ncclCommGetAsyncError(std::vector<int64_t> const& group)
+{
+#if ENABLE_MULTI_DEVICE
+    std::set<int> ranks;
+    for (auto const rank : group)
+    {
+        TLLM_CHECK_WITH_INFO(rank >= 0 && rank <= std::numeric_limits<int>::max(),
+            "NCCL error: group rank is out of range: %lld", static_cast<long long>(rank));
+        ranks.insert(static_cast<int>(rank));
+    }
+    TLLM_CHECK_WITH_INFO(ranks.size() == group.size(), "NCCL error: group contains duplicate ranks");
+    auto error = getCommAsyncError(ranks);
+    if (error.has_value())
+    {
+        return *error;
+    }
+    return c10::nullopt;
+#else
+    (void) group;
+    return c10::nullopt;
+#endif
+}
+
 } // namespace torch_ext
 
 TRTLLM_NAMESPACE_END
@@ -57,4 +208,20 @@ static auto trtllmNcclCommunicator
     = torch::jit::class_<tensorrt_llm::torch_ext::NcclCommunicatorOp>("trtllm", "NcclCommunicatorOp")
           .def(torch::jit::init<int64_t, int64_t>())
           .def("send", &tensorrt_llm::torch_ext::NcclCommunicatorOp::send)
-          .def("recv", &tensorrt_llm::torch_ext::NcclCommunicatorOp::recv);
+          .def("recv", &tensorrt_llm::torch_ext::NcclCommunicatorOp::recv)
+          .def("abort", &tensorrt_llm::torch_ext::NcclCommunicatorOp::abort)
+          .def("abort_and_reinit", &tensorrt_llm::torch_ext::NcclCommunicatorOp::abortAndReinit)
+          .def("get_async_error", &tensorrt_llm::torch_ext::NcclCommunicatorOp::getAsyncError)
+          .def("get_active_ranks", &tensorrt_llm::torch_ext::NcclCommunicatorOp::getActiveRanks);
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def("nccl_comm_abort_and_reinit(int[] old_group, int[] active_group, int rendezvous_id) -> ()");
+    m.def("nccl_comm_get_async_error(int[] group) -> str?");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CompositeExplicitAutograd, m)
+{
+    m.impl("nccl_comm_abort_and_reinit", &tensorrt_llm::torch_ext::ncclCommAbortAndReinit);
+    m.impl("nccl_comm_get_async_error", &tensorrt_llm::torch_ext::ncclCommGetAsyncError);
+}

--- a/cpp/tensorrt_llm/thop/ncclCommunicatorOp.h
+++ b/cpp/tensorrt_llm/thop/ncclCommunicatorOp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@
 #include "tensorrt_llm/common/config.h"
 #include "tensorrt_llm/runtime/ncclCommunicator.h"
 #include "tensorrt_llm/thop/thUtils.h"
+#include <cstdint>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace th = torch;
 
@@ -34,6 +37,10 @@ public:
 
     void send(th::Tensor tensor, int64_t toRank) const;
     void recv(th::Tensor& tensor, int64_t fromRank) const;
+    void abort();
+    void abortAndReinit(std::vector<int64_t> const& activeRanks, int64_t rendezvousId);
+    [[nodiscard]] std::string getAsyncError() const;
+    [[nodiscard]] std::vector<int64_t> getActiveRanks() const;
 
 private:
     int32_t mRank;

--- a/cpp/tensorrt_llm/thop/outputTensor.h
+++ b/cpp/tensorrt_llm/thop/outputTensor.h
@@ -70,7 +70,7 @@ inline std::pair<at::Tensor, BufferKind> allocate_output(std::vector<int64_t> co
             {
                 TLLM_LOG_DEBUG("[allocate_output] getComm threw (MPI disabled?): %s; fallback to default", e.what());
             }
-            if (commPtr && *commPtr != nullptr)
+            if (commPtr)
             {
                 auto [tensor, buffer]
                     = tensorrt_llm::common::nccl_util::createNCCLWindowTensor(commPtr, output_size, dtype);

--- a/cpp/tensorrt_llm/thop/reducescatterOp.cpp
+++ b/cpp/tensorrt_llm/thop/reducescatterOp.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 1993-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,11 @@
 #include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
 #endif // ENABLE_MULTI_DEVICE
 
+#include <algorithm>
 #include <cassert>
+#include <functional>
+#include <iterator>
+#include <numeric>
 #include <set>
 #include <vector>
 
@@ -56,7 +60,11 @@ public:
     {
         TLLM_LOG_TRACE("%s start for rank %d", __PRETTY_FUNCTION__, -1);
         mNcclComm = getComm(mGroup);
-        TLLM_LOG_TRACE("%s stop for rank %d", __PRETTY_FUNCTION__, -1);
+        auto const rank = getCommWorldRank(mNcclComm);
+        auto const rankIt = mGroup.find(rank);
+        TLLM_CHECK_WITH_INFO(rankIt != mGroup.end(), "Global rank %d is not in the reduce-scatter group", rank);
+        mGroupRank = static_cast<int>(std::distance(mGroup.begin(), rankIt));
+        TLLM_LOG_TRACE("%s stop for rank %d", __PRETTY_FUNCTION__, rank);
         return 0;
     }
 
@@ -66,25 +74,14 @@ public:
         bool use_nccl_reducescatter = !sizes.has_value()
             || std::all_of(sizes.value().begin(), sizes.value().end(),
                 [&sizes](int64_t size) { return size == sizes.value()[0]; });
-        int groupRank = 0;
-        if (sizes.has_value())
-        {
-            auto rank = COMM_SESSION.getRank();
-            for (auto const& currentRank : mGroup)
-            {
-                if (rank == currentRank)
-                    break;
-                ++groupRank;
-            }
-            TLLM_CHECK(static_cast<size_t>(groupRank) < mGroup.size());
-        }
+        int const groupRank = sizes.has_value() ? mGroupRank : 0;
+        TLLM_CHECK_WITH_INFO(!sizes.has_value() || groupRank >= 0, "ReducescatterOp must be initialized before use");
         std::vector<torch::Tensor> output_list;
+        std::vector<cudaStream_t> streams;
+        bool const trackOperations = isNcclFaultToleranceEnabled();
         output_list.reserve(input_list.size());
-        ncclGroupStart();
         for (auto const& input : input_list)
         {
-            auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
-            auto type = tensorrt_llm::runtime::TorchUtils::dataType(input.scalar_type());
             std::vector<int64_t> outputShape = input.sizes().vec();
             if (sizes.has_value())
             {
@@ -94,29 +91,68 @@ public:
             {
                 outputShape[0] = outputShape[0] / mGroup.size();
             }
-            auto output = torch::empty(outputShape, input.options());
+            output_list.push_back(torch::empty(outputShape, input.options()));
+            if (trackOperations)
+            {
+                auto const stream = at::cuda::getCurrentCUDAStream(input.get_device());
+                if (std::find(streams.begin(), streams.end(), stream) == streams.end())
+                {
+                    streams.push_back(stream);
+                }
+            }
+        }
+
+        auto commLease = acquireComm(mNcclComm);
+        auto const comm = commLease.get();
+        std::vector<uint64_t> watchdogTokens;
+        if (trackOperations)
+        {
+            watchdogTokens.reserve(streams.size());
+            for (auto const stream : streams)
+            {
+                watchdogTokens.push_back(commLease.begin(stream, "ncclReduceScatter"));
+            }
+        }
+        commLease.groupStart("ncclGroupStart(reducescatter)");
+        for (size_t index = 0; index < input_list.size(); ++index)
+        {
+            auto const& input = input_list[index];
+            auto& output = output_list[index];
+            auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
+            auto type = tensorrt_llm::runtime::TorchUtils::dataType(input.scalar_type());
             if (use_nccl_reducescatter)
             {
-                ncclReduceScatter(input.data_ptr(), output.mutable_data_ptr(), output.numel(), (*getDtypeMap())[type],
-                    ncclSum, *mNcclComm, stream);
+                commLease.checkEnqueue(ncclReduceScatter(input.data_ptr(), output.mutable_data_ptr(), output.numel(),
+                                           (*getDtypeMap())[type], ncclSum, comm, stream),
+                    "ncclReduceScatter");
             }
             else
             {
+                auto const& outputShape = output.sizes();
                 size_t numel_base
                     = std::accumulate(outputShape.cbegin() + 1, outputShape.cend(), 1, std::multiplies<>{});
                 int64_t split_offset = 0;
                 for (int root = 0; root < static_cast<int>(mGroup.size()); ++root)
                 {
                     auto split_size = sizes.value()[root];
-                    ncclReduce(input.index({torch::indexing::Slice(split_offset, torch::indexing::None)}).data_ptr(),
-                        output.mutable_data_ptr(), numel_base * split_size, (*getDtypeMap())[type], ncclSum, root,
-                        *mNcclComm, stream);
+                    commLease.checkEnqueue(
+                        ncclReduce(
+                            input.index({torch::indexing::Slice(split_offset, torch::indexing::None)}).data_ptr(),
+                            output.mutable_data_ptr(), numel_base * split_size, (*getDtypeMap())[type], ncclSum, root,
+                            comm, stream),
+                        "ncclReduce(reducescatter)");
                     split_offset += split_size;
                 }
             }
-            output_list.push_back(output);
         }
-        NCCLCHECK_THROW(ncclGroupEnd());
+        commLease.groupEnd("ncclGroupEnd(reducescatter)");
+        if (trackOperations)
+        {
+            for (size_t index = 0; index < streams.size(); ++index)
+            {
+                commLease.track(watchdogTokens[index], streams[index]);
+            }
+        }
         return output_list;
     }
 
@@ -128,6 +164,7 @@ public:
 private:
     std::set<int> mGroup;
     std::shared_ptr<ncclComm_t> mNcclComm;
+    int mGroupRank{-1};
 };
 
 class ReducescatterPgOp

--- a/cpp/tests/unit_tests/multi_gpu/CMakeLists.txt
+++ b/cpp/tests/unit_tests/multi_gpu/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION &
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION &
 # AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -19,6 +19,133 @@ add_gtest(cacheTransceiverTest cacheTransceiverTest.cpp)
 target_link_libraries(cacheTransceiverTest PRIVATE ${Python3_LIBRARIES})
 
 add_gtest(mpiUtilsTest mpiUtilsTest.cpp)
+add_gtest(ncclUniqueIdRendezvousTest ncclUniqueIdRendezvousTest.cpp)
+if(ENABLE_MULTI_DEVICE)
+  set(NCCL_RENDEZVOUS_RAW_RECOVERY_TEST
+      NcclUniqueIdRendezvousTest.RawCommunicatorRebuildRunsPostRecoveryCollective
+  )
+  set(NCCL_RENDEZVOUS_PP_RECOVERY_TEST
+      NcclUniqueIdRendezvousTest.PipelineCommunicatorRebuildRunsPostRecoverySendRecv
+  )
+  set(NCCL_RENDEZVOUS_PROCESS_DEATH_TEST
+      NcclUniqueIdRendezvousTest.ProcessDeathRendezvousRequiresOptInFaultTolerantMpiLauncher
+  )
+  set(NCCL_RENDEZVOUS_ISOLATED_TESTS
+      "${NCCL_RENDEZVOUS_RAW_RECOVERY_TEST}:${NCCL_RENDEZVOUS_PP_RECOVERY_TEST}:${NCCL_RENDEZVOUS_PROCESS_DEATH_TEST}"
+  )
+  add_test(
+    NAME ncclUniqueIdRendezvousTest.mpi3
+    COMMAND
+      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+      $<TARGET_FILE:ncclUniqueIdRendezvousTest>
+      --gtest_filter=NcclUniqueIdRendezvousTest.*-${NCCL_RENDEZVOUS_ISOLATED_TESTS}
+      ${MPIEXEC_POSTFLAGS})
+  set_tests_properties(
+    ncclUniqueIdRendezvousTest.mpi3
+    PROPERTIES ENVIRONMENT
+               "CUDA_MODULE_LOADING=LAZY;TLLM_FAULT_TOLERANCE_MODE=1"
+               PROCESSORS 3 TIMEOUT 180)
+
+  # Raw communicator replacement mutates process-global NCCL state and needs one
+  # distinct physical GPU per MPI rank. Keep it in its own CTest process.
+  add_test(
+    NAME ncclUniqueIdRendezvousTest.rawRecoveryMpi3
+    COMMAND
+      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+      $<TARGET_FILE:ncclUniqueIdRendezvousTest>
+      --gtest_filter=${NCCL_RENDEZVOUS_RAW_RECOVERY_TEST} ${MPIEXEC_POSTFLAGS})
+  set_tests_properties(
+    ncclUniqueIdRendezvousTest.rawRecoveryMpi3
+    PROPERTIES ENVIRONMENT
+               "CUDA_MODULE_LOADING=LAZY;TLLM_FAULT_TOLERANCE_MODE=1"
+               PROCESSORS 3 TIMEOUT 180)
+
+  # The runtime PP wrapper owns a distinct communicator implementation and
+  # rendezvous tag set. Exercise its real post-recovery send/receive path in a
+  # separate process so it cannot share native singleton state with raw ops.
+  add_test(
+    NAME ncclUniqueIdRendezvousTest.ppRecoveryMpi3
+    COMMAND
+      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 ${MPIEXEC_PREFLAGS}
+      $<TARGET_FILE:ncclUniqueIdRendezvousTest>
+      --gtest_filter=${NCCL_RENDEZVOUS_PP_RECOVERY_TEST} ${MPIEXEC_POSTFLAGS})
+  set_tests_properties(
+    ncclUniqueIdRendezvousTest.ppRecoveryMpi3
+    PROPERTIES ENVIRONMENT
+               "CUDA_MODULE_LOADING=LAZY;TLLM_FAULT_TOLERANCE_MODE=1"
+               PROCESSORS 3 TIMEOUT 180)
+
+  option(TRTLLM_ENABLE_NCCL_PROCESS_DEATH_TEST
+         "Enable the destructive NCCL rendezvous test that exits one MPI rank"
+         OFF)
+  set(TRTLLM_NCCL_PROCESS_DEATH_MPIEXEC_PREFLAGS
+      ""
+      CACHE
+        STRING
+        "Semicolon-separated launcher recovery flags for the NCCL process-death test"
+  )
+  if(TRTLLM_ENABLE_NCCL_PROCESS_DEATH_TEST)
+    if("${TRTLLM_NCCL_PROCESS_DEATH_MPIEXEC_PREFLAGS}" STREQUAL "")
+      message(
+        FATAL_ERROR
+          "TRTLLM_ENABLE_NCCL_PROCESS_DEATH_TEST requires launcher-specific "
+          "TRTLLM_NCCL_PROCESS_DEATH_MPIEXEC_PREFLAGS (for example OpenMPI recovery flags)"
+      )
+    endif()
+    # Keep a launcher-level signal from bypassing the sentinel properties. The
+    # CMake wrapper translates it to a normal nonzero process result.
+    set(NCCL_RENDEZVOUS_PROCESS_DEATH_ENV
+        CUDA_MODULE_LOADING=LAZY
+        TLLM_FAULT_TOLERANCE_MODE=1
+        TRTLLM_TEST_NCCL_PROCESS_DEATH=1
+        TRTLLM_NCCL_NONBLOCKING_TIMEOUT_MS=20000
+        TRTLLM_NCCL_RECOVERY_TIMEOUT_MS=20000)
+    add_test(
+      NAME ncclUniqueIdRendezvousTest.processDeathMpi3
+      COMMAND
+        ${CMAKE_COMMAND} -E env ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3
+        ${MPIEXEC_PREFLAGS} ${TRTLLM_NCCL_PROCESS_DEATH_MPIEXEC_PREFLAGS}
+        $<TARGET_FILE:ncclUniqueIdRendezvousTest>
+        --gtest_filter=${NCCL_RENDEZVOUS_PROCESS_DEATH_TEST}
+        ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(
+      ncclUniqueIdRendezvousTest.processDeathMpi3
+      PROPERTIES ENVIRONMENT
+                 "${NCCL_RENDEZVOUS_PROCESS_DEATH_ENV}"
+                 PROCESSORS
+                 3
+                 TIMEOUT
+                 60
+                 RUN_SERIAL
+                 TRUE
+                 # A launcher may report failure solely because the injected
+                 # victim intentionally skips MPI_Finalize. The root emits this
+                 # sentinel only after survivor-only communicator rebuild and a
+                 # successful allreduce, so it is the authoritative pass
+                 # condition.
+                 PASS_REGULAR_EXPRESSION
+                 "TRTLLM_PROCESS_DEATH_RENDEZVOUS_OK"
+                 FAIL_REGULAR_EXPRESSION
+                 "TRTLLM_PROCESS_DEATH_RENDEZVOUS_FAIL")
+  endif()
+
+  add_test(
+    NAME ncclUniqueIdRendezvousTest.defaultOff
+    COMMAND
+      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS}
+      $<TARGET_FILE:ncclUniqueIdRendezvousTest>
+      --gtest_filter=NcclUniqueIdRendezvousTest.FaultToleranceDisabledPreservesLegacyOperationPath
+      ${MPIEXEC_POSTFLAGS})
+  set_tests_properties(
+    ncclUniqueIdRendezvousTest.defaultOff
+    PROPERTIES
+      ENVIRONMENT
+      "CUDA_MODULE_LOADING=LAZY;TLLM_FAULT_TOLERANCE_MODE=0;TRTLLM_TEST_FT_DEFAULT_OFF=1"
+      PROCESSORS
+      1
+      TIMEOUT
+      60)
+endif()
 add_gtest(userBufferTest userBufferTest.cpp)
 add_gtest(ncclUtilsTest ncclUtilsTest.cpp)
 target_link_libraries(ncclUtilsTest PRIVATE ${Python3_LIBRARIES})

--- a/cpp/tests/unit_tests/multi_gpu/ncclUniqueIdRendezvousTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/ncclUniqueIdRendezvousTest.cpp
@@ -1,0 +1,982 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/runtime/utils/ncclUniqueIdRendezvous.h"
+#include "tensorrt_llm/common/opUtils.h"
+#include "tensorrt_llm/runtime/ncclCommunicator.h"
+#include "tensorrt_llm/runtime/utils/ncclHostApi.h"
+
+#include <gtest/gtest.h>
+
+#if ENABLE_MULTI_DEVICE
+
+#include <cuda_runtime_api.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+namespace
+{
+
+using tensorrt_llm::runtime::NcclUniqueIdRendezvousComm;
+using tensorrt_llm::runtime::createNcclUniqueIdRendezvousComm;
+using tensorrt_llm::runtime::exchangeNcclUniqueId;
+
+constexpr int kTestControlTagSeed = 0x4e43;
+constexpr std::uint64_t kSubsetRendezvousId = 1;
+constexpr std::uint64_t kStaleAttemptRendezvousId = 2;
+constexpr std::uint64_t kRetryRendezvousId = 3;
+constexpr std::uint64_t kStaleFloodFirstRendezvousId = 100;
+constexpr std::uint64_t kStaleFloodCurrentRendezvousId = 10'000;
+constexpr int kStaleFloodAttemptCount = 4'097;
+constexpr std::uint64_t kRawRecoveryRendezvousId = 4;
+constexpr std::uint64_t kRawCleanupRendezvousId = 5;
+constexpr std::uint64_t kPpRecoveryRendezvousId = 6;
+constexpr std::uint64_t kPpExcludedCleanupRendezvousId = 7;
+constexpr std::uint64_t kProcessDeathRendezvousId = 8;
+
+tensorrt_llm::runtime::NcclUniqueIdRendezvousTags rawRendezvousTags()
+{
+    return {tensorrt_llm::mpi::MpiTag::kNcclCommReady, tensorrt_llm::mpi::MpiTag::kNcclCommUniqueId,
+        tensorrt_llm::mpi::MpiTag::kNcclCommAck};
+}
+
+std::vector<int> allSessionRanks()
+{
+    std::vector<int> ranks(COMM_SESSION.getSize());
+    std::iota(ranks.begin(), ranks.end(), 0);
+    return ranks;
+}
+
+std::shared_ptr<NcclUniqueIdRendezvousComm> createTestControlComm()
+{
+    return createNcclUniqueIdRendezvousComm(
+        allSessionRanks(), COMM_SESSION.getRank(), COMM_SESSION, kTestControlTagSeed);
+}
+
+class EnvironmentVariableGuard
+{
+public:
+    EnvironmentVariableGuard(char const* name, char const* value)
+        : mName(name)
+    {
+        if (auto const* previous = std::getenv(mName.c_str()); previous != nullptr)
+        {
+            mPrevious = previous;
+        }
+#if defined(_WIN32)
+        _putenv_s(mName.c_str(), value);
+#else
+        setenv(mName.c_str(), value, 1);
+#endif
+    }
+
+    ~EnvironmentVariableGuard()
+    {
+#if defined(_WIN32)
+        _putenv_s(mName.c_str(), mPrevious.value_or("").c_str());
+#else
+        if (mPrevious.has_value())
+        {
+            setenv(mName.c_str(), mPrevious->c_str(), 1);
+        }
+        else
+        {
+            unsetenv(mName.c_str());
+        }
+#endif
+    }
+
+    EnvironmentVariableGuard(EnvironmentVariableGuard const&) = delete;
+    EnvironmentVariableGuard& operator=(EnvironmentVariableGuard const&) = delete;
+
+private:
+    std::string mName;
+    std::optional<std::string> mPrevious;
+};
+
+bool isEnvironmentFlagEnabled(char const* name)
+{
+    auto const* value = std::getenv(name);
+    return value != nullptr && std::string{value} == "1";
+}
+
+cudaError_t getCudaDeviceUuid(cudaUUID_t& uuid, int device)
+{
+    cudaDeviceProp properties{};
+    auto const result = cudaGetDeviceProperties(&properties, device);
+    if (result == cudaSuccess)
+    {
+        uuid = properties.uuid;
+    }
+    return result;
+}
+
+bool configureDistinctCudaDeviceForEveryRank(std::string& failure)
+{
+    int const rank = COMM_SESSION.getRank();
+    int const worldSize = COMM_SESSION.getSize();
+    int deviceCount = 0;
+    cudaUUID_t deviceUuid{};
+    int localReady = 0;
+    auto const countResult = cudaGetDeviceCount(&deviceCount);
+    if (countResult == cudaSuccess && deviceCount > 0)
+    {
+        int const device = rank % deviceCount;
+        auto const setResult = cudaSetDevice(device);
+        auto const uuidResult = setResult == cudaSuccess ? getCudaDeviceUuid(deviceUuid, device) : setResult;
+        localReady = setResult == cudaSuccess && uuidResult == cudaSuccess ? 1 : 0;
+    }
+
+    std::vector<int> gatheredReady(static_cast<std::size_t>(worldSize));
+    COMM_SESSION.allgather(&localReady, gatheredReady.data(), 1, tensorrt_llm::mpi::MpiType::kINT32);
+    std::vector<char> gatheredUuids(
+        static_cast<std::size_t>(worldSize) * static_cast<std::size_t>(sizeof(deviceUuid.bytes)));
+    COMM_SESSION.allgather(deviceUuid.bytes, gatheredUuids.data(), static_cast<int>(sizeof(deviceUuid.bytes)),
+        tensorrt_llm::mpi::MpiType::kBYTE);
+
+    if (!std::all_of(gatheredReady.begin(), gatheredReady.end(), [](int ready) { return ready != 0; }))
+    {
+        failure = "every MPI rank must have a usable CUDA device";
+        return false;
+    }
+
+    std::unordered_set<std::string> uniqueUuids;
+    for (int peer = 0; peer < worldSize; ++peer)
+    {
+        auto const* bytes = gatheredUuids.data()
+            + static_cast<std::size_t>(peer) * static_cast<std::size_t>(sizeof(deviceUuid.bytes));
+        uniqueUuids.emplace(bytes, bytes + sizeof(deviceUuid.bytes));
+    }
+    if (uniqueUuids.size() != static_cast<std::size_t>(worldSize))
+    {
+        failure = "every MPI rank must use a distinct physical GPU";
+        return false;
+    }
+    return true;
+}
+
+[[noreturn]] void exitProcessDeathTestFailure(int rank, std::string const& failure) noexcept
+{
+    std::fprintf(stderr, "TRTLLM_PROCESS_DEATH_RENDEZVOUS_FAIL rank=%d: %s\n", rank, failure.c_str());
+    std::fflush(stderr);
+    std::_Exit(EXIT_FAILURE);
+}
+
+void CUDART_CB waitForRelease(void* data)
+{
+    auto* release = static_cast<std::atomic<bool>*>(data);
+    while (!release->load(std::memory_order_acquire))
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{1});
+    }
+}
+
+class HostCallbackReleaseGuard
+{
+public:
+    explicit HostCallbackReleaseGuard(std::atomic<bool>& release)
+        : mRelease(release)
+    {
+    }
+
+    ~HostCallbackReleaseGuard()
+    {
+        mRelease.store(true, std::memory_order_release);
+    }
+
+private:
+    std::atomic<bool>& mRelease;
+};
+
+TEST(NcclUniqueIdRendezvousTest, DedicatedControlCommPreservesParentErrorHandlerAndRankMap)
+{
+    MPI_Errhandler parentBefore = MPI_ERRHANDLER_NULL;
+    ASSERT_EQ(MPI_Comm_get_errhandler(static_cast<MPI_Comm>(COMM_SESSION), &parentBefore), MPI_SUCCESS);
+
+    auto control = createTestControlComm();
+
+    MPI_Errhandler parentAfter = MPI_ERRHANDLER_NULL;
+    MPI_Errhandler controlHandler = MPI_ERRHANDLER_NULL;
+    ASSERT_EQ(MPI_Comm_get_errhandler(static_cast<MPI_Comm>(COMM_SESSION), &parentAfter), MPI_SUCCESS);
+    ASSERT_EQ(MPI_Comm_get_errhandler(static_cast<MPI_Comm>(control->mpiComm()), &controlHandler), MPI_SUCCESS);
+    EXPECT_EQ(parentAfter, parentBefore);
+    EXPECT_EQ(controlHandler, MPI_ERRORS_RETURN);
+    EXPECT_EQ(control->worldRank(), COMM_SESSION.getRank());
+    EXPECT_EQ(control->worldRank(control->commRank(COMM_SESSION.getRank())), COMM_SESSION.getRank());
+
+    ASSERT_EQ(MPI_Errhandler_free(&parentBefore), MPI_SUCCESS);
+    ASSERT_EQ(MPI_Errhandler_free(&parentAfter), MPI_SUCCESS);
+    ASSERT_EQ(MPI_Errhandler_free(&controlHandler), MPI_SUCCESS);
+}
+
+TEST(NcclUniqueIdRendezvousTest, DedicatedControlCommCacheReusesSameTopology)
+{
+    auto const firstControl = createTestControlComm();
+    auto const secondControl = createTestControlComm();
+
+    ASSERT_NE(firstControl, nullptr);
+    ASSERT_NE(secondControl, nullptr);
+    EXPECT_EQ(firstControl.get(), secondControl.get());
+    EXPECT_EQ(MPI_Comm_c2f(static_cast<MPI_Comm>(firstControl->mpiComm())),
+        MPI_Comm_c2f(static_cast<MPI_Comm>(secondControl->mpiComm())));
+}
+
+TEST(NcclUniqueIdRendezvousTest, DedicatedControlCommCacheSurvivesCustomParentHandleLifetime)
+{
+    auto const sessionControl = createTestControlComm();
+    std::shared_ptr<NcclUniqueIdRendezvousComm> firstDuplicateControl;
+    {
+        MPI_Comm duplicate = MPI_COMM_NULL;
+        ASSERT_EQ(MPI_Comm_dup(static_cast<MPI_Comm>(COMM_SESSION), &duplicate), MPI_SUCCESS);
+        auto duplicateParent = tensorrt_llm::mpi::MpiComm{duplicate, true};
+        firstDuplicateControl = createNcclUniqueIdRendezvousComm(
+            allSessionRanks(), COMM_SESSION.getRank(), duplicateParent, kTestControlTagSeed);
+    }
+
+    std::shared_ptr<NcclUniqueIdRendezvousComm> secondDuplicateControl;
+    {
+        MPI_Comm duplicate = MPI_COMM_NULL;
+        ASSERT_EQ(MPI_Comm_dup(static_cast<MPI_Comm>(COMM_SESSION), &duplicate), MPI_SUCCESS);
+        auto duplicateParent = tensorrt_llm::mpi::MpiComm{duplicate, true};
+        secondDuplicateControl = createNcclUniqueIdRendezvousComm(
+            allSessionRanks(), COMM_SESSION.getRank(), duplicateParent, kTestControlTagSeed);
+    }
+
+    EXPECT_EQ(firstDuplicateControl.get(), sessionControl.get());
+    EXPECT_EQ(secondDuplicateControl.get(), sessionControl.get());
+}
+
+TEST(NcclUniqueIdRendezvousTest, NonContiguousSurvivorSubsetExchangesWithoutExcludedRank)
+{
+    auto control = createTestControlComm();
+    int const rank = COMM_SESSION.getRank();
+    int const worldSize = COMM_SESSION.getSize();
+    if (worldSize < 2)
+    {
+        GTEST_SKIP() << "Test requires at least two MPI processes";
+    }
+
+    // With three or more processes rank 1 is deliberately excluded, proving
+    // that recovery rendezvous does not contain a hidden world collective.
+    std::vector<int> activeRanks{0, worldSize - 1};
+    std::array<unsigned char, sizeof(ncclUniqueId)> localId{};
+    if (std::binary_search(activeRanks.begin(), activeRanks.end(), rank))
+    {
+        auto const id = exchangeNcclUniqueId(activeRanks, *control, rawRendezvousTags(), kSubsetRendezvousId,
+            std::chrono::steady_clock::now() + std::chrono::seconds{10});
+        std::memcpy(localId.data(), &id, sizeof(id));
+    }
+
+    // This synchronization is test-only and happens after the survivor
+    // exchange. The production recovery path performs no MPI collective.
+    COMM_SESSION.barrier();
+    std::vector<unsigned char> gathered(static_cast<std::size_t>(worldSize) * localId.size());
+    COMM_SESSION.allgather(
+        localId.data(), gathered.data(), static_cast<int>(localId.size()), tensorrt_llm::mpi::MpiType::kBYTE);
+
+    auto const* first = gathered.data();
+    auto const* last = gathered.data() + static_cast<std::size_t>(worldSize - 1) * localId.size();
+    EXPECT_TRUE(std::any_of(first, first + localId.size(), [](unsigned char value) { return value != 0; }));
+    EXPECT_TRUE(std::equal(first, first + localId.size(), last));
+    if (worldSize >= 3)
+    {
+        auto const* excluded = gathered.data() + localId.size();
+        EXPECT_TRUE(std::all_of(excluded, excluded + localId.size(), [](unsigned char value) { return value == 0; }));
+    }
+}
+
+TEST(NcclUniqueIdRendezvousTest, RetryGenerationCannotPairWithStaleAttemptMessages)
+{
+    auto const control = createTestControlComm();
+    int const rank = COMM_SESSION.getRank();
+    int const worldSize = COMM_SESSION.getSize();
+    if (worldSize < 2)
+    {
+        GTEST_SKIP() << "Test requires at least two MPI processes";
+    }
+
+    std::vector<int> const activeRanks{0, worldSize - 1};
+    bool const isRoot = rank == activeRanks.front();
+    bool const isClient = rank == activeRanks.back();
+    bool staleAttemptTimedOut = false;
+    bool retrySucceeded = false;
+    std::array<unsigned char, sizeof(ncclUniqueId)> retryId{};
+
+    // The root times out generation A before the client starts it, then enters
+    // generation B. The client deliberately sends a late generation-A READY
+    // while the root is already waiting in B. That message must be stashed,
+    // not accepted as B's READY; both ranks converge only after the client also
+    // advances to B.
+    control->mpiComm().barrier();
+    if (isRoot)
+    {
+        try
+        {
+            static_cast<void>(exchangeNcclUniqueId(activeRanks, *control, rawRendezvousTags(),
+                kStaleAttemptRendezvousId, std::chrono::steady_clock::now() + std::chrono::milliseconds{100}));
+        }
+        catch (std::exception const& error)
+        {
+            staleAttemptTimedOut = std::string{error.what()}.find("timed out") != std::string::npos;
+        }
+
+        try
+        {
+            auto const id = exchangeNcclUniqueId(activeRanks, *control, rawRendezvousTags(), kRetryRendezvousId,
+                std::chrono::steady_clock::now() + std::chrono::seconds{5});
+            std::memcpy(retryId.data(), &id, sizeof(id));
+            retrySucceeded = true;
+        }
+        catch (std::exception const&)
+        {
+            // Assert after every rank reaches the test-only barrier. If the
+            // generation key regresses, the late A exchange can consume B and
+            // leave this retry waiting until its bounded deadline.
+        }
+    }
+    else if (isClient)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{500});
+        try
+        {
+            static_cast<void>(exchangeNcclUniqueId(activeRanks, *control, rawRendezvousTags(),
+                kStaleAttemptRendezvousId, std::chrono::steady_clock::now() + std::chrono::milliseconds{150}));
+        }
+        catch (std::exception const& error)
+        {
+            staleAttemptTimedOut = std::string{error.what()}.find("timed out") != std::string::npos;
+        }
+
+        try
+        {
+            auto const id = exchangeNcclUniqueId(activeRanks, *control, rawRendezvousTags(), kRetryRendezvousId,
+                std::chrono::steady_clock::now() + std::chrono::seconds{5});
+            std::memcpy(retryId.data(), &id, sizeof(id));
+            retrySucceeded = true;
+        }
+        catch (std::exception const&)
+        {
+            // Keep the MPI test convergent on the regression path; the
+            // assertions below retain the failure details.
+        }
+    }
+
+    control->mpiComm().barrier();
+    std::vector<unsigned char> gathered(static_cast<std::size_t>(worldSize) * retryId.size());
+    control->mpiComm().allgather(
+        retryId.data(), gathered.data(), static_cast<int>(retryId.size()), tensorrt_llm::mpi::MpiType::kBYTE);
+
+    if (isRoot || isClient)
+    {
+        EXPECT_TRUE(staleAttemptTimedOut);
+        EXPECT_TRUE(retrySucceeded);
+    }
+    auto const* rootId = gathered.data();
+    auto const* clientId = gathered.data() + static_cast<std::size_t>(worldSize - 1) * retryId.size();
+    EXPECT_TRUE(std::any_of(rootId, rootId + retryId.size(), [](unsigned char value) { return value != 0; }));
+    EXPECT_TRUE(std::equal(rootId, rootId + retryId.size(), clientId));
+}
+
+TEST(NcclUniqueIdRendezvousTest, RepeatedStaleGenerationsDoNotExhaustPendingQueue)
+{
+    auto const control = createTestControlComm();
+    int const rank = COMM_SESSION.getRank();
+    int const worldSize = COMM_SESSION.getSize();
+    if (worldSize < 2)
+    {
+        GTEST_SKIP() << "Test requires at least two MPI processes";
+    }
+
+    std::vector<int> const activeRanks{0, worldSize - 1};
+    bool const isRoot = rank == activeRanks.front();
+    bool const isClient = rank == activeRanks.back();
+    bool currentAttemptSucceeded = false;
+    int staleAttemptsTimedOut = 0;
+    std::array<unsigned char, sizeof(ncclUniqueId)> currentId{};
+
+    // The old opaque-key protocol stashed every lower-generation READY while
+    // the root waited on the current generation, then failed at its 4,096
+    // pending-message cap. Distinct increasing stale IDs honor the caller
+    // contract while proving that same-communicator generations older than the
+    // root's current ID are discarded instead of retained indefinitely.
+    control->mpiComm().barrier();
+    if (isRoot)
+    {
+        try
+        {
+            auto const id = exchangeNcclUniqueId(activeRanks, *control, rawRendezvousTags(),
+                kStaleFloodCurrentRendezvousId, std::chrono::steady_clock::now() + std::chrono::seconds{120});
+            std::memcpy(currentId.data(), &id, sizeof(id));
+            currentAttemptSucceeded = true;
+        }
+        catch (std::exception const&)
+        {
+            // Converge at the final test-only barrier even when the old queue
+            // limit is hit; the assertions below report the regression.
+        }
+    }
+    else if (isClient)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{100});
+        for (int attempt = 0; attempt < kStaleFloodAttemptCount; ++attempt)
+        {
+            auto const staleId = kStaleFloodFirstRendezvousId + static_cast<std::uint64_t>(attempt);
+            try
+            {
+                static_cast<void>(exchangeNcclUniqueId(activeRanks, *control, rawRendezvousTags(), staleId,
+                    std::chrono::steady_clock::now() + std::chrono::milliseconds{2}));
+            }
+            catch (std::exception const& error)
+            {
+                if (std::string{error.what()}.find("timed out waiting for survivor communicator ID")
+                    != std::string::npos)
+                {
+                    ++staleAttemptsTimedOut;
+                }
+            }
+        }
+
+        try
+        {
+            auto const id = exchangeNcclUniqueId(activeRanks, *control, rawRendezvousTags(),
+                kStaleFloodCurrentRendezvousId, std::chrono::steady_clock::now() + std::chrono::seconds{60});
+            std::memcpy(currentId.data(), &id, sizeof(id));
+            currentAttemptSucceeded = true;
+        }
+        catch (std::exception const&)
+        {
+            // The root may already have failed on the old pending-queue cap.
+        }
+    }
+
+    control->mpiComm().barrier();
+    std::vector<unsigned char> gathered(static_cast<std::size_t>(worldSize) * currentId.size());
+    control->mpiComm().allgather(
+        currentId.data(), gathered.data(), static_cast<int>(currentId.size()), tensorrt_llm::mpi::MpiType::kBYTE);
+
+    if (isRoot || isClient)
+    {
+        EXPECT_TRUE(currentAttemptSucceeded);
+    }
+    if (isClient)
+    {
+        EXPECT_EQ(staleAttemptsTimedOut, kStaleFloodAttemptCount);
+    }
+    auto const* rootId = gathered.data();
+    auto const* clientId = gathered.data() + static_cast<std::size_t>(worldSize - 1) * currentId.size();
+    EXPECT_TRUE(std::any_of(rootId, rootId + currentId.size(), [](unsigned char value) { return value != 0; }));
+    EXPECT_TRUE(std::equal(rootId, rootId + currentId.size(), clientId));
+}
+
+TEST(NcclUniqueIdRendezvousTest, WaitOperationDoesNotHoldGlobalGateForUnrelatedStreamPrefix)
+{
+    EnvironmentVariableGuard const faultToleranceMode{"TLLM_FAULT_TOLERANCE_MODE", "1"};
+    EnvironmentVariableGuard const operationTimeout{"TRTLLM_NCCL_NONBLOCKING_TIMEOUT_MS", "200"};
+    EnvironmentVariableGuard const watchdogPoll{"TRTLLM_NCCL_WATCHDOG_POLL_INTERVAL_MS", "10"};
+
+    int deviceCount = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+    if (deviceCount == 0)
+    {
+        GTEST_SKIP() << "Test requires a visible CUDA device";
+    }
+    int const rank = COMM_SESSION.getRank();
+    ASSERT_EQ(cudaSetDevice(rank % deviceCount), cudaSuccess);
+
+    auto comm = tensorrt_llm::getComm({rank});
+    cudaStream_t stream = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+    std::atomic<bool> releasePrefix{false};
+    HostCallbackReleaseGuard const releaseGuard{releasePrefix};
+    ASSERT_EQ(cudaLaunchHostFunc(stream, waitForRelease, &releasePrefix), cudaSuccess);
+
+    std::uint64_t token = 0;
+    {
+        auto lease = tensorrt_llm::acquireComm(comm);
+        token = lease.begin(stream, "operation behind unrelated stream prefix");
+        lease.track(token, stream);
+    }
+
+    std::atomic<bool> waiterStarted{false};
+    std::exception_ptr waiterError;
+    std::thread waiter(
+        [&]()
+        {
+            try
+            {
+                waiterStarted.store(true, std::memory_order_release);
+                tensorrt_llm::waitCommOperation(comm, token, "operation behind unrelated stream prefix");
+            }
+            catch (...)
+            {
+                waiterError = std::current_exception();
+            }
+        });
+    while (!waiterStarted.load(std::memory_order_acquire))
+    {
+        std::this_thread::yield();
+    }
+    // Give the waiter time to enter its polling path before contending for the
+    // process-wide NCCL host gate from an unrelated control thread.
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+    std::atomic<bool> gateAcquired{false};
+    std::thread gateContender(
+        [&]()
+        {
+            auto gate = tensorrt_llm::runtime::acquireNcclHostApiLock();
+            gateAcquired.store(true, std::memory_order_release);
+        });
+    auto const gateDeadline = std::chrono::steady_clock::now() + std::chrono::seconds{2};
+    while (!gateAcquired.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < gateDeadline)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{1});
+    }
+    bool const acquiredBeforePrefixRelease = gateAcquired.load(std::memory_order_acquire);
+
+    releasePrefix.store(true, std::memory_order_release);
+    gateContender.join();
+    waiter.join();
+
+    EXPECT_TRUE(acquiredBeforePrefixRelease)
+        << "waitCommOperation retained the process-wide NCCL host gate while waiting for an unrelated stream prefix";
+    EXPECT_FALSE(waiterError);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+    EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+}
+
+TEST(NcclUniqueIdRendezvousTest, FaultToleranceRejectsGraphCaptureAndTimesOutStalledOperation)
+{
+    EnvironmentVariableGuard const faultToleranceMode{"TLLM_FAULT_TOLERANCE_MODE", "1"};
+    EnvironmentVariableGuard const operationTimeout{"TRTLLM_NCCL_NONBLOCKING_TIMEOUT_MS", "100"};
+    EnvironmentVariableGuard const watchdogPoll{"TRTLLM_NCCL_WATCHDOG_POLL_INTERVAL_MS", "10"};
+
+    int deviceCount = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+    if (deviceCount == 0)
+    {
+        GTEST_SKIP() << "Test requires a visible CUDA device";
+    }
+    int const rank = COMM_SESSION.getRank();
+    ASSERT_EQ(cudaSetDevice(rank % deviceCount), cudaSuccess);
+
+    std::set<int> const singletonGroup{rank};
+    auto comm = tensorrt_llm::getComm(singletonGroup);
+    cudaStream_t stream = nullptr;
+    int* captureScratch = nullptr;
+    ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(reinterpret_cast<void**>(&captureScratch), sizeof(*captureScratch)), cudaSuccess);
+
+    ASSERT_EQ(cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal), cudaSuccess);
+    ASSERT_EQ(cudaMemsetAsync(captureScratch, 0, sizeof(*captureScratch), stream), cudaSuccess);
+    {
+        auto lease = tensorrt_llm::acquireComm(comm);
+        EXPECT_THROW(static_cast<void>(lease.begin(stream, "captured NCCL test operation")), std::exception);
+    }
+    cudaGraph_t graph = nullptr;
+    ASSERT_EQ(cudaStreamEndCapture(stream, &graph), cudaSuccess);
+    if (graph != nullptr)
+    {
+        ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
+    }
+    ASSERT_EQ(cudaFree(captureScratch), cudaSuccess);
+
+    std::atomic<bool> releaseCallback{false};
+    HostCallbackReleaseGuard const releaseGuard{releaseCallback};
+    {
+        auto lease = tensorrt_llm::acquireComm(comm);
+        auto const token = lease.begin(stream, "injected stalled NCCL operation");
+        ASSERT_EQ(cudaLaunchHostFunc(stream, waitForRelease, &releaseCallback), cudaSuccess);
+        lease.track(token, stream);
+    }
+
+    auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds{5};
+    std::optional<std::string> error;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        error = tensorrt_llm::getCommAsyncError(singletonGroup);
+        if (error.has_value())
+        {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+    }
+    EXPECT_TRUE(error.has_value());
+    if (error.has_value())
+    {
+        EXPECT_NE(error->find("timed out"), std::string::npos);
+    }
+
+    releaseCallback.store(true, std::memory_order_release);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+    EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+}
+
+TEST(NcclUniqueIdRendezvousTest, FaultToleranceDisabledPreservesLegacyOperationPath)
+{
+    if (!isEnvironmentFlagEnabled("TRTLLM_TEST_FT_DEFAULT_OFF"))
+    {
+        GTEST_SKIP() << "Run in the isolated default-off CTest process";
+    }
+    ASSERT_FALSE(tensorrt_llm::mpi::isFaultToleranceModeEnabled());
+
+    int deviceCount = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+    if (deviceCount == 0)
+    {
+        GTEST_SKIP() << "Test requires a visible CUDA device";
+    }
+    int const rank = COMM_SESSION.getRank();
+    ASSERT_EQ(cudaSetDevice(rank % deviceCount), cudaSuccess);
+
+    std::set<int> const singletonGroup{rank};
+    auto comm = tensorrt_llm::getComm(singletonGroup);
+    auto lease = tensorrt_llm::acquireComm(comm);
+    EXPECT_EQ(lease.begin(nullptr, "default-off legacy operation"), 0);
+    EXPECT_EQ(lease.get(), *comm);
+    EXPECT_THROW(
+        tensorrt_llm::abortAndReinitComm(singletonGroup, singletonGroup, kRawRecoveryRendezvousId), std::exception);
+}
+
+TEST(NcclUniqueIdRendezvousTest, ProcessDeathRendezvousRequiresOptInFaultTolerantMpiLauncher)
+{
+    if (!isEnvironmentFlagEnabled("TRTLLM_TEST_NCCL_PROCESS_DEATH"))
+    {
+        GTEST_SKIP() << "This destructive test requires a dedicated fault-tolerant MPI launcher";
+    }
+    int const rank = COMM_SESSION.getRank();
+    int const worldSize = COMM_SESSION.getSize();
+    if (worldSize != 3)
+    {
+        exitProcessDeathTestFailure(rank, "the opt-in process-death test requires exactly three MPI processes");
+    }
+
+    try
+    {
+        std::string gpuFailure;
+        if (!configureDistinctCudaDeviceForEveryRank(gpuFailure))
+        {
+            exitProcessDeathTestFailure(rank, gpuFailure);
+        }
+
+        // Establish both the production raw-NCCL communicator and its retained
+        // MPI control channel while every rank is healthy. The separate test
+        // control channel supplies only the pre-failure synchronization below.
+        auto const control = createTestControlComm();
+        auto const fullRanks = allSessionRanks();
+        std::set<int> const fullGroup(fullRanks.begin(), fullRanks.end());
+        auto const fullComm = tensorrt_llm::getComm(fullGroup);
+        if (fullComm == nullptr || *fullComm == nullptr)
+        {
+            throw std::runtime_error("healthy full-group NCCL communicator is null");
+        }
+        control->mpiComm().barrier();
+        if (rank == 1)
+        {
+            std::_Exit(EXIT_SUCCESS);
+        }
+
+        // This probes the stronger Mode-A contract: after one process exits,
+        // surviving ranks must still exchange a fresh NCCL ID over the retained
+        // MPI channel, abort the poisoned full communicator, and execute real
+        // data-plane work on its replacement.
+        std::this_thread::sleep_for(std::chrono::milliseconds{500});
+        std::set<int> const survivorGroup{0, 2};
+        tensorrt_llm::abortAndReinitComm(fullGroup, survivorGroup, kProcessDeathRendezvousId);
+        auto const rebuiltComm = tensorrt_llm::getComm(survivorGroup);
+        if (rebuiltComm == nullptr || *rebuiltComm == nullptr)
+        {
+            throw std::runtime_error("rebuilt survivor NCCL communicator is null");
+        }
+
+        auto const checkCuda = [](cudaError_t result, char const* operation)
+        {
+            if (result != cudaSuccess)
+            {
+                throw std::runtime_error(std::string{operation} + " failed: " + cudaGetErrorString(result));
+            }
+        };
+        int const hostInput = rank + 1;
+        int hostOutput = 0;
+        int* deviceInput = nullptr;
+        int* deviceOutput = nullptr;
+        cudaStream_t stream = nullptr;
+        checkCuda(cudaMalloc(reinterpret_cast<void**>(&deviceInput), sizeof(hostInput)), "cudaMalloc(input)");
+        checkCuda(cudaMalloc(reinterpret_cast<void**>(&deviceOutput), sizeof(hostOutput)), "cudaMalloc(output)");
+        checkCuda(cudaStreamCreate(&stream), "cudaStreamCreate");
+        checkCuda(cudaMemcpyAsync(deviceInput, &hostInput, sizeof(hostInput), cudaMemcpyHostToDevice, stream),
+            "cudaMemcpyAsync(input)");
+
+        std::uint64_t operationToken = 0;
+        {
+            auto lease = tensorrt_llm::acquireComm(rebuiltComm);
+            operationToken = lease.begin(stream, "ncclAllReduce(process-death recovery test)");
+            lease.check(ncclAllReduce(deviceInput, deviceOutput, 1, ncclInt32, ncclSum, lease.get(), stream),
+                "ncclAllReduce(process-death recovery test)");
+            lease.track(operationToken, stream);
+        }
+        tensorrt_llm::waitCommOperation(rebuiltComm, operationToken, "ncclAllReduce(process-death recovery test)");
+        checkCuda(
+            cudaMemcpy(&hostOutput, deviceOutput, sizeof(hostOutput), cudaMemcpyDeviceToHost), "cudaMemcpy(output)");
+        constexpr int kExpectedSurvivorSum = 4;
+        if (hostOutput != kExpectedSurvivorSum)
+        {
+            throw std::runtime_error("post-recovery allreduce returned " + std::to_string(hostOutput) + ", expected "
+                + std::to_string(kExpectedSurvivorSum));
+        }
+
+        if (rank == *survivorGroup.begin())
+        {
+            // Some fault-tolerant launchers still return nonzero because the
+            // victim intentionally skipped MPI_Finalize. CTest keys off this
+            // flushed sentinel, reached only after survivor communicator
+            // rebuild and the expected allreduce, instead of that exit code.
+            std::fprintf(stdout, "TRTLLM_PROCESS_DEATH_RENDEZVOUS_OK\n");
+            std::fflush(stdout);
+        }
+        std::_Exit(EXIT_SUCCESS);
+    }
+    catch (std::exception const& error)
+    {
+        exitProcessDeathTestFailure(rank, error.what());
+    }
+    catch (...)
+    {
+        exitProcessDeathTestFailure(rank, "unknown exception");
+    }
+}
+
+TEST(NcclUniqueIdRendezvousTest, RawCommunicatorRebuildRunsPostRecoveryCollective)
+{
+    int const rank = COMM_SESSION.getRank();
+    int const worldSize = COMM_SESSION.getSize();
+    if (worldSize < 3)
+    {
+        GTEST_SKIP() << "Test requires at least three MPI processes";
+    }
+    EnvironmentVariableGuard const faultToleranceMode{"TLLM_FAULT_TOLERANCE_MODE", "1"};
+
+    int deviceCount = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+    if (deviceCount == 0)
+    {
+        GTEST_SKIP() << "Test requires a visible CUDA device";
+    }
+    int const device = rank % deviceCount;
+    ASSERT_EQ(cudaSetDevice(device), cudaSuccess);
+
+    // A launcher may expose all GPUs to every rank or bind each rank to one
+    // different physical GPU. Compare UUIDs rather than local ordinals so both
+    // layouts work, and never run multiple NCCL ranks on the same device.
+    cudaUUID_t deviceUuid{};
+    ASSERT_EQ(getCudaDeviceUuid(deviceUuid, device), cudaSuccess);
+    std::vector<char> gatheredUuids(
+        static_cast<std::size_t>(worldSize) * static_cast<std::size_t>(sizeof(deviceUuid.bytes)));
+    COMM_SESSION.allgather(deviceUuid.bytes, gatheredUuids.data(), static_cast<int>(sizeof(deviceUuid.bytes)),
+        tensorrt_llm::mpi::MpiType::kBYTE);
+    std::unordered_set<std::string> uniqueUuids;
+    for (int peer = 0; peer < worldSize; ++peer)
+    {
+        auto const* bytes = gatheredUuids.data()
+            + static_cast<std::size_t>(peer) * static_cast<std::size_t>(sizeof(deviceUuid.bytes));
+        uniqueUuids.emplace(bytes, bytes + sizeof(deviceUuid.bytes));
+    }
+    if (uniqueUuids.size() != static_cast<std::size_t>(worldSize))
+    {
+        GTEST_SKIP() << "Test requires one distinct physical GPU per MPI rank";
+    }
+
+    auto const fullRanks = allSessionRanks();
+    std::set<int> const fullGroup(fullRanks.begin(), fullRanks.end());
+    std::set<int> const survivorGroup{0, worldSize - 1};
+    auto const testSync = createTestControlComm();
+    auto oldComm = tensorrt_llm::getComm(fullGroup);
+    ASSERT_NE(oldComm, nullptr);
+    EXPECT_EQ(tensorrt_llm::getCommWorldRank(oldComm), rank);
+
+    // Keep the old registry state alive so its storage cannot be recycled;
+    // pointer inequality then proves recovery installed a fresh state.
+    std::shared_ptr<ncclComm_t> cachedSurvivorComm;
+    ncclComm_t* cachedSurvivorState = nullptr;
+    if (survivorGroup.count(rank) != 0)
+    {
+        cachedSurvivorComm = tensorrt_llm::getComm(survivorGroup);
+        ASSERT_NE(cachedSurvivorComm, nullptr);
+        cachedSurvivorState = cachedSurvivorComm.get();
+    }
+
+    // Ensure the survivor-target cache entry exists before any rank begins
+    // recovery. Use a dedicated test communicator so the excluded rank does
+    // not enter a parent-communicator collective while survivors create their
+    // subgroup control channel.
+    testSync->mpiComm().barrier();
+
+    if (survivorGroup.count(rank) != 0)
+    {
+        tensorrt_llm::abortAndReinitComm(fullGroup, survivorGroup, kRawRecoveryRendezvousId);
+        auto rebuiltComm = tensorrt_llm::getComm(survivorGroup);
+        ASSERT_NE(rebuiltComm, nullptr);
+        EXPECT_EQ(tensorrt_llm::getCommWorldRank(rebuiltComm), rank);
+        EXPECT_NE(rebuiltComm.get(), cachedSurvivorState);
+        EXPECT_EQ(tensorrt_llm::getComm(survivorGroup).get(), rebuiltComm.get());
+
+        int const hostInput = rank + 1;
+        int hostOutput = 0;
+        int* deviceInput = nullptr;
+        int* deviceOutput = nullptr;
+        cudaStream_t stream = nullptr;
+        ASSERT_EQ(cudaMalloc(reinterpret_cast<void**>(&deviceInput), sizeof(hostInput)), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(reinterpret_cast<void**>(&deviceOutput), sizeof(hostOutput)), cudaSuccess);
+        ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+        ASSERT_EQ(
+            cudaMemcpyAsync(deviceInput, &hostInput, sizeof(hostInput), cudaMemcpyHostToDevice, stream), cudaSuccess);
+
+        std::uint64_t operationToken = 0;
+        {
+            auto lease = tensorrt_llm::acquireComm(rebuiltComm);
+            operationToken = lease.begin(stream, "ncclAllReduce(recovery test)");
+            lease.check(ncclAllReduce(deviceInput, deviceOutput, 1, ncclInt32, ncclSum, lease.get(), stream),
+                "ncclAllReduce(recovery test)");
+            lease.track(operationToken, stream);
+        }
+        tensorrt_llm::waitCommOperation(rebuiltComm, operationToken, "ncclAllReduce(recovery test)");
+
+        ASSERT_EQ(cudaMemcpy(&hostOutput, deviceOutput, sizeof(hostOutput), cudaMemcpyDeviceToHost), cudaSuccess);
+        EXPECT_EQ(hostOutput, worldSize + 1);
+        EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+        EXPECT_EQ(cudaFree(deviceOutput), cudaSuccess);
+        EXPECT_EQ(cudaFree(deviceInput), cudaSuccess);
+
+        // Leave only a singleton communicator for process teardown. This is
+        // test cleanup, not another simulated survivor-membership decision.
+        tensorrt_llm::abortAndReinitComm(survivorGroup, {rank}, kRawCleanupRendezvousId);
+    }
+    else
+    {
+        // The excluded rank deliberately does not participate in the survivor
+        // rendezvous. Once survivors have started rebuilding, replace its old
+        // local communicator with a singleton so test-process teardown never
+        // calls ncclCommDestroy on a half-aborted full-group communicator.
+        tensorrt_llm::abortAndReinitComm(fullGroup, {rank}, kRawCleanupRendezvousId);
+    }
+
+    // Test-only synchronization after every local recovery path has finished.
+    testSync->mpiComm().barrier();
+}
+
+TEST(NcclUniqueIdRendezvousTest, PipelineCommunicatorRebuildRunsPostRecoverySendRecv)
+{
+    int const rank = COMM_SESSION.getRank();
+    int const worldSize = COMM_SESSION.getSize();
+    if (worldSize < 3)
+    {
+        GTEST_SKIP() << "Test requires at least three MPI processes";
+    }
+    EnvironmentVariableGuard const faultToleranceMode{"TLLM_FAULT_TOLERANCE_MODE", "1"};
+
+    int deviceCount = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+    if (deviceCount == 0)
+    {
+        GTEST_SKIP() << "Test requires a visible CUDA device";
+    }
+    int const device = rank % deviceCount;
+    ASSERT_EQ(cudaSetDevice(device), cudaSuccess);
+
+    cudaUUID_t deviceUuid{};
+    ASSERT_EQ(getCudaDeviceUuid(deviceUuid, device), cudaSuccess);
+    std::vector<char> gatheredUuids(
+        static_cast<std::size_t>(worldSize) * static_cast<std::size_t>(sizeof(deviceUuid.bytes)));
+    COMM_SESSION.allgather(deviceUuid.bytes, gatheredUuids.data(), static_cast<int>(sizeof(deviceUuid.bytes)),
+        tensorrt_llm::mpi::MpiType::kBYTE);
+    std::unordered_set<std::string> uniqueUuids;
+    for (int peer = 0; peer < worldSize; ++peer)
+    {
+        auto const* bytes = gatheredUuids.data()
+            + static_cast<std::size_t>(peer) * static_cast<std::size_t>(sizeof(deviceUuid.bytes));
+        uniqueUuids.emplace(bytes, bytes + sizeof(deviceUuid.bytes));
+    }
+    if (uniqueUuids.size() != static_cast<std::size_t>(worldSize))
+    {
+        GTEST_SKIP() << "Test requires one distinct physical GPU per MPI rank";
+    }
+
+    auto const testSync = createTestControlComm();
+    auto communicator = std::make_unique<tensorrt_llm::runtime::NcclCommunicator>(worldSize, rank);
+    std::vector<int> const survivorRanks{0, worldSize - 1};
+    bool const isSurvivor = std::binary_search(survivorRanks.begin(), survivorRanks.end(), rank);
+
+    testSync->mpiComm().barrier();
+    if (isSurvivor)
+    {
+        communicator->abortAndReinit(survivorRanks, kPpRecoveryRendezvousId);
+        EXPECT_EQ(communicator->getActiveRanks(), survivorRanks);
+    }
+    else
+    {
+        communicator->abortAndReinit({rank}, kPpExcludedCleanupRendezvousId);
+        EXPECT_EQ(communicator->getActiveRanks(), std::vector<int>{rank});
+    }
+    EXPECT_TRUE(communicator->getAsyncError().empty());
+
+    int* deviceValue = nullptr;
+    ASSERT_EQ(cudaMalloc(reinterpret_cast<void**>(&deviceValue), sizeof(*deviceValue)), cudaSuccess);
+    int hostValue = rank == survivorRanks.front() ? 0x1a07 : 0;
+    ASSERT_EQ(cudaMemcpy(deviceValue, &hostValue, sizeof(hostValue), cudaMemcpyHostToDevice), cudaSuccess);
+    auto buffer = tensorrt_llm::runtime::IBuffer::wrap(deviceValue, nvinfer1::DataType::kINT32, 1);
+    tensorrt_llm::runtime::CudaStream stream;
+
+    if (rank == survivorRanks.front())
+    {
+        communicator->send(*buffer, survivorRanks.back(), stream);
+        stream.synchronize();
+    }
+    else if (rank == survivorRanks.back())
+    {
+        communicator->receive(*buffer, survivorRanks.front(), stream);
+        stream.synchronize();
+        ASSERT_EQ(cudaMemcpy(&hostValue, deviceValue, sizeof(hostValue), cudaMemcpyDeviceToHost), cudaSuccess);
+        EXPECT_EQ(hostValue, 0x1a07);
+    }
+
+    buffer.reset();
+    ASSERT_EQ(cudaFree(deviceValue), cudaSuccess);
+    testSync->mpiComm().barrier();
+    communicator.reset();
+    testSync->mpiComm().barrier();
+}
+
+} // namespace
+
+#endif // ENABLE_MULTI_DEVICE

--- a/cpp/tests/unit_tests/multi_gpu/ncclUniqueIdRendezvousTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/ncclUniqueIdRendezvousTest.cpp
@@ -954,7 +954,7 @@ TEST(NcclUniqueIdRendezvousTest, PipelineCommunicatorRebuildRunsPostRecoverySend
     ASSERT_EQ(cudaMalloc(reinterpret_cast<void**>(&deviceValue), sizeof(*deviceValue)), cudaSuccess);
     int hostValue = rank == survivorRanks.front() ? 0x1a07 : 0;
     ASSERT_EQ(cudaMemcpy(deviceValue, &hostValue, sizeof(hostValue), cudaMemcpyHostToDevice), cudaSuccess);
-    auto buffer = tensorrt_llm::runtime::IBuffer::wrap(deviceValue, nvinfer1::DataType::kINT32, 1);
+    auto buffer = tensorrt_llm::runtime::IBuffer::wrap(deviceValue, tensorrt_llm::DataType::kINT32, 1);
     tensorrt_llm::runtime::CudaStream stream;
 
     if (rank == survivorRanks.front())

--- a/cpp/tests/unit_tests/multi_gpu/ncclUtilsTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/ncclUtilsTest.cpp
@@ -20,7 +20,9 @@
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/common/opUtils.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
+#include "tensorrt_llm/runtime/utils/ncclHostApi.h"
 
+#include <atomic>
 #include <gtest/gtest.h>
 #include <mutex>
 #include <nccl.h>
@@ -87,40 +89,152 @@ TEST(NCCLWindowSupportTest, RuntimeVersionAndGB10Gate)
 
 // Helper function to create a split communicator for testing
 // This allows us to test cleanup behavior explicitly by controlling the lifetime
-std::shared_ptr<ncclComm_t> createSplitComm(ncclComm_t parentComm, int color, int key)
+std::shared_ptr<ncclComm_t> createSplitComm(std::shared_ptr<ncclComm_t> const& parentComm, int color, int key)
 {
-    ncclComm_t newComm;
-    ncclResult_t result = ncclCommSplit(parentComm, color, key, &newComm, nullptr);
-    if (result != ncclSuccess)
+    ncclComm_t newComm = nullptr;
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    // The cached parent is nonblocking. Make the test-owned child blocking so
+    // the legacy raw allocator overload and its simple deleter have an
+    // explicit blocking-communicator contract.
+    config.blocking = 1;
     {
-        TLLM_THROW("ncclCommSplit failed with error: %d", result);
+        auto lease = tensorrt_llm::acquireComm(parentComm);
+        auto const result = ncclCommSplit(lease.get(), color, key, &newComm, &config);
+        lease.check(result, "ncclCommSplit(ncclUtilsTest)");
+    }
+    if (newComm == nullptr)
+    {
+        TLLM_THROW("ncclCommSplit returned a null child communicator");
     }
 
     // Create a shared_ptr with custom deleter that cleans up resources first
     return std::shared_ptr<ncclComm_t>(new ncclComm_t(newComm),
         [](ncclComm_t* comm)
         {
-            if (comm && *comm)
+            if (comm != nullptr && *comm != nullptr)
             {
                 // STEP 1: Clean up all registered resources FIRST
-                tensorrt_llm::common::nccl_util::NcclCommResourceManager::getInstance().cleanupResources(*comm);
+                bool const resourcesCleaned
+                    = tensorrt_llm::common::nccl_util::NcclCommResourceManager::getInstance().cleanupResources(*comm);
 
-                // STEP 2: Now destroy the NCCL communicator
-                ncclResult_t result = ncclCommDestroy(*comm);
+                // STEP 2: Serialize with the cached parent's watchdog and
+                // destroy only after resource cleanup fully completed.
+                auto const hostApiLock = tensorrt_llm::runtime::acquireNcclHostApiLock();
+                ncclResult_t const result = resourcesCleaned ? ncclCommDestroy(*comm) : ncclCommAbort(*comm);
                 if (result != ncclSuccess)
                 {
-                    TLLM_LOG_WARNING("ncclCommDestroy failed with error: %d", result);
+                    TLLM_LOG_WARNING("NCCL test communicator release failed with error: %d", result);
                 }
-
-                // STEP 3: Free the memory
-                delete comm;
+                *comm = nullptr;
             }
+            // STEP 3: Free the holder even if communicator creation failed.
+            delete comm;
         });
 }
 
 //==============================================================================
 // NcclCommResourceManager Tests
 //==============================================================================
+
+TEST(NcclCommResourceManagerStandaloneTest, ReusedHandleWaitsForAbortCleanup)
+{
+    auto& manager = nccl_util::NcclCommResourceManager::getInstance();
+    int handleStorage = 0;
+    auto const comm = reinterpret_cast<ncclComm_t>(&handleStorage);
+    std::atomic<bool> waitStarted{false};
+    std::atomic<bool> waitCompleted{false};
+
+    manager.beginAbortCleanup(comm);
+    std::thread waiter(
+        [&]()
+        {
+            waitStarted.store(true, std::memory_order_release);
+            manager.waitForAbortCleanup(comm);
+            waitCompleted.store(true, std::memory_order_release);
+        });
+    while (!waitStarted.load(std::memory_order_acquire))
+    {
+        std::this_thread::yield();
+    }
+    EXPECT_FALSE(waitCompleted.load(std::memory_order_acquire));
+
+    EXPECT_TRUE(manager.cleanupResources(comm, true));
+    waiter.join();
+    EXPECT_TRUE(waitCompleted.load(std::memory_order_acquire));
+}
+
+TEST(NcclCommResourceManagerStandaloneTest, ConcurrentCleanupCannotReleaseRetiredHandleEarly)
+{
+    auto& manager = nccl_util::NcclCommResourceManager::getInstance();
+    int handleStorage = 0;
+    auto const comm = reinterpret_cast<ncclComm_t>(&handleStorage);
+    std::atomic<bool> cleanupEntered{false};
+    std::atomic<bool> releaseCleanup{false};
+    std::atomic<bool> cleanupSucceeded{false};
+    manager.registerResource(
+        comm,
+        [&]()
+        {
+            cleanupEntered.store(true, std::memory_order_release);
+            while (!releaseCleanup.load(std::memory_order_acquire))
+            {
+                std::this_thread::yield();
+            }
+            return true;
+        },
+        "BlockingAbortCleanup");
+    manager.beginAbortCleanup(comm);
+
+    std::thread cleanupOwner(
+        [&]() { cleanupSucceeded.store(manager.cleanupResources(comm, true), std::memory_order_release); });
+    while (!cleanupEntered.load(std::memory_order_acquire))
+    {
+        std::this_thread::yield();
+    }
+
+    EXPECT_TRUE(manager.cleanupResources(comm, true));
+    EXPECT_TRUE(manager.isAbortCleanup(comm));
+    releaseCleanup.store(true, std::memory_order_release);
+    cleanupOwner.join();
+    EXPECT_TRUE(cleanupSucceeded.load(std::memory_order_acquire));
+    EXPECT_FALSE(manager.isAbortCleanup(comm));
+}
+
+TEST(NcclCommResourceManagerStandaloneTest, NormalCleanupOwnsRetirementUntilCallbacksComplete)
+{
+    auto& manager = nccl_util::NcclCommResourceManager::getInstance();
+    int handleStorage = 0;
+    auto const comm = reinterpret_cast<ncclComm_t>(&handleStorage);
+    std::atomic<bool> cleanupEntered{false};
+    std::atomic<bool> releaseCleanup{false};
+    std::atomic<bool> cleanupSucceeded{false};
+    manager.registerResource(
+        comm,
+        [&]()
+        {
+            cleanupEntered.store(true, std::memory_order_release);
+            while (!releaseCleanup.load(std::memory_order_acquire))
+            {
+                std::this_thread::yield();
+            }
+            return true;
+        },
+        "BlockingNormalCleanup");
+    std::thread cleanupOwner(
+        [&]() { cleanupSucceeded.store(manager.cleanupResources(comm, false), std::memory_order_release); });
+    while (!cleanupEntered.load(std::memory_order_acquire))
+    {
+        std::this_thread::yield();
+    }
+
+    manager.beginAbortCleanup(comm);
+    EXPECT_TRUE(manager.cleanupResources(comm, true));
+    EXPECT_TRUE(manager.isAbortCleanup(comm));
+    releaseCleanup.store(true, std::memory_order_release);
+    cleanupOwner.join();
+    EXPECT_TRUE(cleanupSucceeded.load(std::memory_order_acquire));
+    EXPECT_FALSE(manager.isAbortCleanup(comm));
+}
 
 class NcclCommResourceManagerTest : public ::testing::Test
 {
@@ -170,12 +284,18 @@ TEST_F(NcclCommResourceManagerTest, ResourceRegistration)
     auto& manager = nccl_util::NcclCommResourceManager::getInstance();
 
     // Create a separate comm using split for this test
-    auto testComm = createSplitComm(*mComm, 0, mRank);
+    auto testComm = createSplitComm(mComm, 0, mRank);
 
     // Register a resource
     bool cleanupCalled = false;
     manager.registerResource(
-        *testComm, [&cleanupCalled]() { cleanupCalled = true; }, "TestResource");
+        *testComm,
+        [&cleanupCalled]()
+        {
+            cleanupCalled = true;
+            return true;
+        },
+        "TestResource");
 
     EXPECT_TRUE(manager.hasResources(*testComm));
     EXPECT_EQ(manager.getResourceCount(*testComm), 1);
@@ -202,15 +322,33 @@ TEST_F(NcclCommResourceManagerTest, MultipleResources)
     auto& manager = nccl_util::NcclCommResourceManager::getInstance();
 
     // Create a separate comm using split for this test
-    auto testComm = createSplitComm(*mComm, 0, mRank);
+    auto testComm = createSplitComm(mComm, 0, mRank);
 
     std::vector<int> cleanupOrder;
     manager.registerResource(
-        *testComm, [&cleanupOrder]() { cleanupOrder.push_back(1); }, "Resource1");
+        *testComm,
+        [&cleanupOrder]()
+        {
+            cleanupOrder.push_back(1);
+            return true;
+        },
+        "Resource1");
     manager.registerResource(
-        *testComm, [&cleanupOrder]() { cleanupOrder.push_back(2); }, "Resource2");
+        *testComm,
+        [&cleanupOrder]()
+        {
+            cleanupOrder.push_back(2);
+            return true;
+        },
+        "Resource2");
     manager.registerResource(
-        *testComm, [&cleanupOrder]() { cleanupOrder.push_back(3); }, "Resource3");
+        *testComm,
+        [&cleanupOrder]()
+        {
+            cleanupOrder.push_back(3);
+            return true;
+        },
+        "Resource3");
 
     EXPECT_EQ(manager.getResourceCount(*testComm), 3);
 
@@ -229,20 +367,32 @@ TEST_F(NcclCommResourceManagerTest, ResourceCount)
     auto& manager = nccl_util::NcclCommResourceManager::getInstance();
 
     // Create a separate comm using split for this test
-    auto testComm = createSplitComm(*mComm, 0, mRank);
+    auto testComm = createSplitComm(mComm, 0, mRank);
 
     EXPECT_FALSE(manager.hasResources(*testComm));
     EXPECT_EQ(manager.getResourceCount(*testComm), 0);
 
     manager.registerResource(
-        *testComm, []() {}, "Test1");
+        *testComm, []() { return true; }, "Test1");
     EXPECT_EQ(manager.getResourceCount(*testComm), 1);
 
     manager.registerResource(
-        *testComm, []() {}, "Test2");
+        *testComm, []() { return true; }, "Test2");
     EXPECT_EQ(manager.getResourceCount(*testComm), 2);
 
     testComm.reset();
+}
+
+TEST_F(NcclCommResourceManagerTest, CleanupFailureIsReportedToCommunicatorOwner)
+{
+    auto& manager = nccl_util::NcclCommResourceManager::getInstance();
+    auto testComm = createSplitComm(mComm, 0, mRank);
+
+    manager.registerResource(
+        *testComm, []() { return false; }, "InjectedCleanupFailure");
+
+    EXPECT_FALSE(manager.cleanupResources(*testComm));
+    EXPECT_FALSE(manager.hasResources(*testComm));
 }
 
 //==============================================================================
@@ -302,7 +452,7 @@ TEST_F(NCCLWindowAllocatorTest, BasicAllocation)
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
 
     const size_t bufferSize = 1024 * 1024; // 1MB
-    auto buffer = allocator.requestBuffer(*mComm, bufferSize);
+    auto buffer = allocator.requestBuffer(mComm, bufferSize);
 
     EXPECT_TRUE(buffer.isValid());
     EXPECT_NE(buffer.ptr, nullptr);
@@ -326,7 +476,7 @@ TEST_F(NCCLWindowAllocatorTest, BufferReuse)
     const size_t bufferSize = 512 * 1024; // 512KB
 
     // Allocate first buffer
-    auto buffer1 = allocator.requestBuffer(*mComm, bufferSize);
+    auto buffer1 = allocator.requestBuffer(mComm, bufferSize);
     EXPECT_TRUE(buffer1.isValid());
     void* ptr1 = buffer1.ptr;
 
@@ -334,7 +484,7 @@ TEST_F(NCCLWindowAllocatorTest, BufferReuse)
     allocator.releaseBuffer(*mComm, ptr1);
 
     // Request another buffer of the same size - should reuse
-    auto buffer2 = allocator.requestBuffer(*mComm, bufferSize);
+    auto buffer2 = allocator.requestBuffer(mComm, bufferSize);
     EXPECT_TRUE(buffer2.isValid());
     EXPECT_EQ(buffer2.ptr, ptr1); // Should be the same buffer
 
@@ -346,9 +496,9 @@ TEST_F(NCCLWindowAllocatorTest, BestFitReuse)
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
 
     // Allocate buffers of different sizes
-    auto buffer1MB = allocator.requestBuffer(*mComm, 1024 * 1024);
-    auto buffer2MB = allocator.requestBuffer(*mComm, 2 * 1024 * 1024);
-    auto buffer512KB = allocator.requestBuffer(*mComm, 512 * 1024);
+    auto buffer1MB = allocator.requestBuffer(mComm, 1024 * 1024);
+    auto buffer2MB = allocator.requestBuffer(mComm, 2 * 1024 * 1024);
+    auto buffer512KB = allocator.requestBuffer(mComm, 512 * 1024);
 
     void* ptr1MB = buffer1MB.ptr;
     void* ptr2MB = buffer2MB.ptr;
@@ -360,7 +510,7 @@ TEST_F(NCCLWindowAllocatorTest, BestFitReuse)
     allocator.releaseBuffer(*mComm, ptr512KB);
 
     // Request 768KB - should reuse 1MB (best fit, smallest that fits)
-    auto buffer768KB = allocator.requestBuffer(*mComm, 768 * 1024);
+    auto buffer768KB = allocator.requestBuffer(mComm, 768 * 1024);
     EXPECT_TRUE(buffer768KB.isValid());
     EXPECT_EQ(buffer768KB.ptr, ptr1MB);       // Should reuse 1MB buffer
     EXPECT_EQ(buffer768KB.size, 1024 * 1024); // Original size
@@ -371,7 +521,7 @@ TEST_F(NCCLWindowAllocatorTest, BestFitReuse)
 TEST_F(NCCLWindowAllocatorTest, FailureCacheIsSizeAwareForNewAllocations)
 {
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
-    auto testComm = createSplitComm(*mComm, 0, mRank);
+    auto testComm = createSplitComm(mComm, 0, mRank);
 
     constexpr size_t failureSize = 1024 * 1024;
     nccl_util::NCCLWindowAllocatorTestAccess::recordSymmetricFailure(allocator, *testComm, failureSize);
@@ -391,7 +541,7 @@ TEST_F(NCCLWindowAllocatorTest, FailureCacheIsSizeAwareForNewAllocations)
 TEST_F(NCCLWindowAllocatorTest, FailureCacheDoesNotDisableReusableBuffers)
 {
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
-    auto testComm = createSplitComm(*mComm, 0, mRank);
+    auto testComm = createSplitComm(mComm, 0, mRank);
 
     auto buffer1MB = allocator.requestBuffer(*testComm, 1024 * 1024);
     ASSERT_TRUE(buffer1MB.isValid());
@@ -416,7 +566,7 @@ TEST_F(NCCLWindowAllocatorTest, FailureCacheDoesNotDisableReusableBuffers)
 TEST_F(NCCLWindowAllocatorTest, FailureCacheKeepsSmallestFailureSize)
 {
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
-    auto testComm = createSplitComm(*mComm, 0, mRank);
+    auto testComm = createSplitComm(mComm, 0, mRank);
 
     nccl_util::NCCLWindowAllocatorTestAccess::recordSymmetricFailure(allocator, *testComm, 2 * 1024 * 1024);
     nccl_util::NCCLWindowAllocatorTestAccess::recordSymmetricFailure(allocator, *testComm, 1024 * 1024);
@@ -459,7 +609,7 @@ TEST_F(NCCLWindowAllocatorTest, MultipleBuffers)
     // Allocate multiple buffers
     for (int i = 0; i < 5; ++i)
     {
-        auto buffer = allocator.requestBuffer(*mComm, bufferSize);
+        auto buffer = allocator.requestBuffer(mComm, bufferSize);
         EXPECT_TRUE(buffer.isValid());
         ptrs.push_back(buffer.ptr);
     }
@@ -482,7 +632,7 @@ TEST_F(NCCLWindowAllocatorTest, SearchBuffer)
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
 
     const size_t bufferSize = 128 * 1024;
-    auto buffer = allocator.requestBuffer(*mComm, bufferSize);
+    auto buffer = allocator.requestBuffer(mComm, bufferSize);
 
     // Test searchBuffer
     auto found = allocator.searchBuffer(*mComm, buffer.ptr);
@@ -505,7 +655,7 @@ TEST_F(NCCLWindowAllocatorTest, GetWindowAndSize)
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
 
     const size_t bufferSize = 64 * 1024;
-    auto buffer = allocator.requestBuffer(*mComm, bufferSize);
+    auto buffer = allocator.requestBuffer(mComm, bufferSize);
 
     // Test getWindow
     auto window = allocator.getWindow(*mComm, buffer.ptr);
@@ -530,7 +680,7 @@ TEST_F(NCCLWindowAllocatorTest, GetBufferInfo)
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
 
     const size_t bufferSize = 32 * 1024;
-    auto buffer = allocator.requestBuffer(*mComm, bufferSize);
+    auto buffer = allocator.requestBuffer(mComm, bufferSize);
 
     auto info = allocator.getBufferInfo(*mComm, buffer.ptr);
     EXPECT_TRUE(info.isValid());
@@ -570,7 +720,7 @@ TEST_F(NCCLWindowAllocatorTest, CleanupOnCommDestroy)
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
 
     // Create a separate comm using split for this test
-    auto testComm = createSplitComm(*mComm, 0, mRank);
+    auto testComm = createSplitComm(mComm, 0, mRank);
 
     // Store the raw comm value before destruction
     ncclComm_t rawComm = *testComm;
@@ -627,8 +777,8 @@ TEST_F(NCCLWindowAllocatorTest, MultipleComms)
     auto& allocator = nccl_util::NCCLWindowAllocator::getInstance();
 
     // Create two different communicators using split (different colors)
-    auto comm1 = createSplitComm(*mComm, 0, mRank);
-    auto comm2 = createSplitComm(*mComm, 1, mRank);
+    auto comm1 = createSplitComm(mComm, 0, mRank);
+    auto comm2 = createSplitComm(mComm, 1, mRank);
 
     const size_t bufferSize = 4 * 1024;
 
@@ -829,6 +979,25 @@ TEST_F(CreateNCCLWindowTensorTest, TensorDeleterReleasesBuffer)
 
     // Buffer should still exist in the pool (for reuse)
     EXPECT_GE(allocator.getBufferCount(*mComm), 1);
+}
+
+TEST_F(CreateNCCLWindowTensorTest, TensorKeepsGenericCommunicatorOwnerAlive)
+{
+    if (tensorrt_llm::isNcclFaultToleranceEnabled())
+    {
+        GTEST_SKIP() << "Generic communicator holders use the legacy default-off allocator contract";
+    }
+    auto comm = createSplitComm(mComm, 0, mRank);
+    std::weak_ptr<ncclComm_t> weakComm = comm;
+    std::vector<int64_t> shape = {16, 16};
+    auto [tensor, buffer] = nccl_util::createNCCLWindowTensor(comm, shape, torch::kFloat32);
+    ASSERT_TRUE(tensor.defined());
+    ASSERT_TRUE(buffer.isValid());
+
+    comm.reset();
+    EXPECT_FALSE(weakComm.expired());
+    tensor = torch::Tensor();
+    EXPECT_TRUE(weakComm.expired());
 }
 
 TEST_F(CreateNCCLWindowTensorTest, MultipleTensors)

--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -18,7 +18,7 @@ import os
 import platform
 import sys
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import pynvml
 import torch
@@ -406,17 +406,48 @@ class HelixCpMnnvlMemory(MnnvlMemory):
     its own isolated state separate from MnnvlMemory.
     """
 
+    comm_topology = None
+
+    @staticmethod
+    def get_comm_topology(
+        mapping: Mapping,
+    ) -> Tuple[int, int, int, Tuple[int, ...]]:
+        """Return the exact local CP topology used by ``MPI_Comm_split``."""
+        return (
+            int(mapping.world_size),
+            int(mapping.rank),
+            int(mapping.cp_rank),
+            tuple(int(rank) for rank in mapping.cp_group),
+        )
+
     @classmethod
     def get_comm(cls, mapping: Mapping):
         """Get CP-based communicator (ranks grouped by PP+TP+MOE_TP, ordered by CP rank)."""
+        topology = cls.get_comm_topology(mapping)
         if cls.comm is not None:
+            if cls.comm_topology != topology:
+                raise RuntimeError(
+                    "Helix MNNVL CP communicator is already initialized for "
+                    f"topology {cls.comm_topology}; cannot reuse it for "
+                    f"incompatible topology {topology}"
+                )
             return cls.comm
         comm = mpi_comm().Split(
             mapping.pp_rank * mapping.tp_size + mapping.tp_rank,
             mapping.cp_rank,
         )
         cls.comm = comm
+        cls.comm_topology = topology
         return comm
+
+
+def get_helix_cp_mnnvl_topology(
+    mapping: Mapping,
+) -> Optional[Tuple[int, int, int, Tuple[int, ...]]]:
+    """Return the Helix MNNVL topology relevant to communicator sharing."""
+    if mapping.has_cp_helix() and not mapping.cp_config.get("use_nccl_for_alltoall", True):
+        return HelixCpMnnvlMemory.get_comm_topology(mapping)
+    return None
 
 
 def init_helix_cp_comm(mapping: Mapping) -> None:

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -57,6 +57,22 @@ if IS_CUTLASS_DSL_AVAILABLE:
 # BufferKind is bound from C++; see cpp/tensorrt_llm/thop/outputTensor.h (torch_ext::BufferKind).
 from tensorrt_llm.bindings.internal.thop import BufferKind
 
+# Communicator mode is startup-only. Keep this local cached flag so importing
+# the custom-op registry does not recursively initialize the distributed
+# package merely to filter allreduce tactics.
+NCCL_FAULT_TOLERANCE_ENABLED = os.environ.get(
+    "TLLM_FAULT_TOLERANCE_MODE") == "1"
+
+
+def _use_cuda_graph_for_allreduce_tuning() -> bool:
+    """Whether raw-NCCL tactics may be captured by the autotuner.
+
+    The 1a.7 communicator can be replaced after failure, so captured NCCL
+    nodes are intentionally rejected in FT mode until graph invalidation and
+    recapture land in 1a.11.  Eager profiling preserves valid tactic timings.
+    """
+    return os.environ.get("TLLM_FAULT_TOLERANCE_MODE") != "1"
+
 
 # Used to WAR an issue in torch.bmm that it would break the graph when the out is not contiguous.
 @torch.library.custom_op("trtllm::bmm_out", mutates_args=("out", ))
@@ -2186,6 +2202,8 @@ class AllReduceRunner(TunableRunner):
             AllReduceStrategy.NCCL_SYMMETRIC.value,
             AllReduceStrategy.NCCL.value,
         ]
+        if NCCL_FAULT_TOLERANCE_ENABLED:
+            return [AllReduceStrategy.NCCL.value]
         # Fallback in allreduceOp is set to NCCL_SYMMETRIC as default
         # So we need to check if the workspace size is too large to avoid hanging.
         workspace_size = inputs[0].numel() * inputs[0].element_size()
@@ -2228,10 +2246,17 @@ class AllReduceRunner(TunableRunner):
             return input
         if tactic == -1:
             # tactic == -1 means the autotuner cache missed for this shape.
-            # Fall back to NCCL_SYMMETRIC; asymmetric ncclMemAlloc failures are handled
-            # by a cross-rank barrier in NCCLWindowAllocator which falls back
-            # to plain NCCL.
-            tactic = AllReduceStrategy.NCCL_SYMMETRIC.value
+            # FT mode must avoid NCCL_SYMMETRIC's MPI-local topology discovery;
+            # otherwise retain the optimized default-off fallback.
+            tactic = (AllReduceStrategy.NCCL.value
+                      if NCCL_FAULT_TOLERANCE_ENABLED else
+                      AllReduceStrategy.NCCL_SYMMETRIC.value)
+
+        if (NCCL_FAULT_TOLERANCE_ENABLED
+                and tactic != AllReduceStrategy.NCCL.value):
+            raise RuntimeError(
+                "NCCL error: fault-tolerant allreduce tuning selected a "
+                "custom tactic without a peer-failure abort path")
 
         return torch.ops.trtllm.allreduce(
             input,
@@ -2325,9 +2350,11 @@ def tunable_allreduce(
     tuning_config = AllReduceRunner.tuning_config
     if input_uses_nccl_window:
         tuning_config = replace(
-            AllReduceRunner.tuning_config,
+            tuning_config,
             inputs_pre_hook=
             _inputs_pre_hook_register_nccl_symmetric_memory_window)
+    if not _use_cuda_graph_for_allreduce_tuning():
+        tuning_config = replace(tuning_config, use_cuda_graph=False)
 
     _, best_tactic = tuner.choose_one(
         "trtllm::tunable_allreduce::allreduce",

--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -1,5 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import pickle  # nosec B403
+import threading
 from abc import ABC, abstractmethod
 from enum import IntEnum
 from functools import lru_cache, wraps
@@ -16,7 +20,11 @@ try:
 except Exception:
     MPI = None  # deferred; functions will error if used when ENABLE_MULTI_DEVICE is True
 
-from tensorrt_llm._mnnvl_utils import init_helix_cp_comm
+from tensorrt_llm._mnnvl_utils import (get_helix_cp_mnnvl_topology,
+                                       init_helix_cp_comm)
+from tensorrt_llm._torch.distributed.nccl_fault_tolerance import (
+    NCCL_FAULT_TOLERANCE_ENABLED, _canonical_recovery_generation,
+    _recovery_rendezvous_id)
 from tensorrt_llm._utils import (local_mpi_size, mpi_allgather, mpi_barrier,
                                  mpi_comm, mpi_disabled, mpi_isend,
                                  mpi_isend_object, mpi_recv, mpi_recv_object,
@@ -1184,16 +1192,83 @@ class PPCommNCCL:
 
     def __init__(self, global_mapping: Mapping):
         self.mapping = global_mapping
+        self._topology = self._mapping_topology(global_mapping)
+        self._reconfigure_lock = threading.Lock()
+        self._reconfigure_generation = 0
+        self._completed_recovery = None
         self.nccl_comm = torch.classes.trtllm.NcclCommunicatorOp(
             self.mapping.world_size,
             self.mapping.rank,
         )
+        if NCCL_FAULT_TOLERANCE_ENABLED:
+            # The FT native communicator survives process-local Python wrapper
+            # churn. Mirror its actual survivor membership instead of assuming
+            # a newly-created wrapper always represents the initial world.
+            self._active_ranks = tuple(
+                int(rank) for rank in self.nccl_comm.get_active_ranks())
+        else:
+            # Preserve the legacy constructor path when FT is disabled.
+            self._active_ranks = tuple(range(self.mapping.world_size))
         self.tensor_ready_event = torch.cuda.Event()
         self.send_stream = torch.cuda.Stream()
 
+    @staticmethod
+    def _mapping_topology(mapping: Mapping) -> tuple:
+        return (
+            int(mapping.world_size),
+            int(mapping.rank),
+            tuple(mapping.pp_group),
+            get_helix_cp_mnnvl_topology(mapping),
+        )
+
+    def is_native_compatible(self, mapping: Mapping) -> bool:
+        """Whether ``mapping`` can reuse the process-lifetime WORLD comm."""
+        return self._topology[:2] == (
+            int(mapping.world_size),
+            int(mapping.rank),
+        )
+
+    def is_compatible(self, mapping: Mapping) -> bool:
+        """Whether another live engine can share the current PP routing."""
+        return self._topology == self._mapping_topology(mapping)
+
+    def rebind(self, mapping: Mapping) -> None:
+        """Refresh routing for a sequential engine on the same native comm."""
+        if not self.is_native_compatible(mapping):
+            raise RuntimeError(
+                "NCCL error: cannot rebind a communicator to a different "
+                "world size or rank")
+        self.mapping = mapping
+        self._topology = self._mapping_topology(mapping)
+
+    def _validate_peer(self, peer: int) -> int:
+        peer = int(peer)
+        if peer not in self._topology[2]:
+            raise RuntimeError(
+                f"NCCL error: peer world rank {peer} is not in this rank's PP group "
+                f"{list(self._topology[2])}")
+        if peer not in self._active_ranks:
+            raise RuntimeError(
+                f"NCCL error: peer world rank {peer} is not active in the current PP communicator"
+            )
+        return peer
+
+    def _required_pp_peer(self, *, next_peer: bool) -> int:
+        # Do not silently skip a failed stage: connecting non-adjacent stages
+        # would bypass model layers. A higher-level topology reconstruction may
+        # pass an explicit remapped peer once it has reassigned those layers.
+        peer = (self.mapping.next_pp_rank()
+                if next_peer else self.mapping.prev_pp_rank())
+        return self._validate_peer(peer)
+
     def send(self, tensor: torch.Tensor, dest: Optional[int] = None):
-        if dest is None:
-            dest = self.mapping.next_pp_rank()
+        if not NCCL_FAULT_TOLERANCE_ENABLED:
+            if dest is None:
+                dest = self.mapping.next_pp_rank()
+        elif dest is None:
+            dest = self._required_pp_peer(next_peer=True)
+        else:
+            dest = self._validate_peer(dest)
 
         # NCCL send kernel in send_stream cannot be captured,
         # so we send in the current stream instead in CUDA graph cases.
@@ -1211,9 +1286,109 @@ class PPCommNCCL:
             self.nccl_comm.send(tensor, dest)
 
     def recv(self, tensor: torch.Tensor, src: Optional[int] = None):
-        if src is None:
-            src = self.mapping.prev_pp_rank()
+        if not NCCL_FAULT_TOLERANCE_ENABLED:
+            if src is None:
+                src = self.mapping.prev_pp_rank()
+        elif src is None:
+            src = self._required_pp_peer(next_peer=False)
+        else:
+            src = self._validate_peer(src)
         self.nccl_comm.recv(tensor, src)
+
+    def abort(self, generation: Optional[int] = None) -> None:
+        """Abort the PP communicator on this survivor."""
+        # Capture the generation before waiting for a concurrent rebuild. If
+        # that rebuild succeeds, this abort belongs to the old communicator
+        # and must not tear down its replacement. An abort that starts after
+        # the rebuild observes the new generation and still takes effect.
+        if generation is None:
+            generation = self._reconfigure_generation
+        with self._reconfigure_lock:
+            if generation != self._reconfigure_generation:
+                return
+            self.nccl_comm.abort()
+
+    def abort_and_reinit(self,
+                         active_ranks: List[int],
+                         generation: Optional[int] = None) -> None:
+        """Rebuild the PP communicator using only surviving world ranks.
+
+        Every survivor must call this with the same rank set. The C++ wrapper
+        exchanges a fresh NCCL unique ID point-to-point, so excluded ranks do
+        not participate in communicator initialization.
+
+        ``generation`` is the coordinator's shared monotonic recovery-event
+        generation, advanced for every distinct attempt. It is required for
+        same-membership recovery so every rank enters the native rendezvous
+        even when local watchdog observations differ. Repeated callbacks with
+        the same generation and target are idempotent. A retry after any native
+        failure must use a newly advanced generation so stale rendezvous traffic
+        cannot pair different recovery attempts.
+        """
+        canonical_ranks = tuple(sorted(int(rank) for rank in active_ranks))
+        if not canonical_ranks:
+            raise ValueError("active_ranks must not be empty")
+        if len(canonical_ranks) != len(set(canonical_ranks)):
+            raise ValueError("active_ranks must not contain duplicates")
+        if self.mapping.rank not in canonical_ranks:
+            raise ValueError(
+                f"current world rank {self.mapping.rank} is not active")
+        generation = _canonical_recovery_generation(generation)
+        rendezvous_id = _recovery_rendezvous_id(generation)
+
+        # Failure notifications can be duplicated or delivered concurrently by
+        # independent control paths. Keep the native rebuild and its Python
+        # membership mirror in one transaction so a stale callback cannot
+        # widen membership after a newer shrink has completed.
+        with self._reconfigure_lock:
+            current_ranks = tuple(
+                int(rank) for rank in self.nccl_comm.get_active_ranks())
+            self._active_ranks = current_ranks
+            if generation is not None and self._completed_recovery is not None:
+                completed_generation, completed_target = self._completed_recovery
+                if generation < completed_generation:
+                    return
+                if generation == completed_generation:
+                    if canonical_ranks != completed_target:
+                        raise RuntimeError(
+                            "NCCL error: conflicting PP communicator recovery "
+                            f"target for generation {generation}: completed "
+                            f"{list(completed_target)}, requested {list(canonical_ranks)}"
+                        )
+                    return
+            if canonical_ranks == current_ranks and generation is None:
+                raise ValueError(
+                    "generation is required for same-membership PP communicator "
+                    "recovery so every survivor makes the same rebuild decision"
+                )
+            if not set(canonical_ranks).issubset(current_ranks):
+                raise ValueError(
+                    "abort_and_reinit cannot reactivate a removed rank")
+
+            self.nccl_comm.abort_and_reinit(list(canonical_ranks),
+                                            rendezvous_id)
+            native_ranks = tuple(
+                int(rank) for rank in self.nccl_comm.get_active_ranks())
+            self._active_ranks = native_ranks
+            self._reconfigure_generation += 1
+            if native_ranks != canonical_ranks:
+                raise RuntimeError(
+                    "NCCL error: rebuilt PP communicator returned unexpected "
+                    f"membership {list(native_ranks)}; expected {list(canonical_ranks)}"
+                )
+            if generation is not None:
+                self._completed_recovery = (generation, canonical_ranks)
+
+    def get_async_error(self) -> str:
+        """Return the C++ wrapper's latched NCCL abort/error reason, if any."""
+        return self.nccl_comm.get_async_error()
+
+    def get_active_ranks(self) -> List[int]:
+        """Return original world-rank IDs in the current PP communicator."""
+        with self._reconfigure_lock:
+            self._active_ranks = tuple(
+                int(rank) for rank in self.nccl_comm.get_active_ranks())
+            return list(self._active_ranks)
 
 
 class PPCommTorch:
@@ -1246,37 +1421,162 @@ class PPCommTorch:
 
 
 _pp_comm = None
+_pp_comm_refcount = 0
+_pp_comm_lock = threading.Lock()
+_pp_comm_condition = threading.Condition(_pp_comm_lock)
+_pp_comm_control_refcount = 0
+_pp_comm_final_release_pending = False
 
 
 def init_pp_comm(mapping):
-    """Initialize PPComm once at startup"""
-    global _pp_comm
-    if mpi_disabled():
-        _pp_comm = PPCommTorch(mapping)
-    elif isinstance(_pp_comm, PPCommNCCL) and \
-            _pp_comm.mapping.world_size == mapping.world_size:
-        # Reuse the existing world NCCL communicator across LLM instances that
-        # share the same worker processes (e.g. a reused MpiPoolSession). The
-        # underlying comm depends only on (world_size, rank) -- it is a world
-        # communicator, independent of the pp/tp/ep layout -- so only the
-        # routing mapping needs refreshing. Recreating it would drop the old
-        # comm and trigger a collective ncclCommDestroy at an unsynchronized
-        # point during the next model build, which can deadlock on reused
-        # workers. Single-LLM (production) runs are unaffected: _pp_comm starts
-        # as None, so the first call still constructs a fresh PPCommNCCL.
-        _pp_comm.mapping = mapping
-    else:
-        if _pp_comm is not None:
-            # Rebinding drops the old comm; its ncclCommDestroy runs at an
-            # unsynchronized point and can deadlock on reused worker processes
-            # (see the reuse branch above). Surface it instead of hanging
-            # silently -- pools sharing workers must keep one world_size.
-            logger.warning(
-                "init_pp_comm: replacing existing PP comm (world_size "
-                f"{_pp_comm.mapping.world_size} -> {mapping.world_size}) on a "
-                "live process; this can deadlock on reused MPI workers.")
-        _pp_comm = PPCommNCCL(mapping)
-    init_helix_cp_comm(mapping)
+    """Acquire the process-local PP communicator for one model engine."""
+    global _pp_comm, _pp_comm_refcount
+    with _pp_comm_condition:
+        while (_pp_comm_control_refcount > 0 or _pp_comm_final_release_pending):
+            _pp_comm_condition.wait()
+        created = False
+        if mpi_disabled():
+            if _pp_comm is None:
+                _pp_comm = PPCommTorch(mapping)
+                created = True
+            elif not isinstance(_pp_comm, PPCommTorch):
+                raise RuntimeError(
+                    "PP communicator is already initialized with a different backend"
+                )
+            elif _pp_comm.mapping != mapping:
+                raise RuntimeError(
+                    "PP communicator is already initialized for a different topology"
+                )
+        else:
+            if _pp_comm is None:
+                _pp_comm = PPCommNCCL(mapping)
+                created = True
+            elif not isinstance(_pp_comm, PPCommNCCL):
+                raise RuntimeError(
+                    "NCCL error: PP communicator is already initialized with a different backend"
+                )
+            elif not _pp_comm.is_native_compatible(mapping):
+                raise RuntimeError(
+                    "NCCL error: PP communicator is already initialized for "
+                    "a different world size or rank")
+            elif (_pp_comm_refcount > 0
+                  and not _pp_comm.is_compatible(mapping)):
+                raise RuntimeError(
+                    "NCCL error: PP communicator is already in use with a "
+                    "different topology (PP or Helix MNNVL CP topology)")
+        try:
+            init_helix_cp_comm(mapping)
+        except Exception:
+            if created and _pp_comm_refcount == 0:
+                _pp_comm = None
+            raise
+        if (isinstance(_pp_comm, PPCommNCCL)
+                and _pp_comm_refcount == 0
+                and not _pp_comm.is_compatible(mapping)):
+            # The native communicator is a process-lifetime WORLD
+            # communicator and is independent of the PP/TP/EP layout. A
+            # sequential engine on a reused MPI worker may therefore refresh
+            # the Python routing topology after Helix compatibility has been
+            # validated. Never mutate routing while another engine owns it.
+            _pp_comm.rebind(mapping)
+        _pp_comm_refcount += 1
+
+
+def release_pp_comm() -> None:
+    """Release one model engine's ownership of the shared PP communicator."""
+    global _pp_comm, _pp_comm_refcount, _pp_comm_final_release_pending
+    with _pp_comm_condition:
+        if _pp_comm_refcount <= 0:
+            raise RuntimeError(
+                "PP communicator release has no matching acquisition")
+        _pp_comm_refcount -= 1
+        if _pp_comm_refcount == 0:
+            _pp_comm_final_release_pending = True
+            while _pp_comm_control_refcount > 0:
+                _pp_comm_condition.wait()
+            if isinstance(_pp_comm, PPCommTorch):
+                _pp_comm = None
+            # The NCCL wrapper is process-lifetime in both modes. A rank-local
+            # final release is not a distributed teardown barrier, so dropping
+            # it could run collective ncclCommDestroy at an unsynchronized
+            # point. FT mode also needs its Python recovery generation state
+            # to survive sequential engine wrapper churn.
+            _pp_comm_final_release_pending = False
+            _pp_comm_condition.notify_all()
+
+
+def _get_pp_nccl_comm_locked() -> PPCommNCCL:
+    """Return the NCCL PP communicator while ``_pp_comm_lock`` is held."""
+    if not isinstance(_pp_comm, PPCommNCCL):
+        raise RuntimeError("NCCL error: PP communicator is not initialized")
+    return _pp_comm
+
+
+def _acquire_pp_nccl_control(
+        *,
+        capture_generation: bool = False) -> tuple[PPCommNCCL, Optional[int]]:
+    """Keep the shared communicator alive without holding its lifecycle lock."""
+    global _pp_comm_control_refcount
+    with _pp_comm_lock:
+        comm = _get_pp_nccl_comm_locked()
+        if _pp_comm_refcount <= 0 or _pp_comm_final_release_pending:
+            raise RuntimeError("NCCL error: PP communicator is being released")
+        _pp_comm_control_refcount += 1
+        generation = (comm._reconfigure_generation
+                      if capture_generation else None)
+        return comm, generation
+
+
+def _release_pp_nccl_control() -> None:
+    global _pp_comm_control_refcount
+    with _pp_comm_condition:
+        if _pp_comm_control_refcount <= 0:
+            raise RuntimeError(
+                "NCCL error: PP communicator control reference underflow")
+        _pp_comm_control_refcount -= 1
+        if _pp_comm_control_refcount == 0:
+            _pp_comm_condition.notify_all()
+
+
+def pp_comm_abort() -> None:
+    """Abort the process-local NCCL PP communicator."""
+    comm, generation = _acquire_pp_nccl_control(capture_generation=True)
+    try:
+        comm.abort(generation)
+    finally:
+        comm = None
+        _release_pp_nccl_control()
+
+
+def pp_comm_abort_and_reinit(active_ranks: List[int],
+                             generation: Optional[int] = None) -> None:
+    """Rebuild the NCCL PP communicator using surviving original world ranks."""
+    comm, _ = _acquire_pp_nccl_control()
+    try:
+        comm.abort_and_reinit(active_ranks, generation)
+    finally:
+        comm = None
+        _release_pp_nccl_control()
+
+
+def pp_comm_get_async_error() -> str:
+    """Return the NCCL PP communicator's latched abort/error reason."""
+    comm, _ = _acquire_pp_nccl_control()
+    try:
+        return comm.get_async_error()
+    finally:
+        comm = None
+        _release_pp_nccl_control()
+
+
+def pp_comm_get_active_ranks() -> List[int]:
+    """Return original world-rank IDs in the NCCL PP communicator."""
+    comm, _ = _acquire_pp_nccl_control()
+    try:
+        return comm.get_active_ranks()
+    finally:
+        comm = None
+        _release_pp_nccl_control()
 
 
 @TorchDist.log_op

--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import math
 import pickle  # nosec B403

--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -23,8 +23,8 @@ except Exception:
 from tensorrt_llm._mnnvl_utils import (get_helix_cp_mnnvl_topology,
                                        init_helix_cp_comm)
 from tensorrt_llm._torch.distributed.nccl_fault_tolerance import (
-    NCCL_FAULT_TOLERANCE_ENABLED, _canonical_recovery_generation,
-    _recovery_rendezvous_id)
+    NCCL_FAULT_TOLERANCE_ENABLED, _canonical_group,
+    _canonical_recovery_generation, _recovery_rendezvous_id)
 from tensorrt_llm._utils import (local_mpi_size, mpi_allgather, mpi_barrier,
                                  mpi_comm, mpi_disabled, mpi_isend,
                                  mpi_isend_object, mpi_recv, mpi_recv_object,
@@ -1196,6 +1196,8 @@ class PPCommNCCL:
         self._reconfigure_lock = threading.Lock()
         self._reconfigure_generation = 0
         self._completed_recovery = None
+        self._latest_recovery_attempt = None
+        self._unavailable_recovery_attempt = None
         self.nccl_comm = torch.classes.trtllm.NcclCommunicatorOp(
             self.mapping.world_size,
             self.mapping.rank,
@@ -1234,14 +1236,26 @@ class PPCommNCCL:
 
     def rebind(self, mapping: Mapping) -> None:
         """Refresh routing for a sequential engine on the same native comm."""
-        if not self.is_native_compatible(mapping):
+        topology = self._mapping_topology(mapping)
+        if self._topology[:2] != topology[:2]:
             raise RuntimeError(
                 "NCCL error: cannot rebind a communicator to a different "
                 "world size or rank")
         self.mapping = mapping
-        self._topology = self._mapping_topology(mapping)
+        self._topology = topology
 
     def _validate_peer(self, peer: int) -> int:
+        unavailable = self._unavailable_recovery_attempt
+        if unavailable is not None:
+            generation, requested = unavailable
+            generation_description = ("legacy generation" if generation is None
+                                      else f"generation {generation}")
+            raise RuntimeError(
+                "NCCL error: PP communicator recovery "
+                f"{generation_description} to {list(requested)} did not "
+                "complete; advance the coordinator generation and "
+                "successfully rebuild the communicator before resuming "
+                "communication")
         peer = int(peer)
         if peer not in self._topology[2]:
             raise RuntimeError(
@@ -1325,11 +1339,8 @@ class PPCommNCCL:
         failure must use a newly advanced generation so stale rendezvous traffic
         cannot pair different recovery attempts.
         """
-        canonical_ranks = tuple(sorted(int(rank) for rank in active_ranks))
-        if not canonical_ranks:
-            raise ValueError("active_ranks must not be empty")
-        if len(canonical_ranks) != len(set(canonical_ranks)):
-            raise ValueError("active_ranks must not contain duplicates")
+        canonical_ranks = tuple(
+            sorted(_canonical_group(active_ranks, "active_ranks")))
         if self.mapping.rank not in canonical_ranks:
             raise ValueError(
                 f"current world rank {self.mapping.rank} is not active")
@@ -1344,7 +1355,8 @@ class PPCommNCCL:
             current_ranks = tuple(
                 int(rank) for rank in self.nccl_comm.get_active_ranks())
             self._active_ranks = current_ranks
-            if generation is not None and self._completed_recovery is not None:
+            if (generation is not None and self._completed_recovery is not None
+                    and self._unavailable_recovery_attempt is None):
                 completed_generation, completed_target = self._completed_recovery
                 if generation < completed_generation:
                     return
@@ -1365,19 +1377,49 @@ class PPCommNCCL:
                 raise ValueError(
                     "abort_and_reinit cannot reactivate a removed rank")
 
+            latest_attempt = self._latest_recovery_attempt
+            if latest_attempt is not None:
+                attempted_generation, attempted_target = latest_attempt
+                if generation is None:
+                    raise RuntimeError(
+                        "NCCL error: generation is required after a previous "
+                        "PP communicator recovery attempt; advance the "
+                        "coordinator generation before retrying")
+                if attempted_generation is not None and generation <= attempted_generation:
+                    if generation == attempted_generation and canonical_ranks != attempted_target:
+                        raise RuntimeError(
+                            "NCCL error: conflicting PP communicator recovery "
+                            f"target for generation {generation}: attempted "
+                            f"{list(attempted_target)}, requested {list(canonical_ranks)}"
+                        )
+                    raise RuntimeError(
+                        "NCCL error: PP communicator recovery generation "
+                        f"{generation} has already been attempted or is stale; "
+                        f"use a generation greater than {attempted_generation}")
+
+            # A native failure may leave only some survivors past rendezvous.
+            # Reserve the wire namespace before entering native code and never
+            # reuse it after an exception. Poison data-plane use before native
+            # entry because an asymmetric failure can leave survivors holding
+            # different, aborted, or partially rebuilt communicators.
+            self._latest_recovery_attempt = (generation, canonical_ranks)
+            self._unavailable_recovery_attempt = (generation, canonical_ranks)
             self.nccl_comm.abort_and_reinit(list(canonical_ranks),
                                             rendezvous_id)
             native_ranks = tuple(
                 int(rank) for rank in self.nccl_comm.get_active_ranks())
             self._active_ranks = native_ranks
-            self._reconfigure_generation += 1
             if native_ranks != canonical_ranks:
                 raise RuntimeError(
                     "NCCL error: rebuilt PP communicator returned unexpected "
                     f"membership {list(native_ranks)}; expected {list(canonical_ranks)}"
                 )
+            self._reconfigure_generation += 1
             if generation is not None:
                 self._completed_recovery = (generation, canonical_ranks)
+            # Publish validated membership and completion metadata before
+            # unblocking send/recv.
+            self._unavailable_recovery_attempt = None
 
     def get_async_error(self) -> str:
         """Return the C++ wrapper's latched NCCL abort/error reason, if any."""
@@ -1467,11 +1509,17 @@ def init_pp_comm(mapping):
         try:
             init_helix_cp_comm(mapping)
         except Exception:
-            if created and _pp_comm_refcount == 0:
+            if (created and _pp_comm_refcount == 0
+                    and isinstance(_pp_comm, PPCommTorch)):
                 _pp_comm = None
+            # Keep a newly-created NCCL wrapper even when this engine fails to
+            # acquire its Helix companion. Its native WORLD communicator is a
+            # process-lifetime resource: dropping the sole Python reference
+            # here could run collective ncclCommDestroy on only this rank.
+            # Refcount remains zero, so a later sequential engine can retry
+            # Helix initialization and rebind routing transactionally.
             raise
-        if (isinstance(_pp_comm, PPCommNCCL)
-                and _pp_comm_refcount == 0
+        if (isinstance(_pp_comm, PPCommNCCL) and _pp_comm_refcount == 0
                 and not _pp_comm.is_compatible(mapping)):
             # The native communicator is a process-lifetime WORLD
             # communicator and is independent of the PP/TP/EP layout. A

--- a/tensorrt_llm/_torch/distributed/nccl_fault_tolerance.py
+++ b/tensorrt_llm/_torch/distributed/nccl_fault_tolerance.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Process-local survivor membership for raw NCCL communicators.
+
+The C++ raw-NCCL registry keys communicators by their global-rank set.  After
+``nccl_comm_abort_and_reinit`` replaces a communicator, explicitly dynamic
+callers must use the replacement set, while statically sharded TP/CP callers
+must stop until their missing state is redistributed. This module keeps that
+membership and fail-fast decision in one place instead of attaching it to the
+MoE communication object that initiated recovery.
+
+ProcessGroup-backed collectives intentionally do not use this registry: their
+groups need to be reconstructed by the ProcessGroup owner.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Callable, Iterable, List, Tuple
+
+_Group = Tuple[int, ...]
+_MAX_RECOVERY_GENERATION = (1 << 63) - 3
+
+# Fault tolerance is a startup-only mode. Cache the flag once so the default
+# collective hot path pays only a cheap boolean branch and never consults the
+# survivor registry.
+NCCL_FAULT_TOLERANCE_ENABLED = os.environ.get("TLLM_FAULT_TOLERANCE_MODE") == "1"
+
+_registry_lock = threading.RLock()
+_active_groups: dict[_Group, _Group] = {}
+_completed_reconfigurations: dict[_Group, tuple[int, _Group]] = {}
+
+
+def _canonical_group(group: Iterable[int], name: str) -> _Group:
+    ranks = tuple(int(rank) for rank in group)
+    if not ranks:
+        raise ValueError(f"{name} must not be empty")
+    if len(ranks) != len(set(ranks)):
+        raise ValueError(f"{name} must not contain duplicate ranks")
+    return ranks
+
+
+def _canonical_recovery_generation(generation: int | None) -> int | None:
+    """Validate a coordinator generation accepted by the Torch ``int`` ABI."""
+    if generation is None:
+        return None
+    canonical_generation = int(generation)
+    if (
+        canonical_generation < 0
+        or canonical_generation != generation
+        or canonical_generation > _MAX_RECOVERY_GENERATION
+    ):
+        raise ValueError(
+            f"generation must be a nonnegative integer no greater than {_MAX_RECOVERY_GENERATION}"
+        )
+    return canonical_generation
+
+
+def _recovery_rendezvous_id(generation: int | None) -> int:
+    """Map a recovery generation to its wire ID.
+
+    ID 0 is reserved for initial bootstrap and ID 1 for the legacy one-shot
+    membership shrink without a coordinator generation. Explicit generations
+    start at ID 2, keeping every namespace distinct on the retained MPI control
+    communicator.
+    """
+    return 1 if generation is None else generation + 2
+
+
+def resolve_nccl_group(group: Iterable[int]) -> List[int]:
+    """Return the latest survivor set for a raw NCCL rank group."""
+    if not NCCL_FAULT_TOLERANCE_ENABLED:
+        return list(group)
+    ranks = _canonical_group(group, "group")
+    # Keep the hot-path lookup free of synchronization primitives so Dynamo
+    # can guard the dictionary value and recompile when recovery publishes a
+    # new group. Recovery quiesces collective submission before publishing.
+    return list(_active_groups.get(ranks, ranks))
+
+
+def resolve_nccl_group_and_rank(group: Iterable[int], world_rank: int) -> tuple[List[int], int]:
+    """Resolve a raw NCCL group and the caller's compact communicator rank."""
+    active_group = resolve_nccl_group(group)
+    try:
+        compact_rank = active_group.index(int(world_rank))
+    except ValueError as error:
+        raise RuntimeError(
+            f"NCCL error: world rank {world_rank} is not in active communicator {active_group}"
+        ) from error
+    return active_group, compact_rank
+
+
+def is_nccl_group_reconfigured(group: Iterable[int]) -> bool:
+    """Cheap hot-path membership-change check for a trusted rank group."""
+    if not NCCL_FAULT_TOLERANCE_ENABLED:
+        return False
+    original_group = group if isinstance(group, tuple) else tuple(group)
+    active_group = _active_groups.get(original_group)
+    return active_group is not None and active_group != original_group
+
+
+def assert_nccl_group_not_reconfigured(group: Iterable[int], operation: str) -> None:
+    """Reject static rank sharding after transport-only recovery.
+
+    This hot-path check trusts Mapping-owned groups to already be canonical. A
+    single dictionary lookup is enough before recovery; full validation stays
+    in the control-path APIs that publish membership.
+    """
+    if not NCCL_FAULT_TOLERANCE_ENABLED:
+        return
+    original_group = group if isinstance(group, tuple) else tuple(group)
+    active_group = _active_groups.get(original_group)
+    if active_group is not None and active_group != original_group:
+        raise RuntimeError(
+            "NCCL error: "
+            f"{operation} cannot use survivor-only communicator {list(active_group)} "
+            f"for statically sharded group {list(original_group)}; redistribute the "
+            "missing rank's state and rebuild the mapping before resuming"
+        )
+
+
+def publish_nccl_group_reconfiguration(
+    original_group: Iterable[int],
+    current_group: Iterable[int],
+    active_group: Iterable[int],
+) -> None:
+    """Publish a successful native raw-NCCL communicator replacement.
+
+    ``current_group`` makes stale or racing reconfiguration attempts fail
+    before they can overwrite newer membership.  Publishing happens only
+    after the coordinated native rebuild succeeds.
+    """
+    original = _canonical_group(original_group, "original_group")
+    current = _canonical_group(current_group, "current_group")
+    active = _canonical_group(active_group, "active_group")
+
+    if not set(active).issubset(current):
+        raise ValueError("active_group must be a subset of current_group")
+
+    with _registry_lock:
+        registered = _active_groups.get(original, original)
+        if registered == active:
+            return
+        if registered != current:
+            raise RuntimeError(
+                "NCCL error: stale communicator membership update: "
+                f"expected {list(registered)}, got {list(current)}"
+            )
+
+        # Preserve aliases for the model's original mapping and for any
+        # survivor-only mapping views already handed to communication helpers.
+        aliases = [key for key, value in _active_groups.items() if value == current]
+        aliases.extend((original, current, active))
+        for alias in aliases:
+            _active_groups[alias] = active
+
+
+def reconfigure_nccl_group(
+    original_group: Iterable[int],
+    active_group: Iterable[int],
+    rebuild: Callable[[List[int], List[int], int], None],
+    generation: int | None = None,
+) -> List[int]:
+    """Serialize a native communicator rebuild and membership publication.
+
+    Recovery is a process-wide safe-point operation.  Holding the registry
+    lock across ``rebuild`` prevents two local layers or worker threads from
+    rebuilding the same native communicator to different survivor sets before
+    either update is published. ``generation`` is the coordinator's monotonic
+    recovery-event generation, advanced for every distinct attempt (including
+    transport-only retries). It is required to distinguish a same-membership
+    transport rebuild from a duplicate callback without consulting rank-local
+    watchdog state, which can differ transiently across survivors. A first
+    membership shrink may omit it for compatibility, but every retry after a
+    native failure must provide a newly advanced generation so the wire
+    rendezvous cannot pair different attempts.
+    """
+    if not NCCL_FAULT_TOLERANCE_ENABLED:
+        raise RuntimeError(
+            "NCCL error: communicator reinitialization requires TLLM_FAULT_TOLERANCE_MODE=1"
+        )
+
+    original = _canonical_group(original_group, "original_group")
+    requested = _canonical_group(active_group, "active_group")
+    generation = _canonical_recovery_generation(generation)
+    rendezvous_id = _recovery_rendezvous_id(generation)
+
+    with _registry_lock:
+        current = _active_groups.get(original, original)
+        completed = _completed_reconfigurations.get(original)
+        if generation is not None and completed is not None:
+            completed_generation, completed_target = completed
+            if generation < completed_generation:
+                return list(current)
+            if generation == completed_generation:
+                if requested != completed_target:
+                    raise RuntimeError(
+                        "NCCL error: conflicting communicator recovery target "
+                        f"for generation {generation}: completed "
+                        f"{list(completed_target)}, requested {list(requested)}"
+                    )
+                return list(current)
+
+        if not set(requested).issubset(current):
+            raise ValueError("active_group must be a subset of the current_group")
+        if requested == current:
+            if generation is None:
+                raise ValueError(
+                    "generation is required for same-membership communicator "
+                    "recovery so every survivor makes the same rebuild decision"
+                )
+
+        rebuild(list(current), list(requested), rendezvous_id)
+
+        aliases = [key for key, value in _active_groups.items() if value == current]
+        aliases.extend((original, current, requested))
+        for alias in aliases:
+            _active_groups[alias] = requested
+        if generation is not None:
+            _completed_reconfigurations[original] = (generation, requested)
+        return list(requested)
+
+
+def _reset_nccl_group_registry_for_tests() -> None:
+    """Clear process-local membership.  Tests only; native state is untouched."""
+    with _registry_lock:
+        _active_groups.clear()
+        _completed_reconfigurations.clear()

--- a/tensorrt_llm/_torch/distributed/nccl_fault_tolerance.py
+++ b/tensorrt_llm/_torch/distributed/nccl_fault_tolerance.py
@@ -15,6 +15,7 @@ groups need to be reconstructed by the ProcessGroup owner.
 
 from __future__ import annotations
 
+import operator
 import os
 import threading
 from typing import Callable, Iterable, List, Tuple
@@ -29,11 +30,24 @@ NCCL_FAULT_TOLERANCE_ENABLED = os.environ.get("TLLM_FAULT_TOLERANCE_MODE") == "1
 
 _registry_lock = threading.RLock()
 _active_groups: dict[_Group, _Group] = {}
+_reconfiguration_lineages: dict[_Group, _Group] = {}
 _completed_reconfigurations: dict[_Group, tuple[int, _Group]] = {}
+_latest_reconfiguration_attempts: dict[_Group, tuple[int | None, _Group]] = {}
+_unavailable_reconfiguration_lineages: dict[_Group, tuple[int | None, _Group]] = {}
+
+
+def _canonical_integer(value: object, name: str) -> int:
+    """Return an exact integral value without accepting bools or coercion."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        return int(operator.index(value))
+    except TypeError as error:
+        raise ValueError(f"{name} must be an integer") from error
 
 
 def _canonical_group(group: Iterable[int], name: str) -> _Group:
-    ranks = tuple(int(rank) for rank in group)
+    ranks = tuple(_canonical_integer(rank, f"{name} entries") for rank in group)
     if not ranks:
         raise ValueError(f"{name} must not be empty")
     if len(ranks) != len(set(ranks)):
@@ -45,12 +59,13 @@ def _canonical_recovery_generation(generation: int | None) -> int | None:
     """Validate a coordinator generation accepted by the Torch ``int`` ABI."""
     if generation is None:
         return None
-    canonical_generation = int(generation)
-    if (
-        canonical_generation < 0
-        or canonical_generation != generation
-        or canonical_generation > _MAX_RECOVERY_GENERATION
-    ):
+    try:
+        canonical_generation = _canonical_integer(generation, "generation")
+    except ValueError as error:
+        raise ValueError(
+            f"generation must be a nonnegative integer no greater than {_MAX_RECOVERY_GENERATION}"
+        ) from error
+    if canonical_generation < 0 or canonical_generation > _MAX_RECOVERY_GENERATION:
         raise ValueError(
             f"generation must be a nonnegative integer no greater than {_MAX_RECOVERY_GENERATION}"
         )
@@ -76,7 +91,20 @@ def resolve_nccl_group(group: Iterable[int]) -> List[int]:
     # Keep the hot-path lookup free of synchronization primitives so Dynamo
     # can guard the dictionary value and recompile when recovery publishes a
     # new group. Recovery quiesces collective submission before publishing.
-    return list(_active_groups.get(ranks, ranks))
+    root = _reconfiguration_lineages.get(ranks, ranks)
+    unavailable = _unavailable_reconfiguration_lineages.get(root)
+    if unavailable is not None:
+        generation, requested = unavailable
+        generation_description = (
+            "legacy generation" if generation is None else f"generation {generation}"
+        )
+        raise RuntimeError(
+            "NCCL error: communicator recovery "
+            f"{generation_description} to {list(requested)} did not complete; "
+            "advance the coordinator generation and successfully rebuild the "
+            "communicator before resuming communication"
+        )
+    return list(_active_groups.get(root, root))
 
 
 def resolve_nccl_group_and_rank(group: Iterable[int], world_rank: int) -> tuple[List[int], int]:
@@ -96,7 +124,10 @@ def is_nccl_group_reconfigured(group: Iterable[int]) -> bool:
     if not NCCL_FAULT_TOLERANCE_ENABLED:
         return False
     original_group = group if isinstance(group, tuple) else tuple(group)
-    active_group = _active_groups.get(original_group)
+    root = _reconfiguration_lineages.get(original_group, original_group)
+    if root in _unavailable_reconfiguration_lineages:
+        return True
+    active_group = _active_groups.get(root)
     return active_group is not None and active_group != original_group
 
 
@@ -110,7 +141,20 @@ def assert_nccl_group_not_reconfigured(group: Iterable[int], operation: str) -> 
     if not NCCL_FAULT_TOLERANCE_ENABLED:
         return
     original_group = group if isinstance(group, tuple) else tuple(group)
-    active_group = _active_groups.get(original_group)
+    root = _reconfiguration_lineages.get(original_group, original_group)
+    unavailable = _unavailable_reconfiguration_lineages.get(root)
+    if unavailable is not None:
+        generation, requested = unavailable
+        generation_description = (
+            "legacy generation" if generation is None else f"generation {generation}"
+        )
+        raise RuntimeError(
+            "NCCL error: communicator recovery "
+            f"{generation_description} to {list(requested)} did not complete; "
+            f"{operation} cannot resume until the coordinator advances the "
+            "generation and the communicator rebuild succeeds"
+        )
+    active_group = _active_groups.get(root)
     if active_group is not None and active_group != original_group:
         raise RuntimeError(
             "NCCL error: "
@@ -139,8 +183,10 @@ def publish_nccl_group_reconfiguration(
         raise ValueError("active_group must be a subset of current_group")
 
     with _registry_lock:
-        registered = _active_groups.get(original, original)
+        root = _reconfiguration_lineages.get(original, original)
+        registered = _active_groups.get(root, root)
         if registered == active:
+            _unavailable_reconfiguration_lineages.pop(root, None)
             return
         if registered != current:
             raise RuntimeError(
@@ -150,10 +196,15 @@ def publish_nccl_group_reconfiguration(
 
         # Preserve aliases for the model's original mapping and for any
         # survivor-only mapping views already handed to communication helpers.
-        aliases = [key for key, value in _active_groups.items() if value == current]
-        aliases.extend((original, current, active))
+        aliases = {
+            key for key, lineage_root in _reconfiguration_lineages.items() if lineage_root == root
+        }
+        aliases.update(key for key, value in _active_groups.items() if value == current)
+        aliases.update((root, original, current, active))
         for alias in aliases:
+            _reconfiguration_lineages[alias] = root
             _active_groups[alias] = active
+        _unavailable_reconfiguration_lineages.pop(root, None)
 
 
 def reconfigure_nccl_group(
@@ -187,9 +238,11 @@ def reconfigure_nccl_group(
     rendezvous_id = _recovery_rendezvous_id(generation)
 
     with _registry_lock:
-        current = _active_groups.get(original, original)
-        completed = _completed_reconfigurations.get(original)
-        if generation is not None and completed is not None:
+        root = _reconfiguration_lineages.get(original, original)
+        current = _active_groups.get(root, root)
+        completed = _completed_reconfigurations.get(root)
+        unavailable = _unavailable_reconfiguration_lineages.get(root)
+        if generation is not None and completed is not None and unavailable is None:
             completed_generation, completed_target = completed
             if generation < completed_generation:
                 return list(current)
@@ -211,14 +264,55 @@ def reconfigure_nccl_group(
                     "recovery so every survivor makes the same rebuild decision"
                 )
 
+        latest_attempt = _latest_reconfiguration_attempts.get(root)
+        if latest_attempt is not None:
+            attempted_generation, attempted_target = latest_attempt
+            if generation is None:
+                raise RuntimeError(
+                    "NCCL error: generation is required after a previous "
+                    "communicator recovery attempt; advance the coordinator "
+                    "generation before retrying"
+                )
+            if attempted_generation is not None and generation <= attempted_generation:
+                if generation == attempted_generation and requested != attempted_target:
+                    raise RuntimeError(
+                        "NCCL error: conflicting communicator recovery target "
+                        f"for generation {generation}: attempted "
+                        f"{list(attempted_target)}, requested {list(requested)}"
+                    )
+                raise RuntimeError(
+                    "NCCL error: communicator recovery generation "
+                    f"{generation} has already been attempted or is stale; "
+                    f"use a generation greater than {attempted_generation}"
+                )
+
+        # Link the requested survivor tuple to the original communicator before
+        # native code can partially consume rendezvous traffic. A new layer
+        # constructed from that tuple will still resolve the last successfully
+        # published native group after an asymmetric failure.
+        aliases = {
+            key for key, lineage_root in _reconfiguration_lineages.items() if lineage_root == root
+        }
+        aliases.update(key for key, value in _active_groups.items() if value == current)
+        aliases.update((root, original, current, requested))
+        for alias in aliases:
+            _reconfiguration_lineages[alias] = root
+
+        # Reserve the wire namespace before native code can partially consume
+        # rendezvous traffic. Retain it on failure so only a newer generation
+        # can retry on every survivor in this communicator lineage.
+        _latest_reconfiguration_attempts[root] = (generation, requested)
+        _unavailable_reconfiguration_lineages[root] = (generation, requested)
         rebuild(list(current), list(requested), rendezvous_id)
 
-        aliases = [key for key, value in _active_groups.items() if value == current]
-        aliases.extend((original, current, requested))
         for alias in aliases:
             _active_groups[alias] = requested
         if generation is not None:
-            _completed_reconfigurations[original] = (generation, requested)
+            _completed_reconfigurations[root] = (generation, requested)
+        # Publish active membership before unblocking hot paths. A reader may
+        # fail closed briefly while publication is in progress, but can never
+        # dispatch through the terminal communicator from a failed attempt.
+        _unavailable_reconfiguration_lineages.pop(root, None)
         return list(requested)
 
 
@@ -226,4 +320,7 @@ def _reset_nccl_group_registry_for_tests() -> None:
     """Clear process-local membership.  Tests only; native state is untouched."""
     with _registry_lock:
         _active_groups.clear()
+        _reconfiguration_lineages.clear()
         _completed_reconfigurations.clear()
+        _latest_reconfiguration_attempts.clear()
+        _unavailable_reconfiguration_lineages.clear()

--- a/tensorrt_llm/_torch/distributed/nccl_fault_tolerance.py
+++ b/tensorrt_llm/_torch/distributed/nccl_fault_tolerance.py
@@ -107,18 +107,6 @@ def resolve_nccl_group(group: Iterable[int]) -> List[int]:
     return list(_active_groups.get(root, root))
 
 
-def resolve_nccl_group_and_rank(group: Iterable[int], world_rank: int) -> tuple[List[int], int]:
-    """Resolve a raw NCCL group and the caller's compact communicator rank."""
-    active_group = resolve_nccl_group(group)
-    try:
-        compact_rank = active_group.index(int(world_rank))
-    except ValueError as error:
-        raise RuntimeError(
-            f"NCCL error: world rank {world_rank} is not in active communicator {active_group}"
-        ) from error
-    return active_group, compact_rank
-
-
 def is_nccl_group_reconfigured(group: Iterable[int]) -> bool:
     """Cheap hot-path membership-change check for a trusted rank group."""
     if not NCCL_FAULT_TOLERANCE_ENABLED:
@@ -162,49 +150,6 @@ def assert_nccl_group_not_reconfigured(group: Iterable[int], operation: str) -> 
             f"for statically sharded group {list(original_group)}; redistribute the "
             "missing rank's state and rebuild the mapping before resuming"
         )
-
-
-def publish_nccl_group_reconfiguration(
-    original_group: Iterable[int],
-    current_group: Iterable[int],
-    active_group: Iterable[int],
-) -> None:
-    """Publish a successful native raw-NCCL communicator replacement.
-
-    ``current_group`` makes stale or racing reconfiguration attempts fail
-    before they can overwrite newer membership.  Publishing happens only
-    after the coordinated native rebuild succeeds.
-    """
-    original = _canonical_group(original_group, "original_group")
-    current = _canonical_group(current_group, "current_group")
-    active = _canonical_group(active_group, "active_group")
-
-    if not set(active).issubset(current):
-        raise ValueError("active_group must be a subset of current_group")
-
-    with _registry_lock:
-        root = _reconfiguration_lineages.get(original, original)
-        registered = _active_groups.get(root, root)
-        if registered == active:
-            _unavailable_reconfiguration_lineages.pop(root, None)
-            return
-        if registered != current:
-            raise RuntimeError(
-                "NCCL error: stale communicator membership update: "
-                f"expected {list(registered)}, got {list(current)}"
-            )
-
-        # Preserve aliases for the model's original mapping and for any
-        # survivor-only mapping views already handed to communication helpers.
-        aliases = {
-            key for key, lineage_root in _reconfiguration_lineages.items() if lineage_root == root
-        }
-        aliases.update(key for key, value in _active_groups.items() if value == current)
-        aliases.update((root, original, current, active))
-        for alias in aliases:
-            _reconfiguration_lineages[alias] = root
-            _active_groups[alias] = active
-        _unavailable_reconfiguration_lineages.pop(root, None)
 
 
 def reconfigure_nccl_group(

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import os
 import platform
@@ -10,6 +13,9 @@ from torch import nn
 from tensorrt_llm._mnnvl_utils import HelixCpMnnvlMemory, MnnvlMemory
 from tensorrt_llm._torch.distributed.allreduce_helper import \
     CustomAllReduceHelper
+from tensorrt_llm._torch.distributed.nccl_fault_tolerance import (
+    NCCL_FAULT_TOLERANCE_ENABLED, assert_nccl_group_not_reconfigured,
+    is_nccl_group_reconfigured, resolve_nccl_group)
 from tensorrt_llm._torch.distributed.symm_mem_allreduce import \
     SymmetricMemoryAllReduce
 from tensorrt_llm._torch.utils import get_model_extra_attrs
@@ -161,6 +167,10 @@ def get_or_scale_allreduce_mnnvl_workspace(
 def userbuffers_allreduce_finalize(
         input: torch.Tensor,
         force_applying_finalize: bool = False) -> torch.Tensor:
+    if NCCL_FAULT_TOLERANCE_ENABLED and not mpi_disabled():
+        raise RuntimeError(
+            "NCCL error: userbuffers allreduce has no peer-failure abort path "
+            "and is unavailable while TLLM_FAULT_TOLERANCE_MODE=1")
     output = torch.ops.trtllm.userbuffers_allreduce_finalize(
         input, force_applying_finalize)
     return output
@@ -308,9 +318,17 @@ def allgather(
     Returns:
         The gathered tensor or tensor list.
     '''
-    group_boxed = mapping.tp_group_pg.boxed() if mpi_disabled() else None
-    return _allgather(input, mapping.tp_group, mapping.tp_rank, group_boxed,
-                      dim, sizes)
+    if mpi_disabled():
+        group = mapping.tp_group
+        rank = mapping.tp_rank
+        group_boxed = mapping.tp_group_pg.boxed()
+    else:
+        group = mapping.tp_group
+        if NCCL_FAULT_TOLERANCE_ENABLED:
+            assert_nccl_group_not_reconfigured(group, "allgather")
+        rank = mapping.tp_rank
+        group_boxed = None
+    return _allgather(input, group, rank, group_boxed, dim, sizes)
 
 
 def cp_allgather(
@@ -332,9 +350,17 @@ def cp_allgather(
     Returns:
         The gathered tensor or tensor list.
     '''
-    group_boxed = mapping.cp_group_pg.boxed() if mpi_disabled() else None
-    return _allgather(input, mapping.cp_group, mapping.cp_rank, group_boxed,
-                      dim, sizes)
+    if mpi_disabled():
+        group = mapping.cp_group
+        rank = mapping.cp_rank
+        group_boxed = mapping.cp_group_pg.boxed()
+    else:
+        group = mapping.cp_group
+        if NCCL_FAULT_TOLERANCE_ENABLED:
+            assert_nccl_group_not_reconfigured(group, "CP allgather")
+        rank = mapping.cp_rank
+        group_boxed = None
+    return _allgather(input, group, rank, group_boxed, dim, sizes)
 
 
 def alltoall_helix(
@@ -358,6 +384,16 @@ def alltoall_helix(
         For each group of input tensors (of size group size),
         there is one output tensor with shape (group size, *input shape).
     '''
+    if NCCL_FAULT_TOLERANCE_ENABLED and not mpi_disabled():
+        original_group = list(group)
+        group = resolve_nccl_group(original_group)
+        if group != original_group:
+            raise RuntimeError(
+                "NCCL error: Helix alltoall cannot use survivor-only "
+                f"communicator {group} for statically sharded CP group "
+                f"{original_group}; redistribute the missing rank's state "
+                "and rebuild the mapping before resuming")
+
     n_ranks = len(group)
     if n_ranks == 1:
         return inputs
@@ -460,11 +496,20 @@ def reducescatter(
     dim: int = -1,
     sizes: Optional[List[int]] = None,
 ) -> Union[torch.Tensor, List[torch.Tensor]]:
-    if mapping.tp_size == 1:
+    if mpi_disabled():
+        group = mapping.tp_group
+        group_size = mapping.tp_size
+    else:
+        group = mapping.tp_group
+        if NCCL_FAULT_TOLERANCE_ENABLED:
+            assert_nccl_group_not_reconfigured(group, "reducescatter")
+        group_size = len(group)
+
+    if group_size == 1:
         return input
 
     if sizes is not None:
-        assert len(sizes) == len(mapping.tp_group)
+        assert len(sizes) == group_size
         sum_split_size = sum(sizes)
         if isinstance(input, torch.Tensor):
             assert input.shape[dim] == sum_split_size
@@ -480,7 +525,7 @@ def reducescatter(
             x = x.contiguous().view(-1, x_info['numel_base'])
         else:
             if sizes is None:
-                x_list = x.chunk(mapping.tp_size, dim=dim)
+                x_list = x.chunk(group_size, dim=dim)
             else:
                 x_list = x.split(sizes, dim=dim)
             x = torch.cat([x.reshape(-1, x_info['numel_base']) for x in x_list])
@@ -506,10 +551,9 @@ def reducescatter(
         ]
 
     if mpi_disabled():
-        output = torch_op(input, sizes, mapping.tp_group,
-                          mapping.tp_group_pg.boxed())
+        output = torch_op(input, sizes, group, mapping.tp_group_pg.boxed())
     else:
-        output = torch_op(input, sizes, mapping.tp_group)
+        output = torch_op(input, sizes, group)
 
     if isinstance(input, torch.Tensor):
         output = output.view(output_info['output_shape'])
@@ -707,6 +751,19 @@ class AllReduce(nn.Module):
         self.mnnvl_allreduce = None
         self.symm_mem_allreduce = None
         self._disable_mpi = mpi_disabled()
+        self._fault_tolerant_raw_nccl = (NCCL_FAULT_TOLERANCE_ENABLED
+                                         and not self._disable_mpi)
+        self._tp_group_tuple = (tuple(mapping.tp_group)
+                                if self._fault_tolerant_raw_nccl
+                                and mapping.tp_size > 1 else ())
+
+        if (self._fault_tolerant_raw_nccl and self.strategy
+                not in (AllReduceStrategy.AUTO, AllReduceStrategy.NCCL)):
+            strategy_name = AllReduceStrategy(self.strategy).name
+            raise RuntimeError(
+                "NCCL error: TLLM_FAULT_TOLERANCE_MODE=1 requires a "
+                "watchdog-managed NCCL allreduce; strategy "
+                f"{strategy_name} has no peer-failure abort path")
 
         self.all_reduce_op = torch.ops.trtllm.allreduce_pg if self._disable_mpi else torch.ops.trtllm.allreduce
 
@@ -730,7 +787,8 @@ class AllReduce(nn.Module):
 
         if self.mapping.tp_size > 1 and not self.mapping.enable_attention_dp:
             # Initialize Symmetric Memory AllReduce if needed (before workspace allocation)
-            if self.strategy == AllReduceStrategy.SYMM_MEM:
+            if (not self._fault_tolerant_raw_nccl
+                    and self.strategy == AllReduceStrategy.SYMM_MEM):
                 try:
                     symm_mem = SymmetricMemoryAllReduce(
                         self.mapping,
@@ -759,7 +817,8 @@ class AllReduce(nn.Module):
             # Allocate workspace for strategies that need it
             # Note: SYMM_MEM now also needs workspace for fallback scenarios (fused ops, etc.)
             # Only UB doesn't need workspace
-            if self.strategy != AllReduceStrategy.UB:
+            if (not self._fault_tolerant_raw_nccl
+                    and self.strategy != AllReduceStrategy.UB):
                 if self.strategy == AllReduceStrategy.LOWPRECISION:
                     allocate_low_presicion_allreduce_workspace(self.mapping)
                 if self.strategy not in (AllReduceStrategy.UB,
@@ -768,8 +827,8 @@ class AllReduce(nn.Module):
                     self.workspace = get_allreduce_workspace(self.mapping)
 
             # Initialize MNNVL if using AUTO or MNNVL strategy
-            if self.strategy in (AllReduceStrategy.AUTO,
-                                 AllReduceStrategy.MNNVL):
+            if (not self._fault_tolerant_raw_nccl and self.strategy
+                    in (AllReduceStrategy.AUTO, AllReduceStrategy.MNNVL)):
                 # Try to initialize MNNVL
                 if MNNVLAllReduce.is_mnnvl(self.mapping, dtype):
                     # ALWAYS capture the exception when creating this instance
@@ -792,6 +851,12 @@ class AllReduce(nn.Module):
         Requires TLLM_NCCL_SYMMETRIC_ZERO_COPY=1 AND NCCL_SYMMETRIC/NCCL/AUTO
         strategy AND tp_size > 1 AND MPI not disabled.
         """
+        if (NCCL_FAULT_TOLERANCE_ENABLED and not self._disable_mpi
+                and is_nccl_group_reconfigured(self._tp_group_tuple)):
+            # Window registration and its allocation workspace belong to the
+            # original communicator. Forward will reject the incomplete static
+            # shard; avoid allocating another stale window before that check.
+            return False
         return (_NCCL_SYMMETRIC_ZERO_COPY and self.strategy
                 in (AllReduceStrategy.NCCL_SYMMETRIC, AllReduceStrategy.NCCL,
                     AllReduceStrategy.AUTO) and self.mapping.tp_size > 1
@@ -803,8 +868,9 @@ class AllReduce(nn.Module):
         be passed into this allreduce.
 
         Returns int(BufferKind.NCCL_WINDOW) when zero-copy window output is
-        active, int(BufferKind.DEFAULT) otherwise.  The value depends solely on
-        compile-time constants so it is safe to branch on inside torch.compile.
+        active, int(BufferKind.DEFAULT) otherwise. Dynamo guards the survivor
+        registry lookup and recompiles after membership is published at the
+        recovery safe point, so this remains safe inside ``torch.compile``.
         """
         return (int(BufferKind.NCCL_WINDOW)
                 if self.uses_nccl_symmetric_memory_window() else int(
@@ -845,23 +911,36 @@ class AllReduce(nn.Module):
                                          == False):
             return input
 
+        active_group = self.mapping.tp_group
+        if NCCL_FAULT_TOLERANCE_ENABLED and not self._disable_mpi:
+            assert_nccl_group_not_reconfigured(self._tp_group_tuple,
+                                               "allreduce")
+
         input = input.contiguous()  # Underlying op requires contiguous input
 
         allreduce_strategy = self.strategy
+        if (self._fault_tolerant_raw_nccl
+                and allreduce_strategy == AllReduceStrategy.AUTO):
+            # AUTO includes one-shot/two-shot and other custom transports with
+            # no abort hook. NCCL_SYMMETRIC also performs MPI-local topology
+            # discovery, whose communicator may still contain the dead rank.
+            allreduce_strategy = AllReduceStrategy.NCCL
 
         if all_reduce_params is None:
             all_reduce_params = AllReduceParams()
 
         # Try Symmetric Memory AllReduce first if available
         # Note: Currently only supports NONE fusion op (plain allreduce)
-        if self.symm_mem_allreduce and all_reduce_params.fusion_op == AllReduceFusionOp.NONE:
+        if (self.symm_mem_allreduce
+                and all_reduce_params.fusion_op == AllReduceFusionOp.NONE):
             symm_mem_output = self.symm_mem_allreduce(input)
             if symm_mem_output is not None:
                 logger.debug(
                     f"Using SymmetricMemoryAllReduce (MULTIMEM) for input shape {input.shape}"
                 )
                 return symm_mem_output
-        elif self.symm_mem_allreduce and all_reduce_params.fusion_op != AllReduceFusionOp.NONE:
+        elif (self.symm_mem_allreduce
+              and all_reduce_params.fusion_op != AllReduceFusionOp.NONE):
             # Log once per rank that we're skipping symm_mem due to fusion
             logger.debug_once(
                 f"Skipping SymmetricMemoryAllReduce for fused operation (fusion_op={all_reduce_params.fusion_op}), using regular allreduce",
@@ -881,7 +960,6 @@ class AllReduce(nn.Module):
         if allreduce_strategy in (AllReduceStrategy.MNNVL,
                                   AllReduceStrategy.SYMM_MEM):
             allreduce_strategy = AllReduceStrategy.AUTO
-
         additional_args = {}
         if self._disable_mpi:
             # Get ProcessGroup from mapping
@@ -897,7 +975,8 @@ class AllReduce(nn.Module):
         disable_allreduce_autotune = os.environ.get(
             "TLLM_DISABLE_ALLREDUCE_AUTOTUNE", "0") == "1"
 
-        if allreduce_strategy == AllReduceStrategy.AUTO and not disable_allreduce_autotune and not self._disable_mpi:
+        if (allreduce_strategy == AllReduceStrategy.AUTO
+                and not disable_allreduce_autotune and not self._disable_mpi):
             output = torch.ops.trtllm.tunable_allreduce(
                 input=input,
                 residual=all_reduce_params.residual,
@@ -905,7 +984,7 @@ class AllReduce(nn.Module):
                 scale=all_reduce_params.scale,
                 bias=all_reduce_params.bias,
                 workspace=self.workspace,
-                group=self.mapping.tp_group,
+                group=active_group,
                 strategy=allreduce_strategy,
                 op=all_reduce_params.fusion_op,
                 eps=all_reduce_params.eps,
@@ -920,7 +999,7 @@ class AllReduce(nn.Module):
                 scale=all_reduce_params.scale,
                 bias=all_reduce_params.bias,
                 workspace=self.workspace,
-                group=self.mapping.tp_group,
+                group=active_group,
                 strategy=allreduce_strategy,
                 op=all_reduce_params.fusion_op,
                 eps=all_reduce_params.eps,
@@ -962,6 +1041,11 @@ class MoEAllReduce(nn.Module):
             output_hidden_states = rms_norm(output_residual, norm_weight, eps)
         """
         super().__init__()
+        if NCCL_FAULT_TOLERANCE_ENABLED and not mpi_disabled():
+            raise RuntimeError(
+                "NCCL error: MoEAllReduce uses a custom collective without a "
+                "peer-failure abort path and is unavailable while "
+                "TLLM_FAULT_TOLERANCE_MODE=1")
         self.mapping = mapping
         self.workspace = get_allreduce_workspace(self.mapping)
         # Pls keep this value in sync with the kOneShotMaxToken in moeAllReduceFusionKernels.h
@@ -1225,6 +1309,11 @@ class MiniMaxAllReduceRMS(nn.Module):
 
     def __init__(self, mapping: Mapping):
         super().__init__()
+        if NCCL_FAULT_TOLERANCE_ENABLED and not mpi_disabled():
+            raise RuntimeError(
+                "NCCL error: MiniMaxAllReduceRMS uses a custom collective "
+                "without a peer-failure abort path and is unavailable while "
+                "TLLM_FAULT_TOLERANCE_MODE=1")
         self.mapping = mapping
         self.workspace = get_allreduce_workspace(self.mapping)
 

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -442,6 +442,11 @@ class HelixAllToAllNative:
         Returns:
             Cached or newly-created HelixAllToAllNative instance
         """
+        if NCCL_FAULT_TOLERANCE_ENABLED and not mpi_disabled():
+            raise RuntimeError(
+                "NCCL error: Helix MNNVL alltoall has no peer-failure "
+                "abort or survivor-rebuild path and is unavailable while "
+                "TLLM_FAULT_TOLERANCE_MODE=1")
         if mapping not in HelixAllToAllNative._cache:
             logger.info(
                 f"Rank {mapping.cp_rank} initializing HelixCpMnnvlMemory for Helix"

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -8,12 +8,15 @@ import torch
 import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 
+from tensorrt_llm._utils import mpi_disabled
 from tensorrt_llm.functional import AllReduceParams
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.math_utils import ceil_div
 
 from ..distributed import AllReduce, allgather
+from ..distributed.nccl_fault_tolerance import (
+    NCCL_FAULT_TOLERANCE_ENABLED, assert_nccl_group_not_reconfigured)
 from .linear import Linear, TensorParallelMode
 
 
@@ -304,6 +307,13 @@ class Embedding(LMHead):
             self.vocab_end_index = num_embeddings
 
     def forward(self, input):
+        if (NCCL_FAULT_TOLERANCE_ENABLED and self.tp_mode
+                in (TensorParallelMode.ROW, TensorParallelMode.COLUMN)
+                and self.tp_size > 1 and not mpi_disabled()):
+            assert_nccl_group_not_reconfigured(
+                self._tp_group_tuple,
+                f"{self.tp_mode.name.lower()}-parallel embedding")
+
         if self.tp_size > 1:
             # Run the ops before all_reduce/all_gather.
             # We use torch.compile() to fuse the tiny pointwise ops before all_reduce/all_gather for Embedding module.

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 from typing import Dict, List, Optional, Tuple
 
@@ -10,7 +13,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.math_utils import ceil_div
 
-from ..distributed import allgather
+from ..distributed import AllReduce, allgather
 from .linear import Linear, TensorParallelMode
 
 
@@ -281,6 +284,13 @@ class Embedding(LMHead):
             reduce_output=reduce_output,
             use_custom_cublas_mm=use_custom_cublas_mm,
         )
+
+        # Column-parallel embeddings reduce masked vocabulary shards, whereas
+        # Linear only owns an allreduce for row-parallel projections.
+        if (self.all_reduce is None
+                and self.tp_mode == TensorParallelMode.COLUMN
+                and self.tp_size > 1 and self.reduce_output):
+            self.all_reduce = AllReduce(mapping=self.mapping, dtype=self.dtype)
 
         self.enable_torch_compile_for_embedding = enable_torch_compile_for_embedding
 

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/allgather_reducescatter.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/allgather_reducescatter.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 AllGather + ReduceScatter Communication Strategy
 
@@ -27,9 +26,45 @@ from typing import List, Optional, Tuple
 import torch
 
 from tensorrt_llm._torch.distributed import allgather, reducescatter
+from tensorrt_llm._torch.distributed.nccl_fault_tolerance import (
+    NCCL_FAULT_TOLERANCE_ENABLED,
+    reconfigure_nccl_group,
+    resolve_nccl_group,
+)
+from tensorrt_llm._utils import mpi_disabled
 from tensorrt_llm.mapping import Mapping
 
 from .base import Communication
+
+
+class _ActiveGroupMapping:
+    """Read-only mapping view for a survivor-only NCCL communicator.
+
+    The model-wide :class:`Mapping` remains immutable because TP/PP users may
+    still be inspecting it while the MoE fallback switches membership.
+    Attributes unrelated to the TP communicator delegate to the original
+    mapping.
+    """
+
+    def __init__(self, mapping: Mapping, group: List[int], rank: int) -> None:
+        self._mapping = mapping
+        self._group = tuple(group)
+        self._rank = rank
+
+    @property
+    def tp_group(self) -> List[int]:
+        return list(self._group)
+
+    @property
+    def tp_size(self) -> int:
+        return len(self._group)
+
+    @property
+    def tp_rank(self) -> int:
+        return self._rank
+
+    def __getattr__(self, name):
+        return getattr(self._mapping, name)
 
 
 class AllGatherReduceScatter(Communication):
@@ -41,6 +76,11 @@ class AllGatherReduceScatter(Communication):
 
         # Initialize dispatch state
         self._dispatch_state = {}
+        self._original_group = tuple(mapping.tp_group)
+        self._active_local_ranks = tuple(range(len(self._original_group)))
+        self._active_global_group = self._original_group
+        self._active_mapping = mapping
+        self._raw_nccl_fault_tolerance = NCCL_FAULT_TOLERANCE_ENABLED and not mpi_disabled()
 
     @staticmethod
     def is_platform_supported() -> bool:
@@ -57,6 +97,113 @@ class AllGatherReduceScatter(Communication):
         """
         return True
 
+    def abort_and_reinit(self, active_ranks: List[int], generation: Optional[int] = None) -> None:
+        """Abort the current NCCL communicator and rebuild it for survivors.
+
+        ``active_ranks`` contains global/world rank IDs from the original TP
+        communication group.  A global-rank API is intentional: when MoE TP is
+        enabled, one TP communicator spans several MoE-EP slices, so an
+        EP-local rank number is ambiguous without the failure coordinator's
+        slice identity.  The coordinator must translate its health snapshot to
+        global ranks before calling this method.
+
+        Reconfiguration is monotonic: a removed rank cannot be reintroduced by
+        this Phase-1 API. Replacement-rank joins belong to process-group
+        reconstruction. The failure coordinator must pass a shared monotonic
+        recovery-event generation for same-membership recovery and advance it
+        for every distinct attempt, including transport-only retries. Passing
+        it for every recovery also deduplicates callbacks on every survivor.
+        """
+        if not NCCL_FAULT_TOLERANCE_ENABLED:
+            raise RuntimeError(
+                "NCCL error: communicator reinitialization requires TLLM_FAULT_TOLERANCE_MODE=1"
+            )
+        if not self._raw_nccl_fault_tolerance:
+            raise NotImplementedError(
+                "AllGatherReduceScatter fault tolerance requires the raw NCCL/MPI path; "
+                "ProcessGroup reconstruction is not implemented"
+            )
+
+        if not active_ranks:
+            raise ValueError("active_ranks must not be empty")
+        if len(active_ranks) != len(set(active_ranks)):
+            raise ValueError("active_ranks must not contain duplicates")
+        requested = {int(rank) for rank in active_ranks}
+        if not requested.issubset(self._original_group):
+            raise ValueError(
+                "active_ranks must be global ranks from the original TP group "
+                f"{list(self._original_group)}, got {active_ranks}"
+            )
+        if self.mapping.rank not in requested:
+            raise ValueError(f"current world rank {self.mapping.rank} is not active")
+
+        active_global_group = tuple(rank for rank in self._original_group if rank in requested)
+
+        # Commit Python metadata only after the coordinated native rebuild
+        # succeeds. The old transport is terminal once native recovery starts,
+        # even if construction of its replacement fails.
+        reconfigure_nccl_group(
+            self._original_group,
+            active_global_group,
+            torch.ops.trtllm.nccl_comm_abort_and_reinit,
+            generation,
+        )
+        self._refresh_active_mapping()
+
+    def _refresh_active_mapping(self) -> None:
+        """Synchronize this layer with process-wide survivor membership."""
+        active_global_group = tuple(resolve_nccl_group(self._original_group))
+        if active_global_group == self._active_global_group:
+            return
+        global_rank = self.mapping.rank
+        if global_rank not in active_global_group:
+            raise RuntimeError(
+                f"NCCL error: world rank {global_rank} is not in the active communicator"
+            )
+        active_global_ranks = set(active_global_group)
+        active_local_ranks = tuple(
+            index
+            for index, world_rank in enumerate(self._original_group)
+            if world_rank in active_global_ranks
+        )
+        active_mapping = _ActiveGroupMapping(
+            self.mapping,
+            list(active_global_group),
+            active_global_group.index(global_rank),
+        )
+        self._active_local_ranks = active_local_ranks
+        self._active_mapping = active_mapping
+        # Publish the value used by the fast-path guard last. A concurrent
+        # reader that observes this generation must also observe its mapping.
+        self._active_global_group = active_global_group
+
+    def check_async_error(self) -> None:
+        """Raise a classifier-friendly exception for a watchdog failure."""
+        if not NCCL_FAULT_TOLERANCE_ENABLED:
+            raise RuntimeError(
+                "NCCL error: async-error monitoring requires TLLM_FAULT_TOLERANCE_MODE=1"
+            )
+        if not self._raw_nccl_fault_tolerance:
+            raise NotImplementedError(
+                "AllGatherReduceScatter fault tolerance cannot inspect ProcessGroup errors; "
+                "the raw NCCL/MPI watchdog is not active"
+            )
+        self._refresh_active_mapping()
+        error = torch.ops.trtllm.nccl_comm_get_async_error(list(self._active_global_group))
+        if error is not None:
+            raise RuntimeError(f"NCCL error: communicator was aborted: {error}")
+
+    def _active_sizes(self, all_rank_num_tokens: List[int]) -> List[int]:
+        self._refresh_active_mapping()
+        if len(all_rank_num_tokens) != len(self._original_group):
+            raise ValueError(
+                "all_rank_num_tokens must remain indexed by the original communicator "
+                f"({len(self._original_group)} entries), got {len(all_rank_num_tokens)}"
+            )
+        if self._active_global_group == self._original_group:
+            return all_rank_num_tokens
+        return [all_rank_num_tokens[rank] for rank in self._active_local_ranks]
+
     def dispatch(
         self,
         hidden_states: torch.Tensor,
@@ -70,11 +217,20 @@ class AllGatherReduceScatter(Communication):
         """
         AllGather dispatch (always post-quant dispatch)
         """
-        sizes = None if use_dp_padding else all_rank_num_tokens
+        if self._raw_nccl_fault_tolerance:
+            if use_dp_padding:
+                self._refresh_active_mapping()
+                sizes = None
+            else:
+                sizes = self._active_sizes(all_rank_num_tokens)
+            mapping = self._active_mapping
+        else:
+            sizes = None if use_dp_padding else all_rank_num_tokens
+            mapping = self.mapping
 
         hidden_states, hidden_states_sf, token_selected_slots, token_final_scales = allgather(
             [hidden_states, hidden_states_sf, token_selected_slots, token_final_scales],
-            self.mapping,
+            mapping,
             dim=0,
             sizes=sizes,
         )
@@ -92,7 +248,15 @@ class AllGatherReduceScatter(Communication):
         """
         ReduceScatter combine phase
         """
+        if self._raw_nccl_fault_tolerance:
+            self._refresh_active_mapping()
+            mapping = self._active_mapping
+        else:
+            mapping = self.mapping
         outputs = reducescatter(
-            final_hidden_states, self.mapping, dim=0, sizes=self._dispatch_state.get("sizes")
+            final_hidden_states,
+            mapping,
+            dim=0,
+            sizes=self._dispatch_state.get("sizes"),
         )
         return outputs

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/allgather_reducescatter.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/allgather_reducescatter.py
@@ -28,6 +28,7 @@ import torch
 from tensorrt_llm._torch.distributed import allgather, reducescatter
 from tensorrt_llm._torch.distributed.nccl_fault_tolerance import (
     NCCL_FAULT_TOLERANCE_ENABLED,
+    _canonical_group,
     reconfigure_nccl_group,
     resolve_nccl_group,
 )
@@ -124,11 +125,8 @@ class AllGatherReduceScatter(Communication):
                 "ProcessGroup reconstruction is not implemented"
             )
 
-        if not active_ranks:
-            raise ValueError("active_ranks must not be empty")
-        if len(active_ranks) != len(set(active_ranks)):
-            raise ValueError("active_ranks must not contain duplicates")
-        requested = {int(rank) for rank in active_ranks}
+        canonical_ranks = _canonical_group(active_ranks, "active_ranks")
+        requested = set(canonical_ranks)
         if not requested.issubset(self._original_group):
             raise ValueError(
                 "active_ranks must be global ranks from the original TP group "

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import enum
@@ -14,6 +17,8 @@ from torch.nn.parameter import Parameter
 
 import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
 from tensorrt_llm._torch.custom_ops.torch_custom_ops import BufferKind
+from tensorrt_llm._torch.distributed.nccl_fault_tolerance import (
+    NCCL_FAULT_TOLERANCE_ENABLED, assert_nccl_group_not_reconfigured)
 from tensorrt_llm._torch.peft.lora.layer import LoraLayer
 from tensorrt_llm._utils import is_device_integrated, mpi_disabled
 from tensorrt_llm.bindings import ipc_nvls_supported
@@ -3283,6 +3288,12 @@ class Linear(nn.Module):
         self.tp_size = self.mapping.tp_size
         self.tp_rank = self.mapping.tp_rank
         self.tp_mode = tensor_parallel_mode
+        self._tp_group_tuple = (tuple(self.mapping.tp_group)
+                                if NCCL_FAULT_TOLERANCE_ENABLED
+                                and self.tp_mode in (TensorParallelMode.ROW,
+                                                     TensorParallelMode.COLUMN)
+                                and self.tp_size > 1 and not mpi_disabled() else
+                                ())
         self.gather_output = gather_output
         self.force_dynamic_quantization = force_dynamic_quantization
         self.use_cute_dsl_blockscaling_mm = use_cute_dsl_blockscaling_mm
@@ -3365,9 +3376,10 @@ class Linear(nn.Module):
         if self.tp_mode == TensorParallelMode.COLUMN:
             reduce_output = False if self.mapping.enable_attention_dp else reduce_output
 
-        self.all_reduce = AllReduce(mapping=self.mapping,
-                                    strategy=allreduce_strategy,
-                                    dtype=self.dtype) if reduce_output else None
+        self.all_reduce = (AllReduce(
+            mapping=self.mapping, strategy=allreduce_strategy, dtype=self.dtype)
+                           if self.tp_mode == TensorParallelMode.ROW
+                           and reduce_output else None)
 
         self._weights_created = False
         self._weights_transformed = False
@@ -3389,10 +3401,17 @@ class Linear(nn.Module):
             "TRTLLM_GEMM_ALLREDUCE_FUSION_ENABLED", "0") == "1")
 
         self.use_fused_gemm_allreduce = all([
-            self.reduce_output, mpi_enabled, dtype_supported,
-            in_features_aligned, out_features_aligned, tp_valid, quant_valid,
-            device_supported, enable_gemm_allreduce_fusion,
-            enable_gemm_allreduce_fusion_env
+            self.reduce_output,
+            mpi_enabled,
+            dtype_supported,
+            in_features_aligned,
+            out_features_aligned,
+            tp_valid,
+            quant_valid,
+            device_supported,
+            enable_gemm_allreduce_fusion,
+            enable_gemm_allreduce_fusion_env,
+            not (NCCL_FAULT_TOLERANCE_ENABLED and mpi_enabled),
         ])
         if self.use_fused_gemm_allreduce:
             self.use_fused_gemm_allreduce = ipc_nvls_supported()
@@ -3666,8 +3685,14 @@ class Linear(nn.Module):
                                input,
                                bias,
                                layer_idx: Optional[int] | None = None):
+        tp_group = self.mapping.tp_group
+        tp_rank = self.tp_rank
+        if NCCL_FAULT_TOLERANCE_ENABLED and not mpi_disabled():
+            raise RuntimeError(
+                "NCCL error: fused GEMM allreduce has no peer-failure abort "
+                "path and is unavailable while TLLM_FAULT_TOLERANCE_MODE=1")
         output = self.quant_method.apply_linear_allreduce(
-            self, input, bias, self.tp_rank, self.mapping.tp_group)
+            self, input, bias, tp_rank, tp_group)
         return output
 
     def _maybe_fuse_bias_into_allreduce(
@@ -3695,12 +3720,19 @@ class Linear(nn.Module):
         lora_params: Optional[dict] = None,
         layer_idx: Optional[int] = None,
     ) -> torch.Tensor:
+        if (NCCL_FAULT_TOLERANCE_ENABLED and self.tp_mode
+                in (TensorParallelMode.ROW, TensorParallelMode.COLUMN)
+                and self.tp_size > 1 and not mpi_disabled()):
+            assert_nccl_group_not_reconfigured(
+                self._tp_group_tuple,
+                f"{self.tp_mode.name.lower()}-parallel linear")
+
         if self.tp_mode == TensorParallelMode.ROW:
             use_fused_gemm_allreduce = self.use_fused_gemm_allreduce and lora_params is None
             if use_fused_gemm_allreduce and all_reduce_params is not None:
                 use_fused_gemm_allreduce = all_reduce_params.enable_allreduce and all_reduce_params.fusion_op == AllReduceFusionOp.NONE
 
-            bias = None if (self.tp_rank > 0) else self.bias
+            bias = None if self.tp_rank > 0 else self.bias
             if self.reduce_output:
                 if use_fused_gemm_allreduce:
                     output = self.apply_linear_allreduce(

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -48,7 +48,7 @@ from ..autotuner import AutoTuner, autotune
 from ..compilation.backend import Backend
 from ..compilation.utils import capture_piecewise_cuda_graph
 from ..distributed import Distributed
-from ..distributed.communicator import init_pp_comm
+from ..distributed.communicator import init_pp_comm, release_pp_comm
 from ..expert_statistic import ExpertStatistic
 from ..memory_buffer_utils import clear_memory_buffers, with_shared_pool
 from ..metadata import KVCacheParams
@@ -115,6 +115,40 @@ class ModelEngine(ABC):
         warmup actions: instantiating CUDA graphs, running torch.compile, etc.
         """
         return
+
+
+def _force_eager_mode_for_nccl_fault_tolerance(
+        llm_args: TorchLlmArgs) -> TorchLlmArgs:
+    """Disable CUDA capture until communicator-aware recapture lands.
+
+    A captured NCCL graph node retains the communicator handle used during
+    capture.  PR 1a.7 can replace that handle after a rank failure, but PR
+    1a.11 owns graph-cache invalidation and recapture.  Keep the MVP usable by
+    running both whole-model and piecewise paths eagerly while FT mode is on.
+    Work on the engine-local Pydantic copy so callers can reuse their original
+    arguments for a non-FT engine.
+    """
+    if os.environ.get("TLLM_FAULT_TOLERANCE_MODE") != "1":
+        return llm_args
+
+    updates = {}
+    if llm_args.cuda_graph_config is not None:
+        updates["cuda_graph_config"] = None
+
+    torch_compile_config = llm_args.torch_compile_config
+    if (torch_compile_config is not None
+            and torch_compile_config.enable_piecewise_cuda_graph):
+        updates["torch_compile_config"] = torch_compile_config.model_copy(
+            update={"enable_piecewise_cuda_graph": False})
+
+    if not updates:
+        return llm_args
+
+    logger.warning(
+        "TLLM_FAULT_TOLERANCE_MODE=1 disables CUDA graph capture until "
+        "communicator-aware invalidation and recapture are available; this "
+        "engine will serve in eager mode.")
+    return llm_args.model_copy(update=updates)
 
 
 def _filter_piecewise_capture_num_tokens(
@@ -289,9 +323,11 @@ class PyTorchModelEngine(ModelEngine):
         model_weights_restore_mode=None,
     ):
         _configure_deep_gemm_pdl()
+        llm_args = _force_eager_mode_for_nccl_fault_tolerance(llm_args)
 
         self.forward_pass_callable = None
         self.ub_buffers = None
+        self._pp_comm_acquired = False
         if llm_args.encode_only and llm_args.mm_encoder_only:
             raise ValueError(
                 "encode_only and mm_encoder_only are mutually exclusive.")
@@ -325,6 +361,7 @@ class PyTorchModelEngine(ModelEngine):
         self.mapping = mapping
         if mapping.has_pp():
             init_pp_comm(mapping)
+            self._pp_comm_acquired = True
         # Start with the established pool size. Once the model is loaded we
         # selectively enable headroom for the non-PP DeepSeek-V4 overlap path.
         from ._util import (compute_max_num_sequences,
@@ -2571,7 +2608,9 @@ class PyTorchModelEngine(ModelEngine):
         5. Userbuffers (``ub.ub_deallocate`` per buffer); on per-buffer
            failure the unfreed buffers are kept attached so a deterministic
            retry doesn't double-free already-released ones, and the
-           collected errors are re-raised after the loop.
+           collected errors are re-raised after unrelated global ownership is
+           released.
+        6. This engine's reference to the process-local PP communicator.
 
         Idempotency:
             Subsequent calls are no-ops (guarded by ``_cleanup_done``).
@@ -2608,9 +2647,9 @@ class PyTorchModelEngine(ModelEngine):
         self.input_processor_with_hash = None
 
         ub_buffers = getattr(self, 'ub_buffers', None)
+        ub_errors = []
         if ub_buffers:
             remaining_ub_buffers = []
-            ub_errors = []
             for u in ub_buffers:
                 try:
                     ub.ub_deallocate(u.addr)
@@ -2621,13 +2660,21 @@ class PyTorchModelEngine(ModelEngine):
                     remaining_ub_buffers.append(u)
                     ub_errors.append(e)
             self.ub_buffers = remaining_ub_buffers or None
-            if ub_errors:
-                raise RuntimeError(
-                    "Failed to deallocate one or more userbuffers during "
-                    "PyTorchModelEngine cleanup") from ub_errors[0]
+
+        if getattr(self, "_pp_comm_acquired", False):
+            release_pp_comm()
+            self._pp_comm_acquired = False
 
         # Release model weights.
         release_gc()
+        if ub_errors:
+            # Terminal teardown may not get another deterministic retry. Defer
+            # the userbuffer error until unrelated process-global ownership is
+            # released, while retaining only the failed buffers for a caller
+            # that can retry cleanup.
+            raise RuntimeError(
+                "Failed to deallocate one or more userbuffers during "
+                "PyTorchModelEngine cleanup") from ub_errors[0]
         self._cleanup_done = True
 
     def __del__(self) -> None:
@@ -2738,8 +2785,9 @@ class PyTorchModelEngine(ModelEngine):
         self._init_max_num_tokens()
 
     def _release_cuda_graphs(self):
-        if self._torch_compile_backend is not None:
-            self._torch_compile_backend.clear_piecewise_cuda_graphs()
+        torch_compile_backend = getattr(self, "_torch_compile_backend", None)
+        if torch_compile_backend is not None:
+            torch_compile_backend.clear_piecewise_cuda_graphs()
         if hasattr(self,
                    'cuda_graph_runner') and self.cuda_graph_runner is not None:
             self.cuda_graph_runner.clear()

--- a/tests/integration/defs/cpp/_nccl_rendezvous_recovery_mpi_worker.py
+++ b/tests/integration/defs/cpp/_nccl_rendezvous_recovery_mpi_worker.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end raw-NCCL recovery for AllGatherReduceScatter.
+
+This file is launched directly under three MPI ranks by test_multi_gpu.py.
+Keeping it in a fresh process is important: fault-tolerance mode is captured
+when TensorRT-LLM is imported, and raw NCCL communicator replacement is
+process-global.
+"""
+
+import torch
+
+from tensorrt_llm._torch.distributed.nccl_fault_tolerance import NCCL_FAULT_TOLERANCE_ENABLED
+from tensorrt_llm._torch.modules.fused_moe.communication.allgather_reducescatter import (
+    AllGatherReduceScatter,
+)
+from tensorrt_llm._torch.utils import get_device_uuid
+from tensorrt_llm._utils import (
+    default_gpus_per_node,
+    local_mpi_rank,
+    mpi_comm,
+    mpi_rank,
+    mpi_world_size,
+)
+from tensorrt_llm.mapping import Mapping
+
+_WORLD_SIZE = 3
+_FULL_GROUP = [0, 1, 2]
+_SURVIVORS = [0, 2]
+_RECOVERY_GENERATION = 0
+# Generation 0 maps to recovery rendezvous ID 2; keep cleanup on the next
+# namespace. Singleton cleanup performs no peer exchange, and the survivor and
+# full-group paths also have distinct communicator keys.
+_CLEANUP_RENDEZVOUS_ID = 3
+
+
+def _assert_full_group_bootstrap(comm: AllGatherReduceScatter, rank: int) -> None:
+    """Create the full-group raw communicator through the production class."""
+    hidden_states = torch.tensor(
+        [[float(rank + 1), float((rank + 1) * 10)]],
+        dtype=torch.float32,
+        device="cuda",
+    )
+    token_selected_slots = torch.tensor([[rank]], dtype=torch.int32, device="cuda")
+
+    gathered_hidden, hidden_sf, gathered_slots, final_scales = comm.dispatch(
+        hidden_states,
+        None,
+        token_selected_slots,
+        None,
+        [1, 1, 1],
+    )
+
+    expected_hidden = torch.tensor(
+        [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]],
+        dtype=torch.float32,
+        device="cuda",
+    )
+    expected_slots = torch.tensor([[0], [1], [2]], dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(gathered_hidden, expected_hidden)
+    torch.testing.assert_close(gathered_slots, expected_slots)
+    assert hidden_sf is None
+    assert final_scales is None
+    torch.cuda.synchronize()
+
+
+def _assert_survivor_collectives(comm: AllGatherReduceScatter, rank: int) -> None:
+    """Verify real variable-size allgather and reducescatter after recovery."""
+    local_hidden = {
+        0: [[1.0, 10.0]],
+        2: [[3.0, 30.0], [4.0, 40.0]],
+    }[rank]
+    local_slots = {
+        0: [[0]],
+        2: [[20], [21]],
+    }[rank]
+    hidden_states = torch.tensor(local_hidden, dtype=torch.float32, device="cuda")
+    token_selected_slots = torch.tensor(local_slots, dtype=torch.int32, device="cuda")
+
+    gathered_hidden, hidden_sf, gathered_slots, final_scales = comm.dispatch(
+        hidden_states,
+        None,
+        token_selected_slots,
+        None,
+        [1, 0, 2],
+    )
+
+    expected_hidden = torch.tensor(
+        [[1.0, 10.0], [3.0, 30.0], [4.0, 40.0]],
+        dtype=torch.float32,
+        device="cuda",
+    )
+    expected_slots = torch.tensor([[0], [20], [21]], dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(gathered_hidden, expected_hidden)
+    torch.testing.assert_close(gathered_slots, expected_slots)
+    assert hidden_sf is None
+    assert final_scales is None
+
+    # Rank 0 contributes 1x and rank 2 contributes 3x. A real sum
+    # reducescatter therefore returns the rank-local slice of 4x the gathered
+    # tensor; a local-only or stale-full-group operation cannot satisfy this.
+    combined = comm.combine(gathered_hidden * float(rank + 1))
+    expected_reduced = expected_hidden * 4.0
+    expected_local = expected_reduced[:1] if rank == 0 else expected_reduced[1:]
+    torch.testing.assert_close(combined, expected_local)
+    torch.cuda.synchronize()
+
+
+def main() -> None:
+    if not NCCL_FAULT_TOLERANCE_ENABLED:
+        raise RuntimeError("worker must import TensorRT-LLM with TLLM_FAULT_TOLERANCE_MODE=1")
+
+    rank = mpi_rank()
+    world_size = mpi_world_size()
+    if world_size != _WORLD_SIZE:
+        raise RuntimeError(f"expected {_WORLD_SIZE} MPI ranks, got {world_size}")
+
+    device_count = torch.cuda.device_count()
+    if device_count == 0:
+        raise RuntimeError("test requires visible CUDA devices")
+    # These helpers preserve TensorRT-LLM's normal mapping semantics both when
+    # every rank sees all allocated GPUs and when the launcher remaps each rank
+    # to one CUDA-visible device.
+    device = local_mpi_rank()
+    torch.cuda.set_device(device)
+
+    # Support both launchers that expose all devices to every rank and those
+    # that bind each rank to a single visible device. Refuse duplicate physical
+    # devices before entering NCCL, where such a setup could hang.
+    device_uuids = mpi_comm().allgather(get_device_uuid(device))
+    if len(set(device_uuids)) != _WORLD_SIZE:
+        raise RuntimeError(
+            f"test requires one distinct physical CUDA device per MPI rank; got {device_uuids}"
+        )
+
+    # Keep test-only synchronization off the communicator used internally by
+    # the raw NCCL rendezvous, matching the native recovery test's isolation.
+    test_sync = mpi_comm().Dup()
+    mapping = Mapping(
+        world_size=_WORLD_SIZE,
+        rank=rank,
+        tp_size=_WORLD_SIZE,
+        gpus_per_node=default_gpus_per_node(),
+    )
+    comm = AllGatherReduceScatter(mapping)
+
+    _assert_full_group_bootstrap(comm, rank)
+    test_sync.Barrier()
+
+    if rank in _SURVIVORS:
+        # Exercise the Python class API all the way through the registered
+        # torch op and native raw-communicator replacement.
+        comm.abort_and_reinit(_SURVIVORS, generation=_RECOVERY_GENERATION)
+    else:
+        # The excluded rank does not enter the survivor rendezvous. Replace
+        # its half-aborted full-group state with a singleton for safe teardown.
+        torch.ops.trtllm.nccl_comm_abort_and_reinit(
+            _FULL_GROUP,
+            [rank],
+            _CLEANUP_RENDEZVOUS_ID,
+        )
+    test_sync.Barrier()
+
+    if rank in _SURVIVORS:
+        _assert_survivor_collectives(comm, rank)
+        # Avoid rank-skewed destruction of the final survivor communicator.
+        torch.ops.trtllm.nccl_comm_abort_and_reinit(
+            _SURVIVORS,
+            [rank],
+            _CLEANUP_RENDEZVOUS_ID,
+        )
+
+    test_sync.Barrier()
+    test_sync.Free()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/defs/cpp/test_multi_gpu.py
+++ b/tests/integration/defs/cpp/test_multi_gpu.py
@@ -1,6 +1,7 @@
 import os as _os
 import pathlib as _pl
 import platform
+import sys as _sys
 from enum import Enum, auto
 
 import defs.cpp.cpp_common as _cpp
@@ -147,6 +148,79 @@ def run_nccl_utils_tests(build_dir: _pl.Path, nprocs=2, timeout=300):
                      timeout=timeout)
 
 
+def run_nccl_rendezvous_recovery_tests(build_dir: _pl.Path, timeout=900):
+    tests_dir = build_dir / "tests" / "unit_tests" / "multi_gpu"
+    report = build_dir / "results-nccl-rendezvous-recovery.xml"
+    test_filter = (r"^ncclUniqueIdRendezvousTest\."
+                   r"(mpi3|rawRecoveryMpi3|ppRecoveryMpi3|defaultOff)$")
+    ctest_command = [
+        "ctest",
+        "--output-on-failure",
+        "--no-tests=error",
+        "--parallel",
+        "1",
+        "--test-dir",
+        str(tests_dir),
+        "--tests-regex",
+        test_filter,
+        "--output-junit",
+        str(report),
+    ]
+
+    # The raw and PP cases intentionally replace process-global NCCL state.
+    # Their CTest definitions isolate the native processes; keep CTest itself
+    # serial so no two recovery cases share the node concurrently.
+    mgpu_env = get_multi_gpu_env()
+    # CTest owns the portable MPIEXEC command, so use OpenMPI's environment
+    # opt-in instead of injecting a launcher-specific command-line flag. This
+    # is required by the root CI container and is ignored by other MPI stacks.
+    mgpu_env["OMPI_ALLOW_RUN_AS_ROOT"] = "1"
+    mgpu_env["OMPI_ALLOW_RUN_AS_ROOT_CONFIRM"] = "1"
+    _cpp.parallel_run_ctest(
+        ctest_command,
+        cwd=build_dir,
+        env=mgpu_env,
+        timeout=timeout,
+        parallel=1,
+    )
+
+
+def run_nccl_allgather_reducescatter_recovery_test(timeout=300):
+    worker = _pl.Path(__file__).with_name(
+        "_nccl_rendezvous_recovery_mpi_worker.py")
+    repo_root = worker.resolve().parents[4]
+    thop_library = repo_root / "tensorrt_llm" / "libs" / "libth_common.so"
+    if not thop_library.is_file():
+        raise FileNotFoundError(
+            f"freshly built Torch operators are missing: {thop_library}")
+    command = [
+        "mpirun",
+        "-n",
+        "3",
+        "--allow-run-as-root",
+        _sys.executable,
+        str(worker),
+    ]
+    mgpu_env = get_multi_gpu_env()
+    mgpu_env["TLLM_FAULT_TOLERANCE_MODE"] = "1"
+    mgpu_env.pop("TLLM_DISABLE_MPI", None)
+    mgpu_env.pop("TRT_LLM_NO_LIB_INIT", None)
+    # Make the PR's Python sources authoritative even when the CI image also
+    # contains an installed TensorRT-LLM package.
+    previous_pythonpath = mgpu_env.get("PYTHONPATH")
+    pythonpath = [str(repo_root)]
+    if previous_pythonpath:
+        pythonpath.append(previous_pythonpath)
+    mgpu_env["PYTHONPATH"] = _os.pathsep.join(pythonpath)
+
+    _cpp.run_command(
+        command,
+        cwd=repo_root,
+        env=mgpu_env,
+        timeout=timeout,
+    )
+
+
 @pytest.mark.parametrize("build_google_tests", ["80", "86", "89", "90"],
                          indirect=True)
 def test_mpi_utils(build_google_tests, build_dir):
@@ -195,3 +269,11 @@ def test_nccl_utils(build_google_tests, nprocs, build_dir):
 
     if platform.system() != "Windows":
         run_nccl_utils_tests(build_dir=build_dir, nprocs=nprocs, timeout=300)
+
+
+@pytest.mark.parametrize("build_google_tests", ["90"], indirect=True)
+def test_nccl_rendezvous_recovery(build_google_tests, build_dir):
+
+    if platform.system() != "Windows":
+        run_nccl_rendezvous_recovery_tests(build_dir=build_dir, timeout=900)
+        run_nccl_allgather_reducescatter_recovery_test(timeout=300)

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -44,6 +44,8 @@ l0_a10:
   - unittest/_torch/modules/dwdp/test_dwdp_manager.py
   - unittest/_torch/modules/dwdp/test_dwdp_mapping.py
   - unittest/_torch/modules/dwdp/test_dwdp_peer_ranges.py
+  - unittest/_torch/modules/moe/test_allgather_reducescatter_ft.py
+  - unittest/_torch/modules/test_pp_nccl_communicator.py
   # NOTE: this is a CPU-only test, but we do not have a dedicated job for this (and therefore no
   # test list either).
   - unittest/_torch/models/checkpoints

--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -283,6 +283,7 @@ l0_dgx_h100:
   - cpp/test_multi_gpu.py::test_cache_transceiver[8proc-ucx_kvcache-90] ISOLATION
   - cpp/test_multi_gpu.py::test_cache_transceiver[8proc-mooncake_kvcache-90] ISOLATION
   - cpp/test_multi_gpu.py::test_user_buffer[2proc-90]
+  - cpp/test_multi_gpu.py::test_nccl_rendezvous_recovery[90] ISOLATION
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/unittest/_torch/modules/moe/test_allgather_reducescatter_ft.py
+++ b/tests/unittest/_torch/modules/moe/test_allgather_reducescatter_ft.py
@@ -18,6 +18,7 @@ import pytest
 from tensorrt_llm._torch.custom_ops import torch_custom_ops
 from tensorrt_llm._torch.distributed import nccl_fault_tolerance
 from tensorrt_llm._torch.distributed import ops as distributed_ops
+from tensorrt_llm._torch.modules import embedding as embedding_module
 from tensorrt_llm._torch.modules import linear as linear_module
 from tensorrt_llm._torch.modules.fused_moe.communication import (
     allgather_reducescatter as allgather_rs_module,
@@ -354,6 +355,38 @@ def test_ft_nonparallel_linear_does_not_resolve_tp_group(monkeypatch):
 
     assert linear._tp_group_tuple == ()
     assert linear.all_reduce is None
+
+
+def test_ft_column_parallel_embedding_owns_allreduce(monkeypatch):
+    monkeypatch.setattr(linear_module, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(linear_module, "get_sm_version", lambda: 0)
+    monkeypatch.setattr(linear_module.torch.cuda, "is_available", lambda: False)
+    calls = []
+
+    class FakeAllReduce(distributed_ops.torch.nn.Module):
+        def __init__(self, mapping, dtype):
+            super().__init__()
+            calls.append((mapping, dtype))
+
+        def forward(self, output):
+            calls.append(output)
+            return output
+
+    monkeypatch.setattr(embedding_module, "AllReduce", FakeAllReduce)
+    mapping = _FakeMapping()
+    embedding = embedding_module.Embedding(
+        num_embeddings=8,
+        embedding_dim=4,
+        dtype=distributed_ops.torch.float16,
+        mapping=mapping,
+        tensor_parallel_mode=TensorParallelMode.COLUMN,
+    )
+
+    output = embedding(distributed_ops.torch.tensor([4]))
+
+    assert len(calls) == 2
+    assert calls[0] == (mapping, distributed_ops.torch.float16)
+    assert calls[1] is output
 
 
 def test_ft_auto_allreduce_uses_only_watchdog_managed_nccl(monkeypatch):

--- a/tests/unittest/_torch/modules/moe/test_allgather_reducescatter_ft.py
+++ b/tests/unittest/_torch/modules/moe/test_allgather_reducescatter_ft.py
@@ -1,0 +1,899 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the NCCL fault-tolerance hooks on AllGatherReduceScatter.
+
+These tests intentionally mock the C++ custom op.  They verify the Python-side
+contract (global-rank validation, survivor publication, and dispatch-size
+bookkeeping) without requiring NCCL, MPI, or GPUs.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Callable
+
+import pytest
+
+from tensorrt_llm._torch.custom_ops import torch_custom_ops
+from tensorrt_llm._torch.distributed import nccl_fault_tolerance
+from tensorrt_llm._torch.distributed import ops as distributed_ops
+from tensorrt_llm._torch.modules import linear as linear_module
+from tensorrt_llm._torch.modules.fused_moe.communication import (
+    allgather_reducescatter as allgather_rs_module,
+)
+from tensorrt_llm._torch.modules.fused_moe.communication.allgather_reducescatter import (
+    AllGatherReduceScatter,
+)
+from tensorrt_llm._torch.modules.linear import Linear, TensorParallelMode
+
+
+@pytest.fixture(autouse=True)
+def _enable_and_clear_nccl_survivor_membership(monkeypatch):
+    monkeypatch.setattr(nccl_fault_tolerance, "NCCL_FAULT_TOLERANCE_ENABLED", True)
+    monkeypatch.setattr(distributed_ops, "NCCL_FAULT_TOLERANCE_ENABLED", True)
+    monkeypatch.setattr(torch_custom_ops, "NCCL_FAULT_TOLERANCE_ENABLED", True)
+    monkeypatch.setattr(allgather_rs_module, "NCCL_FAULT_TOLERANCE_ENABLED", True)
+    monkeypatch.setattr(linear_module, "NCCL_FAULT_TOLERANCE_ENABLED", True)
+    nccl_fault_tolerance._reset_nccl_group_registry_for_tests()
+    yield
+    nccl_fault_tolerance._reset_nccl_group_registry_for_tests()
+
+
+@dataclass
+class _FakeMapping:
+    """A PP slice whose EP-local ranks map to non-zero global ranks."""
+
+    world_size: int = 8
+    rank: int = 6
+    tp_size: int = 4
+    tp_rank: int = 2
+    moe_ep_size: int = 4
+    moe_ep_rank: int = 2
+    enable_attention_dp: bool = False
+    _group: list[int] = field(default_factory=lambda: [4, 5, 6, 7])
+    _moe_group: list[int] | None = None
+
+    @property
+    def tp_group(self) -> list[int]:
+        return list(self._group)
+
+    @property
+    def moe_ep_group(self) -> list[int]:
+        return list(self._group if self._moe_group is None else self._moe_group)
+
+
+class _MappingWithoutTpGroup(_FakeMapping):
+    @property
+    def tp_group(self) -> list[int]:
+        raise AssertionError("non-TP construction resolved an unavailable TP group")
+
+
+def _patch_reinit_op(
+    monkeypatch: pytest.MonkeyPatch,
+    implementation: Callable[[list[int], list[int], int], None],
+) -> None:
+    monkeypatch.setattr(
+        allgather_rs_module.torch.ops.trtllm,
+        "nccl_comm_abort_and_reinit",
+        implementation,
+        raising=False,
+    )
+
+
+def _patch_async_error_op(
+    monkeypatch: pytest.MonkeyPatch,
+    implementation: Callable[[list[int]], str | None],
+) -> None:
+    monkeypatch.setattr(
+        allgather_rs_module.torch.ops.trtllm,
+        "nccl_comm_get_async_error",
+        implementation,
+        raising=False,
+    )
+
+
+def _assert_active_mapping(mapping, expected_group: list[int], expected_rank: int) -> None:
+    """Assert the distributed op sees compact ranks for the rebuilt comm."""
+    assert list(mapping.tp_group) == expected_group
+    assert mapping.tp_size == len(expected_group)
+    assert mapping.tp_rank == expected_rank
+
+
+def test_abort_and_reinit_canonicalizes_global_ranks(monkeypatch):
+    calls: list[tuple[list[int], list[int], int]] = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append(
+            (list(group), list(active_group), rendezvous_id)
+        ),
+    )
+    comm = AllGatherReduceScatter(_FakeMapping())
+
+    # Input order must not affect NCCL rank assignment: the C++ op receives the
+    # original TP-group order in the global/world-rank domain.
+    comm.abort_and_reinit([7, 4, 6])
+
+    assert calls == [([4, 5, 6, 7], [4, 6, 7], 1)]
+
+
+def test_reconfiguration_rejects_static_sharded_allgather(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    observed = []
+
+    def fake_allgather(input, group, rank, group_boxed, dim, sizes):
+        observed.append((input, group, rank, group_boxed, dim, sizes))
+        return "gathered"
+
+    monkeypatch.setattr(distributed_ops, "_allgather", fake_allgather)
+
+    mapping = _FakeMapping()
+    comm = AllGatherReduceScatter(mapping)
+    comm.abort_and_reinit([4, 6, 7])
+
+    # Transport recovery alone cannot recreate a TP shard. A normal model-wide
+    # call using the original Mapping must fail instead of returning fewer
+    # output features. AllGatherReduceScatter uses its explicit survivor mapping below.
+    with pytest.raises(RuntimeError, match="statically sharded|redistribute"):
+        distributed_ops.allgather("input", mapping, dim=0, sizes=[5, 7, 11, 13])
+    assert observed == []
+
+
+def test_reconfiguration_rejects_static_sharded_helix_alltoall(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    AllGatherReduceScatter(_FakeMapping()).abort_and_reinit([4, 6, 7])
+    calls = []
+
+    def fake_alltoall(inputs, group, num_lists):
+        calls.append((list(inputs), list(group), num_lists))
+        return ["output"]
+
+    monkeypatch.setattr(
+        distributed_ops.torch.ops.trtllm,
+        "alltoall_helix",
+        fake_alltoall,
+        raising=False,
+    )
+
+    inputs = [allgather_rs_module.torch.tensor([rank]) for rank in range(4)]
+    with pytest.raises(RuntimeError, match="statically sharded|redistribute"):
+        distributed_ops.alltoall_helix(inputs, [4, 5, 6, 7])
+    assert calls == []
+
+
+def test_reconfiguration_is_shared_and_idempotent_across_moe_layers(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append((list(group), list(active_group))),
+    )
+    first_layer = AllGatherReduceScatter(_FakeMapping())
+    second_layer = AllGatherReduceScatter(_FakeMapping())
+
+    first_layer.abort_and_reinit([4, 6, 7], generation=1)
+    second_layer.abort_and_reinit([4, 6, 7], generation=1)
+
+    assert calls == [([4, 5, 6, 7], [4, 6, 7])]
+    _assert_active_mapping(second_layer._active_mapping, [4, 6, 7], 1)
+
+
+def test_reconfiguration_transaction_serializes_same_target(monkeypatch):
+    entered_native = threading.Event()
+    release_native = threading.Event()
+    calls = []
+
+    def native_rebuild(group, active_group, rendezvous_id):
+        calls.append((list(group), list(active_group)))
+        entered_native.set()
+        assert release_native.wait(timeout=5)
+
+    _patch_reinit_op(monkeypatch, native_rebuild)
+    first_layer = AllGatherReduceScatter(_FakeMapping())
+    second_layer = AllGatherReduceScatter(_FakeMapping())
+    errors = []
+
+    def reconfigure(layer):
+        try:
+            layer.abort_and_reinit([4, 6, 7], generation=1)
+        except Exception as error:  # pragma: no cover - assertion reports details
+            errors.append(error)
+
+    first = threading.Thread(target=reconfigure, args=(first_layer,))
+    second = threading.Thread(target=reconfigure, args=(second_layer,))
+    first.start()
+    assert entered_native.wait(timeout=5)
+    second.start()
+    release_native.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert calls == [([4, 5, 6, 7], [4, 6, 7])]
+
+
+def test_shared_generation_deduplicates_and_advances_same_membership_rebuild(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append(
+            (list(group), list(active_group), rendezvous_id)
+        ),
+    )
+
+    comm = AllGatherReduceScatter(_FakeMapping())
+    comm.abort_and_reinit([4, 5, 6, 7], generation=1)
+    comm.abort_and_reinit([4, 5, 6, 7], generation=1)
+    comm.abort_and_reinit([4, 5, 6, 7], generation=2)
+
+    assert calls == [
+        ([4, 5, 6, 7], [4, 5, 6, 7], 3),
+        ([4, 5, 6, 7], [4, 5, 6, 7], 4),
+    ]
+
+
+def test_same_membership_recovery_requires_shared_generation(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append((list(group), list(active_group))),
+    )
+
+    comm = AllGatherReduceScatter(_FakeMapping())
+    with pytest.raises(ValueError, match="generation is required"):
+        comm.abort_and_reinit([4, 5, 6, 7])
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("generation", [-1, 1.5, (1 << 63) - 2])
+def test_raw_recovery_generation_must_fit_reserved_torch_int_range(monkeypatch, generation):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append(
+            (group, active_group, rendezvous_id)
+        ),
+    )
+
+    with pytest.raises(ValueError, match="generation must be a nonnegative integer"):
+        AllGatherReduceScatter(_FakeMapping()).abort_and_reinit([4, 6, 7], generation=generation)
+
+    assert calls == []
+
+
+def test_generation_rejects_conflicting_raw_recovery_targets(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append((list(group), list(active_group))),
+    )
+
+    comm = AllGatherReduceScatter(_FakeMapping())
+    comm.abort_and_reinit([4, 6, 7], generation=9)
+    with pytest.raises(RuntimeError, match="conflicting.*generation 9"):
+        comm.abort_and_reinit([6, 7], generation=9)
+
+    assert calls == [([4, 5, 6, 7], [4, 6, 7])]
+
+
+def test_fault_tolerance_control_path_requires_startup_mode(monkeypatch):
+    monkeypatch.setattr(allgather_rs_module, "NCCL_FAULT_TOLERANCE_ENABLED", False)
+    calls = []
+    _patch_reinit_op(
+        monkeypatch, lambda group, active_group, rendezvous_id: calls.append((group, active_group))
+    )
+
+    comm = AllGatherReduceScatter(_FakeMapping())
+    with pytest.raises(RuntimeError, match="TLLM_FAULT_TOLERANCE_MODE=1"):
+        comm.abort_and_reinit([4, 6, 7])
+
+    assert calls == []
+
+
+def test_default_off_collective_skips_survivor_registry(monkeypatch):
+    monkeypatch.setattr(distributed_ops, "NCCL_FAULT_TOLERANCE_ENABLED", False)
+    monkeypatch.setattr(distributed_ops, "mpi_disabled", lambda: False)
+
+    def unexpected_registry_lookup(group, operation):
+        raise AssertionError("default-off allgather consulted survivor state")
+
+    observed = []
+    monkeypatch.setattr(
+        distributed_ops, "assert_nccl_group_not_reconfigured", unexpected_registry_lookup
+    )
+    monkeypatch.setattr(
+        distributed_ops,
+        "_allgather",
+        lambda input, group, rank, group_boxed, dim, sizes: observed.append(
+            (group, rank, group_boxed, dim, sizes)
+        )
+        or "gathered",
+    )
+
+    class ReferenceMapping:
+        tp_group = [4, 5, 6, 7]
+        tp_rank = 2
+
+    mapping = ReferenceMapping()
+    result = distributed_ops.allgather("input", mapping, dim=0, sizes=[1, 2, 3, 4])
+
+    assert result == "gathered"
+    assert observed == [([4, 5, 6, 7], 2, None, 0, [1, 2, 3, 4])]
+    assert observed[0][0] is mapping.tp_group
+
+
+def test_default_off_allreduce_does_not_resolve_tp_group(monkeypatch):
+    monkeypatch.setattr(distributed_ops, "NCCL_FAULT_TOLERANCE_ENABLED", False)
+    monkeypatch.setattr(distributed_ops, "mpi_disabled", lambda: False)
+
+    allreduce = distributed_ops.AllReduce(
+        _MappingWithoutTpGroup(),
+        strategy=distributed_ops.AllReduceStrategy.NCCL,
+        dtype=distributed_ops.torch.float16,
+    )
+
+    assert allreduce._tp_group_tuple == ()
+
+
+def test_ft_nonparallel_linear_does_not_resolve_tp_group(monkeypatch):
+    monkeypatch.setattr(linear_module, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(linear_module, "get_sm_version", lambda: 0)
+    monkeypatch.setattr(linear_module.torch.cuda, "is_available", lambda: False)
+
+    linear = Linear(
+        16,
+        16,
+        bias=False,
+        dtype=distributed_ops.torch.float16,
+        mapping=_MappingWithoutTpGroup(),
+        tensor_parallel_mode=None,
+        skip_create_weights_in_init=True,
+    )
+
+    assert linear._tp_group_tuple == ()
+    assert linear.all_reduce is None
+
+
+def test_ft_auto_allreduce_uses_only_watchdog_managed_nccl(monkeypatch):
+    monkeypatch.setattr(distributed_ops, "mpi_disabled", lambda: False)
+    calls = []
+
+    def fake_allreduce(**kwargs):
+        calls.append(kwargs)
+        return [kwargs["input"]]
+
+    monkeypatch.setattr(
+        distributed_ops.torch.ops.trtllm, "allreduce", fake_allreduce, raising=False
+    )
+    monkeypatch.setattr(
+        distributed_ops,
+        "get_allreduce_workspace",
+        lambda mapping: (_ for _ in ()).throw(
+            AssertionError("FT AUTO allocated a custom-allreduce workspace")
+        ),
+    )
+    monkeypatch.setattr(
+        distributed_ops.MNNVLAllReduce,
+        "is_mnnvl",
+        lambda mapping, dtype: (_ for _ in ()).throw(
+            AssertionError("FT AUTO probed the MNNVL allreduce backend")
+        ),
+    )
+
+    allreduce = distributed_ops.AllReduce(
+        _FakeMapping(),
+        strategy=distributed_ops.AllReduceStrategy.AUTO,
+        dtype=distributed_ops.torch.float16,
+    )
+    input_tensor = distributed_ops.torch.ones(2)
+    output = allreduce(input_tensor)
+
+    assert output is input_tensor
+    assert allreduce.workspace is None
+    assert allreduce.mnnvl_allreduce is None
+    assert len(calls) == 1
+    assert calls[0]["strategy"] == distributed_ops.AllReduceStrategy.NCCL
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        distributed_ops.AllReduceStrategy.UB,
+        distributed_ops.AllReduceStrategy.ONESHOT,
+        distributed_ops.AllReduceStrategy.MNNVL,
+        distributed_ops.AllReduceStrategy.NCCL_SYMMETRIC,
+        distributed_ops.AllReduceStrategy.SYMM_MEM,
+    ],
+)
+def test_ft_allreduce_rejects_custom_transport_strategies(monkeypatch, strategy):
+    monkeypatch.setattr(distributed_ops, "mpi_disabled", lambda: False)
+    with pytest.raises(RuntimeError, match="watchdog-managed NCCL allreduce"):
+        distributed_ops.AllReduce(_FakeMapping(), strategy=strategy)
+
+
+def test_ft_tunable_allreduce_exposes_only_nccl_tactics():
+    runner = torch_custom_ops.AllReduceRunner(
+        4,
+        [4, 5, 6, 7],
+        int(distributed_ops.AllReduceFusionOp.NONE),
+        1e-6,
+        False,
+    )
+    inputs = [distributed_ops.torch.ones(2)]
+    assert runner.get_valid_tactics(inputs, torch_custom_ops.OptimizationProfile()) == [
+        distributed_ops.AllReduceStrategy.NCCL.value,
+    ]
+
+
+def test_ft_custom_allreduce_helpers_fail_before_workspace_allocation(monkeypatch):
+    monkeypatch.setattr(distributed_ops, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(
+        distributed_ops,
+        "get_allreduce_workspace",
+        lambda mapping: (_ for _ in ()).throw(
+            AssertionError("unsupported FT helper allocated a workspace")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="MoEAllReduce.*custom collective"):
+        distributed_ops.MoEAllReduce(_FakeMapping())
+    with pytest.raises(RuntimeError, match="MiniMaxAllReduceRMS.*custom collective"):
+        distributed_ops.MiniMaxAllReduceRMS(_FakeMapping())
+    monkeypatch.setattr(
+        distributed_ops.torch.ops.trtllm,
+        "userbuffers_allreduce_finalize",
+        lambda *args: (_ for _ in ()).throw(
+            AssertionError("unsupported FT userbuffers op was invoked")
+        ),
+        raising=False,
+    )
+    with pytest.raises(RuntimeError, match="userbuffers allreduce"):
+        distributed_ops.userbuffers_allreduce_finalize(distributed_ops.torch.ones(1))
+
+
+def test_ft_disables_fused_nvfp4_gemm_allreduce(monkeypatch):
+    class QuantMode:
+        @staticmethod
+        def has_nvfp4():
+            return True
+
+    class QuantConfig:
+        layer_quant_mode = QuantMode()
+
+    monkeypatch.setattr(linear_module, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(linear_module, "get_sm_version", lambda: 100)
+    monkeypatch.setenv("TRTLLM_GEMM_ALLREDUCE_FUSION_ENABLED", "1")
+    nvls_queries = []
+    monkeypatch.setattr(
+        linear_module, "ipc_nvls_supported", lambda: nvls_queries.append(True) or True
+    )
+
+    linear = Linear(
+        128,
+        64,
+        bias=False,
+        dtype=distributed_ops.torch.float16,
+        mapping=_FakeMapping(),
+        tensor_parallel_mode=TensorParallelMode.ROW,
+        quant_config=QuantConfig(),
+        skip_create_weights_in_init=True,
+        enable_gemm_allreduce_fusion=True,
+    )
+
+    assert not linear.use_fused_gemm_allreduce
+    assert nvls_queries == []
+    with pytest.raises(RuntimeError, match="fused GEMM allreduce"):
+        linear.apply_linear_allreduce(None, None)
+
+
+def test_active_mapping_and_sizes_are_reused_until_membership_changes(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append((list(group), list(active_group))),
+    )
+    comm = AllGatherReduceScatter(_FakeMapping())
+    original_mapping = comm._active_mapping
+    original_sizes = [5, 7, 11, 13]
+
+    assert comm._active_sizes(original_sizes) is original_sizes
+    assert comm._active_mapping is original_mapping
+
+    comm.abort_and_reinit([4, 6, 7])
+    survivor_mapping = comm._active_mapping
+    assert comm._active_sizes(original_sizes) == [5, 11, 13]
+    assert comm._active_mapping is survivor_mapping
+    comm._refresh_active_mapping()
+    assert comm._active_mapping is survivor_mapping
+
+
+def test_process_group_backend_skips_raw_nccl_membership_refresh(monkeypatch):
+    monkeypatch.setattr(allgather_rs_module, "mpi_disabled", lambda: True)
+    comm = AllGatherReduceScatter(_FakeMapping())
+    monkeypatch.setattr(
+        allgather_rs_module,
+        "resolve_nccl_group",
+        lambda group: (_ for _ in ()).throw(
+            AssertionError("ProcessGroup dispatch consulted raw NCCL state")
+        ),
+    )
+    observed = []
+    monkeypatch.setattr(
+        allgather_rs_module,
+        "allgather",
+        lambda inputs, mapping, *, dim, sizes: observed.append((mapping, sizes)) or inputs,
+    )
+    sizes = [5, 7, 11, 13]
+
+    comm.dispatch("hidden", None, "slots", None, sizes)
+
+    assert observed == [(comm.mapping, sizes)]
+
+
+def test_reconfiguration_rejects_static_sharded_allreduce(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    mapping = _FakeMapping()
+    comm = AllGatherReduceScatter(mapping)
+    comm.abort_and_reinit([4, 6, 7])
+
+    calls = []
+
+    def fake_allreduce(**kwargs):
+        calls.append(kwargs)
+        return ("reduced",)
+
+    allreduce = object.__new__(distributed_ops.AllReduce)
+    allreduce.mapping = mapping
+    allreduce._tp_group_tuple = tuple(mapping.tp_group)
+    allreduce.strategy = distributed_ops.AllReduceStrategy.AUTO
+    allreduce.workspace = None
+    allreduce.symm_mem_allreduce = None
+    allreduce.mnnvl_allreduce = None
+    allreduce._disable_mpi = False
+    allreduce.all_reduce_op = fake_allreduce
+
+    tensor = allgather_rs_module.torch.ones(1)
+    with pytest.raises(RuntimeError, match="statically sharded|redistribute"):
+        allreduce.forward(tensor)
+    assert calls == []
+    assert not allreduce.uses_nccl_symmetric_memory_window()
+
+
+@pytest.mark.parametrize(
+    "active_ranks",
+    [
+        pytest.param([], id="empty"),
+        pytest.param([4, 6, 6], id="duplicate"),
+        pytest.param([-1, 6], id="negative"),
+        pytest.param([4, 6, 8], id="outside_tp_group"),
+        pytest.param([4, 5, 7], id="world_rank_missing"),
+    ],
+)
+def test_abort_and_reinit_rejects_invalid_active_ranks(monkeypatch, active_ranks):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch, lambda group, active_group, rendezvous_id: calls.append((group, active_group))
+    )
+    comm = AllGatherReduceScatter(_FakeMapping())
+
+    with pytest.raises(ValueError):
+        comm.abort_and_reinit(active_ranks)
+
+    assert calls == []
+
+
+def test_abort_and_reinit_supports_mixed_tp_and_ep_topology(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch, lambda group, active_group, rendezvous_id: calls.append((group, active_group))
+    )
+    mapping = _FakeMapping(
+        rank=6,
+        tp_rank=2,
+        moe_ep_size=2,
+        moe_ep_rank=1,
+        _group=[4, 5, 6, 7],
+        _moe_group=[4, 6],
+    )
+    comm = AllGatherReduceScatter(mapping)
+
+    # Global ranks are unambiguous even when the TP communicator spans several
+    # MoE-EP slices. The higher-level health coordinator performs its local to
+    # global translation before entering this API.
+    comm.abort_and_reinit([4, 6, 7])
+
+    assert calls == [([4, 5, 6, 7], [4, 6, 7])]
+
+
+def test_abort_and_reinit_rejects_process_group_backend(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch, lambda group, active_group, rendezvous_id: calls.append((group, active_group))
+    )
+    monkeypatch.setattr(allgather_rs_module, "mpi_disabled", lambda: True, raising=False)
+    comm = AllGatherReduceScatter(_FakeMapping())
+
+    # The raw communicator cache is not used in Ray/ProcessGroup mode, and the
+    # active mapping would otherwise delegate to the stale tp_group_pg.
+    with pytest.raises(NotImplementedError, match="ProcessGroup|MPI-disabled"):
+        comm.abort_and_reinit([4, 6, 7])
+
+    assert calls == []
+
+
+def test_check_async_error_returns_cleanly_when_watchdog_is_healthy(monkeypatch):
+    queried_groups = []
+    _patch_async_error_op(
+        monkeypatch,
+        lambda group: queried_groups.append(list(group)),
+    )
+    comm = AllGatherReduceScatter(_FakeMapping())
+
+    comm.check_async_error()
+
+    assert queried_groups == [[4, 5, 6, 7]]
+
+
+def test_check_async_error_rejects_process_group_backend(monkeypatch):
+    queried_groups = []
+    _patch_async_error_op(
+        monkeypatch,
+        lambda group: queried_groups.append(list(group)),
+    )
+    monkeypatch.setattr(allgather_rs_module, "mpi_disabled", lambda: True, raising=False)
+    comm = AllGatherReduceScatter(_FakeMapping())
+
+    with pytest.raises(NotImplementedError, match="ProcessGroup|watchdog"):
+        comm.check_async_error()
+
+    assert queried_groups == []
+
+
+def test_check_async_error_raises_stable_nccl_error_for_active_group(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    queried_groups = []
+
+    def get_async_error(group):
+        queried_groups.append(list(group))
+        return "ncclSystemError: peer disconnected"
+
+    _patch_async_error_op(monkeypatch, get_async_error)
+    comm = AllGatherReduceScatter(_FakeMapping())
+    comm.abort_and_reinit([4, 6, 7])
+
+    with pytest.raises(
+        RuntimeError,
+        match="NCCL error: communicator was aborted: ncclSystemError: peer disconnected",
+    ):
+        comm.check_async_error()
+
+    assert queried_groups == [[4, 6, 7]]
+
+
+def test_other_layer_queries_shared_active_group_after_recovery(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    queried_groups = []
+    _patch_async_error_op(monkeypatch, lambda group: queried_groups.append(list(group)))
+    first_layer = AllGatherReduceScatter(_FakeMapping())
+    second_layer = AllGatherReduceScatter(_FakeMapping())
+
+    first_layer.abort_and_reinit([4, 6, 7])
+    second_layer.check_async_error()
+
+    assert queried_groups == [[4, 6, 7]]
+    _assert_active_mapping(second_layer._active_mapping, [4, 6, 7], 1)
+
+
+def test_reconfigured_row_linear_fails_before_using_incomplete_tp_shards(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    AllGatherReduceScatter(_FakeMapping()).abort_and_reinit([6, 7])
+    calls = []
+
+    class QuantMethod:
+        supports_nccl_symmetric_memory_window_output = False
+
+    class FakeRowLinear:
+        tp_mode = TensorParallelMode.ROW
+        mapping = _FakeMapping(rank=6, tp_rank=2)
+        _tp_group_tuple = tuple(mapping.tp_group)
+        tp_rank = 2
+        tp_size = 4
+        use_fused_gemm_allreduce = True
+        reduce_output = True
+        bias = "bias"
+        quant_method = QuantMethod()
+        lora = None
+
+        def apply_linear_allreduce(self, *args, **kwargs):
+            raise AssertionError("stale fused GEMM-allreduce path was used")
+
+        def _maybe_fuse_bias_into_allreduce(self, bias, all_reduce_params):
+            return False
+
+        def apply_linear(self, input, bias, lora_params, layer_idx):
+            calls.append(("gemm", input, bias))
+            return "gemm-output"
+
+        def all_reduce(self, output, *, all_reduce_params):
+            calls.append(("allreduce", output))
+            return "reduced"
+
+    with pytest.raises(RuntimeError, match="statically sharded|redistribute"):
+        Linear.forward(FakeRowLinear(), "input")
+    assert calls == []
+
+
+def test_reconfigured_column_linear_without_gather_fails_before_gemm(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    AllGatherReduceScatter(_FakeMapping()).abort_and_reinit([6, 7])
+    calls = []
+
+    class FakeColumnLinear:
+        tp_mode = TensorParallelMode.COLUMN
+        mapping = _FakeMapping(rank=6, tp_rank=2)
+        _tp_group_tuple = tuple(mapping.tp_group)
+        tp_size = 4
+        gather_output = False
+        bias = None
+
+        def apply_linear(self, *args, **kwargs):
+            calls.append((args, kwargs))
+            return "partial-output"
+
+    with pytest.raises(RuntimeError, match="statically sharded|redistribute"):
+        Linear.forward(FakeColumnLinear(), "input")
+    assert calls == []
+
+
+def test_dispatch_and_combine_filter_sizes_to_active_ranks(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    gather_calls = []
+    scatter_calls = []
+
+    def fake_allgather(inputs, mapping, *, dim, sizes):
+        gather_calls.append((inputs, mapping, dim, sizes))
+        return inputs
+
+    def fake_reducescatter(input_tensor, mapping, *, dim, sizes):
+        scatter_calls.append((input_tensor, mapping, dim, sizes))
+        return "combined"
+
+    monkeypatch.setattr(allgather_rs_module, "allgather", fake_allgather)
+    monkeypatch.setattr(allgather_rs_module, "reducescatter", fake_reducescatter)
+
+    mapping = _FakeMapping()
+    comm = AllGatherReduceScatter(mapping)
+    comm.abort_and_reinit([4, 6, 7])
+
+    inputs = ["hidden", None, "slots", "scales"]
+    assert comm.dispatch(*inputs, all_rank_num_tokens=[5, 7, 11, 13]) == tuple(inputs)
+    assert comm.combine("moe-output") == "combined"
+
+    assert len(gather_calls) == 1
+    gathered_inputs, gather_mapping, gather_dim, gather_sizes = gather_calls[0]
+    assert gathered_inputs == inputs
+    assert gather_dim == 0
+    assert gather_sizes == [5, 11, 13]
+    _assert_active_mapping(gather_mapping, [4, 6, 7], 1)
+
+    assert len(scatter_calls) == 1
+    scatter_input, scatter_mapping, scatter_dim, scatter_sizes = scatter_calls[0]
+    assert scatter_input == "moe-output"
+    assert scatter_dim == 0
+    assert scatter_sizes == [5, 11, 13]
+    _assert_active_mapping(scatter_mapping, [4, 6, 7], 1)
+
+    # Reconfiguration does not mutate Mapping, but the shared raw-NCCL
+    # membership registry reroutes other collectives that consume it.
+    assert mapping.tp_group == [4, 5, 6, 7]
+    assert mapping.tp_rank == 2
+
+
+def test_dp_padding_keeps_sizes_none_after_reconfiguration(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    observed = []
+
+    def fake_allgather(inputs, mapping, *, dim, sizes):
+        observed.append((mapping, sizes))
+        return inputs
+
+    monkeypatch.setattr(allgather_rs_module, "allgather", fake_allgather)
+
+    comm = AllGatherReduceScatter(_FakeMapping())
+    comm.abort_and_reinit([4, 6, 7])
+    comm.dispatch("hidden", None, "slots", None, [5, 7, 11, 13], use_dp_padding=True)
+
+    assert len(observed) == 1
+    active_mapping, sizes = observed[0]
+    assert sizes is None
+    _assert_active_mapping(active_mapping, [4, 6, 7], 1)
+
+
+def test_dp_padding_refreshes_mapping_after_another_layer_recovers(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    observed = []
+
+    def fake_allgather(inputs, mapping, *, dim, sizes):
+        observed.append((mapping, sizes))
+        return inputs
+
+    monkeypatch.setattr(allgather_rs_module, "allgather", fake_allgather)
+    recovering_layer = AllGatherReduceScatter(_FakeMapping())
+    stale_layer = AllGatherReduceScatter(_FakeMapping())
+
+    recovering_layer.abort_and_reinit([4, 6, 7])
+    stale_layer.dispatch("hidden", None, "slots", None, [5, 7, 11, 13], use_dp_padding=True)
+
+    assert len(observed) == 1
+    active_mapping, sizes = observed[0]
+    assert sizes is None
+    _assert_active_mapping(active_mapping, [4, 6, 7], 1)
+
+
+def test_later_reconfiguration_replaces_active_rank_filter(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append((list(group), list(active_group))),
+    )
+    observed = []
+
+    def fake_allgather(inputs, mapping, *, dim, sizes):
+        observed.append((mapping, sizes))
+        return inputs
+
+    monkeypatch.setattr(allgather_rs_module, "allgather", fake_allgather)
+
+    comm = AllGatherReduceScatter(_FakeMapping())
+    comm.abort_and_reinit([4, 6, 7])
+    comm.abort_and_reinit([6, 7])
+    comm.dispatch("hidden", None, "slots", None, [5, 7, 11, 13])
+
+    assert calls == [
+        ([4, 5, 6, 7], [4, 6, 7]),
+        ([4, 6, 7], [6, 7]),
+    ]
+    assert len(observed) == 1
+    active_mapping, sizes = observed[0]
+    assert sizes == [11, 13]
+    _assert_active_mapping(active_mapping, [6, 7], 0)
+
+
+def test_reconfiguration_cannot_reactivate_a_removed_rank(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append((list(group), list(active_group))),
+    )
+
+    comm = AllGatherReduceScatter(_FakeMapping())
+    comm.abort_and_reinit([4, 6, 7])
+
+    with pytest.raises(ValueError, match="reactivate|subset"):
+        comm.abort_and_reinit([4, 5, 6, 7])
+
+    assert calls == [([4, 5, 6, 7], [4, 6, 7])]
+
+
+def test_failed_reinit_does_not_commit_active_rank_filter(monkeypatch):
+    def fail_reinit(group, active_group, rendezvous_id):
+        raise RuntimeError("NCCL communicator rebuild failed")
+
+    _patch_reinit_op(monkeypatch, fail_reinit)
+    comm = AllGatherReduceScatter(_FakeMapping())
+    old_local_ranks = comm._active_local_ranks
+    old_global_group = comm._active_global_group
+    old_mapping = comm._active_mapping
+
+    with pytest.raises(RuntimeError, match="NCCL communicator rebuild failed"):
+        comm.abort_and_reinit([4, 6, 7])
+
+    # The native call aborts the old communicator before initializing its
+    # replacement, so transport is terminal after this failure. The only
+    # transactional guarantee is that Python membership metadata does not
+    # claim the failed replacement was committed.
+    assert comm._active_local_ranks is old_local_ranks
+    assert comm._active_global_group is old_global_group
+    assert comm._active_mapping is old_mapping

--- a/tests/unittest/_torch/modules/moe/test_allgather_reducescatter_ft.py
+++ b/tests/unittest/_torch/modules/moe/test_allgather_reducescatter_ft.py
@@ -36,6 +36,7 @@ def _enable_and_clear_nccl_survivor_membership(monkeypatch):
     monkeypatch.setattr(torch_custom_ops, "NCCL_FAULT_TOLERANCE_ENABLED", True)
     monkeypatch.setattr(allgather_rs_module, "NCCL_FAULT_TOLERANCE_ENABLED", True)
     monkeypatch.setattr(linear_module, "NCCL_FAULT_TOLERANCE_ENABLED", True)
+    monkeypatch.setattr(embedding_module, "NCCL_FAULT_TOLERANCE_ENABLED", True)
     nccl_fault_tolerance._reset_nccl_group_registry_for_tests()
     yield
     nccl_fault_tolerance._reset_nccl_group_registry_for_tests()
@@ -178,6 +179,108 @@ def test_reconfiguration_is_shared_and_idempotent_across_moe_layers(monkeypatch)
     _assert_active_mapping(second_layer._active_mapping, [4, 6, 7], 1)
 
 
+def test_completed_generation_is_idempotent_through_survivor_alias(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append(
+            (list(group), list(active_group), rendezvous_id)
+        ),
+    )
+    original_layer = AllGatherReduceScatter(_FakeMapping())
+    alias_layer = AllGatherReduceScatter(
+        _FakeMapping(
+            tp_size=3,
+            tp_rank=1,
+            moe_ep_size=3,
+            moe_ep_rank=1,
+            _group=[4, 6, 7],
+        )
+    )
+
+    original_layer.abort_and_reinit([4, 6, 7], generation=7)
+    alias_layer.abort_and_reinit([4, 6, 7], generation=7)
+
+    assert calls == [([4, 5, 6, 7], [4, 6, 7], 9)]
+    _assert_active_mapping(alias_layer._active_mapping, [4, 6, 7], 1)
+
+
+def test_failed_generation_is_reserved_through_survivor_alias(monkeypatch):
+    calls = []
+
+    def fail_first_attempt(group, active_group, rendezvous_id):
+        calls.append((list(group), list(active_group), rendezvous_id))
+        if len(calls) == 1:
+            raise RuntimeError("injected asymmetric native failure")
+
+    _patch_reinit_op(monkeypatch, fail_first_attempt)
+    original_layer = AllGatherReduceScatter(_FakeMapping())
+    alias_layer = AllGatherReduceScatter(
+        _FakeMapping(
+            tp_size=3,
+            tp_rank=1,
+            moe_ep_size=3,
+            moe_ep_rank=1,
+            _group=[4, 6, 7],
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="injected asymmetric native failure"):
+        original_layer.abort_and_reinit([4, 6, 7], generation=7)
+    with pytest.raises(RuntimeError, match="already been attempted"):
+        alias_layer.abort_and_reinit([4, 6, 7], generation=7)
+    for group in ([4, 5, 6, 7], [4, 6, 7]):
+        with pytest.raises(RuntimeError, match="did not complete"):
+            nccl_fault_tolerance.resolve_nccl_group(group)
+        with pytest.raises(RuntimeError, match="did not complete"):
+            nccl_fault_tolerance.assert_nccl_group_not_reconfigured(group, "test collective")
+        assert nccl_fault_tolerance.is_nccl_group_reconfigured(group)
+
+    alias_layer.abort_and_reinit([4, 6, 7], generation=8)
+
+    assert calls == [
+        ([4, 5, 6, 7], [4, 6, 7], 9),
+        ([4, 5, 6, 7], [4, 6, 7], 10),
+    ]
+    assert nccl_fault_tolerance.resolve_nccl_group([4, 5, 6, 7]) == [4, 6, 7]
+    assert nccl_fault_tolerance.resolve_nccl_group([4, 6, 7]) == [4, 6, 7]
+    assert not nccl_fault_tolerance.is_nccl_group_reconfigured([4, 6, 7])
+
+
+def test_later_alias_reconfiguration_updates_the_whole_lineage(monkeypatch):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append(
+            (list(group), list(active_group), rendezvous_id)
+        ),
+    )
+    original_layer = AllGatherReduceScatter(_FakeMapping())
+    alias_layer = AllGatherReduceScatter(
+        _FakeMapping(
+            tp_size=3,
+            tp_rank=1,
+            moe_ep_size=3,
+            moe_ep_rank=1,
+            _group=[4, 6, 7],
+        )
+    )
+
+    original_layer.abort_and_reinit([4, 6, 7], generation=7)
+    alias_layer.abort_and_reinit([6, 7], generation=8)
+    original_layer.abort_and_reinit([6, 7], generation=7)
+    alias_layer.abort_and_reinit([6, 7], generation=7)
+
+    assert calls == [
+        ([4, 5, 6, 7], [4, 6, 7], 9),
+        ([4, 6, 7], [6, 7], 10),
+    ]
+    assert nccl_fault_tolerance.resolve_nccl_group([4, 5, 6, 7]) == [6, 7]
+    assert nccl_fault_tolerance.resolve_nccl_group([4, 6, 7]) == [6, 7]
+    _assert_active_mapping(original_layer._active_mapping, [6, 7], 0)
+    _assert_active_mapping(alias_layer._active_mapping, [6, 7], 0)
+
+
 def test_reconfiguration_transaction_serializes_same_target(monkeypatch):
     entered_native = threading.Event()
     release_native = threading.Event()
@@ -248,7 +351,7 @@ def test_same_membership_recovery_requires_shared_generation(monkeypatch):
     assert calls == []
 
 
-@pytest.mark.parametrize("generation", [-1, 1.5, (1 << 63) - 2])
+@pytest.mark.parametrize("generation", [-1, True, 1.0, 1.5, (1 << 63) - 2])
 def test_raw_recovery_generation_must_fit_reserved_torch_int_range(monkeypatch, generation):
     calls = []
     _patch_reinit_op(
@@ -260,6 +363,30 @@ def test_raw_recovery_generation_must_fit_reserved_torch_int_range(monkeypatch, 
 
     with pytest.raises(ValueError, match="generation must be a nonnegative integer"):
         AllGatherReduceScatter(_FakeMapping()).abort_and_reinit([4, 6, 7], generation=generation)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "active_ranks",
+    [
+        pytest.param([4, True, 7], id="bool"),
+        pytest.param([4, 6.0, 7], id="integral-float"),
+        pytest.param([4, 6.5, 7], id="fractional-float"),
+        pytest.param([4, "6", 7], id="string"),
+    ],
+)
+def test_raw_recovery_rejects_non_integral_rank_values(monkeypatch, active_ranks):
+    calls = []
+    _patch_reinit_op(
+        monkeypatch,
+        lambda group, active_group, rendezvous_id: calls.append(
+            (group, active_group, rendezvous_id)
+        ),
+    )
+
+    with pytest.raises(ValueError, match="active_ranks entries must be an integer"):
+        AllGatherReduceScatter(_FakeMapping()).abort_and_reinit(active_ranks, generation=1)
 
     assert calls == []
 
@@ -277,6 +404,40 @@ def test_generation_rejects_conflicting_raw_recovery_targets(monkeypatch):
         comm.abort_and_reinit([6, 7], generation=9)
 
     assert calls == [([4, 5, 6, 7], [4, 6, 7])]
+
+
+@pytest.mark.parametrize(
+    ("failed_generation", "retry_generation", "expected_rendezvous_ids"),
+    [
+        pytest.param(None, 0, [1, 2], id="legacy-first-attempt"),
+        pytest.param(4, 5, [6, 7], id="explicit-generation"),
+    ],
+)
+def test_failed_raw_recovery_requires_a_new_wire_generation(
+    monkeypatch,
+    failed_generation,
+    retry_generation,
+    expected_rendezvous_ids,
+):
+    calls = []
+
+    def fail_one_survivor_then_succeed(group, active_group, rendezvous_id):
+        calls.append((list(group), list(active_group), rendezvous_id))
+        if len(calls) == 1:
+            raise RuntimeError("injected asymmetric native failure")
+
+    _patch_reinit_op(monkeypatch, fail_one_survivor_then_succeed)
+    comm = AllGatherReduceScatter(_FakeMapping())
+
+    with pytest.raises(RuntimeError, match="injected asymmetric native failure"):
+        comm.abort_and_reinit([4, 6, 7], generation=failed_generation)
+    with pytest.raises(RuntimeError, match="generation.*(required|attempted)"):
+        comm.abort_and_reinit([4, 6, 7], generation=failed_generation)
+
+    comm.abort_and_reinit([4, 6, 7], generation=retry_generation)
+
+    assert [rendezvous_id for _, _, rendezvous_id in calls] == expected_rendezvous_ids
+    _assert_active_mapping(comm._active_mapping, [4, 6, 7], 1)
 
 
 def test_fault_tolerance_control_path_requires_startup_mode(monkeypatch):
@@ -484,6 +645,20 @@ def test_ft_custom_allreduce_helpers_fail_before_workspace_allocation(monkeypatc
     )
     with pytest.raises(RuntimeError, match="userbuffers allreduce"):
         distributed_ops.userbuffers_allreduce_finalize(distributed_ops.torch.ones(1))
+
+
+def test_ft_helix_mnnvl_alltoall_fails_before_workspace_initialization(monkeypatch):
+    monkeypatch.setattr(distributed_ops, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(
+        distributed_ops.MnnvlMemory,
+        "initialize",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("unsupported FT Helix path initialized MNNVL")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Helix MNNVL alltoall.*unavailable"):
+        distributed_ops.HelixAllToAllNative.get(_FakeMapping())
 
 
 def test_ft_disables_fused_nvfp4_gemm_allreduce(monkeypatch):
@@ -780,6 +955,29 @@ def test_reconfigured_column_linear_without_gather_fails_before_gemm(monkeypatch
     assert calls == []
 
 
+def test_reconfigured_row_embedding_without_gather_fails_before_lookup(monkeypatch):
+    _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
+    AllGatherReduceScatter(_FakeMapping()).abort_and_reinit([6, 7])
+    calls = []
+
+    monkeypatch.setattr(embedding_module, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(
+        embedding_module,
+        "pre_comm_embedding_ops",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    class FakeRowEmbedding:
+        tp_mode = TensorParallelMode.ROW
+        _tp_group_tuple = (4, 5, 6, 7)
+        tp_size = 4
+        gather_output = False
+
+    with pytest.raises(RuntimeError, match="statically sharded|redistribute"):
+        embedding_module.Embedding.forward(FakeRowEmbedding(), distributed_ops.torch.tensor([0]))
+    assert calls == []
+
+
 def test_dispatch_and_combine_filter_sizes_to_active_ranks(monkeypatch):
     _patch_reinit_op(monkeypatch, lambda group, active_group, rendezvous_id: None)
     gather_calls = []
@@ -880,8 +1078,8 @@ def test_later_reconfiguration_replaces_active_rank_filter(monkeypatch):
     monkeypatch.setattr(allgather_rs_module, "allgather", fake_allgather)
 
     comm = AllGatherReduceScatter(_FakeMapping())
-    comm.abort_and_reinit([4, 6, 7])
-    comm.abort_and_reinit([6, 7])
+    comm.abort_and_reinit([4, 6, 7], generation=1)
+    comm.abort_and_reinit([6, 7], generation=2)
     comm.dispatch("hidden", None, "slots", None, [5, 7, 11, 13])
 
     assert calls == [
@@ -930,3 +1128,5 @@ def test_failed_reinit_does_not_commit_active_rank_filter(monkeypatch):
     assert comm._active_local_ranks is old_local_ranks
     assert comm._active_global_group is old_global_group
     assert comm._active_mapping is old_mapping
+    with pytest.raises(RuntimeError, match="did not complete"):
+        comm.dispatch("hidden", None, "slots", None, [5, 7, 11, 13])

--- a/tests/unittest/_torch/modules/moe/test_allgather_reducescatter_ft.py
+++ b/tests/unittest/_torch/modules/moe/test_allgather_reducescatter_ft.py
@@ -668,6 +668,7 @@ def test_ft_disables_fused_nvfp4_gemm_allreduce(monkeypatch):
             return True
 
     class QuantConfig:
+        quant_algo = None
         layer_quant_mode = QuantMode()
 
     monkeypatch.setattr(linear_module, "mpi_disabled", lambda: False)

--- a/tests/unittest/_torch/modules/test_pp_nccl_communicator.py
+++ b/tests/unittest/_torch/modules/test_pp_nccl_communicator.py
@@ -1,0 +1,782 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+
+import pytest
+
+from tensorrt_llm import _mnnvl_utils as mnnvl_module
+from tensorrt_llm._torch.distributed import communicator as communicator_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_pp_comm_lifecycle(monkeypatch):
+    previous_helix_comm = mnnvl_module.HelixCpMnnvlMemory.comm
+    previous_helix_topology = mnnvl_module.HelixCpMnnvlMemory.comm_topology
+    communicator_module._pp_comm = None
+    communicator_module._pp_comm_refcount = 0
+    communicator_module._pp_comm_control_refcount = 0
+    communicator_module._pp_comm_final_release_pending = False
+    monkeypatch.setattr(communicator_module, "NCCL_FAULT_TOLERANCE_ENABLED", True)
+    mnnvl_module.HelixCpMnnvlMemory.comm = None
+    mnnvl_module.HelixCpMnnvlMemory.comm_topology = None
+    yield
+    communicator_module._pp_comm = None
+    communicator_module._pp_comm_refcount = 0
+    communicator_module._pp_comm_control_refcount = 0
+    communicator_module._pp_comm_final_release_pending = False
+    mnnvl_module.HelixCpMnnvlMemory.comm = previous_helix_comm
+    mnnvl_module.HelixCpMnnvlMemory.comm_topology = previous_helix_topology
+
+
+class _FakeNcclCommunicatorOp:
+    def __init__(self):
+        self.aborted = False
+        self.reinitialized_with = None
+        self.reinit_calls = []
+        self.rendezvous_ids = []
+        self.active_ranks = [0, 1, 2, 3]
+        self.async_error = "NCCL error: communicator was aborted after injected async failure"
+        self.received_from = None
+
+    def abort(self):
+        self.aborted = True
+
+    def abort_and_reinit(self, active_ranks, rendezvous_id):
+        self.reinitialized_with = list(active_ranks)
+        self.reinit_calls.append(list(active_ranks))
+        self.rendezvous_ids.append(rendezvous_id)
+        self.active_ranks = list(active_ranks)
+        self.async_error = ""
+
+    def get_async_error(self):
+        return self.async_error
+
+    def get_active_ranks(self):
+        return list(self.active_ranks)
+
+    def recv(self, tensor, src):
+        self.received_from = src
+
+    def send(self, tensor, dest):
+        self.sent_to = dest
+
+
+class _FakeMapping:
+    world_size = 4
+    rank = 2
+    pp_group = [0, 1, 2, 3]
+    cp_config = {}
+
+    def has_cp_helix(self):
+        return False
+
+    def prev_pp_rank(self):
+        return 1
+
+    def next_pp_rank(self):
+        return 3
+
+
+class _CompatibleMapping(_FakeMapping):
+    pass
+
+
+class _HelixMapping(_FakeMapping):
+    cp_config = {"use_nccl_for_alltoall": False}
+    cp_group = [0, 2]
+    cp_rank = 1
+    pp_rank = 0
+    tp_size = 2
+    tp_rank = 0
+
+    def has_cp_helix(self):
+        return True
+
+
+class _OtherHelixMapping(_HelixMapping):
+    cp_group = [1, 2]
+
+
+def _make_pp_comm(mapping=None):
+    pp_comm = object.__new__(communicator_module.PPCommNCCL)
+    pp_comm.mapping = mapping or _FakeMapping()
+    pp_comm._topology = pp_comm._mapping_topology(pp_comm.mapping)
+    pp_comm._active_ranks = tuple(range(pp_comm.mapping.world_size))
+    pp_comm._reconfigure_lock = threading.Lock()
+    pp_comm._reconfigure_generation = 0
+    pp_comm._completed_recovery = None
+    pp_comm.nccl_comm = _FakeNcclCommunicatorOp()
+    return pp_comm
+
+
+def test_pp_wrapper_initializes_membership_from_persistent_native_comm(monkeypatch):
+    native_comm = _FakeNcclCommunicatorOp()
+    native_comm.active_ranks = [0, 2, 3]
+    monkeypatch.setattr(
+        communicator_module.torch.classes.trtllm,
+        "NcclCommunicatorOp",
+        lambda world_size, rank: native_comm,
+        raising=False,
+    )
+    monkeypatch.setattr(communicator_module.torch.cuda, "Event", object)
+    monkeypatch.setattr(communicator_module.torch.cuda, "Stream", object)
+
+    pp_comm = communicator_module.PPCommNCCL(_FakeMapping())
+
+    assert pp_comm.get_active_ranks() == [0, 2, 3]
+
+
+def test_default_off_wrapper_does_not_query_native_membership(monkeypatch):
+    native_comm = _FakeNcclCommunicatorOp()
+    native_comm.get_active_ranks = lambda: (_ for _ in ()).throw(
+        AssertionError("default-off PP constructor queried native membership")
+    )
+    monkeypatch.setattr(communicator_module, "NCCL_FAULT_TOLERANCE_ENABLED", False)
+    monkeypatch.setattr(
+        communicator_module.torch.classes.trtllm,
+        "NcclCommunicatorOp",
+        lambda world_size, rank: native_comm,
+        raising=False,
+    )
+    monkeypatch.setattr(communicator_module.torch.cuda, "Event", object)
+    monkeypatch.setattr(communicator_module.torch.cuda, "Stream", object)
+
+    pp_comm = communicator_module.PPCommNCCL(_FakeMapping())
+
+    assert pp_comm._active_ranks == (0, 1, 2, 3)
+
+
+def test_pp_nccl_fault_tolerance_methods_forward_to_custom_class():
+    pp_comm = _make_pp_comm()
+
+    assert "NCCL error" in pp_comm.get_async_error()
+    pp_comm.abort_and_reinit((0, 2, 3))
+    assert pp_comm.nccl_comm.reinitialized_with == [0, 2, 3]
+    assert pp_comm.nccl_comm.rendezvous_ids == [1]
+    assert pp_comm.get_async_error() == ""
+    assert pp_comm.get_active_ranks() == [0, 2, 3]
+
+    pp_comm.abort()
+    assert pp_comm.nccl_comm.aborted
+
+
+def test_module_level_pp_nccl_fault_tolerance_api(monkeypatch):
+    pp_comm = _make_pp_comm()
+    monkeypatch.setattr(communicator_module, "_pp_comm", pp_comm)
+    monkeypatch.setattr(communicator_module, "_pp_comm_refcount", 1)
+
+    assert "NCCL error" in communicator_module.pp_comm_get_async_error()
+    communicator_module.pp_comm_abort_and_reinit([0, 2, 3], generation=3)
+    assert pp_comm.nccl_comm.reinitialized_with == [0, 2, 3]
+    assert pp_comm.nccl_comm.rendezvous_ids == [5]
+    assert communicator_module.pp_comm_get_async_error() == ""
+    assert communicator_module.pp_comm_get_active_ranks() == [0, 2, 3]
+
+    communicator_module.pp_comm_abort()
+    assert pp_comm.nccl_comm.aborted
+
+
+def test_module_level_pp_nccl_api_requires_nccl_backend(monkeypatch):
+    monkeypatch.setattr(communicator_module, "_pp_comm", object())
+
+    with pytest.raises(RuntimeError, match="NCCL error: PP communicator is not initialized"):
+        communicator_module.pp_comm_get_async_error()
+
+
+def test_reinit_rejects_stale_default_peer_and_accepts_explicit_remap():
+    pp_comm = _make_pp_comm()
+    pp_comm.abort_and_reinit([0, 2, 3])
+
+    # Static Mapping.prev_pp_rank() names failed rank 1. Silently skipping it
+    # would bypass that stage's model layers, so default routing must fail.
+    with pytest.raises(RuntimeError, match="peer world rank 1 is not active"):
+        pp_comm.recv(object())
+
+    # A higher-level layer/topology reconstruction may provide an explicit
+    # replacement peer after it has reassigned the failed stage.
+    pp_comm.recv(object(), src=0)
+    assert pp_comm.nccl_comm.received_from == 0
+    assert pp_comm._required_pp_peer(next_peer=True) == 3
+
+
+def test_explicit_peer_must_belong_to_the_callers_pp_lane():
+    class LaneMapping:
+        world_size = 8
+        rank = 2
+        pp_group = [2, 6]
+        cp_config = {}
+
+        def has_cp_helix(self):
+            return False
+
+        def prev_pp_rank(self):
+            return 6
+
+        def next_pp_rank(self):
+            return 6
+
+    pp_comm = _make_pp_comm(LaneMapping())
+
+    with pytest.raises(RuntimeError, match="not in this rank's PP group"):
+        pp_comm.recv(object(), src=3)
+
+    pp_comm.recv(object(), src=6)
+    assert pp_comm.nccl_comm.received_from == 6
+
+
+def test_default_off_preserves_legacy_peer_routing(monkeypatch):
+    pp_comm = _make_pp_comm()
+    monkeypatch.setattr(communicator_module, "NCCL_FAULT_TOLERANCE_ENABLED", False)
+    monkeypatch.setattr(
+        communicator_module.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
+    )
+
+    # Before FT wiring, explicit peers were forwarded to the native wrapper
+    # without a Python PP-lane scan. Preserve that behavior and cost when the
+    # startup mode is disabled.
+    tensor = object()
+    pp_comm.send(tensor, dest=7)
+    pp_comm.recv(tensor, src=7)
+
+    assert pp_comm.nccl_comm.sent_to == 7
+    assert pp_comm.nccl_comm.received_from == 7
+
+
+def test_reinit_rejects_reactivating_removed_pp_rank():
+    pp_comm = _make_pp_comm()
+    pp_comm.abort_and_reinit([0, 2, 3])
+
+    with pytest.raises(ValueError, match="reactivate"):
+        pp_comm.abort_and_reinit([0, 1, 2, 3])
+
+
+def test_duplicate_reinit_target_is_idempotent():
+    pp_comm = _make_pp_comm()
+
+    pp_comm.abort_and_reinit([0, 2, 3], generation=1)
+    pp_comm.abort_and_reinit([3, 2, 0], generation=1)
+
+    assert pp_comm.nccl_comm.reinit_calls == [[0, 2, 3]]
+    assert pp_comm.nccl_comm.rendezvous_ids == [3]
+    assert pp_comm.get_active_ranks() == [0, 2, 3]
+
+
+def test_shared_generation_forces_same_membership_rebuild():
+    pp_comm = _make_pp_comm()
+
+    pp_comm.abort_and_reinit([0, 1, 2, 3], generation=1)
+    pp_comm.abort_and_reinit([0, 1, 2, 3], generation=1)
+    pp_comm.abort_and_reinit([0, 1, 2, 3], generation=2)
+
+    assert pp_comm.nccl_comm.reinit_calls == [[0, 1, 2, 3], [0, 1, 2, 3]]
+    assert pp_comm.nccl_comm.rendezvous_ids == [3, 4]
+    assert pp_comm.get_async_error() == ""
+
+
+def test_same_membership_recovery_requires_shared_generation():
+    pp_comm = _make_pp_comm()
+
+    with pytest.raises(ValueError, match="generation is required"):
+        pp_comm.abort_and_reinit([0, 1, 2, 3])
+
+    assert pp_comm.nccl_comm.reinit_calls == []
+
+
+@pytest.mark.parametrize("generation", [-1, 1.5, (1 << 63) - 2])
+def test_recovery_generation_must_fit_reserved_torch_int_range(generation):
+    pp_comm = _make_pp_comm()
+
+    with pytest.raises(ValueError, match="generation must be a nonnegative integer"):
+        pp_comm.abort_and_reinit([0, 2, 3], generation=generation)
+
+    assert pp_comm.nccl_comm.reinit_calls == []
+
+
+def test_generation_rejects_conflicting_pp_recovery_targets():
+    pp_comm = _make_pp_comm()
+    pp_comm.abort_and_reinit([0, 2, 3], generation=7)
+
+    with pytest.raises(RuntimeError, match="conflicting.*generation 7"):
+        pp_comm.abort_and_reinit([0, 2], generation=7)
+
+    assert pp_comm.nccl_comm.reinit_calls == [[0, 2, 3]]
+
+
+def test_concurrent_nested_reinit_requests_commit_newest_membership():
+    pp_comm = _make_pp_comm()
+    first_entered_native = threading.Event()
+    second_entered_native = threading.Event()
+    release_first = threading.Event()
+    calls = []
+
+    def blocking_reinit(active_ranks, rendezvous_id):
+        active_ranks = list(active_ranks)
+        calls.append((active_ranks, rendezvous_id))
+        pp_comm.nccl_comm.active_ranks = active_ranks
+        if active_ranks == [0, 2, 3]:
+            first_entered_native.set()
+            assert release_first.wait(timeout=5)
+        else:
+            second_entered_native.set()
+
+    pp_comm.nccl_comm.abort_and_reinit = blocking_reinit
+    errors = []
+
+    def reconfigure(active_ranks):
+        try:
+            pp_comm.abort_and_reinit(active_ranks)
+        except Exception as error:  # pragma: no cover - assertion reports details
+            errors.append(error)
+
+    first = threading.Thread(target=reconfigure, args=([0, 2, 3],))
+    second = threading.Thread(target=reconfigure, args=([0, 2],))
+    first.start()
+    assert first_entered_native.wait(timeout=5)
+    second.start()
+
+    # The second callback must not enter the native rendezvous while the first
+    # callback is between native completion and Python membership publication.
+    serialized = not second_entered_native.wait(timeout=0.1)
+    release_first.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert serialized
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert calls == [([0, 2, 3], 1), ([0, 2], 1)]
+    assert pp_comm.get_active_ranks() == [0, 2]
+
+
+def test_abort_waiting_for_reinit_does_not_abort_replacement():
+    pp_comm = _make_pp_comm()
+    abort_generation = pp_comm._reconfigure_generation
+    entered_reinit = threading.Event()
+    release_reinit = threading.Event()
+    abort_started = threading.Event()
+
+    def blocking_reinit(active_ranks, rendezvous_id):
+        assert rendezvous_id == 1
+        entered_reinit.set()
+        assert release_reinit.wait(timeout=5)
+        pp_comm.nccl_comm.active_ranks = list(active_ranks)
+        pp_comm.nccl_comm.async_error = ""
+
+    pp_comm.nccl_comm.abort_and_reinit = blocking_reinit
+    errors = []
+
+    def reconfigure():
+        try:
+            pp_comm.abort_and_reinit([0, 2, 3])
+        except Exception as error:  # pragma: no cover - assertion reports details
+            errors.append(error)
+
+    def abort():
+        abort_started.set()
+        try:
+            pp_comm.abort(abort_generation)
+        except Exception as error:  # pragma: no cover - assertion reports details
+            errors.append(error)
+
+    rebuild_thread = threading.Thread(target=reconfigure)
+    abort_thread = threading.Thread(target=abort)
+    rebuild_thread.start()
+    assert entered_reinit.wait(timeout=5)
+    abort_thread.start()
+    assert abort_started.wait(timeout=5)
+    release_reinit.set()
+    rebuild_thread.join(timeout=5)
+    abort_thread.join(timeout=5)
+
+    assert not rebuild_thread.is_alive()
+    assert not abort_thread.is_alive()
+    assert errors == []
+    assert not pp_comm.nccl_comm.aborted
+    assert pp_comm.get_active_ranks() == [0, 2, 3]
+
+    # A genuinely new abort request after the rebuild must still take effect.
+    pp_comm.abort()
+    assert pp_comm.nccl_comm.aborted
+
+
+def test_module_abort_waiting_for_reinit_does_not_abort_replacement(monkeypatch):
+    pp_comm = _make_pp_comm()
+    entered_reinit = threading.Event()
+    abort_captured_generation = threading.Event()
+    release_reinit = threading.Event()
+    errors = []
+
+    def blocking_reinit(active_ranks, rendezvous_id):
+        assert rendezvous_id == 1
+        entered_reinit.set()
+        assert release_reinit.wait(timeout=5)
+        pp_comm.nccl_comm.active_ranks = list(active_ranks)
+        pp_comm.nccl_comm.async_error = ""
+
+    pp_comm.nccl_comm.abort_and_reinit = blocking_reinit
+    original_abort = pp_comm.abort
+
+    def observed_abort(generation=None):
+        # The module wrapper has already captured the epoch before it invokes
+        # the class method. Do not let the rebuild finish until that point.
+        abort_captured_generation.set()
+        return original_abort(generation)
+
+    pp_comm.abort = observed_abort
+    monkeypatch.setattr(communicator_module, "_pp_comm", pp_comm)
+    monkeypatch.setattr(communicator_module, "_pp_comm_refcount", 1)
+
+    def reconfigure():
+        try:
+            communicator_module.pp_comm_abort_and_reinit([0, 2, 3])
+        except Exception as error:  # pragma: no cover - assertion reports details
+            errors.append(error)
+
+    def abort():
+        try:
+            communicator_module.pp_comm_abort()
+        except Exception as error:  # pragma: no cover - assertion reports details
+            errors.append(error)
+
+    rebuild_thread = threading.Thread(target=reconfigure)
+    abort_thread = threading.Thread(target=abort)
+    rebuild_thread.start()
+    assert entered_reinit.wait(timeout=5)
+    abort_thread.start()
+    assert abort_captured_generation.wait(timeout=5)
+    release_reinit.set()
+    rebuild_thread.join(timeout=5)
+    abort_thread.join(timeout=5)
+
+    assert not rebuild_thread.is_alive()
+    assert not abort_thread.is_alive()
+    assert errors == []
+    assert not pp_comm.nccl_comm.aborted
+    assert pp_comm.get_active_ranks() == [0, 2, 3]
+
+    communicator_module.pp_comm_abort()
+    assert pp_comm.nccl_comm.aborted
+
+
+def test_module_control_call_blocks_final_release(monkeypatch):
+    pp_comm = _make_pp_comm()
+    entered_query = threading.Event()
+    release_query = threading.Event()
+    final_release_completed = threading.Event()
+    errors = []
+
+    def blocking_get_async_error():
+        entered_query.set()
+        assert release_query.wait(timeout=5)
+        return ""
+
+    pp_comm.nccl_comm.get_async_error = blocking_get_async_error
+    monkeypatch.setattr(communicator_module, "_pp_comm", pp_comm)
+    monkeypatch.setattr(communicator_module, "_pp_comm_refcount", 1)
+
+    def query():
+        try:
+            communicator_module.pp_comm_get_async_error()
+        except Exception as error:  # pragma: no cover - assertion reports details
+            errors.append(error)
+
+    def final_release():
+        try:
+            communicator_module.release_pp_comm()
+            final_release_completed.set()
+        except Exception as error:  # pragma: no cover - assertion reports details
+            errors.append(error)
+
+    query_thread = threading.Thread(target=query)
+    release_thread = threading.Thread(target=final_release)
+    query_thread.start()
+    assert entered_query.wait(timeout=5)
+    release_thread.start()
+
+    # The control call owns a transient reference under _pp_comm_lock, so a
+    # final engine release cannot complete its ownership transition yet.
+    assert not final_release_completed.wait(timeout=0.1)
+    release_query.set()
+    query_thread.join(timeout=5)
+    release_thread.join(timeout=5)
+
+    assert not query_thread.is_alive()
+    assert not release_thread.is_alive()
+    assert errors == []
+    assert final_release_completed.is_set()
+    assert communicator_module._pp_comm is pp_comm
+    assert communicator_module._pp_comm_refcount == 0
+
+
+def test_init_pp_comm_reuses_compatible_nccl_communicator(monkeypatch):
+    created = []
+
+    class FakePPComm:
+        def __init__(self, mapping):
+            self.topology = (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
+            created.append(self)
+
+        def is_compatible(self, mapping):
+            return self.topology == (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
+
+    monkeypatch.setattr(communicator_module, "PPCommNCCL", FakePPComm)
+    monkeypatch.setattr(communicator_module, "_pp_comm", None)
+    monkeypatch.setattr(communicator_module, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(communicator_module, "init_helix_cp_comm", lambda mapping: None)
+
+    communicator_module.init_pp_comm(_FakeMapping())
+    first = communicator_module._pp_comm
+    # A target and draft engine construct equivalent Mapping objects. They
+    # must share the sole process-local native PP communicator.
+    communicator_module.init_pp_comm(_CompatibleMapping())
+
+    assert communicator_module._pp_comm is first
+    assert len(created) == 1
+    assert communicator_module._pp_comm_refcount == 2
+
+    communicator_module.release_pp_comm()
+    assert communicator_module._pp_comm is first
+    communicator_module.release_pp_comm()
+    assert communicator_module._pp_comm is first
+    assert communicator_module._pp_comm_refcount == 0
+
+
+def test_ft_wrapper_churn_preserves_completed_recovery_generation(monkeypatch):
+    pp_comm = _make_pp_comm()
+    monkeypatch.setattr(communicator_module, "_pp_comm", pp_comm)
+    monkeypatch.setattr(communicator_module, "_pp_comm_refcount", 1)
+    monkeypatch.setattr(communicator_module, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(communicator_module, "init_helix_cp_comm", lambda mapping: None)
+
+    communicator_module.pp_comm_abort_and_reinit([0, 2, 3], generation=7)
+    communicator_module.release_pp_comm()
+    assert communicator_module._pp_comm is pp_comm
+    assert communicator_module._pp_comm_refcount == 0
+
+    communicator_module.init_pp_comm(_CompatibleMapping())
+    communicator_module.pp_comm_abort_and_reinit([0, 2, 3], generation=7)
+
+    assert communicator_module._pp_comm is pp_comm
+    assert pp_comm.nccl_comm.reinit_calls == [[0, 2, 3]]
+    assert pp_comm.nccl_comm.rendezvous_ids == [9]
+
+
+def test_init_pp_comm_rejects_incompatible_live_topology(monkeypatch):
+    existing = _make_pp_comm()
+    monkeypatch.setattr(communicator_module, "_pp_comm", existing)
+    monkeypatch.setattr(communicator_module, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(communicator_module, "init_helix_cp_comm", lambda mapping: None)
+
+    class OtherMapping(_FakeMapping):
+        pp_group = [0, 2]
+
+    with pytest.raises(RuntimeError, match="different topology"):
+        communicator_module.init_pp_comm(OtherMapping())
+
+
+def test_init_pp_comm_rejects_incompatible_live_helix_topology(monkeypatch):
+    existing = _make_pp_comm(_HelixMapping())
+    monkeypatch.setattr(communicator_module, "_pp_comm", existing)
+    monkeypatch.setattr(communicator_module, "mpi_disabled", lambda: False)
+
+    with pytest.raises(RuntimeError, match="Helix MNNVL CP topology"):
+        communicator_module.init_pp_comm(_OtherHelixMapping())
+
+
+def test_helix_mnnvl_comm_rejects_incompatible_cached_topology(monkeypatch):
+    split_calls = []
+    comm = object()
+
+    class FakeMpiComm:
+        def Split(self, color, key):
+            split_calls.append((color, key))
+            return comm
+
+    monkeypatch.setattr(mnnvl_module, "mpi_comm", lambda: FakeMpiComm())
+
+    assert mnnvl_module.HelixCpMnnvlMemory.get_comm(_HelixMapping()) is comm
+    assert mnnvl_module.HelixCpMnnvlMemory.get_comm(_HelixMapping()) is comm
+    with pytest.raises(RuntimeError, match="cannot reuse.*incompatible topology"):
+        mnnvl_module.HelixCpMnnvlMemory.get_comm(_OtherHelixMapping())
+
+    assert split_calls == [(0, 1)]
+
+
+def test_final_release_preserves_helix_comm_topology(monkeypatch):
+    original_pp_comm_class = communicator_module.PPCommNCCL
+    split_calls = []
+
+    class FakeMpiComm:
+        def Split(self, color, key):
+            split_calls.append((color, key))
+            return object()
+
+    class FakePPComm:
+        def __init__(self, mapping):
+            self.topology = original_pp_comm_class._mapping_topology(mapping)
+
+        def is_compatible(self, mapping):
+            return self.topology == original_pp_comm_class._mapping_topology(mapping)
+
+    monkeypatch.setattr(mnnvl_module, "mpi_comm", lambda: FakeMpiComm())
+    monkeypatch.setattr(communicator_module, "PPCommNCCL", FakePPComm)
+    monkeypatch.setattr(communicator_module, "NCCL_FAULT_TOLERANCE_ENABLED", False)
+    monkeypatch.setattr(communicator_module, "mpi_disabled", lambda: False)
+
+    # Reacquiring the ordinary PP wrapper after its final release is valid when
+    # the persistent Helix MPI communicator has the same CP rank topology.
+    communicator_module.init_pp_comm(_HelixMapping())
+    communicator_module.release_pp_comm()
+    communicator_module.init_pp_comm(_HelixMapping())
+    communicator_module.release_pp_comm()
+
+    # A later engine may create a fresh PP wrapper, but it cannot reinterpret
+    # the process-lifetime Helix MPI communicator with a different CP group.
+    with pytest.raises(RuntimeError, match="cannot reuse.*incompatible topology"):
+        communicator_module.init_pp_comm(_OtherHelixMapping())
+
+    assert split_calls == [(0, 1)]
+    assert communicator_module._pp_comm is None
+    assert communicator_module._pp_comm_refcount == 0
+
+
+def test_default_off_final_release_allows_a_later_incompatible_topology(monkeypatch):
+    created = []
+
+    class FakePPComm:
+        def __init__(self, mapping):
+            self.topology = (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
+            created.append(self.topology)
+
+        def is_compatible(self, mapping):
+            return self.topology == (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
+
+    class OtherMapping(_FakeMapping):
+        pp_group = [0, 2]
+
+    monkeypatch.setattr(communicator_module, "PPCommNCCL", FakePPComm)
+    monkeypatch.setattr(communicator_module, "NCCL_FAULT_TOLERANCE_ENABLED", False)
+    monkeypatch.setattr(communicator_module, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(communicator_module, "init_helix_cp_comm", lambda mapping: None)
+
+    communicator_module.init_pp_comm(_FakeMapping())
+    communicator_module.release_pp_comm()
+    assert communicator_module._pp_comm is None
+    communicator_module.init_pp_comm(OtherMapping())
+
+    assert len(created) == 2
+    assert created[0] != created[1]
+
+
+def test_model_engine_cleanup_releases_pp_before_reporting_ub_failure(monkeypatch):
+    from types import SimpleNamespace
+
+    from tensorrt_llm._torch.pyexecutor import model_engine
+
+    engine = object.__new__(model_engine.PyTorchModelEngine)
+    engine._cleanup_done = False
+    engine._pp_comm_acquired = True
+    engine.model_loader = None
+    engine.model = object()
+    engine.input_processor = object()
+    engine.input_processor_with_hash = object()
+    engine.ub_buffers = [SimpleNamespace(addr=123)]
+    engine._release_cuda_graphs = lambda: None
+
+    released = []
+    gc_calls = []
+    monkeypatch.setattr(model_engine, "release_pp_comm", lambda: released.append(True))
+    monkeypatch.setattr(model_engine, "release_gc", lambda: gc_calls.append(True))
+    monkeypatch.setattr(
+        model_engine.ub,
+        "ub_deallocate",
+        lambda addr: (_ for _ in ()).throw(RuntimeError("injected UB failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="userbuffers"):
+        engine.cleanup()
+
+    assert released == [True]
+    assert gc_calls == [True]
+    assert not engine._pp_comm_acquired
+    assert not engine._cleanup_done
+    assert [buffer.addr for buffer in engine.ub_buffers] == [123]
+
+    monkeypatch.setattr(model_engine.ub, "ub_deallocate", lambda addr: None)
+    engine.cleanup()
+    assert released == [True]
+    assert engine._cleanup_done
+    assert engine.ub_buffers is None
+
+
+def test_ft_mode_uses_engine_local_eager_graph_configuration(monkeypatch):
+    from tensorrt_llm._torch.pyexecutor import model_engine
+
+    class FakeTorchCompileConfig:
+        def __init__(self, enable_piecewise_cuda_graph):
+            self.enable_piecewise_cuda_graph = enable_piecewise_cuda_graph
+
+        def model_copy(self, *, update):
+            copied = FakeTorchCompileConfig(self.enable_piecewise_cuda_graph)
+            for name, value in update.items():
+                setattr(copied, name, value)
+            return copied
+
+    class FakeLlmArgs:
+        def __init__(self, cuda_graph_config, torch_compile_config):
+            self.cuda_graph_config = cuda_graph_config
+            self.torch_compile_config = torch_compile_config
+
+        def model_copy(self, *, update):
+            copied = FakeLlmArgs(self.cuda_graph_config, self.torch_compile_config)
+            for name, value in update.items():
+                setattr(copied, name, value)
+            return copied
+
+    original = FakeLlmArgs(object(), FakeTorchCompileConfig(True))
+    monkeypatch.setenv("TLLM_FAULT_TOLERANCE_MODE", "1")
+
+    effective = model_engine._force_eager_mode_for_nccl_fault_tolerance(original)
+
+    assert effective is not original
+    assert effective.cuda_graph_config is None
+    assert not effective.torch_compile_config.enable_piecewise_cuda_graph
+    # The caller-owned arguments remain reusable by a non-FT engine.
+    assert original.cuda_graph_config is not None
+    assert original.torch_compile_config.enable_piecewise_cuda_graph
+
+
+def test_ft_mode_uses_eager_allreduce_autotuning(monkeypatch):
+    from tensorrt_llm._torch.custom_ops import torch_custom_ops
+
+    monkeypatch.delenv("TLLM_FAULT_TOLERANCE_MODE", raising=False)
+    assert torch_custom_ops._use_cuda_graph_for_allreduce_tuning()
+
+    monkeypatch.setenv("TLLM_FAULT_TOLERANCE_MODE", "1")
+    assert not torch_custom_ops._use_cuda_graph_for_allreduce_tuning()
+
+
+def test_partially_constructed_engine_cleanup_releases_pp(monkeypatch):
+    from tensorrt_llm._torch.pyexecutor import model_engine
+
+    # Simulate a constructor failure immediately after init_pp_comm(), before
+    # model/model_loader/input-processor attributes have been populated.
+    engine = object.__new__(model_engine.PyTorchModelEngine)
+    engine._cleanup_done = False
+    engine._pp_comm_acquired = True
+
+    released = []
+    gc_calls = []
+    monkeypatch.setattr(model_engine, "release_pp_comm", lambda: released.append(True))
+    monkeypatch.setattr(model_engine, "release_gc", lambda: gc_calls.append(True))
+
+    engine.cleanup()
+
+    assert released == [True]
+    assert gc_calls == [True]
+    assert not engine._pp_comm_acquired
+    assert engine._cleanup_done

--- a/tests/unittest/_torch/modules/test_pp_nccl_communicator.py
+++ b/tests/unittest/_torch/modules/test_pp_nccl_communicator.py
@@ -106,6 +106,8 @@ def _make_pp_comm(mapping=None):
     pp_comm._reconfigure_lock = threading.Lock()
     pp_comm._reconfigure_generation = 0
     pp_comm._completed_recovery = None
+    pp_comm._latest_recovery_attempt = None
+    pp_comm._unavailable_recovery_attempt = None
     pp_comm.nccl_comm = _FakeNcclCommunicatorOp()
     return pp_comm
 
@@ -285,12 +287,30 @@ def test_same_membership_recovery_requires_shared_generation():
     assert pp_comm.nccl_comm.reinit_calls == []
 
 
-@pytest.mark.parametrize("generation", [-1, 1.5, (1 << 63) - 2])
+@pytest.mark.parametrize("generation", [-1, True, 1.0, 1.5, (1 << 63) - 2])
 def test_recovery_generation_must_fit_reserved_torch_int_range(generation):
     pp_comm = _make_pp_comm()
 
     with pytest.raises(ValueError, match="generation must be a nonnegative integer"):
         pp_comm.abort_and_reinit([0, 2, 3], generation=generation)
+
+    assert pp_comm.nccl_comm.reinit_calls == []
+
+
+@pytest.mark.parametrize(
+    "active_ranks",
+    [
+        pytest.param([0, True, 3], id="bool"),
+        pytest.param([0, 2.0, 3], id="integral-float"),
+        pytest.param([0, 2.5, 3], id="fractional-float"),
+        pytest.param([0, "2", 3], id="string"),
+    ],
+)
+def test_pp_recovery_rejects_non_integral_rank_values(active_ranks):
+    pp_comm = _make_pp_comm()
+
+    with pytest.raises(ValueError, match="active_ranks entries must be an integer"):
+        pp_comm.abort_and_reinit(active_ranks, generation=1)
 
     assert pp_comm.nccl_comm.reinit_calls == []
 
@@ -303,6 +323,126 @@ def test_generation_rejects_conflicting_pp_recovery_targets():
         pp_comm.abort_and_reinit([0, 2], generation=7)
 
     assert pp_comm.nccl_comm.reinit_calls == [[0, 2, 3]]
+
+
+@pytest.mark.parametrize(
+    ("failed_generation", "retry_generation", "expected_rendezvous_ids"),
+    [
+        pytest.param(None, 0, [1, 2], id="legacy-first-attempt"),
+        pytest.param(4, 5, [6, 7], id="explicit-generation"),
+    ],
+)
+def test_failed_pp_recovery_requires_a_new_wire_generation(
+    failed_generation,
+    retry_generation,
+    expected_rendezvous_ids,
+):
+    pp_comm = _make_pp_comm()
+    calls = []
+
+    def fail_one_survivor_then_succeed(active_ranks, rendezvous_id):
+        calls.append((list(active_ranks), rendezvous_id))
+        if len(calls) == 1:
+            raise RuntimeError("injected asymmetric native failure")
+        pp_comm.nccl_comm.active_ranks = list(active_ranks)
+
+    pp_comm.nccl_comm.abort_and_reinit = fail_one_survivor_then_succeed
+
+    with pytest.raises(RuntimeError, match="injected asymmetric native failure"):
+        pp_comm.abort_and_reinit([0, 2, 3], generation=failed_generation)
+    with pytest.raises(RuntimeError, match="generation.*(required|attempted)"):
+        pp_comm.abort_and_reinit([0, 2, 3], generation=failed_generation)
+
+    pp_comm.abort_and_reinit([0, 2, 3], generation=retry_generation)
+
+    assert [rendezvous_id for _, rendezvous_id in calls] == expected_rendezvous_ids
+    assert pp_comm.get_active_ranks() == [0, 2, 3]
+
+
+def test_completed_pp_generation_is_not_reported_successful_while_retry_is_incomplete():
+    pp_comm = _make_pp_comm()
+    pp_comm.abort_and_reinit([0, 2, 3], generation=4)
+
+    def fail_later_rebuild(_active_ranks, _rendezvous_id):
+        raise RuntimeError("injected later native failure")
+
+    pp_comm.nccl_comm.abort_and_reinit = fail_later_rebuild
+
+    with pytest.raises(RuntimeError, match="injected later native failure"):
+        pp_comm.abort_and_reinit([0, 2, 3], generation=5)
+    with pytest.raises(RuntimeError, match="already been attempted or is stale"):
+        pp_comm.abort_and_reinit([0, 2, 3], generation=4)
+
+
+@pytest.mark.parametrize(
+    ("operation", "peer_argument"),
+    [
+        pytest.param("send", {"dest": 3}, id="send"),
+        pytest.param("recv", {"src": 3}, id="recv"),
+    ],
+)
+def test_failed_pp_recovery_blocks_data_plane_until_retry_succeeds(
+    monkeypatch,
+    operation,
+    peer_argument,
+):
+    pp_comm = _make_pp_comm()
+    rebuild_calls = []
+    data_plane_calls = []
+
+    def fail_first_rebuild(active_ranks, rendezvous_id):
+        rebuild_calls.append((list(active_ranks), rendezvous_id))
+        if len(rebuild_calls) == 1:
+            raise RuntimeError("injected asymmetric native failure")
+        pp_comm.nccl_comm.active_ranks = list(active_ranks)
+
+    pp_comm.nccl_comm.abort_and_reinit = fail_first_rebuild
+    pp_comm.nccl_comm.send = lambda tensor, dest: data_plane_calls.append(("send", dest))
+    pp_comm.nccl_comm.recv = lambda tensor, src: data_plane_calls.append(("recv", src))
+    monkeypatch.setattr(
+        communicator_module.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
+    )
+
+    with pytest.raises(RuntimeError, match="injected asymmetric native failure"):
+        pp_comm.abort_and_reinit([0, 2, 3], generation=4)
+
+    with pytest.raises(RuntimeError, match="did not complete"):
+        getattr(pp_comm, operation)(object(), **peer_argument)
+    assert data_plane_calls == []
+
+    pp_comm.abort_and_reinit([0, 2, 3], generation=5)
+    getattr(pp_comm, operation)(object(), **peer_argument)
+
+    assert rebuild_calls == [([0, 2, 3], 6), ([0, 2, 3], 7)]
+    assert data_plane_calls == [(operation, 3)]
+
+
+def test_unexpected_pp_rebuild_membership_keeps_data_plane_poisoned(monkeypatch):
+    pp_comm = _make_pp_comm()
+    data_plane_calls = []
+
+    def return_unexpected_membership(active_ranks, rendezvous_id):
+        # Simulate a native wrapper that returns without publishing the
+        # requested membership. The old communicator is no longer safe merely
+        # because its reported group is unchanged.
+        pp_comm.nccl_comm.active_ranks = [0, 1, 2, 3]
+
+    pp_comm.nccl_comm.abort_and_reinit = return_unexpected_membership
+    pp_comm.nccl_comm.send = lambda tensor, dest: data_plane_calls.append(dest)
+    monkeypatch.setattr(
+        communicator_module.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected membership"):
+        pp_comm.abort_and_reinit([0, 2, 3], generation=4)
+    with pytest.raises(RuntimeError, match="did not complete"):
+        pp_comm.send(object(), dest=3)
+
+    assert data_plane_calls == []
 
 
 def test_concurrent_nested_reinit_requests_commit_newest_membership():
@@ -325,14 +465,14 @@ def test_concurrent_nested_reinit_requests_commit_newest_membership():
     pp_comm.nccl_comm.abort_and_reinit = blocking_reinit
     errors = []
 
-    def reconfigure(active_ranks):
+    def reconfigure(active_ranks, generation):
         try:
-            pp_comm.abort_and_reinit(active_ranks)
+            pp_comm.abort_and_reinit(active_ranks, generation=generation)
         except Exception as error:  # pragma: no cover - assertion reports details
             errors.append(error)
 
-    first = threading.Thread(target=reconfigure, args=([0, 2, 3],))
-    second = threading.Thread(target=reconfigure, args=([0, 2],))
+    first = threading.Thread(target=reconfigure, args=([0, 2, 3], 1))
+    second = threading.Thread(target=reconfigure, args=([0, 2], 2))
     first.start()
     assert first_entered_native.wait(timeout=5)
     second.start()
@@ -348,7 +488,7 @@ def test_concurrent_nested_reinit_requests_commit_newest_membership():
     assert not first.is_alive()
     assert not second.is_alive()
     assert errors == []
-    assert calls == [([0, 2, 3], 1), ([0, 2], 1)]
+    assert calls == [([0, 2, 3], 3), ([0, 2], 4)]
     assert pp_comm.get_active_ranks() == [0, 2]
 
 
@@ -520,8 +660,14 @@ def test_init_pp_comm_reuses_compatible_nccl_communicator(monkeypatch):
             self.topology = (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
             created.append(self)
 
+        def is_native_compatible(self, mapping):
+            return self.topology[:2] == (mapping.world_size, mapping.rank)
+
         def is_compatible(self, mapping):
             return self.topology == (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
+
+        def rebind(self, mapping):
+            self.topology = (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
 
     monkeypatch.setattr(communicator_module, "PPCommNCCL", FakePPComm)
     monkeypatch.setattr(communicator_module, "_pp_comm", None)
@@ -568,6 +714,7 @@ def test_ft_wrapper_churn_preserves_completed_recovery_generation(monkeypatch):
 def test_init_pp_comm_rejects_incompatible_live_topology(monkeypatch):
     existing = _make_pp_comm()
     monkeypatch.setattr(communicator_module, "_pp_comm", existing)
+    monkeypatch.setattr(communicator_module, "_pp_comm_refcount", 1)
     monkeypatch.setattr(communicator_module, "mpi_disabled", lambda: False)
     monkeypatch.setattr(communicator_module, "init_helix_cp_comm", lambda mapping: None)
 
@@ -581,6 +728,7 @@ def test_init_pp_comm_rejects_incompatible_live_topology(monkeypatch):
 def test_init_pp_comm_rejects_incompatible_live_helix_topology(monkeypatch):
     existing = _make_pp_comm(_HelixMapping())
     monkeypatch.setattr(communicator_module, "_pp_comm", existing)
+    monkeypatch.setattr(communicator_module, "_pp_comm_refcount", 1)
     monkeypatch.setattr(communicator_module, "mpi_disabled", lambda: False)
 
     with pytest.raises(RuntimeError, match="Helix MNNVL CP topology"):
@@ -617,10 +765,21 @@ def test_final_release_preserves_helix_comm_topology(monkeypatch):
 
     class FakePPComm:
         def __init__(self, mapping):
+            self.mapping = mapping
             self.topology = original_pp_comm_class._mapping_topology(mapping)
+
+        def is_native_compatible(self, mapping):
+            return self.topology[:2] == (
+                int(mapping.world_size),
+                int(mapping.rank),
+            )
 
         def is_compatible(self, mapping):
             return self.topology == original_pp_comm_class._mapping_topology(mapping)
+
+        def rebind(self, mapping):
+            self.mapping = mapping
+            self.topology = original_pp_comm_class._mapping_topology(mapping)
 
     monkeypatch.setattr(mnnvl_module, "mpi_comm", lambda: FakeMpiComm())
     monkeypatch.setattr(communicator_module, "PPCommNCCL", FakePPComm)
@@ -633,27 +792,40 @@ def test_final_release_preserves_helix_comm_topology(monkeypatch):
     communicator_module.release_pp_comm()
     communicator_module.init_pp_comm(_HelixMapping())
     communicator_module.release_pp_comm()
+    pp_comm = communicator_module._pp_comm
+    old_mapping = pp_comm.mapping
+    old_topology = pp_comm.topology
 
-    # A later engine may create a fresh PP wrapper, but it cannot reinterpret
-    # the process-lifetime Helix MPI communicator with a different CP group.
+    # A later engine cannot reinterpret either process-lifetime communicator
+    # with a different CP group. A failed refresh must be transactional.
     with pytest.raises(RuntimeError, match="cannot reuse.*incompatible topology"):
         communicator_module.init_pp_comm(_OtherHelixMapping())
 
     assert split_calls == [(0, 1)]
-    assert communicator_module._pp_comm is None
+    assert communicator_module._pp_comm is pp_comm
+    assert pp_comm.mapping is old_mapping
+    assert pp_comm.topology == old_topology
     assert communicator_module._pp_comm_refcount == 0
 
 
-def test_default_off_final_release_allows_a_later_incompatible_topology(monkeypatch):
+def test_default_off_final_release_reuses_native_comm_with_new_pp_topology(monkeypatch):
     created = []
 
     class FakePPComm:
         def __init__(self, mapping):
+            self.mapping = mapping
             self.topology = (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
             created.append(self.topology)
 
+        def is_native_compatible(self, mapping):
+            return self.topology[:2] == (mapping.world_size, mapping.rank)
+
         def is_compatible(self, mapping):
             return self.topology == (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
+
+        def rebind(self, mapping):
+            self.mapping = mapping
+            self.topology = (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
 
     class OtherMapping(_FakeMapping):
         pp_group = [0, 2]
@@ -664,12 +836,64 @@ def test_default_off_final_release_allows_a_later_incompatible_topology(monkeypa
     monkeypatch.setattr(communicator_module, "init_helix_cp_comm", lambda mapping: None)
 
     communicator_module.init_pp_comm(_FakeMapping())
+    pp_comm = communicator_module._pp_comm
     communicator_module.release_pp_comm()
-    assert communicator_module._pp_comm is None
-    communicator_module.init_pp_comm(OtherMapping())
+    assert communicator_module._pp_comm is pp_comm
+    other_mapping = OtherMapping()
+    communicator_module.init_pp_comm(other_mapping)
 
-    assert len(created) == 2
-    assert created[0] != created[1]
+    assert communicator_module._pp_comm is pp_comm
+    assert pp_comm.mapping is other_mapping
+    assert pp_comm.topology == (4, 2, (0, 2))
+    assert len(created) == 1
+
+
+def test_initial_helix_failure_preserves_process_lifetime_nccl_wrapper(monkeypatch):
+    created = []
+
+    class FakePPComm:
+        def __init__(self, mapping):
+            self.mapping = mapping
+            self.topology = (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
+            created.append(self)
+
+        def is_native_compatible(self, mapping):
+            return self.topology[:2] == (mapping.world_size, mapping.rank)
+
+        def is_compatible(self, mapping):
+            return self.topology == (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
+
+        def rebind(self, mapping):
+            self.mapping = mapping
+            self.topology = (mapping.world_size, mapping.rank, tuple(mapping.pp_group))
+
+    helix_attempts = 0
+
+    def fail_first_helix_attempt(mapping):
+        nonlocal helix_attempts
+        helix_attempts += 1
+        if helix_attempts == 1:
+            raise RuntimeError("injected Helix initialization failure")
+
+    monkeypatch.setattr(communicator_module, "PPCommNCCL", FakePPComm)
+    monkeypatch.setattr(communicator_module, "NCCL_FAULT_TOLERANCE_ENABLED", False)
+    monkeypatch.setattr(communicator_module, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(communicator_module, "init_helix_cp_comm", fail_first_helix_attempt)
+
+    mapping = _FakeMapping()
+    with pytest.raises(RuntimeError, match="injected Helix initialization failure"):
+        communicator_module.init_pp_comm(mapping)
+
+    pp_comm = communicator_module._pp_comm
+    assert pp_comm is created[0]
+    assert communicator_module._pp_comm_refcount == 0
+
+    communicator_module.init_pp_comm(mapping)
+
+    assert communicator_module._pp_comm is pp_comm
+    assert communicator_module._pp_comm_refcount == 1
+    assert len(created) == 1
+    assert helix_attempts == 2
 
 
 def test_model_engine_cleanup_releases_pp_before_reporting_ub_failure(monkeypatch):


### PR DESCRIPTION
@coderabbitai summary

## Description

Implements WideEP fault-tolerance plan item 1a.7: an opt-in NCCL fault-tolerance wrapper for raw TRT-LLM collectives and pipeline-parallel communication.

Today, a failed rank leaves survivor NCCL communicators containing the dead rank. Subsequent TP, CP, PP, or AllGather/ReduceScatter traffic can hang or terminate the surviving processes, and rebuilding a communicator needs a failure-safe way to exchange a fresh NCCL unique ID without consulting the poisoned parent MPI session.

This PR:

- adds tracked asynchronous NCCL operations, async-error polling, bounded operation timeouts, communicator abort, and survivor-only reinitialization;
- adds a dedicated pre-failure MPI control communicator and generation-aware NCCL unique-ID rendezvous, including stale-message reclamation and retry isolation;
- wires recovery through raw allreduce/allgather/alltoall/reduce-scatter, CP attention, PP `NcclCommunicator`, and the AllGatherReduceScatter Python backend;
- keeps fault tolerance disabled by default and preserves the existing synchronous/default-off behavior;
- maintains process-lifetime PP communicator state so wrapper churn cannot abort a communicator still used by peers or reuse an old recovery generation;
- rejects CUDA graph capture while the opt-in recovery path is active; graph invalidation and background recapture remain scoped to plan item 1a.11.

Design context: https://github.com/chienchunhung/TensorRT-LLM/tree/docs-and-plans/docs/design/wide-ep-fault-tolerance

## Test Coverage

Added coverage for:

- generation-isolated and bounded unique-ID rendezvous, including 4,097 stale attempts;
- communicator watchdog lifecycle, timeout classification, graph-capture rejection, and default-off behavior;
- raw communicator rebuild followed by a real NCCL allreduce;
- PP communicator rebuild followed by real NCCL send/receive;
- an opt-in destructive three-rank test that exits one process, rebuilds the production raw communicator for survivors, and verifies a post-recovery NCCL allreduce;
- Python raw-communicator registry behavior, recovery generation allocation, PP wrapper lifetime, engine integration, and AllGatherReduceScatter recovery.

Local checks completed:

- `git diff --check upstream/main`
- repository-pinned `clang-format --dry-run --Werror`
- repository-pinned `cmake-format --check`
- Ruff formatting and linting for modern Python files
- isort, YAPF, autoflake, and legacy Ruff checks for legacy Python files
- Python syntax compilation
- standalone recovery-generation registry smoke test

Full Python pytest collection was unavailable in the local workspace because PyTorch is not installed. Native CUDA/NCCL/MPI execution was also unavailable locally; the corresponding tests are included for GPU CI, with the destructive process-death case disabled unless explicitly configured with fault-tolerant MPI launcher flags.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

## Corrected integration contract (2026-06-30)

This draft PR is a **manual, generation-scoped NCCL recovery primitive**. The recovery coordinator supplies the survivor set and generation; this PR aborts/rebuilds the supported raw communicator paths and publishes native membership only after rebuild succeeds.

Hard logical integration dependencies:

- #15785 / 1c.3 for failure-notification evidence;
- 1c.3a for the survivor `ActiveRankMap` and ordinary control membership;
- 1c.4b for detect → failed-epoch abort → admission/quiesce → EPLB/control/NCCL prepare → atomic mask+generation commit → resume;
- promoted 1a.11 for stale CUDA-graph invalidation and eager fallback.

Explicit non-goals of this PR:

- no detector callback wiring or detected-to-committed state transition;
- no EPLB/mask atomic commit;
- no degraded attention-DP/PyExecutor MPI membership;
- no failed-request disposition;
- no remapping of unsupported static TP/CP/PP sharding (fail closed);
- no full-N replacement-rank process-group lifecycle.

The destructive process-death native test is opt-in; standard CI coverage must not be described as proving the complete production E2E path. That proof belongs to 1d.4 and 1d.4a.

Canonical plan: https://github.com/chienchunhung/TensorRT-LLM/blob/docs-and-plans/docs/design/wide-ep-fault-tolerance/pr-execution/08-implementation-plan.md
