### PR TITLE
[None][feat] Add low-latency host task dispatch mode for guided decoding

### DIFF
--- a/cpp/tensorrt_llm/nanobind/runtime/hostfunc.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/hostfunc.cpp
@@ -73,15 +73,31 @@ static void cudaHostFuncTrampoline(void* userData)
     }
 }
 
-std::optional<uintptr_t> launchHostFunc(
-    uintptr_t streamPtr, bool freeUserData, nb::callable pyHostFunc, nb::args pyArgs, nb::kwargs pyKwargs)
+std::optional<uintptr_t> launchHostFunc(uintptr_t streamPtr, bool freeUserData, bool lowLatency,
+    nb::callable pyHostFunc, nb::args pyArgs, nb::kwargs pyKwargs)
 {
     auto const stream = reinterpret_cast<cudaStream_t>(streamPtr);
 
     auto hostFuncUserData
         = std::make_unique<HostFuncUserData>(freeUserData, pyHostFunc, nb::tuple(pyArgs), nb::dict(pyKwargs));
 
-    cudaError_t err = cudaLaunchHostFunc(stream, cudaHostFuncTrampoline, hostFuncUserData.get());
+    cudaError_t err;
+#if CUDART_VERSION >= 13020
+    if (lowLatency)
+    {
+        err = cudaLaunchHostFunc_v2(stream, cudaHostFuncTrampoline, hostFuncUserData.get(), cudaHostTaskSpinWait);
+    }
+    else
+    {
+        err = cudaLaunchHostFunc(stream, cudaHostFuncTrampoline, hostFuncUserData.get());
+    }
+#else
+    if (lowLatency)
+    {
+        TLLM_LOG_WARNING("Low-latency host task dispatch requires CUDA 13.2+; falling back to default.");
+    }
+    err = cudaLaunchHostFunc(stream, cudaHostFuncTrampoline, hostFuncUserData.get());
+#endif
     if (err != cudaSuccess)
     {
         throw std::runtime_error("Failed to launch host function.");
@@ -105,7 +121,9 @@ void freeHostFuncUserData(uintptr_t userDataPtr)
 
 void initHostFuncBindings(nb::module_& m)
 {
-    m.def("launch_hostfunc", &launchHostFunc, "Launch a Python host function to a CUDA stream");
+    m.def("launch_hostfunc", &launchHostFunc,
+        "Launch a Python host function to a CUDA stream. Set low_latency=True to use "
+        "spin-wait dispatch (requires CUDA 13.2+).");
     m.def("free_hostfunc_user_data", &freeHostFuncUserData, "Free the user data for the Python host function");
 }
 } // namespace tensorrt_llm::nanobind::runtime

--- a/cpp/tensorrt_llm/nanobind/runtime/hostfunc.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/hostfunc.cpp
@@ -21,6 +21,7 @@
 
 #include <cuda_runtime.h>
 #include <memory>
+#include <mutex>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/function.h>
 #include <nanobind/stl/optional.h>
@@ -94,7 +95,9 @@ std::optional<uintptr_t> launchHostFunc(uintptr_t streamPtr, bool freeUserData, 
 #else
     if (lowLatency)
     {
-        TLLM_LOG_WARNING("Low-latency host task dispatch requires CUDA 13.2+; falling back to default.");
+        static std::once_flag sWarnOnce;
+        std::call_once(sWarnOnce,
+            []() { TLLM_LOG_WARNING("Low-latency host task dispatch requires CUDA 13.2+; falling back to default."); });
     }
     err = cudaLaunchHostFunc(stream, cudaHostFuncTrampoline, hostFuncUserData.get());
 #endif

--- a/tensorrt_llm/_torch/hostfunc.py
+++ b/tensorrt_llm/_torch/hostfunc.py
@@ -6,12 +6,20 @@ from ..bindings.internal import runtime as bindings
 
 HOSTFUNC_USER_DATA_HANDLES = set()
 
+_low_latency_dispatch: bool = False
+
+
+def set_low_latency_dispatch(enabled: bool) -> None:
+    global _low_latency_dispatch
+    _low_latency_dispatch = enabled
+
 
 def launch_hostfunc(hostfunc, *args, **kwargs):
     stream = torch.cuda.current_stream()
     is_capturing = torch.cuda.is_current_stream_capturing()
     handle = bindings.launch_hostfunc(stream.cuda_stream, not is_capturing,
-                                      hostfunc, *args, **kwargs)
+                                      _low_latency_dispatch, hostfunc, *args,
+                                      **kwargs)
     if is_capturing:
         HOSTFUNC_USER_DATA_HANDLES.add(handle)
     else:

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1973,7 +1973,8 @@ def create_py_executor_instance(
     execution_stream: Optional[torch.cuda.Stream] = None,
     dwdp_manager: Optional[DwdpManager] = None,
 ) -> PyExecutor:
-    set_low_latency_dispatch(llm_args.enable_low_latency_host_dispatch)
+    set_low_latency_dispatch(
+        getattr(llm_args, 'enable_low_latency_host_dispatch', False))
 
     kv_cache_manager = resources.get(ResourceManagerType.KV_CACHE_MANAGER, None)
 

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -41,6 +41,7 @@ from tensorrt_llm.lora_manager import load_torch_lora
 from tensorrt_llm.mapping import CpType, Mapping
 
 from ..attention_backend import get_sparse_attn_kv_cache_manager
+from ..hostfunc import set_low_latency_dispatch
 from ..model_config import ModelConfig
 from ..models.modeling_multimodal_mixin import MultimodalModelMixin
 from ..speculative import (get_num_extra_kv_tokens, get_num_spec_layers,
@@ -1972,6 +1973,8 @@ def create_py_executor_instance(
     execution_stream: Optional[torch.cuda.Stream] = None,
     dwdp_manager: Optional[DwdpManager] = None,
 ) -> PyExecutor:
+    set_low_latency_dispatch(llm_args.enable_low_latency_host_dispatch)
+
     kv_cache_manager = resources.get(ResourceManagerType.KV_CACHE_MANAGER, None)
 
     spec_config = model_engine.spec_config

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -4865,6 +4865,15 @@ class TorchLlmArgs(BaseLlmArgs):
         "scheduler is disabled.",
         status="prototype")
 
+    enable_low_latency_host_dispatch: bool = Field(
+        default=False,
+        description="Use low-latency spin-wait mode for CUDA host task dispatch "
+        "(cudaLaunchHostFunc_v2 with cudaHostTaskSpinWait). "
+        "Reduces callback latency at the cost of a CPU core spinning while "
+        "waiting for the GPU event. Requires CUDA 13.2+; silently falls back "
+        "to the default blocking mode on older drivers.",
+        status="prototype")
+
     enable_iter_perf_stats: bool = Field(
         default=False,
         description="Enable iteration performance statistics.",

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -4870,8 +4870,9 @@ class TorchLlmArgs(BaseLlmArgs):
         description="Use low-latency spin-wait mode for CUDA host task dispatch "
         "(cudaLaunchHostFunc_v2 with cudaHostTaskSpinWait). "
         "Reduces callback latency at the cost of a CPU core spinning while "
-        "waiting for the GPU event. Requires CUDA 13.2+; silently falls back "
-        "to the default blocking mode on older drivers.",
+        "waiting for the GPU event. Requires CUDA 13.2+; on older CUDA "
+        "versions, falls back to the default blocking mode and logs a "
+        "one-time warning.",
         status="prototype")
 
     enable_iter_perf_stats: bool = Field(

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -855,6 +855,35 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
 
     @skip_pre_hopper
     @pytest.mark.parametrize("backend", ["xgrammar", "llguidance"])
+    def test_guided_decoding_with_eagle3_low_latency_dispatch(
+            self, backend: str, mocker):
+        """Smoke-test enable_low_latency_host_dispatch with Eagle3 + guided decoding.
+
+        Eagle3 spec-dec captures guided-decoder hostfuncs inside the CUDA graph
+        (via _execute_guided_decoder_if_present in the target forward pass), so
+        this combination exercises the cudaLaunchHostFunc_v2 / spin-wait path.
+        """
+        mocker.patch.dict(os.environ, {"TRTLLM_XGUIDANCE_LENIENT": "1"})
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)
+        cuda_graph_config = CudaGraphConfig(enable_padding=True)
+        spec_config = Eagle3DecodingConfig(
+            max_draft_len=3,
+            speculative_model=f"{llm_models_root()}/EAGLE3-LLaMA3.1-Instruct-8B",
+            eagle3_one_model=True)
+        llm = LLM(self.MODEL_PATH,
+                  guided_decoding_backend=backend,
+                  kv_cache_config=kv_cache_config,
+                  cuda_graph_config=cuda_graph_config,
+                  enable_chunked_prefill=True,
+                  max_num_tokens=256,
+                  speculative_config=spec_config,
+                  enable_low_latency_host_dispatch=True)
+        with llm:
+            task = JsonModeEval(self.MODEL_NAME)
+            task.evaluate(llm)
+
+    @skip_pre_hopper
+    @pytest.mark.parametrize("backend", ["xgrammar", "llguidance"])
     def test_guided_decoding_with_ngram(self, backend: str, mocker):
         mocker.patch.dict(os.environ, {"TRTLLM_XGUIDANCE_LENIENT": "1"})
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.8)

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -167,6 +167,10 @@ methods:
         annotation: bool
         default: False
         status: prototype
