### PR TITLE
[None][fix] Disable tinygemm2 kernel by default

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -19,7 +19,7 @@ import torch
 
 from tensorrt_llm._torch.distributed.moe_alltoall import MoeAlltoAll
 from tensorrt_llm._torch.modules.fused_moe.routing import RoutingMethodType
-from tensorrt_llm._utils import get_sm_version
+from tensorrt_llm._utils import get_sm_version, is_tinygemm2_disabled
 from tensorrt_llm.mapping import Mapping
 
 from ..._compat import ActivationType, is_sm_100f
@@ -44,7 +44,8 @@ def _router_use_tinygemm(x2d: torch.Tensor, weight: torch.Tensor, bias) -> bool:
     # tinygemm2 only supports these SM archs (see thop/tinygemm2.cpp).
     _TINYGEMM_SM = (90, 100, 103)
     return (
-        bias is not None
+        not is_tinygemm2_disabled()  # off by default (TLLM_DISABLE_TINYGEMM2); falls back to F.linear
+        and bias is not None
         and get_sm_version() in _TINYGEMM_SM
         and x2d.shape[0] <= _MIN_LATENCY_TINYGEMM_NUM_TOKENS
         and x2d.dtype == torch.bfloat16

--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -6,7 +6,8 @@ from torch.nn.parameter import Parameter
 from tqdm import tqdm
 from transformers import GptOssConfig
 
-from tensorrt_llm._utils import get_hf_rope_theta, get_sm_version
+from tensorrt_llm._utils import (get_hf_rope_theta, get_sm_version,
+                                 is_tinygemm2_disabled)
 from tensorrt_llm.functional import PositionEmbeddingType, RotaryScalingType
 
 from ..attention_backend import AttentionMetadata
@@ -210,7 +211,9 @@ class MLPBlock(torch.nn.Module):
                             x: torch.Tensor,
                             lora_params: Optional[dict] = None) -> torch.Tensor:
         # Skip tinygemm2 optimization when LoRA is active (tinygemm2 doesn't support LoRA)
-        use_tinygemm = (get_sm_version() in [90, 100, 103]
+        # tinygemm2 is disabled by default (TLLM_DISABLE_TINYGEMM2); falls back to self.gate.
+        use_tinygemm = (not is_tinygemm2_disabled()
+                        and get_sm_version() in [90, 100, 103]
                         and x.shape[0] <= MIN_LATENCY_TINYGEMM_NUM_TOKENS
                         and (lora_params is None or not bool(lora_params)))
 

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -590,6 +590,16 @@ def mpi_disabled() -> bool:
     return os.environ.get("TLLM_DISABLE_MPI") == "1"
 
 
+def is_tinygemm2_disabled() -> bool:
+    """True if the tinygemm2 kernel (gpt-oss small-M router GEMM) is disabled.
+
+    tinygemm2 is disabled by default; set ``TLLM_DISABLE_TINYGEMM2=0`` to re-enable
+    it. When disabled, every dispatch site falls back to its standard GEMM path
+    (cuBLAS / ``F.linear``), so there is no functional change beyond kernel choice.
+    """
+    return os.environ.get("TLLM_DISABLE_TINYGEMM2", "1") == "1"
+
+
 def mpi_rank():
     if mpi_disabled():
         try:


### PR DESCRIPTION
The tinygemm2 small-M router GEMM (gpt-oss) is now disabled by default and gated behind the TLLM_DISABLE_TINYGEMM2 env var (default "1" = disabled; set to "0" to re-enable). Both dispatch sites — MLPBlock.compute_gate_output in modeling_gpt_oss.py and _router_use_tinygemm in the auto_deploy trtllm_moe custom op — now consult is_tinygemm2_disabled() and fall back to their standard GEMM path (self.gate / F.linear) when disabled. No functional change beyond kernel selection.

Reason: https://github.com/NVIDIA/TensorRT-LLM/pull/15729 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new environment-based setting to disable a specific optimization at runtime.
* **Bug Fixes**
  * Improved safeguards so the optimization is only used when supported and not explicitly turned off.
  * Tightened routing behavior to avoid enabling the faster path in unsupported cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
