### PR TITLE
[None][feat] VisualGen: Add CuTe DSL JIT kernels for FMHA

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,5 @@ docs/source/blogs/media/tech_blog10_full_strategy_performance.png filter=lfs dif
 docs/source/blogs/media/tech_blog10_context_wait_performance.png  filter=lfs diff=lfs merge=lfs -text
 cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/cubin/kernelMetaInfo_cubin.cpp filter=lfs diff=lfs merge=lfs -text
 cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/cubin/xqa_kernel_cubin.cpp filter=lfs diff=lfs merge=lfs -text
-tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/*/*/*.so filter=lfs diff=lfs merge=lfs -text
 docs/source/blogs/media/tech_blog26_deepseek_v4_hybrid_attention.png filter=lfs diff=lfs merge=lfs -text
 docs/source/blogs/media/tech_blog26_deepseek_v4_mhc_moe.png filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ tensorrt_llm/flash_mla/
 tensorrt_llm/flash_mla_cpp_tllm.*.so
 tensorrt_llm/flash_mla_cpp_tllm.pyi
 tensorrt_llm/runtime/kv_cache_manager_v2/**/*.so
-!tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/**/*.so
 **/*__mypyc*.so
 tensorrt_llm/scripts
 *docs/cpp_docs*

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,6 @@ package_data += [
     # Include CUDA source for fused MoE align extension so runtime JIT can find it in wheels
     '_torch/auto_deploy/custom_ops/fused_moe/moe_align_kernel.cu',
     '_torch/auto_deploy/custom_ops/fused_moe/triton_fused_moe_configs/*',
-    '_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/**/*.so',
     'usage/schemas/*.json',
 ]
 

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/cute_dsl/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/cute_dsl/__init__.py
@@ -15,7 +15,7 @@
 """
 CuTe DSL attention backend family for visual generation models.
 
-  fmha.py  — CuTeDSLAttention  (dense cubin path, head_dim=128)
+  fmha.py  — CuTeDSLAttention  (dense and blockscaled JIT FMHA)
   vsa.py   — VSAAttention       (Video Sparse Attention, CuTe JIT + SDPA fallback)
 """
 

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/cute_dsl/fmha.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/cute_dsl/fmha.py
@@ -15,40 +15,530 @@
 """
 CuTe DSL (NVIDIA kernels) Dense FMHA Backend for Visual Generation Models
 
-Uses pre-compiled cubins derived from CUTLASS CuTe DSL FMHA.
-Expects NHD layout ([B, S, H, D]) and supports float16/bfloat16.
-For the VSA sparse path use VSAAttention in vsa.py.
+JIT-compiles the dense FMHA kernel and caches the compiled artifact for each kernel configuration.
+Expects NHD layout ([B, S, H, D]) and supports float16/bfloat16 inputs. The VSA sparse path uses
+VSAAttention from vsa.py instead.
 """
 
 import math
-from typing import Optional, Tuple
+from typing import Any, NamedTuple, Tuple
 
 import torch
 
+from tensorrt_llm.logger import logger
 from tensorrt_llm.visual_gen.args import QuantAttentionConfig
 
 from ....attention_backend.interface import PredefinedAttentionMask
 from ..interface import AttentionBackend, AttentionTensorLayout
 
-_cute_dsl_import_error = None
+_cute_dsl_import_error: BaseException | None = None
 try:
-    import tensorrt_llm._torch.visual_gen.cute_dsl_kernels.blackwell.attention as cute_dsl
-    from tensorrt_llm._torch.visual_gen.cute_dsl_kernels.blackwell.attention.fmha import (
-        _cute_runtime_import_error,
+    import cutlass
+    from cuda.bindings import driver as cuda_driver
+    from cutlass import cute
+    from cutlass.cute import typing as cute_typing
+    from cutlass.cute.runtime import from_dlpack
+
+    from tensorrt_llm._torch.visual_gen.cute_dsl_kernels.blackwell.attention import (
+        BlackwellFusedMultiHeadAttentionForward,
+        BlackwellFusedMultiHeadBlockScaledAttentionForward,
+    )
+    from tensorrt_llm._torch.visual_gen.cute_dsl_kernels.helpers import fmha_helpers as fmha_utils
+except (ImportError, OSError) as e:
+    cutlass = None
+    cuda_driver = None
+    cute = None
+    cute_typing = None
+    from_dlpack = None
+    BlackwellFusedMultiHeadAttentionForward = None
+    BlackwellFusedMultiHeadBlockScaledAttentionForward = None
+    fmha_utils = None
+    _cute_dsl_import_error = e
+
+
+SUPPORTED_GPU_ARCHS: Tuple[str, ...] = ("sm_100a", "sm_103a")
+
+
+# ============================================================================
+# Runtime helpers
+# ============================================================================
+
+
+def _check_cute_runtime_available() -> None:
+    if _cute_dsl_import_error is None:
+        return
+    raise ImportError(
+        f"CuTe DSL runtime is not available. Import error: {_cute_dsl_import_error}"
+    ) from _cute_dsl_import_error
+
+
+def _get_gpu_arch(device: torch.device | None = None) -> str:
+    capability = torch.cuda.get_device_capability(device)
+    gpu_arch = f"sm_{capability[0]}{capability[1]}a"
+    if gpu_arch not in SUPPORTED_GPU_ARCHS:
+        supported = ", ".join(SUPPORTED_GPU_ARCHS)
+        raise ValueError(
+            f"Unsupported GPU architecture {gpu_arch}. Supported architectures: {supported}."
+        )
+    return gpu_arch
+
+
+def _validate_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+) -> None:
+    """Validate the (B, S, H, D) layout the backend feeds the kernel."""
+    if not (q.dim() == k.dim() == v.dim() == o.dim() == 4):
+        raise ValueError("FMHA expects 4D (B, S, H, D) Q/K/V/O tensors.")
+    if q.dtype != k.dtype:
+        raise ValueError(f"Q/K dtype mismatch: {q.dtype} vs {k.dtype}")
+    if q.shape[0] != k.shape[0]:
+        raise ValueError(f"Batch size mismatch: q={q.shape[0]} vs k={k.shape[0]}")
+    if q.shape[-1] != k.shape[-1]:
+        raise ValueError(f"Q/K head dim mismatch: {q.shape[-1]} vs {k.shape[-1]}")
+    if k.shape[:-1] != v.shape[:-1]:
+        raise ValueError(f"K/V shape mismatch: {k.shape[:-1]} vs {v.shape[:-1]}")
+    expected_o_shape = (*q.shape[:-1], v.shape[-1])
+    if tuple(o.shape) != expected_o_shape:
+        raise ValueError(f"Output shape mismatch: {tuple(o.shape)} vs {expected_o_shape}")
+
+
+def _to_cute_tensor(tensor: torch.Tensor, leading_dim: int, cutlass_element_type=None):
+    """Wrap a torch tensor as a CuTe tensor.
+
+    For sub-byte / non-torch-dtype elements (FP4 packed as uint8, MXFP8 SF exponents stored as
+    uint8), pass `cutlass_element_type` to override the interpretation; the tensor storage must be
+    byte-addressable (uint8 / int8). Otherwise the FP8-e4m3 path and the default
+    direct-from-dlpack path apply.
+    """
+    # Match cutlass.torch.cute_tensor_like: set element_type BEFORE mark_layout_dynamic so the
+    # layout transformation sees the override-typed tensor and carries it forward.
+    if cutlass_element_type is not None:
+        cute_tensor = from_dlpack(tensor.view(torch.int8), assumed_align=16)
+        cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+        cute_tensor.element_type = cutlass_element_type
+        return cute_tensor
+    if tensor.dtype == torch.float8_e4m3fn:
+        cute_tensor = from_dlpack(tensor.view(torch.int8), assumed_align=16)
+        cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+        cute_tensor.element_type = cutlass.Float8E4M3FN
+        return cute_tensor
+    return from_dlpack(tensor, assumed_align=16).mark_layout_dynamic(leading_dim=leading_dim)
+
+
+# ============================================================================
+# JIT compile + cache
+# ============================================================================
+
+
+def _torch_to_cutlass_dtype(t: torch.dtype):
+    table = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+        torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+    }
+    try:
+        return table[t]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported torch dtype for CuTe DSL FMHA: {t}") from exc
+
+
+class _CacheKey(NamedTuple):
+    qk_cutlass_dtype: Any
+    pv_cutlass_dtype: Any
+    out_cutlass_dtype: Any
+    qk_acc_dtype: Any
+    pv_acc_dtype: Any
+    head_dim: int
+    head_dim_v: int
+    mma_tiler_mn: Tuple[int, int]
+    qk_sf_vec: int  # 0 = dense/sage/QK16PV8; 32 = MXFP8; 16 = NVFP4 (selects block-scaled kernel)
+    is_persistent: bool
+    mask_type: Any  # fmha_utils.MaskEnum
+    with_lse: bool
+    with_sink: bool
+    has_window: bool
+    has_skip_softmax: bool
+    use_tma_store: bool
+    enable_ex2_emulation: bool
+    enable_skip_correction: bool
+    gpu_arch_str: str
+
+
+_COMPILE_CACHE: dict = {}
+
+
+def clear_cute_dsl_fmha_cache() -> None:
+    """Drop all compiled CuTe DSL FMHA kernels (for tests / teardown)."""
+    _COMPILE_CACHE.clear()
+
+
+def _get_or_compile(key: _CacheKey, compile_args: tuple):
+    cached = _COMPILE_CACHE.get(key)
+    if cached is not None:
+        return cached
+    hd, hd_v = key.head_dim, key.head_dim_v
+    head_dim_arg = hd if hd == hd_v else (hd, hd_v)
+    if key.qk_sf_vec != 0:
+        fmha = BlackwellFusedMultiHeadBlockScaledAttentionForward(
+            key.qk_acc_dtype,
+            key.pv_acc_dtype,
+            key.mma_tiler_mn,
+            head_dim_arg,
+            key.is_persistent,
+            key.mask_type,
+            key.enable_ex2_emulation,
+            key.enable_skip_correction,
+            key.qk_sf_vec,
+            use_tma_store=key.use_tma_store,
+        )
+    else:
+        fmha = BlackwellFusedMultiHeadAttentionForward(
+            key.qk_acc_dtype,
+            key.pv_acc_dtype,
+            key.mma_tiler_mn,
+            head_dim_arg,
+            key.is_persistent,
+            key.mask_type,
+            key.enable_ex2_emulation,
+            key.enable_skip_correction,
+            use_tma_store=key.use_tma_store,
+        )
+    logger.info(
+        f"Compiling CuTe DSL FMHA kernel for {key.qk_cutlass_dtype.__name__}/"
+        f"{key.pv_cutlass_dtype.__name__} head_dim={key.head_dim} "
+        f"mask={key.mask_type.name} persistent={key.is_persistent} "
+        f"lse={key.with_lse} on {key.gpu_arch_str} ..."
+        f"qk_sf_vec={key.qk_sf_vec} "
+    )
+    compiled = cute.compile(fmha, *compile_args)
+    _COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+@torch.compiler.disable
+def cute_dsl_fmha_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    *,
+    is_causal: bool = False,
+    sm_scale: float | None = None,
+    window_left: int = -1,
+    window_right: int = -1,
+    lse: torch.Tensor | None = None,
+    scale_q: float | torch.Tensor = 1.0,
+    scale_k: float | torch.Tensor = 1.0,
+    scale_v: float | torch.Tensor = 1.0,
+    scale_o: float | torch.Tensor = 1.0,
+    is_persistent: bool = True,
+    skip_softmax_threshold_scale_factor: float | None = None,
+    qk_sf_vec: int = 0,
+    q_sf: torch.Tensor | None = None,
+    k_sf: torch.Tensor | None = None,
+    qk_cutlass_dtype: Any = None,
+) -> None:
+    """JIT-compile (or fetch from cache) and launch the CuTe DSL FMHA kernel.
+
+    Expects contiguous 4D (B, S, H, D) Q/K/V/O tensors with uniform per-batch sequence lengths.
+    Varlen via indptr is intentionally not exposed — callers pack uniform-length sequences.
+
+    When `qk_sf_vec` is non-zero, dispatches to the block-scaled kernel class:
+    32 selects MXFP8 (Q/K stored as FP8 e4m3, SFs as Float8E8M0FNU uint8 storage);
+    16 selects NVFP4 (Q/K stored as packed FP4 in torch.uint8, SFs as Float8E4M3FN in uint8 storage).
+    """
+    _check_cute_runtime_available()
+    _validate_inputs(q, k, v, o)
+    if qk_sf_vec != 0:
+        if q_sf is None or k_sf is None:
+            raise ValueError("Block-scaled path (qk_sf_vec != 0) requires q_sf and k_sf tensors.")
+        if not q_sf.is_contiguous() or not k_sf.is_contiguous():
+            raise ValueError("q_sf and k_sf must be contiguous.")
+
+    # The kernel hard-codes dense strides in its CuTe layout (fmha.py:447-461) and ignores the
+    # input tensor's actual strides, so non-dense inputs (e.g. `qkv.split(...)` views) would
+    # be read at wrong offsets. .contiguous() is a no-op when the tensor is already dense.
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    if not o.is_contiguous():
+        raise ValueError("Output tensor `o` must be contiguous (writes happen in place).")
+    if lse is not None and not lse.is_contiguous():
+        raise ValueError("LSE tensor must be contiguous (writes happen in place).")
+
+    # Delay scalar extraction to inside @torch.compiler.disable decoration
+    def _scalar_float(t):
+        if isinstance(t, torch.Tensor):
+            return t.item()
+        else:
+            return t
+
+    scale_q = _scalar_float(scale_q)
+    scale_k = _scalar_float(scale_k)
+    scale_v = _scalar_float(scale_v)
+    scale_o = _scalar_float(scale_o)
+
+    # Reshape (B, S, H, D) → (B, S, h_kv, h_r, D) for Q/O and (B, S, h_kv, 1, D) for K/V; LSE
+    # goes (B, S, H) → (B, S, h_kv, h_r). Layout matches fmha.py:run() (no head_dim split).
+    # For NVFP4 (qk_cutlass_dtype == Float4E2M1FN), Q/K's storage last-dim is head_dim//2.
+    # We keep the packed shape through the view; the kernel's FP4 element_type override resolves
+    # element-unit strides to the right byte addresses.
+    batch_size, seq_len_q, num_heads_q, qk_storage_dim = q.shape
+    _, seq_len_kv, num_heads_kv, _ = k.shape
+    value_head_dim = v.shape[-1]
+    num_head_groups = num_heads_q // num_heads_kv
+    is_fp4 = qk_cutlass_dtype is cutlass.Float4E2M1FN
+    head_dim = qk_storage_dim * 2 if is_fp4 else qk_storage_dim
+    if qk_sf_vec != 0 and head_dim != 128:
+        raise ValueError(
+            f"MXFP8 / NVFP4 (qk_sf_vec={qk_sf_vec}) currently requires head_dim=128, "
+            f"got head_dim={head_dim}."
+        )
+
+    q_5d = q.view(batch_size, seq_len_q, num_heads_kv, num_head_groups, qk_storage_dim)
+    o_5d = o.view(batch_size, seq_len_q, num_heads_kv, num_head_groups, value_head_dim)
+    k_5d = k.view(batch_size, seq_len_kv, num_heads_kv, 1, qk_storage_dim)
+    v_5d = v.view(batch_size, seq_len_kv, num_heads_kv, 1, value_head_dim)
+    lse_4d = (
+        lse.view(batch_size, seq_len_q, num_heads_kv, num_head_groups) if lse is not None else None
     )
 