+      enable_low_latency_host_dispatch:
+        annotation: bool
+        default: False
+        status: prototype
       enable_iter_perf_stats:
         annotation: bool
         default: False

--- a/tests/unittest/bindings/test_hostfunc.py
+++ b/tests/unittest/bindings/test_hostfunc.py
@@ -1,6 +1,7 @@
 import torch
 
-from tensorrt_llm._torch.hostfunc import HOSTFUNC_USER_DATA_HANDLES, hostfunc
+from tensorrt_llm._torch.hostfunc import (HOSTFUNC_USER_DATA_HANDLES, hostfunc,
+                                          set_low_latency_dispatch)
 
 
 def test_hostfunc():
@@ -30,3 +31,32 @@ def test_hostfunc():
 
     assert (x == 25).all().item()
     assert len(HOSTFUNC_USER_DATA_HANDLES) == 2
+
+
+def test_low_latency_dispatch():
+    """set_low_latency_dispatch toggles the module-level flag.
+
+    Hostfuncs fire correctly in both modes (cudaLaunchHostFunc v1 and v2 spin-wait).
+    """
+    import tensorrt_llm._torch.hostfunc as hf_mod
+
+    for enabled in (False, True):
+        set_low_latency_dispatch(enabled)
+        assert hf_mod._low_latency_dispatch is enabled
+
+        results = []
+
+        @hostfunc
+        def record(val):
+            results.append(val)
+
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            record(enabled)
+        torch.cuda.synchronize()
+
+        assert results == [enabled
+                           ], f"hostfunc failed with low_latency={enabled}"
+
+    # Restore default
+    set_low_latency_dispatch(False)

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -2895,3 +2895,28 @@ class TestDeepSeekV4SparseAttentionConfig:
     def test_invalid_compress_ratios_raise(self, compress_ratios):
         with pytest.raises(ValidationError, match="compress_ratios"):
             DeepSeekV4SparseAttentionConfig(compress_ratios=compress_ratios)
