### PR TITLE
[https://nvbugs/6215107][fix] Namespace cnn_dailymail repo id in load_calib_dataset

### DIFF
--- a/tensorrt_llm/models/convert_utils.py
+++ b/tensorrt_llm/models/convert_utils.py
@@ -317,6 +317,11 @@ def load_calib_dataset(dataset_name_or_dir: str,
                     key = meta[2]
                 break
 
+    # Bare "cnn_dailymail" id is rejected by newer huggingface_hub, which
+    # requires a "namespace/name" repo id; use the namespaced repo instead.
+    if dataset_name_or_dir == "cnn_dailymail":
+        dataset_name_or_dir = "abisee/cnn_dailymail"
+
     dataset = load_dataset(dataset_name_or_dir,
                            name=config_name,
                            split=split,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset loading compatibility by recognizing the `cnn_dailymail` dataset name in its newer namespaced form, helping avoid load failures with updated Hugging Face requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Newer `huggingface_hub` releases reject the legacy *bare* `cnn_dailymail`
dataset id and raise:

```
huggingface_hub.errors.HfUriError: Invalid HF URI
'hf://datasets/cnn_dailymail@.../.huggingface.yaml'.
Repository id must be 'namespace/name', got 'cnn_dailymail'.
```

The ModelOpt calibration path (`quantize_by_modelopt.get_calib_dataloader` /
`get_nemo_calib_dataloader`) was already fixed to rewrite the bare id to the
namespaced `abisee/cnn_dailymail` repo (#14930). However,
`tensorrt_llm/models/convert_utils.py::load_calib_dataset` — the calibration
dataset loader used by the TensorRT-backend `convert.py` scripts (llama, gpt,
qwen, chatglm, baichuan, bert, gemma, …), which all default `calib_dataset`
to `cnn_dailymail` — still forwarded the bare id straight to
`datasets.load_dataset()` and hit the same `HfUriError`.

This PR closes that remaining gap: `load_calib_dataset` now rewrites the bare
`cnn_dailymail` id to the namespaced `abisee/cnn_dailymail` repo before
loading, mirroring the existing ModelOpt fix. Already-namespaced ids (e.g.
`ccdv/cnn_dailymail`) and local dataset directories are unaffected.

NVBug: https://nvbugs/6215107

## Test Coverage

The change mirrors the already-merged ModelOpt fix (#14930) for the identical
root cause. It is exercised by the existing Triton-backend FP8 quantization
tests that originally hit the `HfUriError`, e.g.:

- `triton_server/test_triton_llm.py::test_llama_v3_speculative_decoding_bls`
- `triton_server/test_triton_rcca.py::test_rcca_bug_4714193`

as well as any TensorRT-backend `convert.py` calibration run that uses the
default `--calib_dataset cnn_dailymail`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
