### PR TITLE
[None][feat] BREAKING: add per-model KV cache manager v2 auto selection

### DIFF
--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -1,6 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import json
 import time
+from typing import Literal
 
 from tensorrt_llm import LLM, SamplingParams
 from tensorrt_llm.llmapi import (AttentionDpConfig, AutoDecodingConfig,
@@ -15,6 +31,16 @@ example_prompts = [
     "The capital of France is",
     "The future of AI is",
 ]
+
+
+def _parse_kv_cache_manager_v2(value: str) -> bool | Literal["auto"]:
+    if value == "auto":
+        return "auto"
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected one of: auto, true, false")
 
 
 def add_llm_args(parser):
@@ -132,9 +158,10 @@ def add_llm_args(parser):
     parser.add_argument(
         '--use_kv_cache_manager_v2',
         default='auto',
-        action='store_true',
+        type=_parse_kv_cache_manager_v2,
+        metavar='{auto,true,false}',
         help=
-        'Use KVCacheManagerV2 for KV cache management (PyTorch backend). Defaults to model-specific auto selection.',
+        'Whether to use KVCacheManagerV2 for KV cache management (PyTorch backend). Defaults to model-specific auto selection.',
     )
 
     # Runtime

--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -131,9 +131,10 @@ def add_llm_args(parser):
                         action='store_true')
     parser.add_argument(
         '--use_kv_cache_manager_v2',
-        default=False,
+        default='auto',
         action='store_true',
-        help='Use KVCacheManagerV2 for KV cache management (PyTorch backend).',
+        help=
+        'Use KVCacheManagerV2 for KV cache management (PyTorch backend). Defaults to model-specific auto selection.',
     )
 
     # Runtime

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -81,7 +81,7 @@ def ceil_div(a: int, b: int) -> int:
 def _non_hybrid_kv_cache_manager_cls(config, kv_cache_config: KvCacheConfig):
     # Models with per-layer head_dim (e.g., Gemma4 hybrid attention)
     # require KVCacheManagerV2 for per-layer buffer sizes.
-    needs_v2 = (kv_cache_config.use_kv_cache_manager_v2
+    needs_v2 = (kv_cache_config.use_kv_cache_manager_v2 is True
                 or is_gemma4_hybrid(config))
     return KVCacheManagerV2 if needs_v2 else KVCacheManager
 
@@ -344,9 +344,9 @@ class KvCacheCreator:
                         f"Gemma4 hybrid attention requires KVCacheManagerV2, "
                         f"which is not yet supported with {incompat_str}. "
                         f"Disable these features to run Gemma4 hybrid models.")
-                # Plain V2 (user opt-in via ``use_kv_cache_manager_v2=True``):
-                # V2 was a preference, not a structural requirement, so we
-                # can safely fall back to V1.
+                # Plain V2 (explicitly enabled or selected by a model default):
+                # V2 was a preference, not a structural requirement, so we can
+                # safely fall back to V1.
                 logger.warning(
                     "KVCacheManagerV2 is not supported with %s. "
                     "Falling back to KVCacheManager.", incompat_str)

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -15,7 +15,8 @@ from tensorrt_llm._utils import str_dtype_to_torch
 from tensorrt_llm.llmapi.llm_args import (ExecutorMemoryType,
                                           ModelExpressConfig,
                                           SparseAttentionConfig, TorchLlmArgs)
-from tensorrt_llm.llmapi.llm_utils import apply_model_defaults_to_llm_args
+from tensorrt_llm.llmapi.llm_utils import (_resolve_kv_cache_manager_v2_auto,
+                                           apply_model_defaults_to_llm_args)
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_helper import LoraConfig
 from tensorrt_llm.mapping import Mapping
@@ -333,8 +334,9 @@ class ModelLoader:
         model_cls = AutoModelForCausalLM._resolve_class(config)
 
         # model_cls is None when the architecture is unknown/unsupported.
+        model_defaults = {}
         if model_cls and hasattr(model_cls, 'get_model_defaults'):
-            model_defaults = model_cls.get_model_defaults(llm_args)
+            model_defaults = model_cls.get_model_defaults(llm_args) or {}
             if model_defaults:
                 applied_defaults = apply_model_defaults_to_llm_args(
                     llm_args, model_defaults)
@@ -342,6 +344,15 @@ class ModelLoader:
                     logger.info(
                         f"Applied model defaults for {model_cls.__name__}: {applied_defaults}"
                     )
+
+        use_kv_cache_manager_v2 = llm_args.kv_cache_config.use_kv_cache_manager_v2
+        _resolve_kv_cache_manager_v2_auto(llm_args, model_defaults)
+        if use_kv_cache_manager_v2 == "auto":
+            logger.info(
+                "Resolved use_kv_cache_manager_v2='auto' to %s for %s",
+                llm_args.kv_cache_config.use_kv_cache_manager_v2,
+                model_cls.__name__
+                if model_cls is not None else "unknown model")
 
         return llm_args
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3374,10 +3374,13 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         description=
         "The number of tokens between cache steps in the Mamba prefix cache.")
 
