### PR TITLE
[https://nvbugs/6395803][fix] Add `W4A16_NVFP4 = auto()` to the `QuantAlgo` StrEnum next to `W4A16_MXFP4`…

### DIFF
--- a/tensorrt_llm/quantization/mode.py
+++ b/tensorrt_llm/quantization/mode.py
@@ -44,6 +44,7 @@ class QuantAlgo(StrEnum, metaclass=BaseEnumMeta):
     W4A8_MXFP4_FP8 = auto()
     W4A8_MXFP4_MXFP8 = auto()
     W4A16_MXFP4 = auto()
+    W4A16_NVFP4 = auto()
     MXFP8 = auto()
     NVFP4_AWQ = auto()
     NVFP4_ARC = auto()


### PR DESCRIPTION
## Summary
- **Root cause**: `QuantAlgo` StrEnum in `tensorrt_llm/quantization/mode.py` is missing the `W4A16_NVFP4` value published by `nvidia/Qwen3.6-27B-NVFP4`'s `hf_quant_config.json`.
- **Fix**: Add `W4A16_NVFP4 = auto()` to the `QuantAlgo` StrEnum next to `W4A16_MXFP4`; the unmapped algo falls through `QuantMode.from_quant_algo` to `QuantMode(0)` — the same graceful path used by other config-only algos.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6395803
