### PR TITLE
[TRTLLM-11608][feat] Add chunked KV transfer and early release for C++ transceiver

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -273,10 +273,22 @@ public:
 
     virtual bool cancelRequest(std::shared_ptr<LlmRequest> llmRequest) override;
 
+    [[nodiscard]] std::optional<SizeType32> getTransferChunkSizeBlocks() const noexcept
+    {
+        return mCacheState == nullptr ? std::nullopt : mCacheState->getTransferChunkSizeBlocks();
+    }
+
+    [[nodiscard]] bool isTransferEarlyReleaseEnabled() const noexcept
+    {
+        return mEnableTransferEarlyRelease;
+    }
+
 private:
     void initializeCommState();
 
     void setContextState(LlmRequest* llmRequest);
+
+    void endTransferLease(LlmRequest::RequestIdType requestId);
 
     std::unique_ptr<CacheSender> mCacheSender;
     std::unique_ptr<CacheReceiver> mCacheReceiver;
@@ -302,6 +314,10 @@ private:
     executor::kv_cache::CommState const* mCommState;
     std::unique_ptr<executor::kv_cache::CacheState> mCacheState;
     std::unique_ptr<executor::kv_cache::ConnectionManager> mManager;
+    // Non-owning; the executor's KV-cache manager outlives the transceiver.
+    kv_cache_manager::BaseKVCacheManager* mCacheManager{nullptr};
+    bool mEnableTransferEarlyRelease{false};
+    std::unordered_set<LlmRequest::RequestIdType> mActiveTransferLeaseIds;
     std::optional<executor::CacheTransceiverConfig> mCacheTransceiverConfig;
     std::vector<std::unique_ptr<kv_cache_manager::CacheTransBufferManager>> mCacheTransBufferManagers;
     std::vector<BaseTransBufferManager*> mCacheTransBufferManagerPtrs;

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <deque>
 #include <limits>
 #include <list>
 #include <memory>
@@ -46,6 +47,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -574,6 +576,11 @@ private:
     size_t mHash;
 };
 
+//! \brief Window-qualified KV-cache block IDs owned by a transfer lease.
+//! \details Block IDs are scoped to a WindowBlockManager, so the window-size key is required even for
+//! single-window models. Each vector preserves the sequence allocation order and contains each real block once.
+using TransferBlockIds = std::unordered_map<WindowSizeType, std::vector<KVCacheBlock::IdType>>;
+
 class GenerationRequest
 {
 public:
@@ -984,6 +991,13 @@ public:
     //! \brief Pin blocks associated with a sequence to prevent eviction.
     void pinBlocks(GenerationRequest& sequence);
 
+    //! \brief Pin every distinct, non-placeholder block allocated to a sequence exactly once.
+    //! \return Block IDs in allocation order.
+    [[nodiscard]] std::vector<KVCacheBlock::IdType> pinBlocksForTransferLease(GenerationRequest& sequence);
+
+    //! \brief Release exact block pins previously acquired for a transfer lease.
+    void unpinBlocksForTransferLease(std::vector<KVCacheBlock::IdType> const& blockIds);
+
     //! \brief Release blocks of the sequence.
     //! \details When llmRequest is provided and reuse is enabled, blocks will be stored.
     std::optional<KVCacheBlock::IdType> releaseBlocks(
@@ -1231,6 +1245,11 @@ public:
     [[nodiscard]] bool isEnablePartialReuse() const
     {
         return mEnablePartialReuse;
+    }
+
+    [[nodiscard]] bool hasKVCacheConnector() const noexcept
+    {
+        return mKvCacheConnectorManager != nullptr;
     }
 
     [[nodiscard]] std::shared_ptr<KVCacheBlock> findBlocksInReuseTreeByBlockKey(BlockKey const& blockKey);
@@ -1535,11 +1554,21 @@ public:
     [[nodiscard]] std::vector<KVCacheBlock::IdType> storeBlocksForReuse(
         GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest = std::nullopt, bool pinBlocks = false);
 
+    //! \brief Store blocks using the same eligibility rules as releaseBlocks, without releasing sequence ownership.
+    void storeBlocksForTransferLease(
+        GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest = std::nullopt);
+
     void schedulingReleaseBlocks(LlmRequest::RequestIdType requestId);
 
     /// @brief Pin all blocks associated with a sequence across all window managers.
     /// @param sequence The generation request whose blocks should be pinned.
     void pinBlocks(GenerationRequest& sequence);
+
+    //! \brief Pin every distinct, non-placeholder block once and return window-qualified IDs.
+    [[nodiscard]] TransferBlockIds pinBlocksForTransferLease(GenerationRequest& sequence);
+
+    //! \brief Release window-qualified pins previously acquired for a transfer lease.
+    void unpinBlocksForTransferLease(TransferBlockIds const& blockIds);
 
     void unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds);
 
@@ -1770,6 +1799,12 @@ public:
     [[nodiscard]] bool isVariableWindow() const noexcept
     {
         return mIsVariableWindow;
+    }
+
+    [[nodiscard]] bool hasKVCacheConnector() const noexcept
+    {
+        return std::any_of(mWindowBlockManagers.begin(), mWindowBlockManagers.end(),
+            [](auto const& entry) { return entry.second.hasKVCacheConnector(); });
     }
 
     [[nodiscard]] SizeType32 getMaxBlockPerSeqWhenSingleWindowSize() const
@@ -2011,6 +2046,55 @@ public:
     /// @brief Pin blocks associated with a request to prevent eviction.
     /// @param requestId The ID of the request whose blocks should be pinned.
     virtual void pinBlocks(LlmRequest::RequestIdType requestId) = 0;
+
+    //! \brief Whether this manager can transfer sequence ownership to exact, window-qualified leases.
+    [[nodiscard]] virtual bool supportsTransferLeases() const noexcept
+    {
+        return false;
+    }
+
+    //! \brief Make a transfer lease the owner of a request's real allocated blocks and detach the sequence.
+    //! \param requestId Request whose KV blocks should be leased.
+    //! \param llmRequest Optional request metadata used to store reusable blocks before detaching the sequence.
+    virtual void beginTransferLease(
+        LlmRequest::RequestIdType requestId, OptionalRef<LlmRequest const> llmRequest = std::nullopt)
+    {
+        static_cast<void>(requestId);
+        static_cast<void>(llmRequest);
+        TLLM_THROW("Transfer leases are not supported by this KV cache manager.");
+    }
+
+    //! \brief Return the full ordered, window-qualified block set for an active transfer lease.
+    [[nodiscard]] virtual std::optional<TransferBlockIds> getTransferLeaseBlockIds(
+        LlmRequest::RequestIdType requestId) const
+    {
+        static_cast<void>(requestId);
+        return std::nullopt;
+    }
+
+    //! \brief Whether an exact transfer lease currently owns this request's blocks.
+    [[nodiscard]] virtual bool hasActiveTransferLease(LlmRequest::RequestIdType requestId) const
+    {
+        static_cast<void>(requestId);
+        return false;
+    }
+
+    //! \brief Queue transferred block IDs for later release on the KV-cache manager's caller thread.
+    virtual void enqueueTransferLeaseRelease(LlmRequest::RequestIdType requestId, TransferBlockIds blockIds)
+    {
+        static_cast<void>(requestId);
+        static_cast<void>(blockIds);
+        TLLM_THROW("Transfer leases are not supported by this KV cache manager.");
+    }
+
+    //! \brief Apply queued transfer-lease releases. Must be called from the KV-cache manager's caller thread.
+    virtual void drainTransferLeaseReleases() {}
+
+    //! \brief End a lease and release every lease-owned block that has not already been drained.
+    virtual void endTransferLease(LlmRequest::RequestIdType requestId)
+    {
+        static_cast<void>(requestId);
+    }
 
     /// @brief Increase size for request at seqSlotIdx. Allocate new KV cache block(s) if needed.
     virtual void addToken(LlmRequest::RequestIdType requestId) = 0;
@@ -2552,6 +2636,25 @@ public:
 
     void pinBlocks(LlmRequest::RequestIdType requestId) override;
 
+    [[nodiscard]] bool supportsTransferLeases() const noexcept override
+    {
+        return true;
+    }
+
+    void beginTransferLease(
+        LlmRequest::RequestIdType requestId, OptionalRef<LlmRequest const> llmRequest = std::nullopt) override;
+
+    [[nodiscard]] std::optional<TransferBlockIds> getTransferLeaseBlockIds(
+        LlmRequest::RequestIdType requestId) const override;
+
+    [[nodiscard]] bool hasActiveTransferLease(LlmRequest::RequestIdType requestId) const override;
+
+    void enqueueTransferLeaseRelease(LlmRequest::RequestIdType requestId, TransferBlockIds blockIds) override;
+
+    void drainTransferLeaseReleases() override;
+
+    void endTransferLease(LlmRequest::RequestIdType requestId) override;
+
     void unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds) override;
 
     [[nodiscard]] executor::RetentionPriority getPriorityByBlockId(
@@ -2642,6 +2745,12 @@ public:
     void truncateBlocks(LlmRequest::VecTokens const& targetTokens, SizeType32 numTokensToKeep) override;
 
 private:
+    struct TransferLeaseState
+    {
+        TransferBlockIds blockIds;
+        std::unordered_map<WindowSizeType, std::unordered_set<KVCacheBlock::IdType>> remainingBlockIds;
+    };
+
     // Maximum number of sequences
     SizeType32 mMaxNumSequences;
     // Maximum beam width
@@ -2665,6 +2774,10 @@ private:
     bool mEnableBlockReuse;
     // Mutex to protect access to mSequences
     mutable std::mutex mSequencesMtx;
+    // Active transfer leases and the worker-to-main-thread release queue.
+    std::unordered_map<LlmRequest::RequestIdType, TransferLeaseState> mTransferLeases;
+    std::deque<std::pair<LlmRequest::RequestIdType, TransferBlockIds>> mPendingTransferLeaseReleases;
+    mutable std::mutex mTransferLeaseMtx;
     // buffers for static tensors, will be created after allocating pools
     runtime::ITensor::SharedPtr mBlockPoolPointers;
     runtime::ITensor::SharedPtr mLayerToPoolMapping;

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,76 @@
 #include "tensorrt_llm/batch_manager/kvCacheManager.h"
 #include "tensorrt_llm/runtime/iTensor.h"
 
+#include <cstddef>
+#include <unordered_set>
+
 namespace tensorrt_llm::batch_manager::kv_cache_manager
 {
 
 class BlockIterator;
+
+//! \brief Select the requested suffix from a single-window transfer lease while preserving allocation order.
+inline TransferBlockIds selectTransferLeaseTail(TransferBlockIds const& leasedBlockIds, int32_t indexFromEnd)
+{
+    TLLM_CHECK_WITH_INFO(
+        leasedBlockIds.size() == 1, "Transfer-lease tail selection currently requires exactly one cache window.");
+    TLLM_CHECK_WITH_INFO(indexFromEnd >= 0, "Requested KV-cache block index must be non-negative.");
+    auto const& [windowSize, orderedBlockIds] = *leasedBlockIds.begin();
+    auto const requestedBlockCount = static_cast<size_t>(indexFromEnd) + 1;
+    TLLM_CHECK_WITH_INFO(requestedBlockCount <= orderedBlockIds.size(),
+        "Requested %zu KV-cache blocks from a lease containing only %zu blocks.", requestedBlockCount,
+        orderedBlockIds.size());
+
+    TransferBlockIds requestedBlockIds;
+    requestedBlockIds.emplace(windowSize,
+        std::vector<KVCacheBlock::IdType>(
+            orderedBlockIds.end() - static_cast<std::ptrdiff_t>(requestedBlockCount), orderedBlockIds.end()));
+    return requestedBlockIds;
+}
+
+//! \brief Return lease-owned blocks that are absent from the selected transfer set, preserving lease order.
+inline TransferBlockIds getUntransferredLeaseBlockIds(
+    TransferBlockIds const& leasedBlockIds, TransferBlockIds const& selectedBlockIds)
+{
+    std::unordered_map<WindowSizeType, std::unordered_set<KVCacheBlock::IdType>> selectedBlockIdSets;
+    for (auto const& [windowSize, windowBlockIds] : selectedBlockIds)
+    {
+        auto const leaseWindowIt = leasedBlockIds.find(windowSize);
+        TLLM_CHECK_WITH_INFO(leaseWindowIt != leasedBlockIds.end(),
+            "Transferred KV-cache window %d is absent from the lease.", windowSize);
+        std::unordered_set<KVCacheBlock::IdType> const leaseWindowBlockIds(
+            leaseWindowIt->second.begin(), leaseWindowIt->second.end());
+        auto& selectedForWindow = selectedBlockIdSets[windowSize];
+        selectedForWindow.reserve(windowBlockIds.size());
+        for (auto const blockId : windowBlockIds)
+        {
+            TLLM_CHECK_WITH_INFO(leaseWindowBlockIds.find(blockId) != leaseWindowBlockIds.end(),
+                "Transferred KV-cache block %d in window %d is absent from the lease.", blockId, windowSize);
+            selectedForWindow.insert(blockId);
+        }
+    }
+
+    TransferBlockIds untransferredBlockIds;
+    for (auto const& [windowSize, windowBlockIds] : leasedBlockIds)
+    {
+        auto const selectedWindowIt = selectedBlockIdSets.find(windowSize);
+        auto& untransferredForWindow = untransferredBlockIds[windowSize];
+        untransferredForWindow.reserve(windowBlockIds.size());
+        for (auto const blockId : windowBlockIds)
+        {
+            if (selectedWindowIt == selectedBlockIdSets.end()
+                || selectedWindowIt->second.find(blockId) == selectedWindowIt->second.end())
+            {
+                untransferredForWindow.push_back(blockId);
+            }
+        }
+        if (untransferredForWindow.empty())
+        {
+            untransferredBlockIds.erase(windowSize);
+        }
+    }
+    return untransferredBlockIds;
+}
 
 class BlockRangeForWindow
 {
@@ -67,6 +133,12 @@ public:
     {
 
         return BlockRange(cacheManager, requestId);
+    }
+
+    static BlockRange fromBlockIds(
+        BaseKVCacheManager const& cacheManager, TransferBlockIds blockIds, LlmRequest::RequestIdType requestId)
+    {
+        return BlockRange(cacheManager, std::move(blockIds), requestId);
     }
 
     static BlockRange fromReuseTree(

--- a/cpp/include/tensorrt_llm/executor/dataTransceiverState.h
+++ b/cpp/include/tensorrt_llm/executor/dataTransceiverState.h
@@ -119,7 +119,8 @@ public:
             && mEnablePartialReuse == other.mEnablePartialReuse && mHasIndexerKCache == other.mHasIndexerKCache
             && mIndexerDimPerHead == other.mIndexerDimPerHead
             && mIndexerKCacheQuantBlockSize == other.mIndexerKCacheQuantBlockSize
-            && mIndexerKCacheUseFp4 == other.mIndexerKCacheUseFp4;
+            && mIndexerKCacheUseFp4 == other.mIndexerKCacheUseFp4
+            && mTransferChunkSizeBlocks == other.mTransferChunkSizeBlocks;
     }
 
     struct ModelConfig
@@ -298,6 +299,18 @@ public:
         return mIndexerKCacheUseFp4;
     }
 
+    [[nodiscard]] std::optional<SizeType32> getTransferChunkSizeBlocks() const noexcept
+    {
+        return mTransferChunkSizeBlocks;
+    }
+
+    void setTransferChunkSizeBlocks(std::optional<SizeType32> transferChunkSizeBlocks)
+    {
+        TLLM_CHECK_WITH_INFO(!transferChunkSizeBlocks.has_value() || transferChunkSizeBlocks.value() > 0,
+            "KV-cache transfer chunk size must be positive when set.");
+        mTransferChunkSizeBlocks = transferChunkSizeBlocks;
+    }
+
     // =========================================================================
     // RNN/Mamba cache state (optional, present only for hybrid models)
     // =========================================================================
@@ -360,6 +373,9 @@ public:
         sstring << "indexerDimPerHead:" << mIndexerDimPerHead << "\n";
         sstring << "indexerKCacheQuantBlockSize:" << mIndexerKCacheQuantBlockSize << "\n";
         sstring << "indexerKCacheUseFp4:" << mIndexerKCacheUseFp4 << "\n";
+        sstring << "transferChunkSizeBlocks:"
+                << (mTransferChunkSizeBlocks.has_value() ? std::to_string(mTransferChunkSizeBlocks.value()) : "off")
+                << "\n";
         if (mRnnCacheState.has_value())
         {
             auto const& rnn = mRnnCacheState.value();
@@ -403,6 +419,7 @@ private:
     SizeType32 mIndexerDimPerHead{0};
     SizeType32 mIndexerKCacheQuantBlockSize{128};
     bool mIndexerKCacheUseFp4{false};
+    std::optional<SizeType32> mTransferChunkSizeBlocks;
     // RNN/Mamba cache state (optional, for hybrid models)
     std::optional<RnnCacheState> mRnnCacheState;
 };

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,21 @@ std::optional<int> BaseTransBufferManager::assignBufferIndexForRecv()
 void BaseTransBufferManager::freeBufferIndexForRecv(std::optional<int> bufferId)
 {
     freeBufferIndex(mConcurrenceRecvResource, bufferId, mRecvBufferCount, mOnlyUseDynamicBuffer);
+}
+
+void BaseTransBufferManager::abortRecvBufferAssignments()
+{
+    {
+        std::scoped_lock lk(mConcurrenceRecvResource.mBuffersMutex);
+        mConcurrenceRecvResource.mAssignmentsAborted = true;
+    }
+    mConcurrenceRecvResource.mBuffersCV.notify_all();
+}
+
+bool BaseTransBufferManager::areRecvBufferAssignmentsAborted()
+{
+    std::scoped_lock lk(mConcurrenceRecvResource.mBuffersMutex);
+    return mConcurrenceRecvResource.mAssignmentsAborted;
 }
 
 std::tuple<std::vector<runtime::ITensor::SharedPtr>, size_t, bool> BaseTransBufferManager::getOrAllocateSendBuffers(
@@ -257,8 +272,11 @@ std::optional<int> BaseTransBufferManager::assignBufferIndex(
         return std::nullopt;
     }
     std::unique_lock lk(resource.mBuffersMutex);
-    resource.mBuffersCV.wait(
-        lk, [&resource, bufferCount]() { return static_cast<size_t>(resource.mConcurrence) < bufferCount; });
+    resource.mBuffersCV.wait(lk,
+        [&resource, bufferCount]()
+        { return resource.mAssignmentsAborted || static_cast<size_t>(resource.mConcurrence) < bufferCount; });
+    TLLM_CHECK_WITH_INFO(!resource.mAssignmentsAborted,
+        "KV-cache receive-buffer assignments were aborted after a published buffer was quarantined.");
     int bufferId = -1;
     for (size_t i = 0; i < bufferCount; i++)
     {

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -153,6 +153,13 @@ public:
     /// @param bufferId The buffer index to free.
     void freeBufferIndexForRecv(std::optional<int> bufferId);
 
+    /// @brief Permanently fail current and future receive-buffer assignments.
+    /// @details Used after a published one-sided-write destination must be quarantined.
+    void abortRecvBufferAssignments();
+
+    /// @brief Return whether receive-buffer assignment has been permanently aborted.
+    bool areRecvBufferAssignmentsAborted();
+
     /// @brief Get or allocate send buffers for cache transfer.
     /// @param bufferId The assigned buffer ID.
     /// @param targetNum Number of target sequences.
@@ -206,6 +213,7 @@ protected:
         std::mutex mBuffersMutex;
         std::condition_variable mBuffersCV;
         std::atomic<int> mConcurrence{0};
+        bool mAssignmentsAborted{false};
     };
 
     std::tuple<std::vector<runtime::ITensor::SharedPtr>, size_t, bool> getOrAllocateBuffers(std::optional<int> bufferId,

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -36,8 +36,12 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <future>
+#include <limits>
+#include <memory>
 #include <numeric>
+#include <string_view>
 
 namespace tensorrt_llm::batch_manager
 {
@@ -178,6 +182,249 @@ void sendAllBuffers(TransferSession& session, int deviceId,
             targetInfo, pickUpConnections);
     }
 }
+
+enum class ChunkControl : uint8_t
+{
+    kAbort = 0,
+    kReceiverEntered = 1,
+    kReceiverReady = 2,
+    kSenderPrepared = 3,
+    kSenderProceed = 4,
+    kChunkComplete = 5,
+    kReceiverFinished = 6,
+    kSenderDone = 7,
+};
+
+constexpr uint8_t kChunkControlBitCount{3};
+
+executor::kv_cache::DataContext getChunkControlContext(TransferSession const& session)
+{
+    auto const& dataContext = session.getDataContext();
+    // Request data tags reserve the low byte for a channel discriminator (the data
+    // channel uses 43). The adjacent tag therefore remains request-scoped while
+    // keeping control messages out of the payload stream for MPI and UCX.
+    return executor::kv_cache::DataContext{dataContext.getTag() + 1, dataContext.getTransferTerminate()};
+}
+
+void sendChunkControl(
+    TransferSession const& session, std::vector<size_t> const& pickUpConnections, ChunkControl control)
+{
+    auto const controlContext = getChunkControlContext(session);
+    auto const& connections = session.getConnections();
+    auto const encodedControl = static_cast<uint8_t>(control);
+    for (auto const connectionIdx : pickUpConnections)
+    {
+        auto const* connection = connections.at(connectionIdx);
+        auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection);
+        if (agentConnection != nullptr)
+        {
+            // ReadySignalInfo currently carries one bool. Encode the typed control
+            // message in three ordered notifications so Agent transports get the
+            // same framing and mismatch detection as MPI/UCX without touching the
+            // staging buffer used by AgentConnection::send().
+            for (uint8_t bit = 0; bit < kChunkControlBitCount; ++bit)
+            {
+                agentConnection->sendReadySignal(controlContext, (encodedControl & (uint8_t{1} << bit)) != 0);
+            }
+        }
+        else
+        {
+            connection->send(controlContext, &encodedControl, sizeof(encodedControl));
+        }
+    }
+}
+
+ChunkControl recvChunkControl(TransferSession const& session, std::vector<size_t> const& pickUpConnections)
+{
+    auto const controlContext = getChunkControlContext(session);
+    auto const& connections = session.getConnections();
+    std::optional<uint8_t> commonControl;
+    bool controlsMatch = true;
+    bool sawAbortOrInvalidControl = false;
+
+    for (auto const connectionIdx : pickUpConnections)
+    {
+        auto const* connection = connections.at(connectionIdx);
+        auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection);
+        uint8_t encodedControl{0};
+        if (agentConnection != nullptr)
+        {
+            for (uint8_t bit = 0; bit < kChunkControlBitCount; ++bit)
+            {
+                if (agentConnection->recvReadySignal(controlContext))
+                {
+                    encodedControl |= uint8_t{1} << bit;
+                }
+            }
+        }
+        else
+        {
+            connection->recv(controlContext, &encodedControl, sizeof(encodedControl));
+        }
+
+        sawAbortOrInvalidControl |= encodedControl == static_cast<uint8_t>(ChunkControl::kAbort)
+            || encodedControl > static_cast<uint8_t>(ChunkControl::kSenderDone);
+
+        if (!commonControl.has_value())
+        {
+            commonControl = encodedControl;
+        }
+        else
+        {
+            controlsMatch &= commonControl.value() == encodedControl;
+        }
+    }
+
+    TLLM_CHECK(commonControl.has_value());
+    // Treat any peer abort, malformed value, or disagreement as a collective
+    // abort. Throwing here would strand peers that already sent a valid status
+    // and are waiting for this rank to finish the current protocol phase.
+    if (sawAbortOrInvalidControl || !controlsMatch)
+    {
+        if (!controlsMatch)
+        {
+            TLLM_LOG_WARNING("Chunked KV-cache peers returned inconsistent control messages; aborting the phase.");
+        }
+        else if (commonControl.value() > static_cast<uint8_t>(ChunkControl::kSenderDone))
+        {
+            TLLM_LOG_WARNING("Chunked KV-cache peer returned invalid control message %u; aborting the phase.",
+                static_cast<unsigned>(commonControl.value()));
+        }
+        return ChunkControl::kAbort;
+    }
+    return static_cast<ChunkControl>(commonControl.value());
+}
+
+[[noreturn]] void throwUnexpectedChunkControl(ChunkControl actual, ChunkControl expected, std::string_view phase)
+{
+    TLLM_THROW("Unexpected chunked KV-cache control message %u while waiting for %u during %s.",
+        static_cast<unsigned>(actual), static_cast<unsigned>(expected), phase.data());
+}
+
+class ChunkSetupHandshake
+{
+public:
+    enum class Role : uint8_t
+    {
+        kSender,
+        kReceiver,
+    };
+
+    ChunkSetupHandshake(TransferSession const& session, std::vector<size_t> const& pickUpConnections, Role role)
+        : mSession(session)
+        , mPickUpConnections(pickUpConnections)
+        , mRole(role)
+    {
+        if (mRole == Role::kReceiver)
+        {
+            sendChunkControl(mSession, mPickUpConnections, ChunkControl::kReceiverEntered);
+        }
+        else
+        {
+            auto const control = recvChunkControl(mSession, mPickUpConnections);
+            if (control != ChunkControl::kReceiverEntered)
+            {
+                sendChunkControl(mSession, mPickUpConnections, ChunkControl::kAbort);
+                throwUnexpectedChunkControl(control, ChunkControl::kReceiverEntered, "chunked transfer initialization");
+            }
+        }
+    }
+
+    ChunkSetupHandshake(ChunkSetupHandshake const&) = delete;
+    ChunkSetupHandshake& operator=(ChunkSetupHandshake const&) = delete;
+
+    ~ChunkSetupHandshake()
+    {
+        if (!mActive)
+        {
+            return;
+        }
+
+        // A local exception during formatter setup must wake the peer. Complete
+        // the fixed receiver-status -> sender-status -> receiver-authorization
+        // exchange so simultaneous failures do not leave stale request-scoped
+        // controls behind.
+        try
+        {
+            if (mRole == Role::kReceiver)
+            {
+                sendChunkControl(mSession, mPickUpConnections, ChunkControl::kAbort);
+                static_cast<void>(recvChunkControl(mSession, mPickUpConnections));
+                sendChunkControl(mSession, mPickUpConnections, ChunkControl::kAbort);
+            }
+            else
+            {
+                static_cast<void>(recvChunkControl(mSession, mPickUpConnections));
+                sendChunkControl(mSession, mPickUpConnections, ChunkControl::kAbort);
+                static_cast<void>(recvChunkControl(mSession, mPickUpConnections));
+            }
+        }
+        catch (std::exception const& error)
+        {
+            TLLM_LOG_WARNING("Failed to abort chunked KV-cache setup: %s", error.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_WARNING("Failed to abort chunked KV-cache setup.");
+        }
+    }
+
+    void complete()
+    {
+        TLLM_CHECK(mActive);
+        // Once the explicit exchange starts, a failure is a control-transport
+        // failure. Retrying it from the destructor could consume the next phase.
+        mActive = false;
+
+        if (mRole == Role::kReceiver)
+        {
+            sendChunkControl(mSession, mPickUpConnections, ChunkControl::kReceiverReady);
+            auto const control = recvChunkControl(mSession, mPickUpConnections);
+            auto const authorization
+                = control == ChunkControl::kSenderPrepared ? ChunkControl::kSenderProceed : ChunkControl::kAbort;
+            sendChunkControl(mSession, mPickUpConnections, authorization);
+            if (control != ChunkControl::kSenderPrepared)
+            {
+                if (control == ChunkControl::kAbort)
+                {
+                    TLLM_THROW("Sender rejected chunked KV-cache setup.");
+                }
+                throwUnexpectedChunkControl(control, ChunkControl::kSenderPrepared, "formatter setup");
+            }
+        }
+        else
+        {
+            auto const control = recvChunkControl(mSession, mPickUpConnections);
+            auto const senderStatus
+                = control == ChunkControl::kReceiverReady ? ChunkControl::kSenderPrepared : ChunkControl::kAbort;
+            sendChunkControl(mSession, mPickUpConnections, senderStatus);
+            auto const authorization = recvChunkControl(mSession, mPickUpConnections);
+            if (control != ChunkControl::kReceiverReady || authorization != ChunkControl::kSenderProceed)
+            {
+                if (control == ChunkControl::kAbort)
+                {
+                    TLLM_THROW("Receiver rejected chunked KV-cache setup.");
+                }
+                if (control != ChunkControl::kReceiverReady)
+                {
+                    throwUnexpectedChunkControl(control, ChunkControl::kReceiverReady, "formatter setup");
+                }
+                if (authorization == ChunkControl::kAbort)
+                {
+                    TLLM_THROW("Receiver denied chunked KV-cache setup authorization.");
+                }
+                throwUnexpectedChunkControl(
+                    authorization, ChunkControl::kSenderProceed, "formatter setup authorization");
+            }
+        }
+    }
+
+private:
+    TransferSession const& mSession;
+    std::vector<size_t> const& mPickUpConnections;
+    Role mRole;
+    bool mActive{true};
+};
 } // namespace tensorrt_llm::batch_manager
 
 namespace tensorrt_llm::batch_manager::kv_cache_manager
@@ -186,6 +433,21 @@ namespace tensorrt_llm::batch_manager::kv_cache_manager
 BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest const& llmRequest,
     BlockKey const& lastBlockKey, int32_t indexFromEnd, bool recvSideHasCP, SizeType32 ppSize)
 {
+    auto const leasedBlockIds = cacheManager->getTransferLeaseBlockIds(llmRequest.mRequestId);
+    if (leasedBlockIds.has_value())
+    {
+        TLLM_CHECK_WITH_INFO(cacheManager->supportsTransferLeases(),
+            "Early KV-cache release requires an active transfer lease for request %ld.", llmRequest.mRequestId);
+    }
+    auto makeAllBlockRange = [&]()
+    {
+        if (leasedBlockIds.has_value())
+        {
+            return BlockRange::fromBlockIds(*cacheManager, leasedBlockIds.value(), llmRequest.mRequestId);
+        }
+        return BlockRange::fromAllBlockIds(*cacheManager, llmRequest.mRequestId);
+    };
+
     auto poolNum = cacheManager->getBlockManager().getNumPools(
         /*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
 
@@ -199,7 +461,7 @@ BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest 
         // disable reuse path, and vwsa don't support reuse.
         bool needSendAllForWindow = common::getEnvKVCacheTransferAllBlocksForWindow();
 
-        auto blockRange = BlockRange::fromAllBlockIds(*cacheManager, llmRequest.mRequestId);
+        auto blockRange = makeAllBlockRange();
 
         auto const& windowsMetadata = cacheManager->getBlockManager().getWindowSizesMetadata();
 
@@ -235,6 +497,12 @@ BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest 
 
     TLLM_CHECK_WITH_INFO(lastBlockKey.uniqueTokens.size() > 0, "lastBlockKey must be non-empty when reuse is enabled");
 
+    if (leasedBlockIds.has_value())
+    {
+        auto requestedBlockIds = selectTransferLeaseTail(leasedBlockIds.value(), indexFromEnd);
+        return BlockRange::fromBlockIds(*cacheManager, std::move(requestedBlockIds), llmRequest.mRequestId);
+    }
+
     auto multimodalHashes = llmRequest.getMultimodalHashes();
     bool isMultimodal = multimodalHashes.has_value() && *multimodalHashes && !(*multimodalHashes)->empty();
     if (isMultimodal)
@@ -248,6 +516,24 @@ BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest 
     }
 
     return BlockRange::fromReuseTree(*cacheManager, lastBlockKey, indexFromEnd);
+}
+
+void enqueueUntransferredLeaseBlocksForRelease(
+    BaseKVCacheManager* cacheManager, LlmRequest::RequestIdType requestId, BlockRange const& blockRange)
+{
+    auto const leasedBlockIds = cacheManager->getTransferLeaseBlockIds(requestId);
+    if (!leasedBlockIds.has_value())
+    {
+        return;
+    }
+
+    auto untransferredBlockIds
+        = getUntransferredLeaseBlockIds(leasedBlockIds.value(), blockRange.getBlockIdsPerWindow());
+
+    if (!untransferredBlockIds.empty())
+    {
+        cacheManager->enqueueTransferLeaseRelease(requestId, std::move(untransferredBlockIds));
+    }
 }
 
 BlockRange getBlockRangeForReceiving(BaseKVCacheManager* cacheManager, LlmRequest const& llmRequest,
@@ -371,6 +657,9 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
     auto const& connections = session.getConnections();
     auto const& selfConfig = session.getSelfState().getCacheState().value();
     auto const& destConfig = session.getOtherState().getCacheState().value();
+    auto const transferChunkSizeBlocks = selfConfig.getTransferChunkSizeBlocks();
+    TLLM_CHECK_WITH_INFO(transferChunkSizeBlocks == destConfig.getTransferChunkSizeBlocks(),
+        "Chunked KV-cache transfer configuration must match on sender and receiver.");
     auto const selfIdx = session.getSelfState().getCommState().value().getSelfIdx();
     auto indexFromEnd = session.getIndexFromEnd();
     auto& bufferManager = session.getBufferManager();
@@ -389,12 +678,22 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         return;
     }
 
+    std::optional<ChunkSetupHandshake> chunkSetupHandshake;
+    if (transferChunkSizeBlocks.has_value())
+    {
+        chunkSetupHandshake.emplace(session, pickUpConnections, ChunkSetupHandshake::Role::kSender);
+        TLLM_CHECK_WITH_INFO(pickUpConnections.size() == 1,
+            "Chunked KV-cache transfer currently requires exactly one transfer peer per participating rank; "
+            "uneven TP/PP fan-in or fan-out needs global cross-rank failure consensus.");
+    }
+
     auto& blockManager = mCacheManager->getBlockManager();
     auto const& lastBlockKey = session.getLastBlockKey();
     auto const ppSize = selfConfig.getParallelConfig().mPipelineParallelism;
     bool const recvSideHasCP = destConfig.getParallelConfig().mContextParallelism > 1;
     auto blockRange
         = getBlockRangeForSending(mCacheManager, llmRequest, lastBlockKey, indexFromEnd, recvSideHasCP, ppSize);
+    enqueueUntransferredLeaseBlocksForRelease(mCacheManager, llmRequest.mRequestId, blockRange);
     auto const numPools
         = blockManager.getNumPools(/*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
     // TODO(oargov): are we sure the other side has the same number of pools? this might not hold for pp_size>1...
@@ -412,6 +711,21 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
     }
 
     SizeType32 const numKvPools = static_cast<SizeType32>(kvWindowSizes.size());
+
+    if (transferChunkSizeBlocks.has_value())
+    {
+        TLLM_CHECK_WITH_INFO(
+            kvWindowSizes.size() == 1, "Chunked KV-cache transfer currently requires exactly one KV-cache window.");
+        TLLM_CHECK_WITH_INFO(selfConfig.getParallelConfig().mContextParallelism == 1
+                && destConfig.getParallelConfig().mContextParallelism == 1,
+            "Chunked KV-cache transfer does not support context parallelism.");
+        TLLM_CHECK_WITH_INFO(!selfConfig.hasRnnConfig() && !destConfig.hasRnnConfig(),
+            "Chunked KV-cache transfer does not support RNN or hybrid cache state.");
+        TLLM_CHECK_WITH_INFO(!common::getEnvDisaggLayerwise(),
+            "Chunked KV-cache transfer does not support layer-wise disaggregated serving.");
+        TLLM_CHECK_WITH_INFO(!common::getEnvTryZCopyForKVCacheTransfer(),
+            "Chunked KV-cache transfer does not support zero-copy KV-cache transfer.");
+    }
 
     TLLM_LOG_DEBUG("CacheFormatter::format: allWindowSizes=%zu, kvWindowSizes=%d, numPools=%d, requestId=%lu",
         allWindowSizes.size(), numKvPools, numPools, llmRequest.mRequestId);
@@ -529,6 +843,229 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         // cache blocks to the corresponding buffer.
         // 5. send the buffer to the corresponding target. Ideally, we send only once (one buffer) for each target.
 
+        if (transferChunkSizeBlocks.has_value())
+        {
+            auto const windowSize = kvWindowSizes.front();
+            auto const& allBlocks = inputKvCacheBlocksPerWindow.at(windowSize);
+            auto const& allBlockIds = blockRange.getBlockIdsPerWindow().at(windowSize);
+            TLLM_CHECK_WITH_INFO(allBlocks.size() == allBlockIds.size(),
+                "Chunked KV-cache transfer block tensors and IDs must have the same size.");
+
+            auto cacheBufferId = mCacheTransBufferManager->assignBufferIndexForSend();
+            BufferIndexHolder sendHolder(*mCacheTransBufferManager, cacheBufferId, /*isRecv=*/false);
+            int const peerDuplicateHeadFactor = targetInfo.mPeerDupHeadFactor;
+            TLLM_CHECK_WITH_INFO(
+                peerDuplicateHeadFactor > 0, "Chunked KV-cache transfer requires a positive duplicate-head factor.");
+            TLLM_CHECK_WITH_INFO(targetNum % peerDuplicateHeadFactor == 0,
+                "Chunked KV-cache transfer target count must be divisible by the duplicate-head factor.");
+            auto const bufferTargetNum = targetNum / peerDuplicateHeadFactor;
+            auto const ppRank = selfIdx
+                / (selfConfig.getParallelConfig().mTensorParallelism
+                    * selfConfig.getParallelConfig().mContextParallelism);
+            int const selfAttentionLayerNum = selfConfig.getParallelConfig().mAttentionLayerNumPerPP.at(ppRank);
+            TLLM_CHECK_WITH_INFO(
+                selfAttentionLayerNum > 0, "Chunked KV-cache transfer requires at least one local attention layer.");
+            auto const chunkSize = static_cast<size_t>(transferChunkSizeBlocks.value());
+            auto const chunkCount = allBlocks.size() / chunkSize + (allBlocks.size() % chunkSize != 0 ? 1 : 0);
+            TLLM_CHECK_WITH_INFO(targetNum == 0 || chunkCount <= std::numeric_limits<size_t>::max() / targetNum,
+                "Chunked KV-cache transfer measurement count overflow.");
+            std::vector<TransferSession::Measure> chunkMeasures;
+            chunkMeasures.reserve(chunkCount * targetNum);
+
+            TLLM_CHECK(chunkSetupHandshake.has_value());
+            chunkSetupHandshake->complete();
+            chunkSetupHandshake.reset();
+
+            for (size_t chunkBegin = 0; chunkBegin < allBlocks.size(); chunkBegin += chunkSize)
+            {
+                auto const chunkEnd = std::min(chunkBegin + chunkSize, allBlocks.size());
+                std::vector<runtime::ITensor::SharedPtr> outputSplitCaches;
+                std::exception_ptr preparationError;
+                try
+                {
+                    auto const chunkBlockNum = chunkEnd - chunkBegin;
+                    std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>> chunkBlocksPerWindow;
+                    auto& chunkBlocks = chunkBlocksPerWindow[windowSize];
+                    chunkBlocks.assign(allBlocks.begin() + static_cast<std::ptrdiff_t>(chunkBegin),
+                        allBlocks.begin() + static_cast<std::ptrdiff_t>(chunkEnd));
+                    size_t const chunkCacheBlockSize = std::accumulate(chunkBlocks.begin(), chunkBlocks.end(),
+                        size_t{0},
+                        [](size_t size, runtime::ITensor::SharedPtr const& block) { return size + block->getSize(); });
+
+                    std::vector<size_t> bufferEleSizes(bufferTargetNum, 0);
+                    size_t const sizePerBlockPerLayerPerTP = chunkCacheBlockSize * peerDuplicateHeadFactor
+                        / targetInfo.mDomainTPSize / selfAttentionLayerNum / chunkBlockNum;
+                    size_t const numTPCaches = targetInfo.mDomainTPSize / peerDuplicateHeadFactor;
+                    for (size_t tpIdx = 0; tpIdx < numTPCaches; ++tpIdx)
+                    {
+                        for (size_t ppIdx = 0; ppIdx < targetInfo.mDomainPPSize; ++ppIdx)
+                        {
+                            size_t const bufferIdx = tpIdx * targetInfo.mDomainPPSize + ppIdx;
+                            size_t const peerLayerNum = targetInfo.getPeerPPDomainLayerNum(ppIdx);
+                            bufferEleSizes[bufferIdx] = sizePerBlockPerLayerPerTP * peerLayerNum * chunkBlockNum;
+                        }
+                    }
+
+                    auto [allocatedBuffers, bufferCoverTargetNum, onlyUseDynamicBuffer]
+                        = mCacheTransBufferManager->getOrAllocateSendBuffers(
+                            cacheBufferId, static_cast<int>(bufferTargetNum), bufferEleSizes, bufferManager);
+                    TLLM_CHECK(cacheBufferId.has_value() || onlyUseDynamicBuffer);
+                    TLLM_CHECK_WITH_INFO(bufferCoverTargetNum == bufferTargetNum,
+                        "Chunked KV-cache transfer requires one complete staging buffer per target.");
+                    outputSplitCaches = std::move(allocatedBuffers);
+
+                    executor::kv_cache::splitKVCacheDispatch(
+                        chunkBlocksPerWindow, outputSplitCaches, destConfig, selfConfig, selfIdx, bufferManager);
+                    bufferManager.getStream().synchronize();
+                    session.setTime(TransferSession::kTimePreprocess);
+
+                    auto const preAllocSendBuffer = mCacheTransBufferManager->getSendBuffer(cacheBufferId);
+                    if (preAllocSendBuffer != nullptr)
+                    {
+                        TLLM_CHECK(preAllocSendBuffer->getDataType() == chunkBlocks.front()->getDataType());
+                    }
+
+                    // Everything except the transport call is validated before
+                    // announcing payload, so a local setup error can still be
+                    // reported on the control channel without stranding recv().
+                    TLLM_CUDA_CHECK(cudaSetDevice(deviceId));
+                    for (size_t localIdx = 0; localIdx < targetNum; ++localIdx)
+                    {
+                        auto const connectionIdx = pickUpConnections.at(localIdx);
+                        TLLM_CHECK(connectionIdx < session.getConnections().size());
+                        auto const bufferIdx = computeBufferIdx(localIdx, targetInfo);
+                        TLLM_CHECK(bufferIdx < outputSplitCaches.size());
+                        TLLM_CHECK(outputSplitCaches.at(bufferIdx) != nullptr);
+                    }
+                }
+                catch (...)
+                {
+                    preparationError = std::current_exception();
+                }
+
+                // Payload starts only after the receiver-status -> sender-status
+                // -> receiver-authorization barrier has reached consensus across
+                // every participating connection.
+                auto const receiverControl = recvChunkControl(session, pickUpConnections);
+                auto const senderStatus = !preparationError && receiverControl == ChunkControl::kReceiverReady
+                    ? ChunkControl::kSenderPrepared
+                    : ChunkControl::kAbort;
+                sendChunkControl(session, pickUpConnections, senderStatus);
+                auto const authorizationControl = recvChunkControl(session, pickUpConnections);
+                if (senderStatus != ChunkControl::kSenderPrepared
+                    || authorizationControl != ChunkControl::kSenderProceed)
+                {
+                    if (preparationError)
+                    {
+                        std::rethrow_exception(preparationError);
+                    }
+                    if (receiverControl == ChunkControl::kAbort)
+                    {
+                        TLLM_THROW("Receiver rejected a chunked KV-cache chunk.");
+                    }
+                    if (receiverControl != ChunkControl::kReceiverReady)
+                    {
+                        throwUnexpectedChunkControl(receiverControl, ChunkControl::kReceiverReady, "chunk preparation");
+                    }
+                    if (authorizationControl == ChunkControl::kAbort)
+                    {
+                        TLLM_THROW("Receiver denied chunked KV-cache payload authorization.");
+                    }
+                    throwUnexpectedChunkControl(
+                        authorizationControl, ChunkControl::kSenderProceed, "chunk payload authorization");
+                }
+
+                for (size_t localIdx = 0; localIdx < targetNum; ++localIdx)
+                {
+                    auto const connectionIdx = pickUpConnections[localIdx];
+                    auto const bufferIdx = computeBufferIdx(localIdx, targetInfo);
+                    auto const& outputBuffer = outputSplitCaches[bufferIdx];
+                    auto const startTime = LlmRequest::getSteadyClockNow();
+                    session.send(connectionIdx, outputBuffer->data(), outputBuffer->getSizeInBytes());
+                    auto const endTime = LlmRequest::getSteadyClockNow();
+                    chunkMeasures.push_back(
+                        TransferSession::Measure{startTime, endTime, outputBuffer->getSizeInBytes()});
+                }
+                session.setTime(TransferSession::kTimeTransmissions);
+
+                auto const completionControl = recvChunkControl(session, pickUpConnections);
+                if (completionControl != ChunkControl::kChunkComplete)
+                {
+                    if (completionControl == ChunkControl::kAbort)
+                    {
+                        TLLM_THROW("Receiver failed to commit a chunked KV-cache chunk.");
+                    }
+                    sendChunkControl(session, pickUpConnections, ChunkControl::kAbort);
+                    throwUnexpectedChunkControl(completionControl, ChunkControl::kChunkComplete, "chunk completion");
+                }
+
+                try
+                {
+                    if (mCacheManager->hasActiveTransferLease(llmRequest.mRequestId))
+                    {
+                        TransferBlockIds completedBlockIds;
+                        completedBlockIds.emplace(windowSize,
+                            std::vector<KVCacheBlock::IdType>(
+                                allBlockIds.begin() + static_cast<std::ptrdiff_t>(chunkBegin),
+                                allBlockIds.begin() + static_cast<std::ptrdiff_t>(chunkEnd)));
+                        mCacheManager->enqueueTransferLeaseRelease(llmRequest.mRequestId, std::move(completedBlockIds));
+                    }
+                    session.setTime(TransferSession::kTimePostprocess);
+                }
+                catch (...)
+                {
+                    auto const postprocessError = std::current_exception();
+                    try
+                    {
+                        // The receiver is either preparing the next chunk or
+                        // announcing transfer completion. Consume that boundary
+                        // message before aborting so it never waits for a reply.
+                        static_cast<void>(recvChunkControl(session, pickUpConnections));
+                        sendChunkControl(session, pickUpConnections, ChunkControl::kAbort);
+                        static_cast<void>(recvChunkControl(session, pickUpConnections));
+                    }
+                    catch (std::exception const& controlError)
+                    {
+                        TLLM_LOG_WARNING(
+                            "Failed to abort chunked KV-cache transfer after sender postprocessing for "
+                            "request %ld: %s",
+                            llmRequest.mRequestId, controlError.what());
+                    }
+                    catch (...)
+                    {
+                        TLLM_LOG_WARNING(
+                            "Failed to abort chunked KV-cache transfer after sender postprocessing for request %ld.",
+                            llmRequest.mRequestId);
+                    }
+                    std::rethrow_exception(postprocessError);
+                }
+            }
+
+            auto const receiverFinishedControl = recvChunkControl(session, pickUpConnections);
+            if (receiverFinishedControl != ChunkControl::kReceiverFinished)
+            {
+                sendChunkControl(session, pickUpConnections, ChunkControl::kAbort);
+                static_cast<void>(recvChunkControl(session, pickUpConnections));
+                if (receiverFinishedControl == ChunkControl::kAbort)
+                {
+                    TLLM_THROW("Receiver aborted chunked KV-cache transfer completion.");
+                }
+                throwUnexpectedChunkControl(
+                    receiverFinishedControl, ChunkControl::kReceiverFinished, "transfer completion");
+            }
+            sendChunkControl(session, pickUpConnections, ChunkControl::kSenderDone);
+
+            for (auto const& measure : chunkMeasures)
+            {
+                session.appendMeasure(measure.start, measure.end, measure.size);
+            }
+
+            sendHolder.release();
+            TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), "End chunked KV-cache sending for request ID: %ld.",
+                llmRequest.mRequestId);
+            return;
+        }
+
         auto cacheBufferId = mCacheTransBufferManager->assignBufferIndexForSend();
         BufferIndexHolder sendHolder(*mCacheTransBufferManager, cacheBufferId, /*isRecv=*/false);
         int peerDuplicateHeadFactor = targetInfo.mPeerDupHeadFactor;