-    if _cute_runtime_import_error is not None:
-        raise ImportError(_cute_runtime_import_error)
-except (ImportError, OSError) as e:
-    cute_dsl = None
-    _cute_dsl_import_error = e
+    # Map is_causal / window args onto the published MaskEnum surface.
+    has_window = is_causal or window_left != -1 or window_right != -1
+    if is_causal:
+        mask_type = fmha_utils.MaskEnum.WINDOW_MASK
+        ws_l_int = None if window_left == -1 else window_left
+        ws_r_int = 0 if window_right == -1 else window_right
+    elif has_window:
+        mask_type = fmha_utils.MaskEnum.WINDOW_MASK
+        ws_l_int = None if window_left == -1 else window_left
+        ws_r_int = None if window_right == -1 else window_right
+    else:
+        mask_type = fmha_utils.MaskEnum.RESIDUAL_MASK
+        ws_l_int = None
+        ws_r_int = None
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+    scale_softmax = scale_q * scale_k * sm_scale
+    scale_softmax_log2 = scale_softmax * math.log2(math.exp(1.0))
+    scale_output = scale_v / scale_o
+
+    use_skip_softmax = (
+        skip_softmax_threshold_scale_factor is not None and skip_softmax_threshold_scale_factor > 0
+    )
+    skip_threshold_log2 = (
+        cute_typing.Float32(math.log2(skip_softmax_threshold_scale_factor / seq_len_kv))
+        if use_skip_softmax
+        else None
+    )
+
+    # For the block-scaled paths Q/K may be FP4 (stored as torch.uint8) or FP8 e4m3; pass
+    # qk_cutlass_dtype to override the inferred element type for FP4 (FP8 e4m3 is auto-detected).
+    q_cute = _to_cute_tensor(q_5d, leading_dim=4, cutlass_element_type=qk_cutlass_dtype)
+    k_cute = _to_cute_tensor(k_5d, leading_dim=4, cutlass_element_type=qk_cutlass_dtype)
+    v_cute = _to_cute_tensor(v_5d, leading_dim=4)
+    o_cute = _to_cute_tensor(o_5d, leading_dim=4)
+    if qk_sf_vec != 0:
+        # MXFP8 SFs are Float8E8M0FNU (uint8 storage); NVFP4 SFs are Float8E4M3FN.
+        sf_dtype = cutlass.Float8E8M0FNU if qk_sf_vec == 32 else cutlass.Float8E4M3FN
+        q_sf_cute = _to_cute_tensor(q_sf, leading_dim=0, cutlass_element_type=sf_dtype)
+        k_sf_cute = _to_cute_tensor(k_sf, leading_dim=0, cutlass_element_type=sf_dtype)
+    else:
+        q_sf_cute = None
+        k_sf_cute = None
+    # lse_4d is (B, S_q, h_kv, h_r) contiguous → h_r is the stride-1 inner dim (index 3).
+    lse_cute = (
+        from_dlpack(lse_4d, assumed_align=16).mark_layout_dynamic(leading_dim=3)
+        if lse_4d is not None
+        else None
+    )
+
+    ws_left = None if ws_l_int is None else cute_typing.Int32(ws_l_int)
+    ws_right = None if ws_r_int is None else cute_typing.Int32(ws_r_int)
+
+    # problem_size = (b, s_q_max, s_lse_max, s_k_max, h_q, h_k, d, dv); with cum_seqlen_* = None,
+    # s_lse_max collapses to s_q (per fmha.py:run()).
+    problem_size = (
+        batch_size,
+        seq_len_q,
+        seq_len_q,
+        seq_len_kv,
+        num_heads_q,
+        num_heads_kv,
+        head_dim,
+        value_head_dim,
+    )
+    stream = cuda_driver.CUstream(torch.cuda.current_stream(q.device).cuda_stream)
+
+    gpu_arch_str = _get_gpu_arch(q.device)
+    qk_dtype_cache = (
+        qk_cutlass_dtype if qk_cutlass_dtype is not None else _torch_to_cutlass_dtype(q.dtype)
+    )
+    # SM100 needs ex2 emulation; SM103 (and any other SM10X SKU) does not.
+    enable_ex2_emulation = gpu_arch_str == "sm_100a"
+
+    key = _CacheKey(
+        qk_cutlass_dtype=qk_dtype_cache,
+        pv_cutlass_dtype=_torch_to_cutlass_dtype(v.dtype),
+        out_cutlass_dtype=_torch_to_cutlass_dtype(o.dtype),
+        qk_acc_dtype=cutlass.Float32,
+        pv_acc_dtype=cutlass.Float32,
+        head_dim=head_dim,
+        head_dim_v=value_head_dim,
+        mma_tiler_mn=(128, 128),
+        qk_sf_vec=qk_sf_vec,
+        is_persistent=is_persistent,
+        mask_type=mask_type,
+        with_lse=lse is not None,
+        with_sink=False,
+        has_window=has_window,
+        has_skip_softmax=use_skip_softmax,
+        use_tma_store=True,
+        enable_ex2_emulation=enable_ex2_emulation,
+        enable_skip_correction=True,
+        gpu_arch_str=gpu_arch_str,
+    )
+
+    if qk_sf_vec != 0:
+        launch_args = (
+            q_cute,
+            k_cute,
+            q_sf_cute,
+            k_sf_cute,
+            v_cute,
+            o_cute,
+            problem_size,
+            None,  # cum_seqlen_q
+            None,  # cum_seqlen_k
+            lse_cute,
+            None,  # sink
+            cute_typing.Float32(scale_softmax_log2),
+            cute_typing.Float32(scale_softmax),
+            cute_typing.Float32(scale_output),
+            None,  # scale_v_channels
+            skip_threshold_log2,
+            ws_left,
+            ws_right,
+            None,  # skip_softmax_count
+            None,  # total_softmax_count
+            stream,
+            False,  # use_pdl
+        )
+    else:
+        launch_args = (
+            q_cute,
+            k_cute,
+            v_cute,
+            o_cute,
+            problem_size,
+            None,  # cum_seqlen_q
+            None,  # cum_seqlen_k
+            lse_cute,
+            None,  # sink
+            cute_typing.Float32(scale_softmax_log2),
+            cute_typing.Float32(scale_softmax),
+            cute_typing.Float32(scale_output),
+            skip_threshold_log2,
+            ws_left,
+            ws_right,
+            None,  # skip_softmax_count
+            None,  # total_softmax_count
+            stream,
+            False,  # use_pdl
+        )
+
+    compiled = _get_or_compile(key, launch_args)
+    compiled(*launch_args)
+
+
+# ============================================================================
+# Block-scaled (MXFP8 / NVFP4) Q/K quantization
+# ============================================================================
+
+
+_FP8_E4M3_MAX = 448.0  # FP8 e4m3 max magnitude
+_FP4_E2M1_MAX = 6.0  # FP4 e2m1 max magnitude
+
+
+def _quantize_blockscaled_one(
+    x_bshd: torch.Tensor, qk_sf_vec: int
+) -> Tuple[torch.Tensor, torch.Tensor, float]:
+    """Quantize a single (B, S, H, D) bf16/fp16 tensor for the block-scaled kernel.
+
+    Steps:
+      1. Transpose to (B, H, S, D) — GEMM-compatible (num_heads is batch-like).
+      2. Pad S -> S_pad (multiple of 128) along the row axis.
+      3. Invoke the TRT-LLM op with proper options.
+      4. Reshape the quantized data, unpad to S, and transpose back to BSHD.
+         The SF tensor stays at S_pad per kernel constraints.
+
+    The returned data tensor's last dim is the *storage* dim: D for MXFP8 ; D/2 for NVFP4.
+
+    Returns:
+        x_q:    quantized data in (B, S, H, D_storage);
+        x_sf:   swizzled SF tensor produced by the op (kept padded to S_pad).
+        scale:  scalar dequant factor to fold into scale_softmax.
+                1.0 for MXFP8 (per-block SFs carry the full range);
+                amax/(448*6) for NVFP4 (the per-tensor global scale).
+    """
+    if x_bshd.dim() != 4:
+        raise ValueError(f"_quantize_blockscaled_one expects (B, S, H, D); got {x_bshd.shape}")
+    batch_size, seq_len, num_heads, head_dim = x_bshd.shape
+
+    x_bhsd = x_bshd.transpose(1, 2).contiguous()  # (B, H, S, D)
+    s_pad = ((seq_len + 127) // 128) * 128
+    if s_pad != seq_len:
+        pad = torch.zeros(
+            batch_size,
+            num_heads,
+            s_pad - seq_len,
+            head_dim,
+            dtype=x_bhsd.dtype,
+            device=x_bhsd.device,
+        )
+        x_bhsd = torch.cat([x_bhsd, pad], dim=2)
+    x_2d = x_bhsd.reshape(batch_size * num_heads * s_pad, head_dim)
+
+    if qk_sf_vec == 32:
+        # MXFP8: per-32-element block, UE8M0 SFs in swizzled layout.
+        x_q_2d, x_sf = torch.ops.trtllm.mxfp8_quantize(x_2d, True, alignment=32)
+        # x_q_2d shape: (M, D) fp8_e4m3fn; storage last-dim == logical head_dim.
+        x_q = x_q_2d.view(batch_size, num_heads, s_pad, head_dim)
+        x_q = x_q[:, :, :seq_len, :].transpose(1, 2).contiguous()  # (B, S, H, D)
+        return x_q, x_sf, 1.0
+
+    if qk_sf_vec == 16:
+        # NVFP4: per-16-element block, E4M3 SFs in swizzled layout; per-tensor global scale folded
+        # into the returned `scale` (caller multiplies it into scale_softmax via scale_q / scale_k).
+        amax = x_2d.float().abs().amax().clamp(min=1e-6)
+        global_sf = (_FP8_E4M3_MAX * _FP4_E2M1_MAX) / amax
+        global_sf_t = global_sf.to(torch.float32).reshape(1)
+        x_q_2d, x_sf = torch.ops.trtllm.fp4_quantize(x_2d, global_sf_t, 16, False)
+        # x_q_2d shape: (M, D/2) uint8 — natural packed layout (2 FP4 / byte).
+        head_dim_packed = head_dim // 2
+        x_q = x_q_2d.view(batch_size, num_heads, s_pad, head_dim_packed)
+        x_q = x_q[:, :, :seq_len, :].transpose(1, 2).contiguous()  # (B, S, H, D/2)
+        return x_q, x_sf, amax / (_FP8_E4M3_MAX * _FP4_E2M1_MAX)
+
+    raise ValueError(f"Unsupported qk_sf_vec={qk_sf_vec}; expected 0, 16, or 32.")
+
+
+# ============================================================================
+# VisualGen AttentionBackend class
+# ============================================================================
 
 
 class CuTeDSLAttention(AttentionBackend):
     """
     CuTe DSL (NVIDIA kernels) backend for diffusion models.
 
-    Uses pre-compiled cubin kernels (head_dim=128 only).
+    JIT-compiles BlackwellFusedMultiHeadAttentionForward on first use and caches the
+    compiled artifact per (dtype, mask, head_dim, ...) configuration.
     """
 
     def __init__(
@@ -56,15 +546,12 @@ class CuTeDSLAttention(AttentionBackend):
         layer_idx: int = 0,
         num_heads: int = 8,
         head_dim: int = 64,
-        num_kv_heads: Optional[int] = None,
-        dtype: Optional[torch.dtype] = None,
-        quant_attention_config: Optional[QuantAttentionConfig] = None,
-        skip_softmax_threshold_scale: Optional[float] = None,
+        num_kv_heads: int | None = None,
+        dtype: torch.dtype | None = None,
+        quant_attention_config: QuantAttentionConfig | None = None,
+        skip_softmax_threshold_scale: float | None = None,
         **kwargs,
     ):
-        # Only head_dim=128 cubins are packaged.
-        if head_dim != 128:
-            raise ValueError(f"CUTEDSL cubins require head_dim=128, got head_dim={head_dim}.")
         self.layer_idx = layer_idx
         self.num_heads = num_heads
         self.head_dim = head_dim
@@ -76,6 +563,31 @@ class CuTeDSLAttention(AttentionBackend):
 
         # CuTe DSL expects [B, S, H, D] format
         self._preferred_layout = AttentionTensorLayout.NHD
+
+    def _smooth_qk(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        alpha: float = 0.7,
+    ):
+        """Smooth-Smooth technique:
+        Performs SmoothQuant-like handling for Qk, leveraging the additional fact that
+        K - K_mean doesn't affect attention result.
+        """
+        k = k.unflatten(2, (-1, 1))  # (B, S, H_K, 1, D)
+        q = q.unflatten(2, (k.shape[2], -1))  # (B, S, H_K, H_R, D)
+        q_max = (
+            q.abs().amax(dim=(0, 1, 3), keepdim=True).float().clamp_min(1e-4)
+        )  # (1, 1, H_K, 1, D)
+        k_max = (
+            k.abs().amax(dim=(0, 1, 3), keepdim=True).float().clamp_min(1e-4)
+        )  # (1, 1, H_K, 1, D)
+        s = (q_max.pow(alpha) / k_max.pow(1 - alpha)).clamp(1e-4, 1e4)
+        q = q * s.reciprocal().bfloat16()
+        # Per-channel shift commutes with the per-channel smooth scale `s`.
+        k = k - k.mean(dim=(0, 1, 3), keepdim=True)
+        k = k * s.bfloat16()
+        return q.flatten(2, 3), k.flatten(2, 3)
 
     def _prepare_inputs(
         self,
@@ -92,16 +604,22 @@ class CuTeDSLAttention(AttentionBackend):
 
         is_causal = attention_mask == PredefinedAttentionMask.CAUSAL
 
-        # Packaged cubins support float16 and bfloat16 only.
+        # Perform QK-smoothing if Bmm1 is to be quantized.
+        qac = self.quant_attention_config
+        smooth_qk = qac is not None and qac.qk_dtype not in ["bf16", "fp16"]
+
+        # Published kernel supports float16 and bfloat16 only.
         origin_dtype = q.dtype
         if q.dtype not in (torch.float16, torch.bfloat16):
             q = q.to(torch.bfloat16)
             k = k.to(torch.bfloat16)
             v = v.to(torch.bfloat16)
+        if smooth_qk:
+            q, k = self._smooth_qk(q, k)
         return q, k, v, is_causal, origin_dtype
 
-    # cute_dsl.cute_dsl_fmha_fwd is already decorated with @torch.compiler.disable
-    # Allow torch.compile to fuse preceding linear/norm with quantization of V / seq-preprocess
+    # cute_dsl_fmha_fwd is already @torch.compiler.disable'd, so torch.compile may still fuse
+    # preceding linear/norm with the V quantization below.
     def _fwd(
         self,
         q: torch.Tensor,
@@ -111,7 +629,7 @@ class CuTeDSLAttention(AttentionBackend):
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         batch_size, seq_len_q, num_heads, _ = q.shape
-        _, seq_len_kv, _, value_head_dim = v.shape
+        value_head_dim = v.shape[-1]
         out = torch.empty(
             batch_size,
             seq_len_q,
@@ -128,42 +646,48 @@ class CuTeDSLAttention(AttentionBackend):
             device=q.device,
         )
 
-        # Options that instructs quantization of V
+        # V quantization (per-tensor FP8) for QK16PV8 / MXFP8 / NVFP4.
         scale_v = kwargs.get("scale_v", 1.0)
-        if self.quant_attention_config is not None:
+        scale_q = kwargs.get("scale_q", 1.0)
+        scale_k = kwargs.get("scale_k", 1.0)
+        qac = self.quant_attention_config
+        q_sf = k_sf = qk_cutlass_dtype = None
+        qk_sf_vec = 0
+        if qac is not None:
+            if qac.qk_sf_vec != 0:
+                # MXFP8 / NVFP4 (block-scaled Q@K). Per-block SFs come from ops.trtllm.*_quantize.
+                qk_sf_vec = qac.qk_sf_vec
+                q, q_sf, gs_q = _quantize_blockscaled_one(q, qk_sf_vec)
+                k, k_sf, gs_k = _quantize_blockscaled_one(k, qk_sf_vec)
+                scale_q = scale_q * gs_q
+                scale_k = scale_k * gs_k
+                qk_cutlass_dtype = cutlass.Float4E2M1FN if qk_sf_vec == 16 else cutlass.Float8E4M3FN
             v_qscale = 448.0 / v.abs().amax().clamp(min=1e-3)
             v = (v * v_qscale).to(torch.float8_e4m3fn)
             scale_v = scale_v / v_qscale
-
-        # Sequence preproc.
-        qo_indptr_host = [i * seq_len_q for i in range(batch_size + 1)]
-        qo_indptr = torch.tensor(qo_indptr_host).to(device=q.device, dtype=torch.int32)
-        kv_indptr_host = [i * seq_len_kv for i in range(batch_size + 1)]
-        kv_indptr = torch.tensor(kv_indptr_host).to(device=q.device, dtype=torch.int32)
 
         # Skip softmax.
         skip_softmax_threshold_scale = self.skip_softmax_threshold_scale
         if skip_softmax_threshold_scale is not None and skip_softmax_threshold_scale <= 0.0:
             skip_softmax_threshold_scale = None
 
-        cute_dsl.cute_dsl_fmha_fwd(
-            q.flatten(0, 1).contiguous(),
-            k.flatten(0, 1).contiguous(),
-            v.flatten(0, 1).contiguous(),
-            out.flatten(0, 1),
-            qo_indptr=qo_indptr,
-            kv_indptr=kv_indptr,
+        cute_dsl_fmha_fwd(
+            q,
+            k,
+            v,
+            out,
             is_causal=is_causal,
             sm_scale=self.scale,
-            lse=lse.flatten(0, 1).contiguous(),
-            scale_q=kwargs.get("scale_q", 1.0),
-            scale_k=kwargs.get("scale_k", 1.0),
+            lse=lse,
+            scale_q=scale_q,
+            scale_k=scale_k,
             scale_v=scale_v,
             scale_o=kwargs.get("scale_o", 1.0),
-            max_qo_len=seq_len_q,
-            max_kv_len=seq_len_kv,
-            is_persistent=False,
             skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale,
+            qk_sf_vec=qk_sf_vec,
+            q_sf=q_sf,
+            k_sf=k_sf,
+            qk_cutlass_dtype=qk_cutlass_dtype,
         )
         return out, lse
 

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/cute_dsl/fmha.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/cute_dsl/fmha.py
@@ -155,11 +155,12 @@ class _CacheKey(NamedTuple):
     head_dim: int
     head_dim_v: int
     mma_tiler_mn: Tuple[int, int]
-    qk_sf_vec: int  # 0 = dense/sage/QK16PV8; 32 = MXFP8; 16 = NVFP4 (selects block-scaled kernel)
+    qk_sf_vec: int  # 0 = dense Q/K; 32 = MXFP8; 16 = NVFP4
     is_persistent: bool
     mask_type: Any  # fmha_utils.MaskEnum
     with_lse: bool
     with_sink: bool
+    with_scale_v_channels: bool
     has_window: bool
     has_skip_softmax: bool
     use_tma_store: bool
@@ -234,6 +235,7 @@ def cute_dsl_fmha_fwd(
     scale_q: float | torch.Tensor = 1.0,
     scale_k: float | torch.Tensor = 1.0,
     scale_v: float | torch.Tensor = 1.0,
+    scale_v_channels: torch.Tensor | None = None,
     scale_o: float | torch.Tensor = 1.0,
     is_persistent: bool = True,
     skip_softmax_threshold_scale_factor: float | None = None,
@@ -258,6 +260,8 @@ def cute_dsl_fmha_fwd(
             raise ValueError("Block-scaled path (qk_sf_vec != 0) requires q_sf and k_sf tensors.")
         if not q_sf.is_contiguous() or not k_sf.is_contiguous():
             raise ValueError("q_sf and k_sf must be contiguous.")
+    elif scale_v_channels is not None:
+        raise ValueError("scale_v_channels is only supported by MXFP8 and NVFP4 kernels.")
 
     # The kernel hard-codes dense strides in its CuTe layout (fmha.py:447-461) and ignores the
     # input tensor's actual strides, so non-dense inputs (e.g. `qkv.split(...)` views) would
@@ -298,6 +302,19 @@ def cute_dsl_fmha_fwd(
             f"MXFP8 / NVFP4 (qk_sf_vec={qk_sf_vec}) currently requires head_dim=128, "
             f"got head_dim={head_dim}."
         )
+    if scale_v_channels is not None:
+        expected_scale_shape = (num_heads_kv, value_head_dim)
+        if tuple(scale_v_channels.shape) != expected_scale_shape:
+            raise ValueError(
+                f"scale_v_channels must have shape {expected_scale_shape}; "
+                f"got {tuple(scale_v_channels.shape)}."
+            )
+        if scale_v_channels.dtype != torch.float32:
+            raise ValueError("scale_v_channels must use torch.float32.")
+        if scale_v_channels.device != v.device:
+            raise ValueError("scale_v_channels must be on the same device as V.")
+        if not scale_v_channels.is_contiguous():
+            raise ValueError("scale_v_channels must be contiguous.")
 
     q_5d = q.view(batch_size, seq_len_q, num_heads_kv, num_head_groups, qk_storage_dim)
     o_5d = o.view(batch_size, seq_len_q, num_heads_kv, num_head_groups, value_head_dim)
@@ -348,9 +365,15 @@ def cute_dsl_fmha_fwd(
         sf_dtype = cutlass.Float8E8M0FNU if qk_sf_vec == 32 else cutlass.Float8E4M3FN
         q_sf_cute = _to_cute_tensor(q_sf, leading_dim=0, cutlass_element_type=sf_dtype)
         k_sf_cute = _to_cute_tensor(k_sf, leading_dim=0, cutlass_element_type=sf_dtype)
+        scale_v_channels_cute = (
+            _to_cute_tensor(scale_v_channels.view(-1), leading_dim=0)
+            if scale_v_channels is not None
+            else None
+        )
     else:
         q_sf_cute = None
         k_sf_cute = None
+        scale_v_channels_cute = None
     # lse_4d is (B, S_q, h_kv, h_r) contiguous → h_r is the stride-1 inner dim (index 3).
     lse_cute = (
         from_dlpack(lse_4d, assumed_align=16).mark_layout_dynamic(leading_dim=3)
@@ -396,6 +419,7 @@ def cute_dsl_fmha_fwd(
         mask_type=mask_type,
         with_lse=lse is not None,
         with_sink=False,
+        with_scale_v_channels=scale_v_channels is not None,
         has_window=has_window,
         has_skip_softmax=use_skip_softmax,
         use_tma_store=True,
@@ -420,7 +444,7 @@ def cute_dsl_fmha_fwd(
             cute_typing.Float32(scale_softmax_log2),
             cute_typing.Float32(scale_softmax),
             cute_typing.Float32(scale_output),
-            None,  # scale_v_channels
+            scale_v_channels_cute,
             skip_threshold_log2,
             ws_left,
             ws_right,
@@ -463,6 +487,20 @@ def cute_dsl_fmha_fwd(
 
 _FP8_E4M3_MAX = 448.0  # FP8 e4m3 max magnitude
 _FP4_E2M1_MAX = 6.0  # FP4 e2m1 max magnitude
+
+
+def _quantize_fp8_v(
+    v_bshd: torch.Tensor, per_head_channel: bool
+) -> Tuple[torch.Tensor, float | torch.Tensor, torch.Tensor | None]:
+    """Quantize V to FP8 with either one tensor scale or an (H, D) scale tensor."""
+    if per_head_channel:
+        v_qscale = _FP8_E4M3_MAX / v_bshd.float().abs().amax(dim=(0, 1)).clamp(min=1e-3)
+        v_quantized = (v_bshd * v_qscale).to(torch.float8_e4m3fn)
+        return v_quantized, 1.0, v_qscale.reciprocal().contiguous()
+
+    v_qscale = _FP8_E4M3_MAX / v_bshd.abs().amax().clamp(min=1e-3)
+    v_quantized = (v_bshd * v_qscale).to(torch.float8_e4m3fn)
+    return v_quantized, v_qscale.reciprocal(), None
 
 
 def _quantize_blockscaled_one(
@@ -646,25 +684,26 @@ class CuTeDSLAttention(AttentionBackend):
             device=q.device,
         )
 
-        # V quantization (per-tensor FP8) for QK16PV8 / MXFP8 / NVFP4.
+        # V is tensor-scaled by default. MXFP8/NVFP4 with v_block_size=1 use an (H, D) scale.
         scale_v = kwargs.get("scale_v", 1.0)
         scale_q = kwargs.get("scale_q", 1.0)
         scale_k = kwargs.get("scale_k", 1.0)
         qac = self.quant_attention_config
         q_sf = k_sf = qk_cutlass_dtype = None
         qk_sf_vec = 0
+        scale_v_channels = None
         if qac is not None:
-            if qac.qk_sf_vec != 0:
-                # MXFP8 / NVFP4 (block-scaled Q@K). Per-block SFs come from ops.trtllm.*_quantize.
-                qk_sf_vec = qac.qk_sf_vec
+            if qac.qk_dtype in ("mxfp8", "nvfp4"):
+                qk_sf_vec = 32 if qac.qk_dtype == "mxfp8" else 16
                 q, q_sf, gs_q = _quantize_blockscaled_one(q, qk_sf_vec)
                 k, k_sf, gs_k = _quantize_blockscaled_one(k, qk_sf_vec)
                 scale_q = scale_q * gs_q
                 scale_k = scale_k * gs_k
                 qk_cutlass_dtype = cutlass.Float4E2M1FN if qk_sf_vec == 16 else cutlass.Float8E4M3FN
-            v_qscale = 448.0 / v.abs().amax().clamp(min=1e-3)
-            v = (v * v_qscale).to(torch.float8_e4m3fn)
-            scale_v = scale_v / v_qscale
+            v, v_dequant_scale, scale_v_channels = _quantize_fp8_v(
+                v, per_head_channel=qk_sf_vec != 0 and qac.v_block_size == 1
+            )
+            scale_v = scale_v * v_dequant_scale
 
         # Skip softmax.
         skip_softmax_threshold_scale = self.skip_softmax_threshold_scale
@@ -682,6 +721,7 @@ class CuTeDSLAttention(AttentionBackend):
             scale_q=scale_q,
             scale_k=scale_k,
             scale_v=scale_v,
+            scale_v_channels=scale_v_channels,
             scale_o=kwargs.get("scale_o", 1.0),
             skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale,
             qk_sf_vec=qk_sf_vec,

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
@@ -49,8 +49,8 @@ def get_visual_gen_attention_backend(
                     Better performance but requires fused QKV
         - "FA4": Flash Attention 4; provides higher speedup on Blackwell GPUs (sm100)
                  Requires flash-attn package with cute interface
-        - "CUTEDSL": CuTe DSL FMHA kernels; uses packaged cubins when present,
-                     otherwise compiles from CuTe DSL source
+        - "CUTEDSL": CuTe DSL FMHA kernels; Best performance on Blackwell GPUs (sm100/sm103)
+                     Compiles from CuTe DSL source
     """
     # Lazy imports to avoid circular dependency
     from .cute_dsl import CuTeDSLAttention
@@ -116,9 +116,8 @@ def create_attention(
     """
     attn_cls = get_visual_gen_attention_backend(backend)
 
-    # Extract quant_attention_config from AttentionConfig and pass to backends
-    # that support it (TRTLLM SAGE recipes, CUTEDSL QK16PV8). AttentionConfig
-    # validation rejects unsupported (backend, recipe) combinations upstream.
+    # Extract quant_attention_config from AttentionConfig and pass to supported backends
+    # (TRTLLM SAGE / CUTEDSL QK16PV8); AttentionConfig's validator rejects unsupported combos.
     if attention_config is not None and attention_config.quant_attention_config is not None:
         kwargs["quant_attention_config"] = attention_config.quant_attention_config
     if backend.upper() == "TRTLLM":

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
@@ -49,7 +49,8 @@ def get_visual_gen_attention_backend(
                     Better performance but requires fused QKV
         - "FA4": Flash Attention 4; provides higher speedup on Blackwell GPUs (sm100)
                  Requires flash-attn package with cute interface
-        - "CUTEDSL": CuTe DSL FMHA kernels
+        - "CUTEDSL": CuTe DSL kernels. create_attention selects dense FMHA or VSA from
+                      AttentionConfig.sparse_attention_config.
     """
     # Lazy imports to avoid circular dependency
     from .cute_dsl import CuTeDSLAttention
@@ -104,8 +105,8 @@ def create_attention(
             will automatically reallocate if larger batches are encountered.
         max_seq_len: Initial sequence length for metadata pre-allocation. The backend
             will automatically reallocate if longer sequences are encountered.
-        attention_config: Optional AttentionConfig; quant_attention_config is
-            extracted and forwarded to the TRTLLM backend when present.
+        attention_config: Optional AttentionConfig used to select the attention algorithm and
+            forward its quantization or sparsity configuration.
         attention_metadata_state: Optional model-scoped metadata state from
             visual-gen config. Required for TRTLLM backend.
         **kwargs: Additional backend-specific arguments
@@ -115,8 +116,7 @@ def create_attention(
     """
     attn_cls = get_visual_gen_attention_backend(backend)
 
-    # Extract quant_attention_config from AttentionConfig and pass to supported backends
-    # (TRTLLM SAGE / CUTEDSL QK16PV8); AttentionConfig's validator rejects unsupported combos.
+    # Forward the validated quantization recipe to TRTLLM or the dense CuTe DSL FMHA backend.
     if attention_config is not None and attention_config.quant_attention_config is not None:
         kwargs["quant_attention_config"] = attention_config.quant_attention_config
     if backend.upper() == "TRTLLM":
@@ -131,7 +131,6 @@ def create_attention(
             attention_config.sparse_attention_config is not None
             and getattr(attention_config.sparse_attention_config, "algorithm", None) == "vsa"
         ):
-            # VSA sparse path: use VSAAttention
             from .cute_dsl.vsa import VSAAttention
 
             attn_cls = VSAAttention

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
@@ -49,8 +49,7 @@ def get_visual_gen_attention_backend(
                     Better performance but requires fused QKV
         - "FA4": Flash Attention 4; provides higher speedup on Blackwell GPUs (sm100)
                  Requires flash-attn package with cute interface
-        - "CUTEDSL": CuTe DSL FMHA kernels; Best performance on Blackwell GPUs (sm100/sm103)
-                     Compiles from CuTe DSL source
+        - "CUTEDSL": CuTe DSL FMHA kernels
     """
     # Lazy imports to avoid circular dependency
     from .cute_dsl import CuTeDSLAttention

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bde8e845611c0ff97738d3822da3ab406169596065bc703a8c8f1af58aeb4fbd
-size 711184

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d962a68d6d0c89ca5e71d0514b2ea5f1b1da3099c7c89ea4c05cf7c5468f6b0c
-size 686552

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4bc6c9ff687d1a49bdff39dffcf9e08f74c0114dc63921b458695d1b1add12df
-size 702960

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d71eff9707d7e4464e6b2847ece251c352c783b60056086841cfc1ad5767489
-size 682416

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:117b99d4733a4cf500515a22f5fb2c87b5c89ffdf7736bc302fff48b27b68289
-size 645672

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aed8d36370827808578ee1b2a7927a8bb964772ba1446a84d7eb66ae11857c28
-size 625128

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:909f85670f5cfeae51fb7e7ca2ec6ee648f272c72c0e65545c2f94a084bbd8d7
-size 637440

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb1bd11b767de8d4b039a4456f799a0461cc0cfa423e4ce97d6bddf1f289a81d
-size 616896

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4451124313741a07ee5c616c5fbaf3db110a1ab531bfc5955eeb2a126eb33d3e
-size 711096

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bad02325167d25248a381c9e8cfa4479d93e4f7f2d2bbfff0816db8b03e52ea
-size 690552

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:38e71c573fad3a61051b4037cd38ca42daaa2cc6f2c1a007af74c7d5e0107b71
-size 702872

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40cb6caa255f53e90c8c84fb5b5cf13b4776863d76f1d0ead0553fb3b574b169
-size 686424

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d48995a1b50324fb7f103a543bd8aa2d48ab8617a972e7bc594a834f78e7888
-size 645576

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fff35882b5e0bfbebf2b313a67c7a80398a68df411a1fb30542f11a2e9212f1
-size 629136

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1436b06493487e07c260e5ce283dcd85bfd9551db272d96d2e395788ed34ba5b
-size 637352

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:460134c26759d391ac0d4df94627e63794898425f887a210871259fc030d2157
-size 620904

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a6ea5c21b35d5562eec533b601348f527da2ed159c8d6f2a413f02d8b3dfce4
-size 657936

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed589e4c6f369afb05903be7bee828ab5f8293736cca734390d6eab9ac609f56
-size 637400

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99801a8fb3c547c9f5778764b14049229e07a7395a2f26e098112ca3968884eb
-size 653808

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:834109925ad81a8b50d44a436c34b9b9ff2f37bf87dc1c3420da10082f951f71
-size 629168

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:962849852e70fd20d8f086b9257173ddda4f6ca654ed4fa165768a5398e50e75
-size 596520

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8a040d0f9333c99a78cdf2baa42f2dc71cf2d8252ac3d1b7005f3afd7b4b536
-size 575976

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c241a35bb7ab27b9b4fe26c03f1a8ac4ba1eeb28cfc68fcc0f0d5133a74f393
-size 588288

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:285541f2d3d081f8726d79c7e6f484af55a06e52e7580fb58a360f9aad5e846b
-size 567744

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7284ff86f4d04fedf14e87947411e1765b55851ee9d9f12450f0314644abd8e
-size 657848

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f26d9fb521fea7260587558e4a5ec016c2c21b53f0fca580e65c46f7599c898
-size 641400

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d951a82391c4df1933bf1ff13bf7c455d90c95b19ebf3360c34a3151763ad9cc
-size 653720

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce18821322bdb617a5c26e52465ff1c02d6bd03f6f24ce7604a538a2862e107a
-size 633176

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5af2f95b9ff7328f1dce2863345ddbf72a39ec4cc0c3ce7601ad904d1c279bb3
-size 592328

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:afe75060cd7f3dd1a37704e2a4fe70aec59bcf60e83f6cc77c510fae8adb1209
-size 575888

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:807fc151395aabe1f4fb2bd0451d6d4f8def14e591cff121dc5426c2ee24b841
-size 588200

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/aarch64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e0faf35561762e27fbf861fe3385298f08da3aa9cc9564b9d3cd99c7fb2f74e5
-size 567656

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:20f59a88225f55116a6269dde1eb677bd527cb91eb1200058765c8c64356b9fb
-size 716248

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7666214fc5357f11f4db5cdae11c11f2c3a42679b30c1534535e12916aed578
-size 694232

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd18be0827da75961d58cb09d0c63fe0826ad9d1a83e16a44b74db43fb7b183b
-size 705936

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3a3da59ea39eb5d41e345a04ba0ab573fb6ef7d950091d4757ac27af2c736e5
-size 683984

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecd8a2048373f40ddf71a9706f7a16aef9fb0e5b6487937be695f6e7d0744161
-size 651128

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3407c3c3f177c8ab0b02c69c7cae9968710041d06acef9a10fc5ffa534ec274f
-size 630200

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f64ccf41ae8680369363660c1c350386a8b9784141853832fb49d2767e283a9e
-size 639728

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4eca236d41155a0e2c5b0f3289c5399b60589ffb5b679abff456202566e2bdf0
-size 618192

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d5ad69ef4a76110e48c4f1b6642e3e8b321dc1d794e83957b6228a8c68edfd4
-size 714872

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1896d588ebbbb6ffde8331432dafccbf996507504b6b86a0ba17bf539f2e8f9
-size 697240

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ce41d196fa54fb89e5848891e1e402d6511d0e5635098e98f00b0312ce3ad77
-size 704296

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2f45b423c9980f32c116718dca45f1b05e65ad9abd1e0a70e37a07c9106c6827
-size 686888

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:150cd0b8fa1834d00aa2de8ead15916bc08c4e4f5ba002683ceccca5dc15a793
-size 650496

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c0eab2d74850c29abd02aa927cc53da3ac730ebed1f8d62e5836c68c3c86a42
-size 635008

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d044e658d6d3fda52a038a0d0d8b9cce502f7e383bb96deec344d10e217a6e98
-size 640056

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_100a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:20bc7f069ea456ff8274d71dccaceeb979ba877e19a29d956753ebfa8e6000ad
-size 624504

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77fee6189e75f9b0233f7ccce9eec7d2f70b277f2f62d599c01f057e1c179235
-size 665400

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:182a606d2ca126fc83c2f914a6e5547d84a9aa668e3526710ca3e7396aac2f8e
-size 642776

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96052f92a4a4e9b8edc152a2e4e60d0b3c9ffc3e8cad0f72716f4be1072cea5e
-size 656112

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c4ca62124eb16d29903dde0f9cf9a46b8a72d3480fee3447736b6c4f2d71895
-size 632560

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9b8919f036acd199b4aed790563b63de6d1cfa3ef37bfeec00751a25ee5c29d
-size 600408

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eff71a1a8838b98ec684ada9e693db4f39a69527d8f072bb52ad3b136e2ad966
-size 580200

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e7d9c9e4ca723169a115029633811b97d6a57880274f668678218466bef9ee0
-size 591488

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_e4m3_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30f0681109e2520f4135d1bb4910d31c11b6d0aae64e09efc6705ba461e2eede
-size 568848

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a761c98700c565c98a0e7c7a67a569cf165cdf1fe1262c541ec066f60ffa7c1
-size 663704

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f21a9a2fc02f9ada3d126ee7c054f130fad0b16b62daadd63c881dc63991cf6b
-size 644472

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9edebdc6f4c23e407f057fba17144122f625db87a29bdd61d14951b8d05aadf
-size 655176

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_causal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9becebe7efb3c0342b41668b6d82888e5a100bccdf906a25c10402ee76b56115
-size 635160

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8239bc1f03bef805f46a356a9dcffa449dfa1f112ce8d39297f7cc272da60e48
-size 599536

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_lse_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:deb5f65d94e50b7466c027004c9fbfe0c7a5b9b67eec6c139496b70a7a0a85eb
-size 581984

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_skipsm_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dca9eeb79fe6a289db4cee5e9c2e8700dd9e138c149da1ec1299ea471efc3c8e
-size 589096

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/cubins/x86_64/sm_103a/cute_dsl_fmha_bf16_h128_nocausal_nonpersistent_varlen_tvmffi.so
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c24bd23172aa6d42fc3df1f7221e9ca3ce9c2b4e608386879f1734d58956fa45
-size 571544

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/fmha.py
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/fmha.py
@@ -309,7 +309,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             p_source,
         )
 
-    def _setup_attributes(self):
+    def _setup_attributes(self, enable_skip_softmax: bool) -> None:
         """Set up configurations and parameters for the FMHA kernel operation.
 
         This method initializes and configures various attributes required for the
@@ -334,7 +334,12 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.epi_stage = 2
 
         # Tunable parameters
-        self.rescale_threshold = 8.0 if self.enable_skip_correction else 0.0
+        if not self.enable_skip_correction:
+            self.rescale_threshold = 0.0
+        elif enable_skip_softmax:
+            self.rescale_threshold = 1.0
+        else:
+            self.rescale_threshold = 8.0
         # FP8 P pre-scale: offset added to exp2 exponent so that P*2^offset fills
         # more of E4M3's [0, 448] range, improving quantization precision.
         # Derived from rescale_threshold to guarantee P*2^offset <= 448.
@@ -503,7 +508,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         # V may use a different dtype (pv_dtype) to allow qk_dtype != pv_dtype.
         if cutlass.const_expr(self.q_dtype != self.k_dtype):
             raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
-        self._setup_attributes()
+        self._setup_attributes(skip_softmax_threshold_log2 is not None)
 
         cta_group = tcgen05.CtaGroup.ONE
         # the intermediate tensor p is from tmem & k-major

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/fmha_blockscaled.py
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/fmha_blockscaled.py
@@ -424,7 +424,7 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
             p_source,
         )
 
-    def _setup_attributes(self):
+    def _setup_attributes(self, enable_skip_softmax: bool) -> None:
         """Set up configurations and parameters for the FMHA kernel operation.
 
         This method initializes and configures various attributes required for the
@@ -449,7 +449,12 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
         self.epi_stage = 2
 
         # Tunable parameters
-        self.rescale_threshold = 8.0 if self.enable_skip_correction else 0.0
+        if not self.enable_skip_correction:
+            self.rescale_threshold = 0.0
+        elif enable_skip_softmax:
+            self.rescale_threshold = 1.0
+        else:
+            self.rescale_threshold = 8.0
         # FP8 P pre-scale: offset added to exp2 exponent so that P*2^offset fills
         # more of E4M3's [0, 448] range, improving quantization precision.
         # Derived from rescale_threshold to guarantee P*2^offset <= 448.
@@ -664,7 +669,7 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
                 "QK scale-factor TMEM footprint exceeds the static 32-column slot "
                 f"(qk_sf_tmem_cols={_qk_sf_tmem_cols}, k_sf_tmem_cols={_kqk_sf_tmem_cols})"
             )
-        self._setup_attributes()
+        self._setup_attributes(skip_softmax_threshold_log2 is not None)
 
         cta_group = tcgen05.CtaGroup.ONE
         # the intermediate tensor p is from tmem & k-major

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/fmha_blockscaled.py
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/blackwell/attention/fmha_blockscaled.py
@@ -26,12 +26,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# ruff: noqa: I001, E501, F841
+# ruff: noqa: I001, E501, F841, E712, E741
 
 import math
 from typing import Callable, Type, Tuple, Union, Optional
 from functools import partial
 
+import torch
 import cuda.bindings.driver as cuda
 
 import cutlass
@@ -41,7 +42,9 @@ from cutlass.cute.nvgpu.common import OperandMajorMode
 import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.torch as cutlass_torch
 import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass.cute.typing import Int8, Int32, Int64, Float32
 from cutlass.base_dsl.arch import Arch
 from cutlass.cutlass_dsl import BaseDSL
@@ -49,7 +52,8 @@ from cutlass.cutlass_dsl import BaseDSL
 from ...helpers import fmha_helpers as fmha_utils
 
 """
-A fused multi-head attention (FMHA) example for the NVIDIA Blackwell SM100 architecture using CUTE DSL
+A fused multi-head attention (FMHA) example where Bmm1(Q@K) is block-scaled with MXFP8 or NVFP4 for
+NVIDIA Blackwell SM100 architecture using CUTE DSL
 
 This example demonstrates an implementation of fused multi-head attention using a TMA + Blackwell SM100
 TensorCore warp-specialized persistent kernel. The implementation integrates the Q*K^T matrix multiplication,
@@ -66,21 +70,23 @@ To run this example:
 
 .. code-block:: bash
 
-    python examples/cute/blackwell/kernel/attention/fmha/fmha.py                                     \
+    python nvidia-internal/fmha_blockscaled.py                            \
+      --qk_mode MXFP8                                                     \
       --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
       --mma_tiler_mn 128,128                                              \
       --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \
       --is_persistent
 
 The above example runs FMHA with batch size 4, sequence length 1024, 8 attention heads, and head
-dimension 64. The Blackwell tcgen05 MMA tile shape is (128, 128), and the kernel uses fp16 for input/output
-with fp32 for accumulation.
+dimension 64. The Blackwell tcgen05 MMA tile shape is (128, 128), and the default runner uses BF16
+for V/output with FP32 for accumulation.
 
 To collect performance with NCU profiler:
 
 .. code-block:: bash
 
-    ncu python examples/cute/blackwell/kernel/attention/fmha/fmha.py                                 \
+    ncu python nvidia-internal/fmha_blockscaled.py                        \
+      --qk_mode NVFP4                                                     \
       --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
       --mma_tiler_mn 128,128                                              \
       --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \
@@ -88,7 +94,11 @@ To collect performance with NCU profiler:
       --iterations 10 --skip_ref_check
 
 Constraints for this example:
-* Supported head dimensions: 32, 64, and 128
+* Q and K use supports two microscaling schema:
+  MXFP8 (qk_dtype in {Float8E4M3FN, Float8E5M2}, qk_sf_dtype=Float8E8M0FNU, qk_sf_vec_size=32)
+  and NVFP4 (qk_dtype=Float4E2M1FN, qk_sf_dtype=Float8E4M3FN, qk_sf_vec_size=16)
+* Bmm2 (P@V) remains dense FP8 or BF16 through pv_dtype
+* Supported QK head dimensions: 128 (due to current limitations in blockscaled_utils)
 * Number of heads in Q must be divisible by number of heads in K
 * mma_tiler_mn must be 128,128
 * Batch size must be the same for Q, K, and V tensors
@@ -103,7 +113,92 @@ def make_thread_cooperative_group(size: int):
     return pipeline.CooperativeGroup(pipeline.Agent.Thread, size)
 
 
-class BlackwellFusedMultiHeadAttentionForward:
+def create_scale_factor_tensor(
+    mn: int,
+    k: int,
+    l: int,
+    sf_vec_size: int,
+    sf_dtype: Type[cutlass.Numeric],
+):
+    """
+    Create dense reference SFs and blocked device SF storage for QK block-scaled MMA.
+
+    Generates per-position SFs sampled from {0.5, 1.0, 2.0} (which are exactly representable in both
+    E8M0 and E4M3) and arranges them into the blocked storage that tile_atom_to_shape_SF,
+    BlockScaledBasicChunk consume on the kernel side. The SF atom layout is:
+        ((32,4),(sf_vec,4)) : ((16,4),(0,1))
+    so for a logical mn in [0,128) inside an atom, the SF byte lives at offset:
+        (mn % 32) * 16 + (mn // 32) * 4 + k_inner
+    """
+
+    def ceil_div(a: int, b: int) -> int:
+        return (a + b - 1) // b
+
+    atom_m = 32 * 4
+    atom_k = 4
+    m_atoms = ceil_div(mn, atom_m)
+    sf_k = ceil_div(k, sf_vec_size)
+    sf_k_atoms = ceil_div(sf_k, atom_k)
+
+    # Generate SFs in the LOGICAL (mn, sf_k, l) layout first, then re-arrange into the blocked
+    # storage layout explained in docstring above.
+    # CuTe decomposes mn in [0,128) column-major as (mn % 32, mn // 32), so the size-32 axis
+    # gets the LOW 5 bits of mn (stride 16) and the size-4 axis gets the HIGH 2 bits (stride 4).
+    mn_padded = m_atoms * atom_m
+    sf_k_padded = sf_k_atoms * atom_k
+    sf_choices = torch.tensor([0.5, 1.0, 2.0], dtype=torch.float32)
+    sf_logical_padded = sf_choices[torch.randint(0, len(sf_choices), (mn_padded, sf_k_padded, l))]
+    sf_storage_f32 = (
+        # K-mode: k_padded -> (sf_k_atoms, atom_k=4)
+        # MN-mode: mn_padded -> (sf_m_atoms, proton_m=4, neutron_m=32)
+        sf_logical_padded.reshape(m_atoms, 4, 32, sf_k_atoms, atom_k, l)
+        # Arrangement (last-idx-major): (l, sf_m_atoms, sf_k_atoms, neutron_m, proton_m, atom_k)
+        # (l, sf_m_atoms, sf_k_atoms) follows a traditional K-major interblock layout
+        # (atom_k) is the last index -> reproduces (sf_vec,atom_k):(0,1)
+        # (neutron_m, proton_m) -> reproduces
+        #   prod((neutron_m,proton_m):(proton_m:1), 1:atom_k) = (32,4):(16,4)
+        .permute(5, 0, 3, 2, 1, 4)
+        .contiguous()
+    )
+
+    sf_tensor, _ = cutlass_torch.cute_tensor_like(
+        sf_storage_f32,
+        sf_dtype,
+        is_dynamic_layout=True,
+        assumed_align=16,
+    )
+
+    sf_logical = sf_logical_padded[:mn, :sf_k, :]
+    # Broadcast each SF across its sf_vec_size K elements to build a elementwise (mn, k, l)
+    # reference whose (m, j, b) entry is the SF the kernel multiplies into the same logical position
+    ref_elementwise = (
+        sf_logical.unsqueeze(2)
+        .expand(-1, -1, sf_vec_size, -1)
+        .reshape(mn, sf_k * sf_vec_size, l)[:, :k, :]
+        .contiguous()
+    )
+
+    return ref_elementwise, sf_tensor
+
+
+def compact_fp4_data(torch_underlying: torch.Tensor, dtype: Type[cutlass.Numeric]) -> None:
+    """Compact packed FP4 rows to match CuTe's sub-byte stride interpretation."""
+    if dtype is not cutlass.Float4E2M1FN:
+        return
+
+    # torch lacks fill_/copy_ kernels for Float4_e2m1fn_x2 on CUDA, but the
+    # storage is byte-packed (two FP4 per byte), so a uint8 view is a free
+    # reinterpret and supports the in-place primitives we need.
+    d = torch_underlying.shape[-1]
+    packed_size = d // (8 // dtype.width)
+    underlying_u8 = torch_underlying.view(torch.uint8)
+    rows = underlying_u8.reshape(-1, d)
+    packed = rows[:, :packed_size].contiguous()
+    underlying_u8.fill_(0)
+    underlying_u8.flatten()[: packed.numel()].copy_(packed.flatten())
+
+
+class BlackwellFusedMultiHeadBlockScaledAttentionForward:
     arch_str: str = "sm_100"
     arch_name: str = "Blackwell SM100"
 
@@ -117,6 +212,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         mask_type: fmha_utils.MaskEnum,
         enable_ex2_emulation: bool,
         enable_skip_correction: bool,
+        qk_sf_vec_size: int,
         use_tma_store: bool = True,
     ):
         """Initializes the configuration for a Blackwell Fused Multi-Head Attention (FMHA) kernel.
@@ -163,6 +259,10 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         self.qk_acc_dtype = qk_acc_dtype
         self.pv_acc_dtype = pv_acc_dtype
+        if mma_tiler != (128, 128):
+            raise ValueError(
+                "This standalone kernel uses a static TMEM map and currently supports only mma_tiler=(128, 128)"
+            )
         if isinstance(head_dim, tuple):
             self.head_dim = head_dim[0]
             self.head_dim_v = head_dim[1]
@@ -191,6 +291,16 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.mask_type = mask_type
         self.enable_skip_correction = enable_skip_correction
         self.enable_ex2_emulation = enable_ex2_emulation
+        self.qk_sf_vec_size = qk_sf_vec_size
+        self.qk_mma_inst_bits_k = 256
+        if qk_sf_vec_size == 16:
+            # NVFP4: a 256-bit MMA operand tile covers 64 logical K values.
+            self.qk_mma_inst_tile_k = self.head_dim // (self.qk_mma_inst_bits_k // 4)
+        elif qk_sf_vec_size == 32:
+            # MXFP8: a 256-bit MMA operand tile covers 32 logical K values.
+            self.qk_mma_inst_tile_k = self.head_dim // (self.qk_mma_inst_bits_k // 8)
+        else:
+            self.qk_mma_inst_tile_k = 0
         self.use_tma_store = use_tma_store
 
         self.softmax0_warp_ids = (0, 1, 2, 3)
@@ -257,6 +367,10 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.tmem_p0_offset = 160
         # inplaced with s0
         self.tmem_p1_offset = 32
+        # Block-scaled QK scale factors are live only while issuing QK MMA.
+        # Keep each stage's scale buffers in the opposite S/P tile's tail columns.
+        self.tmem_qk0_sf_offset = 224
+        self.tmem_qk1_sf_offset = 96
         # vec buffer for row_max & row_sum
         # inplaced with s0
         self.tmem_vec0_offset = 0
@@ -275,7 +389,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.arch = BaseDSL._get_dsl().get_arch_enum()
 
         if self.arch >= Arch.sm_103:
-            assert self.enable_ex2_emulation == False, (  # noqa
+            assert self.enable_ex2_emulation == False, (
                 f"Don't enable exp2 emulation for {self.arch}, it doesn't help performance"
             )
 
@@ -286,12 +400,13 @@ class BlackwellFusedMultiHeadAttentionForward:
 
     def _make_qk_tiled_mma(self, cta_group):
         """Build the QK tiled MMA. Override in subclasses to target a different arch."""
-        return sm100_utils.make_trivial_tiled_mma(
+        return sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.q_dtype,
-            self.q_dtype,
+            self.k_dtype,
             self.q_major_mode,
             self.k_major_mode,
-            self.qk_acc_dtype,
+            self.qk_sf_dtype,
+            self.qk_sf_vec_size,
             cta_group,
             self.qk_mma_tiler[:2],
         )
@@ -353,6 +468,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         self,
         q_tensor: cute.Tensor,
         k_tensor: cute.Tensor,
+        q_sf_tensor: cute.Tensor,
+        k_sf_tensor: cute.Tensor,
         v_tensor: cute.Tensor,
         o_tensor: cute.Tensor,
         problem_size: Tuple[Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32],
@@ -363,6 +480,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         scale_softmax_log2: Float32,
         scale_softmax: Float32,
         scale_output: Float32,
+        scale_v_channels: Optional[cute.Tensor],
         skip_softmax_threshold_log2: Optional[Float32],
         window_size_left: Optional[Int32],
         window_size_right: Optional[Int32],
@@ -413,11 +531,12 @@ class BlackwellFusedMultiHeadAttentionForward:
         :raises TypeError: If tensor data types don't match or aren't supported
         :raises RuntimeError: If tensor layouts aren't in supported formats
         """
-        b, s_q_max, s_lse_max, s_k_max, h_q, h_k, d, dv = problem_size
+        b, s_q_max, s_lse_max, s_k_max, h_q, h_k, d_, dv_ = problem_size
         h_r = h_q // h_k
         # setup static attributes before smem/grid/tma computation
         self.q_dtype = q_tensor.element_type
         self.k_dtype = k_tensor.element_type
+        self.qk_sf_dtype = q_sf_tensor.element_type
         self.v_dtype = v_tensor.element_type
         self.o_dtype = o_tensor.element_type
 
@@ -426,10 +545,12 @@ class BlackwellFusedMultiHeadAttentionForward:
         s_k = k_tensor.shape[1]
         s_v = v_tensor.shape[1]
         s_lse = s_lse_max
+        d = self.head_dim
+        dv = self.head_dim_v
         # Important for performance
         align = 256 // self.o_dtype.width
-        d = cute.assume(Int32(d), align)
-        dv = cute.assume(Int32(dv), align)
+        assert d % align == 0, f"head_dim must be multiple of {align} for the given datatypes."
+        assert dv % align == 0, f"head_dim_v must be multiple of {align} for the given datatypes."
 
         stride_b_q = h_r * h_k * s_q * d if cum_seqlen_q is None else 0
         stride_b_o = h_r * h_k * s_q * dv if cum_seqlen_q is None else 0
@@ -449,6 +570,12 @@ class BlackwellFusedMultiHeadAttentionForward:
             stride=(d * h_k, 1, ((0, d), stride_b_k)),
         )
         k = cute.make_tensor(k_tensor.iterator, k_layout)
+        q_sf_layout = blockscaled_utils.tile_atom_to_shape_SF(q.shape, self.qk_sf_vec_size)
+        q_sf = cute.make_tensor(q_sf_tensor.iterator, q_sf_layout)
+        k_sf_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            (s_k, d, (h_k, b)), self.qk_sf_vec_size
+        )
+        k_sf = cute.make_tensor(k_sf_tensor.iterator, k_sf_layout)
         # (b, s_v, h_k, 1, dv) -> (dv, s_v, ((h_r, h_k), b)), 0-stride for h_r to broadcast
         v_layout = cute.make_layout(
             (dv, s_v, ((h_r, h_k), b)),
@@ -482,6 +609,19 @@ class BlackwellFusedMultiHeadAttentionForward:
         else:
             sink = None
 
+        if cutlass.const_expr(scale_v_channels is not None):
+            # scale_v_channels is per (h_k, dv): shape (h_k * dv,) row-major.
+            # Expose as (dv, ((h_r, h_k), b)) where h_r and b are 0-stride broadcasts.
+            scale_v_channels_layout = cute.make_layout(
+                (dv, ((h_r, h_k), b)),
+                stride=(1, ((0, dv), 0)),
+            )
+            m_scale_v_channels = cute.make_tensor(
+                scale_v_channels.iterator, scale_v_channels_layout
+            )
+        else:
+            m_scale_v_channels = None
+
         self.tile_sched_params, grid = fmha_utils.compute_grid(
             cute.shape((s_q_max, d, ((h_r, h_k), b))),
             self.cta_tiler,
@@ -503,6 +643,27 @@ class BlackwellFusedMultiHeadAttentionForward:
         # V may use a different dtype (pv_dtype) to allow qk_dtype != pv_dtype.
         if cutlass.const_expr(self.q_dtype != self.k_dtype):
             raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
+        if cutlass.const_expr(self.qk_sf_dtype != k_sf_tensor.element_type):
+            raise TypeError(
+                f"Q/K scale type mismatch: {self.qk_sf_dtype} != {k_sf_tensor.element_type}"
+            )
+        if cutlass.const_expr(self.qk_mma_inst_tile_k <= 0):
+            raise RuntimeError(
+                f"Invalid QK scale-factor tiling for head_dim={self.head_dim}, qk_sf_vec_size={self.qk_sf_vec_size}"
+            )
+        # SFQ + SFK share one 32-column TMEM slot per stage (see kernel TMEM layout
+        # below). Validate the static footprint on the host so we don't smuggle a
+        # `raise` into @cute.kernel.
+        _sf_atom_mn = 32
+        _qk_sf_tmem_cols = (self.qk_mma_tiler[0] // _sf_atom_mn) * self.qk_mma_inst_tile_k
+        _kqk_sf_tmem_cols = (
+            ((self.qk_mma_tiler[1] + 127) // 128 * 128) // _sf_atom_mn
+        ) * self.qk_mma_inst_tile_k
+        if cutlass.const_expr(_qk_sf_tmem_cols + _kqk_sf_tmem_cols > 32):
+            raise RuntimeError(
+                "QK scale-factor TMEM footprint exceeds the static 32-column slot "
+                f"(qk_sf_tmem_cols={_qk_sf_tmem_cols}, k_sf_tmem_cols={_kqk_sf_tmem_cols})"
+            )
         self._setup_attributes()
 
         cta_group = tcgen05.CtaGroup.ONE
@@ -529,6 +690,18 @@ class BlackwellFusedMultiHeadAttentionForward:
             qk_tiled_mma,
             self.qk_mma_tiler,
             self.k_dtype,
+            self.kv_stage,
+        )
+        q_sf_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.qk_sf_vec_size,
+            self.q_stage,
+        )
+        k_sf_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.qk_sf_vec_size,
             self.kv_stage,
         )
         p_tmem_layout_staged = sm100_utils.make_smem_layout_a(
@@ -588,6 +761,16 @@ class BlackwellFusedMultiHeadAttentionForward:
             qk_tiled_mma,
             self.cluster_layout_vmnk.shape,
         )
+        q_sf_smem_layout = cute.slice_(q_sf_smem_layout_staged, (None, None, None, 0))
+        tma_atom_q_sf, tma_tensor_q_sf = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            q_sf,
+            q_sf_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
 
         # TMA load for K
         k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
@@ -598,6 +781,16 @@ class BlackwellFusedMultiHeadAttentionForward:
             self.qk_mma_tiler,
             qk_tiled_mma,
             self.cluster_layout_vmnk.shape,
+        )
+        k_sf_smem_layout = cute.slice_(k_sf_smem_layout_staged, (None, None, None, 0))
+        tma_atom_k_sf, tma_tensor_k_sf = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            k_sf,
+            k_sf_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
         )
         # TMA load for V
         v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
@@ -620,9 +813,11 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
         k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
+        q_sf_copy_size = cute.size_in_bytes(self.qk_sf_dtype, q_sf_smem_layout)
+        k_sf_copy_size = cute.size_in_bytes(self.qk_sf_dtype, k_sf_smem_layout)
         v_copy_size = cute.size_in_bytes(self.v_dtype, v_smem_layout)
-        self.tma_copy_q_bytes = q_copy_size
-        self.tma_copy_k_bytes = k_copy_size
+        self.tma_copy_q_bytes = q_copy_size + q_sf_copy_size
+        self.tma_copy_k_bytes = k_copy_size + k_sf_copy_size
         self.tma_copy_v_bytes = v_copy_size
 
         @cute.struct
@@ -640,6 +835,11 @@ class BlackwellFusedMultiHeadAttentionForward:
             mma_corr_mbar_ptr: cute.struct.MemRange[Int64, self.mma_corr_stage * 2]
             s0_p1_inplace_barrier_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
             s1_p0_inplace_barrier_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
+            # Softmax_{1-j} signals MMA that S_{1-j}'s TMEM region (whose tail
+            # columns hold SFQ_j / SFK_j) is no longer being read, so mma_qk's
+            # SFQ/SFK S2T copy is safe to issue. One pipeline per QK stage.
+            qk_sf_inplace_0_barrier_ptr: cute.struct.MemRange[Int64, 1 * 2]
+            qk_sf_inplace_1_barrier_ptr: cute.struct.MemRange[Int64, 1 * 2]
             # Tmem holding buffer
             tmem_holding_buf: Int32
             # Smem tensors
@@ -651,8 +851,16 @@ class BlackwellFusedMultiHeadAttentionForward:
                 cute.struct.MemRange[self.q_dtype, cute.cosize(q_smem_layout_staged)],
                 self.buffer_align_bytes,
             ]
+            sQSF: cute.struct.Align[
+                cute.struct.MemRange[self.qk_sf_dtype, cute.cosize(q_sf_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
             sK: cute.struct.Align[
                 cute.struct.MemRange[self.k_dtype, sK_cosize],
+                self.buffer_align_bytes,
+            ]
+            sKSF: cute.struct.Align[
+                cute.struct.MemRange[self.qk_sf_dtype, cute.cosize(k_sf_smem_layout_staged)],
                 self.buffer_align_bytes,
             ]
             # Skip softmax and PV warpgroup votes
@@ -667,8 +875,12 @@ class BlackwellFusedMultiHeadAttentionForward:
             pv_tiled_mma,
             tma_atom_q,
             tma_tensor_q,
+            tma_atom_q_sf,
+            tma_tensor_q_sf,
             tma_atom_k,
             tma_tensor_k,
+            tma_atom_k_sf,
+            tma_tensor_k_sf,
             tma_atom_v,
             tma_tensor_v,
             tma_atom_o,
@@ -681,11 +893,14 @@ class BlackwellFusedMultiHeadAttentionForward:
             scale_softmax_log2,
             scale_softmax,
             scale_output,
+            m_scale_v_channels,
             skip_softmax_threshold_log2,
             window_size_left,
             window_size_right,
             q_smem_layout_staged,
             k_smem_layout_staged,
+            q_sf_smem_layout_staged,
+            k_sf_smem_layout_staged,
             p_tmem_layout_staged,
             v_smem_layout_staged,
             o_smem_layout_staged,
@@ -709,8 +924,12 @@ class BlackwellFusedMultiHeadAttentionForward:
         pv_tiled_mma: cute.TiledMma,
         tma_atom_q: cute.CopyAtom,
         mQ_qdl: cute.Tensor,
+        tma_atom_q_sf: cute.CopyAtom,
+        mQSF_qdl: cute.Tensor,
         tma_atom_k: cute.CopyAtom,
         mK_kdl: cute.Tensor,
+        tma_atom_k_sf: cute.CopyAtom,
+        mKSF_kdl: cute.Tensor,
         tma_atom_v: cute.CopyAtom,
         mV_dkl: cute.Tensor,
         tma_atom_o: cute.CopyAtom,
@@ -723,11 +942,14 @@ class BlackwellFusedMultiHeadAttentionForward:
         scale_softmax_log2: Float32,
         scale_softmax: Float32,
         scale_output: Float32,
+        m_scale_v_channels: Optional[cute.Tensor],
         skip_softmax_threshold_log2: Optional[Float32],
         window_size_left: Optional[Int32],
         window_size_right: Optional[Int32],
         q_smem_layout_staged: cute.ComposedLayout,
         k_smem_layout_staged: cute.ComposedLayout,
+        q_sf_smem_layout_staged: cute.Layout,
+        k_sf_smem_layout_staged: cute.Layout,
         p_tmem_layout_staged: cute.ComposedLayout,
         v_smem_layout_staged: cute.ComposedLayout,
         o_smem_layout_staged: cute.ComposedLayout,
@@ -800,7 +1022,9 @@ class BlackwellFusedMultiHeadAttentionForward:
         #
         if warp_idx == self.load_warp_id:
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q_sf)
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k_sf)
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
             if cutlass.const_expr(self.use_tma_store):
                 cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o)
@@ -927,6 +1151,27 @@ class BlackwellFusedMultiHeadAttentionForward:
             barrier_storage=storage.s1_p0_inplace_barrier_ptr.data_ptr(),
             defer_sync=True,
         ).make_participants()
+        # QK SF TMEM-slot release pipelines: softmax_{1-j} (producer) signals
+        # MMA (consumer) once its T2R-load of S_{1-j} is done, so mma_qk(j)'s
+        # SFQ/SFK S2T copy is safe to overwrite the tail of TMEM[S_{1-j}].
+        qk_sf_inplace_0_producer, qk_sf_inplace_0_consumer = pipeline.PipelineAsync.create(
+            num_stages=1,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.qk_sf_inplace_0_barrier_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        qk_sf_inplace_1_producer, qk_sf_inplace_1_consumer = pipeline.PipelineAsync.create(
+            num_stages=1,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.qk_sf_inplace_1_barrier_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
         tmem = utils.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
@@ -939,8 +1184,12 @@ class BlackwellFusedMultiHeadAttentionForward:
         #  Generate smem tensor Q/K/V/O
         # (MMA, MMA_Q, MMA_D, PIPE)
         sQ = storage.sQ.get_tensor(q_smem_layout_staged.outer, swizzle=q_smem_layout_staged.inner)
+        # (MMA, MMA_Q, MMA_D, PIPE)
+        sQSF = storage.sQSF.get_tensor(q_sf_smem_layout_staged)
         # (MMA, MMA_K, MMA_D, PIPE)
         sK = storage.sK.get_tensor(k_smem_layout_staged.outer, swizzle=k_smem_layout_staged.inner)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        sKSF = storage.sKSF.get_tensor(k_sf_smem_layout_staged)
         # (MMA, MMA_K, MMA_D, PIPE)
         # Reuse k's smem buffer for v. Recast element type so MMA descriptor matches v_dtype.
         sV_ptr = cute.recast_ptr(
@@ -1016,6 +1265,13 @@ class BlackwellFusedMultiHeadAttentionForward:
             ),
             mask_args=(window_size_left, window_size_right),
             sched_args=(tile_sched, work_tile),
+            # Each softmax warpgroup picks its producer by stage: softmax0
+            # (stage=0) produces on qk_sf_inplace_1, softmax1 (stage=1) on
+            # qk_sf_inplace_0.
+            qk_sf_inplace_producers=(
+                qk_sf_inplace_1_producer,
+                qk_sf_inplace_0_producer,
+            ),
         )
         # ///////////////////////////////////////////////////////////////////////////////
         #  EMPTY
@@ -1053,14 +1309,22 @@ class BlackwellFusedMultiHeadAttentionForward:
                 if not continue_cond:
                     mQ_qdl_ = mQ_qdl
                     mK_kdl_ = mK_kdl
+                    mQSF_qdl_ = mQSF_qdl
+                    mKSF_kdl_ = mKSF_kdl
                     mV_dkl_ = mV_dkl
                     if cutlass.const_expr(cum_seqlen_q is not None):
                         mQ_qdl_ = cute.domain_offset(
                             (cum_seqlen_q[batch_coord], 0, ((0, 0), 0)), mQ_qdl
                         )
+                        mQSF_qdl_ = cute.domain_offset(
+                            (cum_seqlen_q[batch_coord], 0, (0, 0)), mQSF_qdl
+                        )
                     if cutlass.const_expr(cum_seqlen_k is not None):
                         mK_kdl_ = cute.domain_offset(
                             (cum_seqlen_k[batch_coord], 0, ((0, 0), 0)), mK_kdl
+                        )
+                        mKSF_kdl_ = cute.domain_offset(
+                            (cum_seqlen_k[batch_coord], 0, (0, 0)), mKSF_kdl
                         )
                         mV_dkl_ = cute.domain_offset(
                             (0, cum_seqlen_k[batch_coord], ((0, 0), 0)), mV_dkl
@@ -1076,6 +1340,32 @@ class BlackwellFusedMultiHeadAttentionForward:
                         cute.group_modes(tSgQ_qdl, 0, 3),
                     )
                     tQgQ = tQgQ_qdl[None, None, 0, curr_block_coord[2]]
+                    gQSF_qdl = cute.local_tile(
+                        mQSF_qdl_,
+                        cute.select(self.qk_mma_tiler, mode=[0, 2]),
+                        (None, None, None),
+                    )
+                    tSgQSF_qdl = qk_thr_mma.partition_A(gQSF_qdl)
+                    tQsQSF, tQgQSF_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_q_sf,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sQSF, 0, 3),
+                        cute.group_modes(tSgQSF_qdl, 0, 3),
+                    )
+                    tQsQSF = cute.filter_zeros(tQsQSF)
+                    tQgQSF_qdl = cute.filter_zeros(tQgQSF_qdl)
+                    # tile_atom_to_shape_SF coalesces Q's ((h_r, h_k), b) mode into (1, h_r*h_k*b),
+                    # One needs to reconstruct the correct layout here to correctly map block_coord
+                    # onto this linearlized L-like mode.
+                    sf_l_q = cute.make_layout(
+                        mQ_qdl.shape[2],
+                        stride=(
+                            (1, mQ_qdl.shape[2][0][0]),
+                            cute.size(mQ_qdl.shape[2][0]),
+                        ),
+                    )(curr_block_coord[2])
+                    tQgQSF = tQgQSF_qdl[None, None, 0, sf_l_q]
                     gK_kdl = cute.flat_divide(mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2]))
                     tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
                     tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
@@ -1086,6 +1376,28 @@ class BlackwellFusedMultiHeadAttentionForward:
                         cute.group_modes(tSgK_kdl, 0, 3),
                     )
                     tKgK = tKgK_kdl[None, None, 0, curr_block_coord[2]]
+                    gKSF_kdl = cute.local_tile(
+                        mKSF_kdl_,
+                        cute.select(self.qk_mma_tiler, mode=[1, 2]),
+                        (None, None, None),
+                    )
+                    tSgKSF_kdl = qk_thr_mma.partition_B(gKSF_kdl)
+                    tKsKSF, tKgKSF_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k_sf,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sKSF, 0, 3),
+                        cute.group_modes(tSgKSF_kdl, 0, 3),
+                    )
+                    tKsKSF = cute.filter_zeros(tKsKSF)
+                    tKgKSF_kdl = cute.filter_zeros(tKgKSF_kdl)
+                    # Same L-mode trick as Q's SF (see comment above). K's SF is shared across h_r heads
+                    # (it indexes h_k, not h_q), which we express by a 0-stride for the h_r sub-mode.
+                    sf_l_k = cute.make_layout(
+                        mK_kdl.shape[2],
+                        stride=((0, 1), mK_kdl.shape[2][0][1]),
+                    )(curr_block_coord[2])
+                    tKgKSF = tKgKSF_kdl[None, None, 0, sf_l_k]
                     gV_dkl = cute.flat_divide(mV_dkl_, cute.select(self.pv_mma_tiler, mode=[1, 2]))
                     tSgV_dkl = pv_thr_mma.partition_B(gV_dkl)
                     tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
@@ -1113,6 +1425,12 @@ class BlackwellFusedMultiHeadAttentionForward:
                         tQsQ[None, q0_handle.index],
                         tma_bar_ptr=q0_handle.barrier,
                     )
