### PR TITLE
[https://nvbugs/6394425][fix] Added _is_effective_dynamic_tree() helper in utils.py that returns True only…

### DIFF
--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -32,6 +32,13 @@ from .save_hidden_state import (SaveHiddenStatesResourceManager,
 from .suffix_automaton import SuffixAutomatonManager
 
 
+def _is_effective_dynamic_tree(spec_config) -> bool:
+    # At dynamic_tree_max_topK == 1 the tree collapses to a linear chain; route
+    # to the linear Eagle3 one-model path to avoid divergence in tree bookkeeping.
+    return (getattr(spec_config, 'use_dynamic_tree', False)
+            and getattr(spec_config, 'dynamic_tree_max_topK', 0) > 1)
+
+
 def get_spec_metadata(spec_config,
                       model_config,
                       max_num_requests,
@@ -87,6 +94,7 @@ def get_spec_metadata(spec_config,
             is_mtp_eagle=True,
         )
     if spec_config.spec_dec_mode.is_eagle3():
+        effective_dynamic_tree = _is_effective_dynamic_tree(spec_config)
         return Eagle3SpecMetadata(
             max_draft_len=spec_config.max_draft_len,
             max_total_draft_tokens=spec_config.tokens_per_gen_step - 1,
@@ -102,8 +110,8 @@ def get_spec_metadata(spec_config,
             is_mtp_eagle=False,
             eagle_choices=spec_config.eagle_choices,
             is_spec_dec_tree=spec_config.eagle_choices is not None
-            or spec_config.use_dynamic_tree,
-            is_spec_dec_dynamic_tree=spec_config.use_dynamic_tree,
+            or effective_dynamic_tree,
+            is_spec_dec_dynamic_tree=effective_dynamic_tree,
         )
     if spec_config.spec_dec_mode.is_eagle3_one_model():
         return Eagle3OneModelSpecMetadata(
@@ -118,7 +126,7 @@ def get_spec_metadata(spec_config,
             use_rejection_sampling=use_rejection_sampling,
             vocab_size=vocab_size,
             spec_resource_manager=spec_resource_manager,
-            use_dynamic_tree=spec_config.use_dynamic_tree,
+            use_dynamic_tree=_is_effective_dynamic_tree(spec_config),
             eagle_choices=spec_config.eagle_choices,
         )
     if spec_config.spec_dec_mode.is_pard():
@@ -236,8 +244,8 @@ def get_spec_resource_manager(model_engine, draft_model_engine=None):
             max_num_requests,
             sa_manager=sa_manager,
         )
-    if spec_dec_mode.is_eagle3_one_model() and getattr(
-            spec_config, 'use_dynamic_tree', False):
+    if spec_dec_mode.is_eagle3_one_model() and _is_effective_dynamic_tree(
+            spec_config):
         return Eagle3OneModelDynamicTreeResourceManager(spec_config,
                                                         max_num_requests)
     if spec_dec_mode.is_eagle3_one_model():
@@ -384,7 +392,7 @@ def get_spec_worker(spec_config,
         return MTPEagleWorker(spec_config, model_config,
                               use_separate_draft_kv_cache)
     if spec_dec_mode.is_eagle3_one_model():
-        if getattr(spec_config, 'use_dynamic_tree', False):
+        if _is_effective_dynamic_tree(spec_config):
             return Eagle3OneModelDynamicTreeWorker(spec_config, mapping,
                                                    use_separate_draft_kv_cache)
         return Eagle3OneModelWorker(


### PR DESCRIPTION
## Summary
- **Root cause**: When dynamic_tree_max_topK=1 the validator promotes use_dynamic_tree=True and the dispatcher routes to Eagle3OneModelDynamicTreeWorker whose step-0 tree mask, KV rewind, and tree bookkeeping diverge numerically from the equivalent linear chain, lowering the acceptance length vs. the linear Eagle3OneModelWorker.
- **Fix**: Added _is_effective_dynamic_tree() helper in utils.py that returns True only when use_dynamic_tree AND dynamic_tree_max_topK >= 2; used it at all three utils.py gate sites (get_spec_metadata, get_spec_resource_manager, get_spec_worker) so K=1 configs pick the linear metadata / resource manager / worker.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6394425


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how speculative decoding chooses the dynamic-tree path, so the feature now activates only when the relevant settings are properly enabled.
  * Updated routing decisions for certain Eagle3 workflows to follow the same dynamic-tree behavior, helping keep execution consistent across modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->