### PR TITLE
[None][fix] align KV slice token_range.end with transferred block count

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -757,18 +757,14 @@ class Sender(SenderBase):
                 src_block_ids = src_block_ids_per_groups[self_lg]
                 dst_block_ids = dst_block_ids_per_groups[peer_lg]
 
-                # Speculative decoding: generation may have one extra draft-token block.
+                # Both sides trim block lists to ceil(prompt_len / tpb) in
+                # _create_kv_slice, so dst must never exceed src. A smaller dst
+                # (generation prefix-cache reuse) is handled via dst_start below.
                 block_diff = dst_block_ids.size - src_block_ids.size
-                if block_diff == 1:
-                    logger.debug(
-                        f"Trimming 1 extra dst block for draft tokens: "
-                        f"src={src_block_ids.size}, dst={dst_block_ids.size}"
-                    )
-                    dst_block_ids = dst_block_ids[:-1]
-                elif block_diff > 1:
+                if block_diff > 0:
                     raise ValueError(
                         f"src/dst block count mismatch: {src_block_ids.size} vs "
-                        f"{dst_block_ids.size} (expected diff <= 1)"
+                        f"{dst_block_ids.size} (dst must not exceed src)"
                     )
                 tpb = extractor.page_table.tokens_per_block
                 token_range = task._slice.token_range

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -182,12 +182,16 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
 
         token_range = None
         if req.prompt_len > 0:
-            # Align with KV cache allocation (prepare_disagg_gen_init /
-            # _get_context_bytes), which reserves prompt_len +
-            # num_extra_kv_tokens slots for speculative decoding methods
-            # (e.g. EAGLE3) that consume extra KV positions per request.
-            num_extra_kv_tokens = getattr(self._kv_cache_manager, "num_extra_kv_tokens", 0) or 0
-            token_range = TokenRange(start=0, end=req.prompt_len + num_extra_kv_tokens)
+            # end must match the trimmed block list below (ceil(prompt_len / tpb)
+            # blocks). num_extra_kv_tokens slots (speculative decoding) are not
+            # transferred. In the previously added support for ctx disabling
+            # speculative decoding while gen enables it, both sides currently
+            # use prompt_len as the transfer range, so the ranges stay
+            # consistent.
+            # TODO: the accuracy impact of not transferring num_extra_kv_tokens
+            # on MTP and other speculative decoding paths is currently unclear;
+            # revisit whether these extra KV slots need to be transferred.
+            token_range = TokenRange(start=0, end=req.prompt_len)
 
         groups = []
         for idx, lg in enumerate(layer_groups):
@@ -196,8 +200,6 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 continue
             block_ids = adapter.get_block_ids(req, idx, lg)
             # Limit to prompt_len blocks, matching C++ cacheFormatter behavior.
-            # Extra blocks from num_extra_kv_tokens (speculative decoding) have
-            # uninitialized KV data and must not be transferred.
             total_blocks = (req.prompt_len + tpb - 1) // tpb
             if block_ids.size > total_blocks:
                 block_ids = block_ids[:total_blocks]

--- a/tests/unittest/disaggregated/test_cache_reuse_adapter.py
+++ b/tests/unittest/disaggregated/test_cache_reuse_adapter.py
@@ -269,8 +269,8 @@ class TestTokenRange:
 
 
 # ---------------------------------------------------------------------------
-# _create_kv_slice: default TokenRange spans prompt_len + num_extra_kv_tokens
-# so transferred KV matches what resize_context / _get_context_bytes allocate.
+# _create_kv_slice: default TokenRange spans prompt_len, matching the
+# trimmed block list actually transferred.
 # ---------------------------------------------------------------------------
 
 
@@ -310,15 +310,14 @@ def _build_transceiver_for_kv_slice(num_extra_kv_tokens: int, prompt_len: int):
 
 
 class TestCreateKvSliceTokenRange:
-    """Default TokenRange built by _create_kv_slice must align with KV-cache allocation.
+    """token_range.end must be prompt_len, matching the trimmed block list.
 
