### PR TITLE
[None][feat] Support DSA MTP indexer top-k sharing

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -115,6 +115,7 @@ class DSAParams(SparseParams):
     # ("full") or reuses the previous full layer's top-k ("shared"). Always
     # True for a dense per-layer indexer (e.g. DeepSeek-V3.2).
     is_full_indexer_layer: bool = True
+    mtp_index_share: bool = False
 
     @property
     def indices_block_size(self) -> int:
@@ -825,9 +826,10 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         # pool_view cache here so it is recomputed on the next
         # transform_local_topk_and_prepare_pool_view() call.
         self._invalidate_pool_view_cache()
-        # Per-step state for cross-layer indexer sharing; clear at the step
-        # boundary so a "shared" layer never reuses a stale top-k.
-        self.shared_topk_indices = None
+        # Clear per-step cross-layer top-k, but keep it inside the MTP draft
+        # loop so the step-0 stash survives for the reuse branch.
+        if not self.in_mtp_draft_loop:
+            self.shared_topk_indices = None
 
         if self.kv_cache_manager is not None and self.num_tokens > 0:
             seq_lens = self.seq_lens_cuda[:self.num_seqs]
@@ -1221,6 +1223,11 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
                     capture_graph=capture_graph,
                 )
 
+        # MTP cross-step indexer Top-K reuse state.
+        self.indexer_skip_topk = False
+        self.in_mtp_draft_loop = False
+        self.mtp_num_accepted = None
+
         # Persistent scratch for the Radix-split-work indexer path. Re-created
         # in update_spec_dec_param when max_draft_tokens changes so it stays
         # large enough for the MTP generation-row count.
@@ -1363,6 +1370,15 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         pool_indices = pool_indices.clamp(min=0,
                                           max=max_pool_idx).to(torch.int32)
         return pool_indices
