### PR TITLE
[TRTLLM-13617][feat] Inclusive host KV-cache tier (shadow reuse) for KVCacheManager V2

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1048,6 +1048,8 @@ class KVCacheManagerV2(BaseResourceManager):
             max_util_for_resume=kv_cache_config.max_util_for_resume,
             enable_stats=self.enable_stats,
             layers=layer_configs,
+            enable_inclusive_host_cache=kv_cache_config.
+            enable_inclusive_host_cache,
         )
 
     def _extra_buffers_per_layer(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3370,6 +3370,15 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         "Set to 0 to disable prefetch. Only effective with KV cache manager v2 and block reuse enabled."
     )
 
+    enable_inclusive_host_cache: bool = Field(
+        default=False,
+        status="prototype",
+        description=
+        "Keep a block's clean host copy when it is recalled host->GPU so a later eviction can "
+        "reuse it instead of re-writing to host, avoiding redundant device-to-host copies for "
+        "blocks that bounce GPU<->host. Requires a host cache tier (``host_cache_size`` > 0). "
+        "Default False. Only used with KV cache manager v2 (experimental).")
+
     def _to_pybind(self):
         config = _KvCacheConfig(
             enable_block_reuse=self.enable_block_reuse,

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -212,6 +212,12 @@ class KVCacheManagerConfig:
     If True, we will try to reuse tokens from partially matched blocks.
     """
 
+    enable_inclusive_host_cache: bool = False
+    """
+    If True, keep a page's clean host copy after recall so a later eviction reuses it instead of
+    re-copying to host. Reclaimed under host memory pressure.
+    """
+
     constraints: list[BatchDesc] = field(default_factory=list)
     """
     A list of step configurations that must always be supported.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -261,6 +261,7 @@ class KVCacheManager:
             typical_batch=config.typical_step,
             constraints=config.constraints,
             event_manager=event_manager,
+            enable_inclusive_host_cache=config.enable_inclusive_host_cache,
         )
         self._living_kv_caches = set[rawref.ref[_KVCache]]()
         decay = 0.9999

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
@@ -17,6 +17,8 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, NamedTuple, cast
 
+from llist import dllistnode
+
 from . import rawref
 from ._block_radix_tree import Block
 from ._common import (
@@ -205,6 +207,13 @@ class UncommittedPage(Page):
 class CommittedPage(Page):
     block: rawref.ref["Block"]
     __rawref__: rawref.ref["CommittedPage"]
+    # Inclusive host cache: a retained clean copy of this immutable page at a lower (host/disk)
+    # tier. When set, a later eviction of this page to shadow_level can reuse this slot and skip
+    # the device->host copy. None when no shadow is held (the default / exclusive behavior).
+    # shadow_node is this page's node in the StorageManager shadow reclaim FIFO for shadow_level.
+    shadow_slot: "Slot | None"
+    shadow_level: CacheLevel
+    shadow_node: "dllistnode | None"
 
     def is_committed(self) -> bool:
         return True
@@ -220,6 +229,9 @@ class CommittedPage(Page):
     ):
         self.block = rawref.ref(block)
         self.__rawref__ = rawref.NULL
