### PR TITLE
[https://nvbugs/6412133][fix] Only populate `self.all_weights[self.device_id]` at construction; lazily…

### DIFF
--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
@@ -330,10 +330,12 @@ class RefNVFP4ModelWithIPCHandles(RefHFModel):
 
         assert not fusion_buffer, f"Incomplete fusion groups: {list(fusion_buffer.keys())}"
 
+        # Only populate the owning device. Extra replicas are created on
+        # demand by ``get_weight_ipc_handles_serialized`` so that GPUs not
+        # actually asked for via IPC (e.g. cuda:2/3 on a 4-GPU CI runner
+        # when a TP=2 test only requests device_ids=[0, 1]) don't hold
+        # onto NVFP4 quantized tensors that persist across parametrize IDs.
         self.all_weights[self.device_id] = model_weights
-        for i in range(torch.cuda.device_count()):
-            if i != self.device_id:
-                self.all_weights[i] = [(n, p.to(f"cuda:{i}")) for n, p in model_weights]
 
         with torch.no_grad():
             param_dict = dict(self.model.named_parameters())
@@ -435,6 +437,10 @@ class RefNVFP4ModelWithIPCHandles(RefHFModel):
         device_list = list(range(torch.cuda.device_count())) if device_ids is None else device_ids
 
         for device in device_list:
+            if device not in self.all_weights:
+                src = self.all_weights[self.device_id]
+                self.all_weights[device] = [(n, p.to(f"cuda:{device}")) for n, p in src]
+
             all_handles = []
             for item in self.all_weights[device]:
                 name, p = item


### PR DESCRIPTION
## Summary
- **Root cause**: `_quantize_and_replicate_weights` eagerly replicates NVFP4 quantized weights to every visible CUDA device (0..3), so cuda:2/3 retain stale replicas across parametrized test runs on the 4-GPU CI runner, occasionally SIGABRT-ing subsequent test setup.
- **Fix**: Only populate `self.all_weights[self.device_id]` at construction; lazily materialize per-device replicas on the first `get_weight_ipc_handles_serialized(device_ids=[...])` call and cache them so partial-update paths aren't slower. Also removed the waives.txt entry.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6412133


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-GPU weight handling so quantized weights are copied only when needed, helping avoid missing-device issues during model updates.
  * Fixed on-demand GPU weight availability when serializing inter-process handles, which should make multi-GPU test runs more reliable.
* **Chores**
  * Removed an outdated waived test entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->