@@ -632,13 +1169,21 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
     auto const& connections = session.getConnections();
     auto const& selfConfig = session.getSelfState().getCacheState().value();
     auto const& destConfig = session.getOtherState().getCacheState().value();
+    auto const transferChunkSizeBlocks = destConfig.getTransferChunkSizeBlocks();
+    TLLM_CHECK_WITH_INFO(transferChunkSizeBlocks == selfConfig.getTransferChunkSizeBlocks(),
+        "Chunked KV-cache transfer configuration must match on sender and receiver.");
     auto const selfIdx = session.getSelfState().getCommState().value().getSelfIdx();
     auto& bufferManager = session.getBufferManager();
     auto const srcPpSize = destConfig.getParallelConfig().mPipelineParallelism;
     bool const recvSideHasCP = selfConfig.getParallelConfig().mContextParallelism > 1;
-    auto blockRange = getBlockRangeForReceiving(mCacheManager, llmRequest, destConfig.getEnableBlockReuse(),
-        destConfig.getEnablePartialReuse(), recvSideHasCP, srcPpSize);
-
+    std::optional<BlockRange> blockRangeStorage;
+    if (!transferChunkSizeBlocks.has_value())
+    {
+        // Preserve the legacy feature-off ordering. Chunking moves this setup
+        // behind the entry handshake so any failure can be reported to senders.
+        blockRangeStorage.emplace(getBlockRangeForReceiving(mCacheManager, llmRequest, destConfig.getEnableBlockReuse(),
+            destConfig.getEnablePartialReuse(), recvSideHasCP, srcPpSize));
+    }
     auto pickRecvConnResult
         = pickRecvConnections(connections.size(), selfConfig, selfIdx, destConfig, session.getCounterPartRanks());
     auto pickUpConnections = std::get<0>(pickRecvConnResult);
@@ -648,6 +1193,20 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
         TLLM_LOG_DEBUG("No targets to receive KV cache for request ID: %ld", llmRequest.mRequestId);
         return;
     }
+
+    std::optional<ChunkSetupHandshake> chunkSetupHandshake;
+    if (transferChunkSizeBlocks.has_value())
+    {
+        chunkSetupHandshake.emplace(session, pickUpConnections, ChunkSetupHandshake::Role::kReceiver);
+        TLLM_CHECK_WITH_INFO(pickUpConnections.size() == 1,
+            "Chunked KV-cache transfer currently requires exactly one transfer peer per participating rank; "
+            "uneven TP/PP fan-in or fan-out needs global cross-rank failure consensus.");
+        blockRangeStorage.emplace(getBlockRangeForReceiving(mCacheManager, llmRequest, destConfig.getEnableBlockReuse(),
+            destConfig.getEnablePartialReuse(), recvSideHasCP, srcPpSize));
+    }
+
+    TLLM_CHECK(blockRangeStorage.has_value());
+    auto& blockRange = blockRangeStorage.value();
 
     TLLM_LOG_DEBUG("pickUpConnections size: %d connections size: %d", pickUpConnections.size(), connections.size());
     std::vector<runtime::ITensor::SharedPtr> recvBufferTmps;
@@ -670,6 +1229,21 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
         }
     }
     SizeType32 const numKvPools = static_cast<SizeType32>(kvWindowSizes.size());
+
+    if (transferChunkSizeBlocks.has_value())
+    {
+        TLLM_CHECK_WITH_INFO(
+            kvWindowSizes.size() == 1, "Chunked KV-cache transfer currently requires exactly one KV-cache window.");
+        TLLM_CHECK_WITH_INFO(selfConfig.getParallelConfig().mContextParallelism == 1
+                && destConfig.getParallelConfig().mContextParallelism == 1,
+            "Chunked KV-cache transfer does not support context parallelism.");
+        TLLM_CHECK_WITH_INFO(!selfConfig.hasRnnConfig() && !destConfig.hasRnnConfig(),
+            "Chunked KV-cache transfer does not support RNN or hybrid cache state.");
+        TLLM_CHECK_WITH_INFO(!common::getEnvDisaggLayerwise(),
+            "Chunked KV-cache transfer does not support layer-wise disaggregated serving.");
+        TLLM_CHECK_WITH_INFO(!common::getEnvTryZCopyForKVCacheTransfer(),
+            "Chunked KV-cache transfer does not support zero-copy KV-cache transfer.");
+    }
 
     TLLM_LOG_DEBUG("CacheFormatter::unformat: allWindowSizes=%zu, kvWindowSizes=%d, numPools=%d, requestId=%lu",
         allWindowSizes.size(), numKvPools, numPools, llmRequest.mRequestId);
@@ -808,6 +1382,208 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
                     ctxReqId);
                 return;
             }
+
+            if (transferChunkSizeBlocks.has_value())
+            {
+                auto const windowSize = kvWindowSizes.front();
+                auto const& allOutputBlocks = outputBuffersPerWindow.at(windowSize);
+                auto const chunkSize = static_cast<size_t>(transferChunkSizeBlocks.value());
+                auto const targetNum = pickUpConnections.size();
+                auto const targetInfo = executor::kv_cache::targetIRanks(destConfig, selfConfig, selfIdx);
+                auto const ppRank = selfIdx
+                    / (selfConfig.getParallelConfig().mTensorParallelism
+                        * selfConfig.getParallelConfig().mContextParallelism);
+                int const selfAttentionLayerNum = selfConfig.getParallelConfig().mAttentionLayerNumPerPP.at(ppRank);
+                TLLM_CHECK_WITH_INFO(selfAttentionLayerNum > 0,
+                    "Chunked KV-cache transfer requires at least one local attention layer.");
+                TLLM_CHECK_WITH_INFO(
+                    targetInfo.mDomainPPSize > 0, "Chunked KV-cache transfer requires a positive PP domain size.");
+                TLLM_CHECK_WITH_INFO(targetNum % targetInfo.mDomainPPSize == 0,
+                    "Chunked KV-cache transfer target count must be divisible by the PP domain size.");
+                size_t const validTpSize = targetNum / targetInfo.mDomainPPSize;
+
+                auto const preAssignedKvId = session.getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kKV));
+                std::optional<int> cacheBufferId;
+                if (preAssignedKvId.has_value())
+                {
+                    TLLM_CHECK_WITH_INFO(
+                        preAssignedKvId.value() <= static_cast<size_t>(std::numeric_limits<int>::max()),
+                        "Preassigned receive-buffer index is out of range: %zu", preAssignedKvId.value());
+                    cacheBufferId = static_cast<int>(preAssignedKvId.value());
+                }
+                else
+                {
+                    cacheBufferId = mCacheTransBufferManager->assignBufferIndexForRecv();
+                }
+                // Agent preassigned receive buffers are owned by the request-level
+                // synchronization guard, which also covers failures before the
+                // formatter is entered. Only dynamically assigned formatter
+                // buffers are released by this local holder.
+                auto const formatterOwnedBufferId = preAssignedKvId.has_value() ? std::optional<int>{} : cacheBufferId;
+                BufferIndexHolder recvHolder(*mCacheTransBufferManager, formatterOwnedBufferId, /*isRecv=*/true);
+                auto const chunkCount
+                    = allOutputBlocks.size() / chunkSize + (allOutputBlocks.size() % chunkSize != 0 ? 1 : 0);
+                TLLM_CHECK_WITH_INFO(targetNum == 0 || chunkCount <= std::numeric_limits<size_t>::max() / targetNum,
+                    "Chunked KV-cache transfer measurement count overflow.");
+                std::vector<TransferSession::Measure> chunkMeasures;
+                chunkMeasures.reserve(chunkCount * targetNum);
+
+                TLLM_CHECK(chunkSetupHandshake.has_value());
+                chunkSetupHandshake->complete();
+                chunkSetupHandshake.reset();
+
+                for (size_t chunkBegin = 0; chunkBegin < allOutputBlocks.size(); chunkBegin += chunkSize)
+                {
+                    auto const chunkEnd = std::min(chunkBegin + chunkSize, allOutputBlocks.size());
+                    std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>> chunkOutputBuffersPerWindow;
+                    std::vector<runtime::ITensor::SharedPtr> recvSplitCaches;
+                    std::exception_ptr preparationError;
+                    try
+                    {
+                        auto& chunkOutputBlocks = chunkOutputBuffersPerWindow[windowSize];
+                        chunkOutputBlocks.assign(allOutputBlocks.begin() + static_cast<std::ptrdiff_t>(chunkBegin),
+                            allOutputBlocks.begin() + static_cast<std::ptrdiff_t>(chunkEnd));
+                        size_t const chunkCacheBlockSize
+                            = std::accumulate(chunkOutputBlocks.begin(), chunkOutputBlocks.end(), size_t{0},
+                                [](size_t size, runtime::ITensor::SharedPtr const& block)
+                                { return size + block->getSize(); });
+                        TLLM_CHECK_WITH_INFO(chunkCacheBlockSize % (selfAttentionLayerNum * validTpSize) == 0,
+                            "Chunked KV-cache size must be divisible by the local layer and TP counts.");
+                        size_t const cacheBlockSizePerLayer
+                            = chunkCacheBlockSize / (selfAttentionLayerNum * validTpSize);
+
+                        std::vector<size_t> bufferEleSizes(targetNum, 0);
+                        for (size_t targetIdx = 0; targetIdx < targetNum; ++targetIdx)
+                        {
+                            auto const layerNum = targetInfo.getPeerPPDomainLayerNum(
+                                static_cast<SizeType32>(localRankIndices[targetIdx]));
+                            bufferEleSizes[targetIdx] = cacheBlockSizePerLayer * layerNum;
+                        }
+
+                        auto [allocatedBuffers, bufferCoverTargetNum, onlyUseDynamicBuffer]
+                            = mCacheTransBufferManager->getOrAllocateRecvBuffers(
+                                cacheBufferId, static_cast<int>(targetNum), bufferEleSizes, bufferManager);
+                        TLLM_CHECK(cacheBufferId.has_value() || onlyUseDynamicBuffer);
+                        TLLM_CHECK_WITH_INFO(bufferCoverTargetNum == targetNum,
+                            "Chunked KV-cache transfer requires one complete staging buffer per target.");
+                        recvSplitCaches = std::move(allocatedBuffers);
+                        bufferManager.getStream().synchronize();
+                        session.setTime(TransferSession::kTimePreprocess);
+
+                        if (cacheBufferId.has_value())
+                        {
+                            auto const preAllocRecvBuffer = mCacheTransBufferManager->getRecvBuffer(cacheBufferId);
+                            TLLM_CHECK(preAllocRecvBuffer != nullptr);
+                            TLLM_CHECK(preAllocRecvBuffer->getDataType() == chunkOutputBlocks.front()->getDataType());
+                        }
+
+                        TLLM_CUDA_CHECK(cudaSetDevice(deviceId));
+                        for (size_t targetIdx = 0; targetIdx < targetNum; ++targetIdx)
+                        {
+                            auto const& recvBuffer = recvSplitCaches.at(targetIdx);
+                            TLLM_CHECK(recvBuffer != nullptr);
+                            TLLM_CHECK(pickUpConnections.at(targetIdx) < session.getConnections().size());
+                            llmRequest.updateKvCacheSize(recvBuffer->getSizeInBytes());
+                        }
+                    }
+                    catch (...)
+                    {
+                        preparationError = std::current_exception();
+                    }
+
+                    // Mirror the sender's three-phase barrier. In particular,
+                    // always send the final authorization, including on abort,
+                    // so otherwise healthy senders cannot enter payload transfer.
+                    sendChunkControl(session, pickUpConnections,
+                        preparationError ? ChunkControl::kAbort : ChunkControl::kReceiverReady);
+                    auto const senderStatus = recvChunkControl(session, pickUpConnections);
+                    auto const authorization = !preparationError && senderStatus == ChunkControl::kSenderPrepared
+                        ? ChunkControl::kSenderProceed
+                        : ChunkControl::kAbort;
+                    sendChunkControl(session, pickUpConnections, authorization);
+                    if (authorization != ChunkControl::kSenderProceed)
+                    {
+                        if (preparationError)
+                        {
+                            std::rethrow_exception(preparationError);
+                        }
+                        if (senderStatus == ChunkControl::kAbort)
+                        {
+                            TLLM_THROW("Sender rejected a chunked KV-cache chunk.");
+                        }
+                        throwUnexpectedChunkControl(senderStatus, ChunkControl::kSenderPrepared, "chunk preparation");
+                    }
+
+                    try
+                    {
+                        for (size_t targetIdx = 0; targetIdx < targetNum; ++targetIdx)
+                        {
+                            auto const startTime = LlmRequest::getSteadyClockNow();
+                            auto const& recvBuffer = recvSplitCaches[targetIdx];
+                            session.recv(
+                                pickUpConnections[targetIdx], recvBuffer->data(), recvBuffer->getSizeInBytes());
+                            auto const endTime = LlmRequest::getSteadyClockNow();
+                            chunkMeasures.push_back(
+                                TransferSession::Measure{startTime, endTime, recvBuffer->getSizeInBytes()});
+                        }
+                        session.setTime(TransferSession::kTimeTransmissions);
+
+                        executor::kv_cache::concatKvCacheV2Dispatch(recvSplitCaches, chunkOutputBuffersPerWindow,
+                            destConfig, selfConfig, selfIdx, bufferManager);
+                        bufferManager.getStream().synchronize();
+                        session.setTime(TransferSession::kTimePostprocess);
+                    }
+                    catch (...)
+                    {
+                        try
+                        {
+                            sendChunkControl(session, pickUpConnections, ChunkControl::kAbort);
+                        }
+                        catch (std::exception const& controlError)
+                        {
+                            TLLM_LOG_WARNING("Failed to abort chunked KV-cache transfer for request %ld: %s",
+                                llmRequest.mRequestId, controlError.what());
+                        }
+                        catch (...)
+                        {
+                            TLLM_LOG_WARNING(
+                                "Failed to abort chunked KV-cache transfer for request %ld.", llmRequest.mRequestId);
+                        }
+                        throw;
+                    }
+
+                    // A chunk is complete only after its staging data has been
+                    // copied into final KV blocks. This also protects the single
+                    // reusable remote Agent staging slot from early overwrite.
+                    sendChunkControl(session, pickUpConnections, ChunkControl::kChunkComplete);
+                }
+
+                sendChunkControl(session, pickUpConnections, ChunkControl::kReceiverFinished);
+                auto const senderDoneControl = recvChunkControl(session, pickUpConnections);
+                if (senderDoneControl != ChunkControl::kSenderDone)
+                {
+                    // A sender with an extra chunk is waiting for the receiver's
+                    // authorization phase after reporting Abort. Complete that
+                    // phase before surfacing terminal/count mismatches.
+                    sendChunkControl(session, pickUpConnections, ChunkControl::kAbort);
+                    if (senderDoneControl == ChunkControl::kAbort)
+                    {
+                        TLLM_THROW("Sender aborted chunked KV-cache transfer completion.");
+                    }
+                    throwUnexpectedChunkControl(senderDoneControl, ChunkControl::kSenderDone, "transfer completion");
+                }
+
+                for (auto const& measure : chunkMeasures)
+                {
+                    session.appendMeasure(measure.start, measure.end, measure.size);
+                }
+
+                recvHolder.release();
+                TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
+                    "End chunked KV-cache receiving for request ID: %ld, context request ID: %ld.",
+                    llmRequest.mRequestId, ctxReqId);
+                return;
+            }
             // unformatted flow
             // 1. collect cache blocks of the request.
             // 2. compute the buffer size for each target.