+                    cute.copy(
+                        tma_atom_q_sf,
+                        tQgQSF[None, q0_coord],
+                        tQsQSF[None, q0_handle.index],
+                        tma_bar_ptr=q0_handle.barrier,
+                    )
                     seqlen_kv_loop_steps = fmha_utils.FusedMask.get_trip_count(
                         self.mask_type,
                         curr_block_coord,
@@ -1131,6 +1449,12 @@ class BlackwellFusedMultiHeadAttentionForward:
                         tKsK[None, k_handle.index],
                         tma_bar_ptr=k_handle.barrier,
                     )
+                    cute.copy(
+                        tma_atom_k_sf,
+                        tKgKSF[None, kv_coord],
+                        tKsKSF[None, k_handle.index],
+                        tma_bar_ptr=k_handle.barrier,
+                    )
                     # Q1
                     q1_coord = q0_coord + 1
                     q1_handle = load_q_producer.acquire_and_advance()
@@ -1138,6 +1462,12 @@ class BlackwellFusedMultiHeadAttentionForward:
                         tma_atom_q,
                         tQgQ[None, q1_coord],
                         tQsQ[None, q1_handle.index],
+                        tma_bar_ptr=q1_handle.barrier,
+                    )
+                    cute.copy(
+                        tma_atom_q_sf,
+                        tQgQSF[None, q1_coord],
+                        tQsQSF[None, q1_handle.index],
                         tma_bar_ptr=q1_handle.barrier,
                     )
                     kv_coord += 1
