### PR TITLE
[https://nvbugs/6385673][fix] Add `isinstance` guards for `parameters`, `properties`, and the per-parameter…

### DIFF
--- a/tensorrt_llm/serve/tool_parser/minimax_m2_parser.py
+++ b/tensorrt_llm/serve/tool_parser/minimax_m2_parser.py
@@ -13,20 +13,23 @@ from tensorrt_llm.serve.tool_parser.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from tensorrt_llm.serve.tool_parser.utils import infer_type_from_json_schema
 
 
 def _get_param_types(param_name: str, func_name: str, tools: List[Tool]) -> Optional[str]:
     """Get the expected type of a parameter from tool definitions."""
     for tool in tools:
-        if tool.function.name == func_name:
-            props = (tool.function.parameters or {}).get("properties", {})
-            if param_name in props:
-                type_val = props[param_name].get("type")
-                if isinstance(type_val, str):
-                    return type_val
-                if isinstance(type_val, list):
-                    non_null = [t for t in type_val if t != "null"]
-                    return non_null[0] if non_null else "string"
+        if tool.function.name != func_name:
+            continue
+        parameters = tool.function.parameters
+        if not isinstance(parameters, dict):
+            continue
+        properties = parameters.get("properties")
+        if not isinstance(properties, dict):
+            continue
+        if param_name not in properties:
+            continue
+        return infer_type_from_json_schema(properties[param_name])
     return None
 
 

--- a/tensorrt_llm/serve/tool_parser/minimax_m3_parser.py
+++ b/tensorrt_llm/serve/tool_parser/minimax_m3_parser.py
@@ -13,6 +13,7 @@ from tensorrt_llm.serve.tool_parser.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from tensorrt_llm.serve.tool_parser.utils import infer_type_from_json_schema
 
 # M3's chat template prefixes every tool-call-related tag with this literal
 # namespace string (the ``ns_token`` in chat_template.jinja). It is just
@@ -25,15 +26,17 @@ _M3_NS_RE = re.escape(_M3_NS)
 def _get_param_type(param_name: str, func_name: str, tools: List[Tool]) -> Optional[str]:
     """Look up the declared JSON-schema type of a parameter, if any."""
     for tool in tools:
-        if tool.function.name == func_name:
-            props = (tool.function.parameters or {}).get("properties", {})
-            if param_name in props:
-                type_val = props[param_name].get("type")
-                if isinstance(type_val, str):
-                    return type_val
-                if isinstance(type_val, list):
-                    non_null = [t for t in type_val if t != "null"]
-                    return non_null[0] if non_null else "string"
+        if tool.function.name != func_name:
+            continue
+        parameters = tool.function.parameters
+        if not isinstance(parameters, dict):
+            continue
+        properties = parameters.get("properties")
+        if not isinstance(properties, dict):
+            continue
+        if param_name not in properties:
+            continue
+        return infer_type_from_json_schema(properties[param_name])
     return None
 
 


### PR DESCRIPTION
## Summary
- **Root cause**: `_get_param_type` assumed `properties[<param>]` is a dict, but OpenAI `tools[].function.parameters` is client-controlled `Dict[str, Any]` so it can be any JSON value.
- **Fix**: Add `isinstance` guards for `parameters`, `properties`, and the per-parameter schema in both `minimax_m3_parser._get_param_type` and the identical `minimax_m2_parser._get_param_types`; return `None` on malformed schema so downstream coercion defaults to string.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6385673


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool parameter type detection for MiniMax-M2 and MiniMax-M3 integrations, making schema-based parsing more reliable.
  * Added stricter validation for tool parameter structures, helping prevent incorrect type handling when schema data is missing or malformed.
  * Better support for parameters defined with richer JSON schema formats, resulting in more consistent tool parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->