### PR TITLE
[https://nvbugs/6410963][fix] Make cache transceiver transport reporting deterministic

### DIFF
--- a/examples/disaggregated/slurm/cache_transceiver_test/report.py
+++ b/examples/disaggregated/slurm/cache_transceiver_test/report.py
@@ -253,10 +253,14 @@ def _parse_python_csvs(csv_dir):
     return per_rid  # {rid: [per-rank GB/s]}
 
 
-# Transport in the last column of a UCX_PROTO_INFO=y table row, e.g.
+# Protocol selection in the last column of a UCX_PROTO_INFO=y table row, e.g.
 #   "... | rendezvous zero-copy read from remote | cuda_ipc/cuda |"
-# Group 1 is the transport name, group 2 the memory/device suffix.
-_PROTO_LAST_COL = re.compile(r"\|\s*([a-z0-9_]+)(?:/([a-z0-9_]+))?\s*\|\s*$")
+# Multi-lane configs may contain weighted entries such as
+# `50% on rc_mlx5/mlx5_0:1 and 50% on rc_mlx5/mlx5_1:1`.
+_PROTO_LAST_COL = re.compile(r"\|\s*([^|]+?)\s*\|\s*$")
+_TRANSPORT_TOKEN = re.compile(
+    rf"(?<![a-z0-9_])({'|'.join(map(re.escape, TRANSPORT_TOKENS))})(?![a-z0-9_])"
+)
 # A UCX_PROTO_INFO config header line (one per operation/peer/size-class).
 _CONFIG_HEADER = re.compile(r"cfg#\d")
 # Case boundary the driver prints at the start of each (sweep, combination) case.
@@ -281,6 +285,15 @@ def _is_kv_data_header(line):
     return any(op in line for op in _KV_DATA_OPS)
 
 
+def _proto_row_transports(line):
+    """Return known transports from the final column of a protocol-table row."""
+    match = _PROTO_LAST_COL.search(line)
+    if not match:
+        return []
+    found = set(_TRANSPORT_TOKEN.findall(match.group(1)))
+    return [tok for tok in TRANSPORT_TOKENS if tok in found]
+
+
 class _TransportAcc:
     """Scans a UCX_PROTO_INFO=y table, tracking the current config header.
 
@@ -299,18 +312,17 @@ class _TransportAcc:
         if _CONFIG_HEADER.search(line):
             self._in_kv = _is_kv_data_header(line)
             return
-        m = _PROTO_LAST_COL.search(line)
-        if not m or m.group(1) not in TRANSPORT_TOKENS:
+        transports = _proto_row_transports(line)
+        if not transports:
             return
-        tok = m.group(1)
-        self.any.add(tok)
+        self.any.update(transports)
         if self._in_kv:
-            self.kv.add(tok)
+            self.kv.update(transports)
             if "software emulation" in line:
                 self.sw_emul = True
 
-    def ranked(self):
-        chosen = self.kv or self.any
+    def ranked(self, kv_only=False):
+        chosen = self.kv if kv_only else self.kv or self.any
         out = [t for t in TRANSPORT_TOKENS if t in chosen]
         # Flag host-staged fallback so a tcp KV path isn't read as "fine".
         if self.sw_emul and "tcp" in out:
@@ -318,7 +330,7 @@ class _TransportAcc:
         return out
 
 
-def _parse_proto_info(log_glob):
+def _parse_proto_info(log_glob, kv_only=False):
     """Sweep-level transport(s) UCX selected for the KV transfer.
 
     UCX_PROTO_INFO=y prints a protocol-selection table; the transport that
@@ -327,7 +339,8 @@ def _parse_proto_info(log_glob):
     instead of grepping token substrings anywhere in the log -- the latter also
     matches the `UCX_TLS=...` echo line and small-message/control protocols.
     The KV blocks are large CUDA buffers, so CUDA-memory bulk rows win. Falls
-    back to a substring scan only if no parseable table is present (older logs).
+    back to a substring scan only if no parseable table is present (older logs),
+    unless `kv_only` requires evidence from a CUDA KV-data table.
 
     This is sweep-granular; prefer `_parse_proto_info_by_case` when the per-case
     CTT_CASE_BEGIN markers are present.
@@ -341,9 +354,11 @@ def _parse_proto_info(log_glob):
             continue
         for line in lines:
             acc.feed(line)
-    ranked = acc.ranked()
+    ranked = acc.ranked(kv_only=kv_only)
     if ranked:
         return ranked
+    if kv_only:
+        return []
     # Fallback: no parseable proto table (e.g. older logs) -- substring scan.
     chosen = set()
     for path in glob.glob(log_glob):
@@ -358,14 +373,15 @@ def _parse_proto_info(log_glob):
     return [t for t in TRANSPORT_TOKENS if t in chosen]
 
 
-def _parse_proto_info_by_case(log_glob):
+def _parse_proto_info_by_case(log_glob, kv_only=False):
     """Return {case_idx: [transports]} attributed per (sweep, combination).
 
     Splits each rank log on the driver's `[CTT_CASE_BEGIN] ci=N` markers.
     Transport is constant across a case's request lengths (one transceiver per
     case), so this is the right granularity. Returns {} if no markers are
     present (older logs), so the caller can fall back to sweep-level
-    `_parse_proto_info`.
+    `_parse_proto_info`. When `kv_only` is true, control-table fallbacks are
+    excluded from each case.
     """
     accs = {}  # ci -> _TransportAcc
     saw_marker = False
@@ -387,7 +403,7 @@ def _parse_proto_info_by_case(log_glob):
                 accs[cur].feed(line)
     if not saw_marker:
         return {}
-    return {ci: acc.ranked() for ci, acc in accs.items()}
+    return {ci: acc.ranked(kv_only=kv_only) for ci, acc in accs.items()}
 
 
 # Driver per-request log timestamp, e.g. "[06/03/2026-06:59:17] ... rid=12 ...
@@ -466,13 +482,13 @@ def _parse_proto_info_by_case_ts(log_glob, case_starts):
                 if not in_kv:
                     continue
                 mt = _UCX_TS.search(line)
-                mr = _PROTO_LAST_COL.search(line)
-                if not mt or not mr or mr.group(1) not in TRANSPORT_TOKENS:
+                transports = _proto_row_transports(line)
+                if not mt or not transports:
                     continue
                 ci = _ci_for(float(mt.group(1)))
                 if ci is None:
                     continue
-                kv.setdefault(ci, set()).add(mr.group(1))
+                kv.setdefault(ci, set()).update(transports)
                 if "software emulation" in line:
                     sw[ci] = True
     out = {}
@@ -511,7 +527,7 @@ def _read_status(work_dir, sweep_idx):
     return merged
 
 
-def aggregate(cfg, out_path):
+def aggregate(cfg, out_path, require_kv_transport=False):
     work_dir = cfg["environment"]["work_dir"]
     cases = build_cases(cfg)
     req_lens = cfg["test_matrix"]["request_lengths"]
@@ -537,8 +553,8 @@ def aggregate(cfg, out_path):
         # then sweep-level, for logs lacking per-request timestamps.
         per_case_transport = _parse_proto_info_by_case_ts(log_glob, _case_start_times(log_glob))
         if not per_case_transport:
-            per_case_transport = _parse_proto_info_by_case(log_glob)
-        sweep_transport = _parse_proto_info(log_glob)
+            per_case_transport = _parse_proto_info_by_case(log_glob, kv_only=require_kv_transport)
+        sweep_transport = _parse_proto_info(log_glob, kv_only=require_kv_transport)
         status_map = _read_status(work_dir, sweep_idx)
 
         cpp_bw = _parse_cpp_recv_csvs(gen_csv_dir)
@@ -702,6 +718,11 @@ def main():
     g.add_argument("--aggregate", action="store_true")
     ap.add_argument("--sweep", type=int, default=0)
     ap.add_argument("--out", type=str, default=None)
+    ap.add_argument(
+        "--require-kv-transport",
+        action="store_true",
+        help="accept transport only from CUDA KV-data protocol tables",
+    )
     args = ap.parse_args()
 
     cfg = load_config(args.config)
@@ -711,7 +732,7 @@ def main():
         emit_ucx_env(cfg, args.sweep)
     elif args.aggregate:
         out = args.out or os.path.join(cfg["environment"]["work_dir"], "results.json")
-        aggregate(cfg, out)
+        aggregate(cfg, out, require_kv_transport=args.require_kv_transport)
         print(f"\nWrote {out}", file=sys.stderr)
 
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -349,7 +349,6 @@ unittest/auto_deploy/multigpu/custom_ops/test_ad_dist_strategies.py::test_allred
 unittest/auto_deploy/multigpu/custom_ops/test_ad_dist_strategies.py::test_allreduce_strategies[SYMM_MEM] SKIP (https://nvbugs/6403920)
 unittest/bindings/test_executor_bindings.py SKIP (TRTLLM-13781: legacy TensorRT examples removed; tests to be removed in follow-up PR3)
 unittest/bindings/test_transfer_agent_bindings.py::TestNixlFunctionalTransfer::test_nixl_wait_in_progress_on_zero_timeout SKIP (https://nvbugs/6260897)
-unittest/disaggregated/test_cache_transceiver_harness.py::test_single_node_transfer SKIP (https://nvbugs/6410963)
 unittest/executor/test_rpc.py::TestRpcCorrectness::test_incremental_task_async SKIP (https://nvbugs/5741476)
 unittest/executor/test_rpc_proxy.py SKIP (https://nvbugs/5605741)
 unittest/executor/test_rpc_worker.py SKIP (https://nvbugs/5605741)

--- a/tests/unittest/disaggregated/test_cache_transceiver_harness.py
+++ b/tests/unittest/disaggregated/test_cache_transceiver_harness.py
@@ -29,10 +29,9 @@ import socket
 import subprocess
 import sys
 import time
+from unittest.mock import MagicMock, call
 
 import pytest
-
-pytest.importorskip("mpi4py")
 
 CTT_DIR = os.path.normpath(
     os.path.join(
@@ -82,8 +81,7 @@ def _wait_for_processes(processes: list[subprocess.Popen]) -> None:
         proc.wait(timeout=remaining)
 
 
-def _terminate_process_groups(processes: list[subprocess.Popen]) -> None:
-    group_ids = [proc.pid for proc in processes if proc.poll() is None]
+def _terminate_process_groups(processes: list[subprocess.Popen], group_ids: list[int]) -> None:
     for group_id in group_ids:
         try:
             os.killpg(group_id, signal.SIGTERM)
@@ -104,8 +102,62 @@ def _terminate_process_groups(processes: list[subprocess.Popen]) -> None:
             os.killpg(group_id, signal.SIGKILL)
         except ProcessLookupError:
             pass
+
+    deadline = time.monotonic() + _TERMINATE_GRACE_SECONDS
     for proc in processes:
-        proc.wait()
+        if proc.poll() is not None:
+            continue
+        try:
+            proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            pass
+
+
+class TestProcessHelpers:
+    def test_wait_for_processes_uses_shared_deadline(self, monkeypatch):
+        first = MagicMock()
+        second = MagicMock()
+        monotonic = MagicMock(side_effect=[100.0, 101.0, 111.0])
+        monkeypatch.setattr(time, "monotonic", monotonic)
+
+        _wait_for_processes([first, second])
+
+        first.wait.assert_called_once_with(timeout=119.0)
+        second.wait.assert_called_once_with(timeout=109.0)
+
+    def test_terminate_process_groups_bounds_post_kill_wait(self, monkeypatch):
+        proc = MagicMock(pid=1234)
+        proc.poll.return_value = None
+        proc.wait.side_effect = [
+            subprocess.TimeoutExpired("mpirun", 4.0),
+            subprocess.TimeoutExpired("mpirun", 4.0),
+        ]
+        killpg = MagicMock()
+        monotonic = MagicMock(side_effect=[100.0, 101.0, 200.0, 201.0])
+        monkeypatch.setattr(os, "killpg", killpg)
+        monkeypatch.setattr(time, "monotonic", monotonic)
+
+        _terminate_process_groups([proc], [proc.pid])
+
+        assert proc.wait.call_args_list == [call(timeout=4.0), call(timeout=4.0)]
+        assert killpg.call_args_list == [
+            call(proc.pid, signal.SIGTERM),
+            call(proc.pid, signal.SIGKILL),
+        ]
+
+    def test_terminate_process_groups_signals_group_after_leader_exit(self, monkeypatch):
+        proc = MagicMock(pid=1234)
+        proc.poll.return_value = 1
+        killpg = MagicMock()
+        monkeypatch.setattr(os, "killpg", killpg)
+
+        _terminate_process_groups([proc], [proc.pid])
+
+        assert killpg.call_args_list == [
+            call(proc.pid, signal.SIGTERM),
+            call(proc.pid, signal.SIGKILL),
+        ]
+        proc.wait.assert_not_called()
 
 
 def _build_config(work_dir: str) -> dict:
@@ -146,6 +198,7 @@ def _build_config(work_dir: str) -> dict:
 @pytest.mark.timeout(180)
 def test_single_node_transfer(tmp_path):
     """Launch ctx and gen via mpirun on a single node, verify transfer passes."""
+    pytest.importorskip("mpi4py")
     mpirun = _find_mpirun()
 
     work_dir = str(tmp_path / "work")
@@ -165,8 +218,8 @@ def test_single_node_transfer(tmp_path):
             "CTT_SWEEP": "0",
             "CTT_SWEEP_NAME": "default",
             "CUDA_VISIBLE_DEVICES": "0",
-            # The report parser consumes full protocol-selection tables. Unlike
-            # `used`, `y` does not depend on UCX worker teardown to emit them.
+            # Emit protocol-selection tables while transfers are active so the
+            # report can deterministically identify the CUDA KV-data transport.
             "UCX_PROTO_INFO": "y",
         }
     )
@@ -192,7 +245,8 @@ def test_single_node_transfer(tmp_path):
     gen_log_path = os.path.join(log_dir, "sweep0_gen_rank0.log")
     timeout_error = None
     processes = []
-    processes_completed = False
+    process_group_ids = []
+    processes_succeeded = False
     with open(ctx_log_path, "wb") as ctx_log_file, open(gen_log_path, "wb") as gen_log_file:
         try:
             ctx_proc = subprocess.Popen(
@@ -203,6 +257,7 @@ def test_single_node_transfer(tmp_path):
                 start_new_session=True,
             )
             processes.append(ctx_proc)
+            process_group_ids.append(ctx_proc.pid)
             gen_proc = subprocess.Popen(
                 mpi_args + ["--role", "gen"],
                 env=env,
@@ -211,13 +266,14 @@ def test_single_node_transfer(tmp_path):
                 start_new_session=True,
             )
             processes.append(gen_proc)
+            process_group_ids.append(gen_proc.pid)
             _wait_for_processes(processes)
-            processes_completed = True
+            processes_succeeded = all(proc.returncode == 0 for proc in processes)
         except subprocess.TimeoutExpired as exc:
             timeout_error = exc
         finally:
-            if not processes_completed:
-                _terminate_process_groups(processes)
+            if not processes_succeeded:
+                _terminate_process_groups(processes, process_group_ids)
 
     with open(ctx_log_path, errors="replace") as f:
         ctx_log = f.read()
@@ -258,7 +314,15 @@ def test_single_node_transfer(tmp_path):
     # Verify report aggregation produces valid results.
     results_path = os.path.join(work_dir, "results.json")
     agg_result = subprocess.run(
-        [sys.executable, REPORT_SCRIPT, config_path, "--aggregate", "--out", results_path],
+        [
+            sys.executable,
+            REPORT_SCRIPT,
+            config_path,
+            "--aggregate",
+            "--require-kv-transport",
+            "--out",
+            results_path,
+        ],
         capture_output=True,
         text=True,
         timeout=30,

--- a/tests/unittest/disaggregated/test_cache_transceiver_harness.py
+++ b/tests/unittest/disaggregated/test_cache_transceiver_harness.py
@@ -24,9 +24,11 @@ Requires: 1 GPU, mpirun, mpi4py, tensorrt_llm.
 import json
 import os
 import shutil
+import signal
 import socket
 import subprocess
 import sys
+import time
 
 import pytest
 
@@ -47,6 +49,9 @@ CTT_DIR = os.path.normpath(
 
 DRIVER_SCRIPT = os.path.join(CTT_DIR, "run_cache_transceiver_test.py")
 REPORT_SCRIPT = os.path.join(CTT_DIR, "report.py")
+_LOG_TAIL_CHARS = 16 * 1024
+_PROCESS_TIMEOUT_SECONDS = 120
+_TERMINATE_GRACE_SECONDS = 5
 
 
 def _find_free_port():
@@ -61,6 +66,46 @@ def _find_mpirun():
     if path is None:
         pytest.skip("mpirun not found on PATH")
     return path
+
+
+def _log_tail(log: str) -> str:
+    if len(log) <= _LOG_TAIL_CHARS:
+        return log
+    omitted = len(log) - _LOG_TAIL_CHARS
+    return f"... {omitted} earlier characters omitted ...\n{log[-_LOG_TAIL_CHARS:]}"
+
+
+def _wait_for_processes(processes: list[subprocess.Popen]) -> None:
+    deadline = time.monotonic() + _PROCESS_TIMEOUT_SECONDS
+    for proc in processes:
+        remaining = max(0.0, deadline - time.monotonic())
+        proc.wait(timeout=remaining)
+
+
+def _terminate_process_groups(processes: list[subprocess.Popen]) -> None:
+    group_ids = [proc.pid for proc in processes if proc.poll() is None]
+    for group_id in group_ids:
+        try:
+            os.killpg(group_id, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+    deadline = time.monotonic() + _TERMINATE_GRACE_SECONDS
+    for proc in processes:
+        if proc.poll() is not None:
+            continue
+        try:
+            proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            pass
+
+    for group_id in group_ids:
+        try:
+            os.killpg(group_id, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    for proc in processes:
+        proc.wait()
 
 
 def _build_config(work_dir: str) -> dict:
@@ -120,7 +165,9 @@ def test_single_node_transfer(tmp_path):
             "CTT_SWEEP": "0",
             "CTT_SWEEP_NAME": "default",
             "CUDA_VISIBLE_DEVICES": "0",
-            "UCX_PROTO_INFO": "used",
+            # The report parser consumes full protocol-selection tables. Unlike
+            # `used`, `y` does not depend on UCX worker teardown to emit them.
+            "UCX_PROTO_INFO": "y",
         }
     )
     sweep_env = cfg["ucx_env_sweep"][0].get("env") or {}
@@ -136,37 +183,63 @@ def test_single_node_transfer(tmp_path):
         DRIVER_SCRIPT,
     ]
 
-    ctx_proc = subprocess.Popen(
-        mpi_args + ["--role", "ctx"], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-    )
-    gen_proc = subprocess.Popen(
-        mpi_args + ["--role", "gen"], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-    )
-
-    ctx_out, _ = ctx_proc.communicate(timeout=120)
-    gen_out, _ = gen_proc.communicate(timeout=120)
-
-    ctx_log = ctx_out.decode(errors="replace")
-    gen_log = gen_out.decode(errors="replace")
-
-    # Persist logs to work_dir matching the glob pattern that report.py expects
-    # (sweep<N>_<role>_rank<R>.log). mpirun merges all rank outputs into one
-    # stream, so we write the combined output as rank0; report still picks it up.
+    # Write directly to the filenames report.py consumes. Full UCX protocol
+    # tables are verbose, so files also prevent either child from blocking on a
+    # full stdout pipe while the other child is being drained.
     log_dir = os.path.join(work_dir, "logs")
     os.makedirs(log_dir, exist_ok=True)
-    for role, content in [("ctx", ctx_log), ("gen", gen_log)]:
-        with open(os.path.join(log_dir, f"sweep0_{role}_rank0.log"), "w") as f:
-            f.write(content)
+    ctx_log_path = os.path.join(log_dir, "sweep0_ctx_rank0.log")
+    gen_log_path = os.path.join(log_dir, "sweep0_gen_rank0.log")
+    timeout_error = None
+    processes = []
+    processes_completed = False
+    with open(ctx_log_path, "wb") as ctx_log_file, open(gen_log_path, "wb") as gen_log_file:
+        try:
+            ctx_proc = subprocess.Popen(
+                mpi_args + ["--role", "ctx"],
+                env=env,
+                stdout=ctx_log_file,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            processes.append(ctx_proc)
+            gen_proc = subprocess.Popen(
+                mpi_args + ["--role", "gen"],
+                env=env,
+                stdout=gen_log_file,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            processes.append(gen_proc)
+            _wait_for_processes(processes)
+            processes_completed = True
+        except subprocess.TimeoutExpired as exc:
+            timeout_error = exc
+        finally:
+            if not processes_completed:
+                _terminate_process_groups(processes)
+
+    with open(ctx_log_path, errors="replace") as f:
+        ctx_log = f.read()
+    with open(gen_log_path, errors="replace") as f:
+        gen_log = f.read()
+
+    if timeout_error is not None:
+        pytest.fail(
+            f"mpirun timed out: {timeout_error}\n"
+            f"ctx log tail:\n{_log_tail(ctx_log)}\n"
+            f"gen log tail:\n{_log_tail(gen_log)}"
+        )
 
     if ctx_proc.returncode != 0:
-        pytest.fail(f"ctx mpirun failed (rc={ctx_proc.returncode}):\n{ctx_log}")
+        pytest.fail(f"ctx mpirun failed (rc={ctx_proc.returncode}):\n{_log_tail(ctx_log)}")
     if gen_proc.returncode != 0:
-        pytest.fail(f"gen mpirun failed (rc={gen_proc.returncode}):\n{gen_log}")
+        pytest.fail(f"gen mpirun failed (rc={gen_proc.returncode}):\n{_log_tail(gen_log)}")
 
     # Parse gen status JSONL and verify all entries are PASS.
     status_path = os.path.join(work_dir, "status", "sweep0_gen.jsonl")
     assert os.path.exists(status_path), (
-        f"gen status file not found at {status_path}\ngen log:\n{gen_log}"
+        f"gen status file not found at {status_path}\ngen log tail:\n{_log_tail(gen_log)}"
     )
 
     with open(status_path) as f:
@@ -179,7 +252,7 @@ def test_single_node_transfer(tmp_path):
             f"(combination_idx={rec.get('combination_idx')}, "
             f"reqlen_idx={rec.get('reqlen_idx')}, "
             f"reason={rec.get('reason', '')})\n"
-            f"gen log:\n{gen_log}"
+            f"gen log tail:\n{_log_tail(gen_log)}"
         )
 
     # Verify report aggregation produces valid results.
@@ -212,8 +285,9 @@ def test_single_node_transfer(tmp_path):
             )
             assert sweep["selected_transport"], (
                 f"selected_transport is empty for {combo['combination']} "
-                f"sweep={sweep['sweep']} — UCX_PROTO_INFO may not be set or "
-                f"log filenames may not match report.py's glob pattern"
+                f"sweep={sweep['sweep']} — UCX did not emit a parseable protocol table\n"
+                f"ctx log tail:\n{_log_tail(ctx_log)}\n"
+                f"gen log tail:\n{_log_tail(gen_log)}"
             )
 
     best_path = os.path.splitext(results_path)[0] + ".best.json"

--- a/tests/unittest/disaggregated/test_cache_transceiver_harness_report.py
+++ b/tests/unittest/disaggregated/test_cache_transceiver_harness_report.py
@@ -277,6 +277,14 @@ class TestTransportAcc:
         acc = _TransportAcc()
         assert acc.ranked() == []
 
+    def test_kv_only_excludes_control_transport(self):
+        acc = _TransportAcc()
+        acc.feed("cfg#0 tagged message (cuda/cuda)")
+        acc.feed("  | eager short | self/memory |")
+
+        assert acc.ranked() == ["self"]
+        assert acc.ranked(kv_only=True) == []
+
 
 class TestParseProtoInfo:
     def _write_log(self, path, lines):
@@ -288,11 +296,38 @@ class TestParseProtoInfo:
             tmp_path / "rank0.log",
             [
                 "cfg#0 ucp_put (cuda/cuda)",
-                "  | rendezvous zero-copy | rc_mlx5/cuda |",
+                "  | rendezvous zero-copy | rc_mlx5/mlx5_0:1 |",
             ],
         )
         result = _parse_proto_info(str(tmp_path / "rank*.log"))
         assert "rc_mlx5" in result
+
+    def test_kv_only_ignores_control_traffic_and_env_echo(self, tmp_path):
+        self._write_log(
+            tmp_path / "rank0.log",
+            [
+                "export UCX_TLS=all,self,rc_mlx5",
+                "cfg#0 tagged message (cuda/cuda)",
+                "  | eager short | self/memory |",
+            ],
+        )
+
+        result = _parse_proto_info(str(tmp_path / "rank*.log"), kv_only=True)
+
+        assert result == []
+
+    def test_kv_only_parses_weighted_multi_lane_transport(self, tmp_path):
+        self._write_log(
+            tmp_path / "rank0.log",
+            [
+                "cfg#0 ucp_put (cuda/cuda)",
+                "  | rendezvous zero-copy | 50% on rc_mlx5/mlx5_0:1 and 50% on rc_mlx5/mlx5_1:1 |",
+            ],
+        )
+
+        result = _parse_proto_info(str(tmp_path / "rank*.log"), kv_only=True)
+
+        assert result == ["rc_mlx5"]
 
     def test_no_files(self, tmp_path):
         result = _parse_proto_info(str(tmp_path / "rank*.log"))
@@ -313,6 +348,21 @@ class TestParseProtoInfo:
         result = _parse_proto_info_by_case(str(tmp_path / "rank*.log"))
         assert "cuda_ipc" in result[0]
         assert "rc_mlx5" in result[1]
+
+    def test_by_case_kv_only_ignores_control_traffic(self, tmp_path):
+        self._write_log(
+            tmp_path / "rank0.log",
+            [
+                "[CTT_CASE_BEGIN] ci=0 label=NIXL/PYTHON/V1",
+                "export UCX_TLS=all,self",
+                "cfg#0 tagged message (cuda/cuda)",
+                "  | eager short | self/memory |",
+            ],
+        )
+
+        result = _parse_proto_info_by_case(str(tmp_path / "rank*.log"), kv_only=True)
+
+        assert result == {0: []}
 
 
 # ---------------------------------------------------------------------------
@@ -466,3 +516,19 @@ class TestAggregate:
         # Best file should also be written
         best_path = str(work / "results.best.json")
         assert os.path.exists(best_path)
+
+    def test_aggregate_requires_kv_data_transport(self, tmp_path, sample_cfg):
+        work = self._setup_work_dir(tmp_path, sample_cfg)
+        with open(work / "logs" / "sweep0_gen_rank0.log", "w") as f:
+            f.write(
+                "[CTT_CASE_BEGIN] ci=0 label=NIXL/PYTHON/V1\n"
+                "export UCX_TLS=all,self\n"
+                "cfg#0 tagged message (cuda/cuda)\n"
+                "  | eager short | self/memory |\n"
+            )
+
+        out_path = str(work / "results.json")
+        results = aggregate(sample_cfg, out_path, require_kv_transport=True)
+
+        sweep = results["by_combination"][0]["sweeps"][0]
+        assert sweep["selected_transport"] == ""


### PR DESCRIPTION
@coderabbitai summary

## Description

`test_single_node_transfer` currently sets `UCX_PROTO_INFO=used` and requires `selected_transport` to be non-empty.

`used` emits diagnostics during UCX worker teardown, so the output depends on the active MPI/UCX runtime and object lifecycle. After the PyTorch 26.04 image transition, the KV transfer still completes successfully, but `report.py` observes no transport and the test fails.

This has caused the exact test to fail in all 46 observed `DGX_H100-PyTorch-4` runs, including unrelated PRs and main.

## Changes

- Use `UCX_PROTO_INFO=y` in `test_single_node_transfer` so protocol-selection tables are emitted deterministically.
- Keep the existing transfer-status and non-empty transport assertions.
- Include captured ctx/gen logs when transport detection fails.
- Bound TERM/SIGKILL cleanup and retain process-group IDs so failed launchers cannot leave MPI ranks behind.
- Add parser coverage ensuring transport detection uses a CUDA KV-data path rather than incidental MPI control traffic or echoed `UCX_TLS` values, including weighted UCX 1.21 multi-lane rows.
- Leave the normal cache-transceiver sweep default unchanged to avoid increasing production harness log volume.

## Root Cause

The test and mandatory transport assertion were introduced by #14933. The PyTorch 26.04 runtime transition from #12643 exposed the teardown-dependent diagnostic behavior; it did not cause the KV transfer itself to fail.

## Test Coverage

- `tests/unittest/disaggregated/test_cache_transceiver_harness_report.py`
- `tests/unittest/disaggregated/test_cache_transceiver_harness.py`
- Targeted CI: `/bot run --disable-fail-fast --stage-list "DGX_H100-PyTorch-4"`

## Related PRs

- #14933
- #12643

## GitHub Bot Help

To see a list of available CI bot commands, comment `/bot help`.
