### PR TITLE
[https://nvbugs/6411931][fix] Append `,fo` to the `ignore-words-list` in `pyproject.toml`…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ column_limit = 80
 
 [tool.codespell]
 skip = ".git,3rdparty,triton_kernels,tests/integration/test_input_files**,**.jsonl,**.json"
-ignore-words-list = "rouge,inout,atleast,strat,nd,subtile,thrid,improbe,NotIn,te,iteract,anythin,tru,Tracin,vEw,dOut,indext,asend,medias"
+ignore-words-list = "rouge,inout,atleast,strat,nd,subtile,thrid,improbe,NotIn,te,iteract,anythin,tru,Tracin,vEw,dOut,indext,asend,medias,fo"
 
 [tool.autoflake]
 in-place = true


### PR DESCRIPTION
## Summary
- **Root cause**: codespell v2.4.1 flags `"fo"` (Faroese ISO-639-1 code) in vendored Whisper LANGUAGES dict as typo suggesting of/for/to/do/go.
- **Fix**: Append `,fo` to the `ignore-words-list` in `pyproject.toml` `[tool.codespell]`, matching the pattern used for other short-token exemptions (`nd`, `te`, `tru`, …); auto-picked-up by both the pre-commit hook and manual codespell.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6411931


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spelling-check settings to ignore a broader set of approved terms, reducing false-positive warnings during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->