@@ -1149,6 +1479,12 @@ class BlackwellFusedMultiHeadAttentionForward:
                             tma_atom_k,
                             tKgK[None, kv_coord],
                             tKsK[None, k_handle.index],
+                            tma_bar_ptr=k_handle.barrier,
+                        )
+                        cute.copy(
+                            tma_atom_k_sf,
+                            tKgKSF[None, kv_coord],
+                            tKsKSF[None, k_handle.index],
                             tma_bar_ptr=k_handle.barrier,
                         )
                         # Vi-1
@@ -1192,6 +1528,60 @@ class BlackwellFusedMultiHeadAttentionForward:
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1 = make_tmem_tensors(
                 self, qk_thr_mma, pv_thr_mma, p_tmem_layout_staged, tmem_ptr
+            )
+            q_sf_tmem_layout = blockscaled_utils.make_tmem_layout_sfa(
+                qk_tiled_mma,
+                self.qk_mma_tiler,
+                self.qk_sf_vec_size,
+                cute.slice_(q_sf_smem_layout_staged, (None, None, None, 0)),
+            )
+            k_sf_tmem_layout = blockscaled_utils.make_tmem_layout_sfb(
+                qk_tiled_mma,
+                self.qk_mma_tiler,
+                self.qk_sf_vec_size,
+                cute.slice_(k_sf_smem_layout_staged, (None, None, None, 0)),
+            )
+            # TMEM offsets are in u32 columns. Follow FA4's explicit SFQ footprint
+            # calculation instead of deriving the offset from the recast FP8 tensor
+            # view, which can under-count for block-scaled layouts.
+            sf_atom_mn = 32
+            q_sf_tmem_cols = (self.qk_mma_tiler[0] // sf_atom_mn) * self.qk_mma_inst_tile_k
+            k_sf_tmem_cols = (
+                ((self.qk_mma_tiler[1] + 127) // 128 * 128) // sf_atom_mn
+            ) * self.qk_mma_inst_tile_k
+            tCtQSF0 = cute.make_tensor(
+                cute.recast_ptr(tmem_ptr + self.tmem_qk0_sf_offset, dtype=self.qk_sf_dtype),
+                q_sf_tmem_layout,
+            )
+            tCtKSF0 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr + self.tmem_qk0_sf_offset + q_sf_tmem_cols,
+                    dtype=self.qk_sf_dtype,
+                ),
+                k_sf_tmem_layout,
+            )
+            tCtQSF1 = cute.make_tensor(
+                cute.recast_ptr(tmem_ptr + self.tmem_qk1_sf_offset, dtype=self.qk_sf_dtype),
+                q_sf_tmem_layout,
+            )
+            tCtKSF1 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr + self.tmem_qk1_sf_offset + q_sf_tmem_cols,
+                    dtype=self.qk_sf_dtype,
+                ),
+                k_sf_tmem_layout,
+            )
+            tiled_copy_s2t_qsf0, tCsQSF_s2t, tCtQSF0_s2t = self.mainloop_s2t_copy_and_partition(
+                sQSF, tCtQSF0
+            )
+            tiled_copy_s2t_ksf0, tCsKSF_s2t, tCtKSF0_s2t = self.mainloop_s2t_copy_and_partition(
+                sKSF, tCtKSF0
+            )
+            tiled_copy_s2t_qsf1, tCsQSF1_s2t, tCtQSF1_s2t = self.mainloop_s2t_copy_and_partition(
+                sQSF, tCtQSF1
+            )
+            tiled_copy_s2t_ksf1, tCsKSF1_s2t, tCtKSF1_s2t = self.mainloop_s2t_copy_and_partition(
+                sKSF, tCtKSF1
             )
             enable_skip_softmax = skip_softmax_threshold_log2 is not None
             tiled_tmem_load_v = None
@@ -1251,20 +1641,45 @@ class BlackwellFusedMultiHeadAttentionForward:
                     # Wait for K0
                     k_handle = load_kv_consumer.wait_and_advance()
                     tSrK0 = tSrK[None, None, None, k_handle.index]
+                    q0_sf_stage = (None, None, None, None, q0_handle.index)
+                    k_sf_stage = (None, None, None, None, k_handle.index)
                     # GEMM_QK00 (Q0 * K0 -> S0)
-                    mma_s0_producer, s0_corr_producer = self.mma_qk(
+                    mma_s0_producer, s0_corr_producer, qk_sf_inplace_0_consumer = self.mma_qk(
                         qk_tiled_mma,
                         (tSrQ0, tSrK0, tStS0),
+                        (
+                            tiled_copy_s2t_qsf0,
+                            tCsQSF_s2t[q0_sf_stage],
+                            tCtQSF0_s2t,
+                            tCtQSF0,
+                            tiled_copy_s2t_ksf0,
+                            tCsKSF_s2t[k_sf_stage],
+                            tCtKSF0_s2t,
+                            tCtKSF0,
+                        ),
                         (mma_s0_producer, s0_corr_producer),
+                        qk_sf_inplace_0_consumer,
                     )
                     # Wait for Q1
                     q1_handle = load_q_consumer.wait_and_advance()
                     tSrQ1 = tSrQ[None, None, None, q1_handle.index]
+                    q1_sf_stage = (None, None, None, None, q1_handle.index)
                     # GEMM_QK10 (Q1 * K0 -> S1), K0 is ready in GEMM_QK00
-                    mma_s1_producer, s1_corr_producer = self.mma_qk(
+                    mma_s1_producer, s1_corr_producer, qk_sf_inplace_1_consumer = self.mma_qk(
                         qk_tiled_mma,
                         (tSrQ1, tSrK0, tStS1),
+                        (
+                            tiled_copy_s2t_qsf1,
+                            tCsQSF1_s2t[q1_sf_stage],
+                            tCtQSF1_s2t,
+                            tCtQSF1,
+                            tiled_copy_s2t_ksf1,
+                            tCsKSF1_s2t[k_sf_stage],
+                            tCtKSF1_s2t,
+                            tCtKSF1,
+                        ),
                         (mma_s1_producer, s1_corr_producer),
+                        qk_sf_inplace_1_consumer,
                     )
                     # Release K0
                     k_handle.release()
@@ -1285,11 +1700,23 @@ class BlackwellFusedMultiHeadAttentionForward:
                         # Wait for Ki
                         k_handle = load_kv_consumer.wait_and_advance()
                         tSrKi = tSrK[None, None, None, k_handle.index]
+                        k_sf_stage = (None, None, None, None, k_handle.index)
                         # GEMM_QK0i (Q0 * Ki -> S0)
-                        mma_s0_producer, s0_corr_producer = self.mma_qk(
+                        mma_s0_producer, s0_corr_producer, qk_sf_inplace_0_consumer = self.mma_qk(
                             qk_tiled_mma,
                             (tSrQ0, tSrKi, tStS0),
+                            (
+                                tiled_copy_s2t_qsf0,
+                                tCsQSF_s2t[q0_sf_stage],
+                                tCtQSF0_s2t,
+                                tCtQSF0,
+                                tiled_copy_s2t_ksf0,
+                                tCsKSF_s2t[k_sf_stage],
+                                tCtKSF0_s2t,
+                                tCtKSF0,
+                            ),
                             (mma_s0_producer, s0_corr_producer),
+                            qk_sf_inplace_0_consumer,
                         )
                         # Wait for Vi-1
                         v_handle = load_kv_consumer.wait_and_advance()
@@ -1308,10 +1735,21 @@ class BlackwellFusedMultiHeadAttentionForward:
                             ),
                         )
                         # GEMM_QK1i (Q1 * Ki -> S1)
-                        mma_s1_producer, s1_corr_producer = self.mma_qk(
+                        mma_s1_producer, s1_corr_producer, qk_sf_inplace_1_consumer = self.mma_qk(
                             qk_tiled_mma,
                             (tSrQ1, tSrKi, tStS1),
+                            (
+                                tiled_copy_s2t_qsf1,
+                                tCsQSF1_s2t[q1_sf_stage],
+                                tCtQSF1_s2t,
+                                tCtQSF1,
+                                tiled_copy_s2t_ksf1,
+                                tCsKSF1_s2t[k_sf_stage],
+                                tCtKSF1_s2t,
+                                tCtKSF1,
+                            ),
                             (mma_s1_producer, s1_corr_producer),
+                            qk_sf_inplace_1_consumer,
                         )
                         # Release Ki
                         k_handle.release()
@@ -1620,6 +2058,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                                     sO[None, None, 0],
                                     mLSE,
                                     mSink,
+                                    m_scale_v_channels,
                                 ),
                                 (
                                     s0_corr_consumer,
@@ -1642,6 +2081,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                                     sO[None, None, 1],
                                     mLSE,
                                     mSink,
+                                    m_scale_v_channels,
                                 ),
                                 (
                                     s1_corr_consumer,
@@ -1683,6 +2123,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                                 gO0,
                                 mLSE,
                                 mSink,
+                                m_scale_v_channels,
                             ),
                             (s0_corr_consumer, mma_corr_consumer),
                             (row_idx, *value_args),
@@ -1699,6 +2140,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                                 gO1,
                                 mLSE,
                                 mSink,
+                                m_scale_v_channels,
                             ),
                             (s1_corr_consumer, mma_corr_consumer),
                             (row_idx, *value_args),
@@ -1715,6 +2157,26 @@ class BlackwellFusedMultiHeadAttentionForward:
             self.tmem_dealloc_barrier.arrive_and_wait()
             tmem.free(tmem_ptr)
         return
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """Partition one block-scaled QK scale-factor tensor for SMEM to TMEM copy."""
+        tCsSF_compact = cute.filter_zeros(sSF)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(tcgen05.CtaGroup.ONE),
+            self.qk_sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
 
     @cute.jit
     def kv_producer_update_tx_acquire_and_advance(
@@ -1745,9 +2207,15 @@ class BlackwellFusedMultiHeadAttentionForward:
         self,
         tiled_mma: cute.TiledMma,
         tensor_args: Tuple,
+        scale_args: Tuple,
         pipeline_args: Tuple,
+        qk_sf_inplace_consumer: pipeline.PipelineConsumer,
         pipeline_tokens: Tuple = (None, None),
-    ) -> Tuple[pipeline.PipelineProducer, pipeline.PipelineProducer]:
+    ) -> Tuple[
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineConsumer,
+    ]:
         """Perform a single step of the QK GEMM computation on a block of attention scores.
 
         :param tiled_mma: Tiled MMA for QK GEMM
@@ -1756,37 +2224,56 @@ class BlackwellFusedMultiHeadAttentionForward:
         :type tensor_args: Tuple
         :param pipeline_args: Tuple containing mma_si_producer and si_corr_producer
         :type pipeline_args: Tuple
+        :param qk_sf_inplace_consumer: PipelineAsync consumer guarding the SFQ/SFK TMEM slot
+            (the tail of the OPPOSITE-stage S region).
+        :type qk_sf_inplace_consumer: pipeline.PipelineConsumer
         :param pipeline_tokens: Optional non-blocking peek tokens for the Si and
             vec_i producers, in the form ``(si_peek_status, veci_peek_status)``.
             ``None`` for either token falls back to a blocking acquire.
         :type pipeline_tokens: Tuple
-        :return: Tuple containing mma_si_producer and si_corr_producer
-        :rtype: Tuple[pipeline.PipelineProducer, pipeline.PipelineProducer]
+        :return: Tuple containing mma_si_producer, si_corr_producer, and the
+            (advanced) qk_sf_inplace_consumer.
+        :rtype: Tuple[pipeline.PipelineProducer, pipeline.PipelineProducer,
+            pipeline.PipelineConsumer]
         """
         tSrQi, tSrK, tStSi = tensor_args
+        (
+            tiled_copy_s2t_qsf,
+            tCsQSF_stage,
+            tCtQSF_s2t,
+            tCtQSF,
+            tiled_copy_s2t_ksf,
+            tCsKSF_stage,
+            tCtKSF_s2t,
+            tCtKSF,
+        ) = scale_args
         mma_si_producer, si_corr_producer = pipeline_args
         si_peek_status, veci_peek_status = pipeline_tokens
+        qk_tiled_mma = cutlass.new_from_mlir_values(
+            tiled_mma, cutlass.extract_mlir_values(tiled_mma)
+        )
         # 0. Make sure Qi & K are ready when calling mma_qk
         # 1. acquire S0
         si_handle = mma_si_producer.acquire_and_advance(si_peek_status)
         # 2. make sure vec is already released in corr
         veci_handle = si_corr_producer.acquire_and_advance(veci_peek_status)
         veci_handle.commit()
-        # 3. gemm
-        num_kphases = cute.size(tSrQi, mode=[2])
-        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-            kphase_coord = (None, None, kphase_idx)
-            tiled_mma.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
-            cute.gemm(
-                tiled_mma,
-                tStSi,
-                tSrQi[kphase_coord],
-                tSrK[kphase_coord],
-                tStSi,
-            )
+        # 3. Wait until softmax_{1-j} has finished T2R-loading S_{1-j} to avoid SFQK_j race cond
+        qk_sf_inplace_consumer.wait_and_advance()
+        # 4. Copy MXFP8 scale factors and issue block-scaled gemm
+        cute.copy(tiled_copy_s2t_qsf, tCsQSF_stage, tCtQSF_s2t)
+        cute.copy(tiled_copy_s2t_ksf, tCsKSF_stage, tCtKSF_s2t)
+        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+        cute.gemm(
+            qk_tiled_mma,
+            tStSi,
+            [tSrQi, tCtQSF],
+            [tSrK, tCtKSF],
+            tStSi,
+        )
         # 4. release S0
         si_handle.commit()
-        return mma_si_producer, si_corr_producer
+        return mma_si_producer, si_corr_producer, qk_sf_inplace_consumer
 
     @cute.jit
     def mma_pv(
@@ -2139,6 +2626,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             skip_softmax_threshold_log2,
             thread_idx,
             logical_offset,
+            qk_sf_inplace_producer,
         ) = value_args
         (
             si_peek_status,
@@ -2221,6 +2709,10 @@ class BlackwellFusedMultiHeadAttentionForward:
                     skip_softmax_count,
                     total_softmax_count,
                 )
+            # Fence the T2R load above, then signal MMA that the opposite-stage S is loaded.
+            cute.arch.fence_view_async_tmem_load()
+            qk_sf_inplace_producer.commit()
+            qk_sf_inplace_producer.advance()
             si_handle.release()
             # S0 -> P1 / S1 -> P0
             inplace_producer.commit()
@@ -2265,6 +2757,10 @@ class BlackwellFusedMultiHeadAttentionForward:
                     tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 2, 2, 0, 0])
                     tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 3, 2, 0, 0])
                 cute.arch.fence_view_async_tmem_store()
+                # Fence T2R loads then release the QK SF TMEM slot before we release S to MMA
+                cute.arch.fence_view_async_tmem_load()
+                qk_sf_inplace_producer.commit()
+                qk_sf_inplace_producer.advance()
                 si_handle.release()
                 # S0 -> P1 / S1 -> P0
                 inplace_producer.commit()
@@ -2322,6 +2818,10 @@ class BlackwellFusedMultiHeadAttentionForward:
                         skip_softmax_count,
                         total_softmax_count,
                     )
+                # Fence the T2R loads then release the QK SF TMEM slot.
+                cute.arch.fence_view_async_tmem_load()
+                qk_sf_inplace_producer.commit()
+                qk_sf_inplace_producer.advance()
                 si_handle.release()
                 # S0 -> P1 / S1 -> P0
                 inplace_producer.commit()
@@ -2505,6 +3005,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         value_args: Tuple,
         mask_args: Tuple,
         sched_args: Tuple,
+        qk_sf_inplace_producers: Tuple[pipeline.PipelineProducer, pipeline.PipelineProducer],
     ):
         """Compute softmax on attention scores from QK matrix multiplication.
 
@@ -2622,6 +3123,20 @@ class BlackwellFusedMultiHeadAttentionForward:
         tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tStS_P)
         thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
         tTMEM_STOREtS_x4 = thr_tmem_store.partition_D(tStS_P)
+        # Each softmax warpgroup releases the OPPOSITE-stage S region (where
+        # SFQ_{1-stage}/SFK_{1-stage} live in the tail) by committing to its qk_sf_inplace producer
+        # once per kv block:
+        # softmax0 (stage=0) drives qk_sf_inplace_1
+        # softmax1 (stage=1) drives qk_sf_inplace_0
+        qk_sf_inplace_producer = qk_sf_inplace_producers[stage]
+        # Bootstrap: MMA's first mma_qk(stage=0) waits on qk_sf_inplace_0 before
+        # softmax1 has produced any in-loop commit. Each thread of softmax1
+        # pre-commits once so the first wait succeeds. qk_sf_inplace_1 needs no
+        # pre-commit because mma_qk(stage=1) runs after mma_qk(stage=0),
+        # giving softmax0 enough time to consume S0 and commit naturally.
+        if cutlass.const_expr(stage == 1):
+            qk_sf_inplace_producer.commit()
+            qk_sf_inplace_producer.advance()
         if cutlass.const_expr(self.enable_sequence_barrier):
             if cutlass.const_expr(stage == 1):
                 self.sequence_s0_s1_barrier.arrive()
@@ -2663,6 +3178,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                     skip_softmax_threshold_log2,
                     thread_idx,
                     logical_offset,
+                    qk_sf_inplace_producer,
                 )
                 atom_args = (
                     qk_thr_mma,
@@ -3005,7 +3521,15 @@ class BlackwellFusedMultiHeadAttentionForward:
         :param value_args: Tuple containing (row_idx, cuseqlen_q, seqlen_q, blk_coord, scale_softmax, scale_output)
         :type value_args: Tuple
         """
