### PR TITLE
[https://nvbugs/6321874][fix] Filter `.lock` from `os.listdir(...)` in the test's rank-file count; skip the…

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -1221,7 +1221,14 @@ class AutoTuner:
             candidates.append(
                 (runner_id, runner, runner_arg_names, all_valid_tactics))
 
-        if total_pairs == 1:
+        # MERGE/PARALLEL strategies rely on comparing per-rank timings to
+        # pick the winning tactic across ranks. If a rank's local set of
+        # tactics has only one entry we must still time it — the shortcut
+        # would record min_time=0.0, which collides with peer ranks' 0.0
+        # in the tie-break and silently drops slower tactics on the floor.
+        if total_pairs == 1 and tuning_config.distributed_tuning_strategy not in (
+                DistributedTuningStrategy.MERGE,
+                DistributedTuningStrategy.PARALLEL):
             # Single-pair shortcut. There is nothing to compare against, so
             # the timed warmup + profile-repeat loop is pure overhead. We
             # fire one forward call on every rank to drive any JIT side

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -320,7 +320,6 @@ test_e2e.py::test_ptp_quickstart_advanced_deepseek_r1_w4afp8_8gpus[DeepSeek-R1-W
 test_e2e.py::test_trtllm_bench_iteration_log[TRT-streaming-meta-llama/Llama-3.1-8B-llama-3.1-model/Meta-Llama-3.1-8B] SKIP (https://nvbugs/5448523)
 triton_server/test_triton.py::test_cpp_unit_tests[cpp-unit-tests] SKIP (https://nvbugs/5619359)
 triton_server/test_triton.py::test_python_bls_unit_tests[python-bls-unit-tests] SKIP (https://nvbugs/5477392)
-unittest/_torch/misc/test_autotuner.py::test_autotuner_distributed_strategy SKIP (https://nvbugs/6321874)
 unittest/_torch/misc/test_share_tensor.py::TestShareTensor::test_share_tensor_different_dtypes SKIP (https://nvbugs/6418021)
 unittest/_torch/modules/moe/test_moe_backend.py::test_moe_backend[act=Relu2-e60_k4_h2048_i1408-seq=8-dtype=torch.bfloat16-backend=TRTLLM-quant=NVFP4-routing=Renormalize] SKIP (https://nvbugs/5989912)
 unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py -m "part0" SKIP (https://nvbugs/6372711)

--- a/tests/unittest/_torch/misc/test_autotuner.py
+++ b/tests/unittest/_torch/misc/test_autotuner.py
@@ -765,9 +765,13 @@ def _distributed_worker_function(world_size, strategy):
                          tuning_config=config_independent,
                          inputs=inputs)
 
-    # Check only one file is created in the cache path
-    assert len(os.listdir(os.path.dirname(
-        cache_path))) == 1, "Only one rank file should be created"
+    # Check only one cache file is created in the cache path.
+    # The sibling ".lock" file is an implementation artifact of
+    # _exclusive_cache_lock (see tensorrt_llm/_torch/autotuner.py) and is not
+    # a per-rank cache file.
+    cache_dir = os.path.dirname(cache_path)
+    cache_files = [f for f in os.listdir(cache_dir) if not f.endswith(".lock")]
+    assert len(cache_files) == 1, "Only one rank file should be created"
 
     dist.barrier()
 


### PR DESCRIPTION
## Summary
- **Root cause**: Recent commit b02b6b4642 introduced (a) a persistent sibling `.lock` file next to the cache JSON that breaks the test's "1 file only" assertion, and (b) a single-pair profiling shortcut that records `min_time=0.0` and thereby breaks MERGE/PARALLEL cross-rank tie-breaking when each rank sees only its own tactic.
- **Fix**: Filter `.lock` from `os.listdir(...)` in the test's rank-file count; skip the single-pair shortcut in `_profile_runners` when `distributed_tuning_strategy` is MERGE or PARALLEL.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6321874


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed autotuning so single valid candidate sets still go through timed profiling on merge/parallel strategies, helping results compare correctly across ranks.
  * Adjusted cache validation to ignore lock artifacts and confirm the expected cache output is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->