### PR TITLE
[https://nvbugs/6398200][fix] Remove fixture-level params on mpi_pool_executor to avoid duplicate parametrization

### DIFF
--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -337,10 +337,13 @@ def torch_empty_cache() -> None:
         torch.cuda.empty_cache()
 
 
-@pytest.fixture(scope="module", params=[2, 4, 8])
+@pytest.fixture(scope="module")
 def mpi_pool_executor(request):
     """
     Start an MPIPoolExecutor with `request.param` workers.
+
+    Consumers must set the worker count via indirect parametrization, e.g.
+    ``@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)``.
     """
     num_workers = request.param
     with MPIPoolExecutor(num_workers) as executor:


### PR DESCRIPTION
## Description

Fixes the flaky `test_moe_comm_postquant` (and other multi-GPU tests) on GB200 — NVBUG 6398200.

### Root cause
`mpi_pool_executor` in `tests/unittest/conftest.py` declared `params=[2, 4, 8]`, giving it fixture-level parametrization. But every consumer (16 test files) supplies the worker count through indirect mark parametrization instead, e.g. `@pytest.mark.parametrize("mpi_pool_executor", [N], indirect=True)`.

Under pytest 9.x (CI runs 9.0.3 / 9.1.0), combining a fixture-level `params=` with indirect parametrization of the same argument makes collection raise `duplicate parametrization of 'mpi_pool_executor'`, which aborts collection of the whole module. Depending on how CI shards tests across pytest processes, this surfaced intermittently as failures of unrelated cases in the module (e.g. `test_moe_comm_postquant`) — matching the flaky pattern in NVBUG 6398200 (73 of 80 GB200 failures over 30 days were this collection error).

### Solution
Remove `params=[2, 4, 8]` from the fixture. The worker count is already provided by every consumer via indirect parametrization, so no test behavior changes.

Verified (whole-repo AST audit) that all 53 consuming tests feed the fixture via indirect and none rely on the fixture-level params. Reproduced on pytest 9.1.0: the collection error appears before the change and disappears after, with the indirect worker count still delivered correctly.

## Test Coverage

Existing multi-GPU tests that consume `mpi_pool_executor` (e.g. `tests/unittest/_torch/modules/moe/test_moe_comm.py`).

## PR Checklist

- [x] PR title follows the required format `[NVBUG][fix] ...`
- [x] Change tested locally (pytest 9.1.0 collection repro before/after)
- [x] `pre-commit run` passes on the changed file
- [x] No new features / no API change; test-infra only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test fixture handling to avoid pytest collection failures caused by duplicate parametrization.
  * MPI test runs now accept worker counts through indirect parametrization more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->