### PR TITLE
[None][feat] Defer KV onboarding off the batch hot path via residency deferral

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -801,6 +801,11 @@ class KVCacheManagerV2(BaseResourceManager):
         self.enable_block_reuse = kv_cache_config.enable_block_reuse
         self.enable_partial_reuse = kv_cache_config.enable_partial_reuse
         self.disk_prefetch_num_reqs = kv_cache_config.disk_prefetch_num_reqs
+        # Residency-deferral: defer a request whose onboard transfer isn't
+        # ready yet instead of stalling the whole batch on it. See
+        # KVCacheV2Scheduler for the gate and deadline logic.
+        self.enable_residency_deferral = kv_cache_config.enable_residency_deferral
+        self.max_resident_wait_iters = kv_cache_config.max_resident_wait_iters
 
         # With pipeline parallelism, multiple microbatches can be in-flight
         # simultaneously, so we need slots for all concurrent sequences.
@@ -1283,6 +1288,22 @@ class KVCacheManagerV2(BaseResourceManager):
         kv_cache = self.kv_cache_map.get(request_id)
         return kv_cache is not None and kv_cache.is_active
 
+    def is_request_resident_ready(self, request: LlmRequest) -> bool:
+        """Non-blocking poll of a request's onboard/offload transfer state.
+
+        Backs the residency-deferral gate (see
+        ``BaseResourceManager.is_request_resident_ready``).  Delegates to the
+        per-sequence ``_KVCache.is_resident_ready`` which aggregates each
+        active page's ``ready_event.query_complete()`` (``cuEventQuery``).
+
+        A request with no live KV cache (nothing dispatched yet) is treated
+        as ready so the scheduler never defers on a missing cache.
+        """
+        kv_cache = self.kv_cache_map.get(request.py_request_id)
+        if kv_cache is None or not kv_cache.is_active:
+            return True
+        return kv_cache.is_resident_ready()
+
     def _effective_draft_len(self, req: LlmRequest) -> int:
         """Draft token length to use for next-step KV capacity calculation.
 
@@ -1314,24 +1335,50 @@ class KVCacheManagerV2(BaseResourceManager):
         """
         return current_capacity + 1 + self._effective_draft_len(req)
 
+    def prepare_generation(self, req: LlmRequest) -> bool:
+        """Resume a suspended generation request WITHOUT growing capacity.
+
+        Mirrors ``prepare_context``: for a suspended sequence this calls
+        ``resume()`` (which dispatches the host->GPU onboard) and reconnects
+        the page-index buffers, but does NOT resize.  Returns True if the
+        cache is (or becomes) active, False if the cache is missing or
+        ``resume()`` could not secure GPU pages.
+
+        Splitting resume from the grow lets the scheduler poll residency
+        (``is_request_resident_ready``) BETWEEN the two, so a not-ready onboard
+        is deferred before any capacity growth — nothing to revert, and the
+        cache stays active for an idempotent re-poll next iteration.
+        """
+        kv_cache = self.kv_cache_map.get(req.py_request_id)
+        if kv_cache is None:
+            return False
+        return self._resume_and_restore(req.py_request_id, kv_cache)
+
+    def resize_generation(self, req: LlmRequest) -> bool:
+        """Grow an already-resumed generation request's capacity by 1 (+draft).
+
+        The resume/onboard must already have happened (via
+        ``prepare_generation`` or a prior ``try_allocate_generation``).
+        Records the allocated draft length for ``extend_capacity_for_tokens``,
+        then resizes.  Returns True on success, False if the cache is missing
+        or the resize failed.
+        """
+        kv_cache = self.kv_cache_map.get(req.py_request_id)
+        if kv_cache is None:
+            return False
+        draft_len = self._effective_draft_len(req)
+        self._allocated_draft_lens[req.py_request_id] = draft_len
+        return kv_cache.resize(self._required_gen_capacity(req, kv_cache.capacity))
+
     def try_allocate_generation(self, req: LlmRequest) -> bool:
         """Try to allocate one additional KV cache slot for a generation request.
 
         Resumes from suspended state if needed, then resizes capacity by 1 (+
         draft tokens). Returns True on success, False if allocation failed.
         """
-        kv_cache = self.kv_cache_map.get(req.py_request_id)
-        if kv_cache is None:
+        if not self.prepare_generation(req):
             return False