@@ -870,8 +1646,7 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
 
                 TLLM_CHECK(blockNum > 0);
 
-                auto preAssignedKvId
-                    = connections[pickUpConnections[0]]->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kKV));
+                auto preAssignedKvId = session.getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kKV));
                 if (preAssignedKvId.has_value())
                 {
                     cacheBufferId = static_cast<int>(*preAssignedKvId);
@@ -1027,6 +1802,34 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
 
 [[nodiscard]] bool CacheFormatter::inquireSupport(CacheState const& selfConfig, CacheState const& destConfig) const
 {
+    if (!cache_formatter_utils::hasCompatibleTransferChunkSize(selfConfig, destConfig))
+    {
+        TLLM_LOG_WARNING(
+            "CacheFormatter::inquireSupport: chunked KV-cache transfer configuration must match on both peers");
+        return false;
+    }
+    if (selfConfig.getTransferChunkSizeBlocks().has_value())
+    {
+        if (selfConfig.getParallelConfig().mContextParallelism != 1
+            || destConfig.getParallelConfig().mContextParallelism != 1)
+        {
+            TLLM_LOG_WARNING("CacheFormatter::inquireSupport: chunked KV-cache transfer requires CP=1 on both peers");
+            return false;
+        }
+        if (selfConfig.hasRnnConfig() || destConfig.hasRnnConfig())
+        {
+            TLLM_LOG_WARNING("CacheFormatter::inquireSupport: chunked KV-cache transfer does not support RNN state");
+            return false;
+        }
+        if (common::getEnvDisaggLayerwise() || common::getEnvTryZCopyForKVCacheTransfer())
+        {
+            TLLM_LOG_WARNING(
+                "CacheFormatter::inquireSupport: chunked KV-cache transfer does not support layer-wise or zero-copy "
+                "transfer");
+            return false;
+        }
+    }
+
     if (selfConfig.getDataType() != destConfig.getDataType())
     {
         TLLM_LOG_WARNING("CacheFormatter::inquireSupport: selfConfig.getDataType() != destConfig.getDataType()");

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.h
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,6 +55,12 @@ namespace cache_formatter_utils
 {
 
 using CacheState = executor::kv_cache::CacheState;
+
+//! \brief Chunking changes wire framing, so both peers must negotiate the same optional block count.
+inline bool hasCompatibleTransferChunkSize(CacheState const& selfConfig, CacheState const& destConfig) noexcept
+{
+    return selfConfig.getTransferChunkSizeBlocks() == destConfig.getTransferChunkSizeBlocks();
+}
 
 /**
  * @brief Check if this rank should send cache data, given a pre-computed TargetRanksInfo.

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +22,32 @@
 #include "tensorrt_llm/executor/executor.h"
 
 #include <NvInferRuntimeBase.h>
+#include <algorithm>
 #include <mutex>
 
 namespace tensorrt_llm::batch_manager::kv_cache_manager
 {
+
+namespace
+{
+
+std::optional<size_t> getEffectiveMaxNumTokens(std::optional<size_t> maxNumTokens, SizeType32 tokensPerBlock)
+{
+    auto const chunkSizeBlocks = common::getEnvKVCacheTransferChunkSizeBlocks();
+    if (!chunkSizeBlocks.has_value())
+    {
+        return maxNumTokens;
+    }
+
+    TLLM_CHECK_WITH_INFO(tokensPerBlock > 0, "KV-cache tokens per block must be positive.");
+    auto const chunkNumTokens = static_cast<size_t>(chunkSizeBlocks.value()) * static_cast<size_t>(tokensPerBlock);
+    // The env knob defines the wire-protocol chunk size. Both peers must be
+    // able to stage a complete chunk even when a smaller legacy
+    // max_tokens_in_buffer value is configured.
+    return chunkNumTokens;
+}
+
+} // namespace
 
 // ============================================================================
 // FabricMemory Implementation
@@ -205,6 +227,7 @@ size_t CacheTransBufferManager::computeTransferBufferSize(
     }
 
     auto tokensPerBlock = cacheManager->getBlockManager().getTokensPerBlock();
+    maxNumTokens = getEffectiveMaxNumTokens(maxNumTokens, tokensPerBlock);
     size_t bufferSizeFromMaxNumToken = 0;
 
     if (maxNumTokens.has_value())
@@ -233,7 +256,10 @@ size_t CacheTransBufferManager::computeTransferBufferSize(
             {
                 validTokenNum = maxNumTokens.value();
             }
-            validTokenNum += tokensPerBlock; // add one more block
+            if (!common::getEnvKVCacheTransferChunkSizeBlocks().has_value())
+            {
+                validTokenNum += tokensPerBlock; // legacy path keeps one-block headroom
+            }
 
             bufferSizeFromMaxNumToken += validTokenNum * kvCacheByteSizePerTokenPerLayer;
         }
@@ -247,7 +273,7 @@ CacheTransBufferManager::CacheTransBufferManager(
     : BaseTransBufferManager(computeTransferBufferSize(cacheManager, maxNumTokens, transferIndexerKCache),
         transferIndexerKCache ? cacheManager->getIndexerKCachePool()->getDataType()
                               : cacheManager->getPrimaryPool(0)->getDataType(),
-        maxNumTokens)
+        getEffectiveMaxNumTokens(maxNumTokens, cacheManager->getBlockManager().getTokensPerBlock()))
     , mCacheManager{cacheManager}
     , mTransferIndexerKCache{transferIndexerKCache}
 {
@@ -290,7 +316,7 @@ size_t CacheTransBufferManager::preAllocBufferSize(
     {
         return 0;
     }
-    auto maxNumTokens = cacheTransceiverConfig->getMaxTokensInBuffer();
+    auto maxNumTokens = getEffectiveMaxNumTokens(cacheTransceiverConfig->getMaxTokensInBuffer(), tokensPerBlock);
     size_t transferBufferSize = common::getEnvMemSizeForKVCacheTransferBuffer();
     if (maxNumTokens.has_value())
     {
@@ -305,7 +331,10 @@ size_t CacheTransBufferManager::preAllocBufferSize(
             {
                 validTokenNum = maxNumTokens.value();
             }
-            validTokenNum += tokensPerBlock; // add one more block
+            if (!common::getEnvKVCacheTransferChunkSizeBlocks().has_value())
+            {
+                validTokenNum += tokensPerBlock; // legacy path keeps one-block headroom
+            }
             transferBufferSize += validTokenNum * cacheSizeBytesPerToken;
         }
     }

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -294,10 +294,56 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
     executor::kv_cache::CacheState::AttentionType attentionType,
     std::optional<executor::CacheTransceiverConfig> cacheTransceiverConfig,
     rnn_state_manager::RnnStateManager* rnnStateManager, std::vector<SizeType32> const& rnnLayerNumPerPP)
-    : mCacheTransceiverConfig{cacheTransceiverConfig}
+    : mCacheManager{cacheManager}
+    , mEnableTransferEarlyRelease{common::getEnvKVCacheTransferEarlyRelease()}
+    , mCacheTransceiverConfig{cacheTransceiverConfig}
     , mRnnStateManager{rnnStateManager}
 {
     using tensorrt_llm::batch_manager::kv_cache_manager::CacheFormatter;
+    TLLM_CHECK_WITH_INFO(mCacheManager != nullptr, "CacheTransceiver requires a KV-cache manager.");
+
+    auto const transferChunkSizeBlocks = common::getEnvKVCacheTransferChunkSizeBlocks();
+    TLLM_CHECK_WITH_INFO(!mEnableTransferEarlyRelease || transferChunkSizeBlocks.has_value(),
+        "TRTLLM_KVCACHE_TRANSFER_EARLY_RELEASE requires TRTLLM_KVCACHE_TRANSFER_CHUNK_SIZE_BLOCKS to be set to a "
+        "positive value.");
+    if (transferChunkSizeBlocks.has_value())
+    {
+        auto const& blockManager = mCacheManager->getBlockManager();
+        TLLM_CHECK_WITH_INFO(attentionType != executor::kv_cache::CacheState::AttentionType::kMLA,
+            "Chunked KV-cache transfer does not support MLA cache layouts.");
+        TLLM_CHECK_WITH_INFO(
+            !mCacheManager->isEnableIndexerKCache(), "Chunked KV-cache transfer does not support indexer K-cache.");
+        TLLM_CHECK_WITH_INFO(blockManager.getWindowSizesMetadata().size() == 1,
+            "Chunked KV-cache transfer currently requires exactly one KV-cache window.");
+        TLLM_CHECK_WITH_INFO(blockManager.getNumPools(
+                                 /*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false)
+                == 1,
+            "Chunked KV-cache transfer currently requires exactly one primary KV-cache pool.");
+        TLLM_CHECK_WITH_INFO(!blockManager.getWindowSizesMetadata().begin()->second.isSWA,
+            "Chunked KV-cache transfer does not yet support sliding-window cache layouts.");
+        TLLM_CHECK_WITH_INFO(worldConfig.getContextParallelism() == 1,
+            "Chunked KV-cache transfer does not support context parallelism.");
+        TLLM_CHECK_WITH_INFO(!common::getEnvDisaggLayerwise(),
+            "Chunked KV-cache transfer does not support layer-wise disaggregated serving.");
+        TLLM_CHECK_WITH_INFO(!common::getEnvTryZCopyForKVCacheTransfer(),
+            "Chunked KV-cache transfer does not support zero-copy KV-cache transfer.");
+        TLLM_CHECK_WITH_INFO(rnnStateManager == nullptr && rnnLayerNumPerPP.empty()
+                && !blockManager.getLinearAttentionMetadata().has_value(),
+            "Chunked KV-cache transfer does not support RNN, linear-attention, or hybrid cache state.");
+
+        if (mEnableTransferEarlyRelease)
+        {
+            TLLM_CHECK_WITH_INFO(mCacheManager->supportsTransferLeases(),
+                "Early KV-cache release requires a KV-cache manager with exact transfer-lease support.");
+            TLLM_CHECK_WITH_INFO(!blockManager.hasKVCacheConnector(),
+                "Early KV-cache release cannot be combined with a KV-cache connector until all consumers share "
+                "per-chunk transfer leases.");
+            TLLM_CHECK_WITH_INFO(worldConfig.getTensorParallelism() == 1 && worldConfig.getPipelineParallelism() == 1
+                    && worldConfig.getContextParallelism() == 1,
+                "Early KV-cache release currently requires TP=PP=CP=1.");
+        }
+    }
+
     if (useMPI())
     {
         mGroupComm = std::make_shared<CacheTransceiverComm>(std::addressof(tensorrt_llm::mpi::MpiComm::session()));
@@ -329,6 +375,7 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
             dataType, attentionType, kvFactor, cacheManager->isEnableBlockReuse(), cacheManager->isEnablePartialReuse(),
             cacheManager->isEnableIndexerKCache(), cacheManager->getIndexerKCacheIndexHeadDim(),
             cacheManager->getIndexerKCacheQuantBlockSize(), cacheManager->getIndexerKCacheUseFp4());
+    mCacheState->setTransferChunkSizeBlocks(transferChunkSizeBlocks);
 
     if (mCacheState->getParallelConfig().mEnableAttentionDP)
     {
@@ -443,85 +490,105 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
         mCacheTransBufferManagerPtrs.push_back(mRnnCacheTransBufferManager.get());
     }
 
-    if (backendType.value() == executor::CacheTransceiverConfig::BackendType::UCX)
+    try
     {
-        std::lock_guard<std::mutex> lock(mDllMutex);
-        mWrapperLibHandle = dllOpen(UCX_WRAPPER_LIB_NAME);
-        TLLM_CHECK_WITH_INFO(
-            mWrapperLibHandle != nullptr, "UCX wrapper library is not open correctly. error : %s", dlerror());
-        auto load_sym = [](void* handle, char const* name)
+        if (backendType.value() == executor::CacheTransceiverConfig::BackendType::UCX)
         {
-            void* ret = dllGetSym(handle, name);
-            TLLM_CHECK_WITH_INFO(ret != nullptr,
-                "Unable to load UCX wrapper library symbol, possible cause is that TensorRT LLM library is not "
-                "built with UCX support, please rebuild in UCX-enabled environment.");
-            return ret;
+            std::lock_guard<std::mutex> lock(mDllMutex);
+            mWrapperLibHandle = dllOpen(UCX_WRAPPER_LIB_NAME);
+            TLLM_CHECK_WITH_INFO(
+                mWrapperLibHandle != nullptr, "UCX wrapper library is not open correctly. error : %s", dlerror());
+            auto load_sym = [](void* handle, char const* name)
+            {
+                void* ret = dllGetSym(handle, name);
+                TLLM_CHECK_WITH_INFO(ret != nullptr,
+                    "Unable to load UCX wrapper library symbol, possible cause is that TensorRT LLM library is not "
+                    "built with UCX support, please rebuild in UCX-enabled environment.");
+                return ret;
+            };
+            std::unique_ptr<tensorrt_llm::executor::kv_cache::ConnectionManager> (*makeUcxConnectionManager)();
+            *(void**) (&makeUcxConnectionManager) = load_sym(mWrapperLibHandle, "makeUcxConnectionManager");
+            mManager = makeUcxConnectionManager();
+            TLLM_LOG_INFO("UCX Connection Manager created");
+        }
+        else if (backendType.value() == executor::CacheTransceiverConfig::BackendType::NIXL)
+        {
+            auto rnnState
+                = mCacheState->hasRnnConfig() ? std::make_optional(mCacheState->getRnnCacheState()) : std::nullopt;
+            mManager = std::make_unique<tensorrt_llm::executor::kv_cache::AgentConnectionManager>(
+                mCacheTransBufferManagerPtrs, *mCacheState, "nixl", rnnState);
+            TLLM_LOG_INFO("NIXL Connection Manager created");
+        }
+        else if (backendType.value() == executor::CacheTransceiverConfig::BackendType::MOONCAKE)
+        {
+            auto rnnState
+                = mCacheState->hasRnnConfig() ? std::make_optional(mCacheState->getRnnCacheState()) : std::nullopt;
+            mManager = std::make_unique<tensorrt_llm::executor::kv_cache::AgentConnectionManager>(
+                mCacheTransBufferManagerPtrs, *mCacheState, "mooncake", rnnState);
+            TLLM_LOG_INFO("MOONCAKE Connection Manager created");
+        }
+        else if (backendType.value() == executor::CacheTransceiverConfig::BackendType::MPI)
+        {
+            mMpiWorldComm = std::addressof(tensorrt_llm::mpi::MpiComm::world());
+            mManager = std::make_unique<executor::kv_cache::MpiConnectionManager>(mMpiWorldComm);
+            TLLM_LOG_INFO("MPI Connection Manager created");
+        }
+        else
+        {
+            TLLM_THROW("Unsupported cache transceiver backend type ");
+        }
+
+        auto makeFormatter = [cacheManager, isMLA, this]()
+        {
+            std::vector<kv_cache_manager::CacheTransBufferManager*> kvBufferPtrs;
+            kvBufferPtrs.reserve(mCacheTransBufferManagers.size());
+            for (auto& mgr : mCacheTransBufferManagers)
+            {
+                kvBufferPtrs.push_back(mgr.get());
+            }
+            return createCacheFormatter(cacheManager, kvBufferPtrs, isMLA);
         };
-        std::unique_ptr<tensorrt_llm::executor::kv_cache::ConnectionManager> (*makeUcxConnectionManager)();
-        *(void**) (&makeUcxConnectionManager) = load_sym(mWrapperLibHandle, "makeUcxConnectionManager");
-        mManager = makeUcxConnectionManager();
-        TLLM_LOG_INFO("UCX Connection Manager created");
-    }
-    else if (backendType.value() == executor::CacheTransceiverConfig::BackendType::NIXL)
-    {
-        auto rnnState
-            = mCacheState->hasRnnConfig() ? std::make_optional(mCacheState->getRnnCacheState()) : std::nullopt;
-        mManager = std::make_unique<tensorrt_llm::executor::kv_cache::AgentConnectionManager>(
-            mCacheTransBufferManagerPtrs, *mCacheState, "nixl", rnnState);
-        TLLM_LOG_INFO("NIXL Connection Manager created");
-    }
-    else if (backendType.value() == executor::CacheTransceiverConfig::BackendType::MOONCAKE)
-    {
-        auto rnnState
-            = mCacheState->hasRnnConfig() ? std::make_optional(mCacheState->getRnnCacheState()) : std::nullopt;
-        mManager = std::make_unique<tensorrt_llm::executor::kv_cache::AgentConnectionManager>(
-            mCacheTransBufferManagerPtrs, *mCacheState, "mooncake", rnnState);
-        TLLM_LOG_INFO("MOONCAKE Connection Manager created");
-    }
-    else if (backendType.value() == executor::CacheTransceiverConfig::BackendType::MPI)
-    {
-        mMpiWorldComm = std::addressof(tensorrt_llm::mpi::MpiComm::world());
-        mManager = std::make_unique<executor::kv_cache::MpiConnectionManager>(mMpiWorldComm);
-        TLLM_LOG_INFO("MPI Connection Manager created");
-    }
-    else
-    {
-        TLLM_THROW("Unsupported cache transceiver backend type ");
-    }
 
-    auto makeFormatter = [cacheManager, isMLA, this]()
-    {
-        std::vector<kv_cache_manager::CacheTransBufferManager*> kvBufferPtrs;
-        kvBufferPtrs.reserve(mCacheTransBufferManagers.size());
-        for (auto& mgr : mCacheTransBufferManagers)
+        auto makeRnnFormatter = [this, cacheManager]() -> std::unique_ptr<RnnCacheFormatter>
         {
-            kvBufferPtrs.push_back(mgr.get());
-        }
-        return createCacheFormatter(cacheManager, kvBufferPtrs, isMLA);
-    };
+            if (mRnnStateManager != nullptr && mRnnCacheTransBufferManager != nullptr)
+            {
+                // Slot-based path (CppMambaCacheManager)
+                return std::make_unique<RnnCacheFormatter>(mRnnStateManager, mRnnCacheTransBufferManager.get());
+            }
+            // Unified pool path (CppMambaHybridCacheManager)
+            if (mCacheState->hasRnnConfig() && mRnnCacheTransBufferManager != nullptr)
+            {
+                return std::make_unique<RnnCacheFormatter>(cacheManager, mRnnCacheTransBufferManager.get());
+            }
+            return nullptr;
+        };
 
-    auto makeRnnFormatter = [this, cacheManager]() -> std::unique_ptr<RnnCacheFormatter>
+        auto makeCacheTransferLayer
+            = [&]() { return CacheTransferLayer(*mCacheState, makeFormatter(), makeRnnFormatter()); };
+
+        mCacheSender = std::make_unique<CacheSender>(mManager.get(), worldConfig.getRank(), makeCacheTransferLayer());
+        mCacheReceiver
+            = std::make_unique<CacheReceiver>(mManager.get(), worldConfig.getRank(), makeCacheTransferLayer());
+
+        initializeCommState();
+    }
+    catch (...)
     {
-        if (mRnnStateManager != nullptr && mRnnCacheTransBufferManager != nullptr)
+        // A constructor exception skips CacheTransceiver::~CacheTransceiver.
+        // Tear dependencies down explicitly while staging buffers and the UCX
+        // wrapper are still alive.
+        mCacheReceiver.reset();
+        mCacheSender.reset();
+        mManager.reset();
+        if (mWrapperLibHandle)
         {
-            // Slot-based path (CppMambaCacheManager)
-            return std::make_unique<RnnCacheFormatter>(mRnnStateManager, mRnnCacheTransBufferManager.get());
+            std::lock_guard<std::mutex> lock(mDllMutex);
+            dllClose(mWrapperLibHandle);
+            mWrapperLibHandle = nullptr;
         }
-        // Unified pool path (CppMambaHybridCacheManager)
-        if (mCacheState->hasRnnConfig() && mRnnCacheTransBufferManager != nullptr)
-        {
-            return std::make_unique<RnnCacheFormatter>(cacheManager, mRnnCacheTransBufferManager.get());
-        }
-        return nullptr;
-    };
-
-    auto makeCacheTransferLayer
-        = [&]() { return CacheTransferLayer(*mCacheState, makeFormatter(), makeRnnFormatter()); };
-
-    mCacheSender = std::make_unique<CacheSender>(mManager.get(), worldConfig.getRank(), makeCacheTransferLayer());
-    mCacheReceiver = std::make_unique<CacheReceiver>(mManager.get(), worldConfig.getRank(), makeCacheTransferLayer());
-
-    initializeCommState();
+        throw;
+    }
 }
 
 CacheTransceiver::~CacheTransceiver()
@@ -530,6 +597,48 @@ CacheTransceiver::~CacheTransceiver()
     // plugin are still alive. The workers can access both during termination.
     mCacheSender.reset();
     mCacheReceiver.reset();
+
+    if (mEnableTransferEarlyRelease)
+    {
+        try
+        {
+            mCacheManager->drainTransferLeaseReleases();
+        }
+        catch (std::exception const& e)
+        {
+            TLLM_LOG_ERROR("Failed to drain KV-cache transfer leases during transceiver shutdown: %s", e.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_ERROR("Failed to drain KV-cache transfer leases during transceiver shutdown.");
+        }
+        while (!mActiveTransferLeaseIds.empty())
+        {
+            auto const requestId = *mActiveTransferLeaseIds.begin();
+            try
+            {
+                endTransferLease(requestId);
+            }
+            catch (std::exception const& e)
+            {
+                TLLM_LOG_ERROR(
+                    "Failed to end KV-cache transfer lease for request %ld during shutdown: %s", requestId, e.what());
+                // A destructor cannot retry forever. Drop local tracking so
+                // cleanup can continue for other requests.
+                mActiveTransferLeaseIds.erase(requestId);
+            }
+            catch (...)
+            {
+                TLLM_LOG_ERROR("Failed to end KV-cache transfer lease for request %ld during shutdown.", requestId);
+                mActiveTransferLeaseIds.erase(requestId);
+            }
+        }
+    }
+
+    // Connection-manager teardown can deregister the staging buffers and may
+    // call into the dynamically loaded UCX wrapper. Destroy it while both the
+    // buffers and wrapper library are still alive.
+    mManager.reset();
 
     if (mWrapperLibHandle)
     {
@@ -561,6 +670,16 @@ void CacheTransceiver::setContextState(LlmRequest* llmRequest)
     }
 }
 
+void CacheTransceiver::endTransferLease(LlmRequest::RequestIdType requestId)
+{
+    auto const leaseIt = mActiveTransferLeaseIds.find(requestId);
+    if (mEnableTransferEarlyRelease && leaseIt != mActiveTransferLeaseIds.end())
+    {
+        mCacheManager->endTransferLease(requestId);
+        mActiveTransferLeaseIds.erase(leaseIt);
+    }
+}
+
 void CacheTransceiver::respondAndSendAsync(std::shared_ptr<LlmRequest> llmRequest)
 {
     TLLM_CHECK(llmRequest && llmRequest->isContextOnlyRequest());
@@ -575,9 +694,38 @@ void CacheTransceiver::respondAndSendAsync(std::shared_ptr<LlmRequest> llmReques
         }
         return;
     }
-    setContextState(llmRequest.get());
-    auto future = mCacheSender->sendAsync(llmRequest);
-    mSenderFutures.emplace_back(std::move(llmRequest), std::move(future));
+    auto const requestId = llmRequest->mRequestId;
+    bool const chunkRequestSupported
+        = !mCacheState->getTransferChunkSizeBlocks().has_value() || llmRequest->mSamplingConfig.beamWidth == 1;
+    // Allocate status bookkeeping before the sender can observe the request.
+    // Once sendAsync returns, no throwing vector growth may be allowed to
+    // release the lease underneath queued worker work.
+    mSenderFutures.reserve(mSenderFutures.size() + 1);
+    if (mEnableTransferEarlyRelease && chunkRequestSupported)
+    {
+        bool const inserted = mActiveTransferLeaseIds.insert(requestId).second;
+        TLLM_CHECK_WITH_INFO(inserted, "A KV-cache transfer lease is already active for request %ld.", requestId);
+        try
+        {
+            mCacheManager->beginTransferLease(requestId, *llmRequest);
+        }
+        catch (...)
+        {
+            mActiveTransferLeaseIds.erase(requestId);
+            throw;
+        }
+    }
+    try
+    {
+        setContextState(llmRequest.get());
+        auto future = mCacheSender->sendAsync(llmRequest);
+        mSenderFutures.emplace_back(std::move(llmRequest), std::move(future));
+    }
+    catch (...)
+    {
+        endTransferLease(requestId);
+        throw;
+    }
 }
 
 void CacheTransceiver::respondAndSendLayerWise(
@@ -724,6 +872,12 @@ void updateKVCacheTransferBW(std::shared_ptr<CacheTransceiverComm> const& mComm,
 RequestStatuses CacheTransceiver::checkContextTransferStatus(
     std::optional<int> const& atLeastRequestNum, bool markComplete)
 {
+    if (mEnableTransferEarlyRelease)
+    {
+        // CacheFormatter workers only enqueue completed chunks. Refcounts and
+        // eviction queues are mutated here on the transceiver caller thread.
+        mCacheManager->drainTransferLeaseReleases();
+    }
     bool const blockAll = !atLeastRequestNum.has_value();
     std::optional<int> senderFutureTimeoutMs = std::nullopt;
     if (mCacheTransceiverConfig.has_value())
@@ -864,6 +1018,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         {
             continue;
         }
+        endTransferLease(requestId);
         requestIt->second->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
         requestsStatus.errorRequestIds.insert(requestId);
         mTimedOutSenderIds.erase(requestId);
@@ -877,6 +1032,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         {
             continue;
         }
+        endTransferLease(requestId);
         requestsStatus.completedRequestIds.insert(requestId);
         if (markComplete)
         {
@@ -1108,7 +1264,12 @@ bool CacheTransceiver::cancelRequest(std::shared_ptr<LlmRequest> llmRequest)
 {
     if (llmRequest->isContextOnlyRequest())
     {
-        return mCacheSender->cancelRequest(*llmRequest);
+        bool const cancelled = mCacheSender->cancelRequest(*llmRequest);
+        if (cancelled)
+        {
+            endTransferLease(llmRequest->mRequestId);
+        }
+        return cancelled;
     }
     else if (llmRequest->isGenerationOnlyRequest())
     {

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -30,11 +30,14 @@
 #include "tensorrt_llm/runtime/common.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include <chrono>
+#include <exception>
 #include <future>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace tensorrt_llm::batch_manager
 {
@@ -105,7 +108,36 @@ LlmRequest const& TransferSession::getLlmRequest() const
 
 void TransferSession::setLlmRequest(LlmRequest const& llmRequest)
 {
+    for (auto const* connection : mConnections)
+    {
+        if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
+        {
+            agentConnection->activateRequestSenderState(llmRequest.mRequestId);
+        }
+    }
     mRequest = &llmRequest;
+}
+
+void TransferSession::eraseAgentSenderState(LlmRequest::RequestIdType requestId) const noexcept
+{
+    for (auto const* connection : mConnections)
+    {
+        try
+        {
+            if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
+            {
+                agentConnection->eraseRequestSenderState(requestId);
+            }
+        }
+        catch (std::exception const& error)
+        {
+            TLLM_LOG_WARNING("Failed to erase Agent sender state for request %ld: %s", requestId, error.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_WARNING("Failed to erase Agent sender state for request %ld", requestId);
+        }
+    }
 }
 
 void TransferSession::setTime(TimeNames name)
@@ -183,6 +215,71 @@ int32_t tagFromRequestId(LlmRequest::RequestIdType requestId)
     constexpr int32_t kDATA_TAG{43};
     return ((requestId & 0xFFF) << 8) | (kDATA_TAG & 0xFF);
 }
+
+DataContext chunkRequestHandshakeContext(TransferSession const& session)
+{
+    auto const& dataContext = session.getDataContext();
+    return DataContext{dataContext.getTag() + 2, dataContext.getTransferTerminate()};
+}
+
+class AssignedRecvBufferGuard
+{
+public:
+    AssignedRecvBufferGuard(AgentConnectionManager* manager, std::vector<std::optional<size_t>>& bufferIds)
+        : mManager(manager)
+        , mBufferIds(bufferIds)
+    {
+    }
+
+    AssignedRecvBufferGuard(AssignedRecvBufferGuard const&) = delete;
+    AssignedRecvBufferGuard& operator=(AssignedRecvBufferGuard const&) = delete;
+
+    ~AssignedRecvBufferGuard()
+    {
+        if (!mActive || mManager == nullptr)
+        {
+            return;
+        }
+
+        auto const& managers = mManager->getCacheTransBufferManagers();
+        auto const bufferCount = std::min(managers.size(), mBufferIds.size());
+        for (size_t i = 0; i < bufferCount; ++i)
+        {
+            if (!mBufferIds[i].has_value())
+            {
+                continue;
+            }
+            auto const bufferId = mBufferIds[i].value();
+            if (bufferId > static_cast<size_t>(std::numeric_limits<int>::max()))
+            {
+                TLLM_LOG_ERROR("Cannot release out-of-range preassigned receive-buffer index %zu", bufferId);
+                continue;
+            }
+            try
+            {
+                managers[i]->freeBufferIndexForRecv(static_cast<int>(bufferId));
+            }
+            catch (std::exception const& error)
+            {
+                TLLM_LOG_ERROR("Failed to release preassigned receive-buffer index %zu: %s", bufferId, error.what());
+            }
+            catch (...)
+            {
+                TLLM_LOG_ERROR("Failed to release preassigned receive-buffer index %zu", bufferId);
+            }
+        }
+    }
+
+    void detach() noexcept
+    {
+        mActive = false;
+    }
+
+private:
+    AgentConnectionManager* mManager;
+    std::vector<std::optional<size_t>>& mBufferIds;
+    bool mActive{true};
+};
 
 std::filesystem::path getTransferOutputPath(char const* tag)
 {
@@ -303,9 +400,21 @@ public:
         std::promise<void> promise;
         auto future = promise.get_future();
         llmRequest->setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
+        if (mTerminate || !mManager->isRunning())
+        {
+            promise.set_exception(std::make_exception_ptr(TLLM_REQUEST_EXCEPTION(llmRequest->mRequestId,
+                common::RequestErrorCode::kNETWORK_ERROR, "KV-cache sender service is not running")));
+            return future;
+        }
         {
             {
                 std::scoped_lock lkResp(mSenderMutex);
+                if (mTerminate)
+                {
+                    promise.set_exception(std::make_exception_ptr(TLLM_REQUEST_EXCEPTION(llmRequest->mRequestId,
+                        common::RequestErrorCode::kNETWORK_ERROR, "KV-cache sender service is not running")));
+                    return future;
+                }
                 mReadyResponses.emplace(llmRequest->mRequestId, Response{llmRequest, std::move(promise)});
             }
             std::unique_lock lkCond(mCondMutex);
@@ -333,23 +442,41 @@ public:
         return it->second.getConnections().size();
     }
 
-    void release(LlmRequest::RequestIdType requestId)
+    void release(LlmRequest::RequestIdType requestId, bool exportMeasures = true)
     {
         std::unique_lock<std::mutex> lk(mMtxForMap);
         auto it = mRequestToSession.find(requestId);
-        TLLM_CHECK(it != mRequestToSession.end());
-        if (!common::getEnvKVCacheTimeOutputPath().empty())
+        if (it == mRequestToSession.end())
         {
-            if (!mMeasuresFile.is_open())
+            mIncompatibleChunkRequestIds.erase(requestId);
+            return;
+        }
+        it->second.eraseAgentSenderState(requestId);
+        try
+        {
+            if (exportMeasures && !common::getEnvKVCacheTimeOutputPath().empty())
             {
-                auto outputPath = getTransferOutputPath("send");
-                mMeasuresFile.open(outputPath);
-                TLLM_CHECK_WITH_INFO(
-                    mMeasuresFile.is_open(), "Failed to open transfer output file: %s", outputPath.string().c_str());
+                if (!mMeasuresFile.is_open())
+                {
+                    auto outputPath = getTransferOutputPath("send");
+                    mMeasuresFile.open(outputPath);
+                    TLLM_CHECK_WITH_INFO(mMeasuresFile.is_open(), "Failed to open transfer output file: %s",
+                        outputPath.string().c_str());
+                }
+                it->second.exportMeasure(mMeasuresFile, true);
             }
-            it->second.exportMeasure(mMeasuresFile, true);
+        }
+        catch (...)
+        {
+            // Session ownership must never depend on optional metrics output.
+            // Erase before propagating so a failed request ID cannot retain
+            // stale connections or chunk-compatibility state.
+            mRequestToSession.erase(it);
+            mIncompatibleChunkRequestIds.erase(requestId);
+            throw;
         }
         mRequestToSession.erase(it);
+        mIncompatibleChunkRequestIds.erase(requestId);
     }
 
     [[nodiscard]] std::optional<RequestInfo> recvRequestInfo()
@@ -380,31 +507,65 @@ public:
             info = RequestInfo::deserialize(iss);
         }
 
-        auto requestId = info.getRequestId();
-        mCacheTransferLayer.validateSupport(info.getTransState());
-
-        auto allCounterparts = mCacheTransferLayer.computeCounterparts(
-            mSelfState.getCommState().value().getSelfIdx(), info.getTransState());
-
-        auto peerSelfIdx = info.getTransState().getCommState()->getSelfIdx();
-        int peerIdx = std::distance(
-            allCounterparts.begin(), std::find(allCounterparts.begin(), allCounterparts.end(), peerSelfIdx));
-
-        TLLM_CHECK_WITH_INFO(peerIdx < static_cast<int>(allCounterparts.size()),
-            "Peer rank %d not found in expected counterparts", peerSelfIdx);
+        auto const requestId = info.getRequestId();
+        try
         {
-            std::unique_lock<std::mutex> lk(mMtxForMap);
-            auto it = mRequestToSession.find(requestId);
-            if (it == mRequestToSession.end())
+            auto const& peerCacheState = info.getTransState().getCacheState().value();
+            bool const chunkConfigMismatch = mCacheTransferLayer.getCacheState().getTransferChunkSizeBlocks()
+                != peerCacheState.getTransferChunkSizeBlocks();
+            if (!chunkConfigMismatch)
             {
-                auto session = TransferSession(std::vector<Connection const*>(allCounterparts.size(), nullptr),
-                    DataContext{tagFromRequestId(requestId), mTerminate}, allCounterparts, mSelfState,
-                    info.getTransState(), mBufferManager, info.getIndexFromEnd(), info.getLastBlockKey(), nullptr,
-                    !common::getEnvKVCacheTimeOutputPath().empty());
-                session.setTime(TransferSession::kTimeRequestInfo);
-                it = mRequestToSession.emplace(requestId, std::move(session)).first;
+                mCacheTransferLayer.validateSupport(info.getTransState());
             }
-            it->second.setConnection(peerIdx, connection);
+            else
+            {
+                std::unique_lock<std::mutex> lock(mMtxForMap);
+                mIncompatibleChunkRequestIds.insert(requestId);
+            }
+
+            auto allCounterparts = mCacheTransferLayer.computeCounterparts(
+                mSelfState.getCommState().value().getSelfIdx(), info.getTransState());
+
+            auto peerSelfIdx = info.getTransState().getCommState()->getSelfIdx();
+            int peerIdx = std::distance(
+                allCounterparts.begin(), std::find(allCounterparts.begin(), allCounterparts.end(), peerSelfIdx));
+
+            {
+                TLLM_CHECK_WITH_INFO(peerIdx < static_cast<int>(allCounterparts.size()),
+                    "Peer rank %d not found in expected counterparts", peerSelfIdx);
+                std::unique_lock<std::mutex> lk(mMtxForMap);
+                auto it = mRequestToSession.find(requestId);
+                if (it == mRequestToSession.end())
+                {
+                    auto session = TransferSession(std::vector<Connection const*>(allCounterparts.size(), nullptr),
+                        DataContext{tagFromRequestId(requestId), mTerminate}, allCounterparts, mSelfState,
+                        info.getTransState(), mBufferManager, info.getIndexFromEnd(), info.getLastBlockKey(), nullptr,
+                        !common::getEnvKVCacheTimeOutputPath().empty());
+                    session.setTime(TransferSession::kTimeRequestInfo);
+                    it = mRequestToSession.emplace(requestId, std::move(session)).first;
+                }
+                it->second.setConnection(peerIdx, connection);
+            }
+        }
+        catch (...)
+        {
+            try
+            {
+                if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
+                {
+                    agentConnection->eraseRequestSenderState(requestId);
+                }
+            }
+            catch (std::exception const& cleanupError)
+            {
+                TLLM_LOG_WARNING(
+                    "Failed to erase Agent sender state for rejected request %ld: %s", requestId, cleanupError.what());
+            }
+            catch (...)
+            {
+                TLLM_LOG_WARNING("Failed to erase Agent sender state for rejected request %ld", requestId);
+            }
+            throw;
         }
         return info;
     }
@@ -452,6 +613,11 @@ public:
             session = std::addressof(it->second);
         }
         auto const& connections = session->getConnections();
+        // Use a request-scoped readiness channel for every same-build peer.
+        // Besides avoiding cross-request signal stealing, this lets a request
+        // containing inconsistently configured ranks reject all connections on
+        // the same channel before deciding whether chunk phases are enabled.
+        auto const readyContext = chunkRequestHandshakeContext(*session);
         for (size_t i = 0; i < connections.size(); i++)
         {
             auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
@@ -459,15 +625,153 @@ public:
             {
                 auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections.at(i));
                 TLLM_CHECK(agentConnection);
-                agentConnection->sendReadySignal(
-                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG}, isReady);
+                agentConnection->sendReadySignal(readyContext, isReady);
             }
             else
             {
-                connections.at(i)->send(
-                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG}, &isReady, sizeof(isReady));
+                connections.at(i)->send(readyContext, &isReady, sizeof(isReady));
             }
         }
+    }
+
+    bool usesChunkRequestHandshake(LlmRequest::RequestIdType requestId)
+    {
+        std::unique_lock<std::mutex> lock(mMtxForMap);
+        auto const it = mRequestToSession.find(requestId);
+        TLLM_CHECK(it != mRequestToSession.end());
+        auto const& session = it->second;
+        return session.getSelfState().getCacheState()->getTransferChunkSizeBlocks().has_value()
+            || session.getOtherState().getCacheState()->getTransferChunkSizeBlocks().has_value();
+    }
+
+    bool hasCompatibleChunkConfig(LlmRequest::RequestIdType requestId)
+    {
+        std::unique_lock<std::mutex> lock(mMtxForMap);
+        auto const it = mRequestToSession.find(requestId);
+        TLLM_CHECK(it != mRequestToSession.end());
+        auto const& session = it->second;
+        return mIncompatibleChunkRequestIds.find(requestId) == mIncompatibleChunkRequestIds.end()
+            && session.getSelfState().getCacheState()->getTransferChunkSizeBlocks()
+            == session.getOtherState().getCacheState()->getTransferChunkSizeBlocks();
+    }
+
+    bool hasSupportedChunkTopology(LlmRequest::RequestIdType requestId)
+    {
+        try
+        {
+            std::unique_lock<std::mutex> lock(mMtxForMap);
+            auto const it = mRequestToSession.find(requestId);
+            TLLM_CHECK(it != mRequestToSession.end());
+            auto const& session = it->second;
+            if (!session.getSelfState().getCacheState()->getTransferChunkSizeBlocks().has_value()
+                && !session.getOtherState().getCacheState()->getTransferChunkSizeBlocks().has_value())
+            {
+                return true;
+            }
+            auto const& selfState = session.getSelfState();
+            auto const& peerState = session.getOtherState();
+            if (!cache_formatter_utils::needSendCache(selfState.getCacheState().value(),
+                    peerState.getCacheState().value(), selfState.getCommState()->getSelfIdx()))
+            {
+                return true;
+            }
+            auto const pickedConnections = cache_formatter_utils::pickSendConnections(session.getConnections().size(),
+                selfState.getCacheState().value(), selfState.getCommState()->getSelfIdx(),
+                peerState.getCacheState().value(), session.getCounterPartRanks());
+            // Every participating rank must have one peer so request- and
+            // chunk-level failure decisions cannot diverge across an uneven graph.
+            return pickedConnections.size() == 1;
+        }
+        catch (std::exception const& error)
+        {
+            TLLM_LOG_WARNING(
+                "Failed to validate chunked KV-cache topology for request %ld: %s", requestId, error.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_WARNING("Failed to validate chunked KV-cache topology for request %ld", requestId);
+        }
+        return false;
+    }
+
+    bool receiveRequesterReadySignal(LlmRequest::RequestIdType requestId)
+    {
+        TransferSession* session = nullptr;
+        {
+            std::unique_lock<std::mutex> lock(mMtxForMap);
+            auto const it = mRequestToSession.find(requestId);
+            TLLM_CHECK(it != mRequestToSession.end());
+            session = std::addressof(it->second);
+        }
+
+        bool allPeersReady = true;
+        auto const handshakeContext = chunkRequestHandshakeContext(*session);
+        for (auto const* connection : session->getConnections())
+        {
+            bool isReady = false;
+            if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
+            {
+                isReady = agentConnection->recvReadySignal(handshakeContext);
+            }
+            else
+            {
+                connection->recv(handshakeContext, &isReady, sizeof(isReady));
+            }
+            allPeersReady &= isReady;
+        }
+        return allPeersReady;
+    }
+
+    void sendResponderDecisionSignal(LlmRequest::RequestIdType requestId, bool isReady)
+    {
+        TransferSession* session = nullptr;
+        {
+            std::unique_lock<std::mutex> lock(mMtxForMap);
+            auto const it = mRequestToSession.find(requestId);
+            TLLM_CHECK(it != mRequestToSession.end());
+            session = std::addressof(it->second);
+        }
+
+        auto const handshakeContext = chunkRequestHandshakeContext(*session);
+        for (auto const* connection : session->getConnections())
+        {
+            if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
+            {
+                agentConnection->sendReadySignal(handshakeContext, isReady);
+            }
+            else
+            {
+                connection->send(handshakeContext, &isReady, sizeof(isReady));
+            }
+        }
+    }
+
+    bool receiveRequesterAuthorizationSignal(LlmRequest::RequestIdType requestId)
+    {
+        TransferSession* session = nullptr;
+        {
+            std::unique_lock<std::mutex> lock(mMtxForMap);
+            auto const it = mRequestToSession.find(requestId);
+            TLLM_CHECK(it != mRequestToSession.end());
+            session = std::addressof(it->second);
+        }
+
+        bool allAuthorized = true;
+        auto const handshakeContext = chunkRequestHandshakeContext(*session);
+        for (auto const* connection : session->getConnections())
+        {
+            bool isAuthorized = false;
+            if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
+            {
+                isAuthorized = agentConnection->recvReadySignal(handshakeContext);
+            }
+            else
+            {
+                connection->recv(handshakeContext, &isAuthorized, sizeof(isAuthorized));
+            }
+            allAuthorized &= isAuthorized;
+        }
+        return allAuthorized;
     }
 
     ~Impl()
@@ -525,23 +829,61 @@ private:
 
     void sendAndRemoveResponse(RequestIdType id, Response resp) noexcept
     {
+        std::exception_ptr transferError;
         try
         {
             TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
             sendSync(*resp.mRequest);
-            release(id);
-            resp.mPromise.set_value();
         }
         catch (tensorrt_llm::common::RequestSpecificException const& e)
         {
             TLLM_LOG_ERROR("Exception in sendAndRemoveResponse: %s ", e.what());
             auto new_exception = TLLM_REQUEST_EXCEPTION(id, e.getErrorCode(), "%s", e.what());
-            resp.mPromise.set_exception(std::make_exception_ptr(new_exception));
+            transferError = std::make_exception_ptr(new_exception);
         }
         catch (std::exception const& e)
         {
             TLLM_LOG_ERROR("Exception in sendAndRemoveResponse: %s request id: %ld", e.what(), id);
-            resp.mPromise.set_exception(std::current_exception());
+            transferError = std::current_exception();
+        }
+        catch (...)
+        {
+            TLLM_LOG_ERROR("Unknown exception in sendAndRemoveResponse for request id: %ld", id);
+            transferError = std::current_exception();
+        }
+
+        try
+        {
+            release(id, /*exportMeasures=*/transferError == nullptr);
+        }
+        catch (...)
+        {
+            if (transferError == nullptr)
+            {
+                transferError = std::current_exception();
+            }
+            else
+            {
+                TLLM_LOG_WARNING("Failed to clean up KV-cache sender session for request id: %ld", id);
+            }
+        }
+
+        try
+        {
+            if (transferError != nullptr)
+            {
+                resp.mPromise.set_exception(transferError);
+            }
+            else
+            {
+                resp.mPromise.set_value();
+            }
+        }
+        catch (std::future_error const& e)
+        {
+            // The caller may already have abandoned or resolved the promise;
+            // sender cleanup above is still complete.
+            TLLM_LOG_WARNING("Failed to resolve KV-cache sender promise for request id %ld: %s", id, e.what());
         }
     }
 
@@ -570,9 +912,35 @@ private:
                     isReady = false;
                 }
             }
