### PR TITLE
[https://nvbugs/6396420][fix] Restore single-node NVLS over POSIX-FD

### DIFF
--- a/cpp/include/tensorrt_llm/runtime/ipcNvlsMemory.h
+++ b/cpp/include/tensorrt_llm/runtime/ipcNvlsMemory.h
@@ -44,13 +44,22 @@ struct IpcNvlsHandle
 
 void MPI_group_barrier(std::set<int> ranks);
 
-//! \brief Whether NVLS (NVLink SHARP) multicast can actually be used on this
-//! node. Checks the static capability (CUDA driver >= 12010 and
-//! CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED) and then confirms the fabric/IMEX
-//! plane can really bind multicast memory -- the static attribute alone is a
-//! false positive when nvidia-imex is not provisioned. Returns true only when
-//! multicast is both supported and usable. The (heavy) result is cached.
+//! \brief Whether NVLS (NVLink SHARP) multicast memory can be allocated on this
+//! node. Checks only the static capability (CUDA driver >= 12010 and
+//! CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED). This is the precondition for
+//! ipcNvlsAllocate(): the allocator itself selects a fabric or POSIX-FD handle
+//! via getMemHandleType(), so single-node NVLS works over POSIX-FD even when the
+//! fabric/IMEX plane is not provisioned. The result is cached.
 bool ipcNvlsSupported();
+
+//! \brief Whether the NVLink fabric/IMEX plane is provisioned so that NVLS
+//! multicast memory can actually be *bound* (not merely statically supported).
+//! Extends ipcNvlsSupported() with a live fabric probe (getMemHandleType() must
+//! resolve to CU_MEM_HANDLE_TYPE_FABRIC). Use this to decide whether NCCL may
+//! attempt NVLS: on an unprovisioned node the static multicast attribute is a
+//! false positive and NCCL aborts during init, so callers should disable
+//! NCCL_NVLS when this returns false. The (heavy) result is cached.
+bool ipcNvlsFabricUsable();
 
 IpcNvlsHandle* ipcNvlsAllocate(size_t size, std::set<int> ranks);
 

--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -162,9 +162,9 @@ std::shared_ptr<ncclComm_t> getComm(std::set<int> const& group)
     setenv("NCCL_RUNTIME_CONNECT", "0", 0);
     setenv("NCCL_GRAPH_REGISTER", "0", 0);
     // NCCL aborts during init if it tries NVLS multicast but the fabric/IMEX
-    // plane can't bind it. Disable NVLS when it isn't actually usable so NCCL
+    // plane can't bind it. Disable NVLS when the fabric is not usable so NCCL
     // falls back to NVLink P2P. No-overwrite preserves an explicit user setting.
-    if (!tensorrt_llm::runtime::ipcNvlsSupported())
+    if (!tensorrt_llm::runtime::ipcNvlsFabricUsable())
     {
         setenv("NCCL_NVLS_ENABLE", "0", 0);
     }

--- a/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cu
+++ b/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cu
@@ -148,7 +148,7 @@ private:
 // Returns CU_MEM_HANDLE_TYPE_FABRIC when fabric-handle memory can actually be
 // allocated and exported on the current device (i.e. the fabric/IMEX plane is
 // provisioned), else CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR. Used both to pick
-// the NVLS allocation handle type and by ipcNvlsSupported() to gauge usability.
+// the NVLS allocation handle type and by ipcNvlsFabricUsable() to gauge usability.
 static CUmemAllocationHandleType getMemHandleType()
 {
     int device_id;
@@ -453,13 +453,13 @@ void MPI_group_barrier(std::set<int> group)
 bool ipcNvlsSupported()
 {
 #if ENABLE_MULTI_DEVICE
-    // The result is static for the process and the fabric probe below is
-    // relatively heavy (it allocates and exports fabric-handle memory), so
-    // compute it once and cache it.
+    // Static capability check only (driver version + the multicast attribute on
+    // every device). This is the precondition for allocating NVLS multicast
+    // memory: ipcNvlsAllocate() selects a fabric or POSIX-FD handle itself, so
+    // single-node NVLS works without a provisioned fabric/IMEX plane. The result
+    // is static for the process, so compute it once and cache it.
     static bool const supported = []() -> bool
     {
-        // Cheap static capability check first (driver version + the multicast
-        // attribute on every device); short-circuits the fabric probe.
         int cuda_driver_version = -1;
         TLLM_CUDA_CHECK(cudaDriverGetVersion(&cuda_driver_version));
         if (cuda_driver_version < 12010)
@@ -483,6 +483,26 @@ bool ipcNvlsSupported()
                 return false;
             }
         }
+        return true;
+    }();
+    return supported;
+#else
+    return false;
+#endif
+}
+
+bool ipcNvlsFabricUsable()
+{
+#if ENABLE_MULTI_DEVICE
+    // Extends ipcNvlsSupported() with a live fabric probe. The probe is
+    // relatively heavy (it allocates and exports fabric-handle memory), so
+    // compute it once and cache it.
+    static bool const usable = []() -> bool
+    {
+        if (!ipcNvlsSupported())
+        {
+            return false;
+        }
 #if !ENABLE_NVSHMEM
         // The multicast attribute is a false positive when the fabric/IMEX plane
         // is not provisioned (e.g. nvidia-imex not running): NVLS multicast
@@ -497,13 +517,13 @@ bool ipcNvlsSupported()
                 TLLM_LOG_WARNING(
                     "\n"
                     "**************************************************************************\n"
-                    "* NVLS (NVLink SHARP) DISABLED -- falling back to NVLink P2P              *\n"
+                    "* NVLS (NVLink SHARP) DISABLED for NCCL -- falling back to NVLink P2P     *\n"
                     "**************************************************************************\n"
                     "* The GPU advertises multicast support, but the NVLink fabric/IMEX plane *\n"
                     "* is NOT provisioned on this node, so NVLS multicast memory cannot be    *\n"
                     "* bound. Collectives will still work over NVLink P2P, but NVLS-           *\n"
-                    "* accelerated paths (NCCL NVLS, fused GEMM-allreduce / MNNVL) are off    *\n"
-                    "* and performance may be reduced.                                        *\n"
+                    "* accelerated NCCL is off and performance may be reduced. (Single-node   *\n"
+                    "* NVLS over POSIX-FD, e.g. MNNVL allreduce, is unaffected.)              *\n"
                     "*                                                                        *\n"
                     "* To enable NVLS: start nvidia-imex and expose                           *\n"
                     "* /dev/nvidia-caps-imex-channels to the container. Set                   *\n"
@@ -519,7 +539,7 @@ bool ipcNvlsSupported()
 #endif // !ENABLE_NVSHMEM
         return true;
     }();
-    return supported;
+    return usable;
 #else
     return false;
 #endif

--- a/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
+++ b/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
@@ -152,7 +152,7 @@ ncclComm_t NcclCommunicator::createComm(int worldSize, int rank, mpi::MpiComm co
         _putenv_s("NCCL_RUNTIME_CONNECT", "0");
 #else
     setenv("NCCL_RUNTIME_CONNECT", "0", 0);
-    if (getenv("NCCL_NVLS_ENABLE") == nullptr && !ipcNvlsSupported())
+    if (getenv("NCCL_NVLS_ENABLE") == nullptr && !ipcNvlsFabricUsable())
     {
         setenv("NCCL_NVLS_ENABLE", "0", 0);
     }

--- a/cpp/tests/unit_tests/runtime/CMakeLists.txt
+++ b/cpp/tests/unit_tests/runtime/CMakeLists.txt
@@ -22,6 +22,7 @@ add_gtest(gptDecoderTest gptDecoderTest.cpp)
 add_gtest(hostAccessibleDeviceAllocatorTest
           hostAccessibleDeviceAllocatorTest.cu)
 add_gtest(iBufferTest iBufferTest.cpp)
+add_gtest(ipcNvlsMemoryTest ipcNvlsMemoryTest.cpp)
 add_gtest(iTensorTest iTensorTest.cpp)
 add_gtest(loraCacheTest loraCacheTest.cpp)
 add_gtest(loraManagerTest loraManagerTest.cpp)

--- a/cpp/tests/unit_tests/runtime/ipcNvlsMemoryTest.cpp
+++ b/cpp/tests/unit_tests/runtime/ipcNvlsMemoryTest.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/runtime/ipcNvlsMemory.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+namespace tr = tensorrt_llm::runtime;
+
+namespace
+{
+#if ENABLE_MULTI_DEVICE
+// Recompute the static NVLS multicast capability exactly as ipcNvlsSupported()
+// must: CUDA driver >= 12010 and CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED on the
+// device. Deliberately does NO fabric/IMEX probe -- that is what
+// ipcNvlsFabricUsable() adds on top.
+bool computeStaticNvlsCapability()
+{
+    int driverVersion = -1;
+    TLLM_CUDA_CHECK(cudaDriverGetVersion(&driverVersion));
+    if (driverVersion < 12010)
+    {
+        return false;
+    }
+    int cudaDev = -1;
+    TLLM_CUDA_CHECK(cudaGetDevice(&cudaDev));
+    CUdevice device{};
+    EXPECT_EQ(cuDeviceGet(&device, cudaDev), CUDA_SUCCESS);
+    int multicastSupported = 0;
+    EXPECT_EQ(cuDeviceGetAttribute(&multicastSupported, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, device), CUDA_SUCCESS);
+    return multicastSupported != 0;
+}
+#endif // ENABLE_MULTI_DEVICE
+
+class IpcNvlsMemoryTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+#if !ENABLE_MULTI_DEVICE
+        GTEST_SKIP() << "ipcNvls* helpers require ENABLE_MULTI_DEVICE.";
+#else
+        int deviceCount = 0;
+        TLLM_CUDA_CHECK(cudaGetDeviceCount(&deviceCount));
+        if (deviceCount == 0)
+        {
+            GTEST_SKIP() << "No CUDA devices available.";
+        }
+        // Ensure the CUDA runtime (and primary context) is initialized so the
+        // driver-API device attribute query below is valid.
+        TLLM_CUDA_CHECK(cudaFree(nullptr));
+#endif // ENABLE_MULTI_DEVICE
+    }
+};
+
+// Regression guard for https://nvbugs/6396420.
+//
+// ipcNvlsSupported() must report only the *static* multicast capability
+// (driver + CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED). It must NOT depend on
+// whether the NVLink fabric/IMEX plane is provisioned: single-node NVLS is
+// allocated over a POSIX-FD handle and does not need the fabric plane.
+//
+// PR #15302 folded a fabric probe into ipcNvlsSupported(), which on a
+// multicast-capable but fabric-unprovisioned node made it return false. That
+// wrongly disabled the single-node NVLS allocator (ipcNvlsAllocate) and fused
+// GEMM-allreduce. The fabric probe now lives in ipcNvlsFabricUsable(); if it
+// leaks back into ipcNvlsSupported() this assertion fails on such nodes.
+TEST_F(IpcNvlsMemoryTest, SupportedReflectsStaticCapabilityOnly)
+{
+#if ENABLE_MULTI_DEVICE
+    EXPECT_EQ(tr::ipcNvlsSupported(), computeStaticNvlsCapability());
+#endif // ENABLE_MULTI_DEVICE
+}
+
+// Fabric usability is a strict refinement of static capability, so it must
+// never be reported as usable when NVLS is not even statically supported.
+TEST_F(IpcNvlsMemoryTest, FabricUsableImpliesSupported)
+{
+#if ENABLE_MULTI_DEVICE
+    if (tr::ipcNvlsFabricUsable())
+    {
+        EXPECT_TRUE(tr::ipcNvlsSupported());
+    }
+#endif // ENABLE_MULTI_DEVICE
+}
+} // namespace

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -592,7 +592,6 @@ unittest/_torch/misc/test_autotuner.py::test_autotuner_distributed_strategy SKIP
 unittest/_torch/modules/moe/test_moe_backend.py::test_moe_backend[act=Relu2-e60_k4_h2048_i1408-seq=8-dtype=torch.bfloat16-backend=TRTLLM-quant=NVFP4-routing=Renormalize] SKIP (https://nvbugs/5989912)
 unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_multi_gpu -k "CUTLASS and FP8 and not FP8_BLOCK_SCALES and not W4A8" SKIP (https://nvbugs/6402048)
 unittest/_torch/modules/tests_lora_modules/test_lora_attention_pytorch_flow_vs_trt.py::TestLoraAttentionPytorchFlowVsTRT::test_lora_attention SKIP (https://nvbugs/5701421)
-unittest/_torch/multi_gpu/test_mnnvl_allreduce.py::test_mnnvl_nvfp4_rejects_fp32_before_launch[2] SKIP (https://nvbugs/6396420)
 unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py -m "part0" SKIP (https://nvbugs/6372711)
 unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py::test_llm_partial_update_weights_nvfp4[auto-Qwen3/Qwen3-8B] SKIP (https://nvbugs/6372690)
 unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py::test_llm_partial_update_weights_nvfp4[fp8-Qwen3/Qwen3-30B-A3B] SKIP (https://nvbugs/6372690)


### PR DESCRIPTION
# Features
PR #15302 added a fabric/IMEX probe to ipcNvlsSupported(). That probe is right for the NCCL NVLS decision, but ipcNvlsSupported() also guards ipcNvlsAllocate(), and single-node NVLS works over a POSIX-FD handle without a fabric plane. On nodes without a provisioned fabric the guard now throws before the POSIX-FD allocator runs, disabling single-node NVLS / fused GEMM-allreduce and breaking test_mnnvl_nvfp4_rejects_fp32_before_launch.

Split the check:
- ipcNvlsSupported(): static capability only (driver + MULTICAST_SUPPORTED), as before #15302. Guards ipcNvlsAllocate() (which picks FABRIC vs POSIX-FD itself), the Python binding, and the gemm test.
- ipcNvlsFabricUsable() (new): static check plus the fabric probe. Drives the NCCL_NVLS_ENABLE fallback in opUtils.cpp / ncclCommunicator.cpp, keeping #15302's NCCL-init fix.

Remove the now-unneeded waiver and add ipcNvlsMemoryTest, a regression guard asserting ipcNvlsSupported() reflects only the static multicast capability and that ipcNvlsFabricUsable() implies ipcNvlsSupported().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved NVLS readiness detection so the system can distinguish between basic support and actual fabric availability.
  * Added clearer fallback behavior when NVLS cannot be used, helping communication setup proceed more reliably.

* **Bug Fixes**
  * Reduced chances of NVLS initialization failures on nodes where the fabric is not provisioned.
  * Ensured fallback to NVLink P2P happens when NVLS is unavailable.

* **Tests**
  * Added unit coverage for NVLS capability and fabric usability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
