### PR TITLE
[https://nvbugs/6412108][fix] Restore original order — `all_reduce` the routed partial first, then add the…

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -780,13 +780,14 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
             layer_type="moe",
         )
 
-        # Single merge-point all_reduce for routed + shared partial sums.
-        # Both branches produce per-rank partial outputs under TP/EP sharding
-        # (routed: MoEShardableNode; shared: rowwise down_proj inside the MLP).
-        # One reduction on the sum lifts both to full; reducing before the add
-        # would mix a full routed contribution with an unreduced shared one.
-        expert_output = expert_output + shared_expert_output
+        # The shared expert is replicated (Qwen3_5MoeMLP intentionally omits
+        # ``layer_type`` and the yaml ``shard_layers`` whitelist excludes it),
+        # so its output is already the full value on every rank. All-reduce
+        # the sharded routed-expert partial first, then add the replicated
+        # shared output; adding before would scale the shared output by the
+        # TP world size.
         expert_output = torch.ops.auto_deploy.all_reduce(expert_output, layer_type="moe")
+        expert_output = expert_output + shared_expert_output
 
         expert_output = expert_output.reshape(batch_size, sequence_length, hidden_dim)
         return expert_output


### PR DESCRIPTION
## Summary
- **Root cause**: Sharding-IR refactor swapped the order of `expert_output + shared_expert_output` and `all_reduce`, scaling the replicated (unsharded) shared_expert output by world_size (8×) and corrupting MMLU/GSM8K outputs.
- **Fix**: Restore original order — `all_reduce` the routed partial first, then add the replicated shared output — and update the comment; also removed the nvbugs/6412108 waiver line.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6412108


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of mixture-of-experts outputs to make the final result more stable and consistent across distributed runs.

* **Tests**
  * Removed a test waiver, so one previously skipped accuracy check will now run normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->