+            isReady &= hasCompatibleChunkConfig(reqId);
+            isReady &= hasSupportedChunkTopology(reqId);
+            bool const usesChunkHandshake = usesChunkRequestHandshake(reqId);
+            if (usesChunkHandshake && it->second.mRequest->mSamplingConfig.beamWidth != 1)
+            {
+                TLLM_LOG_WARNING(
+                    "Rejecting chunked KV-cache transfer for request %ld because beam width %d is unsupported.", reqId,
+                    it->second.mRequest->mSamplingConfig.beamWidth);
+                isReady = false;
+            }
             sendReadySignal(reqId, isReady);
-
+            bool requesterReady = true;
+            bool requesterAuthorized = true;
             if (isReady)
+            {
+                requesterReady = receiveRequesterReadySignal(reqId);
+                // Every requester that observed this responder as locally
+                // ready waits for the responder's final all-requester decision.
+                // This third phase makes readiness atomic across overlapping
+                // multi-rank counterpart graphs.
+                sendResponderDecisionSignal(reqId, requesterReady);
+                // Do not enter payload transfer until every requester has
+                // collected every responder decision and explicitly commits
+                // the request. This prevents one ready responder from sending
+                // into buffers owned by a requester that rejected another edge.
+                requesterAuthorized = receiveRequesterAuthorizationSignal(reqId);
+            }
+
+            if (isReady && requesterReady && requesterAuthorized)
             {
                 if (dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager) != nullptr)
                 {
@@ -606,19 +974,15 @@ private:
                     mCancelledRequests.erase(cancelledReqId);
                     mRemainSendCount.erase(cancelledReqId);
                 }
-                cancelledResponse.mPromise.set_exception(std::make_exception_ptr(
-                    TLLM_REQUEST_EXCEPTION(cancelledReqId, common::RequestErrorCode::kNETWORK_ERROR,
-                        "KV cache transfer for request %zu was cancelled", cancelledReqId)));
-                mCurrentRequest = std::nullopt;
-
-                if (mReadyResponses.empty())
-                {
-                    std::unique_lock lk(mCondMutex);
-                    mAnyReady = false;
-                }
+                release(cancelledReqId, /*exportMeasures=*/false);
+                cancelledResponse.mPromise.set_exception(std::make_exception_ptr(TLLM_REQUEST_EXCEPTION(cancelledReqId,
+                    common::RequestErrorCode::kNETWORK_ERROR,
+                    "KV cache transfer for request %zu was cancelled or rejected by its requester", cancelledReqId)));
+                clearCurrentRequest();
+                refreshAnyReadyFromResponses();
             }
         }
-        mCurrentRequest = std::nullopt;
+        clearCurrentRequest();
     }
 
     void response() noexcept
@@ -627,7 +991,7 @@ private:
         {
             tensorrt_llm::common::setThreadName("dataTransResp");
             TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
-            while (!mTerminate || !mAnyReady)
+            while (!mTerminate)
             {
                 if (!mAnyReady)
                 {
@@ -638,59 +1002,111 @@ private:
                 {
                     break;
                 }
-                if (!mReadyResponses.empty())
+                if (!hasReadyResponses())
                 {
-                    auto requestInfo = recvRequestInfo();
-                    if (!requestInfo.has_value() || mTerminate || !mManager->isRunning())
-                    {
-                        return;
-                    }
-                    auto reqId = requestInfo->getRequestId();
-
-                    {
-                        std::scoped_lock lk(mSenderMutex);
-                        mCurrentRequest = reqId;
-                    }
-
-                    if (mRemainSendCount.find(reqId) == mRemainSendCount.end())
-                    {
-                        mRemainSendCount[reqId] = getCounterpartsCount(reqId);
-                    }
+                    refreshAnyReadyFromResponses();
+                    continue;
                 }
-                auto it = getCurrentResponse();
-                if (it != mReadyResponses.end())
+                auto requestInfo = recvRequestInfo();
+                if (!requestInfo.has_value() || mTerminate || !mManager->isRunning())
                 {
-                    sendResponse(it);
-                }
-                else
-                {
-                    auto it = getCurrentResponse();
-                    while (it == mReadyResponses.end())
-                    {
-                        std::unique_lock lk(mCondMutex);
-                        mSenderCv.wait(lk, [this]() { return (mAnyReady || mTerminate); });
-                        if (mTerminate)
-                        {
-                            break;
-                        }
-                        it = getCurrentResponse();
-                    }
-                    if (mTerminate || it == mReadyResponses.end())
+                    if (mTerminate)
                     {
                         break;
                     }
-                    sendResponse(it);
+                    TLLM_THROW("KV-cache sender service stopped while responses were pending.");
                 }
+                auto reqId = requestInfo->getRequestId();
+
+                {
+                    std::scoped_lock lk(mSenderMutex);
+                    mCurrentRequest = reqId;
+                }
+
+                if (mRemainSendCount.find(reqId) == mRemainSendCount.end())
+                {
+                    mRemainSendCount[reqId] = getCounterpartsCount(reqId);
+                }
+                if (!hasCurrentResponse())
+                {
+                    std::unique_lock lk(mCondMutex);
+                    mSenderCv.wait(lk, [this]() { return (hasCurrentResponse() || mTerminate); });
+                    if (mTerminate)
+                    {
+                        break;
+                    }
+                }
+                auto it = getCurrentResponse();
+                sendResponse(it);
             }
         }
         catch (std::exception const& err)
         {
             TLLM_LOG_ERROR("Exception in CacheSender response: %s", err.what());
-            for (auto& it : mReadyResponses)
+            failResponseService(std::current_exception());
+        }
+        catch (...)
+        {
+            TLLM_LOG_ERROR("Unknown exception in CacheSender response");
+            failResponseService(std::current_exception());
+        }
+    }
+
+    void failResponseService(std::exception_ptr error) noexcept
+    {
+        mTerminate = true;
+        std::vector<std::pair<RequestIdType, Response>> pendingResponses;
+        {
+            std::scoped_lock lk(mSenderMutex);
+            pendingResponses.reserve(mReadyResponses.size());
+            for (auto& [requestId, response] : mReadyResponses)
             {
-                it.second.mPromise.set_exception(std::current_exception());
+                pendingResponses.emplace_back(requestId, std::move(response));
+            }
+            mReadyResponses.clear();
+            mCancelledRequests.clear();
+            mRemainSendCount.clear();
+            mCurrentRequest = std::nullopt;
+        }
+
+        for (auto& [requestId, response] : pendingResponses)
+        {
+            try
+            {
+                release(requestId, /*exportMeasures=*/false);
+            }
+            catch (std::exception const& cleanupError)
+            {
+                TLLM_LOG_WARNING(
+                    "Failed to clean up KV-cache session %ld after sender failure: %s", requestId, cleanupError.what());
+            }
+            catch (...)
+            {
+                TLLM_LOG_WARNING("Failed to clean up KV-cache session %ld after sender failure", requestId);
+            }
+
+            try
+            {
+                response.mPromise.set_exception(error);
+            }
+            catch (std::future_error const& promiseError)
+            {
+                TLLM_LOG_WARNING("Failed to reject KV-cache response promise %ld: %s", requestId, promiseError.what());
             }
         }
+        // Agent transfers execute synchronously on this response thread, so
+        // no worker can still reference a session here. Other backends may
+        // have in-flight async workers and are drained by terminate().
+        if (dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager) != nullptr)
+        {
+            clearTransferSessions();
+        }
+
+        {
+            std::unique_lock lk(mCondMutex);
+            mAnyReady = false;
+        }
+        mSenderCv.notify_all();
     }
 
     void terminate()
@@ -712,6 +1128,29 @@ private:
         {
             mResponseFuture.get();
         }
+        clearTransferSessions();
+    }
+
+    void clearTransferSessions() noexcept
+    {
+        try
+        {
+            std::unique_lock<std::mutex> lock(mMtxForMap);
+            for (auto const& [requestId, session] : mRequestToSession)
+            {
+                session.eraseAgentSenderState(requestId);
+            }
+            mRequestToSession.clear();
+            mIncompatibleChunkRequestIds.clear();
+        }
+        catch (std::exception const& error)
+        {
+            TLLM_LOG_WARNING("Failed to clear KV-cache sender sessions: %s", error.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_WARNING("Failed to clear KV-cache sender sessions");
+        }
     }
 
     void removeResponse(std::map<RequestIdType, Response>::iterator it)
@@ -720,11 +1159,35 @@ private:
             std::scoped_lock lkResp(mSenderMutex);
             mReadyResponses.erase(it);
         }
-        if (mReadyResponses.empty())
-        {
-            std::unique_lock lkCond(mCondMutex);
-            mAnyReady = false;
-        }
+        refreshAnyReadyFromResponses();
+    }
+
+    void refreshAnyReadyFromResponses()
+    {
+        // The condition mutex serializes this recheck with sendAsync's true
+        // transition. Locking it before the response mutex also matches the
+        // condition-variable predicates below.
+        std::unique_lock lkCond(mCondMutex);
+        std::scoped_lock lkResp(mSenderMutex);
+        mAnyReady = !mReadyResponses.empty();
+    }
+
+    [[nodiscard]] bool hasReadyResponses()
+    {
+        std::scoped_lock lk(mSenderMutex);
+        return !mReadyResponses.empty();
+    }
+
+    [[nodiscard]] bool hasCurrentResponse()
+    {
+        std::scoped_lock lk(mSenderMutex);
+        return mCurrentRequest.has_value() && mReadyResponses.find(*mCurrentRequest) != mReadyResponses.end();
+    }
+
+    void clearCurrentRequest()
+    {
+        std::scoped_lock lk(mSenderMutex);
+        mCurrentRequest.reset();
     }
 
     [[nodiscard]] RequestIdType getCurrentRequestId() const
@@ -735,7 +1198,9 @@ private:
     [[nodiscard]] std::map<RequestIdType, Response>::iterator getCurrentResponse()
     {
         std::scoped_lock lk(mSenderMutex);
-        return mReadyResponses.find(getCurrentRequestId());
+        auto it = mReadyResponses.find(getCurrentRequestId());
+        TLLM_CHECK(it != mReadyResponses.end());
+        return it;
     }
 
 public:
@@ -762,6 +1227,7 @@ private:
 
     executor::kv_cache::ConnectionManager* mManager;
     std::map<LlmRequest::RequestIdType, TransferSession> mRequestToSession;
+    std::unordered_set<LlmRequest::RequestIdType> mIncompatibleChunkRequestIds;
     executor::DataTransceiverState mSelfState;
     CacheTransferLayer mCacheTransferLayer;
     std::mutex mMtxForMap;
@@ -850,7 +1316,12 @@ public:
         auto const& contextState = llmRequest.getDataTransceiverState();
         auto const& commState = contextState.getCommState().value();
         auto const& destCacheState = contextState.getCacheState().value();
-        mCacheTransferLayer.validateSupport(contextState);
+        auto const chunkConfigMismatch = mCacheTransferLayer.getCacheState().getTransferChunkSizeBlocks()
+            != destCacheState.getTransferChunkSizeBlocks();
+        if (!chunkConfigMismatch)
+        {
+            mCacheTransferLayer.validateSupport(contextState);
+        }
 
         RequestInfo requestInfo(requestId, mSelfState);
 
@@ -885,17 +1356,6 @@ public:
             }
         }
 
-        auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
-        std::vector<std::optional<size_t>> cacheBufferIds;
-        if (agentConnectionManager)
-        {
-            for (auto& cacheTransBufferManager : agentConnectionManager->getCacheTransBufferManagers())
-            {
-                cacheBufferIds.push_back(cacheTransBufferManager->assignBufferIndexForRecv());
-            }
-            TLLM_CHECK(!cacheBufferIds.empty());
-        }
-
         auto allCounterparts
             = mCacheTransferLayer.computeCounterparts(mSelfState.getCommState().value().getSelfIdx(), contextState);
 
@@ -920,70 +1380,144 @@ public:
             allConnections.emplace_back(connection);
         }
 
-        for (size_t ci = 0; ci < allCounterparts.size(); ci++)
+        // Finish every local allocation that can fail before publishing Agent
+        // receive-buffer descriptors. Once a descriptor is sent, its slot must
+        // remain quarantined until request-level completion or connection
+        // teardown because a peer may still issue an RDMA write to it.
+        auto const& resource = getReceiveCacheResource(llmRequest);
+        auto session = TransferSession(allConnections, DataContext{tagFromRequestId(requestId), mTerminate},
+            allCounterparts, mSelfState, contextState, resource->mBufferManager, requestInfo.getIndexFromEnd(),
+            requestInfo.getLastBlockKey(), &llmRequest, !common::getEnvKVCacheTimeOutputPath().empty());
+
+        auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
+        std::vector<std::optional<size_t>> cacheBufferIds;
+        AssignedRecvBufferGuard assignedBufferGuard(agentConnectionManager, cacheBufferIds);
+        if (agentConnectionManager)
         {
-            auto rank = allCounterparts[ci];
-            auto const* connection = connections.at(rank);
-
-            bool isKvCounterpart
-                = std::find(kvCounterParts.begin(), kvCounterParts.end(), rank) != kvCounterParts.end();
-            bool isRnnCounterpart
-                = hasRnn && std::find(rnnCounterParts.begin(), rnnCounterParts.end(), rank) != rnnCounterParts.end();
-
-            if (agentConnectionManager)
+            auto const& cacheTransBufferManagers = agentConnectionManager->getCacheTransBufferManagers();
+            cacheBufferIds.reserve(cacheTransBufferManagers.size());
+            std::unordered_map<uint8_t, size_t> preAssignedBufferIds;
+            preAssignedBufferIds.reserve(cacheTransBufferManagers.size());
+            for (auto* cacheTransBufferManager : cacheTransBufferManagers)
             {
-                auto idsForRank = cacheBufferIds;
-                auto const& managers = agentConnectionManager->getCacheTransBufferManagers();
-                for (size_t i = 0; i < idsForRank.size(); i++)
+                auto const bufferId = cacheTransBufferManager->assignBufferIndexForRecv();
+                cacheBufferIds.push_back(bufferId);
+                if (bufferId.has_value())
                 {
-                    auto kind = managers[i]->getBufferKind();
-                    bool include = (kind != BufferKind::kRNN) ? isKvCounterpart : isRnnCounterpart;
-                    if (!include)
-                    {
-                        idsForRank[i] = std::nullopt;
-                    }
+                    auto const kind = static_cast<uint8_t>(cacheTransBufferManager->getBufferKind());
+                    bool const inserted
+                        = preAssignedBufferIds.emplace(kind, static_cast<size_t>(bufferId.value())).second;
+                    TLLM_CHECK_WITH_INFO(
+                        inserted, "Duplicate Agent receive-buffer kind %u", static_cast<unsigned>(kind));
                 }
-
-                int validConnectionIdx = 0;
-                if (isKvCounterpart)
-                {
-                    auto kvCpIdx
-                        = std::find(kvCounterParts.begin(), kvCounterParts.end(), rank) - kvCounterParts.begin();
-                    auto [pickUpIdx, localRankIdx] = mCacheTransferLayer.getKvFormatter()->pickRecvConnections(
-                        allCounterparts.size(), mSelfState.getCacheState().value(),
-                        mSelfState.getCommState().value().getSelfIdx(), destCacheState, allCounterparts);
-                    validConnectionIdx
-                        = std::find(localRankIdx.begin(), localRankIdx.end(), kvCpIdx) - localRankIdx.begin();
-                }
-                else if (isRnnCounterpart)
-                {
-                    auto rnnTargetInfo = executor::kv_cache::targetIRanksForRnn(destCacheState,
-                        mCacheTransferLayer.getCacheState(), mSelfState.getCommState().value().getSelfIdx());
-                    auto rnnCpIdx
-                        = std::find(rnnCounterParts.begin(), rnnCounterParts.end(), rank) - rnnCounterParts.begin();
-                    auto [pickUpIdx, localRankIdx] = cache_formatter_utils::pickRecvConnections(rnnCounterParts.size(),
-                        mCacheTransferLayer.getCacheState(), mSelfState.getCommState().value().getSelfIdx(),
-                        destCacheState, rnnCounterParts, rnnTargetInfo);
-                    validConnectionIdx
-                        = std::find(localRankIdx.begin(), localRankIdx.end(), rnnCpIdx) - localRankIdx.begin();
-                }
-
-                auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection);
-                TLLM_CHECK(agentConnection != nullptr);
-
-                const_cast<executor::kv_cache::AgentConnection*>(agentConnection)
-                    ->sendRequestAndBufferInfo(requestInfo, idsForRank, validConnectionIdx);
             }