+
+    def set_skip_topk(self, skip: bool):
+        self.indexer_skip_topk = skip
+
+    def set_in_mtp_draft_loop(self, active: bool):
+        self.in_mtp_draft_loop = active
+
+    def set_mtp_num_accepted(self, num_accepted):
+        self.mtp_num_accepted = num_accepted
 
     def _invalidate_pool_view_cache(self):
         """Invalidate the cached pool view and related step-invariant values.
@@ -1873,6 +1889,10 @@ class Indexer(nn.Module):
 
         self._enable_heuristic_topk = (sparse_params.enable_heuristic_topk
                                        and get_sm_version() >= 100)
+
+        # Default False for sparse configs that don't define it (e.g. the
+        # DeepSeekV4 path shares this DSA constructor with its own config class).
+        self.mtp_index_share = getattr(sparse_params, "mtp_index_share", False)
 
         if self._enable_heuristic_topk and layer_idx == 0:
             # Populate static caches (sm_count, L2 cache size) inside the C++
@@ -2705,7 +2725,14 @@ class Indexer(nn.Module):
                 local_layer, num_generations:num_generations +
                 num_contexts].copy_(topk_indices_buffer[last_ctx_idx, :])
 
-        if has_decode and not metadata.skip_indexer_for_gen_reqs:
+        reuse_topk = (self.mtp_index_share and metadata.indexer_skip_topk
+                      and metadata.shared_topk_indices is not None)
+
+        if has_decode and not metadata.skip_indexer_for_gen_reqs and reuse_topk:
+            topk_indices_buffer[num_ctx_tokens:num_ctx_tokens +
+                                num_gen_tokens, :] = \
+                metadata.shared_topk_indices[:num_generations, :]
+        elif has_decode and not metadata.skip_indexer_for_gen_reqs:
             # Get decode lengths per request (from seq_lens) for validation
             gen_seq_lens = metadata.seq_lens[num_contexts:num_contexts +
                                              num_generations]
@@ -2961,7 +2988,45 @@ class Indexer(nn.Module):
             # Fill topk_indices_buffer with pre-defined dense topk indices
             topk_indices_buffer[num_ctx_tokens:num_tokens, :] = \
                 metadata.topk_indices_buffer[num_ctx_tokens:num_tokens, :]
+
+        # MTP Top-K stash: save each request's last accepted Top-K for reuse
+        # by subsequent draft steps.
+        if (self.mtp_index_share and metadata.in_mtp_draft_loop
+                and not reuse_topk):
+            rows = None
+            if num_generations > 0:
+                next_n = num_gen_tokens // num_generations
+                gen_topk = topk_indices_buffer[num_ctx_tokens:num_ctx_tokens +
+                                               num_gen_tokens]
+                rows = self._mtp_last_accepted_rows(gen_topk, metadata,
+                                                    num_contexts,
+                                                    num_generations, next_n)
+            if num_contexts > 0:
+                ctx_last = torch.cumsum(
+                    metadata.seq_lens_cuda[:num_contexts].to(
+                        torch.long), dim=0) - 1
+                ctx_rows = topk_indices_buffer[ctx_last]
+                rows = ctx_rows if rows is None else torch.cat([ctx_rows, rows])
+            if rows is not None:
+                metadata.shared_topk_indices = rows.contiguous()
         return topk_indices_buffer
+
+    def _mtp_last_accepted_rows(self, gen_topk, metadata, num_contexts,
+                                num_generations, next_n):
+        """Return each gen request's last accepted Top-K row
+        (base + num_accepted - 1); rows past num_accepted are rejected-branch
+        padding that corrupts partial-accept reuse. CUDA-graph safe; falls back
+        to the last row when accepted counts aren't plumbed in.
+        """
+        num_accepted = getattr(metadata, "mtp_num_accepted", None)
+        if num_accepted is None:
+            return gen_topk[next_n - 1::next_n]
+        gen_num_accepted = num_accepted[num_contexts:num_contexts +
+                                        num_generations]
+        base = torch.arange(
+            num_generations, device=gen_topk.device, dtype=torch.long) * next_n
+        offset = (gen_num_accepted - 1).clamp(0, next_n - 1)
+        return gen_topk[base + offset]
 
     def _weight_scale(self, weights: torch.Tensor,
                       q_scale: torch.Tensor) -> torch.Tensor:

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -922,6 +922,7 @@ class ModelConfig(Generic[TConfig]):
                         q_split_threshold = sparse_attention_config.q_split_threshold
                         enable_heuristic_topk = sparse_attention_config.enable_heuristic_topk
                         indexer_k_dtype = sparse_attention_config.indexer_k_dtype
+                        index_share_for_mtp_iteration = sparse_attention_config.index_share_for_mtp_iteration
                     else:
                         index_n_heads = pretrained_config.index_n_heads
                         index_head_dim = pretrained_config.index_head_dim
@@ -933,6 +934,7 @@ class ModelConfig(Generic[TConfig]):
                         q_split_threshold = 8192
                         enable_heuristic_topk = False
                         indexer_k_dtype = "fp8"
+                        index_share_for_mtp_iteration = None
                     kwargs[
                         'sparse_attention_config'] = DeepSeekSparseAttentionConfig(
                             index_n_heads=index_n_heads,
@@ -947,7 +949,9 @@ class ModelConfig(Generic[TConfig]):
                             q_split_threshold=q_split_threshold,
                             indexer_rope_interleave=indexer_rope_interleave,
                             enable_heuristic_topk=enable_heuristic_topk,
-                            indexer_k_dtype=indexer_k_dtype)
+                            indexer_k_dtype=indexer_k_dtype,
+                            index_share_for_mtp_iteration=
+                            index_share_for_mtp_iteration)
                 elif pretrained_config.architectures[
                         0] == "DeepseekV4ForCausalLM":
                     if cls._is_deepseek_v4_base_checkpoint(checkpoint_dir):

--- a/tensorrt_llm/_torch/modules/mla.py
+++ b/tensorrt_llm/_torch/modules/mla.py
@@ -1672,9 +1672,15 @@ class MLA(nn.Module):
                 weights,
                 q_scale=q_scale,
             )
-            # Stash for subsequent DSA "shared" layers (full -> shared reuse);
-            # unused by a dense per-layer indexer.
-            attn_metadata.shared_topk_indices = topk_indices
+            # Stash top-k for subsequent DSA "shared" layers. Skip only inside
+            # the MTP draft loop *when index-share reuse is active*, so the
+            # indexer's per-request stash is preserved; for non-index-share
+            # models the stash always runs, keeping cross-layer sharing intact.
+            if not (
+                getattr(attn_metadata, "in_mtp_draft_loop", False)
+                and getattr(self.indexer, "mtp_index_share", False)
+            ):
+                attn_metadata.shared_topk_indices = topk_indices
 
         assert output is not None, "output must be provided"
 

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -839,8 +839,17 @@ class Eagle3OneModelWorker(SpecWorkerBase):
             attn_metadata.seq_lens_cuda, dim=0, dtype=torch.long) - 1
         position_ids = inputs["position_ids"]
 
+        reuse_mtp_topk = (self.is_mtp_eagle
+                          and hasattr(attn_metadata, "set_skip_topk"))
+        if reuse_mtp_topk:
+            attn_metadata.set_in_mtp_draft_loop(True)
+            # Accepted counts let the indexer stash each gen's last-accepted row.
+            attn_metadata.set_mtp_num_accepted(num_accepted_tokens)
+
         with self.draft_kv_cache_context(attn_metadata, draft_kv_cache_manager):
             for i in range(runtime_draft_len):
+                if reuse_mtp_topk:
+                    attn_metadata.set_skip_topk(i > 0)
                 # Run draft model (mode-specific via helper). The helper
                 # passes ``all_rank_num_tokens`` as a kwarg so the draft model
                 # handles save/restore internally (Eagle3DraftModel.forward
@@ -1034,6 +1043,11 @@ class Eagle3OneModelWorker(SpecWorkerBase):
                     "spec_metadata": spec_metadata,
                 }
         next_draft_tokens = torch.stack(next_draft_tokens, dim=1)
+
+        if reuse_mtp_topk:
+            attn_metadata.set_skip_topk(False)
+            attn_metadata.set_in_mtp_draft_loop(False)
+            attn_metadata.set_mtp_num_accepted(None)
 
         # Override with SA draft tokens after all draft layers have run,
         # so that draft layers never see SA tokens in their inputs.

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -918,6 +918,11 @@ class DeepSeekSparseAttentionConfig(SeqLenAwareSparseAttentionConfig):
         "`fp4` requires Blackwell+ (SM>=100) at runtime and "
         "index_head_dim=128.",
     )
+    index_share_for_mtp_iteration: Optional[bool] = Field(
+        default=None,
+        description=
+        "Reuse the indexer Top-K across MTP draft steps instead of recomputing "
+        "it each step. Defaults to the model's HF config value.")
 
     @model_validator(mode="after")
     def _validate_indexer_k_dtype(self):
@@ -1046,6 +1051,8 @@ class DeepSeekSparseAttentionConfig(SeqLenAwareSparseAttentionConfig):
             indexer_k_dtype=self.indexer_k_dtype,
             is_full_indexer_layer=self._is_full_indexer_layer(
                 pretrained_config, kwargs.get("layer_idx")),
+            mtp_index_share=bool(_value("index_share_for_mtp_iteration",
+                                        False)),
         )
 
     def to_sparse_metadata_params(self, **kwargs):

--- a/tensorrt_llm/usage/llm_args_golden_manifest.json
+++ b/tensorrt_llm/usage/llm_args_golden_manifest.json
@@ -1434,6 +1434,13 @@
     },
     {
       "allowed_values": [],
+      "annotation": "Optional[bool]",
+      "converter": "",
+      "kind": "value",
+      "path": "sparse_attention_config.index_share_for_mtp_iteration"
+    },
+    {
+      "allowed_values": [],
       "annotation": "Optional[int]",
       "converter": "",
       "kind": "value",

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -7925,6 +7925,110 @@ class TestGLM52(LlmapiAccuracyTestHarness):
             task = GSM8K(model_name)
             task.evaluate(llm)
 
+    @skip_pre_blackwell
+    @pytest.mark.skip_less_device(8)
+    @parametrize_with_ids("tp_size,ep_size", [(8, 8)])
+    def test_nvfp4_mtp_index_share(self, tp_size, ep_size):
+        # Like test_nvfp4 but max_draft_len=3, exercising DSA indexer Top-K reuse
+        # across MTP draft steps (index_share_for_mtp_iteration=true from the checkpoint).
+        model_name = "zai-org/GLM-5.2"
+        model_path = f"{llm_models_root()}/GLM-5.2-NVFP4"
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.7)
+
+        pytorch_config = dict(
+            disable_overlap_scheduler=False,
+            cuda_graph_config=CudaGraphConfig(max_batch_size=128,
+                                              enable_padding=True),
+            moe_config=MoeConfig(backend="CUTEDSL"),
+            speculative_config=MTPDecodingConfig(max_draft_len=3),
+            enable_chunked_prefill=True,
+        )
+
+        with LLM(model_path,
+                 tensor_parallel_size=tp_size,
+                 pipeline_parallel_size=1,
+                 moe_expert_parallel_size=ep_size,
+                 kv_cache_config=kv_cache_config,
+                 max_seq_len=8192,
+                 **pytorch_config) as llm:
+            assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4
+            task = GSM8K(model_name)
+            task.evaluate(llm)
+
+    @skip_pre_blackwell
+    @pytest.mark.skip_less_device(8)
+    @parametrize_with_ids("tp_size,ep_size", [(8, 8)])
+    def test_nvfp4_mtp_index_share_mtp_ar(self, tp_size, ep_size):
+        # Acceptance-rate guard for max_draft_len=3 + index-share; counts accepted
+        # drafts from streaming (get_stats needs enable_iter_perf_stats).
+        model_path = f"{llm_models_root()}/GLM-5.2-NVFP4"
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.7)
+        max_draft_len = 3
+
+        pytorch_config = dict(
+            disable_overlap_scheduler=False,
+            cuda_graph_config=CudaGraphConfig(max_batch_size=128,
+                                              enable_padding=True),
+            moe_config=MoeConfig(backend="CUTEDSL"),
+            speculative_config=MTPDecodingConfig(max_draft_len=max_draft_len),
+            enable_chunked_prefill=True,
+        )
+
+        with LLM(model_path,
+                 tensor_parallel_size=tp_size,
+                 pipeline_parallel_size=1,
+                 moe_expert_parallel_size=ep_size,
+                 kv_cache_config=kv_cache_config,
+                 max_seq_len=8192,
+                 **pytorch_config) as llm:
+            raw_prompts = [
+                "The capital of France is",
+                "The president of the United States is",
+                "The future of AI is",
+            ]
+            prompts = [
+                llm.tokenizer.apply_chat_template(
+                    [{
+                        "role": "user",
+                        "content": p
+                    }],
+                    tokenize=False,
+                    add_generation_prompt=True,
+                ) for p in raw_prompts
+            ]
+            tok_ids = [llm.tokenizer.encode(p) for p in prompts]
+            sampling_params = SamplingParams(max_tokens=128, temperature=0)
+
+            total_drafted = 0
+            total_accepted = 0
+            for i, prompt_ids in enumerate(tok_ids):
+                num_tokens = 0
+                num_drafted = 0
+                num_accepted = 0
+                for output in llm.generate_async(prompt_ids,
+                                                 sampling_params,
+                                                 streaming=True):
+                    new_tokens = output.outputs[0].token_ids
+                    num_drafted += max_draft_len
+                    num_accepted += len(new_tokens) - num_tokens - 1
+                    num_tokens = len(new_tokens)
+
+                accept_rate = num_accepted / num_drafted
+                total_drafted += num_drafted
+                total_accepted += num_accepted
+                print(
+                    f"GLM-5.2 MTP index-share prompt {i} acceptance rate: "
+                    f"{accept_rate:.2%} ({num_accepted}/{num_drafted} tokens)")
+
+            aggregate_accept_rate = (total_accepted / total_drafted
+                                     if total_drafted > 0 else 0.0)
+            print("GLM-5.2 MTP index-share aggregate acceptance rate: "
+                  f"{aggregate_accept_rate:.2%} ({total_accepted}/"
+                  f"{total_drafted} tokens across {len(tok_ids)} prompts)")
+            assert aggregate_accept_rate > 0.2, (
+                f"Aggregate acceptance rate {aggregate_accept_rate:.2%} "
+                f"below threshold 20%")
+
 
 @skip_pre_blackwell
 class TestStep3_7(LlmapiAccuracyTestHarness):

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -461,6 +461,7 @@ accuracy/test_llm_api_pytorch.py::TestGemma3_27BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestGemma3_27BInstruct::test_fp8_prequantized
 accuracy/test_llm_api_pytorch.py::TestGLM5FP8::test_8gpus[tp_size=8-ep_size=8]
 accuracy/test_llm_api_pytorch.py::TestGLM52::test_nvfp4[tp_size=8-ep_size=8]
+accuracy/test_llm_api_pytorch.py::TestGLM52::test_nvfp4_mtp_index_share[tp_size=8-ep_size=8]
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_dummy_load_format
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_2gpus[cutlass-one_model-overlap_scheduler]
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_2gpus[triton-one_model-overlap_scheduler]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -164,6 +164,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp1] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp3_no_adp] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestGLM52::test_nvfp4[tp_size=8-ep_size=8] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestGLM52::test_nvfp4_mtp_index_share[tp_size=8-ep_size=8] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Pro::test_gsm8k_full_accuracy TIMEOUT (240)
   - examples/test_deepseek_v4_pro.py::test_short_token_boundary_smoke TIMEOUT (120)
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False] TIMEOUT (60)

--- a/tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py
+++ b/tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py
@@ -2671,6 +2671,174 @@ def test_indexer_decode_custom_vs_fallback(batch_size, next_n, index_topk, seq_l
 
 @pytest.mark.skipif(not has_deep_gemm(), reason="DeepGEMM not available")
 @skip_pre_hopper
+@pytest.mark.parametrize("step0_mode", ["gen", "context"])
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_indexer_decode_mtp_topk_reuse(step0_mode, batch_size):
+    """Verify mtp_index_share: draft step 0 stashes each request's last-token
+    Top-K and draft steps > 0 reuse it verbatim (bit-exact), across > 1 draft
+    step. Covers both step-0 shapes: "gen" (steady state, next_n > 1) and
+    "context" (the first gen round after prefill, which runs the context path).
+    Step-0 Top-K correctness is covered by test_indexer_decode_custom_vs_fallback.
+    """
+    torch.manual_seed(7)
+    heads, head_dim, block_size = 32, 128, 64
+    max_model_len, index_topk, kv_len = 16384, 2048, 4096
+    step0_next_n = 2 if step0_mode == "gen" else 1
+    num_reuse_steps = 2
+    # md=1: on SM100, max_draft_tokens 2/>3 triggers the mock's expanded-MTP-buffer
+    # path, which assumes num_gen_tokens == num_generations * (1 + md).
+    md = 1
+
+    cache_manager, sparse_attn_config = create_dsa_cache_manager(
+        batch_size=batch_size,
+        head_dim=head_dim,
+        tokens_per_block=block_size,
+        max_seq_len=max_model_len,
+        num_layers=1,
+        index_topk=index_topk,
+    )
+    indexer = create_indexer(sparse_attn_config, layer_idx=0)
+    indexer.mtp_index_share = True
+
+    request_ids = list(range(batch_size))
+    kv_lens = torch.full((batch_size,), kv_len, dtype=torch.int32)
+    reserve = (kv_lens + step0_next_n + num_reuse_steps).tolist()
+    cache_manager.add_dummy_requests(
+        request_ids=request_ids,
+        token_nums=reserve,
+        is_gen=False,
+        prepare_resource=True,
+    )
+
+    def make_inputs(n_tokens):
+        q = torch.randn((n_tokens, heads, head_dim), device="cuda", dtype=torch.bfloat16).to(
+            torch.float8_e4m3fn
+        )
+        k = torch.randn((n_tokens, head_dim), device="cuda", dtype=torch.bfloat16)
+        k_fp8, k_scale = fp8_utils.fp8_quantize_1x128_sf_transpose(k)
+        w = torch.randn((n_tokens, heads), device="cuda", dtype=torch.float32)
+        h = torch.randn((n_tokens, 4096), device="cuda", dtype=torch.bfloat16)
+        return h, q, k_fp8, k_scale, w
+
+    # Draft step 0: compute Top-K and stash each request's last-token row.
+    if step0_mode == "gen":
+        # Populate historical context so step 0 is a steady-state gen batch.
+        ctx_k = torch.randn((kv_lens.sum().item(), head_dim), device="cuda", dtype=torch.bfloat16)
+        ctx_k_fp8, ctx_k_scale = fp8_utils.fp8_quantize_1x128_sf_transpose(ctx_k)
+        meta_ctx = _create_mock_metadata(
+            request_ids,
+            batch_size,
+            batch_size,
+            0,
+            kv_lens.clone(),
+            kv_lens.clone(),
+            [0] * batch_size,
+            cache_manager,
+            kv_lens.sum().item(),
+            kv_lens.sum().item(),
+            max_draft_tokens=md,
+        )
+        Indexer.prepare(meta_ctx)
+        indexer._update_k_cache(ctx_k_fp8, ctx_k_scale, meta_ctx)
+
+        step0_tokens = batch_size * step0_next_n
+        meta0 = _create_mock_metadata(
+            request_ids,
+            batch_size,
+            0,
+            batch_size,
+            torch.full((batch_size,), step0_next_n, dtype=torch.int32),
+            (kv_lens + step0_next_n).clone(),
+            kv_lens.tolist(),
+            cache_manager,
+            0,
+            step0_tokens,
+            max_model_len,
+            max_draft_tokens=md,
+        )
+        Indexer.prepare(meta0)
+        # indexer_topk_decode needs caller-owned radix aux buffers for small gen batches.
+        _radix_bp = 10
+        meta0.radix_aux_indices = torch.zeros(
+            (step0_tokens, _radix_bp, index_topk), device="cuda", dtype=torch.int32
+        )
+        meta0.radix_aux_logits = torch.zeros(
+            (step0_tokens, _radix_bp, index_topk), device="cuda", dtype=torch.float32
+        )
+    else:  # context: first gen round -- step 0 runs the context/prefill path.
+        step0_tokens = kv_lens.sum().item()
+        meta0 = _create_mock_metadata(
+            request_ids,
+            batch_size,
+            batch_size,
+            0,
+            kv_lens.clone(),
+            kv_lens.clone(),
+            [0] * batch_size,
+            cache_manager,
+            step0_tokens,
+            step0_tokens,
+            max_model_len,
+            max_draft_tokens=md,
+        )
+        Indexer.prepare(meta0)
+        # context stash branch reads seq_lens_cuda (a read-only property); set its backing field.
+        meta0._seq_lens_cuda = kv_lens.clone().cuda()
+
+    meta0.in_mtp_draft_loop = True
+    # Step 0 computes (does not skip) Top-K; the reuse gate reads this directly.
+    meta0.indexer_skip_topk = False
+    h0, q0, k0_fp8, k0_scale, w0 = make_inputs(step0_tokens)
+    indexer._update_k_cache(k0_fp8, k0_scale, meta0)
+    try:
+        topk0 = indexer.sparse_attn_indexer(
+            meta0, h0, q0, k0_fp8, k0_scale, w0, use_custom_topk=True
+        )
+    except Exception as e:
+        pytest.skip(f"Custom topk not available: {e}")
+
+    if step0_mode == "gen":
+        expected_rows = topk0[step0_next_n - 1 :: step0_next_n, :]
+    else:
+        ctx_last = torch.cumsum(kv_lens.to(torch.long), dim=0).cuda() - 1
+        expected_rows = topk0[ctx_last, :]
+
+    stash = meta0.shared_topk_indices
+    assert stash is not None, "Step 0 should stash shared_topk_indices"
+    assert stash.shape[0] == batch_size
+    assert torch.equal(stash, expected_rows), f"{step0_mode} step-0 stash mismatch"
+
+    # Draft steps 1..N: reuse the stash verbatim (next_n=1, skip_topk).
+    for step in range(1, num_reuse_steps + 1):
+        prior = step0_next_n + (step - 1)
+        meta = _create_mock_metadata(
+            request_ids,
+            batch_size,
+            0,
+            batch_size,
+            torch.ones(batch_size, dtype=torch.int32),
+            (kv_lens + prior + 1).clone(),
+            (kv_lens + prior).tolist(),
+            cache_manager,
+            0,
+            batch_size,
+            max_model_len,
+            max_draft_tokens=md,
+        )
+        Indexer.prepare(meta)
+        meta.in_mtp_draft_loop = True
+        meta.shared_topk_indices = stash
+        meta.indexer_skip_topk = True
+        hs, qs, ks_fp8, ks_scale, ws = make_inputs(batch_size)
+        indexer._update_k_cache(ks_fp8, ks_scale, meta)
+        topk = indexer.sparse_attn_indexer(meta, hs, qs, ks_fp8, ks_scale, ws, use_custom_topk=True)
+        assert torch.equal(topk, stash[:batch_size, :]), (
+            f"{step0_mode} draft reuse step {step} should copy the stash 1:1 (next_n=1)"
+        )
+
+
+@pytest.mark.skipif(not has_deep_gemm(), reason="DeepGEMM not available")
+@skip_pre_hopper
 @pytest.mark.parametrize("batch_size", [4, 16])
 @pytest.mark.parametrize("index_topk", [2048])
 @pytest.mark.parametrize("chunk_size", [1024, 2048])


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Top-K reuse for sparse attention during multi-token draft iterations, improving decoding efficiency.
  * Introduced a new configuration option to enable index sharing behavior for this workflow.
* **Bug Fixes**
  * Top-K results can now be preserved and reused across draft steps instead of being recomputed every time.
* **Tests**
  * Added coverage for the new Top-K reuse flow in multi-step decoding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Implement GLM-5.2 IndexShare for the one-model MTP path: the indexer top-k indices are computed on the first draft step and reused for all following draft steps.

Based on #15574 for full GLM-5.2 IndexShare support - this PR covers MTP side.


<!--
Please explain the issue and the solution in short.
-->

A new `index_share_for_mtp_iteration` field is added to `DeepSeekSparseAttentionConfig`. It is resolved from the HF checkpoint config when left unset and threaded into the DSA indexer as `mtp_index_share`. On draft step 0 the per-request last-token top-k is stashed on the attention metadata; for draft steps > 0 the indexer skips the logits computation and the top-k selection, reusing the stashed indices via a copy instead.

## Test Coverage

**Unit test** — `tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py::test_indexer_decode_mtp_topk_reuse`: verifies that draft step 0 stores each request's last-token top-k and that later draft steps reuse it bit-exactly (no recompute). Covered for both the steady-state generation case and the first generation step right after prefill, at BS 1 and 2.

**E2E tests** — in `TestGLM52`:
  - `test_nvfp4_mtp_index_share` — GSM8K accuracy (GLM-5.2-NVFP4, CuteDSL MoE, MTP 3, TEP8). Measured 93.86.
  - `test_nvfp4_mtp_index_share_mtp_ar` — MTP acceptance-rate guard. Measured AR 62.75%.

**Accuracy A/B validation** (index-share in MTP is lossless).
  | Dataset | mtp3 index-share ON | mtp3 dense topk | mtp1 baseline |
  | --- | --- | --- | --- |
  | GSM8K (full) | 94.12 | 94.20 | 93.75 |
  | LongBench (20 samples) | 48.18 | 48.16 | 48.08 |

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->



## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