-        tOtO, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECcS, dest_O, mLSE, mSink = tensor_args
+        (
+            tOtO,
+            tTMEM_LOAD_VECtSi,
+            tTMEM_LOAD_VECcS,
+            dest_O,
+            mLSE,
+            mSink,
+            m_scale_v_channels,
+        ) = tensor_args
         row_idx, cuseqlen_q, seqlen_q, blk_coord, scale_softmax, scale_output = value_args
 
         pv_tiled_mma_shape = (
@@ -3071,16 +3595,27 @@ class BlackwellFusedMultiHeadAttentionForward:
             row_sum = row_sum + sink_exp
         scale = scale_output / row_sum
 
+        if cutlass.const_expr(m_scale_v_channels is not None):
+            scale_v_ch_h = m_scale_v_channels[None, blk_coord[2]]
         for i in range(self.cta_tiler[2] // corr_tile_size):
             tTMEM_LOADtO_i = tTMEM_LOADtO[None, 0, 0, i]
             tTMEM_LOADdO_i = tTMEM_LOADdO[None, 0, 0, i]
-            tTMrO = cute.make_rmem_tensor(tTMEM_LOADoO[None, 0, 0, i].shape, self.pv_acc_dtype)
+            tTMEM_LOADoO_i = tTMEM_LOADoO[None, 0, 0, i]
+            tTMrO = cute.make_rmem_tensor(tTMEM_LOADoO_i.shape, self.pv_acc_dtype)
             cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
             for j in range(0, cute.size(tTMrO), 2):
                 tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
                     (tTMrO[j], tTMrO[j + 1]),
                     (scale, scale),
                 )
+            if cutlass.const_expr(m_scale_v_channels is not None):
+                for j in range(0, cute.size(tTMrO), 2):
+                    _, n0 = tTMEM_LOADoO_i[j]
+                    _, n1 = tTMEM_LOADoO_i[j + 1]
+                    tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
+                        (tTMrO[j], tTMrO[j + 1]),
+                        (scale_v_ch_h[n0], scale_v_ch_h[n1]),
+                    )
             tDMrO = cute.make_rmem_tensor(tTMrO.shape, self.o_dtype)
             o_vec = tTMrO.load()
             tDMrO.store(o_vec.to(self.o_dtype))
@@ -3117,14 +3652,28 @@ class BlackwellFusedMultiHeadAttentionForward:
         qk_dtype: Type[cutlass.Numeric],
         pv_dtype: Type[cutlass.Numeric],
         out_dtype: Type[cutlass.Numeric],
+        qk_sf_dtype: Type[cutlass.Numeric],
+        qk_sf_vec_size: int,
         qk_acc_dtype: Type[cutlass.Numeric],
         pv_acc_dtype: Type[cutlass.Numeric],
     ):
-        supported = {cutlass.Float8E4M3FN, cutlass.Float16, cutlass.BFloat16}
-        if qk_dtype not in supported:
-            raise NotImplementedError("Unsupported qk_dtype")
-        if pv_dtype not in supported:
-            raise NotImplementedError("Unsupported pv_dtype")
+        if qk_dtype in {cutlass.Float8E4M3FN, cutlass.Float8E5M2}:
+            if qk_sf_dtype is not cutlass.Float8E8M0FNU:
+                raise NotImplementedError("MXFP8 QK requires qk_sf_dtype Float8E8M0FNU")
+            if qk_sf_vec_size != 32:
+                raise NotImplementedError("MXFP8 QK requires qk_sf_vec_size 32")
+        elif qk_dtype is cutlass.Float4E2M1FN:
+            if qk_sf_dtype is not cutlass.Float8E4M3FN:
+                raise NotImplementedError("NVFP4 QK requires qk_sf_dtype Float8E4M3FN")
+            if qk_sf_vec_size != 16:
+                raise NotImplementedError("NVFP4 QK requires qk_sf_vec_size 16")
+        else:
+            raise NotImplementedError(
+                "qk_dtype must be Float8E4M3FN/Float8E5M2 for MXFP8 or Float4E2M1FN for NVFP4"
+            )
+
+        if pv_dtype not in {cutlass.Float8E4M3FN, cutlass.BFloat16}:
+            raise NotImplementedError("pv_dtype must be Float8E4M3FN or BFloat16")
         if out_dtype not in {cutlass.Float8E4M3FN, cutlass.Float16, cutlass.BFloat16}:
             raise NotImplementedError("Unsupported out_dtype")
         if qk_acc_dtype not in {cutlass.Float32}:
@@ -3135,6 +3684,7 @@ class BlackwellFusedMultiHeadAttentionForward:
     def check_invalid_shape(
         self,
         qk_dtype: Type[cutlass.Numeric],
+        qk_sf_vec_size: int,
         q_shape: Tuple[int, int, int, int],
         k_shape: Tuple[int, int, int, int],
     ):
@@ -3146,16 +3696,19 @@ class BlackwellFusedMultiHeadAttentionForward:
             raise NotImplementedError("q & k must have the same batch size")
         if d != d_:
             raise NotImplementedError("q & k must have the same head dimension")
-        if d not in {32, 64, 128, 192}:
-            raise NotImplementedError("Unsupported head dimension")
+        if qk_dtype is cutlass.Float4E2M1FN:
+            if d not in {64, 128}:
+                raise NotImplementedError("NVFP4 QK supports headdim 64 or 128")
+        elif d not in {32, 64, 128}:
+            raise NotImplementedError("MXFP8 QK supports headdim 32, 64, or 128")
+        if d % qk_sf_vec_size != 0:
+            raise NotImplementedError("head dimension must be divisible by qk_sf_vec_size")
         if h_q % h_k != 0:
             raise NotImplementedError("h_q must be divisible by h_k")
         if isinstance(s_q, tuple) and len(s_q) != b:
             raise NotImplementedError("variable_seqlen s_q must have the length of batch size")
         if isinstance(s_k, tuple) and len(s_k) != b:
             raise NotImplementedError("variable_seqlen s_k must have the length of batch size")
-        if d == 192 and qk_dtype not in {cutlass.Float8E4M3FN}:
-            raise NotImplementedError("unimplemented dtypes for headdim 192")
 
     def can_implement(
         self,
@@ -3164,6 +3717,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         qk_dtype: Type[cutlass.Numeric],
         pv_dtype: Type[cutlass.Numeric],
         out_dtype: Type[cutlass.Numeric],
+        qk_sf_dtype: Type[cutlass.Numeric],
+        qk_sf_vec_size: int,
         qk_acc_dtype: Type[cutlass.Numeric],
         pv_acc_dtype: Type[cutlass.Numeric],
     ) -> bool:
@@ -3191,12 +3746,15 @@ class BlackwellFusedMultiHeadAttentionForward:
                 qk_dtype,
                 pv_dtype,
                 out_dtype,
