### PR TITLE
[https://nvbugs/6337051][fix] Refresh inputs on graph capture to avoid unintended modification

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -378,7 +378,8 @@ class CUDAGraphRunner:
                 forward_fn: Callable,
                 initial_inputs: Dict[str, Any],
                 enable_spec_decode: bool = False,
-                postprocess_fn: Optional[Callable] = None):
+                postprocess_fn: Optional[Callable] = None,
+                prepare_inputs_fn: Optional[Callable] = None):
         """Captures the forward pass for a given batch size."""
         batch_size = key[0]
         # [CUDA graph spec decode padding]
@@ -413,6 +414,15 @@ class CUDAGraphRunner:
             "spec_metadata": initial_inputs.get("spec_metadata", None),
         }
 
+        def _refresh_capture_inputs():
+            # A warmup forward can mutate attention/speculative metadata
+            # Rebuild it through the same path used before a normal replay
+            if prepare_inputs_fn is None:
+                return
+            refreshed_inputs, _ = prepare_inputs_fn()
+            capture_inputs.update(refreshed_inputs)
+            capture_inputs.update(sliced_static_tensors)
+
         def _setup_spec_decoding_and_forward(key: KeyType, forward_fn: Callable,
                                              capture_inputs: Dict[str, Any]):
             is_first_draft = key[2]
@@ -428,17 +438,19 @@ class CUDAGraphRunner:
         # This also lets us initialize states in the attn_metadata.
         graph = torch.cuda.CUDAGraph()
         with with_multi_stream(True), piecewise_cuda_graph(False):
-            for _ in range(self.WARMUP_STEPS):
+            for warmup_iter in range(self.WARMUP_STEPS):
+                if warmup_iter != 0:
+                    _refresh_capture_inputs()
                 _setup_spec_decoding_and_forward(key, forward_fn,
                                                  capture_inputs)
                 if postprocess_fn is not None:
                     postprocess_fn(capture_inputs)
 
+            _refresh_capture_inputs()
+            # Capture has no kernel execution, so no post-process or refresh.
             with torch.cuda.graph(graph, pool=self.memory_pool):
                 output = _setup_spec_decoding_and_forward(
                     key, forward_fn, capture_inputs)
-            if postprocess_fn is not None:
-                postprocess_fn(capture_inputs)
 
         self.graphs[key] = graph
         self.graph_outputs[key] = make_weak_ref(output)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -5469,22 +5469,28 @@ class PyTorchModelEngine(ModelEngine):
                 else:
                     spec_metadata = None
 
-            # Fill slot-ID buffer for scatter inside draft loop
-            if (self.enable_spec_decode and spec_tree_manager is not None
-                    and spec_tree_manager.use_dynamic_tree
-                    and not self.is_draft_model):
-                spec_tree_manager.slot_storage.fill_all_slot_ids(
-                    padded_requests.context_requests,
-                    padded_requests.generation_requests,
-                )
+            def prepare_forward_inputs_fn(
+            ) -> Tuple[Dict[str, Any], Optional[torch.Tensor]]:
+                # Fill slot-ID buffer for scatter inside draft loop
+                if (self.enable_spec_decode and spec_tree_manager is not None
+                        and spec_tree_manager.use_dynamic_tree
+                        and not self.is_draft_model):
+                    spec_tree_manager.slot_storage.fill_all_slot_ids(
+                        padded_requests.context_requests,
+                        padded_requests.generation_requests,
+                    )
 
-            inputs, gather_ids = self._prepare_inputs(
-                padded_requests, kv_cache_manager, attn_metadata, spec_metadata,
-                new_tensors_device, cache_indirection_buffer,
-                num_accepted_tokens_device, req_id_to_old_request,
-                resource_manager, can_run_graph)
-            self._prepare_inputs_event = torch.cuda.Event()
-            self._prepare_inputs_event.record()
+                inputs, gather_ids = self._prepare_inputs(
+                    padded_requests, kv_cache_manager, attn_metadata,
+                    spec_metadata, new_tensors_device, cache_indirection_buffer,
+                    num_accepted_tokens_device, req_id_to_old_request,
+                    resource_manager, can_run_graph)
+
+                self._prepare_inputs_event = torch.cuda.Event()
+                self._prepare_inputs_event.record()
+                return inputs, gather_ids
+
+            inputs, gather_ids = prepare_forward_inputs_fn()
 
             with with_shared_pool(self.cuda_graph_runner.get_graph_pool()):
                 if not can_run_graph:
@@ -5512,7 +5518,8 @@ class PyTorchModelEngine(ModelEngine):
                             capture_forward_fn,
                             inputs,
                             enable_spec_decode=self.enable_spec_decode,
-                            postprocess_fn=capture_postprocess_fn)
+                            postprocess_fn=capture_postprocess_fn,
+                            prepare_inputs_fn=prepare_forward_inputs_fn)
 
                         # Pre-replay: set DSA slot mappings for current batch's draft cache (fixes 2nd warmup)
                         saved_draft = prepare_attn_metadata_for_draft_replay(


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Cuda graph capture will need to run warmup twice before actual capture. The warmup runs use identical input, but the forward_fn will modify the input, including attention metadata.

When MTP is present, it will increase KV len after execution. But page table of DSA is prepared before execution with old, shorter kv seq len. So on second run a OOB access will occur and dirty sparseIdx will lead to IMA.

This PR fixes the issue by refresh input data before every execution, and made sure to match one prepare to one execution (as our `prepare_input` function is stateful and have global effects).

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