-            else
+            TLLM_CHECK(!cacheBufferIds.empty());
+            session.setPreAssignedBufferIds(std::move(preAssignedBufferIds));
+        }
+
+        std::unique_lock<std::mutex> agentPublicationLock;
+        if (agentConnectionManager)
+        {
+            agentPublicationLock = std::unique_lock<std::mutex>(mAgentPublicationMutex);
+            for (auto* bufferManager : agentConnectionManager->getCacheTransBufferManagers())
             {
-                sendRequestInfo(connection, requestInfo);
+                TLLM_CHECK_WITH_INFO(!bufferManager->areRecvBufferAssignmentsAborted(),
+                    "Agent receive-buffer publication is disabled after an earlier destination was quarantined.");
             }
         }
-        auto const& resource = getReceiveCacheResource(llmRequest);
-        return TransferSession(std::move(allConnections), DataContext{tagFromRequestId(requestId), mTerminate},
-            std::move(allCounterparts), mSelfState, contextState, resource->mBufferManager,
-            requestInfo.getIndexFromEnd(), requestInfo.getLastBlockKey(), &llmRequest,
-            !common::getEnvKVCacheTimeOutputPath().empty());
+
+        bool descriptorMayBePublished = false;
+        try
+        {
+            for (size_t ci = 0; ci < allCounterparts.size(); ci++)
+            {
+                auto rank = allCounterparts[ci];
+                auto const* connection = connections.at(rank);
+
+                bool isKvCounterpart
+                    = std::find(kvCounterParts.begin(), kvCounterParts.end(), rank) != kvCounterParts.end();
+                bool isRnnCounterpart = hasRnn
+                    && std::find(rnnCounterParts.begin(), rnnCounterParts.end(), rank) != rnnCounterParts.end();
+
+                if (agentConnectionManager)
+                {
+                    auto idsForRank = cacheBufferIds;
+                    auto const& managers = agentConnectionManager->getCacheTransBufferManagers();
+                    for (size_t i = 0; i < idsForRank.size(); i++)
+                    {
+                        auto kind = managers[i]->getBufferKind();
+                        bool include = (kind != BufferKind::kRNN) ? isKvCounterpart : isRnnCounterpart;
+                        if (!include)
+                        {
+                            idsForRank[i] = std::nullopt;
+                        }
+                    }
+
+                    int validConnectionIdx = 0;
+                    if (isKvCounterpart)
+                    {
+                        auto kvCpIdx
+                            = std::find(kvCounterParts.begin(), kvCounterParts.end(), rank) - kvCounterParts.begin();
+                        auto [pickUpIdx, localRankIdx] = mCacheTransferLayer.getKvFormatter()->pickRecvConnections(
+                            allCounterparts.size(), mSelfState.getCacheState().value(),
+                            mSelfState.getCommState().value().getSelfIdx(), destCacheState, allCounterparts);
+                        validConnectionIdx
+                            = std::find(localRankIdx.begin(), localRankIdx.end(), kvCpIdx) - localRankIdx.begin();
+                    }
+                    else if (isRnnCounterpart)
+                    {
+                        auto rnnTargetInfo = executor::kv_cache::targetIRanksForRnn(destCacheState,
+                            mCacheTransferLayer.getCacheState(), mSelfState.getCommState().value().getSelfIdx());
+                        auto rnnCpIdx
+                            = std::find(rnnCounterParts.begin(), rnnCounterParts.end(), rank) - rnnCounterParts.begin();
+                        auto [pickUpIdx, localRankIdx]
+                            = cache_formatter_utils::pickRecvConnections(rnnCounterParts.size(),
+                                mCacheTransferLayer.getCacheState(), mSelfState.getCommState().value().getSelfIdx(),
+                                destCacheState, rnnCounterParts, rnnTargetInfo);
+                        validConnectionIdx
+                            = std::find(localRankIdx.begin(), localRankIdx.end(), rnnCpIdx) - localRankIdx.begin();
+                    }
+
+                    auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection);
+                    TLLM_CHECK(agentConnection != nullptr);
+
+                    // sendRequestAndBufferInfo may partially publish before
+                    // reporting a transport error. From this point onward the
+                    // slot cannot be returned to the local pool without a peer
+                    // abort acknowledgement, which this transport does not expose.
+                    descriptorMayBePublished = true;
+                    assignedBufferGuard.detach();
+                    const_cast<executor::kv_cache::AgentConnection*>(agentConnection)
+                        ->sendRequestAndBufferInfo(requestInfo, idsForRank, validConnectionIdx);
+                }
+                else
+                {
+                    sendRequestInfo(connection, requestInfo);
+                }
+            }
+        }
+        catch (...)
+        {
+            auto const publicationError = std::current_exception();
+            if (descriptorMayBePublished)
+            {
+                try
+                {
+                    abortPreAssignedRecvBufferAssignments(session);
+                }
+                catch (std::exception const& cleanupError)
+                {
+                    TLLM_LOG_WARNING("Failed to abort Agent receive-buffer assignments after publication failure: %s",
+                        cleanupError.what());
+                }
+                catch (...)
+                {
+                    TLLM_LOG_WARNING("Failed to abort Agent receive-buffer assignments after publication failure.");
+                }
+            }
+            std::rethrow_exception(publicationError);
+        }
+        return session;
     }
 
     std::unique_ptr<ReceiveCacheResource> const& getReceiveCacheResource(LlmRequest const& llmRequest)
@@ -1062,11 +1596,12 @@ public:
         return isCancelled;
     }
 
-    bool receiveReadySignal(TransferSession& session)
+    bool receiveReadySignal(TransferSession& session, std::vector<bool>* connectionReadiness = nullptr)
     {
         bool isReadyFinal = true;
         bool isReady = false;
         auto const& connections = session.getConnections();
+        auto const readyContext = chunkRequestHandshakeContext(session);
 
         for (size_t i = 0; i < connections.size(); i++)
         {
@@ -1075,18 +1610,137 @@ public:
             {
                 auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections.at(i));
                 TLLM_CHECK(agentConnection);
-                isReady = agentConnection->recvReadySignal(
-                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG, mTerminate});
+                isReady = agentConnection->recvReadySignal(readyContext);
             }
             else
             {
-                connections.at(i)->recv(
-                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG}, &isReady, sizeof(isReady));
+                connections.at(i)->recv(readyContext, &isReady, sizeof(isReady));
             }
             isReadyFinal &= isReady;
+            if (connectionReadiness != nullptr)
+            {
+                connectionReadiness->push_back(isReady);
+            }
         }
 
         return isReadyFinal;
+    }
+
+    void sendAggregateReadySignal(
+        TransferSession const& session, std::vector<bool> const& connectionReadiness, bool isReady)
+    {
+        auto const& connections = session.getConnections();
+        auto const handshakeContext = chunkRequestHandshakeContext(session);
+        TLLM_CHECK(connections.size() == connectionReadiness.size());
+        for (size_t i = 0; i < connections.size(); ++i)
+        {
+            if (!connectionReadiness[i])
+            {
+                continue;
+            }
+            auto const* connection = connections[i];
+            if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
+            {
+                agentConnection->sendReadySignal(handshakeContext, isReady);
+            }
+            else
+            {
+                connection->send(handshakeContext, &isReady, sizeof(isReady));
+            }
+        }
+    }
+
+    bool receiveResponderDecisionSignals(TransferSession const& session, std::vector<bool> const& connectionReadiness)
+    {
+        auto const& connections = session.getConnections();
+        auto const handshakeContext = chunkRequestHandshakeContext(session);
+        TLLM_CHECK(connections.size() == connectionReadiness.size());
+        bool allPeersReady = true;
+        for (size_t i = 0; i < connections.size(); ++i)
+        {
+            if (!connectionReadiness[i])
+            {
+                continue;
+            }
+            auto const* connection = connections[i];
+            bool isReady = false;
+            if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
+            {
+                isReady = agentConnection->recvReadySignal(handshakeContext);
+            }
+            else
+            {
+                connection->recv(handshakeContext, &isReady, sizeof(isReady));
+            }
+            allPeersReady &= isReady;
+        }
+        return allPeersReady;
+    }
+
+    void sendRequesterAuthorizationSignals(
+        TransferSession const& session, std::vector<bool> const& connectionReadiness, bool isAuthorized)
+    {
+        auto const& connections = session.getConnections();
+        auto const handshakeContext = chunkRequestHandshakeContext(session);
+        TLLM_CHECK(connections.size() == connectionReadiness.size());
+        for (size_t i = 0; i < connections.size(); ++i)
+        {
+            if (!connectionReadiness[i])
+            {
+                continue;
+            }
+            auto const* connection = connections[i];
+            if (auto const* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection))
+            {
+                agentConnection->sendReadySignal(handshakeContext, isAuthorized);
+            }
+            else
+            {
+                connection->send(handshakeContext, &isAuthorized, sizeof(isAuthorized));
+            }
+        }
+    }
+
+    void releasePreAssignedRecvBuffers(TransferSession const& session)
+    {
+        auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
+        if (agentConnectionManager == nullptr)
+        {
+            return;
+        }
+
+        auto const& managers = agentConnectionManager->getCacheTransBufferManagers();
+        for (auto* bufferManager : managers)
+        {
+            auto const kind = static_cast<uint8_t>(bufferManager->getBufferKind());
+            auto const bufferId = session.getPreAssignedBufferId(kind);
+            if (bufferId.has_value())
+            {
+                TLLM_CHECK_WITH_INFO(bufferId.value() <= static_cast<size_t>(std::numeric_limits<int>::max()),
+                    "Preassigned receive-buffer index is out of range: %zu", bufferId.value());
+                bufferManager->freeBufferIndexForRecv(static_cast<int>(bufferId.value()));
+            }
+        }
+    }
+
+    void abortPreAssignedRecvBufferAssignments(TransferSession const& session)
+    {
+        if (session.getPreAssignedBufferIds().empty())
+        {
+            return;
+        }
+        auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
+        TLLM_CHECK(agentConnectionManager != nullptr);
+        for (auto* bufferManager : agentConnectionManager->getCacheTransBufferManagers())
+        {
+            bufferManager->abortRecvBufferAssignments();
+        }
+    }
+
+    void quarantinePreAssignedRecvBuffers(TransferSession const& session)
+    {
+        std::scoped_lock lock(mAgentPublicationMutex);
+        abortPreAssignedRecvBufferAssignments(session);
     }
 
     ~Impl()
@@ -1113,15 +1767,131 @@ private:
         TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
         auto session = sendRequestInfo(llmRequest);
         session.setTime(TransferSession::kTimeRequestInfo);
-        bool isReady = receiveReadySignal(session);
-        if (!isReady)
+        auto const& selfCacheState = session.getSelfState().getCacheState().value();
+        auto const& peerCacheState = session.getOtherState().getCacheState().value();
+        bool const usesChunkHandshake = selfCacheState.getTransferChunkSizeBlocks().has_value()
+            || peerCacheState.getTransferChunkSizeBlocks().has_value();
+        bool preAssignedBuffersReleased = false;
+        bool payloadMayHaveStarted = false;
+        bool formatterOwnsPreAssignedBuffers = false;
+        auto releasePreAssignedBuffersOnce = [&]
         {
-            // Reuse the error state for the cancelled request.
-            llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-            llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
-            return;
+            if (!preAssignedBuffersReleased)
+            {
+                preAssignedBuffersReleased = true;
+                releasePreAssignedRecvBuffers(session);
+            }
+        };
+        try
+        {
+            std::vector<bool> connectionReadiness;
+            connectionReadiness.reserve(session.getConnections().size());
+            bool isReady = receiveReadySignal(session, &connectionReadiness);
+            if (usesChunkHandshake)
+            {
+                try
+                {
+                    auto const pickedConnections
+                        = cache_formatter_utils::pickRecvConnections(session.getConnections().size(), selfCacheState,
+                            session.getSelfState().getCommState()->getSelfIdx(), peerCacheState,
+                            session.getCounterPartRanks())
+                              .first;
+                    isReady &= pickedConnections.size() <= 1;
+                }
+                catch (std::exception const& error)
+                {
+                    TLLM_LOG_WARNING("Failed to validate chunked KV-cache receive topology for request %ld: %s",
+                        llmRequest.mRequestId, error.what());
+                    isReady = false;
+                }
+                catch (...)
+                {
+                    TLLM_LOG_WARNING(
+                        "Failed to validate chunked KV-cache receive topology for request %ld", llmRequest.mRequestId);
+                    isReady = false;
+                }
+            }
+
+            // Every same-build request uses the complete readiness protocol,
+            // even when this rank has chunking disabled. Otherwise per-rank
+            // flag skew can let a legacy responder enter payload transfer while
+            // another edge causes the requester to reject the request.
+            sendAggregateReadySignal(session, connectionReadiness, isReady);
+            isReady &= receiveResponderDecisionSignals(session, connectionReadiness);
+
+            // A fourth commit phase prevents any responder from entering the
+            // payload path until this requester has collected all decisions.
+            // Once a positive authorization may have been delivered, Agent
+            // receive slots must be quarantined on failure because a peer can
+            // still hold and write the published GPU descriptor.
+            if (isReady
+                && std::any_of(
+                    connectionReadiness.begin(), connectionReadiness.end(), [](bool ready) { return ready; }))
+            {
+                payloadMayHaveStarted = true;
+            }
+            sendRequesterAuthorizationSignals(session, connectionReadiness, isReady);
+            if (!isReady)
+            {
+                releasePreAssignedBuffersOnce();
+                // Reuse the error state for the cancelled request.
+                llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
+                return;
+            }
+            // Legacy formatters retain their existing local BufferIndexHolder
+            // ownership. The chunked formatter leaves request-owned Agent slots
+            // to this outer request lifecycle so failures can quarantine them.
+            formatterOwnsPreAssignedBuffers = !usesChunkHandshake;
+            receiveSync(session);
+            if (usesChunkHandshake)
+            {
+                releasePreAssignedBuffersOnce();
+            }
         }
-        receiveSync(session);
+        catch (...)
+        {
+            auto const transferError = std::current_exception();
+            if (payloadMayHaveStarted && !session.getPreAssignedBufferIds().empty())
+            {
+                TLLM_LOG_WARNING(
+                    "Quarantining Agent KV-cache receive buffers and aborting further assignments for failed request "
+                    "%ld because payload transfer may have started.",
+                    llmRequest.mRequestId);
+                try
+                {
+                    quarantinePreAssignedRecvBuffers(session);
+                }
+                catch (std::exception const& cleanupError)
+                {
+                    TLLM_LOG_WARNING("Failed to abort Agent receive-buffer assignments for request %ld: %s",
+                        llmRequest.mRequestId, cleanupError.what());
+                }
+                catch (...)
+                {
+                    TLLM_LOG_WARNING(
+                        "Failed to abort Agent receive-buffer assignments for request %ld", llmRequest.mRequestId);
+                }
+            }
+            else if (!formatterOwnsPreAssignedBuffers)
+            {
+                try
+                {
+                    releasePreAssignedBuffersOnce();
+                }
+                catch (std::exception const& cleanupError)
+                {
+                    TLLM_LOG_WARNING("Failed to release chunked KV-cache receive buffers for request %ld: %s",
+                        llmRequest.mRequestId, cleanupError.what());
+                }
+                catch (...)
+                {
+                    TLLM_LOG_WARNING(
+                        "Failed to release chunked KV-cache receive buffers for request %ld", llmRequest.mRequestId);
+                }
+            }
+            std::rethrow_exception(transferError);
+        }
         llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
 
         TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
@@ -1253,6 +2023,7 @@ private:
     CacheTransferLayer mCacheTransferLayer;
     std::unordered_map<std::string, std::unique_ptr<ReceiveCacheResource>> mProcessToResources;
     std::mutex mProcessIoResouceMutex;
+    std::mutex mAgentPublicationMutex;
     runtime::BufferManager mBufferManager;
     std::ofstream mMeasuresFile;
     std::mutex mMeasuresFileMutex;

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,9 @@
 #include <fstream>
 #include <future>
 #include <map>
+#include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "tensorrt_llm/batch_manager/cacheTransceiver.h"
@@ -124,6 +126,8 @@ public:
     // in CacheSender, the LlmRequest is not available until the sendSync is called
     void setLlmRequest(LlmRequest const& llmRequest);
 
+    void eraseAgentSenderState(LlmRequest::RequestIdType requestId) const noexcept;
+
     void setTime(TimeNames name);
 
     void appendMeasure(LlmRequest::TimePoint start, LlmRequest::TimePoint end, size_t size);
@@ -151,6 +155,22 @@ public:
         mCounterPartRanks = std::move(ranks);
     }
 
+    void setPreAssignedBufferIds(std::unordered_map<uint8_t, size_t> bufferIds)
+    {
+        mPreAssignedBufferIds = std::move(bufferIds);
+    }
+
+    [[nodiscard]] std::optional<size_t> getPreAssignedBufferId(uint8_t kind) const
+    {
+        auto const it = mPreAssignedBufferIds.find(kind);
+        return it == mPreAssignedBufferIds.end() ? std::nullopt : std::make_optional(it->second);
+    }
+
+    [[nodiscard]] std::unordered_map<uint8_t, size_t> const& getPreAssignedBufferIds() const noexcept
+    {
+        return mPreAssignedBufferIds;
+    }
+
 private:
     std::vector<Connection const*> mConnections;
     std::vector<SizeType32> mCounterPartRanks;        // Ranks corresponding to mConnections indices
@@ -162,6 +182,9 @@ private:
     std::unique_ptr<KVCacheTimes> mTimes;
     int32_t mIndexFromEnd{0};
     BlockKey mLastBlockKey{};
+    // Agent connections are shared by remote rank, so request-owned receive
+    // slots must live in the session rather than mutable connection state.
+    std::unordered_map<uint8_t, size_t> mPreAssignedBufferIds;
 };
 
 using UniqueToken = tensorrt_llm::runtime::UniqueToken;

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -37,6 +37,7 @@
 #include "tensorrt_llm/runtime/worldConfig.h"
 
 #include <algorithm>
+#include <exception>
 #include <limits>
 #include <map>
 #include <optional>
@@ -2926,6 +2927,16 @@ std::vector<KVCacheBlock::IdType> BlockManager::storeBlocksForReuse(
     return pinnedBlockIds;
 }
 
+void BlockManager::storeBlocksForTransferLease(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest)
+{
+    if (!llmRequest.has_value() || llmRequest->isDummyRequest() || sequence.getBeamWidth() > 1
+        || mLinearAttentionMetadata.has_value())
+    {
+        return;
+    }
+    static_cast<void>(storeBlocksForReuse(sequence, llmRequest, /*pinBlocks=*/false));
+}
+
 std::optional<KVCacheBlock::IdType> BlockManager::releaseBlocks(
     GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest, bool pinBlocks)
 {
@@ -2957,6 +2968,41 @@ void BlockManager::pinBlocks(GenerationRequest& sequence)
     }
 }
 
+TransferBlockIds BlockManager::pinBlocksForTransferLease(GenerationRequest& sequence)
+{
+    TransferBlockIds blockIds;
+    blockIds.reserve(mWindowBlockManagers.size());
+    for (auto& [windowSize, manager] : mWindowBlockManagers)
+    {
+        auto windowBlockIds = manager.pinBlocksForTransferLease(sequence);
+        try
+        {
+            blockIds.emplace(windowSize, windowBlockIds);
+        }
+        catch (...)
+        {
+            manager.unpinBlocksForTransferLease(windowBlockIds);
+            for (auto const& [pinnedWindowSize, pinnedBlockIds] : blockIds)
+            {
+                mWindowBlockManagers.at(pinnedWindowSize).unpinBlocksForTransferLease(pinnedBlockIds);
+            }
+            throw;
+        }
+    }
+    return blockIds;
+}
+
+void BlockManager::unpinBlocksForTransferLease(TransferBlockIds const& blockIds)
+{
+    for (auto const& [windowSize, windowBlockIds] : blockIds)
+    {
+        auto managerIt = mWindowBlockManagers.find(windowSize);
+        TLLM_CHECK_WITH_INFO(managerIt != mWindowBlockManagers.end(),
+            "Cannot release transfer lease blocks for unknown window size %d", windowSize);
+        managerIt->second.unpinBlocksForTransferLease(windowBlockIds);
+    }
+}
+
 void BlockManager::unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds)
 {
     if (mWindowBlockManagers.empty())
@@ -2982,6 +3028,82 @@ void WindowBlockManager::pinBlocks(GenerationRequest& sequence)
     for (auto& block : allocatedBlocks)
     {
         block->incRefCount();
+    }
+}
+
+std::vector<KVCacheBlock::IdType> WindowBlockManager::pinBlocksForTransferLease(GenerationRequest& sequence)
+{
+    auto const requestId = sequence.getRequestId();
+    auto const& allocatedBlocks = mAllocatedBlocksPerSeq.at(requestId);
+
+    std::vector<KVCacheBlock::IdType> blockIds;
+    std::vector<BlockPtr> blocks;
+    std::unordered_set<KVCacheBlock::IdType> seenBlockIds;
+    blockIds.reserve(allocatedBlocks.size());
+    blocks.reserve(allocatedBlocks.size());
+    seenBlockIds.reserve(allocatedBlocks.size());
+
+    for (auto const& block : allocatedBlocks)
+    {
+        TLLM_CHECK_WITH_INFO(block != nullptr, "Request %lu has a null KV cache block", requestId);
+        if (block->isPlaceholder())
+        {
+            continue;
+        }
+
+        auto const blockId = block->getBlockId();
+        TLLM_CHECK_WITH_INFO(blockId >= 0, "Request %lu has invalid real KV cache block id %d", requestId, blockId);
+        if (seenBlockIds.emplace(blockId).second)
+        {
+            blockIds.push_back(blockId);
+            blocks.push_back(block);
+        }
+    }
+
+    // Validate and allocate all temporary bookkeeping before changing refcounts, so pinning itself cannot fail
+    // part-way through.
+    for (auto const& block : blocks)
+    {
+        TLLM_CHECK_WITH_INFO(block->hasRefs(), "Cannot lease unowned KV cache block %d", block->getBlockId());
+    }
+    for (auto const& block : blocks)
+    {
+        block->incRefCount();
+    }
+    return blockIds;
+}
+
+void WindowBlockManager::unpinBlocksForTransferLease(std::vector<KVCacheBlock::IdType> const& blockIds)
+{
+    std::unordered_set<KVCacheBlock::IdType> seenBlockIds;
+    std::vector<BlockPtr> blocks;
+    seenBlockIds.reserve(blockIds.size());
+    blocks.reserve(blockIds.size());
+    for (auto const blockId : blockIds)
+    {
+        if (!seenBlockIds.emplace(blockId).second)
+        {
+            continue;
+        }
+
+        TLLM_CHECK_WITH_INFO(blockId >= 0 && static_cast<size_t>(blockId) < mAllBlocksById.size(),
+            "Transfer lease block id %d is out of range", blockId);
+        auto const& block = mAllBlocksById[blockId];
+        TLLM_CHECK_WITH_INFO(
+            block != nullptr && !block->isPlaceholder() && block->getBlockId() != KVCacheBlock::kCachedBlocksRootId,
+            "Transfer lease block id %d does not identify a real KV cache block", blockId);
+        TLLM_CHECK_WITH_INFO(block->hasRefs(), "Transfer lease block %d is already unpinned", blockId);
+        blocks.push_back(block);
+    }
+
+    for (auto const& block : blocks)
+    {
+        block->decRefCount();
+        if (!block->hasRefs())
+        {
+            // Match the sequence-release policy: uncached blocks should be reclaimed before reusable tree entries.
+            mEvictionPolicy->releaseBlock(block, /*toFront=*/block->isDetached());
+        }
     }
 }
 