-    use_kv_cache_manager_v2: bool = Field(
-        default=False,
+    use_kv_cache_manager_v2: bool | Literal["auto"] = Field(
+        default="auto",
         status="prototype",
-        description="Whether to use the KV cache manager v2 (experimental).")
+        description=
+        "Whether to use the KV cache manager v2 (experimental). 'auto' uses "
+        "the model-specific default and falls back to False when the model "
+        "does not specify one.")
 
     # This is a pure python field, not a pybind field. It is only for the Pytorch backend.
     enable_swa_scratch_reuse: bool = Field(

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -1130,3 +1130,24 @@ def apply_model_defaults_to_llm_args(
         return applied
 
     return _compute_applied(model_defaults_dict, user_overrides)
+
+
+def _resolve_kv_cache_manager_v2_auto(
+        llm_args: 'TorchLlmArgs', model_defaults_dict: Dict[str, Any]) -> bool:
+    """Resolve the KV cache manager auto setting after model defaults are applied."""
+    setting = llm_args.kv_cache_config.use_kv_cache_manager_v2
+    if setting != "auto":
+        return setting
+
+    kv_cache_defaults = model_defaults_dict.get("kv_cache_config", {})
+    model_default = (kv_cache_defaults.get("use_kv_cache_manager_v2", False)
+                     if isinstance(kv_cache_defaults, dict) else False)
+    if model_default == "auto":
+        model_default = False
+    if not isinstance(model_default, bool):
+        raise ValueError(
+            "Model default kv_cache_config.use_kv_cache_manager_v2 must be "
+            f"True, False, or 'auto', got {model_default!r}.")
+
+    llm_args.kv_cache_config.use_kv_cache_manager_v2 = model_default
+    return model_default

--- a/tensorrt_llm/usage/llm_args_golden_manifest.json
+++ b/tensorrt_llm/usage/llm_args_golden_manifest.json
@@ -647,8 +647,10 @@
       "path": "kv_cache_config.tokens_per_block"
     },
     {
-      "allowed_values": [],
-      "annotation": "<class 'bool'>",
+      "allowed_values": [
+        "auto"
+      ],
+      "annotation": "Union[bool, Literal['auto']]",
       "converter": "",
       "kind": "value",
       "path": "kv_cache_config.use_kv_cache_manager_v2"
@@ -2910,8 +2912,10 @@
       "path": "kv_cache_config.tokens_per_block"
     },
     {
-      "allowed_values": [],
-      "annotation": "<class 'bool'>",
+      "allowed_values": [
+        "auto"
+      ],
+      "annotation": "Union[bool, Literal['auto']]",
       "converter": "",
       "kind": "value",
       "path": "kv_cache_config.use_kv_cache_manager_v2"

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -52,7 +52,8 @@ from tensorrt_llm.llmapi.llm_args import (BaseLlmArgs, CacheTransceiverConfig,
                                           UserProvidedDecodingConfig,
                                           update_llm_args_with_extra_dict)
 # fmt: on
-from tensorrt_llm.llmapi.llm_utils import apply_model_defaults_to_llm_args
+from tensorrt_llm.llmapi.llm_utils import (_resolve_kv_cache_manager_v2_auto,
+                                           apply_model_defaults_to_llm_args)
 from tensorrt_llm.llmapi.mm_encoder import MultimodalEncoder
 from tensorrt_llm.llmapi.utils import print_traceback_on_error
 from tensorrt_llm.models.modeling_utils import LayerQuantConfig, QuantConfig
@@ -309,6 +310,43 @@ class TestModelDefaults:
         applied = apply_model_defaults_to_llm_args(llm_args, model_defaults)
         assert applied == model_defaults
 
+    @pytest.mark.parametrize("explicit_auto", [False, True])
+    def test_kv_cache_manager_v2_auto_uses_model_default(self, explicit_auto):
+        kv_cache_config = (KvCacheConfig(use_kv_cache_manager_v2="auto")
+                           if explicit_auto else KvCacheConfig())
+        llm_args = TorchLlmArgs(model="/tmp/dummy_model",
+                                kv_cache_config=kv_cache_config)
+        model_defaults = {"kv_cache_config": {"use_kv_cache_manager_v2": True}}
+
+        apply_model_defaults_to_llm_args(llm_args, model_defaults)
+        _resolve_kv_cache_manager_v2_auto(llm_args, model_defaults)
+
+        assert llm_args.kv_cache_config.use_kv_cache_manager_v2 is True
+
+    def test_kv_cache_manager_v2_auto_falls_back_to_false(self):
+        llm_args = TorchLlmArgs(model="/tmp/dummy_model")
+
+        _resolve_kv_cache_manager_v2_auto(llm_args, {})
+
+        assert llm_args.kv_cache_config.use_kv_cache_manager_v2 is False
+
+    @pytest.mark.parametrize("user_setting", [False, True])
+    def test_kv_cache_manager_v2_explicit_value_overrides_model_default(
+            self, user_setting):
+        llm_args = TorchLlmArgs(
+            model="/tmp/dummy_model",
+            kv_cache_config=KvCacheConfig(use_kv_cache_manager_v2=user_setting))
+        model_defaults = {
+            "kv_cache_config": {
+                "use_kv_cache_manager_v2": not user_setting
+            }
+        }
+
+        apply_model_defaults_to_llm_args(llm_args, model_defaults)
+        _resolve_kv_cache_manager_v2_auto(llm_args, model_defaults)
+
+        assert llm_args.kv_cache_config.use_kv_cache_manager_v2 is user_setting
+
     @pytest.mark.parametrize(
         "defaults_dict,should_raise,error_contains",
         [
@@ -410,6 +448,13 @@ def test_KvCacheConfig_declaration():
     assert KvCacheConfig().kv_cache_event_hash_algo == "auto"
     assert KvCacheConfig().block_reuse_policy == "all_reusable"
     assert KvCacheConfig().enable_swa_scratch_reuse is False
+    assert KvCacheConfig().use_kv_cache_manager_v2 == "auto"
+    assert KvCacheConfig(
+        use_kv_cache_manager_v2=True).use_kv_cache_manager_v2 is True
+    assert KvCacheConfig(
+        use_kv_cache_manager_v2=False).use_kv_cache_manager_v2 is False
+    with pytest.raises(ValidationError, match="use_kv_cache_manager_v2"):
+        KvCacheConfig(use_kv_cache_manager_v2="invalid")
 
     config = KvCacheConfig(enable_block_reuse=True,
                            max_tokens=1024,

--- a/tests/unittest/llmapi/test_quickstart_advanced.py
+++ b/tests/unittest/llmapi/test_quickstart_advanced.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "examples" / "llm-api" / "quickstart_advanced.py"
+_SPEC = importlib.util.spec_from_file_location("quickstart_advanced", _MODULE_PATH)
+if _SPEC is None or _SPEC.loader is None:
+    raise ImportError(f"Unable to load {_MODULE_PATH}")
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+@pytest.mark.parametrize(
+    ("cli_value", "expected"),
+    [
+        ("auto", "auto"),
+        ("true", True),
+        ("false", False),
+    ],
+)
+def test_use_kv_cache_manager_v2_cli_values(cli_value: str, expected: str | bool) -> None:
+    parser = _MODULE.add_llm_args(argparse.ArgumentParser())
+
+    args = parser.parse_args(["--model_dir", "dummy-model", "--use_kv_cache_manager_v2", cli_value])
+
+    assert args.use_kv_cache_manager_v2 == expected
+
+
+def test_use_kv_cache_manager_v2_cli_default_is_auto() -> None:
+    parser = _MODULE.add_llm_args(argparse.ArgumentParser())
+
+    args = parser.parse_args(["--model_dir", "dummy-model"])
+
+    assert args.use_kv_cache_manager_v2 == "auto"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “auto” option for KV cache manager selection, allowing the app to choose a model-specific default when supported.
  * Improved argument handling so model defaults can influence cache manager behavior during startup.

* **Bug Fixes**
  * Tightened cache manager selection logic for more reliable behavior.
  * Ensured models with built-in cache preferences use those defaults consistently.

* **Tests**
  * Expanded coverage for default resolution, explicit overrides, and validation of accepted values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Add `"auto"` as the default value of `KvCacheConfig.use_kv_cache_manager_v2` so models can opt in to KV cache manager V2 through their model defaults. Explicit user-provided `true` or `false` values continue to take precedence, while models without a V2 default resolve to `false`.

DeepSeek V4 opts in to V2. Gemma and DeepSeek R1 defaults are unchanged.

## Test Coverage

- `pytest` targeted KV cache auto-resolution and DeepSeek V4 model-default tests: 7 passed.
- Clean C++ build for SM80, SM90, SM100, and SM103 (A100, H100/H200, B200, and B300): passed.
- `pre-commit run --files <changed files>`: passed.
- DeepSeek R1 compatibility validation on 4x B200 with a temporary V2 model default: confirmed `KVCacheManagerV2` and `KVCacheV2Scheduler`; MMLU and GSM8K completed and passed their accuracy thresholds. The remaining CNN/DailyMail evaluation could not start because the local cached `test` split contained zero samples. The temporary R1 default was reverted before this PR.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
