### PR TITLE
[None][fix] KV cache manager V2: don't cap max_tokens with estimation dummy count

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -575,7 +575,11 @@ class KvCacheCreator:
                     max_gpu_total_bytes = min(max_gpu_total_bytes,
                                               self._max_gpu_total_bytes_in)
                 self._kv_cache_config.max_gpu_total_bytes = max_gpu_total_bytes
-                self._kv_cache_config.max_tokens = max_tokens
+                # V2 pool capacity is governed by max_gpu_total_bytes; for V2
+                # _get_token_num_for_estimation() returns only the dummy-workload token
+                # count, so writing it into max_tokens starves the real pool. Restore the
+                # incoming config value (None => no artificial cap).
+                self._kv_cache_config.max_tokens = self._max_kv_tokens_in
             else:
                 self._kv_cache_config.max_tokens = max_tokens
         return estimating_kv_cache


### PR DESCRIPTION
## Description

PR #15091 unified the `max_tokens` computation in `KvCacheCreator.try_prepare_estimation()` for the V1 and V2 KV cache managers:

```python
max_tokens = min(estimate_max_tokens, config.max_tokens) if config.max_tokens is not None else estimate_max_tokens
```

For the **V2** manager this is incorrect. `_get_token_num_for_estimation()` returns only the *dummy-workload* token count used to drive estimation — per its own comment: *"V2 capacity is controlled by max_gpu_total_bytes; max_tokens only describes the dummy workload needed for estimation."* Writing that small value into `kv_cache_config.max_tokens` caps the real V2 pool.

On a long-context DeepSeek-V4 sparse-attention workload (ISL ~39.6k, `avg_seq_len=39040`) this collapsed the V2 device quota to ~0.37 GiB, so the context server could not schedule even a single request (`indexmapper_free=2`) and hung indefinitely at startup ("Scheduler could not fit any request this iteration ... KV cache pool full").

**Fix:** for the V2 branch, keep `max_tokens` at the incoming config value (`self._max_kv_tokens_in`; `None` => no artificial cap), so V2 capacity is governed by `max_gpu_total_bytes` as intended. The V1 path and the other #15091 changes (CP / VANILLA early-outs) are unchanged.

## Test Coverage

Validated on DeepSeek-V4-Pro disaggregated gen-only serving (ISL 39.6k, OSL 260, MTP3, DEP8, `avg_seq_len=39040`, KV cache manager V2). The per-rank device-quota log line changes as follows:

| | `KV cache manager v2 device quota` | Result |
|---|---|---|
| **Before fix** (as of PR #15091) | `0.3738 GiB` | `indexmapper_free=2`; context server cannot fit a single 39.6k request and **hangs at startup** |
| **After fix** | `103.70 GiB` | server starts and serves normally; benchmark completes (MTP accept length ~2.68) |

~~A dedicated unit test for the V2 max_tokens/max_gpu_total_bytes interaction is TODO.~~

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.