@@ -3959,6 +4081,218 @@ void KVCacheManager::pinBlocks(RequestIdType requestId)
 {
     auto& sequence = getSequence(requestId);
     mBlockManager.pinBlocks(sequence);
+}
+
+void KVCacheManager::beginTransferLease(RequestIdType requestId, OptionalRef<LlmRequest const> llmRequest)
+{
+    TLLM_LOG_TRACE("[%s]::%s start", isCrossKv() ? "CROSS" : "SELF", __PRETTY_FUNCTION__);
+
+    decltype(mSequences)::node_type sequenceNode;
+    {
+        std::scoped_lock lock(mSequencesMtx, mTransferLeaseMtx);
+        TLLM_CHECK_WITH_INFO(mTransferLeases.find(requestId) == mTransferLeases.end(),
+            "A KV transfer lease already exists for request %lu", requestId);
+
+        auto sequenceIt = mSequences.find(requestId);
+        TLLM_CHECK_WITH_INFO(
+            sequenceIt != mSequences.end(), "Cannot begin a KV transfer lease for unknown request %lu", requestId);
+        TLLM_CHECK_WITH_INFO(sequenceIt->second.getBeamWidth() == 1,
+            "KV transfer leases currently support only beam width 1 (request %lu has beam width %d).", requestId,
+            sequenceIt->second.getBeamWidth());
+
+        if (mEnableBlockReuse)
+        {
+            // Store while the sequence is still registered. If hashing/reuse bookkeeping fails, no transfer pins or
+            // detached sequence can be left behind.
+            mBlockManager.storeBlocksForTransferLease(sequenceIt->second, llmRequest);
+        }
+
+        auto blockIds = mBlockManager.pinBlocksForTransferLease(sequenceIt->second);
+        TransferLeaseState leaseState;
+        try
+        {
+            leaseState.blockIds = blockIds;
+            leaseState.remainingBlockIds.reserve(blockIds.size());
+            for (auto const& [windowSize, windowBlockIds] : blockIds)
+            {
+                leaseState.remainingBlockIds.emplace(
+                    windowSize, std::unordered_set<KVCacheBlock::IdType>(windowBlockIds.begin(), windowBlockIds.end()));
+            }
+            mTransferLeases.emplace(requestId, std::move(leaseState));
+        }
+        catch (...)
+        {
+            mBlockManager.unpinBlocksForTransferLease(blockIds);
+            throw;
+        }
+
+        sequenceNode = mSequences.extract(sequenceIt);
+    }
+
+    // Reuse storage was completed before extraction. Drop only the sequence-owned references here; the transfer-lease
+    // pins remain as the sole ownership needed by the asynchronous sender.
+    try
+    {
+        static_cast<void>(mBlockManager.releaseBlocks(sequenceNode.mapped(), std::nullopt, /*pinBlocks=*/false));
+    }
+    catch (...)
+    {
+        auto releaseError = std::current_exception();
+        try
+        {
+            endTransferLease(requestId);
+        }
+        catch (std::exception const& cleanupError)
+        {
+            TLLM_LOG_ERROR("Failed to clean up KV transfer lease for request %lu after detach failure: %s", requestId,
+                cleanupError.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_ERROR("Failed to clean up KV transfer lease for request %lu after detach failure", requestId);
+        }
+        std::rethrow_exception(releaseError);
+    }
+
+    TLLM_LOG_TRACE("[%s]::%s stop", isCrossKv() ? "CROSS" : "SELF", __PRETTY_FUNCTION__);
+}
+
+std::optional<TransferBlockIds> KVCacheManager::getTransferLeaseBlockIds(RequestIdType requestId) const
+{
+    std::scoped_lock lock(mTransferLeaseMtx);
+    auto const leaseIt = mTransferLeases.find(requestId);
+    if (leaseIt == mTransferLeases.end())
+    {
+        return std::nullopt;
+    }
+    return leaseIt->second.blockIds;
+}
+
+bool KVCacheManager::hasActiveTransferLease(RequestIdType requestId) const
+{
+    std::scoped_lock lock(mTransferLeaseMtx);
+    return mTransferLeases.find(requestId) != mTransferLeases.end();
+}
+
+void KVCacheManager::enqueueTransferLeaseRelease(RequestIdType requestId, TransferBlockIds blockIds)
+{
+    std::scoped_lock lock(mTransferLeaseMtx);
+    if (mTransferLeases.find(requestId) == mTransferLeases.end())
+    {
+        // A worker can finish after cancellation/end. The lease has already released its remainder in that case.
+        return;
+    }
+    mPendingTransferLeaseReleases.emplace_back(requestId, std::move(blockIds));
+}
+
+void KVCacheManager::drainTransferLeaseReleases()
+{
+    std::scoped_lock lock(mTransferLeaseMtx);
+    while (!mPendingTransferLeaseReleases.empty())
+    {
+        auto const& [requestId, completedBlockIds] = mPendingTransferLeaseReleases.front();
+
+        auto leaseIt = mTransferLeases.find(requestId);
+        if (leaseIt == mTransferLeases.end())
+        {
+            mPendingTransferLeaseReleases.pop_front();
+            continue;
+        }
+
+        TransferBlockIds releasableBlockIds;
+        releasableBlockIds.reserve(completedBlockIds.size());
+        for (auto const& [windowSize, windowBlockIds] : completedBlockIds)
+        {
+            auto remainingIt = leaseIt->second.remainingBlockIds.find(windowSize);
+            if (remainingIt == leaseIt->second.remainingBlockIds.end())
+            {
+                continue;
+            }
+
+            auto& releasableForWindow = releasableBlockIds[windowSize];
+            releasableForWindow.reserve(windowBlockIds.size());
+            for (auto const blockId : windowBlockIds)
+            {
+                if (remainingIt->second.find(blockId) != remainingIt->second.end())
+                {
+                    releasableForWindow.push_back(blockId);
+                }
+            }
+            if (releasableForWindow.empty())
+            {
+                releasableBlockIds.erase(windowSize);
+            }
+        }
+
+        if (!releasableBlockIds.empty())
+        {
+            mBlockManager.unpinBlocksForTransferLease(releasableBlockIds);
+            for (auto const& [windowSize, windowBlockIds] : releasableBlockIds)
+            {
+                auto& remainingBlockIds = leaseIt->second.remainingBlockIds.at(windowSize);
+                for (auto const blockId : windowBlockIds)
+                {
+                    remainingBlockIds.erase(blockId);
+                }
+            }
+        }
+        // Keep the queue entry and lease state intact if unpinning throws so
+        // the caller can retry without silently leaking the remaining pins.
+        mPendingTransferLeaseReleases.pop_front();
+    }
+}
+
+void KVCacheManager::endTransferLease(RequestIdType requestId)
+{
+    drainTransferLeaseReleases();
+
+    std::scoped_lock lock(mTransferLeaseMtx);
+    auto leaseIt = mTransferLeases.find(requestId);
+    if (leaseIt != mTransferLeases.end())
+    {
+        TransferBlockIds remainingBlockIds;
+        remainingBlockIds.reserve(leaseIt->second.blockIds.size());
+        for (auto const& [windowSize, orderedBlockIds] : leaseIt->second.blockIds)
+        {
+            auto const remainingIt = leaseIt->second.remainingBlockIds.find(windowSize);
+            if (remainingIt == leaseIt->second.remainingBlockIds.end())
+            {
+                continue;
+            }
+
+            auto& remainingForWindow = remainingBlockIds[windowSize];
+            remainingForWindow.reserve(remainingIt->second.size());
+            for (auto const blockId : orderedBlockIds)
+            {
+                if (remainingIt->second.find(blockId) != remainingIt->second.end())
+                {
+                    remainingForWindow.push_back(blockId);
+                }
+            }
+            if (remainingForWindow.empty())
+            {
+                remainingBlockIds.erase(windowSize);
+            }
+        }
+
+        if (!remainingBlockIds.empty())
+        {
+            mBlockManager.unpinBlocksForTransferLease(remainingBlockIds);
+        }
+        mTransferLeases.erase(leaseIt);
+    }
+
+    for (auto pendingIt = mPendingTransferLeaseReleases.begin(); pendingIt != mPendingTransferLeaseReleases.end();)
+    {
+        if (pendingIt->first == requestId)
+        {
+            pendingIt = mPendingTransferLeaseReleases.erase(pendingIt);
+        }
+        else
+        {
+            ++pendingIt;
+        }
+    }
 }
 
 void KVCacheManager::unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds)

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -503,7 +503,7 @@ void MLACacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& s
         {
             auto bufferKind = transferIndexerKCache ? static_cast<uint8_t>(BufferKind::kKV_INDEXER)
                                                     : static_cast<uint8_t>(BufferKind::kKV);
-            auto preAssignedId = connections[pickUpConnections[0]]->getPreAssignedBufferId(bufferKind);
+            auto preAssignedId = session.getPreAssignedBufferId(bufferKind);
             if (preAssignedId.has_value())
             {
                 cacheBufferId = static_cast<int>(*preAssignedId);

--- a/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -349,8 +349,7 @@ void RnnCacheFormatter::unformatSlotMode(TransferSession& session)
     size_t bufferCoverSourceNum = 0;
     std::optional<int> cacheBufferId = std::nullopt;
 
-    auto preAssignedRnnId
-        = connections[pickUpConnections[0]]->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kRNN));
+    auto preAssignedRnnId = session.getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kRNN));
     if (preAssignedRnnId.has_value())
     {
         cacheBufferId = static_cast<int>(*preAssignedRnnId);
@@ -821,8 +820,7 @@ void RnnCacheFormatter::unformatUnifiedPoolMode(TransferSession& session)
 
             // Use pre-assigned buffer ID from NIXL connection if available (same as slot mode).
             std::optional<int> cacheBufferId = std::nullopt;
-            auto preAssignedRnnId
-                = connections[rnnRecvConns[0]]->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kRNN));
+            auto preAssignedRnnId = session.getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kRNN));
             if (preAssignedRnnId.has_value())
             {
                 cacheBufferId = static_cast<int>(*preAssignedRnnId);

--- a/cpp/tensorrt_llm/common/envUtils.cpp
+++ b/cpp/tensorrt_llm/common/envUtils.cpp
@@ -16,12 +16,16 @@
  */
 
 #include "envUtils.h"
+#include "tensorrt_llm/common/assert.h"
 #include "tensorrt_llm/common/config.h"
 #include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/common/stringUtils.h"
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
+#include <exception>
+#include <limits>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -393,6 +397,51 @@ bool getEnvTryZCopyForKVCacheTransfer()
 {
     static bool const zcopyForSysmmetricKVCache = getBoolEnv("TRTLLM_TRY_ZCOPY_FOR_KVCACHE_TRANSFER");
     return zcopyForSysmmetricKVCache;
+}
+
+std::optional<runtime::SizeType32> getEnvKVCacheTransferChunkSizeBlocks()
+{
+    static auto const chunkSizeBlocks = []() -> std::optional<runtime::SizeType32>
+    {
+        constexpr char const* envName = "TRTLLM_KVCACHE_TRANSFER_CHUNK_SIZE_BLOCKS";
+        char const* const env = std::getenv(envName);
+        if (env == nullptr)
+        {
+            return std::nullopt;
+        }
+
+        std::string const valueString{env};
+        TLLM_CHECK_WITH_INFO(!valueString.empty()
+                && std::all_of(valueString.begin(), valueString.end(), [](char ch) { return ch >= '0' && ch <= '9'; }),
+            "%s must be a non-negative decimal integer, got '%s'.", envName, env);
+        size_t parsedCharacters = 0;
+        long long value = 0;
+        try
+        {
+            value = std::stoll(valueString, &parsedCharacters, 10);
+        }
+        catch (std::exception const&)
+        {
+            TLLM_THROW("%s must be a non-negative decimal integer, got '%s'.", envName, env);
+        }
+        TLLM_CHECK_WITH_INFO(parsedCharacters == valueString.size(),
+            "%s must be a non-negative decimal integer, got '%s'.", envName, env);
+        TLLM_CHECK_WITH_INFO(value <= std::numeric_limits<runtime::SizeType32>::max(),
+            "%s exceeds the supported maximum (%d), got '%s'.", envName,
+            std::numeric_limits<runtime::SizeType32>::max(), env);
+        if (value == 0)
+        {
+            return std::nullopt;
+        }
+        return static_cast<runtime::SizeType32>(value);
+    }();
+    return chunkSizeBlocks;
+}
+
+bool getEnvKVCacheTransferEarlyRelease()
+{
+    static bool const earlyRelease = getBoolEnv("TRTLLM_KVCACHE_TRANSFER_EARLY_RELEASE");
+    return earlyRelease;
 }
 
 bool getEnvForceDeterministic()

--- a/cpp/tensorrt_llm/common/envUtils.h
+++ b/cpp/tensorrt_llm/common/envUtils.h
@@ -18,6 +18,7 @@
 #pragma once
 #include "tensorrt_llm/common/config.h"
 #include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/runtime/common.h"
 #include <cstdint>
 #include <cuda_runtime.h>
 #include <optional>
@@ -109,6 +110,12 @@ bool getEnvEnableReceiveKVCacheParallel();
 std::string const& getEnvKVCacheTimeOutputPath();
 
 bool getEnvTryZCopyForKVCacheTransfer();
+
+/// Number of KV-cache blocks transferred in one chunk. Unset or zero disables chunking.
+std::optional<runtime::SizeType32> getEnvKVCacheTransferChunkSizeBlocks();
+
+/// Whether transferred KV-cache chunks may be released before the whole request completes.
+bool getEnvKVCacheTransferEarlyRelease();
 
 // Force deterministic behavior for all kernels.
 bool getEnvForceDeterministic();

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
@@ -165,11 +165,29 @@ size_t MemoryDesc::serializedSize(MemoryDesc const& memoryDesc)
 
 void AgentConnection::send(DataContext const& ctx, void const* data, size_t size) const
 {
+    struct SenderStateSnapshot
+    {
+        MemoryDesc mBufferDesc;
+        std::pair<size_t, size_t> mOffsetRatio;
+        int mValidSegmentIdx;
+    };
+
     MemoryDesc srcDesc{
         reinterpret_cast<uintptr_t>(data), size, static_cast<uint32_t>(mAgentConnectionManager->getDeviceId())};
     MemoryDescs srcDescs{MemoryType::kVRAM, {srcDesc}};
-    auto const& dstBaseDesc = mSenderState.activeBufferDesc();
-    auto const& offsetRatio = mSenderState.activeOffsetRatio();
+    auto const senderState = [this]()
+    {
+        std::scoped_lock lock(mSenderStateMutex);
+        TLLM_CHECK_WITH_INFO(
+            mActiveSenderRequestId.has_value(), "AgentConnection::send called without an active request");
+        auto const stateIt = mSenderStates.find(*mActiveSenderRequestId);
+        TLLM_CHECK_WITH_INFO(stateIt != mSenderStates.end(),
+            "AgentConnection::send has no destination state for request %ld", *mActiveSenderRequestId);
+        return SenderStateSnapshot{
+            stateIt->second.activeBufferDesc(), stateIt->second.activeOffsetRatio(), stateIt->second.validSegmentIdx};
+    }();
+    auto const& dstBaseDesc = senderState.mBufferDesc;
+    auto const& offsetRatio = senderState.mOffsetRatio;
     TLLM_CHECK_WITH_INFO(offsetRatio.second != 0, "AgentConnection::send offset ratio denominator cannot be 0");
     TLLM_CHECK_WITH_INFO(size <= dstBaseDesc.getLen(), "AgentConnection::send size exceeds destination buffer");
     auto const chunkSize = size / offsetRatio.second;
@@ -181,7 +199,7 @@ void AgentConnection::send(DataContext const& ctx, void const* data, size_t size
         "AgentConnection::send destination address overflow");
     MemoryDesc dstDesc{dstBaseDesc.getAddr() + offset, size, dstBaseDesc.getDeviceId()};
     TLLM_LOG_DEBUG(
-        "send dstDesc: %p, size: %ld ,validSegmentIdx: %ld", dstDesc.getAddr(), size, mSenderState.validSegmentIdx);
+        "send dstDesc: %p, size: %ld ,validSegmentIdx: %ld", dstDesc.getAddr(), size, senderState.mValidSegmentIdx);
     MemoryDescs dstDescs{MemoryType::kVRAM, {dstDesc}};
     TransferRequest request{TransferOp::kWRITE, srcDescs, dstDescs, mRemoteAgentName};
     auto status = mAgentConnectionManager->getAgent()->submitTransferRequests(request);
@@ -205,6 +223,7 @@ void AgentConnection::recv(DataContext const& ctx, void* data, size_t size) cons
 void AgentConnection::sendRequestAndBufferInfo(batch_manager::RequestInfo& requestInfo,
     std::vector<std::optional<size_t>> const& cacheBufferIds, int connectionIdx)
 {
+    std::scoped_lock lock(mRequestInfoMutex);
     TLLM_CHECK(!common::getEnvTryZCopyForKVCacheTransfer());
 
     TLLM_CHECK(!cacheBufferIds.empty());
@@ -229,9 +248,6 @@ void AgentConnection::sendRequestAndBufferInfo(batch_manager::RequestInfo& reque
         activeKinds.push_back(allKinds[i]);
     }
     TLLM_CHECK(!activeCacheBufferIds.empty());
-
-    mCacheBufferIds = std::move(activeCacheBufferIds);
-    mBufferKinds = activeKinds;
 
     int deviceId = -1;
     TLLM_CUDA_CHECK(cudaGetDevice(&deviceId));
@@ -258,17 +274,42 @@ void AgentConnection::sendRequestAndBufferInfo(batch_manager::RequestInfo& reque
     mAgentConnectionManager->getAgent()->notifySyncMessage(mRemoteAgentName, ss.str());
 }
 
-void AgentConnection::setSenderState(std::vector<MemoryDesc> cacheReceiverBufferDescs, int validSegmentIdx,
-    std::vector<std::pair<size_t, size_t>> offsetRatios, std::vector<uint8_t> bufferKinds)
+void AgentConnection::setSenderState(RequestIdType requestId, std::vector<MemoryDesc> cacheReceiverBufferDescs,
+    int validSegmentIdx, std::vector<std::pair<size_t, size_t>> offsetRatios, std::vector<uint8_t> bufferKinds)
 {
     TLLM_CHECK(!cacheReceiverBufferDescs.empty());
     TLLM_CHECK(offsetRatios.size() == cacheReceiverBufferDescs.size());
     TLLM_CHECK(bufferKinds.size() == cacheReceiverBufferDescs.size());
-    mSenderState.mCacheReceiverBufferDescs = std::move(cacheReceiverBufferDescs);
-    mSenderState.validSegmentIdx = validSegmentIdx;
-    mSenderState.mOffsetRatios = std::move(offsetRatios);
-    mSenderState.setActiveBufferIdx(0);
-    mBufferKinds = std::move(bufferKinds);
+    SenderState senderState;
+    senderState.mCacheReceiverBufferDescs = std::move(cacheReceiverBufferDescs);
+    senderState.validSegmentIdx = validSegmentIdx;
+    senderState.mOffsetRatios = std::move(offsetRatios);
+    senderState.mBufferKinds = std::move(bufferKinds);
+    senderState.setActiveBufferIdx(0);
+
+    std::scoped_lock lock(mSenderStateMutex);
+    auto const inserted = mSenderStates.emplace(requestId, std::move(senderState)).second;
+    TLLM_CHECK_WITH_INFO(inserted, "AgentConnection received duplicate destination state for request %ld", requestId);
+}
+
+void AgentConnection::activateRequestSenderState(RequestIdType requestId) const
+{
+    std::scoped_lock lock(mSenderStateMutex);
+    auto const stateIt = mSenderStates.find(requestId);
+    TLLM_CHECK_WITH_INFO(
+        stateIt != mSenderStates.end(), "AgentConnection has no destination state for request %ld", requestId);
+    stateIt->second.setActiveBufferIdx(0);
+    mActiveSenderRequestId = requestId;
+}
+
+void AgentConnection::eraseRequestSenderState(RequestIdType requestId) const
+{
+    std::scoped_lock lock(mSenderStateMutex);
+    mSenderStates.erase(requestId);
+    if (mActiveSenderRequestId == requestId)
+    {
+        mActiveSenderRequestId.reset();
+    }
 }
 
 void AgentConnection::setHasLoadRemoteAgent(bool hasLoadRemoteAgent)
@@ -299,26 +340,23 @@ bool AgentConnection::recvReadySignal(DataContext const& ctx) const
 
 void AgentConnection::activateBuffer(uint8_t kind) const
 {
-    for (size_t i = 0; i < mBufferKinds.size(); i++)
+    std::scoped_lock lock(mSenderStateMutex);
+    TLLM_CHECK_WITH_INFO(
+        mActiveSenderRequestId.has_value(), "AgentConnection::activateBuffer called without an active request");
+    auto const stateIt = mSenderStates.find(*mActiveSenderRequestId);
+    TLLM_CHECK_WITH_INFO(stateIt != mSenderStates.end(),
+        "AgentConnection::activateBuffer has no destination state for request %ld", *mActiveSenderRequestId);
+    auto const& bufferKinds = stateIt->second.mBufferKinds;
+    for (size_t i = 0; i < bufferKinds.size(); i++)
     {
-        if (mBufferKinds[i] == kind)
+        if (bufferKinds[i] == kind)
         {
-            mSenderState.setActiveBufferIdx(i);
+            stateIt->second.setActiveBufferIdx(i);
             return;
         }
     }
-}
-
-std::optional<size_t> AgentConnection::getPreAssignedBufferId(uint8_t kind) const
-{
-    for (size_t i = 0; i < mBufferKinds.size(); i++)
-    {
-        if (mBufferKinds[i] == kind && i < mCacheBufferIds.size())
-        {
-            return mCacheBufferIds[i];
-        }
-    }
-    return std::nullopt;
+    TLLM_THROW("AgentConnection has no destination buffer of kind %u for request %ld", static_cast<unsigned>(kind),
+        *mActiveSenderRequestId);
 }
 
 AgentConnectionManager::AgentConnectionManager(
@@ -548,8 +586,8 @@ AgentConnection const* AgentConnectionManager::recvConnectionAndRequestInfo(
                         }
                         }
                     }
-                    connection->setSenderState(
-                        std::move(bufferDescs), connectionIdx, std::move(offsetRatios), std::move(bufferKinds));
+                    connection->setSenderState(requestInfo.getRequestId(), std::move(bufferDescs), connectionIdx,
+                        std::move(offsetRatios), std::move(bufferKinds));
                     notifIt = notifs.erase(notifIt);
                     if (notifs.empty())
                     {

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,8 @@
 #include "tensorrt_llm/executor/dataTransceiverState.h"
 #include "tensorrt_llm/executor/transferAgent.h"
 #include <map>
+#include <mutex>
+#include <unordered_map>
 
 namespace tensorrt_llm::executor::kv_cache
 {
@@ -255,21 +257,24 @@ class AgentConnectionManager;
 class AgentConnection : public Connection
 {
 public:
+    using RequestIdType = batch_manager::LlmRequest::RequestIdType;
+
     AgentConnection(
         std::string mAgentName, std::string mRemoteAgentName, AgentConnectionManager* mAgentConnectionManager);
     void send(DataContext const& ctx, void const* data, size_t size) const override;
     void recv(DataContext const& ctx, void* data, size_t size) const override;
     void sendRequestAndBufferInfo(batch_manager::RequestInfo& requestInfo,
         std::vector<std::optional<size_t>> const& cacheBufferIds, int validConnectionIdx);
-    void setSenderState(std::vector<MemoryDesc> cacheReceiverBufferDescs, int valideSegmentIdx,
+    void setSenderState(RequestIdType requestId, std::vector<MemoryDesc> cacheReceiverBufferDescs, int validSegmentIdx,
         std::vector<std::pair<size_t, size_t>> offsetRatios, std::vector<uint8_t> bufferKinds);
+    void activateRequestSenderState(RequestIdType requestId) const;
+    void eraseRequestSenderState(RequestIdType requestId) const;
     void setHasLoadRemoteAgent(bool hasLoadRemoteAgent);
     [[nodiscard]] bool hasLoadRemoteAgent() const;
     void sendReadySignal(DataContext const& ctx, bool isReady) const;
     bool recvReadySignal(DataContext const& ctx) const;
 
     void activateBuffer(uint8_t kind) const override;
-    [[nodiscard]] std::optional<size_t> getPreAssignedBufferId(uint8_t kind) const override;
 
 private:
     std::string mAgentName;
@@ -281,6 +286,7 @@ private:
         int validSegmentIdx{0};
         /// Per-buffer offset ratios. Index corresponds to mCacheReceiverBufferDescs / mActiveBufferIdx.
         std::vector<std::pair<size_t, size_t>> mOffsetRatios;
+        std::vector<uint8_t> mBufferKinds;
         mutable size_t mActiveBufferIdx{0};
         [[nodiscard]] MemoryDesc const& activeBufferDesc() const;
         [[nodiscard]] std::pair<size_t, size_t> const& activeOffsetRatio() const;
@@ -291,9 +297,10 @@ private:
     AgentConnectionManager* mAgentConnectionManager;
 
     std::vector<batch_manager::BaseTransBufferManager*> const& mCacheTransBufferManagers;
-    std::vector<std::optional<size_t>> mCacheBufferIds;
-    std::vector<uint8_t> mBufferKinds;
-    mutable SenderState mSenderState;
+    mutable std::unordered_map<RequestIdType, SenderState> mSenderStates;
+    mutable std::optional<RequestIdType> mActiveSenderRequestId;
+    mutable std::mutex mSenderStateMutex;
+    std::mutex mRequestInfoMutex;
     bool mNeedSendMetadata{true};
     bool mHasLoadRemoteAgent{false};
 };

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -622,6 +622,7 @@ kv_cache::CacheState Serialization::deserializeCacheState(std::istream& is)
     auto indexerDimPerHead = su::deserialize<decltype(CacheState::ModelConfig::mSizePerHead)>(is);
     auto indexerKCacheQuantBlockSize = su::deserialize<decltype(CacheState::ModelConfig::mTokensPerBlock)>(is);
     auto indexerKCacheUseFp4 = su::deserialize<bool>(is);
+    auto transferChunkSizeBlocks = su::deserialize<std::optional<SizeType32>>(is);
     // RNN config (optional)
     auto hasRnnConfig = su::deserialize<bool>(is);
     std::optional<CacheState::RnnModelConfig> rnnModelConfig;
@@ -655,6 +656,7 @@ kv_cache::CacheState Serialization::deserializeCacheState(std::istream& is)
         cacheState.setRnnConfig(
             std::move(rnnModelConfig.value()), std::move(rnnLayerNumPerPP), convStateDataType, ssmStateDataType);
     }
+    cacheState.setTransferChunkSizeBlocks(transferChunkSizeBlocks);
     return cacheState;
 }
 
@@ -679,6 +681,7 @@ void Serialization::serialize(kv_cache::CacheState const& state, std::ostream& o
     su::serialize(state.getIndexerDimPerHead(), os);
     su::serialize(state.getIndexerKCacheQuantBlockSize(), os);
     su::serialize(state.getIndexerKCacheUseFp4(), os);
+    su::serialize(state.getTransferChunkSizeBlocks(), os);
     // RNN config (optional)
     su::serialize(state.mRnnCacheState.has_value(), os);
     if (state.mRnnCacheState.has_value())
@@ -721,6 +724,7 @@ size_t Serialization::serializedSize(kv_cache::CacheState const& state)
     totalSize += su::serializedSize(state.getIndexerDimPerHead());
     totalSize += su::serializedSize(state.getIndexerKCacheQuantBlockSize());
     totalSize += su::serializedSize(state.getIndexerKCacheUseFp4());
+    totalSize += su::serializedSize(state.getTransferChunkSizeBlocks());
     // RNN config (optional)
     totalSize += su::serializedSize(state.mRnnCacheState.has_value());
     if (state.mRnnCacheState.has_value())

--- a/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
@@ -124,7 +124,10 @@ void tb::CacheTransceiverBindings::initBindings(nb::module_& m)
             nb::arg("cache_manager"), nb::arg("num_kv_heads_per_layer"), nb::arg("size_per_head"),
             nb::arg("tokens_per_block"), nb::arg("world_config"), nb::arg("attention_layer_num_per_pp"),
             nb::arg("dtype"), nb::arg("attention_type"), nb::arg("cache_transceiver_config") = std::nullopt,
-            nb::arg("rnn_state_manager") = nullptr, nb::arg("rnn_layer_num_per_pp") = std::vector<SizeType32>{});
+            nb::arg("rnn_state_manager") = nullptr, nb::arg("rnn_layer_num_per_pp") = std::vector<SizeType32>{},
+            nb::keep_alive<1, 2>())
+        .def_prop_ro("transfer_chunk_size_blocks", &tb::CacheTransceiver::getTransferChunkSizeBlocks)
+        .def_prop_ro("transfer_early_release_enabled", &tb::CacheTransceiver::isTransferEarlyReleaseEnabled);
 
     nb::class_<tb::CacheTransceiverComm>(m, "CacheTransceiverComm")
         .def(

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -468,6 +468,7 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
             nb::arg("request_infos"), nb::arg("llm_requests"))
         .def("remove_sequence", &BaseKVCacheManager::removeSequence, nb::call_guard<nb::gil_scoped_release>())
         .def("pin_blocks", &BaseKVCacheManager::pinBlocks, nb::call_guard<nb::gil_scoped_release>())
+        .def_prop_ro("supports_transfer_leases", &BaseKVCacheManager::supportsTransferLeases)
         .def("truncate_blocks", &BaseKVCacheManager::truncateBlocks, nb::call_guard<nb::gil_scoped_release>())
         .def("scheduling_remove_sequence", &BaseKVCacheManager::schedulingRemoveSequence,
             nb::call_guard<nb::gil_scoped_release>())

--- a/cpp/tests/unit_tests/batch_manager/cacheTransBufferTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/cacheTransBufferTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,8 +21,11 @@
 #include "tensorrt_llm/executor/executor.h"
 #include "tensorrt_llm/runtime/bufferManager.h"
 #include "tensorrt_llm/runtime/iTensor.h"
+#include <chrono>
+#include <future>
 #include <gtest/gtest.h>
 #include <memory>
+#include <thread>
 using namespace tensorrt_llm::batch_manager::kv_cache_manager;
 using namespace tensorrt_llm::runtime;
 
@@ -175,6 +178,53 @@ TEST_F(CacheTransBufferTest, TestPreAllocBufferSize2)
     }
 }
 
+TEST_F(CacheTransBufferTest, TestPreAllocBufferSizeChunked)
+{
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1) << "Fork failed";
+
+    if (pid == 0)
+    {
+        SizeType32 constexpr maxBlocksPerSeq = 10;
+        SizeType32 constexpr chunkSizeBlocks = 3;
+        SizeType32 constexpr tokensPerBlock = 8;
+        // The protocol chunk size must override a smaller legacy staging cap.
+        std::optional<size_t> maxNumTokens = 2 * tokensPerBlock;
+        setenv("TRTLLM_KVCACHE_TRANSFER_CHUNK_SIZE_BLOCKS", "3", 1);
+        setenv("TRTLLM_KVCACHE_TRANSFER_USE_SYNC_BUFFER", "1", 1);
+        SetUpCacheTransBuffer(4, 2, 64, tokensPerBlock, CacheType::kSELF, maxNumTokens, maxBlocksPerSeq);
+
+        size_t const recvBufferCount = tensorrt_llm::common::getEnvRequestKVCacheConcurrent()
+            ? tensorrt_llm::common::getEnvKVCacheRecvBufferCount()
+            : 1;
+        size_t const sendBufferCount = tensorrt_llm::common::getEnvKVCacheSendMaxConcurrenceNum();
+        size_t const cacheSizeBytesPerToken = kvCacheSizePerToken(4, 2, 64, CacheType::kSELF);
+        std::map<SizeType32, SizeType32> cacheSizeBytesPerTokenPerWindow{
+            {maxBlocksPerSeq * tokensPerBlock, cacheSizeBytesPerToken}};
+        tensorrt_llm::executor::CacheTransceiverConfig cacheTransceiverConfig{
+            tensorrt_llm::executor::CacheTransceiverConfig::BackendType::UCX, maxNumTokens};
+
+        size_t const bufferSizeBytes = CacheTransBufferManager::preAllocBufferSize(
+            cacheSizeBytesPerTokenPerWindow, tokensPerBlock, cacheTransceiverConfig);
+        size_t const expectedTransferBufferSize = chunkSizeBlocks * tokensPerBlock * cacheSizeBytesPerToken;
+        auto bufferId = mTransBufferManager->assignBufferIndexForSend();
+        ASSERT_TRUE(bufferId.has_value());
+        ASSERT_TRUE(mTransBufferManager->getMaxNumTokens().has_value());
+        EXPECT_EQ(
+            mTransBufferManager->getMaxNumTokens().value(), static_cast<size_t>(chunkSizeBlocks * tokensPerBlock));
+        EXPECT_EQ(mTransBufferManager->getSendBuffer(bufferId)->getSizeInBytes(), expectedTransferBufferSize);
+        EXPECT_EQ(bufferSizeBytes,
+            mTransBufferManager->getSendBuffer(bufferId)->getSizeInBytes() * (recvBufferCount + sendBufferCount));
+        mTransBufferManager->freeBufferIndexForSend(bufferId);
+        exit(testing::Test::HasFailure() ? 1 : 0);
+    }
+
+    int status;
+    ASSERT_NE(-1, waitpid(pid, &status, 0)) << "waitpid failed";
+    ASSERT_TRUE(WIFEXITED(status)) << "Child process terminated abnormally";
+    ASSERT_EQ(0, WEXITSTATUS(status)) << "Test in child process failed";
+}
+
 TEST_F(CacheTransBufferTest, TestBufferIndexAssignment0)
 {
     pid_t pid = fork();
@@ -243,6 +293,53 @@ TEST_F(CacheTransBufferTest, TestBufferIndexAssignment0)
         ASSERT_TRUE(WIFEXITED(status)) << "Child process terminated abnormally";
         ASSERT_EQ(0, WEXITSTATUS(status)) << "Test in child process failed";
     }
+}
+
+TEST_F(CacheTransBufferTest, TestAbortRecvBufferAssignmentsWakesWaiter)
+{
+    pid_t pid = fork();
+    ASSERT_NE(pid, -1) << "Fork failed";
+
+    if (pid == 0)
+    {
+        SizeType32 constexpr maxBlocksPerSeq = 10;
+        SizeType32 constexpr tokensPerBlock = 8;
+        std::optional<size_t> const maxNumTokens = maxBlocksPerSeq * tokensPerBlock;
+        SetUpCacheTransBuffer(4, 2, 64, tokensPerBlock, CacheType::kSELF, maxNumTokens, maxBlocksPerSeq);
+
+        std::vector<std::optional<int>> quarantinedIds;
+        for (size_t i = 0; i < mTransBufferManager->getRecvBufferCount(); ++i)
+        {
+            quarantinedIds.push_back(mTransBufferManager->assignBufferIndexForRecv());
+            ASSERT_TRUE(quarantinedIds.back().has_value());
+        }
+
+        auto waiter = std::async(std::launch::async,
+            [this]
+            {
+                try
+                {
+                    static_cast<void>(mTransBufferManager->assignBufferIndexForRecv());
+                }
+                catch (std::exception const&)
+                {
+                    return true;
+                }
+                return false;
+            });
+        EXPECT_EQ(waiter.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+
+        mTransBufferManager->abortRecvBufferAssignments();
+        EXPECT_TRUE(mTransBufferManager->areRecvBufferAssignmentsAborted());
+        EXPECT_EQ(waiter.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+        EXPECT_TRUE(waiter.get());
+        exit(testing::Test::HasFailure() ? 1 : 0);
+    }
+
+    int status;
+    ASSERT_NE(-1, waitpid(pid, &status, 0)) << "waitpid failed";
+    ASSERT_TRUE(WIFEXITED(status)) << "Child process terminated abnormally";
+    ASSERT_EQ(0, WEXITSTATUS(status)) << "Test in child process failed";
 }
 
 TEST_F(CacheTransBufferTest, TestBufferIndexAssignment1)

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -2420,6 +2420,169 @@ TEST_F(KVCacheManagerTest, KVCacheManagerPerRequestStatsTest)
         static_cast<float>(numSharedBlocks) / static_cast<float>(numBlocks));
 }
 