+                qk_sf_dtype,
+                qk_sf_vec_size,
                 qk_acc_dtype,
                 pv_acc_dtype,
             )
             # Skip invalid shape
             self.check_invalid_shape(
                 qk_dtype,
+                qk_sf_vec_size,
                 q_shape,
                 k_shape,
             )

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/helpers/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/helpers/__init__.py
@@ -12,18 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .fmha import BlackwellFusedMultiHeadAttentionForward, make_thread_cooperative_group
-from .fmha_blockscaled import (
-    BlackwellFusedMultiHeadBlockScaledAttentionForward,
-    compact_fp4_data,
-    create_scale_factor_tensor,
-)
-
-__all__ = [
-    "BlackwellFusedMultiHeadAttentionForward",
-    "BlackwellFusedMultiHeadBlockScaledAttentionForward",
-    "compact_fp4_data",
-    "create_scale_factor_tensor",
-    "make_thread_cooperative_group",
-]

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/helpers/fmha_helpers.py
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/helpers/fmha_helpers.py
@@ -1,0 +1,1176 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# ruff: noqa: I001, E501, F841
+
+import enum
+from typing import Tuple, Optional
+import cutlass
+from cutlass.cute.typing import Boolean
+from cutlass._mlir.dialects import llvm, vector
+
+from cutlass.cutlass_dsl import (
+    Int32,
+    Float32,
+    T,
+    min,
+    extract_mlir_values,
+    new_from_mlir_values,
+    dsl_user_op,
+)
+from cutlass.utils.hardware_info import HardwareInfo
+from .static_persistent_tile_scheduler import WorkTileInfo
+import cutlass.cute as cute
+
+
+##############################################################################
+# Fmha static tile scheduler
+##############################################################################
+
+
+class FmhaStaticTileSchedulerParams:
+    """A class to represent parameters for the FMHA (Fused Multi-Head Attention) static tile scheduler.
+
+    This class holds the configuration parameters needed to initialize and configure
+    the tile scheduler for FMHA operations.
+
+    :ivar is_persistent: Whether to use persistent kernel mode.
+    :type is_persistent: bool
+    :ivar problem_shape_mhb: Problem shape in (M, H, B) format.
+    :type problem_shape_mhb: cute.Shape
+    """
+
+    def __init__(
+        self,
+        is_persistent: bool,
+        problem_shape_mhb: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        Initializes the FmhaStaticTileSchedulerParams with the given parameters.
+
+        :param is_persistent: Whether to use persistent kernel mode.
+        :type is_persistent: bool
+        :param problem_shape_mhb: Problem shape in (M, H, B) format.
+        :type problem_shape_mhb: cute.Shape
+        """
+        self.is_persistent = is_persistent
+        self.problem_shape_mhb = problem_shape_mhb
+        self._loc = loc
+        self._ip = ip
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.problem_shape_mhb]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip([self.problem_shape_mhb], self._values_pos):
+            obj_list.append(new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return FmhaStaticTileSchedulerParams(self.is_persistent, *(tuple(obj_list)), loc=self._loc)
+
+
+class FmhaStaticTileScheduler:
+    """A static tile scheduler for FMHA (Fused Multi-Head Attention) operations.
+
+    This class manages the scheduling of work tiles for FMHA kernels, supporting
+    both persistent and non-persistent kernel modes. It tracks the current work
+    position and advances through the problem space efficiently.
+
+    :ivar _params: Scheduler parameters.
+    :type _params: FmhaStaticTileSchedulerParams
+    :ivar _blk_coord: Block coordinates.
+    :type _blk_coord: cute.Coord
+    :ivar _grid_shape: Grid shape for the kernel.
+    :type _grid_shape: cute.Shape
+    :ivar _is_persistent: Whether to use persistent kernel mode.
+    :type _is_persistent: bool
+    :ivar _current_work_linear_idx: Current linear work index.
+    :type _current_work_linear_idx: Int32
+    :ivar _problem_shape_mhb: Problem shape in (M, H, B) format.
+    :type _problem_shape_mhb: cute.Layout
+    :ivar _num_blocks: Number of blocks in the problem.
+    :type _num_blocks: Int32
+    :ivar _is_first_block: Whether this is the first block.
+    :type _is_first_block: bool
+    :ivar num_persistent_sm: Number of persistent SMs.
+    :type num_persistent_sm: Int32
+    """
+
+    def __init__(
+        self,
+        params: FmhaStaticTileSchedulerParams,
+        current_work_linear_idx: Int32,
+        blk_coord: cute.Coord,
+        grid_shape: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        Initializes the FmhaStaticTileScheduler with the given parameters.
+
+        :param params: Scheduler parameters.
+        :type params: FmhaStaticTileSchedulerParams
+        :param current_work_linear_idx: Current linear work index.
+        :type current_work_linear_idx: Int32
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param grid_shape: Grid shape for the kernel.
+        :type grid_shape: cute.Shape
+        """
+        self._params = params
+        self._blk_coord = blk_coord
+        self._grid_shape = grid_shape
+        self._is_persistent = params.is_persistent
+        self._current_work_linear_idx = current_work_linear_idx
+        self._problem_shape_mhb = cute.make_layout(params.problem_shape_mhb, loc=loc, ip=ip)
+        self._num_blocks = cute.size(self._problem_shape_mhb, loc=loc, ip=ip)
+        self._is_first_block = True
+        self.num_persistent_sm = cute.size(grid_shape, loc=loc, ip=ip)
+        self._loc = loc
+        self._ip = ip
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: FmhaStaticTileSchedulerParams,
+        *,
+        loc=None,
+        ip=None,
+    ) -> cute.Shape:
+        """
+        Determine the grid shape for the FMHA kernel.
+
+        For persistent kernels, the grid shape is limited by the number of SMs
+        (Streaming Multiprocessors) available on the device. For non-persistent
+        kernels, the grid shape matches the problem shape.
+
+        :param params: Scheduler parameters.
+        :type params: FmhaStaticTileSchedulerParams
+
+        :return: Grid shape as (M, H, B) tuple.
+        :rtype: cute.Shape
+        """
+        if params.is_persistent:
+            hardware_info = HardwareInfo()
+            sm_count = hardware_info.get_device_multiprocessor_count()
+            return (
+                min(sm_count, cute.size(params.problem_shape_mhb, loc=loc, ip=ip)),
+                1,
+                1,
+            )
+        else:
+            return params.problem_shape_mhb
+
+    @staticmethod
+    def check_valid_work_for_seqlen_q(
+        q_tiler: int,
+        current_idx: Int32,
+        seqlen_q: Int32,
+    ) -> Boolean:
+        """
+        Check if the current work index is valid for the given query sequence length.
+
+        This method verifies that the current work tile index multiplied by the
+        query tiler size is within the bounds of the query sequence length.
+
+        :param q_tiler: Query tiler size.
+        :type q_tiler: int
+        :param current_idx: Current work index.
+        :type current_idx: Int32
+        :param seqlen_q: Query sequence length.
+        :type seqlen_q: Int32
+
+        :return: True if the work is valid, False otherwise.
+        :rtype: Boolean
+        """
+        return current_idx * q_tiler < seqlen_q
+
+    def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
+        """
+        Get information about the current work tile.
+
+        Determines if the current work is valid and computes the tile coordinates
+        based on whether the kernel is persistent or non-persistent.
+
+        :return: WorkTileInfo containing tile coordinates and validity flag.
+        :rtype: WorkTileInfo
+        """
+        is_valid = (
+            self._current_work_linear_idx < self._num_blocks
+            if self._is_persistent
+            else self._is_first_block
+        )
+
+        blk_coord = (0, 0, 0)
+        if self._is_persistent:
+            blk_coord = self._problem_shape_mhb.get_hier_coord(
+                self._current_work_linear_idx, loc=loc, ip=ip
+            )
+        else:
+            blk_coord = self._blk_coord
+
+        # cur_tile_coord is (mid, 0, (bid, hid))
+        cur_tile_coord = (
+            blk_coord[0],
+            0,
+            (blk_coord[1], blk_coord[2]),
+        )
+
+        return WorkTileInfo(cur_tile_coord, is_valid)
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        """
+        Get the initial work tile information.
+
+        :return: Initial WorkTileInfo.
+        :rtype: WorkTileInfo
+        """
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def advance_to_next_work(self, *, advance_count=1, loc=None, ip=None):
+        """
+        Advance to the next work tile.
+
+        For persistent kernels, advances by the number of persistent SMs.
+        For non-persistent kernels, marks that the first block has been processed.
+
+        :param advance_count: Number of steps to advance (default: 1).
+        :type advance_count: int
+        """
+        if self._is_persistent:
+            self._current_work_linear_idx += advance_count * self.num_persistent_sm
+        self._is_first_block = False
+
+    def __extract_mlir_values__(self):
+        # Only pass mutable per-iteration state as scf.while block arguments.
+        # _params and _grid_shape are loop-invariant and captured from outer
+        # scope, keeping block arg count low (4 instead of 10).
+        values = extract_mlir_values(self._current_work_linear_idx)
+        values.extend(extract_mlir_values(self._blk_coord))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        assert len(values) == 4
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[0]]
+        )
+        new_blk_coord = new_from_mlir_values(self._blk_coord, values[1:4])
+        return FmhaStaticTileScheduler(
+            self._params, new_current_work_linear_idx, new_blk_coord, self._grid_shape
+        )
+
+
+def create_fmha_static_tile_scheduler(
+    params: FmhaStaticTileSchedulerParams,
+    blk_coord: cute.Coord,
+    grid_shape: cute.Shape,
+) -> FmhaStaticTileScheduler:
+    """
+    Create a new FMHA static tile scheduler.
+
+    :param params: Scheduler parameters.
+    :type params: FmhaStaticTileSchedulerParams
+    :param blk_coord: Block coordinates.
+    :type blk_coord: cute.Coord
+    :param grid_shape: Grid shape.
+    :type grid_shape: cute.Shape
+
+    :return: New FmhaStaticTileScheduler instance.
+    :rtype: FmhaStaticTileScheduler
+    """
+    return FmhaStaticTileScheduler(params, blk_coord[0], blk_coord, grid_shape)
+
+
+def create_fmha_static_tile_scheduler_params(
+    is_persistent: bool,
+    problem_shape_mhb: cute.Shape,
+) -> FmhaStaticTileSchedulerParams:
+    """
+    Create FMHA static tile scheduler parameters.
+
+    :param is_persistent: Whether to use persistent kernel mode.
+    :type is_persistent: bool
+    :param problem_shape_mhb: Problem shape in (M, H, B) format.
+    :type problem_shape_mhb: cute.Shape
+
+    :return: New FmhaStaticTileSchedulerParams instance.
+    :rtype: FmhaStaticTileSchedulerParams
+    """
+    return FmhaStaticTileSchedulerParams(is_persistent, problem_shape_mhb)
+
+
+def compute_grid(
+    o_shape: cute.Shape,
+    cta_tiler: Tuple[int, int, int],
+    is_persistent: bool,
+    is_2cta: bool = False,
+) -> Tuple[FmhaStaticTileSchedulerParams, Tuple[int, int, int]]:
+    """
+    Compute grid parameters for FMHA operation.
+
+    This function calculates the appropriate grid shape and scheduler parameters
+    based on the output tensor shape, CTA (Cooperative Thread Array) tiler,
+    and whether to use persistent kernel mode.
+
+    The output tensor o has shape (s, d, ((h_r, h_k), b)) where:
+    - s: sequence length
+    - d: head dimension
+    - h_r: number of heads for query
+    - h_k: number of heads for key
+    - b: batch size
+
+    :param o_shape: Output tensor shape for grid computation.
+    :type o_shape: cute.Shape
+    :param cta_tiler: CTA tiler dimensions (M, N, K).
+    :type cta_tiler: Tuple[int, int, int]
+    :param is_persistent: Whether to use persistent kernel mode.
+    :type is_persistent: bool
+    :param is_2cta: Whether to use 2CTA mode.
+    :type is_2cta: bool
+
+    :return: Tuple of (scheduler_params, grid_shape).
+    :rtype: Tuple[FmhaStaticTileSchedulerParams, Tuple[int, int, int]]
+    """
+    tile_sched_params = create_fmha_static_tile_scheduler_params(
+        is_persistent,
+        (
+            cute.round_up(cute.ceil_div(cute.size(o_shape[0]), cta_tiler[0]), 2 if is_2cta else 1),
+            cute.size(o_shape[2][0]),
+            cute.size(o_shape[2][1]),
+        ),
+    )
+    grid = FmhaStaticTileScheduler.get_grid_shape(tile_sched_params)
+
+    return tile_sched_params, grid
+
+
+##############################################################################
+# Fused Mask
+##############################################################################
+
+
+class MaskEnum(enum.Enum):
+    """Enumeration of mask types for FMHA operations.
+
+    - RESIDUAL_MASK: Residual mask for handling variable sequence lengths
+    - WINDOW_MASK: Window mask for attention which also includes causal and no mask
+    - WINDOW_MASK_INFERENCE: Same as the window mask, but has the limitation that the end of q is aligned with the end of k
+    - WINDOW_MASK_BWD: Window mask for backward pass
+    - WINDOW_MASK_BWD_INFERENCE: Same as the window mask for backward pass, but has the limitation that the end of q is aligned with the end of k
+    """
+
+    RESIDUAL_MASK = enum.auto()
+    RESIDUAL_MASK_BWD = enum.auto()
+    WINDOW_MASK = enum.auto()
+    WINDOW_MASK_INFERENCE = enum.auto()
+    WINDOW_MASK_BWD = enum.auto()
+    WINDOW_MASK_BWD_INFERENCE = enum.auto()
+
+
+class FusedMask:
+    """A fused mask implementation for FMHA operations.
+
+    This class handles different types of attention masks including no mask,
+    residual mask for variable sequence lengths, and causal mask for
+    autoregressive attention patterns.
+
+    The class provides methods to:
+    - Calculate trip counts for different mask types
+    - Apply masks to attention scores
+    - Handle masked and unmasked trip calculations
+    """
+
+    def get_trip_count(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of trips needed for the current block.
+
+        The trip count depends on the mask type and the block coordinates.
+        For causal masks, it considers the autoregressive constraint.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of trips needed.
+        :rtype: Int32
+        """
+        result = 0
+        offset = 0
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        if cutlass.const_expr(mask_type == MaskEnum.RESIDUAL_MASK):
+            result = cute.ceil_div(seqlen_k, tile_shape[1])
+        if cutlass.const_expr(mask_type is MaskEnum.RESIDUAL_MASK_BWD):
+            result = cute.ceil_div(seqlen_q, tile_shape[0])
+        if cutlass.const_expr(
+            mask_type == MaskEnum.WINDOW_MASK or mask_type == MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is None):
+                result = cute.ceil_div(seqlen_k, tile_shape[1])
+            else:
+                max_idx_q = (blk_coord[0] + 1) * tile_shape[0]
+                idx_k = max_idx_q + offset + window_size_right
+                tmp_blocks_k = cute.ceil_div(idx_k, tile_shape[1])
+                max_blocks_k = cute.ceil_div(seqlen_k, tile_shape[1])
+                result = min(max_blocks_k, tmp_blocks_k)
+        if cutlass.const_expr(
+            mask_type == MaskEnum.WINDOW_MASK_BWD or mask_type == MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is None):
+                result = cute.ceil_div(seqlen_q, tile_shape[0])
+            else:
+                max_idx_k = (blk_coord[1] + 1) * tile_shape[1]
+                idx_k = max_idx_k + offset + window_size_left
+                tmp_blocks_q = cute.ceil_div(idx_k, tile_shape[0])
+                max_blocks_q = cute.ceil_div(seqlen_q, tile_shape[0])
+                result = min(max_blocks_q, tmp_blocks_q)
+        start_block = FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        result = result - start_block
+        return result
+
+    @cute.jit
+    def get_trip_start(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Get the start of the trip for the current block.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        """
+        result = 0
+        offset = 0
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        if cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK or mask_type is MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_q = blk_coord[0] * tile_shape[0]
+                idx_k = min_idx_q + offset - window_size_left
+                tmp_blocks_k = idx_k // tile_shape[1]
+                result = max(tmp_blocks_k, result)
+        if cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK_BWD or mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_k = blk_coord[1] * tile_shape[1]
+                idx_q = min_idx_k + offset - window_size_right
+                tmp_blocks_q = idx_q // tile_shape[0]
+                result = max(tmp_blocks_q, result)
+        return result
+
+    @cute.jit
+    def get_leading_mask_id(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Int32, Int32]:
+        """
+        Get the begin and end tile idx for the leading mask.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Tuple of (begin, end) tile idx for the leading mask.
+        :rtype: Tuple[Int32, Int32]
+        """
+        offset = 0
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        leading_mask_begin = FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trip_count = FusedMask.get_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+
+        leading_mask_end = leading_mask_begin
+        if cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK or mask_type is MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_q = (blk_coord[0] + 1) * tile_shape[0] + offset - window_size_left
+                leading_mask_end = min(
+                    cute.ceil_div(min_idx_q, tile_shape[1]) - 1,
+                    trip_count + leading_mask_begin - 1,
+                )
+            else:
+                leading_mask_end = leading_mask_begin - 1
+        elif cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK_BWD or mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_k = (blk_coord[1] + 1) * tile_shape[1] + offset - window_size_right
+                leading_mask_end = cute.ceil_div(min_idx_k, tile_shape[0]) - 1
+            else:
+                leading_mask_end = leading_mask_begin - 1
+        return leading_mask_begin, leading_mask_end
+
+    @cute.jit
+    def get_trailing_mask_id(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Optional[Int32], Optional[Int32]]:
+        """
+        Get the begin and end tile idx for the trailing mask.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Tuple of (begin, end) tile idx for the trailing mask.
+        :rtype: Tuple[Int32, Int32]
+        """
+        offset = 0
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        trip_start = FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trip_count = FusedMask.get_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+
+        trailing_mask_begin, trailing_mask_end = None, None
+        if cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK or mask_type is MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_q = blk_coord[0] * tile_shape[0] + offset + window_size_right
+                trailing_mask_begin = min(min_idx_q // tile_shape[1], trip_count + trip_start - 1)
+                trailing_mask_end = trip_count + trip_start - 1
+            else:
+                # last tile, we always apply mask on it regardless whether it's a residual tile
+                trailing_mask_begin = trip_count + trip_start - 1
+                trailing_mask_end = trip_count + trip_start - 1
+        else:
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_k = blk_coord[1] * tile_shape[1] + offset + window_size_left + 1
+                max_idx_k = (blk_coord[1] + 1) * tile_shape[1] + offset + window_size_left
+                trailing_mask_begin = min(
+                    cute.ceil_div(min_idx_k, tile_shape[0]) - 1,
+                    trip_count + trip_start - 1,
+                )
+                trailing_mask_end = min(
+                    cute.ceil_div(max_idx_k, tile_shape[0]) - 1,
+                    trip_count + trip_start - 1,
+                )
+            else:
+                # last tile, we always apply mask on it regardless whether it's a residual tile
+                trailing_mask_begin = trip_count + trip_start - 1
+                trailing_mask_end = trip_count + trip_start - 1
+
+        return trailing_mask_begin, trailing_mask_end
+
+    @cute.jit
+    def get_masked_leading_count(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of masked trips for the leading mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of masked trips.
+        :rtype: Int32
+        """
+        result = 0
+        if cutlass.const_expr(
+            mask_type is not MaskEnum.RESIDUAL_MASK and mask_type is not MaskEnum.RESIDUAL_MASK_BWD
+        ):
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                leading_mask_begin, leading_mask_end = FusedMask.get_leading_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                result = max(leading_mask_end - leading_mask_begin + 1, 0)
+
+        return result
+
+    @cute.jit
+    def get_masked_trailing_count(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+        rem_count: Optional[Int32] = 0,
+    ) -> Int32:
+        """
+        Calculate the number of masked trips for the trailing mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param rem_count: Remaining count from previous calculations.
+        :type rem_count: Int32
+
+        :return: Number of masked trips.
+        :rtype: Int32
+        """
+        result = 0
+
+        if cutlass.const_expr(
+            mask_type is not MaskEnum.RESIDUAL_MASK and mask_type is not MaskEnum.RESIDUAL_MASK_BWD
+        ):
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                trailing_mask_begin, trailing_mask_end = FusedMask.get_trailing_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                leading_mask_begin, leading_mask_end = FusedMask.get_leading_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                if cutlass.const_expr(
+                    trailing_mask_begin is not None and trailing_mask_end is not None
+                ):
+                    if trailing_mask_begin <= leading_mask_end:
+                        result = max(trailing_mask_end - leading_mask_end, 0)
+                    else:
+                        result = max(trailing_mask_end - trailing_mask_begin + 1, 0)
+        else:
+            if seqlen_k % tile_shape[1] != 0:
+                result = 1
+            else:
+                result = 0
+
+        return result + rem_count
+
+    @cute.jit
+    def get_unmasked_trip_count(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of unmasked trips for the current block.
+
+        This represents the number of trips that don't require special
+        masking treatment.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of unmasked trips.
+        :rtype: Int32
+        """
+        result = (
+            FusedMask.get_trip_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            - FusedMask.get_masked_leading_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            - FusedMask.get_masked_trailing_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+                0,
+            )
+        )
+        return result
+
+    @cute.jit
+    def get_masked_info(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+        rem_count: Optional[Int32] = 0,
+    ) -> Tuple[Int32, Int32, Int32, Int32, Int32]:
+        """
+        Calculate the number of masked trips for the trailing mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param rem_count: Remaining count from previous calculations.
+        :type rem_count: Int32
+
+        :return: Number of masked info.
+        :rtype: Tuple[Int32, Int32, Int32, Int32, Int32]
+        """
+        start_count = FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        leading_mask_count = FusedMask.get_masked_leading_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        unmask_count = FusedMask.get_unmasked_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trailing_mask_count = FusedMask.get_masked_trailing_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+            rem_count,
+        )
+        end_count = start_count + leading_mask_count + unmask_count + trailing_mask_count
+        return (
+            start_count,
+            end_count,
+            leading_mask_count,
+            unmask_count,
+            trailing_mask_count,
+        )
+
+    @cute.jit
+    def apply_mask(
+        mask_type: MaskEnum,
+        acc_qk: cute.Tensor,
+        index_qk: cute.Tensor,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[int] = None,
+        window_size_right: Optional[int] = None,
+        index_transform: cutlass.Constexpr = lambda index_q, index_k: (
+            index_q,
+            index_k,
+        ),
+    ):
+        """
+        Apply the appropriate mask to the attention scores.
+
+        This method modifies the attention scores (acc_qk) based on the mask type
+        and the positions in the index tensor.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param acc_qk: Accumulated QK attention scores tensor.
+        :type acc_qk: cute.Tensor
+        :param index_qk: Index tensor containing position information.
+        :type index_qk: cute.Tensor
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Optional[int]
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[int]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[int]
+        """
+
+        tidx, tidy, tidx = cute.arch.thread_idx()
+        offset = 0
+        offset = (
+            seqlen_k - seqlen_q
+            if cutlass.const_expr(
+                mask_type is MaskEnum.WINDOW_MASK_INFERENCE
+                or mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE
+            )
+            else 0
+        )
+        for i in cutlass.range(cute.size(acc_qk), unroll_full=True):
+            index_q, index_k = index_transform(*index_qk[i])
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                if cutlass.const_expr(window_size_left is None):
+                    if index_q + offset + window_size_right < index_k:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+                elif cutlass.const_expr(window_size_right is None):
+                    if index_q + offset - window_size_left > index_k:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+                else:
+                    max_K_index = min(index_q + offset + window_size_right, seqlen_k)
+                    min_K_index = max(0, index_q + offset - window_size_left)
+                    if index_k > max_K_index or index_k < min_K_index:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+
+            if cutlass.const_expr(
+                mask_type == MaskEnum.RESIDUAL_MASK or mask_type == MaskEnum.RESIDUAL_MASK_BWD
+            ):
+                if index_k >= seqlen_k or index_q >= seqlen_q:
+                    acc_qk[i] = -Float32.inf
+
+
+@dsl_user_op
+def ex2_emulation_packed_f32x2(
+    x: Float32, y: Float32, *, loc=None, ip=None
+) -> Tuple[Float32, Float32]:
+    # Clamp the xy so they fit within the FP32 exponent range
+    # The upper side is ensured by the (s - row_max)
+    xy_clamped = (cute.arch.fmax(x, -127.0), cute.arch.fmax(y, -127.0))
+
+    fp32_round_int = float(2**23 + 2**22)
+    # |  0   | 10010110 | 10000000000000000000000 |
+    # | sign | exponent |        mantissa         |
+    #                                           ^
+    #                                           |
+    #                                  digit of ones place
+    # During FP32 addition, any number that smaller than this will be
+    # aligned the exponent to 2^23, so that the digit of ones
+    # is at the rightest place
+    # We want to round down here, so that the fractional part is in [0, 1)
+    xy_rounded = cute.arch.add_packed_f32x2(xy_clamped, (fp32_round_int, fp32_round_int), rnd="rm")
+    # The integer floor of x & y are now in the last 8 bits of xy_rounded
+    # We want the next 2 ops to round to nearest even. The rounding mode is important.
+    xy_rounded_back = cute.arch.sub_packed_f32x2(xy_rounded, (fp32_round_int, fp32_round_int))
+    xy_frac = cute.arch.sub_packed_f32x2(xy_clamped, xy_rounded_back)
+
+    @dsl_user_op
+    @cute.jit
+    def polynomial_deg3_packed_f32x2(
+        x: Float32, y: Float32, *, loc=None, ip=None
+    ) -> Tuple[Float32, Float32]:
+        # 2^x ~= (0.077 * x + 0.228) * x + 0.695) * x + 1, for x in [0, 1)
+        coeff = (
+            1.0,  # coeff of deg0
+            0.695146143436431884765625,  # coeff of deg1
+            0.227564394474029541015625,  # coeff of deg2
+            0.077119089663028717041015625,  # coeff of deg3
+        )
+        deg = len(coeff) - 1  # started with highest degree
+        out = (coeff[deg], coeff[deg])
+        for i in cutlass.range_constexpr(deg - 1, -1, -1):
+            out = cute.arch.fma_packed_f32x2(out, (x, y), (coeff[i], coeff[i]), loc=loc, ip=ip)
+        return out
+
+    xy_frac_ex2 = polynomial_deg3_packed_f32x2(*xy_frac, loc=loc, ip=ip)
+
+    @dsl_user_op
+    def combine_int_frac_ex2(
+        x_rounded: Float32, frac_ex2: Float32, *, loc=None, ip=None
+    ) -> Float32:
+        return cutlass.Float32(
+            llvm.inline_asm(
+                T.f32(),
+                [
+                    Float32(x_rounded).ir_value(loc=loc, ip=ip),
+                    Float32(frac_ex2).ir_value(loc=loc, ip=ip),
+                ],
+                "{\n\t"
+                ".reg .s32 x_rounded_i, frac_ex_i, x_rounded_e, out_i;\n\t"
+                "mov.b32 x_rounded_i, $1;\n\t"
+                "mov.b32 frac_ex_i, $2;\n\t"
+                "shl.b32 x_rounded_e, x_rounded_i, 23;\n\t"
+                "add.s32 out_i, x_rounded_e, frac_ex_i;\n\t"
+                "mov.b32 $0, out_i;\n\t"
+                "}\n",
+                "=f,f,f",
+                has_side_effects=False,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    x_out = combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0], loc=loc, ip=ip)
+    y_out = combine_int_frac_ex2(xy_rounded[1], xy_frac_ex2[1], loc=loc, ip=ip)
+
+    return x_out, y_out
+
+
+@cute.jit
+def cvt_f32x4_to_f8x4_pack_i32(fp32x4, fp8_type, *, loc=None, ip=None):
+    fp32x4 = fp32x4.load()
+    src_vec4 = fp32x4.ir_value(loc=loc, ip=ip) if hasattr(fp32x4, "ir_value") else fp32x4
+
+    src0 = Float32(vector.extract(src_vec4, [], [0])).ir_value(loc=loc, ip=ip)
+    src1 = Float32(vector.extract(src_vec4, [], [1])).ir_value(loc=loc, ip=ip)
+    src2 = Float32(vector.extract(src_vec4, [], [2])).ir_value(loc=loc, ip=ip)
+    src3 = Float32(vector.extract(src_vec4, [], [3])).ir_value(loc=loc, ip=ip)
+
+    cvt_instruction = ""
+    if cutlass.const_expr(fp8_type == cutlass.Float8E4M3FN):
+        cvt_instruction = "cvt.rn.satfinite.e4m3x2.f32"
+    else:
+        assert False, "Unsupported fp8 element type"
+
+    asm_tmpl = (
+        "{\n"
+        "  .reg .b16 lo;\n"
+        "  .reg .b16 hi;\n"
+        f"  {cvt_instruction} lo, $2, $1;\n"
+        f"  {cvt_instruction} hi, $4, $3;\n"
+        "  mov.b32 $0, {lo, hi};\n"
+        "}"
+    )
+    packed_i32 = llvm.inline_asm(
+        T.i32(),
+        [src0, src1, src2, src3],
+        asm_tmpl,
+        "=r,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+    return packed_i32
+
+
+@cute.jit
+def cvt_f32x4_to_f8x4(fp32x4, fp8x4, *, loc=None, ip=None):
+    packed_i32 = cvt_f32x4_to_f8x4_pack_i32(fp32x4, fp8x4.element_type)
+    fp8x4_i32 = cute.recast_tensor(fp8x4, cutlass.Int32)
+    fp8x4_i32[0] = cutlass.Int32(packed_i32)
+    return

--- a/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/helpers/static_persistent_tile_scheduler.py
+++ b/tensorrt_llm/_torch/visual_gen/cute_dsl_kernels/helpers/static_persistent_tile_scheduler.py
@@ -1,0 +1,814 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# ruff: noqa: I001, E501
+
+import inspect
+from typing import Optional, Tuple
+
+from cutlass.cutlass_dsl import (
+    Boolean,
+    Integer,
+    Int32,
+    min,
+    extract_mlir_values,
+    new_from_mlir_values,
+    dsl_user_op,
+    const_expr,
+)
+from cutlass._mlir import ir
+import cutlass.cute as cute
+
+##############################################################################
+# Static persistent tile scheduler
+##############################################################################
+
+
+class WorkTileInfo:
+    """A class to represent information about a work tile.
+
+    :ivar tile_idx: The index of the tile.
+    :type tile_idx: cute.Coord
+    :ivar is_valid_tile: Whether the tile is valid.
+    :type is_valid_tile: Boolean
+    """
+
+    def __init__(self, tile_idx: cute.Coord, is_valid_tile: Boolean):
+        self._tile_idx = tile_idx
+        self._is_valid_tile = Boolean(is_valid_tile)
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values = extract_mlir_values(self.tile_idx)
+        values.extend(extract_mlir_values(self.is_valid_tile))
+        return values
+
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "WorkTileInfo":
+        assert len(values) == 4
+        new_tile_idx = new_from_mlir_values(self._tile_idx, values[:-1])
+        new_is_valid_tile = new_from_mlir_values(self._is_valid_tile, [values[-1]])
+        return WorkTileInfo(new_tile_idx, new_is_valid_tile)
+
+    @property
+    @cute.jit
+    def is_valid_tile(self) -> Boolean:
+        """Check latest tile returned by the scheduler is valid or not. Any scheduling
+        requests after all tasks completed will return an invalid tile.
+
+        :return: The validity of the tile.
+        :rtype: Boolean
+        """
+        return self._is_valid_tile
+
+    @property
+    @cute.jit
+    def tile_idx(self) -> cute.Coord:
+        """
+        Get the index of the tile.
+
+        :return: The index of the tile.
+        :rtype: cute.Coord
+        """
+        return self._tile_idx
+
+
+class PersistentTileSchedulerParams:
+    """A class to represent parameters for a persistent tile scheduler.
+
+    This class is designed to manage and compute the layout of clusters and tiles
+    in a batched gemm problem.
+
+    :ivar cluster_shape_mn: Shape of the cluster in (m, n) dimensions (K dimension cta count must be 1).
+    :type cluster_shape_mn: tuple
+    :ivar problem_layout_ncluster_mnl: Layout of the problem in terms of
+        number of clusters in (m, n, l) dimensions.
+    :type problem_layout_ncluster_mnl: cute.Layout
+    """
+
+    @dsl_user_op
+    def __init__(
+        self,
+        problem_shape_ntile_mnl: cute.Shape,
+        cluster_shape_mnk: cute.Shape,
+        swizzle_size: int = 1,
+        raster_along_m: bool = True,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """
+        Initializes the PersistentTileSchedulerParams with the given parameters.
+
+        :param problem_shape_ntile_mnl: The shape of the problem in terms of
+            number of CTA (Cooperative Thread Array) in (m, n, l) dimensions.
+        :type problem_shape_ntile_mnl: cute.Shape
+        :param cluster_shape_mnk: The shape of the cluster in (m, n) dimensions.
+        :type cluster_shape_mnk: cute.Shape
+        :param swizzle_size: Swizzling size in the unit of cluster. 1 means no swizzle
+        :type swizzle_size: int
+        :param raster_along_m: Rasterization order of clusters. Only used when swizzle_size > 1.
+            True means along M, false means along N.
+        :type raster_along_m: bool
+
+        :raises ValueError: If cluster_shape_k is not 1.
+        """
+
+        if cluster_shape_mnk[2] != 1:  # type: ignore[index]
+            raise ValueError(f"unsupported cluster_shape_k {cluster_shape_mnk[2]}")  # type: ignore[index]
+        if swizzle_size < 1:
+            raise ValueError(f"expect swizzle_size >= 1, but get {swizzle_size}")
+
+        self.problem_shape_ntile_mnl = problem_shape_ntile_mnl
+        # cluster_shape_mnk is kept for reconstruction
+        self._cluster_shape_mnk = cluster_shape_mnk
+        self.cluster_shape_mn = cluster_shape_mnk[:2]  # type: ignore[index]
+        self.swizzle_size = swizzle_size
+        self.raster_along_m = raster_along_m
+        self._loc = loc
+
+        # By default, we follow m major (col-major) raster order, so make a col-major layout
+        self.problem_layout_ncluster_mnl = cute.make_layout(
+            cute.ceil_div(
+                self.problem_shape_ntile_mnl,
+                cluster_shape_mnk[:2],  # type: ignore[index]
+                loc=loc,
+                ip=ip,
+            ),
+            loc=loc,
+            ip=ip,
+        )
+
+        # Apply swizzle if swizzle_size > 1
+        if swizzle_size > 1:
+            problem_shape_ncluster_mnl = cute.round_up(
+                self.problem_layout_ncluster_mnl.shape,
+                (1, swizzle_size, 1) if raster_along_m else (swizzle_size, 1, 1),
+            )
+
+            if raster_along_m:
+                self.problem_layout_ncluster_mnl = cute.make_layout(
+                    (
+                        problem_shape_ncluster_mnl[0],  # type: ignore[index]
+                        (swizzle_size, problem_shape_ncluster_mnl[1] // swizzle_size),  # type: ignore[index, operator]
+                        problem_shape_ncluster_mnl[2],  # type: ignore[index]
+                    ),
+                    stride=(
+                        swizzle_size,
+                        (1, swizzle_size * problem_shape_ncluster_mnl[0]),  # type: ignore[index]
+                        problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],  # type: ignore[index, operator]
+                    ),
+                    loc=loc,
+                    ip=ip,
+                )
+            else:
+                self.problem_layout_ncluster_mnl = cute.make_layout(
+                    (
+                        (swizzle_size, problem_shape_ncluster_mnl[0] // swizzle_size),  # type: ignore[index, operator]
+                        problem_shape_ncluster_mnl[1],  # type: ignore[index]
+                        problem_shape_ncluster_mnl[2],  # type: ignore[index]
+                    ),
+                    stride=(
+                        (1, swizzle_size * problem_shape_ncluster_mnl[1]),  # type: ignore[index]
+                        swizzle_size,
+                        problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],  # type: ignore[index, operator]
+                    ),
+                    loc=loc,
+                    ip=ip,
+                )
+
+        # Create FastDivmod divisors (only when swizzle_size == 1 for correctness)
+        # FastDivmod assumes simple col-major layout, incompatible with swizzled layouts
+        if swizzle_size == 1:
+            _problem_layout_size = cute.size(self.problem_layout_ncluster_mnl, loc=loc, ip=ip)
+            cluster_count_m = self.problem_layout_ncluster_mnl.shape[0]
+            cluster_count_n = self.problem_layout_ncluster_mnl.shape[1]
+
+            if raster_along_m:
+                cluster_count_major = cluster_count_m
+                cluster_count_minor = cluster_count_n
+            else:
+                cluster_count_major = cluster_count_n
+                cluster_count_minor = cluster_count_m
+
+            # cluster_shape_major_fdd: Used to decode work_unit_id to cluster coordinates
+            self.cluster_shape_major_fdd = cute.fast_divmod_create_divisor(
+                cluster_count_major, loc=loc, ip=ip
+            )
+
+            # cluster_shape_minor_fdd: Used for the second level decomposition
+            self.cluster_shape_minor_fdd = cute.fast_divmod_create_divisor(
+                cluster_count_minor, loc=loc, ip=ip
+            )
+        else:
+            # FastDivmod not applicable with swizzling, set to None
+            self.cluster_shape_major_fdd = None
+            self.cluster_shape_minor_fdd = None
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values, self._values_pos = [], []
+        for obj in [
+            self.problem_shape_ntile_mnl,
+            self._cluster_shape_mnk,
+            self.swizzle_size,
+            self.raster_along_m,
+        ]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+
+        # Add FastDivmod divisors to MLIR values for Host->Device transfer
+        # Only add non-None values to avoid MLIR type errors
+        fastdivmod_values = []
+        fastdivmod_indices = []  # Track which FastDivmod objects are present
+        fastdivmod_lengths = []  # Track serialized MLIR value count per FDD
+
+        for i, (fdd_name, fdd_obj) in enumerate(
+            [
+                ("cluster_shape_major_fdd", self.cluster_shape_major_fdd),
+                ("cluster_shape_minor_fdd", self.cluster_shape_minor_fdd),
+            ]
+        ):
+            if fdd_obj is not None:
+                # Extract MLIR values from FastDivmodDivisor objects
+                fdd_values = extract_mlir_values(fdd_obj)
+                fastdivmod_values.extend(fdd_values)
+                fastdivmod_indices.append(i)
+                fastdivmod_lengths.append(len(fdd_values))
+
+        values += fastdivmod_values
+        self._values_pos.append(
+            len(fastdivmod_indices)
+        )  # Store count of FastDivmod objects, not values
+        self._fastdivmod_indices = fastdivmod_indices  # Store for reconstruction
+        self._fastdivmod_lengths = fastdivmod_lengths  # Per-FDD value count
+
+        return values
+
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "PersistentTileSchedulerParams":
+        obj_list = []
+        values_copy = list(values)  # Make a copy to avoid modifying original
+
+        # Reconstruct original objects from MLIR values
+        for obj, n_items in zip(
+            [
+                self.problem_shape_ntile_mnl,
+                self._cluster_shape_mnk,
+                self.swizzle_size,
+                self.raster_along_m,
+            ],
+            self._values_pos[:-1],  # Exclude FastDivmod count
+        ):
+            obj_list.append(new_from_mlir_values(obj, values_copy[:n_items]))
+            values_copy = values_copy[n_items:]
+
+        # Create new params object by calling __init__ with reconstructed values
+        # This properly recreates layouts and other derived attributes in the device context
+        new_params = PersistentTileSchedulerParams(*(tuple(obj_list)), loc=self._loc)
+
+        # Restore FastDivmod divisors from remaining values
+        fdd_names = ["cluster_shape_major_fdd", "cluster_shape_minor_fdd"]
+
+        if hasattr(self, "_fastdivmod_indices") and len(self._fastdivmod_indices) > 0:
+            # Override the FastDivmod divisors created by __init__ with reconstructed ones.
+            # FastDivmodDivisor now emits multiple MLIR values per object (see issue #3243);
+            # use the per-FDD length recorded during __extract_mlir_values__ to slice the
+            # tail of values_copy without re-emitting IR.
+            fdd_tail_offset = 0
+            for original_index, n_fdd in zip(self._fastdivmod_indices, self._fastdivmod_lengths):
+                fdd_name = fdd_names[original_index]
+                original_fdd = getattr(self, fdd_name)
+                if original_fdd is None:
+                    continue
+                end = fdd_tail_offset + n_fdd
+                if end > len(values_copy):
+                    raise ValueError(
+                        f"FastDivmod values out of range for {fdd_name}: "
+                        f"need {end}, have {len(values_copy)}"
+                    )
+                reconstructed_fdd = new_from_mlir_values(
+                    original_fdd, values_copy[fdd_tail_offset:end]
+                )
+                setattr(new_params, fdd_name, reconstructed_fdd)
+                fdd_tail_offset = end
+            if fdd_tail_offset != len(values_copy):
+                raise ValueError(
+                    "Unexpected trailing FastDivmod MLIR values: "
+                    f"consumed {fdd_tail_offset}, have {len(values_copy)}"
+                )
+
+        return new_params
+
+    @dsl_user_op
+    def get_grid_shape(
+        self,
+        max_active_clusters: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Integer, Integer, Integer]:
+        """
+        Computes the grid shape based on the maximum active clusters allowed.
+
+        :param max_active_clusters: The maximum number of active clusters that
+            can run in one wave.
+        :type max_active_clusters: Int32
+
+        :return: A tuple containing the grid shape in (m, n, persistent_clusters).
+            - m: self.cluster_shape_m.
+            - n: self.cluster_shape_n.
+            - persistent_clusters: Number of persistent clusters that can run.
+        """
+
+        # Total ctas in problem size
+        num_ctas_mnl = tuple(
+            cute.size(x) * y
+            for x, y in zip(self.problem_layout_ncluster_mnl.shape, self.cluster_shape_mn)
+        ) + (self.problem_layout_ncluster_mnl.shape[2],)
+
+        num_ctas_in_problem = cute.size(num_ctas_mnl, loc=loc, ip=ip)
+
+        num_ctas_per_cluster = cute.size(self.cluster_shape_mn, loc=loc, ip=ip)
+        # Total ctas that can run in one wave
+        num_ctas_per_wave = max_active_clusters * num_ctas_per_cluster
+
+        num_persistent_ctas = min(num_ctas_in_problem, num_ctas_per_wave)
+        num_persistent_clusters = num_persistent_ctas // num_ctas_per_cluster
+
+        return (*self.cluster_shape_mn, num_persistent_clusters)
+
+
+# Set explicit signature for Sphinx documentation to avoid issues with @dsl_user_op decorator
+PersistentTileSchedulerParams.__init__.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+    [
+        inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    ]
+)
+
+
+class StaticPersistentTileScheduler:
+    """A scheduler for static persistent tile execution in CUTLASS/CuTe kernels.
+
+    :ivar params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl
+    :type params: PersistentTileSchedulerParams
+    :ivar num_persistent_clusters: Number of persistent clusters that can be launched
+    :type num_persistent_clusters: Int32
+    :ivar cta_id_in_cluster: ID of the CTA within its cluster
+    :type cta_id_in_cluster: cute.Coord
+    :ivar _num_tiles_executed: Counter for executed tiles
+    :type _num_tiles_executed: Int32
+    :ivar _current_work_linear_idx: Current cluster index
+    :type _current_work_linear_idx: Int32
+    """
+
+    def __init__(
+        self,
+        params: PersistentTileSchedulerParams,
+        num_persistent_clusters: Int32,
+        current_work_linear_idx: Int32,
+        cta_id_in_cluster: cute.Coord,
+        num_tiles_executed: Int32,
+    ):
+        """
+        Initializes the StaticPersistentTileScheduler with the given parameters.
+
+        :param params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl.
+        :type params: PersistentTileSchedulerParams
+        :param num_persistent_clusters: Number of persistent clusters that can be launched.
+        :type num_persistent_clusters: Int32
+        :param current_work_linear_idx: Current cluster index.
+        :type current_work_linear_idx: Int32
+        :param cta_id_in_cluster: ID of the CTA within its cluster.
+        :type cta_id_in_cluster: cute.Coord
+        :param num_tiles_executed: Counter for executed tiles.
+        :type num_tiles_executed: Int32
+        """
+        self.params = params
+        self.num_persistent_clusters = num_persistent_clusters
+        self._current_work_linear_idx = current_work_linear_idx
+        self.cta_id_in_cluster = cta_id_in_cluster
+        self._num_tiles_executed = num_tiles_executed
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values = extract_mlir_values(self.num_persistent_clusters)
+        values.extend(extract_mlir_values(self._current_work_linear_idx))
+        values.extend(extract_mlir_values(self.cta_id_in_cluster))
+        values.extend(extract_mlir_values(self._num_tiles_executed))
+
+        # CRITICAL: Also extract FastDivmod divisors from params
+        values.extend(extract_mlir_values(self.params))
+
+        return values
+
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "StaticPersistentTileScheduler":
+        assert len(values) >= 6
+        new_num_persistent_clusters = new_from_mlir_values(
+            self.num_persistent_clusters, [values[0]]
+        )
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[1]]
+        )
+        new_cta_id_in_cluster = new_from_mlir_values(self.cta_id_in_cluster, values[2:5])
+        new_num_tiles_executed = new_from_mlir_values(self._num_tiles_executed, [values[5]])
+
+        # Reconstruct params with FastDivmod divisors
+        params_values = values[6:]  # Remaining values are from params
+        new_params = new_from_mlir_values(self.params, params_values)
+
+        return StaticPersistentTileScheduler(
+            new_params,  # Use reconstructed params with FastDivmod divisors
+            new_num_persistent_clusters,
+            new_current_work_linear_idx,
+            new_cta_id_in_cluster,
+            new_num_tiles_executed,
+        )
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: PersistentTileSchedulerParams,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "StaticPersistentTileScheduler":
+        """Initialize the static persistent tile scheduler.
+
+        :param params: Parameters for the persistent
+            tile scheduler.
+        :type params: PersistentTileSchedulerParams
+        :param block_idx: The 3d block index in the format (bidx, bidy, bidz).
+        :type block_idx: Tuple[Integer, Integer, Integer]
+        :param grid_dim: The 3d grid dimensions for kernel launch.
+        :type grid_dim: Tuple[Integer, Integer, Integer]
+
+        :return: A StaticPersistentTileScheduler object.
+        :rtype: StaticPersistentTileScheduler
+        """
+
+        # Calculate the number of persistent clusters by dividing the total grid size
+        # by the number of CTAs per cluster
+        num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+            params.cluster_shape_mn, loc=loc, ip=ip
+        )
+
+        bidx, bidy, bidz = block_idx
+
+        # Initialize workload index equals to the cluster index in the grid
+        current_work_linear_idx = Int32(bidz)
+
+        # CTA id in the cluster
+        cta_id_in_cluster = (
+            Int32(bidx % params.cluster_shape_mn[0]),
+            Int32(bidy % params.cluster_shape_mn[1]),
+            Int32(0),
+        )
+        # Initialize number of tiles executed to zero
+        num_tiles_executed = Int32(0)
+        return StaticPersistentTileScheduler(
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+        )
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: PersistentTileSchedulerParams,
+        max_active_clusters: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Integer, Integer, Integer]:
+        """Calculates the grid shape to be launched on GPU using problem shape,
+        threadblock shape, and active cluster size.
+
+        :param params: Parameters for grid shape calculation.
+        :type params: PersistentTileSchedulerParams
+        :param max_active_clusters: Maximum active clusters allowed.
+        :type max_active_clusters: Int32
+
+        :return: The calculated 3d grid shape.
+        :rtype: Tuple[Integer, Integer, Integer]
+        """
+
+        return params.get_grid_shape(max_active_clusters, loc=loc, ip=ip)
+
+    # private method
+    def _get_current_work_for_linear_idx(
+        self,
+        current_work_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        """Compute current tile coord given current_work_linear_idx and cta_id_in_cluster.
+
+        :param current_work_linear_idx: The linear index of the current work.
+        :type current_work_linear_idx: Int32
+
+        :return: An object containing information about the current tile coordinates
+            and validity status.
+        :rtype: WorkTileInfo
+        """
+
+        is_valid = current_work_linear_idx < cute.size(
+            self.params.problem_layout_ncluster_mnl, loc=loc, ip=ip
+        )
+
+        # Choose coordinate calculation method based on swizzle configuration
+        if self.params.swizzle_size == 1:
+            # Use FastDivmod optimization for non-swizzled layouts
+            cur_cluster_coord = self._get_cluster_work_idx_with_fastdivmod(
+                current_work_linear_idx, loc=loc, ip=ip
+            )
+        else:
+            # Use get_flat_coord for swizzled layouts (FastDivmod doesn't support them)
+            cur_cluster_coord = self.params.problem_layout_ncluster_mnl.get_flat_coord(
+                current_work_linear_idx, loc=loc, ip=ip
+            )
+
+        cur_tile_coord = tuple(
+            cute.arch.make_warp_uniform(Int32(x) * Int32(z) + Int32(y))
+            for x, y, z in zip(
+                cur_cluster_coord,
+                self.cta_id_in_cluster,  # type: ignore[arg-type]
+                (*self.params.cluster_shape_mn, Int32(1)),
+            )
+        )
+
+        return WorkTileInfo(cur_tile_coord, cute.arch.make_warp_uniform(is_valid))
+
+    def _get_cluster_work_idx_with_fastdivmod(
+        self,
+        current_work_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        """
+        FastDivmod optimized CLUSTER coordinate calculation.
+
+        CRITICAL: This should mimic problem_layout_ncluster_mnl.get_hier_coord()
+        which returns CLUSTER coordinates, not tile coordinates!
+
+        :param current_work_linear_idx: Linear index in the work space
+        :type current_work_linear_idx: Int32
+        :return: Cluster coordinates (m, n, l) or None if FastDivmod not available
+        :rtype: Tuple[Int32, Int32, Int32] or None
+        """
+
+        # Step 1: Decode current_work_linear_idx using FastDivmod objects
+        # The layout structure is: problem_layout_ncluster_mnl has shape (cluster_count_m, cluster_count_n, batch_count)
+        # current_work_linear_idx needs to be decomposed into (batch_l, cluster_minor, cluster_major) in little-endian order
+
+        # First, get cluster_major using cluster_shape_major_fdd
+        cluster_minor_batch, cluster_major = divmod(
+            current_work_linear_idx, self.params.cluster_shape_major_fdd
+        )
+
+        # Then decode cluster_minor_batch to get cluster_minor and batch_l using FastDivmod
+        batch_l, cluster_minor = divmod(cluster_minor_batch, self.params.cluster_shape_minor_fdd)
+
+        if self.params.raster_along_m:
+            cluster_m = cluster_major
+            cluster_n = cluster_minor
+        else:
+            cluster_m = cluster_minor
+            cluster_n = cluster_major
+
+        return (cluster_m, cluster_n, batch_l)
+
+    @dsl_user_op
+    @cute.jit
+    def get_current_work(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        return self._get_current_work_for_linear_idx(self._current_work_linear_idx, loc=loc, ip=ip)
+
+    @dsl_user_op
+    @cute.jit
+    def initial_work_tile_info(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        return self.get_current_work(loc=loc, ip=ip)
+
+    @dsl_user_op
+    @cute.jit
+    def advance_to_next_work(
+        self,
+        *,
+        advance_count: int = 1,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        self._current_work_linear_idx += Int32(advance_count) * Int32(self.num_persistent_clusters)
+        self._num_tiles_executed += Int32(1)
+
+    @property
+    @cute.jit
+    def num_tiles_executed(self) -> Int32:
+        return self._num_tiles_executed
+
+
+class StaticPersistentRuntimeTileScheduler(StaticPersistentTileScheduler):
+    """A scheduler for static persistent runtime tile execution in CUTLASS/CuTe kernels.
+    This scheduler will always launch all the SMs and the scheduler will generate the real tile info for each SM.
+
+    :ivar params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl
+    :type params: PersistentTileSchedulerParams
+    :ivar num_persistent_clusters: Number of persistent clusters that can be launched
+    :type num_persistent_clusters: Int32
+    :ivar cta_id_in_cluster: ID of the CTA within its cluster
+    :type cta_id_in_cluster: cute.Coord
+    :ivar _num_tiles_executed: Counter for executed tiles
+    :type _num_tiles_executed: Int32
+    :ivar _current_work_linear_idx: Current cluster index
+    :type _current_work_linear_idx: Int32
+    """
+
+    def __init__(
+        self,
+        params: PersistentTileSchedulerParams,
+        num_persistent_clusters: Int32,
+        current_work_linear_idx: Int32,
+        cta_id_in_cluster: cute.Coord,
+        num_tiles_executed: Int32,
+        inner_mode: int = 1,
+    ):
+        """
+        Initializes the StaticPersistentRuntimeTileScheduler with the given parameters.
+
+        :param params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl.
+        :type params: PersistentTileSchedulerParams
+        :param num_persistent_clusters: Number of persistent clusters that can be launched.
+        :type num_persistent_clusters: Int32
+        :param current_work_linear_idx: Current cluster index.
+        :type current_work_linear_idx: Int32
+        :param cta_id_in_cluster: ID of the CTA within its cluster.
+        :type cta_id_in_cluster: cute.Coord
+        :param num_tiles_executed: Counter for executed tiles.
+        :type num_tiles_executed: Int32
+        :param inner_mode: The inner mode along which the linear index will be decomposed first.
+        :type inner_mode: int
+        """
+        super().__init__(
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+        )
+        if inner_mode not in [0, 1]:
+            raise ValueError(
+                f"inner_mode must be 0(for M mode) or 1(for N mode), but got {inner_mode}"
+            )
+        self.inner_mode = inner_mode
+
+    def __new_from_mlir_values__(
+        self, values: list[ir.Value]
+    ) -> "StaticPersistentRuntimeTileScheduler":
+        assert len(values) >= 6
+        new_num_persistent_clusters = new_from_mlir_values(
+            self.num_persistent_clusters, [values[0]]
+        )
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[1]]
+        )
+        new_cta_id_in_cluster = new_from_mlir_values(self.cta_id_in_cluster, values[2:5])
+        new_num_tiles_executed = new_from_mlir_values(self._num_tiles_executed, [values[5]])
+
+        # Reconstruct params with FastDivmod divisors (same as parent class)
+        params_values = values[6:]  # Remaining values are from params
+        new_params = new_from_mlir_values(self.params, params_values)
+
+        return StaticPersistentRuntimeTileScheduler(
+            new_params,  # Use reconstructed params with FastDivmod divisors
+            new_num_persistent_clusters,
+            new_current_work_linear_idx,
+            new_cta_id_in_cluster,
+            new_num_tiles_executed,
+            self.inner_mode,
+        )
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: PersistentTileSchedulerParams,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        inner_mode: int = 1,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "StaticPersistentRuntimeTileScheduler":
+        """Initialize the static persistent tile scheduler.
+
+        :param params: Parameters for the persistent
+            tile scheduler.
+        :type params: PersistentTileSchedulerParams
+        :param block_idx: The 3d block index in the format (bidx, bidy, bidz).
+        :type block_idx: Tuple[Integer, Integer, Integer]
+        :param grid_dim: The 3d grid dimensions for kernel launch.
+        :type grid_dim: Tuple[Integer, Integer, Integer]
+        :param inner_mode: The inner mode along which the linear index will be decomposed first.
+        :type inner_mode: int
+
+        :return: A StaticPersistentRuntimeTileScheduler object.
+        :rtype: StaticPersistentRuntimeTileScheduler
+        """
+
+        # Calculate the number of persistent clusters by dividing the total grid size
+        # by the number of CTAs per cluster
+        num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+            params.cluster_shape_mn, loc=loc, ip=ip
+        )
+
+        bidx, bidy, bidz = block_idx
+
+        # Initialize workload index equals to the cluster index in the grid
+        current_work_linear_idx = Int32(bidz)
+
+        # CTA id in the cluster
+        cta_id_in_cluster = (
+            Int32(bidx % params.cluster_shape_mn[0]),
+            Int32(bidy % params.cluster_shape_mn[1]),
+            Int32(0),
+        )
+        # Initialize number of tiles executed to zero
+        num_tiles_executed = Int32(0)
+        return StaticPersistentRuntimeTileScheduler(
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+            inner_mode,
+        )
+
+    # private method
+    def _get_current_work_for_linear_idx(
+        self,
+        current_work_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        """Compute current tile coord given current_work_linear_idx and cta_id_in_cluster.
+
+        :param current_work_linear_idx: The linear index of the current work.
+        :type current_work_linear_idx: Int32
+
+        :return: An object containing information about the current tile coordinates
+            and validity status.
+        :rtype: WorkTileInfo
+        """
+        ntile_shape = self.params.problem_layout_ncluster_mnl.shape
+        int_max = 2147483647
+        if const_expr(self.inner_mode == 1):
+            ntile_layout = cute.make_layout((int_max, ntile_shape[1]), stride=(ntile_shape[1], 1))
+        else:
+            ntile_layout = cute.make_layout((ntile_shape[0], int_max), stride=(1, ntile_shape[0]))
+        cluster_tile_coord_mn = ntile_layout.get_hier_coord(current_work_linear_idx)
+        cur_tile_coord = (
+            cluster_tile_coord_mn[0],
+            cluster_tile_coord_mn[1],
+            Int32(0),
+        )
+
+        # it is determined by kernel implementation
+        is_valid = Boolean(True)
+
+        return WorkTileInfo(cur_tile_coord, is_valid)

--- a/tensorrt_llm/visual_gen/args.py
+++ b/tensorrt_llm/visual_gen/args.py
@@ -54,10 +54,13 @@ class QuantAttentionConfig(StrictBaseModel):
     Unsupported recipes are rejected by AttentionConfig's validator with a ValueError.
     """
 
-    qk_dtype: Literal["bf16", "int8", "fp8"] = Field(
+    qk_dtype: Literal["bf16", "int8", "fp8", "fp4"] = Field(
         "bf16",
         status="prototype",
-        description="Q/K quantization dtype; bf16 leaves Q/K unquantized.",
+        description=(
+            "Q/K quantization dtype; bf16 leaves Q/K unquantized."
+            "fp4 must be accompanied by qk_sf_vec==16 for NVFP4."
+        ),
     )
     v_dtype: Literal["fp8"] = Field(
         "fp8",
@@ -81,6 +84,17 @@ class QuantAttentionConfig(StrictBaseModel):
         ge=0,
         status="prototype",
         description="Elements per quantization block for V; 0 for per-tensor quantization.",
+    )
+    qk_sf_vec: int = Field(
+        0,
+        ge=0,
+        status="prototype",
+        description=(
+            "Scale-factor vector size for the block-scaled Q@K kernel. 0 disables "
+            "the block-scaled path (SAGE / QK16PV8 / dense). "
+            "32 selects MXFP8 (requires qk_dtype==fp8); "
+            "16 selects NVFP4 (requires qk_dtype==fp4)."
+        ),
     )
 
 
@@ -119,17 +133,21 @@ class AttentionConfig(StrictBaseModel):
 
     @model_validator(mode="after")
     def _validate_quant_attention_config(self) -> "AttentionConfig":
-        # SAGE recipes target the TRTLLM backend (per-block Q/K/V scales).
+        # Recipe tuple: (qk_dtype, v_dtype, (q_block, k_block, v_block), qk_sf_vec).
+        # SAGE recipes target the TRTLLM backend; qk_sf_vec is always 0 for SAGE.
         SAGE_RECIPES = {
-            ("int8", "fp8", (1, 1, 1)),
-            ("int8", "fp8", (1, 4, 1)),
-            ("int8", "fp8", (1, 16, 1)),
-            ("fp8", "fp8", (1, 1, 1)),
-            ("fp8", "fp8", (1, 4, 1)),
+            ("int8", "fp8", (1, 1, 1), 0),
+            ("int8", "fp8", (1, 4, 1), 0),
+            ("int8", "fp8", (1, 16, 1), 0),
+            ("fp8", "fp8", (1, 1, 1), 0),
+            ("fp8", "fp8", (1, 4, 1), 0),
         }
-        # QK16PV8 (CUTEDSL backend): Q/K kept in bf16, V quantized to FP8.
-        QK16PV8_DTYPES = {
-            ("bf16", "fp8", (0, 0, 0)),
+        # CUTEDSL accepts QK16PV8 (dense path) plus the MXFP8 / NVFP4 block-scaled paths
+        # (qk_sf_vec == 0 deselects the block-scaled kernel class).
+        CUTEDSL_RECIPES = {
+            ("bf16", "fp8", (0, 0, 0), 0),  # QK16PV8
+            ("fp8", "fp8", (1, 1, 0), 32),  # MXFP8
+            ("fp4", "fp8", (1, 1, 0), 16),  # NVFP4
         }
 
         if self.quant_attention_config is None:
@@ -140,21 +158,23 @@ class AttentionConfig(StrictBaseModel):
             q_config.qk_dtype,
             q_config.v_dtype,
             (q_config.q_block_size, q_config.k_block_size, q_config.v_block_size),
+            q_config.qk_sf_vec,
         )
         if self.backend == "TRTLLM":
             if recipe not in SAGE_RECIPES:
                 raise ValueError(
                     f"Unsupported quant_attention_config={self.quant_attention_config!r} "
                     f"for backend='TRTLLM'. Supported SAGE recipes "
-                    f"(qk_dtype, v_dtype, (q_block, k_block, v_block)): "
+                    f"(qk_dtype, v_dtype, (q_block, k_block, v_block), qk_sf_vec): "
                     f"{sorted(SAGE_RECIPES)}."
                 )
         elif self.backend == "CUTEDSL":
-            if recipe not in QK16PV8_DTYPES:
+            if recipe not in CUTEDSL_RECIPES:
                 raise ValueError(
                     f"Unsupported quant_attention_config={self.quant_attention_config!r} "
-                    f"for backend='CUTEDSL'. Supported (qk_dtype, v_dtype): "
-                    f"{sorted(QK16PV8_DTYPES)}."
+                    f"for backend='CUTEDSL'. Supported recipes "
+                    f"(qk_dtype, v_dtype, (q_block, k_block, v_block), qk_sf_vec): "
+                    f"{sorted(CUTEDSL_RECIPES)}."
                 )
         else:
             raise ValueError(

--- a/tensorrt_llm/visual_gen/args.py
+++ b/tensorrt_llm/visual_gen/args.py
@@ -46,20 +46,18 @@ CacheBackendName = Literal["teacache", "cache_dit"]
 class QuantAttentionConfig(StrictBaseModel):
     """Attention quantization recipe (TRTLLM / CUTEDSL backends).
 
-    Describes user intent for quantized attention: per-bmm dtype and per-block layout for Q, K, V.
-    Providing this config to AttentionConfig enables quantized attention; setting
-    AttentionConfig.quant_attention_config = None disables it.
+    Specifies Q/K and V quantization formats and their optional block sizes.
 
     Bare QuantAttentionConfig() is a valid Qk16Pv8 recipe.
     Unsupported recipes are rejected by AttentionConfig's validator with a ValueError.
     """
 
-    qk_dtype: Literal["bf16", "int8", "fp8", "fp4"] = Field(
+    qk_dtype: Literal["bf16", "int8", "fp8", "mxfp8", "nvfp4"] = Field(
         "bf16",
         status="prototype",
         description=(
-            "Q/K quantization dtype; bf16 leaves Q/K unquantized."
-            "fp4 must be accompanied by qk_sf_vec==16 for NVFP4."
+            "Q/K quantization format. bf16 leaves Q/K unquantized; int8 and fp8 use 8-bit "
+            "integer and floating-point element formats; mxfp8 and nvfp4 are block-scaled formats."
         ),
     )
     v_dtype: Literal["fp8"] = Field(
@@ -71,29 +69,20 @@ class QuantAttentionConfig(StrictBaseModel):
         0,
         ge=0,
         status="prototype",
-        description="Elements per quantization block for Q; 0 for per-tensor quantization.",
+        description="Number of Q tokens per SageAttention quantization block; 0 otherwise.",
     )
     k_block_size: int = Field(
         0,
         ge=0,
         status="prototype",
-        description="Elements per quantization block for K; 0 for per-tensor quantization.",
+        description="Number of K tokens per SageAttention quantization block; 0 otherwise.",
     )
     v_block_size: int = Field(
         0,
         ge=0,
         status="prototype",
-        description="Elements per quantization block for V; 0 for per-tensor quantization.",
-    )
-    qk_sf_vec: int = Field(
-        0,
-        ge=0,
-        status="prototype",
         description=(
-            "Scale-factor vector size for the block-scaled Q@K kernel. 0 disables "
-            "the block-scaled path (SAGE / QK16PV8 / dense). "
-            "32 selects MXFP8 (requires qk_dtype==fp8); "
-            "16 selects NVFP4 (requires qk_dtype==fp4)."
+            "V quantization block size on the hidden dimension; 0 uses one tensor-wide V scale."
         ),
     )
 
@@ -133,21 +122,20 @@ class AttentionConfig(StrictBaseModel):
 
     @model_validator(mode="after")
     def _validate_quant_attention_config(self) -> "AttentionConfig":
-        # Recipe tuple: (qk_dtype, v_dtype, (q_block, k_block, v_block), qk_sf_vec).
-        # SAGE recipes target the TRTLLM backend; qk_sf_vec is always 0 for SAGE.
+        # Recipe tuple: (qk_dtype, v_dtype, (q_block, k_block, v_block)).
         SAGE_RECIPES = {
-            ("int8", "fp8", (1, 1, 1), 0),
-            ("int8", "fp8", (1, 4, 1), 0),
-            ("int8", "fp8", (1, 16, 1), 0),
-            ("fp8", "fp8", (1, 1, 1), 0),
-            ("fp8", "fp8", (1, 4, 1), 0),
+            ("int8", "fp8", (1, 1, 1)),
+            ("int8", "fp8", (1, 4, 1)),
+            ("int8", "fp8", (1, 16, 1)),
+            ("fp8", "fp8", (1, 1, 1)),
+            ("fp8", "fp8", (1, 4, 1)),
         }
-        # CUTEDSL accepts QK16PV8 (dense path) plus the MXFP8 / NVFP4 block-scaled paths
-        # (qk_sf_vec == 0 deselects the block-scaled kernel class).
         CUTEDSL_RECIPES = {
-            ("bf16", "fp8", (0, 0, 0), 0),  # QK16PV8
-            ("fp8", "fp8", (1, 1, 0), 32),  # MXFP8
-            ("fp4", "fp8", (1, 1, 0), 16),  # NVFP4
+            ("bf16", "fp8", (0, 0, 0)),
+            ("mxfp8", "fp8", (0, 0, 0)),
+            ("mxfp8", "fp8", (0, 0, 1)),
+            ("nvfp4", "fp8", (0, 0, 0)),
+            ("nvfp4", "fp8", (0, 0, 1)),
         }
 
         if self.quant_attention_config is None:
@@ -158,14 +146,13 @@ class AttentionConfig(StrictBaseModel):
             q_config.qk_dtype,
             q_config.v_dtype,
             (q_config.q_block_size, q_config.k_block_size, q_config.v_block_size),
-            q_config.qk_sf_vec,
         )
         if self.backend == "TRTLLM":
             if recipe not in SAGE_RECIPES:
                 raise ValueError(
                     f"Unsupported quant_attention_config={self.quant_attention_config!r} "
                     f"for backend='TRTLLM'. Supported SAGE recipes "
-                    f"(qk_dtype, v_dtype, (q_block, k_block, v_block), qk_sf_vec): "
+                    f"(qk_dtype, v_dtype, (q_block, k_block, v_block)): "
                     f"{sorted(SAGE_RECIPES)}."
                 )
         elif self.backend == "CUTEDSL":
@@ -173,7 +160,7 @@ class AttentionConfig(StrictBaseModel):
                 raise ValueError(
                     f"Unsupported quant_attention_config={self.quant_attention_config!r} "
                     f"for backend='CUTEDSL'. Supported recipes "
-                    f"(qk_dtype, v_dtype, (q_block, k_block, v_block), qk_sf_vec): "
+                    f"(qk_dtype, v_dtype, (q_block, k_block, v_block)): "
                     f"{sorted(CUTEDSL_RECIPES)}."
                 )
         else:

--- a/tests/unittest/_torch/visual_gen/test_attention_cute_dsl.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_cute_dsl.py
@@ -13,34 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import cutlass
 import pytest
 import torch
 import torch.nn.functional as F
 
-from tensorrt_llm._torch.visual_gen.cute_dsl_kernels.blackwell.attention import cute_dsl_fmha_fwd
-from tensorrt_llm._torch.visual_gen.cute_dsl_kernels.blackwell.attention.fmha import (
-    get_cute_dsl_fmha_cubin,
+from tensorrt_llm._torch.visual_gen.attention_backend.cute_dsl import (
+    _COMPILE_CACHE,
+    _quantize_blockscaled_one,
+    clear_cute_dsl_fmha_cache,
+    cute_dsl_fmha_fwd,
 )
-
-
-def test_cute_dsl_cubin_kernel_can_import_and_load() -> None:
-    gpu_arch = _require_supported_gpu_arch()
-    try:
-        kernel = get_cute_dsl_fmha_cubin(
-            torch.bfloat16,
-            torch.bfloat16,
-            torch.bfloat16,
-            128,
-            is_causal=False,
-            is_persistent=False,
-            varlen=True,
-            enable_tvm_ffi=True,
-            gpu_arch=gpu_arch,
-        )
-    except ImportError as exc:
-        pytest.skip(str(exc))
-
-    assert kernel is not None
 
 
 def _require_supported_gpu_arch() -> str:
@@ -55,19 +38,31 @@ def _require_supported_gpu_arch() -> str:
     return gpu_arch
 
 
-def _make_indptr(lens: list[int], device: torch.device) -> torch.Tensor:
-    lens_tensor = torch.tensor(lens, dtype=torch.int32, device=device)
-    return torch.cat(
-        [
-            torch.zeros(1, dtype=torch.int32, device=device),
-            lens_tensor.cumsum(0).int(),
-        ]
+def test_cute_dsl_jit_compile_smoke() -> None:
+    """Compile (or fetch from cache) the kernel once and verify the cache grew."""
+    _require_supported_gpu_arch()
+    device = torch.device("cuda:0")
+    batch_size, seq_len, num_heads, head_dim = 1, 128, 1, 128
+    sm_scale = head_dim**-0.5
+
+    torch.manual_seed(0)
+    q = (
+        torch.randn(batch_size, seq_len, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+        * 0.4
     )
+    k = torch.randn_like(q) * 0.4
+    v = torch.randn_like(q) * 0.4
+    out = torch.empty_like(q)
+
+    clear_cute_dsl_fmha_cache()
+    cute_dsl_fmha_fwd(q, k, v, out, is_causal=False, sm_scale=sm_scale)
+    torch.cuda.synchronize()
+    assert len(_COMPILE_CACHE) == 1
 
 
 def _make_tensor(
-    max_len: int,
-    total_len: int,
+    batch_size: int,
+    seq_len: int,
     num_heads: int,
     head_dim: int,
     dtype: torch.dtype,
@@ -75,63 +70,54 @@ def _make_tensor(
     scale: float,
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    tensor_f32 = torch.randn(
-        max_len + total_len,
-        num_heads,
-        head_dim,
-        dtype=torch.float32,
-        device=device,
+    """Build a (B, S, H, D) tensor in `dtype` plus its dequantized reference."""
+    tensor_f32 = (
+        torch.randn(
+            batch_size,
+            seq_len,
+            num_heads,
+            head_dim,
+            dtype=torch.float32,
+            device=device,
+        )
+        * 0.4
     )
-    tensor_f32 *= 0.1
     if dtype == torch.float8_e4m3fn:
         tensor = (tensor_f32 / scale).to(dtype)
         ref = (tensor.float() * scale).to(ref_dtype)
     else:
         tensor = tensor_f32.to(dtype)
         ref = tensor.to(ref_dtype)
-    return tensor[max_len:], ref[max_len:]
+    return tensor, ref
 
 
 def _sdpa_ref(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    qo_indptr: torch.Tensor,
-    kv_indptr: torch.Tensor,
     is_causal: bool,
     sm_scale: float,
 ) -> torch.Tensor:
-    out = []
-    for batch_idx in range(qo_indptr.numel() - 1):
-        q_start = int(qo_indptr[batch_idx].item())
-        q_end = int(qo_indptr[batch_idx + 1].item())
-        kv_start = int(kv_indptr[batch_idx].item())
-        kv_end = int(kv_indptr[batch_idx + 1].item())
-
-        q_i = q[q_start:q_end].transpose(0, 1).unsqueeze(0)
-        k_i = k[kv_start:kv_end].transpose(0, 1).unsqueeze(0)
-        v_i = v[kv_start:kv_end].transpose(0, 1).unsqueeze(0)
-        if q_i.shape[1] != k_i.shape[1]:
-            repeat_factor = q_i.shape[1] // k_i.shape[1]
-            k_i = k_i.repeat_interleave(repeat_factor, dim=1)
-            v_i = v_i.repeat_interleave(repeat_factor, dim=1)
-        out_i = F.scaled_dot_product_attention(
-            q_i,
-            k_i,
-            v_i,
-            is_causal=is_causal,
-            scale=sm_scale,
-        )
-        out.append(out_i.squeeze(0).transpose(0, 1))
-    return torch.cat(out, dim=0)
+    """Reference: SDPA on (B, S, H, D) tensors, with GQA broadcast if needed."""
+    q_bhsd = q.transpose(1, 2)
+    k_bhsd = k.transpose(1, 2)
+    v_bhsd = v.transpose(1, 2)
+    if q_bhsd.shape[1] != k_bhsd.shape[1]:
+        repeat = q_bhsd.shape[1] // k_bhsd.shape[1]
+        k_bhsd = k_bhsd.repeat_interleave(repeat, dim=1)
+        v_bhsd = v_bhsd.repeat_interleave(repeat, dim=1)
+    out = F.scaled_dot_product_attention(
+        q_bhsd, k_bhsd, v_bhsd, is_causal=is_causal, scale=sm_scale
+    )
+    return out.transpose(1, 2)
 
 
 @pytest.mark.parametrize(
-    ("q_lens", "kv_lens", "is_causal"),
+    ("batch_size", "seq_len_q", "seq_len_kv", "is_causal"),
     [
-        pytest.param([256], [256], False, id="single_nocausal"),
-        pytest.param([512], [512], True, id="single_causal"),
-        pytest.param([64, 128], [128, 512], False, id="varlen_nocausal"),
+        pytest.param(1, 256, 256, False, id="b1_s256_nocausal"),
+        pytest.param(1, 512, 512, True, id="b1_s512_causal"),
+        pytest.param(2, 256, 256, False, id="b2_s256_nocausal"),
     ],
 )
 @pytest.mark.parametrize(
@@ -164,9 +150,10 @@ def _sdpa_ref(
     ],
 )
 @pytest.mark.parametrize("head_dim", [128])
-def test_cute_dsl_fmha_context_forward_cubin_smoke(
-    q_lens: list[int],
-    kv_lens: list[int],
+def test_cute_dsl_fmha_context_forward(
+    batch_size: int,
+    seq_len_q: int,
+    seq_len_kv: int,
     is_causal: bool,
     qk_dtype: torch.dtype,
     pv_dtype: torch.dtype,
@@ -177,72 +164,162 @@ def test_cute_dsl_fmha_context_forward_cubin_smoke(
     atol: float,
     rtol: float,
 ) -> None:
-    gpu_arch = _require_supported_gpu_arch()
+    _require_supported_gpu_arch()
     device = torch.device("cuda:0")
     sm_scale = head_dim**-0.5
     scale_v = 0.06 if pv_dtype == torch.float8_e4m3fn else 1.0
 
     torch.manual_seed(42)
     torch.cuda.manual_seed_all(42)
-    qo_indptr = _make_indptr(q_lens, device)
-    kv_indptr = _make_indptr(kv_lens, device)
-    total_q = int(qo_indptr[-1].item())
-    total_kv = int(kv_indptr[-1].item())
-    max_qo_len = max(q_lens)
-    max_kv_len = max(kv_lens)
 
     q, q_ref = _make_tensor(
-        max_qo_len, total_q, num_heads, head_dim, qk_dtype, out_dtype, 1.0, device
+        batch_size, seq_len_q, num_heads, head_dim, qk_dtype, out_dtype, 1.0, device
     )
     k, k_ref = _make_tensor(
-        max_kv_len, total_kv, num_heads_kv, head_dim, qk_dtype, out_dtype, 1.0, device
+        batch_size, seq_len_kv, num_heads_kv, head_dim, qk_dtype, out_dtype, 1.0, device
     )
     v, v_ref = _make_tensor(
-        max_kv_len, total_kv, num_heads_kv, head_dim, pv_dtype, out_dtype, scale_v, device
+        batch_size, seq_len_kv, num_heads_kv, head_dim, pv_dtype, out_dtype, scale_v, device
     )
-    out_storage = torch.empty(
-        max_qo_len + total_q,
-        num_heads,
-        head_dim,
-        dtype=out_dtype,
-        device=device,
-    )
-    out = out_storage[max_qo_len:]
-    kernel_fn = get_cute_dsl_fmha_cubin(
-        qk_dtype,
-        pv_dtype,
-        out_dtype,
-        head_dim,
-        is_causal,
-        is_persistent=False,
-        varlen=True,
-        enable_tvm_ffi=True,
-        gpu_arch=gpu_arch,
-    )
+    out = torch.empty(batch_size, seq_len_q, num_heads, head_dim, dtype=out_dtype, device=device)
+    lse = torch.empty(batch_size, seq_len_q, num_heads, dtype=torch.float32, device=device)
 
     cute_dsl_fmha_fwd(
         q,
         k,
         v,
         out,
-        qo_indptr,
-        kv_indptr,
         is_causal=is_causal,
         sm_scale=sm_scale,
         scale_v=scale_v,
-        max_qo_len=max_qo_len,
-        max_kv_len=max_kv_len,
-        kernel_fn=kernel_fn,
+        lse=lse,
     )
     torch.cuda.synchronize()
 
-    out_ref = _sdpa_ref(
-        q_ref,
-        k_ref,
-        v_ref,
-        qo_indptr,
-        kv_indptr,
-        is_causal,
-        sm_scale,
+    out_ref = _sdpa_ref(q_ref, k_ref, v_ref, is_causal, sm_scale)
+    torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize(
+    ("qk_sf_vec", "qk_cutlass_dtype_name", "atol", "rtol"),
+    [
+        pytest.param(32, "Float8E4M3FN", 8e-2, 8e-2, id="mxfp8"),
+        pytest.param(16, "Float4E2M1FN", 2e-1, 2e-1, id="nvfp4"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("batch_size", "seq_len_q", "seq_len_kv", "is_causal"),
+    [
+        pytest.param(1, 256, 256, False, id="b1_s256_nocausal"),
+        pytest.param(1, 512, 512, True, id="b1_s512_causal"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("num_heads", "num_heads_kv"),
+    [
+        pytest.param(4, 4, id="mha"),
+        pytest.param(4, 2, id="gqa"),
+    ],
+)
+def test_cute_dsl_fmha_blockscaled_forward(
+    batch_size: int,
+    seq_len_q: int,
+    seq_len_kv: int,
+    is_causal: bool,
+    qk_sf_vec: int,
+    qk_cutlass_dtype_name: str,
+    num_heads: int,
+    num_heads_kv: int,
+    atol: float,
+    rtol: float,
+) -> None:
+    """End-to-end MXFP8 / NVFP4 block-scaled Q@K path through cute_dsl_fmha_fwd.
+
+    Drives the block-scaled kernel with TRT-LLM-quantized Q/K and bf16 V. Tolerance
+    is loose to accommodate FP8/FP4 quantization error vs. the bf16 SDPA reference.
+    """
+    _require_supported_gpu_arch()
+
+    device = torch.device("cuda:0")
+    head_dim = 128  # kernel-imposed for block-scaled MXFP8 / NVFP4
+    sm_scale = head_dim**-0.5
+
+    torch.manual_seed(42)
+    torch.cuda.manual_seed_all(42)
+
+    q_bf16 = (
+        torch.randn(
+            batch_size,
+            seq_len_q,
+            num_heads,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        * 0.5
     )
+    k_bf16 = (
+        torch.randn(
+            batch_size,
+            seq_len_kv,
+            num_heads_kv,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        * 0.5
+    )
+    v_bf16 = (
+        torch.randn(
+            batch_size,
+            seq_len_kv,
+            num_heads_kv,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        * 0.5
+    )
+
+    # Quantize Q/K via the same helper the backend uses; V stays bf16 (kernel's
+    # pv_dtype is inferred from v.dtype).
+    q_q, q_sf, scale_q = _quantize_blockscaled_one(q_bf16, qk_sf_vec)
+    k_q, k_sf, scale_k = _quantize_blockscaled_one(k_bf16, qk_sf_vec)
+    qk_cutlass_dtype = getattr(cutlass, qk_cutlass_dtype_name)
+
+    out = torch.empty(
+        batch_size,
+        seq_len_q,
+        num_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    lse = torch.empty(
+        batch_size,
+        seq_len_q,
+        num_heads,
+        dtype=torch.float32,
+        device=device,
+    )
+
+    cute_dsl_fmha_fwd(
+        q_q,
+        k_q,
+        v_bf16,
+        out,
+        is_causal=is_causal,
+        sm_scale=sm_scale,
+        lse=lse,
+        scale_q=scale_q,
+        scale_k=scale_k,
+        qk_sf_vec=qk_sf_vec,
+        q_sf=q_sf,
+        k_sf=k_sf,
+        qk_cutlass_dtype=qk_cutlass_dtype,
+    )
+    torch.cuda.synchronize()
+
+    out_ref = _sdpa_ref(q_bf16, k_bf16, v_bf16, is_causal, sm_scale)
+    assert torch.isfinite(out).all(), "Block-scaled FMHA produced NaN / Inf"
     torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)

--- a/tests/unittest/_torch/visual_gen/test_attention_cute_dsl.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_cute_dsl.py
@@ -18,7 +18,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from tensorrt_llm._torch.visual_gen.attention_backend.cute_dsl import (
+from tensorrt_llm._torch.visual_gen.attention_backend.cute_dsl.fmha import (
     _COMPILE_CACHE,
     _quantize_blockscaled_one,
     _quantize_fp8_v,

--- a/tests/unittest/_torch/visual_gen/test_attention_cute_dsl.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_cute_dsl.py
@@ -21,6 +21,7 @@ import torch.nn.functional as F
 from tensorrt_llm._torch.visual_gen.attention_backend.cute_dsl import (
     _COMPILE_CACHE,
     _quantize_blockscaled_one,
+    _quantize_fp8_v,
     clear_cute_dsl_fmha_cache,
     cute_dsl_fmha_fwd,
 )
@@ -221,10 +222,12 @@ def test_cute_dsl_fmha_context_forward(
         pytest.param(4, 2, id="gqa"),
     ],
 )
+@pytest.mark.parametrize("v_block_size", [0, 1])
 def test_cute_dsl_fmha_blockscaled_forward(
     batch_size: int,
     seq_len_q: int,
     seq_len_kv: int,
+    v_block_size: int,
     is_causal: bool,
     qk_sf_vec: int,
     qk_cutlass_dtype_name: str,
@@ -235,8 +238,8 @@ def test_cute_dsl_fmha_blockscaled_forward(
 ) -> None:
     """End-to-end MXFP8 / NVFP4 block-scaled Q@K path through cute_dsl_fmha_fwd.
 
-    Drives the block-scaled kernel with TRT-LLM-quantized Q/K and bf16 V. Tolerance
-    is loose to accommodate FP8/FP4 quantization error vs. the bf16 SDPA reference.
+    Drives the block-scaled kernel with TRT-LLM-quantized Q/K and FP8 V using either
+    one tensor scale or per-head-per-channel scales.
     """
     _require_supported_gpu_arch()
 
@@ -281,10 +284,10 @@ def test_cute_dsl_fmha_blockscaled_forward(
         * 0.5
     )
 
-    # Quantize Q/K via the same helper the backend uses; V stays bf16 (kernel's
-    # pv_dtype is inferred from v.dtype).
+    # Exercise both V modes: one tensor scale (0) and an (H, D) scale tensor (1).
     q_q, q_sf, scale_q = _quantize_blockscaled_one(q_bf16, qk_sf_vec)
     k_q, k_sf, scale_k = _quantize_blockscaled_one(k_bf16, qk_sf_vec)
+    v_q, scale_v, scale_v_channels = _quantize_fp8_v(v_bf16, per_head_channel=v_block_size == 1)
     qk_cutlass_dtype = getattr(cutlass, qk_cutlass_dtype_name)
 
     out = torch.empty(
@@ -306,9 +309,11 @@ def test_cute_dsl_fmha_blockscaled_forward(
     cute_dsl_fmha_fwd(
         q_q,
         k_q,
-        v_bf16,
+        v_q,
         out,
         is_causal=is_causal,
+        scale_v=scale_v,
+        scale_v_channels=scale_v_channels,
         sm_scale=sm_scale,
         lse=lse,
         scale_q=scale_q,

--- a/tests/unittest/_torch/visual_gen/test_attention_cute_dsl_vsa.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_cute_dsl_vsa.py
@@ -24,13 +24,49 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from tensorrt_llm._torch.visual_gen.attention_backend import VSAMetadataBuilder
+from tensorrt_llm._torch.visual_gen.attention_backend import (
+    CuTeDSLAttention,
+    VSAAttention,
+    VSAMetadataBuilder,
+)
+from tensorrt_llm._torch.visual_gen.attention_backend.utils import create_attention
 from tensorrt_llm._torch.visual_gen.config import (
     DiffusionModelConfig,
     create_attention_metadata_state,
 )
 from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
-from tensorrt_llm.visual_gen.args import AttentionConfig, VideoSparseAttentionConfig
+from tensorrt_llm.visual_gen.args import (
+    AttentionConfig,
+    QuantAttentionConfig,
+    VideoSparseAttentionConfig,
+)
+
+
+def test_cute_dsl_factory_dispatches_quantized_fmha_and_vsa() -> None:
+    quant_config = QuantAttentionConfig(qk_dtype="mxfp8", v_dtype="fp8", v_block_size=1)
+    dense_config = AttentionConfig(backend="CUTEDSL", quant_attention_config=quant_config)
+    dense_attention = create_attention(
+        backend="CUTEDSL",
+        layer_idx=0,
+        num_heads=8,
+        head_dim=128,
+        attention_config=dense_config,
+    )
+
+    sparse_config = VideoSparseAttentionConfig(vsa_sparsity=0.9)
+    vsa_config = AttentionConfig(backend="CUTEDSL", sparse_attention_config=sparse_config)
+    vsa_attention = create_attention(
+        backend="CUTEDSL",
+        layer_idx=0,
+        num_heads=8,
+        head_dim=128,
+        attention_config=vsa_config,
+    )
+
+    assert isinstance(dense_attention, CuTeDSLAttention)
+    assert dense_attention.quant_attention_config is quant_config
+    assert isinstance(vsa_attention, VSAAttention)
+    assert vsa_attention.sparse_attention_config is sparse_config
 
 
 def _make_config(

--- a/tests/unittest/_torch/visual_gen/test_attention_integration.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_integration.py
@@ -7,7 +7,6 @@ naive implementation to ensure numerical equivalence.
 """
 
 from types import SimpleNamespace
-from typing import Optional
 
 import pytest
 import torch
@@ -167,7 +166,7 @@ def create_model_config(
     return config
 
 
-def _require_attention_backend(attn_backend: str, head_dim: Optional[int] = None) -> None:
+def _require_attention_backend(attn_backend: str) -> None:
     if attn_backend == "FA4" and not _flash_attn4_available:
         pytest.fail("FlashAttention 4 backend is required for FA4 attention test")
     if attn_backend == "CUTEDSL" and not _cute_dsl_available:
@@ -177,8 +176,6 @@ def _require_attention_backend(attn_backend: str, head_dim: Optional[int] = None
         gpu_arch = f"sm_{compute_capability[0]}{compute_capability[1]}a"
         if gpu_arch not in ("sm_100a", "sm_103a"):
             pytest.skip("CUTEDSL attention test requires a supported Blackwell-class GPU")
-        if head_dim is not None and head_dim != 128:
-            pytest.skip("CUTEDSL attention test requires head_dim=128")
 
 
 def _make_cross_attention_with_mapping(
@@ -357,7 +354,7 @@ def test_self_attention_equivalence(
     head_dim: int, attn_backend: str, quant_attention_config: "QuantAttentionConfig | None"
 ):
     """Test that integrated self-attention produces same output as naive."""
-    _require_attention_backend(attn_backend, head_dim)
+    _require_attention_backend(attn_backend)
 
     print("\n" + "=" * 60)
     print("Testing Self-Attention Equivalence")
@@ -550,7 +547,7 @@ def test_cross_attention_equivalence(
     head_dim: int, attn_backend: str, quant_attention_config: "QuantAttentionConfig | None"
 ):
     """Test that integrated cross-attention produces same output as naive."""
-    _require_attention_backend(attn_backend, head_dim)
+    _require_attention_backend(attn_backend)
 
     print("\n" + "=" * 60)
     print("Testing Cross-Attention Equivalence")
@@ -651,7 +648,7 @@ def test_fast_cross_attention_wan_shapes(
     quant_attention_config: "QuantAttentionConfig | None",
 ):
     """Test fast cross-attention correctness at Wan-realistic shapes."""
-    _require_attention_backend(attn_backend, head_dim)
+    _require_attention_backend(attn_backend)
 
     hidden_size = num_heads * head_dim
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/tests/unittest/_torch/visual_gen/test_attention_perf.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_perf.py
@@ -64,7 +64,7 @@ _flash_attn4_available = _fa4_fwd is not None
 _cute_dsl_available = _cute_dsl_import_error is None
 
 
-def _require_attention_backend(backend: str, head_dim: Optional[int] = None) -> None:
+def _require_attention_backend(backend: str) -> None:
     if backend == "FA4" and not _flash_attn4_available:
         pytest.fail(
             "FlashAttention 4 backend is required for FA4 attention perf test"
@@ -82,8 +82,6 @@ def _require_attention_backend(backend: str, head_dim: Optional[int] = None) -> 
         gpu_arch = f"sm_{compute_capability[0]}{compute_capability[1]}a"
         if gpu_arch not in ("sm_100a", "sm_103a"):
             pytest.skip("CUTEDSL attention perf test requires a supported Blackwell-class GPU")
-        if head_dim is not None and head_dim != 128:
-            pytest.skip("CUTEDSL attention perf test requires head_dim=128")
 
 
 # NVTX support for profiling
@@ -808,7 +806,7 @@ class TestWanAttentionPerformance:
         quant_attention_config: "QuantAttentionConfig | None",
     ):
         """Test that attention backend runs without errors."""
-        _require_attention_backend(backend, head_dim)
+        _require_attention_backend(backend)
 
         batch_size, num_heads, seq_len = 1, 24, 1024
 

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -120,6 +120,52 @@ class TestAttentionConfigQuantValidation:
 
         assert attention.quant_attention_config is not None
 
+    def test_supported_quant_config_cute_mxfp8(self):
+        attention = AttentionConfig(
+            backend="CUTEDSL",
+            quant_attention_config=QuantAttentionConfig(
+                qk_dtype="fp8",
+                v_dtype="fp8",
+                q_block_size=1,
+                k_block_size=1,
+                v_block_size=0,
+                qk_sf_vec=32,
+            ),
+        )
+
+        assert attention.quant_attention_config is not None
+        assert attention.quant_attention_config.qk_sf_vec == 32
+
+    def test_supported_quant_config_cute_nvfp4(self):
+        attention = AttentionConfig(
+            backend="CUTEDSL",
+            quant_attention_config=QuantAttentionConfig(
+                qk_dtype="fp4",
+                v_dtype="fp8",
+                q_block_size=1,
+                k_block_size=1,
+                v_block_size=0,
+                qk_sf_vec=16,
+            ),
+        )
+
+        assert attention.quant_attention_config is not None
+        assert attention.quant_attention_config.qk_sf_vec == 16
+
+    def test_fp4_qk_dtype_rejected_on_trtllm(self):
+        with pytest.raises(ValidationError, match="Unsupported quant_attention_config"):
+            AttentionConfig(
+                backend="TRTLLM",
+                quant_attention_config=QuantAttentionConfig(
+                    qk_dtype="fp4",
+                    v_dtype="fp8",
+                    q_block_size=1,
+                    k_block_size=1,
+                    v_block_size=0,
+                    qk_sf_vec=16,
+                ),
+            )
+
 
 class TestPipelineRegistryUnique:
     """Guard against duplicate HF IDs across PIPELINE_REGISTRY entries.

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -120,50 +120,46 @@ class TestAttentionConfigQuantValidation:
 
         assert attention.quant_attention_config is not None
 
-    def test_supported_quant_config_cute_mxfp8(self):
+    @pytest.mark.parametrize("v_block_size", [0, 1])
+    def test_supported_quant_config_cute_mxfp8(self, v_block_size):
         attention = AttentionConfig(
             backend="CUTEDSL",
             quant_attention_config=QuantAttentionConfig(
-                qk_dtype="fp8",
+                qk_dtype="mxfp8",
                 v_dtype="fp8",
-                q_block_size=1,
-                k_block_size=1,
-                v_block_size=0,
-                qk_sf_vec=32,
+                v_block_size=v_block_size,
             ),
         )
 
         assert attention.quant_attention_config is not None
-        assert attention.quant_attention_config.qk_sf_vec == 32
+        assert attention.quant_attention_config.v_block_size == v_block_size
 
-    def test_supported_quant_config_cute_nvfp4(self):
+    @pytest.mark.parametrize("v_block_size", [0, 1])
+    def test_supported_quant_config_cute_nvfp4(self, v_block_size):
         attention = AttentionConfig(
             backend="CUTEDSL",
             quant_attention_config=QuantAttentionConfig(
-                qk_dtype="fp4",
+                qk_dtype="nvfp4",
                 v_dtype="fp8",
-                q_block_size=1,
-                k_block_size=1,
-                v_block_size=0,
-                qk_sf_vec=16,
+                v_block_size=v_block_size,
             ),
         )
 
         assert attention.quant_attention_config is not None
-        assert attention.quant_attention_config.qk_sf_vec == 16
+        assert attention.quant_attention_config.v_block_size == v_block_size
 
-    def test_fp4_qk_dtype_rejected_on_trtllm(self):
+    def test_blockscaled_qk_dtype_rejected_on_trtllm(self):
         with pytest.raises(ValidationError, match="Unsupported quant_attention_config"):
             AttentionConfig(
                 backend="TRTLLM",
-                quant_attention_config=QuantAttentionConfig(
-                    qk_dtype="fp4",
-                    v_dtype="fp8",
-                    q_block_size=1,
-                    k_block_size=1,
-                    v_block_size=0,
-                    qk_sf_vec=16,
-                ),
+                quant_attention_config=QuantAttentionConfig(qk_dtype="nvfp4"),
+            )
+
+    def test_sage_qk_block_size_rejected_on_cute(self):
+        with pytest.raises(ValidationError, match="Unsupported quant_attention_config"):
+            AttentionConfig(
+                backend="CUTEDSL",
+                quant_attention_config=QuantAttentionConfig(qk_dtype="mxfp8", q_block_size=1),
             )
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for runtime-compiled attention kernels, with caching for repeated runs.
  * Expanded attention support to include block-scaled Q/K paths and new FP4-based quantization options.
  * Improved handling of causal, windowed, and optional LSE outputs in attention workflows.

* **Bug Fixes**
  * Tightened validation for attention configurations to better reject unsupported combinations.
  * Removed outdated file-tracking and packaging rules for certain kernel binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Replace the packaged Blackwell CuTe DSL FMHA binaries with runtime JIT compilation and port the forward kernels and scheduling helpers into VisualGen using public CuTe DSL interfaces.

Add dense QK16PV8 and block-scaled MXFP8/NVFP4 attention paths, including quantized Q/K scale handling and QK smoothing. Extend the VisualGen attention configuration with validated backend-specific recipes while keeping internal kernel controls private.

Update kernel integration, packaging metadata, and unit and performance coverage for the JIT and quantized execution paths.

### Performance (B300, TFLOPS, higher is better)

| Sequence | cubin (QK16PV8) | JIT (QK16PV8) | Difference (QK16PV8) | JIT(MXFP8) | JIT(NVFP4) |
|---:|---:|---:|---:|---:|---:|
| 4,096 | 1,869.2 | 1,814.3 | -2.9% | 1,976.3 | 2,056.2 |
| 32,768 | 1,924.1 | 1,838.0 | -4.5% | 2,206.6 | 2,483.6 |
| 44,160 | 1,908.9 | 1,822.1 | -4.5% | 2,194.1 | 2,458.5 |
| 65,536 | 1,890.2 | 1,855.9 | -1.8% | 2,188.8 | 2,482.4 |
| 98,304 | 1,850.5 | 1,840.0 | -0.6% | 2,184.7 | 2,490.3 |
| 131,072 | 1,843.5 | 1,839.1 | -0.2% | 2,201.0 | 2,495.5 |

Above results use CuTe DSL 4.5.0, as pinned by `requirements.txt`.
Measured from CUPTI device-kernel timestamps collected by PyTorch Profiler/Kineto. Compilation, quantization, allocation, and model execution are excluded.

**if CuTe DSL version was upgraded from 4.5.0 to 4.6.0**

| Sequence | cubin (QK16PV8) | JIT (QK16PV8) | JIT(MXFP8) | JIT(NVFP4) |
|---:|---:|---:|---:|---:|
| 44,160 | 1,909.3 | 1,818.0 | 2,243.9 | 2,540.1 |
| 131,072 | 1,842.6 | 1,839.5 | 2,265.4 | 2,513.3 |

## Test Coverage

- tests/unittest/_torch/visual_gen/test_attention_cute_dsl.py
    - Verifies runtime JIT compilation and compile-cache population on Blackwell GPUs.
    - Compares dense BF16 and QK16PV8 FMHA outputs against PyTorch SDPA across causal/non-causal attention, MHA/GQA, multiple batch sizes, and sequence lengths.
    - Compares block-scaled MXFP8 and NVFP4 outputs against a dequantized BF16 SDPA reference across causal/non-causal and MHA/GQA configurations.
- tests/unittest/_torch/visual_gen/test_visual_gen_args.py
    - Validates supported CUTEDSL recipes for QK16PV8, MXFP8, and NVFP4.
    - Verifies qk_sf_vec handling and rejection of unsupported backend/quantization combinations.
- tests/unittest/_torch/visual_gen/test_attention_integration.py
    - Exercises CUTEDSL through the integrated VisualGen attention module.
    - Checks self-attention, cross-attention, and Wan-shaped attention against reference implementations.
    - Extends CUTEDSL coverage beyond head dimension 128 where supported.
- tests/unittest/_torch/visual_gen/test_attention_perf.py
    - Exercises the JIT CUTEDSL backend in the existing performance matrix, including newly supported head dimensions.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