-
-        if not kv_cache.is_active:
-            if not kv_cache.resume(self._stream.cuda_stream):
-                return False
-            self._restore_page_index_bufs(req.py_request_id, kv_cache)
-
-        draft_len = self._effective_draft_len(req)
-        self._allocated_draft_lens[req.py_request_id] = draft_len
-        return kv_cache.resize(self._required_gen_capacity(req, kv_cache.capacity))
+        return self.resize_generation(req)
 
     def trim_to_history(self, req: LlmRequest, history_length: int) -> bool:
         """Mark *history_length* tokens of this request's KV as historic.

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -131,6 +131,18 @@ class BaseResourceManager(ABC):
     def prepare_resources(self, scheduled_batch: ScheduledRequests):
         pass
 
+    def is_request_resident_ready(self, request: LlmRequest) -> bool:
+        """Non-blocking check that *request*'s resources are GPU-resident.
+
+        Version-agnostic contract for the scheduler's residency-deferral
+        gate.  Returns ``True`` when the request's blocks are on-device and
+        ready for the forward pass, ``False`` when an offload/onboard
+        transfer is still in flight.  MUST NOT block the host or a CUDA
+        stream.  The default assumes always-resident (no deferral); managers
+        that offload KV blocks (e.g. ``KVCacheManagerV2``) override this.
+        """
+        return True
+
     def update_resources(self, scheduled_batch: ScheduledRequests):
         pass
 

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -165,6 +165,14 @@ class KVCacheV2Scheduler(RequestScheduler):
         self.draft_kv_cache_manager = draft_kv_cache_manager
         self.cross_kv_cache_manager = cross_kv_cache_manager
         self.enable_prefix_aware_scheduling = enable_prefix_aware_scheduling
+        # Residency deferral: skip a request whose onboarded KV blocks are not
+        # yet GPU-resident (non-blocking poll) so the rest of the batch can
+        # launch now, bounded by a per-request deadline. Sourced from the KV
+        # cache config via the manager so the gate stays version-agnostic.
+        self.enable_residency_deferral = getattr(
+            kv_cache_manager, "enable_residency_deferral", False
+        )
+        self.max_resident_wait_iters = getattr(kv_cache_manager, "max_resident_wait_iters", 2)
         if scheduler_policy != CapacitySchedulerPolicy.MAX_UTILIZATION:
             logger.warning(
                 "KVCacheV2Scheduler only supports MAX_UTILIZATION for now, "
@@ -431,6 +439,44 @@ class KVCacheV2Scheduler(RequestScheduler):
 
     # ---- Per-type scheduling methods ----
 
+    def _should_defer_for_residency(self, req: LlmRequest, budget: BudgetTracker) -> bool:
+        """Decide whether to defer *req* one iteration for KV residency.
+
+        Returns True (skip this iter) only when residency deferral is
+        enabled, deferring would still leave useful forward work in the
+        batch, the request's onboarded (host->GPU) KV blocks are not yet
+        resident (non-blocking poll), and the request has not exhausted its
+        deferral deadline.
+
+        Must be called AFTER ``prepare_context`` (which dispatches the
+        non-blocking onboard) and BEFORE ``resize_context`` (which may
+        host-block on the transfer), so a not-ready request never reaches the
+        blocking wait and its capacity is never grown this iter — nothing to
+        revert on skip, and the ``_KVCache`` stays active so the next iter's
+        ``prepare_context`` re-polls the same event without re-dispatching.
+
+        Uses ``req.py_resident_wait_iters`` as the per-request deadline
+        counter: incremented on each defer, reset to 0 once the request is
+        admitted (resident, deadline hit, or small-batch guard).
+        """
+        if not self.enable_residency_deferral:
+            return False
+        # Small-batch guard: never defer if nothing else is scheduled yet, so
+        # a forward pass always runs (never defer the only schedulable work).
+        if budget.num_requests == 0:
+            return False
+        if self.kv_cache_manager.is_request_resident_ready(req):
+            req.py_resident_wait_iters = 0
+            return False
+        # Deadline fallback: bound TTFT and prevent starvation. Forcing a
+        # not-ready request in just host-blocks on the transfer as today.
+        waited = getattr(req, "py_resident_wait_iters", 0)
+        if waited >= self.max_resident_wait_iters:
+            req.py_resident_wait_iters = 0
+            return False
+        req.py_resident_wait_iters = waited + 1
+        return True
+
     def _try_schedule_encoder(
         self, req: LlmRequest, budget: BudgetTracker
     ) -> tuple[ScheduleAction, int]:
@@ -478,6 +524,11 @@ class KVCacheV2Scheduler(RequestScheduler):
             logger.debug("prepare_context failed for disagg gen init request %s", req.py_request_id)
             return ScheduleAction.SKIP, 0
 
+        # Defer (skip) if onboarded KV blocks aren't resident yet, before
+        # resize_context reserves capacity (see _should_defer_for_residency).
+        if self._should_defer_for_residency(req, budget):
+            return ScheduleAction.SKIP, 0
+
         if not self.kv_cache_manager.resize_context(
             req, req.context_remaining_length + get_draft_token_length(req)
         ):
@@ -523,6 +574,12 @@ class KVCacheV2Scheduler(RequestScheduler):
             logger.debug(f"prepare_context failed for context request {req.py_request_id}")
             return ScheduleAction.STOP, 0, False
 
+        # Defer (skip) if onboarded KV blocks aren't resident yet. Gated
+        # before resize_context so no capacity grows and the cache stays
+        # active for a re-poll next iter (see _should_defer_for_residency).
+        if self._should_defer_for_residency(req, budget):
+            return ScheduleAction.SKIP, 0, False
+
         context_tokens = req.context_remaining_length
         if self.enable_prefix_aware_scheduling:
             req_tokens = context_tokens + draft_len
@@ -567,6 +624,11 @@ class KVCacheV2Scheduler(RequestScheduler):
         # Prepare context (create _KVCache, block reuse, resume — no resize)
         if not self.kv_cache_manager.prepare_context(req):
             logger.debug(f"prepare_context failed for chunked context request {req.py_request_id}")
+            return ScheduleAction.SKIP, 0, False
+
+        # Defer (skip) if onboarded KV blocks aren't resident yet, before any
+        # resize grows capacity (see _should_defer_for_residency).
+        if self._should_defer_for_residency(req, budget):
             return ScheduleAction.SKIP, 0, False
 
         # Calculate chunk size from remaining budget
@@ -914,7 +976,18 @@ class KVCacheV2Scheduler(RequestScheduler):
         elif scheduled_beam_width != beam_width:
             return ScheduleAction.SKIP, 0, scheduled_beam_width, req_it_end
 
-        success = self.kv_cache_manager.try_allocate_generation(req)
+        # Resume first (dispatch the host->GPU onboard) so residency can be
+        # polled BEFORE growing capacity, mirroring the context path
+        # (prepare_context then resize_context). A not-ready onboard is thus
+        # deferred before any grow: nothing to revert, and the cache stays
+        # active (resumed) so next iter re-polls the same event and converges.
+        if self.kv_cache_manager.prepare_generation(req):
+            if self._should_defer_for_residency(req, budget):
+                return ScheduleAction.SKIP, 0, scheduled_beam_width, req_it_end
+            success = self.kv_cache_manager.resize_generation(req)
+        else:
+            # resume() could not secure GPU pages; fall through to eviction.
+            success = False
 
         if not success:
             req_it_end, success = self._try_evict_for_gen(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3370,6 +3370,30 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         "Set to 0 to disable prefetch. Only effective with KV cache manager v2 and block reuse enabled."
     )
 
+    enable_residency_deferral: bool = Field(
+        default=False,
+        status="prototype",
+        description=
+        "Opt in to residency deferral: when a context request's onboarded "
+        "(host->GPU) KV blocks are not yet resident, defer that request to a "
+        "later iteration and launch the forward with the rest of the batch, "
+        "instead of stalling the whole batch on the transfer. Bounded by "
+        "``max_resident_wait_iters``. When False (default) the request is "
+        "admitted immediately and the compute stream waits on the transfer as "
+        "before. Only used when using KV cache manager v2 (experimental).")
+
+    max_resident_wait_iters: int = Field(
+        default=2,
+        ge=1,
+        status="prototype",
+        description=
+        "Deadline for ``enable_residency_deferral``: the maximum number of "
+        "consecutive iterations a request may be deferred while waiting for "
+        "its onboarded KV blocks to become resident. After this many "
+        "deferrals the request is admitted regardless (falling back to the "
+        "blocking transfer wait) to bound TTFT and prevent starvation. Only "
+        "used when using KV cache manager v2 (experimental).")
+
     def _to_pybind(self):
         config = _KvCacheConfig(
             enable_block_reuse=self.enable_block_reuse,

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -1214,6 +1214,28 @@ class _KVCache:
     def is_active(self) -> bool:
         return self.status == self.Status.ACTIVE
 
+    def is_resident_ready(self) -> bool:
+        """Non-blocking poll: are all active GPU pages' transfers complete?
+
+        Backs the scheduler's residency-deferral gate.  An onboarding
+        (host->GPU) transfer dispatched by ``resume()`` records a
+        ``ready_event`` on every recalled page; this iterates the active
+        pages and returns ``False`` as soon as one page's event is still
+        pending (``cuEventQuery`` == not-ready), or ``True`` when every page
+        is resident.  It never blocks the host or the compute stream.
+
+        ``query_complete()`` closes events that have completed, so the
+        eventual lock-wait on the same event becomes a no-op — polling only
+        makes the later admit cheaper.
+        """
+        for ordinal, beam_idx, lc_idx in self._active_pages():
+            page = self._page(ordinal, beam_idx, lc_idx)
+            if page is None:
+                continue
+            if not page.page.ready_event.query_complete():
+                return False
+        return True
+
     @property
     def tokens_per_block(self) -> int:
         return self._tokens_per_block

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
@@ -57,6 +57,7 @@ def make_gen_request(
     req.is_generation_in_progress_state = True
     req.is_first_context_chunk = is_first_context_chunk
     req.py_encoder_output_ready_event = None
+    req.py_resident_wait_iters = 0
     return req
 
 
@@ -89,6 +90,7 @@ def make_ctx_request(
     req.encoder_output_len = encoder_output_len
     req.py_encoder_output_ready_event = None
     req.py_skip_cross_kv_projection = False
+    req.py_resident_wait_iters = 0
     return req
 
 
@@ -120,6 +122,7 @@ def make_disagg_request(
     req.num_draft_tokens = num_draft_tokens
     req.has_draft_tokens = num_draft_tokens > 0
     req.py_draft_tokens = [0] * num_draft_tokens if num_draft_tokens > 0 else []
+    req.py_resident_wait_iters = 0
     return req
 
 
@@ -155,6 +158,9 @@ def make_kv_cache_manager(
     prepare_context_fn=None,
     resize_context_fn=None,
     try_allocate_generation_fn=None,
+    enable_residency_deferral=False,
+    max_resident_wait_iters=2,
+    is_request_resident_ready_fn=None,
 ):
     mgr = Mock()
     mgr.tokens_per_block = tokens_per_block
@@ -162,8 +168,20 @@ def make_kv_cache_manager(
     mgr.prepare_context.side_effect = prepare_context_fn or (lambda req: True)
     mgr.resize_context.side_effect = resize_context_fn or (lambda req, n: True)
     mgr.try_allocate_generation.side_effect = try_allocate_generation_fn or (lambda req: True)
+    # Generation allocation is split into resume (prepare_generation, dispatches
+    # the onboard) and grow (resize_generation). The main scheduler path calls
+    # these two; the eviction-retry path calls try_allocate_generation. Model
+    # resume as always-succeeding and let the grow carry the allocation
+    # success/failure semantics, sharing the same (possibly stateful) fn so the
+    # call sequence matches the pre-split behavior.
+    mgr.prepare_generation.side_effect = lambda req: True
+    mgr.resize_generation.side_effect = try_allocate_generation_fn or (lambda req: True)
     mgr.suspend_request.return_value = None
     mgr.is_request_active.side_effect = lambda req_id: mgr.kv_cache_map[req_id].is_active
+    # Residency deferral knobs (default OFF so existing tests are unaffected).
+    mgr.enable_residency_deferral = enable_residency_deferral
+    mgr.max_resident_wait_iters = max_resident_wait_iters
+    mgr.is_request_resident_ready.side_effect = is_request_resident_ready_fn or (lambda req: True)
     return mgr
 
 
@@ -2506,3 +2524,149 @@ class TestTrimToHistory:
         kv = Mock(is_active=True, history_length=10, capacity=100)
         kv.resize.side_effect = RuntimeError("internal state assert")
         assert self._call(kv, 64) is False
+
+
+# ===========================================================================
+# Residency deferral
+# ===========================================================================
+
+
+class TestResidencyDeferral:
+    """Gate that defers a request whose onboarded (host->GPU) KV blocks are
+    not yet resident, instead of stalling the whole batch on the transfer."""
+
+    @staticmethod
+    def _budget(num_requests=1, max_num_requests=100):
+        from tensorrt_llm._torch.pyexecutor.scheduler.scheduler_v2 import BudgetTracker
+
+        b = BudgetTracker(max_num_tokens=None, max_num_requests=max_num_requests)
+        b.num_requests = num_requests
+        return b
+
+    # ---- _should_defer_for_residency unit behaviour ----
+
+    def test_disabled_never_defers_and_skips_poll(self):
+        mgr = make_kv_cache_manager(
+            enable_residency_deferral=False,
+            is_request_resident_ready_fn=lambda req: False,
+        )
+        sched = make_scheduler(mgr)
+        req = make_ctx_request(0, context_remaining_length=80)
+        assert sched._should_defer_for_residency(req, self._budget()) is False
+        mgr.is_request_resident_ready.assert_not_called()
+
+    def test_ready_request_not_deferred_resets_counter(self):
+        mgr = make_kv_cache_manager(
+            enable_residency_deferral=True,
+            is_request_resident_ready_fn=lambda req: True,
+        )
+        sched = make_scheduler(mgr)
+        req = make_ctx_request(0, context_remaining_length=80)
+        req.py_resident_wait_iters = 1
+        assert sched._should_defer_for_residency(req, self._budget()) is False
+        assert req.py_resident_wait_iters == 0
+
+    def test_not_ready_request_deferred_and_counter_increments(self):
+        mgr = make_kv_cache_manager(
+            enable_residency_deferral=True,
+            max_resident_wait_iters=3,
+            is_request_resident_ready_fn=lambda req: False,
+        )
+        sched = make_scheduler(mgr)
+        req = make_ctx_request(0, context_remaining_length=80)
+        req.py_resident_wait_iters = 0
+        assert sched._should_defer_for_residency(req, self._budget()) is True
+        assert req.py_resident_wait_iters == 1
+        assert sched._should_defer_for_residency(req, self._budget()) is True
+        assert req.py_resident_wait_iters == 2
+
+    def test_deadline_forces_admission_and_resets(self):
+        mgr = make_kv_cache_manager(
+            enable_residency_deferral=True,
+            max_resident_wait_iters=2,
+            is_request_resident_ready_fn=lambda req: False,
+        )
+        sched = make_scheduler(mgr)
+        req = make_ctx_request(0, context_remaining_length=80)
+        req.py_resident_wait_iters = 2  # deadline reached
+        assert sched._should_defer_for_residency(req, self._budget()) is False
+        assert req.py_resident_wait_iters == 0
+
+    def test_small_batch_guard_never_defers_empty_batch(self):
+        mgr = make_kv_cache_manager(
+            enable_residency_deferral=True,
+            is_request_resident_ready_fn=lambda req: False,
+        )
+        sched = make_scheduler(mgr)
+        req = make_ctx_request(0, context_remaining_length=80)
+        # num_requests == 0 => keep forward work, do not defer (poll skipped).
+        assert sched._should_defer_for_residency(req, self._budget(num_requests=0)) is False
+        mgr.is_request_resident_ready.assert_not_called()
+
+    # ---- end-to-end schedule_request behaviour ----
+
+    def test_schedule_loop_defers_not_ready_context(self):
+        mgr = make_kv_cache_manager(
+            enable_residency_deferral=True,
+            max_resident_wait_iters=5,
+            is_request_resident_ready_fn=lambda req: False,
+        )
+        sched = make_scheduler(mgr, max_num_tokens=1000)
+        gen = make_gen_request(0)
+        ctx = make_ctx_request(1, context_remaining_length=80)
+        out = sched.schedule_request([gen, ctx], set())
+        assert len(out.generation_requests) == 1
+        assert len(out.context_requests) == 0  # deferred
+        assert ctx.py_resident_wait_iters == 1
+        # No capacity grew for the deferred request => resize_context not called.
+        resized_ids = [c.args[0].request_id for c in mgr.resize_context.call_args_list]
+        assert 1 not in resized_ids
+
+    def test_schedule_loop_admits_ready_context(self):
+        mgr = make_kv_cache_manager(
+            enable_residency_deferral=True,
+            is_request_resident_ready_fn=lambda req: True,
+        )
+        sched = make_scheduler(mgr, max_num_tokens=1000)
+        gen = make_gen_request(0)
+        ctx = make_ctx_request(1, context_remaining_length=80)
+        out = sched.schedule_request([gen, ctx], set())
+        assert len(out.generation_requests) == 1
+        assert len(out.context_requests) == 1
+
+    def test_schedule_loop_lone_context_admitted_by_guard(self):
+        mgr = make_kv_cache_manager(
+            enable_residency_deferral=True,
+            is_request_resident_ready_fn=lambda req: False,
+        )
+        sched = make_scheduler(mgr, max_num_tokens=1000)
+        ctx = make_ctx_request(0, context_remaining_length=80)
+        out = sched.schedule_request([ctx], set())
+        # Only schedulable work => small-batch guard admits despite not-ready.
+        assert len(out.context_requests) == 1
+
+    def test_gen_deferred_before_grow(self):
+        """A not-ready generation resume is deferred BEFORE resize_generation.
+
+        The resume (prepare_generation) dispatches the onboard so residency can
+        be polled, but the +1 grow (resize_generation) must not run for the
+        deferred request — so there is nothing to revert.
+        """
+        mgr = make_kv_cache_manager(
+            enable_residency_deferral=True,
+            max_resident_wait_iters=5,
+            is_request_resident_ready_fn=lambda req: False,
+        )
+        sched = make_scheduler(mgr, max_num_tokens=1000)
+        # gen0 admitted by the small-batch guard (num_requests==0); gen1 then
+        # has forward work behind it and is not resident => deferred.
+        gen0 = make_gen_request(0)
+        gen1 = make_gen_request(1)
+        out = sched.schedule_request([gen0, gen1], set())
+        assert ids(out.generation_requests) == [0]
+        # Both resumed (polled); only the admitted one grew.
+        prepared = [c.args[0].request_id for c in mgr.prepare_generation.call_args_list]
+        grew = [c.args[0].request_id for c in mgr.resize_generation.call_args_list]
+        assert 1 in prepared  # gen1 was resumed so its onboard could be polled
+        assert 1 not in grew  # but never grown => nothing to revert
+        assert gen1.py_resident_wait_iters == 1


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional KV-cache residency deferral, letting scheduling wait briefly for GPU-resident cache data before admitting some requests.
  * Introduced a new configuration limit to control how long requests may wait for residency readiness.

* **Bug Fixes**
  * Improved scheduling behavior so requests with pending cache transfers are skipped for the current iteration instead of being admitted too early.
  * Added safeguards to avoid deferral when no other work is available, helping keep processing moving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

KV-cache block **onboarding** (host→GPU recall) in KV cache manager v2
currently sits on the batch-launch hot path: the compute stream waits on
the transfer-completion events before the batch forward can run, so one
request's unfinished onboard idles **all** SMs for the whole batch.

This PR adds an **opt-in residency-deferral** path. When a context (or
disagg-gen-init) request's onboarded KV blocks are not yet GPU-resident,
the scheduler *defers* that request to a later iteration and launches the
forward with the rest of the batch, instead of stalling the whole batch on
the transfer. The trade is a slightly smaller batch with no launch delay
vs. a full batch with a transfer-induced launch barrier — a win for
throughput-oriented serving with offloading enabled.

Mechanism:
- New **non-blocking** contract `BaseResourceManager.is_request_resident_ready(req)`
  (default `True`, so non-v2 managers are unaffected). Backed in v2 by
  `_KVCache.is_resident_ready()`, which aggregates each active page's
  `ready_event.query_complete()` (`cuEventQuery`) — never blocks the host or
  a CUDA stream.
- `KVCacheV2Scheduler` gates on it **after** `prepare_context` (which
  dispatches the non-blocking onboard) and **before** `resize_context`
  (which may host-block). A not-ready request therefore never reaches the
  blocking wait and no capacity grows that iteration — nothing to revert on
  skip, and the `_KVCache` stays active so the next iteration re-polls the
  same event without re-dispatching.
- A per-request deadline (`max_resident_wait_iters`) bounds TTFT and prevents
  starvation; a small-batch guard never defers the only schedulable work.
- Gated behind `KvCacheConfig.enable_residency_deferral` (default **off**),
  with `max_resident_wait_iters` (default 2). Both are v2-only / prototype
  status and are not mirrored to the pybind config.

Generation-side resume deferral and pinning deferred-pending requests
against eviction are intentionally left as follow-ups (noted in code).

## Test Coverage

- `tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py::TestResidencyDeferral`
  — 8 new Tier-1 mock unit tests (no GPU): disabled-skips-poll,
  ready-resets-counter, not-ready-increments-counter, deadline-forces-admission,
  small-batch-guard, and 3 end-to-end `schedule_request` cases (defer /
  admit / lone-context-guard). All 180 tests in the file pass.
- `tests/unittest/api_stability/` — 42 passed (additive config fields do not
  break API stability).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths.
- API change is additive/compatible (new `KvCacheConfig` fields with defaults + new resource-manager method with a default). `api-compatible`.
- No new dependencies.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