+
+
+class TestEnableLowLatencyHostDispatch:
+
+    def test_default_is_false(self):
+        args = TorchLlmArgs(model="gpt2")
+        assert args.enable_low_latency_host_dispatch is False
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_accepts_bool(self, value):
+        args = TorchLlmArgs(model="gpt2",
+                            enable_low_latency_host_dispatch=value)
+        assert args.enable_low_latency_host_dispatch is value
+
+    def test_yaml_round_trip(self):
+        args = TorchLlmArgs(model="gpt2", enable_low_latency_host_dispatch=True)
+        data = args.model_dump()
+        assert data["enable_low_latency_host_dispatch"] is True
+        restored = TorchLlmArgs(**data)
+        assert restored.enable_low_latency_host_dispatch is True
+
+    def test_rejects_non_bool(self):
+        with pytest.raises(ValidationError):
+            TorchLlmArgs(model="gpt2",
+                         enable_low_latency_host_dispatch={"val": 1})


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional low-latency host dispatch setting for faster callback handling in supported environments.
  * Exposed a new configuration option so it can be enabled from the public API.

* **Bug Fixes**
  * Older CUDA setups now fall back gracefully to the standard dispatch path when low-latency mode isn’t supported.

* **Documentation**
  * Updated API help text to describe the new option and its compatibility requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Adds `enable_low_latency_host_dispatch` (default `False`) to `TorchLlmArgs`.
When enabled, CUDA host callbacks are dispatched via `cudaLaunchHostFunc_v2`
with `cudaHostTaskSpinWait` instead of the default blocking mode, reducing
guided-decoder callback latency by keeping the CPU thread spinning until the
GPU event fires rather than sleeping.

This matters most when Eagle3 speculative decoding is combined with guided
decoding: in that configuration the guided-decoder `@hostfunc` callbacks are
captured inside the CUDA graph (called from `_execute_guided_decoder_if_present`
during the target model forward pass), so the spin-wait policy applies to every
decode step and the per-step wake-up latency directly affects inter-token delay.

Requires CUDA 13.2+ (`cudaHostTaskSyncMode` enum, `cudaHostTaskSpinWait = 0x1`).
Falls back silently to `cudaLaunchHostFunc` on older drivers with a log warning.

**Files changed:**
- `cpp/tensorrt_llm/nanobind/runtime/hostfunc.cpp` — add `bool lowLatency` param; use `cudaLaunchHostFunc_v2` behind `CUDART_VERSION >= 13020` guard
- `tensorrt_llm/_torch/hostfunc.py` — module-level `_low_latency_dispatch` flag + `set_low_latency_dispatch()` setter
- `tensorrt_llm/_torch/pyexecutor/_util.py` — call setter from `create_py_executor_instance`
- `tensorrt_llm/llmapi/llm_args.py` — `TorchLlmArgs` field (`status="prototype"`)

## Test Coverage

**Unit tests (no GPU required beyond existing fixture):**
- `tests/unittest/bindings/test_hostfunc.py` — `test_low_latency_dispatch`: verifies the module-level flag is toggled and hostfuncs fire correctly in both dispatch modes
- `tests/unittest/llmapi/test_llm_args.py` — `TestEnableLowLatencyHostDispatch`: default value, explicit True/False, YAML round-trip, invalid-type rejection

**API stability:**
- `tests/unittest/api_stability/references/llm.yaml` — field entry added (required to keep `test_api_status` green)

**Integration test:**
- `tests/integration/defs/accuracy/test_llm_api_pytorch.py` — `test_guided_decoding_with_eagle3_low_latency_dispatch`: exercises the flag with Eagle3 one-model + xgrammar/llguidance + CUDA graphs on Hopper+, validating end-to-end correctness via `JsonModeEval`

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.