### PR TITLE
[https://nvbugs/6385283][fix] Add empty/absent-content guard in the "message" and "reasoning" branches that…

### DIFF
--- a/tensorrt_llm/serve/responses_utils.py
+++ b/tensorrt_llm/serve/responses_utils.py
@@ -663,16 +663,17 @@ def _response_output_item_to_chat_completion_message(
                 return item
             else:
                 raise ValueError(f"Invalid input message item: {item}")
-        case "message":
-            return {
-                "role": "assistant",
-                "content": item["content"][0]["text"],
-            }
-        case "reasoning":
-            return {
-                "role": "assistant",
-                "reasoning": item["content"][0]["text"],
-            }
+        case "message" | "reasoning":
+            content = item.get("content") or []
+            if not content:
+                raise ValueError(
+                    f"Input item of type {item_type!r} has empty or missing 'content'"
+                )
+            first = content[0]
+            text = first.get("text", "") if isinstance(
+                first, dict) else getattr(first, "text", "")
+            key = "content" if item_type == "message" else "reasoning"
+            return {"role": "assistant", key: text}
         case "function_call":
             return {
                 "role": "function",


### PR DESCRIPTION
## Summary
- **Root cause**: Parser dereferences item["content"][0]["text"] for "message"/"reasoning" branches without checking that content is present or non-empty, but pydantic accepts items with empty/absent content (openai TypedDicts have content optional with no min length).
- **Fix**: Add empty/absent-content guard in the "message" and "reasoning" branches that raises a descriptive ValueError, which the outer handler maps to HTTP 400 without a server traceback; use .get("text", "") on the first element for symmetry.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6385283


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message handling for both regular messages and reasoning outputs.
  * Added validation to avoid empty content errors and made text extraction more reliable across different response formats.
  * Returned normalized payloads so message content is mapped consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->