+TEST_F(KVCacheManagerTest, TransferLeaseRejectsMultipleBeamsBeforeDetaching)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numHeads = 2;
+    auto constexpr sizePerHead = 16;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr maxSequenceLength = 8;
+    auto constexpr maxNumSequences = 2;
+    auto constexpr blocksInPrimaryPool = 8;
+    auto constexpr beamWidth = 4;
+    auto constexpr requestId = LlmRequest::RequestIdType{41};
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const blocksPerWindow = BlocksPerWindow{{maxSequenceLength, {blocksInPrimaryPool, 0}}};
+
+    KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
+        beamWidth, std::vector<SizeType32>{maxSequenceLength}, nvinfer1::DataType::kHALF, 0, stream, maxSequenceLength,
+        maxSequenceLength, /*enableBlockReuse=*/false);
+    kvCacheManager.allocatePools(false);
+
+    auto inputTokens = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7});
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    auto llmRequest = std::make_shared<LlmRequest>(
+        requestId, /*maxNewTokens=*/0, inputTokens, samplingConfig, /*isStreaming=*/false);
+    kvCacheManager.addSequenceBatch(
+        {{{requestId, static_cast<SizeType32>(inputTokens->size()), beamWidth}}}, {std::ref(*llmRequest)});
+
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 2);
+    EXPECT_THROW(kvCacheManager.beginTransferLease(requestId), std::exception);
+    EXPECT_FALSE(kvCacheManager.getTransferLeaseBlockIds(requestId).has_value());
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 2);
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.getSequence(requestId)));
+
+    kvCacheManager.removeSequence(requestId);
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool);
+}
+
+TEST_F(KVCacheManagerTest, TransferLeaseReleasesOneChunkWhileRemainderStaysPinned)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numHeads = 2;
+    auto constexpr sizePerHead = 16;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr maxSequenceLength = 16;
+    auto constexpr maxNumSequences = 2;
+    auto constexpr blocksInPrimaryPool = 8;
+    auto constexpr beamWidth = 1;
+    auto constexpr requestId = LlmRequest::RequestIdType{42};
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const blocksPerWindow = BlocksPerWindow{{maxSequenceLength, {blocksInPrimaryPool, 0}}};
+
+    KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
+        beamWidth, std::vector<SizeType32>{maxSequenceLength}, nvinfer1::DataType::kHALF, 0, stream, maxSequenceLength,
+        maxSequenceLength, /*enableBlockReuse=*/true);
+    kvCacheManager.allocatePools(false);
+
+    auto inputTokens = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7, 8});
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    auto llmRequest = std::make_shared<LlmRequest>(
+        requestId, /*maxNewTokens=*/0, inputTokens, samplingConfig, /*isStreaming=*/false);
+    kvCacheManager.addSequenceBatch(
+        {{{requestId, static_cast<SizeType32>(inputTokens->size()), beamWidth}}}, {std::ref(*llmRequest)});
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*llmRequest);
+    kvCacheManager.beginTransferLease(requestId, *llmRequest);
+
+    auto const leaseBlockIds = kvCacheManager.getTransferLeaseBlockIds(requestId);
+    ASSERT_TRUE(leaseBlockIds.has_value());
+    auto const& orderedBlockIds = leaseBlockIds->at(maxSequenceLength);
+    ASSERT_EQ(orderedBlockIds.size(), 3);
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 3);
+
+    TransferBlockIds firstCompletion{{maxSequenceLength,
+        {orderedBlockIds.at(0), orderedBlockIds.at(1), orderedBlockIds.at(0),
+            std::numeric_limits<KVCacheBlock::IdType>::max()}}};
+    std::thread worker([&kvCacheManager, requestId, firstCompletion = std::move(firstCompletion)]() mutable
+        { kvCacheManager.enqueueTransferLeaseRelease(requestId, std::move(firstCompletion)); });
+    worker.join();
+
+    // Enqueue is worker-safe but never mutates eviction/refcount state itself.
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 3);
+    kvCacheManager.drainTransferLeaseReleases();
+    // The first two-block chunk is now evictable while the final block remains
+    // pinned by the active transfer lease.
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 1);
+
+    // Duplicate completions and unknown windows are ignored; the first block is not unpinned twice.
+    kvCacheManager.enqueueTransferLeaseRelease(requestId,
+        TransferBlockIds{
+            {maxSequenceLength, {orderedBlockIds.at(0)}}, {maxSequenceLength + 1, {orderedBlockIds.at(1)}}});
+    kvCacheManager.drainTransferLeaseReleases();
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 1);
+
+    kvCacheManager.endTransferLease(requestId);
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool);
+}
+
+TEST_F(KVCacheManagerTest, TransferLeaseEarlyReleasePreservesSharedPrefix)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numHeads = 2;
+    auto constexpr sizePerHead = 16;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr maxSequenceLength = 16;
+    auto constexpr maxNumSequences = 2;
+    auto constexpr blocksInPrimaryPool = 8;
+    auto constexpr beamWidth = 1;
+    auto constexpr requestIdA = LlmRequest::RequestIdType{43};
+    auto constexpr requestIdB = LlmRequest::RequestIdType{44};
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const blocksPerWindow = BlocksPerWindow{{maxSequenceLength, {blocksInPrimaryPool, 0}}};
+
+    KVCacheManager kvCacheManager(numLayers, numHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
+        beamWidth, std::vector<SizeType32>{maxSequenceLength}, nvinfer1::DataType::kHALF, 0, stream, maxSequenceLength,
+        maxSequenceLength, /*enableBlockReuse=*/true);
+    kvCacheManager.allocatePools(false);
+
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    auto inputTokensA = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7, 8});
+    auto llmRequestA = std::make_shared<LlmRequest>(
+        requestIdA, /*maxNewTokens=*/0, inputTokensA, samplingConfig, /*isStreaming=*/false);
+    kvCacheManager.addSequenceBatch(
+        {{{requestIdA, static_cast<SizeType32>(inputTokensA->size()), beamWidth}}}, {std::ref(*llmRequestA)});
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*llmRequestA);
+    kvCacheManager.beginTransferLease(requestIdA, *llmRequestA);
+
+    auto const leaseBlockIds = kvCacheManager.getTransferLeaseBlockIds(requestIdA);
+    ASSERT_TRUE(leaseBlockIds.has_value());
+    auto const& requestABlockIds = leaseBlockIds->at(maxSequenceLength);
+    ASSERT_EQ(requestABlockIds.size(), 3);
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 3);
+
+    // While A's transfer lease owns the stored prefix, B reuses the two full
+    // prefix blocks and allocates a distinct tail block.
+    auto inputTokensB = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7, 99});
+    auto llmRequestB = std::make_shared<LlmRequest>(
+        requestIdB, /*maxNewTokens=*/0, inputTokensB, samplingConfig, /*isStreaming=*/false);
+    kvCacheManager.addSequenceBatch(
+        {{{requestIdB, static_cast<SizeType32>(inputTokensB->size()), beamWidth}}}, {std::ref(*llmRequestB)});
+    auto const& requestBBlockIds = kvCacheManager.getCacheBlockIds(requestIdB, maxSequenceLength).at(0);
+    ASSERT_EQ(requestBBlockIds.size(), 3);
+    EXPECT_EQ(requestBBlockIds.at(0), requestABlockIds.at(0));
+    EXPECT_EQ(requestBBlockIds.at(1), requestABlockIds.at(1));
+    EXPECT_NE(requestBBlockIds.at(2), requestABlockIds.at(2));
+    EXPECT_EQ(llmRequestB->getReusedBlocksPerRequest(), 2);
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 4);
+
+    // Releasing A's transferred prefix drops only the lease references. B's
+    // sequence references keep the shared blocks resident and non-evictable.
+    kvCacheManager.enqueueTransferLeaseRelease(
+        requestIdA, TransferBlockIds{{maxSequenceLength, {requestABlockIds.at(0), requestABlockIds.at(1)}}});
+    kvCacheManager.drainTransferLeaseReleases();
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 4);
+
+    kvCacheManager.enqueueTransferLeaseRelease(
+        requestIdA, TransferBlockIds{{maxSequenceLength, {requestABlockIds.at(2)}}});
+    kvCacheManager.drainTransferLeaseReleases();
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool - 3);
+    kvCacheManager.endTransferLease(requestIdA);
+
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*llmRequestB);
+    kvCacheManager.removeSequence(requestIdB, llmRequestB);
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), blocksInPrimaryPool);
+}
+
 TEST_F(KVCacheManagerTest, BlockManagerBlockPriorityTest)
 {
     auto constexpr numLayers = 12;

--- a/cpp/tests/unit_tests/batch_manager/kvCacheUtilsTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheUtilsTest.cpp
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "tensorrt_llm/batch_manager/cacheFormatter.h"
 #include "tensorrt_llm/common/cudaUtils.h"
 
 namespace tc = tensorrt_llm::common;
@@ -139,4 +140,43 @@ TEST_F(BlockIteratorTest, CacheManagerTest)
         EXPECT_EQ(iter->getSize(), numLayers * numKvHeads * sizePerHead * tokensPerBlock * 2);
     }
     EXPECT_EQ(cnt, blockIds.size());
+}
+
+TEST(TransferLeaseBlockUtilsTest, SelectsExactOrderedLeaseTail)
+{
+    SizeType32 constexpr windowSize{128};
+    TransferBlockIds const leasedBlockIds{{windowSize, {41, 7, 99, 12}}};
+
+    auto const selectedBlockIds = selectTransferLeaseTail(leasedBlockIds, /*indexFromEnd=*/1);
+
+    ASSERT_THAT(selectedBlockIds, ::testing::SizeIs(1));
+    EXPECT_THAT(selectedBlockIds.at(windowSize), ::testing::ElementsAre(99, 12));
+}
+
+TEST(TransferLeaseBlockUtilsTest, ReturnsOnlyUnselectedLeasePrefix)
+{
+    SizeType32 constexpr windowSize{128};
+    TransferBlockIds const leasedBlockIds{{windowSize, {41, 7, 99, 12}}};
+    TransferBlockIds const selectedBlockIds{{windowSize, {99, 12}}};
+
+    auto const untransferredBlockIds = getUntransferredLeaseBlockIds(leasedBlockIds, selectedBlockIds);
+
+    ASSERT_THAT(untransferredBlockIds, ::testing::SizeIs(1));
+    EXPECT_THAT(untransferredBlockIds.at(windowSize), ::testing::ElementsAre(41, 7));
+}
+
+TEST(CacheFormatterChunkConfigurationTest, RejectsMismatchedChunkSizes)
+{
+    using CacheState = tensorrt_llm::executor::kv_cache::CacheState;
+    CacheState selfConfig{/*nbAttentionLayers=*/2, /*nbKvHeads=*/4, /*sizePerHead=*/16, /*tokensPerBlock=*/8,
+        /*tensorParallelism=*/1, /*pipelineParallelism=*/1, /*contextParallelism=*/1,
+        /*attentionLayerNumPerPP=*/{2}, nvinfer1::DataType::kFLOAT};
+    auto destConfig = selfConfig;
+    selfConfig.setTransferChunkSizeBlocks(2);
+
+    EXPECT_FALSE(cache_formatter_utils::hasCompatibleTransferChunkSize(selfConfig, destConfig));
+    destConfig.setTransferChunkSizeBlocks(3);
+    EXPECT_FALSE(cache_formatter_utils::hasCompatibleTransferChunkSize(selfConfig, destConfig));
+    destConfig.setTransferChunkSizeBlocks(2);
+    EXPECT_TRUE(cache_formatter_utils::hasCompatibleTransferChunkSize(selfConfig, destConfig));
 }

--- a/cpp/tests/unit_tests/common/CMakeLists.txt
+++ b/cpp/tests/unit_tests/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION &
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION &
 # AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -15,6 +15,9 @@
 
 add_gtest(cudaProfilerUtilsTest cudaProfilerUtilsTest.cpp)
 add_gtest(cudaUtilsTest cudaUtilsTest.cpp)
+if(NOT WIN32)
+  add_gtest(envUtilsTest envUtilsTest.cpp)
+endif()
 add_gtest(attentionWorkspaceTest attentionWorkspaceTest.cpp)
 add_gtest(memoryUtilsTest memoryUtilsTest.cu)
 add_gtest(optionalRefTest optionalRefTest.cpp)

--- a/cpp/tests/unit_tests/common/envUtilsTest.cpp
+++ b/cpp/tests/unit_tests/common/envUtilsTest.cpp
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/envUtils.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <limits>
+#include <optional>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace
+{
+
+template <typename TestBody>
+void runInFork(TestBody&& testBody)
+{
+    pid_t const pid = fork();
+    ASSERT_NE(pid, -1) << "fork failed";
+    if (pid == 0)
+    {
+        testBody();
+        std::exit(testing::Test::HasFailure() ? 1 : 0);
+    }
+
+    int status = 0;
+    ASSERT_NE(waitpid(pid, &status, 0), -1) << "waitpid failed";
+    ASSERT_TRUE(WIFEXITED(status)) << "child process terminated abnormally";
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "expectation failed in child process";
+}
+
+void setChunkSizeEnv(std::optional<std::string> const& value)
+{
+    constexpr char const* envName = "TRTLLM_KVCACHE_TRANSFER_CHUNK_SIZE_BLOCKS";
+    if (value.has_value())
+    {
+        ASSERT_EQ(setenv(envName, value->c_str(), 1), 0);
+    }
+    else
+    {
+        ASSERT_EQ(unsetenv(envName), 0);
+    }
+}
+
+} // namespace
+
+TEST(EnvUtilsTest, KVCacheTransferChunkSizeBlocksUnset)
+{
+    runInFork(
+        []
+        {
+            setChunkSizeEnv(std::nullopt);
+            EXPECT_EQ(tensorrt_llm::common::getEnvKVCacheTransferChunkSizeBlocks(), std::nullopt);
+        });
+}
+
+TEST(EnvUtilsTest, KVCacheTransferChunkSizeBlocksZero)
+{
+    runInFork(
+        []
+        {
+            setChunkSizeEnv(std::string{"0"});
+            EXPECT_EQ(tensorrt_llm::common::getEnvKVCacheTransferChunkSizeBlocks(), std::nullopt);
+        });
+}
+
+TEST(EnvUtilsTest, KVCacheTransferChunkSizeBlocksPositive)
+{
+    runInFork(
+        []
+        {
+            setChunkSizeEnv(std::string{"17"});
+            auto const chunkSize = tensorrt_llm::common::getEnvKVCacheTransferChunkSizeBlocks();
+            ASSERT_TRUE(chunkSize.has_value());
+            EXPECT_EQ(chunkSize.value(), 17);
+        });
+}
+
+TEST(EnvUtilsTest, KVCacheTransferChunkSizeBlocksInvalid)
+{
+    for (auto const& value : {std::string{""}, std::string{"17blocks"}, std::string{"+1"}, std::string{"1_0"},
+             std::string{"1 "}, std::string{" 1"}})
+    {
+        runInFork(
+            [&value]
+            {
+                setChunkSizeEnv(value);
+                EXPECT_THROW(tensorrt_llm::common::getEnvKVCacheTransferChunkSizeBlocks(), std::exception);
+            });
+    }
+}
+
+TEST(EnvUtilsTest, KVCacheTransferChunkSizeBlocksNegative)
+{
+    runInFork(
+        []
+        {
+            setChunkSizeEnv(std::string{"-1"});
+            EXPECT_THROW(tensorrt_llm::common::getEnvKVCacheTransferChunkSizeBlocks(), std::exception);
+        });
+}
+
+TEST(EnvUtilsTest, KVCacheTransferChunkSizeBlocksOverflow)
+{
+    runInFork(
+        []
+        {
+            setChunkSizeEnv(std::to_string(static_cast<long long>(std::numeric_limits<int32_t>::max()) + 1));
+            EXPECT_THROW(tensorrt_llm::common::getEnvKVCacheTransferChunkSizeBlocks(), std::exception);
+        });
+}
+
+TEST(EnvUtilsTest, KVCacheTransferEarlyRelease)
+{
+    runInFork(
+        []
+        {
+            ASSERT_EQ(setenv("TRTLLM_KVCACHE_TRANSFER_EARLY_RELEASE", "1", 1), 0);
+            EXPECT_TRUE(tensorrt_llm::common::getEnvKVCacheTransferEarlyRelease());
+        });
+}

--- a/cpp/tests/unit_tests/executor/agentCommTest.cpp
+++ b/cpp/tests/unit_tests/executor/agentCommTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -203,6 +203,7 @@ TEST_P(AgentCommTest, AgentConnectionManagerConnect)
     tensorrt_llm::batch_manager::RequestInfo recvRequestInfo;
     auto connection1 = connectionManager1->recvConnectionAndRequestInfo(recvRequestInfo, std::atomic<bool>(false));
     ASSERT_EQ(recvRequestInfo.getRequestId(), requestId);
+    connection1->activateRequestSenderState(requestId);
 
     auto sendBuffer = mTransBufferManager->getSendBuffer(cacheBufferIds[0].value());
     auto sendSize = 1024;
@@ -228,6 +229,7 @@ TEST_P(AgentCommTest, AgentConnectionManagerConnect)
     {
         ASSERT_EQ(recvData[i], 'a');
     }
+    connection1->eraseRequestSenderState(requestId);
     TLLM_LOG_INFO("after finish");
 }
 

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -1568,9 +1568,11 @@ TEST(SerializeUtilsTest, CacheStateIndexerKCache)
     CacheState state{nbKvHeadsPerLayer, sizePerHead, tokensPerBlock, tp, pp, cp, attentionLayerNumPerPP, dataType,
         attentionType, kvFactor, enableAttentionDP, dpRank, dpSize, enableBlockReuse, enablePartialReuse,
         hasIndexerKCache, indexerDimPerHead, indexerKCacheQuantBlockSize};
+    state.setTransferChunkSizeBlocks(7);
 
     std::ostringstream oss;
     texec::Serialization::serialize(state, oss);
+    EXPECT_EQ(texec::Serialization::serializedSize(state), oss.str().size());
     std::istringstream iss(oss.str());
     auto state2 = texec::Serialization::deserializeCacheState(iss);
 
@@ -1589,4 +1591,6 @@ TEST(SerializeUtilsTest, CacheStateIndexerKCache)
     EXPECT_EQ(state.getHasIndexerKCache(), state2.getHasIndexerKCache());
     EXPECT_EQ(state.getIndexerDimPerHead(), state2.getIndexerDimPerHead());
     EXPECT_EQ(state.getIndexerKCacheQuantBlockSize(), state2.getIndexerKCacheQuantBlockSize());
+    EXPECT_EQ(state.getTransferChunkSizeBlocks(), state2.getTransferChunkSizeBlocks());
+    EXPECT_EQ(state, state2);
 }

--- a/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
@@ -180,6 +180,10 @@ protected:
                 future.get();
             }
         }
+        mSender.reset();
+        mRequester.reset();
+        mConnectionManager.reset();
+        mCacheTransBufferManager.reset();
     }
 
     SizeType32 setUpCommunicator()
@@ -191,6 +195,39 @@ protected:
         isSender = mComm->getRank() % 2 == 0;
         tensorrt_llm::mpi::MpiComm::setSession(mComm->split(static_cast<int>(isSender), mlocalRank));
         return mWorldSize;
+    }
+
+    void exchangeContextCommState()
+    {
+        auto const& commState = mConnectionManager->getCommState();
+        namespace su = tensorrt_llm::executor::serialize_utils;
+
+        if (tensorrt_llm::mpi::MpiComm::world().getRank() == 0)
+        {
+            std::ostringstream oStream;
+            su::serialize(commState, oStream);
+            auto str = oStream.str();
+            std::vector<char> buffer(str.begin(), str.end());
+            int constexpr genRank = 1;
+            int64_t const bufferSize = buffer.size();
+            tensorrt_llm::mpi::MpiComm::world().sendRawTag(
+                &bufferSize, 1, tensorrt_llm::mpi::MpiType::kINT64, genRank, 0x1F);
+            tensorrt_llm::mpi::MpiComm::world().sendRawTag(
+                buffer.data(), buffer.size(), tensorrt_llm::mpi::MpiType::kCHAR, genRank, 0x2F);
+            mContextCommState = std::make_unique<texec::kv_cache::CommState>(commState);
+        }
+        else
+        {
+            int64_t bufferSize;
+            tensorrt_llm::mpi::MpiComm::world().recvRawTag(&bufferSize, 1, tensorrt_llm::mpi::MpiType::kINT64, 0, 0x1F);
+            std::vector<char> recvBuffer(bufferSize);
+            tensorrt_llm::mpi::MpiComm::world().recvRawTag(
+                recvBuffer.data(), bufferSize, tensorrt_llm::mpi::MpiType::kCHAR, 0, 0x2F);
+            su::VectorWrapBuf<char> strbuf(recvBuffer);
+            std::istream is(&strbuf);
+            mContextCommState
+                = std::make_unique<texec::kv_cache::CommState>(su::deserialize<texec::kv_cache::CommState>(is));
+        }
     }
 
     void setUpCacheManager()
@@ -246,46 +283,9 @@ protected:
             std::unique_ptr<tensorrt_llm::executor::kv_cache::ConnectionManager> (*makeUcxConnectionManager)();
             *(void**) (&makeUcxConnectionManager) = load_sym(WrapperLibHandle, "makeUcxConnectionManager");
             mConnectionManager = makeUcxConnectionManager();
-            auto commState = mConnectionManager->getCommState();
-            namespace su = tensorrt_llm::executor::serialize_utils;
-
-            if (tensorrt_llm::mpi::MpiComm::world().getRank() == 0)
-            {
-
-                std::ostringstream oStream;
-                su::serialize(commState, oStream);
-                auto str = oStream.str();
-                std::vector<char> buffer(str.begin(), str.end());
-                int genRank = 1;
-                int64_t bufferSize = buffer.size();
-                TLLM_LOG_DEBUG(
-                    tensorrt_llm::mpi::MpiComm::world().getRank(), "send bufferSize: %ld to %d", bufferSize, genRank);
-                tensorrt_llm::mpi::MpiComm::world().sendRawTag(
-                    &bufferSize, 1, tensorrt_llm::mpi::MpiType::kINT64, genRank, 0x1F);
-                tensorrt_llm::mpi::MpiComm::world().sendRawTag(
-                    buffer.data(), buffer.size(), tensorrt_llm::mpi::MpiType::kCHAR, genRank, 0x2F);
-                TLLM_LOG_DEBUG(tensorrt_llm::mpi::MpiComm::world().getRank(), "send buffer to %d", genRank);
-                mContextCommState = std::make_unique<tensorrt_llm::executor::kv_cache::CommState>(commState);
-            }
-            else
-            {
-                int64_t bufferSize;
-                tensorrt_llm::mpi::MpiComm::world().recvRawTag(
-                    &bufferSize, 1, tensorrt_llm::mpi::MpiType::kINT64, 0, 0x1F);
-                TLLM_LOG_DEBUG(
-                    tensorrt_llm::mpi::MpiComm::world().getRank(), "recv bufferSize: %ld from 0", bufferSize);
-                std::vector<char> recvBuffer(bufferSize);
-                tensorrt_llm::mpi::MpiComm::world().recvRawTag(
-                    recvBuffer.data(), bufferSize, tensorrt_llm::mpi::MpiType::kCHAR, 0, 0x2F);
-                TLLM_LOG_DEBUG(tensorrt_llm::mpi::MpiComm::world().getRank(), "recv buffer from 0", bufferSize);
-                std::istringstream iStream(std::string(recvBuffer.begin(), recvBuffer.end()));
-                su::VectorWrapBuf<char> strbuf(recvBuffer);
-                std::istream is(&strbuf);
-                mContextCommState = std::make_unique<tensorrt_llm::executor::kv_cache::CommState>(
-                    su::deserialize<tensorrt_llm::executor::kv_cache::CommState>(is));
-            }
+            exchangeContextCommState();
         }
-        else
+        else if (!tensorrt_llm::common::getEnvUseNixlKvCache() && !tensorrt_llm::common::getEnvUseMooncakeKvCache())
         {
             mConnectionManager = std::make_unique<texec::kv_cache::MpiConnectionManager>(mComm);
             mContextCommState
@@ -302,6 +302,19 @@ protected:
         mCacheTransBufferManager = std::make_unique<CacheTransBufferManager>(mManager.get(), maxNumTokens);
         std::vector<CacheTransBufferManager*> bufferManagers;
         bufferManagers.push_back(mCacheTransBufferManager.get());
+        if (tensorrt_llm::common::getEnvUseNixlKvCache() || tensorrt_llm::common::getEnvUseMooncakeKvCache())
+        {
+            bool const isNixl = tensorrt_llm::common::getEnvUseNixlKvCache();
+            if (isNixl)
+            {
+                constexpr auto port = 22345;
+                setenv("TRTLLM_NIXL_PORT", std::to_string(port).c_str(), 1);
+            }
+            std::vector<BaseTransBufferManager*> baseBufferManagers{mCacheTransBufferManager.get()};
+            mConnectionManager = std::make_unique<texec::kv_cache::AgentConnectionManager>(
+                baseBufferManagers, *mCacheState, isNixl ? "nixl" : "mooncake");
+            exchangeContextCommState();
+        }
         if (isSender)
         {
             mSender = std::make_unique<CacheSender>(mConnectionManager.get(), mlocalRank,
@@ -329,7 +342,7 @@ protected:
         return std::make_unique<LlmRequest>(mRequestId++, std::move(request));
     }
 
-    void addRequestAndTransportCache(std::shared_ptr<LlmRequest> const& llmRequest)
+    void addRequestAndTransportCache(std::shared_ptr<LlmRequest> const& llmRequest, bool useTransferLease = false)
     {
         auto constexpr beamIdx{0};
         auto constexpr beamWidth{1};
@@ -347,6 +360,10 @@ protected:
                     // fill cache with tokens (= request length), for reuse test
                     TLLM_CUDA_CHECK(cudaMemset(it->data(), llmRequest->getPromptLen(), it->getSizeInBytes()));
                 }
+            }
+            if (useTransferLease)
+            {
+                mManager->beginTransferLease(llmRequest->mRequestId, *llmRequest);
             }
             mFutures.emplace_back(mSender->sendAsync(llmRequest));
         }
@@ -423,6 +440,84 @@ TEST_F(SymmetricalCacheTest, SimpleTest)
     for (auto& future : mFutures)
     {
         future.get();
+    }
+}
+
+TEST_F(SymmetricalCacheTest, ChunkedTransfer)
+{
+    auto worldSize = setUpCommunicator();
+    if (worldSize != 2)
+    {
+        GTEST_SKIP() << "mpirun 2 processes is required to run this test.";
+    }
+    setUpCacheManager();
+    mCacheState->setTransferChunkSizeBlocks(3);
+    setUpCacheTransceiver();
+    std::vector<std::shared_ptr<tensorrt_llm::batch_manager::LlmRequest>> requests;
+
+    // Exercise multiple chunks, a short final chunk, and concurrent requests
+    // through the real sender/receiver request and chunk-control protocols.
+    for (auto len : {10, 20, 30})
+    {
+        requests.emplace_back(makeLlmRequest(len));
+        addRequestAndTransportCache(requests.back());
+    }
+    for (auto& future : mFutures)
+    {
+        future.get();
+    }
+    mFutures.clear();
+    for (auto& request : requests)
+    {
+        tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*request);
+        mManager->removeSequence(request->mRequestId, request);
+    }
+    requests.clear();
+
+    // Repeat after releasing the first batch to cover buffer/session reuse.
+    for (auto len : {10, 20, 30})
+    {
+        requests.emplace_back(makeLlmRequest(len));
+        addRequestAndTransportCache(requests.back());
+    }
+    for (auto& future : mFutures)
+    {
+        future.get();
+    }
+}
+
+TEST_F(SymmetricalCacheTest, ChunkedTransferReleasesExactLeaseBlocks)
+{
+    auto worldSize = setUpCommunicator();
+    if (worldSize != 2)
+    {
+        GTEST_SKIP() << "mpirun 2 processes is required to run this test.";
+    }
+    setUpCacheManager();
+    mCacheState->setTransferChunkSizeBlocks(3);
+    setUpCacheTransceiver();
+
+    std::shared_ptr<LlmRequest> request = makeLlmRequest(30);
+    auto const requestId = request->mRequestId;
+    addRequestAndTransportCache(request, /*useTransferLease=*/true);
+    for (auto& future : mFutures)
+    {
+        future.get();
+    }
+    mFutures.clear();
+
+    if (isSender)
+    {
+        ASSERT_TRUE(mManager->hasActiveTransferLease(requestId));
+        mManager->drainTransferLeaseReleases();
+        EXPECT_EQ(mManager->getNumFreeBlocks(), mManager->getMaxNumBlocks());
+        mManager->endTransferLease(requestId);
+        EXPECT_FALSE(mManager->hasActiveTransferLease(requestId));
+    }
+    else
+    {
+        tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*request);
+        mManager->removeSequence(requestId, request);
     }
 }
 

--- a/docs/source/features/disagg-serving.md
+++ b/docs/source/features/disagg-serving.md
@@ -252,6 +252,12 @@ TRT-LLM uses some environment variables to control the behavior of disaggregated
 
 * `TRTLLM_KVCACHE_TRANSFER_BUFFER_SIZE`: By default, TRT-LLM uses a `stream-ordered memory allocator` to allocate temporary buffers. If this environment variable is set to #Size, TRT-LLM will use `cudaMalloc` to allocate buffer of size #Size for KV cache transmission. The default value is `512MB`. Users can set `TRTLLM_KVCACHE_TRANSFER_BUFFER_SIZE=1GB` to allocate a 1 GB buffer with `cudaMalloc` for KV cache transmission.
 
+**Protocol compatibility:** Context and generation peers must run the same TensorRT-LLM build, even when chunked transfer is disabled. The C++ transceiver's serialized cache state and request-readiness protocol are not wire-compatible with older builds. Mixed-version deployments are unsupported and can hang. All ranks in a deployment must also use identical values for both chunked-transfer environment variables below.
+
+* `TRTLLM_KVCACHE_TRANSFER_CHUNK_SIZE_BLOCKS`: A positive decimal integer enables the C++ transceiver's chunked protocol and sets the number of KV-cache blocks staged per chunk. Unset or `0` disables chunking. The initial implementation supports beam width 1, one primary KV pool and cache window, CP=1, and a 1:1 transfer-peer topology; it rejects MLA/indexer, sliding-window, RNN/hybrid, layer-wise, and zero-copy cache layouts.
+
+* `TRTLLM_KVCACHE_TRANSFER_EARLY_RELEASE`: If set to `1`, the context executor releases exact sender-side KV blocks after each chunk has been committed by the receiver. This requires a positive `TRTLLM_KVCACHE_TRANSFER_CHUNK_SIZE_BLOCKS`. The initial implementation also requires the C++ transceiver, TP=PP=CP=1 (`world_size=1` in the PyExecutor), and no KV-cache connector.
+
 * `TRTLLM_KVCACHE_TRANSFER_USE_ASYNC_BUFFER`: If set to `1`, TRT-LLM will use `cudaMallocAsync` to allocate buffers for KV cache transmission. The default value is `0`. This environment variable only takes effect when `TRTLLM_KVCACHE_TRANSFER_BUFFER_SIZE` is greater than 0.
 
 * `TRTLLM_KVCACHE_SEND_MAX_CONCURRENCY_NUM`: The maximum number of concurrent KV cache sends. The default value is `1`. This environment variable only takes effect when `TRTLLM_KVCACHE_TRANSFER_BUFFER_SIZE` is greater than 0.

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from abc import ABC, abstractmethod
 from os import getenv
 from typing import Any, Dict, List, Optional
@@ -19,6 +34,34 @@ AttentionTypeCpp = tensorrt_llm.bindings.internal.batch_manager.AttentionType
 CacheTransBufferManagerCpp = tensorrt_llm.bindings.internal.batch_manager.CacheTransBufferManager
 BackendTypeCpp = tensorrt_llm.bindings.executor.CacheTransceiverBackendType
 
+KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME = \
+    "TRTLLM_KVCACHE_TRANSFER_CHUNK_SIZE_BLOCKS"
+KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME = \
+    "TRTLLM_KVCACHE_TRANSFER_EARLY_RELEASE"
+
+
+def get_kv_cache_transfer_chunk_size_blocks() -> Optional[int]:
+    value = getenv(KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME)
+    if value is None:
+        return None
+
+    if not value or not value.isascii() or not value.isdigit():
+        raise ValueError(
+            f"{KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME} must be a "
+            f"non-negative decimal integer, got {value!r}.")
+
+    try:
+        chunk_size_blocks = int(value)
+    except ValueError as error:
+        raise ValueError(
+            f"{KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME} must be a "
+            f"non-negative decimal integer, got {value!r}.") from error
+    if chunk_size_blocks > 2**31 - 1:
+        raise ValueError(
+            f"{KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME} exceeds "
+            f"the supported maximum ({2**31 - 1}), got {value!r}.")
+    return chunk_size_blocks or None
+
 
 def mapping_to_world_config(mapping: Mapping) -> WorldConfig:
 
@@ -38,9 +81,26 @@ def create_kv_cache_transceiver(
         attention_type: AttentionTypeCpp,
         cache_transceiver_config: CacheTransceiverConfig,
         mamba_cache_manager: Optional[BaseMambaCacheManager] = None):
+    chunk_size_blocks = get_kv_cache_transfer_chunk_size_blocks()
+    early_release = getenv(KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME) == "1"
+    if early_release and chunk_size_blocks is None:
+        raise ValueError(
+            f"{KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME}=1 requires a "
+            f"positive {KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME}.")
     if cache_transceiver_config is None or cache_transceiver_config.backend is None:
+        if chunk_size_blocks is not None or early_release:
+            raise ValueError(
+                "Chunked KV-cache transfer requires an enabled C++ KV cache "
+                "transceiver.")
         logger.info("cache_transceiver is disabled")
         return None
+
+    if (cache_transceiver_config.transceiver_runtime == "PYTHON"
+            and (chunk_size_blocks is not None or early_release)):
+        raise NotImplementedError(
+            "Chunked KV-cache transfer and early release are supported only "
+            "by the C++ KV cache transceiver; set "
+            "cache_transceiver_config.transceiver_runtime='CPP'.")
 
     if cache_transceiver_config.backend == "DEFAULT":
         # When cache_transceiver_config.backend is not set, fallback to env_vars settings
@@ -94,6 +154,21 @@ def create_kv_cache_transceiver(
 
 
 class KvCacheTransceiver(ABC):
+
+    @property
+    def supports_cpp_chunked_transfer(self) -> bool:
+        """Whether this implementation uses the env-gated C++ chunk protocol."""
+        return False
+
+    @property
+    def transfer_chunk_size_blocks(self) -> Optional[int]:
+        """Chunk size actually selected by the transceiver implementation."""
+        return None
+
+    @property
+    def transfer_early_release_enabled(self) -> bool:
+        """Whether this transceiver actually owns exact early-release leases."""
+        return False
 
     @abstractmethod
     def respond_and_send_async(self, req: LlmRequest):
@@ -149,6 +224,18 @@ class KvCacheTransceiver(ABC):
 
 
 class BindKvCacheTransceiver(KvCacheTransceiver):
+
+    @property
+    def supports_cpp_chunked_transfer(self) -> bool:
+        return True
+
+    @property
+    def transfer_chunk_size_blocks(self) -> Optional[int]:
+        return self.impl.transfer_chunk_size_blocks
+
+    @property
+    def transfer_early_release_enabled(self) -> bool:
+        return self.impl.transfer_early_release_enabled
 
     def __init__(self,
                  mapping: Mapping,
@@ -227,6 +314,13 @@ class BindKvCacheTransceiver(KvCacheTransceiver):
 
     def cancel_request(self, req: LlmRequest):
         return self.impl.cancel_request(req)
+
+    def shutdown(self):
+        # Destroy the C++ transceiver while the KV-cache manager and its pools
+        # are still alive. Its destructor joins workers and closes any active
+        # transfer leases.
+        if self.impl is not None:
+            self.impl = None
 
     def prepare_context_requests(self, requests: List[LlmRequest]):
         # not implemented, an empty placeholder to allow being invoked unconditionally

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import dataclasses
 import datetime
 import functools
@@ -65,7 +80,10 @@ from .handle_logits import HandleLogits
 from .hang_detector import HangDetector
 from .kv_cache_manager_v2 import KVCacheManagerV2
 from .kv_cache_stats import append_kv_cache_iteration_stats
-from .kv_cache_transceiver import KvCacheTransceiver
+from .kv_cache_transceiver import (
+    KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME,
+    KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME, KvCacheTransceiver,
+    get_kv_cache_transfer_chunk_size_blocks)
 from .llm_request import (ATTENTION_DP_DUMMY_REQUEST_ID,
                           MAX_SPEC_DECODE_POSITIONS, ExecutorRequest,
                           LlmRequest, LlmRequestState, LlmResponse,
@@ -101,6 +119,28 @@ PROFILE_TRACE_ENV_VAR_NAME = "TLLM_TORCH_PROFILE_TRACE"
 # Format: comma-separated rank IDs, e.g. "0,1,3", or "all" for all ranks.
 # Default: "0" (only rank 0 prints, matching existing behavior).
 PROFILE_LOG_RANKS_ENV_VAR_NAME = "TLLM_PROFILE_LOG_RANKS"
+
+
+def _resolve_active_kv_cache_transfer_config(
+    requested_chunk_size_blocks: Optional[int],
+    requested_early_release: bool,
+    kv_cache_transceiver: Optional[KvCacheTransceiver],
+) -> Tuple[Optional[int], bool]:
+    """Match dynamic Python flags to the C++ transceiver's cached config."""
+    actual_chunk_size_blocks = (kv_cache_transceiver.transfer_chunk_size_blocks
+                                if kv_cache_transceiver is not None else None)
+    actual_early_release = (kv_cache_transceiver.transfer_early_release_enabled
+                            if kv_cache_transceiver is not None else False)
+    if (requested_chunk_size_blocks != actual_chunk_size_blocks
+            or requested_early_release != actual_early_release):
+        raise RuntimeError(
+            "KV-cache transfer environment changed after the C++ "
+            "transceiver configuration was initialized: requested "
+            f"chunk_size_blocks={requested_chunk_size_blocks}, "
+            f"early_release={requested_early_release}; active "
+            f"chunk_size_blocks={actual_chunk_size_blocks}, "
+            f"early_release={actual_early_release}.")
+    return actual_chunk_size_blocks, actual_early_release
 
 
 class PPCommTag(IntEnum):
@@ -316,12 +356,14 @@ class AsyncTransferManager:
 
     def __init__(self,
                  resource_manager: "ResourceManager",
-                 should_store_blocks: bool = True):
+                 should_store_blocks: bool = True,
+                 use_cpp_transfer_lease: bool = False):
         self.resource_manager = resource_manager
         self.kv_cache_manager = resource_manager.resource_managers.get(
             ResourceManagerType.KV_CACHE_MANAGER)
 
         self.should_store_blocks = should_store_blocks
+        self.use_cpp_transfer_lease = use_cpp_transfer_lease
 
         # Mapping of request id to the LlmRequest
         self._requests_in_transfer: Dict[int, LlmRequest] = dict()
@@ -354,7 +396,7 @@ class AsyncTransferManager:
 
             request.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
 
-            if self.should_store_blocks:
+            if self.should_store_blocks and not self.use_cpp_transfer_lease:
                 block_id = self.kv_cache_manager.store_blocks_for_reuse(
                     request, True)
             else:
@@ -388,7 +430,7 @@ class AsyncTransferManager:
             self._requests_in_transfer.pop(request.py_request_id)
             self._request_transfer_metadata.pop(request.py_request_id)
 
-            if self.should_store_blocks:
+            if self.should_store_blocks and not self.use_cpp_transfer_lease:
                 self.kv_cache_manager.unpin_blocks_by_id(
                     transfer_metadata.block_id)
 
@@ -562,6 +604,65 @@ class PyExecutor:
             self.enable_kv_cache_reuse
             and self.kv_cache_manager.enable_partial_reuse)
 
+        requested_chunk_size_blocks = get_kv_cache_transfer_chunk_size_blocks()
+        requested_early_release = os.getenv(
+            KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME) == "1"
+        self.kv_cache_transfer_chunk_size_blocks = requested_chunk_size_blocks
+        self.enable_kv_cache_transfer_early_release = requested_early_release
+        if self.kv_cache_transfer_chunk_size_blocks is not None:
+            if self.max_beam_width != 1:
+                raise NotImplementedError(
+                    "Chunked KV-cache transfer currently requires "
+                    "max_beam_width=1.")
+            if kv_cache_transceiver is None:
+                raise ValueError(
+                    f"{KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME} "
+                    "requires the C++ KV cache transceiver.")
+            if not kv_cache_transceiver.supports_cpp_chunked_transfer:
+                raise NotImplementedError(
+                    f"{KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME} is "
+                    "supported only by the C++ KV cache transceiver; set "
+                    "cache_transceiver_config.transceiver_runtime='CPP'.")
+        if self.enable_kv_cache_transfer_early_release:
+            if self.kv_cache_transfer_chunk_size_blocks is None:
+                raise ValueError(
+                    f"{KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME}=1 "
+                    f"requires a positive "
+                    f"{KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME}.")
+            if kv_cache_transceiver is None:
+                raise ValueError(
+                    f"{KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME}=1 "
+                    "requires the C++ KV cache transceiver.")
+            if not kv_cache_transceiver.supports_cpp_chunked_transfer:
+                raise NotImplementedError(
+                    "Chunked KV-cache early release is supported only by the "
+                    "C++ KV cache transceiver; set "
+                    "cache_transceiver_config.transceiver_runtime='CPP'.")
+            if not getattr(self.kv_cache_manager, "supports_transfer_leases",
+                           False):
+                raise NotImplementedError(
+                    "Chunked KV-cache early release requires a KV cache "
+                    "manager with exact transfer-lease support.")
+            if kv_connector_manager is not None:
+                raise NotImplementedError(
+                    "Chunked KV-cache early release cannot be combined with "
+                    "the KV cache connector because both consumers do not "
+                    "yet share per-chunk transfer leases.")
+            if self.dist.world_size != 1:
+                raise NotImplementedError(
+                    "Chunked KV-cache early release currently requires "
+                    "world_size=1; cross-rank per-chunk completion consensus "
+                    "is not implemented.")
+
+        actual_chunk_size_blocks, actual_early_release = \
+            _resolve_active_kv_cache_transfer_config(
+                requested_chunk_size_blocks, requested_early_release,
+                kv_cache_transceiver)
+        # Lease ownership must follow the transceiver's actual C++ state, not
+        # a second dynamic environment read.
+        self.kv_cache_transfer_chunk_size_blocks = actual_chunk_size_blocks
+        self.enable_kv_cache_transfer_early_release = actual_early_release
+
         self.max_input_len = max_input_len
         # _executor_loop private data
         self.max_num_active_requests = model_engine.get_max_num_sequences()
@@ -604,7 +705,8 @@ class PyExecutor:
         self.async_transfer_manager = AsyncTransferManager(
             self.resource_manager,
             should_store_blocks=self.enable_partial_reuse_for_disagg
-            and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1)
+            and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1,
+            use_cpp_transfer_lease=self.enable_kv_cache_transfer_early_release)
 
         # Router is built after async_transfer_manager so KVCacheAwareADPRouter
         # can receive the transfer-manager reference at construction time.
@@ -1159,6 +1261,14 @@ class PyExecutor:
         # resource managers start freeing GPU-backed workspaces.
         if torch.cuda.is_available():
             torch.cuda.synchronize()
+        # Stop C++ transfer workers and close leases before the KV-cache
+        # resource manager releases its pools. The Python transceiver owns a
+        # separate shutdown lifecycle and cannot use these env-gated features.
+        kv_cache_transceiver = getattr(self, "kv_cache_transceiver", None)
+        if (kv_cache_transceiver is not None
+                and kv_cache_transceiver.supports_cpp_chunked_transfer):
+            kv_cache_transceiver.shutdown()
+            self.kv_cache_transceiver = None
         for manager in self.resource_manager.resource_managers.values():
             if manager:
                 manager.shutdown()
@@ -3944,6 +4054,11 @@ class PyExecutor:
         # Validate beam width
         sampling_config = request.sampling_config
         if sampling_config is not None:
+            if (self.kv_cache_transfer_chunk_size_blocks is not None
+                    and sampling_config.beam_width != 1):
+                raise ValueError(
+                    "Chunked KV-cache transfer currently supports only beam "
+                    "width 1.")
             if sampling_config.beam_width != self.max_beam_width:
                 raise ValueError(
                     f"Request beam width {sampling_config.beam_width} "
@@ -4906,7 +5021,25 @@ class PyExecutor:
                     # Order is important here: we need to start the transfer before responding
                     # to make sure the blocks are stored for reuse before they are sent.
                     self.async_transfer_manager.start_transfer(req)
-                    self.kv_cache_transceiver.respond_and_send_async(req)
+                    try:
+                        self.kv_cache_transceiver.respond_and_send_async(req)
+                    except Exception:
+                        # Roll back Python-side transfer bookkeeping. The C++
+                        # transceiver independently closes a lease if startup
+                        # fails after lease creation.
+                        req.state = LlmRequestState.DISAGG_TRANS_ERROR
+                        try:
+                            if self.async_transfer_manager.end_transfer(req):
+                                # beginTransferLease may fail before it detaches
+                                # the sequence. Release any request resources that
+                                # are still owned by the normal executor path; if
+                                # C++ already detached it, KV removal is a no-op.
+                                self._terminate_request(req)
+                        except Exception:
+                            logger.exception(
+                                "Failed to roll back transfer resources for "
+                                f"request {req.py_request_id}")
+                        raise
 
                     if self.kv_cache_transceiver.kv_transfer_timeout_ms is not None:
                         req.py_kv_transfer_start_time = time.time()

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1013,6 +1013,10 @@ class KVCacheManager(BaseResourceManager):
         return self.impl.remove_sequence(request.py_request_id, request,
                                          pin_on_release)
 
+    @property
+    def supports_transfer_leases(self) -> bool:
+        return self.impl.supports_transfer_leases
+
     def store_blocks_for_reuse(self,
                                request: LlmRequest,
                                pin_blocks: bool = False):

--- a/tests/integration/defs/cpp/test_multi_gpu.py
+++ b/tests/integration/defs/cpp/test_multi_gpu.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os as _os
 import pathlib as _pl
 import platform
@@ -507,8 +522,9 @@ def test_fused_gemm_allreduce(build_google_tests, nprocs, build_dir):
 @pytest.mark.parametrize("build_google_tests", ["80", "86", "89", "90"],
                          indirect=True)
 @pytest.mark.parametrize(
-    "kvcache_type", [KVCacheType.NIXL, KVCacheType.UCX, KVCacheType.MOONCAKE],
-    ids=["nixl_kvcache", "ucx_kvcache", "mooncake_kvcache"])
+    "kvcache_type",
+    [KVCacheType.MPI, KVCacheType.NIXL, KVCacheType.UCX, KVCacheType.MOONCAKE],
+    ids=["mpi_kvcache", "nixl_kvcache", "ucx_kvcache", "mooncake_kvcache"])
 @pytest.mark.parametrize("nprocs", [2, 8], ids=["2proc", "8proc"])
 def test_cache_transceiver(build_google_tests, nprocs, kvcache_type, build_dir):
 

--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -272,6 +272,8 @@ l0_dgx_h100:
   # ------------- CPP tests ---------------
   - cpp/test_multi_gpu.py::test_mpi_utils[90]
   - cpp/test_multi_gpu.py::test_fused_gemm_allreduce[4proc-90]
+  - cpp/test_multi_gpu.py::test_cache_transceiver[2proc-mpi_kvcache-90] ISOLATION
+  - cpp/test_multi_gpu.py::test_cache_transceiver[2proc-nixl_kvcache-90] ISOLATION
   - cpp/test_multi_gpu.py::test_cache_transceiver[2proc-ucx_kvcache-90] ISOLATION
   - cpp/test_multi_gpu.py::test_cache_transceiver[8proc-nixl_kvcache-90] ISOLATION
   - cpp/test_multi_gpu.py::test_cache_transceiver[8proc-ucx_kvcache-90] ISOLATION

--- a/tests/unittest/_torch/executor/test_async_transfer_manager.py
+++ b/tests/unittest/_torch/executor/test_async_transfer_manager.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,13 @@
 
 from unittest.mock import MagicMock
 
-from tensorrt_llm._torch.pyexecutor.py_executor import AsyncTransferManager
+import pytest
+
+from tensorrt_llm._torch.pyexecutor.py_executor import (
+    KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME,
+    AsyncTransferManager,
+    get_kv_cache_transfer_chunk_size_blocks,
+)
 from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
 from tensorrt_llm.bindings import LlmRequestState
 
@@ -49,6 +55,39 @@ def create_mock_resource_manager(
         )
 
     return resource_manager
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, None), ("0", None), ("7", 7)],
+)
+def test_chunk_size_env_parsing(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv(KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME, raising=False)
+    else:
+        monkeypatch.setenv(KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME, value)
+
+    assert get_kv_cache_transfer_chunk_size_blocks() == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "blocks",
+        "-1",
+        "+1",
+        "1_0",
+        "1 ",
+        " 1",
+        str(2**31),
+    ],
+)
+def test_chunk_size_env_rejects_invalid_values(monkeypatch, value):
+    monkeypatch.setenv(KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME, value)
+
+    with pytest.raises(ValueError):
+        get_kv_cache_transfer_chunk_size_blocks()
 
 
 def test_start_transfer_single_request():
@@ -137,6 +176,26 @@ def test_transfer_without_storing_blocks():
 
     assert manager.end_transfer(request)
 
+    kv_cache_manager.unpin_blocks_by_id.assert_not_called()
+
+
+def test_cpp_transfer_lease_skips_coarse_pin_and_unpin():
+    """The C++ lease owns exact block pins when early release is enabled."""
+    kv_cache_manager = MagicMock()
+    resource_manager = create_mock_resource_manager(kv_cache_manager=kv_cache_manager)
+    manager = AsyncTransferManager(
+        resource_manager,
+        should_store_blocks=True,
+        use_cpp_transfer_lease=True,
+    )
+
+    request = create_mock_request(42)
+    manager.start_transfer(request)
+
+    assert manager._request_transfer_metadata[42].block_id is None
+    kv_cache_manager.store_blocks_for_reuse.assert_not_called()
+
+    assert manager.end_transfer(request)
     kv_cache_manager.unpin_blocks_by_id.assert_not_called()
 
 

--- a/tests/unittest/_torch/executor/test_disagg_index_mapper_early_release.py
+++ b/tests/unittest/_torch/executor/test_disagg_index_mapper_early_release.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,11 +19,16 @@ the transfer phase, preventing exhaustion when transfers are slow and multiple
 iterations of requests accumulate in-flight.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
-from tensorrt_llm._torch.pyexecutor.py_executor import AsyncTransferManager, PyExecutor
+from tensorrt_llm._torch.pyexecutor.py_executor import (
+    AsyncTransferManager,
+    PyExecutor,
+    _resolve_active_kv_cache_transfer_config,
+)
 from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
 from tensorrt_llm.bindings import LlmRequestState
 
@@ -76,6 +81,7 @@ class _FakeExecutor:
         self.kv_connector_manager = None
         self.disable_overlap_scheduler = True
         self.previous_batch = None
+        self._terminate_request = MagicMock()
 
     def _check_disagg_ctx_cache_transfer_status(self, _):
         return None
@@ -86,9 +92,11 @@ class TestSendKvAsyncReleasesIndexSlot:
     transfer is started, which is where the production code actually lives
     (see py_executor._send_kv_async)."""
 
-    def _build(self, kv_cache_manager):
+    def _build(self, kv_cache_manager, *, use_cpp_transfer_lease: bool = False):
         resource_manager = create_mock_resource_manager(kv_cache_manager=kv_cache_manager)
-        transfer_manager = AsyncTransferManager(resource_manager)
+        transfer_manager = AsyncTransferManager(
+            resource_manager, use_cpp_transfer_lease=use_cpp_transfer_lease
+        )
         transceiver = MagicMock()
         transceiver.kv_transfer_timeout_ms = None
         return _FakeExecutor(kv_cache_manager, transfer_manager, transceiver), transfer_manager
@@ -135,6 +143,101 @@ class TestSendKvAsyncReleasesIndexSlot:
         PyExecutor._send_kv_async(executor, [request])
 
         kv_cache_manager.release_index_slot.assert_called_once_with(42)
+
+    def test_send_start_failure_rolls_back_transfer_tracking(self):
+        kv_cache_manager = MagicMock()
+        kv_cache_manager.store_blocks_for_reuse.return_value = 100
+
+        executor, transfer_manager = self._build(kv_cache_manager)
+        executor.kv_cache_transceiver.respond_and_send_async.side_effect = RuntimeError(
+            "send startup failed"
+        )
+        request = create_mock_request(42)
+
+        with pytest.raises(RuntimeError, match="send startup failed"):
+            PyExecutor._send_kv_async(executor, [request])
+
+        assert transfer_manager.requests_in_transfer() == {}
+        assert request.state == LlmRequestState.DISAGG_TRANS_ERROR
+        kv_cache_manager.unpin_blocks_by_id.assert_called_once_with(100)
+        executor._terminate_request.assert_called_once_with(request)
+
+    def test_send_start_failure_rolls_back_cpp_lease_tracking(self):
+        kv_cache_manager = MagicMock()
+
+        executor, transfer_manager = self._build(kv_cache_manager, use_cpp_transfer_lease=True)
+        executor.kv_cache_transceiver.respond_and_send_async.side_effect = RuntimeError(
+            "send startup failed"
+        )
+        request = create_mock_request(42)
+
+        with pytest.raises(RuntimeError, match="send startup failed"):
+            PyExecutor._send_kv_async(executor, [request])
+
+        assert transfer_manager.requests_in_transfer() == {}
+        assert request.state == LlmRequestState.DISAGG_TRANS_ERROR
+        kv_cache_manager.store_blocks_for_reuse.assert_not_called()
+        kv_cache_manager.unpin_blocks_by_id.assert_not_called()
+        executor._terminate_request.assert_called_once_with(request)
+
+
+def test_shutdown_stops_cpp_transceiver_before_resource_managers(monkeypatch):
+    events = []
+    transceiver = MagicMock()
+    transceiver.supports_cpp_chunked_transfer = True
+    transceiver.shutdown.side_effect = lambda: events.append("transceiver")
+    resource_manager = MagicMock()
+    resource_manager.shutdown.side_effect = lambda: events.append("manager")
+
+    executor = SimpleNamespace(
+        executor_request_queue=MagicMock(),
+        shutdown_event=MagicMock(),
+        hang_detector=MagicMock(),
+        worker_thread=MagicMock(),
+        worker_started=True,
+        dist=SimpleNamespace(pp_size=1),
+        model_engine=MagicMock(),
+        draft_model_engine=None,
+        kv_cache_transceiver=transceiver,
+        resource_manager=SimpleNamespace(resource_managers={"kv_cache": resource_manager}),
+        virtual_memory_pools=None,
+        sampler=object(),
+        dwdp_manager=None,
+    )
+    executor.hang_detector.detected.return_value = False
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.pyexecutor.py_executor.torch.cuda.is_available", lambda: False
+    )
+
+    PyExecutor.shutdown(executor)
+
+    assert events == ["transceiver", "manager"]
+    assert executor.kv_cache_transceiver is None
+
+
+def test_request_validation_rejects_chunked_beam_search():
+    executor = SimpleNamespace(
+        kv_cache_transfer_chunk_size_blocks=4,
+        max_beam_width=4,
+        _validate_token_id_range=MagicMock(),
+        sampler=MagicMock(),
+    )
+    request = SimpleNamespace(sampling_config=SimpleNamespace(beam_width=4))
+
+    with pytest.raises(ValueError, match="only beam width 1"):
+        PyExecutor._validate_request(executor, request)
+
+    executor._validate_token_id_range.assert_not_called()
+    executor.sampler.validate_request.assert_not_called()
+
+
+def test_active_cpp_transfer_config_is_source_of_truth():
+    transceiver = SimpleNamespace(transfer_chunk_size_blocks=4, transfer_early_release_enabled=True)
+
+    assert _resolve_active_kv_cache_transfer_config(4, True, transceiver) == (4, True)
+
+    with pytest.raises(RuntimeError, match="environment changed"):
+        _resolve_active_kv_cache_transfer_config(None, False, transceiver)
 
 
 class TestIndexMapperSlotReuse:

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -1,8 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import gc
 import sys
 import time
+import types
 import uuid
 import weakref
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -11,8 +28,12 @@ import tensorrt_llm
 import tensorrt_llm.bindings
 import tensorrt_llm.bindings.executor as trtllm
 from tensorrt_llm._torch.distributed import Distributed
-from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import \
-    create_kv_cache_transceiver
+from tensorrt_llm._torch.pyexecutor import \
+    kv_cache_transceiver as transceiver_module
+from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import (
+    KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME,
+    KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME, BindKvCacheTransceiver,
+    create_kv_cache_transceiver)
 from tensorrt_llm._torch.pyexecutor.llm_request import (LlmRequest,
                                                         LlmRequestState)
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import \
@@ -30,6 +51,90 @@ DEFAULT_KV_TRANSFER_TIMEOUT_S = (
     CacheTransceiverConfig.model_fields["kv_transfer_timeout_ms"].default /
     1000.0)
 KV_TRANSFER_COMPLETION_MARGIN_S = 10.0
+
+
+def install_transport_constructor_guards(monkeypatch):
+    cpp_constructor = MagicMock(name="BindKvCacheTransceiver")
+    python_constructor = MagicMock(name="KvCacheTransceiverV2")
+    python_transceiver_module = types.ModuleType(
+        "tensorrt_llm._torch.disaggregation.transceiver")
+    python_transceiver_module.KvCacheTransceiverV2 = python_constructor
+
+    monkeypatch.setattr(transceiver_module, "BindKvCacheTransceiver",
+                        cpp_constructor)
+    monkeypatch.setitem(sys.modules,
+                        "tensorrt_llm._torch.disaggregation.transceiver",
+                        python_transceiver_module)
+    return cpp_constructor, python_constructor
+
+
+def create_transceiver_with_mock_dependencies(cache_transceiver_config):
+    return create_kv_cache_transceiver(
+        MagicMock(name="mapping"),
+        MagicMock(name="dist"),
+        MagicMock(name="kv_cache_manager"),
+        MagicMock(name="attention_type"),
+        cache_transceiver_config,
+    )
+
+
+def test_bind_transceiver_reports_active_cpp_transfer_config():
+    transceiver = BindKvCacheTransceiver.__new__(BindKvCacheTransceiver)
+    transceiver.impl = types.SimpleNamespace(
+        transfer_chunk_size_blocks=4,
+        transfer_early_release_enabled=True,
+    )
+
+    assert transceiver.transfer_chunk_size_blocks == 4
+    assert transceiver.transfer_early_release_enabled is True
+
+
+def test_early_release_without_chunking_fails_before_transport_construction(
+        monkeypatch):
+    monkeypatch.delenv(KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME,
+                       raising=False)
+    monkeypatch.setenv(KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME, "1")
+    cpp_constructor, python_constructor = install_transport_constructor_guards(
+        monkeypatch)
+
+    with pytest.raises(ValueError, match="requires a positive"):
+        create_transceiver_with_mock_dependencies(
+            CacheTransceiverConfig(backend="NIXL"))
+
+    cpp_constructor.assert_not_called()
+    python_constructor.assert_not_called()
+
+
+def test_chunking_with_disabled_transceiver_fails_before_transport_construction(
+        monkeypatch):
+    monkeypatch.setenv(KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME, "4")
+    monkeypatch.setenv(KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME, "1")
+    cpp_constructor, python_constructor = install_transport_constructor_guards(
+        monkeypatch)
+
+    with pytest.raises(ValueError, match=r"requires an enabled C\+\+ KV cache"):
+        create_transceiver_with_mock_dependencies(None)
+
+    cpp_constructor.assert_not_called()
+    python_constructor.assert_not_called()
+
+
+def test_chunking_with_python_runtime_fails_before_transport_construction(
+        monkeypatch):
+    monkeypatch.setenv(KV_CACHE_TRANSFER_CHUNK_SIZE_BLOCKS_ENV_VAR_NAME, "4")
+    monkeypatch.delenv(KV_CACHE_TRANSFER_EARLY_RELEASE_ENV_VAR_NAME,
+                       raising=False)
+    cpp_constructor, python_constructor = install_transport_constructor_guards(
+        monkeypatch)
+
+    with pytest.raises(NotImplementedError,
+                       match=r"supported only by the C\+\+"):
+        create_transceiver_with_mock_dependencies(
+            CacheTransceiverConfig(backend="NIXL",
+                                   transceiver_runtime="PYTHON"))
+
+    cpp_constructor.assert_not_called()
+    python_constructor.assert_not_called()
 
 
 def create_kv_cache_manager(mapping, dtype):


### PR DESCRIPTION
## Description

### Summary

This revives the chunked KV-cache transfer work from #12907 on top of current `main` and adds optional sender-side early release for the production C++ transfer path.

The C++ transceiver partitions a request's KV blocks into bounded chunks, transfers and commits each chunk independently, and reuses the staging buffer across chunks. When early release is enabled, the V1 KV cache manager holds an exact request-scoped transfer lease and releases each committed chunk's sender-side blocks without waiting for the full request transfer to finish.

### Supported path (important)

This PR intentionally supports only:

- the **C++ KV cache transceiver** (`cache_transceiver_config.transceiver_runtime: CPP`); and
- the **V1 KV cache manager** (`KVCacheManager`).

The Python transceiver and the V2 KV cache manager are not supported by these features. Unsupported combinations fail during configuration or request readiness instead of silently falling back.

The initial chunked-transfer topology supports beam width 1, one primary KV pool and cache window, CP=1, and a 1:1 transfer-peer topology. MLA/indexer cache, sliding-window attention, RNN/hybrid cache, layer-wise transfer, and zero-copy cache layouts are rejected.

Early release has the additional restrictions TP=PP=CP=1 (`world_size=1` in `PyExecutor`) and no KV-cache connector, because cross-rank per-chunk release consensus and shared connector/transfer leases are not implemented yet.

### Configuration

The features are independently gated by environment variables:

```bash
# Positive decimal block count enables chunked transfer; unset or 0 disables it.
export TRTLLM_KVCACHE_TRANSFER_CHUNK_SIZE_BLOCKS=64

# Optional. Releases exact sender-side blocks after each receiver commit.
export TRTLLM_KVCACHE_TRANSFER_EARLY_RELEASE=1
```

Early release cannot be enabled without a positive chunk size. Context and generation peers must use the same TensorRT-LLM build and identical values for both variables. The updated serialized cache state and request-readiness protocol are not wire-compatible with older builds, even when chunking is disabled.

### Design

- Extends the C++ transfer protocol with request-scoped chunk metadata, receiver commit acknowledgements, and atomic multi-peer readiness/authorization.
- Reuses one assigned staging slot while formatting and sending bounded block ranges chunk by chunk.
- Adds exact transfer leases to the V1 KV cache manager so shared-prefix refcounts remain correct and only committed blocks become releasable.
- Keeps Agent destination descriptors and preassigned receive-buffer IDs request-owned, including interleaved-request handling.
- Quarantines published one-sided-write destinations after post-authorization failures and wakes blocked buffer allocators during abort.
- Exposes the active C++ configuration through nanobind so Python orchestration follows the transceiver's cached state and owns shutdown in the correct resource order.

### Validation

- Added C++ unit coverage for environment parsing, block ranges, exact transfer leases, buffer assignment/abort, serialization, and Agent request-scoped state lifecycle.
- Added two-process C++ transfer coverage for chunked transfer and early release, including MPI and NIXL test selection.
- Added Python unit coverage for C++-only gating, configuration consistency, transfer ownership, incremental release, and shared-prefix refcounts.
- All applicable pre-commit hooks pass on the rebased PR diff.
- `git diff --check` and Python bytecode compilation pass.

Local C++ execution was not available because this workspace has no configured CUDA build tree. Focused pytest collection is also blocked in the local environment by the missing `transformers` dependency.

### References

- Revives and supersedes #12907.
- Original design document: https://docs.google.com/document/d/1j1rtYYfyOvPlUDvSY-TxltJ5m1EHV8LhEcM7fLhjHzw/edit?usp=sharing

## PR Checklist

- [x] PR description clearly explains the change and supported scope.
- [x] Changes follow the TensorRT-LLM coding guidelines.
- [x] Tests and CI test-list coverage are included for the new paths.
- [x] Documentation is updated.
