### PR TITLE
[None][doc] add NVL72 video generation blog to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ TensorRT LLM
 
 <!-- Use github markdown link to link for the latest blog since the doc build has not happened yet. When the doc build is updated, it should be updated to the webpage link. -->
 
+* [07/01] Scaling Video Generation Across NVL72 Rack with TensorRT-LLM
+✨ [➡️ link](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/blogs/tech_blog/blog25_Scaling_Video_Generation_Across_NVL72_Rack_with_TensorRT-LLM.md)
+
 * [05/15] Joint Optimization of Agent Applications and TensorRT-LLM
 ✨ [➡️ link](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/blogs/tech_blog/blog23_Joint_Optimization_of_Agent_Applications_and_TensorRT-LLM.md)
 


### PR DESCRIPTION
## What changed

- Add the "Scaling Video Generation Across NVL72 Rack with TensorRT-LLM" blog to the README Tech Blogs section.
- Link to the source Markdown while it is the latest blog, following the existing README convention.

## Why

PR #15420 added the VisualGen NVL72 scaling blog and example configurations, but omitted the corresponding homepage entry, making the blog harder to discover.

## Impact

Documentation only; there are no runtime or API changes.

## Validation

- `git diff --check`
- Repository pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Tech Blogs” entry dated 07/01.
  * Linked the entry to the latest blog post in the tech blogs section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->