+        self.shadow_slot = None
+        self.shadow_level = cache_level
+        self.shadow_node = None
         Page.__init__(
             self,
             None,
@@ -234,16 +246,23 @@ class CommittedPage(Page):
         self.set_slot(slot)
 
     def __del__(self) -> None:
-        block = self.block()
-        # block may be None when rebase happens, i.e. another block with the same key is committed,
-        # replacing it, but the page is still used by a _KVCache.
-        if block is not None:
-            block.unset_page(
-                self.life_cycle,
-                self.manager._life_cycles.get_life_cycle(self.life_cycle),
-            )
-        Page.__del__(self)
-        self.__rawref__.invalidate()
+        try:
+            # Release any retained host shadow first so its slot returns to the pool.
+            if self.shadow_slot is not None:
+                self.manager.drop_shadow(self)
+            block = self.block()
+            # block may be None when rebase happens, i.e. another block with the same key is
+            # committed, replacing it, but the page is still used by a _KVCache.
+            if block is not None:
+                block.unset_page(
+                    self.life_cycle,
+                    self.manager._life_cycles.get_life_cycle(self.life_cycle),
+                )
+        finally:
+            try:
+                Page.__del__(self)
+            finally:
+                self.__rawref__.invalidate()
 
 
 @dataclass(slots=True)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 from fractions import Fraction
 from typing import TYPE_CHECKING, Callable, Iterator, Sequence, cast
 
+from llist import dllist
+
 from . import rawref
 from ._common import (
     GPU_LEVEL,
@@ -185,6 +187,8 @@ class StorageManager:
         "_levels",
         "_min_slots",
         "_event_manager",
+        "_enable_inclusive_host_cache",
+        "_shadow_reclaim",
         "__rawref__",
     )
     _life_cycles: LifeCycleRegistry
@@ -198,6 +202,11 @@ class StorageManager:
     _levels: TypedIndexList[CacheLevel, CacheLevelManager]
     _min_slots: TypedIndexList[PoolGroupIndex, int]
     _event_manager: "KVCacheEventManager | None"
+    _enable_inclusive_host_cache: bool
+    # Per-(level, pool group) FIFO of shadow-holding pages, reclaimed oldest-first under pressure.
+    # dllist, not list: shadows are usually removed from the middle (when their page is reused or
+    # dropped), and each page holds its own node for O(1) removal; list.remove would be O(n).
+    _shadow_reclaim: "TypedIndexList[CacheLevel, TypedIndexList[PoolGroupIndex, dllist]]"
     __rawref__: rawref.ref["StorageManager"]
 
     def __init__(
@@ -209,9 +218,11 @@ class StorageManager:
         typical_batch: BatchDesc | None = None,
         constraints: list[BatchDesc] | None = None,
         event_manager: "KVCacheEventManager | None" = None,
+        enable_inclusive_host_cache: bool = False,
     ) -> None:
         self.__rawref__ = rawref.NULL
         self._event_manager = event_manager
+        self._enable_inclusive_host_cache = enable_inclusive_host_cache
         assert config.cache_tiers[GPU_LEVEL].tier == CacheTier.GPU_MEM, (
             "The first cache tier must be GPU memory"
         )
@@ -274,6 +285,17 @@ class StorageManager:
         assert self.num_pool_groups == get_uniform_attribute(
             self._levels, lambda level: level.storage.num_pool_groups
         )
+        # One reclaim FIFO per (level, pool group); only lower-than-GPU levels are ever populated.
+        self._shadow_reclaim = cast(
+            TypedIndexList,
+            [
+                cast(
+                    TypedIndexList,
+                    [dllist() for _ in typed_range(self.num_pool_groups)],
+                )
+                for _ in typed_range(num_levels)
+            ],
+        )
 
     def __del__(self) -> None:
         self.destroy()
@@ -281,6 +303,11 @@ class StorageManager:
     def destroy(self) -> None:
         if self.__rawref__.is_valid:
             self.__rawref__.invalidate()
+            # Reclaim outstanding shadows so their slots are freed before allocator teardown.
+            if self._enable_inclusive_host_cache:
+                for lvl in typed_range(self.num_cache_levels):
+                    for pg_idx in typed_range(self.num_pool_groups):
+                        self._reclaim_shadows(lvl, pg_idx, self._num_shadow_slots(lvl, pg_idx))
             for lvl in self._levels:
                 lvl.storage.destroy()
 
@@ -435,6 +462,14 @@ class StorageManager:
             fallen = len(fallen_pages[pg_idx])
             old_free_cnt = storage.get_num_free_slots(pg_idx)
             evictable_cnt = ctrl.num_evictable_pages(pg_idx)
+            # Shadows are reclaimable for free (GPU holds the real copy), so reclaim them oldest
+            # -first to cover any shortfall before evicting real pages or raising.
+            shadow_cnt = self._num_shadow_slots(lvl_id, pg_idx)
+            if shadow_cnt > 0:
+                deficit = (goal + fallen) - (old_free_cnt + evictable_cnt)
+                if deficit > 0:
+                    self._reclaim_shadows(lvl_id, pg_idx, min(deficit, shadow_cnt))
+                    old_free_cnt = storage.get_num_free_slots(pg_idx)
             num_to_evict[pg_idx] = max(0, min(goal + fallen - old_free_cnt, evictable_cnt))
             fallen_held_cnt = 0  # fallen held pages we must accept in the current level.
             if self.is_last_level(lvl_id):
@@ -522,6 +557,36 @@ class StorageManager:
                     self._levels[dst_lvl].controller.schedule_for_eviction(p)
         return
 
+    def _is_inclusive_recall(
+        self, page: Page, src_level: CacheLevel, dst_level: CacheLevel
+    ) -> bool:
+        """A migration that should retain the source slot as a clean host shadow.
+
+        True only for the inclusive-host-cache fast path: a committed (immutable) page being
+        recalled from a lower tier toward GPU. The retained source slot becomes the page's shadow.
+        """
+        return (
+            self._enable_inclusive_host_cache
+            and dst_level < src_level
+            and isinstance(page, CommittedPage)
+            and page.shadow_slot is None
+        )
+
+    def _shadow_reuse_slot(
+        self, page: Page, src_level: CacheLevel, dst_level: CacheLevel
+    ) -> "Slot | None":
+        """Return the page's retained shadow slot if it can satisfy this GPU->host eviction.
+
+        When a committed page that holds a clean shadow at exactly dst_level is evicted back down,
+        the shadow already mirrors the (immutable) GPU contents, so we can rebind to it and skip
+        the device->host copy entirely. Returns the detached shadow slot, or None if not applicable.
+        """
+        if not self._enable_inclusive_host_cache or not isinstance(page, CommittedPage):
+            return None
+        if page.shadow_slot is None or page.shadow_level != dst_level or dst_level <= src_level:
+            return None
+        return self._detach_shadow(page)
+
     def _batched_migrate(
         self,
         pool_group_index: PoolGroupIndex,
@@ -536,11 +601,31 @@ class StorageManager:
         assert defrag or dst_level != src_level, (
             "dst_level and src_level must be different unless performing defragmentation"
         )
-        num_slots = len(src_pages)
         num_pools = self.num_pools(pool_group_index)
         src_pool_group = self._pool_group(src_level, pool_group_index)
         dst_pool_group = self._pool_group(dst_level, pool_group_index)
+
+        # A page evicted back to the level holding its shadow just rebinds to it (no dst slot, no
+        # copy). Partition those out; reused_shadow parallels src_pages (detached slot or None).
+        reused_shadow: list["Slot | None"] = [None] * len(src_pages)
+        copy_pages: list[Page] = []
+        if update_src and not defrag:
+            for i, src in enumerate(src_pages):
+                shadow = self._shadow_reuse_slot(src, src_level, dst_level)
+                if shadow is not None:
+                    reused_shadow[i] = shadow
+                else:
+                    copy_pages.append(src)
+        else:
+            copy_pages = list(src_pages)
+
+        num_slots = len(copy_pages)
         if dst_pool_group.num_free_slots < num_slots:
+            # Roll back any shadow detaches we performed for this batch.
+            for i, shadow in enumerate(reused_shadow):
+                if shadow is not None:
+                    self._levels[dst_level].storage.release(pool_group_index, shadow)
+                    reused_shadow[i] = None
             raise OutOfPagesError("Not enough free slots")
         dst_slots = dst_pool_group.allocate_multiple(num_slots)
         try:
@@ -549,7 +634,7 @@ class StorageManager:
             tasks_per_pool: TypedIndexList[PoolIndex, list[CopyTask]] = make_typed(
                 lambda _: list[CopyTask](), num_pools
             )
-            for src, dst in zip(src_pages, dst_slots):
+            for src, dst in zip(copy_pages, dst_slots):
                 assert defrag or src.node_ref is None
                 prior_events.update((dst.ready_event, src.ready_event))
                 dst_addresses = dst_pool_group.slot_address(dst.slot_id)
@@ -560,11 +645,14 @@ class StorageManager:
                     )
             dst_tier = self._levels[dst_level].cache_tier
             src_tier = self._levels[src_level].cache_tier
-            with TemporaryCudaStream(prior_events) as stream:
-                slot_sizes = self.slot_size(pool_group_index)
-                for pool_idx, tasks in typed_enumerate(tasks_per_pool):
-                    batched_copy(dst_tier, src_tier, slot_sizes[pool_idx], tasks, stream.get())
-            finish_event = stream.take_finish_event()
+            finish_event = CachedCudaEvent.NULL
+            if num_slots > 0:
+                with TemporaryCudaStream(prior_events) as stream:
+                    slot_sizes = self.slot_size(pool_group_index)
+                    for pool_idx, tasks in typed_enumerate(tasks_per_pool):
+                        batched_copy(dst_tier, src_tier, slot_sizes[pool_idx], tasks, stream.get())
+                # Must be called after the `with`: the finish event is recorded in __exit__.
+                finish_event = stream.take_finish_event()
             emit_cache_level_updates = (
                 update_src
                 and not defrag
@@ -572,9 +660,10 @@ class StorageManager:
                 and self._event_manager is not None
             )
             emitted_update_keys: set[tuple[bytes, LifeCycleId]] = set()
-            if migration_recorder is not None and not defrag:
-                migration_recorder(src_pages, dst_slots, src_level, dst_level)
-            for src, dst in zip(src_pages, dst_slots):
+            if migration_recorder is not None and not defrag and copy_pages:
+                migration_recorder(copy_pages, dst_slots, src_level, dst_level)
+            # Update the copied pages, rebinding each to its freshly allocated dst slot.
+            for src, dst in zip(copy_pages, dst_slots):
                 dst.ready_event = finish_event
                 src.ready_event = (
                     finish_event  # compulsory for the next owner getting this slot from the pool.
@@ -583,8 +672,39 @@ class StorageManager:
                     scheduled_for_eviction = src.scheduled_for_eviction
                     if scheduled_for_eviction:
                         self.exclude_from_eviction(src)
-                    src_pool_group.release(src)
+                    if self._is_inclusive_recall(src, src_level, dst_level):
+                        # Retain the source (host) slot as a shadow instead of releasing it.
+                        self._attach_shadow(cast(CommittedPage, src), src_level)
+                    else:
+                        # Drop a stale shadow not strictly colder than the new level (e.g. a host
+                        # shadow while evicting to disk).
+                        if (
+                            self._enable_inclusive_host_cache
+                            and isinstance(src, CommittedPage)
+                            and src.shadow_slot is not None
+                            and src.shadow_level <= dst_level
+                        ):
+                            self.drop_shadow(src)
+                        src_pool_group.release(src)
                     src.set_slot(dst)
+                    src.cache_level = dst_level
+                    if emit_cache_level_updates:
+                        self._emit_cache_level_updated_event(
+                            src, src_level, dst_level, emitted_update_keys
+                        )
+                    if scheduled_for_eviction:
+                        self.schedule_for_eviction(src)
+            if update_src and not defrag:
+                # Rebind shadow-reuse pages to their retained shadow slots (no copy happened).
+                for i, shadow in enumerate(reused_shadow):
+                    if shadow is None:
+                        continue
+                    src = src_pages[i]
+                    scheduled_for_eviction = src.scheduled_for_eviction
+                    if scheduled_for_eviction:
+                        self.exclude_from_eviction(src)
+                    src_pool_group.release(src)
+                    src.set_slot(shadow)
                     src.cache_level = dst_level
                     if emit_cache_level_updates:
                         self._emit_cache_level_updated_event(
@@ -596,7 +716,72 @@ class StorageManager:
         except Exception:
             for s in dst_slots:
                 dst_pool_group.release(s)
+            # Release any detached-but-not-yet-rebound shadow slots so they are not leaked.
+            for shadow in reused_shadow:
+                if shadow is not None and shadow.has_valid_slot:
+                    self._levels[dst_level].storage.release(pool_group_index, shadow)
             raise
+
+    # ------------------------------------------------------------------
+    # Inclusive host cache: clean-shadow lifecycle
+    # ------------------------------------------------------------------
+    def _attach_shadow(self, page: CommittedPage, shadow_level: CacheLevel) -> None:
+        """Retain `page`'s source slot as a shadow and register it in the reclaim FIFO.
+
+        Caller must not have released the source slot yet, and rebinds the page to GPU right after.
+        """
+        assert self._enable_inclusive_host_cache
+        assert page.shadow_slot is None and page.shadow_node is None
+        assert shadow_level > GPU_LEVEL, "Shadows only live in lower (host/disk) tiers"
+        page.shadow_slot = page.move_to_new_slot()
+        page.shadow_level = shadow_level
+        pg_idx = self.get_pool_group_index(page.life_cycle)
+        page.shadow_node = self._shadow_reclaim[shadow_level][pg_idx].append(page)
+
+    def _detach_shadow(self, page: CommittedPage) -> Slot:
+        """Remove the page from the reclaim FIFO and return its shadow slot.
+
+        The slot is no longer owned by the page; caller must rebind or release it.
+        """
+        assert page.shadow_slot is not None and page.shadow_node is not None
+        pg_idx = self.get_pool_group_index(page.life_cycle)
+        self._shadow_reclaim[page.shadow_level][pg_idx].remove(page.shadow_node)
+        shadow = page.shadow_slot
+        page.shadow_slot = None
+        page.shadow_node = None
+        return shadow
+
+    def drop_shadow(self, page: CommittedPage) -> None:
+        """Reclaim a page's shadow: detach it from the FIFO and release the slot to its pool."""
+        if page.shadow_slot is None:
+            return
+        shadow_level = page.shadow_level
+        pg_idx = self.get_pool_group_index(page.life_cycle)
+        shadow = self._detach_shadow(page)
+        self._levels[shadow_level].storage.release(pg_idx, shadow)
+
+    def _reclaim_shadows(self, level: CacheLevel, pg_idx: PoolGroupIndex, max_count: int) -> int:
+        """Reclaim up to max_count shadows (oldest first) at (level, pg_idx); returns the count.
+
+        Always safe: the real copy lives on the GPU page, so this only forfeits a future D2H saving.
+        """
+        if max_count <= 0:
+            return 0
+        fifo = self._shadow_reclaim[level][pg_idx]
+        storage = self._levels[level].storage
+        reclaimed = 0
+        while reclaimed < max_count and len(fifo) > 0:
+            page = cast(CommittedPage, fifo.first.value)
+            shadow = self._detach_shadow(page)
+            storage.release(pg_idx, shadow)
+            reclaimed += 1
+        return reclaimed
+
+    def _num_shadow_slots(self, level: CacheLevel, pg_idx: PoolGroupIndex) -> int:
+        """Number of reclaimable shadow slots currently held at (level, pg_idx)."""
+        if not self._enable_inclusive_host_cache:
+            return 0
+        return len(self._shadow_reclaim[level][pg_idx])
 
     def _emit_cache_level_updated_event(
         self,
@@ -713,6 +898,9 @@ class StorageManager:
         assert len(persistent_pages) <= new_num_slots and all(
             p.cache_level == level and lc2pg[p.life_cycle] == pg_idx for p in persistent_pages
         ), "Not enough slots"
+        # Shadow slots aren't tracked by the eviction/defrag logic and may occupy to-be-removed
+        # overflow ids, so reclaim them first (free, since the GPU page holds the real copy).
+        self._reclaim_shadows(level, pg_idx, self._num_shadow_slots(level, pg_idx))
         pool_group = self._levels[level].storage._pool_groups[pg_idx]
         assert new_num_slots < pool_group.num_slots, "Not required for expansion of pools"
         allocator = pool_group._slot_allocator

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -245,6 +245,7 @@ def create_config(
     sink_tokens: int,
     kv_buf_size: int = 8192,
     block_quant_buf_size: int | None = None,
+    enable_inclusive_host_cache: bool = False,
 ) -> KVCacheManagerConfig:
     layer_buffers = [
         BufferConfig(role=Role.KEY, size=kv_buf_size),
@@ -279,6 +280,7 @@ def create_config(
             )
             for layer_id in typed_range(LayerId(num_layers))
         ],
+        enable_inclusive_host_cache=enable_inclusive_host_cache,
     )
 
 
@@ -318,6 +320,7 @@ class TestKVCacheManagerV2(unittest.TestCase):
         tokens_per_block: int = 32,
         kv_buf_size: int = 8192,
         block_quant_buf_size: int | None = None,
+        enable_inclusive_host_cache: bool = False,
     ):
         self.cfg = create_config(
             tokens_per_block,
@@ -329,6 +332,7 @@ class TestKVCacheManagerV2(unittest.TestCase):
             sink_tokens,
             kv_buf_size,
             block_quant_buf_size,
+            enable_inclusive_host_cache,
         )
         self.engine = FakeEngine(self.cfg)
         self.manager = KVCacheManager(self.cfg)
@@ -496,6 +500,71 @@ class TestNoBatching(TestKVCacheManagerV2):
         # run another longer request and expect OutOfPagesError
         # This also tests eviction to disk.
         self.assertRaises(OutOfPagesError, lambda: self.run_naive(seq_len + 1, 1, False))
+
+    # @assert_no_ref_cycle
+    def test_inclusive_host_cache_shadow_reuse(self) -> None:
+        # With enable_inclusive_host_cache, recalling an immutable page host->GPU retains its clean
+        # host copy as a shadow; a later eviction back to host reuses that shadow (copy-free) and
+        # does not consume a fresh host slot. Drive the GPU<->host bounce via suspend/resume under
+        # GPU memory pressure and observe the per-level shadow FIFO via _num_shadow_slots().
+        HOST_LEVEL = CacheLevel(1)
+        # Small GPU pool + generous host pool so suspend offloads to host and a competing request
+        # forces the hot request's blocks to bounce GPU<->host. No disk tier: host is last level.
+        self.prepare(
+            32 << 20, 128 << 20, 0, 36, 128, 1,
+            kv_buf_size=32768, enable_inclusive_host_cache=True,
+        )
+        storage = self.manager._storage
+        assert storage._enable_inclusive_host_cache
+
+        def total_shadows() -> int:
+            return sum(
+                storage._num_shadow_slots(HOST_LEVEL, pg)
+                for pg in typed_range(storage.num_pool_groups)
+            )
+
+        def host_free() -> int:
+            host_storage = storage._levels[HOST_LEVEL].storage
+            return sum(
+                host_storage.get_num_free_slots(pg)
+                for pg in typed_range(storage.num_pool_groups)
+            )
+
+        max_seq_len = 32 * 22
+        seq_len = max_seq_len
+
+        # Warm up the hot request, then suspend it (its blocks offload GPU->host).
+        hot = self.new_request(0, None, 256, seq_len - 256)
+        with TemporaryCudaStream([]) as s:
+            stream = cast(CudaStream, s.handle)
+            assert hot.kv_cache.resume(stream)
+            self.run_request(hot, 32, False)
+        s.take_finish_event()
+        hot.kv_cache.suspend()
+
+        # No shadows yet: the hot request has only been offloaded, never recalled+re-evicted.
+        assert total_shadows() == 0
+
+        # Bounce: recall the hot request to GPU (attaches shadows), then a filler request takes the
+        # GPU pool, forcing the hot blocks back to host — reusing the retained shadows copy-free.
+        host_free_before = host_free()
+        with TemporaryCudaStream([]) as s:
+            stream = cast(CudaStream, s.handle)
+            assert hot.kv_cache.resume(stream)
+        s.take_finish_event()
+        # After recall, immutable committed blocks retained their host copy as shadows.
+        shadows_after_recall = total_shadows()
+        self.assertGreater(shadows_after_recall, 0)
+        # Shadows occupy host slots, so free host slots dropped versus before the recall.
+        self.assertLess(host_free(), host_free_before)
+
+        # Suspend again: the hot blocks evict GPU->host and reuse their shadows (no fresh host slot,
+        # no D2H copy). The shadow FIFO drains as shadows are rebound to the evicted pages.
+        hot.kv_cache.suspend()
+        self.assertLess(total_shadows(), shadows_after_recall)
+
+        hot.kv_cache.close()
+        self.manager.clear_reusable_blocks()
 
     @parameterized.expand([(1,), (2,), (4,)])
     # @assert_no_ref_cycle


### PR DESCRIPTION
Add an optional inclusive host cache tier to KVCacheManager V2. When a full, immutable committed page is recalled host->GPU, its clean host copy is retained as a "shadow" instead of being freed; a later eviction of that page back to host reuses the shadow and skips the redundant device-to-host (D2H) copy. This eliminates redundant D2H rewrites of hot prefixes that repeatedly bounce GPU<->host, which dominate host-tier write traffic on agentic multi-turn workloads. Gated by a new KvCacheConfig flag enable_inclusive_host_cache (default False; exclusive paging unchanged).

- _config.py / llm_args.py / kv_cache_manager_v2.py / _kv_cache_manager.py: plumb enable_inclusive_host_cache into StorageManager.
- _page.py: add shadow_slot/shadow_level/shadow_node to CommittedPage; release the shadow on drop/rebase.
- _storage_manager.py: retain a shadow on inclusive recall, reuse it copy-free on eviction, and reclaim shadows oldest-first under host memory pressure (per-(level,pool-group) FIFO), on shrink, and on destroy. Also fix take_finish_event() to run after the TemporaryCudaStream `with` block so the offload path does not raise on an empty copy batch.
- test: behavioral test asserting a shadow is attached on recall and reused on re-eviction (host free-slot count and shadow FIFO tracked via _num_shadow_slots), on top of the existing StorageManager suspend/resume harness.

This feature is able to reduce offloaded KvCache, but no E2E perf gain was observed:

```
  KV-Cache Offloaded Size (D2H) _ OFF vs ON

  ┌─────────────_───────────_──────────_───────────┐
  │ Concurrency │ OFF (GiB) │ ON (GiB) │ Reduction │
  ├─────────────┼───────────┼──────────┼───────────┤
  │ 8           │    435.54 │   221.69 │     49.1% │
  ├─────────────┼───────────┼──────────┼───────────┤
  │ 16          │  1,559.96 │   549.85 │     64.8% │
  ├─────────────┼───────────┼──────────┼───────────┤
  │ 32          │  4,243.05 │   960.75 │     77.4% │
  └─────────────┴───────────┴──────────┴───────────┘
E2E perf

  ┌──────_───────────────────────────_───────────────_───────────────_───────────────_─────────────┐
  │ Conc │ Throughput (tok/s) OFF_ON │  Avg Lat (s)  │   TTFT (ms)   │   TPOT (ms)   │  KV Hit %   │
  ├──────┼───────────────────────────┼───────────────┼───────────────┼───────────────┼─────────────┤
  │ 8    │ 47,182 _ 46,716           │ 8.59 _ 8.75   │ 1,957 _ 2,103 │ 13.28 _ 13.31 │ 77.0 _ 76.4 │
  ├──────┼───────────────────────────┼───────────────┼───────────────┼───────────────┼─────────────┤
  │ 16   │ 77,675 _ 76,958           │ 10.44 _ 10.60 │ 2,567 _ 2,754 │ 15.78 _ 15.72 │ 80.4 _ 80.5 │
  ├──────┼───────────────────────────┼───────────────┼───────────────┼───────────────┼─────────────┤
  │ 32   │ 106,038 _ 106,294         │ 15.14 _ 15.16 │ 5,740 _ 5,792 │ 18.84 _ 18.76 │ 81.6 _ 82.0 │
  └──────┴───────────────────────────┴───────────────┴───────────────┴───────────────┴─────────────┘

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional inclusive host-cache mode for KV cache management.
  * When enabled, recalled data can keep a reusable host copy to reduce repeated transfers and improve reuse under memory pressure.
  * The new setting is available in KV cache configuration and is supported by the latest cache manager path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
