### PR TITLE
[https://nvbugs/6396728][fix] Populate only `self.all_weights[self.device_id]` at construction and lazily…

### DIFF
--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
@@ -322,10 +322,12 @@ class RefNVFP4ModelWithIPCHandles(RefHFModel):
 
         assert not fusion_buffer, f"Incomplete fusion groups: {list(fusion_buffer.keys())}"
 
+        # Only populate the owning device. Extra replicas are created on
+        # demand by ``get_weight_ipc_handles_serialized`` so that GPUs not
+        # actually asked for via IPC (e.g. cuda:2/3 on a 4-GPU CI runner
+        # when a TP=2 test only requests device_ids=[0, 1]) don't hold
+        # onto NVFP4 quantized tensors that persist across parametrize IDs.
         self.all_weights[self.device_id] = model_weights
-        for i in range(torch.cuda.device_count()):
-            if i != self.device_id:
-                self.all_weights[i] = [(n, p.to(f"cuda:{i}")) for n, p in model_weights]
 
         with torch.no_grad():
             param_dict = dict(self.model.named_parameters())
@@ -427,6 +429,10 @@ class RefNVFP4ModelWithIPCHandles(RefHFModel):
         device_list = list(range(torch.cuda.device_count())) if device_ids is None else device_ids
 
         for device in device_list:
+            if device not in self.all_weights:
+                src = self.all_weights[self.device_id]
+                self.all_weights[device] = [(n, p.to(f"cuda:{device}")) for n, p in src]
+
             all_handles = []
             for item in self.all_weights[device]:
                 name, p = item


### PR DESCRIPTION
## Summary
- **Root cause**: NVFP4 quantized weights were eagerly replicated to every visible CUDA device, so cuda:2/3 replicas persisted across parametrize IDs on the 4-GPU CI runner and sporadically triggered SIGABRT during the next test's setup.
- **Fix**: Populate only `self.all_weights[self.device_id]` at construction and lazily materialize + cache replicas for other devices inside `get_weight_ipc_handles_serialized`.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6396728


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-GPU weight handling so model weights are only populated on the active device when needed, reducing unnecessary replication.
  * Added on-demand copying for weights requested on other devices, which should make GPU weight transfers more reliable during model updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->