### PR TITLE
[https://nvbugs/6398197][fix] In `_distributed_worker`, add `os._exit(0)` after the `try/except/finally` so…

### DIFF
--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py
@@ -100,6 +100,12 @@ def _distributed_worker(rank, world_size, backend, test_fn, port):
     finally:
         cleanup_distributed()
 
+    # ProcessGroupNCCL's destructor can throw c10::AcceleratorError from
+    # ExchangeDevice during Py_FinalizeEx (destructor-throw -> std::terminate
+    # -> SIGABRT) when torch's internal references to the PG outlive
+    # destroy_process_group(). Bypass interpreter shutdown on success.
+    os._exit(0)
+
 
 def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool = True):
     """Run a test function in a distributed environment."""


### PR DESCRIPTION
## Summary
- **Root cause**: ProcessGroupNCCL destructor runs during Python interpreter shutdown (frame stack shows Py_RunMain → module cleanup) after `destroy_process_group()`, because torch's internal references (device mesh caches, autograd, etc.) keep the PG alive; inside the destructor `c10::cuda::ExchangeDevice` throws `c10::AcceleratorError` → destructor-throw → `std::terminate()` → SIGABRT.
- **Fix**: In `_distributed_worker`, add `os._exit(0)` after the `try/except/finally` so the child process exits cleanly on success and skips `Py_FinalizeEx`; failure path is unchanged so `mp.spawn` still reports real errors.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6398197


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for distributed workloads by making worker shutdown complete more reliably, reducing cleanup-related crashes at process exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->