### PR TITLE
[TRTLLM-14040][perf] VisualGen: Eliminate worker-server decoded media IPC by using shared-tensor handle

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -435,6 +435,7 @@ class DiffusionExecutor:
             output = self.pipeline.infer(req)
             generation = time.perf_counter() - generation_start  # seconds
             if self.rank == 0:
+                output.to_handle()
                 self.response_queue.put(
                     DiffusionResponse(
                         request_id=req.request_id,
@@ -812,6 +813,9 @@ class DiffusionRemoteClient:
                 if isinstance(response, DiffusionResponse):
                     if response.request_id == -1:
                         logger.info("DiffusionClient: Received READY signal")
+
+                    if isinstance(response.output, PipelineOutput):
+                        response.output.to_tensor()
 
                     # Schedule the lock acquisition and event setting in the event loop
                     asyncio.run_coroutine_threadsafe(

--- a/tensorrt_llm/_torch/visual_gen/output.py
+++ b/tensorrt_llm/_torch/visual_gen/output.py
@@ -20,10 +20,12 @@ without adding host syncs in the hot path; the implicit sync from
 occurs when the response is consumed.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, List, Optional
 
 import torch
+
+from tensorrt_llm._torch.shared_tensor import SharedTensorContainer
 
 if TYPE_CHECKING:
     from tensorrt_llm._torch.visual_gen.executor import DiffusionResponse
@@ -75,6 +77,22 @@ class PipelineOutput:
     pre_denoise: float = 0.0
     denoise: float = 0.0
     post_denoise: float = 0.0
+
+    def to_handle(self) -> None:
+        """Replace media tensors with handle dicts in place (avoids pickling the full blob over IPC)."""
+        for f in fields(self):
+            t = getattr(self, f.name)
+            if isinstance(t, torch.Tensor):
+                setattr(self, f.name, SharedTensorContainer.from_tensor(t).dump_to_dict())
+
+    def to_tensor(self) -> None:
+        """Rebuild media tensors from handle dicts, in place. ``clone()`` so the client
+        owns the data and the producer's shared block releases via the refcount.
+        """
+        for f in fields(self):
+            v = getattr(self, f.name)
+            if isinstance(v, dict) and "method_key" in v:
+                setattr(self, f.name, SharedTensorContainer.from_dict(v).get_local_view().clone())
 
 
 class CudaPhaseTimer:

--- a/tests/unittest/visual_gen/test_executor_shared_tensor_ipc.py
+++ b/tests/unittest/visual_gen/test_executor_shared_tensor_ipc.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Round-trip tests for worker->client media IPC via SharedTensorContainer handles.
+
+The producer (worker) replaces ``PipelineOutput`` media tensors with handle dicts;
+the client rebuilds them. CUDA IPC handles cannot be opened in the process that
+created them, so the producer runs in a spawned subprocess and the consumer in the
+main process, mirroring the real worker/client split.
+"""
+
+import multiprocessing as mp
+import unittest
+
+import torch
+
+from tensorrt_llm._torch.visual_gen.executor import DiffusionResponse
+from tensorrt_llm._torch.visual_gen.output import PipelineOutput
+
+
+def _producer(q, device):
+    """Build a PipelineOutput, convert its media tensors to handle dicts, hand off."""
+    try:
+        video = torch.arange(2 * 3 * 4 * 5 * 3, dtype=torch.uint8).reshape(2, 3, 4, 5, 3).to(device)
+        audio = torch.randn(2, 2, 100).to(device)
+        output = PipelineOutput(video=video, audio=audio, frame_rate=24.0)
+        output.to_handle()
+        q.put(("ok", output, video.cpu(), audio.cpu()))
+        # Stay alive until the consumer has rebuilt the views (IPC refcount).
+        q.get()
+    except Exception as e:  # noqa: BLE001 - surface producer errors to the test
+        q.put(("error", repr(e), None, None))
+
+
+class TestExecutorSharedTensorIPC(unittest.TestCase):
+    def _run_roundtrip(self, device):
+        mp.set_start_method("spawn", force=True)
+        q = mp.Queue()
+        try:
+            producer = mp.Process(target=_producer, args=(q, device))
+            producer.start()
+            status, output, ref_video, ref_audio = q.get(timeout=120)
+            self.assertEqual(status, "ok", msg=str(output))
+            # Media fields cross the IPC as handle dicts, not tensors.
+            self.assertIsInstance(output.video, dict)
+            self.assertIn("method_key", output.video)
+            self.assertIsInstance(output.audio, dict)
+
+            resp = DiffusionResponse(request_id=0, output=output)
+            resp.output.to_tensor()
+            q.put("done")
+
+            self.assertTrue(torch.equal(resp.output.video.cpu(), ref_video))
+            self.assertTrue(torch.equal(resp.output.audio.cpu(), ref_audio))
+            self.assertEqual(resp.output.frame_rate, 24.0)
+            producer.join()
+        finally:
+            q.close()
+            q.join_thread()
+
+    def test_roundtrip_cpu(self):
+        self._run_roundtrip("cpu")
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    def test_roundtrip_cuda(self):
+        torch.cuda.set_device(0)
+        self._run_roundtrip("cuda")
+
+    def test_restore_noop_without_handles(self):
+        """A response carrying plain tensors (handle-passing off) is untouched."""
+        video = torch.zeros(1, 2, 3, 4, 3, dtype=torch.uint8)
+        resp = DiffusionResponse(request_id=1, output=PipelineOutput(video=video))
+        resp.output.to_tensor()
+        self.assertIs(resp.output.video, video)
+
+    def test_restore_skipped_for_non_pipeline_output(self):
+        """READY responses carry a plain dict output; the client's isinstance guard skips it."""
+        resp = DiffusionResponse(request_id=-1, output={"status": "READY"})
+        if isinstance(resp.output, PipelineOutput):  # mirrors DiffusionRemoteClient guard
+            resp.output.to_tensor()
+        self.assertEqual(resp.output, {"status": "READY"})
+
+
+if __name__ == "__main__":
+    mp.set_start_method("spawn", force=True)
+    unittest.main()


### PR DESCRIPTION
@coderabbitai summary

## Description

VisualGen returns generated media (image/video/audio) from the GPU worker process to the client process over a `ZeroMqQueue`. Today the whole `PipelineOutput` is pickled + HMAC-signed + copied through the ZMQ socket and unpickled on the client. For a decoded video this dominates the result-return path — e.g. LTX-2 768×1280×121 is a ~357 MB `uint8` tensor on `cuda:0`, so the round trip does a device→host copy inside `pickle.dumps`, HMAC-SHA256 over the blob, a full-blob socket transfer, another HMAC, and an unpickle that copies back host→device.

This PR returns the media tensors **by handle** instead of by value, reusing the `SharedTensorContainer` mechanism the multimodal-input path already uses. Before enqueuing the response the worker replaces each `PipelineOutput` media tensor with a small handle dict (`from_tensor(t).dump_to_dict()`, ~1 KB); the client detects the handle dict and rebuilds a zero-copy view (`from_dict(d).get_local_view()`), then `clone()`s it into a client-owned tensor so the producer's block is released promptly and the returned tensor has the same self-owned semantics as the old pickle path. The change lives entirely in the **model-agnostic executor** (`PipelineOutput.image/video/audio`), so every VisualGen model benefits with no model-specific code — verified on both LTX-2 and Wan 2.2.

This relies on the client and workers running on the same node with the client able to access the producer's GPU, which holds for VisualGen (the client spawns the workers locally).

## Performance

Measured on B200 (NVFP4). `IPC` = worker→client media transfer (direct instrumentation); `e2e` = client-side `generate()` wall (same seed); `saved` = OFF−ON e2e delta.

| Model | GPUs | video (H×W×frames) | IPC before → after | e2e before → after | saved/gen | e2e speedup |
|---|---|---|---|---|---|---|
| LTX-2 | 8 | 768×1280×121 (357 MB) | ~2.1 s → ~1–2 ms | 7.85 → 5.73 s | ~2.1 s | ~27% |
| Wan 2.2 | 8 | 720×1280×81 (224 MB) | ~1.35 s → ~1–2 ms | 62.3 → 61.0 s | ~1.35 s | ~2.2% |

Direct instrumentation of where that time goes (OFF), eliminated to ~1–2 ms (`to_handle` + `to_tensor`+`clone`) with the change:

- LTX-2 (357 MB): worker `pickle` 505 + `hmac` 349 + `zmq` 155 ms; client `recv` 180 + `hmac` 357 + `loads` 437 ms (plus the overlapped 357 MB wire transfer).
- Wan (224 MB): worker ~0.65 s; client ~0.62 s (plus wire).

The eliminated cost is **payload-bound** — it scales with the video byte size (357 MB → ~2.1 s, 224 MB → ~1.35 s) and is independent of denoise-step count and GPU count. So the per-generation saving is a fixed serial tail; the `e2e speedup` percentage just reflects how compute-heavy the config is (large when generation is fast, e.g. LTX-2 8-GPU 27%; small when compute dominates, e.g. Wan 50-step 2.2%).

## Correctness

The change is bit-exact — both paths deliver the worker's exact bytes:
- LTX-2(8-GPU, 768×1280×121, 40 steps), Wan 2.2 (8-GPU, 720×1280×81, 50 steps): generated video is **byte-identical (md5)** OFF (pickle) vs ON (shared-tensor) — LPIPS 0.0.

## Test Coverage

- `tests/unittest/visual_gen/test_executor_shared_tensor_ipc.py` — cross-process round-trip (CPU and CUDA) building a `PipelineOutput`, converting its media tensors to handles in a spawned producer, and asserting the client-restored tensors equal the source; plus no-op behavior when the response carries plain tensors (handle-passing off) and when it carries the READY dict.

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