-    KV cache allocation in resize_context (V2) and prepare_resources (V1) reserves
-    prompt_len + num_extra_kv_tokens slots whenever speculative decoding (e.g.
-    EAGLE3, MTP) consumes extra KV positions per request. The transferred token
-    range must cover the same span, otherwise the receiver under-receives KV.
+    The sender reconstructs total_blocks from token_range.end (ceil(end / tpb)),
+    so end must stay at prompt_len -- not prompt_len + num_extra_kv_tokens --
+    to match the blocks actually transferred.
     """
 
-    def test_includes_num_extra_kv_tokens(self):
+    def test_excludes_num_extra_kv_tokens(self):
         prompt_len = 17
         num_extra_kv_tokens = 7
         transceiver, req = _build_transceiver_for_kv_slice(num_extra_kv_tokens, prompt_len)
@@ -326,10 +325,25 @@ class TestCreateKvSliceTokenRange:
         kv_slice = transceiver._create_kv_slice(req)
 
         assert kv_slice.token_range is not None
-        assert (kv_slice.token_range.start, kv_slice.token_range.end) == (
-            0,
-            prompt_len + num_extra_kv_tokens,
-        )
+        assert (kv_slice.token_range.start, kv_slice.token_range.end) == (0, prompt_len)
+
+    def test_extra_tokens_do_not_cross_block_boundary(self):
+        # Reconstructed total_blocks (ceil(end / tpb)) must match the blocks sent.
+        prompt_len = 16
+        num_extra_kv_tokens = 7
+        transceiver, req = _build_transceiver_for_kv_slice(num_extra_kv_tokens, prompt_len)
+        tpb = transceiver._reuse_adapter.tokens_per_block
+
+        # Setup must actually exercise a boundary crossing: prompt_len ends on a
+        # block boundary and the extra tokens would otherwise add a block.
+        assert prompt_len % tpb == 0
+        assert (prompt_len + num_extra_kv_tokens + tpb - 1) // tpb == prompt_len // tpb + 1
+
+        kv_slice = transceiver._create_kv_slice(req)
+
+        end = kv_slice.token_range.end
+        transferred_blocks = kv_slice.block_ids_per_layer_groups[0].size
+        assert (end + tpb - 1) // tpb == transferred_blocks
 
     def test_defaults_to_prompt_len_when_no_extra(self):
         prompt_len = 17


### PR DESCRIPTION
_create_kv_slice set the default token_range.end to req.prompt_len + num_extra_kv_tokens, but the block list is trimmed to total_blocks = ceil(prompt_len / tpb). The sender re-derives per-layer token starts from token_range.end via total_blocks = ceil(end / tpb), so including num_extra_kv_tokens inflates total_blocks past the trimmed block count whenever the extra tokens cross a block boundary, mis-deriving token_start by one block and corrupting the transfer.

Set token_range.end to req.prompt_len so it matches the blocks actually sent. The extra blocks reserved for speculative decoding hold uninitialized KV and should not be transferred (see NVIDIA/TensorRT-LLM PR #14546 review discussion).

Update the unit tests: flip test_includes_num_extra_kv_tokens to test_excludes_num_extra_kv_tokens and add a block-boundary regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt KV cache transfers so the default token range now stops at the prompt length, avoiding inclusion of extra speculative tokens.
  * Kept block transfer boundaries consistent when prompt lengths align with block sizes, reducing mismatches in reconstructed KV slices.

* **Tests**
  * Updated unit coverage to reflect the new token range behavior and verify correct block-boundary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description


## Description

`KvCacheTransceiverV2._create_kv_slice` sets the default `token_range.end` to
`req.prompt_len + num_extra_kv_tokens`, but the block list is independently
trimmed to `total_blocks = (req.prompt_len + tpb - 1) // tpb`. This makes the
slice metadata inconsistent with the blocks it carries: `base/transfer.py`
documents the contract `total_blocks = ceil(token_range.end / tpb)`, and the
sender reconstructs `total_blocks` from `token_range.end` (native/transfer.py)
to derive per-layer token starts. When `num_extra_kv_tokens` pushes
`token_range.end` across a block boundary, the reconstructed count no longer
matches the trimmed block list.

**Scope — this is a metadata/contract-consistency fix, not a data-movement
change.** The extra `num_extra_kv_tokens` blocks are already excluded from the
transfer by the existing `block_ids[:total_blocks]` trim, so which blocks get
sent does not depend on `token_range.end`. The inflated `total_blocks` only
shifts `src_start` and `dst_start` by the same delta, which cancels in
`_align_kv_blocks` (the sole asymmetric consumer, `dst_start_token`, is always
`None`). So no transfer is corrupted today; this fix restores the documented
invariant and removes a latent hazard that would surface if `dst_start_token`
becomes non-`None`, or if `num_extra_kv_tokens > tokens_per_block` combines with
asymmetric prefix reuse.

Set `token_range.end = req.prompt_len` so the metadata matches what is actually
transferred. Keeping the extra speculative-decoding blocks out of the transfer
is consistent with the review discussion in
https://github.com/NVIDIA/TensorRT-LLM/pull/14546/changes#r3386942085; the
accuracy impact on speculative decoding is not yet confirmed.

## Test Coverage

- `tests/unittest/disaggregated/test_cache_reuse_adapter.py`
  - `test_includes_num_extra_kv_tokens` → `test_excludes_num_extra_kv_tokens`
    (asserts `token_range.end == prompt_len`).
  - Added `test_extra_tokens_do_not_cross_block_boundary` (block-boundary
    consistency regression).
- All 58 tests in the file pass.
## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
