### PR TITLE
[None][feat] Contiguous primary KV cache (P0): per-sequence VMM arenas for KVCacheManagerV2

### DIFF
--- a/cpp/kernels/xqa/defines.h
+++ b/cpp/kernels/xqa/defines.h
@@ -114,6 +114,23 @@ static_assert(SPEC_DEC, "SPEC_Q_SEQ_LEN should only be used when SPEC_DEC is ena
 // don't modify
 #define USE_BEAM_SEARCH (BEAM_WIDTH > 1)
 
+// When non-zero, KV cache pages of one sequence are assumed consecutive in the pool:
+// page-list entry j == entry 0 + j * PAGED_KV_IDX_STRIDE. Entry 0 is loaded once per
+// sequence and later entries are computed arithmetically, skipping the per-tile
+// page-table load. Requires a runtime that allocates each sequence's cache pages
+// consecutively (e.g. contiguous KV arenas).
+#ifndef PAGED_KV_LINEAR
+#define PAGED_KV_LINEAR 0
+#endif
+#if PAGED_KV_LINEAR
+#ifndef PAGED_KV_IDX_STRIDE
+#define PAGED_KV_IDX_STRIDE 1
+#endif
+#if !USE_PAGED_KV_CACHE || USE_BEAM_SEARCH
+#error "PAGED_KV_LINEAR requires paged KV cache and beam width 1"
+#endif
+#endif
+
 #if CACHE_ELEM_ENUM == 0
 #define PRAGMA_UNROLL_FP16_ONLY _Pragma("unroll")
 #else

--- a/cpp/kernels/xqa/mha.cu
+++ b/cpp/kernels/xqa/mha.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1770,13 +1770,20 @@ CUBIN_EXPORT __global__
 #if USE_PAGED_KV_CACHE
 #if BEAM_WIDTH == 1
         KCachePageIndices pageIdx = KCachePageIndices::filled(kBAD_PAGE_INDEX);
+#if PAGED_KV_LINEAR
+        KVCachePageIndex const kSeqBasePage = getLinearBasePage(cacheList, true, idxReq, 0);
+#endif
 #endif
         auto loadPages = [&](uint32_t idxPage) mutable
         {
 #if BEAM_WIDTH == 1
+#if PAGED_KV_LINEAR
+            pageIdx = getPageLinear<KCachePageIndices::size>(kSeqBasePage, idxPage, nbPages, nbSkipLeadingPages);
+#else
             uint32_t const idxBeam = 0;
             pageIdx = getPage<KCachePageIndices::size>(
                 cacheList, true, idxReq, idxBeam, idxPage, nbPages, nbSkipLeadingPages);
+#endif
 #else
             auto& dst = smem.kCachePages[warpIdx.x];
             loadPagesForBeamSearchAsync<1>(0U, dst, cacheList, true, idxReq, idxPage, nbPages, nbSkipLeadingPages);
@@ -2098,13 +2105,20 @@ CUBIN_EXPORT __global__
 #if USE_PAGED_KV_CACHE
 #if BEAM_WIDTH == 1
         VCachePageIndices pageIdx = VCachePageIndices::filled(kBAD_PAGE_INDEX);
+#if PAGED_KV_LINEAR
+        KVCachePageIndex const vSeqBasePage = getLinearBasePage(cacheList, false, idxReq, 0);
+#endif
 #endif
         auto loadPages = [&](uint32_t idxPageBeg) mutable
         {
 #if BEAM_WIDTH == 1
+#if PAGED_KV_LINEAR
+            pageIdx = getPageLinear<VCachePageIndices::size>(vSeqBasePage, idxPageBeg, nbPages, nbSkipLeadingPages);
+#else
             uint32_t const idxBeam = 0;
             pageIdx = getPage<VCachePageIndices::size>(
                 cacheList, false, idxReq, idxBeam, idxPageBeg, nbPages, nbSkipLeadingPages);
+#endif
 #else
             auto& dst = smem.vCachePages[grpLoadV ? warpGrpIdx : warpIdx.x];
             loadPagesForBeamSearchAsync<grpLoadV ? gemm1WarpsPerGrp : 1U>(

--- a/cpp/kernels/xqa/mhaUtils.cuh
+++ b/cpp/kernels/xqa/mhaUtils.cuh
@@ -320,6 +320,40 @@ __device__ inline Vec<KVCachePageIndex, nbLoadedPages> getPage(KVCacheList<true>
     return ret;
 }
 
+#if PAGED_KV_LINEAR
+// Pages of one sequence are consecutive in the pool (entry j == entry 0 + j * PAGED_KV_IDX_STRIDE),
+// so load entry 0 once per sequence and compute later page indices arithmetically.
+__device__ inline KVCachePageIndex getLinearBasePage(
+    KVCacheList<true> const& cacheList, bool isK, uint32_t idxReq, uint32_t idxBeam)
+{
+    auto const maxNbPagesPerSeq = cacheList.maxNbPagesPerSeq;
+#if PAGED_KV_CACHE_LAYOUT == 1
+    unused(isK);
+    unused(idxBeam);
+    return cacheList.kvCachePageList[maxNbPagesPerSeq * idxReq];
+#else
+    return cacheList.kvCachePageList[beamWidth * 2 * maxNbPagesPerSeq * idxReq + 2 * maxNbPagesPerSeq * idxBeam
+        + maxNbPagesPerSeq * (isK ? 0U : 1U)];
+#endif
+}
+
+template <uint32_t nbLoadedPages>
+__device__ inline Vec<KVCachePageIndex, nbLoadedPages> getPageLinear(
+    KVCachePageIndex basePage, uint32_t idxPageBeg, uint32_t nbPages, uint32_t nbSkipLeadingPages)
+{
+    Vec<KVCachePageIndex, nbLoadedPages> ret;
+#pragma unroll
+    for (uint32_t i = 0; i < nbLoadedPages; i++)
+    {
+        uint32_t const idxPage = idxPageBeg + i;
+        ret[i] = ((idxPage >= nbSkipLeadingPages && idxPage < nbPages)
+                ? static_cast<KVCachePageIndex>(basePage + static_cast<int32_t>(idxPage) * PAGED_KV_IDX_STRIDE)
+                : kBAD_PAGE_INDEX);
+    }
+    return ret;
+}
+#endif
+
 template <uint32_t nbWarps, uint32_t nbLoadedPages>
 __device__ inline void loadPagesForBeamSearchAsync(uint32_t idxWarp,
     Vec<Vec<KVCachePageIndex, nbLoadedPages>, beamWidth>& dst, KVCacheList<true> const& cacheList, bool isK,

--- a/cpp/kernels/xqa/test/test.cpp
+++ b/cpp/kernels/xqa/test/test.cpp
@@ -558,7 +558,8 @@ void runTest(uint32_t batchSize, uint32_t seqLen, bool testPerf, bool refCheck, 
         std::fill_n(output[0][0][0].data, outElems, OutputElem(NAN));
 #endif
 #endif
-#if USE_PAGED_KV_CACHE
+#if USE_PAGED_KV_CACHE && !PAGED_KV_LINEAR
+// PAGED_KV_LINEAR assumes each sequence's pages are consecutive; keep the identity fill.
 #if PAGED_KV_CACHE_LAYOUT == 1
         std::shuffle(&pageList[0][0], &pageList[0][0] + totalNbPages, rng);
 #else
@@ -677,7 +678,7 @@ void runTest(uint32_t batchSize, uint32_t seqLen, bool testPerf, bool refCheck, 
         }
     }
 
-#if USE_PAGED_KV_CACHE && SLIDING_WINDOW && XQA_TEST_POISON_SLIDING_WINDOW_PREFIX_PAGES
+#if USE_PAGED_KV_CACHE && SLIDING_WINDOW && XQA_TEST_POISON_SLIDING_WINDOW_PREFIX_PAGES && !PAGED_KV_LINEAR
     {
         constexpr KVCachePageIndex kPoisonPageIdx = static_cast<KVCachePageIndex>(1U << 20);
 #if SPEC_DEC

--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -266,6 +266,11 @@ bool AttentionOp::convertMMHAParamsToXQAParams(tensorrt_llm::kernels::XQAParams&
     xqaParams.max_attention_window_size = generationsParams.max_attention_window_size;
     xqaParams.cyclic_attention_window_size = generationsParams.cyclic_attention_window_size;
     xqaParams.max_blocks_per_sequence = generationsParams.max_blocks_per_sequence;
+    // Linear (consecutive-pages) KV addressing: only valid for paged self-attention with beam width 1.
+    xqaParams.linear_kv_page_stride
+        = (mLinearKvPageStride > 0 && generationsParams.beam_width == 1 && mPagedKVCache && !mCrossAttention)
+        ? mLinearKvPageStride
+        : 0;
     xqaParams.sink_token_length = generationsParams.sink_token_length;
     xqaParams.max_past_kv_length = generationsParams.max_past_kv_length;
     xqaParams.qkv_bias = generationsParams.qkv_bias;

--- a/cpp/tensorrt_llm/common/attentionOp.h
+++ b/cpp/tensorrt_llm/common/attentionOp.h
@@ -474,6 +474,10 @@ public:
     // NOTE: default values for paged kv cache.
     bool mPagedKVCache = true;
     int mTokensPerBlock = 0;
+    // When > 0, each sequence's KV cache pages are consecutive in the pool with this stride between
+    // page-list entries (requires a per-sequence-contiguous cache allocator, e.g. contiguous KV
+    // arenas); generation kernels may then compute page indices arithmetically. 0 disables.
+    int32_t mLinearKvPageStride = 0;
     tensorrt_llm::common::QuantMode mKVCacheQuantMode;
     int mTpSize = 1;
     int mTpRank = 0;
@@ -564,7 +568,8 @@ public:
             (int8_t) mRotaryEmbeddingScaleType, mRotaryEmbeddingScale, mRotaryEmbeddingShortMscale,
             mRotaryEmbeddingLongMscale, mRotaryEmbeddingMaxPositions, mRotaryEmbeddingOriginalMaxPositions,
             (int8_t) mPositionEmbeddingType, mUseLognScaling, mRemovePadding, (int32_t) mMaskType,
-            mBlockSparseParams.data(), mPagedKVCache, mTokensPerBlock, mKVCacheQuantMode.value(), mTpSize, mTpRank,
+            mBlockSparseParams.data(), mPagedKVCache, mTokensPerBlock, mLinearKvPageStride,
+            mKVCacheQuantMode.value(), mTpSize, mTpRank,
             mUnfuseQkvGemm, (int32_t) mType, mMaxContextLength, mMaxSeqLen, mMaxNumRequests, mQKVBiasEnabled,
             mCrossAttention, mMaxDistance, mPosShiftEnabled, mPagedContextFMHA, mFP8ContextFMHA, mFP8AttenOutput,
             mFP8ContextMLA, mFP8GenerationMLA, mChunkPrefillBufferBatchSize, mDenseContextFMHA, mHasFullAttentionMask,

--- a/cpp/tensorrt_llm/common/envUtils.cpp
+++ b/cpp/tensorrt_llm/common/envUtils.cpp
@@ -292,6 +292,12 @@ bool getEnvUseMooncakeKvCache()
     return useMooncakeKvCache;
 }
 
+bool getEnvKvArenaLinearKernels()
+{
+    static bool const kvArenaLinearKernels = getBoolEnv("TRTLLM_KV_ARENA_LINEAR_KERNELS");
+    return kvArenaLinearKernels;
+}
+
 std::string getEnvUCXInterface()
 {
     static std::once_flag flag;

--- a/cpp/tensorrt_llm/common/envUtils.h
+++ b/cpp/tensorrt_llm/common/envUtils.h
@@ -88,6 +88,11 @@ bool getEnvUseNixlKvCache();
 
 bool getEnvUseMooncakeKvCache();
 
+// Opt-in for linear (consecutive-pages) KV cache addressing in generation kernels. Only valid when
+// the runtime allocates each sequence's cache pages consecutively (KVCacheManagerV2 contiguous
+// arenas, KvCacheConfig.use_contiguous_kv_arena).
+bool getEnvKvArenaLinearKernels();
+
 std::string getEnvUCXInterface();
 
 std::string getEnvNixlInterface();

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/compileEngine.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/compileEngine.cpp
@@ -19,6 +19,7 @@
 #include "nvrtcWrapper/include/nvrtcWrapper.h"
 #include "tensorrt_llm/common/assert.h"
 #include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/common/stringUtils.h"
 #include "tensorrt_llm/common/tllmException.h"
 #include "tensorrt_llm/common/utils.h"
@@ -108,13 +109,22 @@ CubinObj CompileEngine::compile() const
         applyRoPEInXqaKernel ? static_cast<uint32_t>(mXqaParams.rotary_embedding_dim)
                              : static_cast<uint32_t>(mXqaParams.head_size),
         /*is_spec_dec_tree=*/mXqaParams.is_spec_dec_tree,
-        /*use_skip_softmax_attn=*/mXqaParams.skip_softmax_threshold_scale_factor != 0};
+        /*use_skip_softmax_attn=*/mXqaParams.skip_softmax_threshold_scale_factor != 0,
+        /*linear_kv_page_stride=*/static_cast<unsigned int>(mXqaParams.linear_kv_page_stride > 0 ? mXqaParams.linear_kv_page_stride : 0)};
     if (context.kernel_type == TLLM_XQA_JIT_MLA)
     {
         auto const& c = context;
         TLLM_CHECK(c.head_size == 576 && c.num_q_heads == 128 && c.num_kv_heads == 1 && c.beam_width == 1
             && c.data_type == DATA_TYPE_E4M3 && c.kv_cache_data_type == DATA_TYPE_E4M3 && c.fp8_output == false
             && !c.use_input_kv && ropeStyle == TLLM_XQA_JIT_ROPE_NONE);
+    }
+
+    if (context.linear_kv_page_stride > 0 && context.kernel_type == TLLM_XQA_JIT_HMMA && context.beam_width == 1
+        && context.paged_kv_cache)
+    {
+        TLLM_LOG_INFO(
+            "XQA JIT: compiling HMMA kernel with linear KV page addressing (stride %u)",
+            context.linear_kv_page_stride);
     }
 
     CHECK_TLLM_XQA_JIT_ERROR(tllmXqaJitCreateAndCompileProgram(&program, &context));

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/include/nvrtcWrapper.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/include/nvrtcWrapper.h
@@ -72,6 +72,11 @@ extern "C"
         bool is_spec_dec_tree
             = true; // useful only when multi_query_tokens, should be true unless using linear tree in spec-dec.
         bool use_skip_softmax_attn;
+
+        // When > 0, each sequence's KV cache pages are consecutive in the pool with this stride
+        // between page-list entries; the kernel computes page indices arithmetically instead of
+        // loading them per tile. 0 disables. Only honored by the HMMA kernel with beam width 1.
+        unsigned int linear_kv_page_stride;
     } tllmXqaJitContext;
 
     // tllmXqaJitProgram is an opaque handle for a program.

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/src/nvrtcWrapper.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/src/nvrtcWrapper.cpp
@@ -193,6 +193,13 @@ tllmXqaJitStatus getMacroFlags(tllmXqaJitContext const* context, std::vector<std
         = std::to_string(context->rotary_embedding_dim != 0 ? context->rotary_embedding_dim : head_size);
     macros["IS_SPEC_DEC_TREE"] = context->is_spec_dec_tree ? "1" : "0";
     macros["SKIP_SOFTMAX_ATTN"] = context->use_skip_softmax_attn ? "1" : "0";
+    // Linear (consecutive-pages) KV addressing: only the HMMA kernel implements it.
+    if (context->linear_kv_page_stride > 0 && context->kernel_type == TLLM_XQA_JIT_HMMA && context->beam_width == 1
+        && context->paged_kv_cache)
+    {
+        macros["PAGED_KV_LINEAR"] = "1";
+        macros["PAGED_KV_IDX_STRIDE"] = std::to_string(context->linear_kv_page_stride);
+    }
 #ifdef SKIP_SOFTMAX_STAT
     macros["SKIP_SOFTMAX_ATTN_BLOCK_STATS"] = context->use_skip_softmax_attn ? "1" : "0";
 #endif

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunnerUtils.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunnerUtils.h
@@ -79,6 +79,8 @@ struct XQAKernelRuntimeHashKey
     PositionEmbeddingType position_embedding_type;
     // Number of head elements RoPE is applied to. A value of 0 means rotary dim is not part of this key.
     int rotary_embedding_dim;
+    // Linear (consecutive-pages) KV addressing stride; 0 means disabled. Compiled into the kernel.
+    int linear_kv_page_stride;
 
     bool operator==(XQAKernelRuntimeHashKey const& other) const
     {
@@ -87,7 +89,8 @@ struct XQAKernelRuntimeHashKey
             && multi_query_tokens == other.multi_query_tokens && m_tilesize == other.m_tilesize
             && tokens_per_page == other.tokens_per_page && paged_kv_cache == other.paged_kv_cache
             && is_fp8_output == other.is_fp8_output && position_embedding_type == other.position_embedding_type
-            && rotary_embedding_dim == other.rotary_embedding_dim;
+            && rotary_embedding_dim == other.rotary_embedding_dim
+            && linear_kv_page_stride == other.linear_kv_page_stride;
     }
 };
 
@@ -127,7 +130,8 @@ inline XQAKernelRuntimeHashKey getRuntimeHashKeyFromXQAParams(XQAParams const& x
     return {xqaParams.kv_cache_data_type, headSize, beamWidth, kernelNumQHeadsOverKV, kernelMTilesize,
         xqaParams.paged_kv_cache ? static_cast<unsigned int>(xqaParams.tokens_per_block) : 0, xqaParams.paged_kv_cache,
         xqaParams.multi_query_tokens, xqaParams.is_fp8_output, xqaParams.position_embedding_type,
-        includesRotaryDim ? xqaParams.rotary_embedding_dim : 0};
+        includesRotaryDim ? xqaParams.rotary_embedding_dim : 0,
+        xqaParams.linear_kv_page_stride > 0 ? xqaParams.linear_kv_page_stride : 0};
 }
 
 struct XQAKernelRuntimeHasher
@@ -155,6 +159,8 @@ struct XQAKernelRuntimeHasher
         key ^= static_cast<int8_t>(s.position_embedding_type);
         key <<= 9;                   // 62; rotary dims are <= 256, 0 means not used.
         key ^= static_cast<size_t>(s.rotary_embedding_dim);
+        key <<= 2;                   // 64; fold the linear stride into the low bits.
+        key ^= static_cast<size_t>(s.linear_kv_page_stride);
         return key;
     }
 };

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/xqaParams.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/xqaParams.h
@@ -99,6 +99,11 @@ struct XQAParams
     bool paged_kv_cache;
     int tokens_per_block;
     int max_blocks_per_sequence;
+    // When > 0, each sequence's KV cache pages are consecutive in the pool: page-list entry j ==
+    // entry 0 + j * linear_kv_page_stride. Lets the kernel compute page indices arithmetically
+    // instead of loading them per tile. Requires a runtime with per-sequence-contiguous cache
+    // (e.g. KVCacheManagerV2 contiguous arenas) and beam width 1. 0 disables.
+    int32_t linear_kv_page_stride = 0;
     tensorrt_llm::common::QuantMode kv_cache_quant_mode;
     int tp_size = 1;
     int tp_rank = 0;

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -1252,8 +1252,8 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
     // consecutive blocks of one sequence equals num_layers_in_this_pool * kv_factor
     // (KVCacheManagerV2's page-index scale). Computed before the op cache key / runner->prepare()
     // so the prepared cubin matches the runtime dispatch key.
-    if (tensorrt_llm::common::getEnvKvArenaLinearKernels() && op->useKVCache()
-        && host_kv_cache_pool_mapping.has_value() && beam_width == 1 && !op->mIsMLAEnabled)
+    if (tensorrt_llm::common::getEnvKvArenaLinearKernels() && op->useKVCache() && host_kv_cache_pool_mapping.has_value()
+        && beam_width == 1 && !op->mIsMLAEnabled)
     {
         auto const& pool_mapping = host_kv_cache_pool_mapping.value();
         int32_t const pool_index = pool_mapping.index({op->mLayerIdx, 0}).item<int32_t>();
@@ -1551,8 +1551,21 @@ std::tuple<at::Tensor, std::optional<at::Tensor>> buildFlashinferTrtllmGenPagedK
     auto options = at::TensorOptions()
                        .dtype(storageDtype)
                        .device(c10::Device(at::kCUDA, static_cast<c10::DeviceIndex>(at::cuda::current_device())));
-    auto kv_pool = torch::from_blob(
-        poolPointers.primaryPoolPtr, {total_num_blocks, num_kv_heads, tokens_per_block, containerDim}, options);
+    // The contiguous KV arena reserves one large VA range and maps physical
+    // pages on demand, so the pool base VA (slot 0) is not guaranteed resident
+    // when this view is built -- e.g. a tightly-sized KV-estimation pool at
+    // small max_batch_size leaves slot 0 unmapped at context-preprocess time.
+    // torch::from_blob's options-only overload resolves the device via
+    // getDeviceFromPtr, which throws "pointer resides on host memory" on an
+    // unmapped VA. The base is only an addressing origin (the kernel indexes
+    // into mapped blocks via block offsets and never dereferences offset 0
+    // unless a block table points there), so pin the device explicitly and
+    // skip the residency probe. Classic (fully-resident) pools are unaffected.
+    auto kv_pool
+        = at::for_blob(poolPointers.primaryPoolPtr, {total_num_blocks, num_kv_heads, tokens_per_block, containerDim})
+              .options(options)
+              .target_device(options.device())
+              .make_tensor();
 
     std::optional<at::Tensor> kvScalePool = std::nullopt;
     if (isFp4 && poolPointers.primaryBlockScalePoolPtr != nullptr)
@@ -1561,8 +1574,13 @@ std::tuple<at::Tensor, std::optional<at::Tensor>> buildFlashinferTrtllmGenPagedK
             = at::TensorOptions()
                   .dtype(at::kFloat8_e4m3fn)
                   .device(c10::Device(at::kCUDA, static_cast<c10::DeviceIndex>(at::cuda::current_device())));
-        kvScalePool = torch::from_blob(poolPointers.primaryBlockScalePoolPtr,
-            {total_num_blocks, num_kv_heads, tokens_per_block, head_dim / 16}, scaleOptions);
+        // See the kv_pool note above: pin the device to avoid getDeviceFromPtr
+        // probing a possibly-unmapped arena base VA.
+        kvScalePool = at::for_blob(
+            poolPointers.primaryBlockScalePoolPtr, {total_num_blocks, num_kv_heads, tokens_per_block, head_dim / 16})
+                          .options(scaleOptions)
+                          .target_device(scaleOptions.device())
+                          .make_tensor();
     }
 
     return {kv_pool, kvScalePool};

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -18,6 +18,7 @@
 #include "tensorrt_llm/common/attentionOp.h"
 #include "tensorrt_llm/common/attentionWorkspace.h"
 #include "tensorrt_llm/common/dataType.h"
+#include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/kernels/flashMLA/flash_mla.h"
 #include "tensorrt_llm/kernels/gptKernels.h"
 #include "tensorrt_llm/kernels/mlaKernels.h"
@@ -1243,6 +1244,27 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
         // For chunked prefill MLA, we need larger buffer size for k and v
         op->mChunkPrefillBufferBatchSize
             = chunked_prefill_buffer_batch_size.has_value() ? chunked_prefill_buffer_batch_size.value() : 1;
+    }
+
+    // Linear (consecutive-pages) KV addressing (design §4.9 phase 1): opt-in via
+    // TRTLLM_KV_ARENA_LINEAR_KERNELS, only valid when the runtime allocates each sequence's cache
+    // pages consecutively (KVCacheManagerV2 contiguous arenas). The page-index stride between
+    // consecutive blocks of one sequence equals num_layers_in_this_pool * kv_factor
+    // (KVCacheManagerV2's page-index scale). Computed before the op cache key / runner->prepare()
+    // so the prepared cubin matches the runtime dispatch key.
+    if (tensorrt_llm::common::getEnvKvArenaLinearKernels() && op->useKVCache()
+        && host_kv_cache_pool_mapping.has_value() && beam_width == 1 && !op->mIsMLAEnabled)
+    {
+        auto const& pool_mapping = host_kv_cache_pool_mapping.value();
+        int32_t const pool_index = pool_mapping.index({op->mLayerIdx, 0}).item<int32_t>();
+        auto const* mapping_ptr = pool_mapping.data_ptr<int32_t>();
+        auto const row_stride = pool_mapping.stride(0);
+        int32_t num_layers_in_pool = 0;
+        for (int64_t l = 0; l < pool_mapping.size(0); ++l)
+        {
+            num_layers_in_pool += (mapping_ptr[l * row_stride] == pool_index) ? 1 : 0;
+        }
+        op->mLinearKvPageStride = num_layers_in_pool * 2; // kv_factor is 2 (non-MLA)
     }
 
     auto cache_key = std::make_tuple(op->data(), runner->data());

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1095,16 +1095,8 @@ class KVCacheManagerV2(BaseResourceManager):
         - ``TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB``: physical mapping granularity
           ("super-page", multiple of 2; default 2). Larger pages amortize the
           fixed per-mapping cuMemSetAccess cost (§4.8).
-        - ``TRTLLM_KV_ARENA_MAP_AHEAD_PAGES``: demand-paging margin (§4.2).
-          Default ``-1`` = pre-map each sequence's whole reserved range at
-          its first mapping (the margin is clamped to the reserved extent).
-          Growth-time ``cuMemMap``/``cuMemSetAccess`` concurrent with
-          in-flight kernels reading the same range is the only remaining
-          trigger of the H100 MMU-fault interference (see
-          ``_sequence_arena._SYNC_BEFORE_UNMAP``): pre-mapping at admission
-          removes growth maps entirely and is the one configuration
-          validated crash-free at every tested scale. Small margins trade
-          that safety for lower physical footprint (experiments only).
+        - ``TRTLLM_KV_ARENA_MAP_AHEAD_PAGES``: demand-paging margin (§4.2,
+          default 1).
         - ``TRTLLM_KV_ARENA_WRITE_THROUGH``: ``on_free`` (default) or
           ``on_commit`` (§4.3).
         - ``TRTLLM_KV_ARENA_LAZY_RETENTION``: ``1`` keeps freed sequence
@@ -1124,12 +1116,7 @@ class KVCacheManagerV2(BaseResourceManager):
           without ``use_contiguous_kv_arena``. Default ``0``.
         """
         page_mb = int(os.environ.get("TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB", "2"))
-        map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "-1"))
-        if map_ahead < 0:
-            # Pre-map-at-resume: a margin larger than any range pre-maps the
-            # whole reserved extent on first touch (the mapping plan clamps
-            # to the range), so no growth maps ever run under kernels.
-            map_ahead = 1 << 30
+        map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "1"))
         write_through_env = os.environ.get("TRTLLM_KV_ARENA_WRITE_THROUGH", "on_free").lower()
         assert write_through_env in ("on_free", "on_commit"), (
             f"TRTLLM_KV_ARENA_WRITE_THROUGH must be 'on_free' or 'on_commit', "

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -66,12 +66,11 @@ from tensorrt_llm.runtime.kv_cache_manager_v2._common import (
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
 from tensorrt_llm.runtime.kv_cache_manager_v2._event_manager import KVCacheEventManager
 from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import CuError
-from tensorrt_llm.runtime.kv_cache_manager_v2._utils import CachedCudaEvent
 from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import (
     OutOfMemoryError as KVCacheOutOfMemoryError,
 )
 from tensorrt_llm.runtime.kv_cache_manager_v2._life_cycle_registry import AttnLifeCycle, LifeCycleId
-from tensorrt_llm.runtime.kv_cache_manager_v2._utils import exact_div, typed_range
+from tensorrt_llm.runtime.kv_cache_manager_v2._utils import CachedCudaEvent, exact_div, typed_range
 from tensorrt_llm.sampling_params import SamplingParams
 
 from ..._utils import binding_to_torch_dtype, mpi_rank, nvtx_range, str_dtype_to_torch
@@ -535,6 +534,14 @@ class KVCacheManagerV2(BaseResourceManager):
             execution_stream if execution_stream is not None else torch.cuda.current_stream()
         )
         logger.info(f"[KVCacheManager] execution_stream: {self._stream}")
+
+        # Per-call host staging buffers for copy_batch_block_offsets, kept alive
+        # until their consuming async gather kernel drains (nvbug 6293536). Each
+        # entry is (cuda_event, host_block_offsets, copy_index); retired once the
+        # event completes. See copy_batch_block_offsets for the rationale.
+        self._inflight_block_offset_buffers: List[
+            Tuple[torch.cuda.Event, torch.Tensor, torch.Tensor]
+        ] = []
 
         # Determine max_attention_window_vec
         if kv_cache_config.max_attention_window is not None:
@@ -2706,14 +2713,68 @@ class KVCacheManagerV2(BaseResourceManager):
         # (as done previously) lets a forward read STALE rows — which point at
         # freed sequences' ranges: silently wrong reads in classic paged mode,
         # and illegal accesses in arena mode once the range is unmapped.
+        #
+        # nvbug 6293536: copy_batch_block_offsets_to_device launches an
+        # asynchronous gather kernel that reads its host inputs at *execution*
+        # time, not enqueue time. Two of those inputs are reused in place across
+        # iterations: host_kv_cache_block_offsets (the C++ KV cache writes page
+        # indices straight into a sequence's slot, and a freed slot is rebound to
+        # a different request on reuse) and copy_idx (a slice of the IndexMapper's
+        # single persistent copyIndex_ buffer, overwritten by the next
+        # get_copy_index call). Under the overlap scheduler the CPU runs an
+        # iteration ahead, so either could be clobbered before this iteration's
+        # still-pending kernel drains, making the kernel gather another batch's
+        # blocks. Snapshot the rows this call needs into a fresh pinned buffer
+        # and feed the kernel an identity index. Unlike the v1
+        # KVCacheManager.copy_batch_block_offsets fix, we cannot rely on PyTorch's
+        # caching host allocator to keep the freed buffer alive: that protection
+        # is only recorded for cudaMemcpyAsync out of pinned memory, not for a
+        # custom kernel reading host memory directly. So keep an explicit
+        # reference to each per-call buffer and retire it only once a CUDA event
+        # recorded after the kernel completes (see _inflight_block_offset_buffers).
+        #
+        # The persistent host_kv_cache_block_offsets attribute is intentionally
+        # left in place: the C++ KV cache holds raw pointers into it
+        # (set_base_page_index_buf) and same-iteration CPU readers (DSA sparse
+        # attention) expect it to hold the current page table.
+
+        # Retire buffers whose consuming kernel has drained. Kernels run in order
+        # on a single stream, so their events complete FIFO.
+        inflight = self._inflight_block_offset_buffers
+        while inflight and inflight[0][0].query():
+            inflight.pop(0)
+
+        host_block_offsets = torch.zeros(
+            self.num_pools,
+            num_seqs,
+            2,  # key and value; only the key row is read by the gather kernel
+            self.max_blocks_per_seq,
+            dtype=torch.int32,
+            pin_memory=prefer_pinned(),
+            device="cpu",
+        )
+        host_block_offsets[:, :, 0, :] = self.host_kv_cache_block_offsets[
+            :, copy_idx.to(torch.long), 0, :
+        ]
+        identity_idx = torch.arange(
+            num_seqs, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
+        )
+
         copy_batch_block_offsets_to_device(
-            self.host_kv_cache_block_offsets,
+            host_block_offsets,
             dst_tensor,
-            copy_idx,
+            identity_idx,
             self.index_scales,
             self.kv_offset,
             torch.cuda.current_stream().cuda_stream,
         )
+
+        # Record on the SAME stream the gather kernel was enqueued on (the
+        # caller's current stream, see above) so retirement really means the
+        # kernel has drained.
+        done = torch.cuda.Event()
+        done.record(torch.cuda.current_stream())
+        inflight.append((done, host_block_offsets, identity_idx))
 
     def _create_kv_cache(
         self,

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -40,6 +40,7 @@ from tensorrt_llm.runtime.kv_cache_manager_v2 import (
     AttentionLayerConfig,
     BufferConfig,
     CacheTierConfig,
+    ContiguousArenaConfig,
     DiskCacheTierConfig,
     GpuCacheTierConfig,
     HostCacheTierConfig,
@@ -47,6 +48,7 @@ from tensorrt_llm.runtime.kv_cache_manager_v2 import (
     LayerId,
     ReuseScope,
     TokenIdExt,
+    WriteThroughPolicy,
     _KVCache,
 )
 from tensorrt_llm.runtime.kv_cache_manager_v2 import KVCacheManager as KVCacheManagerPy
@@ -714,10 +716,15 @@ class KVCacheManagerV2(BaseResourceManager):
         )
 
         self.kv_cache_manager_py_config = config
+        self._arena_enabled = config.contiguous_arena is not None
 
         try:
             self.impl = KVCacheManagerPy(config, event_manager=self.event_manager)
         except (CuError, KVCacheOutOfMemoryError):
+            if self._arena_enabled:
+                # The GPU-only fallback below would silently drop the stale
+                # tier the arena's write-out path depends on (§4.3).
+                raise
             if len(cache_tiers) > 1:
                 logger.warning(
                     "Failed to initialize KV cache manager with host cache "
@@ -1041,6 +1048,15 @@ class KVCacheManagerV2(BaseResourceManager):
                 )
             )
 
+        contiguous_arena = None
+        if kv_cache_config.use_contiguous_kv_arena:
+            assert any(isinstance(t, HostCacheTierConfig) for t in cache_tiers), (
+                "use_contiguous_kv_arena requires a host cache tier (the stale tier, "
+                "DESIGN.md contiguous_primary_kvcache §4.3); configure host_cache_size "
+                "or leave the default host quota enabled"
+            )
+            contiguous_arena = self._build_arena_config()
+
         return KVCacheManagerConfigPy(
             tokens_per_block=tokens_per_block,
             vocab_size=vocab_size,
@@ -1048,6 +1064,37 @@ class KVCacheManagerV2(BaseResourceManager):
             max_util_for_resume=kv_cache_config.max_util_for_resume,
             enable_stats=self.enable_stats,
             layers=layer_configs,
+            contiguous_arena=contiguous_arena,
+        )
+
+    @staticmethod
+    def _build_arena_config() -> ContiguousArenaConfig:
+        """Resolve the contiguous-arena prototype config (DESIGN.md
+        contiguous_primary_kvcache). The enable switch is the public
+        ``KvCacheConfig.use_contiguous_kv_arena``; tuning knobs stay on env
+        vars while the feature is a prototype:
+
+        - ``TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB``: physical mapping granularity
+          ("super-page", multiple of 2; default 2). Larger pages amortize the
+          fixed per-mapping cuMemSetAccess cost (§4.8).
+        - ``TRTLLM_KV_ARENA_MAP_AHEAD_PAGES``: demand-paging margin (§4.2,
+          default 1).
+        - ``TRTLLM_KV_ARENA_WRITE_THROUGH``: ``on_free`` (default) or
+          ``on_commit`` (§4.3).
+        """
+        page_mb = int(os.environ.get("TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB", "2"))
+        map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "1"))
+        write_through_env = os.environ.get("TRTLLM_KV_ARENA_WRITE_THROUGH", "on_free").lower()
+        assert write_through_env in ("on_free", "on_commit"), (
+            f"TRTLLM_KV_ARENA_WRITE_THROUGH must be 'on_free' or 'on_commit', "
+            f"got {write_through_env!r}"
+        )
+        return ContiguousArenaConfig(
+            phys_page_size=page_mb << 20,
+            map_ahead_pages=map_ahead,
+            write_through=WriteThroughPolicy.ON_COMMIT
+            if write_through_env == "on_commit"
+            else WriteThroughPolicy.ON_FREE,
         )
 
     def _extra_buffers_per_layer(
@@ -1250,6 +1297,20 @@ class KVCacheManagerV2(BaseResourceManager):
         assert len(self.kv_cache_map) == 0, (
             "get_num_free_blocks is only used when the kv cache manager is empty"
         )
+        if self._arena_enabled:
+            # Page-index bounds describe VA in arena mode; physical capacity
+            # is the page budget (§4.6). Count whole per-sequence block
+            # columns (one block in every pool group) the budget can back.
+            storage = self.impl._storage
+            arena_cfg = storage.arena_config
+            assert arena_cfg is not None
+            total_bytes = storage.gpu_page_budget.total_pages * arena_cfg.phys_page_size
+            bytes_per_block_column = sum(
+                size
+                for pg_idx in range(int(storage.num_pool_groups))
+                for size in storage.slot_size(pg_idx)
+            )
+            return total_bytes // bytes_per_block_column
         max_num_pages = max(
             [
                 self.impl.get_page_index_upper_bound(layer_id, Role.KEY)
@@ -1598,6 +1659,12 @@ class KVCacheManagerV2(BaseResourceManager):
 
     @nvtx_range("prepare_resources_kv_cache_manager_v2")
     def prepare_resources(self, scheduled_batch: ScheduledRequests):
+        if self._arena_enabled:
+            # Arena mode: unmap and recycle freed sequence ranges whose gating
+            # events completed (deferred reclaim, DESIGN.md §4.2). Growth
+            # paths also drain on demand; this keeps the page budget fresh at
+            # iteration boundaries.
+            self.impl.drain_gpu_reclaim()
         if self.is_draft:
             # Draft V2 manager: mirror the main manager by creating/resizing
             # KV caches for scheduled requests (the main V2 scheduler does not
@@ -2551,6 +2618,11 @@ class KVCacheManagerV2(BaseResourceManager):
             input_tokens,
             id=request_id,
             expected_prompt_length=expected_prompt_length,
+            # Arena mode: size the sequence's contiguous VA reservation for
+            # the per-request maximum (matches the offset-table sizing).
+            max_capacity=(
+                self.max_blocks_per_seq * self.tokens_per_block if self._arena_enabled else None
+            ),
         )
         self.kv_cache_map[request_id] = kv_cache
         if is_dummy:

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -2644,6 +2644,11 @@ class KVCacheManagerV2(BaseResourceManager):
                         f"[arena] pool group {pg_idx}: ghost hits={group.ghost_hits} "
                         f"misses={group.ghost_misses} spilled ranges={group.spilled_ranges}"
                     )
+                if group.alias_hits or group.alias_misses or group.spilled_spans:
+                    logger.info(
+                        f"[arena] pool group {pg_idx}: alias hits={group.alias_hits} "
+                        f"misses={group.alias_misses} spilled spans={group.spilled_spans}"
+                    )
         self.impl.shutdown()
 
     def get_max_resource_count(self) -> int:

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1081,6 +1081,10 @@ class KVCacheManagerV2(BaseResourceManager):
           default 1).
         - ``TRTLLM_KV_ARENA_WRITE_THROUGH``: ``on_free`` (default) or
           ``on_commit`` (§4.3).
+        - ``TRTLLM_KV_ARENA_LAZY_RETENTION``: ``1`` keeps freed sequence
+          ranges mapped until the page budget needs them, turning reuse hits
+          on still-resident blocks into D2D copies (§4.4 phase 2; default
+          ``0``).
         """
         page_mb = int(os.environ.get("TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB", "2"))
         map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "1"))
@@ -1089,12 +1093,14 @@ class KVCacheManagerV2(BaseResourceManager):
             f"TRTLLM_KV_ARENA_WRITE_THROUGH must be 'on_free' or 'on_commit', "
             f"got {write_through_env!r}"
         )
+        lazy_retention = os.environ.get("TRTLLM_KV_ARENA_LAZY_RETENTION", "0") == "1"
         return ContiguousArenaConfig(
             phys_page_size=page_mb << 20,
             map_ahead_pages=map_ahead,
             write_through=WriteThroughPolicy.ON_COMMIT
             if write_through_env == "on_commit"
             else WriteThroughPolicy.ON_FREE,
+            lazy_gpu_retention=lazy_retention,
         )
 
     def _extra_buffers_per_layer(
@@ -2443,6 +2449,15 @@ class KVCacheManagerV2(BaseResourceManager):
         for kv_cache in self.kv_cache_map.values():
             kv_cache.close()
         self.kv_cache_map.clear()
+        if self._arena_enabled:
+            storage = self.impl._storage._gpu_arena_storage()
+            for pg_idx in range(int(storage.num_pool_groups)):
+                group = storage.pool_group(pg_idx)
+                if group.ghost_hits or group.ghost_misses or group.spilled_ranges:
+                    logger.info(
+                        f"[arena] pool group {pg_idx}: ghost hits={group.ghost_hits} "
+                        f"misses={group.ghost_misses} spilled ranges={group.spilled_ranges}"
+                    )
         self.impl.shutdown()
 
     def get_max_resource_count(self) -> int:

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1085,6 +1085,11 @@ class KVCacheManagerV2(BaseResourceManager):
           ranges mapped until the page budget needs them, turning reuse hits
           on still-resident blocks into D2D copies (§4.4 phase 2; default
           ``0``).
+        - ``TRTLLM_KV_ARENA_BATCHED_MAP``: ``1`` defers growth maps and
+          executes them in one batched pass per iteration (§4.2); the adapter
+          owns the flush points. Measured perf-neutral versus synchronous
+          mapping (same driver-call count), so it defaults to ``0`` until the
+          flush can run on a helper thread.
         """
         page_mb = int(os.environ.get("TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB", "2"))
         map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "1"))
@@ -1094,6 +1099,7 @@ class KVCacheManagerV2(BaseResourceManager):
             f"got {write_through_env!r}"
         )
         lazy_retention = os.environ.get("TRTLLM_KV_ARENA_LAZY_RETENTION", "0") == "1"
+        batched_map = os.environ.get("TRTLLM_KV_ARENA_BATCHED_MAP", "0") == "1"
         return ContiguousArenaConfig(
             phys_page_size=page_mb << 20,
             map_ahead_pages=map_ahead,
@@ -1101,6 +1107,7 @@ class KVCacheManagerV2(BaseResourceManager):
             if write_through_env == "on_commit"
             else WriteThroughPolicy.ON_FREE,
             lazy_gpu_retention=lazy_retention,
+            batched_map_sweep=batched_map,
         )
 
     def _extra_buffers_per_layer(
@@ -1652,6 +1659,10 @@ class KVCacheManagerV2(BaseResourceManager):
                 f"{request.py_request_id} by {delta} tokens "
                 f"(target capacity {new_capacity})"
             )
+        if self._arena_enabled:
+            # This runs after prepare_resources (CUDA-graph padding), so the
+            # per-iteration sweep has already flushed: map the delta now.
+            self.impl.flush_gpu_mappings()
 
     def suspend_request(self, req: LlmRequest) -> None:
         """Suspend a request's KV cache (move to host tier)."""
@@ -1675,18 +1686,22 @@ class KVCacheManagerV2(BaseResourceManager):
 
     @nvtx_range("prepare_resources_kv_cache_manager_v2")
     def prepare_resources(self, scheduled_batch: ScheduledRequests):
-        if self._arena_enabled:
-            # Arena mode: unmap and recycle freed sequence ranges whose gating
-            # events completed (deferred reclaim, DESIGN.md §4.2). Growth
-            # paths also drain on demand; this keeps the page budget fresh at
-            # iteration boundaries.
-            self.impl.drain_gpu_reclaim()
         if self.is_draft:
             # Draft V2 manager: mirror the main manager by creating/resizing
             # KV caches for scheduled requests (the main V2 scheduler does not
             # know about the draft manager).
             self._prepare_draft_resources(scheduled_batch)
+            if self._arena_enabled:
+                self.impl.flush_gpu_mappings()
+                self.impl.drain_gpu_reclaim()
             return
+        if self._arena_enabled:
+            # Arena mode: execute the batched map sweep for this iteration's
+            # growth (§4.2) BEFORE any forward touches the new blocks, then
+            # unmap/recycle freed ranges whose gating events completed
+            # (deferred reclaim). Growth paths also drain on demand.
+            self.impl.flush_gpu_mappings()
+            self.impl.drain_gpu_reclaim()
 
     def _prepare_draft_resources(self, scheduled_batch: ScheduledRequests):
         """Create/resize KV caches in the draft V2 manager for scheduled requests.
@@ -2248,6 +2263,15 @@ class KVCacheManagerV2(BaseResourceManager):
                 _populate_dummy_mrope_config(req, token_num, is_gen)
             requests.append(req)
 
+        if prepare_resource and self._arena_enabled:
+            # Warmup / CUDA-graph capture runs forwards over these caches
+            # without going through prepare_resources: execute any deferred
+            # growth maps now (§4.2 batched sweep flush point).
+            self.impl.flush_gpu_mappings()
+            if draft_kv_cache_manager is not None and getattr(
+                draft_kv_cache_manager, "_arena_enabled", False
+            ):
+                draft_kv_cache_manager.impl.flush_gpu_mappings()
         return requests
 
     def try_commit_blocks_for_reuse(self, request: LlmRequest, kv_cache) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1114,6 +1114,10 @@ class KVCacheManagerV2(BaseResourceManager):
           C++ attention op; XQA HMMA family, beam width 1). Only valid with
           the arena allocator; both KV cache managers fail loudly if it is set
           without ``use_contiguous_kv_arena``. Default ``0``.
+        - ``TRTLLM_KV_ARENA_SPAN_PROTECT_FRACTION``: fraction of the page
+          budget up to which canonical-span pins (P3 prefix aliasing) are
+          exempt from pressure spills (read directly by the storage layer;
+          default 0.05, ``0`` restores unprotected spilling).
         """
         page_mb = int(os.environ.get("TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB", "2"))
         map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "1"))

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -65,7 +65,7 @@ from tensorrt_llm.runtime.kv_cache_manager_v2._common import (
 )
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
 from tensorrt_llm.runtime.kv_cache_manager_v2._event_manager import KVCacheEventManager
-from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import CuError
+from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import CuError, OutOfPagesError
 from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import (
     OutOfMemoryError as KVCacheOutOfMemoryError,
 )
@@ -1579,7 +1579,16 @@ class KVCacheManagerV2(BaseResourceManager):
                 f"{kv_cache.capacity} to {pre_cap}"
             )
         if pre_cap > 0:
-            kv_cache.suspend(self._arena_write_out_fence())
+            try:
+                kv_cache.suspend(self._arena_write_out_fence())
+            except OutOfPagesError:
+                # This suspend only donates the deferred request's GPU pages
+                # to the wait window (an optimization); if the host tier
+                # cannot absorb the write-out, staying resident is safe.
+                logger.debug(
+                    f"KV cache manager V2: skipping revert-suspend for request "
+                    f"{req.py_request_id}: host tier full; cache stays resident."
+                )
 
     def _restore_page_index_bufs(self, request_id: int, kv_cache) -> None:
         """Re-connect host page-index buffers after resume().
@@ -1704,7 +1713,21 @@ class KVCacheManagerV2(BaseResourceManager):
             success = kv_cache.resize(capacity, history_length)
         if not success:
             if req.is_first_context_chunk:
-                kv_cache.suspend(self._arena_write_out_fence())
+                try:
+                    kv_cache.suspend(self._arena_write_out_fence())
+                except OutOfPagesError:
+                    # A first context chunk holds no computed KV worth
+                    # preserving; if the host tier cannot absorb even this
+                    # write-out, drop the cache outright (frees the GPU pages
+                    # without host capacity). prepare_context recreates it —
+                    # with a fresh reuse lookup — when the request is
+                    # scheduled again.
+                    logger.warning(
+                        f"KV cache manager V2: host tier full during context "
+                        f"backoff for request {req.py_request_id}; dropping "
+                        f"its (first-chunk) KV cache for re-preparation."
+                    )
+                    self.free_resources(req)
             return False
 
         # None means "no growth this iter, nothing to revert"; this also
@@ -1748,11 +1771,36 @@ class KVCacheManagerV2(BaseResourceManager):
             # per-iteration sweep has already flushed: map the delta now.
             self.impl.flush_gpu_mappings()
 
-    def suspend_request(self, req: LlmRequest) -> None:
-        """Suspend a request's KV cache (move to host tier)."""
+    def suspend_request(self, req: LlmRequest) -> bool:
+        """Suspend a request's KV cache (move to host tier).
+
+        Returns True if the cache was offloaded (resumable later) or there
+        was nothing to do. Returns False if the host tier could not absorb
+        the write-out — its capacity can be pinned by already-suspended
+        sequences' HELD pages, which LRU eviction cannot drop — and the
+        cache was DROPPED instead (v1-style preemption): the GPU pages are
+        freed either way, but the caller must pause the request so it
+        recomputes its KV from the prompt (whatever canonical prefix
+        survives in the reuse tree still shortens the re-prefill).
+        suspend() is atomic on failure, so the drop starts from an intact
+        ACTIVE cache and close()'s exhaustion-safe write-out path.
+        """
         kv_cache = self.kv_cache_map.get(req.py_request_id)
-        if kv_cache is not None and kv_cache.is_active:
+        if kv_cache is None or not kv_cache.is_active:
+            return True
+        try:
             kv_cache.suspend(self._arena_write_out_fence())
+            return True
+        except OutOfPagesError:
+            logger.warning(
+                f"KV cache manager V2: host tier cannot absorb the suspension "
+                f"write-out for request {req.py_request_id} (host capacity "
+                f"pinned by suspended sequences); dropping its KV cache for "
+                f"recomputation instead. Consider increasing "
+                f"kv_cache_config.host_cache_size."
+            )
+            self.free_resources(req)
+            return False
 
     def resume_request(self, req: LlmRequest) -> bool:
         """Resume a previously-suspended KV cache for *req*.

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -2648,10 +2648,16 @@ class KVCacheManagerV2(BaseResourceManager):
                         f"[arena] pool group {pg_idx}: ghost hits={group.ghost_hits} "
                         f"misses={group.ghost_misses} spilled ranges={group.spilled_ranges}"
                     )
-                if group.alias_hits or group.alias_misses or group.spilled_spans:
+                if (
+                    group.alias_hits
+                    or group.alias_misses
+                    or group.spilled_spans
+                    or group.dedup_remapped_pages
+                ):
                     logger.info(
                         f"[arena] pool group {pg_idx}: alias hits={group.alias_hits} "
-                        f"misses={group.alias_misses} spilled spans={group.spilled_spans}"
+                        f"misses={group.alias_misses} spilled spans={group.spilled_spans} "
+                        f"dedup remapped pages={group.dedup_remapped_pages}"
                     )
         self.impl.shutdown()
 

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -61,10 +61,12 @@ from tensorrt_llm.runtime.kv_cache_manager_v2._common import (
     CACHE_LEVEL1,
     GPU_LEVEL,
     CacheLevel,
+    CudaStream,
 )
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
 from tensorrt_llm.runtime.kv_cache_manager_v2._event_manager import KVCacheEventManager
 from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import CuError
+from tensorrt_llm.runtime.kv_cache_manager_v2._utils import CachedCudaEvent
 from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import (
     OutOfMemoryError as KVCacheOutOfMemoryError,
 )
@@ -1558,6 +1560,13 @@ class KVCacheManagerV2(BaseResourceManager):
         """
         if kv_cache.is_active:
             return True
+        if self._arena_enabled:
+            # resume() drains reclaim before its utilization gate (the §4.2 x
+            # §4.6 anti-livelock); ranges freed since the last fenced drain
+            # need their iteration fence (risk #3) assigned first or they can
+            # pin utilization forever when prepare_resources is never reached
+            # (e.g. the KV-capacity estimation phase).
+            self.impl.fence_gpu_reclaim(self._reclaim_fence())
         if not kv_cache.resume(self._stream.cuda_stream):
             return False
         self._restore_page_index_bufs(req_id, kv_cache)
@@ -1637,6 +1646,16 @@ class KVCacheManagerV2(BaseResourceManager):
         pre_cap = kv_cache.capacity
 
         success = kv_cache.resize(capacity, history_length)
+        if not success and self._arena_enabled:
+            # Growth may have failed only because freed ranges still await
+            # their iteration fence (risk #3) and no fenced drain has run yet
+            # — prepare_resources (the usual fence point) is skipped when
+            # nothing was scheduled, e.g. during KV-capacity estimation.
+            # Fence now and retry once; the impl's internal pressure drain can
+            # then reclaim fence-complete ranges. If the fence has not
+            # completed yet, the scheduler simply retries next iteration.
+            self.impl.fence_gpu_reclaim(self._reclaim_fence())
+            success = kv_cache.resize(capacity, history_length)
         if not success:
             if req.is_first_context_chunk:
                 kv_cache.suspend()
@@ -1668,6 +1687,10 @@ class KVCacheManagerV2(BaseResourceManager):
         kv_cache = self.kv_cache_map[request.py_request_id]
         new_capacity = kv_cache.capacity + delta
         success = kv_cache.resize(new_capacity)
+        if not success and self._arena_enabled:
+            # Same fence-then-retry as resize_context (risk #3).
+            self.impl.fence_gpu_reclaim(self._reclaim_fence())
+            success = kv_cache.resize(new_capacity)
         if not success:
             raise ValueError(
                 f"Failed to extend capacity of KV cache for request "
@@ -1699,6 +1722,21 @@ class KVCacheManagerV2(BaseResourceManager):
 
     # ---- prepare_resources ----
 
+    def _reclaim_fence(self) -> CachedCudaEvent:
+        """Forward-stream fence for the arena's deferred reclaim (risk #3).
+
+        With the overlap scheduler, a step that still reads (and appends to) a
+        just-finished request's range may already be enqueued when the request
+        is freed, and the free/gate events (recorded on the manager stream at
+        close time) do not order against it. An event recorded *here* — at the
+        iteration boundary, on the executor thread's CURRENT stream — covers
+        every previously enqueued step, because ``_forward_step`` runs on that
+        same thread-current stream (it is NOT wrapped in the executor's
+        side ``execution_stream``); steps enqueued later no longer contain the
+        freed sequence. Hence a completed fence is a safe unmap gate.
+        """
+        return CachedCudaEvent(CudaStream(torch.cuda.current_stream().cuda_stream))
+
     @nvtx_range("prepare_resources_kv_cache_manager_v2")
     def prepare_resources(self, scheduled_batch: ScheduledRequests):
         if self.is_draft:
@@ -1708,15 +1746,18 @@ class KVCacheManagerV2(BaseResourceManager):
             self._prepare_draft_resources(scheduled_batch)
             if self._arena_enabled:
                 self.impl.flush_gpu_mappings()
-                self.impl.drain_gpu_reclaim()
+                self.impl.drain_gpu_reclaim(self._reclaim_fence())
             return
         if self._arena_enabled:
             # Arena mode: execute the batched map sweep for this iteration's
             # growth (§4.2) BEFORE any forward touches the new blocks, then
             # unmap/recycle freed ranges whose gating events completed
             # (deferred reclaim). Growth paths also drain on demand.
+            # The fence (recorded on the execution stream) keeps ranges freed
+            # since the previous iteration from being unmapped under a
+            # speculatively enqueued overlap-scheduler step (risk #3).
             self.impl.flush_gpu_mappings()
-            self.impl.drain_gpu_reclaim()
+            self.impl.drain_gpu_reclaim(self._reclaim_fence())
 
     def _prepare_draft_resources(self, scheduled_batch: ScheduledRequests):
         """Create/resize KV caches in the draft V2 manager for scheduled requests.
@@ -2645,13 +2686,20 @@ class KVCacheManagerV2(BaseResourceManager):
         copy_idx = self.index_mapper.get_copy_index(request_ids, num_contexts, beam_width)
         assert copy_idx.shape[0] == num_seqs
 
+        # Enqueue on the CALLER'S current stream (the forward stream), exactly
+        # like the v1 manager's plain ``.copy_()``: the block-offset refresh
+        # must be ordered before this iteration's attention kernels and after
+        # the previous iteration's. Enqueuing it on the manager's side stream
+        # (as done previously) lets a forward read STALE rows — which point at
+        # freed sequences' ranges: silently wrong reads in classic paged mode,
+        # and illegal accesses in arena mode once the range is unmapped.
         copy_batch_block_offsets_to_device(
             self.host_kv_cache_block_offsets,
             dst_tensor,
             copy_idx,
             self.index_scales,
             self.kv_offset,
-            self._stream.cuda_stream,
+            torch.cuda.current_stream().cuda_stream,
         )
 
     def _create_kv_cache(

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1422,11 +1422,44 @@ class KVCacheManagerV2(BaseResourceManager):
         """
         return current_capacity + 1 + self._effective_draft_len(req)
 
+    def _arena_reclaim_blocking(self) -> bool:
+        """Fence and BLOCKING-drain the arena's deferred reclaim mid-scheduling.
+
+        Pages freed by the scheduler's own evictions (suspend) — and by
+        requests that finished since the last iteration — are stuck in the
+        pending-reclaim queue until (a) their evacuation copies finish and
+        (b) a fence recorded on the execution stream at a drain point covers
+        them (risk #3). Both normally happen at the next
+        ``prepare_resources``, which runs AFTER scheduling — so within a
+        scheduling pass an eviction frees nothing, the scheduler cascades
+        through every victim, and a fully suspended batch deadlocks (resume
+        refused by the utilization gate while the freed pages are still
+        charged; nothing left to evict).
+
+        Recording the fence here is safe by the same argument as
+        ``_reclaim_fence``: the scheduler runs on the executor thread whose
+        current stream is the forward stream, so the event orders after
+        every previously enqueued step, and this iteration's forward (not
+        yet enqueued) cannot reference freed sequences. The wait is bounded
+        by the just-enqueued evacuation copies and any in-flight forward.
+
+        Returns True if any range was reclaimed (or parked reclaimable-for-
+        budget under lazy retention) — i.e. whether a retry can make
+        progress."""
+        if not self._arena_enabled:
+            return False
+        return self.impl.drain_gpu_reclaim(self._reclaim_fence(), wait=True) > 0
+
     def try_allocate_generation(self, req: LlmRequest) -> bool:
         """Try to allocate one additional KV cache slot for a generation request.
 
         Resumes from suspended state if needed, then resizes capacity by 1 (+
         draft tokens). Returns True on success, False if allocation failed.
+
+        In arena mode a failed resume/resize retries once after a blocking
+        fenced reclaim drain (see ``_arena_reclaim_blocking``) so pages freed
+        mid-scheduling-pass — by this pass's evictions or by just-finished
+        requests — actually become allocatable within the pass.
         """
         kv_cache = self.kv_cache_map.get(req.py_request_id)
         if kv_cache is None:
@@ -1434,12 +1467,18 @@ class KVCacheManagerV2(BaseResourceManager):
 
         if not kv_cache.is_active:
             if not kv_cache.resume(self._stream.cuda_stream):
-                return False
+                if not (
+                    self._arena_reclaim_blocking() and kv_cache.resume(self._stream.cuda_stream)
+                ):
+                    return False
             self._restore_page_index_bufs(req.py_request_id, kv_cache)
 
         draft_len = self._effective_draft_len(req)
         self._allocated_draft_lens[req.py_request_id] = draft_len
-        return kv_cache.resize(self._required_gen_capacity(req, kv_cache.capacity))
+        target = self._required_gen_capacity(req, kv_cache.capacity)
+        if kv_cache.resize(target):
+            return True
+        return self._arena_reclaim_blocking() and kv_cache.resize(target)
 
     def trim_to_history(self, req: LlmRequest, history_length: int) -> bool:
         """Mark *history_length* tokens of this request's KV as historic.

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1096,7 +1096,14 @@ class KVCacheManagerV2(BaseResourceManager):
           ("super-page", multiple of 2; default 2). Larger pages amortize the
           fixed per-mapping cuMemSetAccess cost (§4.8).
         - ``TRTLLM_KV_ARENA_MAP_AHEAD_PAGES``: demand-paging margin (§4.2,
-          default 1).
+          default 0). The margin is charged against the page budget per
+          sequence, so near the admission-utilization ceiling it converts
+          directly into fewer admitted sequences (measured on Llama-3.1-8B
+          at 256-way concurrency, 16 MiB pages, 0.85 memory fraction:
+          margin 1 cost 9.5 mean batch and 1.7% throughput versus margin
+          0), while its latency hiding does not measure — at super-page
+          granularity a sequence crosses a page boundary only every
+          ``page_size / bytes_per_token`` tokens.
         - ``TRTLLM_KV_ARENA_WRITE_THROUGH``: ``on_free`` (default) or
           ``on_commit`` (§4.3).
         - ``TRTLLM_KV_ARENA_LAZY_RETENTION``: ``1`` keeps freed sequence
@@ -1120,7 +1127,7 @@ class KVCacheManagerV2(BaseResourceManager):
           default 0.05, ``0`` restores unprotected spilling).
         """
         page_mb = int(os.environ.get("TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB", "2"))
-        map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "1"))
+        map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "0"))
         write_through_env = os.environ.get("TRTLLM_KV_ARENA_WRITE_THROUGH", "on_free").lower()
         assert write_through_env in ("on_free", "on_commit"), (
             f"TRTLLM_KV_ARENA_WRITE_THROUGH must be 'on_free' or 'on_commit', "

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1122,6 +1122,16 @@ class KVCacheManagerV2(BaseResourceManager):
         return self.impl.get_page_index_upper_bound(0, Role.KEY)
 
     def get_buffers(self, layer_idx: int, kv_layout: str = "NHD") -> Optional[torch.Tensor]:
+        if self._arena_enabled:
+            # A dense pool-wide tensor view is incompatible with sparsely
+            # mapped arena pools; consumers that need it (FlashInfer-style
+            # backends, MLA latent append) are later-phase work (DESIGN.md
+            # contiguous_primary_kvcache §7).
+            raise NotImplementedError(
+                "get_buffers is not supported with use_contiguous_kv_arena: arena "
+                "pools are sparse VA reservations and cannot be viewed as one dense "
+                "tensor. Use the TRTLLM attention backend, or disable the arena."
+            )
         layer_offset = self.layer_offsets[layer_idx]
         addr_key = self.impl.get_mem_pool_base_address(layer_offset, Role.KEY)
         if self.kv_cache_type != CacheTypeCpp.SELFKONLY:
@@ -2389,6 +2399,14 @@ class KVCacheManagerV2(BaseResourceManager):
         return get_size_in_bytes(cache_size // quant_vector_size, scaling_factor_dtype)
 
     def check_invalid_values_in_kv_cache(self, fill_with_zero: bool = False) -> bool:
+        if self._arena_enabled:
+            # Arena pools are sparse VA reservations; a dense tensor view over
+            # the whole pool would touch unmapped pages (and warmup sequences'
+            # pages are already unmapped by the time this runs). Skip the scan.
+            logger.debug(
+                "Skipping KV cache NaN/Inf warmup scan: contiguous-arena pools are sparsely mapped"
+            )
+            return False
         some_checks_unavailable = False
         has_invalid_values = torch.tensor(
             [False], dtype=torch.bool, device=torch.cuda.current_device()

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1088,8 +1088,16 @@ class KVCacheManagerV2(BaseResourceManager):
         - ``TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB``: physical mapping granularity
           ("super-page", multiple of 2; default 2). Larger pages amortize the
           fixed per-mapping cuMemSetAccess cost (§4.8).
-        - ``TRTLLM_KV_ARENA_MAP_AHEAD_PAGES``: demand-paging margin (§4.2,
-          default 1).
+        - ``TRTLLM_KV_ARENA_MAP_AHEAD_PAGES``: demand-paging margin (§4.2).
+          Default ``-1`` = pre-map each sequence's whole reserved range at
+          its first mapping (the margin is clamped to the reserved extent).
+          Growth-time ``cuMemMap``/``cuMemSetAccess`` concurrent with
+          in-flight kernels reading the same range is the only remaining
+          trigger of the H100 MMU-fault interference (see
+          ``_sequence_arena._SYNC_BEFORE_UNMAP``): pre-mapping at admission
+          removes growth maps entirely and is the one configuration
+          validated crash-free at every tested scale. Small margins trade
+          that safety for lower physical footprint (experiments only).
         - ``TRTLLM_KV_ARENA_WRITE_THROUGH``: ``on_free`` (default) or
           ``on_commit`` (§4.3).
         - ``TRTLLM_KV_ARENA_LAZY_RETENTION``: ``1`` keeps freed sequence
@@ -1109,7 +1117,12 @@ class KVCacheManagerV2(BaseResourceManager):
           without ``use_contiguous_kv_arena``. Default ``0``.
         """
         page_mb = int(os.environ.get("TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB", "2"))
-        map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "1"))
+        map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "-1"))
+        if map_ahead < 0:
+            # Pre-map-at-resume: a margin larger than any range pre-maps the
+            # whole reserved extent on first touch (the mapping plan clamps
+            # to the range), so no growth maps ever run under kernels.
+            map_ahead = 1 << 30
         write_through_env = os.environ.get("TRTLLM_KV_ARENA_WRITE_THROUGH", "on_free").lower()
         assert write_through_env in ("on_free", "on_commit"), (
             f"TRTLLM_KV_ARENA_WRITE_THROUGH must be 'on_free' or 'on_commit', "

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -717,6 +717,15 @@ class KVCacheManagerV2(BaseResourceManager):
 
         self.kv_cache_manager_py_config = config
         self._arena_enabled = config.contiguous_arena is not None
+        if os.getenv("TRTLLM_KV_ARENA_LINEAR_KERNELS") == "1" and not self._arena_enabled:
+            # The attention op reads this env var directly and would compute page indices
+            # arithmetically against a cache whose pages are NOT consecutive.
+            raise ValueError(
+                "TRTLLM_KV_ARENA_LINEAR_KERNELS=1 requires "
+                "KvCacheConfig(use_contiguous_kv_arena=True): linear kernel addressing assumes "
+                "each sequence's cache pages are consecutive, which only the contiguous arena "
+                "allocator guarantees."
+            )
 
         try:
             self.impl = KVCacheManagerPy(config, event_manager=self.event_manager)
@@ -1090,6 +1099,12 @@ class KVCacheManagerV2(BaseResourceManager):
           owns the flush points. Measured perf-neutral versus synchronous
           mapping (same driver-call count), so it defaults to ``0`` until the
           flush can run on a helper thread.
+        - ``TRTLLM_KV_ARENA_LINEAR_KERNELS``: ``1`` lets generation attention
+          kernels compute KV page indices arithmetically instead of loading
+          them from the block-offset table (§4.9 phase 1; read directly by the
+          C++ attention op; XQA HMMA family, beam width 1). Only valid with
+          the arena allocator; both KV cache managers fail loudly if it is set
+          without ``use_contiguous_kv_arena``. Default ``0``.
         """
         page_mb = int(os.environ.get("TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB", "2"))
         map_ahead = int(os.environ.get("TRTLLM_KV_ARENA_MAP_AHEAD_PAGES", "1"))

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1579,7 +1579,7 @@ class KVCacheManagerV2(BaseResourceManager):
                 f"{kv_cache.capacity} to {pre_cap}"
             )
         if pre_cap > 0:
-            kv_cache.suspend()
+            kv_cache.suspend(self._arena_write_out_fence())
 
     def _restore_page_index_bufs(self, request_id: int, kv_cache) -> None:
         """Re-connect host page-index buffers after resume().
@@ -1704,7 +1704,7 @@ class KVCacheManagerV2(BaseResourceManager):
             success = kv_cache.resize(capacity, history_length)
         if not success:
             if req.is_first_context_chunk:
-                kv_cache.suspend()
+                kv_cache.suspend(self._arena_write_out_fence())
             return False
 
         # None means "no growth this iter, nothing to revert"; this also
@@ -1752,7 +1752,7 @@ class KVCacheManagerV2(BaseResourceManager):
         """Suspend a request's KV cache (move to host tier)."""
         kv_cache = self.kv_cache_map.get(req.py_request_id)
         if kv_cache is not None and kv_cache.is_active:
-            kv_cache.suspend()
+            kv_cache.suspend(self._arena_write_out_fence())
 
     def resume_request(self, req: LlmRequest) -> bool:
         """Resume a previously-suspended KV cache for *req*.
@@ -1804,6 +1804,18 @@ class KVCacheManagerV2(BaseResourceManager):
             # speculatively enqueued overlap-scheduler step (risk #3).
             self.impl.flush_gpu_mappings()
             self.impl.drain_gpu_reclaim(self._reclaim_fence())
+
+    def _arena_write_out_fence(self) -> CachedCudaEvent:
+        """Forward-stream event covering a sequence's last KV writes, passed
+        to the arena write-outs at suspend/close (see
+        ``StorageManager.offload_arena_pages``). Under the overlap scheduler a
+        victim's / finishing request's current step may still be in flight;
+        an event recorded here on the executor thread's current stream (= the
+        forward stream) orders after it. NULL in classic mode (no arena
+        write-out exists there)."""
+        if not self._arena_enabled:
+            return CachedCudaEvent.NULL
+        return self._reclaim_fence()
 
     def _prepare_draft_resources(self, scheduled_batch: ScheduledRequests):
         """Create/resize KV caches in the draft V2 manager for scheduled requests.
@@ -2411,7 +2423,7 @@ class KVCacheManagerV2(BaseResourceManager):
             return
         kv_cache.discard_pending_stats()
         self.try_commit_blocks_for_reuse(request, kv_cache)
-        kv_cache.close()
+        kv_cache.close(self._arena_write_out_fence())
         self.impl.clear_stats_excluded(request.py_request_id)
         if request.py_request_id in self._early_freed_index_requests:
             self._early_freed_index_requests.discard(request.py_request_id)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3154,6 +3154,8 @@ class PyExecutor:
                 if not self._is_kv_manager_v2:
                     self._terminate_requests(scheduled_batch.paused_requests)
                     self._pause_requests(scheduled_batch.paused_requests)
+                else:
+                    self._pause_dropped_requests(scheduled_batch)
 
                 finished_requests = []
                 sample_state = None
@@ -3726,6 +3728,8 @@ class PyExecutor:
 
                 if not self._is_kv_manager_v2:
                     self._pause_requests(scheduled_batch.paused_requests)
+                else:
+                    self._pause_dropped_requests(scheduled_batch)
 
                 if can_queue:
                     guided_decoder_failed_requests = None
@@ -5751,6 +5755,31 @@ class PyExecutor:
     def _pause_requests(self, requests_to_pause):
         for req in requests_to_pause:
             req.pause(self.max_input_len)
+
+    def _pause_dropped_requests(self, scheduled_batch: ScheduledRequests):
+        """V2 manager: pause only host-exhaustion drops.
+
+        V2 suspension normally preserves the KV on the host tier for a later
+        resume, so evicted (paused_requests) entries must NOT be paused. But
+        a suspend that degraded to a DROP under host-tier exhaustion
+        (``py_kv_dropped``, see ``V2Scheduler._suspend_request``) freed the
+        KV outright — reset those requests to CONTEXT_INIT (v1-style
+        preemption) so they recompute from the prompt on their next
+        scheduling.
+        """
+        dropped = [
+            req for req in scheduled_batch.paused_requests
+            if getattr(req, "py_kv_dropped", False)
+        ]
+        if dropped:
+            # Mirror the v1 pause flow: terminate first so ALL per-request
+            # resources are released (notably the seq slot — a paused request
+            # re-enters as context and add_slot asserts on a duplicate ID;
+            # the KV free is idempotent, the scheduler already dropped it).
+            self._terminate_requests(dropped)
+            self._pause_requests(dropped)
+            for req in dropped:
+                req.py_kv_dropped = False
 
     def _add_inflight_ids(self, scheduled_requests: ScheduledRequests):
         """Add request IDs of current sampling requests to self.inflight_req_ids.

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -283,6 +283,13 @@ class KVCacheManager(BaseResourceManager):
         pool_configurations: Optional[List[PoolConfiguration]] = None,
         **kwargs,
     ) -> None:
+        if os.getenv("TRTLLM_KV_ARENA_LINEAR_KERNELS") == "1":
+            # The attention op reads this env var directly; the classic paged manager does not
+            # allocate consecutive pages, so linear kernel addressing would read wrong blocks.
+            raise ValueError(
+                "TRTLLM_KV_ARENA_LINEAR_KERNELS=1 requires the KVCacheManagerV2 contiguous arena "
+                "(KvCacheConfig(use_contiguous_kv_arena=True)); it cannot be used with the "
+                "classic paged KV cache manager.")
         self.mapping = mapping
         self.dtype = dtype
         self.kv_cache_type = kv_cache_type

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -952,6 +952,16 @@ class KVCacheV2Scheduler(RequestScheduler):
     def _suspend_request(self, req: LlmRequest) -> None:
         """Suspend a request's KV cache in both main and draft managers.
 
+        Either manager may DROP the cache instead of offloading it when the
+        host tier cannot absorb the write-out (suspend_request returns
+        False).  The victim's GPU pages are freed in both cases, so callers
+        treat it as evicted either way; a dropped request is additionally
+        flagged with ``py_kv_dropped`` so the executor pauses it
+        (CONTEXT_INIT reset) for v1-style recomputation.  Main and draft
+        caches must drop together — a paused request re-runs its context
+        phase from the prompt, so a leftover suspended copy in the other
+        manager would leak host pages and desync from the recomputed KV.
+
         TODO: Also release PEFT resources (mark_request_done) for the
         suspended request so the C++ PeftCacheManager can evict its
         adapter pages.  Currently only KV cache is freed; the adapter
@@ -959,9 +969,14 @@ class KVCacheV2Scheduler(RequestScheduler):
         fail if it needs to load a different adapter into a full cache.
         """
         self._clear_request_runtime_state(req)
-        self.kv_cache_manager.suspend_request(req)
+        offloaded = self.kv_cache_manager.suspend_request(req)
         if self.draft_kv_cache_manager is not None:
-            self.draft_kv_cache_manager.suspend_request(req)
+            offloaded = self.draft_kv_cache_manager.suspend_request(req) and offloaded
+        if not offloaded:
+            self.kv_cache_manager.free_resources(req)
+            if self.draft_kv_cache_manager is not None:
+                self.draft_kv_cache_manager.free_resources(req)
+            req.py_kv_dropped = True
 
     def _clear_request_runtime_state(self, req: LlmRequest) -> None:
         req.py_batch_idx = None

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3330,6 +3330,16 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         status="prototype",
         description="Whether to use the KV cache manager v2 (experimental).")
 
+    use_contiguous_kv_arena: bool = Field(
+        default=False,
+        status="prototype",
+        description=
+        "Whether active KV cache blocks of a sequence are contiguous in "
+        "virtual memory (per-sequence VMM arenas with demand paging; "
+        "experimental). Requires use_kv_cache_manager_v2 and a host cache "
+        "tier; incompatible with sliding-window attention, SSM layers and "
+        "beam search.")
+
     kv_cache_event_hash_algo: Literal[
         "auto", "v1_block_key", "v2_sha256", "v2_sha256_64"] = Field(
             default="auto",
@@ -3470,6 +3480,13 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
             raise ValueError(
                 "kv_cache_config.max_util_for_resume must be between 0 and 1")
         return v
+
+    @model_validator(mode='after')
+    def sync_contiguous_kv_arena(self) -> 'KvCacheConfig':
+        # The contiguous arena is a KV cache manager v2 storage mode.
+        if self.use_contiguous_kv_arena:
+            self.use_kv_cache_manager_v2 = True
+        return self
 
 
 @PybindMirror.mirror_pybind_fields(_ExtendedRuntimePerfKnobConfig)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.py
@@ -32,6 +32,7 @@ from ._config import (
     BatchDesc,
     BufferConfig,
     CacheTierConfig,
+    ContiguousArenaConfig,
     DataRole,
     DiskCacheTierConfig,
     GpuCacheTierConfig,
@@ -40,6 +41,7 @@ from ._config import (
     KVCacheManagerConfig,
     SsmLayerConfig,
     SwaScratchReuseConfig,
+    WriteThroughPolicy,
 )
 from ._core import (
     DEFAULT_BEAM_INDEX,
@@ -93,6 +95,8 @@ __all__ = [
     "NDEBUG",
     "KVCacheManagerConfig",
     "SwaScratchReuseConfig",
+    "ContiguousArenaConfig",
+    "WriteThroughPolicy",
     "AttentionLayerConfig",
     "SsmLayerConfig",
     "BufferConfig",

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -248,6 +248,17 @@ class ContiguousArenaConfig:
     # with prefix-affine range adoption. Prototype; off by default. Also
     # settable via TRTLLM_KV_ARENA_PREFIX_ALIASING=1.
     prefix_aliasing: bool = False
+    # Span-spill protection: canonical-span pins are EXEMPT from pressure
+    # spills up to this fraction of the page budget (the excess stays
+    # spillable, LRU-first). Shared prefixes are the hottest bytes on the
+    # level, and spilling them "last" alone still forfeits the whole
+    # registry under sustained pressure -- and with it every zero-copy
+    # alias hit -- to cover a transient need worth a handful of pages;
+    # protected callers back off like any failed allocation instead
+    # (§4.6). 0.0 restores unprotected spilling. Only meaningful with
+    # ``prefix_aliasing``. Also settable via
+    # TRTLLM_KV_ARENA_SPAN_PROTECT_FRACTION.
+    protected_span_fraction: float = 0.05
 
     def __post_init__(self) -> None:
         _MIN_GRANULARITY = 2 << 20
@@ -257,6 +268,9 @@ class ContiguousArenaConfig:
         )
         assert self.map_ahead_pages >= 0, "map_ahead_pages must be non-negative"
         assert self.max_va_bytes_per_pool >= 0, "max_va_bytes_per_pool must be non-negative"
+        assert 0.0 <= self.protected_span_fraction <= 1.0, (
+            f"protected_span_fraction ({self.protected_span_fraction}) must be in [0, 1]"
+        )
 
 
 @dataclass(slots=True)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -355,12 +355,13 @@ class KVCacheManagerConfig:
             assert self.helix_config is None, (
                 "contiguous_arena is not yet supported together with helix_config"
             )
-            assert all(layer.type == LayerType.ATTENTION for layer in self.layers), (
-                "contiguous_arena does not support SSM layers yet (DESIGN.md §4.7)"
-            )
-            assert all(layer.sliding_window_size is None for layer in self.layers), (
-                "contiguous_arena does not support sliding-window layers yet (DESIGN.md §4.7)"
-            )
+            for layer in self.layers:
+                assert isinstance(layer, AttentionLayerConfig), (
+                    "contiguous_arena does not support SSM layers yet (DESIGN.md §4.7)"
+                )
+                assert layer.sliding_window_size is None, (
+                    "contiguous_arena does not support sliding-window layers yet (DESIGN.md §4.7)"
+                )
             assert self.swa_scratch_reuse is None, (
                 "contiguous_arena does not support SWA scratch reuse (scattered scratch slots)"
             )

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -188,6 +188,64 @@ class SwaScratchReuseConfig:
         assert self.max_rewind_len >= 0, "max_rewind_len must be non-negative"
 
 
+class WriteThroughPolicy(IntEnum):
+    """When active (GPU) blocks are copied out to the host (stale) tier.
+
+    See ``contiguous_primary_kvcache/DESIGN.md`` §4.3.
+    """
+
+    # Copy a committed block to host only when its arena pages are freed
+    # (sequence completion / preemption). Simplest; bursts D2H at free time.
+    ON_FREE = 0
+    # Copy a committed block to host opportunistically the moment it commits
+    # (blocks are immutable once committed), making the common free path
+    # copy-free. Must be rate-limited (DESIGN.md §4.3 risk #4).
+    ON_COMMIT = 1
+
+
+@dataclass(slots=True)
+class ContiguousArenaConfig:
+    """Enables the contiguous-in-VA active KV cache (per-sequence arenas backed
+    by CUDA VMM demand paging).
+
+    This is a **prototype** feature; see ``contiguous_primary_kvcache/DESIGN.md``
+    for the full design. When this config is ``None`` on
+    :class:`KVCacheManagerConfig`, behavior is unchanged (classic paged v2).
+
+    Args:
+        phys_page_size: Physical mapping granularity in bytes ("super-page").
+            Must be a multiple of the VMM allocation granularity (2 MiB). Larger
+            pages amortize the fixed per-mapping ``cuMemSetAccess`` cost (~8x
+            cheaper per byte at 16 MiB vs 2 MiB) at the cost of more tail waste
+            (~page_size/2 per sequence per pool group). See DESIGN.md §4.8.
+        map_ahead_pages: Number of physical pages to keep mapped ahead of a
+            growing sequence's write frontier, to hide driver-call latency and
+            absorb speculative-decoding bursts (DESIGN.md §4.2).
+        write_through: See :class:`WriteThroughPolicy`.
+        lazy_gpu_retention: If True, keep a freed sequence's pages mapped
+            (LRU-ordered) until the shared pool needs them, so a reuse hit on a
+            still-resident block is a D2D copy instead of H2D (DESIGN.md §4.4,
+            phase 1). P0 default is False (stale is host-only).
+        max_va_bytes_per_pool: Hard cap on the VA reservation per (pool group,
+            pool) arena. 0 means derive from per-request maxima at startup.
+    """
+
+    phys_page_size: int = 2 << 20
+    map_ahead_pages: int = 1
+    write_through: WriteThroughPolicy = WriteThroughPolicy.ON_FREE
+    lazy_gpu_retention: bool = False
+    max_va_bytes_per_pool: int = 0
+
+    def __post_init__(self) -> None:
+        _MIN_GRANULARITY = 2 << 20
+        assert self.phys_page_size > 0 and self.phys_page_size % _MIN_GRANULARITY == 0, (
+            f"phys_page_size ({self.phys_page_size}) must be a positive multiple of "
+            f"the 2 MiB VMM granularity"
+        )
+        assert self.map_ahead_pages >= 0, "map_ahead_pages must be non-negative"
+        assert self.max_va_bytes_per_pool >= 0, "max_va_bytes_per_pool must be non-negative"
+
+
 @dataclass(slots=True)
 class KVCacheManagerConfig:
     """
@@ -248,6 +306,15 @@ class KVCacheManagerConfig:
     Collect V2 KV cache allocation, reuse, and transfer statistics.
     """
 
+    contiguous_arena: ContiguousArenaConfig | None = None
+    """
+    When set, enables the prototype contiguous-in-VA active KV cache: each
+    sequence's active blocks are laid out contiguously in a per-sequence virtual
+    address range backed by CUDA VMM demand paging, and stale (reusable) blocks
+    live in the host tier. When None (default), behavior is unchanged.
+    See ``contiguous_primary_kvcache/DESIGN.md``.
+    """
+
     # unsupported yet
     helix_config: HelixConfig | None = None
 
@@ -274,4 +341,10 @@ class KVCacheManagerConfig:
             )
             assert not self.enable_partial_reuse, (
                 "enable_partial_reuse must be False when SSM layers are present"
+            )
+        if self.contiguous_arena is not None:
+            # Prototype feature; a few combinations are not wired up yet (P0 scope,
+            # DESIGN.md §7). Fail loudly rather than silently misbehave.
+            assert self.helix_config is None, (
+                "contiguous_arena is not yet supported together with helix_config"
             )

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -235,6 +235,13 @@ class ContiguousArenaConfig:
     write_through: WriteThroughPolicy = WriteThroughPolicy.ON_FREE
     lazy_gpu_retention: bool = False
     max_va_bytes_per_pool: int = 0
+    # Defer growth maps and execute them in one batched pass per iteration
+    # (§4.2). The budget is still charged at resize time, so admission
+    # control is unchanged -- but the OWNER of the manager must call
+    # KVCacheManager.flush_gpu_mappings() after scheduling and before any
+    # GPU work touches the newly grown blocks (the executor adapter does).
+    # Off by default so direct users keep synchronous mapping semantics.
+    batched_map_sweep: bool = False
 
     def __post_init__(self) -> None:
         _MIN_GRANULARITY = 2 << 20

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -242,6 +242,12 @@ class ContiguousArenaConfig:
     # GPU work touches the newly grown blocks (the executor adapter does).
     # Off by default so direct users keep synchronous mapping semantics.
     batched_map_sweep: bool = False
+    # P3 prefix aliasing: pin a closing canonical owner's fully-committed
+    # prefix pages (refcounted) and cuMemMap the SAME physical pages into
+    # later same-prefix sequences' ranges -- zero-copy, zero-budget reuse,
+    # with prefix-affine range adoption. Prototype; off by default. Also
+    # settable via TRTLLM_KV_ARENA_PREFIX_ALIASING=1.
+    prefix_aliasing: bool = False
 
     def __post_init__(self) -> None:
         _MIN_GRANULARITY = 2 << 20

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -348,3 +348,12 @@ class KVCacheManagerConfig:
             assert self.helix_config is None, (
                 "contiguous_arena is not yet supported together with helix_config"
             )
+            assert all(layer.type == LayerType.ATTENTION for layer in self.layers), (
+                "contiguous_arena does not support SSM layers yet (DESIGN.md §4.7)"
+            )
+            assert all(layer.sliding_window_size is None for layer in self.layers), (
+                "contiguous_arena does not support sliding-window layers yet (DESIGN.md §4.7)"
+            )
+            assert self.swa_scratch_reuse is None, (
+                "contiguous_arena does not support SWA scratch reuse (scattered scratch slots)"
+            )

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -220,7 +220,11 @@ class ContiguousArenaConfig:
             (~page_size/2 per sequence per pool group). See DESIGN.md §4.8.
         map_ahead_pages: Number of physical pages to keep mapped ahead of a
             growing sequence's write frontier, to hide driver-call latency and
-            absorb speculative-decoding bursts (DESIGN.md §4.2).
+            absorb speculative-decoding bursts (DESIGN.md §4.2). The margin
+            is charged against the page budget per sequence, so near the
+            admission-utilization ceiling it converts into fewer admitted
+            sequences; at super-page granularity boundary crossings are rare
+            enough that the latency hiding does not measure. Default 0.
         write_through: See :class:`WriteThroughPolicy`.
         lazy_gpu_retention: If True, keep a freed sequence's pages mapped
             (LRU-ordered) until the shared pool needs them, so a reuse hit on a
@@ -231,7 +235,7 @@ class ContiguousArenaConfig:
     """
 
     phys_page_size: int = 2 << 20
-    map_ahead_pages: int = 1
+    map_ahead_pages: int = 0
     write_through: WriteThroughPolicy = WriteThroughPolicy.ON_FREE
     lazy_gpu_retention: bool = False
     max_va_bytes_per_pool: int = 0

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -1265,6 +1265,11 @@ class _KVCache:
         if new_num_full_blocks > num_committed_blocks:
             with self._record_event():
                 for ordinal in typed_range(num_committed_blocks, new_num_full_blocks):
+                    if self._commit_state != self.CommitState.ALLOWED:
+                        # A block in this batch hit a commit conflict
+                        # (virtual stop); the remaining tokens stay virtually
+                        # committed, same as the entry guard above.
+                        break
                     self._commit_block(ordinal, False)
         if self.history_length < self.num_committed_tokens:
             self.history_length = self.num_committed_tokens
@@ -1814,6 +1819,25 @@ class _KVCache:
             )
             for (lc, _), lock in zip(reuse_list, locks):
                 beam_block[lc] = lock
+            seq_block.tree_block = tree_block
+            assert self._get_tree_block(ordinal) is tree_block
+            self._num_committed_blocks = BlockOrdinal(ordinal + 1)
+        elif tree_block.is_full and is_full and self._arena_ranges is not None:
+            # Arena mode: another sequence committed the same tokens first
+            # (common for shared system prompts under concurrency). Rebasing
+            # onto its pages would share GPU pages across arenas (§4.4
+            # invariant), so keep our own pages as sequence-private committed
+            # copies referencing the existing tree block, and keep committing.
+            skip_lcs = {ssm_lc_id} if ssm_lc_id is not None else None
+            uncommitted_pages = self._take_uncommitted_page(ordinal, beam_idx, skip_lcs)
+            for lc, (page, locked) in typed_enumerate(uncommitted_pages):
+                if page is None:
+                    continue
+                p = page.convert_to_private_committed(tree_block, self.finish_event)
+                # The page comes from an uncommitted page of self, so safe to skip wait.
+                beam_block[lc] = (
+                    p.lock(self, beam_idx, ordinal, lc, skip_wait=True) if locked else p.hold()
+                )
             seq_block.tree_block = tree_block
             assert self._get_tree_block(ordinal) is tree_block
             self._num_committed_blocks = BlockOrdinal(ordinal + 1)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -37,6 +37,7 @@ from .._common import (
     CudaStream,
     PageIndex,
     PageIndexMode,
+    PageStatus,
     Priority,
     TokenIdExt,
 )
@@ -76,6 +77,7 @@ from .._utils import (
     intersect,
     make_typed,
     map_optional,
+    merge_events,
     stream_wait_events,
     to_typed,
     typed_enumerate,
@@ -225,6 +227,7 @@ class _KVCache:
         "_write_through_slots",
         "_alias_spans",
         "_arena_live_span_registered",
+        "_arena_promote_pending",
         "__rawref__",
     )
 
@@ -292,6 +295,12 @@ class _KVCache:
     # its first commit burst (context end). Post-resume onboarded blocks are
     # private copies, never registrable, so the flag never re-arms.
     _arena_live_span_registered: bool
+    # P3 v3 R1(b): copy-onboarded committed blocks awaiting the promotion
+    # pass -- stashed by _arena_onboard_matched, consumed by
+    # _arena_promote_onboarded AFTER the onboarding frame exits (the
+    # incumbent must be DROPPABLE, so our transient source holders must have
+    # died first).
+    _arena_promote_pending: "list[tuple[BlockOrdinal, LifeCycleId]]"
 
     def __init__(
         self,
@@ -341,6 +350,7 @@ class _KVCache:
         self._write_through_slots = {}
         self._alias_spans = None
         self._arena_live_span_registered = False
+        self._arena_promote_pending = []
         # Arena-mode preconditions are validated by KVCacheManager.create_kv_cache
         # (raising here would leave a partially constructed object for __del__).
         assert not manager._storage.is_arena_mode or (max_capacity is not None and max_capacity > 0)
@@ -661,6 +671,7 @@ class _KVCache:
                 storage.free_gpu_sequence(pg_idx, rng, arena_last_consumer)
             self._arena_ranges = None
         self._status = self.Status.CLOSED
+        manager._arena_dedup_dirty.pop(id(self), None)
         manager._living_kv_caches.remove(self.__rawref__)
 
     def __del__(self) -> None:
@@ -879,6 +890,173 @@ class _KVCache:
             return None
         return ref()
 
+    def _arena_canonical_chain(self, num_blocks: int, lc_idx: LifeCycleId) -> "list[CommittedPage]":
+        """The contiguous run of live canonical tree pages for this
+        sequence's first ``num_blocks`` COMMITTED blocks (mappability probe
+        input, P3 v3 R1). Stops at the first missing/dead entry: a
+        registered span identity-covers pages only through an unbroken run
+        from its head, so a break already proves no live span covers
+        anything past it."""
+        chain: list[CommittedPage] = []
+        for i in range(num_blocks):
+            blk = self._get_tree_block(BlockOrdinal(i))
+            ref = blk.storage[lc_idx]
+            if ref is None:
+                break
+            page = ref()
+            if page is None:
+                break
+            chain.append(page)
+        return chain
+
+    def _arena_try_displace_canonical(
+        self, tree_block: "Block", lc_idx: LifeCycleId, ordinal: BlockOrdinal
+    ) -> bool:
+        """Mappability-weighted conflict resolution (P3 v3 R1): decide
+        whether a GPU-resident challenger may take over ``tree_block``'s
+        canonical entry for ``lc_idx``, and if so displace the incumbent.
+
+        The challenger wins iff the incumbent is UNMAPPABLE -- it is not
+        GPU-resident and no live registered span identity-covers this
+        ordinal (a span-covered host page IS aliasable; killing it would
+        forfeit the span pin) -- and DROPPABLE (no holders: nobody is
+        mid-read or keeping it recallable). A dead/absent incumbent is a
+        win by default.
+
+        Displacement discipline (see P3_DESIGN.md v3): exclude the
+        incumbent from eviction (dropping the controller's strong ref),
+        steal its host slot into the write-through stash (the bytes are
+        identical -- our future eviction becomes copy-free; disk slots are
+        not adoptable and just die), neutralize its block back-reference so
+        its ``__del__`` cannot unset OUR entry, and clear ``storage[lc]``
+        for the caller's ``convert_to_committed``. Returns True on a win
+        (``storage[lc]`` is now None); False means keep today's
+        private-copy path."""
+        storage = self.manager._storage
+        ref = tree_block.storage[lc_idx]
+        incumbent = ref() if ref is not None else None
+        if incumbent is None:
+            tree_block.storage[lc_idx] = None  # drop a dangling ref, if any
+            return True
+        if incumbent.cache_level == GPU_LEVEL:
+            return False  # live GPU canonical: mappable (owner-live aliasing)
+        if incumbent.status != PageStatus.DROPPABLE:
+            return False  # held: someone is mid-read or keeping it recallable
+        if storage.arena_prefix_aliasing:
+            # Blocks [0, ordinal) are committed (commit proceeds in order);
+            # the incumbent completes the chain at position ``ordinal``.
+            chain = self._arena_canonical_chain(int(ordinal), lc_idx)
+            if len(chain) == int(ordinal):
+                chain.append(incumbent)
+                pg_idx = storage.get_pool_group_index(lc_idx)
+                hit = storage.lookup_arena_canonical_span(
+                    pg_idx, chain[0], chain, count_stats=False
+                )
+                if hit is not None:
+                    span: Any = hit[1]
+                    if span.num_blocks > int(ordinal):
+                        return False  # a live span covers it: mappable, keep it
+        if incumbent.scheduled_for_eviction:
+            storage.exclude_from_eviction(incumbent)
+        if (
+            storage.num_cache_levels > 1
+            and incumbent.cache_level == GPU_LEVEL + 1
+            and incumbent.has_valid_slot
+        ):
+            # Byte-identical host copy: adopt it as our pre-valid host
+            # backing (the write-through stash the close/suspend paths
+            # consume) -- a future eviction of the promoted canonical is
+            # then copy-free. Its ready event rides along in the slot.
+            self._write_through_slots[(int(ordinal), int(lc_idx))] = incumbent.move_to_new_slot()
+        # CommittedPage.__del__ unsets its block's entry unconditionally --
+        # after the takeover that would clobber the NEW canonical (and can
+        # remove whole subtrees). Sever the back-reference first.
+        incumbent.block = rawref.NULL
+        tree_block.storage[lc_idx] = None
+        return True
+
+    def _arena_promote_onboarded(self) -> None:
+        """Mappability-weighted promotion at the onboarding seam (P3 v3
+        R1(b)) -- the fix for the canonical-residency trap: once a canonical
+        is evicted to host, every same-prefix admission copy-onboards from
+        host forever (matched blocks never re-commit, so the commit-conflict
+        seam alone cannot break the loop). For each copy-onboarded block
+        whose canonical is unmappable-and-droppable, our GPU-resident
+        private copy becomes the NEW canonical: a fresh ``CommittedPage``
+        takes over its arena slot (same slot id -- offset tables unchanged),
+        ``block.storage`` re-points to it, and the incumbent's host slot is
+        adopted into the write-through stash. The promoted pages then
+        satisfy ``_arena_register_live_span``'s canonical-run walk at
+        context-end, so descendants ALIAS instead of copying.
+
+        Must run after ``_arena_onboard_matched``'s frame has exited: the
+        displacement requires the incumbent DROPPABLE, and onboarding held
+        the copy sources until then. Blocks that stay private under a
+        MAPPABLE canonical flag this sequence for the pressure-time dedup
+        scan instead (P3 v3 R2 site 2/3: copy- and resume-onboarding)."""
+        pending = self._arena_promote_pending
+        if not pending:
+            return
+        self._arena_promote_pending = []
+        if self._arena_ranges is None:
+            return
+        storage = self.manager._storage
+        beam_idx = DEFAULT_BEAM_INDEX
+        dirty = False
+        with self._record_event():  # unlock() notifies our finish event
+            for ordinal, lc_idx in pending:
+                entry = self._block(ordinal, beam_idx)[lc_idx]
+                if entry is None:
+                    continue
+                old_lock = expect_type(_SharedPageLock, entry)
+                private = old_lock.page
+                if type(private) is not PrivateCommittedPage or private.cache_level != GPU_LEVEL:
+                    continue
+                tree_block = private.block()
+                if tree_block is None or tree_block.is_orphan:
+                    continue  # sole copy of an orphaned block: not a duplicate
+                if not self._arena_try_displace_canonical(tree_block, lc_idx, ordinal):
+                    # Mappable (or held) canonical: our copy stays a private
+                    # duplicate -- harvestable by the pressure-time dedup
+                    # remap.
+                    dirty = True
+                    continue
+                # The onboarding copy READS the incumbent's host slot; the
+                # displacement stole that slot into the write-through stash.
+                # Merge the copy's finish (our private page's ready event)
+                # into the slot's ready event so a future recycle of the
+                # slot cannot overwrite bytes the copy is still reading.
+                stolen = self._write_through_slots.get((int(ordinal), int(lc_idx)))
+                if stolen is not None:
+                    stolen.ready_event = merge_events([stolen.ready_event, private.ready_event])
+                # Transplant the private copy's arena slot into a fresh
+                # canonical page: same bytes, same slot id, ready event (the
+                # onboarding copy's finish) rides along in the slot. Unlock
+                # explicitly first -- locals still reference the old lock, so
+                # replacement alone would not release the base-page-index
+                # entry the new lock re-registers.
+                old_lock.unlock()
+                self._block(ordinal, beam_idx)[lc_idx] = None
+                promoted = CommittedPage(
+                    storage,
+                    tree_block,
+                    lc_idx,
+                    GPU_LEVEL,
+                    private.move_to_new_slot(),
+                    private.priority,
+                )
+                tree_block.storage[lc_idx] = rawref.ref(promoted)
+                # The onboarding already made this stream wait the copy
+                # events.
+                self._block(ordinal, beam_idx)[lc_idx] = promoted.lock(
+                    self, beam_idx, ordinal, lc_idx, skip_wait=True
+                )
+                event_manager = self.manager.event_manager
+                if event_manager is not None:
+                    event_manager.add_stored_life_cycle_event_from_block(tree_block, int(lc_idx))
+        if dirty:
+            self.manager._arena_mark_dedup_dirty(self)
+
     def _arena_evacuate(self, prior_event: CachedCudaEvent = CachedCudaEvent.NULL) -> None:
         """Suspend-side write-out (DESIGN.md §4.5): move this sequence's GPU
         pages out of its arena ranges so the ranges can be unmapped.
@@ -1070,7 +1248,11 @@ class _KVCache:
         commit-conflict loser) -- replaceable by aliases of the canonical
         physical pages with zero information loss. Page holders, slot ids,
         and offsets are untouched by the remap (same-VA swap), so no
-        per-sequence state changes here. Returns
+        per-sequence state changes here. Mappability filter (P3 v3 R3): a
+        candidate requires a LIVE span-registry hit on its canonical chain,
+        so the hard-reclaim path never pays a device quiesce for a harvest
+        it cannot collect (a host-resident canonical without a span pin
+        yields no candidate). Returns
         ``(pg_idx, rng, key, span, usable_blocks, pages_freeable)``."""
         storage = self._storage
         ranges = self._arena_ranges
@@ -1129,13 +1311,13 @@ class _KVCache:
         now but the driver calls are deferred to the owner's per-iteration
         ``flush_gpu_mappings`` sweep; callers that touch the pages immediately
         (e.g. reuse onboarding copies) pass ``sync=True``. On page exhaustion,
-        walks the reclaim ladder -- drain deferred reclaim, spill lazily
-        retained ranges (LRU-first, §4.4 phase 2), DEDUP-REMAP duplicate
-        prefixes onto their canonical spans (P3 v2: frees pages from live
-        sequences with zero information loss), and only then spill the
-        registry excess -- retrying while any rung makes progress; returns
-        False if pages are still unavailable — the caller backs off exactly
-        like a failed slot allocation (§4.6)."""
+        calls ``hard_reclaim_gpu`` (P3 v3): fenced drain, dedup remap of ALL
+        flagged sequences' duplicate prefixes, parked-range spill, and
+        registry-excess spill -- destruction-ordered, behind ONE device
+        quiesce (zero syncs when nothing is reclaimable anywhere) -- retrying
+        while it makes progress; returns False if pages are still
+        unavailable — the caller backs off exactly like a failed slot
+        allocation (§4.6)."""
         storage = self._storage
         ranges = self._arena_ranges
         assert ranges is not None
@@ -1150,16 +1332,16 @@ class _KVCache:
                         storage.ensure_gpu_mapped(pg_idx, rng, num_valid_blocks)
                     break
                 except OutOfPagesError:
-                    if storage.drain_gpu_reclaim() > 0:
-                        continue
+                    # The fence is recorded BEFORE the quiesce inside
+                    # hard_reclaim_gpu, so it completes under it -- letting
+                    # the fenced drain take ranges freed since the last
+                    # iteration-boundary fence (risk #3 stays honored).
                     if (
-                        storage.spill_gpu_retained(self._ARENA_SPILL_CHUNK_PAGES, spill_spans=False)
+                        self.manager.hard_reclaim_gpu(
+                            self._ARENA_SPILL_CHUNK_PAGES, CachedCudaEvent(self.cuda_stream)
+                        )
                         > 0
                     ):
-                        continue
-                    if self.manager.dedup_remap_gpu(self._ARENA_SPILL_CHUNK_PAGES) > 0:
-                        continue
-                    if storage.spill_gpu_retained(self._ARENA_SPILL_CHUNK_PAGES) > 0:
                         continue
                     return False
         return True
@@ -1284,6 +1466,7 @@ class _KVCache:
                 copied[i] = slot
         # P3 aliased blocks: the slot IS the data (no copy ran); the lock
         # loop below builds the same sequence-private page over it.
+        aliased_set = set(aliased_idx)
         for i in aliased_idx:
             copied[i] = dst_slots[i]
         stream_wait_events(
@@ -1296,7 +1479,8 @@ class _KVCache:
         # Lock everything in place. For copies, the private page replaces the
         # holder; dropping it releases the source back to eviction control at
         # its current level. Moved pages keep their holder and simply lock.
-        for (ordinal, lc_idx, holder), copied_slot in zip(entries, copied):
+        assert not self._arena_promote_pending
+        for i, ((ordinal, lc_idx, holder), copied_slot) in enumerate(zip(entries, copied)):
             src_page = holder.page
             if copied_slot is None:  # moved uncommitted page, now living in the arena
                 assert src_page.cache_level == GPU_LEVEL
@@ -1311,6 +1495,13 @@ class _KVCache:
                     storage, tree_block, lc_idx, GPU_LEVEL, copied_slot, src_page.priority
                 )
                 lock = private.lock(self, beam_idx, ordinal, lc_idx, skip_wait=True)
+                if i not in aliased_set:
+                    # A committed copy is either a promotion candidate (its
+                    # canonical is unmappable, P3 v3 R1(b)) or a duplicate
+                    # to flag for the pressure-time dedup (R2 sites 2/3) --
+                    # the promotion pass decides, once our transient source
+                    # holders have died with this frame.
+                    self._arena_promote_pending.append((ordinal, lc_idx))
             self._block(ordinal, beam_idx)[lc_idx] = lock
         return True
 
@@ -1858,6 +2049,11 @@ class _KVCache:
             assert all(slot is None for slot in deferred_slots)
             if not self._arena_onboard_matched():
                 return False
+            # P3 v3 R1(b): _arena_onboard_matched's frame (and with it our
+            # transient holders on the copy sources) is gone -- promote
+            # copied blocks whose canonical is unmappable, so this prompt
+            # class stops copying from host forever.
+            self._arena_promote_onboarded()
         else:
             tasks = list[BatchedLockTarget]()
             for ordinal, beam_idx, lc_idx in self._active_pages():
@@ -2242,16 +2438,35 @@ class _KVCache:
             # onto its pages would share GPU pages across arenas (§4.4
             # invariant), so keep our own pages as sequence-private committed
             # copies referencing the existing tree block, and keep committing.
+            # Mappability-weighted resolution (P3 v3 R1): if the incumbent
+            # canonical is UNMAPPABLE (no live span covers it -- e.g. its
+            # owner closed and offloaded before we committed) and droppable,
+            # our GPU-resident page WINS the conflict instead: it becomes the
+            # canonical entry (descendants alias it rather than copying from
+            # host forever) and the incumbent's host slot is adopted as our
+            # pre-valid host backing (a future eviction is copy-free).
             skip_lcs = {ssm_lc_id} if ssm_lc_id is not None else None
             uncommitted_pages = self._take_uncommitted_page(ordinal, beam_idx, skip_lcs)
+            lost = False
             for lc, (page, locked) in typed_enumerate(uncommitted_pages):
                 if page is None:
                     continue
-                p = page.convert_to_private_committed(tree_block, self.finish_event)
+                if self._arena_try_displace_canonical(tree_block, lc, ordinal):
+                    p: CommittedPage = page.convert_to_committed(tree_block, self.finish_event)
+                    event_manager = self.manager.event_manager
+                    if event_manager is not None:
+                        event_manager.add_stored_life_cycle_event_from_block(tree_block, int(lc))
+                else:
+                    p = page.convert_to_private_committed(tree_block, self.finish_event)
+                    lost = True
                 # The page comes from an uncommitted page of self, so safe to skip wait.
                 beam_block[lc] = (
                     p.lock(self, beam_idx, ordinal, lc, skip_wait=True) if locked else p.hold()
                 )
+            if lost:
+                # Loser to a MAPPABLE incumbent: our private copy is a
+                # duplicate the pressure-time dedup can remap (P3 v3 R2).
+                self.manager._arena_mark_dedup_dirty(self)
             seq_block.tree_block = tree_block
             assert self._get_tree_block(ordinal) is tree_block
             self._num_committed_blocks = BlockOrdinal(ordinal + 1)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -20,7 +20,7 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import chain
-from typing import TYPE_CHECKING, Callable, ClassVar, Iterator, NamedTuple, Type, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterator, NamedTuple, Type, cast
 
 from .. import rawref
 from .._block_radix_tree import Block, ReuseMatch, ReuseScope, RootBlock, UselessBlockError
@@ -223,6 +223,7 @@ class _KVCache:
         "_max_capacity",
         "_arena_ranges",
         "_write_through_slots",
+        "_alias_spans",
         "__rawref__",
     )
 
@@ -281,6 +282,11 @@ class _KVCache:
     # (ordinal, life cycle). A slot's ready event completes when its copy is
     # valid; close()/suspend() adopt these instead of copying.
     _write_through_slots: dict[tuple[int, int], Slot]
+    # P3 prefix aliasing: per pool group, the canonical-span registry hit for
+    # this admission's reuse match -- (key, span) or None. Set at
+    # _setup_for_reuse, consumed (and cleared) by the FIRST resume's
+    # reserve+onboard; never set on suspend/resume round-trips.
+    _alias_spans: "list[tuple[int, Any] | None] | None"
 
     def __init__(
         self,
@@ -328,6 +334,7 @@ class _KVCache:
         self._max_capacity = max_capacity
         self._arena_ranges = None
         self._write_through_slots = {}
+        self._alias_spans = None
         # Arena-mode preconditions are validated by KVCacheManager.create_kv_cache
         # (raising here would leave a partially constructed object for __del__).
         assert not manager._storage.is_arena_mode or (max_capacity is not None and max_capacity > 0)
@@ -603,6 +610,22 @@ class _KVCache:
                                 )
                             ),
                         )
+                    # P3 prefix aliasing: pin the committed prefix's resident
+                    # pages so same-prefix admissions alias them (zero-copy).
+                    # The prefix must be a contiguous ordinal run from 0 with
+                    # a unique page per ordinal (v1: single-lc pool groups).
+                    ordinals = arena_closing.offload_ordinals[pg_idx]
+                    if ordinals and len(set(ordinals)) == len(ordinals):
+                        by_ordinal = dict(zip(ordinals, arena_closing.offload[pg_idx]))
+                        prefix_pages: list[CommittedPage] = []
+                        o = 0
+                        while o in by_ordinal:
+                            prefix_pages.append(by_ordinal[o])
+                            o += 1
+                        if prefix_pages:
+                            storage.register_arena_canonical_span(
+                                pg_idx, arena_ranges[pg_idx], prefix_pages, prior_event
+                            )
                 except OutOfPagesError:
                     # Host tier cannot take the write-out: drop the blocks
                     # instead of keeping them (reuse loss only, never an
@@ -1031,7 +1054,25 @@ class _KVCache:
             holder = expect_type(_PageHolder, self._block(ordinal, beam_idx)[lc_idx])
             entries.append((ordinal, lc_idx, holder))
         if not entries:
+            self._alias_spans = None
             return True
+        # P3 prefix aliasing: map the registry-pinned canonical span into any
+        # FRESH range before growth maps run (frontier still at the range
+        # start); a signature-matched adopted range already carries the
+        # mappings. Consumed once -- suspend/resume round-trips never alias.
+        alias_spans = self._alias_spans
+        self._alias_spans = None
+        if alias_spans is not None:
+            for pg_idx, rng in typed_enumerate(ranges):
+                hit = alias_spans[pg_idx]
+                if hit is None:
+                    continue
+                if rng._alias_span_key is None:
+                    storage.alias_arena_span(pg_idx, rng, hit[0], hit[1])
+                else:
+                    assert rng._alias_span_key == hit[0], (
+                        "adopted range's alias signature must match the admission's span"
+                    )
         if not self._arena_ensure_mapped(self.num_blocks, sync=True):
             return False
         # One explicit-destination migrate per (pool group, source level,
@@ -1042,11 +1083,25 @@ class _KVCache:
         ghost_groups: dict[PoolGroupIndex, list[int]] = {}
         ghost_srcs: dict[PoolGroupIndex, list[SlotId]] = {}
         ghost_rngs: dict[PoolGroupIndex, list[SequenceRange]] = {}
+        aliased_idx = list[int]()
         for i, (ordinal, lc_idx, holder) in enumerate(entries):
             pg_idx = storage.get_pool_group_index(lc_idx)
             dst_slots.append(storage.take_gpu_sequence_slot(pg_idx, ranges[pg_idx], int(ordinal)))
             page = holder.page
             if page.is_committed():
+                if alias_spans is not None:
+                    hit = alias_spans[pg_idx]
+                    if (
+                        hit is not None
+                        and int(ordinal) < hit[1].num_blocks
+                        and hit[1].page_refs[int(ordinal)]() is page
+                    ):
+                        # P3: the block's bytes are already visible at this
+                        # exact slot through the alias mapping -- no copy.
+                        # Consumers wait the span's ready event.
+                        dst_slots[-1].ready_event = hit[1].ready_event
+                        aliased_idx.append(i)
+                        continue
                 ghost = storage.lookup_arena_ghost(pg_idx, page)
                 if ghost is not None:
                     src_id, src_rng = ghost
@@ -1082,6 +1137,10 @@ class _KVCache:
             )
             for i, slot in zip(idx_list, ghost_dsts):
                 copied[i] = slot
+        # P3 aliased blocks: the slot IS the data (no copy ran); the lock
+        # loop below builds the same sequence-private page over it.
+        for i in aliased_idx:
+            copied[i] = dst_slots[i]
         stream_wait_events(
             self.cuda_stream,
             (
@@ -1555,11 +1614,18 @@ class _KVCache:
             assert max_capacity is not None
             max_blocks = div_up(max_capacity, self.tokens_per_block)
             ranges = list[SequenceRange]()
+            alias_spans = self._alias_spans
             try:
                 pg_idx = PoolGroupIndex(0)
                 while pg_idx < storage.num_pool_groups:
                     try:
-                        ranges.append(storage.reserve_gpu_sequence(pg_idx, max_blocks))
+                        # P3: a registry hit makes adoption prefix-affine --
+                        # a parked range already alias-mapping this span is
+                        # handed over with its mappings (and content) intact.
+                        alias_key = None
+                        if alias_spans is not None and alias_spans[pg_idx] is not None:
+                            alias_key = alias_spans[pg_idx][0]
+                        ranges.append(storage.reserve_gpu_sequence(pg_idx, max_blocks, alias_key))
                         pg_idx = PoolGroupIndex(pg_idx + 1)
                     except MemoryError:
                         # VA exhaustion: retained ranges hold VA too (§4.4
@@ -2424,6 +2490,49 @@ class _KVCache:
                     indices.extend([BAD_PAGE_INDEX] * (self.num_blocks - len(indices)))
                 else:
                     assert len(indices) >= self.num_blocks
+        if self.manager._storage.is_arena_mode:
+            self._arena_lookup_alias_spans(matched, int(full_reused_end))
+
+    def _arena_lookup_alias_spans(self, matched: "Sequence[Block]", full_blocks: int) -> None:
+        """Resolve this admission's reuse match against the canonical-span
+        registry (P3 prefix aliasing): a hit means the matched prefix's bytes
+        are still GPU-resident and refcount-pinned, so the first resume
+        aliases them into the fresh ranges (or adopts a signature-matched
+        parked range) instead of copying. V1 scope: pool groups with exactly
+        one non-SSM life cycle; any staleness simply falls back to the copy
+        paths."""
+        storage = self._storage
+        if not storage.arena_prefix_aliasing or full_blocks <= 0:
+            return
+        life_cycles = self.manager._life_cycles
+        ssm_lc_id = life_cycles.ssm_life_cycle_id
+        lc_of_pg: dict[int, "LifeCycleId | None"] = {}
+        for lc_idx, _lc in life_cycles.items():
+            if lc_idx == ssm_lc_id:
+                continue
+            pg = int(storage.get_pool_group_index(lc_idx))
+            lc_of_pg[pg] = lc_idx if pg not in lc_of_pg else None  # None: multi-lc, skip
+        spans: "list[tuple[int, Any] | None]" = [None] * int(storage.num_pool_groups)
+        found = False
+        for pg, lc_idx in lc_of_pg.items():
+            if lc_idx is None:
+                continue
+            pages: list[CommittedPage] = []
+            for ordinal in range(full_blocks):
+                ref = matched[ordinal].storage[lc_idx]
+                page = None if ref is None else ref()
+                if page is None:
+                    pages.clear()
+                    break
+                pages.append(page)
+            if not pages:
+                continue
+            hit = storage.lookup_arena_canonical_span(PoolGroupIndex(pg), pages[0], pages)
+            if hit is not None:
+                spans[pg] = hit
+                found = True
+        if found:
+            self._alias_spans = spans
 
     def _free_scratch_slots(self) -> None:
         """Free all scratch slots back to the storage manager."""

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -172,6 +172,27 @@ IndexSeq = array.array | memoryview
 # three lengths equal to the number of reused tokens.
 # TODO: in __del__, we should check if committed pages are usable for SWA cases. e.g. all pages are
 # dropped except the last one. The last one is not usable.
+class _ArenaClosingPages(NamedTuple):
+    """Partition of a sequence's committed GPU pages at close() (arena mode).
+
+    A module-level class: mypyc cannot compile class definitions nested in a
+    class body."""
+
+    # canonical committed pages without a write-through copy: copy-on-free
+    offload: "TypedIndexList[PoolGroupIndex, list[CommittedPage]]"
+    offload_ordinals: "TypedIndexList[PoolGroupIndex, list[int]]"
+    # canonical committed pages with a valid write-through host copy, and
+    # those copies: adopted copy-free (§4.3)
+    adopt_pages: "TypedIndexList[PoolGroupIndex, list[CommittedPage]]"
+    adopt_slots: "TypedIndexList[PoolGroupIndex, list[Slot]]"
+    adopt_ordinals: "TypedIndexList[PoolGroupIndex, list[int]]"
+    # sequence-private reuse copies (§4.4): dropped -- but under lazy
+    # retention their bytes re-register as fresh ghosts for the canonical
+    # entry, keeping hot prefixes' D2D sources LRU-recent
+    private: list[CommittedPage]
+    private_meta: list[tuple[int, LifeCycleId]]  # (ordinal, lc) per entry
+
+
 class _KVCache:
     __slots__ = (
         "id",
@@ -523,8 +544,8 @@ class _KVCache:
             manager._num_sampled_kv_caches += 1
             manager._try_update_target_ratios()
         arena_ranges = self._arena_ranges
-        arena_closing: _KVCache._ArenaClosingPages | None = None
-        arena_last_consumer = CachedCudaEvent.NULL
+        arena_closing: _ArenaClosingPages | None = None
+        arena_last_consumer = cast(CachedCudaEvent, CachedCudaEvent.NULL)
         if arena_ranges is not None:
             arena_cfg = manager._storage.arena_config
             if arena_cfg is not None and arena_cfg.batched_map_sweep:
@@ -536,8 +557,9 @@ class _KVCache:
             self._clear_blocks()
             # _record_event clears _finish_event on exit; capture it as the
             # range-reclaim gate (§4.2) while it is live.
-            if self._finish_event is not None:
-                arena_last_consumer = self._finish_event
+            finish_event: CachedCudaEvent | None = self._finish_event
+            if finish_event is not None:
+                arena_last_consumer = finish_event
         if arena_ranges is not None:
             storage = manager._storage
             assert arena_closing is not None
@@ -725,22 +747,7 @@ class _KVCache:
             case PageIndexMode.SHARED:
                 return not self.has_scratch_slots
 
-    class _ArenaClosingPages(NamedTuple):
-        # canonical committed pages without a write-through copy: copy-on-free
-        offload: "TypedIndexList[PoolGroupIndex, list[CommittedPage]]"
-        offload_ordinals: "TypedIndexList[PoolGroupIndex, list[int]]"
-        # canonical committed pages with a valid write-through host copy, and
-        # those copies: adopted copy-free (§4.3)
-        adopt_pages: "TypedIndexList[PoolGroupIndex, list[CommittedPage]]"
-        adopt_slots: "TypedIndexList[PoolGroupIndex, list[Slot]]"
-        adopt_ordinals: "TypedIndexList[PoolGroupIndex, list[int]]"
-        # sequence-private reuse copies (§4.4): dropped -- but under lazy
-        # retention their bytes re-register as fresh ghosts for the canonical
-        # entry, keeping hot prefixes' D2D sources LRU-recent
-        private: list[CommittedPage]
-        private_meta: list[tuple[int, LifeCycleId]]  # (ordinal, lc) per entry
-
-    def _arena_collect_committed_gpu_pages(self) -> "_KVCache._ArenaClosingPages":
+    def _arena_collect_committed_gpu_pages(self) -> "_ArenaClosingPages":
         """Collect this sequence's committed GPU pages before the block chain
         is cleared at close(), partitioned by how they leave the arena:
         written-through pages adopt their host copy (copy-free), the rest are
@@ -755,7 +762,7 @@ class _KVCache:
         the (otherwise unused) GPU eviction queue.
         """
         storage = self.manager._storage
-        ret = _KVCache._ArenaClosingPages(
+        ret = _ArenaClosingPages(
             make_typed(lambda _: list[CommittedPage](), storage.num_pool_groups),
             make_typed(lambda _: list[int](), storage.num_pool_groups),
             make_typed(lambda _: list[CommittedPage](), storage.num_pool_groups),
@@ -1037,9 +1044,9 @@ class _KVCache:
         # Lock everything in place. For copies, the private page replaces the
         # holder; dropping it releases the source back to eviction control at
         # its current level. Moved pages keep their holder and simply lock.
-        for (ordinal, lc_idx, holder), slot in zip(entries, copied):
+        for (ordinal, lc_idx, holder), copied_slot in zip(entries, copied):
             src_page = holder.page
-            if slot is None:  # moved uncommitted page, now living in the arena
+            if copied_slot is None:  # moved uncommitted page, now living in the arena
                 assert src_page.cache_level == GPU_LEVEL
                 lock = holder.lock(self, beam_idx, ordinal, lc_idx, skip_wait=True)
             else:
@@ -1049,7 +1056,7 @@ class _KVCache:
                 tree_block = src_page.block()
                 assert tree_block is not None, "committed page lost its tree block while held"
                 private = PrivateCommittedPage(
-                    storage, tree_block, lc_idx, GPU_LEVEL, slot, src_page.priority
+                    storage, tree_block, lc_idx, GPU_LEVEL, copied_slot, src_page.priority
                 )
                 lock = private.lock(self, beam_idx, ordinal, lc_idx, skip_wait=True)
             self._block(ordinal, beam_idx)[lc_idx] = lock
@@ -1399,13 +1406,18 @@ class _KVCache:
     def suspend(self) -> None:
         assert self.status == self.Status.ACTIVE
         assert self._check_sanity()
-        assert self._finish_event is None
+        # Assert on a local, not the attribute: `assert self._finish_event is
+        # None` narrows the member to None for the rest of the function under
+        # mypy(c) -- it cannot see _record_event's side effect -- and compiled
+        # code would then unbox the later read as literal None.
+        entry_finish_event = self._finish_event
+        assert entry_finish_event is None
         for beam_idx, beam_indices in typed_enumerate(self._base_page_indices):
             for lc, indices in typed_enumerate(beam_indices):
                 if type(indices) is memoryview:
                     self.set_base_page_index_buf(beam_idx, lc, None)
         ssm_lc_id = self.manager._life_cycles.ssm_life_cycle_id
-        arena_last_consumer = CachedCudaEvent.NULL
+        arena_last_consumer = cast(CachedCudaEvent, CachedCudaEvent.NULL)
         with self._record_event():  # used by _SharedPageLock.__del__
             for ordinal, beam_idx, lc_idx in self._active_pages():
                 beam_block = (
@@ -1421,8 +1433,9 @@ class _KVCache:
             self._free_scratch_slots()
             # _record_event clears _finish_event on exit; capture it as the
             # range-reclaim gate (§4.2) while it is live.
-            if self._finish_event is not None:
-                arena_last_consumer = self._finish_event
+            finish_event: CachedCudaEvent | None = self._finish_event
+            if finish_event is not None:
+                arena_last_consumer = finish_event
         if self._arena_ranges is not None:
             # §4.5: move this sequence's pages out of its arena ranges, then
             # release the whole VA reservation (event-gated unmap). Resume
@@ -1484,11 +1497,13 @@ class _KVCache:
             except MemoryError:
                 # VA exhaustion / fragmentation: back off like any other
                 # resource shortage. Nothing was mapped; undo the bookkeeping.
-                for pg_idx, rng in typed_enumerate(cast(TypedIndexList, ranges)):
+                for pg_idx, rng in typed_enumerate(
+                    cast("TypedIndexList[PoolGroupIndex, SequenceRange]", ranges)
+                ):
                     storage.free_gpu_sequence(pg_idx, rng, CachedCudaEvent.NULL)
                 storage.drain_gpu_reclaim()
                 return False
-            self._arena_ranges = cast(TypedIndexList, ranges)
+            self._arena_ranges = cast("TypedIndexList[PoolGroupIndex, SequenceRange]", ranges)
         ssm_lc_id = self.manager._life_cycles.ssm_life_cycle_id
         life_cycles = self.manager._life_cycles
         num_life_cycles = life_cycles.size
@@ -1562,9 +1577,9 @@ class _KVCache:
             try:
                 locks = batched_lock_to_gpu(self, tasks, self._record_migrated_slots)
             except OutOfPagesError:
-                for lc_idx, slot in typed_enumerate(deferred_slots):
-                    if slot is not None:
-                        storage.release_slot(lc_idx, GPU_LEVEL, slot)
+                for lc_idx, deferred_slot in typed_enumerate(deferred_slots):
+                    if deferred_slot is not None:
+                        storage.release_slot(lc_idx, GPU_LEVEL, deferred_slot)
                 return False
 
             # Replace all holders with locks.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -40,6 +40,7 @@ from .._common import (
     Priority,
     TokenIdExt,
 )
+from .._config import WriteThroughPolicy
 from .._copy_engine import CopyTask, batched_copy
 from .._exceptions import LogicError, OutOfPagesError
 from .._life_cycle_registry import (
@@ -200,6 +201,7 @@ class _KVCache:
         "_pending_stats",
         "_max_capacity",
         "_arena_ranges",
+        "_write_through_slots",
         "__rawref__",
     )
 
@@ -254,6 +256,10 @@ class _KVCache:
     # ranges are held.
     _max_capacity: int | None
     _arena_ranges: TypedIndexList[PoolGroupIndex, SequenceRange] | None
+    # Write-through host copies (§4.3, WriteThroughPolicy.ON_COMMIT), keyed by
+    # (ordinal, life cycle). A slot's ready event completes when its copy is
+    # valid; close()/suspend() adopt these instead of copying.
+    _write_through_slots: dict[tuple[int, int], Slot]
 
     def __init__(
         self,
@@ -300,6 +306,7 @@ class _KVCache:
         self._pending_stats = _PendingStats()
         self._max_capacity = max_capacity
         self._arena_ranges = None
+        self._write_through_slots = {}
         # Arena-mode preconditions are validated by KVCacheManager.create_kv_cache
         # (raising here would leave a partially constructed object for __del__).
         assert not manager._storage.is_arena_mode or (max_capacity is not None and max_capacity > 0)
@@ -516,11 +523,10 @@ class _KVCache:
             manager._num_sampled_kv_caches += 1
             manager._try_update_target_ratios()
         arena_ranges = self._arena_ranges
-        arena_offload: TypedIndexList[PoolGroupIndex, list[CommittedPage]] | None = None
-        arena_private: list[CommittedPage] = []
+        arena_closing: _KVCache._ArenaClosingPages | None = None
         arena_last_consumer = CachedCudaEvent.NULL
         if arena_ranges is not None:
-            arena_offload, arena_private = self._arena_collect_committed_gpu_pages()
+            arena_closing = self._arena_collect_committed_gpu_pages()
         with self._record_event():
             self._clear_blocks()
             # _record_event clears _finish_event on exit; capture it as the
@@ -529,21 +535,25 @@ class _KVCache:
                 arena_last_consumer = self._finish_event
         if arena_ranges is not None:
             storage = manager._storage
-            assert arena_offload is not None
-            for pg_idx, pages in typed_enumerate(arena_offload):
+            assert arena_closing is not None
+            for pg_idx in typed_range(storage.num_pool_groups):
+                # Written-through blocks move copy-free (§4.3).
+                storage.adopt_stale_copies(
+                    pg_idx, arena_closing.adopt_pages[pg_idx], arena_closing.adopt_slots[pg_idx]
+                )
                 try:
-                    storage.offload_arena_pages(pg_idx, pages)
+                    storage.offload_arena_pages(pg_idx, arena_closing.offload[pg_idx])
                 except OutOfPagesError:
                     # Host tier cannot take the write-out: drop the blocks
                     # instead of keeping them (reuse loss only, never an
                     # error on the free path).
-                    for page in pages:
+                    for page in arena_closing.offload[pg_idx]:
                         if page.scheduled_for_eviction:
                             storage.exclude_from_eviction(page)
             # Private copies are never evictable (nothing queues them); they
             # die with our refs, freeing their slots into their range.
-            arena_offload = None  # drop our strong refs before range release
-            arena_private.clear()
+            arena_closing = None  # drop our strong refs before range release
+            self._arena_release_unused_write_through()
             for pg_idx, rng in typed_enumerate(arena_ranges):
                 storage.free_gpu_sequence(pg_idx, rng, arena_last_consumer)
             self._arena_ranges = None
@@ -669,16 +679,24 @@ class _KVCache:
             case PageIndexMode.SHARED:
                 return not self.has_scratch_slots
 
-    def _arena_collect_committed_gpu_pages(
-        self,
-    ) -> tuple[TypedIndexList[PoolGroupIndex, list[CommittedPage]], list[CommittedPage]]:
+    class _ArenaClosingPages(NamedTuple):
+        # canonical committed pages without a write-through copy: copy-on-free
+        offload: "TypedIndexList[PoolGroupIndex, list[CommittedPage]]"
+        # canonical committed pages with a valid write-through host copy, and
+        # those copies: adopted copy-free (§4.3)
+        adopt_pages: "TypedIndexList[PoolGroupIndex, list[CommittedPage]]"
+        adopt_slots: "TypedIndexList[PoolGroupIndex, list[Slot]]"
+        # sequence-private reuse copies (§4.4): dropped
+        private: list[CommittedPage]
+
+    def _arena_collect_committed_gpu_pages(self) -> "_KVCache._ArenaClosingPages":
         """Collect this sequence's committed GPU pages before the block chain
-        is cleared at close(). Canonical pages (first return, per pool group)
-        move to the host tier (active->stale copy-on-free, DESIGN.md §4.3) so
-        the arena range can be reclaimed; sequence-private reuse copies
-        (second return, §4.4) are dropped -- their canonical stale copy
-        already exists. In arena mode GPU pages are never shared across
-        sequences, so they are ours to move or drop.
+        is cleared at close(), partitioned by how they leave the arena:
+        written-through pages adopt their host copy (copy-free), the rest are
+        copied out on free (§4.3), and private reuse copies are dropped --
+        their canonical stale copy already exists (§4.4). In arena mode GPU
+        pages are never shared across sequences, so they are ours to move or
+        drop.
 
         A separate method so its loop locals cannot outlive the collection: a
         lingering reference to a block's lock chain would delay the holder's
@@ -686,25 +704,32 @@ class _KVCache:
         the (otherwise unused) GPU eviction queue.
         """
         storage = self.manager._storage
-        arena_offload: TypedIndexList[PoolGroupIndex, list[CommittedPage]] = make_typed(
-            lambda _: list[CommittedPage](), storage.num_pool_groups
+        ret = _KVCache._ArenaClosingPages(
+            make_typed(lambda _: list[CommittedPage](), storage.num_pool_groups),
+            make_typed(lambda _: list[CommittedPage](), storage.num_pool_groups),
+            make_typed(lambda _: list[Slot](), storage.num_pool_groups),
+            [],
         )
-        arena_private: list[CommittedPage] = []
-        for block in self._blocks:
+        for ordinal, block in enumerate(self._blocks):
             if not block.is_committed:
                 continue
             for beam_pages in block.pages:
-                for p in beam_pages:
+                for lc_idx, p in typed_enumerate(beam_pages):
                     if p is None:
                         continue
                     page = p.page
                     if isinstance(page, CommittedPage) and page.cache_level == GPU_LEVEL:
-                        if type(page) is CommittedPage:
-                            pg_idx = storage.get_pool_group_index(page.life_cycle)
-                            arena_offload[pg_idx].append(page)
+                        if type(page) is not CommittedPage:
+                            ret.private.append(page)
+                            continue
+                        pg_idx = storage.get_pool_group_index(lc_idx)
+                        wt_slot = self._arena_take_write_through_slot(ordinal, lc_idx)
+                        if wt_slot is not None:
+                            ret.adopt_pages[pg_idx].append(page)
+                            ret.adopt_slots[pg_idx].append(wt_slot)
                         else:
-                            arena_private.append(page)
-        return arena_offload, arena_private
+                            ret.offload[pg_idx].append(page)
+        return ret
 
     @staticmethod
     def _find_canonical(page: CommittedPage, lc_idx: LifeCycleId) -> "CommittedPage | None":
@@ -722,12 +747,13 @@ class _KVCache:
         """Suspend-side write-out (DESIGN.md §4.5): move this sequence's GPU
         pages out of its arena ranges so the ranges can be unmapped.
 
-        Canonical committed pages and uncommitted pages migrate to the host
-        tier -- the block chain's holders follow their pages, so the logical
-        chain survives suspension unchanged. Sequence-private reuse copies
-        (§4.4) are swapped back to holding their canonical entry and dropped;
-        if the canonical entry is gone, the private copy is the sole copy and
-        migrates like a canonical page.
+        Written-through committed pages adopt their host copy (copy-free,
+        §4.3); other canonical committed pages and uncommitted pages migrate
+        to the host tier -- the block chain's holders follow their pages, so
+        the logical chain survives suspension unchanged. Sequence-private
+        reuse copies (§4.4) are swapped back to holding their canonical entry
+        and dropped; if the canonical entry is gone, the private copy is the
+        sole copy and migrates like a canonical page.
 
         Raises ``OutOfPagesError`` if the host tier cannot absorb the
         write-out even after eviction -- host-quota sizing (§4.6) must
@@ -741,6 +767,12 @@ class _KVCache:
         beam_idx = DEFAULT_BEAM_INDEX
         move: TypedIndexList[PoolGroupIndex, list[Page]] = make_typed(
             lambda _: list[Page](), storage.num_pool_groups
+        )
+        adopt_pages: TypedIndexList[PoolGroupIndex, list[Page]] = make_typed(
+            lambda _: list[Page](), storage.num_pool_groups
+        )
+        adopt_slots: TypedIndexList[PoolGroupIndex, list[Slot]] = make_typed(
+            lambda _: list[Slot](), storage.num_pool_groups
         )
         swaps = list[tuple[BlockOrdinal, LifeCycleId, CommittedPage]]()
         dropped = list[CommittedPage]()
@@ -756,7 +788,17 @@ class _KVCache:
                     swaps.append((ordinal, lc_idx, canonical))
                     dropped.append(page)
                     continue
-            move[storage.get_pool_group_index(lc_idx)].append(page)
+            pg_idx = storage.get_pool_group_index(lc_idx)
+            wt_slot = (
+                self._arena_take_write_through_slot(int(ordinal), lc_idx)
+                if type(page) is CommittedPage
+                else None
+            )
+            if wt_slot is not None:
+                adopt_pages[pg_idx].append(page)
+                adopt_slots[pg_idx].append(wt_slot)
+            else:
+                move[pg_idx].append(page)
         for ordinal, lc_idx, canonical in swaps:
             # Holding the canonical page keeps it recallable for resume; the
             # private copy's holder dies with this assignment. Private copies
@@ -765,8 +807,53 @@ class _KVCache:
             # eviction queue.
             self._block(ordinal, beam_idx)[lc_idx] = canonical.hold()
         dropped.clear()
-        for pg_idx, pages in typed_enumerate(move):
-            storage.offload_arena_pages(pg_idx, pages)
+        for pg_idx in typed_range(storage.num_pool_groups):
+            storage.adopt_stale_copies(pg_idx, adopt_pages[pg_idx], adopt_slots[pg_idx])
+            storage.offload_arena_pages(pg_idx, move[pg_idx])
+        self._arena_release_unused_write_through()
+
+    def _arena_write_through(self, ordinal: BlockOrdinal) -> None:
+        """Write-through on commit (§4.3, ``WriteThroughPolicy.ON_COMMIT``):
+        copy the just-committed block's pages to fresh host slots now, so the
+        free path (close/suspend) adopts them instead of copying. Skipped
+        silently if the host tier cannot take the copy -- the copy-on-free
+        fallback covers the block."""
+        storage = self._storage
+        beam_idx = DEFAULT_BEAM_INDEX
+        beam_block = self._block(ordinal, beam_idx)
+        per_pg_pages: dict[PoolGroupIndex, list[Page]] = {}
+        per_pg_lcs: dict[PoolGroupIndex, list[LifeCycleId]] = {}
+        for lc_idx, p in typed_enumerate(beam_block):
+            if p is None:
+                continue
+            page = p.page
+            if type(page) is not CommittedPage or page.cache_level != GPU_LEVEL:
+                continue
+            pg_idx = storage.get_pool_group_index(lc_idx)
+            per_pg_pages.setdefault(pg_idx, []).append(page)
+            per_pg_lcs.setdefault(pg_idx, []).append(lc_idx)
+        if not per_pg_pages:
+            return
+        # The sources are still locked; order the copies after all work
+        # enqueued so far on the sequence's stream (the block's writes).
+        prior = CachedCudaEvent(self.cuda_stream)
+        for pg_idx, pages in per_pg_pages.items():
+            try:
+                slots = storage.write_through_pages(pg_idx, pages, prior_event=prior)
+            except OutOfPagesError:
+                continue  # fall back to copy-on-free for this block
+            for lc_idx, slot in zip(per_pg_lcs[pg_idx], slots):
+                self._write_through_slots[(int(ordinal), int(lc_idx))] = slot
+
+    def _arena_take_write_through_slot(self, ordinal: int, lc_idx: LifeCycleId) -> Slot | None:
+        return self._write_through_slots.pop((int(ordinal), int(lc_idx)), None)
+
+    def _arena_release_unused_write_through(self) -> None:
+        """Return any unconsumed write-through host slots to their pool."""
+        storage = self.manager._storage
+        for (_, lc_int), slot in self._write_through_slots.items():
+            storage.release_slot(LifeCycleId(lc_int), CacheLevel(GPU_LEVEL + 1), slot)
+        self._write_through_slots.clear()
 
     def _arena_ensure_mapped(self, num_valid_blocks: int) -> bool:
         """Demand-map physical pages covering the first ``num_valid_blocks`` of
@@ -1677,6 +1764,14 @@ class _KVCache:
             event_manager = self.manager.event_manager
             if event_manager is not None:
                 event_manager.add_stored_block_event_from_block(tree_block)
+            arena_cfg = self.manager._storage.arena_config
+            if (
+                self._arena_ranges is not None
+                and arena_cfg is not None
+                and arena_cfg.write_through == WriteThroughPolicy.ON_COMMIT
+                and self.manager._storage.num_cache_levels > 1
+            ):
+                self._arena_write_through(ordinal)
         elif tree_block.is_full and self.manager.allow_seq_rebasing and is_full:
             # Happens when a concurrent request committed the same tokens before us.
             # Try to replace our pages with pages from the existing block to save memory.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -1342,6 +1342,14 @@ class _KVCache:
         assert self.status == self.Status.SUSPENDED
         if cuda_stream is not None:
             self.cuda_stream = cuda_stream
+        if self._storage.is_arena_mode:
+            # Arena frees are deferred (event-gated unmap, §4.2), so page
+            # utilization can stay pinned above the resume gate after other
+            # sequences finished. Classic mode returns slots synchronously and
+            # never needs this. Without the drain here, a caller that retries
+            # resume() in a loop (e.g. the scheduler) can livelock: nothing is
+            # schedulable, so no other path drains either.
+            self._storage.drain_gpu_reclaim()
         utilization = max(self._storage.get_utilization(GPU_LEVEL))
         if utilization > self.manager._init_config.max_util_for_resume:
             return False

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -890,25 +890,6 @@ class _KVCache:
             return None
         return ref()
 
-    def _arena_canonical_chain(self, num_blocks: int, lc_idx: LifeCycleId) -> "list[CommittedPage]":
-        """The contiguous run of live canonical tree pages for this
-        sequence's first ``num_blocks`` COMMITTED blocks (mappability probe
-        input, P3 v3 R1). Stops at the first missing/dead entry: a
-        registered span identity-covers pages only through an unbroken run
-        from its head, so a break already proves no live span covers
-        anything past it."""
-        chain: list[CommittedPage] = []
-        for i in range(num_blocks):
-            blk = self._get_tree_block(BlockOrdinal(i))
-            ref = blk.storage[lc_idx]
-            if ref is None:
-                break
-            page = ref()
-            if page is None:
-                break
-            chain.append(page)
-        return chain
-
     def _arena_try_displace_canonical(
         self, tree_block: "Block", lc_idx: LifeCycleId, ordinal: BlockOrdinal
     ) -> bool:
@@ -943,19 +924,24 @@ class _KVCache:
         if incumbent.status != PageStatus.DROPPABLE:
             return False  # held: someone is mid-read or keeping it recallable
         if storage.arena_prefix_aliasing:
-            # Blocks [0, ordinal) are committed (commit proceeds in order);
-            # the incumbent completes the chain at position ``ordinal``.
-            chain = self._arena_canonical_chain(int(ordinal), lc_idx)
-            if len(chain) == int(ordinal):
-                chain.append(incumbent)
-                pg_idx = storage.get_pool_group_index(lc_idx)
-                hit = storage.lookup_arena_canonical_span(
-                    pg_idx, chain[0], chain, count_stats=False
+            # Non-destructive probe: spans are keyed by their chain's HEAD
+            # canonical, so fetch block 0's entry and ask whether a live
+            # span identity-covers the incumbent at ``ordinal``. Must NOT
+            # go through lookup_arena_canonical_span -- its verify loop
+            # invalidates the span on mismatch, and probe chains diverge
+            # legitimately from the owner's path past the shared prefix
+            # (observed as spurious alias misses on the f070 shape).
+            head = (
+                incumbent
+                if int(ordinal) == 0
+                else map_optional(
+                    self._get_tree_block(BlockOrdinal(0)).storage[lc_idx], lambda p: p()
                 )
-                if hit is not None:
-                    span: Any = hit[1]
-                    if span.num_blocks > int(ordinal):
-                        return False  # a live span covers it: mappable, keep it
+            )
+            if head is not None:
+                pg_idx = storage.get_pool_group_index(lc_idx)
+                if storage.arena_span_covers(pg_idx, head, int(ordinal), incumbent):
+                    return False  # a live span covers it: mappable, keep it
         if incumbent.scheduled_for_eviction:
             storage.exclude_from_eviction(incumbent)
         if (

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -62,7 +62,7 @@ from .._page import (
     batched_lock_to_gpu,
 )
 from .._stats import KVCacheIterationStatsDelta, KVCacheStatsDelta
-from .._storage._core import Slot
+from .._storage._core import PoolGroupIndex, SequenceRange, Slot
 from .._storage_manager import StorageManager
 from .._utils import (
     CachedCudaEvent,
@@ -197,6 +197,8 @@ class _KVCache:
         "_enable_swa_scratch_reuse",
         "_scratch_slots",
         "_pending_stats",
+        "_max_capacity",
+        "_arena_ranges",
         "__rawref__",
     )
 
@@ -245,6 +247,12 @@ class _KVCache:
     # only the additional needed slots are allocated. Freed on teardown/suspend.
     _scratch_slots: TypedIndexList[LifeCycleId, list[ScratchSlotLock]]
     _pending_stats: _PendingStats
+    # Contiguous-arena mode (DESIGN.md §4.1): the request's capacity ceiling in
+    # tokens (sizes the VA reservation) and, while active, one contiguous
+    # block-index range per pool group. None outside arena mode / while no
+    # ranges are held.
+    _max_capacity: int | None
+    _arena_ranges: TypedIndexList[PoolGroupIndex, SequenceRange] | None
 
     def __init__(
         self,
@@ -254,6 +262,7 @@ class _KVCache:
         id: int | None,
         custom_priority_callback: Callable[[BlockOrdinal, LifeCycle], Priority],
         expected_prompt_length: int | None = None,
+        max_capacity: int | None = None,
     ):
         self.id = id
         self._manager = manager
@@ -288,6 +297,17 @@ class _KVCache:
             lambda _: list[ScratchSlotLock](), manager._storage.num_life_cycles
         )
         self._pending_stats = _PendingStats()
+        self._max_capacity = max_capacity
+        self._arena_ranges = None
+        if manager._storage.is_arena_mode:
+            if max_capacity is None or max_capacity <= 0:
+                raise ValueError(
+                    "contiguous-arena mode requires a positive max_capacity to size the "
+                    "sequence's VA reservation (DESIGN.md §4.1)"
+                )
+            assert reuse_match is None, (
+                "reuse onboarding is not wired up in arena mode yet (DESIGN.md §4.4)"
+            )
         self.__rawref__ = rawref.NULL
         if reuse_match is not None:
             self._setup_for_reuse(reuse_match)
@@ -500,8 +520,49 @@ class _KVCache:
             manager._avg_sqr_history_length.update(self._avg_history_length.value**2)
             manager._num_sampled_kv_caches += 1
             manager._try_update_target_ratios()
+        arena_ranges = self._arena_ranges
+        arena_offload: TypedIndexList[PoolGroupIndex, list[CommittedPage]] | None = None
+        if arena_ranges is not None:
+            # Collect this sequence's committed GPU pages before the block
+            # chain is cleared; they move to the host tier (active->stale
+            # copy-on-free, DESIGN.md §4.3) so the arena range can be
+            # reclaimed. In arena mode GPU pages are never shared across
+            # sequences (reuse copies, §4.4), so they are ours to move.
+            storage = manager._storage
+            arena_offload = make_typed(lambda _: list[CommittedPage](), storage.num_pool_groups)
+            for block in self._blocks:
+                if not block.is_committed:
+                    continue
+                for beam_pages in block.pages:
+                    for p in beam_pages:
+                        if p is None:
+                            continue
+                        page = p.page
+                        if isinstance(page, CommittedPage) and page.cache_level == GPU_LEVEL:
+                            pg_idx = storage.get_pool_group_index(page.life_cycle)
+                            arena_offload[pg_idx].append(page)
         with self._record_event():
             self._clear_blocks()
+        if arena_ranges is not None:
+            storage = manager._storage
+            assert arena_offload is not None
+            for pg_idx, pages in typed_enumerate(arena_offload):
+                try:
+                    storage.offload_arena_pages(pg_idx, pages)
+                except OutOfPagesError:
+                    # Host tier cannot take the write-out: drop the blocks
+                    # instead of keeping them (reuse loss only, never an
+                    # error on the free path).
+                    for page in pages:
+                        if page.scheduled_for_eviction:
+                            storage.exclude_from_eviction(page)
+            arena_offload = None  # drop our strong refs before range release
+            last_consumer = (
+                self._finish_event if self._finish_event is not None else CachedCudaEvent.NULL
+            )
+            for pg_idx, rng in typed_enumerate(arena_ranges):
+                storage.free_gpu_sequence(pg_idx, rng, last_consumer)
+            self._arena_ranges = None
         self._status = self.Status.CLOSED
         manager._living_kv_caches.remove(self.__rawref__)
 
@@ -624,6 +685,27 @@ class _KVCache:
             case PageIndexMode.SHARED:
                 return not self.has_scratch_slots
 
+    def _arena_ensure_mapped(self, num_valid_blocks: int) -> bool:
+        """Demand-map physical pages covering the first ``num_valid_blocks`` of
+        this sequence's range in every pool group (DESIGN.md §4.2). On page
+        exhaustion, drains deferred reclaim and retries once; returns False if
+        pages are still unavailable — the caller backs off exactly like a
+        failed slot allocation (§4.6)."""
+        storage = self._storage
+        ranges = self._arena_ranges
+        assert ranges is not None
+        for pg_idx, rng in typed_enumerate(ranges):
+            try:
+                storage.ensure_gpu_mapped(pg_idx, rng, num_valid_blocks)
+            except OutOfPagesError:
+                if storage.drain_gpu_reclaim() == 0:
+                    return False
+                try:
+                    storage.ensure_gpu_mapped(pg_idx, rng, num_valid_blocks)
+                except OutOfPagesError:
+                    return False
+        return True
+
     # reserve space for next inference. Request new blocks from KVCacheManager if necessary.
     # if capacity is increased and beam_width > 1, blocks containing new tokens should be allocated for each beam.
     # Decrease of capacity may destroy stale blocks (if not used by other requests).
@@ -651,6 +733,12 @@ class _KVCache:
             raise ValueError("History length cannot be decreased")
         if capacity < history_length:
             raise ValueError("History length cannot be greater than capacity")
+        if self._arena_ranges is not None and capacity > unwrap_optional(self._max_capacity):
+            raise ValueError(
+                f"capacity ({capacity}) exceeds the max_capacity "
+                f"({self._max_capacity}) declared at creation (contiguous-arena mode, "
+                f"DESIGN.md §4.1)"
+            )
         manager = self.manager
         # Scratch reuse: compute scratch ranges and slot delta
         enable_scratch = self.enable_swa_scratch_reuse
@@ -729,7 +817,21 @@ class _KVCache:
                 lambda lc: num_new_slots[lc] + delta_scratch_slots[lc], num_life_cycles
             )
             storage = self._storage
-            if any(c > 0 for c in net_alloc_counts):
+            arena_ranges = self._arena_ranges
+            if arena_ranges is not None:
+                # Arena growth (DESIGN.md §4.2): no scattered slot allocation.
+                # Demand-map physical pages covering the new block frontier in
+                # every pool group; block-index slots are issued per ordinal in
+                # the construction loop below.
+                assert self.beam_width == 1
+                if new_num_blocks > old_num_blocks and not self._arena_ensure_mapped(
+                    int(new_num_blocks)
+                ):
+                    self._recover_excess_scratch_slots(excess_scratch_slots)
+                    self._lock_held_blocks(backup_holders)
+                    return False
+                new_slots = make_typed(lambda _: list[Slot](), num_life_cycles)
+            elif any(c > 0 for c in net_alloc_counts):
                 try:
                     new_slots = storage.new_gpu_slots(
                         make_typed(lambda lc: max(0, net_alloc_counts[lc]), num_life_cycles),
@@ -764,7 +866,7 @@ class _KVCache:
                             slot.ready_event = self.finish_event
                             storage.release_slot(lc, GPU_LEVEL, slot)
 
-            assert all(
+            assert arena_ranges is not None or all(
                 len(slots[lc]) == num_new_slots[lc] + max(0, delta_scratch_slots[lc])
                 for lc in typed_range(num_life_cycles)
             )
@@ -816,7 +918,15 @@ class _KVCache:
                             stale_beg, stale_end = stale_ranges[lc]
                             if stale_beg <= ordinal < stale_end:
                                 continue
-                        slot = slots[lc].pop()
+                        if arena_ranges is not None:
+                            # slot_id = range base + ordinal: the sequence's
+                            # blocks are consecutive in VA (DESIGN.md §4.1).
+                            pg_idx = storage.get_pool_group_index(lc)
+                            slot = storage.take_gpu_sequence_slot(
+                                pg_idx, arena_ranges[pg_idx], int(ordinal)
+                            )
+                        else:
+                            slot = slots[lc].pop()
                         # We have already waited for ready_event of the slots.
                         block[beam_index][lc] = UncommittedPage(
                             self, ordinal, lc, GPU_LEVEL, slot, beam_index
@@ -934,6 +1044,12 @@ class _KVCache:
     # suspend+resume allows us to implement dynamic batch size. May also be used to support HSTU model.
     def suspend(self) -> None:
         assert self.status == self.Status.ACTIVE
+        if self._arena_ranges is not None:
+            # Requires the §4.5 write-out/range-release path; until then a
+            # sequence can only leave the arena via close().
+            raise LogicError(
+                "suspend/resume is not wired up in contiguous-arena mode yet (DESIGN.md §4.5)"
+            )
         assert self._check_sanity()
         assert self._finish_event is None
         for beam_idx, beam_indices in typed_enumerate(self._base_page_indices):
@@ -967,6 +1083,28 @@ class _KVCache:
         assert self._cuda_stream is not None, "cuda_stream is never set"
         assert self._finish_event is None
         storage = self._storage
+        if storage.is_arena_mode and self._arena_ranges is None:
+            # Reserve this sequence's contiguous block-index range in every
+            # pool group, sized for max_capacity (DESIGN.md §4.1). Pure VA
+            # bookkeeping; pages are mapped on demand by resize().
+            assert self._never_resumed, (
+                "resume after suspend is not wired up in arena mode yet (§4.5)"
+            )
+            max_capacity = self._max_capacity
+            assert max_capacity is not None
+            max_blocks = div_up(max_capacity, self.tokens_per_block)
+            ranges = list[SequenceRange]()
+            try:
+                for pg_idx in typed_range(storage.num_pool_groups):
+                    ranges.append(storage.reserve_gpu_sequence(pg_idx, max_blocks))
+            except MemoryError:
+                # VA exhaustion / fragmentation: back off like any other
+                # resource shortage. Nothing was mapped; undo the bookkeeping.
+                for pg_idx, rng in typed_enumerate(cast(TypedIndexList, ranges)):
+                    storage.free_gpu_sequence(pg_idx, rng, CachedCudaEvent.NULL)
+                storage.drain_gpu_reclaim()
+                return False
+            self._arena_ranges = cast(TypedIndexList, ranges)
         ssm_lc_id = self.manager._life_cycles.ssm_life_cycle_id
         life_cycles = self.manager._life_cycles
         num_life_cycles = life_cycles.size

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -55,6 +55,7 @@ from .._page import (
     BlockPage,
     CommittedPage,
     Page,
+    PrivateCommittedPage,
     ScratchSlotLock,
     UncommittedPage,
     _PageHolder,
@@ -299,15 +300,9 @@ class _KVCache:
         self._pending_stats = _PendingStats()
         self._max_capacity = max_capacity
         self._arena_ranges = None
-        if manager._storage.is_arena_mode:
-            if max_capacity is None or max_capacity <= 0:
-                raise ValueError(
-                    "contiguous-arena mode requires a positive max_capacity to size the "
-                    "sequence's VA reservation (DESIGN.md §4.1)"
-                )
-            assert reuse_match is None, (
-                "reuse onboarding is not wired up in arena mode yet (DESIGN.md §4.4)"
-            )
+        # Arena-mode preconditions are validated by KVCacheManager.create_kv_cache
+        # (raising here would leave a partially constructed object for __del__).
+        assert not manager._storage.is_arena_mode or (max_capacity is not None and max_capacity > 0)
         self.__rawref__ = rawref.NULL
         if reuse_match is not None:
             self._setup_for_reuse(reuse_match)
@@ -522,25 +517,9 @@ class _KVCache:
             manager._try_update_target_ratios()
         arena_ranges = self._arena_ranges
         arena_offload: TypedIndexList[PoolGroupIndex, list[CommittedPage]] | None = None
+        arena_private: list[CommittedPage] = []
         if arena_ranges is not None:
-            # Collect this sequence's committed GPU pages before the block
-            # chain is cleared; they move to the host tier (active->stale
-            # copy-on-free, DESIGN.md §4.3) so the arena range can be
-            # reclaimed. In arena mode GPU pages are never shared across
-            # sequences (reuse copies, §4.4), so they are ours to move.
-            storage = manager._storage
-            arena_offload = make_typed(lambda _: list[CommittedPage](), storage.num_pool_groups)
-            for block in self._blocks:
-                if not block.is_committed:
-                    continue
-                for beam_pages in block.pages:
-                    for p in beam_pages:
-                        if p is None:
-                            continue
-                        page = p.page
-                        if isinstance(page, CommittedPage) and page.cache_level == GPU_LEVEL:
-                            pg_idx = storage.get_pool_group_index(page.life_cycle)
-                            arena_offload[pg_idx].append(page)
+            arena_offload, arena_private = self._arena_collect_committed_gpu_pages()
         with self._record_event():
             self._clear_blocks()
         if arena_ranges is not None:
@@ -556,7 +535,11 @@ class _KVCache:
                     for page in pages:
                         if page.scheduled_for_eviction:
                             storage.exclude_from_eviction(page)
+            for page in arena_private:
+                if page.scheduled_for_eviction:
+                    storage.exclude_from_eviction(page)
             arena_offload = None  # drop our strong refs before range release
+            arena_private.clear()  # private copies die here, freeing their slots
             last_consumer = (
                 self._finish_event if self._finish_event is not None else CachedCudaEvent.NULL
             )
@@ -685,6 +668,43 @@ class _KVCache:
             case PageIndexMode.SHARED:
                 return not self.has_scratch_slots
 
+    def _arena_collect_committed_gpu_pages(
+        self,
+    ) -> tuple[TypedIndexList[PoolGroupIndex, list[CommittedPage]], list[CommittedPage]]:
+        """Collect this sequence's committed GPU pages before the block chain
+        is cleared at close(). Canonical pages (first return, per pool group)
+        move to the host tier (active->stale copy-on-free, DESIGN.md §4.3) so
+        the arena range can be reclaimed; sequence-private reuse copies
+        (second return, §4.4) are dropped -- their canonical stale copy
+        already exists. In arena mode GPU pages are never shared across
+        sequences, so they are ours to move or drop.
+
+        A separate method so its loop locals cannot outlive the collection: a
+        lingering reference to a block's lock chain would delay the holder's
+        death past close()'s eviction-exclusion pass, leaking the page into
+        the (otherwise unused) GPU eviction queue.
+        """
+        storage = self.manager._storage
+        arena_offload: TypedIndexList[PoolGroupIndex, list[CommittedPage]] = make_typed(
+            lambda _: list[CommittedPage](), storage.num_pool_groups
+        )
+        arena_private: list[CommittedPage] = []
+        for block in self._blocks:
+            if not block.is_committed:
+                continue
+            for beam_pages in block.pages:
+                for p in beam_pages:
+                    if p is None:
+                        continue
+                    page = p.page
+                    if isinstance(page, CommittedPage) and page.cache_level == GPU_LEVEL:
+                        if type(page) is CommittedPage:
+                            pg_idx = storage.get_pool_group_index(page.life_cycle)
+                            arena_offload[pg_idx].append(page)
+                        else:
+                            arena_private.append(page)
+        return arena_offload, arena_private
+
     def _arena_ensure_mapped(self, num_valid_blocks: int) -> bool:
         """Demand-map physical pages covering the first ``num_valid_blocks`` of
         this sequence's range in every pool group (DESIGN.md §4.2). On page
@@ -704,6 +724,70 @@ class _KVCache:
                     storage.ensure_gpu_mapped(pg_idx, rng, num_valid_blocks)
                 except OutOfPagesError:
                     return False
+        return True
+
+    def _arena_onboard_matched(self) -> bool:
+        """Copy the matched committed prefix into this sequence's arena ranges
+        (stale->active reuse, DESIGN.md §4.4).
+
+        Each matched block becomes a sequence-private
+        :class:`PrivateCommittedPage` at ``range base + ordinal``; the
+        canonical radix entries are left untouched wherever they live (host,
+        disk, or another sequence's arena -- committed blocks are immutable, so
+        reading them concurrently is safe). Consecutive ordinals give the
+        explicit-destination migrate path contiguous targets to coalesce.
+        Returns False (onboarding nothing) if physical pages are unavailable.
+        """
+        storage = self._storage
+        ranges = self._arena_ranges
+        assert ranges is not None
+        beam_idx = DEFAULT_BEAM_INDEX
+        entries = list[tuple[BlockOrdinal, LifeCycleId, _PageHolder]]()
+        for ordinal, entry_beam, lc_idx in self._active_pages():
+            assert entry_beam == beam_idx
+            holder = expect_type(_PageHolder, self._block(ordinal, beam_idx)[lc_idx])
+            entries.append((ordinal, lc_idx, holder))
+        if not entries:
+            return True
+        if not self._arena_ensure_mapped(self.num_blocks):
+            return False
+        # One explicit-destination migrate per (pool group, source level).
+        dst_slots = list[Slot]()
+        groups: dict[tuple[PoolGroupIndex, CacheLevel], list[int]] = {}
+        for i, (ordinal, lc_idx, holder) in enumerate(entries):
+            pg_idx = storage.get_pool_group_index(lc_idx)
+            dst_slots.append(storage.take_gpu_sequence_slot(pg_idx, ranges[pg_idx], int(ordinal)))
+            groups.setdefault((pg_idx, holder.page.cache_level), []).append(i)
+        copied: list[Slot | None] = [None] * len(entries)
+        for (pg_idx, src_level), idx_list in groups.items():
+            ret = storage._batched_migrate(
+                pg_idx,
+                GPU_LEVEL,
+                src_level,
+                [entries[i][2].page for i in idx_list],
+                update_src=False,
+                migration_recorder=self._record_migrated_slots,
+                dst_slots=[dst_slots[i] for i in idx_list],
+            )
+            assert ret is not None
+            for i, slot in zip(idx_list, ret):
+                copied[i] = slot
+        stream_wait_events(self.cuda_stream, (s.ready_event for s in copied if s is not None))
+        # Wrap the copies as sequence-private committed pages and lock them;
+        # dropping the holders releases the canonical pages back to eviction
+        # control at their current level.
+        for (ordinal, lc_idx, holder), slot in zip(entries, copied):
+            src_page = holder.page
+            assert type(src_page) is CommittedPage, "arena mode matches full committed blocks only"
+            tree_block = src_page.block()
+            assert tree_block is not None
+            assert slot is not None
+            private = PrivateCommittedPage(
+                storage, tree_block, lc_idx, GPU_LEVEL, slot, src_page.priority
+            )
+            self._block(ordinal, beam_idx)[lc_idx] = private.lock(
+                self, beam_idx, ordinal, lc_idx, skip_wait=True
+            )
         return True
 
     # reserve space for next inference. Request new blocks from KVCacheManager if necessary.
@@ -1157,33 +1241,42 @@ class _KVCache:
                         ScratchSlotLock(slot, self, lc_idx, skip_wait=True)
                     )
 
-        tasks = list[BatchedLockTarget]()
-        for ordinal, beam_idx, lc_idx in self._active_pages():
-            beam_block = (
-                self._block(ordinal, beam_idx)
-                if lc_idx != ssm_lc_id
-                else self._ssm_blocks[beam_idx]
-            )
-            page = expect_type(_PageHolder, beam_block[lc_idx]).page
-            tasks.append(BatchedLockTarget(page, beam_idx, ordinal, lc_idx))
-        try:
-            locks = batched_lock_to_gpu(self, tasks, self._record_migrated_slots)
-        except OutOfPagesError:
-            for lc_idx, slot in typed_enumerate(deferred_slots):
-                if slot is not None:
-                    storage.release_slot(lc_idx, GPU_LEVEL, slot)
-            return False
+        if self._arena_ranges is not None:
+            # Stale->active onboarding into this sequence's arena ranges
+            # (DESIGN.md §4.4) instead of locking radix pages in place. No
+            # deferred slots exist in arena mode (no SSM / scratch / partial
+            # matches).
+            assert all(slot is None for slot in deferred_slots)
+            if not self._arena_onboard_matched():
+                return False
+        else:
+            tasks = list[BatchedLockTarget]()
+            for ordinal, beam_idx, lc_idx in self._active_pages():
+                beam_block = (
+                    self._block(ordinal, beam_idx)
+                    if lc_idx != ssm_lc_id
+                    else self._ssm_blocks[beam_idx]
+                )
+                page = expect_type(_PageHolder, beam_block[lc_idx]).page
+                tasks.append(BatchedLockTarget(page, beam_idx, ordinal, lc_idx))
+            try:
+                locks = batched_lock_to_gpu(self, tasks, self._record_migrated_slots)
+            except OutOfPagesError:
+                for lc_idx, slot in typed_enumerate(deferred_slots):
+                    if slot is not None:
+                        storage.release_slot(lc_idx, GPU_LEVEL, slot)
+                return False
 
-        # Replace all holders with locks.
-        for (ordinal, beam_idx, lc_idx), lock in zip(self._active_pages(), locks):
-            beam_block = (
-                self._block(ordinal, beam_idx)
-                if lc_idx != ssm_lc_id
-                else self._ssm_blocks[beam_idx]
-            )
-            page = expect_type(_PageHolder, beam_block[lc_idx]).page
-            assert page is lock.page
-            beam_block[lc_idx] = lock
+            # Replace all holders with locks.
+            for (ordinal, beam_idx, lc_idx), lock in zip(self._active_pages(), locks):
+                beam_block = (
+                    self._block(ordinal, beam_idx)
+                    if lc_idx != ssm_lc_id
+                    else self._ssm_blocks[beam_idx]
+                )
+                page = expect_type(_PageHolder, beam_block[lc_idx]).page
+                assert page is lock.page
+                beam_block[lc_idx] = lock
 
         # Deferred copy: for partial blocks and SSM, copy from now-locked source pages
         # to pre-allocated GPU slots, then unlock sources and replace with new pages.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -613,6 +613,13 @@ class _KVCache:
                             )
                         ),
                     )
+                # The adopted pages are host-controller property now. Drop our
+                # strong refs BEFORE the offload below: its prepare_free_slots
+                # may evict them (under exhaustion they can be the only
+                # droppable pages on the level), and an evicted page that a
+                # live reference keeps from dying frees no slot -- breaking
+                # the free-count invariant _prepare_free_slots asserts.
+                arena_closing.adopt_pages[pg_idx] = []
                 try:
                     storage.offload_arena_pages(pg_idx, arena_closing.offload[pg_idx], prior_event)
                     if arena_lazy:
@@ -635,7 +642,10 @@ class _KVCache:
                         by_ordinal = dict(zip(ordinals, arena_closing.offload[pg_idx]))
                         prefix_pages: list[CommittedPage] = []
                         o = 0
-                        while o in by_ordinal:
+                        # A page still at GPU level was skipped by the offload
+                        # (its tree block died mid-call) -- it ends the
+                        # registrable prefix run.
+                        while o in by_ordinal and by_ordinal[o].cache_level != GPU_LEVEL:
                             prefix_pages.append(by_ordinal[o])
                             o += 1
                         if prefix_pages:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -1068,9 +1068,9 @@ class _KVCache:
                 if hit is None:
                     continue
                 if rng._alias_span_key is None:
-                    storage.alias_arena_span(pg_idx, rng, hit[0], hit[1])
+                    storage.alias_arena_span(pg_idx, rng, hit[0], hit[1], hit[2])
                 else:
-                    assert rng._alias_span_key == hit[0], (
+                    assert rng._alias_span_key == (hit[0], hit[2]), (
                         "adopted range's alias signature must match the admission's span"
                     )
         if not self._arena_ensure_mapped(self.num_blocks, sync=True):
@@ -1093,7 +1093,7 @@ class _KVCache:
                     hit = alias_spans[pg_idx]
                     if (
                         hit is not None
-                        and int(ordinal) < hit[1].num_blocks
+                        and int(ordinal) < hit[2]
                         and hit[1].page_refs[int(ordinal)]() is page
                     ):
                         # P3: the block's bytes are already visible at this
@@ -1623,8 +1623,9 @@ class _KVCache:
                         # a parked range already alias-mapping this span is
                         # handed over with its mappings (and content) intact.
                         alias_key = None
-                        if alias_spans is not None and alias_spans[pg_idx] is not None:
-                            alias_key = alias_spans[pg_idx][0]
+                        hit = None if alias_spans is None else alias_spans[pg_idx]
+                        if hit is not None:
+                            alias_key = (hit[0], hit[2])
                         ranges.append(storage.reserve_gpu_sequence(pg_idx, max_blocks, alias_key))
                         pg_idx = PoolGroupIndex(pg_idx + 1)
                     except MemoryError:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -518,10 +518,15 @@ class _KVCache:
         arena_ranges = self._arena_ranges
         arena_offload: TypedIndexList[PoolGroupIndex, list[CommittedPage]] | None = None
         arena_private: list[CommittedPage] = []
+        arena_last_consumer = CachedCudaEvent.NULL
         if arena_ranges is not None:
             arena_offload, arena_private = self._arena_collect_committed_gpu_pages()
         with self._record_event():
             self._clear_blocks()
+            # _record_event clears _finish_event on exit; capture it as the
+            # range-reclaim gate (§4.2) while it is live.
+            if self._finish_event is not None:
+                arena_last_consumer = self._finish_event
         if arena_ranges is not None:
             storage = manager._storage
             assert arena_offload is not None
@@ -535,16 +540,12 @@ class _KVCache:
                     for page in pages:
                         if page.scheduled_for_eviction:
                             storage.exclude_from_eviction(page)
-            for page in arena_private:
-                if page.scheduled_for_eviction:
-                    storage.exclude_from_eviction(page)
+            # Private copies are never evictable (nothing queues them); they
+            # die with our refs, freeing their slots into their range.
             arena_offload = None  # drop our strong refs before range release
-            arena_private.clear()  # private copies die here, freeing their slots
-            last_consumer = (
-                self._finish_event if self._finish_event is not None else CachedCudaEvent.NULL
-            )
+            arena_private.clear()
             for pg_idx, rng in typed_enumerate(arena_ranges):
-                storage.free_gpu_sequence(pg_idx, rng, last_consumer)
+                storage.free_gpu_sequence(pg_idx, rng, arena_last_consumer)
             self._arena_ranges = None
         self._status = self.Status.CLOSED
         manager._living_kv_caches.remove(self.__rawref__)
@@ -705,6 +706,68 @@ class _KVCache:
                             arena_private.append(page)
         return arena_offload, arena_private
 
+    @staticmethod
+    def _find_canonical(page: CommittedPage, lc_idx: LifeCycleId) -> "CommittedPage | None":
+        """The canonical radix-tree page for a private copy's block, or None
+        if the tree entry is gone (orphaned block / dropped page)."""
+        blk = page.block()
+        if blk is None or blk.is_orphan:
+            return None
+        ref = blk.storage[lc_idx]
+        if ref is None:
+            return None
+        return ref()
+
+    def _arena_evacuate(self) -> None:
+        """Suspend-side write-out (DESIGN.md §4.5): move this sequence's GPU
+        pages out of its arena ranges so the ranges can be unmapped.
+
+        Canonical committed pages and uncommitted pages migrate to the host
+        tier -- the block chain's holders follow their pages, so the logical
+        chain survives suspension unchanged. Sequence-private reuse copies
+        (§4.4) are swapped back to holding their canonical entry and dropped;
+        if the canonical entry is gone, the private copy is the sole copy and
+        migrates like a canonical page.
+
+        Raises ``OutOfPagesError`` if the host tier cannot absorb the
+        write-out even after eviction -- host-quota sizing (§4.6) must
+        guarantee preemption headroom.
+
+        A separate method so loop locals cannot outlive it (see
+        :meth:`_arena_collect_committed_gpu_pages`).
+        """
+        storage = self.manager._storage
+        assert storage.num_cache_levels > 1, "suspend in arena mode requires a host tier"
+        beam_idx = DEFAULT_BEAM_INDEX
+        move: TypedIndexList[PoolGroupIndex, list[Page]] = make_typed(
+            lambda _: list[Page](), storage.num_pool_groups
+        )
+        swaps = list[tuple[BlockOrdinal, LifeCycleId, CommittedPage]]()
+        dropped = list[CommittedPage]()
+        for ordinal, entry_beam, lc_idx in self._active_pages():
+            assert entry_beam == beam_idx
+            holder = expect_type(_PageHolder, self._block(ordinal, beam_idx)[lc_idx])
+            page = holder.page
+            if page.cache_level != GPU_LEVEL:
+                continue
+            if type(page) is PrivateCommittedPage:
+                canonical = self._find_canonical(page, lc_idx)
+                if canonical is not None and canonical is not page:
+                    swaps.append((ordinal, lc_idx, canonical))
+                    dropped.append(page)
+                    continue
+            move[storage.get_pool_group_index(lc_idx)].append(page)
+        for ordinal, lc_idx, canonical in swaps:
+            # Holding the canonical page keeps it recallable for resume; the
+            # private copy's holder dies with this assignment. Private copies
+            # are never evictable, so they die with the last reference
+            # (returning their arena slots) rather than lingering in an
+            # eviction queue.
+            self._block(ordinal, beam_idx)[lc_idx] = canonical.hold()
+        dropped.clear()
+        for pg_idx, pages in typed_enumerate(move):
+            storage.offload_arena_pages(pg_idx, pages)
+
     def _arena_ensure_mapped(self, num_valid_blocks: int) -> bool:
         """Demand-map physical pages covering the first ``num_valid_blocks`` of
         this sequence's range in every pool group (DESIGN.md §4.2). On page
@@ -727,16 +790,21 @@ class _KVCache:
         return True
 
     def _arena_onboard_matched(self) -> bool:
-        """Copy the matched committed prefix into this sequence's arena ranges
-        (stale->active reuse, DESIGN.md §4.4).
+        """Bring this sequence's resident pages into its arena ranges
+        (stale->active, DESIGN.md §4.4/§4.5). Serves both a fresh sequence
+        with a reuse match and a post-suspend resume.
 
-        Each matched block becomes a sequence-private
-        :class:`PrivateCommittedPage` at ``range base + ordinal``; the
-        canonical radix entries are left untouched wherever they live (host,
-        disk, or another sequence's arena -- committed blocks are immutable, so
-        reading them concurrently is safe). Consecutive ordinals give the
-        explicit-destination migrate path contiguous targets to coalesce.
-        Returns False (onboarding nothing) if physical pages are unavailable.
+        Committed sources (canonical radix entries, or a private copy that
+        outlived its entry) are *copied*: each becomes a sequence-private
+        :class:`PrivateCommittedPage` at ``range base + ordinal`` and the
+        source is left untouched wherever it lives (host, disk, or another
+        sequence's arena -- committed blocks are immutable, so reading them
+        concurrently is safe). Uncommitted pages (a suspended sequence's
+        tail) are sequence-private already, so they are *moved*: the page
+        object relocates into the arena slot and its host slot is freed.
+        Consecutive ordinals give the explicit-destination migrate path
+        contiguous targets to coalesce. Returns False (onboarding nothing)
+        if physical pages are unavailable.
         """
         storage = self._storage
         ranges = self._arena_ranges
@@ -751,43 +819,61 @@ class _KVCache:
             return True
         if not self._arena_ensure_mapped(self.num_blocks):
             return False
-        # One explicit-destination migrate per (pool group, source level).
+        # One explicit-destination migrate per (pool group, source level,
+        # copy-vs-move).
         dst_slots = list[Slot]()
-        groups: dict[tuple[PoolGroupIndex, CacheLevel], list[int]] = {}
+        groups: dict[tuple[PoolGroupIndex, CacheLevel, bool], list[int]] = {}
         for i, (ordinal, lc_idx, holder) in enumerate(entries):
             pg_idx = storage.get_pool_group_index(lc_idx)
             dst_slots.append(storage.take_gpu_sequence_slot(pg_idx, ranges[pg_idx], int(ordinal)))
-            groups.setdefault((pg_idx, holder.page.cache_level), []).append(i)
+            page = holder.page
+            if page.scheduled_for_eviction:
+                # Migration requires unscheduled sources; being held again on
+                # the other side of onboarding re-schedules them as usual.
+                storage.exclude_from_eviction(page)
+            is_move = not page.is_committed()
+            groups.setdefault((pg_idx, page.cache_level, is_move), []).append(i)
         copied: list[Slot | None] = [None] * len(entries)
-        for (pg_idx, src_level), idx_list in groups.items():
+        for (pg_idx, src_level, is_move), idx_list in groups.items():
             ret = storage._batched_migrate(
                 pg_idx,
                 GPU_LEVEL,
                 src_level,
                 [entries[i][2].page for i in idx_list],
-                update_src=False,
+                update_src=is_move,
                 migration_recorder=self._record_migrated_slots,
                 dst_slots=[dst_slots[i] for i in idx_list],
             )
-            assert ret is not None
-            for i, slot in zip(idx_list, ret):
-                copied[i] = slot
-        stream_wait_events(self.cuda_stream, (s.ready_event for s in copied if s is not None))
-        # Wrap the copies as sequence-private committed pages and lock them;
-        # dropping the holders releases the canonical pages back to eviction
-        # control at their current level.
+            if not is_move:
+                assert ret is not None
+                for i, slot in zip(idx_list, ret):
+                    copied[i] = slot
+        stream_wait_events(
+            self.cuda_stream,
+            (
+                slot.ready_event if slot is not None else entries[i][2].page.ready_event
+                for i, slot in enumerate(copied)
+            ),
+        )
+        # Lock everything in place. For copies, the private page replaces the
+        # holder; dropping it releases the source back to eviction control at
+        # its current level. Moved pages keep their holder and simply lock.
         for (ordinal, lc_idx, holder), slot in zip(entries, copied):
             src_page = holder.page
-            assert type(src_page) is CommittedPage, "arena mode matches full committed blocks only"
-            tree_block = src_page.block()
-            assert tree_block is not None
-            assert slot is not None
-            private = PrivateCommittedPage(
-                storage, tree_block, lc_idx, GPU_LEVEL, slot, src_page.priority
-            )
-            self._block(ordinal, beam_idx)[lc_idx] = private.lock(
-                self, beam_idx, ordinal, lc_idx, skip_wait=True
-            )
+            if slot is None:  # moved uncommitted page, now living in the arena
+                assert src_page.cache_level == GPU_LEVEL
+                lock = holder.lock(self, beam_idx, ordinal, lc_idx, skip_wait=True)
+            else:
+                assert isinstance(src_page, CommittedPage), (
+                    "arena mode matches full committed blocks only"
+                )
+                tree_block = src_page.block()
+                assert tree_block is not None, "committed page lost its tree block while held"
+                private = PrivateCommittedPage(
+                    storage, tree_block, lc_idx, GPU_LEVEL, slot, src_page.priority
+                )
+                lock = private.lock(self, beam_idx, ordinal, lc_idx, skip_wait=True)
+            self._block(ordinal, beam_idx)[lc_idx] = lock
         return True
 
     # reserve space for next inference. Request new blocks from KVCacheManager if necessary.
@@ -1128,12 +1214,6 @@ class _KVCache:
     # suspend+resume allows us to implement dynamic batch size. May also be used to support HSTU model.
     def suspend(self) -> None:
         assert self.status == self.Status.ACTIVE
-        if self._arena_ranges is not None:
-            # Requires the §4.5 write-out/range-release path; until then a
-            # sequence can only leave the arena via close().
-            raise LogicError(
-                "suspend/resume is not wired up in contiguous-arena mode yet (DESIGN.md §4.5)"
-            )
         assert self._check_sanity()
         assert self._finish_event is None
         for beam_idx, beam_indices in typed_enumerate(self._base_page_indices):
@@ -1141,6 +1221,7 @@ class _KVCache:
                 if type(indices) is memoryview:
                     self.set_base_page_index_buf(beam_idx, lc, None)
         ssm_lc_id = self.manager._life_cycles.ssm_life_cycle_id
+        arena_last_consumer = CachedCudaEvent.NULL
         with self._record_event():  # used by _SharedPageLock.__del__
             for ordinal, beam_idx, lc_idx in self._active_pages():
                 beam_block = (
@@ -1154,6 +1235,19 @@ class _KVCache:
                 beam_block[lc_idx] = holder
             # Free scratch slots on suspend since the data is ephemeral
             self._free_scratch_slots()
+            # _record_event clears _finish_event on exit; capture it as the
+            # range-reclaim gate (§4.2) while it is live.
+            if self._finish_event is not None:
+                arena_last_consumer = self._finish_event
+        if self._arena_ranges is not None:
+            # §4.5: move this sequence's pages out of its arena ranges, then
+            # release the whole VA reservation (event-gated unmap). Resume
+            # reserves fresh ranges and copies the resident state back in.
+            self._arena_evacuate()
+            storage = self.manager._storage
+            for pg_idx, rng in typed_enumerate(self._arena_ranges):
+                storage.free_gpu_sequence(pg_idx, rng, arena_last_consumer)
+            self._arena_ranges = None
         self._status = self.Status.SUSPENDED
 
     # Resume, migrate buffers to GPU memory.
@@ -1170,10 +1264,11 @@ class _KVCache:
         if storage.is_arena_mode and self._arena_ranges is None:
             # Reserve this sequence's contiguous block-index range in every
             # pool group, sized for max_capacity (DESIGN.md §4.1). Pure VA
-            # bookkeeping; pages are mapped on demand by resize().
-            assert self._never_resumed, (
-                "resume after suspend is not wired up in arena mode yet (§4.5)"
-            )
+            # bookkeeping; pages are mapped by _arena_onboard_matched below
+            # (resident prefix) and on demand by resize() (growth). Fresh and
+            # post-suspend resumes take the same path; the base block index
+            # may change across suspend/resume -- harmless, offset tables are
+            # rebuilt from the locks (§4.5).
             max_capacity = self._max_capacity
             assert max_capacity is not None
             max_blocks = div_up(max_capacity, self.tokens_per_block)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -801,6 +801,43 @@ class _KVCache:
                             ret.offload_ordinals[pg_idx].append(ordinal)
         return ret
 
+    def _arena_evacuation_requirements(self) -> TypedIndexList[PoolGroupIndex, int]:
+        """Per-pool-group host slots the §4.5 evacuation write-out will need.
+
+        Mirrors :meth:`_arena_evacuate`'s partition WITHOUT side effects (in
+        particular the write-through stash is inspected, not popped): private
+        copies with a live canonical are dropped (0 slots), written-through
+        pages adopt their pre-copied slot (0 slots), everything else on GPU
+        migrates (1 slot). May overcount pages that later paths free before
+        the migration (e.g. scratch) -- overcounting only reserves extra free
+        slots, which the next consumer reuses; undercounting would break the
+        pre-flight atomicity gate in :meth:`suspend`.
+        """
+        storage = self.manager._storage
+        ssm_lc_id = self.manager._life_cycles.ssm_life_cycle_id
+        requirements = make_typed(lambda _: 0, storage.num_pool_groups)
+        for ordinal, beam_idx, lc_idx in self._active_pages():
+            beam_block = (
+                self._block(ordinal, beam_idx)
+                if lc_idx != ssm_lc_id
+                else self._ssm_blocks[beam_idx]
+            )
+            page = expect_type(_SharedPageLock, beam_block[lc_idx]).page
+            if page.cache_level != GPU_LEVEL:
+                continue
+            if type(page) is PrivateCommittedPage:
+                canonical = self._find_canonical(page, lc_idx)
+                if canonical is not None and canonical is not page:
+                    continue
+            if (
+                type(page) is CommittedPage
+                and (int(ordinal), int(lc_idx)) in self._write_through_slots
+            ):
+                continue
+            pg_idx = storage.get_pool_group_index(lc_idx)
+            requirements[pg_idx] += 1
+        return requirements
+
     @staticmethod
     def _find_canonical(page: CommittedPage, lc_idx: LifeCycleId) -> "CommittedPage | None":
         """The canonical radix-tree page for a private copy's block, or None
@@ -1421,9 +1458,26 @@ class _KVCache:
         *forward* stream (see ``StorageManager.offload_arena_pages``): the
         scheduler evicts mid-pass, when the victim's current step may still be
         in flight, and the evacuation copies would otherwise read its tail
-        block before the step's writes land."""
+        block before the step's writes land.
+
+        Raises ``OutOfPagesError`` -- with the sequence left fully intact and
+        ACTIVE -- if the host tier cannot absorb the evacuation write-out even
+        after LRU eviction (its capacity can be pinned by already-suspended
+        sequences' HELD pages, which are not droppable). The whole write-out
+        is pre-reserved below BEFORE any state mutation, so the error can
+        never leave a half-evacuated sequence; callers degrade to
+        drop-and-recompute (v1-style preemption) instead of crashing."""
         assert self.status == self.Status.ACTIVE
         assert self._check_sanity()
+        if self._arena_ranges is not None and self.manager._storage.num_cache_levels > 1:
+            # Pre-flight atomicity gate (§4.5 hardening): reserve host slots
+            # for the entire evacuation while nothing has been mutated yet.
+            # The manager is single-threaded, so slots freed here stay free
+            # until _arena_evacuate's per-pool-group offloads consume them
+            # (their own prepare_free_slots calls become no-ops).
+            requirements = self._arena_evacuation_requirements()
+            if any(requirements):
+                self.manager._storage.prepare_free_slots(CacheLevel(GPU_LEVEL + 1), requirements)
         # Assert on a local, not the attribute: `assert self._finish_event is
         # None` narrows the member to None for the rest of the function under
         # mypy(c) -- it cannot see _record_event's side effect -- and compiled

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -529,7 +529,13 @@ class _KVCache:
 
     # destroy ownership of memory blocks, so KV cache manager can decide to evict or drop them. After
     # close, uncommitted data in blocks for (beam_index >= beam_width) will be lost.
-    def close(self) -> None:
+    def close(self, prior_event: CachedCudaEvent = CachedCudaEvent.NULL) -> None:
+        """Close the sequence. ``prior_event`` should cover the sequence's
+        last KV writes on the *forward* stream (see
+        ``StorageManager.offload_arena_pages``): under the overlap scheduler a
+        speculatively enqueued step may still be appending to the tail block
+        when the request is freed, and the arena write-out below would
+        otherwise copy it stale."""
         assert NDEBUG or self._check_sanity()
         if self.status == self.Status.CLOSED:
             return
@@ -585,7 +591,7 @@ class _KVCache:
                         ),
                     )
                 try:
-                    storage.offload_arena_pages(pg_idx, arena_closing.offload[pg_idx])
+                    storage.offload_arena_pages(pg_idx, arena_closing.offload[pg_idx], prior_event)
                     if arena_lazy:
                         storage.register_arena_ghosts(
                             pg_idx,
@@ -807,9 +813,14 @@ class _KVCache:
             return None
         return ref()
 
-    def _arena_evacuate(self) -> None:
+    def _arena_evacuate(self, prior_event: CachedCudaEvent = CachedCudaEvent.NULL) -> None:
         """Suspend-side write-out (DESIGN.md §4.5): move this sequence's GPU
         pages out of its arena ranges so the ranges can be unmapped.
+
+        ``prior_event`` orders the evacuation copies after the sequence's last
+        KV writes on the forward stream (see
+        ``StorageManager.offload_arena_pages``) -- a scheduler eviction can
+        suspend a sequence whose current step is still in flight.
 
         Written-through committed pages adopt their host copy (copy-free,
         §4.3); other canonical committed pages and uncommitted pages migrate
@@ -873,7 +884,7 @@ class _KVCache:
         dropped.clear()
         for pg_idx in typed_range(storage.num_pool_groups):
             storage.adopt_stale_copies(pg_idx, adopt_pages[pg_idx], adopt_slots[pg_idx])
-            storage.offload_arena_pages(pg_idx, move[pg_idx])
+            storage.offload_arena_pages(pg_idx, move[pg_idx], prior_event)
         self._arena_release_unused_write_through()
 
     def _arena_write_through(self, ordinal: BlockOrdinal) -> None:
@@ -1403,7 +1414,14 @@ class _KVCache:
 
     # Suspend, allow the KV cache manager to evict buffers from GPU, but don't drop them.
     # suspend+resume allows us to implement dynamic batch size. May also be used to support HSTU model.
-    def suspend(self) -> None:
+    def suspend(self, prior_event: CachedCudaEvent = CachedCudaEvent.NULL) -> None:
+        """Suspend the sequence, evacuating its GPU state to the host tier.
+
+        ``prior_event`` should cover the sequence's last KV writes on the
+        *forward* stream (see ``StorageManager.offload_arena_pages``): the
+        scheduler evicts mid-pass, when the victim's current step may still be
+        in flight, and the evacuation copies would otherwise read its tail
+        block before the step's writes land."""
         assert self.status == self.Status.ACTIVE
         assert self._check_sanity()
         # Assert on a local, not the attribute: `assert self._finish_event is
@@ -1445,7 +1463,7 @@ class _KVCache:
                 # Evacuation reads this sequence's pages; execute any
                 # still-deferred growth maps first.
                 self.manager._storage.flush_gpu_mappings()
-            self._arena_evacuate()
+            self._arena_evacuate(prior_event)
             storage = self.manager._storage
             for pg_idx, rng in typed_enumerate(self._arena_ranges):
                 storage.free_gpu_sequence(pg_idx, rng, arena_last_consumer)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -1060,6 +1060,67 @@ class _KVCache:
     # most of the retained cache, large enough to bound retry loops.
     _ARENA_SPILL_CHUNK_PAGES: ClassVar[int] = 64
 
+    def _arena_collect_dedup_candidates(
+        self,
+    ) -> "list[tuple[int, Any, int, Any, int, int]]":
+        """Pressure-time dedup-remap scan (P3 v2), host-only: per single-lc
+        pool group, this sequence's leading run of committed blocks whose
+        holders are sequence-private DUPLICATES of a registered canonical
+        span's pages (copy-onboarded before the span existed, or a
+        commit-conflict loser) -- replaceable by aliases of the canonical
+        physical pages with zero information loss. Page holders, slot ids,
+        and offsets are untouched by the remap (same-VA swap), so no
+        per-sequence state changes here. Returns
+        ``(pg_idx, rng, key, span, usable_blocks, pages_freeable)``."""
+        storage = self._storage
+        ranges = self._arena_ranges
+        if ranges is None:
+            return []
+        life_cycles = self.manager._life_cycles
+        ssm_lc_id = life_cycles.ssm_life_cycle_id
+        lc_of_pg: dict[int, "LifeCycleId | None"] = {}
+        for lc_idx, _lc in life_cycles.items():
+            if lc_idx == ssm_lc_id:
+                continue
+            pg = int(storage.get_pool_group_index(lc_idx))
+            lc_of_pg[pg] = lc_idx if pg not in lc_of_pg else None  # None: multi-lc, skip
+        out: "list[tuple[int, Any, int, Any, int, int]]" = []
+        num_committed = int(self._num_committed_blocks)
+        beam_idx = DEFAULT_BEAM_INDEX
+        for pg, lc_idx in lc_of_pg.items():
+            if lc_idx is None:
+                continue
+            rng = ranges[PoolGroupIndex(pg)]
+            if rng._alias_span_key is not None:
+                continue  # head already aliased: nothing duplicated
+            canon: list[CommittedPage] = []
+            for ordinal in range(num_committed):
+                block = self._blocks[ordinal]
+                if not block.is_committed:
+                    break
+                p = block.pages[beam_idx][lc_idx]
+                if p is None:
+                    break
+                page = p.page
+                if type(page) is not PrivateCommittedPage or page.cache_level != GPU_LEVEL:
+                    break  # canonical owner / offloaded: not a duplicate
+                canonical = self._find_canonical(page, lc_idx)
+                if canonical is None or canonical is page:
+                    break  # orphaned: our copy is the sole copy, keep it
+                canon.append(canonical)
+            if not canon:
+                continue
+            hit = storage.lookup_arena_canonical_span(
+                PoolGroupIndex(pg), canon[0], canon, count_stats=False
+            )
+            if hit is None:
+                continue
+            key, span, usable = hit
+            pages = storage.arena_span_pages_for_blocks(PoolGroupIndex(pg), span, usable)
+            if pages > 0:
+                out.append((pg, rng, key, span, usable, pages))
+        return out
+
     def _arena_ensure_mapped(self, num_valid_blocks: int, sync: bool = False) -> bool:
         """Make physical pages covering the first ``num_valid_blocks`` of this
         sequence's range available in every pool group (DESIGN.md §4.2).
@@ -1068,10 +1129,13 @@ class _KVCache:
         now but the driver calls are deferred to the owner's per-iteration
         ``flush_gpu_mappings`` sweep; callers that touch the pages immediately
         (e.g. reuse onboarding copies) pass ``sync=True``. On page exhaustion,
-        drains deferred reclaim, then spills lazily retained ranges
-        (LRU-first, §4.4 phase 2), retrying while either makes progress;
-        returns False if pages are still unavailable — the caller backs off
-        exactly like a failed slot allocation (§4.6)."""
+        walks the reclaim ladder -- drain deferred reclaim, spill lazily
+        retained ranges (LRU-first, §4.4 phase 2), DEDUP-REMAP duplicate
+        prefixes onto their canonical spans (P3 v2: frees pages from live
+        sequences with zero information loss), and only then spill the
+        registry excess -- retrying while any rung makes progress; returns
+        False if pages are still unavailable — the caller backs off exactly
+        like a failed slot allocation (§4.6)."""
         storage = self._storage
         ranges = self._arena_ranges
         assert ranges is not None
@@ -1087,6 +1151,13 @@ class _KVCache:
                     break
                 except OutOfPagesError:
                     if storage.drain_gpu_reclaim() > 0:
+                        continue
+                    if (
+                        storage.spill_gpu_retained(self._ARENA_SPILL_CHUNK_PAGES, spill_spans=False)
+                        > 0
+                    ):
+                        continue
+                    if self.manager.dedup_remap_gpu(self._ARENA_SPILL_CHUNK_PAGES) > 0:
                         continue
                     if storage.spill_gpu_retained(self._ARENA_SPILL_CHUNK_PAGES) > 0:
                         continue

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -1068,6 +1068,14 @@ class _KVCache:
                 if hit is None:
                     continue
                 if rng._alias_span_key is None:
+                    # Pressure may have spilled the registry (unpinning the
+                    # handles) between admission and this first resume; a
+                    # dead span cannot be alias-mapped -- fall back to the
+                    # copy path. Adopted ranges below are immune: their
+                    # mappings hold their own references.
+                    if not hit[1].is_live():
+                        alias_spans[pg_idx] = None
+                        continue
                     storage.alias_arena_span(pg_idx, rng, hit[0], hit[1], hit[2])
                 else:
                     assert rng._alias_span_key == (hit[0], hit[2]), (

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -64,7 +64,7 @@ from .._page import (
     batched_lock_to_gpu,
 )
 from .._stats import KVCacheIterationStatsDelta, KVCacheStatsDelta
-from .._storage._core import PoolGroupIndex, SequenceRange, Slot
+from .._storage._core import PoolGroupIndex, SequenceRange, Slot, SlotId
 from .._storage_manager import StorageManager
 from .._utils import (
     CachedCudaEvent,
@@ -536,13 +536,40 @@ class _KVCache:
         if arena_ranges is not None:
             storage = manager._storage
             assert arena_closing is not None
+            arena_lazy = (
+                storage.arena_config is not None and storage.arena_config.lazy_gpu_retention
+            )
             for pg_idx in typed_range(storage.num_pool_groups):
                 # Written-through blocks move copy-free (§4.3).
                 storage.adopt_stale_copies(
                     pg_idx, arena_closing.adopt_pages[pg_idx], arena_closing.adopt_slots[pg_idx]
                 )
+                if arena_lazy:
+                    # The bytes stay resident in the (soon-retained) range:
+                    # register them as D2D reuse sources (§4.4 phase 2).
+                    storage.register_arena_ghosts(
+                        pg_idx,
+                        arena_ranges[pg_idx],
+                        list(
+                            zip(
+                                arena_closing.adopt_ordinals[pg_idx],
+                                arena_closing.adopt_pages[pg_idx],
+                            )
+                        ),
+                    )
                 try:
                     storage.offload_arena_pages(pg_idx, arena_closing.offload[pg_idx])
+                    if arena_lazy:
+                        storage.register_arena_ghosts(
+                            pg_idx,
+                            arena_ranges[pg_idx],
+                            list(
+                                zip(
+                                    arena_closing.offload_ordinals[pg_idx],
+                                    arena_closing.offload[pg_idx],
+                                )
+                            ),
+                        )
                 except OutOfPagesError:
                     # Host tier cannot take the write-out: drop the blocks
                     # instead of keeping them (reuse loss only, never an
@@ -550,6 +577,20 @@ class _KVCache:
                     for page in arena_closing.offload[pg_idx]:
                         if page.scheduled_for_eviction:
                             storage.exclude_from_eviction(page)
+            if arena_lazy:
+                # Re-register each private copy's bytes as a fresh ghost for
+                # its canonical entry: hot prefixes get their D2D source
+                # refreshed by every closing user, so an LRU spill of the
+                # oldest copy does not lose the (newer) resident one.
+                for page, (ordinal, lc_idx) in zip(
+                    arena_closing.private, arena_closing.private_meta, strict=True
+                ):
+                    canonical = self._find_canonical(page, lc_idx)
+                    if canonical is not None and canonical is not page:
+                        pg_idx = storage.get_pool_group_index(lc_idx)
+                        storage.register_arena_ghosts(
+                            pg_idx, arena_ranges[pg_idx], [(ordinal, canonical)]
+                        )
             # Private copies are never evictable (nothing queues them); they
             # die with our refs, freeing their slots into their range.
             arena_closing = None  # drop our strong refs before range release
@@ -682,12 +723,17 @@ class _KVCache:
     class _ArenaClosingPages(NamedTuple):
         # canonical committed pages without a write-through copy: copy-on-free
         offload: "TypedIndexList[PoolGroupIndex, list[CommittedPage]]"
+        offload_ordinals: "TypedIndexList[PoolGroupIndex, list[int]]"
         # canonical committed pages with a valid write-through host copy, and
         # those copies: adopted copy-free (§4.3)
         adopt_pages: "TypedIndexList[PoolGroupIndex, list[CommittedPage]]"
         adopt_slots: "TypedIndexList[PoolGroupIndex, list[Slot]]"
-        # sequence-private reuse copies (§4.4): dropped
+        adopt_ordinals: "TypedIndexList[PoolGroupIndex, list[int]]"
+        # sequence-private reuse copies (§4.4): dropped -- but under lazy
+        # retention their bytes re-register as fresh ghosts for the canonical
+        # entry, keeping hot prefixes' D2D sources LRU-recent
         private: list[CommittedPage]
+        private_meta: list[tuple[int, LifeCycleId]]  # (ordinal, lc) per entry
 
     def _arena_collect_committed_gpu_pages(self) -> "_KVCache._ArenaClosingPages":
         """Collect this sequence's committed GPU pages before the block chain
@@ -706,8 +752,11 @@ class _KVCache:
         storage = self.manager._storage
         ret = _KVCache._ArenaClosingPages(
             make_typed(lambda _: list[CommittedPage](), storage.num_pool_groups),
+            make_typed(lambda _: list[int](), storage.num_pool_groups),
             make_typed(lambda _: list[CommittedPage](), storage.num_pool_groups),
             make_typed(lambda _: list[Slot](), storage.num_pool_groups),
+            make_typed(lambda _: list[int](), storage.num_pool_groups),
+            [],
             [],
         )
         for ordinal, block in enumerate(self._blocks):
@@ -721,14 +770,17 @@ class _KVCache:
                     if isinstance(page, CommittedPage) and page.cache_level == GPU_LEVEL:
                         if type(page) is not CommittedPage:
                             ret.private.append(page)
+                            ret.private_meta.append((ordinal, lc_idx))
                             continue
                         pg_idx = storage.get_pool_group_index(lc_idx)
                         wt_slot = self._arena_take_write_through_slot(ordinal, lc_idx)
                         if wt_slot is not None:
                             ret.adopt_pages[pg_idx].append(page)
                             ret.adopt_slots[pg_idx].append(wt_slot)
+                            ret.adopt_ordinals[pg_idx].append(ordinal)
                         else:
                             ret.offload[pg_idx].append(page)
+                            ret.offload_ordinals[pg_idx].append(ordinal)
         return ret
 
     @staticmethod
@@ -855,24 +907,30 @@ class _KVCache:
             storage.release_slot(LifeCycleId(lc_int), CacheLevel(GPU_LEVEL + 1), slot)
         self._write_through_slots.clear()
 
+    # Pages to free per spill step under pressure; small enough to preserve
+    # most of the retained cache, large enough to bound retry loops.
+    _ARENA_SPILL_CHUNK_PAGES: ClassVar[int] = 64
+
     def _arena_ensure_mapped(self, num_valid_blocks: int) -> bool:
         """Demand-map physical pages covering the first ``num_valid_blocks`` of
         this sequence's range in every pool group (DESIGN.md §4.2). On page
-        exhaustion, drains deferred reclaim and retries once; returns False if
-        pages are still unavailable — the caller backs off exactly like a
-        failed slot allocation (§4.6)."""
+        exhaustion, drains deferred reclaim, then spills lazily retained
+        ranges (LRU-first, §4.4 phase 2), retrying while either makes
+        progress; returns False if pages are still unavailable — the caller
+        backs off exactly like a failed slot allocation (§4.6)."""
         storage = self._storage
         ranges = self._arena_ranges
         assert ranges is not None
         for pg_idx, rng in typed_enumerate(ranges):
-            try:
-                storage.ensure_gpu_mapped(pg_idx, rng, num_valid_blocks)
-            except OutOfPagesError:
-                if storage.drain_gpu_reclaim() == 0:
-                    return False
+            while True:
                 try:
                     storage.ensure_gpu_mapped(pg_idx, rng, num_valid_blocks)
+                    break
                 except OutOfPagesError:
+                    if storage.drain_gpu_reclaim() > 0:
+                        continue
+                    if storage.spill_gpu_retained(self._ARENA_SPILL_CHUNK_PAGES) > 0:
+                        continue
                     return False
         return True
 
@@ -907,13 +965,25 @@ class _KVCache:
         if not self._arena_ensure_mapped(self.num_blocks):
             return False
         # One explicit-destination migrate per (pool group, source level,
-        # copy-vs-move).
+        # copy-vs-move); committed sources whose bytes are still resident in a
+        # retained range short-circuit to D2D copies (§4.4 phase 2).
         dst_slots = list[Slot]()
         groups: dict[tuple[PoolGroupIndex, CacheLevel, bool], list[int]] = {}
+        ghost_groups: dict[PoolGroupIndex, list[int]] = {}
+        ghost_srcs: dict[PoolGroupIndex, list[SlotId]] = {}
+        ghost_rngs: dict[PoolGroupIndex, list[SequenceRange]] = {}
         for i, (ordinal, lc_idx, holder) in enumerate(entries):
             pg_idx = storage.get_pool_group_index(lc_idx)
             dst_slots.append(storage.take_gpu_sequence_slot(pg_idx, ranges[pg_idx], int(ordinal)))
             page = holder.page
+            if page.is_committed():
+                ghost = storage.lookup_arena_ghost(pg_idx, page)
+                if ghost is not None:
+                    src_id, src_rng = ghost
+                    ghost_groups.setdefault(pg_idx, []).append(i)
+                    ghost_srcs.setdefault(pg_idx, []).append(src_id)
+                    ghost_rngs.setdefault(pg_idx, []).append(src_rng)
+                    continue
             if page.scheduled_for_eviction:
                 # Migration requires unscheduled sources; being held again on
                 # the other side of onboarding re-schedules them as usual.
@@ -935,6 +1005,13 @@ class _KVCache:
                 assert ret is not None
                 for i, slot in zip(idx_list, ret):
                     copied[i] = slot
+        for pg_idx, idx_list in ghost_groups.items():
+            ghost_dsts = [dst_slots[i] for i in idx_list]
+            storage.onboard_from_retained(
+                pg_idx, ghost_srcs[pg_idx], ghost_dsts, ghost_rngs[pg_idx]
+            )
+            for i, slot in zip(idx_list, ghost_dsts):
+                copied[i] = slot
         stream_wait_events(
             self.cuda_stream,
             (
@@ -1374,8 +1451,16 @@ class _KVCache:
             max_blocks = div_up(max_capacity, self.tokens_per_block)
             ranges = list[SequenceRange]()
             try:
-                for pg_idx in typed_range(storage.num_pool_groups):
-                    ranges.append(storage.reserve_gpu_sequence(pg_idx, max_blocks))
+                pg_idx = PoolGroupIndex(0)
+                while pg_idx < storage.num_pool_groups:
+                    try:
+                        ranges.append(storage.reserve_gpu_sequence(pg_idx, max_blocks))
+                        pg_idx = PoolGroupIndex(pg_idx + 1)
+                    except MemoryError:
+                        # VA exhaustion: retained ranges hold VA too (§4.4
+                        # phase 2); spill everything spillable and retry once.
+                        if storage.spill_gpu_retained(1 << 62) == 0:
+                            raise
             except MemoryError:
                 # VA exhaustion / fragmentation: back off like any other
                 # resource shortage. Nothing was mapped; undo the bookkeeping.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -224,6 +224,7 @@ class _KVCache:
         "_arena_ranges",
         "_write_through_slots",
         "_alias_spans",
+        "_arena_live_span_registered",
         "__rawref__",
     )
 
@@ -287,6 +288,10 @@ class _KVCache:
     # _setup_for_reuse, consumed (and cleared) by the FIRST resume's
     # reserve+onboard; never set on suspend/resume round-trips.
     _alias_spans: "list[tuple[int, Any] | None] | None"
+    # P3 v2 owner-live aliasing: one registration attempt per sequence, at
+    # its first commit burst (context end). Post-resume onboarded blocks are
+    # private copies, never registrable, so the flag never re-arms.
+    _arena_live_span_registered: bool
 
     def __init__(
         self,
@@ -335,6 +340,7 @@ class _KVCache:
         self._arena_ranges = None
         self._write_through_slots = {}
         self._alias_spans = None
+        self._arena_live_span_registered = False
         # Arena-mode preconditions are validated by KVCacheManager.create_kv_cache
         # (raising here would leave a partially constructed object for __del__).
         assert not manager._storage.is_arena_mode or (max_capacity is not None and max_capacity > 0)
@@ -983,6 +989,66 @@ class _KVCache:
     def _arena_take_write_through_slot(self, ordinal: int, lc_idx: LifeCycleId) -> Slot | None:
         return self._write_through_slots.pop((int(ordinal), int(lc_idx)), None)
 
+    def _arena_register_live_span(self) -> None:
+        """P3 v2 owner-live aliasing: pin this sequence's leading canonical
+        committed blocks in the span registry at its FIRST commit burst
+        (context end), so same-prefix admissions alias the prefix while this
+        sequence is still generating -- with close-time registration alone,
+        the whole first concurrent wave of a prompt class copies.
+
+        The entry stays owner-charged (the pages are our live KV: no
+        registry budget charge, no retain, exempt from spilling) until
+        ``free_sequence`` -- reached from close, evacuate, and error
+        unwinds alike -- flips it to the registry-charged state.
+
+        V1 scope mirrors close-time registration: pool groups with exactly
+        one non-SSM life cycle, and a contiguous CANONICAL run from ordinal
+        0 -- a commit-conflict loser's blocks are private copies
+        (``PrivateCommittedPage``) and stop the run, so losers register
+        nothing and the winner's entry serves their prompt class."""
+        storage = self._storage
+        if not storage.arena_prefix_aliasing:
+            return
+        ranges = self._arena_ranges
+        assert ranges is not None
+        life_cycles = self.manager._life_cycles
+        ssm_lc_id = life_cycles.ssm_life_cycle_id
+        lc_of_pg: dict[int, "LifeCycleId | None"] = {}
+        for lc_idx, _lc in life_cycles.items():
+            if lc_idx == ssm_lc_id:
+                continue
+            pg = int(storage.get_pool_group_index(lc_idx))
+            lc_of_pg[pg] = lc_idx if pg not in lc_of_pg else None  # None: multi-lc, skip
+        num_committed = int(self._num_committed_blocks)
+        beam_idx = DEFAULT_BEAM_INDEX
+        prior: CachedCudaEvent | None = None
+        for pg, lc_idx in lc_of_pg.items():
+            if lc_idx is None:
+                continue
+            rng = ranges[PoolGroupIndex(pg)]
+            if rng._alias_span_key is not None:
+                continue  # head is an alias; the original entry keeps serving
+            pages: list[CommittedPage] = []
+            for ordinal in range(num_committed):
+                block = self._blocks[ordinal]
+                if not block.is_committed:
+                    break
+                p = block.pages[beam_idx][lc_idx]
+                if p is None:
+                    break
+                page = p.page
+                if type(page) is not CommittedPage or page.cache_level != GPU_LEVEL:
+                    break  # private copy (commit loser) or offloaded: not ours to pin
+                pages.append(page)
+            if not pages:
+                continue
+            if prior is None:
+                # Consumers' first reads must order after the prefill step's
+                # KV writes; an event on the sequence's stream covers them
+                # (same discipline as the write-through copies).
+                prior = CachedCudaEvent(self.cuda_stream)
+            storage.register_arena_live_span(PoolGroupIndex(pg), rng, pages, prior)
+
     def _arena_release_unused_write_through(self) -> None:
         """Return any unconsumed write-through host slots to their pool."""
         storage = self.manager._storage
@@ -1485,6 +1551,16 @@ class _KVCache:
                         # committed, same as the entry guard above.
                         break
                     self._commit_block(ordinal, False)
+            if (
+                not self._arena_live_span_registered
+                and self._arena_ranges is not None
+                and self._num_committed_blocks > 0
+            ):
+                # P3 v2: the first commit burst is the context-end signal --
+                # register the owner-live span so concurrent same-prefix
+                # admissions alias instead of copying.
+                self._arena_live_span_registered = True
+                self._arena_register_live_span()
         if self.history_length < self.num_committed_tokens:
             self.history_length = self.num_committed_tokens
 

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -526,6 +526,11 @@ class _KVCache:
         arena_closing: _KVCache._ArenaClosingPages | None = None
         arena_last_consumer = CachedCudaEvent.NULL
         if arena_ranges is not None:
+            arena_cfg = manager._storage.arena_config
+            if arena_cfg is not None and arena_cfg.batched_map_sweep:
+                # The write-out below reads this sequence's pages; make sure
+                # any still-deferred growth maps have executed.
+                manager._storage.flush_gpu_mappings()
             arena_closing = self._arena_collect_committed_gpu_pages()
         with self._record_event():
             self._clear_blocks()
@@ -911,20 +916,30 @@ class _KVCache:
     # most of the retained cache, large enough to bound retry loops.
     _ARENA_SPILL_CHUNK_PAGES: ClassVar[int] = 64
 
-    def _arena_ensure_mapped(self, num_valid_blocks: int) -> bool:
-        """Demand-map physical pages covering the first ``num_valid_blocks`` of
-        this sequence's range in every pool group (DESIGN.md §4.2). On page
-        exhaustion, drains deferred reclaim, then spills lazily retained
-        ranges (LRU-first, §4.4 phase 2), retrying while either makes
-        progress; returns False if pages are still unavailable — the caller
-        backs off exactly like a failed slot allocation (§4.6)."""
+    def _arena_ensure_mapped(self, num_valid_blocks: int, sync: bool = False) -> bool:
+        """Make physical pages covering the first ``num_valid_blocks`` of this
+        sequence's range available in every pool group (DESIGN.md §4.2).
+
+        With ``batched_map_sweep`` (and ``sync=False``) the budget is charged
+        now but the driver calls are deferred to the owner's per-iteration
+        ``flush_gpu_mappings`` sweep; callers that touch the pages immediately
+        (e.g. reuse onboarding copies) pass ``sync=True``. On page exhaustion,
+        drains deferred reclaim, then spills lazily retained ranges
+        (LRU-first, §4.4 phase 2), retrying while either makes progress;
+        returns False if pages are still unavailable — the caller backs off
+        exactly like a failed slot allocation (§4.6)."""
         storage = self._storage
         ranges = self._arena_ranges
         assert ranges is not None
+        arena_cfg = storage.arena_config
+        defer = not sync and arena_cfg is not None and arena_cfg.batched_map_sweep
         for pg_idx, rng in typed_enumerate(ranges):
             while True:
                 try:
-                    storage.ensure_gpu_mapped(pg_idx, rng, num_valid_blocks)
+                    if defer:
+                        storage.queue_gpu_mapping(pg_idx, rng, num_valid_blocks)
+                    else:
+                        storage.ensure_gpu_mapped(pg_idx, rng, num_valid_blocks)
                     break
                 except OutOfPagesError:
                     if storage.drain_gpu_reclaim() > 0:
@@ -962,7 +977,7 @@ class _KVCache:
             entries.append((ordinal, lc_idx, holder))
         if not entries:
             return True
-        if not self._arena_ensure_mapped(self.num_blocks):
+        if not self._arena_ensure_mapped(self.num_blocks, sync=True):
             return False
         # One explicit-destination migrate per (pool group, source level,
         # copy-vs-move); committed sources whose bytes are still resident in a
@@ -1412,6 +1427,11 @@ class _KVCache:
             # §4.5: move this sequence's pages out of its arena ranges, then
             # release the whole VA reservation (event-gated unmap). Resume
             # reserves fresh ranges and copies the resident state back in.
+            arena_cfg = self.manager._storage.arena_config
+            if arena_cfg is not None and arena_cfg.batched_map_sweep:
+                # Evacuation reads this sequence's pages; execute any
+                # still-deferred growth maps first.
+                self.manager._storage.flush_gpu_mappings()
             self._arena_evacuate()
             storage = self.manager._storage
             for pg_idx, rng in typed_enumerate(self._arena_ranges):

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -261,6 +261,7 @@ class KVCacheManager:
             typical_batch=config.typical_step,
             constraints=config.constraints,
             event_manager=event_manager,
+            arena_config=config.contiguous_arena,
         )
         self._living_kv_caches = set[rawref.ref[_KVCache]]()
         decay = 0.9999

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -384,12 +384,16 @@ class KVCacheManager:
         custom_priority_callback: Callable[[BlockOrdinal, LifeCycle], Priority] = lambda _,
         __: PRIORITY_DEFAULT,
         expected_prompt_length: int | None = None,
+        max_capacity: int | None = None,
     ) -> _KVCache:
         """
         reuse_scope: namespace to match before matching any tokens.
         custom_priority_callback: takes block index and layer sliding window size, returns priority.
         If priority returned is higher than existing priority for reused blocks, the block priority is updated.
         expected_prompt_length: optional prompt length hint used to size SWA scratch slots.
+        max_capacity: upper bound on this request's capacity, in tokens. Required in
+        contiguous-arena mode, where it sizes the sequence's VA reservation
+        (DESIGN.md §4.1); resize() beyond it fails. Ignored otherwise.
         Newly created KV cache is suspended. You need to call resume() with a cuda stream to make it active
         & ready in that stream.
         Returns None if suspended=False and we don't have enough resource.
@@ -400,9 +404,11 @@ class KVCacheManager:
         if reuse_scope is None:
             reuse_scope = ReuseScope()
         assert type(reuse_scope) is ReuseScope
-        reuse_match = (
-            self._match_reuse(reuse_scope, input_tokens) if input_tokens is not None else None
-        )
+        # Arena mode P0: reuse onboarding (stale->active copy into the arena,
+        # DESIGN.md §4.4) is not wired up yet, so skip matching rather than
+        # locking radix pages in place.
+        match_allowed = input_tokens is not None and not self._storage.is_arena_mode
+        reuse_match = self._match_reuse(reuse_scope, input_tokens) if match_allowed else None
         if expected_prompt_length is None and input_tokens is not None:
             expected_prompt_length = len(input_tokens)
         return _KVCache(
@@ -412,6 +418,7 @@ class KVCacheManager:
             id,
             custom_priority_callback,
             expected_prompt_length,
+            max_capacity,
         )
 
     def _match_reuse(
@@ -543,7 +550,16 @@ class KVCacheManager:
         same tokens and reuse that block instead to save some memory. Intra-batch reuse will be enabled
         if this is True.
         """
-        return True
+        # Arena mode P0: rebasing locks another sequence's pages in place, which
+        # conflicts with per-sequence contiguous ranges until the stale->active
+        # copy path (DESIGN.md §4.4) lands.
+        return not self._storage.is_arena_mode
+
+    def drain_gpu_reclaim(self) -> int:
+        """Arena mode (DESIGN.md §4.2): unmap and recycle freed sequence ranges
+        whose gating events completed. Call at iteration boundaries. Returns
+        the number of ranges reclaimed."""
+        return self._storage.drain_gpu_reclaim()
 
     @property
     def enable_partial_match(self) -> bool:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -827,18 +827,44 @@ class KVCacheManager:
                 ret[pg_idx] += num_slots
             return ret
 
-        for pg in typed_range(num_pool_groups):
-            remaining_slots[pg] -= get_num_slots(1)[pg] * (batch_size - 1)
-            if remaining_slots[pg] < 0:
+        if storage.is_arena_mode:
+            # Arena mode (DESIGN.md §4.6): GPU capacity is the shared physical
+            # page budget, not per-pool-group slot counts (which describe VA).
+            # A sequence of B blocks consumes, per (pool group, pool),
+            # ceil(B * slot_size / page) physical pages.
+            arena_config = storage.arena_config
+            assert arena_config is not None
+            page_size = arena_config.phys_page_size
+            slot_sizes = [storage.slot_size(pg) for pg in typed_range(num_pool_groups)]
+
+            def pages_for(seq_len: int) -> int:
+                blocks = get_num_slots(seq_len)
+                return sum(
+                    div_up(blocks[pg] * size, page_size)
+                    for pg in typed_range(num_pool_groups)
+                    for size in slot_sizes[pg]
+                )
+
+            remaining_pages = storage.gpu_page_budget.total_pages
+            remaining_pages -= pages_for(1) * (batch_size - 1)
+            if remaining_pages < 0:
                 return 0
 
-        def is_enough(num_blocks: int) -> bool:
-            return all(
-                cnt <= rem
-                for cnt, rem in zip(
-                    get_num_slots(num_blocks * tokens_per_block), remaining_slots, strict=True
+            def is_enough(num_blocks: int) -> bool:
+                return pages_for(num_blocks * tokens_per_block) <= remaining_pages
+        else:
+            for pg in typed_range(num_pool_groups):
+                remaining_slots[pg] -= get_num_slots(1)[pg] * (batch_size - 1)
+                if remaining_slots[pg] < 0:
+                    return 0
+
+            def is_enough(num_blocks: int) -> bool:
+                return all(
+                    cnt <= rem
+                    for cnt, rem in zip(
+                        get_num_slots(num_blocks * tokens_per_block), remaining_slots, strict=True
+                    )
                 )
-            )
 
         if not is_enough(1):
             return 0

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -44,6 +44,7 @@ from .._storage._config import BufferId, create_storage_config
 from .._storage._core import PoolGroupIndex, PoolIndex, SlotId
 from .._storage_manager import StorageManager, StorageStatistics
 from .._utils import (
+    CachedCudaEvent,
     HalfOpenRange,
     HomoTuple,
     TypedIndexList,
@@ -567,11 +568,18 @@ class KVCacheManager:
         # copy path (DESIGN.md §4.4) lands.
         return not self._storage.is_arena_mode
 
-    def drain_gpu_reclaim(self) -> int:
+    def drain_gpu_reclaim(self, fence: CachedCudaEvent | None = None) -> int:
         """Arena mode (DESIGN.md §4.2): unmap and recycle freed sequence ranges
-        whose gating events completed. Call at iteration boundaries. Returns
-        the number of ranges reclaimed."""
-        return self._storage.drain_gpu_reclaim()
+        whose gating events completed. Call at iteration boundaries; pass an
+        execution-stream ``fence`` so ranges freed since the last fenced drain
+        cannot be unmapped under a speculatively enqueued step (risk #3).
+        Returns the number of ranges reclaimed."""
+        return self._storage.drain_gpu_reclaim(fence)
+
+    def fence_gpu_reclaim(self, fence: CachedCudaEvent) -> None:
+        """Arena mode: assign the iteration-boundary reclaim fence (risk #3)
+        to ranges freed since the last fence, without draining."""
+        self._storage.fence_gpu_reclaim(fence)
 
     def flush_gpu_mappings(self) -> int:
         """Arena mode with ``batched_map_sweep`` (DESIGN.md §4.2): execute all

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, Iterator, cast
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, cast
 
 from .. import rawref
 from .._block_radix_tree import BlockRadixTree, ReuseMatch, ReuseScope
@@ -589,6 +589,37 @@ class KVCacheManager:
         scheduling and before any GPU work touches the newly grown blocks.
         Returns the number of pages mapped."""
         return self._storage.flush_gpu_mappings()
+
+    def dedup_remap_gpu(self, min_pages: int) -> int:
+        """Pressure-time dedup remap (P3 v2): free duplicate private copies
+        of registered canonical prefixes by remapping their VA onto the
+        canonical physical pages -- a reclaim-ladder rung between the
+        parked-range spill and the registry-excess spill. Frees memory from
+        LIVE sequences with zero information loss (the byte content is the
+        committed prefix either way), shielding both the registry and the
+        preemption path. Scans ALL live sequences host-side first, then
+        remaps largest-savings-first behind one device quiesce until
+        ``min_pages`` are freed. Returns pages freed."""
+        storage = self._storage
+        if not storage.is_arena_mode or not storage.arena_prefix_aliasing:
+            return 0
+        candidates: "list[tuple[int, Any, int, Any, int, int]]" = []
+        for r in self._living_kv_caches:
+            kv = r()
+            if kv is None:
+                continue
+            candidates.extend(kv._arena_collect_dedup_candidates())
+        if not candidates:
+            return 0
+        candidates.sort(key=lambda c: c[5], reverse=True)
+        picked: "list[tuple[int, Any, int, Any, int]]" = []
+        total = 0
+        for c in candidates:
+            if total >= min_pages:
+                break
+            picked.append((c[0], c[1], c[2], c[3], c[4]))
+            total += c[5]
+        return storage.dedup_remap_arena(picked)
 
     @property
     def enable_partial_match(self) -> bool:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -573,6 +573,13 @@ class KVCacheManager:
         the number of ranges reclaimed."""
         return self._storage.drain_gpu_reclaim()
 
+    def flush_gpu_mappings(self) -> int:
+        """Arena mode with ``batched_map_sweep`` (DESIGN.md §4.2): execute all
+        deferred growth maps back-to-back. The executor must call this after
+        scheduling and before any GPU work touches the newly grown blocks.
+        Returns the number of pages mapped."""
+        return self._storage.flush_gpu_mappings()
+
     @property
     def enable_partial_match(self) -> bool:
         # Arena mode P0 onboards full committed blocks only; partial-block

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -199,6 +199,7 @@ class KVCacheManager:
         "_radix_tree",
         "_storage",
         "_living_kv_caches",
+        "_arena_dedup_dirty",
         "_avg_reused_length",
         "_avg_sqr_capacity",
         "_avg_sqr_history_length",
@@ -220,6 +221,13 @@ class KVCacheManager:
     _radix_tree: BlockRadixTree
     _storage: StorageManager
     _living_kv_caches: set[rawref.ref[_KVCache]]
+    # P3 v3 dedup dirty set: id(kv) -> rawref of sequences that created
+    # sequence-private duplicates of a mappable canonical (commit-conflict
+    # loss, copy-onboarding, resume-onboarding) since their last dedup scan.
+    # Gate for hard_reclaim_gpu's scan: empty set == nothing to dedup, O(1).
+    # Entries clear on scan ATTEMPT (success or failure) and on close; any
+    # later duplicate creation re-enters through one of the three sites.
+    _arena_dedup_dirty: dict[int, rawref.ref[_KVCache]]
     # Eventually we should let the eviction controller evict associated pages together, i.e.
     # when a page eviction makes other pages in the same cache level useless, it should also
     # evict those pages. When we have that, we can simply decide capacity ratio based on
@@ -265,6 +273,7 @@ class KVCacheManager:
             arena_config=config.contiguous_arena,
         )
         self._living_kv_caches = set[rawref.ref[_KVCache]]()
+        self._arena_dedup_dirty = {}
         decay = 0.9999
         self._avg_reused_length = MovingAverage(decay)
         self._avg_sqr_capacity = MovingAverage(decay)
@@ -590,36 +599,47 @@ class KVCacheManager:
         Returns the number of pages mapped."""
         return self._storage.flush_gpu_mappings()
 
-    def dedup_remap_gpu(self, min_pages: int) -> int:
-        """Pressure-time dedup remap (P3 v2): free duplicate private copies
-        of registered canonical prefixes by remapping their VA onto the
-        canonical physical pages -- a reclaim-ladder rung between the
-        parked-range spill and the registry-excess spill. Frees memory from
-        LIVE sequences with zero information loss (the byte content is the
-        committed prefix either way), shielding both the registry and the
-        preemption path. Scans ALL live sequences host-side first, then
-        remaps largest-savings-first behind one device quiesce until
-        ``min_pages`` are freed. Returns pages freed."""
+    def _arena_mark_dedup_dirty(self, kv: _KVCache) -> None:
+        """Flag a sequence for the pressure-time dedup scan (P3 v3): called
+        at the duplicate-creating sites (commit-conflict loss to a mappable
+        incumbent, copy-onboarding of committed blocks, resume-onboarding).
+        No-op unless prefix aliasing is on (nothing could ever be remapped)."""
+        if self._storage.arena_prefix_aliasing:
+            self._arena_dedup_dirty[id(kv)] = kv.__rawref__
+
+    def hard_reclaim_gpu(self, min_pages: int, fence: CachedCudaEvent | None = None) -> int:
+        """Pressure-time hard reclaim (P3 v3), replacing the old ladder's
+        three lower rungs: harvest maximally behind ONE device quiesce, in
+        destruction order -- dedup remap first (duplicates have zero
+        retention value), then parked terminated-request ranges, then
+        registry excess above the protection floor. Pausing (preemption)
+        stays the caller's fallback when this returns 0.
+
+        The dedup scan walks ONLY sequences in the dirty set (flagged at the
+        duplicate-creating sites) and dedups ALL their candidates -- no
+        ``min_pages`` cutoff: if we halt the device, reclaim everything
+        harvestable. Flags clear on the attempt regardless of outcome (a
+        candidate-less sequence stays clean until a new duplicate-creating
+        event re-flags it). If there is nothing to reclaim anywhere, returns
+        0 WITHOUT syncing.
+
+        ``fence``: an execution-stream event recorded by the caller before
+        the call; gates pending frees that have no reclaim fence yet (they
+        complete under the quiesce). Returns pages freed."""
         storage = self._storage
-        if not storage.is_arena_mode or not storage.arena_prefix_aliasing:
+        if not storage.is_arena_mode:
             return 0
-        candidates: "list[tuple[int, Any, int, Any, int, int]]" = []
-        for r in self._living_kv_caches:
-            kv = r()
-            if kv is None:
-                continue
-            candidates.extend(kv._arena_collect_dedup_candidates())
-        if not candidates:
-            return 0
-        candidates.sort(key=lambda c: c[5], reverse=True)
         picked: "list[tuple[int, Any, int, Any, int]]" = []
-        total = 0
-        for c in candidates:
-            if total >= min_pages:
-                break
-            picked.append((c[0], c[1], c[2], c[3], c[4]))
-            total += c[5]
-        return storage.dedup_remap_arena(picked)
+        if storage.arena_prefix_aliasing and self._arena_dedup_dirty:
+            dirty = self._arena_dedup_dirty
+            self._arena_dedup_dirty = {}
+            for r in dirty.values():
+                kv = r()
+                if kv is None:
+                    continue
+                for c in kv._arena_collect_dedup_candidates():
+                    picked.append((c[0], c[1], c[2], c[3], c[4]))
+        return storage.hard_reclaim_gpu(min_pages, picked, fence)
 
     @property
     def enable_partial_match(self) -> bool:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -568,13 +568,15 @@ class KVCacheManager:
         # copy path (DESIGN.md §4.4) lands.
         return not self._storage.is_arena_mode
 
-    def drain_gpu_reclaim(self, fence: CachedCudaEvent | None = None) -> int:
+    def drain_gpu_reclaim(self, fence: CachedCudaEvent | None = None, wait: bool = False) -> int:
         """Arena mode (DESIGN.md §4.2): unmap and recycle freed sequence ranges
         whose gating events completed. Call at iteration boundaries; pass an
         execution-stream ``fence`` so ranges freed since the last fenced drain
         cannot be unmapped under a speculatively enqueued step (risk #3).
-        Returns the number of ranges reclaimed."""
-        return self._storage.drain_gpu_reclaim(fence)
+        Returns the number of ranges reclaimed. ``wait=True`` blocks on
+        in-flight gating events instead of skipping their ranges (§4.6
+        preemption headroom for the scheduler's mid-pass eviction path)."""
+        return self._storage.drain_gpu_reclaim(fence, wait)
 
     def fence_gpu_reclaim(self, fence: CachedCudaEvent) -> None:
         """Arena mode: assign the iteration-boundary reclaim fence (risk #3)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -404,11 +404,23 @@ class KVCacheManager:
         if reuse_scope is None:
             reuse_scope = ReuseScope()
         assert type(reuse_scope) is ReuseScope
-        # Arena mode P0: reuse onboarding (stale->active copy into the arena,
-        # DESIGN.md §4.4) is not wired up yet, so skip matching rather than
-        # locking radix pages in place.
-        match_allowed = input_tokens is not None and not self._storage.is_arena_mode
-        reuse_match = self._match_reuse(reuse_scope, input_tokens) if match_allowed else None
+        reuse_match = (
+            self._match_reuse(reuse_scope, input_tokens) if input_tokens is not None else None
+        )
+        if self._storage.is_arena_mode:
+            # Validate arena preconditions here: raising inside _KVCache.__init__
+            # would leave a partially constructed object for __del__.
+            if max_capacity is None or max_capacity <= 0:
+                raise ValueError(
+                    "contiguous-arena mode requires a positive max_capacity to size the "
+                    "sequence's VA reservation (DESIGN.md §4.1)"
+                )
+            if reuse_match is not None and reuse_match.num_tokens > max_capacity:
+                raise ValueError(
+                    f"reuse match ({reuse_match.num_tokens} tokens) exceeds max_capacity "
+                    f"({max_capacity}); the matched prefix must fit the VA reservation "
+                    f"(DESIGN.md §4.1)"
+                )
         if expected_prompt_length is None and input_tokens is not None:
             expected_prompt_length = len(input_tokens)
         return _KVCache(
@@ -563,7 +575,10 @@ class KVCacheManager:
 
     @property
     def enable_partial_match(self) -> bool:
-        return self._init_config.enable_partial_reuse
+        # Arena mode P0 onboards full committed blocks only; partial-block
+        # reuse needs the deferred private-copy path adapted to arena slots
+        # (DESIGN.md §4.4/§7).
+        return self._init_config.enable_partial_reuse and not self._storage.is_arena_mode
 
     @property
     def ssm_reuse_interval(self) -> int:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_cuda_virt_mem.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_cuda_virt_mem.py
@@ -103,6 +103,46 @@ class PhysMem(ItemHolderWithSharedPool[drv.CUmemGenericAllocationHandle]):
     __slots__ = ()
 
 
+class SharedPhysMem:
+    """Refcounted wrapper around a pooled physical handle (P3 prefix
+    aliasing, DESIGN.md §4.4 phase 3): one ``cuMemCreate`` handle may be
+    mapped at several VA offsets -- across different sequences' arenas --
+    and pinned by the canonical-resident registry. Each mapping and each
+    registry pin holds one reference; the pooled ``PhysMem`` returns to its
+    shared pool only when the last reference drops. The driver keeps a
+    released handle's memory alive while mappings remain (validated by
+    ``bench_alias_map.py``), but this class never relies on that: the
+    ``close()`` is strictly last-reference."""
+
+    __slots__ = ("_phys_mem", "_refs")
+    _phys_mem: PhysMem
+    _refs: int
+
+    def __init__(self, phys_mem: PhysMem) -> None:
+        self._phys_mem = phys_mem
+        self._refs = 1
+
+    @property
+    def handle(self) -> drv.CUmemGenericAllocationHandle:
+        assert self._refs > 0
+        return self._phys_mem.handle
+
+    @property
+    def num_refs(self) -> int:
+        return self._refs
+
+    def add_ref(self) -> "SharedPhysMem":
+        assert self._refs > 0
+        self._refs += 1
+        return self
+
+    def drop_ref(self) -> None:
+        assert self._refs > 0
+        self._refs -= 1
+        if self._refs == 0:
+            self._phys_mem.close()
+
+
 class PooledPhysMemAllocator(PooledFactoryBase[drv.CUmemGenericAllocationHandle, PhysMem]):
     _Holder: Type[PhysMem] = PhysMem
     __slots__ = ("device_id", "phys_mem_size")
@@ -131,8 +171,9 @@ class VirtMem:
     _address: drv.CUdeviceptr
     _pm_stack: list[PhysMem]
     _access_desc: drv.CUmemAccessDesc
-    # chunk_index -> mapped PhysMem, for sparse mode. chunk_index = byte_offset // phys_mem_size.
-    _page_map: dict[int, PhysMem]
+    # chunk_index -> mapped handle, for sparse mode; refcounted so a chunk can
+    # alias a handle owned elsewhere (P3). chunk_index = byte_offset // phys_mem_size.
+    _page_map: dict[int, SharedPhysMem]
 
     def __init__(
         self, vm_size: int, phys_mem_allocator: PooledPhysMemAllocator, init_num_phys_mem: int = 0
@@ -161,11 +202,12 @@ class VirtMem:
         while self._pm_stack:
             self._pop().close()
         # Tear down any sparse mappings (see `_page_map`). Unmap each chunk's VA
-        # and return its handle to the shared pool.
-        for chunk_index, phys_mem in self._page_map.items():
+        # and drop its handle reference (returned to the shared pool when this
+        # was the last mapping/pin -- aliased handles survive, P3).
+        for chunk_index, shared in self._page_map.items():
             vm_ptr = drv.CUdeviceptr(int(self._address) + self.phys_mem_size * chunk_index)
             _unwrap(drv.cuMemUnmap(vm_ptr, self.phys_mem_size))
-            phys_mem.close()
+            shared.drop_ref()
         self._page_map = {}
         _unwrap(drv.cuMemAddressFree(self._address, self._vm_size))
         self._address = drv.CUdeviceptr(0)
@@ -275,7 +317,7 @@ class VirtMem:
                 phys_mem = self._allocator.create()
                 vm_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * chunk_index)
                 _unwrap(drv.cuMemMap(vm_ptr, phys_mem_size, 0, phys_mem.handle, 0))
-                self._page_map[chunk_index] = phys_mem
+                self._page_map[chunk_index] = SharedPhysMem(phys_mem)
                 mapped.append(chunk_index)
             span_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * start_chunk)
             _unwrap(
@@ -285,12 +327,51 @@ class VirtMem:
             for chunk_index in mapped:
                 vm_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * chunk_index)
                 _unwrap(drv.cuMemUnmap(vm_ptr, phys_mem_size))
-                self._page_map.pop(chunk_index).close()
+                self._page_map.pop(chunk_index).drop_ref()
+            raise
+
+    def map_alias(self, byte_offset: int, shared_chunks: "list[SharedPhysMem]") -> None:
+        """Map already-existing physical handles at a contiguous run of chunks
+        starting at ``byte_offset`` (P3 prefix aliasing, DESIGN.md §4.4 phase
+        3): the same physical pages become visible through this reservation's
+        VA addresses in addition to wherever else they are mapped. Takes one reference
+        per chunk; access is granted with a single ``cuMemSetAccess`` over the
+        run. Atomic on failure (mapped prefix rolled back).
+
+        The caller owns read-after-write ordering: aliased bytes must only be
+        read after the events covering their last writes (the canonical
+        blocks' ready events)."""
+        assert not self._pm_stack, "cannot use sparse map_alias() on a tail-stack VirtMem"
+        num_chunks = len(shared_chunks)
+        if num_chunks == 0:
+            return
+        phys_mem_size = self.phys_mem_size
+        start_chunk = self._chunk_index(byte_offset)
+        assert (start_chunk + num_chunks) * phys_mem_size <= self._vm_size
+        mapped: list[int] = []
+        try:
+            for i, shared in enumerate(shared_chunks):
+                chunk_index = start_chunk + i
+                assert chunk_index not in self._page_map, f"chunk {chunk_index} already mapped"
+                vm_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * chunk_index)
+                _unwrap(drv.cuMemMap(vm_ptr, phys_mem_size, 0, shared.handle, 0))
+                self._page_map[chunk_index] = shared.add_ref()
+                mapped.append(chunk_index)
+            span_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * start_chunk)
+            _unwrap(
+                drv.cuMemSetAccess(span_ptr, phys_mem_size * num_chunks, (self._access_desc,), 1)
+            )
+        except Exception:  # keep map_alias atomic
+            for chunk_index in mapped:
+                vm_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * chunk_index)
+                _unwrap(drv.cuMemUnmap(vm_ptr, phys_mem_size))
+                self._page_map.pop(chunk_index).drop_ref()
             raise
 
     def unmap_range(self, byte_offset: int, num_chunks: int) -> None:
-        """Unmap ``num_chunks`` chunks starting at ``byte_offset`` and return
-        their physical handles to the shared pool.
+        """Unmap ``num_chunks`` chunks starting at ``byte_offset`` and drop
+        their handle references (each handle returns to the shared pool when
+        its last mapping/pin drops -- aliased handles survive, P3).
 
         The caller MUST guarantee no in-flight GPU work references this range
         (deferred-reclaim gating, DESIGN.md §4.2). ``cuMemUnmap`` is host-side
@@ -303,11 +384,19 @@ class VirtMem:
         start_chunk = self._chunk_index(byte_offset)
         for i in range(num_chunks):
             chunk_index = start_chunk + i
-            phys_mem = self._page_map.pop(chunk_index, None)
-            assert phys_mem is not None, f"chunk {chunk_index} is not mapped"
+            shared = self._page_map.pop(chunk_index, None)
+            assert shared is not None, f"chunk {chunk_index} is not mapped"
             vm_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * chunk_index)
             _unwrap(drv.cuMemUnmap(vm_ptr, phys_mem_size))
-            phys_mem.close()
+            shared.drop_ref()
+
+    def shared_chunk(self, byte_offset: int) -> "SharedPhysMem":
+        """The refcounted handle mapped at ``byte_offset`` (for registry pins
+        and alias sources, P3). Does NOT take a reference -- callers pin via
+        ``add_ref()``."""
+        shared = self._page_map.get(self._chunk_index(byte_offset))
+        assert shared is not None, "chunk is not mapped"
+        return shared
 
     def is_mapped(self, byte_offset: int) -> bool:
         return self._chunk_index(byte_offset) in self._page_map

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_cuda_virt_mem.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_cuda_virt_mem.py
@@ -119,12 +119,20 @@ class PooledPhysMemAllocator(PooledFactoryBase[drv.CUmemGenericAllocationHandle,
 
 # Virtual memory
 class VirtMem:
-    __slots__ = ("_vm_size", "_allocator", "_address", "_pm_stack", "_access_desc")
+    # NOTE: `_page_map` backs the *sparse* mapping mode used by the contiguous
+    # primary KV cache (per-sequence arenas, see `_sequence_arena.py` and
+    # `contiguous_primary_kvcache/DESIGN.md` §4.1-§4.2). It maps physical chunks
+    # at arbitrary granularity-aligned offsets inside the reservation, in
+    # contrast to `_pm_stack` which is tail-only LIFO. A single `VirtMem`
+    # instance uses one mode or the other, never both (asserted below).
+    __slots__ = ("_vm_size", "_allocator", "_address", "_pm_stack", "_access_desc", "_page_map")
     _vm_size: int
     _allocator: PooledPhysMemAllocator
     _address: drv.CUdeviceptr
     _pm_stack: list[PhysMem]
     _access_desc: drv.CUmemAccessDesc
+    # chunk_index -> mapped PhysMem, for sparse mode. chunk_index = byte_offset // phys_mem_size.
+    _page_map: dict[int, PhysMem]
 
     def __init__(
         self, vm_size: int, phys_mem_allocator: PooledPhysMemAllocator, init_num_phys_mem: int = 0
@@ -135,6 +143,7 @@ class VirtMem:
         self._address = _unwrap(drv.cuMemAddressReserve(vm_size, 0, 0, 0))
         self._vm_size = vm_size
         self._pm_stack = []
+        self._page_map = {}
         self._access_desc = drv.CUmemAccessDesc()
         self._access_desc.location.type = drv.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
         self._access_desc.location.id = device_id
@@ -151,6 +160,13 @@ class VirtMem:
         _unwrap(drv.cuCtxSynchronize())
         while self._pm_stack:
             self._pop().close()
+        # Tear down any sparse mappings (see `_page_map`). Unmap each chunk's VA
+        # and return its handle to the shared pool.
+        for chunk_index, phys_mem in self._page_map.items():
+            vm_ptr = drv.CUdeviceptr(int(self._address) + self.phys_mem_size * chunk_index)
+            _unwrap(drv.cuMemUnmap(vm_ptr, self.phys_mem_size))
+            phys_mem.close()
+        self._page_map = {}
         _unwrap(drv.cuMemAddressFree(self._address, self._vm_size))
         self._address = drv.CUdeviceptr(0)
         self._vm_size = 0
@@ -184,6 +200,8 @@ class VirtMem:
             self.shrink(self.num_phys_mem - required_num_phys_mem)
 
     def _push(self, phy_mem: PhysMem) -> None:
+        # Tail-stack and sparse modes are mutually exclusive on one reservation.
+        assert not self._page_map, "cannot use tail-stack extend() on a sparse-mapped VirtMem"
         phys_mem_size = self.phys_mem_size
         assert phys_mem_size * (len(self._pm_stack) + 1) <= self._vm_size
         vm_ptr = drv.CUdeviceptr(self.address + phys_mem_size * len(self._pm_stack))
@@ -213,3 +231,88 @@ class VirtMem:
     @property
     def address(self) -> MemAddress:
         return MemAddress(int(self._address))
+
+    # ------------------------------------------------------------------
+    # Sparse mapping mode (contiguous primary KV cache)
+    #
+    # Maps/unmaps physical chunks at arbitrary granularity-aligned offsets
+    # inside the reservation, so per-sequence arenas can page memory in on
+    # demand ahead of the write frontier and recycle it on free. See
+    # `_sequence_arena.py` and DESIGN.md §4.2. Callers must ensure that
+    # `unmap_range` is only issued once no in-flight GPU work can touch the
+    # range (deferred-reclaim gating lives in the arena layer, DESIGN.md §4.2
+    # "Shrink/free"): `cuMemUnmap` of a still-referenced range is an IMA.
+    # ------------------------------------------------------------------
+
+    def _chunk_index(self, byte_offset: int) -> int:
+        phys_mem_size = self.phys_mem_size
+        assert byte_offset % phys_mem_size == 0, "byte_offset must be granularity-aligned"
+        assert 0 <= byte_offset < self._vm_size
+        return byte_offset // phys_mem_size
+
+    def map_range(self, byte_offset: int, num_chunks: int) -> None:
+        """Map ``num_chunks`` physical chunks into the reservation starting at
+        ``byte_offset`` (must be a multiple of ``phys_mem_size``).
+
+        Chunks are pulled from the shared physical pool. Access is granted with
+        a single ``cuMemSetAccess`` spanning the whole contiguous run (its cost
+        is per-mapping, not per-byte -- see the microbenchmark in
+        ``contiguous_primary_kvcache/``). On OOM the partial mapping is rolled
+        back so the call behaves atomically.
+        """
+        assert not self._pm_stack, "cannot use sparse map_range() on a tail-stack VirtMem"
+        assert num_chunks >= 0
+        if num_chunks == 0:
+            return
+        phys_mem_size = self.phys_mem_size
+        start_chunk = self._chunk_index(byte_offset)
+        assert (start_chunk + num_chunks) * phys_mem_size <= self._vm_size
+        mapped: list[int] = []
+        try:
+            for i in range(num_chunks):
+                chunk_index = start_chunk + i
+                assert chunk_index not in self._page_map, f"chunk {chunk_index} already mapped"
+                phys_mem = self._allocator.create()
+                vm_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * chunk_index)
+                _unwrap(drv.cuMemMap(vm_ptr, phys_mem_size, 0, phys_mem.handle, 0))
+                self._page_map[chunk_index] = phys_mem
+                mapped.append(chunk_index)
+            span_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * start_chunk)
+            _unwrap(
+                drv.cuMemSetAccess(span_ptr, phys_mem_size * num_chunks, (self._access_desc,), 1)
+            )
+        except Exception:  # roll back to keep map_range atomic on OOM
+            for chunk_index in mapped:
+                vm_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * chunk_index)
+                _unwrap(drv.cuMemUnmap(vm_ptr, phys_mem_size))
+                self._page_map.pop(chunk_index).close()
+            raise
+
+    def unmap_range(self, byte_offset: int, num_chunks: int) -> None:
+        """Unmap ``num_chunks`` chunks starting at ``byte_offset`` and return
+        their physical handles to the shared pool.
+
+        The caller MUST guarantee no in-flight GPU work references this range
+        (deferred-reclaim gating, DESIGN.md §4.2). ``cuMemUnmap`` is host-side
+        and not stream-ordered.
+        """
+        assert num_chunks >= 0
+        if num_chunks == 0:
+            return
+        phys_mem_size = self.phys_mem_size
+        start_chunk = self._chunk_index(byte_offset)
+        for i in range(num_chunks):
+            chunk_index = start_chunk + i
+            phys_mem = self._page_map.pop(chunk_index, None)
+            assert phys_mem is not None, f"chunk {chunk_index} is not mapped"
+            vm_ptr = drv.CUdeviceptr(int(self._address) + phys_mem_size * chunk_index)
+            _unwrap(drv.cuMemUnmap(vm_ptr, phys_mem_size))
+            phys_mem.close()
+
+    def is_mapped(self, byte_offset: int) -> bool:
+        return self._chunk_index(byte_offset) in self._page_map
+
+    @property
+    def num_sparse_chunks(self) -> int:
+        """Number of chunks currently mapped via the sparse path."""
+        return len(self._page_map)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
@@ -246,6 +246,23 @@ class CommittedPage(Page):
         self.__rawref__.invalidate()
 
 
+class PrivateCommittedPage(CommittedPage):
+    """A sequence-private copy of a committed block (contiguous-arena reuse
+    onboarding, DESIGN.md §4.4): same immutable content and tree-block
+    association as the canonical :class:`CommittedPage`, but it is never
+    registered in ``block.storage`` and its death must not unset the canonical
+    radix entry. Dropped (not offloaded) when its sequence frees -- the
+    canonical copy in the stale tier already covers reuse (§4.3)."""
+
+    __slots__ = ()
+
+    def __del__(self) -> None:
+        # Deliberately bypass CommittedPage.__del__: this page does not own
+        # the tree entry.
+        Page.__del__(self)
+        self.__rawref__.invalidate()
+
+
 @dataclass(slots=True)
 class _PageHolder:
     "Prevents pages from being dropped."

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
@@ -183,6 +183,24 @@ class UncommittedPage(Page):
         block.storage[self.life_cycle] = rawref.ref(committed_page)
         return committed_page
 
+    def convert_to_private_committed(
+        self, block: Block, ready_event: CachedCudaEvent
+    ) -> "PrivateCommittedPage":
+        """Arena-mode intra-batch commit conflict (§4.4): another sequence
+        committed the same tokens first, and rebasing onto its pages would
+        share GPU pages across arenas. Keep this sequence's own storage as a
+        sequence-private committed copy referencing the existing tree block;
+        ``block.storage`` (the canonical entry) is left untouched. The
+        uncommitted page becomes invalid."""
+        assert not self.scheduled_for_eviction
+        assert self.status == PageStatus.DROPPABLE, "Release holder/lock first"
+        self.ready_event = ready_event
+        private = PrivateCommittedPage(
+            self.manager, block, self.life_cycle, self.cache_level, self, self.priority
+        )
+        assert not self.has_valid_slot and private.has_valid_slot
+        return private
+
     def __del__(self) -> None:
         def check_page(p: "BlockPage") -> bool:
             return p is None or isinstance(p.page, CommittedPage)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
@@ -287,7 +287,9 @@ class _PageHolder:
             if not page.scheduled_for_eviction:
                 page.manager.schedule_for_eviction(page)
             block = page.block()
-            if block is None or block.is_orphan:
+            # scheduled_for_eviction re-check: never-evictable pages (e.g.
+            # sequence-private arena copies) were not scheduled above.
+            if (block is None or block.is_orphan) and page.scheduled_for_eviction:
                 page.manager.exclude_from_eviction(page)
         elif page.scheduled_for_eviction:
             page = cast(UncommittedPage, self.page)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -62,6 +62,20 @@ from ._utils import CachedCudaEvent, div_up
 # rare and bounded; disable only for experiments.
 _SYNC_BEFORE_UNMAP = os.getenv("TRTLLM_KV_ARENA_SYNC_BEFORE_UNMAP") != "0"
 
+
+def quiesce_before_unmap() -> None:
+    """Quiesce the device before a ``cuMemUnmap`` batch (gated by
+    ``TRTLLM_KV_ARENA_SYNC_BEFORE_UNMAP``, default ON): concurrent unmaps
+    can fault unrelated in-flight reads at the driver level -- see the
+    driver-interference escalation. Callers batch all unmaps behind ONE
+    quiesce per pressure/teardown event."""
+    if _SYNC_BEFORE_UNMAP:
+        from ._cuda_virt_mem import drv
+        from ._utils import _unwrap
+
+        _unwrap(drv.cuCtxSynchronize())
+
+
 # Kernel-facing offsets are int32, and v1's KVCacheIndex steals the high bit for
 # primary/secondary selection, leaving int31. The emitted value is
 # ``block_index * num_coalesced_subbuffers + field``; its maximum must fit. See
@@ -447,6 +461,55 @@ class SequenceArena:
                 self._aliased[base_block] = self._aliased.get(base_block, 0) + total
         return total
 
+    def remap_prefix_to_alias(
+        self, base_block: int, shared_per_pool: "list[list[SharedPhysMem]]"
+    ) -> int:
+        """Replace the PHYSICAL backing of this range's head chunks with
+        aliases of a canonical span's handles (pressure-time dedup remap,
+        P3 v2): the chunks stay mapped at the same VA addresses, so block
+        offsets and slot ids are untouched -- only the bytes behind them
+        become the canonical copy, and the range's private handles are
+        dropped (returning to the pool when unreferenced). Releases the
+        freed pages' budget charge and marks the chunks alias-accounted.
+        Frontiers are untouched (the head is below the frontier).
+
+        The CALLER must quiesce the device first (``quiesce_before_unmap``,
+        once per remap batch): ``cuMemUnmap`` racing in-flight kernels can
+        fault unrelated reads. If re-aliasing a pool fails after its unmap,
+        the pool's original private handles are mapped back (references are
+        held across the swap), so the range is never left with holes.
+
+        Returns the physical pages freed."""
+        page = self._phys_page_size
+        frontiers = self._frontiers[base_block]
+        total = 0
+        for pool, shared in enumerate(shared_per_pool):
+            if not shared:
+                continue
+            lo = self._chunk_range(pool, base_block, 0)[0]
+            n = len(shared)
+            assert frontiers[pool] >= lo + n, "remap head must be below the mapped frontier"
+            vm = self._vms[pool]
+            # Hold the private handles across the swap so a failed alias map
+            # can restore them (unmap dropped their mapping references).
+            saved = [vm.shared_chunk(c * page).add_ref() for c in range(lo, lo + n)]
+            try:
+                vm.unmap_range(lo * page, n)
+                try:
+                    vm.map_alias(lo * page, shared)
+                except Exception:
+                    vm.map_alias(lo * page, saved)  # restore; range stays intact
+                    raise
+            finally:
+                for s in saved:
+                    s.drop_ref()
+            total += n
+        if total:
+            self._aliased[base_block] = self._aliased.get(base_block, 0) + total
+            if self._budget is not None:
+                self._budget.release(total)
+        return total
+
     def shared_prefix_chunks(self, base_block: int, num_blocks: int) -> "list[list[SharedPhysMem]]":
         """Per pool, the refcounted handles of the chunks FULLY covered by the
         first ``num_blocks`` blocks of this range (canonical registration,
@@ -654,11 +717,7 @@ class SequenceArena:
         and, because concurrent unmaps can fault unrelated in-flight reads at
         the driver level (see ``_SYNC_BEFORE_UNMAP``), the GPU is quiesced
         before the unmap batch unless explicitly disabled."""
-        if _SYNC_BEFORE_UNMAP:
-            from ._cuda_virt_mem import drv
-            from ._utils import _unwrap
-
-            _unwrap(drv.cuCtxSynchronize())
+        quiesce_before_unmap()
         frontiers = self._frontiers.pop(base_block)
         num_aliased = self._aliased.pop(base_block, 0)
         page = self._phys_page_size

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -57,8 +57,9 @@ from ._utils import CachedCudaEvent, div_up
 # faults, reproduced on H100 with Llama-3.1-8B under the overlap scheduler;
 # the fault vanishes when unmaps are serialized against kernels and is immune
 # to event-level ordering fixes, pointing at driver-level TLB interference).
-# The sync happens only at reclaim waves - once per admission burst - so the
-# cost is bounded; disable only for experiments.
+# With freed-range adoption parking ranges instead of unmapping them, actual
+# unmaps happen only under pressure spill or teardown, so the sync cost is
+# rare and bounded; disable only for experiments.
 _SYNC_BEFORE_UNMAP = os.getenv("TRTLLM_KV_ARENA_SYNC_BEFORE_UNMAP") != "0"
 
 # Kernel-facing offsets are int32, and v1's KVCacheIndex steals the high bit for
@@ -542,7 +543,6 @@ class SequenceArena:
         before the unmap batch unless explicitly disabled."""
         if _SYNC_BEFORE_UNMAP:
             from ._cuda_virt_mem import drv
-
             from ._utils import _unwrap
 
             _unwrap(drv.cuCtxSynchronize())

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -318,6 +318,7 @@ class SequenceArena:
         "_map_ahead_pages",
         "_budget",
         "_reclaim",
+        "_frontiers",
     )
     _vms: list[VirtMem]
     _alloc: BlockRangeAllocator
@@ -326,6 +327,12 @@ class SequenceArena:
     _map_ahead_pages: int
     _budget: "PageBudget | None"
     _reclaim: list[_ReclaimEntry]
+    # base_block -> per-pool mapped high-water chunk index. A range's mapped
+    # chunks are always the prefix [range start, frontier): every mapping plan
+    # extends from the current frontier and ranges are page-disjoint, so no
+    # holes can form. Lets growth/reclaim work in O(1) per pool instead of
+    # rescanning every chunk from the range start.
+    _frontiers: dict[int, list[int]]
 
     def __init__(
         self,
@@ -350,6 +357,7 @@ class SequenceArena:
         self._map_ahead_pages = map_ahead_pages
         self._budget = page_budget
         self._reclaim = []
+        self._frontiers = {}
 
     @property
     def num_pools(self) -> int:
@@ -379,19 +387,20 @@ class SequenceArena:
     def mapped_pages_in_range(self, base_block: int) -> int:
         """Number of physical pages currently mapped inside the range starting
         at ``base_block``, across all pools."""
-        num_blocks = self._alloc.reserved_len(base_block)
-        page = self._phys_page_size
+        frontiers = self._frontiers[base_block]
         total = 0
         for pool in range(len(self._vms)):
-            lo, hi = self._chunk_range(pool, base_block, num_blocks)
-            vm = self._vms[pool]
-            total += sum(1 for chunk in range(lo, hi) if vm.is_mapped(chunk * page))
+            total += frontiers[pool] - self._chunk_range(pool, base_block, 0)[0]
         return total
 
     def reserve(self, max_blocks: int) -> int:
         """Reserve VA for a sequence's maximum block count; returns base_block.
         No physical memory is mapped yet (that happens in :meth:`ensure_mapped`)."""
-        return self._alloc.allocate(max_blocks)
+        base_block = self._alloc.allocate(max_blocks)
+        self._frontiers[base_block] = [
+            self._chunk_range(pool, base_block, 0)[0] for pool in range(len(self._vms))
+        ]
+        return base_block
 
     def _chunk_range(self, pool: int, base_block: int, num_blocks: int) -> tuple[int, int]:
         """Half-open physical-chunk index range in ``pool`` covering
@@ -404,48 +413,34 @@ class SequenceArena:
         hi = div_up((base_block + num_blocks) * stride, page)
         return lo, hi
 
-    def _missing_runs(self, pool: int, lo: int, hi: int) -> list[tuple[int, int]]:
-        """Contiguous runs of unmapped chunks in ``pool`` within ``[lo, hi)``,
-        as (start_chunk, num_chunks) pairs."""
-        vm = self._vms[pool]
-        page = self._phys_page_size
-        runs: list[tuple[int, int]] = []
-        run_start = -1
-        chunk = lo
-        while chunk < hi:
-            if not vm.is_mapped(chunk * page):
-                if run_start < 0:
-                    run_start = chunk
-            elif run_start >= 0:
-                runs.append((run_start, chunk - run_start))
-                run_start = -1
-            chunk += 1
-        if run_start >= 0:
-            runs.append((run_start, hi - run_start))
-        return runs
-
     def _mapping_plan(
         self, base_block: int, num_valid_blocks: int
     ) -> tuple[list[list[tuple[int, int]]], int]:
         """Missing-page runs per pool (with map-ahead margin, clamped to the
-        reserved extent) for a target frontier, and their total page count."""
+        reserved extent) for a target frontier, and their total page count.
+        At most one run per pool: mapped chunks are the prefix below the
+        range's mapped frontier, so the missing chunks are exactly
+        ``[frontier, target hi)``."""
         assert num_valid_blocks >= 0
         reserved = self._alloc.reserved_len(base_block)
         margin = self._map_ahead_pages
+        frontiers = self._frontiers[base_block]
         runs_per_pool: list[list[tuple[int, int]]] = []
         total_new = 0
         for pool in range(len(self._vms)):
-            lo, hi = self._chunk_range(pool, base_block, num_valid_blocks)
+            _, hi = self._chunk_range(pool, base_block, num_valid_blocks)
             hi += margin
             # Clamp to this sequence's reserved extent so map-ahead never
             # spills into a neighbour's pages.
             max_hi = self._chunk_range(pool, base_block, reserved)[1]
             if hi > max_hi:
                 hi = max_hi
-            runs = self._missing_runs(pool, lo, hi)
-            runs_per_pool.append(runs)
-            for _, num_chunks in runs:
-                total_new += num_chunks
+            frontier = frontiers[pool]
+            if hi > frontier:
+                runs_per_pool.append([(frontier, hi - frontier)])
+                total_new += hi - frontier
+            else:
+                runs_per_pool.append([])
         return runs_per_pool, total_new
 
     def pending_pages(self, base_block: int, num_valid_blocks: int) -> int:
@@ -477,12 +472,14 @@ class SequenceArena:
         if budget is not None and not precharged:
             budget.consume(total_new)  # raises OutOfPagesError; nothing mapped yet
         page = self._phys_page_size
+        frontiers = self._frontiers[base_block]
         num_mapped = 0
         try:
             for pool in range(len(self._vms)):
                 vm = self._vms[pool]
                 for start_chunk, num_chunks in runs_per_pool[pool]:
                     vm.map_range(start_chunk * page, num_chunks)
+                    frontiers[pool] = start_chunk + num_chunks
                     num_mapped += num_chunks
         except Exception:
             # map_range rolls itself back; return the unmapped remainder to
@@ -529,35 +526,19 @@ class SequenceArena:
     def _reclaim_now(self, base_block: int) -> None:
         """Unmap a range's pages in every pool and return the block range to
         the allocator. Caller guarantees no in-flight work references it."""
-        num_blocks = self._alloc.reserved_len(base_block)
+        frontiers = self._frontiers.pop(base_block)
+        page = self._phys_page_size
         num_unmapped = 0
         for pool in range(len(self._vms)):
-            lo, hi = self._chunk_range(pool, base_block, num_blocks)
-            # Unmap only the pages we actually mapped for this range.
-            num_unmapped += self._unmap_mapped_run(pool, lo, hi)
+            # Mapped chunks are exactly the prefix [range start, frontier).
+            lo = self._chunk_range(pool, base_block, 0)[0]
+            hi = frontiers[pool]
+            if hi > lo:
+                self._vms[pool].unmap_range(lo * page, hi - lo)
+                num_unmapped += hi - lo
         self._alloc.free(base_block)
         if self._budget is not None:
             self._budget.release(num_unmapped)
-
-    def _unmap_mapped_run(self, pool: int, lo: int, hi: int) -> int:
-        vm = self._vms[pool]
-        page = self._phys_page_size
-        num_unmapped = 0
-        run_start = -1
-        chunk = lo
-        while chunk < hi:
-            if vm.is_mapped(chunk * page):
-                if run_start < 0:
-                    run_start = chunk
-            elif run_start >= 0:
-                vm.unmap_range(run_start * page, chunk - run_start)
-                num_unmapped += chunk - run_start
-                run_start = -1
-            chunk += 1
-        if run_start >= 0:
-            vm.unmap_range(run_start * page, hi - run_start)
-            num_unmapped += hi - run_start
-        return num_unmapped
 
     def destroy(self) -> None:
         if self._budget is not None:
@@ -565,3 +546,4 @@ class SequenceArena:
         for vm in self._vms:
             vm.destroy()
         self._reclaim = []
+        self._frontiers = {}

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -476,6 +476,26 @@ class SequenceArena:
                 best = blocks
         return max(0, best)
 
+    def aliasable_span_blocks(self, num_blocks: int) -> int:
+        """Base-independent :meth:`aliasable_prefix_blocks` (ranges start
+        page-aligned in every pool, so the trim depends only on the block
+        count) -- usable before any range exists, e.g. at reuse lookup."""
+        return self.aliasable_prefix_blocks(0, num_blocks)
+
+    def trim_shared_to_blocks(
+        self, shared_per_pool: "list[list[SharedPhysMem]]", num_blocks: int
+    ) -> "list[list[SharedPhysMem]]":
+        """Per pool, the prefix of ``shared_per_pool`` fully covered by the
+        first ``num_blocks`` blocks (P3 partial-span aliasing: a match
+        shorter than the registered span aliases only its own chunks)."""
+        page = self._phys_page_size
+        out: list[list[SharedPhysMem]] = []
+        for pool, shared in enumerate(shared_per_pool):
+            stride = self._strides[pool]
+            k = (num_blocks * stride) // page
+            out.append(shared[:k])
+        return out
+
     def reserve(self, max_blocks: int) -> int:
         """Reserve VA for a sequence's maximum block count; returns base_block.
         No physical memory is mapped yet (that happens in :meth:`ensure_mapped`)."""

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -517,16 +517,18 @@ class SequenceArena:
         return lo, hi
 
     def _mapping_plan(
-        self, base_block: int, num_valid_blocks: int
+        self, base_block: int, num_valid_blocks: int, margin: int = -1
     ) -> tuple[list[list[tuple[int, int]]], int]:
         """Missing-page runs per pool (with map-ahead margin, clamped to the
         reserved extent) for a target frontier, and their total page count.
         At most one run per pool: mapped chunks are the prefix below the
         range's mapped frontier, so the missing chunks are exactly
-        ``[frontier, target hi)``."""
+        ``[frontier, target hi)``. ``margin`` overrides the configured
+        map-ahead margin (negative = use the configured value)."""
         assert num_valid_blocks >= 0
         reserved = self._alloc.reserved_len(base_block)
-        margin = self._map_ahead_pages
+        if margin < 0:
+            margin = self._map_ahead_pages
         frontiers = self._frontiers[base_block]
         runs_per_pool: list[list[tuple[int, int]]] = []
         total_new = 0
@@ -546,12 +548,18 @@ class SequenceArena:
                 runs_per_pool.append([])
         return runs_per_pool, total_new
 
-    def pending_pages(self, base_block: int, num_valid_blocks: int) -> int:
-        """Pages :meth:`ensure_mapped` would map for this target frontier."""
-        return self._mapping_plan(base_block, num_valid_blocks)[1]
+    def pending_pages(self, base_block: int, num_valid_blocks: int, margin: int = -1) -> int:
+        """Pages :meth:`ensure_mapped` would map for this target frontier.
+        ``margin`` overrides the configured map-ahead margin (negative =
+        configured value)."""
+        return self._mapping_plan(base_block, num_valid_blocks, margin)[1]
 
     def ensure_mapped(
-        self, base_block: int, num_valid_blocks: int, precharged: bool = False
+        self,
+        base_block: int,
+        num_valid_blocks: int,
+        precharged: bool = False,
+        margin: int = -1,
     ) -> int:
         """Map physical pages covering ``[base_block, base_block + num_valid_blocks)``
         plus ``map_ahead_pages`` of margin, in every pool, skipping
@@ -562,18 +570,32 @@ class SequenceArena:
         Safe to call concurrently with running kernels: it only touches pages
         strictly ahead of the write frontier.
 
-        If a page budget is attached and cannot cover the new pages, raises
-        ``OutOfPagesError`` *before mapping anything* — the caller reclaims or
-        preempts and retries (§4.6). With ``precharged=True`` the caller has
-        already charged the budget (batched map sweep) and no charge happens
-        here; failure rollback still returns unmapped remainders.
+        If a page budget is attached and cannot cover the new pages, the
+        margin degrades before the call fails: the margin is a latency-hiding
+        hint, and at the capacity edge charging it atomically with the
+        frontier converts a satisfiable growth into a failed allocation (and
+        a spill or preemption) for pages nobody needs yet. Only if the
+        frontier alone does not fit does the call raise ``OutOfPagesError``
+        *before mapping anything* — the caller reclaims or preempts and
+        retries (§4.6). With ``precharged=True`` the caller has already
+        charged the budget (batched map sweep) and no charge happens here;
+        ``margin`` must then be the value the charge was computed with.
+        Failure rollback still returns unmapped remainders.
         """
-        runs_per_pool, total_new = self._mapping_plan(base_block, num_valid_blocks)
+        runs_per_pool, total_new = self._mapping_plan(base_block, num_valid_blocks, margin)
         if total_new == 0:
             return 0
         budget = self._budget
         if budget is not None and not precharged:
-            budget.consume(total_new)  # raises OutOfPagesError; nothing mapped yet
+            try:
+                budget.consume(total_new)  # raises OutOfPagesError; nothing mapped yet
+            except OutOfPagesError:
+                if margin == 0 or (margin < 0 and self._map_ahead_pages == 0):
+                    raise
+                runs_per_pool, total_new = self._mapping_plan(base_block, num_valid_blocks, 0)
+                if total_new == 0:
+                    return 0
+                budget.consume(total_new)  # raises; nothing mapped yet
         page = self._phys_page_size
         frontiers = self._frontiers[base_block]
         num_mapped = 0

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -424,20 +424,11 @@ class SequenceArena:
             runs.append((run_start, hi - run_start))
         return runs
 
-    def ensure_mapped(self, base_block: int, num_valid_blocks: int) -> int:
-        """Map physical pages covering ``[base_block, base_block + num_valid_blocks)``
-        plus ``map_ahead_pages`` of margin, in every pool, skipping
-        already-mapped pages. Returns the number of newly mapped pages.
-
-        Maps are issued as contiguous runs (one :meth:`VirtMem.map_range` per
-        run) so a single ``cuMemSetAccess`` covers each run (DESIGN.md §4.2).
-        Safe to call concurrently with running kernels: it only touches pages
-        strictly ahead of the write frontier.
-
-        If a page budget is attached and cannot cover the new pages, raises
-        ``OutOfPagesError`` *before mapping anything* — the caller reclaims or
-        preempts and retries (§4.6).
-        """
+    def _mapping_plan(
+        self, base_block: int, num_valid_blocks: int
+    ) -> tuple[list[list[tuple[int, int]]], int]:
+        """Missing-page runs per pool (with map-ahead margin, clamped to the
+        reserved extent) for a target frontier, and their total page count."""
         assert num_valid_blocks >= 0
         reserved = self._alloc.reserved_len(base_block)
         margin = self._map_ahead_pages
@@ -455,10 +446,35 @@ class SequenceArena:
             runs_per_pool.append(runs)
             for _, num_chunks in runs:
                 total_new += num_chunks
+        return runs_per_pool, total_new
+
+    def pending_pages(self, base_block: int, num_valid_blocks: int) -> int:
+        """Pages :meth:`ensure_mapped` would map for this target frontier."""
+        return self._mapping_plan(base_block, num_valid_blocks)[1]
+
+    def ensure_mapped(
+        self, base_block: int, num_valid_blocks: int, precharged: bool = False
+    ) -> int:
+        """Map physical pages covering ``[base_block, base_block + num_valid_blocks)``
+        plus ``map_ahead_pages`` of margin, in every pool, skipping
+        already-mapped pages. Returns the number of newly mapped pages.
+
+        Maps are issued as contiguous runs (one :meth:`VirtMem.map_range` per
+        run) so a single ``cuMemSetAccess`` covers each run (DESIGN.md §4.2).
+        Safe to call concurrently with running kernels: it only touches pages
+        strictly ahead of the write frontier.
+
+        If a page budget is attached and cannot cover the new pages, raises
+        ``OutOfPagesError`` *before mapping anything* — the caller reclaims or
+        preempts and retries (§4.6). With ``precharged=True`` the caller has
+        already charged the budget (batched map sweep) and no charge happens
+        here; failure rollback still returns unmapped remainders.
+        """
+        runs_per_pool, total_new = self._mapping_plan(base_block, num_valid_blocks)
         if total_new == 0:
             return 0
         budget = self._budget
-        if budget is not None:
+        if budget is not None and not precharged:
             budget.consume(total_new)  # raises OutOfPagesError; nothing mapped yet
         page = self._phys_page_size
         num_mapped = 0

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -26,21 +26,28 @@ Contents (bottom-up):
 
 * :func:`check_index_width` -- the int31 kernel-offset ceiling check (§4.1),
   meant to run at startup.
-* :class:`BlockRangeAllocator` -- allocates page-aligned, contiguous block-index
-  ranges from the arena's index space (§4.1). Pure logic, no CUDA.
-* :class:`SequenceArena` -- ties a sparse :class:`VirtMem` reservation to a
-  :class:`BlockRangeAllocator` and implements demand paging with map-ahead
-  margin (§4.2) and an event-gated deferred-reclaim queue.
+* :class:`PageBudget` -- the GPU-level physical-page quota (§4.6). Shared by
+  every arena of a cache level; replaces per-pool-group slot partitioning.
+* :class:`BlockRangeAllocator` -- allocates page-aligned, contiguous
+  block-index ranges from an arena's index space (§4.1). Pure logic, no CUDA.
+* :class:`SequenceArena` -- one block-index space for a whole *pool group*:
+  a shared :class:`BlockRangeAllocator` plus one sparse :class:`VirtMem` per
+  pool (a block index addresses all pools of its group, exactly like a slot id
+  does today). Implements demand paging with map-ahead margin (§4.2) and an
+  event-gated deferred-reclaim queue.
 
 The pieces that wire this into the rest of v2 (per-sequence growth in
 ``_KVCache``, capacity accounting in the scheduler, active<->stale copies) are
-NOT here yet; see the "Integration points" stubs at the bottom of the file.
+NOT here; the storage-side seam (``ArenaPoolGroup``) lives in
+``_storage/_core.py``.
 """
 
+from collections.abc import Sequence
 from math import gcd
 
 from ._common import MemAddress
 from ._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
+from ._exceptions import OutOfPagesError
 from ._utils import CachedCudaEvent, div_up
 
 # Kernel-facing offsets are int32, and v1's KVCacheIndex steals the high bit for
@@ -57,6 +64,7 @@ def check_index_width(block_capacity: int, num_coalesced_subbuffers: int) -> Non
     ``num_coalesced_subbuffers`` is the per-slot ``scale`` factor (number of
     coalesced sub-buffers per block, e.g. ``num_layers * kv_factor`` plus any
     extra buffers) -- the same value the existing offset-table converter uses.
+    For a pool group whose pools have different scales, pass the maximum.
 
     Raises ``ValueError`` (a clear startup-time error, per DESIGN.md §4.1)
     rather than letting the kernels silently read garbage.
@@ -72,15 +80,71 @@ def check_index_width(block_capacity: int, num_coalesced_subbuffers: int) -> Non
         )
 
 
+class PageBudget:
+    """GPU-level physical-page quota (DESIGN.md §4.6).
+
+    In arena mode the KV GPU quota is enforced here, at *mapping* time, instead
+    of by pre-partitioned per-pool-group slot counts: all arenas of a cache
+    level share one budget and compete for pages. Pure bookkeeping (the actual
+    handles live in the shared :class:`PooledPhysMemAllocator`).
+    """
+
+    __slots__ = ("_total", "_used")
+    _total: int
+    _used: int
+
+    def __init__(self, total_pages: int) -> None:
+        assert total_pages > 0
+        self._total = total_pages
+        self._used = 0
+
+    @property
+    def total_pages(self) -> int:
+        return self._total
+
+    @property
+    def used_pages(self) -> int:
+        return self._used
+
+    @property
+    def free_pages(self) -> int:
+        return self._total - self._used
+
+    def consume(self, num_pages: int) -> None:
+        """Take ``num_pages`` from the budget; raises ``OutOfPagesError``
+        (without side effects) if the budget cannot cover them. This is the
+        signal for the caller to reclaim/preempt (§4.6)."""
+        assert num_pages >= 0
+        if self._used + num_pages > self._total:
+            raise OutOfPagesError(
+                f"KV page budget exhausted: need {num_pages} pages, "
+                f"{self.free_pages}/{self._total} free"
+            )
+        self._used += num_pages
+
+    def release(self, num_pages: int) -> None:
+        assert 0 <= num_pages <= self._used
+        self._used -= num_pages
+
+
+def _normalize_strides(record_stride: "int | Sequence[int]") -> tuple[int, ...]:
+    if isinstance(record_stride, int):
+        return (record_stride,)
+    strides = tuple(record_stride)
+    assert strides, "at least one pool record stride is required"
+    return strides
+
+
 class BlockRangeAllocator:
-    """First-fit free-list allocator over an arena's block-index space.
+    """First-fit free-list allocator over a pool group's block-index space.
 
     Hands out contiguous ``[base_block, base_block + length)`` ranges. Every
-    allocation is aligned and padded to a physical-page boundary so that two
-    sequences never share a physical page (which would couple their map/unmap
-    lifetimes). Alignment is expressed in blocks:
-    ``align = phys_page_size / gcd(record_stride, phys_page_size)`` -- the
-    smallest block count whose byte extent is a whole number of physical pages.
+    allocation is aligned and padded to a physical-page boundary *in every
+    pool of the group* so that two sequences never share a physical page
+    (which would couple their map/unmap lifetimes). Per-pool alignment,
+    expressed in blocks, is ``phys_page_size / gcd(record_stride,
+    phys_page_size)`` -- the smallest block count whose byte extent is a whole
+    number of physical pages; the group alignment is the lcm across pools.
 
     Live allocations are tracked (``base_block -> padded length``) so ranges can
     be freed by base alone. Pure Python logic (no CUDA); unit-testable on its own.
@@ -93,9 +157,19 @@ class BlockRangeAllocator:
     _free: list[list[int]]
     _live: dict[int, int]  # base_block -> padded length in blocks
 
-    def __init__(self, capacity_blocks: int, record_stride: int, phys_page_size: int) -> None:
-        assert capacity_blocks > 0 and record_stride > 0 and phys_page_size > 0
-        align = phys_page_size // gcd(record_stride, phys_page_size)
+    def __init__(
+        self,
+        capacity_blocks: int,
+        record_stride: "int | Sequence[int]",
+        phys_page_size: int,
+    ) -> None:
+        strides = _normalize_strides(record_stride)
+        assert capacity_blocks > 0 and phys_page_size > 0
+        assert all(s > 0 for s in strides)
+        align = 1
+        for stride in strides:
+            pool_align = phys_page_size // gcd(stride, phys_page_size)
+            align = align * pool_align // gcd(align, pool_align)  # lcm
         # The arena's usable capacity is floored to a whole number of alignment units.
         capacity = (capacity_blocks // align) * align
         assert capacity >= align, "arena too small to hold even one page-aligned range"
@@ -116,6 +190,9 @@ class BlockRangeAllocator:
         """Padded length (in blocks) of the live allocation starting at
         ``base_block``."""
         return self._live[base_block]
+
+    def is_live(self, base_block: int) -> bool:
+        return base_block in self._live
 
     def _round_up(self, num_blocks: int) -> int:
         align = self._align
@@ -197,101 +274,179 @@ class _ReclaimEntry:
 
 
 class SequenceArena:
-    """One arena (one ``cuMemAddressReserve``) shared by all sequences of a
-    (pool group, pool). Carves page-aligned block-index ranges and maps physical
-    pages on demand, recycling them through the shared physical pool on free.
+    """The contiguous block-index space of one *pool group*: one shared
+    :class:`BlockRangeAllocator` and one sparse ``cuMemAddressReserve`` per
+    pool. Carves page-aligned block-index ranges for sequences and maps
+    physical pages on demand (in every pool), recycling them through the
+    shared physical pool on free.
 
-    The arena base pointer is fixed for the process lifetime, preserving the
-    kernel/CUDA-graph contract ``pool_base + page_index * page_stride``
-    (DESIGN.md §3). ``record_stride`` is the byte size of one block's coalesced
-    record; the physical mapping granularity (super-page) is the shared
-    allocator's ``phys_mem_size`` -- see :class:`ContiguousArenaConfig`.
+    A block index addresses *all* pools of the group -- byte address in pool
+    ``p`` is ``base_address(p) + block_index * record_stride[p]`` -- mirroring
+    how one slot id addresses every pool today. Arena base pointers are fixed
+    for the process lifetime, preserving the kernel/CUDA-graph contract
+    ``pool_base + page_index * page_stride`` (DESIGN.md §3).
+
+    ``record_stride`` is the byte size of one block's coalesced record per
+    pool (a single int for one-pool groups); the physical mapping granularity
+    (super-page) is the shared allocator's ``phys_mem_size`` -- see
+    :class:`ContiguousArenaConfig`. If ``page_budget`` is given, every page
+    mapped/unmapped is accounted against it (§4.6); ``ensure_mapped`` raises
+    ``OutOfPagesError`` (mapping nothing) when the budget is exhausted.
     """
 
     __slots__ = (
-        "_vm",
+        "_vms",
         "_alloc",
-        "_record_stride",
+        "_strides",
         "_phys_page_size",
         "_map_ahead_pages",
+        "_budget",
         "_reclaim",
     )
-    _vm: VirtMem
+    _vms: list[VirtMem]
     _alloc: BlockRangeAllocator
-    _record_stride: int
+    _strides: tuple[int, ...]
     _phys_page_size: int
     _map_ahead_pages: int
+    _budget: "PageBudget | None"
     _reclaim: list[_ReclaimEntry]
 
     def __init__(
         self,
         block_capacity: int,
-        record_stride: int,
+        record_stride: "int | Sequence[int]",
         phys_mem_allocator: PooledPhysMemAllocator,
         map_ahead_pages: int = 1,
+        page_budget: "PageBudget | None" = None,
     ) -> None:
+        strides = _normalize_strides(record_stride)
         phys_page_size = phys_mem_allocator.phys_mem_size
-        va_size = div_up(block_capacity * record_stride, phys_page_size) * phys_page_size
-        self._vm = VirtMem(va_size, phys_mem_allocator)
-        self._alloc = BlockRangeAllocator(block_capacity, record_stride, phys_page_size)
-        self._record_stride = record_stride
+        self._vms = [
+            VirtMem(
+                div_up(block_capacity * stride, phys_page_size) * phys_page_size,
+                phys_mem_allocator,
+            )
+            for stride in strides
+        ]
+        self._alloc = BlockRangeAllocator(block_capacity, strides, phys_page_size)
+        self._strides = strides
         self._phys_page_size = phys_page_size
         self._map_ahead_pages = map_ahead_pages
+        self._budget = page_budget
         self._reclaim = []
 
     @property
-    def base_address(self) -> MemAddress:
-        return self._vm.address
+    def num_pools(self) -> int:
+        return len(self._vms)
+
+    def base_address(self, pool: int = 0) -> MemAddress:
+        return self._vms[pool].address
 
     @property
     def mapped_pages(self) -> int:
-        return self._vm.num_sparse_chunks
+        total = 0
+        for vm in self._vms:
+            total += vm.num_sparse_chunks
+        return total
+
+    @property
+    def capacity_blocks(self) -> int:
+        return self._alloc.capacity_blocks
+
+    @property
+    def free_blocks(self) -> int:
+        return self._alloc.free_blocks()
+
+    def reserved_len(self, base_block: int) -> int:
+        return self._alloc.reserved_len(base_block)
 
     def reserve(self, max_blocks: int) -> int:
         """Reserve VA for a sequence's maximum block count; returns base_block.
         No physical memory is mapped yet (that happens in :meth:`ensure_mapped`)."""
         return self._alloc.allocate(max_blocks)
 
-    def _chunk_range(self, base_block: int, num_blocks: int) -> tuple[int, int]:
-        """Half-open physical-chunk index range covering ``num_blocks`` blocks
-        starting at ``base_block``. Ranges are page-aligned per sequence, so a
-        chunk belongs to exactly one sequence."""
-        stride = self._record_stride
+    def _chunk_range(self, pool: int, base_block: int, num_blocks: int) -> tuple[int, int]:
+        """Half-open physical-chunk index range in ``pool`` covering
+        ``num_blocks`` blocks starting at ``base_block``. Ranges are
+        page-aligned per sequence in every pool, so a chunk belongs to exactly
+        one sequence."""
+        stride = self._strides[pool]
         page = self._phys_page_size
         lo = (base_block * stride) // page
         hi = div_up((base_block + num_blocks) * stride, page)
         return lo, hi
 
-    def ensure_mapped(self, base_block: int, num_valid_blocks: int) -> None:
+    def _missing_runs(self, pool: int, lo: int, hi: int) -> list[tuple[int, int]]:
+        """Contiguous runs of unmapped chunks in ``pool`` within ``[lo, hi)``,
+        as (start_chunk, num_chunks) pairs."""
+        vm = self._vms[pool]
+        page = self._phys_page_size
+        runs: list[tuple[int, int]] = []
+        run_start = -1
+        chunk = lo
+        while chunk < hi:
+            if not vm.is_mapped(chunk * page):
+                if run_start < 0:
+                    run_start = chunk
+            elif run_start >= 0:
+                runs.append((run_start, chunk - run_start))
+                run_start = -1
+            chunk += 1
+        if run_start >= 0:
+            runs.append((run_start, hi - run_start))
+        return runs
+
+    def ensure_mapped(self, base_block: int, num_valid_blocks: int) -> int:
         """Map physical pages covering ``[base_block, base_block + num_valid_blocks)``
-        plus ``map_ahead_pages`` of margin, skipping already-mapped pages.
+        plus ``map_ahead_pages`` of margin, in every pool, skipping
+        already-mapped pages. Returns the number of newly mapped pages.
 
         Maps are issued as contiguous runs (one :meth:`VirtMem.map_range` per
         run) so a single ``cuMemSetAccess`` covers each run (DESIGN.md §4.2).
         Safe to call concurrently with running kernels: it only touches pages
         strictly ahead of the write frontier.
+
+        If a page budget is attached and cannot cover the new pages, raises
+        ``OutOfPagesError`` *before mapping anything* — the caller reclaims or
+        preempts and retries (§4.6).
         """
         assert num_valid_blocks >= 0
-        lo, hi = self._chunk_range(base_block, num_valid_blocks)
-        hi += self._map_ahead_pages
-        # Clamp to this sequence's reserved extent so map-ahead never spills into
-        # a neighbour's pages.
-        max_hi = self._chunk_range(base_block, self._alloc.reserved_len(base_block))[1]
-        if hi > max_hi:
-            hi = max_hi
+        reserved = self._alloc.reserved_len(base_block)
+        margin = self._map_ahead_pages
+        runs_per_pool: list[list[tuple[int, int]]] = []
+        total_new = 0
+        for pool in range(len(self._vms)):
+            lo, hi = self._chunk_range(pool, base_block, num_valid_blocks)
+            hi += margin
+            # Clamp to this sequence's reserved extent so map-ahead never
+            # spills into a neighbour's pages.
+            max_hi = self._chunk_range(pool, base_block, reserved)[1]
+            if hi > max_hi:
+                hi = max_hi
+            runs = self._missing_runs(pool, lo, hi)
+            runs_per_pool.append(runs)
+            for _, num_chunks in runs:
+                total_new += num_chunks
+        if total_new == 0:
+            return 0
+        budget = self._budget
+        if budget is not None:
+            budget.consume(total_new)  # raises OutOfPagesError; nothing mapped yet
         page = self._phys_page_size
-        run_start = -1
-        chunk = lo
-        while chunk < hi:
-            if not self._vm.is_mapped(chunk * page):
-                if run_start < 0:
-                    run_start = chunk
-            elif run_start >= 0:
-                self._vm.map_range(run_start * page, chunk - run_start)
-                run_start = -1
-            chunk += 1
-        if run_start >= 0:
-            self._vm.map_range(run_start * page, hi - run_start)
+        num_mapped = 0
+        try:
+            for pool in range(len(self._vms)):
+                vm = self._vms[pool]
+                for start_chunk, num_chunks in runs_per_pool[pool]:
+                    vm.map_range(start_chunk * page, num_chunks)
+                    num_mapped += num_chunks
+        except Exception:
+            # map_range rolls itself back; return the unmapped remainder to
+            # the budget (already-mapped runs stay mapped and accounted).
+            if budget is not None:
+                budget.release(total_new - num_mapped)
+            raise
+        return total_new
 
     def enqueue_free(self, base_block: int, last_consumer: CachedCudaEvent) -> None:
         """Queue a freed range for deferred unmap once ``last_consumer`` (the
@@ -301,6 +456,7 @@ class SequenceArena:
         The block-index range stays reserved (not returned to the allocator)
         until :meth:`drain_reclaim` actually unmaps it, so it cannot be reissued
         to another sequence while pages are still live."""
+        assert self._alloc.is_live(base_block)
         self._reclaim.append(_ReclaimEntry(base_block, last_consumer))
 
     def drain_reclaim(self) -> int:
@@ -311,54 +467,57 @@ class SequenceArena:
         reclaimed = 0
         for entry in self._reclaim:
             if entry.event.query_complete():
-                num_blocks = self._alloc.reserved_len(entry.base_block)
-                lo, hi = self._chunk_range(entry.base_block, num_blocks)
-                # Unmap only the pages we actually mapped for this range.
-                self._unmap_mapped_run(lo, hi)
-                self._alloc.free(entry.base_block)
+                self._reclaim_now(entry.base_block)
                 reclaimed += 1
             else:
                 remaining.append(entry)
         self._reclaim = remaining
         return reclaimed
 
-    def _unmap_mapped_run(self, lo: int, hi: int) -> None:
+    def reclaim(self, base_block: int) -> None:
+        """Immediately unmap a range's pages and return its block indices to
+        the allocator. The caller must itself guarantee that no in-flight GPU
+        work references the range (e.g. ``ArenaPoolGroup`` gates on slot
+        release and CUDA events before calling this). For simple single-event
+        gating use :meth:`enqueue_free` + :meth:`drain_reclaim` instead."""
+        self._reclaim_now(base_block)
+
+    def _reclaim_now(self, base_block: int) -> None:
+        """Unmap a range's pages in every pool and return the block range to
+        the allocator. Caller guarantees no in-flight work references it."""
+        num_blocks = self._alloc.reserved_len(base_block)
+        num_unmapped = 0
+        for pool in range(len(self._vms)):
+            lo, hi = self._chunk_range(pool, base_block, num_blocks)
+            # Unmap only the pages we actually mapped for this range.
+            num_unmapped += self._unmap_mapped_run(pool, lo, hi)
+        self._alloc.free(base_block)
+        if self._budget is not None:
+            self._budget.release(num_unmapped)
+
+    def _unmap_mapped_run(self, pool: int, lo: int, hi: int) -> int:
+        vm = self._vms[pool]
         page = self._phys_page_size
+        num_unmapped = 0
         run_start = -1
         chunk = lo
         while chunk < hi:
-            if self._vm.is_mapped(chunk * page):
+            if vm.is_mapped(chunk * page):
                 if run_start < 0:
                     run_start = chunk
             elif run_start >= 0:
-                self._vm.unmap_range(run_start * page, chunk - run_start)
+                vm.unmap_range(run_start * page, chunk - run_start)
+                num_unmapped += chunk - run_start
                 run_start = -1
             chunk += 1
         if run_start >= 0:
-            self._vm.unmap_range(run_start * page, hi - run_start)
+            vm.unmap_range(run_start * page, hi - run_start)
+            num_unmapped += hi - run_start
+        return num_unmapped
 
     def destroy(self) -> None:
-        self._vm.destroy()
-
-
-# ---------------------------------------------------------------------------
-# Integration points (NOT yet implemented -- P0 remaining work, DESIGN.md §5)
-#
-# The following seams connect SequenceArena to the rest of v2. They are called
-# out here so the scaffold documents the full P0 surface; each needs GPU
-# integration testing to build for real.
-#
-# * _storage/_core.py: `GpuSlotPool` -> `GpuArenaPool` holding a SequenceArena
-#   instead of a tail-stack VirtMem; `SlotAllocator` retired for the GPU level.
-# * _core/_kv_cache.py `resize`: grow = extend own range + `ensure_mapped`;
-#   block-index emission = `base_block + ordinal` (replaces scattered slot ids);
-#   suspend/resume = write-out/copy-in + range release/realloc.
-# * _storage_manager.py: GPU-level eviction becomes reclaim/preempt;
-#   `_batched_migrate` gains an explicit-destination mode for reuse placement
-#   (§4.4) and the write-through-on-commit path (§4.3).
-# * pyexecutor/kv_cache_manager_v2.py: capacity API in physical pages (§4.6);
-#   batched `ensure_mapped` sweep in the prepare step; call `drain_reclaim` at
-#   iteration boundaries. Offset-table plumbing is otherwise unchanged.
-# * Startup: call `check_index_width(block_capacity, scale)` when building the
-#   arena for each pool (§4.1).
-# ---------------------------------------------------------------------------
+        if self._budget is not None:
+            self._budget.release(self.mapped_pages)
+        for vm in self._vms:
+            vm.destroy()
+        self._reclaim = []

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -703,21 +703,26 @@ class SequenceArena:
         self._reclaim = remaining
         return reclaimed
 
-    def reclaim(self, base_block: int) -> None:
+    def reclaim(self, base_block: int, quiesce: bool = True) -> None:
         """Immediately unmap a range's pages and return its block indices to
         the allocator. The caller must itself guarantee that no in-flight GPU
         work references the range (e.g. ``ArenaPoolGroup`` gates on slot
         release and CUDA events before calling this). For simple single-event
-        gating use :meth:`enqueue_free` + :meth:`drain_reclaim` instead."""
-        self._reclaim_now(base_block)
+        gating use :meth:`enqueue_free` + :meth:`drain_reclaim` instead.
+        ``quiesce=False`` skips the per-call device quiesce -- ONLY for
+        callers that already quiesced for the whole batch (the hard-reclaim
+        path, P3 v3) and enqueue no GPU work in between."""
+        self._reclaim_now(base_block, quiesce)
 
-    def _reclaim_now(self, base_block: int) -> None:
+    def _reclaim_now(self, base_block: int, quiesce: bool = True) -> None:
         """Unmap a range's pages in every pool and return the block range to
         the allocator. Caller guarantees no in-flight work references it --
         and, because concurrent unmaps can fault unrelated in-flight reads at
         the driver level (see ``_SYNC_BEFORE_UNMAP``), the GPU is quiesced
-        before the unmap batch unless explicitly disabled."""
-        quiesce_before_unmap()
+        before the unmap batch unless explicitly disabled or the caller
+        already quiesced for the batch (``quiesce=False``)."""
+        if quiesce:
+            quiesce_before_unmap()
         frontiers = self._frontiers.pop(base_block)
         num_aliased = self._aliased.pop(base_block, 0)
         page = self._phys_page_size

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -89,14 +89,18 @@ class PageBudget:
     handles live in the shared :class:`PooledPhysMemAllocator`).
     """
 
-    __slots__ = ("_total", "_used")
+    __slots__ = ("_total", "_used", "_retained")
     _total: int
     _used: int
+    # Subset of _used held by lazily retained ranges (§4.4 phase 2): mapped
+    # but reclaimable at will, analogous to classic "evictable" blocks.
+    _retained: int
 
     def __init__(self, total_pages: int) -> None:
         assert total_pages > 0
         self._total = total_pages
         self._used = 0
+        self._retained = 0
 
     @property
     def total_pages(self) -> int:
@@ -107,8 +111,20 @@ class PageBudget:
         return self._used
 
     @property
+    def retained_pages(self) -> int:
+        return self._retained
+
+    @property
     def free_pages(self) -> int:
         return self._total - self._used
+
+    def retain(self, num_pages: int) -> None:
+        assert 0 <= num_pages and self._retained + num_pages <= self._used
+        self._retained += num_pages
+
+    def unretain(self, num_pages: int) -> None:
+        assert 0 <= num_pages <= self._retained
+        self._retained -= num_pages
 
     def consume(self, num_pages: int) -> None:
         """Take ``num_pages`` from the budget; raises ``OutOfPagesError``
@@ -359,6 +375,18 @@ class SequenceArena:
 
     def reserved_len(self, base_block: int) -> int:
         return self._alloc.reserved_len(base_block)
+
+    def mapped_pages_in_range(self, base_block: int) -> int:
+        """Number of physical pages currently mapped inside the range starting
+        at ``base_block``, across all pools."""
+        num_blocks = self._alloc.reserved_len(base_block)
+        page = self._phys_page_size
+        total = 0
+        for pool in range(len(self._vms)):
+            lo, hi = self._chunk_range(pool, base_block, num_blocks)
+            vm = self._vms[pool]
+            total += sum(1 for chunk in range(lo, hi) if vm.is_mapped(chunk * page))
+        return total
 
     def reserve(self, max_blocks: int) -> int:
         """Reserve VA for a sequence's maximum block count; returns base_block.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-sequence contiguous VA arenas for the KV cache (prototype).
+
+This is the storage foundation for the *contiguous-in-VA active KV cache*: a
+single large ``cuMemAddressReserve`` per (pool group, pool) — the **arena** —
+out of which each sequence gets a contiguous run of block indices, backed by
+physical pages mapped on demand and recycled through the shared physical pool.
+See ``contiguous_primary_kvcache/DESIGN.md`` for the full design; section
+references below (§4.1, §4.2, ...) point into it.
+
+Contents (bottom-up):
+
+* :func:`check_index_width` -- the int31 kernel-offset ceiling check (§4.1),
+  meant to run at startup.
+* :class:`BlockRangeAllocator` -- allocates page-aligned, contiguous block-index
+  ranges from the arena's index space (§4.1). Pure logic, no CUDA.
+* :class:`SequenceArena` -- ties a sparse :class:`VirtMem` reservation to a
+  :class:`BlockRangeAllocator` and implements demand paging with map-ahead
+  margin (§4.2) and an event-gated deferred-reclaim queue.
+
+The pieces that wire this into the rest of v2 (per-sequence growth in
+``_KVCache``, capacity accounting in the scheduler, active<->stale copies) are
+NOT here yet; see the "Integration points" stubs at the bottom of the file.
+"""
+
+from math import gcd
+
+from ._common import MemAddress
+from ._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
+from ._utils import CachedCudaEvent, div_up
+
+# Kernel-facing offsets are int32, and v1's KVCacheIndex steals the high bit for
+# primary/secondary selection, leaving int31. The emitted value is
+# ``block_index * num_coalesced_subbuffers + field``; its maximum must fit. See
+# DESIGN.md §4.1.
+INT31_MAX: int = (1 << 31) - 1
+
+
+def check_index_width(block_capacity: int, num_coalesced_subbuffers: int) -> None:
+    """Assert that every kernel-facing offset an arena of ``block_capacity``
+    blocks can emit fits in int31.
+
+    ``num_coalesced_subbuffers`` is the per-slot ``scale`` factor (number of
+    coalesced sub-buffers per block, e.g. ``num_layers * kv_factor`` plus any
+    extra buffers) -- the same value the existing offset-table converter uses.
+
+    Raises ``ValueError`` (a clear startup-time error, per DESIGN.md §4.1)
+    rather than letting the kernels silently read garbage.
+    """
+    assert block_capacity > 0 and num_coalesced_subbuffers > 0
+    max_emitted = block_capacity * num_coalesced_subbuffers - 1
+    if max_emitted > INT31_MAX:
+        raise ValueError(
+            f"contiguous KV arena would emit block offsets up to {max_emitted}, exceeding the "
+            f"int31 kernel-offset ceiling ({INT31_MAX}). block_capacity={block_capacity}, "
+            f"scale={num_coalesced_subbuffers}. Mitigations (DESIGN.md §4.1): larger "
+            f"tokens_per_block, per-size-class arenas, or a wider offset dtype."
+        )
+
+
+class BlockRangeAllocator:
+    """First-fit free-list allocator over an arena's block-index space.
+
+    Hands out contiguous ``[base_block, base_block + length)`` ranges. Every
+    allocation is aligned and padded to a physical-page boundary so that two
+    sequences never share a physical page (which would couple their map/unmap
+    lifetimes). Alignment is expressed in blocks:
+    ``align = phys_page_size / gcd(record_stride, phys_page_size)`` -- the
+    smallest block count whose byte extent is a whole number of physical pages.
+
+    Live allocations are tracked (``base_block -> padded length``) so ranges can
+    be freed by base alone. Pure Python logic (no CUDA); unit-testable on its own.
+    """
+
+    __slots__ = ("_capacity", "_align", "_free", "_live")
+    _capacity: int  # total blocks in the arena
+    _align: int  # allocation granularity in blocks
+    # sorted, coalesced, non-overlapping free extents as [start, length] in blocks
+    _free: list[list[int]]
+    _live: dict[int, int]  # base_block -> padded length in blocks
+
+    def __init__(self, capacity_blocks: int, record_stride: int, phys_page_size: int) -> None:
+        assert capacity_blocks > 0 and record_stride > 0 and phys_page_size > 0
+        align = phys_page_size // gcd(record_stride, phys_page_size)
+        # The arena's usable capacity is floored to a whole number of alignment units.
+        capacity = (capacity_blocks // align) * align
+        assert capacity >= align, "arena too small to hold even one page-aligned range"
+        self._capacity = capacity
+        self._align = align
+        self._free = [[0, capacity]]
+        self._live = {}
+
+    @property
+    def align_blocks(self) -> int:
+        return self._align
+
+    @property
+    def capacity_blocks(self) -> int:
+        return self._capacity
+
+    def reserved_len(self, base_block: int) -> int:
+        """Padded length (in blocks) of the live allocation starting at
+        ``base_block``."""
+        return self._live[base_block]
+
+    def _round_up(self, num_blocks: int) -> int:
+        align = self._align
+        return div_up(num_blocks, align) * align
+
+    def allocate(self, num_blocks: int) -> int:
+        """Reserve a contiguous range of at least ``num_blocks`` (padded to the
+        alignment) and return its aligned ``base_block``.
+
+        Raises ``MemoryError`` if the arena has no free extent large enough
+        (this is VA exhaustion / fragmentation, not physical OOM).
+        """
+        assert num_blocks > 0
+        want = self._round_up(num_blocks)
+        for extent in self._free:
+            start, length = extent[0], extent[1]
+            if length >= want:
+                base = start
+                if length == want:
+                    self._free.remove(extent)
+                else:
+                    extent[0] = start + want
+                    extent[1] = length - want
+                self._live[base] = want
+                return base
+        raise MemoryError(
+            f"contiguous KV arena has no free range of {want} blocks "
+            f"(largest free extent is {self.largest_free_blocks()})"
+        )
+
+    def free(self, base_block: int) -> None:
+        """Return a previously allocated range (identified by its ``base_block``)
+        to the free list, coalescing with adjacent free extents."""
+        length = self._live.pop(base_block)
+        assert base_block % self._align == 0, "base_block must be page-aligned"
+        assert 0 <= base_block and base_block + length <= self._capacity
+        end = base_block + length
+        # Insert sorted by start, then coalesce with neighbours.
+        free = self._free
+        idx = 0
+        while idx < len(free) and free[idx][0] < base_block:
+            idx += 1
+        # No overlap with existing free extents (double-free guard).
+        if idx > 0:
+            assert free[idx - 1][0] + free[idx - 1][1] <= base_block, "double free / overlap"
+        if idx < len(free):
+            assert end <= free[idx][0], "double free / overlap"
+        free.insert(idx, [base_block, length])
+        self._coalesce_at(idx)
+
+    def _coalesce_at(self, idx: int) -> None:
+        free = self._free
+        # merge with right neighbour
+        if idx + 1 < len(free) and free[idx][0] + free[idx][1] == free[idx + 1][0]:
+            free[idx][1] += free[idx + 1][1]
+            free.pop(idx + 1)
+        # merge with left neighbour
+        if idx > 0 and free[idx - 1][0] + free[idx - 1][1] == free[idx][0]:
+            free[idx - 1][1] += free[idx][1]
+            free.pop(idx)
+
+    def largest_free_blocks(self) -> int:
+        return max((extent[1] for extent in self._free), default=0)
+
+    def free_blocks(self) -> int:
+        return sum(extent[1] for extent in self._free)
+
+
+class _ReclaimEntry:
+    """A freed arena range awaiting event-gated unmap (DESIGN.md §4.2)."""
+
+    __slots__ = ("base_block", "event")
+    base_block: int
+    event: CachedCudaEvent
+
+    def __init__(self, base_block: int, event: CachedCudaEvent) -> None:
+        self.base_block = base_block
+        self.event = event
+
+
+class SequenceArena:
+    """One arena (one ``cuMemAddressReserve``) shared by all sequences of a
+    (pool group, pool). Carves page-aligned block-index ranges and maps physical
+    pages on demand, recycling them through the shared physical pool on free.
+
+    The arena base pointer is fixed for the process lifetime, preserving the
+    kernel/CUDA-graph contract ``pool_base + page_index * page_stride``
+    (DESIGN.md §3). ``record_stride`` is the byte size of one block's coalesced
+    record; the physical mapping granularity (super-page) is the shared
+    allocator's ``phys_mem_size`` -- see :class:`ContiguousArenaConfig`.
+    """
+
+    __slots__ = (
+        "_vm",
+        "_alloc",
+        "_record_stride",
+        "_phys_page_size",
+        "_map_ahead_pages",
+        "_reclaim",
+    )
+    _vm: VirtMem
+    _alloc: BlockRangeAllocator
+    _record_stride: int
+    _phys_page_size: int
+    _map_ahead_pages: int
+    _reclaim: list[_ReclaimEntry]
+
+    def __init__(
+        self,
+        block_capacity: int,
+        record_stride: int,
+        phys_mem_allocator: PooledPhysMemAllocator,
+        map_ahead_pages: int = 1,
+    ) -> None:
+        phys_page_size = phys_mem_allocator.phys_mem_size
+        va_size = div_up(block_capacity * record_stride, phys_page_size) * phys_page_size
+        self._vm = VirtMem(va_size, phys_mem_allocator)
+        self._alloc = BlockRangeAllocator(block_capacity, record_stride, phys_page_size)
+        self._record_stride = record_stride
+        self._phys_page_size = phys_page_size
+        self._map_ahead_pages = map_ahead_pages
+        self._reclaim = []
+
+    @property
+    def base_address(self) -> MemAddress:
+        return self._vm.address
+
+    @property
+    def mapped_pages(self) -> int:
+        return self._vm.num_sparse_chunks
+
+    def reserve(self, max_blocks: int) -> int:
+        """Reserve VA for a sequence's maximum block count; returns base_block.
+        No physical memory is mapped yet (that happens in :meth:`ensure_mapped`)."""
+        return self._alloc.allocate(max_blocks)
+
+    def _chunk_range(self, base_block: int, num_blocks: int) -> tuple[int, int]:
+        """Half-open physical-chunk index range covering ``num_blocks`` blocks
+        starting at ``base_block``. Ranges are page-aligned per sequence, so a
+        chunk belongs to exactly one sequence."""
+        stride = self._record_stride
+        page = self._phys_page_size
+        lo = (base_block * stride) // page
+        hi = div_up((base_block + num_blocks) * stride, page)
+        return lo, hi
+
+    def ensure_mapped(self, base_block: int, num_valid_blocks: int) -> None:
+        """Map physical pages covering ``[base_block, base_block + num_valid_blocks)``
+        plus ``map_ahead_pages`` of margin, skipping already-mapped pages.
+
+        Maps are issued as contiguous runs (one :meth:`VirtMem.map_range` per
+        run) so a single ``cuMemSetAccess`` covers each run (DESIGN.md §4.2).
+        Safe to call concurrently with running kernels: it only touches pages
+        strictly ahead of the write frontier.
+        """
+        assert num_valid_blocks >= 0
+        lo, hi = self._chunk_range(base_block, num_valid_blocks)
+        hi += self._map_ahead_pages
+        # Clamp to this sequence's reserved extent so map-ahead never spills into
+        # a neighbour's pages.
+        max_hi = self._chunk_range(base_block, self._alloc.reserved_len(base_block))[1]
+        if hi > max_hi:
+            hi = max_hi
+        page = self._phys_page_size
+        run_start = -1
+        chunk = lo
+        while chunk < hi:
+            if not self._vm.is_mapped(chunk * page):
+                if run_start < 0:
+                    run_start = chunk
+            elif run_start >= 0:
+                self._vm.map_range(run_start * page, chunk - run_start)
+                run_start = -1
+            chunk += 1
+        if run_start >= 0:
+            self._vm.map_range(run_start * page, hi - run_start)
+
+    def enqueue_free(self, base_block: int, last_consumer: CachedCudaEvent) -> None:
+        """Queue a freed range for deferred unmap once ``last_consumer`` (the
+        forward step / D2H copy / transfer agent) completes. Unmapping a range
+        still referenced by in-flight work is an IMA (DESIGN.md §4.2, risk #3).
+
+        The block-index range stays reserved (not returned to the allocator)
+        until :meth:`drain_reclaim` actually unmaps it, so it cannot be reissued
+        to another sequence while pages are still live."""
+        self._reclaim.append(_ReclaimEntry(base_block, last_consumer))
+
+    def drain_reclaim(self) -> int:
+        """Unmap and recycle every queued range whose gating event has
+        completed. Returns the number of ranges reclaimed. Call at iteration
+        boundaries."""
+        remaining: list[_ReclaimEntry] = []
+        reclaimed = 0
+        for entry in self._reclaim:
+            if entry.event.query_complete():
+                num_blocks = self._alloc.reserved_len(entry.base_block)
+                lo, hi = self._chunk_range(entry.base_block, num_blocks)
+                # Unmap only the pages we actually mapped for this range.
+                self._unmap_mapped_run(lo, hi)
+                self._alloc.free(entry.base_block)
+                reclaimed += 1
+            else:
+                remaining.append(entry)
+        self._reclaim = remaining
+        return reclaimed
+
+    def _unmap_mapped_run(self, lo: int, hi: int) -> None:
+        page = self._phys_page_size
+        run_start = -1
+        chunk = lo
+        while chunk < hi:
+            if self._vm.is_mapped(chunk * page):
+                if run_start < 0:
+                    run_start = chunk
+            elif run_start >= 0:
+                self._vm.unmap_range(run_start * page, chunk - run_start)
+                run_start = -1
+            chunk += 1
+        if run_start >= 0:
+            self._vm.unmap_range(run_start * page, hi - run_start)
+
+    def destroy(self) -> None:
+        self._vm.destroy()
+
+
+# ---------------------------------------------------------------------------
+# Integration points (NOT yet implemented -- P0 remaining work, DESIGN.md §5)
+#
+# The following seams connect SequenceArena to the rest of v2. They are called
+# out here so the scaffold documents the full P0 surface; each needs GPU
+# integration testing to build for real.
+#
+# * _storage/_core.py: `GpuSlotPool` -> `GpuArenaPool` holding a SequenceArena
+#   instead of a tail-stack VirtMem; `SlotAllocator` retired for the GPU level.
+# * _core/_kv_cache.py `resize`: grow = extend own range + `ensure_mapped`;
+#   block-index emission = `base_block + ordinal` (replaces scattered slot ids);
+#   suspend/resume = write-out/copy-in + range release/realloc.
+# * _storage_manager.py: GPU-level eviction becomes reclaim/preempt;
+#   `_batched_migrate` gains an explicit-destination mode for reuse placement
+#   (§4.4) and the write-through-on-commit path (§4.3).
+# * pyexecutor/kv_cache_manager_v2.py: capacity API in physical pages (§4.6);
+#   batched `ensure_mapped` sweep in the prepare step; call `drain_reclaim` at
+#   iteration boundaries. Offset-table plumbing is otherwise unchanged.
+# * Startup: call `check_index_width(block_capacity, scale)` when building the
+#   arena for each pool (§4.1).
+# ---------------------------------------------------------------------------

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -47,7 +47,7 @@ from collections.abc import Sequence
 from math import gcd
 
 from ._common import MemAddress
-from ._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
+from ._cuda_virt_mem import PooledPhysMemAllocator, SharedPhysMem, VirtMem
 from ._exceptions import OutOfPagesError
 from ._utils import CachedCudaEvent, div_up
 
@@ -331,6 +331,7 @@ class SequenceArena:
         "_budget",
         "_reclaim",
         "_frontiers",
+        "_aliased",
     )
     _vms: list[VirtMem]
     _alloc: BlockRangeAllocator
@@ -345,6 +346,11 @@ class SequenceArena:
     # holes can form. Lets growth/reclaim work in O(1) per pool instead of
     # rescanning every chunk from the range start.
     _frontiers: dict[int, list[int]]
+    # base_block -> total alias-mapped chunks across pools (P3 prefix
+    # aliasing). Aliased chunks are mapped below the frontier like any others
+    # but were never charged to the budget (their physical charge lives with
+    # the canonical registry pin), so reclaim/retain accounting subtracts them.
+    _aliased: dict[int, int]
 
     def __init__(
         self,
@@ -370,6 +376,7 @@ class SequenceArena:
         self._budget = page_budget
         self._reclaim = []
         self._frontiers = {}
+        self._aliased = {}
 
     @property
     def num_pools(self) -> int:
@@ -404,6 +411,70 @@ class SequenceArena:
         for pool in range(len(self._vms)):
             total += frontiers[pool] - self._chunk_range(pool, base_block, 0)[0]
         return total
+
+    def charged_pages_in_range(self, base_block: int) -> int:
+        """Pages this range holds against the budget: mapped pages minus
+        alias-mapped chunks (whose physical charge lives with the canonical
+        registry pin, P3)."""
+        return self.mapped_pages_in_range(base_block) - self._aliased.get(base_block, 0)
+
+    def aliased_pages_in_range(self, base_block: int) -> int:
+        return self._aliased.get(base_block, 0)
+
+    def alias_prefix(self, base_block: int, shared_per_pool: "list[list[SharedPhysMem]]") -> int:
+        """Map an already-resident canonical prefix's physical pages at the
+        START of this range in every pool (P3 zero-copy reuse). Must run
+        before any of the range's own growth maps (frontier still at the
+        range start). Charges NOTHING against the budget -- the pages'
+        physical charge is carried by their canonical registry pin. Returns
+        the total chunks aliased. Atomic per pool (``map_alias``); on failure
+        earlier pools' aliases remain and are accounted, so the range is
+        still safely reclaimable."""
+        frontiers = self._frontiers[base_block]
+        page = self._phys_page_size
+        total = 0
+        try:
+            for pool, shared in enumerate(shared_per_pool):
+                if not shared:
+                    continue
+                lo = self._chunk_range(pool, base_block, 0)[0]
+                assert frontiers[pool] == lo, "alias_prefix must precede growth maps"
+                self._vms[pool].map_alias(lo * page, shared)
+                frontiers[pool] = lo + len(shared)
+                total += len(shared)
+        finally:
+            if total:
+                self._aliased[base_block] = self._aliased.get(base_block, 0) + total
+        return total
+
+    def shared_prefix_chunks(self, base_block: int, num_blocks: int) -> "list[list[SharedPhysMem]]":
+        """Per pool, the refcounted handles of the chunks FULLY covered by the
+        first ``num_blocks`` blocks of this range (canonical registration,
+        P3). All such chunks are mapped (committed blocks lie below the
+        frontier). Takes no references -- callers pin via ``add_ref()``."""
+        page = self._phys_page_size
+        out: list[list[SharedPhysMem]] = []
+        for pool in range(len(self._vms)):
+            stride = self._strides[pool]
+            lo = self._chunk_range(pool, base_block, 0)[0]
+            hi = ((base_block + num_blocks) * stride) // page  # full coverage only
+            vm = self._vms[pool]
+            out.append([vm.shared_chunk(c * page) for c in range(lo, hi)])
+        return out
+
+    def aliasable_prefix_blocks(self, base_block: int, num_blocks: int) -> int:
+        """The longest block prefix whose bytes lie entirely within
+        fully-covered chunks in EVERY pool -- the aliasable span. The
+        remainder (a partial boundary page) falls back to the copy path."""
+        page = self._phys_page_size
+        best = num_blocks
+        for pool in range(len(self._vms)):
+            stride = self._strides[pool]
+            hi = ((base_block + num_blocks) * stride) // page
+            blocks = (hi * page) // stride - base_block
+            if blocks < best:
+                best = blocks
+        return max(0, best)
 
     def reserve(self, max_blocks: int) -> int:
         """Reserve VA for a sequence's maximum block count; returns base_block.
@@ -547,10 +618,14 @@ class SequenceArena:
 
             _unwrap(drv.cuCtxSynchronize())
         frontiers = self._frontiers.pop(base_block)
+        num_aliased = self._aliased.pop(base_block, 0)
         page = self._phys_page_size
         num_unmapped = 0
         for pool in range(len(self._vms)):
             # Mapped chunks are exactly the prefix [range start, frontier).
+            # Alias-mapped chunks unmap uniformly; their handles survive via
+            # the refcount (registry pin / other aliases) and were never
+            # charged here, so only the surplus returns to the budget.
             lo = self._chunk_range(pool, base_block, 0)[0]
             hi = frontiers[pool]
             if hi > lo:
@@ -558,12 +633,16 @@ class SequenceArena:
                 num_unmapped += hi - lo
         self._alloc.free(base_block)
         if self._budget is not None:
-            self._budget.release(num_unmapped)
+            self._budget.release(num_unmapped - num_aliased)
 
     def destroy(self) -> None:
         if self._budget is not None:
-            self._budget.release(self.mapped_pages)
+            total_aliased = 0
+            for v in self._aliased.values():
+                total_aliased += v
+            self._budget.release(self.mapped_pages - total_aliased)
         for vm in self._vms:
             vm.destroy()
         self._reclaim = []
         self._frontiers = {}
+        self._aliased = {}

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_sequence_arena.py
@@ -42,6 +42,7 @@ NOT here; the storage-side seam (``ArenaPoolGroup``) lives in
 ``_storage/_core.py``.
 """
 
+import os
 from collections.abc import Sequence
 from math import gcd
 
@@ -49,6 +50,16 @@ from ._common import MemAddress
 from ._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
 from ._exceptions import OutOfPagesError
 from ._utils import CachedCudaEvent, div_up
+
+# Quiesce the GPU before every reclaim unmap batch (default on; set to "0" to
+# disable). cuMemUnmap issued while kernels are in flight can fault reads of
+# OTHER, still-mapped ranges of the same VA reservation (device-side MMU
+# faults, reproduced on H100 with Llama-3.1-8B under the overlap scheduler;
+# the fault vanishes when unmaps are serialized against kernels and is immune
+# to event-level ordering fixes, pointing at driver-level TLB interference).
+# The sync happens only at reclaim waves - once per admission burst - so the
+# cost is bounded; disable only for experiments.
+_SYNC_BEFORE_UNMAP = os.getenv("TRTLLM_KV_ARENA_SYNC_BEFORE_UNMAP") != "0"
 
 # Kernel-facing offsets are int32, and v1's KVCacheIndex steals the high bit for
 # primary/secondary selection, leaving int31. The emitted value is
@@ -525,7 +536,16 @@ class SequenceArena:
 
     def _reclaim_now(self, base_block: int) -> None:
         """Unmap a range's pages in every pool and return the block range to
-        the allocator. Caller guarantees no in-flight work references it."""
+        the allocator. Caller guarantees no in-flight work references it --
+        and, because concurrent unmaps can fault unrelated in-flight reads at
+        the driver level (see ``_SYNC_BEFORE_UNMAP``), the GPU is quiesced
+        before the unmap batch unless explicitly disabled."""
+        if _SYNC_BEFORE_UNMAP:
+            from ._cuda_virt_mem import drv
+
+            from ._utils import _unwrap
+
+            _unwrap(drv.cuCtxSynchronize())
         frontiers = self._frontiers.pop(base_block)
         page = self._phys_page_size
         num_unmapped = 0

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -767,6 +767,15 @@ class ArenaPoolGroup(PoolGroupBase):
         # partially constructed group has nothing to tear down.
         if not hasattr(self, "_destroyed") or self._destroyed:
             return
+        # Teardown can run right after sequences finished, with their ranges
+        # still in the event-gated deferred-reclaim queue (§4.2). Teardown is
+        # allowed to block: synchronize the gates and drain, then anything
+        # left is a genuine leak.
+        for rng in self._pending_reclaim:
+            rng._free_event.synchronize()
+            for ev in rng._gate_events:
+                ev.synchronize()
+        self.drain_reclaim()
         assert not self._ranges and not self._pending_reclaim, (
             "destroying ArenaPoolGroup with live sequence ranges"
         )

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -86,18 +86,35 @@ _SPAN_PROTECT_FRACTION = float(os.getenv("TRTLLM_KV_ARENA_SPAN_PROTECT_FRACTION"
 
 
 class _CanonicalSpan:
-    """A closed canonical owner's resident prefix pages, pinned for aliasing
-    (P3). ``page_refs`` guard identity/liveness of every canonical (now
-    host-tier) page in the span -- any mismatch invalidates the entry, the
-    same discipline as the ghost registry. ``shared_per_pool`` holds one
-    registry reference per physical chunk (dropped on spill/invalidation);
-    ``ready_event`` covers the bytes' last writes (alias consumers wait it).
+    """A canonical owner's resident prefix pages, pinned for aliasing (P3).
+    ``page_refs`` guard identity/liveness of every canonical page in the
+    span -- any mismatch invalidates the entry, the same discipline as the
+    ghost registry. ``shared_per_pool`` holds one registry reference per
+    physical chunk (dropped on spill/invalidation); ``ready_event`` covers
+    the bytes' last writes (alias consumers wait it).
+
+    ``owner_base`` >= 0 marks an OWNER-LIVE span (P3 v2): registered at the
+    owner's context-end commit, while the pages are still the owner's
+    active KV in the range at that base block. Owner-live spans hold no
+    registry budget charge (the owner's range charge covers the pages) and
+    are exempt from spilling (dropping the pin frees nothing). The owner's
+    ``free_sequence`` flips the span to the registry-charged state
+    (owner_base = -1) -- the same accounting close-time registration
+    produces directly.
     """
 
-    __slots__ = ("page_refs", "shared_per_pool", "num_blocks", "num_pages", "ready_event")
+    __slots__ = (
+        "page_refs",
+        "shared_per_pool",
+        "num_blocks",
+        "num_pages",
+        "ready_event",
+        "owner_base",
+    )
     page_refs: "list[rawref.ref[Any]]"
     shared_per_pool: "list[list[SharedPhysMem]]"
     num_blocks: int
+    owner_base: int
 
     def is_live(self) -> bool:
         """Whether every pinned handle is still referenced. A registry hit is
@@ -121,6 +138,7 @@ class _CanonicalSpan:
         shared_per_pool: "list[list[SharedPhysMem]]",
         num_blocks: int,
         ready_event: CachedCudaEvent,
+        owner_base: int = -1,
     ) -> None:
         self.page_refs = page_refs
         self.shared_per_pool = shared_per_pool
@@ -130,6 +148,7 @@ class _CanonicalSpan:
             num_pages += len(shared)
         self.num_pages = num_pages
         self.ready_event = ready_event
+        self.owner_base = owner_base
 
 
 # A temporary work-around while migrating to new page index API.
@@ -1131,6 +1150,13 @@ class ArenaPoolGroup(PoolGroupBase):
         ready events of all released slots, and the release of every
         outstanding slot have all happened -- see :meth:`drain_reclaim`."""
         assert not rng._freed, "double free of a sequence range"
+        if rng._alias_span_key is not None:
+            # Single choke point for the owner-live -> registry-charged flip
+            # (P3 v2): close, evacuate, and error unwinds all free the range
+            # here, and an owner-live span must not outlive its range's
+            # charge (the registry pin keeps the physical handles alive, so
+            # unflipped it would hold pages the budget no longer counts).
+            self._commit_live_span_charge(rng)
         rng._freed = True
         rng._free_event = last_consumer
         self._pending_reclaim.append(rng)
@@ -1332,6 +1358,73 @@ class ArenaPoolGroup(PoolGroupBase):
         rng._alias_span_key = (key, num_blocks)
         self._canonical_spans[key] = span
 
+    def register_live_canonical_span(
+        self,
+        rng: SequenceRange,
+        pages: "Sequence[object]",
+        ready_event: CachedCudaEvent,
+    ) -> None:
+        """Pin a LIVE owner's committed leading prefix at context-end commit
+        (P3 v2 owner-live aliasing), so same-prefix admissions alias it while
+        the owner is still generating -- close-time registration makes the
+        whole first concurrent wave copy instead.
+
+        Differences from :meth:`register_canonical_span`: the pages are the
+        owner's active KV, so the span stays OWNER-CHARGED -- no budget
+        transfer, no retain, no alias-accounting mark on the range, and the
+        spill path skips it (dropping the pin frees nothing). The owner's
+        ``free_sequence`` (close, evacuate, and error unwinds all pass
+        through it) flips the entry to the registry-charged state via
+        :meth:`_commit_live_span_charge`."""
+        if not self._prefix_aliasing or not pages:
+            return
+        if rng._alias_span_key is not None:
+            return
+        arena = self._arena
+        num_blocks = arena.aliasable_prefix_blocks(rng.base_block, len(pages))
+        if num_blocks <= 0:
+            return
+        shared_per_pool = arena.shared_prefix_chunks(rng.base_block, num_blocks)
+        span = _CanonicalSpan(
+            [rawref.ref(p) for p in pages[:num_blocks]],
+            shared_per_pool,
+            num_blocks,
+            ready_event,
+            owner_base=rng.base_block,
+        )
+        if span.num_pages == 0:
+            return
+        key = id(pages[0])
+        old = self._canonical_spans.get(key)
+        if old is not None:
+            self._unpin_span(old)
+        for shared in shared_per_pool:
+            for s in shared:
+                s.add_ref()
+        rng._alias_span_key = (key, num_blocks)
+        self._canonical_spans[key] = span
+
+    def _commit_live_span_charge(self, rng: SequenceRange) -> None:
+        """Flip an owner-live span to the registry-charged state as its
+        owner's range is freed: transfer the span's budget charge from the
+        range to the registry (mark the chunks alias-accounted so the
+        range's park/adopt/reclaim math excludes them; release+consume nets
+        zero) and mark it retained -- exactly the accounting close-time
+        registration produces. No-op for alias CONSUMERS (their span belongs
+        to another owner) and for spans already flipped, superseded, or
+        invalidated."""
+        key_extent = rng._alias_span_key
+        assert key_extent is not None
+        span = self._canonical_spans.get(key_extent[0])
+        if span is None or span.owner_base != rng.base_block:
+            return
+        arena = self._arena
+        arena._aliased[rng.base_block] = arena._aliased.get(rng.base_block, 0) + span.num_pages
+        self._budget.release(span.num_pages)
+        self._budget.consume(span.num_pages)
+        self._budget.retain(span.num_pages)
+        span.owner_base = -1
+
     def lookup_canonical_span(
         self, head_page: object, matched_pages: "Sequence[object]"
     ) -> "tuple[int, _CanonicalSpan, int] | None":
@@ -1382,8 +1475,11 @@ class ArenaPoolGroup(PoolGroupBase):
         for shared in span.shared_per_pool:
             for s in shared:
                 s.drop_ref()
-        self._budget.unretain(span.num_pages)
-        self._budget.release(span.num_pages)
+        if span.owner_base < 0:
+            # Owner-live spans hold no registry charge (the owner's range
+            # charge covers the pages); only flipped spans release budget.
+            self._budget.unretain(span.num_pages)
+            self._budget.release(span.num_pages)
 
     def _invalidate_span(self, key: int, span: "_CanonicalSpan") -> None:
         self._canonical_spans.pop(key, None)
@@ -1392,12 +1488,17 @@ class ArenaPoolGroup(PoolGroupBase):
     def spill_canonical_spans(self, min_pages: int) -> int:
         """Drop canonical-span pins (insertion order ≈ LRU) until at least
         ``min_pages`` budget pages are freed. Live aliases keep their handles
-        (refcounts); future admissions fall back to host-copy reuse."""
+        (refcounts); future admissions fall back to host-copy reuse.
+        OWNER-LIVE spans are skipped: they hold no registry charge, so
+        dropping the pin would forfeit future aliasing and free nothing."""
         freed = 0
         for key in list(self._canonical_spans):
             if freed >= min_pages:
                 break
-            span = self._canonical_spans.pop(key)
+            span = self._canonical_spans[key]
+            if span.owner_base >= 0:
+                continue
+            del self._canonical_spans[key]
             self._unpin_span(span)
             self.spilled_spans += 1
             freed += span.num_pages
@@ -1405,7 +1506,10 @@ class ArenaPoolGroup(PoolGroupBase):
 
     @property
     def canonical_span_pages(self) -> int:
-        return sum(s.num_pages for s in self._canonical_spans.values())
+        """Registry-CHARGED span pages (the spillable/protected population).
+        Owner-live spans are excluded: their pages are charged to their
+        owner's range, not the registry."""
+        return sum(s.num_pages for s in self._canonical_spans.values() if s.owner_base < 0)
 
     def _find_range(self, slot_id: int) -> SequenceRange:
         idx = bisect_right(self._range_bases, slot_id) - 1

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -23,7 +23,7 @@ from bisect import bisect_right, insort
 from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import ClassVar, NewType, final
+from typing import Any, ClassVar, NewType, final
 
 if sys.version_info[:2] >= (3, 12):
     from typing import override
@@ -755,7 +755,7 @@ class ArenaPoolGroup(PoolGroupBase):
     _retained: dict[int, SequenceRange]
     # id(host page) -> (identity ref, retained-range base, ordinal): where a
     # committed block's bytes still live on GPU after its owner closed.
-    _ghosts: "dict[int, tuple[rawref.ref, int, int]]"
+    _ghosts: "dict[int, tuple[rawref.ref[Any], int, int]]"
 
     def __init__(
         self,
@@ -797,7 +797,7 @@ class ArenaPoolGroup(PoolGroupBase):
         self.spilled_ranges = 0
         # base_block -> [range, target frontier (blocks), pages charged]:
         # growth maps deferred to the per-iteration batched sweep (§4.2).
-        self._pending_maps: dict[int, list] = {}
+        self._pending_maps: dict[int, list[Any]] = {}
 
     @override
     def destroy(self) -> None:
@@ -881,8 +881,9 @@ class ArenaPoolGroup(PoolGroupBase):
             return 0
         # Nothing was mapped since the first queue call, so pending_pages is
         # monotone in the frontier and the delta charge is exact.
+        charged: int = entry[2]
         pages = self._arena.pending_pages(base, num_valid_blocks)
-        delta = pages - entry[2]
+        delta = pages - charged
         assert delta >= 0
         if delta:
             self._budget.consume(delta)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -23,7 +23,7 @@ from bisect import bisect_right, insort
 from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, ClassVar, NewType, final
+from typing import Any, ClassVar, NewType, cast, final
 
 if sys.version_info[:2] >= (3, 12):
     from typing import override
@@ -42,7 +42,7 @@ from .._common import (
 )
 from .._cuda_virt_mem import PooledPhysMemAllocator, SharedPhysMem, VirtMem
 from .._exceptions import LogicError, OutOfPagesError
-from .._sequence_arena import PageBudget, SequenceArena, check_index_width
+from .._sequence_arena import PageBudget, SequenceArena, check_index_width, quiesce_before_unmap
 from .._utils import (
     CachedCudaEvent,
     DynamicBitset,
@@ -854,6 +854,7 @@ class ArenaPoolGroup(PoolGroupBase):
         "alias_hits",
         "alias_misses",
         "spilled_spans",
+        "dedup_remapped_pages",
     )
     _arena: SequenceArena
     _ranges: dict[int, SequenceRange]  # base_block -> live range
@@ -924,6 +925,7 @@ class ArenaPoolGroup(PoolGroupBase):
         self.alias_hits = 0
         self.alias_misses = 0
         self.spilled_spans = 0
+        self.dedup_remapped_pages = 0
         # base_block -> [range, target frontier (blocks), pages charged]:
         # growth maps deferred to the per-iteration batched sweep (§4.2).
         self._pending_maps: dict[int, list[Any]] = {}
@@ -1426,7 +1428,7 @@ class ArenaPoolGroup(PoolGroupBase):
         span.owner_base = -1
 
     def lookup_canonical_span(
-        self, head_page: object, matched_pages: "Sequence[object]"
+        self, head_page: object, matched_pages: "Sequence[object]", count_stats: bool = True
     ) -> "tuple[int, _CanonicalSpan, int] | None":
         """Registry hit for an admission whose reuse match starts at
         ``head_page`` and covers ``matched_pages`` (canonical page objects in
@@ -1437,25 +1439,31 @@ class ArenaPoolGroup(PoolGroupBase):
         adopter writes strictly past them; the shared-prompt benchmark's
         matches are the system prompt, while spans carry the whole committed
         chain of their owner). A mismatch anywhere in the verified prefix
-        invalidates and unpins the entry."""
+        invalidates and unpins the entry. ``count_stats=False`` keeps the
+        hit/miss counters clean for non-admission callers (the dedup-remap
+        scan probes every live sequence)."""
         if not self._prefix_aliasing:
             return None
         key = id(head_page)
         span = self._canonical_spans.get(key)
         if span is None:
-            self.alias_misses += 1
+            if count_stats:
+                self.alias_misses += 1
             return None
         verified = min(len(matched_pages), span.num_blocks)
         for i in range(verified):
             if span.page_refs[i]() is not matched_pages[i]:
                 self._invalidate_span(key, span)
-                self.alias_misses += 1
+                if count_stats:
+                    self.alias_misses += 1
                 return None
         usable = self._arena.aliasable_span_blocks(verified)
         if usable <= 0:
-            self.alias_misses += 1
+            if count_stats:
+                self.alias_misses += 1
             return None
-        self.alias_hits += 1
+        if count_stats:
+            self.alias_hits += 1
         return key, span, usable
 
     def alias_span_into_range(
@@ -1470,6 +1478,34 @@ class ArenaPoolGroup(PoolGroupBase):
         aliased = self._arena.alias_prefix(rng.base_block, trimmed)
         rng._alias_span_key = (key, num_blocks)
         return aliased
+
+    def span_pages_for_blocks(self, span: "_CanonicalSpan", num_blocks: int) -> int:
+        """Physical pages a dedup remap of ``num_blocks`` onto ``span`` would
+        free (the whole-chunk trim across pools) -- the scan's sort key."""
+        trimmed = self._arena.trim_shared_to_blocks(span.shared_per_pool, num_blocks)
+        pages = 0
+        for shared in trimmed:
+            pages += len(shared)
+        return pages
+
+    def remap_range_onto_span(
+        self, rng: SequenceRange, key: int, span: "_CanonicalSpan", num_blocks: int
+    ) -> int:
+        """Pressure-time dedup remap (P3 v2): replace the physical backing
+        of a LIVE range's head chunks -- currently sequence-private duplicate
+        copies of ``span``'s canonical prefix -- with aliases of the span's
+        handles, freeing the duplicates' pages. Same-VA swap: slot ids,
+        block offsets, page holders, and frontiers are all untouched; the
+        range gains the alias signature so it parks prefix-affinely at
+        close. The CALLER quiesces once per remap batch. Returns pages
+        freed."""
+        assert not rng._freed and rng._alias_span_key is None
+        trimmed = self._arena.trim_shared_to_blocks(span.shared_per_pool, num_blocks)
+        freed = self._arena.remap_prefix_to_alias(rng.base_block, trimmed)
+        if freed:
+            rng._alias_span_key = (key, num_blocks)
+            self.dedup_remapped_pages += freed
+        return freed
 
     def _unpin_span(self, span: "_CanonicalSpan") -> None:
         for shared in span.shared_per_pool:
@@ -1990,7 +2026,7 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
             assert type(pg) is ArenaPoolGroup
             pg.fence_pending_frees(fence)
 
-    def spill_retained(self, min_pages: int) -> int:
+    def spill_retained(self, min_pages: int, spill_spans: bool = True) -> int:
         """Reclaim lazily retained ranges (§4.4 phase 2), LRU-first per pool
         group, until ``min_pages`` physical pages are freed or nothing more
         is spillable; canonical-span pins (P3) are spilled last -- shared
@@ -1999,13 +2035,18 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         still forfeits the whole registry under sustained pressure, and with
         it every zero-copy alias hit, to cover a transient need worth a
         handful of pages. Protected callers back off like any failed
-        allocation instead (§4.6). Returns pages freed."""
+        allocation instead (§4.6). ``spill_spans=False`` skips the span pass
+        entirely -- the reclaim ladder runs the dedup remap (which FREES
+        duplicates instead of forfeiting the registry) between the two.
+        Returns pages freed."""
         freed = 0
         for pg in self._pool_groups:
             if freed >= min_pages:
                 break
             assert type(pg) is ArenaPoolGroup
             freed += pg.spill_retained(min_pages - freed)
+        if not spill_spans:
+            return freed
         spillable = -self._span_spill_floor
         for pg in self._pool_groups:
             assert type(pg) is ArenaPoolGroup
@@ -2017,6 +2058,24 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
             got = pg.spill_canonical_spans(min(min_pages - freed, spillable))
             freed += got
             spillable -= got
+        return freed
+
+    def dedup_remap(self, items: "list[tuple[int, SequenceRange, int, object, int]]") -> int:
+        """Execute a dedup-remap batch (P3 v2) behind ONE device quiesce:
+        each item ``(pg_idx, rng, key, span, num_blocks)`` replaces the
+        range's private duplicate prefix backing with aliases of the span's
+        handles. The caller (the manager's pressure-time scan) has already
+        verified eligibility host-side; nothing here enqueues GPU work, so
+        the batch is atomic with respect to the executor's enqueue thread.
+        Returns total pages freed."""
+        if not items:
+            return 0
+        quiesce_before_unmap()
+        freed = 0
+        for pg_idx, rng, key, span, num_blocks in items:
+            pg = self._pool_groups[PoolGroupIndex(pg_idx)]
+            assert type(pg) is ArenaPoolGroup
+            freed += pg.remap_range_onto_span(rng, key, cast("_CanonicalSpan", span), num_blocks)
         return freed
 
     @property

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -129,6 +129,21 @@ class _CanonicalSpan:
                     return False
         return True
 
+    def has_live_aliases(self) -> bool:
+        """Whether any pinned handle is still referenced beyond the registry's
+        own pin -- i.e. a live sequence currently aliases the span. Spilling
+        such a span frees no physical pages (the aliases keep the handles
+        resident) and only drops it from the reuse lookup, forcing later
+        same-prefix admissions to re-copy pages that are still on the GPU; the
+        pressure path therefore skips it (P3 refcount-gated spill). Meaningful
+        only for registry-charged spans (``owner_base`` < 0), where the sole
+        non-alias reference is the registry pin."""
+        for shared in self.shared_per_pool:
+            for s in shared:
+                if s.num_refs > 1:
+                    return True
+        return False
+
     num_pages: int
     ready_event: CachedCudaEvent
 
@@ -1547,16 +1562,20 @@ class ArenaPoolGroup(PoolGroupBase):
 
     def spill_canonical_spans(self, min_pages: int) -> int:
         """Drop canonical-span pins (insertion order ≈ LRU) until at least
-        ``min_pages`` budget pages are freed. Live aliases keep their handles
-        (refcounts); future admissions fall back to host-copy reuse.
-        OWNER-LIVE spans are skipped: they hold no registry charge, so
-        dropping the pin would forfeit future aliasing and free nothing."""
+        ``min_pages`` budget pages are freed, and remove each spilled span
+        from the reuse lookup. Only spans with NO live aliases are spilled:
+        a span a live sequence still aliases (positive external refcount)
+        frees no physical pages if dropped -- the aliases keep the handles
+        resident -- and unpinning it merely evicts a still-usable prefix from
+        the reuse lookup, so it is left in place until its last aliaser frees
+        (P3 refcount-gated spill). OWNER-LIVE spans are likewise skipped: they
+        hold no registry charge, so dropping the pin frees nothing."""
         freed = 0
         for key in list(self._canonical_spans):
             if freed >= min_pages:
                 break
             span = self._canonical_spans[key]
-            if span.owner_base >= 0:
+            if span.owner_base >= 0 or span.has_live_aliases():
                 continue
             del self._canonical_spans[key]
             self._unpin_span(span)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -95,6 +95,20 @@ class _CanonicalSpan:
     page_refs: "list[rawref.ref[Any]]"
     shared_per_pool: "list[list[SharedPhysMem]]"
     num_blocks: int
+
+    def is_live(self) -> bool:
+        """Whether every pinned handle is still referenced. A registry hit is
+        held UNPINNED across the admission->first-resume window, and pressure
+        can spill the registry in between (dropping the pins); a dead span
+        must fall back to the copy path instead of alias-mapping freed
+        handles. Adopted ranges are immune -- their mappings hold their own
+        references."""
+        for shared in self.shared_per_pool:
+            for s in shared:
+                if s.num_refs == 0:
+                    return False
+        return True
+
     num_pages: int
     ready_event: CachedCudaEvent
 

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -1875,6 +1875,20 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
     def pool_size_granularity(self) -> int:
         return self.shared_phys_mem_pool.phys_mem_size
 
+    @property
+    def total_quota(self) -> int:
+        """The level's PHYSICAL byte quota (page budget x super-page size).
+
+        The base implementation sums pool byte sizes, which for arena pools
+        is the VA reservation extent -- virtual address space, not memory.
+        Consumers of ``total_quota`` (kv stats ``allocated_bytes`` and,
+        through it, the KV memory estimator's temporary-pool credit) need
+        physical bytes: crediting VA back over-grants the final KV budget by
+        the VA-vs-physical difference (observed: +8 GiB on an 80 GiB H100,
+        leaving <0.1 GiB of device headroom at full budget fill).
+        """
+        return self.page_budget.total_pages * self.shared_phys_mem_pool.phys_mem_size
+
     @override
     def destroy(self) -> None:
         # __init__ raises by design on an int31 violation (§4.1); a partially

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -80,6 +80,9 @@ _RANGE_ADOPTION = os.getenv("TRTLLM_KV_ARENA_RANGE_ADOPTION") != "0"
 # fully-committed prefix into multiple sequences' VA ranges (zero-copy,
 # zero-charge reuse). Default OFF while the prototype bakes.
 _PREFIX_ALIASING = os.getenv("TRTLLM_KV_ARENA_PREFIX_ALIASING") == "1"
+# Span-spill protection override (see ContiguousArenaConfig
+# .protected_span_fraction); negative = defer to the config value.
+_SPAN_PROTECT_FRACTION = float(os.getenv("TRTLLM_KV_ARENA_SPAN_PROTECT_FRACTION", "-1"))
 
 
 class _CanonicalSpan:
@@ -1775,9 +1778,12 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
     """
 
     TIER: ClassVar[CacheTier] = CacheTier.GPU_MEM
-    __slots__ = ("shared_phys_mem_pool", "page_budget")
+    __slots__ = ("shared_phys_mem_pool", "page_budget", "_span_spill_floor")
     shared_phys_mem_pool: PooledPhysMemAllocator
     page_budget: PageBudget
+    # Canonical-span pages exempt from pressure spills (P3 span-spill
+    # protection): ``protected_span_fraction`` of the page budget.
+    _span_spill_floor: int
 
     def __init__(
         self,
@@ -1789,6 +1795,7 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         map_ahead_pages: int,
         lazy_retention: bool = False,
         prefix_aliasing: bool = False,
+        protected_span_fraction: float = 0.05,
     ):
         num_pool_groups = typed_len(slot_size_lists)
         assert num_pool_groups == typed_len(block_capacity_list), (
@@ -1805,6 +1812,10 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         super().__init__()
         self.shared_phys_mem_pool = PooledPhysMemAllocator(phys_page_size)
         self.page_budget = PageBudget(quota // phys_page_size)
+        if _SPAN_PROTECT_FRACTION >= 0.0:
+            protected_span_fraction = _SPAN_PROTECT_FRACTION
+        assert 0.0 <= protected_span_fraction <= 1.0
+        self._span_spill_floor = int(self.page_budget.total_pages * protected_span_fraction)
         self._pool_groups = make_typed(
             lambda pg_idx: ArenaPoolGroup(
                 block_capacity_list[pg_idx],
@@ -1848,19 +1859,44 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         """Reclaim lazily retained ranges (§4.4 phase 2), LRU-first per pool
         group, until ``min_pages`` physical pages are freed or nothing more
         is spillable; canonical-span pins (P3) are spilled last -- shared
-        prefixes are the hottest bytes on the level. Returns pages freed."""
+        prefixes are the hottest bytes on the level -- and only above the
+        protected floor (``protected_span_fraction``): spilling-last alone
+        still forfeits the whole registry under sustained pressure, and with
+        it every zero-copy alias hit, to cover a transient need worth a
+        handful of pages. Protected callers back off like any failed
+        allocation instead (§4.6). Returns pages freed."""
         freed = 0
         for pg in self._pool_groups:
             if freed >= min_pages:
                 break
             assert type(pg) is ArenaPoolGroup
             freed += pg.spill_retained(min_pages - freed)
+        spillable = -self._span_spill_floor
         for pg in self._pool_groups:
-            if freed >= min_pages:
+            assert type(pg) is ArenaPoolGroup
+            spillable += pg.canonical_span_pages
+        for pg in self._pool_groups:
+            if freed >= min_pages or spillable <= 0:
                 break
             assert type(pg) is ArenaPoolGroup
-            freed += pg.spill_canonical_spans(min_pages - freed)
+            got = pg.spill_canonical_spans(min(min_pages - freed, spillable))
+            freed += got
+            spillable -= got
         return freed
+
+    @property
+    def protected_span_pages(self) -> int:
+        """Canonical-span pages currently under the spill-protection floor.
+        These are pinned for the registry's benefit and NOT reclaimable
+        under pressure, so utilization gates must not count them available
+        the way plain retained pages are."""
+        if self._span_spill_floor == 0:
+            return 0
+        span_pages = 0
+        for pg in self._pool_groups:
+            assert type(pg) is ArenaPoolGroup
+            span_pages += pg.canonical_span_pages
+        return min(span_pages, self._span_spill_floor)
 
     def flush_mappings(self) -> int:
         """Execute every pool group's deferred growth maps back-to-back

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -19,6 +19,7 @@ import os
 import sys
 import tempfile
 import warnings
+from bisect import bisect_right, insort
 from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -40,6 +41,7 @@ from .._common import (
 )
 from .._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
 from .._exceptions import LogicError, OutOfPagesError
+from .._sequence_arena import PageBudget, SequenceArena, check_index_width
 from .._utils import (
     CachedCudaEvent,
     DynamicBitset,
@@ -153,6 +155,48 @@ class GpuSlotPool(SlotPoolBase):
     @staticmethod
     def _compute_num_slots(slot_size: int, num_phys_mem: int, phys_mem_size: int) -> int:
         return num_phys_mem * phys_mem_size // slot_size
+
+
+@final
+class ArenaSlotPool(SlotPoolBase):
+    """Per-pool *view* over one plane of a :class:`SequenceArena` (contiguous
+    primary KV cache, DESIGN.md §4.1). Exists so the ``PoolGroupBase``
+    machinery (addresses, sizes, statistics) works unchanged in arena mode.
+
+    The arena owns the VA reservation and all mappings; this view owns
+    nothing. ``num_slots``/``num_bytes`` describe the *VA* extent (block-index
+    capacity), not physical residency -- physical capacity is governed by the
+    shared :class:`PageBudget`.
+    """
+
+    __slots__ = ("_arena", "_pool_index")
+    _arena: SequenceArena
+    _pool_index: int
+
+    def __init__(self, arena: SequenceArena, pool_index: int, slot_size: int) -> None:
+        super().__init__(slot_size)
+        self._arena = arena
+        self._pool_index = pool_index
+
+    @override
+    def destroy(self) -> None:
+        pass  # the owning ArenaPoolGroup destroys the arena
+
+    @override
+    def resize(self, new_num_slots: int) -> None:
+        raise LogicError(
+            "arena-backed pools have a fixed VA extent; physical capacity is "
+            "governed by the shared page budget"
+        )
+
+    @override
+    def slot_address(self, slot: int) -> MemAddress:
+        return MemAddress(int(self._arena.base_address(self._pool_index)) + self.slot_size * slot)
+
+    @property
+    @override
+    def num_slots(self) -> int:
+        return self._arena.capacity_blocks
 
 
 class HostSlotPool(SlotPoolBase):
@@ -611,6 +655,242 @@ class GpuPoolGroup(PoolGroupBase):
         )
 
 
+class SequenceRange:
+    """Handle for one sequence's contiguous block-index range in an
+    :class:`ArenaPoolGroup` (DESIGN.md §4.1).
+
+    Tracks the slots issued from the range and the CUDA events that must
+    complete before the range's physical pages can be unmapped (deferred
+    reclaim, §4.2): the ready events of released slots (e.g. D2H write-out
+    copies) plus the sequence's last-consumer event passed to
+    ``free_sequence``.
+    """
+
+    __slots__ = (
+        "base_block",
+        "num_blocks",
+        "_outstanding",
+        "_freed",
+        "_gate_events",
+        "_free_event",
+    )
+    base_block: int
+    num_blocks: int  # reserved (padded) length in blocks
+    _outstanding: int  # slots issued and not yet released
+    _freed: bool
+    _gate_events: list[CachedCudaEvent]  # pending ready events of released slots
+    _free_event: CachedCudaEvent
+
+    def __init__(self, base_block: int, num_blocks: int) -> None:
+        self.base_block = base_block
+        self.num_blocks = num_blocks
+        self._outstanding = 0
+        self._freed = False
+        self._gate_events = []
+        self._free_event = CachedCudaEvent.NULL
+
+    @property
+    def end_block(self) -> int:
+        return self.base_block + self.num_blocks
+
+    def _scrub_gate_events(self) -> None:
+        self._gate_events = [ev for ev in self._gate_events if not ev.query_complete()]
+
+    def _ready_to_reclaim(self) -> bool:
+        if not self._freed or self._outstanding != 0:
+            return False
+        if not self._free_event.query_complete():
+            return False
+        self._scrub_gate_events()
+        return not self._gate_events
+
+
+@final
+class ArenaPoolGroup(PoolGroupBase):
+    """GPU pool group backed by a :class:`SequenceArena` instead of a
+    ``SlotAllocator`` (contiguous primary KV cache, DESIGN.md §4.1-§4.2).
+
+    Allocation is *per-sequence*: :meth:`reserve_sequence` carves a contiguous,
+    page-aligned block-index range sized for the sequence's maximum block
+    count; :meth:`take_slot` then issues ``Slot`` objects with
+    ``slot_id = base_block + ordinal``, so every downstream consumer of slot
+    ids (pages, offset tables, ``slot_address``) works unchanged -- but the ids
+    a sequence sees are consecutive. Physical pages are mapped on demand via
+    :meth:`ensure_mapped` against the level-wide :class:`PageBudget`.
+
+    Scattered allocation (``allocate``/``allocate_multiple``) is retired at the
+    GPU level in arena mode and raises ``LogicError``: growth goes through the
+    owning sequence's range, and reuse onboarding copies into explicit
+    destinations inside that range (§4.4).
+    """
+
+    __slots__ = ("_arena", "_ranges", "_range_bases", "_pending_reclaim")
+    _arena: SequenceArena
+    _ranges: dict[int, SequenceRange]  # base_block -> live range
+    _range_bases: list[int]  # sorted, for slot_id -> range lookup on release
+    _pending_reclaim: list[SequenceRange]
+
+    def __init__(
+        self,
+        block_capacity: int,
+        slot_size_list: TypedIndexList[PoolIndex, int],
+        shared_phys_mem_pool: PooledPhysMemAllocator,
+        page_budget: PageBudget,
+        map_ahead_pages: int,
+        page_index_scale: int,
+    ) -> None:
+        # The int31 kernel-offset ceiling must hold for every offset this
+        # arena can emit (DESIGN.md §4.1); fail loudly at startup.
+        check_index_width(block_capacity, page_index_scale)
+        # SlotAllocator is retired at the GPU level in arena mode; the base
+        # class gets an empty one so its teardown logic is a no-op.
+        super().__init__(0)
+        self._arena = SequenceArena(
+            block_capacity,
+            tuple(slot_size_list),
+            shared_phys_mem_pool,
+            map_ahead_pages,
+            page_budget,
+        )
+        arena = self._arena
+        self._pools = make_typed(
+            lambda pool_idx: ArenaSlotPool(arena, pool_idx, slot_size_list[pool_idx]),
+            typed_len(slot_size_list),
+        )
+        self._ranges = {}
+        self._range_bases = []
+        self._pending_reclaim = []
+
+    @override
+    def destroy(self) -> None:
+        # The int31 check makes __init__ raise before base construction; a
+        # partially constructed group has nothing to tear down.
+        if not hasattr(self, "_destroyed") or self._destroyed:
+            return
+        assert not self._ranges and not self._pending_reclaim, (
+            "destroying ArenaPoolGroup with live sequence ranges"
+        )
+        super().destroy()
+        self._arena.destroy()
+
+    # -- per-sequence API (replaces scattered slot allocation) --------------
+
+    def reserve_sequence(self, max_blocks: int) -> SequenceRange:
+        """Reserve a contiguous block-index range for a sequence's maximum
+        block count. Pure VA bookkeeping; no physical memory is mapped.
+        Raises ``MemoryError`` on VA exhaustion (see DESIGN.md §4.8 sizing)."""
+        base_block = self._arena.reserve(max_blocks)
+        rng = SequenceRange(base_block, self._arena.reserved_len(base_block))
+        self._ranges[base_block] = rng
+        insort(self._range_bases, base_block)
+        return rng
+
+    def take_slot(self, rng: SequenceRange, ordinal: int) -> Slot:
+        """Issue the slot at ``rng.base_block + ordinal``. The caller (the
+        sequence growth path) guarantees each ordinal is taken at most once
+        while the range is live."""
+        assert not rng._freed, "cannot take slots from a freed range"
+        assert 0 <= ordinal < rng.num_blocks
+        rng._outstanding += 1
+        # Newly mapped arena pages have no previous owner, so no ready event.
+        return Slot(SlotId(rng.base_block + ordinal), CachedCudaEvent.NULL)
+
+    def ensure_mapped(self, rng: SequenceRange, num_valid_blocks: int) -> int:
+        """Map physical pages (in every pool) covering the first
+        ``num_valid_blocks`` of the range plus the map-ahead margin. Returns
+        the number of newly mapped pages; raises ``OutOfPagesError`` (mapping
+        nothing) if the page budget is exhausted (§4.6)."""
+        assert num_valid_blocks <= rng.num_blocks
+        return self._arena.ensure_mapped(rng.base_block, num_valid_blocks)
+
+    def free_sequence(self, rng: SequenceRange, last_consumer: CachedCudaEvent) -> None:
+        """Queue the whole range for deferred reclaim (§4.2). The range is
+        unmapped and its block indices reused only once ``last_consumer``, the
+        ready events of all released slots, and the release of every
+        outstanding slot have all happened -- see :meth:`drain_reclaim`."""
+        assert not rng._freed, "double free of a sequence range"
+        rng._freed = True
+        rng._free_event = last_consumer
+        self._pending_reclaim.append(rng)
+
+    def drain_reclaim(self) -> int:
+        """Unmap and recycle every freed range whose gating conditions have
+        all completed. Returns the number of ranges reclaimed. Call at
+        iteration boundaries."""
+        remaining: list[SequenceRange] = []
+        reclaimed = 0
+        for rng in self._pending_reclaim:
+            if rng._ready_to_reclaim():
+                self._arena.reclaim(rng.base_block)
+                del self._ranges[rng.base_block]
+                idx = bisect_right(self._range_bases, rng.base_block) - 1
+                assert self._range_bases[idx] == rng.base_block
+                self._range_bases.pop(idx)
+                reclaimed += 1
+            else:
+                remaining.append(rng)
+        self._pending_reclaim = remaining
+        return reclaimed
+
+    def _find_range(self, slot_id: int) -> SequenceRange:
+        idx = bisect_right(self._range_bases, slot_id) - 1
+        assert idx >= 0, f"slot {slot_id} does not belong to any live range"
+        rng = self._ranges[self._range_bases[idx]]
+        assert rng.base_block <= slot_id < rng.end_block, (
+            f"slot {slot_id} does not belong to any live range"
+        )
+        return rng
+
+    # -- PoolGroupBase interface overrides ----------------------------------
+
+    @override
+    def allocate(self) -> Slot:
+        raise LogicError(
+            "scattered slot allocation is retired in arena mode; use reserve_sequence()/take_slot()"
+        )
+
+    @override
+    def allocate_multiple(self, num_slots: int) -> list[Slot]:
+        raise LogicError(
+            "scattered slot allocation is retired in arena mode; use reserve_sequence()/take_slot()"
+        )
+
+    @override
+    def release(self, slot: Slot) -> None:
+        """Return one issued slot. The block index stays reserved for the
+        owning sequence; the slot's ready event (if still pending) gates the
+        range's eventual reclaim."""
+        slot = slot.move_to_new_slot()
+        rng = self._find_range(slot.slot_id)
+        assert rng._outstanding > 0
+        rng._outstanding -= 1
+        ev = slot.ready_event
+        if ev is not CachedCudaEvent.NULL and not ev.query_complete():
+            rng._gate_events.append(ev)
+        # Detach so Slot.__del__ does not warn; the range owns the index.
+        slot._slot_id = None
+        slot.ready_event = CachedCudaEvent.NULL
+
+    @property
+    @override
+    def num_slots(self) -> int:
+        return self._arena.capacity_blocks
+
+    @property
+    @override
+    def num_free_slots(self) -> int:
+        """Free *VA* blocks. Physical availability is governed by the shared
+        :class:`PageBudget`, not per-group slot counts (§4.6)."""
+        return self._arena.free_blocks
+
+    @property
+    def mapped_pages(self) -> int:
+        return self._arena.mapped_pages
+
+    def _check(self, allow_mismatch: bool = False) -> bool:
+        return True  # the base invariant (SlotAllocator vs pools) does not apply
+
+
 class HostPoolGroup(PoolGroupBase):
     __slots__ = ()
 
@@ -935,6 +1215,89 @@ class GpuCacheLevelStorage(CacheLevelStorage):
 
     @override
     def destroy(self) -> None:
+        super().destroy()
+        self.shared_phys_mem_pool.clear()
+
+
+class GpuArenaCacheLevelStorage(CacheLevelStorage):
+    """GPU cache level backed by per-sequence contiguous arenas
+    (contiguous primary KV cache, DESIGN.md §4). Flag-gated alternative to
+    :class:`GpuCacheLevelStorage`; selected by
+    ``KVCacheManagerConfig.contiguous_arena``.
+
+    Capacity is a level-wide physical :class:`PageBudget` (``quota //
+    phys_page_size`` pages) that every pool group's arena maps against --
+    per-pool-group slot partitioning and copy-based GPU defrag are retired
+    (§4.2/§4.6). ``block_capacity_list`` sizes each pool group's *VA* extent in
+    blocks (see §4.8 sizing); ``page_index_scale_list`` carries each group's
+    maximum kernel page-index scale for the int31 startup check (§4.1).
+    """
+
+    TIER: ClassVar[CacheTier] = CacheTier.GPU_MEM
+    __slots__ = ("shared_phys_mem_pool", "page_budget")
+    shared_phys_mem_pool: PooledPhysMemAllocator
+    page_budget: PageBudget
+
+    def __init__(
+        self,
+        slot_size_lists: TypedIndexList[PoolGroupIndex, TypedIndexList[PoolIndex, int]],
+        block_capacity_list: TypedIndexList[PoolGroupIndex, int],
+        page_index_scale_list: TypedIndexList[PoolGroupIndex, int],
+        quota: int,
+        phys_page_size: int,
+        map_ahead_pages: int,
+    ):
+        num_pool_groups = typed_len(slot_size_lists)
+        assert num_pool_groups == typed_len(block_capacity_list), (
+            "slot_size_lists and block_capacity_list must have the same length"
+        )
+        assert num_pool_groups == typed_len(page_index_scale_list), (
+            "slot_size_lists and page_index_scale_list must have the same length"
+        )
+        assert quota >= phys_page_size, "GPU quota must cover at least one physical page"
+        # Run the int31 startup check (§4.1) for every group before touching
+        # CUDA, so a mis-sized arena fails cleanly with nothing constructed.
+        for pg_idx in typed_range(num_pool_groups):
+            check_index_width(block_capacity_list[pg_idx], page_index_scale_list[pg_idx])
+        super().__init__()
+        self.shared_phys_mem_pool = PooledPhysMemAllocator(phys_page_size)
+        self.page_budget = PageBudget(quota // phys_page_size)
+        self._pool_groups = make_typed(
+            lambda pg_idx: ArenaPoolGroup(
+                block_capacity_list[pg_idx],
+                slot_size_lists[pg_idx],
+                self.shared_phys_mem_pool,
+                self.page_budget,
+                map_ahead_pages,
+                page_index_scale_list[pg_idx],
+            ),
+            num_pool_groups,
+        )
+
+    def pool_group(self, pool_group_index: PoolGroupIndex) -> ArenaPoolGroup:
+        pg = self._pool_groups[pool_group_index]
+        assert type(pg) is ArenaPoolGroup
+        return pg
+
+    def drain_reclaim(self) -> int:
+        """Drain every pool group's deferred-reclaim queue (call at iteration
+        boundaries). Returns the number of sequence ranges reclaimed."""
+        reclaimed = 0
+        for pg in self._pool_groups:
+            assert type(pg) is ArenaPoolGroup
+            reclaimed += pg.drain_reclaim()
+        return reclaimed
+
+    @property
+    def pool_size_granularity(self) -> int:
+        return self.shared_phys_mem_pool.phys_mem_size
+
+    @override
+    def destroy(self) -> None:
+        # __init__ raises by design on an int31 violation (§4.1); a partially
+        # constructed level has nothing to tear down.
+        if not hasattr(self, "_pool_groups"):
+            return
         super().destroy()
         self.shared_phys_mem_pool.clear()
 

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -67,6 +67,16 @@ PoolGroupIndex = NewType("PoolGroupIndex", int)
 PoolIndex = NewType("PoolIndex", int)
 SlotId = NewType("SlotId", int)
 
+# Freed-range adoption (default on): freed arena ranges are parked still
+# mapped and handed whole to the next admitted sequence instead of being
+# unmapped and remapped. Concurrent cuMemMap/cuMemUnmap churn against
+# in-flight kernels reading *other* ranges of the same VA reservation
+# triggers device-side MMU faults (driver TLB interference — see
+# contiguous_primary_kvcache/WORK_LOG.md, 2026-07-07 discriminator matrix);
+# adoption removes that churn from the steady state entirely. "0" disables
+# (debugging only).
+_RANGE_ADOPTION = os.getenv("TRTLLM_KV_ARENA_RANGE_ADOPTION") != "0"
+
 # A temporary work-around while migrating to new page index API.
 # To be removed later.
 PoolIndex0 = PoolIndex(0)
@@ -755,6 +765,7 @@ class ArenaPoolGroup(PoolGroupBase):
         "ghost_misses",
         "spilled_ranges",
         "_pending_maps",
+        "_range_adoption",
     )
     _arena: SequenceArena
     _ranges: dict[int, SequenceRange]  # base_block -> live range
@@ -768,6 +779,9 @@ class ArenaPoolGroup(PoolGroupBase):
     # id(host page) -> (identity ref, retained-range base, ordinal): where a
     # committed block's bytes still live on GPU after its owner closed.
     _ghosts: "dict[int, tuple[rawref.ref[Any], int, int]]"
+    # Freed-range adoption (module default from TRTLLM_KV_ARENA_RANGE_ADOPTION;
+    # instance attribute so tests can pin either behavior).
+    _range_adoption: bool
 
     def __init__(
         self,
@@ -807,6 +821,7 @@ class ArenaPoolGroup(PoolGroupBase):
         self.ghost_hits = 0
         self.ghost_misses = 0
         self.spilled_ranges = 0
+        self._range_adoption = _RANGE_ADOPTION
         # base_block -> [range, target frontier (blocks), pages charged]:
         # growth maps deferred to the per-iteration batched sweep (§4.2).
         self._pending_maps: dict[int, list[Any]] = {}
@@ -852,13 +867,57 @@ class ArenaPoolGroup(PoolGroupBase):
 
     def reserve_sequence(self, max_blocks: int) -> SequenceRange:
         """Reserve a contiguous block-index range for a sequence's maximum
-        block count. Pure VA bookkeeping; no physical memory is mapped.
+        block count, preferring the adoption of a parked (freed but still
+        mapped) range over fresh VA: the adopted range's mapped prefix is
+        reused as-is, so the steady state issues no ``cuMemMap``/``cuMemUnmap``
+        at all (see ``_try_adopt``). A fresh reservation is pure VA
+        bookkeeping; no physical memory is mapped.
         Raises ``MemoryError`` on VA exhaustion (see DESIGN.md §4.8 sizing)."""
+        adopted = self._try_adopt(max_blocks)
+        if adopted is not None:
+            return adopted
         base_block = self._arena.reserve(max_blocks)
         rng = SequenceRange(base_block, self._arena.reserved_len(base_block))
         self._ranges[base_block] = rng
         insort(self._range_bases, base_block)
         return rng
+
+    def _try_adopt(self, max_blocks: int) -> "SequenceRange | None":
+        """Hand a parked freed range (pages still mapped, reclaim gates all
+        complete) to a new sequence. LRU-first, so the most recently retired
+        ranges keep their ghost entries (D2D reuse, §4.4 phase 2) longest.
+        The adopted range keeps its mapped prefix and budget charge; only its
+        ghost entries are purged (its bytes are about to be overwritten).
+        Returns None when nothing parked fits ``max_blocks``."""
+        if not self._range_adoption:
+            return None
+        for base in self._retained:
+            rng = self._retained[base]
+            if rng.num_blocks < max_blocks:
+                continue  # heterogeneous sizing: this range cannot hold it
+            if not rng._ready_to_reclaim():
+                continue  # e.g. an in-flight D2D onboard still reads from it
+            # With lazy retention, a range whose bytes still serve the ghost
+            # registry is worth more as a D2D reuse source than as adopted
+            # VA; keep it parked (pressure spill trims it eventually). Prune
+            # superseded keys so stale entries don't block adoption forever.
+            if rng._ghost_keys:
+                live: list[int] = []
+                for key in rng._ghost_keys:
+                    entry = self._ghosts.get(key)
+                    if entry is not None and entry[1] == base:
+                        live.append(key)
+                rng._ghost_keys = live
+                if live:
+                    continue
+            del self._retained[base]
+            self._budget.unretain(self._arena.mapped_pages_in_range(base))
+            # Fresh handle, same extent: the allocator reservation and the
+            # arena's mapped frontier carry over untouched.
+            fresh = SequenceRange(base, rng.num_blocks)
+            self._ranges[base] = fresh
+            return fresh
+        return None
 
     def take_slot(self, rng: SequenceRange, ordinal: int) -> Slot:
         """Issue the slot at ``rng.base_block + ordinal``. The caller (the
@@ -984,7 +1043,12 @@ class ArenaPoolGroup(PoolGroupBase):
         processed = 0
         for rng in self._pending_reclaim:
             if rng._ready_to_reclaim():
-                if self._lazy_retention:
+                if self._lazy_retention or self._range_adoption:
+                    # Park the range with its pages mapped: adoption hands it
+                    # whole to the next admitted sequence (no unmap+remap
+                    # churn against in-flight kernels); with lazy retention
+                    # its ghosts additionally serve D2D reuse. Unmapped only
+                    # under pressure (:meth:`spill_retained`).
                     self._retained[rng.base_block] = rng
                     self._budget.retain(self._arena.mapped_pages_in_range(rng.base_block))
                 else:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -742,6 +742,7 @@ class ArenaPoolGroup(PoolGroupBase):
         "ghost_hits",
         "ghost_misses",
         "spilled_ranges",
+        "_pending_maps",
     )
     _arena: SequenceArena
     _ranges: dict[int, SequenceRange]  # base_block -> live range
@@ -794,6 +795,9 @@ class ArenaPoolGroup(PoolGroupBase):
         self.ghost_hits = 0
         self.ghost_misses = 0
         self.spilled_ranges = 0
+        # base_block -> [range, target frontier (blocks), pages charged]:
+        # growth maps deferred to the per-iteration batched sweep (§4.2).
+        self._pending_maps: dict[int, list] = {}
 
     @override
     def destroy(self) -> None:
@@ -801,6 +805,10 @@ class ArenaPoolGroup(PoolGroupBase):
         # partially constructed group has nothing to tear down.
         if not hasattr(self, "_destroyed") or self._destroyed:
             return
+        # Deferred maps that never ran only hold budget; return it.
+        for _, (_, _, charged) in self._pending_maps.items():
+            self._budget.release(charged)
+        self._pending_maps.clear()
         # Teardown can run right after sequences finished, with their ranges
         # still in the event-gated deferred-reclaim queue (§4.2). Teardown is
         # allowed to block: synchronize the gates and drain, then anything
@@ -850,6 +858,60 @@ class ArenaPoolGroup(PoolGroupBase):
         nothing) if the page budget is exhausted (§4.6)."""
         assert num_valid_blocks <= rng.num_blocks
         return self._arena.ensure_mapped(rng.base_block, num_valid_blocks)
+
+    # -- batched map sweep (§4.2): defer growth maps to one pass/iteration --
+
+    def queue_mapping(self, rng: SequenceRange, num_valid_blocks: int) -> int:
+        """Charge the page budget for the pages a target frontier needs (so
+        admission control behaves exactly like an immediate map) but defer the
+        actual ``cuMemMap``/``cuMemSetAccess`` calls to :meth:`flush_mappings`.
+        Raises ``OutOfPagesError`` (charging nothing) on budget exhaustion.
+        Returns the pages charged. The caller MUST run the flush before any
+        GPU work touches the new blocks."""
+        assert not rng._freed and num_valid_blocks <= rng.num_blocks
+        base = rng.base_block
+        entry = self._pending_maps.get(base)
+        if entry is None:
+            pages = self._arena.pending_pages(base, num_valid_blocks)
+            if pages:
+                self._budget.consume(pages)  # raises; nothing recorded yet
+                self._pending_maps[base] = [rng, num_valid_blocks, pages]
+            return pages
+        if num_valid_blocks <= entry[1]:
+            return 0
+        # Nothing was mapped since the first queue call, so pending_pages is
+        # monotone in the frontier and the delta charge is exact.
+        pages = self._arena.pending_pages(base, num_valid_blocks)
+        delta = pages - entry[2]
+        assert delta >= 0
+        if delta:
+            self._budget.consume(delta)
+        entry[1] = num_valid_blocks
+        entry[2] = pages
+        return delta
+
+    def flush_mappings(self) -> int:
+        """Execute all deferred maps back-to-back (§4.2's batched
+        per-iteration sweep). Entries whose range was freed in the meantime
+        release their charge instead. Returns pages mapped."""
+        if not self._pending_maps:
+            return 0
+        mapped_total = 0
+        for base, (rng, target, charged) in self._pending_maps.items():
+            if rng._freed or base not in self._ranges:
+                self._budget.release(charged)
+                continue
+            mapped = self._arena.ensure_mapped(base, target, precharged=True)
+            mapped_total += mapped
+            if mapped != charged:
+                # Defensive: the plan is deterministic, so this indicates
+                # concurrent mutation; reconcile the budget either way.
+                if mapped < charged:
+                    self._budget.release(charged - mapped)
+                else:
+                    self._budget.consume(mapped - charged)
+        self._pending_maps.clear()
+        return mapped_total
 
     def free_sequence(self, rng: SequenceRange, last_consumer: CachedCudaEvent) -> None:
         """Queue the whole range for deferred reclaim (§4.2). The range is
@@ -1425,6 +1487,15 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
             assert type(pg) is ArenaPoolGroup
             freed += pg.spill_retained(min_pages - freed)
         return freed
+
+    def flush_mappings(self) -> int:
+        """Execute every pool group's deferred growth maps back-to-back
+        (§4.2 batched per-iteration sweep). Returns pages mapped."""
+        mapped = 0
+        for pg in self._pool_groups:
+            assert type(pg) is ArenaPoolGroup
+            mapped += pg.flush_mappings()
+        return mapped
 
     @property
     def pool_size_granularity(self) -> int:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -40,7 +40,7 @@ from .._common import (
     FileDescriptor,
     MemAddress,
 )
-from .._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
+from .._cuda_virt_mem import PooledPhysMemAllocator, SharedPhysMem, VirtMem
 from .._exceptions import LogicError, OutOfPagesError
 from .._sequence_arena import PageBudget, SequenceArena, check_index_width
 from .._utils import (
@@ -76,6 +76,44 @@ SlotId = NewType("SlotId", int)
 # adoption removes that churn from the steady state entirely. "0" disables
 # (debugging only).
 _RANGE_ADOPTION = os.getenv("TRTLLM_KV_ARENA_RANGE_ADOPTION") != "0"
+# P3 prefix aliasing: map the SAME physical pages holding a shared,
+# fully-committed prefix into multiple sequences' VA ranges (zero-copy,
+# zero-charge reuse). Default OFF while the prototype bakes.
+_PREFIX_ALIASING = os.getenv("TRTLLM_KV_ARENA_PREFIX_ALIASING") == "1"
+
+
+class _CanonicalSpan:
+    """A closed canonical owner's resident prefix pages, pinned for aliasing
+    (P3). ``page_refs`` guard identity/liveness of every canonical (now
+    host-tier) page in the span -- any mismatch invalidates the entry, the
+    same discipline as the ghost registry. ``shared_per_pool`` holds one
+    registry reference per physical chunk (dropped on spill/invalidation);
+    ``ready_event`` covers the bytes' last writes (alias consumers wait it).
+    """
+
+    __slots__ = ("page_refs", "shared_per_pool", "num_blocks", "num_pages", "ready_event")
+    page_refs: "list[rawref.ref[Any]]"
+    shared_per_pool: "list[list[SharedPhysMem]]"
+    num_blocks: int
+    num_pages: int
+    ready_event: CachedCudaEvent
+
+    def __init__(
+        self,
+        page_refs: "list[rawref.ref[Any]]",
+        shared_per_pool: "list[list[SharedPhysMem]]",
+        num_blocks: int,
+        ready_event: CachedCudaEvent,
+    ) -> None:
+        self.page_refs = page_refs
+        self.shared_per_pool = shared_per_pool
+        self.num_blocks = num_blocks
+        num_pages = 0
+        for shared in shared_per_pool:
+            num_pages += len(shared)
+        self.num_pages = num_pages
+        self.ready_event = ready_event
+
 
 # A temporary work-around while migrating to new page index API.
 # To be removed later.
@@ -686,6 +724,7 @@ class SequenceRange:
         "_free_event",
         "_reclaim_fence",
         "_ghost_keys",
+        "_alias_span_key",
     )
     base_block: int
     num_blocks: int  # reserved (padded) length in blocks
@@ -704,6 +743,12 @@ class SequenceRange:
     # Ghost registry keys (§4.4 phase 2): ids of host pages whose bytes still
     # live in this (retained) range; purged when the range is reclaimed.
     _ghost_keys: list[int]
+    # P3 prefix aliasing: the canonical-span registry key whose physical pages
+    # are alias-mapped at this range's start (None = unaliased). Aliased
+    # ranges may only be adopted by a sequence whose reuse match carries the
+    # SAME key -- the span's physical pages are shared, so any other adopter
+    # writing the range head would corrupt every alias of the span.
+    _alias_span_key: "int | None"
 
     def __init__(self, base_block: int, num_blocks: int) -> None:
         self.base_block = base_block
@@ -714,6 +759,7 @@ class SequenceRange:
         self._free_event = CachedCudaEvent.NULL
         self._reclaim_fence = None
         self._ghost_keys = []
+        self._alias_span_key = None
 
     @property
     def end_block(self) -> int:
@@ -766,6 +812,11 @@ class ArenaPoolGroup(PoolGroupBase):
         "spilled_ranges",
         "_pending_maps",
         "_range_adoption",
+        "_prefix_aliasing",
+        "_canonical_spans",
+        "alias_hits",
+        "alias_misses",
+        "spilled_spans",
     )
     _arena: SequenceArena
     _ranges: dict[int, SequenceRange]  # base_block -> live range
@@ -782,6 +833,14 @@ class ArenaPoolGroup(PoolGroupBase):
     # Freed-range adoption (module default from TRTLLM_KV_ARENA_RANGE_ADOPTION;
     # instance attribute so tests can pin either behavior).
     _range_adoption: bool
+    # P3 prefix aliasing (module default from TRTLLM_KV_ARENA_PREFIX_ALIASING,
+    # default OFF for the prototype; instance attribute for tests).
+    _prefix_aliasing: bool
+    # Canonical-span registry (P3): id(head canonical page) -> _CanonicalSpan.
+    # A span pins the refcounted physical pages holding a closed canonical
+    # owner's fully-committed prefix, so same-prefix admissions alias them
+    # (zero-copy, zero-charge) instead of copying from the host tier.
+    _canonical_spans: "dict[int, _CanonicalSpan]"
 
     def __init__(
         self,
@@ -792,6 +851,7 @@ class ArenaPoolGroup(PoolGroupBase):
         map_ahead_pages: int,
         page_index_scale: int,
         lazy_retention: bool = False,
+        prefix_aliasing: bool = False,
     ) -> None:
         # The int31 kernel-offset ceiling must hold for every offset this
         # arena can emit (DESIGN.md §4.1); fail loudly at startup.
@@ -822,6 +882,11 @@ class ArenaPoolGroup(PoolGroupBase):
         self.ghost_misses = 0
         self.spilled_ranges = 0
         self._range_adoption = _RANGE_ADOPTION
+        self._prefix_aliasing = prefix_aliasing or _PREFIX_ALIASING
+        self._canonical_spans = {}
+        self.alias_hits = 0
+        self.alias_misses = 0
+        self.spilled_spans = 0
         # base_block -> [range, target frontier (blocks), pages charged]:
         # growth maps deferred to the per-iteration batched sweep (§4.2).
         self._pending_maps: dict[int, list[Any]] = {}
@@ -860,20 +925,30 @@ class ArenaPoolGroup(PoolGroupBase):
         assert not self._ranges and not self._pending_reclaim, (
             "destroying ArenaPoolGroup with live sequence ranges"
         )
+        # Unpin canonical spans (P3) so their handles return to the pool.
+        for key in list(self._canonical_spans):
+            self._unpin_span(self._canonical_spans.pop(key))
         super().destroy()
         self._arena.destroy()
 
     # -- per-sequence API (replaces scattered slot allocation) --------------
 
-    def reserve_sequence(self, max_blocks: int) -> SequenceRange:
+    def reserve_sequence(self, max_blocks: int, alias_key: "int | None" = None) -> SequenceRange:
         """Reserve a contiguous block-index range for a sequence's maximum
         block count, preferring the adoption of a parked (freed but still
         mapped) range over fresh VA: the adopted range's mapped prefix is
         reused as-is, so the steady state issues no ``cuMemMap``/``cuMemUnmap``
         at all (see ``_try_adopt``). A fresh reservation is pure VA
         bookkeeping; no physical memory is mapped.
+
+        ``alias_key`` is the admission's canonical-span registry key (P3):
+        adoption is prefix-affine -- a parked range whose head alias-maps span
+        ``K`` may only go to an admission with the same key (its prefix
+        content and mappings are exactly what the adopter wants, and any
+        other adopter writing the range head would corrupt every alias of the
+        shared pages).
         Raises ``MemoryError`` on VA exhaustion (see DESIGN.md §4.8 sizing)."""
-        adopted = self._try_adopt(max_blocks)
+        adopted = self._try_adopt(max_blocks, alias_key)
         if adopted is not None:
             return adopted
         base_block = self._arena.reserve(max_blocks)
@@ -882,12 +957,13 @@ class ArenaPoolGroup(PoolGroupBase):
         insort(self._range_bases, base_block)
         return rng
 
-    def _try_adopt(self, max_blocks: int) -> "SequenceRange | None":
+    def _try_adopt(self, max_blocks: int, alias_key: "int | None" = None) -> "SequenceRange | None":
         """Hand a parked freed range (pages still mapped, reclaim gates all
         complete) to a new sequence. LRU-first, so the most recently retired
         ranges keep their ghost entries (D2D reuse, §4.4 phase 2) longest.
         The adopted range keeps its mapped prefix and budget charge; only its
         ghost entries are purged (its bytes are about to be overwritten).
+        Alias-signature filter (P3): see :meth:`reserve_sequence`.
         Returns None when nothing parked fits ``max_blocks``."""
         if not self._range_adoption:
             return None
@@ -895,6 +971,8 @@ class ArenaPoolGroup(PoolGroupBase):
             rng = self._retained[base]
             if rng.num_blocks < max_blocks:
                 continue  # heterogeneous sizing: this range cannot hold it
+            if rng._alias_span_key != alias_key:
+                continue  # prefix-affine: shared span pages must not be overwritten
             if not rng._ready_to_reclaim():
                 continue  # e.g. an in-flight D2D onboard still reads from it
             # With lazy retention, a range whose bytes still serve the ghost
@@ -911,10 +989,12 @@ class ArenaPoolGroup(PoolGroupBase):
                 if live:
                     continue
             del self._retained[base]
-            self._budget.unretain(self._arena.mapped_pages_in_range(base))
+            self._budget.unretain(self._arena.charged_pages_in_range(base))
             # Fresh handle, same extent: the allocator reservation and the
-            # arena's mapped frontier carry over untouched.
+            # arena's mapped frontier (including any alias-mapped span, whose
+            # signature carries over) stay untouched.
             fresh = SequenceRange(base, rng.num_blocks)
+            fresh._alias_span_key = rng._alias_span_key
             self._ranges[base] = fresh
             return fresh
         return None
@@ -1050,7 +1130,7 @@ class ArenaPoolGroup(PoolGroupBase):
                     # its ghosts additionally serve D2D reuse. Unmapped only
                     # under pressure (:meth:`spill_retained`).
                     self._retained[rng.base_block] = rng
-                    self._budget.retain(self._arena.mapped_pages_in_range(rng.base_block))
+                    self._budget.retain(self._arena.charged_pages_in_range(rng.base_block))
                 else:
                     self._reclaim_range(rng)
                 processed += 1
@@ -1095,7 +1175,7 @@ class ArenaPoolGroup(PoolGroupBase):
             rng = self._retained[base]
             if not rng._ready_to_reclaim():
                 continue  # e.g. an in-flight D2D onboard still reads from it
-            pages = self._arena.mapped_pages_in_range(base)
+            pages = self._arena.charged_pages_in_range(base)
             del self._retained[base]
             self._budget.unretain(pages)
             self._reclaim_range(rng)
@@ -1105,7 +1185,7 @@ class ArenaPoolGroup(PoolGroupBase):
 
     @property
     def retained_pages(self) -> int:
-        return sum(self._arena.mapped_pages_in_range(base) for base in self._retained)
+        return sum(self._arena.charged_pages_in_range(base) for base in self._retained)
 
     # -- ghost registry (§4.4 phase 2): D2D reuse from retained ranges ------
 
@@ -1140,6 +1220,127 @@ class ArenaPoolGroup(PoolGroupBase):
             return None  # still pending (bytes not settled) or already spilled
         self.ghost_hits += 1
         return SlotId(base + ordinal), rng
+
+    # -- canonical-span registry (P3): zero-copy prefix aliasing ------------
+
+    def register_canonical_span(
+        self,
+        rng: SequenceRange,
+        pages: "Sequence[object]",
+        ready_event: CachedCudaEvent,
+    ) -> None:
+        """Pin the resident physical pages holding a closing canonical
+        owner's committed prefix (``pages``: the canonical -- by now
+        host-tier -- page objects of blocks ``[0, len(pages))``), so future
+        same-prefix admissions alias them instead of copying (P3).
+
+        Trims to the chunk-aligned aliasable span; no-op if aliasing is off,
+        the span is empty, or this range's head is itself an alias (the
+        registry already pins those pages under the original key -- the
+        adoption signature keeps serving them). The budget charge for the
+        span moves from the range to the registry (release+consume nets zero;
+        the range's later reclaim then correctly skips them) and is marked
+        retained so the pressure/resume gates count it reclaimable."""
+        if not self._prefix_aliasing or not pages:
+            return
+        if rng._alias_span_key is not None:
+            return
+        arena = self._arena
+        num_blocks = arena.aliasable_prefix_blocks(rng.base_block, len(pages))
+        if num_blocks <= 0:
+            return
+        shared_per_pool = arena.shared_prefix_chunks(rng.base_block, num_blocks)
+        span = _CanonicalSpan(
+            [rawref.ref(p) for p in pages[:num_blocks]],
+            shared_per_pool,
+            num_blocks,
+            ready_event,
+        )
+        if span.num_pages == 0:
+            return
+        key = id(pages[0])
+        old = self._canonical_spans.get(key)
+        if old is not None:
+            self._unpin_span(old)
+        for shared in shared_per_pool:
+            for s in shared:
+                s.add_ref()
+        # Transfer the span's budget charge from the owner range to the
+        # registry: mark the chunks alias-accounted in the arena (the range's
+        # park/adopt/reclaim math then excludes them) and re-charge them here,
+        # retained (reclaimable at will via spill_canonical_spans).
+        arena._aliased[rng.base_block] = arena._aliased.get(rng.base_block, 0) + span.num_pages
+        self._budget.release(span.num_pages)
+        self._budget.consume(span.num_pages)
+        self._budget.retain(span.num_pages)
+        rng._alias_span_key = key
+        self._canonical_spans[key] = span
+
+    def lookup_canonical_span(
+        self, head_page: object, matched_pages: "Sequence[object]"
+    ) -> "tuple[int, _CanonicalSpan] | None":
+        """Registry hit for an admission whose reuse match starts at
+        ``head_page`` and covers ``matched_pages`` (canonical page objects in
+        ordinal order): returns ``(key, span)`` iff a live span exists, its
+        FULL extent is covered by the match (a shorter match would write into
+        shared pages), and every span page identity still holds. Any
+        staleness invalidates and unpins the entry."""
+        if not self._prefix_aliasing:
+            return None
+        key = id(head_page)
+        span = self._canonical_spans.get(key)
+        if span is None:
+            self.alias_misses += 1
+            return None
+        if len(matched_pages) < span.num_blocks:
+            self.alias_misses += 1
+            return None  # match too short to safely alias the whole span
+        for i, ref in enumerate(span.page_refs):
+            if ref() is not matched_pages[i]:
+                self._invalidate_span(key, span)
+                self.alias_misses += 1
+                return None
+        self.alias_hits += 1
+        return key, span
+
+    def alias_span_into_range(self, rng: SequenceRange, key: int, span: "_CanonicalSpan") -> int:
+        """Alias-map ``span``'s physical pages at the start of ``rng`` (a
+        FRESH, unmapped range) and stamp its signature. Signature-matched
+        adopted ranges already carry the mappings and skip this. Returns the
+        chunks aliased."""
+        assert rng._alias_span_key is None
+        aliased = self._arena.alias_prefix(rng.base_block, span.shared_per_pool)
+        rng._alias_span_key = key
+        return aliased
+
+    def _unpin_span(self, span: "_CanonicalSpan") -> None:
+        for shared in span.shared_per_pool:
+            for s in shared:
+                s.drop_ref()
+        self._budget.unretain(span.num_pages)
+        self._budget.release(span.num_pages)
+
+    def _invalidate_span(self, key: int, span: "_CanonicalSpan") -> None:
+        self._canonical_spans.pop(key, None)
+        self._unpin_span(span)
+
+    def spill_canonical_spans(self, min_pages: int) -> int:
+        """Drop canonical-span pins (insertion order ≈ LRU) until at least
+        ``min_pages`` budget pages are freed. Live aliases keep their handles
+        (refcounts); future admissions fall back to host-copy reuse."""
+        freed = 0
+        for key in list(self._canonical_spans):
+            if freed >= min_pages:
+                break
+            span = self._canonical_spans.pop(key)
+            self._unpin_span(span)
+            self.spilled_spans += 1
+            freed += span.num_pages
+        return freed
+
+    @property
+    def canonical_span_pages(self) -> int:
+        return sum(s.num_pages for s in self._canonical_spans.values())
 
     def _find_range(self, slot_id: int) -> SequenceRange:
         idx = bisect_right(self._range_bases, slot_id) - 1
@@ -1556,6 +1757,7 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         phys_page_size: int,
         map_ahead_pages: int,
         lazy_retention: bool = False,
+        prefix_aliasing: bool = False,
     ):
         num_pool_groups = typed_len(slot_size_lists)
         assert num_pool_groups == typed_len(block_capacity_list), (
@@ -1581,6 +1783,7 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
                 map_ahead_pages,
                 page_index_scale_list[pg_idx],
                 lazy_retention,
+                prefix_aliasing,
             ),
             num_pool_groups,
         )
@@ -1613,13 +1816,19 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
     def spill_retained(self, min_pages: int) -> int:
         """Reclaim lazily retained ranges (§4.4 phase 2), LRU-first per pool
         group, until ``min_pages`` physical pages are freed or nothing more
-        is spillable. Returns pages freed."""
+        is spillable; canonical-span pins (P3) are spilled last -- shared
+        prefixes are the hottest bytes on the level. Returns pages freed."""
         freed = 0
         for pg in self._pool_groups:
             if freed >= min_pages:
                 break
             assert type(pg) is ArenaPoolGroup
             freed += pg.spill_retained(min_pages - freed)
+        for pg in self._pool_groups:
+            if freed >= min_pages:
+                break
+            assert type(pg) is ArenaPoolGroup
+            freed += pg.spill_canonical_spans(min_pages - freed)
         return freed
 
     def flush_mappings(self) -> int:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -1472,6 +1472,24 @@ class ArenaPoolGroup(PoolGroupBase):
             self.alias_hits += 1
         return key, span, usable
 
+    def span_covers(self, head_page: object, ordinal: int, page: object) -> bool:
+        """Whether a LIVE registered span identity-covers ``page`` at
+        position ``ordinal`` of the chain headed by ``head_page`` -- the
+        mappability probe for promotion decisions (P3 v3 R1).
+
+        Deliberately NOT :meth:`lookup_canonical_span`: that verify loop
+        INVALIDATES the span on any identity mismatch, which is correct for
+        admissions (their matched pages share the owner's tree path, so a
+        mismatch means staleness) but destructive for promotion probes,
+        whose chains legitimately diverge from the span owner's path past
+        the shared prefix. This check touches nothing."""
+        if not self._prefix_aliasing:
+            return False
+        span = self._canonical_spans.get(id(head_page))
+        if span is None or ordinal >= span.num_blocks:
+            return False
+        return span.page_refs[ordinal]() is page
+
     def alias_span_into_range(
         self, rng: SequenceRange, key: int, span: "_CanonicalSpan", num_blocks: int
     ) -> int:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -674,6 +674,7 @@ class SequenceRange:
         "_freed",
         "_gate_events",
         "_free_event",
+        "_reclaim_fence",
         "_ghost_keys",
     )
     base_block: int
@@ -682,6 +683,14 @@ class SequenceRange:
     _freed: bool
     _gate_events: list[CachedCudaEvent]  # pending ready events of released slots
     _free_event: CachedCudaEvent
+    # Execution-stream fence recorded at the first drain point after the free
+    # (DESIGN.md §4.2, risk #3). The overlap scheduler may have speculatively
+    # enqueued a step that still reads this range when free_sequence runs; the
+    # free/gate events do not order against that step. A fence recorded on the
+    # execution stream at a later drain point covers every launch that could
+    # reference the range (steps enqueued after it no longer contain the
+    # sequence). None until the first fenced drain sees this range.
+    _reclaim_fence: CachedCudaEvent | None
     # Ghost registry keys (§4.4 phase 2): ids of host pages whose bytes still
     # live in this (retained) range; purged when the range is reclaimed.
     _ghost_keys: list[int]
@@ -693,6 +702,7 @@ class SequenceRange:
         self._freed = False
         self._gate_events = []
         self._free_event = CachedCudaEvent.NULL
+        self._reclaim_fence = None
         self._ghost_keys = []
 
     @property
@@ -704,6 +714,8 @@ class SequenceRange:
 
     def _ready_to_reclaim(self) -> bool:
         if not self._freed or self._outstanding != 0:
+            return False
+        if self._reclaim_fence is None or not self._reclaim_fence.query_complete():
             return False
         if not self._free_event.query_complete():
             return False
@@ -817,6 +829,13 @@ class ArenaPoolGroup(PoolGroupBase):
             rng._free_event.synchronize()
             for ev in rng._gate_events:
                 ev.synchronize()
+            # Teardown blocks until the device is quiet, so the speculative-step
+            # fence is moot; substitute the (complete) null event for unfenced
+            # ranges and synchronize real ones.
+            if rng._reclaim_fence is None:
+                rng._reclaim_fence = CachedCudaEvent.NULL
+            else:
+                rng._reclaim_fence.synchronize()
         self.drain_reclaim()
         for rng in list(self._retained.values()):
             for ev in rng._gate_events:
@@ -924,13 +943,22 @@ class ArenaPoolGroup(PoolGroupBase):
         rng._free_event = last_consumer
         self._pending_reclaim.append(rng)
 
-    def drain_reclaim(self) -> int:
+    def drain_reclaim(self, fence: CachedCudaEvent | None = None) -> int:
         """Process every freed range whose gating conditions have all
         completed: unmap and recycle it, or -- with lazy retention (§4.4
         phase 2) -- keep its pages mapped and park it on the retained LRU,
         to be reclaimed only under pressure (:meth:`spill_retained`).
         Returns the number of ranges processed. Call at iteration
-        boundaries."""
+        boundaries.
+
+        ``fence`` must be an event recorded on the *execution* stream at the
+        call site; it is attached to ranges freed since the previous fenced
+        drain and gates their reclaim (risk #3: a speculatively enqueued step
+        may still read a just-freed range — see ``SequenceRange._reclaim_fence``).
+        Unfenced ranges are never reclaimed, so fenced drains must happen
+        periodically (the pyexecutor adapter fences every iteration)."""
+        if fence is not None:
+            self.fence_pending_frees(fence)
         remaining: list[SequenceRange] = []
         processed = 0
         for rng in self._pending_reclaim:
@@ -945,6 +973,15 @@ class ArenaPoolGroup(PoolGroupBase):
                 remaining.append(rng)
         self._pending_reclaim = remaining
         return processed
+
+    def fence_pending_frees(self, fence: CachedCudaEvent) -> None:
+        """Attach ``fence`` (an event recorded on the execution stream at an
+        iteration boundary) to every pending freed range that has none yet.
+        Assign-only variant of the ``fence`` parameter of
+        :meth:`drain_reclaim`."""
+        for rng in self._pending_reclaim:
+            if rng._reclaim_fence is None:
+                rng._reclaim_fence = fence
 
     def _reclaim_range(self, rng: SequenceRange) -> None:
         """Unmap a range's pages, return its block indices, purge its ghosts."""
@@ -1468,14 +1505,23 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         assert type(pg) is ArenaPoolGroup
         return pg
 
-    def drain_reclaim(self) -> int:
+    def drain_reclaim(self, fence: CachedCudaEvent | None = None) -> int:
         """Drain every pool group's deferred-reclaim queue (call at iteration
-        boundaries). Returns the number of sequence ranges reclaimed."""
+        boundaries). ``fence`` gates newly freed ranges against speculatively
+        enqueued steps (see :meth:`ArenaPoolGroup.drain_reclaim`). Returns the
+        number of sequence ranges reclaimed."""
         reclaimed = 0
         for pg in self._pool_groups:
             assert type(pg) is ArenaPoolGroup
-            reclaimed += pg.drain_reclaim()
+            reclaimed += pg.drain_reclaim(fence)
         return reclaimed
+
+    def fence_pending_frees(self, fence: CachedCudaEvent) -> None:
+        """Assign the iteration-boundary reclaim fence in every pool group
+        without draining (see :meth:`ArenaPoolGroup.fence_pending_frees`)."""
+        for pg in self._pool_groups:
+            assert type(pg) is ArenaPoolGroup
+            pg.fence_pending_frees(fence)
 
     def spill_retained(self, min_pages: int) -> int:
         """Reclaim lazily retained ranges (§4.4 phase 2), LRU-first per pool

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -916,7 +916,7 @@ class ArenaPoolGroup(PoolGroupBase):
         if not hasattr(self, "_destroyed") or self._destroyed:
             return
         # Deferred maps that never ran only hold budget; return it.
-        for _, (_, _, charged) in self._pending_maps.items():
+        for _, (_, _, charged, _) in self._pending_maps.items():
             self._budget.release(charged)
         self._pending_maps.clear()
         # Teardown can run right after sequences finished, with their ranges
@@ -1045,28 +1045,59 @@ class ArenaPoolGroup(PoolGroupBase):
         """Charge the page budget for the pages a target frontier needs (so
         admission control behaves exactly like an immediate map) but defer the
         actual ``cuMemMap``/``cuMemSetAccess`` calls to :meth:`flush_mappings`.
-        Raises ``OutOfPagesError`` (charging nothing) on budget exhaustion.
-        Returns the pages charged. The caller MUST run the flush before any
-        GPU work touches the new blocks."""
+        The map-ahead margin degrades to zero before the charge fails (the
+        margin is a latency-hiding hint -- see ``SequenceArena.ensure_mapped``);
+        the margin actually charged is recorded on the entry so the flush
+        replays the exact same plan. Raises ``OutOfPagesError`` (charging
+        nothing) only if the frontier alone does not fit. Returns the pages
+        charged. The caller MUST run the flush before any GPU work touches
+        the new blocks."""
         assert not rng._freed and num_valid_blocks <= rng.num_blocks
         base = rng.base_block
         entry = self._pending_maps.get(base)
         if entry is None:
+            margin = -1
             pages = self._arena.pending_pages(base, num_valid_blocks)
-            if pages:
+            if not pages:
+                return 0
+            try:
+                self._budget.consume(pages)
+            except OutOfPagesError:
+                margin = 0
+                pages = self._arena.pending_pages(base, num_valid_blocks, 0)
+                if not pages:
+                    return 0
                 self._budget.consume(pages)  # raises; nothing recorded yet
-                self._pending_maps[base] = [rng, num_valid_blocks, pages]
+            self._pending_maps[base] = [rng, num_valid_blocks, pages, margin]
             return pages
         if num_valid_blocks <= entry[1]:
             return 0
         # Nothing was mapped since the first queue call, so pending_pages is
-        # monotone in the frontier and the delta charge is exact.
+        # monotone in the frontier (at a fixed margin) and the delta charge
+        # is exact.
         charged: int = entry[2]
-        pages = self._arena.pending_pages(base, num_valid_blocks)
+        margin: int = entry[3]
+        pages = self._arena.pending_pages(base, num_valid_blocks, margin)
         delta = pages - charged
         assert delta >= 0
         if delta:
-            self._budget.consume(delta)
+            try:
+                self._budget.consume(delta)
+            except OutOfPagesError:
+                if margin == 0:
+                    raise
+                # Degrade this entry's margin. The margin-less plan for the
+                # new target can even be SMALLER than what is already charged
+                # (margin wider than the added blocks): release the excess so
+                # the invariant charged == pending_pages(target, margin)
+                # holds exactly for the flush.
+                pages = self._arena.pending_pages(base, num_valid_blocks, 0)
+                delta = pages - charged
+                if delta > 0:
+                    self._budget.consume(delta)  # raises; entry unchanged
+                elif delta < 0:
+                    self._budget.release(-delta)
+                entry[3] = 0
         entry[1] = num_valid_blocks
         entry[2] = pages
         return delta
@@ -1078,11 +1109,11 @@ class ArenaPoolGroup(PoolGroupBase):
         if not self._pending_maps:
             return 0
         mapped_total = 0
-        for base, (rng, target, charged) in self._pending_maps.items():
+        for base, (rng, target, charged, margin) in self._pending_maps.items():
             if rng._freed or base not in self._ranges:
                 self._budget.release(charged)
                 continue
-            mapped = self._arena.ensure_mapped(base, target, precharged=True)
+            mapped = self._arena.ensure_mapped(base, target, precharged=True, margin=margin)
             mapped_total += mapped
             if mapped != charged:
                 # Defensive: the plan is deterministic, so this indicates

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -943,7 +943,7 @@ class ArenaPoolGroup(PoolGroupBase):
         rng._free_event = last_consumer
         self._pending_reclaim.append(rng)
 
-    def drain_reclaim(self, fence: CachedCudaEvent | None = None) -> int:
+    def drain_reclaim(self, fence: CachedCudaEvent | None = None, wait: bool = False) -> int:
         """Process every freed range whose gating conditions have all
         completed: unmap and recycle it, or -- with lazy retention (§4.4
         phase 2) -- keep its pages mapped and park it on the retained LRU,
@@ -956,9 +956,30 @@ class ArenaPoolGroup(PoolGroupBase):
         drain and gates their reclaim (risk #3: a speculatively enqueued step
         may still read a just-freed range — see ``SequenceRange._reclaim_fence``).
         Unfenced ranges are never reclaimed, so fenced drains must happen
-        periodically (the pyexecutor adapter fences every iteration)."""
+        periodically (the pyexecutor adapter fences every iteration).
+
+        With ``wait=True`` the call BLOCKS until each pending range's gating
+        events complete (fence, free event, released-slot gates) instead of
+        skipping ranges whose events are still in flight. This is the §4.6
+        preemption-headroom escape hatch: the scheduler's eviction path frees
+        ranges in the middle of a scheduling pass — before the iteration-
+        boundary fenced drain could possibly run — and without a blocking
+        drain those pages stay charged to the budget, admission keeps
+        failing, and a fully suspended batch deadlocks (every resume refused
+        by the utilization gate while nothing is left to evict). The wait is
+        bounded: the gates are the just-enqueued evacuation copies plus
+        already-enqueued forward steps. Ranges with outstanding slots are
+        skipped (their release is host-side state, not an event)."""
         if fence is not None:
             self.fence_pending_frees(fence)
+        if wait:
+            for rng in self._pending_reclaim:
+                if rng._outstanding != 0 or rng._reclaim_fence is None:
+                    continue
+                rng._reclaim_fence.synchronize()
+                rng._free_event.synchronize()
+                for ev in rng._gate_events:
+                    ev.synchronize()
         remaining: list[SequenceRange] = []
         processed = 0
         for rng in self._pending_reclaim:
@@ -1505,15 +1526,17 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         assert type(pg) is ArenaPoolGroup
         return pg
 
-    def drain_reclaim(self, fence: CachedCudaEvent | None = None) -> int:
+    def drain_reclaim(self, fence: CachedCudaEvent | None = None, wait: bool = False) -> int:
         """Drain every pool group's deferred-reclaim queue (call at iteration
         boundaries). ``fence`` gates newly freed ranges against speculatively
-        enqueued steps (see :meth:`ArenaPoolGroup.drain_reclaim`). Returns the
-        number of sequence ranges reclaimed."""
+        enqueued steps; ``wait=True`` blocks on in-flight gating events
+        instead of skipping their ranges (see
+        :meth:`ArenaPoolGroup.drain_reclaim`). Returns the number of sequence
+        ranges reclaimed."""
         reclaimed = 0
         for pg in self._pool_groups:
             assert type(pg) is ArenaPoolGroup
-            reclaimed += pg.drain_reclaim(fence)
+            reclaimed += pg.drain_reclaim(fence, wait)
         return reclaimed
 
     def fence_pending_frees(self, fence: CachedCudaEvent) -> None:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -30,6 +30,7 @@ if sys.version_info[:2] >= (3, 12):
 else:
     from typing_extensions import override
 
+from .. import rawref
 from .._common import (
     BAD_FILE_DESCRIPTOR,
     NDEBUG,
@@ -673,6 +674,7 @@ class SequenceRange:
         "_freed",
         "_gate_events",
         "_free_event",
+        "_ghost_keys",
     )
     base_block: int
     num_blocks: int  # reserved (padded) length in blocks
@@ -680,6 +682,9 @@ class SequenceRange:
     _freed: bool
     _gate_events: list[CachedCudaEvent]  # pending ready events of released slots
     _free_event: CachedCudaEvent
+    # Ghost registry keys (§4.4 phase 2): ids of host pages whose bytes still
+    # live in this (retained) range; purged when the range is reclaimed.
+    _ghost_keys: list[int]
 
     def __init__(self, base_block: int, num_blocks: int) -> None:
         self.base_block = base_block
@@ -688,6 +693,7 @@ class SequenceRange:
         self._freed = False
         self._gate_events = []
         self._free_event = CachedCudaEvent.NULL
+        self._ghost_keys = []
 
     @property
     def end_block(self) -> int:
@@ -724,11 +730,31 @@ class ArenaPoolGroup(PoolGroupBase):
     destinations inside that range (§4.4).
     """
 
-    __slots__ = ("_arena", "_ranges", "_range_bases", "_pending_reclaim")
+    __slots__ = (
+        "_arena",
+        "_ranges",
+        "_range_bases",
+        "_pending_reclaim",
+        "_budget",
+        "_lazy_retention",
+        "_retained",
+        "_ghosts",
+        "ghost_hits",
+        "ghost_misses",
+        "spilled_ranges",
+    )
     _arena: SequenceArena
     _ranges: dict[int, SequenceRange]  # base_block -> live range
     _range_bases: list[int]  # sorted, for slot_id -> range lookup on release
     _pending_reclaim: list[SequenceRange]
+    _budget: PageBudget
+    _lazy_retention: bool
+    # Lazily retained freed ranges (§4.4 phase 2), insertion-ordered = LRU by
+    # retire time. Pages stay mapped; reclaimed only under pressure.
+    _retained: dict[int, SequenceRange]
+    # id(host page) -> (identity ref, retained-range base, ordinal): where a
+    # committed block's bytes still live on GPU after its owner closed.
+    _ghosts: "dict[int, tuple[rawref.ref, int, int]]"
 
     def __init__(
         self,
@@ -738,6 +764,7 @@ class ArenaPoolGroup(PoolGroupBase):
         page_budget: PageBudget,
         map_ahead_pages: int,
         page_index_scale: int,
+        lazy_retention: bool = False,
     ) -> None:
         # The int31 kernel-offset ceiling must hold for every offset this
         # arena can emit (DESIGN.md §4.1); fail loudly at startup.
@@ -760,6 +787,13 @@ class ArenaPoolGroup(PoolGroupBase):
         self._ranges = {}
         self._range_bases = []
         self._pending_reclaim = []
+        self._budget = page_budget
+        self._lazy_retention = lazy_retention
+        self._retained = {}
+        self._ghosts = {}
+        self.ghost_hits = 0
+        self.ghost_misses = 0
+        self.spilled_ranges = 0
 
     @override
     def destroy(self) -> None:
@@ -770,12 +804,17 @@ class ArenaPoolGroup(PoolGroupBase):
         # Teardown can run right after sequences finished, with their ranges
         # still in the event-gated deferred-reclaim queue (§4.2). Teardown is
         # allowed to block: synchronize the gates and drain, then anything
-        # left is a genuine leak.
+        # left besides retained ranges is a genuine leak.
         for rng in self._pending_reclaim:
             rng._free_event.synchronize()
             for ev in rng._gate_events:
                 ev.synchronize()
         self.drain_reclaim()
+        for rng in list(self._retained.values()):
+            for ev in rng._gate_events:
+                ev.synchronize()
+        assert self.spill_retained(1 << 62) >= 0
+        assert not self._retained
         assert not self._ranges and not self._pending_reclaim, (
             "destroying ArenaPoolGroup with live sequence ranges"
         )
@@ -823,23 +862,99 @@ class ArenaPoolGroup(PoolGroupBase):
         self._pending_reclaim.append(rng)
 
     def drain_reclaim(self) -> int:
-        """Unmap and recycle every freed range whose gating conditions have
-        all completed. Returns the number of ranges reclaimed. Call at
-        iteration boundaries."""
+        """Process every freed range whose gating conditions have all
+        completed: unmap and recycle it, or -- with lazy retention (§4.4
+        phase 2) -- keep its pages mapped and park it on the retained LRU,
+        to be reclaimed only under pressure (:meth:`spill_retained`).
+        Returns the number of ranges processed. Call at iteration
+        boundaries."""
         remaining: list[SequenceRange] = []
-        reclaimed = 0
+        processed = 0
         for rng in self._pending_reclaim:
             if rng._ready_to_reclaim():
-                self._arena.reclaim(rng.base_block)
-                del self._ranges[rng.base_block]
-                idx = bisect_right(self._range_bases, rng.base_block) - 1
-                assert self._range_bases[idx] == rng.base_block
-                self._range_bases.pop(idx)
-                reclaimed += 1
+                if self._lazy_retention:
+                    self._retained[rng.base_block] = rng
+                    self._budget.retain(self._arena.mapped_pages_in_range(rng.base_block))
+                else:
+                    self._reclaim_range(rng)
+                processed += 1
             else:
                 remaining.append(rng)
         self._pending_reclaim = remaining
-        return reclaimed
+        return processed
+
+    def _reclaim_range(self, rng: SequenceRange) -> None:
+        """Unmap a range's pages, return its block indices, purge its ghosts."""
+        for key in rng._ghost_keys:
+            entry = self._ghosts.get(key)
+            # A newer registration (e.g. a later sequence's private copy of
+            # the same canonical block) may have superseded this range's
+            # entry; only purge entries that still point here.
+            if entry is not None and entry[1] == rng.base_block:
+                self._ghosts.pop(key)
+        rng._ghost_keys.clear()
+        self._arena.reclaim(rng.base_block)
+        del self._ranges[rng.base_block]
+        idx = bisect_right(self._range_bases, rng.base_block) - 1
+        assert self._range_bases[idx] == rng.base_block
+        self._range_bases.pop(idx)
+
+    def spill_retained(self, min_pages: int) -> int:
+        """Reclaim retained ranges (LRU first, skipping ranges with pending
+        gate events) until at least ``min_pages`` physical pages have been
+        freed or nothing more is spillable. Returns pages freed."""
+        freed = 0
+        for base in list(self._retained):
+            if freed >= min_pages:
+                break
+            rng = self._retained[base]
+            if not rng._ready_to_reclaim():
+                continue  # e.g. an in-flight D2D onboard still reads from it
+            pages = self._arena.mapped_pages_in_range(base)
+            del self._retained[base]
+            self._budget.unretain(pages)
+            self._reclaim_range(rng)
+            self.spilled_ranges += 1
+            freed += pages
+        return freed
+
+    @property
+    def retained_pages(self) -> int:
+        return sum(self._arena.mapped_pages_in_range(base) for base in self._retained)
+
+    # -- ghost registry (§4.4 phase 2): D2D reuse from retained ranges ------
+
+    def register_ghosts(self, rng: SequenceRange, entries: "Sequence[tuple[int, object]]") -> None:
+        """Record that the bytes of ``page`` (now living in the stale tier)
+        are still present at ``rng.base_block + ordinal`` for each
+        ``(ordinal, page)`` entry. Valid until the range is reclaimed."""
+        if not self._lazy_retention:
+            return
+        for ordinal, page in entries:
+            key = id(page)
+            self._ghosts[key] = (rawref.ref(page), rng.base_block, ordinal)
+            rng._ghost_keys.append(key)
+
+    def lookup_ghost(self, page: object) -> "tuple[SlotId, SequenceRange] | None":
+        """If ``page``'s bytes are still resident in a *retained* range,
+        return (slot id of the resident copy, the retained range) -- the
+        caller must gate the range's reclaim on its copy (append to
+        ``_gate_events``). Returns None on any staleness."""
+        entry = self._ghosts.get(id(page))
+        if entry is None:
+            self.ghost_misses += 1
+            return None
+        ref, base, ordinal = entry
+        if ref() is not page:
+            self._ghosts.pop(id(page), None)  # id was reused by a new object
+            self.ghost_misses += 1
+            return None
+        rng = self._retained.get(base)
+        if rng is None:
+            self.ghost_misses += 1
+            return None  # still pending (bytes not settled) or already spilled
+        self.ghost_hits += 1
+        return SlotId(base + ordinal), rng
 
     def _find_range(self, slot_id: int) -> SequenceRange:
         idx = bisect_right(self._range_bases, slot_id) - 1
@@ -1255,6 +1370,7 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         quota: int,
         phys_page_size: int,
         map_ahead_pages: int,
+        lazy_retention: bool = False,
     ):
         num_pool_groups = typed_len(slot_size_lists)
         assert num_pool_groups == typed_len(block_capacity_list), (
@@ -1279,6 +1395,7 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
                 self.page_budget,
                 map_ahead_pages,
                 page_index_scale_list[pg_idx],
+                lazy_retention,
             ),
             num_pool_groups,
         )
@@ -1296,6 +1413,18 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
             assert type(pg) is ArenaPoolGroup
             reclaimed += pg.drain_reclaim()
         return reclaimed
+
+    def spill_retained(self, min_pages: int) -> int:
+        """Reclaim lazily retained ranges (§4.4 phase 2), LRU-first per pool
+        group, until ``min_pages`` physical pages are freed or nothing more
+        is spillable. Returns pages freed."""
+        freed = 0
+        for pg in self._pool_groups:
+            if freed >= min_pages:
+                break
+            assert type(pg) is ArenaPoolGroup
+            freed += pg.spill_retained(min_pages - freed)
+        return freed
 
     @property
     def pool_size_granularity(self) -> int:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -1163,13 +1163,16 @@ class ArenaPoolGroup(PoolGroupBase):
         rng._free_event = last_consumer
         self._pending_reclaim.append(rng)
 
-    def drain_reclaim(self, fence: CachedCudaEvent | None = None, wait: bool = False) -> int:
+    def drain_reclaim(
+        self, fence: CachedCudaEvent | None = None, wait: bool = False, quiesce: bool = True
+    ) -> int:
         """Process every freed range whose gating conditions have all
         completed: unmap and recycle it, or -- with lazy retention (§4.4
         phase 2) -- keep its pages mapped and park it on the retained LRU,
         to be reclaimed only under pressure (:meth:`spill_retained`).
         Returns the number of ranges processed. Call at iteration
-        boundaries.
+        boundaries. ``quiesce=False`` skips the per-range device quiesce
+        (hard-reclaim path, P3 v3: the caller quiesced once for the batch).
 
         ``fence`` must be an event recorded on the *execution* stream at the
         call site; it is attached to ranges freed since the previous fenced
@@ -1213,7 +1216,7 @@ class ArenaPoolGroup(PoolGroupBase):
                     self._retained[rng.base_block] = rng
                     self._budget.retain(self._arena.charged_pages_in_range(rng.base_block))
                 else:
-                    self._reclaim_range(rng)
+                    self._reclaim_range(rng, quiesce)
                 processed += 1
             else:
                 remaining.append(rng)
@@ -1229,7 +1232,7 @@ class ArenaPoolGroup(PoolGroupBase):
             if rng._reclaim_fence is None:
                 rng._reclaim_fence = fence
 
-    def _reclaim_range(self, rng: SequenceRange) -> None:
+    def _reclaim_range(self, rng: SequenceRange, quiesce: bool = True) -> None:
         """Unmap a range's pages, return its block indices, purge its ghosts."""
         for key in rng._ghost_keys:
             entry = self._ghosts.get(key)
@@ -1239,16 +1242,19 @@ class ArenaPoolGroup(PoolGroupBase):
             if entry is not None and entry[1] == rng.base_block:
                 self._ghosts.pop(key)
         rng._ghost_keys.clear()
-        self._arena.reclaim(rng.base_block)
+        self._arena.reclaim(rng.base_block, quiesce)
         del self._ranges[rng.base_block]
         idx = bisect_right(self._range_bases, rng.base_block) - 1
         assert self._range_bases[idx] == rng.base_block
         self._range_bases.pop(idx)
 
-    def spill_retained(self, min_pages: int) -> int:
+    def spill_retained(self, min_pages: int, quiesce: bool = True) -> int:
         """Reclaim retained ranges (LRU first, skipping ranges with pending
         gate events) until at least ``min_pages`` physical pages have been
-        freed or nothing more is spillable. Returns pages freed."""
+        freed or nothing more is spillable. Returns pages freed.
+        ``quiesce=False`` skips the per-range device quiesce (hard-reclaim
+        path, P3 v3: the caller quiesced once for the whole batch -- fixes
+        the per-range re-sync of the old ladder)."""
         freed = 0
         for base in list(self._retained):
             if freed >= min_pages:
@@ -1259,7 +1265,7 @@ class ArenaPoolGroup(PoolGroupBase):
             pages = self._arena.charged_pages_in_range(base)
             del self._retained[base]
             self._budget.unretain(pages)
-            self._reclaim_range(rng)
+            self._reclaim_range(rng, quiesce)
             self.spilled_ranges += 1
             freed += pages
         return freed
@@ -2006,17 +2012,20 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         assert type(pg) is ArenaPoolGroup
         return pg
 
-    def drain_reclaim(self, fence: CachedCudaEvent | None = None, wait: bool = False) -> int:
+    def drain_reclaim(
+        self, fence: CachedCudaEvent | None = None, wait: bool = False, quiesce: bool = True
+    ) -> int:
         """Drain every pool group's deferred-reclaim queue (call at iteration
         boundaries). ``fence`` gates newly freed ranges against speculatively
         enqueued steps; ``wait=True`` blocks on in-flight gating events
         instead of skipping their ranges (see
-        :meth:`ArenaPoolGroup.drain_reclaim`). Returns the number of sequence
-        ranges reclaimed."""
+        :meth:`ArenaPoolGroup.drain_reclaim`); ``quiesce=False`` skips the
+        per-range device quiesce (:meth:`hard_reclaim` quiesced once for the
+        batch). Returns the number of sequence ranges reclaimed."""
         reclaimed = 0
         for pg in self._pool_groups:
             assert type(pg) is ArenaPoolGroup
-            reclaimed += pg.drain_reclaim(fence, wait)
+            reclaimed += pg.drain_reclaim(fence, wait, quiesce)
         return reclaimed
 
     def fence_pending_frees(self, fence: CachedCudaEvent) -> None:
@@ -2026,7 +2035,7 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
             assert type(pg) is ArenaPoolGroup
             pg.fence_pending_frees(fence)
 
-    def spill_retained(self, min_pages: int, spill_spans: bool = True) -> int:
+    def spill_retained(self, min_pages: int, spill_spans: bool = True, quiesce: bool = True) -> int:
         """Reclaim lazily retained ranges (§4.4 phase 2), LRU-first per pool
         group, until ``min_pages`` physical pages are freed or nothing more
         is spillable; canonical-span pins (P3) are spilled last -- shared
@@ -2036,15 +2045,15 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
         it every zero-copy alias hit, to cover a transient need worth a
         handful of pages. Protected callers back off like any failed
         allocation instead (§4.6). ``spill_spans=False`` skips the span pass
-        entirely -- the reclaim ladder runs the dedup remap (which FREES
-        duplicates instead of forfeiting the registry) between the two.
-        Returns pages freed."""
+        entirely; ``quiesce=False`` skips the per-range device quiesce
+        (:meth:`hard_reclaim` quiesced once for the batch). Returns pages
+        freed."""
         freed = 0
         for pg in self._pool_groups:
             if freed >= min_pages:
                 break
             assert type(pg) is ArenaPoolGroup
-            freed += pg.spill_retained(min_pages - freed)
+            freed += pg.spill_retained(min_pages - freed, quiesce)
         if not spill_spans:
             return freed
         spillable = -self._span_spill_floor
@@ -2060,23 +2069,86 @@ class GpuArenaCacheLevelStorage(CacheLevelStorage):
             spillable -= got
         return freed
 
-    def dedup_remap(self, items: "list[tuple[int, SequenceRange, int, object, int]]") -> int:
+    def dedup_remap(
+        self, items: "list[tuple[int, SequenceRange, int, object, int]]", quiesce: bool = True
+    ) -> int:
         """Execute a dedup-remap batch (P3 v2) behind ONE device quiesce:
         each item ``(pg_idx, rng, key, span, num_blocks)`` replaces the
         range's private duplicate prefix backing with aliases of the span's
         handles. The caller (the manager's pressure-time scan) has already
         verified eligibility host-side; nothing here enqueues GPU work, so
         the batch is atomic with respect to the executor's enqueue thread.
-        Returns total pages freed."""
+        ``quiesce=False`` skips the quiesce (:meth:`hard_reclaim` already
+        quiesced). Returns total pages freed."""
         if not items:
             return 0
-        quiesce_before_unmap()
+        if quiesce:
+            quiesce_before_unmap()
         freed = 0
         for pg_idx, rng, key, span, num_blocks in items:
             pg = self._pool_groups[PoolGroupIndex(pg_idx)]
             assert type(pg) is ArenaPoolGroup
             freed += pg.remap_range_onto_span(rng, key, cast("_CanonicalSpan", span), num_blocks)
         return freed
+
+    def hard_reclaim(
+        self,
+        min_pages: int,
+        dedup_items: "list[tuple[int, SequenceRange, int, object, int]]",
+        fence: CachedCudaEvent | None = None,
+    ) -> int:
+        """Pressure-time hard reclaim (P3 v3): every rung that needs the
+        device quiesced, behind ONE quiesce, harvesting maximally
+        (destruction-ordered -- see the manager's ``hard_reclaim_gpu``).
+
+        Sync-free exit first: if there is nothing to reclaim anywhere (no
+        dedup candidates, nothing pending, nothing parked, no registry
+        excess above the protection floor), returns 0 WITHOUT syncing.
+        Otherwise quiesces once, then:
+
+        1. fenced drain -- every pending free's gates are complete
+           post-sync, so all of them park (adoption/retention) or unmap
+           (plain mode) now;
+        2. dedup remap of ALL ``dedup_items`` (duplicates have zero
+           retention value: this frees pages from live sequences without
+           touching the parked cache);
+        3. parked-range spill for the REMAINDER still needed, then registry
+           excess above the floor last (both destroy reuse value).
+
+        ``fence``: an execution-stream event recorded by the caller BEFORE
+        this call (it completes under the quiesce); attached to pending
+        frees that have none yet so the drain can take them. Returns pages
+        freed (budget delta)."""
+        budget = self.page_budget
+        free_before = budget.free_pages
+        has_work = bool(dedup_items)
+        if not has_work:
+            for pg in self._pool_groups:
+                assert type(pg) is ArenaPoolGroup
+                # Pending ranges with outstanding slot refs can never drain
+                # (their release is host-side state, not an event) -- do not
+                # pay a quiesce for them.
+                if pg._retained or any(r._outstanding == 0 for r in pg._pending_reclaim):
+                    has_work = True
+                    break
+        if not has_work:
+            spillable = -self._span_spill_floor
+            for pg in self._pool_groups:
+                assert type(pg) is ArenaPoolGroup
+                spillable += pg.canonical_span_pages
+            has_work = spillable > 0
+        if not has_work:
+            return 0
+        quiesce_before_unmap()
+        if fence is not None:
+            self.fence_pending_frees(fence)
+        self.drain_reclaim(quiesce=False)
+        if dedup_items:
+            self.dedup_remap(dedup_items, quiesce=False)
+        needed = min_pages - (budget.free_pages - free_before)
+        if needed > 0:
+            self.spill_retained(needed, spill_spans=True, quiesce=False)
+        return budget.free_pages - free_before
 
     @property
     def protected_span_pages(self) -> int:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -743,12 +743,13 @@ class SequenceRange:
     # Ghost registry keys (§4.4 phase 2): ids of host pages whose bytes still
     # live in this (retained) range; purged when the range is reclaimed.
     _ghost_keys: list[int]
-    # P3 prefix aliasing: the canonical-span registry key whose physical pages
-    # are alias-mapped at this range's start (None = unaliased). Aliased
-    # ranges may only be adopted by a sequence whose reuse match carries the
-    # SAME key -- the span's physical pages are shared, so any other adopter
-    # writing the range head would corrupt every alias of the span.
-    _alias_span_key: "int | None"
+    # P3 prefix aliasing: (registry key, aliased block extent) of the span
+    # alias-mapped at this range's start (None = unaliased). Aliased ranges
+    # may only be adopted by a sequence whose reuse match carries the SAME
+    # signature -- the span's pages are shared, so an adopter writing past a
+    # SHORTER matched prefix (or any other-key adopter writing the range
+    # head) would corrupt every alias of the span.
+    _alias_span_key: "tuple[int, int] | None"
 
     def __init__(self, base_block: int, num_blocks: int) -> None:
         self.base_block = base_block
@@ -933,7 +934,9 @@ class ArenaPoolGroup(PoolGroupBase):
 
     # -- per-sequence API (replaces scattered slot allocation) --------------
 
-    def reserve_sequence(self, max_blocks: int, alias_key: "int | None" = None) -> SequenceRange:
+    def reserve_sequence(
+        self, max_blocks: int, alias_key: "tuple[int, int] | None" = None
+    ) -> SequenceRange:
         """Reserve a contiguous block-index range for a sequence's maximum
         block count, preferring the adoption of a parked (freed but still
         mapped) range over fresh VA: the adopted range's mapped prefix is
@@ -957,7 +960,9 @@ class ArenaPoolGroup(PoolGroupBase):
         insort(self._range_bases, base_block)
         return rng
 
-    def _try_adopt(self, max_blocks: int, alias_key: "int | None" = None) -> "SequenceRange | None":
+    def _try_adopt(
+        self, max_blocks: int, alias_key: "tuple[int, int] | None" = None
+    ) -> "SequenceRange | None":
         """Hand a parked freed range (pages still mapped, reclaim gates all
         complete) to a new sequence. LRU-first, so the most recently retired
         ranges keep their ghost entries (D2D reuse, §4.4 phase 2) longest.
@@ -1273,18 +1278,25 @@ class ArenaPoolGroup(PoolGroupBase):
         self._budget.release(span.num_pages)
         self._budget.consume(span.num_pages)
         self._budget.retain(span.num_pages)
-        rng._alias_span_key = key
+        # The owner's parked range aliases the FULL span; typical adopters
+        # alias a shorter matched prefix, so this range is usually adopted
+        # only by a full-span match (or spilled under pressure).
+        rng._alias_span_key = (key, num_blocks)
         self._canonical_spans[key] = span
 
     def lookup_canonical_span(
         self, head_page: object, matched_pages: "Sequence[object]"
-    ) -> "tuple[int, _CanonicalSpan] | None":
+    ) -> "tuple[int, _CanonicalSpan, int] | None":
         """Registry hit for an admission whose reuse match starts at
         ``head_page`` and covers ``matched_pages`` (canonical page objects in
-        ordinal order): returns ``(key, span)`` iff a live span exists, its
-        FULL extent is covered by the match (a shorter match would write into
-        shared pages), and every span page identity still holds. Any
-        staleness invalidates and unpins the entry."""
+        ordinal order): returns ``(key, span, usable_blocks)`` where
+        ``usable_blocks`` is the identity-verified matched prefix trimmed to
+        whole chunks in every pool -- the safely aliasable extent. A match
+        SHORTER than the span aliases only its own covered chunks (the
+        adopter writes strictly past them; the shared-prompt benchmark's
+        matches are the system prompt, while spans carry the whole committed
+        chain of their owner). A mismatch anywhere in the verified prefix
+        invalidates and unpins the entry."""
         if not self._prefix_aliasing:
             return None
         key = id(head_page)
@@ -1292,25 +1304,30 @@ class ArenaPoolGroup(PoolGroupBase):
         if span is None:
             self.alias_misses += 1
             return None
-        if len(matched_pages) < span.num_blocks:
-            self.alias_misses += 1
-            return None  # match too short to safely alias the whole span
-        for i, ref in enumerate(span.page_refs):
-            if ref() is not matched_pages[i]:
+        verified = min(len(matched_pages), span.num_blocks)
+        for i in range(verified):
+            if span.page_refs[i]() is not matched_pages[i]:
                 self._invalidate_span(key, span)
                 self.alias_misses += 1
                 return None
+        usable = self._arena.aliasable_span_blocks(verified)
+        if usable <= 0:
+            self.alias_misses += 1
+            return None
         self.alias_hits += 1
-        return key, span
+        return key, span, usable
 
-    def alias_span_into_range(self, rng: SequenceRange, key: int, span: "_CanonicalSpan") -> int:
-        """Alias-map ``span``'s physical pages at the start of ``rng`` (a
-        FRESH, unmapped range) and stamp its signature. Signature-matched
-        adopted ranges already carry the mappings and skip this. Returns the
-        chunks aliased."""
+    def alias_span_into_range(
+        self, rng: SequenceRange, key: int, span: "_CanonicalSpan", num_blocks: int
+    ) -> int:
+        """Alias-map the first ``num_blocks`` blocks' worth of ``span``'s
+        physical pages at the start of ``rng`` (a FRESH, unmapped range) and
+        stamp its signature. Signature-matched adopted ranges already carry
+        the mappings and skip this. Returns the chunks aliased."""
         assert rng._alias_span_key is None
-        aliased = self._arena.alias_prefix(rng.base_block, span.shared_per_pool)
-        rng._alias_span_key = key
+        trimmed = self._arena.trim_shared_to_blocks(span.shared_per_pool, num_blocks)
+        aliased = self._arena.alias_prefix(rng.base_block, trimmed)
+        rng._alias_span_key = (key, num_blocks)
         return aliased
 
     def _unpin_span(self, span: "_CanonicalSpan") -> None:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -751,6 +751,27 @@ class StorageManager:
         requirements = filled_list(0, self.num_pool_groups)
         requirements[pg_idx] = len(pages)
         self.prepare_free_slots(host_lvl, requirements)
+        # The eviction above can collapse radix subtrees (a dying parent
+        # removes its descendants), unlinking some of OUR pages from the tree
+        # mid-call. A treeless droppable canonical is unreachable for reuse:
+        # offloading it would burn a host slot on a copy no lookup can find,
+        # scheduled in the host controller with no tree entry -- which the
+        # shutdown sweep (tree-driven exclusion) can never clear. Skip them;
+        # they die with the caller's references. Held pages (suspension
+        # state) are never skipped -- their bytes must survive regardless of
+        # tree linkage. (Over-reserved free slots above are harmless.)
+        kept: list[Page] = []
+        for p in pages:
+            if p.is_committed() and p.status == PageStatus.DROPPABLE:
+                blk = cast(CommittedPage, p).block()
+                if blk is None or blk.is_orphan:
+                    if p.scheduled_for_eviction:
+                        self.exclude_from_eviction(p)
+                    continue
+            kept.append(p)
+        pages = kept
+        if not pages:
+            return
         # Pages freshly released by a closing sequence are typically already in
         # the (otherwise unused) GPU eviction queue; migration requires them
         # unscheduled.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -607,6 +607,21 @@ class StorageManager:
             rng, pages, ready_event
         )
 
+    def register_arena_live_span(
+        self,
+        pg_idx: PoolGroupIndex,
+        rng: SequenceRange,
+        pages: Sequence[Page],
+        ready_event: CachedCudaEvent,
+    ) -> None:
+        """Pin a LIVE owner's committed leading prefix at context-end commit
+        for zero-copy aliasing while the owner is still generating (P3 v2).
+        ``pages``: the canonical page objects of the committed prefix,
+        ordinal order."""
+        self._gpu_arena_storage().pool_group(pg_idx).register_live_canonical_span(
+            rng, pages, ready_event
+        )
+
     def lookup_arena_canonical_span(
         self, pg_idx: PoolGroupIndex, head_page: Page, matched_pages: Sequence[Page]
     ) -> "tuple[int, object, int] | None":

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -545,11 +545,24 @@ class StorageManager:
         ranges without draining."""
         self._gpu_arena_storage().fence_pending_frees(fence)
 
-    def spill_gpu_retained(self, min_pages: int) -> int:
+    def spill_gpu_retained(self, min_pages: int, spill_spans: bool = True) -> int:
         """Reclaim lazily retained ranges (§4.4 phase 2) until ``min_pages``
         physical pages are freed or nothing is spillable. Returns pages
-        freed."""
-        return self._gpu_arena_storage().spill_retained(min_pages)
+        freed. ``spill_spans=False`` skips the canonical-span pass (the
+        reclaim ladder runs the dedup remap between the two, §P3 v2)."""
+        return self._gpu_arena_storage().spill_retained(min_pages, spill_spans)
+
+    def dedup_remap_arena(self, items: "list[tuple[int, SequenceRange, int, object, int]]") -> int:
+        """Execute a pressure-time dedup-remap batch (P3 v2) behind one
+        device quiesce. Items: ``(pg_idx, rng, key, span, num_blocks)``.
+        Returns pages freed."""
+        return self._gpu_arena_storage().dedup_remap(items)
+
+    def arena_span_pages_for_blocks(
+        self, pg_idx: PoolGroupIndex, span: object, num_blocks: int
+    ) -> int:
+        """Pages a dedup remap of ``num_blocks`` onto ``span`` would free."""
+        return self._gpu_arena_storage().pool_group(pg_idx).span_pages_for_blocks(span, num_blocks)
 
     def queue_gpu_mapping(
         self, pg_idx: PoolGroupIndex, rng: SequenceRange, num_valid_blocks: int
@@ -623,12 +636,16 @@ class StorageManager:
         )
 
     def lookup_arena_canonical_span(
-        self, pg_idx: PoolGroupIndex, head_page: Page, matched_pages: Sequence[Page]
+        self,
+        pg_idx: PoolGroupIndex,
+        head_page: Page,
+        matched_pages: Sequence[Page],
+        count_stats: bool = True,
     ) -> "tuple[int, object, int] | None":
         return (
             self._gpu_arena_storage()
             .pool_group(pg_idx)
-            .lookup_canonical_span(head_page, matched_pages)
+            .lookup_canonical_span(head_page, matched_pages, count_stats)
         )
 
     def alias_arena_span(

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -497,7 +497,7 @@ class StorageManager:
         return caps
 
     def reserve_gpu_sequence(
-        self, pg_idx: PoolGroupIndex, max_blocks: int, alias_key: "int | None" = None
+        self, pg_idx: PoolGroupIndex, max_blocks: int, alias_key: "tuple[int, int] | None" = None
     ) -> SequenceRange:
         """Reserve a contiguous block-index range for a sequence's maximum
         block count in every pool of the group (§4.1). Pure VA bookkeeping;
@@ -608,7 +608,7 @@ class StorageManager:
 
     def lookup_arena_canonical_span(
         self, pg_idx: PoolGroupIndex, head_page: Page, matched_pages: Sequence[Page]
-    ) -> "tuple[int, object] | None":
+    ) -> "tuple[int, object, int] | None":
         return (
             self._gpu_arena_storage()
             .pool_group(pg_idx)
@@ -616,7 +616,7 @@ class StorageManager:
         )
 
     def alias_arena_span(
-        self, pg_idx: PoolGroupIndex, rng: SequenceRange, key: int, span: object
+        self, pg_idx: PoolGroupIndex, rng: SequenceRange, key: int, span: object, num_blocks: int
     ) -> int:
         return (
             self._gpu_arena_storage()
@@ -625,6 +625,7 @@ class StorageManager:
                 rng,
                 key,
                 span,  # type: ignore[arg-type]
+                num_blocks,
             )
         )
 

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -655,6 +655,14 @@ class StorageManager:
             .lookup_canonical_span(head_page, matched_pages, count_stats)
         )
 
+    def arena_span_covers(
+        self, pg_idx: PoolGroupIndex, head_page: Page, ordinal: int, page: Page
+    ) -> bool:
+        """Non-destructive mappability probe (P3 v3 R1): whether a live
+        registered span identity-covers ``page`` at chain position
+        ``ordinal``. See :meth:`ArenaPoolGroup.span_covers`."""
+        return self._gpu_arena_storage().pool_group(pg_idx).span_covers(head_page, ordinal, page)
+
     def alias_arena_span(
         self, pg_idx: PoolGroupIndex, rng: SequenceRange, key: int, span: object, num_blocks: int
     ) -> int:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -169,6 +169,7 @@ class CacheLevelManager:
                         arena_spec.config.map_ahead_pages,
                         arena_spec.config.lazy_gpu_retention,
                         arena_spec.config.prefix_aliasing,
+                        arena_spec.config.protected_span_fraction,
                     )
                 granularity = CacheLevelManager.cache_tier_granularity(
                     CacheTier.GPU_MEM, config.quota
@@ -1162,9 +1163,15 @@ class StorageManager:
             # Slot counts describe VA in arena mode; physical utilization is
             # the shared page budget (§4.6), identical for every pool group.
             # Lazily retained pages are reclaimable at will and count as
-            # available, mirroring classic "evictable" accounting.
-            budget = self.gpu_page_budget
-            frac = (budget.used_pages - budget.retained_pages) / budget.total_pages
+            # available, mirroring classic "evictable" accounting -- EXCEPT
+            # canonical-span pages under the spill-protection floor (P3),
+            # which pressure spills refuse to touch: counting them available
+            # would admit resumes whose mapping then fails.
+            storage = self._gpu_arena_storage()
+            budget = storage.page_budget
+            reclaimable = budget.retained_pages - storage.protected_span_pages
+            assert reclaimable >= 0
+            frac = (budget.used_pages - reclaimable) / budget.total_pages
             return filled_list(frac, self.num_pool_groups)
         ret = filled_list(0.0, self.num_pool_groups)
         stats = self.get_statistics(level)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -540,12 +540,15 @@ class StorageManager:
         requirements = filled_list(0, self.num_pool_groups)
         requirements[pg_idx] = len(pages)
         self.prepare_free_slots(host_lvl, requirements)
+        # Pages freshly released by a closing sequence are typically already in
+        # the (otherwise unused) GPU eviction queue; migration requires them
+        # unscheduled.
+        for p in pages:
+            if p.scheduled_for_eviction:
+                self.exclude_from_eviction(p)
         self._batched_migrate(pg_idx, host_lvl, GPU_LEVEL, pages, update_src=True)
         for p in pages:
-            # _batched_migrate re-schedules pages that were already queued for
-            # eviction at the source level; only schedule the rest.
-            if not p.scheduled_for_eviction:
-                self.schedule_for_eviction(p)
+            self.schedule_for_eviction(p)
 
     def write_through_pages(self, pg_idx: PoolGroupIndex, pages: Sequence[Page]) -> list[Slot]:
         """Write-through on commit (§4.3): copy committed (immutable) GPU
@@ -613,6 +616,8 @@ class StorageManager:
         migration_recorder: MigrationRecorder | None = None,
     ) -> None:
         if level == GPU_LEVEL and self.is_arena_mode:
+            if not any(requirements):
+                return  # nothing requested; keep zero-requirement callers working
             raise LogicError(
                 "GPU-level slot eviction is retired in arena mode; capacity is "
                 "physical pages (§4.6) and reclaim is per-sequence (§4.2)"

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -47,7 +47,7 @@ from ._event_manager import KVCacheEventDiff
 from ._eviction_controller import EvictablePage, PerLevelEvictionController
 from ._exceptions import LogicError, OutOfPagesError
 from ._life_cycle_registry import LifeCycleId, LifeCycleRegistry, compute_scratch_range
-from ._page import CommittedPage, Page
+from ._page import CommittedPage, Page, PrivateCommittedPage
 from ._sequence_arena import INT31_MAX, PageBudget
 from ._storage import CacheLevelStorage
 from ._storage._config import BufferAttr, BufferId, LayerAttr, SlotDesc, StorageConfig
@@ -601,6 +601,11 @@ class StorageManager:
         Check if a page is evictable. If level is specified, check if the page will be evictable after
         migrating to the given level.
         """
+        # Sequence-private reuse copies (arena mode, DESIGN.md §4.4) are not
+        # managed by the eviction machinery at all: their canonical entry is,
+        # and they die with (or before) their owning sequence.
+        if isinstance(page, PrivateCommittedPage):
+            return False
         status = page.status
         level = page.cache_level if level is None else level
         # droppable pages that are not committed should be dropped immediately.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -622,11 +622,25 @@ class StorageManager:
                 seen.add(id(rng))
                 rng._gate_events.append(finish_event)
 
-    def offload_arena_pages(self, pg_idx: PoolGroupIndex, pages: Sequence[Page]) -> None:
+    def offload_arena_pages(
+        self,
+        pg_idx: PoolGroupIndex,
+        pages: Sequence[Page],
+        prior_event: CachedCudaEvent = CachedCudaEvent.NULL,
+    ) -> None:
         """Active->stale copy-on-free (§4.3): migrate a freeing sequence's
         committed GPU pages to the host tier and schedule them for host-level
         eviction. The vacated arena slots return to their sequence range with
-        the copy's finish event as a reclaim gate."""
+        the copy's finish event as a reclaim gate.
+
+        ``prior_event`` must cover the sequence's last KV writes. Those writes
+        run on the *forward* stream, and under the overlap scheduler a
+        speculatively enqueued step may still be writing when the sequence is
+        closed or suspended; the pages' ready events and the sequence's
+        manager-stream events do not order against it, so without this event
+        the copies can read a stale tail block (silent corruption surfacing on
+        reuse or resume). Callers pass an event recorded on the execution
+        stream at the write-out site."""
         if not pages:
             return
         assert self.is_arena_mode
@@ -641,7 +655,9 @@ class StorageManager:
         for p in pages:
             if p.scheduled_for_eviction:
                 self.exclude_from_eviction(p)
-        self._batched_migrate(pg_idx, host_lvl, GPU_LEVEL, pages, update_src=True)
+        self._batched_migrate(
+            pg_idx, host_lvl, GPU_LEVEL, pages, update_src=True, extra_prior_event=prior_event
+        )
         for p in pages:
             self.schedule_for_eviction(p)
 

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -523,13 +523,16 @@ class StorageManager:
         (§4.2)."""
         self._gpu_arena_storage().pool_group(pg_idx).free_sequence(rng, last_consumer)
 
-    def drain_gpu_reclaim(self, fence: CachedCudaEvent | None = None) -> int:
+    def drain_gpu_reclaim(self, fence: CachedCudaEvent | None = None, wait: bool = False) -> int:
         """Unmap and recycle freed ranges whose gating events completed; call
         at iteration boundaries (§4.2). ``fence`` (an execution-stream event
         recorded at the call site) gates newly freed ranges against
         speculatively enqueued steps. Returns the number of ranges
-        reclaimed (or parked on the retained LRU under lazy retention)."""
-        return self._gpu_arena_storage().drain_reclaim(fence)
+        reclaimed (or parked on the retained LRU under lazy retention).
+        ``wait=True`` blocks on in-flight gating events instead of skipping
+        their ranges (§4.6 preemption headroom — see
+        ``ArenaPoolGroup.drain_reclaim``)."""
+        return self._gpu_arena_storage().drain_reclaim(fence, wait)
 
     def fence_gpu_reclaim(self, fence: CachedCudaEvent) -> None:
         """Assign the iteration-boundary reclaim fence (risk #3) to freed

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -36,6 +36,7 @@ from ._common import (
 from ._config import (
     BatchDesc,
     CacheTierConfig,
+    ContiguousArenaConfig,
     DataRole,
     DiskCacheTierConfig,
     KVCacheDesc,
@@ -44,18 +45,21 @@ from ._config import (
 from ._copy_engine import CopyTask, batched_copy
 from ._event_manager import KVCacheEventDiff
 from ._eviction_controller import EvictablePage, PerLevelEvictionController
-from ._exceptions import OutOfPagesError
+from ._exceptions import LogicError, OutOfPagesError
 from ._life_cycle_registry import LifeCycleId, LifeCycleRegistry, compute_scratch_range
 from ._page import CommittedPage, Page
+from ._sequence_arena import INT31_MAX, PageBudget
 from ._storage import CacheLevelStorage
 from ._storage._config import BufferAttr, BufferId, LayerAttr, SlotDesc, StorageConfig
 from ._storage._core import (
     DiskCacheLevelStorage,
+    GpuArenaCacheLevelStorage,
     GpuCacheLevelStorage,
     HostCacheLevelStorage,
     PoolGroupBase,
     PoolGroupIndex,
     PoolIndex,
+    SequenceRange,
     Slot,
     SlotId,
 )
@@ -84,6 +88,22 @@ from ._utils import (
 if TYPE_CHECKING:
     from ._event_manager import KVCacheEventManager
 
+# Default VA over-reservation factor for arena mode, relative to the maximum
+# number of physical blocks the GPU quota could back for a pool group. VA is
+# nearly free (DESIGN.md §4.8); headroom absorbs per-sequence max-length
+# reservations and range fragmentation. Overridable via
+# ContiguousArenaConfig.max_va_bytes_per_pool.
+_ARENA_VA_OVERCOMMIT: int = 8
+
+
+@dataclass(slots=True, frozen=True)
+class _ArenaSpec:
+    """Resolved arena-mode parameters for the GPU cache level (DESIGN.md §4.8)."""
+
+    config: ContiguousArenaConfig
+    block_capacity_list: TypedIndexList[PoolGroupIndex, int]
+    page_index_scale_list: TypedIndexList[PoolGroupIndex, int]
+
 
 class CacheLevelManager:
     __slots__ = ("cache_level", "storage", "controller")
@@ -102,9 +122,12 @@ class CacheLevelManager:
         config: CacheTierConfig,
         slot_size_lists: TypedIndexList[PoolGroupIndex, TypedIndexList[PoolIndex, int]],
         slot_count_list: TypedIndexList[PoolGroupIndex, int],
+        arena_spec: _ArenaSpec | None = None,
     ):
         self.cache_level = cache_level
-        self.storage = self._create_cache_level_storage(config, slot_size_lists, slot_count_list)
+        self.storage = self._create_cache_level_storage(
+            config, slot_size_lists, slot_count_list, arena_spec
+        )
         self.controller = PerLevelEvictionController(life_cycle_grouping, cache_level)
 
     @property
@@ -131,9 +154,19 @@ class CacheLevelManager:
         config: CacheTierConfig,
         slot_size_lists: TypedIndexList[PoolGroupIndex, TypedIndexList[PoolIndex, int]],
         slot_count_list: TypedIndexList[PoolGroupIndex, int],
+        arena_spec: _ArenaSpec | None = None,
     ) -> CacheLevelStorage:
         match config.tier:
             case CacheTier.GPU_MEM:
+                if arena_spec is not None:
+                    return GpuArenaCacheLevelStorage(
+                        slot_size_lists,
+                        arena_spec.block_capacity_list,
+                        arena_spec.page_index_scale_list,
+                        config.quota,
+                        arena_spec.config.phys_page_size,
+                        arena_spec.config.map_ahead_pages,
+                    )
                 granularity = CacheLevelManager.cache_tier_granularity(
                     CacheTier.GPU_MEM, config.quota
                 )
@@ -172,6 +205,33 @@ class StorageStatistics:
 MigrationRecorder = Callable[[Sequence[Page], Sequence[Slot], CacheLevel, CacheLevel], None]
 
 
+def _coalesce_copy_tasks(num_bytes: int, tasks: Sequence[CopyTask]) -> dict[int, list[CopyTask]]:
+    """Merge runs of copy tasks whose dst AND src are both byte-contiguous into
+    fewer, larger transfers (DESIGN.md §4.4), grouped by merged size so each
+    group still dispatches as one ``batched_copy`` call. Non-memory addresses
+    (disk) pass through unmerged."""
+    merged: dict[int, list[CopyTask]] = {}
+    i = 0
+    n = len(tasks)
+    while i < n:
+        head = tasks[i]
+        run = 1
+        if isinstance(head.dst, int) and isinstance(head.src, int):
+            while i + run < n:
+                t = tasks[i + run]
+                if not (
+                    isinstance(t.dst, int)
+                    and isinstance(t.src, int)
+                    and t.dst == head.dst + run * num_bytes
+                    and t.src == head.src + run * num_bytes
+                ):
+                    break
+                run += 1
+        merged.setdefault(run * num_bytes, []).append(head)
+        i += run
+    return merged
+
+
 class StorageManager:
     __slots__ = (
         "_life_cycles",
@@ -184,6 +244,7 @@ class StorageManager:
         "_slot_desc_list",
         "_levels",
         "_min_slots",
+        "_arena_config",
         "_event_manager",
         "__rawref__",
     )
@@ -197,6 +258,7 @@ class StorageManager:
     _slot_desc_list: TypedIndexList[PoolGroupIndex, SlotDesc]
     _levels: TypedIndexList[CacheLevel, CacheLevelManager]
     _min_slots: TypedIndexList[PoolGroupIndex, int]
+    _arena_config: ContiguousArenaConfig | None
     _event_manager: "KVCacheEventManager | None"
     __rawref__: rawref.ref["StorageManager"]
 
@@ -209,6 +271,7 @@ class StorageManager:
         typical_batch: BatchDesc | None = None,
         constraints: list[BatchDesc] | None = None,
         event_manager: "KVCacheEventManager | None" = None,
+        arena_config: ContiguousArenaConfig | None = None,
     ) -> None:
         self.__rawref__ = rawref.NULL
         self._event_manager = event_manager
@@ -255,6 +318,18 @@ class StorageManager:
                 gpu_granularity,
             )
 
+        self._arena_config = arena_config
+        arena_spec: _ArenaSpec | None = None
+        if arena_config is not None:
+            scales = self._compute_page_index_scales()
+            arena_spec = _ArenaSpec(
+                arena_config,
+                self._compute_arena_block_capacities(
+                    arena_config, slot_size_lists, gpu_quota, scales
+                ),
+                scales,
+            )
+
         num_levels = CacheLevel(len(config.cache_tiers))
         self._levels = cast(
             TypedIndexList,
@@ -267,6 +342,7 @@ class StorageManager:
                     self._compute_slot_count_for_level(
                         config.cache_tiers[i], slot_size_lists, init_ratio
                     ),
+                    arena_spec if i == GPU_LEVEL else None,
                 )
                 for i in typed_range(num_levels)
             ],
@@ -300,6 +376,11 @@ class StorageManager:
         num_slots: TypedIndexList[LifeCycleId, int],
         migration_recorder: MigrationRecorder | None = None,
     ) -> TypedIndexList[LifeCycleId, list[Slot]]:
+        if level == GPU_LEVEL and self.is_arena_mode:
+            raise LogicError(
+                "scattered GPU slot allocation is retired in arena mode; use "
+                "reserve_gpu_sequence()/take_gpu_sequence_slot() (DESIGN.md §4.1)"
+            )
         lc2pg = self._life_cycle_grouping
         pg_num_slots = filled_list(0, self.num_pool_groups)
         for lc in typed_range(self.num_life_cycles):
@@ -335,6 +416,11 @@ class StorageManager:
         num_slots: int,
         migration_recorder: MigrationRecorder | None = None,
     ) -> list[Slot]:
+        if level == GPU_LEVEL and self.is_arena_mode:
+            raise LogicError(
+                "scattered GPU slot allocation is retired in arena mode; use "
+                "reserve_gpu_sequence()/take_gpu_sequence_slot() (DESIGN.md §4.1)"
+            )
         storage = self._levels[level].storage
         if num_slots > storage.get_num_free_slots(pg_idx):
             num_slots_list = filled_list(0, self.num_pool_groups)
@@ -346,6 +432,140 @@ class StorageManager:
         except Exception:
             warnings.warn("Exception not expected here. Please report a bug.")
             raise
+
+    # -- contiguous-arena mode (DESIGN.md §4; flag-gated) --------------------
+
+    @property
+    def is_arena_mode(self) -> bool:
+        return self._arena_config is not None
+
+    @property
+    def arena_config(self) -> ContiguousArenaConfig | None:
+        return self._arena_config
+
+    def _gpu_arena_storage(self) -> GpuArenaCacheLevelStorage:
+        storage = self._levels[GPU_LEVEL].storage
+        assert type(storage) is GpuArenaCacheLevelStorage, "not in arena mode"
+        return storage
+
+    @property
+    def gpu_page_budget(self) -> PageBudget:
+        """The level-wide physical page budget governing GPU capacity in arena
+        mode (§4.6)."""
+        return self._gpu_arena_storage().page_budget
+
+    def _compute_page_index_scales(self) -> TypedIndexList[PoolGroupIndex, int]:
+        """Maximum kernel page-index scale per pool group: the largest
+        multiplier any buffer's :class:`PageIndexConverter` applies to a base
+        page index (coalesced sub-buffer count x expansion). Feeds the int31
+        startup check (§4.1)."""
+        scales = filled_list(1, self.num_pool_groups)
+        for attr in self._buffer_attr.values():
+            pg_idx = self._life_cycle_grouping[attr.life_cycle_id]
+            scale = self._slot_to_page_indices[attr.life_cycle_id][attr.pool_index]
+            scales[pg_idx] = max(scales[pg_idx], scale * attr.expansion)
+        return scales
+
+    def _compute_arena_block_capacities(
+        self,
+        arena_config: ContiguousArenaConfig,
+        slot_size_lists: TypedIndexList[PoolGroupIndex, TypedIndexList[PoolIndex, int]],
+        gpu_quota: int,
+        scales: TypedIndexList[PoolGroupIndex, int],
+    ) -> TypedIndexList[PoolGroupIndex, int]:
+        """VA extent, in blocks, of each pool group's arena (§4.8).
+
+        Defaults to ``_ARENA_VA_OVERCOMMIT`` x the physical block count the
+        whole GPU quota could back for the group, clamped to the int31
+        kernel-offset ceiling for the group's scale. An explicit
+        ``max_va_bytes_per_pool`` bounds the byte extent of the group's largest
+        pool instead. ``min_slots`` constraints are honored as a floor; if the
+        floor itself violates int31, level construction fails loudly (§4.1).
+        """
+        caps = filled_list(0, self.num_pool_groups)
+        for pg_idx in typed_range(self.num_pool_groups):
+            record_stride = sum(slot_size_lists[pg_idx])
+            if arena_config.max_va_bytes_per_pool > 0:
+                cap = arena_config.max_va_bytes_per_pool // max(slot_size_lists[pg_idx])
+            else:
+                cap = _ARENA_VA_OVERCOMMIT * max(1, gpu_quota // record_stride)
+            cap = min(cap, (INT31_MAX + 1) // scales[pg_idx])
+            caps[pg_idx] = max(cap, self._min_slots[pg_idx], 1)
+        return caps
+
+    def reserve_gpu_sequence(self, pg_idx: PoolGroupIndex, max_blocks: int) -> SequenceRange:
+        """Reserve a contiguous block-index range for a sequence's maximum
+        block count in every pool of the group (§4.1). Pure VA bookkeeping;
+        physical pages are mapped by :meth:`ensure_gpu_mapped`."""
+        return self._gpu_arena_storage().pool_group(pg_idx).reserve_sequence(max_blocks)
+
+    def take_gpu_sequence_slot(
+        self, pg_idx: PoolGroupIndex, rng: SequenceRange, ordinal: int
+    ) -> Slot:
+        """Issue the slot at ``rng.base_block + ordinal`` (§4.1)."""
+        return self._gpu_arena_storage().pool_group(pg_idx).take_slot(rng, ordinal)
+
+    def ensure_gpu_mapped(
+        self, pg_idx: PoolGroupIndex, rng: SequenceRange, num_valid_blocks: int
+    ) -> int:
+        """Demand-map physical pages covering the range's first
+        ``num_valid_blocks`` plus the map-ahead margin (§4.2). Raises
+        ``OutOfPagesError``, mapping nothing, when the page budget is
+        exhausted (§4.6)."""
+        return self._gpu_arena_storage().pool_group(pg_idx).ensure_mapped(rng, num_valid_blocks)
+
+    def free_gpu_sequence(
+        self, pg_idx: PoolGroupIndex, rng: SequenceRange, last_consumer: CachedCudaEvent
+    ) -> None:
+        """Queue a sequence's whole range for event-gated deferred reclaim
+        (§4.2)."""
+        self._gpu_arena_storage().pool_group(pg_idx).free_sequence(rng, last_consumer)
+
+    def drain_gpu_reclaim(self) -> int:
+        """Unmap and recycle freed ranges whose gating events completed; call
+        at iteration boundaries (§4.2). Returns the number of ranges
+        reclaimed."""
+        return self._gpu_arena_storage().drain_reclaim()
+
+    def offload_arena_pages(self, pg_idx: PoolGroupIndex, pages: Sequence[Page]) -> None:
+        """Active->stale copy-on-free (§4.3): migrate a freeing sequence's
+        committed GPU pages to the host tier and schedule them for host-level
+        eviction. The vacated arena slots return to their sequence range with
+        the copy's finish event as a reclaim gate."""
+        if not pages:
+            return
+        assert self.is_arena_mode
+        assert self.num_cache_levels > 1, "active->stale write-out requires a host tier"
+        host_lvl = CacheLevel(GPU_LEVEL + 1)
+        requirements = filled_list(0, self.num_pool_groups)
+        requirements[pg_idx] = len(pages)
+        self.prepare_free_slots(host_lvl, requirements)
+        self._batched_migrate(pg_idx, host_lvl, GPU_LEVEL, pages, update_src=True)
+        for p in pages:
+            # _batched_migrate re-schedules pages that were already queued for
+            # eviction at the source level; only schedule the rest.
+            if not p.scheduled_for_eviction:
+                self.schedule_for_eviction(p)
+
+    def write_through_pages(self, pg_idx: PoolGroupIndex, pages: Sequence[Page]) -> list[Slot]:
+        """Write-through on commit (§4.3): copy committed (immutable) GPU
+        pages to fresh host slots without touching the sources. Returns the
+        host slots; each slot's ready event completes when its copy does. The
+        caller owns associating the slots with the pages and validating them
+        on event completion."""
+        assert self.is_arena_mode
+        assert self.num_cache_levels > 1, "write-through requires a host tier"
+        if not pages:
+            return []
+        host_lvl = CacheLevel(GPU_LEVEL + 1)
+        requirements = filled_list(0, self.num_pool_groups)
+        requirements[pg_idx] = len(pages)
+        self.prepare_free_slots(host_lvl, requirements)
+        dst_slots = self._batched_migrate(pg_idx, host_lvl, GPU_LEVEL, pages, update_src=False)
+        assert dst_slots is not None
+        return list(dst_slots)
+
+    # ------------------------------------------------------------------------
 
     @property
     def life_cycles(self) -> LifeCycleRegistry:
@@ -392,6 +612,11 @@ class StorageManager:
         requirements: TypedIndexList[PoolGroupIndex, int],
         migration_recorder: MigrationRecorder | None = None,
     ) -> None:
+        if level == GPU_LEVEL and self.is_arena_mode:
+            raise LogicError(
+                "GPU-level slot eviction is retired in arena mode; capacity is "
+                "physical pages (§4.6) and reclaim is per-sequence (§4.2)"
+            )
         goals = filled_array2d(self.num_cache_levels, self.num_pool_groups, 0)
         for pg in typed_range(self.num_pool_groups):
             goals[level, pg] = requirements[pg]
@@ -531,8 +756,17 @@ class StorageManager:
         update_src: bool,
         migration_recorder: MigrationRecorder | None = None,
         defrag: bool = False,  # we are doing defragmentation
+        dst_slots: list[Slot] | None = None,
     ) -> Sequence[Slot] | None:
-        "Free slots must be prepared before calling this function."
+        """Free slots must be prepared before calling this function.
+
+        When ``dst_slots`` is given (arena mode, DESIGN.md §4.4/§4.5), data is
+        copied into those explicit destinations instead of freshly allocated
+        slots — ownership of the slots transfers to this call (they are
+        released back on failure). Copies into explicit destinations are
+        coalesced: adjacent (dst, src) pairs merge into fewer, larger
+        transfers.
+        """
         assert defrag or dst_level != src_level, (
             "dst_level and src_level must be different unless performing defragmentation"
         )
@@ -540,9 +774,13 @@ class StorageManager:
         num_pools = self.num_pools(pool_group_index)
         src_pool_group = self._pool_group(src_level, pool_group_index)
         dst_pool_group = self._pool_group(dst_level, pool_group_index)
-        if dst_pool_group.num_free_slots < num_slots:
-            raise OutOfPagesError("Not enough free slots")
-        dst_slots = dst_pool_group.allocate_multiple(num_slots)
+        explicit_dst = dst_slots is not None
+        if dst_slots is None:
+            if dst_pool_group.num_free_slots < num_slots:
+                raise OutOfPagesError("Not enough free slots")
+            dst_slots = dst_pool_group.allocate_multiple(num_slots)
+        else:
+            assert len(dst_slots) == num_slots
         try:
             assert len(dst_slots) == num_slots
             prior_events: set[CachedCudaEvent] = set()
@@ -563,7 +801,16 @@ class StorageManager:
             with TemporaryCudaStream(prior_events) as stream:
                 slot_sizes = self.slot_size(pool_group_index)
                 for pool_idx, tasks in typed_enumerate(tasks_per_pool):
-                    batched_copy(dst_tier, src_tier, slot_sizes[pool_idx], tasks, stream.get())
+                    if explicit_dst:
+                        # Consecutive ordinals target contiguous arena
+                        # addresses; merge adjacent copies (§4.4).
+                        merged = _coalesce_copy_tasks(slot_sizes[pool_idx], tasks)
+                        for merged_size, merged_tasks in merged.items():
+                            batched_copy(
+                                dst_tier, src_tier, merged_size, merged_tasks, stream.get()
+                            )
+                    else:
+                        batched_copy(dst_tier, src_tier, slot_sizes[pool_idx], tasks, stream.get())
             finish_event = stream.take_finish_event()
             emit_cache_level_updates = (
                 update_src
@@ -689,6 +936,11 @@ class StorageManager:
     def get_utilization(
         self, level: CacheLevel = GPU_LEVEL
     ) -> TypedIndexList[PoolGroupIndex, float]:
+        if level == GPU_LEVEL and self.is_arena_mode:
+            # Slot counts describe VA in arena mode; physical utilization is
+            # the shared page budget (§4.6), identical for every pool group.
+            budget = self.gpu_page_budget
+            return filled_list(budget.used_pages / budget.total_pages, self.num_pool_groups)
         ret = filled_list(0.0, self.num_pool_groups)
         stats = self.get_statistics(level)
         for pg_idx in typed_range(self.num_pool_groups):
@@ -696,6 +948,9 @@ class StorageManager:
         return ret
 
     def get_overall_utilization(self, level: CacheLevel = GPU_LEVEL) -> float:
+        if level == GPU_LEVEL and self.is_arena_mode:
+            budget = self.gpu_page_budget
+            return budget.used_pages / budget.total_pages
         stats = self.get_statistics(level)
         return sum(sum(s.slot_size) * s.unavailable for s in stats) / sum(
             sum(s.slot_size) * s.total for s in stats
@@ -781,6 +1036,11 @@ class StorageManager:
         persistent_pages: TypedIndexList[PoolGroupIndex, list[Page]] | None = None,
     ) -> None:
         """Adapt the cache level by adjusting the ratio list. Persistent pages are those held and not evictable."""
+        if level == GPU_LEVEL and self.is_arena_mode:
+            raise LogicError(
+                "GPU pool-group rebalancing is retired in arena mode: pools "
+                "compete for pages via the shared budget (§4.2/§4.6)"
+            )
         num_cache_levels = self.num_cache_levels
         lvl_storage = self._levels[level].storage
         old_num_slots = lvl_storage.slot_count_list

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -168,6 +168,7 @@ class CacheLevelManager:
                         arena_spec.config.phys_page_size,
                         arena_spec.config.map_ahead_pages,
                         arena_spec.config.lazy_gpu_retention,
+                        arena_spec.config.prefix_aliasing,
                     )
                 granularity = CacheLevelManager.cache_tier_granularity(
                     CacheTier.GPU_MEM, config.quota
@@ -495,11 +496,15 @@ class StorageManager:
             caps[pg_idx] = max(cap, self._min_slots[pg_idx], 1)
         return caps
 
-    def reserve_gpu_sequence(self, pg_idx: PoolGroupIndex, max_blocks: int) -> SequenceRange:
+    def reserve_gpu_sequence(
+        self, pg_idx: PoolGroupIndex, max_blocks: int, alias_key: "int | None" = None
+    ) -> SequenceRange:
         """Reserve a contiguous block-index range for a sequence's maximum
         block count in every pool of the group (§4.1). Pure VA bookkeeping;
-        physical pages are mapped by :meth:`ensure_gpu_mapped`."""
-        return self._gpu_arena_storage().pool_group(pg_idx).reserve_sequence(max_blocks)
+        physical pages are mapped by :meth:`ensure_gpu_mapped`. ``alias_key``
+        makes freed-range adoption prefix-affine (P3, see
+        ``ArenaPoolGroup.reserve_sequence``)."""
+        return self._gpu_arena_storage().pool_group(pg_idx).reserve_sequence(max_blocks, alias_key)
 
     def take_gpu_sequence_slot(
         self, pg_idx: PoolGroupIndex, rng: SequenceRange, ordinal: int
@@ -574,6 +579,54 @@ class StorageManager:
         self, pg_idx: PoolGroupIndex, page: Page
     ) -> "tuple[SlotId, SequenceRange] | None":
         return self._gpu_arena_storage().pool_group(pg_idx).lookup_ghost(page)
+
+    # -- canonical-span registry (P3 prefix aliasing) ------------------------
+
+    @property
+    def arena_prefix_aliasing(self) -> bool:
+        """Whether P3 prefix aliasing is active on the GPU arena level."""
+        if not self.is_arena_mode:
+            return False
+        storage = self._gpu_arena_storage()
+        for pg_idx in typed_range(self.num_pool_groups):
+            return storage.pool_group(pg_idx)._prefix_aliasing
+        return False
+
+    def register_arena_canonical_span(
+        self,
+        pg_idx: PoolGroupIndex,
+        rng: SequenceRange,
+        pages: Sequence[Page],
+        ready_event: CachedCudaEvent,
+    ) -> None:
+        """Pin a closing canonical owner's resident prefix pages for
+        zero-copy aliasing (P3). ``pages``: the canonical page objects of the
+        committed prefix, ordinal order."""
+        self._gpu_arena_storage().pool_group(pg_idx).register_canonical_span(
+            rng, pages, ready_event
+        )
+
+    def lookup_arena_canonical_span(
+        self, pg_idx: PoolGroupIndex, head_page: Page, matched_pages: Sequence[Page]
+    ) -> "tuple[int, object] | None":
+        return (
+            self._gpu_arena_storage()
+            .pool_group(pg_idx)
+            .lookup_canonical_span(head_page, matched_pages)
+        )
+
+    def alias_arena_span(
+        self, pg_idx: PoolGroupIndex, rng: SequenceRange, key: int, span: object
+    ) -> int:
+        return (
+            self._gpu_arena_storage()
+            .pool_group(pg_idx)
+            .alias_span_into_range(
+                rng,
+                key,
+                span,  # type: ignore[arg-type]
+            )
+        )
 
     def onboard_from_retained(
         self,

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -167,6 +167,7 @@ class CacheLevelManager:
                         config.quota,
                         arena_spec.config.phys_page_size,
                         arena_spec.config.map_ahead_pages,
+                        arena_spec.config.lazy_gpu_retention,
                     )
                 granularity = CacheLevelManager.cache_tier_granularity(
                     CacheTier.GPU_MEM, config.quota
@@ -525,8 +526,78 @@ class StorageManager:
     def drain_gpu_reclaim(self) -> int:
         """Unmap and recycle freed ranges whose gating events completed; call
         at iteration boundaries (§4.2). Returns the number of ranges
-        reclaimed."""
+        reclaimed (or parked on the retained LRU under lazy retention)."""
         return self._gpu_arena_storage().drain_reclaim()
+
+    def spill_gpu_retained(self, min_pages: int) -> int:
+        """Reclaim lazily retained ranges (§4.4 phase 2) until ``min_pages``
+        physical pages are freed or nothing is spillable. Returns pages
+        freed."""
+        return self._gpu_arena_storage().spill_retained(min_pages)
+
+    def register_arena_ghosts(
+        self,
+        pg_idx: PoolGroupIndex,
+        rng: SequenceRange,
+        entries: Sequence[tuple[int, Page]],
+    ) -> None:
+        """Record, for each ``(ordinal, page)``, that the (now host-resident)
+        page's bytes are still present at ``rng.base_block + ordinal`` --
+        usable as a D2D reuse source while the range stays retained (§4.4
+        phase 2). No-op unless lazy retention is enabled."""
+        self._gpu_arena_storage().pool_group(pg_idx).register_ghosts(rng, entries)
+
+    def lookup_arena_ghost(
+        self, pg_idx: PoolGroupIndex, page: Page
+    ) -> "tuple[SlotId, SequenceRange] | None":
+        return self._gpu_arena_storage().pool_group(pg_idx).lookup_ghost(page)
+
+    def onboard_from_retained(
+        self,
+        pg_idx: PoolGroupIndex,
+        src_slot_ids: Sequence[SlotId],
+        dst_slots: Sequence[Slot],
+        gate_ranges: Sequence[SequenceRange],
+    ) -> None:
+        """D2D reuse onboarding from retained ranges (§4.4 phase 2): copy each
+        ghost source block into its explicit arena destination. Sources are
+        settled (their range left the pending queue) and immutable; the copy
+        finish event is set as every dst slot's ready event AND appended to
+        each source range's reclaim gates, so a spill can never unmap a range
+        an onboard is still reading."""
+        assert len(src_slot_ids) == len(dst_slots)
+        if not dst_slots:
+            return
+        num_pools = self.num_pools(pg_idx)
+        slot_sizes = self.slot_size(pg_idx)
+        gpu_tier = self._levels[GPU_LEVEL].cache_tier
+        tasks_per_pool: TypedIndexList[PoolIndex, list[CopyTask]] = make_typed(
+            lambda _: list[CopyTask](), num_pools
+        )
+        for src_id, dst in zip(src_slot_ids, dst_slots):
+            for pool_idx in typed_range(num_pools):
+                tasks_per_pool[pool_idx].append(
+                    CopyTask(
+                        self.slot_address(GPU_LEVEL, pg_idx, dst.slot_id, pool_idx),
+                        self.slot_address(GPU_LEVEL, pg_idx, src_id, pool_idx),
+                    )
+                )
+        with TemporaryCudaStream([]) as stream:
+            for pool_idx, tasks in typed_enumerate(tasks_per_pool):
+                # Consecutive ordinals in both the source (dead) and the
+                # destination range make these coalesce well.
+                for merged_size, merged_tasks in _coalesce_copy_tasks(
+                    slot_sizes[pool_idx], tasks
+                ).items():
+                    batched_copy(gpu_tier, gpu_tier, merged_size, merged_tasks, stream.get())
+        finish_event = stream.take_finish_event()
+        for dst in dst_slots:
+            dst.ready_event = finish_event
+        seen = set()
+        for rng in gate_ranges:
+            if id(rng) not in seen:
+                seen.add(id(rng))
+                rng._gate_events.append(finish_event)
 
     def offload_arena_pages(self, pg_idx: PoolGroupIndex, pages: Sequence[Page]) -> None:
         """Active->stale copy-on-free (§4.3): migrate a freeing sequence's
@@ -997,8 +1068,11 @@ class StorageManager:
         if level == GPU_LEVEL and self.is_arena_mode:
             # Slot counts describe VA in arena mode; physical utilization is
             # the shared page budget (§4.6), identical for every pool group.
+            # Lazily retained pages are reclaimable at will and count as
+            # available, mirroring classic "evictable" accounting.
             budget = self.gpu_page_budget
-            return filled_list(budget.used_pages / budget.total_pages, self.num_pool_groups)
+            frac = (budget.used_pages - budget.retained_pages) / budget.total_pages
+            return filled_list(frac, self.num_pool_groups)
         ret = filled_list(0.0, self.num_pool_groups)
         stats = self.get_statistics(level)
         for pg_idx in typed_range(self.num_pool_groups):
@@ -1008,7 +1082,7 @@ class StorageManager:
     def get_overall_utilization(self, level: CacheLevel = GPU_LEVEL) -> float:
         if level == GPU_LEVEL and self.is_arena_mode:
             budget = self.gpu_page_budget
-            return budget.used_pages / budget.total_pages
+            return (budget.used_pages - budget.retained_pages) / budget.total_pages
         stats = self.get_statistics(level)
         return sum(sum(s.slot_size) * s.unavailable for s in stats) / sum(
             sum(s.slot_size) * s.total for s in stats

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -772,14 +772,16 @@ class StorageManager:
         coalesced: adjacent (dst, src) pairs merge into fewer, larger
         transfers.
         """
-        assert defrag or dst_level != src_level, (
+        explicit_dst = dst_slots is not None
+        # Same-level copies are legal when defragmenting or when copying into
+        # explicit arena destinations (D2D reuse onboarding, §4.4).
+        assert defrag or explicit_dst or dst_level != src_level, (
             "dst_level and src_level must be different unless performing defragmentation"
         )
         num_slots = len(src_pages)
         num_pools = self.num_pools(pool_group_index)
         src_pool_group = self._pool_group(src_level, pool_group_index)
         dst_pool_group = self._pool_group(dst_level, pool_group_index)
-        explicit_dst = dst_slots is not None
         if dst_slots is None:
             if dst_pool_group.num_free_slots < num_slots:
                 raise OutOfPagesError("Not enough free slots")

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -523,11 +523,18 @@ class StorageManager:
         (§4.2)."""
         self._gpu_arena_storage().pool_group(pg_idx).free_sequence(rng, last_consumer)
 
-    def drain_gpu_reclaim(self) -> int:
+    def drain_gpu_reclaim(self, fence: CachedCudaEvent | None = None) -> int:
         """Unmap and recycle freed ranges whose gating events completed; call
-        at iteration boundaries (§4.2). Returns the number of ranges
+        at iteration boundaries (§4.2). ``fence`` (an execution-stream event
+        recorded at the call site) gates newly freed ranges against
+        speculatively enqueued steps. Returns the number of ranges
         reclaimed (or parked on the retained LRU under lazy retention)."""
-        return self._gpu_arena_storage().drain_reclaim()
+        return self._gpu_arena_storage().drain_reclaim(fence)
+
+    def fence_gpu_reclaim(self, fence: CachedCudaEvent) -> None:
+        """Assign the iteration-boundary reclaim fence (risk #3) to freed
+        ranges without draining."""
+        self._gpu_arena_storage().fence_pending_frees(fence)
 
     def spill_gpu_retained(self, min_pages: int) -> int:
         """Reclaim lazily retained ranges (§4.4 phase 2) until ``min_pages``

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -528,10 +528,10 @@ class StorageManager:
         at iteration boundaries (§4.2). ``fence`` (an execution-stream event
         recorded at the call site) gates newly freed ranges against
         speculatively enqueued steps. Returns the number of ranges
-        reclaimed (or parked on the retained LRU under lazy retention).
-        ``wait=True`` blocks on in-flight gating events instead of skipping
-        their ranges (§4.6 preemption headroom — see
-        ``ArenaPoolGroup.drain_reclaim``)."""
+        reclaimed (or parked on the retained LRU under lazy retention or
+        freed-range adoption). ``wait=True`` blocks on in-flight gating
+        events instead of skipping their ranges (§4.6 preemption headroom —
+        see ``ArenaPoolGroup.drain_reclaim``)."""
         return self._gpu_arena_storage().drain_reclaim(fence, wait)
 
     def fence_gpu_reclaim(self, fence: CachedCudaEvent) -> None:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -552,11 +552,18 @@ class StorageManager:
         reclaim ladder runs the dedup remap between the two, §P3 v2)."""
         return self._gpu_arena_storage().spill_retained(min_pages, spill_spans)
 
-    def dedup_remap_arena(self, items: "list[tuple[int, SequenceRange, int, object, int]]") -> int:
-        """Execute a pressure-time dedup-remap batch (P3 v2) behind one
-        device quiesce. Items: ``(pg_idx, rng, key, span, num_blocks)``.
+    def hard_reclaim_gpu(
+        self,
+        min_pages: int,
+        dedup_items: "list[tuple[int, SequenceRange, int, object, int]]",
+        fence: CachedCudaEvent | None = None,
+    ) -> int:
+        """Pressure-time hard reclaim (P3 v3): fenced drain, dedup remap of
+        ``dedup_items``, parked-range spill, and registry-excess spill --
+        all behind ONE device quiesce (or zero syncs if there is nothing to
+        reclaim anywhere). See :meth:`GpuArenaCacheLevelStorage.hard_reclaim`.
         Returns pages freed."""
-        return self._gpu_arena_storage().dedup_remap(items)
+        return self._gpu_arena_storage().hard_reclaim(min_pages, dedup_items, fence)
 
     def arena_span_pages_for_blocks(
         self, pg_idx: PoolGroupIndex, span: object, num_blocks: int

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -76,6 +76,7 @@ from ._utils import (
     get_uniform_attribute,
     intersect,
     make_typed,
+    merge_events,
     partition,
     remove_if,
     round_up,
@@ -550,12 +551,20 @@ class StorageManager:
         for p in pages:
             self.schedule_for_eviction(p)
 
-    def write_through_pages(self, pg_idx: PoolGroupIndex, pages: Sequence[Page]) -> list[Slot]:
+    def write_through_pages(
+        self,
+        pg_idx: PoolGroupIndex,
+        pages: Sequence[Page],
+        prior_event: CachedCudaEvent = CachedCudaEvent.NULL,
+    ) -> list[Slot]:
         """Write-through on commit (§4.3): copy committed (immutable) GPU
         pages to fresh host slots without touching the sources. Returns the
         host slots; each slot's ready event completes when its copy does. The
-        caller owns associating the slots with the pages and validating them
-        on event completion."""
+        caller owns associating the slots with the pages (see
+        :meth:`adopt_stale_copies`). ``prior_event`` orders the copies after
+        outstanding work on the owning sequence's stream -- required when the
+        sources are still locked, since their own ready events do not cover
+        in-flight writes from earlier steps."""
         assert self.is_arena_mode
         assert self.num_cache_levels > 1, "write-through requires a host tier"
         if not pages:
@@ -564,9 +573,43 @@ class StorageManager:
         requirements = filled_list(0, self.num_pool_groups)
         requirements[pg_idx] = len(pages)
         self.prepare_free_slots(host_lvl, requirements)
-        dst_slots = self._batched_migrate(pg_idx, host_lvl, GPU_LEVEL, pages, update_src=False)
+        dst_slots = self._batched_migrate(
+            pg_idx,
+            host_lvl,
+            GPU_LEVEL,
+            pages,
+            update_src=False,
+            extra_prior_event=prior_event,
+        )
         assert dst_slots is not None
         return list(dst_slots)
+
+    def adopt_stale_copies(
+        self, pg_idx: PoolGroupIndex, pages: Sequence[Page], host_slots: Sequence[Slot]
+    ) -> None:
+        """Copy-free free path for written-through blocks (§4.3): each page
+        releases its arena slot and takes ownership of its pre-copied host
+        slot. The arena slot's reclaim gate includes the write-through copy's
+        finish event (the copy reads the slot) in addition to the page's own
+        last consumers; the page's ready event becomes the copy's finish
+        event, so future consumers of the host copy wait for its validity."""
+        assert self.is_arena_mode
+        if not pages:
+            return
+        host_lvl = CacheLevel(GPU_LEVEL + 1)
+        gpu_pool = self._pool_group(GPU_LEVEL, pg_idx)
+        emitted: set[tuple[bytes, LifeCycleId]] = set()
+        for page, host_slot in zip(pages, host_slots, strict=True):
+            assert page.cache_level == GPU_LEVEL
+            if page.scheduled_for_eviction:
+                self.exclude_from_eviction(page)
+            released = page.move_to_new_slot()
+            released.ready_event = merge_events([released.ready_event, host_slot.ready_event])
+            gpu_pool.release(released)
+            page.set_slot(host_slot)
+            page.cache_level = host_lvl
+            self._emit_cache_level_updated_event(page, GPU_LEVEL, host_lvl, emitted)
+            self.schedule_for_eviction(page)
 
     # ------------------------------------------------------------------------
 
@@ -767,6 +810,7 @@ class StorageManager:
         migration_recorder: MigrationRecorder | None = None,
         defrag: bool = False,  # we are doing defragmentation
         dst_slots: list[Slot] | None = None,
+        extra_prior_event: CachedCudaEvent | None = None,
     ) -> Sequence[Slot] | None:
         """Free slots must be prepared before calling this function.
 
@@ -796,6 +840,8 @@ class StorageManager:
         try:
             assert len(dst_slots) == num_slots
             prior_events: set[CachedCudaEvent] = set()
+            if extra_prior_event is not None and extra_prior_event is not CachedCudaEvent.NULL:
+                prior_events.add(extra_prior_event)
             tasks_per_pool: TypedIndexList[PoolIndex, list[CopyTask]] = make_typed(
                 lambda _: list[CopyTask](), num_pools
             )

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -535,6 +535,19 @@ class StorageManager:
         freed."""
         return self._gpu_arena_storage().spill_retained(min_pages)
 
+    def queue_gpu_mapping(
+        self, pg_idx: PoolGroupIndex, rng: SequenceRange, num_valid_blocks: int
+    ) -> int:
+        """Charge the page budget for a growth target but defer the driver
+        calls to :meth:`flush_gpu_mappings` (§4.2 batched sweep). Raises
+        ``OutOfPagesError`` (charging nothing) on exhaustion."""
+        return self._gpu_arena_storage().pool_group(pg_idx).queue_mapping(rng, num_valid_blocks)
+
+    def flush_gpu_mappings(self) -> int:
+        """Execute all deferred growth maps back-to-back. Must run after
+        scheduling and before any GPU work touches the grown blocks."""
+        return self._gpu_arena_storage().flush_mappings()
+
     def register_arena_ghosts(
         self,
         pg_idx: PoolGroupIndex,

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/setup_mypyc.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/setup_mypyc.py
@@ -80,6 +80,7 @@ modules = [
     "kv_cache_manager_v2/_exceptions.py",
     "kv_cache_manager_v2/_life_cycle_registry.py",
     "kv_cache_manager_v2/_page.py",
+    "kv_cache_manager_v2/_sequence_arena.py",
     "kv_cache_manager_v2/_storage_manager.py",
     "kv_cache_manager_v2/_utils.py",
     # _core submodule

--- a/tests/unittest/_torch/executor/test_kv_block_offset_overlap_race_v2.py
+++ b/tests/unittest/_torch/executor/test_kv_block_offset_overlap_race_v2.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test for nvbug 6293536 on KVCacheManagerV2.
+
+``KVCacheManagerV2.copy_batch_block_offsets`` ships each iteration's block
+offsets to the device with an *asynchronous* gather kernel
+(``copy_batch_block_offsets_to_device``). The kernel reads its host inputs at
+execution time, not enqueue time, so they must not be overwritten before the
+copy drains. Two of those inputs are reused in place across iterations:
+
+* ``host_kv_cache_block_offsets`` -- the C++ KV cache writes page indices
+  straight into a sequence's slot, and a freed slot is rebound to a different
+  request on reuse; and
+* the ``copy_idx`` returned by ``IndexMapper.get_copy_index`` -- a slice of a
+  single persistent pinned ``copyIndex_`` buffer overwritten by the next call.
+
+Under the overlap scheduler the CPU runs an iteration ahead, so either could be
+clobbered before the previous iteration's still-pending copy drains -> the
+kernel gathers another batch's blocks (memory corruption). The fix snapshots the
+rows each call needs into a fresh pinned buffer and feeds the kernel an identity
+index.
+
+This drives that window deterministically with two simultaneously-live batches
+(so their page-table slots differ): it stalls the stream with
+``torch.cuda._sleep``, enqueues batch A's async gather behind the stall, then
+lets the host immediately issue batch B before A's copy can drain. With the bug
+present, batch B's ``get_copy_index`` overwrites the shared ``copyIndex_`` buffer
+in place, so batch A's still-pending kernel gathers batch B's slots.
+"""
+
+import pytest
+import torch
+
+from tensorrt_llm.bindings import DataType, LayerType
+from tensorrt_llm.bindings import ModelConfig as ModelConfigCpp
+from tensorrt_llm.bindings.internal.batch_manager import CacheType
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+from tensorrt_llm.mapping import Mapping
+
+# Small geometry so each sequence spans several blocks and the two batches get
+# visibly different physical block indices.
+_NUM_LAYERS = 2
+_NUM_KV_HEADS = 2
+_HEAD_DIM = 16
+_TOKENS_PER_BLOCK = 16
+_MAX_SEQ_LEN = 256
+_BATCH = 6
+_TOKENS_PER_SEQ = _TOKENS_PER_BLOCK * 5
+# Long GPU stall so the host reliably wins the race and overwrites the shared
+# copy-index buffer before batch A's gather drains.
+_SLEEP_CYCLES = 2_000_000_000
+
+
+def _build_manager():
+    from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
+
+    model_config = ModelConfigCpp(
+        vocab_size=32000,
+        num_layers=_NUM_LAYERS,
+        num_attention_layers=_NUM_LAYERS,
+        num_rnn_layers=0,
+        num_heads=_NUM_KV_HEADS,
+        hidden_size=_NUM_KV_HEADS * _HEAD_DIM,
+        data_type=DataType.HALF,
+    )
+    model_config.layer_types = [LayerType.ATTENTION] * _NUM_LAYERS
+    model_config.set_num_kv_heads(_NUM_KV_HEADS)
+
+    kv_cache_config = KvCacheConfig(
+        max_tokens=4096, free_gpu_memory_fraction=0.2, enable_block_reuse=False
+    )
+    mapping = Mapping(world_size=1, tp_size=1, pp_size=1)
+
+    return KVCacheManagerV2(
+        kv_cache_config=kv_cache_config,
+        kv_cache_type=CacheType.SELF,
+        num_layers=_NUM_LAYERS,
+        num_kv_heads=_NUM_KV_HEADS,
+        head_dim=_HEAD_DIM,
+        tokens_per_block=_TOKENS_PER_BLOCK,
+        max_seq_len=_MAX_SEQ_LEN,
+        max_batch_size=2 * _BATCH,
+        mapping=mapping,
+        dtype=DataType.HALF,
+        model_config=model_config,
+        max_beam_width=1,
+    )
+
+
+def _empty_device_offsets(mgr):
+    return torch.zeros(
+        mgr.num_pools, 2 * _BATCH, 2, mgr.max_blocks_per_seq, dtype=torch.int32, device="cuda"
+    )
+
+
+def _reference_offsets(mgr, ids):
+    """Non-racy ground truth: copy followed by an immediate synchronize."""
+    dst = _empty_device_offsets(mgr)
+    mgr.copy_batch_block_offsets(dst, ids, 1, len(ids), len(ids))
+    torch.cuda.synchronize()
+    return dst[:, : len(ids)].clone()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device")
+def test_copy_batch_block_offsets_v2_survives_overlap_overwrite():
+    mgr = _build_manager()
+
+    # Two disjoint batches -> different physical block indices and, because both
+    # are kept live, different IndexMapper slots.
+    ids_a = list(range(1, 1 + _BATCH))
+    ids_b = list(range(101, 101 + _BATCH))
+    toks = [_TOKENS_PER_SEQ] * _BATCH
+    mgr.add_dummy_requests(request_ids=ids_a, token_nums=toks, prepare_resource=True)
+    mgr.add_dummy_requests(request_ids=ids_b, token_nums=toks, prepare_resource=True)
+
+    ref_a = _reference_offsets(mgr, ids_a)
+    ref_b = _reference_offsets(mgr, ids_b)
+    assert not torch.equal(ref_a, ref_b), (
+        "test setup invalid: batches A and B produced identical offsets"
+    )
+
+    # Drive the overlap window: stall the stream, enqueue batch A's async gather
+    # behind the stall, then let the host run ahead and issue batch B (whose
+    # get_copy_index overwrites the shared copy-index buffer in place) before
+    # A's copy can drain.
+    dst_a = _empty_device_offsets(mgr)
+    dst_b = _empty_device_offsets(mgr)
+    torch.cuda.synchronize()
+
+    torch.cuda._sleep(_SLEEP_CYCLES)
+    mgr.copy_batch_block_offsets(dst_a, ids_a, 1, _BATCH, _BATCH)
+    mgr.copy_batch_block_offsets(dst_b, ids_b, 1, _BATCH, _BATCH)
+    torch.cuda.synchronize()
+
+    # Batch A's device offsets must still be batch A's, not clobbered by B.
+    assert torch.equal(dst_a[:, :_BATCH], ref_a), (
+        "nvbug 6293536: batch A's async gather read another batch's host inputs "
+        "(overlap-scheduler data race in KVCacheManagerV2.copy_batch_block_offsets)"
+    )
+    # And batch B's copy is independently correct.
+    assert torch.equal(dst_b[:, :_BATCH], ref_b)

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
@@ -204,7 +204,12 @@ class TestArenaAdapter(unittest.TestCase):
         mgr.kv_cache_map.pop(1)
         mgr.index_mapper.remove_sequence(1)
         torch.cuda.synchronize()
-        self.assertGreaterEqual(mgr.impl.drain_gpu_reclaim(), 1)
+        # Fenced drains, as the adapter issues each iteration (risk #3). The
+        # fence may complete between the two calls, so assert on the total.
+        reclaimed = mgr.impl.drain_gpu_reclaim(mgr._reclaim_fence())
+        torch.cuda.synchronize()
+        reclaimed += mgr.impl.drain_gpu_reclaim(mgr._reclaim_fence())
+        self.assertGreaterEqual(reclaimed, 1)
         self.assertEqual(budget.used_pages, 0)
 
 

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
@@ -236,9 +236,11 @@ class TestArenaSchedulerDeadlockRecovery(unittest.TestCase):
         )
 
     def test_try_allocate_generation_recovers_from_all_suspended(self) -> None:
-        # Budget = exactly the pages one 31-block request maps, so a single
-        # suspended request pins utilization at 100% (> the 0.95 resume gate)
-        # until its freed range actually drains.
+        # Budget = exactly the pages one 33-block request maps (2 pages at
+        # 32 blocks/page — the request itself spans both, independent of the
+        # map-ahead margin), so a single suspended request pins utilization
+        # at 100% (> the 0.95 resume gate) until its freed range actually
+        # drains.
         mgr = _create_arena_manager(max_tokens=512)
         try:
             budget = mgr.impl._storage.gpu_page_budget
@@ -246,7 +248,7 @@ class TestArenaSchedulerDeadlockRecovery(unittest.TestCase):
             kv = mgr._create_kv_cache(1, None, None)
             kv.cuda_stream = mgr._stream.cuda_stream
             self.assertTrue(kv.resume(mgr._stream.cuda_stream))
-            self.assertTrue(kv.resize(31 * TOKENS_PER_BLOCK))
+            self.assertTrue(kv.resize(33 * TOKENS_PER_BLOCK))
             self.assertEqual(budget.used_pages, 2)
 
             # Scheduler self-eviction mid-pass: the freed range lands in

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
@@ -98,9 +98,6 @@ class TestKvCacheConfigArenaField(unittest.TestCase):
             arena_cfg = KVCacheManagerV2._build_arena_config()
         self.assertEqual(arena_cfg.phys_page_size, 2 * MiB)
         self.assertEqual(arena_cfg.write_through, WriteThroughPolicy.ON_FREE)
-        # default margin pre-maps the whole reserved range on first touch
-        # (clamped per range) so growth maps never run under kernels
-        self.assertEqual(arena_cfg.map_ahead_pages, 1 << 30)
 
 
 class TestLinearKernelsEnvGuard(unittest.TestCase):

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
@@ -50,9 +50,9 @@ GPU_QUOTA = MAX_TOKENS * BYTES_PER_TOKEN
 
 def _create_arena_manager(**kv_cache_kwargs) -> KVCacheManagerV2:
     kv_cache_kwargs.setdefault("max_tokens", MAX_TOKENS)
+    kv_cache_kwargs.setdefault("host_cache_size", 64 * MiB)
     kv_cache_config = KvCacheConfig(
         enable_block_reuse=True,
-        host_cache_size=64 * MiB,
         use_contiguous_kv_arena=True,
         **kv_cache_kwargs,
     )
@@ -271,6 +271,66 @@ class TestArenaSchedulerDeadlockRecovery(unittest.TestCase):
             self.assertEqual(budget.used_pages, budget.retained_pages)
             mgr.impl._storage.spill_gpu_retained(1 << 62)
             self.assertEqual(budget.used_pages, 0)
+        finally:
+            mgr.shutdown()
+
+
+@requires_cuda
+class TestArenaSuspendDropFallback(unittest.TestCase):
+    """§4.5 hardening: suspend_request degrades to drop-and-recompute.
+
+    When the host tier cannot absorb a suspension write-out (its slots are
+    HELD by already-suspended sequences), ``suspend()`` raises atomically and
+    the adapter must DROP the victim's cache instead (freeing the GPU pages
+    without host capacity) and return False so the scheduler flags the
+    request for a v1-style pause/recompute. The first suspension of the same
+    shape must keep returning True (offloaded, resumable).
+    """
+
+    def _req(self, request_id: int):
+        return mock.Mock(
+            py_request_id=request_id,
+            py_draft_tokens=[],
+            is_disagg_generation_transmission_complete=False,
+            context_phase_params=None,
+            # free_resources -> try_commit_blocks_for_reuse must skip the
+            # commit branch for this synthetic request.
+            is_dummy_request=True,
+        )
+
+    def test_suspend_request_drops_on_host_exhaustion(self) -> None:
+        # Host tier: 3 block columns -- fits one 3-block suspension (HELD),
+        # not two.
+        mgr = _create_arena_manager(host_cache_size=3 * BLOCK_COLUMN_BYTES)
+        try:
+            kv1 = mgr._create_kv_cache(1, None, None)
+            kv1.cuda_stream = mgr._stream.cuda_stream
+            self.assertTrue(kv1.resume(mgr._stream.cuda_stream))
+            self.assertTrue(kv1.resize(3 * TOKENS_PER_BLOCK))
+            kv2 = mgr._create_kv_cache(2, None, None)
+            kv2.cuda_stream = mgr._stream.cuda_stream
+            self.assertTrue(kv2.resume(mgr._stream.cuda_stream))
+            self.assertTrue(kv2.resize(3 * TOKENS_PER_BLOCK))
+
+            # First suspension offloads (resumable) and fills the host tier.
+            self.assertTrue(mgr.suspend_request(self._req(1)))
+            self.assertIn(1, mgr.kv_cache_map)
+            self.assertFalse(mgr.kv_cache_map[1].is_active)
+
+            # Second suspension cannot fit: the adapter drops the cache and
+            # reports False for the pause/recompute flow.
+            self.assertFalse(mgr.suspend_request(self._req(2)))
+            self.assertNotIn(2, mgr.kv_cache_map)
+
+            # The survivor is untouched and still resumable.
+            self.assertTrue(mgr.try_allocate_generation(self._req(1)))
+            self.assertTrue(mgr.kv_cache_map[1].is_active)
+
+            mgr.kv_cache_map[1].close()
+            mgr.kv_cache_map.pop(1)
+            mgr.index_mapper.remove_sequence(1)
+            torch.cuda.synchronize()
+            mgr.impl.drain_gpu_reclaim(mgr._reclaim_fence(), wait=True)
         finally:
             mgr.shutdown()
 

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
@@ -210,6 +210,9 @@ class TestArenaAdapter(unittest.TestCase):
         torch.cuda.synchronize()
         reclaimed += mgr.impl.drain_gpu_reclaim(mgr._reclaim_fence())
         self.assertGreaterEqual(reclaimed, 1)
+        # drained ranges park mapped for adoption; spill to assert release
+        self.assertEqual(budget.used_pages, budget.retained_pages)
+        mgr.impl._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
 
 
@@ -264,6 +267,9 @@ class TestArenaSchedulerDeadlockRecovery(unittest.TestCase):
             mgr.index_mapper.remove_sequence(1)
             torch.cuda.synchronize()
             mgr.impl.drain_gpu_reclaim(mgr._reclaim_fence(), wait=True)
+            # drained ranges park mapped for adoption; spill to assert release
+            self.assertEqual(budget.used_pages, budget.retained_pages)
+            mgr.impl._storage.spill_gpu_retained(1 << 62)
             self.assertEqual(budget.used_pages, 0)
         finally:
             mgr.shutdown()

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
@@ -98,6 +98,9 @@ class TestKvCacheConfigArenaField(unittest.TestCase):
             arena_cfg = KVCacheManagerV2._build_arena_config()
         self.assertEqual(arena_cfg.phys_page_size, 2 * MiB)
         self.assertEqual(arena_cfg.write_through, WriteThroughPolicy.ON_FREE)
+        # default margin pre-maps the whole reserved range on first touch
+        # (clamped per range) so growth maps never run under kernels
+        self.assertEqual(arena_cfg.map_ahead_pages, 1 << 30)
 
 
 class TestLinearKernelsEnvGuard(unittest.TestCase):

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
@@ -100,6 +100,63 @@ class TestKvCacheConfigArenaField(unittest.TestCase):
         self.assertEqual(arena_cfg.write_through, WriteThroughPolicy.ON_FREE)
 
 
+class TestLinearKernelsEnvGuard(unittest.TestCase):
+    """TRTLLM_KV_ARENA_LINEAR_KERNELS is read directly by the C++ attention op; both KV
+    cache managers must fail loudly when it is set without the arena allocator (§4.9)."""
+
+    _ENV = {"TRTLLM_KV_ARENA_LINEAR_KERNELS": "1"}
+
+    def test_v1_manager_rejects(self) -> None:
+        from tensorrt_llm._torch.pyexecutor.resource_manager import (
+            KVCacheManager as KVCacheManagerV1,
+        )
+
+        with mock.patch.dict("os.environ", self._ENV):
+            with self.assertRaisesRegex(ValueError, "use_contiguous_kv_arena"):
+                KVCacheManagerV1(
+                    KvCacheConfig(max_tokens=MAX_TOKENS),
+                    CacheType.SELF,
+                    num_layers=NUM_LAYERS,
+                    num_kv_heads=NUM_KV_HEADS,
+                    head_dim=HEAD_DIM,
+                    tokens_per_block=TOKENS_PER_BLOCK,
+                    max_seq_len=MAX_SEQ_LEN,
+                    max_batch_size=4,
+                    mapping=Mapping(world_size=1, tp_size=1, rank=0),
+                    dtype=DataType.HALF,
+                )
+
+    @requires_cuda
+    def test_v2_without_arena_rejects(self) -> None:
+        kv_cache_config = KvCacheConfig(
+            max_tokens=MAX_TOKENS,
+            enable_block_reuse=True,
+            host_cache_size=64 * MiB,
+            use_kv_cache_manager_v2=True,
+        )
+        with mock.patch.dict("os.environ", self._ENV):
+            with self.assertRaisesRegex(ValueError, "use_contiguous_kv_arena"):
+                KVCacheManagerV2(
+                    kv_cache_config,
+                    CacheType.SELF,
+                    num_layers=NUM_LAYERS,
+                    num_kv_heads=NUM_KV_HEADS,
+                    head_dim=HEAD_DIM,
+                    tokens_per_block=TOKENS_PER_BLOCK,
+                    max_seq_len=MAX_SEQ_LEN,
+                    max_batch_size=4,
+                    mapping=Mapping(world_size=1, tp_size=1, rank=0),
+                    dtype=DataType.HALF,
+                    vocab_size=32000,
+                )
+
+    @requires_cuda
+    def test_arena_accepts(self) -> None:
+        with mock.patch.dict("os.environ", self._ENV):
+            mgr = _create_arena_manager()
+        mgr.shutdown()
+
+
 @requires_cuda
 class TestArenaAdapter(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
@@ -49,8 +49,8 @@ GPU_QUOTA = MAX_TOKENS * BYTES_PER_TOKEN
 
 
 def _create_arena_manager(**kv_cache_kwargs) -> KVCacheManagerV2:
+    kv_cache_kwargs.setdefault("max_tokens", MAX_TOKENS)
     kv_cache_config = KvCacheConfig(
-        max_tokens=MAX_TOKENS,
         enable_block_reuse=True,
         host_cache_size=64 * MiB,
         use_contiguous_kv_arena=True,
@@ -211,6 +211,62 @@ class TestArenaAdapter(unittest.TestCase):
         reclaimed += mgr.impl.drain_gpu_reclaim(mgr._reclaim_fence())
         self.assertGreaterEqual(reclaimed, 1)
         self.assertEqual(budget.used_pages, 0)
+
+
+@requires_cuda
+class TestArenaSchedulerDeadlockRecovery(unittest.TestCase):
+    """§4.6 preemption headroom: pages freed mid-scheduling-pass sit in
+    UNFENCED pending-reclaim (the iteration fence is only assigned in
+    prepare_resources, which runs after scheduling), so they stay charged to
+    the page budget. In the terminal state — every request suspended — each
+    resume() is refused by the max_util_for_resume gate while nothing is
+    left to evict, and the V2 scheduler's deadlock guard raises fatally.
+    try_allocate_generation must recover by fencing + blocking-draining the
+    reclaim queue in-pass."""
+
+    def _gen_req(self, request_id: int):
+        return mock.Mock(
+            py_request_id=request_id,
+            py_draft_tokens=[],
+            is_disagg_generation_transmission_complete=False,
+            context_phase_params=None,
+        )
+
+    def test_try_allocate_generation_recovers_from_all_suspended(self) -> None:
+        # Budget = exactly the pages one 31-block request maps, so a single
+        # suspended request pins utilization at 100% (> the 0.95 resume gate)
+        # until its freed range actually drains.
+        mgr = _create_arena_manager(max_tokens=512)
+        try:
+            budget = mgr.impl._storage.gpu_page_budget
+            self.assertEqual(budget.total_pages, 2)
+            kv = mgr._create_kv_cache(1, None, None)
+            kv.cuda_stream = mgr._stream.cuda_stream
+            self.assertTrue(kv.resume(mgr._stream.cuda_stream))
+            self.assertTrue(kv.resize(31 * TOKENS_PER_BLOCK))
+            self.assertEqual(budget.used_pages, 2)
+
+            # Scheduler self-eviction mid-pass: the freed range lands in
+            # UNFENCED pending-reclaim; the pages stay charged, and a bare
+            # resume() (what the pre-fix allocation path amounts to) is
+            # refused by the utilization gate — the deadlock terminal state.
+            kv.suspend()
+            self.assertEqual(budget.used_pages, 2)
+            self.assertFalse(kv.resume(mgr._stream.cuda_stream))
+
+            # The scheduler's allocation path recovers within the pass:
+            # fence + blocking drain + retry.
+            self.assertTrue(mgr.try_allocate_generation(self._gen_req(1)))
+            self.assertTrue(kv.is_active)
+
+            kv.close()
+            mgr.kv_cache_map.pop(1)
+            mgr.index_mapper.remove_sequence(1)
+            torch.cuda.synchronize()
+            mgr.impl.drain_gpu_reclaim(mgr._reclaim_fence(), wait=True)
+            self.assertEqual(budget.used_pages, 0)
+        finally:
+            mgr.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Executor-side tests for the contiguous primary KV cache prototype
+(``KvCacheConfig.use_contiguous_kv_arena``; see
+``contiguous_primary_kvcache/DESIGN.md``). Manager-internal behavior is
+covered by ``tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py``;
+this file covers the KVCacheManagerV2 adapter plumbing."""
+
+import unittest
+from unittest import mock
+
+import torch
+
+import tensorrt_llm
+import tensorrt_llm.bindings
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.runtime.kv_cache_manager_v2 import WriteThroughPolicy
+
+DataType = tensorrt_llm.bindings.DataType
+CacheType = tensorrt_llm.bindings.internal.batch_manager.CacheType
+
+requires_cuda = unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+
+MiB = 1 << 20
+
+NUM_LAYERS = 4
+NUM_KV_HEADS = 4
+HEAD_DIM = 128
+TOKENS_PER_BLOCK = 8
+MAX_SEQ_LEN = 256
+MAX_TOKENS = 2048
+# fp16 K+V: heads * dim * 2 roles * 2 bytes, per token per layer
+BYTES_PER_TOKEN = NUM_KV_HEADS * HEAD_DIM * 2 * 2 * NUM_LAYERS
+BLOCK_COLUMN_BYTES = BYTES_PER_TOKEN * TOKENS_PER_BLOCK  # all pool groups
+GPU_QUOTA = MAX_TOKENS * BYTES_PER_TOKEN
+
+
+def _create_arena_manager(**kv_cache_kwargs) -> KVCacheManagerV2:
+    kv_cache_config = KvCacheConfig(
+        max_tokens=MAX_TOKENS,
+        enable_block_reuse=True,
+        host_cache_size=64 * MiB,
+        use_contiguous_kv_arena=True,
+        **kv_cache_kwargs,
+    )
+    return KVCacheManagerV2(
+        kv_cache_config,
+        CacheType.SELF,
+        num_layers=NUM_LAYERS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        tokens_per_block=TOKENS_PER_BLOCK,
+        max_seq_len=MAX_SEQ_LEN,
+        max_batch_size=4,
+        mapping=Mapping(world_size=1, tp_size=1, rank=0),
+        dtype=DataType.HALF,
+        vocab_size=32000,
+    )
+
+
+class TestKvCacheConfigArenaField(unittest.TestCase):
+    def test_default_off(self) -> None:
+        cfg = KvCacheConfig()
+        self.assertFalse(cfg.use_contiguous_kv_arena)
+        self.assertFalse(cfg.use_kv_cache_manager_v2)
+
+    def test_arena_implies_v2(self) -> None:
+        cfg = KvCacheConfig(use_contiguous_kv_arena=True)
+        self.assertTrue(cfg.use_kv_cache_manager_v2)
+
+    def test_env_knobs(self) -> None:
+        env = {
+            "TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB": "16",
+            "TRTLLM_KV_ARENA_MAP_AHEAD_PAGES": "3",
+            "TRTLLM_KV_ARENA_WRITE_THROUGH": "on_commit",
+        }
+        with mock.patch.dict("os.environ", env):
+            arena_cfg = KVCacheManagerV2._build_arena_config()
+        self.assertEqual(arena_cfg.phys_page_size, 16 * MiB)
+        self.assertEqual(arena_cfg.map_ahead_pages, 3)
+        self.assertEqual(arena_cfg.write_through, WriteThroughPolicy.ON_COMMIT)
+
+    def test_env_defaults(self) -> None:
+        with mock.patch.dict("os.environ", {}, clear=False):
+            arena_cfg = KVCacheManagerV2._build_arena_config()
+        self.assertEqual(arena_cfg.phys_page_size, 2 * MiB)
+        self.assertEqual(arena_cfg.write_through, WriteThroughPolicy.ON_FREE)
+
+
+@requires_cuda
+class TestArenaAdapter(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mgr = _create_arena_manager()
+
+    def tearDown(self) -> None:
+        self.mgr.shutdown()
+        del self.mgr
+
+    def test_arena_mode_enabled(self) -> None:
+        self.assertTrue(self.mgr._arena_enabled)
+        self.assertTrue(self.mgr.impl._storage.is_arena_mode)
+
+    def test_capacity_accounting_is_physical(self) -> None:
+        # get_num_free_blocks counts what the page budget can back, not VA
+        budget = self.mgr.impl._storage.gpu_page_budget
+        page_size = self.mgr.impl._storage.arena_config.phys_page_size
+        expected_blocks = budget.total_pages * page_size // BLOCK_COLUMN_BYTES
+        self.assertEqual(self.mgr.get_num_free_blocks(), expected_blocks)
+        self.assertEqual(budget.total_pages, GPU_QUOTA // page_size)
+        # clamp is page-based too and must not exceed physical capacity
+        available = self.mgr.get_num_available_tokens(token_num_upper_bound=10**6)
+        self.assertLessEqual(available, budget.total_pages * page_size // BYTES_PER_TOKEN)
+        self.assertGreater(available, 0)
+
+    def test_request_lifecycle_through_adapter(self) -> None:
+        mgr = self.mgr
+        budget = mgr.impl._storage.gpu_page_budget
+        kv = mgr._create_kv_cache(1, None, None)
+        self.assertIsNotNone(kv)
+        # the VA reservation is sized for the per-request maximum
+        self.assertEqual(kv._max_capacity, mgr.max_blocks_per_seq * TOKENS_PER_BLOCK)
+        kv.cuda_stream = mgr._stream.cuda_stream
+        self.assertTrue(kv.resume(mgr._stream.cuda_stream))
+        self.assertTrue(kv.resize(3 * TOKENS_PER_BLOCK))
+        # the adapter pre-sizes index buffers to max_blocks_per_seq; only the
+        # first num_blocks entries are valid -- and they must be consecutive
+        indices = list(kv.get_base_page_indices(0))[:3]
+        self.assertEqual(indices, list(range(indices[0], indices[0] + 3)))
+        self.assertGreater(budget.used_pages, 0)
+        # suspend/resume via the adapter-facing kv methods
+        kv.suspend()
+        self.assertTrue(kv.resume(mgr._stream.cuda_stream))
+        kv.close()
+        mgr.kv_cache_map.pop(1)
+        mgr.index_mapper.remove_sequence(1)
+        torch.cuda.synchronize()
+        self.assertGreaterEqual(mgr.impl.drain_gpu_reclaim(), 1)
+        self.assertEqual(budget.used_pages, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -860,6 +860,95 @@ class TestArenaPoolGroup(unittest.TestCase):
         finally:
             group.destroy()
 
+    def _tight_group(self, budget_pages: int, map_ahead: int) -> "ArenaPoolGroup":
+        """Group with its own small budget for margin-degrade tests."""
+        self.tight_budget = PageBudget(budget_pages)
+        return ArenaPoolGroup(
+            block_capacity=16,
+            slot_size_list=[2 * MiB, 1 * MiB],
+            shared_phys_mem_pool=self.allocator,
+            page_budget=self.tight_budget,
+            map_ahead_pages=map_ahead,
+            page_index_scale=64,
+        )
+
+    def test_map_ahead_margin_degrades_before_failing(self) -> None:
+        """The map-ahead margin is a hint at the budget edge.
+
+        Growth maps the frontier without margin instead of raising
+        OutOfPagesError; only an unsatisfiable frontier raises.
+        """
+        # 2 blocks in pools (2MiB, 1MiB) = 3 frontier pages; margin would
+        # add 1 page per pool (5 total) but only 3 fit.
+        group = self._tight_group(budget_pages=3, map_ahead=1)
+        try:
+            rng = group.reserve_sequence(4)
+            self.assertEqual(group.ensure_mapped(rng, 2), 3)  # frontier only
+            self.assertEqual(self.tight_budget.used_pages, 3)
+            self.assertEqual(group.mapped_pages, 3)
+            # Same frontier again: margin still does not fit, frontier is
+            # covered -> no-op, no exception.
+            self.assertEqual(group.ensure_mapped(rng, 2), 0)
+            self.assertEqual(self.tight_budget.used_pages, 3)
+            # Growing past the budget still fails cleanly (charging nothing).
+            with self.assertRaises(OutOfPagesError):
+                group.ensure_mapped(rng, 4)
+            self.assertEqual(self.tight_budget.used_pages, 3)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            group.drain_reclaim(CachedCudaEvent.NULL)
+            group.spill_retained(1 << 62)
+        finally:
+            group.destroy()
+
+    def test_queued_mapping_margin_degrades_and_flush_replays_charge(self) -> None:
+        """Batched-sweep margin degrade is deterministic across the flush.
+
+        The charge records the degraded margin and the flush maps exactly
+        the charged pages.
+        """
+        group = self._tight_group(budget_pages=3, map_ahead=1)
+        try:
+            rng = group.reserve_sequence(4)
+            self.assertEqual(group.queue_mapping(rng, 2), 3)  # degraded charge
+            self.assertEqual(self.tight_budget.used_pages, 3)
+            self.assertEqual(group.mapped_pages, 0)  # deferred
+            self.assertEqual(group.flush_mappings(), 3)
+            self.assertEqual(group.mapped_pages, 3)
+            self.assertEqual(self.tight_budget.used_pages, 3)  # no reconcile
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            group.drain_reclaim(CachedCudaEvent.NULL)
+            group.spill_retained(1 << 62)
+        finally:
+            group.destroy()
+
+    def test_queued_mapping_delta_degrade_releases_excess(self) -> None:
+        """Delta-degrade on a margin-charged entry releases excess exactly.
+
+        A frontier bump that no longer fits degrades the entry; the
+        margin-less plan can be SMALLER than what is already charged
+        (margin wider than the added blocks) and the difference must be
+        released so charged == pending_pages(target, margin) holds for
+        the flush.
+        """
+        # 1 block with margin 2: pool0 min(1+2, 4)=3, pool1 min(1+2, 2)=2
+        # -> 5 pages charged. Bump to 2 blocks: margin plan needs +1 (no
+        # budget left); margin-less plan is 3 -> release 2.
+        group = self._tight_group(budget_pages=5, map_ahead=2)
+        try:
+            rng = group.reserve_sequence(4)
+            self.assertEqual(group.queue_mapping(rng, 1), 5)  # full margin fits
+            self.assertEqual(self.tight_budget.used_pages, 5)
+            self.assertEqual(group.queue_mapping(rng, 2), -2)  # degrade+release
+            self.assertEqual(self.tight_budget.used_pages, 3)
+            self.assertEqual(group.flush_mappings(), 3)
+            self.assertEqual(group.mapped_pages, 3)
+            self.assertEqual(self.tight_budget.used_pages, 3)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            group.drain_reclaim(CachedCudaEvent.NULL)
+            group.spill_retained(1 << 62)
+        finally:
+            group.destroy()
+
     class _FakeCanonicalPage:
         """Stand-in for a canonical (host-tier) page in registry tests."""
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1205,6 +1205,114 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
 
 
 @requires_cuda
+class TestArenaBatchedMapSweep(unittest.TestCase):
+    """§4.2 batched per-iteration map sweep.
+
+    Growth charges the budget at resize time but defers cuMemMap /
+    cuMemSetAccess to flush_gpu_mappings.
+    """
+
+    TPB = 16
+
+    def setUp(self) -> None:
+        init_cuda_once()
+        cfg = _make_manager_config(gpu_quota=32 * MiB, host_quota=32 * MiB)
+        cfg.contiguous_arena = ContiguousArenaConfig(map_ahead_pages=0, batched_map_sweep=True)
+        self.manager = KVCacheManager(cfg)
+
+    def tearDown(self) -> None:
+        self.manager.shutdown()
+        del self.manager
+
+    def _mapped_pages(self) -> int:
+        return (
+            self.manager._storage._gpu_arena_storage()
+            .pool_group(PoolGroupIndex(0))
+            ._arena.mapped_pages
+        )
+
+    def test_growth_defers_until_flush(self) -> None:
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        kv = manager.create_kv_cache(max_capacity=256 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv.resume(stream))
+            self.assertTrue(kv.resize(128 * self.TPB))  # 2 pages
+            # budget charged (admission control unchanged), nothing mapped yet
+            self.assertEqual(budget.used_pages, 2)
+            self.assertEqual(self._mapped_pages(), 0)
+            # growing again in the same iteration charges only the delta
+            self.assertTrue(kv.resize(256 * self.TPB))  # 4 pages total
+            self.assertEqual(budget.used_pages, 4)
+            self.assertEqual(self._mapped_pages(), 0)
+            self.assertEqual(manager.flush_gpu_mappings(), 4)
+            self.assertEqual(self._mapped_pages(), 4)
+            # pages are writable after the flush
+            for idx in kv.get_base_page_indices(LifeCycleId(0))[:4]:
+                addr = int(
+                    manager._storage.slot_address(GPU_LEVEL, PoolGroupIndex(0), idx, PoolIndex(0))
+                )
+                TestSparseVirtMem._tensor_at(addr, 16).fill_(1.0)
+            torch.cuda.synchronize()
+            kv.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(budget.used_pages, 0)
+
+    def test_freed_before_flush_releases_charge(self) -> None:
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        kv = manager.create_kv_cache(max_capacity=128 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv.resume(stream))
+            self.assertTrue(kv.resize(128 * self.TPB))
+            self.assertEqual(budget.used_pages, 2)
+            kv.close()  # close() itself flushes (its write-out reads pages)
+        s.take_finish_event().synchronize()
+        manager.flush_gpu_mappings()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(budget.used_pages, 0)
+
+    def test_reuse_onboarding_stays_synchronous(self) -> None:
+        manager = self.manager
+        tokens = [970 + i for i in range(2 * self.TPB)]
+        kv1 = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv1.resume(stream))
+            self.assertTrue(kv1.resize(2 * self.TPB))
+            manager.flush_gpu_mappings()
+            for j, idx in enumerate(kv1.get_base_page_indices(LifeCycleId(0))):
+                addr = int(
+                    manager._storage.slot_address(GPU_LEVEL, PoolGroupIndex(0), idx, PoolIndex(0))
+                )
+                TestSparseVirtMem._tensor_at(addr, (4 * 8192) // 4).fill_(3.0 + j)
+            torch.cuda.synchronize()
+            kv1.commit(tokens)
+            kv1.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+        # reuse hit: onboarding maps synchronously (its copies run immediately)
+        kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        self.assertEqual(kv2.history_length, 2 * self.TPB)
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv2.resume(stream2))
+            torch.cuda.synchronize()
+            for j, idx in enumerate(kv2.get_base_page_indices(LifeCycleId(0))):
+                addr = int(
+                    manager._storage.slot_address(GPU_LEVEL, PoolGroupIndex(0), idx, PoolIndex(0))
+                )
+                data = TestSparseVirtMem._tensor_at(addr, (4 * 8192) // 4)
+                self.assertTrue(bool((data == 3.0 + j).all().item()))
+            kv2.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+
+
+@requires_cuda
 class TestArenaLazyRetention(unittest.TestCase):
     """§4.4 phase 2 (P2): lazy GPU retention.
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1008,6 +1008,60 @@ class TestArenaPoolGroup(unittest.TestCase):
         finally:
             group.destroy()
 
+    def test_dedup_remap_replaces_private_backing(self) -> None:
+        """Pressure-time dedup remap (P3 v2) at the pool-group seam.
+
+        A live range's head chunks -- private duplicates of a registered
+        span -- are re-backed by the span's physical pages at the SAME VA:
+        bytes flip to the canonical copy, the duplicates' budget charge is
+        released, and the range gains the alias signature. Frontier and
+        slot bookkeeping are untouched (the range can keep growing).
+        """
+        group = self._group()
+        group._prefix_aliasing = True
+        try:
+            n = (2 * MiB) // 4
+            # Owner A: 2-block committed prefix, span registered owner-live.
+            rng_a = group.reserve_sequence(4)
+            self.assertEqual(group.ensure_mapped(rng_a, 4), 6)
+            addr_a = group._pools[0].slot_address(rng_a.base_block)
+            TestSparseVirtMem._tensor_at(int(addr_a), n).fill_(7.0)
+            canon = [self._FakeCanonicalPage(), self._FakeCanonicalPage()]
+            group.register_live_canonical_span(rng_a, canon, CachedCudaEvent.NULL)
+            # B: same-content private duplicate in its own range.
+            rng_b = group.reserve_sequence(4)
+            self.assertEqual(group.ensure_mapped(rng_b, 4), 6)
+            self.assertEqual(self.budget.used_pages, 12)
+            addr_b = group._pools[0].slot_address(rng_b.base_block)
+            TestSparseVirtMem._tensor_at(int(addr_b), n).fill_(8.0)
+            torch.cuda.synchronize()
+            # Remap B's head onto the span (caller-quiesce contract).
+            hit = group.lookup_canonical_span(canon[0], canon, count_stats=False)
+            self.assertIsNotNone(hit)
+            freed = group.remap_range_onto_span(rng_b, hit[0], hit[1], hit[2])
+            self.assertEqual(freed, 3)  # pool0: 2 chunks, pool1: 1 chunk
+            self.assertEqual(self.budget.used_pages, 9)
+            self.assertEqual(rng_b._alias_span_key, (hit[0], 2))
+            self.assertEqual(group.dedup_remapped_pages, 3)
+            # B's VA now reads the canonical bytes...
+            tb = TestSparseVirtMem._tensor_at(int(addr_b), n)
+            self.assertTrue(bool((tb == 7.0).all().item()))
+            # ...and shares physical pages with A (write A, read B).
+            TestSparseVirtMem._tensor_at(int(addr_a), n).fill_(9.5)
+            torch.cuda.synchronize()
+            tb2 = TestSparseVirtMem._tensor_at(int(addr_b), n)
+            self.assertTrue(bool((tb2 == 9.5).all().item()))
+            group.free_sequence(rng_b, CachedCudaEvent.NULL)
+            group.free_sequence(rng_a, CachedCudaEvent.NULL)
+            torch.cuda.synchronize()
+            group.drain_reclaim(CachedCudaEvent.NULL)
+            group.spill_retained(1 << 62)
+            group.spill_canonical_spans(1 << 62)
+            self.assertEqual(self.budget.used_pages, 0)
+            self.assertEqual(group.mapped_pages, 0)
+        finally:
+            group.destroy()
+
     def test_canonical_span_registry_alias_roundtrip(self) -> None:
         """P3 registry roundtrip: register, alias, park, adopt affinely.
 
@@ -2588,6 +2642,108 @@ class TestArenaPrefixAliasing(unittest.TestCase):
         torch.cuda.synchronize()
         manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
+
+    def test_dedup_remap_frees_commit_conflict_loser(self) -> None:
+        """P3 v2 pressure-time dedup at the manager seam: the loser shape.
+
+        A and B prefill the same tokens concurrently; A commits first
+        (winner, owner-live span), B's commit takes the arena conflict
+        branch (sequence-private duplicates referencing A's tree blocks).
+        The dedup scan finds B, the remap re-backs B's prefix with A's
+        physical pages at the same VA -- B's holders, slots, and offsets
+        are untouched -- and the duplicates' budget charge is freed.
+        """
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        pg = self._pool_group()
+        n_tok = self.PREFIX_BLOCKS * self.TPB
+        tokens = [7000 + i for i in range(n_tok)]
+        cap = (self.PREFIX_BLOCKS + 4) * self.TPB
+
+        kv_a = manager.create_kv_cache(max_capacity=cap)
+        kv_b = manager.create_kv_cache(max_capacity=cap)  # before any commit: no match
+        with TemporaryCudaStream([]) as s, TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv_a.resume(CudaStream(s.handle)))
+            self.assertTrue(kv_b.resume(CudaStream(s2.handle)))
+            self.assertTrue(kv_a.resize(n_tok))
+            self.assertTrue(kv_b.resize(n_tok))
+            a0 = list(kv_a.get_base_page_indices(LifeCycleId(0)))[0]
+            b0 = list(kv_b.get_base_page_indices(LifeCycleId(0)))[0]
+            self._block_floats(a0).fill_(41.0)
+            self._block_floats(b0).fill_(42.0)  # B's own (equivalent) KV
+            torch.cuda.synchronize()
+            kv_a.commit(tokens)  # winner; owner-live span registers here
+            kv_b.commit(tokens)  # loser -> private duplicates of A's blocks
+            self.assertEqual(len(pg._canonical_spans), 1)
+            used_before = budget.used_pages
+            hits_before = pg.alias_hits
+            misses_before = pg.alias_misses
+
+            freed = manager.dedup_remap_gpu(1 << 62)
+            self.assertEqual(freed, 1)  # 64 x 32KiB blocks = 1 chunk
+            self.assertEqual(budget.used_pages, used_before - 1)
+            self.assertEqual(pg.dedup_remapped_pages, 1)
+            self.assertIsNotNone(kv_b._arena_ranges[PoolGroupIndex(0)]._alias_span_key)
+            # The scan must not disturb the admission counters.
+            self.assertEqual(pg.alias_hits, hits_before)
+            self.assertEqual(pg.alias_misses, misses_before)
+            # B's VA now reads A's bytes (same physical page).
+            self.assertTrue(bool((self._block_floats(b0) == 41.0).all().item()))
+            self._block_floats(a0).fill_(43.0)
+            torch.cuda.synchronize()
+            self.assertTrue(bool((self._block_floats(b0) == 43.0).all().item()))
+            # Idempotent: nothing left to dedup.
+            self.assertEqual(manager.dedup_remap_gpu(1 << 62), 0)
+            kv_b.close()
+            kv_a.close()
+        s.take_finish_event().synchronize()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        torch.cuda.synchronize()
+        manager._storage.spill_gpu_retained(1 << 62)
+        self.assertEqual(budget.used_pages, 0)
+
+    def test_reclaim_ladder_dedups_to_grow(self) -> None:
+        """The reclaim ladder reaches the dedup rung under real exhaustion.
+
+        Quota of exactly 2 pages: winner A holds one, loser B the other.
+        B's growth past its first chunk raises OutOfPagesError; drain and
+        the parked-range spill free nothing (both sequences live), so the
+        dedup rung remaps B's duplicate prefix onto A's pages -- and the
+        growth then succeeds. No preemption, no registry spill.
+        """
+        cfg = _make_manager_config(gpu_quota=4 * MiB, host_quota=64 * MiB)
+        cfg.contiguous_arena = ContiguousArenaConfig(map_ahead_pages=0, prefix_aliasing=True)
+        manager = KVCacheManager(cfg)
+        try:
+            budget = manager._storage.gpu_page_budget
+            pg = manager._storage._gpu_arena_storage().pool_group(PoolGroupIndex(0))
+            n_tok = self.PREFIX_BLOCKS * self.TPB
+            tokens = [8000 + i for i in range(n_tok)]
+            cap = (self.PREFIX_BLOCKS + 4) * self.TPB
+            kv_a = manager.create_kv_cache(max_capacity=cap)
+            kv_b = manager.create_kv_cache(max_capacity=cap)
+            with TemporaryCudaStream([]) as s, TemporaryCudaStream([]) as s2:
+                self.assertTrue(kv_a.resume(CudaStream(s.handle)))
+                self.assertTrue(kv_b.resume(CudaStream(s2.handle)))
+                self.assertTrue(kv_a.resize(n_tok))
+                self.assertTrue(kv_b.resize(n_tok))
+                torch.cuda.synchronize()
+                kv_a.commit(tokens)  # winner
+                kv_b.commit(tokens)  # loser duplicates
+                self.assertEqual(budget.free_pages, 0)
+                # Growth needs a second chunk; only the dedup rung can free.
+                self.assertTrue(kv_b.resize(n_tok + self.TPB))
+                self.assertEqual(pg.dedup_remapped_pages, 1)
+                self.assertEqual(pg.spilled_spans, 0)  # registry survived
+                self.assertEqual(budget.free_pages, 0)  # freed page consumed
+                kv_b.close()
+                kv_a.close()
+            s.take_finish_event().synchronize()
+            s2.take_finish_event().synchronize()
+            manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        finally:
+            manager.shutdown()
 
     def test_stale_span_falls_back_to_copy(self) -> None:
         """Spill between an admission's lookup hit and its first resume.

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1023,17 +1023,102 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
         with self.assertRaises(ValueError):
             manager.create_kv_cache(input_tokens=tokens, max_capacity=self.TPB)
 
-    def test_suspend_not_supported_yet(self) -> None:
+    def _host_used(self) -> int:
+        stats = self.manager._storage.get_statistics(CacheLevel(1))[0]
+        return stats.total - stats.free
+
+    def test_suspend_resume_roundtrip(self) -> None:
+        """§4.5 suspend/resume round-trip.
+
+        Suspend writes committed AND uncommitted blocks out to host and
+        releases the VA ranges; resume reserves fresh ranges and copies the
+        resident state back, byte-identical.
+        """
         manager = self.manager
-        kv = manager.create_kv_cache(max_capacity=2 * self.TPB)
+        budget = manager._storage.gpu_page_budget
+        kv = manager.create_kv_cache(max_capacity=4 * self.TPB)
         with TemporaryCudaStream([]) as s:
             stream = CudaStream(s.handle)
             self.assertTrue(kv.resume(stream))
-            with self.assertRaises(LogicError):
-                kv.suspend()
-            kv.close()
+            self.assertTrue(kv.resize(3 * self.TPB))
+            for j, idx in enumerate(kv.get_base_page_indices(LifeCycleId(0))):
+                self._block_floats(idx).fill_(1.0 + j)
+            torch.cuda.synchronize()
+            kv.commit([400 + i for i in range(2 * self.TPB)])  # block 2 stays uncommitted
+            kv.suspend()
         s.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(budget.used_pages, 0)
+        self.assertEqual(self._host_used(), 3)  # 2 canonical + 1 uncommitted
+
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv.resume(stream2))
+            torch.cuda.synchronize()
+            indices = list(kv.get_base_page_indices(LifeCycleId(0)))
+            self.assertEqual(indices, list(range(indices[0], indices[0] + 3)))
+            for j, idx in enumerate(indices):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 1.0 + j).all().item()))
+            # the moved-back uncommitted block freed its host slot
+            self.assertEqual(self._host_used(), 2)
+            # growth continues the same consecutive run
+            self.assertTrue(kv.resize(4 * self.TPB))
+            indices = list(kv.get_base_page_indices(LifeCycleId(0)))
+            self.assertEqual(indices, list(range(indices[0], indices[0] + 4)))
+            kv.close()
+        s2.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(budget.used_pages, 0)
+        self.assertEqual(self._host_used(), 2)
+
+    def test_suspend_drops_private_copies(self) -> None:
+        """§4.5 x §4.4 interaction.
+
+        Suspending a sequence whose prefix was onboarded from the radix tree
+        swaps its private copies back to the canonical entries (no host
+        duplication) and re-onboards them on resume.
+        """
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        tokens = [500 + i for i in range(2 * self.TPB)]
+        kv1 = manager.create_kv_cache(input_tokens=tokens, max_capacity=2 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv1.resume(stream))
+            self.assertTrue(kv1.resize(2 * self.TPB))
+            for j, idx in enumerate(kv1.get_base_page_indices(LifeCycleId(0))):
+                self._block_floats(idx).fill_(5.0 + j)
+            torch.cuda.synchronize()
+            kv1.commit(tokens)
+            kv1.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(self._host_used(), 2)
+
+        kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        self.assertEqual(kv2.history_length, 2 * self.TPB)
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv2.resume(stream2))
+            torch.cuda.synchronize()
+            kv2.suspend()
+        s2.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(budget.used_pages, 0)
+        self.assertEqual(self._host_used(), 2)  # privates dropped, no duplicates
+
+        with TemporaryCudaStream([]) as s3:
+            stream3 = CudaStream(s3.handle)
+            self.assertTrue(kv2.resume(stream3))
+            torch.cuda.synchronize()
+            for j, idx in enumerate(kv2.get_base_page_indices(LifeCycleId(0))):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 5.0 + j).all().item()))
+            kv2.close()
+        s3.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(self._host_used(), 2)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1075,6 +1075,41 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
         manager.drain_gpu_reclaim()
         self.assertEqual(budget.used_pages, 0)
 
+    def test_intra_batch_commit_conflict_keeps_committing(self) -> None:
+        """§4.4 intra-batch commit conflict.
+
+        When another sequence committed the same tokens first (shared system
+        prompts under concurrency), the loser must keep its own pages as
+        private committed copies and continue committing -- not assert and
+        not stop (rebasing is disabled in arena mode).
+        """
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        tokens = [600 + i for i in range(2 * self.TPB)]
+        kv1 = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        kv2 = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv1.resume(stream))
+            self.assertTrue(kv2.resume(stream))
+            self.assertTrue(kv1.resize(2 * self.TPB))
+            self.assertTrue(kv2.resize(2 * self.TPB))
+            kv1.commit(tokens)  # registers both blocks in the radix tree
+            kv2.commit(tokens)  # conflict: same tokens, must go private
+            self.assertEqual(kv2.num_committed_tokens, 2 * self.TPB)
+            self.assertEqual(int(kv2._num_committed_blocks), 2)
+            kv1.close()
+            kv2.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 2)
+        self.assertEqual(budget.used_pages, 0)
+        # only the canonical copies were offloaded: no duplicates on host
+        self.assertEqual(self._host_used(), 2)
+        # and the canonical entries remain reusable
+        kv3 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        self.assertEqual(kv3.history_length, 2 * self.TPB)
+        kv3.close()
+
     def test_suspend_resume_roundtrip(self) -> None:
         """§4.5 suspend/resume round-trip.
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -283,6 +283,75 @@ class TestSparseVirtMem(unittest.TestCase):
         finally:
             vm.destroy()
 
+    def test_alias_map_shares_bytes_and_refcounts(self) -> None:
+        """P3 aliasing: one physical handle mapped at two VA addresses.
+
+        Both mappings (across two reservations) show the same bytes;
+        unmapping either alias in either order keeps the handle alive
+        until the last reference drops.
+        """
+        vm_a = VirtMem(8 * MiB, self.allocator)
+        vm_b = VirtMem(8 * MiB, self.allocator)
+        try:
+            vm_a.map_range(0, 2)
+            shared = [vm_a.shared_chunk(0), vm_a.shared_chunk(2 * MiB)]
+            self.assertEqual([s.num_refs for s in shared], [1, 1])
+            # alias into a DIFFERENT reservation at a different offset
+            vm_b.map_alias(4 * MiB, shared)
+            self.assertEqual([s.num_refs for s in shared], [2, 2])
+            self.assertEqual(vm_b.num_sparse_chunks, 2)
+            n = (2 * MiB) // 4
+            src = self._tensor_at(int(vm_a.address), n)
+            dst = self._tensor_at(int(vm_b.address) + 4 * MiB, n)
+            src.fill_(3.25)
+            torch.cuda.synchronize()
+            self.assertTrue(bool((dst == 3.25).all().item()))
+            # owner unmaps first; alias keeps the bytes (refcount holds)
+            torch.cuda.synchronize()
+            vm_a.unmap_range(0, 2)
+            self.assertEqual([s.num_refs for s in shared], [1, 1])
+            dst2 = self._tensor_at(int(vm_b.address) + 4 * MiB, n)
+            self.assertTrue(bool((dst2 == 3.25).all().item()))
+            torch.cuda.synchronize()
+            vm_b.unmap_range(4 * MiB, 2)
+            self.assertEqual([s.num_refs for s in shared], [0, 0])
+        finally:
+            vm_a.destroy()
+            vm_b.destroy()
+
+    def test_alias_destroy_drops_refs(self) -> None:
+        """destroy() of an alias-holding reservation drops references.
+
+        The shared handle survives while another mapping lives.
+        """
+        vm_a = VirtMem(4 * MiB, self.allocator)
+        vm_b = VirtMem(4 * MiB, self.allocator)
+        try:
+            vm_a.map_range(0, 1)
+            shared = vm_a.shared_chunk(0)
+            vm_b.map_alias(0, [shared])
+            self.assertEqual(shared.num_refs, 2)
+            vm_b.destroy()
+            self.assertEqual(shared.num_refs, 1)
+            self.assertTrue(vm_a.is_mapped(0))
+            n = (2 * MiB) // 4
+            t = self._tensor_at(int(vm_a.address), n)
+            t.fill_(9.5)
+            torch.cuda.synchronize()
+            self.assertTrue(bool((t == 9.5).all().item()))
+        finally:
+            vm_a.destroy()
+
+    def test_alias_collision_asserts(self) -> None:
+        vm = VirtMem(8 * MiB, self.allocator)
+        try:
+            vm.map_range(0, 1)
+            shared = vm.shared_chunk(0)
+            with self.assertRaises(AssertionError):
+                vm.map_alias(0, [shared])  # chunk already mapped
+        finally:
+            vm.destroy()
+
     @staticmethod
     def _tensor_at(ptr: int, num_float32: int) -> "torch.Tensor":
         # Build a torch tensor aliasing an existing device pointer via the
@@ -364,6 +433,79 @@ class TestSequenceArena(unittest.TestCase):
             arena.ensure_mapped(b, 3)
             # mapping b must not have touched a's already-mapped pages twice
             self.assertGreater(arena.mapped_pages, pages_a)
+        finally:
+            arena.destroy()
+
+    def test_alias_prefix_shares_pages_uncharged(self) -> None:
+        """P3: a second sequence alias-maps the canonical prefix's pages.
+
+        Zero budget charge, correct frontier (growth continues past the
+        alias), and reclaim releases only the charged surplus while the
+        alias holds the handles alive.
+        """
+        budget = PageBudget(16)
+        arena = SequenceArena(
+            block_capacity=16,
+            record_stride=4 * MiB,  # 1 block = 2 pages
+            phys_mem_allocator=self.allocator,
+            map_ahead_pages=0,
+            page_budget=budget,
+        )
+        try:
+            a = arena.reserve(4)
+            arena.ensure_mapped(a, 4)  # 8 pages charged
+            self.assertEqual(budget.used_pages, 8)
+            # 3 of A's 4 blocks are the "committed prefix": fully covered
+            # chunks only -> 3 blocks * 4MiB / 2MiB = 6 chunks, all full.
+            self.assertEqual(arena.aliasable_prefix_blocks(a, 3), 3)
+            shared = arena.shared_prefix_chunks(a, 3)
+            self.assertEqual(sum(len(s) for s in shared), 6)
+            b = arena.reserve(4)
+            self.assertEqual(arena.alias_prefix(b, shared), 6)
+            self.assertEqual(budget.used_pages, 8)  # aliases charge nothing
+            self.assertEqual(arena.aliased_pages_in_range(b), 6)
+            self.assertEqual(arena.mapped_pages_in_range(b), 6)
+            self.assertEqual(arena.charged_pages_in_range(b), 0)
+            # growth continues after the aliased frontier
+            arena.ensure_mapped(b, 4)  # 8 chunks target; 6 aliased -> +2
+            self.assertEqual(budget.used_pages, 10)
+            self.assertEqual(arena.charged_pages_in_range(b), 2)
+            # write via A's VA, read via B's VA (same physical bytes)
+            n = (2 * MiB) // 4
+            addr_a = int(arena.base_address(0)) + a * 4 * MiB
+            addr_b = int(arena.base_address(0)) + b * 4 * MiB
+            ta = TestSparseVirtMem._tensor_at(addr_a, n)
+            ta.fill_(5.75)
+            torch.cuda.synchronize()
+            tb = TestSparseVirtMem._tensor_at(addr_b, n)
+            self.assertTrue(bool((tb == 5.75).all().item()))
+            # reclaim A (canonical owner): B's aliases keep the handles
+            torch.cuda.synchronize()
+            arena.reclaim(a)
+            self.assertEqual(budget.used_pages, 2)  # only A's own 8 released
+            tb2 = TestSparseVirtMem._tensor_at(addr_b, n)
+            self.assertTrue(bool((tb2 == 5.75).all().item()))
+            # reclaim B: releases only its charged surplus (2), aliased 6 not
+            torch.cuda.synchronize()
+            arena.reclaim(b)
+            self.assertEqual(budget.used_pages, 0)
+            self.assertEqual(arena.mapped_pages, 0)
+        finally:
+            arena.destroy()
+
+    def test_aliasable_prefix_partial_boundary_page(self) -> None:
+        """A half-covered boundary chunk is trimmed from the aliasable span.
+
+        The remainder falls back to the copy path.
+        """
+        arena = self._arena(record_stride=1 * MiB, capacity=32, margin=0)  # 2 blocks/page
+        try:
+            base = arena.reserve(8)
+            arena.ensure_mapped(base, 8)
+            self.assertEqual(arena.aliasable_prefix_blocks(base, 3), 2)  # 3rd block half-page
+            self.assertEqual(arena.aliasable_prefix_blocks(base, 4), 4)
+            shared = arena.shared_prefix_chunks(base, 3)
+            self.assertEqual(sum(len(s) for s in shared), 1)  # only the full chunk
         finally:
             arena.destroy()
 
@@ -715,6 +857,88 @@ class TestArenaPoolGroup(unittest.TestCase):
             self.assertEqual(group.ensure_mapped(fresh, 4), 6)  # must remap
             group.free_sequence(fresh, CachedCudaEvent.NULL)
             group.drain_reclaim(CachedCudaEvent.NULL)
+        finally:
+            group.destroy()
+
+    class _FakeCanonicalPage:
+        """Stand-in for a canonical (host-tier) page in registry tests."""
+
+        __slots__ = ("__rawref__",)
+
+        def __init__(self) -> None:
+            self.__rawref__ = rawref.NULL
+
+    def test_canonical_span_registry_alias_roundtrip(self) -> None:
+        """P3 registry roundtrip: register, alias, park, adopt affinely.
+
+        The aliased chunks charge nothing, parking carries the alias
+        signature, and charged accounting stays exact through every
+        transition.
+        """
+        group = self._group()
+        group._prefix_aliasing = True
+        try:
+            # Owner A: 4 blocks; blocks 0-1 are the "committed prefix".
+            # Pools (2MiB, 1MiB) on 2MiB pages: prefix covers pool0 2 full
+            # chunks + pool1 1 full chunk -> span = 3 pages.
+            rng_a = group.reserve_sequence(4)
+            self.assertEqual(group.ensure_mapped(rng_a, 4), 6)
+            self.assertEqual(self.budget.used_pages, 6)
+            canon = [self._FakeCanonicalPage(), self._FakeCanonicalPage()]
+            group.register_canonical_span(rng_a, canon, CachedCudaEvent.NULL)
+            key = id(canon[0])
+            self.assertEqual(rng_a._alias_span_key, key)
+            self.assertEqual(group.canonical_span_pages, 3)
+            # charge moved range -> registry (net zero), retained-at-will
+            self.assertEqual(self.budget.used_pages, 6)
+            self.assertEqual(self.budget.retained_pages, 3)
+
+            # Reuse admission B: registry hit requires full-span coverage.
+            self.assertIsNone(group.lookup_canonical_span(canon[0], canon[:1]))
+            hit = group.lookup_canonical_span(canon[0], canon)
+            self.assertIsNotNone(hit)
+            rng_b = group.reserve_sequence(4)  # nothing parked yet -> fresh
+            self.assertNotEqual(rng_b.base_block, rng_a.base_block)
+            self.assertEqual(group.alias_span_into_range(rng_b, hit[0], hit[1]), 3)
+            self.assertEqual(self.budget.used_pages, 6)  # aliases charge nothing
+            # B's remainder maps fresh: pool0 +2, pool1 +1
+            self.assertEqual(group.ensure_mapped(rng_b, 4), 3)
+            self.assertEqual(self.budget.used_pages, 9)
+
+            # Same physical bytes through both ranges' pool-0 VA addresses.
+            n = (2 * MiB) // 4
+            addr_a = group._pools[0].slot_address(rng_a.base_block)
+            addr_b = group._pools[0].slot_address(rng_b.base_block)
+            ta = TestSparseVirtMem._tensor_at(int(addr_a), n)
+            ta.fill_(11.5)
+            torch.cuda.synchronize()
+            tb = TestSparseVirtMem._tensor_at(int(addr_b), n)
+            self.assertTrue(bool((tb == 11.5).all().item()))
+
+            # Owner A parks with its signature; only same-key admissions
+            # adopt it. A None-key reservation must get fresh VA instead.
+            group.free_sequence(rng_a, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)
+            plain = group.reserve_sequence(4)  # alias_key=None
+            self.assertNotEqual(plain.base_block, rng_a.base_block)
+            adopted = group.reserve_sequence(4, alias_key=key)
+            self.assertEqual(adopted.base_block, rng_a.base_block)
+            self.assertEqual(adopted._alias_span_key, key)
+
+            # Spill the registry: pins drop, lookups miss, aliases keep bytes.
+            torch.cuda.synchronize()
+            self.assertEqual(group.spill_canonical_spans(1 << 62), 3)
+            self.assertIsNone(group.lookup_canonical_span(canon[0], canon))
+            tb2 = TestSparseVirtMem._tensor_at(int(addr_b), n)
+            self.assertTrue(bool((tb2 == 11.5).all().item()))
+
+            for rng in (rng_b, plain, adopted):
+                group.free_sequence(rng, CachedCudaEvent.NULL)
+            group.drain_reclaim(CachedCudaEvent.NULL)
+            torch.cuda.synchronize()
+            group.spill_retained(1 << 62)
+            self.assertEqual(self.budget.used_pages, 0)
+            self.assertEqual(group.mapped_pages, 0)
         finally:
             group.destroy()
 
@@ -1889,6 +2113,141 @@ class TestArenaWriteThroughOnCommit(TestArenaKVCacheManagerEndToEnd):
         s2.take_finish_event().synchronize()
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(self._host_used(), 2)
+
+
+@requires_cuda
+class TestArenaPrefixAliasing(unittest.TestCase):
+    """P3 prefix aliasing end-to-end at the manager seam.
+
+    A closing canonical owner's fully-committed prefix pages are pinned in
+    the canonical-span registry; a same-prefix admission adopts the parked
+    range prefix-affinely (or alias-maps a fresh one) and reads the SAME
+    physical bytes -- no H2D copy (proven by corrupting the host copies), no
+    new budget charge for the span. Spilling the registry falls back to the
+    host-copy path.
+    """
+
+    TPB = 16
+    # One full 2 MiB chunk of 32 KiB coalesced block records.
+    PREFIX_BLOCKS = 64
+
+    def setUp(self) -> None:
+        init_cuda_once()
+        cfg = _make_manager_config(gpu_quota=32 * MiB, host_quota=64 * MiB)
+        cfg.contiguous_arena = ContiguousArenaConfig(map_ahead_pages=0, prefix_aliasing=True)
+        self.manager = KVCacheManager(cfg)
+
+    def tearDown(self) -> None:
+        self.manager.shutdown()
+        del self.manager
+
+    def _block_floats(self, page_index: int) -> "torch.Tensor":
+        addr = int(
+            self.manager._storage.slot_address(
+                GPU_LEVEL, PoolGroupIndex(0), page_index, PoolIndex(0)
+            )
+        )
+        return TestSparseVirtMem._tensor_at(addr, (4 * 8192) // 4)
+
+    def _host_floats(self, slot_id: int) -> "torch.Tensor":
+        import ctypes
+
+        addr = int(
+            self.manager._storage.slot_address(
+                CacheLevel(1), PoolGroupIndex(0), slot_id, PoolIndex(0)
+            )
+        )
+        buf = (ctypes.c_float * ((4 * 8192) // 4)).from_address(addr)
+        return torch.frombuffer(buf, dtype=torch.float32)
+
+    def _pool_group(self):
+        return self.manager._storage._gpu_arena_storage().pool_group(PoolGroupIndex(0))
+
+    def test_alias_roundtrip_zero_copy_and_affine_adoption(self) -> None:
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        pg = self._pool_group()
+        n_tok = self.PREFIX_BLOCKS * self.TPB
+        tokens = [1000 + i for i in range(n_tok)]
+
+        # Owner A: write patterns, commit the full-chunk prefix, close.
+        kv_a = manager.create_kv_cache(max_capacity=(self.PREFIX_BLOCKS + 4) * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv_a.resume(stream))
+            self.assertTrue(kv_a.resize(n_tok))
+            a_indices = list(kv_a.get_base_page_indices(LifeCycleId(0)))[: self.PREFIX_BLOCKS]
+            for j, idx in enumerate(a_indices):
+                self._block_floats(idx).fill_(float(j))
+            torch.cuda.synchronize()
+            kv_a.commit(tokens)
+            kv_a.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(pg.canonical_span_pages, 1)  # 64 x 32 KiB = 1 chunk
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)  # parked
+        used_after_a = budget.used_pages
+
+        # B: same-prefix admission. Corrupt every host copy first: correct
+        # GPU bytes can then only have come through the alias mapping.
+        kv_b = manager.create_kv_cache(
+            input_tokens=tokens + [1, 2], max_capacity=(self.PREFIX_BLOCKS + 4) * self.TPB
+        )
+        self.assertEqual(kv_b.history_length, n_tok)
+        for ordinal in range(self.PREFIX_BLOCKS):
+            host_id = kv_b._blocks[ordinal].pages[0][LifeCycleId(0)].page.slot_id
+            self._host_floats(host_id).fill_(-777.0)
+        with TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv_b.resume(CudaStream(s2.handle)))
+            self.assertEqual(pg.alias_hits, 1)
+            torch.cuda.synchronize()
+            b_indices = list(kv_b.get_base_page_indices(LifeCycleId(0)))[: self.PREFIX_BLOCKS]
+            for j, idx in enumerate(b_indices):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == float(j)).all().item()), f"block {j} not aliased")
+            kv_b.close()
+        s2.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+
+        # C: adoption is prefix-affine -- C inherits a parked same-signature
+        # range with the alias mappings intact (no new maps for the span).
+        kv_c = manager.create_kv_cache(
+            input_tokens=tokens + [3, 4], max_capacity=(self.PREFIX_BLOCKS + 4) * self.TPB
+        )
+        with TemporaryCudaStream([]) as s3:
+            self.assertTrue(kv_c.resume(CudaStream(s3.handle)))
+            self.assertEqual(pg.alias_hits, 2)
+            self.assertIsNotNone(kv_c._arena_ranges[PoolGroupIndex(0)]._alias_span_key)
+            torch.cuda.synchronize()
+            c_indices = list(kv_c.get_base_page_indices(LifeCycleId(0)))[: self.PREFIX_BLOCKS]
+            for j, idx in enumerate(c_indices):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == float(j)).all().item()), f"block {j} lost")
+            kv_c.close()
+        s3.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        self.assertLessEqual(budget.used_pages, used_after_a + 2)
+
+        # Pressure spill drops parked ranges AND the registry pin; the next
+        # same-prefix admission misses and falls back to the (corrupted)
+        # host copies -- proving the fallback path engages.
+        torch.cuda.synchronize()
+        manager._storage.spill_gpu_retained(1 << 62)
+        self.assertEqual(budget.used_pages, 0)
+        self.assertEqual(pg.canonical_span_pages, 0)
+        kv_d = manager.create_kv_cache(
+            input_tokens=tokens + [5, 6], max_capacity=(self.PREFIX_BLOCKS + 4) * self.TPB
+        )
+        with TemporaryCudaStream([]) as s4:
+            self.assertTrue(kv_d.resume(CudaStream(s4.handle)))
+            self.assertEqual(pg.alias_hits, 2)  # no new hit
+            self.assertGreater(pg.alias_misses, 0)
+            torch.cuda.synchronize()
+            d_indices = list(kv_d.get_base_page_indices(LifeCycleId(0)))[: self.PREFIX_BLOCKS]
+            data = self._block_floats(d_indices[0])
+            self.assertTrue(bool((data == -777.0).all().item()), "fallback not from host")
+            kv_d.close()
+        s4.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
 
 @requires_cuda

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -957,6 +957,28 @@ class TestGpuArenaCacheLevelStorage(unittest.TestCase):
     def setUp(self) -> None:
         init_cuda_once()
 
+    def test_total_quota_reports_physical_not_va(self) -> None:
+        """``total_quota`` must be the PHYSICAL page-budget bytes.
+
+        The base implementation sums pool byte sizes = the VA reservation
+        extent; the KV memory estimator credits ``total_quota`` back as a
+        "temporary pool to be freed", so reporting VA over-grants the final
+        KV budget (observed +8 GiB on H100: 60.8 vs 52.5 GiB quota).
+        """
+        storage = GpuArenaCacheLevelStorage(
+            slot_size_lists=[[2 * MiB], [1 * MiB]],
+            block_capacity_list=[16, 16],
+            page_index_scale_list=[64, 32],
+            quota=8 * self.PAGE,
+            phys_page_size=self.PAGE,
+            map_ahead_pages=0,
+        )
+        try:
+            # VA extent is 16 blocks x (2 MiB + 1 MiB) = 48 MiB >> quota.
+            self.assertEqual(storage.total_quota, 8 * self.PAGE)
+        finally:
+            storage.destroy()
+
     def test_budget_shared_across_pool_groups(self) -> None:
         storage = GpuArenaCacheLevelStorage(
             slot_size_lists=[[2 * MiB], [1 * MiB]],
@@ -2283,9 +2305,7 @@ class TestArenaPrefixAliasing(unittest.TestCase):
         manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
         # Admission: lookup HIT stored (unpinned) on the kv cache.
-        kv_b = manager.create_kv_cache(
-            input_tokens=tokens + [1], max_capacity=n_tok + 4 * self.TPB
-        )
+        kv_b = manager.create_kv_cache(input_tokens=tokens + [1], max_capacity=n_tok + 4 * self.TPB)
         self.assertEqual(pg.alias_hits, 1)
         # Pressure: everything spills, registry pins drop to zero refs.
         torch.cuda.synchronize()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1121,5 +1121,93 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
         self.assertEqual(self._host_used(), 2)
 
 
+@requires_cuda
+class TestArenaWriteThroughOnCommit(TestArenaKVCacheManagerEndToEnd):
+    """The §4.3 ON_COMMIT write-through policy.
+
+    Every end-to-end scenario must behave identically (inherited tests);
+    additionally, copies happen at commit time and the free path adopts them
+    instead of copying.
+    """
+
+    def setUp(self) -> None:
+        init_cuda_once()
+        cfg = _make_manager_config(gpu_quota=32 * MiB, host_quota=32 * MiB)
+        cfg.contiguous_arena = ContiguousArenaConfig(
+            map_ahead_pages=0, write_through=WriteThroughPolicy.ON_COMMIT
+        )
+        self.manager = KVCacheManager(cfg)
+
+    def test_copies_at_commit_and_adopts_on_close(self) -> None:
+        manager = self.manager
+        tokens = [700 + i for i in range(2 * self.TPB)]
+        kv = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv.resume(stream))
+            self.assertTrue(kv.resize(2 * self.TPB))
+            for j, idx in enumerate(kv.get_base_page_indices(LifeCycleId(0))):
+                self._block_floats(idx).fill_(7.0 + j)
+            torch.cuda.synchronize()
+            self.assertEqual(self._host_used(), 0)
+            kv.commit(tokens)
+            # write-through happened at commit: host copies exist while the
+            # blocks are still live on the GPU
+            self.assertEqual(self._host_used(), 2)
+            wt_ids = sorted(slot.slot_id for slot in kv._write_through_slots.values())
+            self.assertEqual(len(wt_ids), 2)
+            kv.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        # the free path adopted the write-through copies: no new host slots
+        self.assertEqual(self._host_used(), 2)
+        # the canonical pages now live in exactly those pre-copied slots
+        kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        self.assertEqual(kv2.history_length, 2 * self.TPB)
+        host_ids = sorted(kv2._blocks[o].pages[0][LifeCycleId(0)].page.slot_id for o in range(2))
+        self.assertEqual(host_ids, wt_ids)
+        # and the data survived: onboard and verify
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv2.resume(stream2))
+            torch.cuda.synchronize()
+            for j, idx in enumerate(kv2.get_base_page_indices(LifeCycleId(0))):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 7.0 + j).all().item()))
+            kv2.close()
+        s2.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(self._host_used(), 2)
+
+    def test_suspend_adopts_write_through_copies(self) -> None:
+        manager = self.manager
+        kv = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv.resume(stream))
+            self.assertTrue(kv.resize(3 * self.TPB))
+            for j, idx in enumerate(kv.get_base_page_indices(LifeCycleId(0))):
+                self._block_floats(idx).fill_(9.0 + j)
+            torch.cuda.synchronize()
+            kv.commit([800 + i for i in range(2 * self.TPB)])
+            self.assertEqual(self._host_used(), 2)  # written through at commit
+            kv.suspend()
+        s.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        # committed blocks adopted (still 2) + the uncommitted block moved (1)
+        self.assertEqual(self._host_used(), 3)
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv.resume(stream2))
+            torch.cuda.synchronize()
+            for j, idx in enumerate(kv.get_base_page_indices(LifeCycleId(0))):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 9.0 + j).all().item()))
+            kv.close()
+        s2.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(self._host_used(), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -505,7 +505,7 @@ class TestArenaPoolGroup(unittest.TestCase):
             for s in slots:
                 group.release(s)
             group.free_sequence(rng, CachedCudaEvent.NULL)
-            self.assertEqual(group.drain_reclaim(), 1)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)
             self.assertEqual(group.mapped_pages, 0)
             self.assertEqual(self.budget.used_pages, 0)
         finally:
@@ -518,9 +518,31 @@ class TestArenaPoolGroup(unittest.TestCase):
             group.ensure_mapped(rng, 2)
             slot = group.take_slot(rng, 0)
             group.free_sequence(rng, CachedCudaEvent.NULL)
-            self.assertEqual(group.drain_reclaim(), 0)  # slot still outstanding
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 0)  # slot still outstanding
             group.release(slot)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)
+        finally:
+            group.destroy()
+
+    def test_reclaim_gated_on_iteration_fence(self) -> None:
+        """Risk #3: a freed range must NOT be reclaimed before an
+        execution-stream fence recorded at a later drain point completes —
+        the overlap scheduler may have speculatively enqueued a step that
+        still reads the range when free_sequence runs."""
+        group = self._group()
+        try:
+            rng = group.reserve_sequence(2)
+            group.ensure_mapped(rng, 2)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            # Unfenced drains (e.g. the impl's internal pressure drains) must
+            # never reclaim a range that has no fence assigned yet.
+            self.assertEqual(group.drain_reclaim(), 0)
+            self.assertEqual(group.drain_reclaim(None), 0)
+            self.assertGreater(group.mapped_pages, 0)
+            # Assign-only fence, then an unfenced drain may reclaim.
+            group.fence_pending_frees(CachedCudaEvent.NULL)
             self.assertEqual(group.drain_reclaim(), 1)
+            self.assertEqual(group.mapped_pages, 0)
         finally:
             group.destroy()
 
@@ -541,7 +563,7 @@ class TestArenaPoolGroup(unittest.TestCase):
             with self.assertRaises(MemoryError):
                 group.reserve_sequence(1)
             group.free_sequence(rng, CachedCudaEvent.NULL)
-            group.drain_reclaim()
+            group.drain_reclaim(CachedCudaEvent.NULL)
         finally:
             group.destroy()
 
@@ -577,7 +599,7 @@ class TestGpuArenaCacheLevelStorage(unittest.TestCase):
             # free the first sequence; the second can now finish mapping
             g0.free_sequence(r0, CachedCudaEvent.NULL)
             g1.free_sequence(r1, CachedCudaEvent.NULL)
-            self.assertEqual(storage.drain_reclaim(), 2)
+            self.assertEqual(storage.drain_reclaim(CachedCudaEvent.NULL), 2)
             self.assertEqual(storage.page_budget.used_pages, 0)
         finally:
             storage.destroy()
@@ -758,7 +780,7 @@ class TestStorageManagerArenaMode(unittest.TestCase):
         self.assertEqual(slot.slot_id, rng.base_block)
         storage.release_slot(self.LC0, GPU_LEVEL, slot)
         storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
-        self.assertEqual(storage.drain_gpu_reclaim(), 1)
+        self.assertEqual(storage.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(budget.used_pages, 0)
 
     def test_offload_migrates_data_and_gates_reclaim(self) -> None:
@@ -787,7 +809,7 @@ class TestStorageManagerArenaMode(unittest.TestCase):
             self.assertTrue(bool((host_data == value).all().item()))
         # the vacated arena slots returned to the range: reclaim succeeds
         storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
-        self.assertEqual(storage.drain_gpu_reclaim(), 1)
+        self.assertEqual(storage.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(storage.gpu_page_budget.used_pages, 0)
         for page in pages:
             storage.release_slot(self.LC0, CacheLevel(1), page)
@@ -832,7 +854,7 @@ class TestStorageManagerArenaMode(unittest.TestCase):
         for slot in ret:
             storage.release_slot(self.LC0, GPU_LEVEL, slot)
         storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
-        self.assertEqual(storage.drain_gpu_reclaim(), 1)
+        self.assertEqual(storage.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         for page in src_pages:
             storage.release_slot(self.LC0, CacheLevel(1), page)
 
@@ -862,7 +884,7 @@ class TestStorageManagerArenaMode(unittest.TestCase):
         storage.release_slot(self.LC0, CacheLevel(1), host_slots[0])
         storage.release_slot(self.LC0, GPU_LEVEL, page)
         storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
-        self.assertEqual(storage.drain_gpu_reclaim(), 1)
+        self.assertEqual(storage.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
 
 
 @requires_cuda
@@ -907,7 +929,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv.close()
         s.take_finish_event().synchronize()
         # copy-on-free write-out finished -> the range is reclaimable
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(budget.used_pages, 0)
         # the 4 committed blocks live on in the host tier
         host_stats = manager._storage.get_statistics(CacheLevel(1))[0]
@@ -943,7 +965,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
                 kv.resize(3 * self.TPB)  # beyond the VA reservation
             kv.close()
         s.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
     def test_growth_backs_off_on_page_exhaustion(self) -> None:
         manager = self.manager
@@ -957,13 +979,16 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             self.assertTrue(kv1.resize(1024 * self.TPB))  # takes all 16 pages
             self.assertFalse(kv2.resize(512 * self.TPB))  # backs off, no crash
             kv1.close()
-            # kv1's range reclaim is gated on its finish event; once complete,
-            # kv2's next growth attempt drains it and succeeds.
+            # kv1's range reclaim is gated on its finish event AND an
+            # execution-stream fence assigned at an iteration-boundary drain
+            # (risk #3; the pyexecutor adapter fences every iteration). Model
+            # that boundary, then kv2's growth succeeds on the freed pages.
             torch.cuda.synchronize()
+            manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
             self.assertTrue(kv2.resize(512 * self.TPB))
             kv2.close()
         s.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
     def _block_floats(self, page_index: int) -> "torch.Tensor":
         addr = int(
@@ -995,7 +1020,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv1.commit(tokens)
             kv1.close()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         host_stats = manager._storage.get_statistics(CacheLevel(1))[0]
         self.assertEqual(host_stats.total - host_stats.free, 2)
 
@@ -1019,7 +1044,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             self.assertEqual(indices, list(range(indices[0], indices[0] + 3)))
             kv2.close()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(budget.used_pages, 0)
         # private copies were dropped, not offloaded: still exactly 2 host blocks
         host_stats = manager._storage.get_statistics(CacheLevel(1))[0]
@@ -1036,7 +1061,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv1.commit(tokens)
             kv1.close()
         s.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
         with self.assertRaises(ValueError):
             manager.create_kv_cache(input_tokens=tokens, max_capacity=self.TPB)
 
@@ -1063,7 +1088,11 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             self.assertEqual(budget.used_pages, budget.total_pages)
             kv1.close()
         s.take_finish_event().synchronize()
-        # reclaim is queued but deliberately NOT drained: utilization reads 100%
+        # reclaim is queued but deliberately NOT drained: utilization reads 100%.
+        # Assign the iteration-boundary fence only (risk #3) — in production the
+        # adapter fences every iteration; resume()'s internal drain may then
+        # reclaim fenced entries.
+        manager.fence_gpu_reclaim(CachedCudaEvent.NULL)
         self.assertEqual(budget.used_pages, budget.total_pages)
         kv2 = manager.create_kv_cache(max_capacity=2 * self.TPB)
         with TemporaryCudaStream([]) as s2:
@@ -1072,7 +1101,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             self.assertTrue(kv2.resize(2 * self.TPB))
             kv2.close()
         s2.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
         self.assertEqual(budget.used_pages, 0)
 
     def test_intra_batch_commit_conflict_keeps_committing(self) -> None:
@@ -1101,7 +1130,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv1.close()
             kv2.close()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 2)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 2)
         self.assertEqual(budget.used_pages, 0)
         # only the canonical copies were offloaded: no duplicates on host
         self.assertEqual(self._host_used(), 2)
@@ -1130,7 +1159,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv.commit([400 + i for i in range(2 * self.TPB)])  # block 2 stays uncommitted
             kv.suspend()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(budget.used_pages, 0)
         self.assertEqual(self._host_used(), 3)  # 2 canonical + 1 uncommitted
 
@@ -1151,7 +1180,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             self.assertEqual(indices, list(range(indices[0], indices[0] + 4)))
             kv.close()
         s2.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(budget.used_pages, 0)
         self.assertEqual(self._host_used(), 2)
 
@@ -1176,7 +1205,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv1.commit(tokens)
             kv1.close()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(self._host_used(), 2)
 
         kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
@@ -1187,7 +1216,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             torch.cuda.synchronize()
             kv2.suspend()
         s2.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(budget.used_pages, 0)
         self.assertEqual(self._host_used(), 2)  # privates dropped, no duplicates
 
@@ -1200,7 +1229,7 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
                 self.assertTrue(bool((data == 5.0 + j).all().item()))
             kv2.close()
         s3.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(self._host_used(), 2)
 
 
@@ -1257,7 +1286,7 @@ class TestArenaBatchedMapSweep(unittest.TestCase):
             torch.cuda.synchronize()
             kv.close()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(budget.used_pages, 0)
 
     def test_freed_before_flush_releases_charge(self) -> None:
@@ -1272,7 +1301,7 @@ class TestArenaBatchedMapSweep(unittest.TestCase):
             kv.close()  # close() itself flushes (its write-out reads pages)
         s.take_finish_event().synchronize()
         manager.flush_gpu_mappings()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(budget.used_pages, 0)
 
     def test_reuse_onboarding_stays_synchronous(self) -> None:
@@ -1293,7 +1322,7 @@ class TestArenaBatchedMapSweep(unittest.TestCase):
             kv1.commit(tokens)
             kv1.close()
         s.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
         # reuse hit: onboarding maps synchronously (its copies run immediately)
         kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
         self.assertEqual(kv2.history_length, 2 * self.TPB)
@@ -1309,7 +1338,7 @@ class TestArenaBatchedMapSweep(unittest.TestCase):
                 self.assertTrue(bool((data == 3.0 + j).all().item()))
             kv2.close()
         s2.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
 
 @requires_cuda
@@ -1374,7 +1403,7 @@ class TestArenaLazyRetention(unittest.TestCase):
         budget = manager._storage.gpu_page_budget
         tokens = [900 + i for i in range(2 * self.TPB)]
         self._commit_and_close(tokens, 11.0)
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)  # parked, not unmapped
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)  # parked, not unmapped
         self.assertGreater(budget.used_pages, 0)
         self.assertEqual(budget.retained_pages, budget.used_pages)
         # retained pages count as available for the resume gate
@@ -1384,7 +1413,7 @@ class TestArenaLazyRetention(unittest.TestCase):
         manager = self.manager
         tokens = [910 + i for i in range(2 * self.TPB)]
         self._commit_and_close(tokens, 21.0)
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         # corrupt the HOST copies: if onboarding reads from host, the new
         # sequence sees junk; correct data proves the D2D ghost path
         kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
@@ -1401,14 +1430,14 @@ class TestArenaLazyRetention(unittest.TestCase):
                 self.assertTrue(bool((data == 21.0 + j).all().item()), f"block {j} not D2D")
             kv2.close()
         s.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
     def test_pressure_spills_retained_and_falls_back_to_host(self) -> None:
         manager = self.manager
         budget = manager._storage.gpu_page_budget
         tokens = [920 + i for i in range(2 * self.TPB)]
         self._commit_and_close(tokens, 31.0)
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         retained_before = budget.retained_pages
         self.assertGreater(retained_before, 0)
         # a large fresh sequence needs (nearly) the whole 16-page budget:
@@ -1421,7 +1450,7 @@ class TestArenaLazyRetention(unittest.TestCase):
             self.assertEqual(budget.retained_pages, 0)  # spilled
             kv2.close()
         s.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
         # the ghost is gone; reuse now falls back to the (intact) host copy
         kv3 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
         self.assertEqual(kv3.history_length, 2 * self.TPB)
@@ -1434,7 +1463,7 @@ class TestArenaLazyRetention(unittest.TestCase):
                 self.assertTrue(bool((data == 31.0 + j).all().item()))
             kv3.close()
         s2.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
     def test_private_copies_refresh_ghosts(self) -> None:
         """Ghost refresh by private copies.
@@ -1447,7 +1476,7 @@ class TestArenaLazyRetention(unittest.TestCase):
         budget = manager._storage.gpu_page_budget
         tokens = [940 + i for i in range(2 * self.TPB)]
         self._commit_and_close(tokens, 41.0)  # kv1: canonical + oldest ghost
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         # kv2 reuses (D2D) and closes: its private copies refresh the ghosts
         kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
         with TemporaryCudaStream([]) as s:
@@ -1455,7 +1484,7 @@ class TestArenaLazyRetention(unittest.TestCase):
             self.assertTrue(kv2.resume(stream))
             kv2.close()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         # spill ONLY the LRU (kv1's) range; kv2's stays retained
         self.assertGreater(manager._storage.spill_gpu_retained(1), 0)
         self.assertGreater(budget.retained_pages, 0)
@@ -1474,7 +1503,7 @@ class TestArenaLazyRetention(unittest.TestCase):
                 self.assertTrue(bool((data == 41.0 + j).all().item()), f"block {j} lost ghost")
             kv3.close()
         s2.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
     def test_va_pressure_spills_retained(self) -> None:
         manager = self.manager
@@ -1488,7 +1517,7 @@ class TestArenaLazyRetention(unittest.TestCase):
             self.assertTrue(kv1.resize(2 * self.TPB))
             kv1.close()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)  # retained (holds VA)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)  # retained (holds VA)
         kv2 = manager.create_kv_cache(max_capacity=blocks * self.TPB)
         kv3 = manager.create_kv_cache(max_capacity=blocks * self.TPB)
         with TemporaryCudaStream([]) as s2:
@@ -1498,7 +1527,7 @@ class TestArenaLazyRetention(unittest.TestCase):
             kv2.close()
             kv3.close()
         s2.take_finish_event().synchronize()
-        manager.drain_gpu_reclaim()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
 
 @requires_cuda
@@ -1545,7 +1574,7 @@ class TestArenaWriteThroughOnCommit(TestArenaKVCacheManagerEndToEnd):
             self.assertEqual(len(wt_ids), 2)
             kv.close()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         # the free path adopted the write-through copies: no new host slots
         self.assertEqual(self._host_used(), 2)
         # the canonical pages now live in exactly those pre-copied slots
@@ -1563,7 +1592,7 @@ class TestArenaWriteThroughOnCommit(TestArenaKVCacheManagerEndToEnd):
                 self.assertTrue(bool((data == 7.0 + j).all().item()))
             kv2.close()
         s2.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(self._host_used(), 2)
 
     def test_suspend_adopts_write_through_copies(self) -> None:
@@ -1580,7 +1609,7 @@ class TestArenaWriteThroughOnCommit(TestArenaKVCacheManagerEndToEnd):
             self.assertEqual(self._host_used(), 2)  # written through at commit
             kv.suspend()
         s.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         # committed blocks adopted (still 2) + the uncommitted block moved (1)
         self.assertEqual(self._host_used(), 3)
         with TemporaryCudaStream([]) as s2:
@@ -1592,7 +1621,7 @@ class TestArenaWriteThroughOnCommit(TestArenaKVCacheManagerEndToEnd):
                 self.assertTrue(bool((data == 9.0 + j).all().item()))
             kv.close()
         s2.take_finish_event().synchronize()
-        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(self._host_used(), 2)
 
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -2256,6 +2256,55 @@ class TestArenaPrefixAliasing(unittest.TestCase):
         s4.take_finish_event().synchronize()
         manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
+    def test_stale_span_falls_back_to_copy(self) -> None:
+        """Spill between an admission's lookup hit and its first resume.
+
+        The hit is held unpinned across that window; pressure can spill the
+        registry in between, so the dead span must fall back to the
+        host-copy path instead of alias-mapping freed handles (this exact
+        shape crashed the tinyhost pressure run).
+        """
+        manager = self.manager
+        pg = self._pool_group()
+        n_tok = self.PREFIX_BLOCKS * self.TPB
+        tokens = [5000 + i for i in range(n_tok)]
+        kv_a = manager.create_kv_cache(max_capacity=n_tok + 4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            self.assertTrue(kv_a.resume(CudaStream(s.handle)))
+            self.assertTrue(kv_a.resize(n_tok))
+            for j, idx in enumerate(
+                list(kv_a.get_base_page_indices(LifeCycleId(0)))[: self.PREFIX_BLOCKS]
+            ):
+                self._block_floats(idx).fill_(float(j))
+            torch.cuda.synchronize()
+            kv_a.commit(tokens)
+            kv_a.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
+        # Admission: lookup HIT stored (unpinned) on the kv cache.
+        kv_b = manager.create_kv_cache(
+            input_tokens=tokens + [1], max_capacity=n_tok + 4 * self.TPB
+        )
+        self.assertEqual(pg.alias_hits, 1)
+        # Pressure: everything spills, registry pins drop to zero refs.
+        torch.cuda.synchronize()
+        manager._storage.spill_gpu_retained(1 << 62)
+        self.assertEqual(pg.canonical_span_pages, 0)
+        with TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv_b.resume(CudaStream(s2.handle)))  # must not crash
+            self.assertIsNone(kv_b._arena_ranges[PoolGroupIndex(0)]._alias_span_key)
+            torch.cuda.synchronize()
+            # intact host copies served the fallback -> bytes are correct
+            for j, idx in enumerate(
+                list(kv_b.get_base_page_indices(LifeCycleId(0)))[: self.PREFIX_BLOCKS]
+            ):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == float(j)).all().item()), f"block {j} wrong")
+            kv_b.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
     def test_alias_partial_span_from_longer_owner(self) -> None:
         """P3 partial-span aliasing: the shared-prompt benchmark shape.
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -40,9 +40,11 @@ if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
         AttentionLayerConfig,
         BufferConfig,
         ContiguousArenaConfig,
+        CudaStream,
         DataRole,
         GpuCacheTierConfig,
         HostCacheTierConfig,
+        KVCacheManager,
         KVCacheManagerConfig,
         WriteThroughPolicy,
         rawref,
@@ -68,15 +70,17 @@ if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
         PoolIndex,
     )
     from kv_cache_manager_v2._storage_manager import StorageManager, _coalesce_copy_tasks
-    from kv_cache_manager_v2._utils import CachedCudaEvent, init_cuda_once
+    from kv_cache_manager_v2._utils import CachedCudaEvent, TemporaryCudaStream, init_cuda_once
 else:
     from tensorrt_llm.runtime.kv_cache_manager_v2 import (
         AttentionLayerConfig,
         BufferConfig,
         ContiguousArenaConfig,
+        CudaStream,
         DataRole,
         GpuCacheTierConfig,
         HostCacheTierConfig,
+        KVCacheManager,
         KVCacheManagerConfig,
         WriteThroughPolicy,
         rawref,
@@ -116,7 +120,11 @@ else:
         StorageManager,
         _coalesce_copy_tasks,
     )
-    from tensorrt_llm.runtime.kv_cache_manager_v2._utils import CachedCudaEvent, init_cuda_once
+    from tensorrt_llm.runtime.kv_cache_manager_v2._utils import (
+        CachedCudaEvent,
+        TemporaryCudaStream,
+        init_cuda_once,
+    )
 
 MiB = 1 << 20
 requires_cuda = unittest.skipUnless(_CUDA_AVAILABLE, "requires CUDA")
@@ -855,6 +863,120 @@ class TestStorageManagerArenaMode(unittest.TestCase):
         storage.release_slot(self.LC0, GPU_LEVEL, page)
         storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
         self.assertEqual(storage.drain_gpu_reclaim(), 1)
+
+
+@requires_cuda
+class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
+    """The `_KVCache` growth seam (DESIGN.md §5, `_core/_kv_cache.py` row).
+
+    Covers create -> resume (VA reserve) -> resize growth (demand map +
+    consecutive slots) -> commit -> close (copy-on-free write-out +
+    deferred reclaim).
+    """
+
+    TPB = 16  # tokens per block
+
+    def setUp(self) -> None:
+        init_cuda_once()
+        cfg = _make_manager_config(gpu_quota=32 * MiB, host_quota=32 * MiB)
+        cfg.contiguous_arena = ContiguousArenaConfig(map_ahead_pages=0)
+        self.manager = KVCacheManager(cfg)
+
+    def tearDown(self) -> None:
+        self.manager.shutdown()
+        del self.manager
+
+    def test_grow_commit_close_roundtrip(self) -> None:
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        kv = manager.create_kv_cache(max_capacity=8 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv.resume(stream))
+            self.assertEqual(budget.used_pages, 0)  # VA reserve maps nothing
+            self.assertTrue(kv.resize(4 * self.TPB))
+            self.assertGreater(budget.used_pages, 0)
+            # the sequence's kernel-visible page indices are consecutive
+            indices = list(kv.get_base_page_indices(LifeCycleId(0)))
+            self.assertEqual(indices, list(range(indices[0], indices[0] + 4)))
+            # growth extends the same run
+            self.assertTrue(kv.resize(6 * self.TPB))
+            indices = list(kv.get_base_page_indices(LifeCycleId(0)))
+            self.assertEqual(indices, list(range(indices[0], indices[0] + 6)))
+            kv.commit([100 + i for i in range(4 * self.TPB)])
+            kv.close()
+        s.take_finish_event().synchronize()
+        # copy-on-free write-out finished -> the range is reclaimable
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(budget.used_pages, 0)
+        # the 4 committed blocks live on in the host tier
+        host_stats = manager._storage.get_statistics(CacheLevel(1))[0]
+        self.assertEqual(host_stats.total - host_stats.free, 4)
+
+    def test_max_capacity_required_and_enforced(self) -> None:
+        manager = self.manager
+        with self.assertRaises(ValueError):
+            manager.create_kv_cache()  # arena mode requires max_capacity
+        kv = manager.create_kv_cache(max_capacity=2 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv.resume(stream))
+            self.assertTrue(kv.resize(2 * self.TPB))
+            with self.assertRaises(ValueError):
+                kv.resize(3 * self.TPB)  # beyond the VA reservation
+            kv.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+
+    def test_growth_backs_off_on_page_exhaustion(self) -> None:
+        manager = self.manager
+        # 16 budget pages; 1 block = 32 KiB -> 64 blocks per 2 MiB page.
+        kv1 = manager.create_kv_cache(max_capacity=1024 * self.TPB)
+        kv2 = manager.create_kv_cache(max_capacity=512 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv1.resume(stream))
+            self.assertTrue(kv2.resume(stream))
+            self.assertTrue(kv1.resize(1024 * self.TPB))  # takes all 16 pages
+            self.assertFalse(kv2.resize(512 * self.TPB))  # backs off, no crash
+            kv1.close()
+            # kv1's range reclaim is gated on its finish event; once complete,
+            # kv2's next growth attempt drains it and succeeds.
+            torch.cuda.synchronize()
+            self.assertTrue(kv2.resize(512 * self.TPB))
+            kv2.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+
+    def test_reuse_matching_disabled(self) -> None:
+        manager = self.manager
+        tokens = [200 + i for i in range(2 * self.TPB)]
+        kv1 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv1.resume(stream))
+            self.assertTrue(kv1.resize(2 * self.TPB))
+            kv1.commit(tokens)
+            kv1.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+        # the blocks are in the radix tree (host), but arena-mode creation
+        # skips matching until §4.4 onboarding lands
+        kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        self.assertEqual(kv2.history_length, 0)
+        kv2.close()
+
+    def test_suspend_not_supported_yet(self) -> None:
+        manager = self.manager
+        kv = manager.create_kv_cache(max_capacity=2 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv.resume(stream))
+            with self.assertRaises(LogicError):
+                kv.suspend()
+            kv.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
 
 
 if __name__ == "__main__":

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1891,5 +1891,134 @@ class TestArenaWriteThroughOnCommit(TestArenaKVCacheManagerEndToEnd):
         self.assertEqual(self._host_used(), 2)
 
 
+@requires_cuda
+class TestArenaSuspendHostExhaustion(unittest.TestCase):
+    """§4.5 hardening: host-tier exhaustion during suspension.
+
+    The host tier fills with already-suspended sequences' HELD pages, which
+    LRU eviction cannot drop at the last level (``is_evictable``); a further
+    suspend() must then raise ``OutOfPagesError`` BEFORE mutating anything
+    (the pre-flight reservation in ``suspend``), leaving the victim fully
+    ACTIVE so the caller can degrade to drop-and-recompute. Stale DROPPABLE
+    host copies, by contrast, must keep churning through LRU eviction —
+    pressure means reuse loss, never a crash.
+    """
+
+    TPB = 16  # tokens per block
+
+    def setUp(self) -> None:
+        init_cuda_once()
+        # Host tier: exactly 4 block slots (4 x 32 KiB coalesced records).
+        cfg = _make_manager_config(gpu_quota=32 * MiB, host_quota=4 * 32 * 1024)
+        cfg.contiguous_arena = ContiguousArenaConfig(map_ahead_pages=0)
+        self.manager = KVCacheManager(cfg)
+
+    def tearDown(self) -> None:
+        self.manager.shutdown()
+        del self.manager
+
+    def _block_floats(self, page_index: int) -> "torch.Tensor":
+        addr = int(
+            self.manager._storage.slot_address(
+                GPU_LEVEL, PoolGroupIndex(0), page_index, PoolIndex(0)
+            )
+        )
+        return TestSparseVirtMem._tensor_at(addr, (4 * 8192) // 4)
+
+    def _host_used(self) -> int:
+        stats = self.manager._storage.get_statistics(CacheLevel(1))[0]
+        return stats.total - stats.free
+
+    def test_suspend_raises_atomically_when_host_pinned(self) -> None:
+        manager = self.manager
+        kv_a = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        kv_b = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv_a.resume(stream))
+            self.assertTrue(kv_a.resize(3 * self.TPB))
+            self.assertTrue(kv_b.resume(stream))
+            self.assertTrue(kv_b.resize(3 * self.TPB))
+            b_indices = list(kv_b.get_base_page_indices(LifeCycleId(0)))
+            for j, idx in enumerate(b_indices):
+                self._block_floats(idx).fill_(10.0 + j)
+            torch.cuda.synchronize()
+            kv_a.commit([100 + i for i in range(2 * self.TPB)])
+            kv_b.commit([200 + i for i in range(2 * self.TPB)])
+            # A's suspension takes 3 of the 4 host slots as HELD state.
+            kv_a.suspend()
+            self.assertEqual(self._host_used(), 3)
+            # B needs 3 slots; 1 free, and A's HELD pages are not evictable
+            # at the last level -> pre-flight raises with B untouched.
+            with self.assertRaises(OutOfPagesError):
+                kv_b.suspend()
+            # Atomicity: B is still ACTIVE, byte-identical, and usable.
+            indices = list(kv_b.get_base_page_indices(LifeCycleId(0)))
+            self.assertEqual(indices, b_indices)
+            for j, idx in enumerate(indices):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 10.0 + j).all().item()))
+            self.assertTrue(kv_b.resize(4 * self.TPB))  # growth still works
+            # close() under the same exhaustion drops the write-out (reuse
+            # loss only) instead of raising -- the free path never errors.
+            kv_b.close()
+            self.assertEqual(self._host_used(), 3)  # nothing of B landed
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        # A was not perturbed by B's failed suspend: resumes byte-... (A had
+        # no patterns written; assert the roundtrip machinery instead).
+        with TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv_a.resume(CudaStream(s2.handle)))
+            torch.cuda.synchronize()
+            indices = list(kv_a.get_base_page_indices(LifeCycleId(0)))
+            self.assertEqual(indices, list(range(indices[0], indices[0] + 3)))
+            kv_a.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
+    def test_suspend_churns_through_droppable_host_copies(self) -> None:
+        """Pressure evicts stale DROPPABLE host copies, not suspends.
+
+        Stale copies churn through LRU eviction (reuse loss), so a suspend
+        that fits after eviction succeeds.
+        """
+        manager = self.manager
+        kv_a = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        kv_b = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv_a.resume(stream))
+            self.assertTrue(kv_a.resize(3 * self.TPB))
+            self.assertTrue(kv_b.resume(stream))
+            self.assertTrue(kv_b.resize(3 * self.TPB))
+            b_indices = list(kv_b.get_base_page_indices(LifeCycleId(0)))
+            for j, idx in enumerate(b_indices):
+                self._block_floats(idx).fill_(20.0 + j)
+            torch.cuda.synchronize()
+            kv_a.commit([100 + i for i in range(2 * self.TPB)])
+            kv_b.commit([300 + i for i in range(2 * self.TPB)])
+            # A: close (not suspend) -> its 2 committed blocks become stale
+            # DROPPABLE host copies (LRU-evictable), not HELD state.
+            kv_a.close()
+            self.assertEqual(self._host_used(), 2)
+            # B's suspension needs 3 slots; 2 free + A's 2 droppable -> LRU
+            # evicts A's oldest copy (block 0, the tree parent), whose GC
+            # collapses the now-unreachable child copy too (reuse loss), and
+            # the suspend SUCCEEDS: only B's 3 HELD pages remain.
+            kv_b.suspend()
+            self.assertEqual(self._host_used(), 3)
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        with TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv_b.resume(CudaStream(s2.handle)))
+            torch.cuda.synchronize()
+            for j, idx in enumerate(kv_b.get_base_page_indices(LifeCycleId(0))):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 20.0 + j).all().item()))
+            kv_b.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -913,6 +913,23 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
         host_stats = manager._storage.get_statistics(CacheLevel(1))[0]
         self.assertEqual(host_stats.total - host_stats.free, 4)
 
+    def test_clamp_max_seq_len_counts_pages(self) -> None:
+        """§4.6 capacity planning in arena mode counts physical pages.
+
+        Not VA slots: 16 budget pages x 64 blocks/page x 16 tokens/block.
+        """
+        manager = self.manager
+        blocks_per_page = (2 * MiB) // (4 * 8192)  # 64: 32 KiB block record
+        self.assertEqual(
+            manager.clamp_max_seq_len_for_mem(1, 10**6), 16 * blocks_per_page * self.TPB
+        )
+        # batch 4: the 3 other single-token sequences take a page each
+        self.assertEqual(
+            manager.clamp_max_seq_len_for_mem(4, 10**6), 13 * blocks_per_page * self.TPB
+        )
+        # a bound below capacity is returned unchanged
+        self.assertEqual(manager.clamp_max_seq_len_for_mem(1, 500), 500)
+
     def test_max_capacity_required_and_enforced(self) -> None:
         manager = self.manager
         with self.assertRaises(ValueError):

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -215,6 +215,7 @@ class TestContiguousArenaConfig(unittest.TestCase):
     def test_defaults(self) -> None:
         c = ContiguousArenaConfig()
         self.assertEqual(c.phys_page_size, 2 * MiB)
+        self.assertEqual(c.map_ahead_pages, 0)
         self.assertEqual(c.write_through, WriteThroughPolicy.ON_FREE)
         self.assertFalse(c.lazy_gpu_retention)
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -948,10 +948,70 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
         s.take_finish_event().synchronize()
         manager.drain_gpu_reclaim()
 
-    def test_reuse_matching_disabled(self) -> None:
+    def _block_floats(self, page_index: int) -> "torch.Tensor":
+        addr = int(
+            self.manager._storage.slot_address(
+                GPU_LEVEL, PoolGroupIndex(0), page_index, PoolIndex(0)
+            )
+        )
+        return TestSparseVirtMem._tensor_at(addr, (4 * 8192) // 4)
+
+    def test_reuse_onboarding_roundtrip(self) -> None:
+        """§4.4 stale->active reuse round-trip.
+
+        A reuse hit copies the matched prefix from the host tier into the new
+        sequence's arena range as private pages; the canonical host copies
+        survive the second sequence's close (no duplicates).
+        """
         manager = self.manager
+        budget = manager._storage.gpu_page_budget
         tokens = [200 + i for i in range(2 * self.TPB)]
         kv1 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        self.assertEqual(kv1.history_length, 0)  # empty radix tree: no match
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv1.resume(stream))
+            self.assertTrue(kv1.resize(2 * self.TPB))
+            for j, idx in enumerate(kv1.get_base_page_indices(LifeCycleId(0))):
+                self._block_floats(idx).fill_(1.0 + j)
+            torch.cuda.synchronize()
+            kv1.commit(tokens)
+            kv1.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        host_stats = manager._storage.get_statistics(CacheLevel(1))[0]
+        self.assertEqual(host_stats.total - host_stats.free, 2)
+
+        # arena mode matches full blocks only (partial matching disabled)
+        kv2 = manager.create_kv_cache(
+            input_tokens=tokens + [900, 901, 902], max_capacity=4 * self.TPB
+        )
+        self.assertEqual(kv2.history_length, 2 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv2.resume(stream))
+            torch.cuda.synchronize()
+            indices = list(kv2.get_base_page_indices(LifeCycleId(0)))
+            self.assertEqual(indices, list(range(indices[0], indices[0] + 2)))
+            for j, idx in enumerate(indices):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 1.0 + j).all().item()))
+            # growth continues the same consecutive run past the reused prefix
+            self.assertTrue(kv2.resize(3 * self.TPB))
+            indices = list(kv2.get_base_page_indices(LifeCycleId(0)))
+            self.assertEqual(indices, list(range(indices[0], indices[0] + 3)))
+            kv2.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        self.assertEqual(budget.used_pages, 0)
+        # private copies were dropped, not offloaded: still exactly 2 host blocks
+        host_stats = manager._storage.get_statistics(CacheLevel(1))[0]
+        self.assertEqual(host_stats.total - host_stats.free, 2)
+
+    def test_reuse_match_must_fit_max_capacity(self) -> None:
+        manager = self.manager
+        tokens = [300 + i for i in range(2 * self.TPB)]
+        kv1 = manager.create_kv_cache(input_tokens=tokens, max_capacity=2 * self.TPB)
         with TemporaryCudaStream([]) as s:
             stream = CudaStream(s.handle)
             self.assertTrue(kv1.resume(stream))
@@ -960,11 +1020,8 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv1.close()
         s.take_finish_event().synchronize()
         manager.drain_gpu_reclaim()
-        # the blocks are in the radix tree (host), but arena-mode creation
-        # skips matching until §4.4 onboarding lands
-        kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
-        self.assertEqual(kv2.history_length, 0)
-        kv2.close()
+        with self.assertRaises(ValueError):
+            manager.create_kv_cache(input_tokens=tokens, max_capacity=self.TPB)
 
     def test_suspend_not_supported_yet(self) -> None:
         manager = self.manager

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -3012,6 +3012,80 @@ class TestArenaSuspendHostExhaustion(unittest.TestCase):
         s2.take_finish_event().synchronize()
         manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
+    def test_close_offload_can_evict_just_adopted_pages(self) -> None:
+        """close() must not pin its just-adopted pages against eviction.
+
+        The adopt step hands written-through/promoted pages to the host
+        eviction controller BEFORE the offload step asks the same level for
+        free slots. Under exhaustion (everything else HELD) those adopted
+        pages are the only droppable pages on the level, so the offload's
+        eviction pops one -- and if close() still held a strong reference,
+        the page could not die, no slot was freed, and the free-count
+        invariant in ``_prepare_free_slots`` asserted (a mid-run fatal on
+        drop-heavy shapes). With ``on_free`` write-through the adopt set is
+        populated only by v3 promotion's stolen host slots, which is why
+        this fired first on the tinyhost reproducer with aliasing off.
+        """
+        manager = self.manager
+        n_tok = 2 * self.TPB
+        tokens = [4000 + i for i in range(n_tok)]
+        # A: 2 committed blocks become host-resident canonicals (2 slots).
+        kv_a = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            self.assertTrue(kv_a.resume(CudaStream(s.handle)))
+            self.assertTrue(kv_a.resize(3 * self.TPB))
+            torch.cuda.synchronize()
+            kv_a.commit(tokens)
+            kv_a.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        self.assertEqual(self._host_used(), 2)
+        # C: same-prefix admission copy-onboards A's canonicals; promotion
+        # displaces the host incumbents and adopts their slots into C's
+        # write-through stash (host slots stay occupied, controller empty).
+        kv_c = manager.create_kv_cache(
+            input_tokens=tokens + [1, 2], max_capacity=4 * self.TPB
+        )
+        self.assertEqual(kv_c.history_length, n_tok)
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv_c.resume(stream2))
+            self.assertEqual(
+                sorted(self._kv_stash_ordinals(kv_c)), [0, 1], "promotion did not adopt"
+            )
+            # X: suspension pins the remaining 2 host slots as HELD state.
+            kv_x = manager.create_kv_cache(max_capacity=4 * self.TPB)
+            self.assertTrue(kv_x.resume(stream2))
+            self.assertTrue(kv_x.resize(2 * self.TPB))
+            torch.cuda.synchronize()
+            kv_x.commit([5000 + i for i in range(2 * self.TPB)])
+            kv_x.suspend()
+            self.assertEqual(self._host_used(), 4)  # 2 stash + 2 HELD: full
+            # C commits one block past the prefix (no write-through copy) and
+            # closes: adopt(2 promoted) then offload(1) -> the offload must
+            # evict a just-adopted page and actually get its slot back.
+            self.assertTrue(kv_c.resize(3 * self.TPB))
+            kv_c.commit([1] * self.TPB)
+            kv_c.close()  # pre-fix: AssertionError (free-count invariant)
+            # Evicting adopted block 0 collapses the now-unreachable child
+            # copy too (tree-parent GC, as in the churn test above) AND
+            # orphans C's block-2 -- whose page the offload then correctly
+            # skips (a treeless copy is unreachable for reuse). Only X's
+            # HELD suspension state remains.
+            self.assertEqual(self._host_used(), 2)
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        # The manager stays healthy: X resumes and closes cleanly.
+        with TemporaryCudaStream([]) as s3:
+            self.assertTrue(kv_x.resume(CudaStream(s3.handle)))
+            kv_x.close()
+        s3.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
+    @staticmethod
+    def _kv_stash_ordinals(kv) -> "list[int]":
+        return [ordinal for (ordinal, _lc) in kv._write_through_slots.keys()]
+
 
 class TestArenaV3HardReclaimAndPromotion(unittest.TestCase):
     """P3 v3: hard-reclaim ladder + mappability-weighted promotion.

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -36,9 +36,23 @@ except ImportError:  # pragma: no cover
     _CUDA_AVAILABLE = False
 
 if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
-    from kv_cache_manager_v2 import ContiguousArenaConfig, WriteThroughPolicy
+    from kv_cache_manager_v2 import (
+        AttentionLayerConfig,
+        BufferConfig,
+        ContiguousArenaConfig,
+        DataRole,
+        GpuCacheTierConfig,
+        HostCacheTierConfig,
+        KVCacheManagerConfig,
+        WriteThroughPolicy,
+        rawref,
+    )
+    from kv_cache_manager_v2._common import GPU_LEVEL, CacheLevel, LayerId, Priority
+    from kv_cache_manager_v2._copy_engine import CopyTask
     from kv_cache_manager_v2._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
     from kv_cache_manager_v2._exceptions import LogicError, OutOfPagesError
+    from kv_cache_manager_v2._life_cycle_registry import LifeCycleId, LifeCycleRegistry
+    from kv_cache_manager_v2._page import Page
     from kv_cache_manager_v2._sequence_arena import (
         INT31_MAX,
         BlockRangeAllocator,
@@ -46,15 +60,44 @@ if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
         SequenceArena,
         check_index_width,
     )
-    from kv_cache_manager_v2._storage._core import ArenaPoolGroup, GpuArenaCacheLevelStorage
+    from kv_cache_manager_v2._storage._config import create_storage_config
+    from kv_cache_manager_v2._storage._core import (
+        ArenaPoolGroup,
+        GpuArenaCacheLevelStorage,
+        PoolGroupIndex,
+        PoolIndex,
+    )
+    from kv_cache_manager_v2._storage_manager import StorageManager, _coalesce_copy_tasks
     from kv_cache_manager_v2._utils import CachedCudaEvent, init_cuda_once
 else:
-    from tensorrt_llm.runtime.kv_cache_manager_v2 import ContiguousArenaConfig, WriteThroughPolicy
+    from tensorrt_llm.runtime.kv_cache_manager_v2 import (
+        AttentionLayerConfig,
+        BufferConfig,
+        ContiguousArenaConfig,
+        DataRole,
+        GpuCacheTierConfig,
+        HostCacheTierConfig,
+        KVCacheManagerConfig,
+        WriteThroughPolicy,
+        rawref,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._common import (
+        GPU_LEVEL,
+        CacheLevel,
+        LayerId,
+        Priority,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._copy_engine import CopyTask
     from tensorrt_llm.runtime.kv_cache_manager_v2._cuda_virt_mem import (
         PooledPhysMemAllocator,
         VirtMem,
     )
     from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import LogicError, OutOfPagesError
+    from tensorrt_llm.runtime.kv_cache_manager_v2._life_cycle_registry import (
+        LifeCycleId,
+        LifeCycleRegistry,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._page import Page
     from tensorrt_llm.runtime.kv_cache_manager_v2._sequence_arena import (
         INT31_MAX,
         BlockRangeAllocator,
@@ -62,9 +105,16 @@ else:
         SequenceArena,
         check_index_width,
     )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._storage._config import create_storage_config
     from tensorrt_llm.runtime.kv_cache_manager_v2._storage._core import (
         ArenaPoolGroup,
         GpuArenaCacheLevelStorage,
+        PoolGroupIndex,
+        PoolIndex,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._storage_manager import (
+        StorageManager,
+        _coalesce_copy_tasks,
     )
     from tensorrt_llm.runtime.kv_cache_manager_v2._utils import CachedCudaEvent, init_cuda_once
 
@@ -534,6 +584,277 @@ class TestGpuArenaCacheLevelStorage(unittest.TestCase):
                 phys_page_size=self.PAGE,
                 map_ahead_pages=0,
             )
+
+
+class TestCoalesceCopyTasks(unittest.TestCase):
+    SIZE = 1024
+
+    def test_contiguous_run_merges(self) -> None:
+        tasks = [CopyTask(1000 + i * self.SIZE, 5000 + i * self.SIZE) for i in range(4)]
+        merged = _coalesce_copy_tasks(self.SIZE, tasks)
+        self.assertEqual(merged, {4 * self.SIZE: [tasks[0]]})
+
+    def test_broken_run_splits(self) -> None:
+        # dst contiguous but src jumps after 2 tasks -> two runs of 2
+        tasks = [
+            CopyTask(1000, 5000),
+            CopyTask(1000 + self.SIZE, 5000 + self.SIZE),
+            CopyTask(1000 + 2 * self.SIZE, 9000),
+            CopyTask(1000 + 3 * self.SIZE, 9000 + self.SIZE),
+        ]
+        merged = _coalesce_copy_tasks(self.SIZE, tasks)
+        self.assertEqual(merged, {2 * self.SIZE: [tasks[0], tasks[2]]})
+
+    def test_scattered_tasks_pass_through(self) -> None:
+        tasks = [CopyTask(0, 8 * self.SIZE), CopyTask(4 * self.SIZE, 0)]
+        merged = _coalesce_copy_tasks(self.SIZE, tasks)
+        self.assertEqual(merged, {self.SIZE: tasks})
+
+
+def _make_manager_config(
+    gpu_quota: int, host_quota: int, tokens_per_block: int = 16, kv_buf_size: int = 8192
+) -> "KVCacheManagerConfig":
+    """A minimal two-tier (GPU + host) manager config.
+
+    Two attention layers, KEY+VALUE buffers of one size -> a single pool
+    group with one coalesced pool of slot size 4 * kv_buf_size and page-index
+    scale 4.
+    """
+    return KVCacheManagerConfig(
+        tokens_per_block=tokens_per_block,
+        vocab_size=4096,
+        cache_tiers=[
+            GpuCacheTierConfig(quota=gpu_quota),
+            HostCacheTierConfig(quota=host_quota),
+        ],
+        layers=[
+            AttentionLayerConfig(
+                layer_id=LayerId(layer_id),
+                buffers=[
+                    BufferConfig(role=DataRole("key"), size=kv_buf_size),
+                    BufferConfig(role=DataRole("value"), size=kv_buf_size),
+                ],
+            )
+            for layer_id in range(2)
+        ],
+    )
+
+
+@requires_cuda
+class TestStorageManagerArenaMode(unittest.TestCase):
+    """The storage-manager seam (DESIGN.md §5, `_storage_manager.py` row).
+
+    Covers arena-mode construction, retired-path guards, per-sequence
+    pass-throughs, page-based utilization, and explicit-destination
+    migration (§4.3/§4.4).
+    """
+
+    PAGE = 2 * MiB
+    GPU_QUOTA = 32 * MiB  # 16 pages
+    SLOT_SIZE = 4 * 8192  # 2 layers x (KEY+VALUE) coalesced
+    PG0 = PoolGroupIndex(0)
+    LC0 = LifeCycleId(0)
+
+    def setUp(self) -> None:
+        init_cuda_once()
+        cfg = _make_manager_config(gpu_quota=self.GPU_QUOTA, host_quota=32 * MiB)
+        self.storage = StorageManager(
+            LifeCycleRegistry(cfg),
+            create_storage_config(cfg),
+            cfg.tokens_per_block,
+            None,
+            arena_config=ContiguousArenaConfig(phys_page_size=self.PAGE, map_ahead_pages=0),
+        )
+
+    def tearDown(self) -> None:
+        self.storage.destroy()
+        del self.storage
+
+    def _gpu_page(self, slot) -> "Page":
+        page = Page(
+            None,
+            CachedCudaEvent.NULL,
+            rawref.ref(self.storage),
+            self.LC0,
+            GPU_LEVEL,
+            Priority(50),
+            None,
+            None,
+        )
+        page.set_slot(slot)
+        return page
+
+    def _host_page(self, slot) -> "Page":
+        page = Page(
+            None,
+            CachedCudaEvent.NULL,
+            rawref.ref(self.storage),
+            self.LC0,
+            CacheLevel(1),
+            Priority(50),
+            None,
+            None,
+        )
+        page.set_slot(slot)
+        return page
+
+    def _slot_floats(self, level: "CacheLevel", slot_id: int) -> "torch.Tensor":
+        addr = int(self.storage.slot_address(level, self.PG0, slot_id, PoolIndex(0)))
+        n = self.SLOT_SIZE // 4
+        if level == GPU_LEVEL:
+            return TestSparseVirtMem._tensor_at(addr, n)
+        import ctypes
+
+        buf = (ctypes.c_float * n).from_address(addr)
+        return torch.frombuffer(buf, dtype=torch.float32)
+
+    def test_construction_and_sizing(self) -> None:
+        storage = self.storage
+        self.assertTrue(storage.is_arena_mode)
+        gpu_storage = storage._levels[GPU_LEVEL].storage
+        self.assertIs(type(gpu_storage), GpuArenaCacheLevelStorage)
+        self.assertEqual(storage.gpu_page_budget.total_pages, self.GPU_QUOTA // self.PAGE)
+        # 4 coalesced sub-buffers, expansion 1 -> scale 4
+        self.assertEqual(storage._compute_page_index_scales(), [4])
+        # default VA: overcommit x (quota // record_stride)
+        self.assertEqual(storage.num_slots(self.PG0), 8 * (self.GPU_QUOTA // self.SLOT_SIZE))
+        # host level is a classic slot pool, unaffected
+        self.assertGreater(storage.num_slots(self.PG0, CacheLevel(1)), 0)
+
+    def test_retired_paths_raise(self) -> None:
+        storage = self.storage
+        with self.assertRaises(LogicError):
+            storage.new_gpu_slots([1])
+        with self.assertRaises(LogicError):
+            storage.new_slots_for_pool_group(GPU_LEVEL, self.PG0, 1)
+        with self.assertRaises(LogicError):
+            storage.prepare_free_slots(GPU_LEVEL, [1])
+        with self.assertRaises(LogicError):
+            storage.adjust_cache_level(GPU_LEVEL, None, [1.0])
+        # host-level allocation still works
+        slots = storage.new_slots(CacheLevel(1), [2])
+        for s in slots[self.LC0]:
+            storage.release_slot(self.LC0, CacheLevel(1), s)
+
+    def test_sequence_lifecycle_and_utilization(self) -> None:
+        storage = self.storage
+        self.assertEqual(storage.get_utilization(GPU_LEVEL), [0.0])
+        rng = storage.reserve_gpu_sequence(self.PG0, 64)
+        mapped = storage.ensure_gpu_mapped(self.PG0, rng, 64)  # 64 x 32 KiB = 1 page
+        self.assertEqual(mapped, 1)
+        budget = storage.gpu_page_budget
+        self.assertEqual(budget.used_pages, 1)
+        self.assertEqual(storage.get_utilization(GPU_LEVEL), [1 / budget.total_pages])
+        self.assertEqual(storage.get_overall_utilization(GPU_LEVEL), 1 / budget.total_pages)
+        slot = storage.take_gpu_sequence_slot(self.PG0, rng, 0)
+        self.assertEqual(slot.slot_id, rng.base_block)
+        storage.release_slot(self.LC0, GPU_LEVEL, slot)
+        storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
+        self.assertEqual(storage.drain_gpu_reclaim(), 1)
+        self.assertEqual(budget.used_pages, 0)
+
+    def test_offload_migrates_data_and_gates_reclaim(self) -> None:
+        """§4.3 active->stale mechanics.
+
+        Explicit GPU->host migration of arena slots moves the bytes,
+        retargets the pages, and returns the arena slots to their range with
+        the copy event gating reclaim.
+        """
+        storage = self.storage
+        rng = storage.reserve_gpu_sequence(self.PG0, 64)
+        storage.ensure_gpu_mapped(self.PG0, rng, 2)
+        pages = []
+        for ordinal, value in ((0, 1.25), (1, -3.0)):
+            slot = storage.take_gpu_sequence_slot(self.PG0, rng, ordinal)
+            self._slot_floats(GPU_LEVEL, slot.slot_id).fill_(value)
+            pages.append(self._gpu_page(slot))
+        torch.cuda.synchronize()
+
+        storage._batched_migrate(self.PG0, CacheLevel(1), GPU_LEVEL, pages, update_src=True)
+        torch.cuda.synchronize()
+
+        for page, value in zip(pages, (1.25, -3.0)):
+            self.assertEqual(page.cache_level, CacheLevel(1))
+            host_data = self._slot_floats(CacheLevel(1), page.slot_id)
+            self.assertTrue(bool((host_data == value).all().item()))
+        # the vacated arena slots returned to the range: reclaim succeeds
+        storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
+        self.assertEqual(storage.drain_gpu_reclaim(), 1)
+        self.assertEqual(storage.gpu_page_budget.used_pages, 0)
+        for page in pages:
+            storage.release_slot(self.LC0, CacheLevel(1), page)
+
+    def test_onboard_explicit_destination(self) -> None:
+        """§4.4 stale->active mechanics.
+
+        Copies host pages into explicit, consecutive arena destinations
+        without touching the sources (the host copies stay valid for the
+        radix tree).
+        """
+        storage = self.storage
+        host_slots = storage.new_slots(CacheLevel(1), [2])[self.LC0]
+        src_pages = []
+        for slot, value in zip(host_slots, (7.5, 0.5)):
+            self._slot_floats(CacheLevel(1), slot.slot_id).fill_(value)
+            src_pages.append(self._host_page(slot))
+
+        rng = storage.reserve_gpu_sequence(self.PG0, 64)
+        storage.ensure_gpu_mapped(self.PG0, rng, 2)
+        dst_slots = [storage.take_gpu_sequence_slot(self.PG0, rng, j) for j in range(2)]
+        ret = storage._batched_migrate(
+            self.PG0,
+            GPU_LEVEL,
+            CacheLevel(1),
+            src_pages,
+            update_src=False,
+            dst_slots=dst_slots,
+        )
+        assert ret is not None
+        torch.cuda.synchronize()
+
+        for slot, value in zip(ret, (7.5, 0.5)):
+            gpu_data = self._slot_floats(GPU_LEVEL, slot.slot_id)
+            self.assertTrue(bool((gpu_data == value).all().item()))
+        # sources untouched: still valid host pages with their data
+        for page, value in zip(src_pages, (7.5, 0.5)):
+            self.assertEqual(page.cache_level, CacheLevel(1))
+            host_data = self._slot_floats(CacheLevel(1), page.slot_id)
+            self.assertTrue(bool((host_data == value).all().item()))
+
+        for slot in ret:
+            storage.release_slot(self.LC0, GPU_LEVEL, slot)
+        storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
+        self.assertEqual(storage.drain_gpu_reclaim(), 1)
+        for page in src_pages:
+            storage.release_slot(self.LC0, CacheLevel(1), page)
+
+    def test_write_through_copies_without_moving(self) -> None:
+        """§4.3 write-through-on-commit mechanics.
+
+        Host copies materialize; sources keep their GPU slots.
+        """
+        storage = self.storage
+        rng = storage.reserve_gpu_sequence(self.PG0, 64)
+        storage.ensure_gpu_mapped(self.PG0, rng, 1)
+        slot = storage.take_gpu_sequence_slot(self.PG0, rng, 0)
+        gpu_slot_id = slot.slot_id
+        self._slot_floats(GPU_LEVEL, gpu_slot_id).fill_(42.0)
+        page = self._gpu_page(slot)
+        torch.cuda.synchronize()
+
+        host_slots = storage.write_through_pages(self.PG0, [page])
+        torch.cuda.synchronize()
+
+        self.assertEqual(len(host_slots), 1)
+        self.assertEqual(page.cache_level, GPU_LEVEL)  # source not moved
+        self.assertEqual(page.slot_id, gpu_slot_id)
+        host_data = self._slot_floats(CacheLevel(1), host_slots[0].slot_id)
+        self.assertTrue(bool((host_data == 42.0).all().item()))
+
+        storage.release_slot(self.LC0, CacheLevel(1), host_slots[0])
+        storage.release_slot(self.LC0, GPU_LEVEL, page)
+        storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
+        self.assertEqual(storage.drain_gpu_reclaim(), 1)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -525,10 +525,13 @@ class TestArenaPoolGroup(unittest.TestCase):
             group.destroy()
 
     def test_reclaim_gated_on_iteration_fence(self) -> None:
-        """Risk #3: a freed range must NOT be reclaimed before an
+        """Risk #3: reclaim requires a later execution-stream fence.
+
+        A freed range must NOT be reclaimed before an
         execution-stream fence recorded at a later drain point completes —
         the overlap scheduler may have speculatively enqueued a step that
-        still reads the range when free_sequence runs."""
+        still reads the range when free_sequence runs.
+        """
         group = self._group()
         try:
             rng = group.reserve_sequence(2)
@@ -542,6 +545,68 @@ class TestArenaPoolGroup(unittest.TestCase):
             # Assign-only fence, then an unfenced drain may reclaim.
             group.fence_pending_frees(CachedCudaEvent.NULL)
             self.assertEqual(group.drain_reclaim(), 1)
+            self.assertEqual(group.mapped_pages, 0)
+        finally:
+            group.destroy()
+
+    def test_blocking_drain_waits_for_gate_events(self) -> None:
+        """§4.6 preemption headroom: the blocking drain waits out gate events.
+
+        ``drain_reclaim(wait=True)`` blocks on a
+        pending gate event (e.g. a suspend-evacuation copy still in flight)
+        and reclaims in the same call. The scheduler's mid-pass eviction path
+        depends on this — a non-waiting drain skips the range, the freed
+        pages stay charged, and a fully suspended batch deadlocks.
+        """
+        group = self._group()
+        try:
+            rng = group.reserve_sequence(2)
+            group.ensure_mapped(rng, 2)
+            slot = group.take_slot(rng, 0)
+            # Simulate an in-flight evacuation copy: the released slot's
+            # ready event is recorded behind a device sleep.
+            stream = torch.cuda.Stream()
+            with torch.cuda.stream(stream):
+                torch.cuda._sleep(50_000_000)
+            ev = CachedCudaEvent(CudaStream(stream.cuda_stream))
+            slot.ready_event = ev
+            group.release(slot)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            # Pending gate: the plain drain skips the range...
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 0)
+            # ...and the blocking drain waits it out and reclaims.
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL, wait=True), 1)
+            self.assertTrue(ev.query_complete())
+            self.assertEqual(group.mapped_pages, 0)
+            self.assertEqual(self.budget.used_pages, 0)
+        finally:
+            group.destroy()
+
+    def test_blocking_drain_respects_outstanding_slots_and_fence(self) -> None:
+        """``wait=True`` must not bypass non-event gating conditions.
+
+        It must not hang on (or reclaim) ranges whose gating
+        conditions are host-side state rather than events: an outstanding
+        slot has no event to wait for, and an unfenced range keeps its
+        risk-#3 protection.
+        """
+        group = self._group()
+        try:
+            # Outstanding slot: skipped, promptly.
+            rng = group.reserve_sequence(2)
+            group.ensure_mapped(rng, 2)
+            slot = group.take_slot(rng, 0)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL, wait=True), 0)
+            group.release(slot)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL, wait=True), 1)
+            # Unfenced range: wait=True with no fence must not bypass risk #3.
+            rng2 = group.reserve_sequence(2)
+            group.ensure_mapped(rng2, 2)
+            group.free_sequence(rng2, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(None, wait=True), 0)
+            self.assertGreater(group.mapped_pages, 0)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL, wait=True), 1)
             self.assertEqual(group.mapped_pages, 0)
         finally:
             group.destroy()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the contiguous primary KV cache scaffold (DESIGN.md in
+``contiguous_primary_kvcache/``): the block-range allocator, int31 index-width
+check, sparse ``VirtMem`` mapping, and the ``SequenceArena`` demand-paging layer.
+
+The allocator / index-width / config tests are pure logic and always run. The
+sparse ``VirtMem`` and ``SequenceArena`` tests require a CUDA device.
+"""
+
+import unittest
+from importlib.util import find_spec
+from typing import TYPE_CHECKING
+
+try:
+    import torch
+
+    _CUDA_AVAILABLE = torch.cuda.is_available()
+except ImportError:  # pragma: no cover
+    torch = None
+    _CUDA_AVAILABLE = False
+
+if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
+    from kv_cache_manager_v2 import ContiguousArenaConfig, WriteThroughPolicy
+    from kv_cache_manager_v2._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
+    from kv_cache_manager_v2._sequence_arena import (
+        INT31_MAX,
+        BlockRangeAllocator,
+        SequenceArena,
+        check_index_width,
+    )
+    from kv_cache_manager_v2._utils import CachedCudaEvent, init_cuda_once
+else:
+    from tensorrt_llm.runtime.kv_cache_manager_v2 import (
+        ContiguousArenaConfig,
+        WriteThroughPolicy,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._cuda_virt_mem import (
+        PooledPhysMemAllocator,
+        VirtMem,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._sequence_arena import (
+        INT31_MAX,
+        BlockRangeAllocator,
+        SequenceArena,
+        check_index_width,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._utils import (
+        CachedCudaEvent,
+        init_cuda_once,
+    )
+
+MiB = 1 << 20
+requires_cuda = unittest.skipUnless(_CUDA_AVAILABLE, "requires CUDA")
+
+
+class TestBlockRangeAllocator(unittest.TestCase):
+    def test_alignment_derivation(self) -> None:
+        # record_stride divides page -> align = page / stride blocks
+        a = BlockRangeAllocator(capacity_blocks=64, record_stride=1 * MiB, phys_page_size=2 * MiB)
+        self.assertEqual(a.align_blocks, 2)
+        # record_stride multiple of page -> each block is whole pages -> align 1
+        a = BlockRangeAllocator(capacity_blocks=64, record_stride=4 * MiB, phys_page_size=2 * MiB)
+        self.assertEqual(a.align_blocks, 1)
+        # coprime-ish stride -> align = page / gcd
+        a = BlockRangeAllocator(capacity_blocks=64, record_stride=3 * MiB, phys_page_size=2 * MiB)
+        self.assertEqual(a.align_blocks, 2)  # gcd(3,2)=1 -> 2MiB/1MiB=2
+
+    def test_allocate_is_page_aligned_and_padded(self) -> None:
+        a = BlockRangeAllocator(capacity_blocks=64, record_stride=1 * MiB, phys_page_size=2 * MiB)
+        # request 3 -> padded up to align(2)=4
+        base = a.allocate(3)
+        self.assertEqual(base % a.align_blocks, 0)
+        self.assertEqual(a.reserved_len(base), 4)
+
+    def test_no_two_ranges_share_a_page(self) -> None:
+        # stride 1MiB, page 2MiB: two blocks per page. Allocations must not let
+        # two ranges land in the same physical page.
+        a = BlockRangeAllocator(capacity_blocks=64, record_stride=1 * MiB, phys_page_size=2 * MiB)
+        bases = [a.allocate(1) for _ in range(4)]
+        # every base is a multiple of align (2), so byte offset is a page multiple
+        for b in bases:
+            self.assertEqual((b * MiB) % (2 * MiB), 0)
+        self.assertEqual(len(set(bases)), len(bases))
+
+    def test_free_and_coalesce(self) -> None:
+        a = BlockRangeAllocator(capacity_blocks=16, record_stride=2 * MiB, phys_page_size=2 * MiB)
+        b0 = a.allocate(4)
+        b1 = a.allocate(4)
+        b2 = a.allocate(4)
+        self.assertEqual(a.free_blocks(), 4)
+        # free the middle then the ends; everything should coalesce back to 16
+        a.free(b1)
+        a.free(b0)
+        a.free(b2)
+        self.assertEqual(a.free_blocks(), 16)
+        self.assertEqual(a.largest_free_blocks(), 16)
+        # can allocate the whole arena again
+        self.assertEqual(a.allocate(16), 0)
+
+    def test_reuse_after_free(self) -> None:
+        a = BlockRangeAllocator(capacity_blocks=8, record_stride=2 * MiB, phys_page_size=2 * MiB)
+        b = a.allocate(8)
+        a.free(b)
+        self.assertEqual(a.allocate(8), b)
+
+    def test_out_of_space_raises(self) -> None:
+        a = BlockRangeAllocator(capacity_blocks=8, record_stride=2 * MiB, phys_page_size=2 * MiB)
+        a.allocate(8)
+        with self.assertRaises(MemoryError):
+            a.allocate(1)
+
+    def test_double_free_guard(self) -> None:
+        a = BlockRangeAllocator(capacity_blocks=8, record_stride=2 * MiB, phys_page_size=2 * MiB)
+        b = a.allocate(4)
+        a.free(b)
+        with self.assertRaises(KeyError):
+            a.free(b)  # base no longer live
+
+
+class TestIndexWidthCheck(unittest.TestCase):
+    def test_within_limit_ok(self) -> None:
+        # 8k sequences * 4k blocks with scale 1 is far below the ceiling
+        check_index_width(block_capacity=1 << 20, num_coalesced_subbuffers=32)
+
+    def test_exactly_at_limit_ok(self) -> None:
+        # capacity*scale - 1 == INT31_MAX must pass
+        scale = 2
+        cap = (INT31_MAX + 1) // scale
+        check_index_width(block_capacity=cap, num_coalesced_subbuffers=scale)
+
+    def test_over_limit_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            check_index_width(block_capacity=(1 << 26), num_coalesced_subbuffers=64)
+
+
+class TestContiguousArenaConfig(unittest.TestCase):
+    def test_defaults(self) -> None:
+        c = ContiguousArenaConfig()
+        self.assertEqual(c.phys_page_size, 2 * MiB)
+        self.assertEqual(c.write_through, WriteThroughPolicy.ON_FREE)
+        self.assertFalse(c.lazy_gpu_retention)
+
+    def test_super_page_ok(self) -> None:
+        ContiguousArenaConfig(phys_page_size=16 * MiB)
+
+    def test_unaligned_page_size_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            ContiguousArenaConfig(phys_page_size=3 * MiB)
+
+    def test_negative_margin_raises(self) -> None:
+        with self.assertRaises(AssertionError):
+            ContiguousArenaConfig(map_ahead_pages=-1)
+
+
+@requires_cuda
+class TestSparseVirtMem(unittest.TestCase):
+    def setUp(self) -> None:
+        init_cuda_once()
+        self.allocator = PooledPhysMemAllocator(2 * MiB)
+
+    def test_map_unmap_bookkeeping(self) -> None:
+        vm = VirtMem(64 * MiB, self.allocator)
+        try:
+            vm.map_range(0, 4)
+            self.assertEqual(vm.num_sparse_chunks, 4)
+            self.assertTrue(vm.is_mapped(0))
+            self.assertTrue(vm.is_mapped(3 * 2 * MiB))
+            self.assertFalse(vm.is_mapped(4 * 2 * MiB))
+            # map a non-adjacent run at a higher offset
+            vm.map_range(8 * 2 * MiB, 2)
+            self.assertEqual(vm.num_sparse_chunks, 6)
+            vm.unmap_range(0, 4)
+            self.assertEqual(vm.num_sparse_chunks, 2)
+            vm.unmap_range(8 * 2 * MiB, 2)
+            self.assertEqual(vm.num_sparse_chunks, 0)
+        finally:
+            vm.destroy()
+
+    def test_unaligned_offset_asserts(self) -> None:
+        vm = VirtMem(16 * MiB, self.allocator)
+        try:
+            with self.assertRaises(AssertionError):
+                vm.map_range(1 * MiB, 1)  # not a multiple of 2 MiB
+        finally:
+            vm.destroy()
+
+    def test_mode_mutual_exclusion(self) -> None:
+        vm = VirtMem(16 * MiB, self.allocator)
+        try:
+            vm.extend(1)  # tail-stack mode
+            with self.assertRaises(AssertionError):
+                vm.map_range(4 * MiB, 1)  # cannot mix
+        finally:
+            vm.destroy()
+
+    def test_data_roundtrip(self) -> None:
+        # Write through a torch tensor viewing the mapped VA, read it back.
+        vm = VirtMem(8 * MiB, self.allocator)
+        try:
+            vm.map_range(0, 1)
+            n = (2 * MiB) // 4
+            t = self._tensor_at(int(vm.address), n)
+            t.fill_(1.5)
+            torch.cuda.synchronize()
+            self.assertTrue(bool((t == 1.5).all().item()))
+        finally:
+            vm.destroy()
+
+    @staticmethod
+    def _tensor_at(ptr: int, num_float32: int) -> "torch.Tensor":
+        # Build a torch tensor aliasing an existing device pointer via the
+        # CUDA array interface.
+        class _Aliaser:
+            __cuda_array_interface__ = {
+                "shape": (num_float32,),
+                "typestr": "<f4",
+                "data": (ptr, False),
+                "version": 3,
+                "strides": None,
+            }
+
+        return torch.as_tensor(_Aliaser(), device="cuda")
+
+
+@requires_cuda
+class TestSequenceArena(unittest.TestCase):
+    def setUp(self) -> None:
+        init_cuda_once()
+        self.allocator = PooledPhysMemAllocator(2 * MiB)
+
+    def _arena(self, record_stride: int, capacity: int, margin: int = 1) -> "SequenceArena":
+        return SequenceArena(
+            block_capacity=capacity,
+            record_stride=record_stride,
+            phys_mem_allocator=self.allocator,
+            map_ahead_pages=margin,
+        )
+
+    def test_reserve_then_demand_map(self) -> None:
+        # 1 block = 2 physical pages; 16 blocks capacity.
+        arena = self._arena(record_stride=4 * MiB, capacity=16, margin=1)
+        try:
+            base = arena.reserve(8)
+            self.assertEqual(arena.mapped_pages, 0)  # reservation maps nothing
+            arena.ensure_mapped(base, 3)  # 3 blocks -> 6 pages, +1 margin = 7
+            self.assertEqual(arena.mapped_pages, 7)
+            # growing is incremental: only new pages get mapped
+            arena.ensure_mapped(base, 4)  # now up to 8 pages + margin, but 7 already mapped
+            self.assertEqual(arena.mapped_pages, 9)
+        finally:
+            arena.destroy()
+
+    def test_map_ahead_clamped_to_reserved(self) -> None:
+        arena = self._arena(record_stride=2 * MiB, capacity=8, margin=100)
+        try:
+            base = arena.reserve(2)  # 2 blocks -> 2 pages reserved
+            arena.ensure_mapped(base, 2)
+            # margin is huge but must not exceed the 2 reserved pages
+            self.assertEqual(arena.mapped_pages, 2)
+        finally:
+            arena.destroy()
+
+    def test_deferred_reclaim_frees_pages_and_range(self) -> None:
+        arena = self._arena(record_stride=4 * MiB, capacity=16, margin=0)
+        try:
+            base = arena.reserve(4)
+            arena.ensure_mapped(base, 4)
+            self.assertEqual(arena.mapped_pages, 8)
+            # NULL event is always complete -> reclaim happens on first drain
+            arena.enqueue_free(base, CachedCudaEvent.NULL)
+            reclaimed = arena.drain_reclaim()
+            self.assertEqual(reclaimed, 1)
+            self.assertEqual(arena.mapped_pages, 0)
+            # the block range is back and reusable
+            self.assertEqual(arena.reserve(16), 0)
+        finally:
+            arena.destroy()
+
+    def test_two_sequences_disjoint_pages(self) -> None:
+        arena = self._arena(record_stride=1 * MiB, capacity=32, margin=0)
+        try:
+            a = arena.reserve(3)
+            b = arena.reserve(3)
+            self.assertNotEqual(a, b)
+            arena.ensure_mapped(a, 3)
+            pages_a = arena.mapped_pages
+            arena.ensure_mapped(b, 3)
+            # mapping b must not have touched a's already-mapped pages twice
+            self.assertGreater(arena.mapped_pages, pages_a)
+        finally:
+            arena.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1044,6 +1044,37 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
         stats = self.manager._storage.get_statistics(CacheLevel(1))[0]
         return stats.total - stats.free
 
+    def test_resume_gate_drains_deferred_reclaim(self) -> None:
+        """Anti-livelock (§4.2 x §4.6).
+
+        Arena frees are deferred, so page utilization can stay pinned above
+        max_util_for_resume after other sequences finished. resume() must
+        drain the reclaim queue before evaluating the gate, or a scheduler
+        retrying resume forever livelocks (observed in the KV-cache-capacity
+        estimation phase).
+        """
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        kv1 = manager.create_kv_cache(max_capacity=1024 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv1.resume(stream))
+            self.assertTrue(kv1.resize(1024 * self.TPB))  # maps the full budget
+            self.assertEqual(budget.used_pages, budget.total_pages)
+            kv1.close()
+        s.take_finish_event().synchronize()
+        # reclaim is queued but deliberately NOT drained: utilization reads 100%
+        self.assertEqual(budget.used_pages, budget.total_pages)
+        kv2 = manager.create_kv_cache(max_capacity=2 * self.TPB)
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv2.resume(stream2))  # must drain, not refuse
+            self.assertTrue(kv2.resize(2 * self.TPB))
+            kv2.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+        self.assertEqual(budget.used_pages, 0)
+
     def test_suspend_resume_roundtrip(self) -> None:
         """§4.5 suspend/resume round-trip.
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -957,6 +957,57 @@ class TestArenaPoolGroup(unittest.TestCase):
         def __init__(self) -> None:
             self.__rawref__ = rawref.NULL
 
+    def test_live_span_owner_charged_lifecycle(self) -> None:
+        """P3 v2 owner-live span: registered at commit time, owner-charged.
+
+        No budget transfer or retain while the owner lives, excluded from
+        the spillable population, spill-exempt, but fully lookupable and
+        aliasable; the owner's free_sequence flips it to the
+        registry-charged state with close-time-identical accounting.
+        """
+        group = self._group()
+        group._prefix_aliasing = True
+        try:
+            rng = group.reserve_sequence(4)
+            self.assertEqual(group.ensure_mapped(rng, 4), 6)
+            canon = [self._FakeCanonicalPage(), self._FakeCanonicalPage()]
+            group.register_live_canonical_span(rng, canon, CachedCudaEvent.NULL)
+            key = id(canon[0])
+            self.assertEqual(rng._alias_span_key, (key, 2))
+            # Owner-charged: no budget movement, not in the spillable set.
+            self.assertEqual(self.budget.used_pages, 6)
+            self.assertEqual(self.budget.retained_pages, 0)
+            self.assertEqual(group.canonical_span_pages, 0)
+            self.assertEqual(group.spill_canonical_spans(1 << 62), 0)  # exempt
+            self.assertEqual(group.spilled_spans, 0)
+            # Lookup + alias work exactly like a charged span.
+            hit = group.lookup_canonical_span(canon[0], canon)
+            self.assertIsNotNone(hit)
+            rng_b = group.reserve_sequence(4)
+            self.assertEqual(group.alias_span_into_range(rng_b, hit[0], hit[1], hit[2]), 3)
+            self.assertEqual(self.budget.used_pages, 6)  # aliases charge nothing
+            # Consumer close first: flip must NOT trigger (span belongs to rng).
+            group.free_sequence(rng_b, CachedCudaEvent.NULL)
+            self.assertEqual(self.budget.retained_pages, 0)
+            self.assertEqual(group.canonical_span_pages, 0)
+            # Owner close: charge flips range -> registry (release+consume
+            # nets zero; retained-at-will; alias-accounted on the range).
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            self.assertEqual(self.budget.used_pages, 6)
+            self.assertEqual(self.budget.retained_pages, 3)
+            self.assertEqual(group.canonical_span_pages, 3)
+            self.assertIsNotNone(group.lookup_canonical_span(canon[0], canon))
+            # Full teardown drains cleanly: parked ranges spill their
+            # non-aliased charge, the (now spillable) span spills the rest.
+            torch.cuda.synchronize()
+            group.drain_reclaim(CachedCudaEvent.NULL)
+            group.spill_retained(1 << 62)
+            self.assertEqual(group.spill_canonical_spans(1 << 62), 3)
+            self.assertEqual(self.budget.used_pages, 0)
+            self.assertEqual(group.mapped_pages, 0)
+        finally:
+            group.destroy()
+
     def test_canonical_span_registry_alias_roundtrip(self) -> None:
         """P3 registry roundtrip: register, alias, park, adopt affinely.
 
@@ -2465,6 +2516,78 @@ class TestArenaPrefixAliasing(unittest.TestCase):
             kv_d.close()
         s4.take_finish_event().synchronize()
         manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
+    def test_owner_live_alias_while_owner_generating(self) -> None:
+        """P3 v2 owner-live aliasing at the manager seam.
+
+        A same-prefix admission aliases the owner's prefix pages while the
+        owner is still ACTIVE (just past its context-end commit) -- no
+        close required. Physical sharing is proven by writing through the
+        owner's VA and reading the change through the consumer's VA (a D2D
+        copy could not see it). The owner's later close flips the span to
+        the registry-charged state without disturbing anything.
+        """
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        pg = self._pool_group()
+        n_tok = self.PREFIX_BLOCKS * self.TPB
+        tokens = [9000 + i for i in range(n_tok)]
+
+        kv_a = manager.create_kv_cache(max_capacity=(self.PREFIX_BLOCKS + 4) * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            self.assertTrue(kv_a.resume(CudaStream(s.handle)))
+            self.assertTrue(kv_a.resize(n_tok))
+            a_indices = list(kv_a.get_base_page_indices(LifeCycleId(0)))[: self.PREFIX_BLOCKS]
+            for j, idx in enumerate(a_indices):
+                self._block_floats(idx).fill_(float(j))
+            torch.cuda.synchronize()
+            kv_a.commit(tokens)
+            # Registered at the commit burst, owner-charged: entry exists
+            # but holds no registry charge and is not spillable.
+            self.assertEqual(len(pg._canonical_spans), 1)
+            self.assertEqual(pg.canonical_span_pages, 0)
+            self.assertEqual(budget.retained_pages, 0)
+            used_with_a_live = budget.used_pages
+
+            # B admits and resumes WHILE A is still generating.
+            kv_b = manager.create_kv_cache(
+                input_tokens=tokens + [1, 2],
+                max_capacity=(self.PREFIX_BLOCKS + 4) * self.TPB,
+            )
+            self.assertEqual(pg.alias_hits, 1)
+            with TemporaryCudaStream([]) as s2:
+                self.assertTrue(kv_b.resume(CudaStream(s2.handle)))
+                torch.cuda.synchronize()
+                b_indices = list(kv_b.get_base_page_indices(LifeCycleId(0)))[: self.PREFIX_BLOCKS]
+                for j, idx in enumerate(b_indices):
+                    self.assertTrue(
+                        bool((self._block_floats(idx) == float(j)).all().item()),
+                        f"block {j} bytes wrong through the alias",
+                    )
+                # Same physical pages, not a copy: a write through A's VA is
+                # visible through B's VA.
+                self._block_floats(a_indices[0]).fill_(-123.0)
+                torch.cuda.synchronize()
+                self.assertTrue(
+                    bool((self._block_floats(b_indices[0]) == -123.0).all().item()),
+                    "consumer VA does not share the owner's physical page",
+                )
+                # The aliased span chunk charged nothing for B.
+                self.assertLessEqual(budget.used_pages, used_with_a_live + 2)
+                # Consumer closes FIRST: the flip must not trigger.
+                kv_b.close()
+            s2.take_finish_event().synchronize()
+            self.assertEqual(pg.canonical_span_pages, 0)
+
+            kv_a.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        # A's close flipped the span to the registry-charged state.
+        self.assertEqual(pg.canonical_span_pages, 1)
+        self.assertGreaterEqual(budget.retained_pages, 1)
+        torch.cuda.synchronize()
+        manager._storage.spill_gpu_retained(1 << 62)
+        self.assertEqual(budget.used_pages, 0)
 
     def test_stale_span_falls_back_to_copy(self) -> None:
         """Spill between an admission's lookup hit and its first resume.

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -505,9 +505,17 @@ class TestArenaPoolGroup(unittest.TestCase):
             for s in slots:
                 group.release(s)
             group.free_sequence(rng, CachedCudaEvent.NULL)
+            # The fenced drain parks the range still mapped (freed-range
+            # adoption): pages stay charged but become retained/spillable.
             self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)
+            self.assertEqual(group.mapped_pages, 6)
+            self.assertEqual(self.budget.used_pages, 6)
+            self.assertEqual(self.budget.retained_pages, 6)
+            # Pressure spill actually unmaps and releases.
+            self.assertEqual(group.spill_retained(1 << 62), 6)
             self.assertEqual(group.mapped_pages, 0)
             self.assertEqual(self.budget.used_pages, 0)
+            self.assertEqual(self.budget.retained_pages, 0)
         finally:
             group.destroy()
 
@@ -542,10 +550,12 @@ class TestArenaPoolGroup(unittest.TestCase):
             self.assertEqual(group.drain_reclaim(), 0)
             self.assertEqual(group.drain_reclaim(None), 0)
             self.assertGreater(group.mapped_pages, 0)
-            # Assign-only fence, then an unfenced drain may reclaim.
+            # Assign-only fence, then an unfenced drain may reclaim (into the
+            # parked/adoptable pool — pages stay mapped until spilled).
             group.fence_pending_frees(CachedCudaEvent.NULL)
             self.assertEqual(group.drain_reclaim(), 1)
-            self.assertEqual(group.mapped_pages, 0)
+            self.assertGreater(group.mapped_pages, 0)
+            group.spill_retained(1 << 62)
         finally:
             group.destroy()
 
@@ -554,9 +564,10 @@ class TestArenaPoolGroup(unittest.TestCase):
 
         ``drain_reclaim(wait=True)`` blocks on a
         pending gate event (e.g. a suspend-evacuation copy still in flight)
-        and reclaims in the same call. The scheduler's mid-pass eviction path
-        depends on this — a non-waiting drain skips the range, the freed
-        pages stay charged, and a fully suspended batch deadlocks.
+        and processes the range in the same call (parking it for adoption).
+        The scheduler's mid-pass eviction path depends on this — a
+        non-waiting drain skips the range, the freed pages stay charged and
+        unadoptable, and a fully suspended batch deadlocks.
         """
         group = self._group()
         try:
@@ -574,9 +585,12 @@ class TestArenaPoolGroup(unittest.TestCase):
             group.free_sequence(rng, CachedCudaEvent.NULL)
             # Pending gate: the plain drain skips the range...
             self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 0)
-            # ...and the blocking drain waits it out and reclaims.
+            # ...and the blocking drain waits it out and parks it (freed-range
+            # adoption keeps the pages mapped; retained = spillable/adoptable).
             self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL, wait=True), 1)
             self.assertTrue(ev.query_complete())
+            self.assertEqual(self.budget.used_pages, self.budget.retained_pages)
+            group.spill_retained(1 << 62)
             self.assertEqual(group.mapped_pages, 0)
             self.assertEqual(self.budget.used_pages, 0)
         finally:
@@ -607,6 +621,8 @@ class TestArenaPoolGroup(unittest.TestCase):
             self.assertEqual(group.drain_reclaim(None, wait=True), 0)
             self.assertGreater(group.mapped_pages, 0)
             self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL, wait=True), 1)
+            # Both processed ranges are parked for adoption; spill releases.
+            group.spill_retained(1 << 62)
             self.assertEqual(group.mapped_pages, 0)
         finally:
             group.destroy()
@@ -628,6 +644,76 @@ class TestArenaPoolGroup(unittest.TestCase):
             with self.assertRaises(MemoryError):
                 group.reserve_sequence(1)
             group.free_sequence(rng, CachedCudaEvent.NULL)
+            group.drain_reclaim(CachedCudaEvent.NULL)
+        finally:
+            group.destroy()
+
+    def test_adoption_reuses_parked_range_without_new_maps(self) -> None:
+        """Freed-range adoption: parked ranges are reused without new maps.
+
+        A fenced-drained range is handed whole to
+        the next reservation — same base, mapped prefix intact, zero new
+        cuMemMap calls (the anti-churn fix for the driver TLB interference
+        IMA — WORK_LOG 2026-07-07).
+        """
+        group = self._group()
+        try:
+            rng = group.reserve_sequence(4)
+            self.assertEqual(group.ensure_mapped(rng, 4), 6)  # 4 + 2 pages
+            base = rng.base_block
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)
+            self.assertEqual(self.budget.retained_pages, 6)
+            adopted = group.reserve_sequence(4)
+            self.assertEqual(adopted.base_block, base)
+            self.assertEqual(self.budget.retained_pages, 0)  # charge kept, not retained
+            self.assertEqual(self.budget.used_pages, 6)
+            # the mapped prefix carries over: nothing new to map
+            self.assertEqual(group.ensure_mapped(adopted, 4), 0)
+            self.assertEqual(group.mapped_pages, 6)
+            group.free_sequence(adopted, CachedCudaEvent.NULL)
+            group.drain_reclaim(CachedCudaEvent.NULL)
+        finally:
+            group.destroy()
+
+    def test_adoption_skips_unfit_and_unready_ranges(self) -> None:
+        group = self._group()
+        try:
+            rng = group.reserve_sequence(2)
+            group.ensure_mapped(rng, 2)
+            base = rng.base_block
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            # not drained yet -> nothing parked -> fresh VA
+            bigger = group.reserve_sequence(4)
+            self.assertNotEqual(bigger.base_block, base)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)
+            # parked, but too small for 4 blocks -> fresh VA again
+            another = group.reserve_sequence(4)
+            self.assertNotEqual(another.base_block, base)
+            # fits a 2-block request -> adopted
+            fit = group.reserve_sequence(2)
+            self.assertEqual(fit.base_block, base)
+            for r in (bigger, another, fit):
+                group.free_sequence(r, CachedCudaEvent.NULL)
+            group.drain_reclaim(CachedCudaEvent.NULL)
+        finally:
+            group.destroy()
+
+    def test_adoption_disabled_restores_unmap_on_drain(self) -> None:
+        group = self._group()
+        group._range_adoption = False
+        try:
+            rng = group.reserve_sequence(4)
+            group.ensure_mapped(rng, 4)
+            base = rng.base_block
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)
+            self.assertEqual(group.mapped_pages, 0)
+            self.assertEqual(self.budget.used_pages, 0)
+            fresh = group.reserve_sequence(4)
+            self.assertEqual(fresh.base_block, base)  # allocator reuse, unmapped
+            self.assertEqual(group.ensure_mapped(fresh, 4), 6)  # must remap
+            group.free_sequence(fresh, CachedCudaEvent.NULL)
             group.drain_reclaim(CachedCudaEvent.NULL)
         finally:
             group.destroy()
@@ -665,6 +751,9 @@ class TestGpuArenaCacheLevelStorage(unittest.TestCase):
             g0.free_sequence(r0, CachedCudaEvent.NULL)
             g1.free_sequence(r1, CachedCudaEvent.NULL)
             self.assertEqual(storage.drain_reclaim(CachedCudaEvent.NULL), 2)
+            # both ranges parked for adoption; spill returns the pages
+            self.assertEqual(storage.page_budget.used_pages, storage.page_budget.retained_pages)
+            storage.spill_retained(1 << 62)
             self.assertEqual(storage.page_budget.used_pages, 0)
         finally:
             storage.destroy()
@@ -846,6 +935,8 @@ class TestStorageManagerArenaMode(unittest.TestCase):
         storage.release_slot(self.LC0, GPU_LEVEL, slot)
         storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
         self.assertEqual(storage.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+        self.assertEqual(budget.used_pages, budget.retained_pages)  # parked
+        storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
 
     def test_offload_migrates_data_and_gates_reclaim(self) -> None:
@@ -875,6 +966,8 @@ class TestStorageManagerArenaMode(unittest.TestCase):
         # the vacated arena slots returned to the range: reclaim succeeds
         storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
         self.assertEqual(storage.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+        self.assertEqual(storage.gpu_page_budget.used_pages, storage.gpu_page_budget.retained_pages)
+        storage.spill_gpu_retained(1 << 62)
         self.assertEqual(storage.gpu_page_budget.used_pages, 0)
         for page in pages:
             storage.release_slot(self.LC0, CacheLevel(1), page)
@@ -1036,6 +1129,8 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
         s.take_finish_event().synchronize()
         # copy-on-free write-out finished -> the range is reclaimable
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+        # ranges park for adoption on drain; spill to assert full release
+        manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
         # the 4 committed blocks live on in the host tier
         host_stats = manager._storage.get_statistics(CacheLevel(1))[0]
@@ -1151,6 +1246,8 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv2.close()
         s.take_finish_event().synchronize()
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+        # ranges park for adoption on drain; spill to assert full release
+        manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
         # private copies were dropped, not offloaded: still exactly 2 host blocks
         host_stats = manager._storage.get_statistics(CacheLevel(1))[0]
@@ -1208,6 +1305,8 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv2.close()
         s2.take_finish_event().synchronize()
         manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        # ranges park for adoption on drain; spill to assert full release
+        manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
 
     def test_intra_batch_commit_conflict_keeps_committing(self) -> None:
@@ -1237,6 +1336,8 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv2.close()
         s.take_finish_event().synchronize()
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 2)
+        # ranges park for adoption on drain; spill to assert full release
+        manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
         # only the canonical copies were offloaded: no duplicates on host
         self.assertEqual(self._host_used(), 2)
@@ -1266,6 +1367,8 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv.suspend()
         s.take_finish_event().synchronize()
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+        # ranges park for adoption on drain; spill to assert full release
+        manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
         self.assertEqual(self._host_used(), 3)  # 2 canonical + 1 uncommitted
 
@@ -1287,6 +1390,8 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv.close()
         s2.take_finish_event().synchronize()
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+        # ranges park for adoption on drain; spill to assert full release
+        manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
         self.assertEqual(self._host_used(), 2)
 
@@ -1372,6 +1477,8 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
             kv2.suspend()
         s2.take_finish_event().synchronize()
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+        # ranges park for adoption on drain; spill to assert full release
+        manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
         self.assertEqual(self._host_used(), 2)  # privates dropped, no duplicates
 
@@ -1442,6 +1549,8 @@ class TestArenaBatchedMapSweep(unittest.TestCase):
             kv.close()
         s.take_finish_event().synchronize()
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+        # ranges park for adoption on drain; spill to assert full release
+        manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
 
     def test_freed_before_flush_releases_charge(self) -> None:
@@ -1457,6 +1566,8 @@ class TestArenaBatchedMapSweep(unittest.TestCase):
         s.take_finish_event().synchronize()
         manager.flush_gpu_mappings()
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
+        # ranges park for adoption on drain; spill to assert full release
+        manager._storage.spill_gpu_retained(1 << 62)
         self.assertEqual(budget.used_pages, 0)
 
     def test_reuse_onboarding_stays_synchronous(self) -> None:

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -887,7 +887,7 @@ class TestArenaPoolGroup(unittest.TestCase):
             canon = [self._FakeCanonicalPage(), self._FakeCanonicalPage()]
             group.register_canonical_span(rng_a, canon, CachedCudaEvent.NULL)
             key = id(canon[0])
-            self.assertEqual(rng_a._alias_span_key, key)
+            self.assertEqual(rng_a._alias_span_key, (key, 2))
             self.assertEqual(group.canonical_span_pages, 3)
             # charge moved range -> registry (net zero), retained-at-will
             self.assertEqual(self.budget.used_pages, 6)
@@ -897,9 +897,10 @@ class TestArenaPoolGroup(unittest.TestCase):
             self.assertIsNone(group.lookup_canonical_span(canon[0], canon[:1]))
             hit = group.lookup_canonical_span(canon[0], canon)
             self.assertIsNotNone(hit)
+            self.assertEqual(hit[2], 2)  # usable extent = the verified match
             rng_b = group.reserve_sequence(4)  # nothing parked yet -> fresh
             self.assertNotEqual(rng_b.base_block, rng_a.base_block)
-            self.assertEqual(group.alias_span_into_range(rng_b, hit[0], hit[1]), 3)
+            self.assertEqual(group.alias_span_into_range(rng_b, hit[0], hit[1], hit[2]), 3)
             self.assertEqual(self.budget.used_pages, 6)  # aliases charge nothing
             # B's remainder maps fresh: pool0 +2, pool1 +1
             self.assertEqual(group.ensure_mapped(rng_b, 4), 3)
@@ -921,9 +922,14 @@ class TestArenaPoolGroup(unittest.TestCase):
             self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)
             plain = group.reserve_sequence(4)  # alias_key=None
             self.assertNotEqual(plain.base_block, rng_a.base_block)
-            adopted = group.reserve_sequence(4, alias_key=key)
+            # extent is part of the signature: a shorter-extent admission
+            # must NOT adopt the owner's full-span range
+            self.assertNotEqual(
+                group.reserve_sequence(4, alias_key=(key, 1)).base_block, rng_a.base_block
+            )
+            adopted = group.reserve_sequence(4, alias_key=(key, 2))
             self.assertEqual(adopted.base_block, rng_a.base_block)
-            self.assertEqual(adopted._alias_span_key, key)
+            self.assertEqual(adopted._alias_span_key, (key, 2))
 
             # Spill the registry: pins drop, lookups miss, aliases keep bytes.
             torch.cuda.synchronize()
@@ -932,8 +938,9 @@ class TestArenaPoolGroup(unittest.TestCase):
             tb2 = TestSparseVirtMem._tensor_at(int(addr_b), n)
             self.assertTrue(bool((tb2 == 11.5).all().item()))
 
-            for rng in (rng_b, plain, adopted):
-                group.free_sequence(rng, CachedCudaEvent.NULL)
+            for base, rng in list(group._ranges.items()):
+                if not rng._freed:
+                    group.free_sequence(rng, CachedCudaEvent.NULL)
             group.drain_reclaim(CachedCudaEvent.NULL)
             torch.cuda.synchronize()
             group.spill_retained(1 << 62)
@@ -2247,6 +2254,85 @@ class TestArenaPrefixAliasing(unittest.TestCase):
             self.assertTrue(bool((data == -777.0).all().item()), "fallback not from host")
             kv_d.close()
         s4.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
+    def test_alias_partial_span_from_longer_owner(self) -> None:
+        """P3 partial-span aliasing: the shared-prompt benchmark shape.
+
+        The canonical owner's committed chain is LONGER than the shared
+        prefix (system prompt + its own continuation), so a later
+        admission's match covers only part of the registered span. The
+        match aliases exactly its own fully-covered chunks and writes
+        strictly past them; the parked signature carries the extent so
+        adoption stays exact, and the owner's tail chunks are never
+        corrupted by a shorter adopter.
+        """
+        manager = self.manager
+        pg = self._pool_group()
+        shared_tok = self.PREFIX_BLOCKS * self.TPB  # 64 blocks = 1 chunk
+        owner_tok = 2 * shared_tok  # owner commits 128 blocks = 2 chunks
+        tokens = [3000 + i for i in range(owner_tok)]
+
+        kv_a = manager.create_kv_cache(max_capacity=owner_tok + 4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            self.assertTrue(kv_a.resume(CudaStream(s.handle)))
+            self.assertTrue(kv_a.resize(owner_tok))
+            a_indices = list(kv_a.get_base_page_indices(LifeCycleId(0)))
+            for j, idx in enumerate(a_indices[: 2 * self.PREFIX_BLOCKS]):
+                self._block_floats(idx).fill_(float(j))
+            torch.cuda.synchronize()
+            kv_a.commit(tokens)
+            kv_a.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(pg.canonical_span_pages, 2)  # the full 128-block span
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
+        # B shares only the first 64 blocks; its match is HALF the span.
+        kv_b = manager.create_kv_cache(
+            input_tokens=tokens[:shared_tok] + [1, 2],
+            max_capacity=owner_tok + 4 * self.TPB,
+        )
+        self.assertEqual(kv_b.history_length, shared_tok)
+        for ordinal in range(self.PREFIX_BLOCKS):
+            host_id = kv_b._blocks[ordinal].pages[0][LifeCycleId(0)].page.slot_id
+            self._host_floats(host_id).fill_(-555.0)
+        with TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv_b.resume(CudaStream(s2.handle)))
+            self.assertEqual(pg.alias_hits, 1)
+            rng = kv_b._arena_ranges[PoolGroupIndex(0)]
+            self.assertEqual(rng._alias_span_key[1], self.PREFIX_BLOCKS)  # extent
+            torch.cuda.synchronize()
+            b_indices = list(kv_b.get_base_page_indices(LifeCycleId(0)))
+            for j, idx in enumerate(b_indices[: self.PREFIX_BLOCKS]):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == float(j)).all().item()), f"block {j} not aliased")
+            # B writes past the aliased extent: its block 64 lives in a
+            # FRESH chunk of its own range, not the owner's second chunk.
+            self.assertTrue(kv_b.resize(shared_tok + self.TPB))
+            tail_idx = list(kv_b.get_base_page_indices(LifeCycleId(0)))[self.PREFIX_BLOCKS]
+            self._block_floats(tail_idx).fill_(-1.0)
+            torch.cuda.synchronize()
+            kv_b.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
+        # C matches the FULL owner chain: adoption is extent-exact (it takes
+        # the owner's (key, 128) range, not B's (key, 64) one), and the
+        # owner's tail chunk was never corrupted by B's shorter alias.
+        kv_c = manager.create_kv_cache(
+            input_tokens=tokens + [9], max_capacity=owner_tok + 4 * self.TPB
+        )
+        self.assertEqual(kv_c.history_length, owner_tok)
+        with TemporaryCudaStream([]) as s3:
+            self.assertTrue(kv_c.resume(CudaStream(s3.handle)))
+            self.assertEqual(pg.alias_hits, 2)
+            torch.cuda.synchronize()
+            c_indices = list(kv_c.get_base_page_indices(LifeCycleId(0)))
+            for j in (0, self.PREFIX_BLOCKS, 2 * self.PREFIX_BLOCKS - 1):
+                data = self._block_floats(c_indices[j])
+                self.assertTrue(bool((data == float(j)).all().item()), f"block {j} corrupted")
+            kv_c.close()
+        s3.take_finish_event().synchronize()
         manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
 
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1011,6 +1011,105 @@ class TestGpuArenaCacheLevelStorage(unittest.TestCase):
         finally:
             storage.destroy()
 
+    def _aliasing_storage(self, fraction: float) -> "GpuArenaCacheLevelStorage":
+        """Aliasing-enabled level storage for the span-spill tests.
+
+        Single pool group, 2 MiB slots on 2 MiB pages (1 block = 1 page),
+        8-page budget.
+        """
+        return GpuArenaCacheLevelStorage(
+            slot_size_lists=[[2 * MiB]],
+            block_capacity_list=[16],
+            page_index_scale_list=[64],
+            quota=8 * self.PAGE,
+            phys_page_size=self.PAGE,
+            map_ahead_pages=0,
+            prefix_aliasing=True,
+            protected_span_fraction=fraction,
+        )
+
+    def _register_owner_span(
+        self, group: "ArenaPoolGroup", span_blocks: int = 2, range_blocks: int = 4
+    ):
+        """Map an owner range and register a canonical span over its prefix."""
+        rng = group.reserve_sequence(range_blocks)
+        group.ensure_mapped(rng, range_blocks)
+        canon = [TestArenaPoolGroup._FakeCanonicalPage() for _ in range(span_blocks)]
+        group.register_canonical_span(rng, canon, CachedCudaEvent.NULL)
+        return rng, canon
+
+    def test_span_spill_protection_floor(self) -> None:
+        """Pressure spills must not consume span pins under the floor.
+
+        P3 span-spill protection: parked ranges spill, the registry
+        survives, and the protected pages are reported so the utilization
+        gate can stop counting them reclaimable.
+        """
+        storage = self._aliasing_storage(fraction=0.5)  # floor = 4 pages
+        try:
+            group = storage.pool_group(0)
+            rng, canon = self._register_owner_span(group)  # 4 pages, 2-page span
+            self.assertEqual(group.canonical_span_pages, 2)
+            self.assertEqual(storage.protected_span_pages, 2)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)  # parked
+            torch.cuda.synchronize()
+            # The parked owner range spills (its 2 non-aliased pages); the
+            # 2-page span sits under the 4-page floor and survives.
+            self.assertEqual(storage.spill_retained(1 << 62), 2)
+            self.assertEqual(group.spilled_spans, 0)
+            self.assertEqual(group.canonical_span_pages, 2)
+            self.assertEqual(storage.protected_span_pages, 2)
+            self.assertEqual(storage.page_budget.used_pages, 2)
+            self.assertIsNotNone(group.lookup_canonical_span(canon[0], canon))
+        finally:
+            storage.destroy()
+
+    def test_span_spill_excess_above_floor_lru(self) -> None:
+        """Only the registry excess above the protected floor spills.
+
+        Oldest span first; the floor's worth of spans survives arbitrary
+        pressure.
+        """
+        storage = self._aliasing_storage(fraction=0.25)  # floor = 2 pages
+        try:
+            group = storage.pool_group(0)
+            rng_a, canon_a = self._register_owner_span(group)
+            rng_b, canon_b = self._register_owner_span(group)
+            self.assertEqual(group.canonical_span_pages, 4)
+            self.assertEqual(storage.protected_span_pages, 2)  # min(4, floor)
+            group.free_sequence(rng_a, CachedCudaEvent.NULL)
+            group.free_sequence(rng_b, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 2)
+            torch.cuda.synchronize()
+            # 4 pages from the two parked ranges + the 2-page excess (span A).
+            self.assertEqual(storage.spill_retained(1 << 62), 6)
+            self.assertEqual(group.spilled_spans, 1)
+            self.assertEqual(group.canonical_span_pages, 2)
+            self.assertEqual(storage.protected_span_pages, 2)
+            self.assertIsNone(group.lookup_canonical_span(canon_a[0], canon_a))
+            self.assertIsNotNone(group.lookup_canonical_span(canon_b[0], canon_b))
+        finally:
+            storage.destroy()
+
+    def test_span_spill_unprotected_when_fraction_zero(self) -> None:
+        """fraction=0 restores the previous spans-spilled-last behavior."""
+        storage = self._aliasing_storage(fraction=0.0)
+        try:
+            group = storage.pool_group(0)
+            rng, canon = self._register_owner_span(group)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(CachedCudaEvent.NULL), 1)
+            torch.cuda.synchronize()
+            self.assertEqual(storage.spill_retained(1 << 62), 4)
+            self.assertEqual(group.spilled_spans, 1)
+            self.assertEqual(group.canonical_span_pages, 0)
+            self.assertEqual(storage.protected_span_pages, 0)
+            self.assertEqual(storage.page_budget.used_pages, 0)
+            self.assertIsNone(group.lookup_canonical_span(canon[0], canon))
+        finally:
+            storage.destroy()
+
     def test_int31_violation_fails_before_cuda_setup(self) -> None:
         with self.assertRaises(ValueError):
             GpuArenaCacheLevelStorage(

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -879,6 +879,47 @@ class TestStorageManagerArenaMode(unittest.TestCase):
         for page in pages:
             storage.release_slot(self.LC0, CacheLevel(1), page)
 
+    def test_batched_migrate_orders_after_extra_prior_event(self) -> None:
+        """§4.5 write-out ordering, mechanism level.
+
+        The batched-copy kernel reads its sources at execution time with no
+        ordering against other streams. A suspend/close write-out's source
+        blocks may still be receiving the in-flight step's KV writes on the
+        forward stream (overlap scheduler); ``extra_prior_event`` must gate
+        the copy or the host tier captures the block pre-write.
+        """
+        storage = self.storage
+        rng = storage.reserve_gpu_sequence(self.PG0, 64)
+        storage.ensure_gpu_mapped(self.PG0, rng, 2)
+        # Warm up the batched-copy kernel first: its first-call module-load
+        # latency exceeds the race window and would mask the assertion.
+        s0 = storage.take_gpu_sequence_slot(self.PG0, rng, 0)
+        p0 = self._gpu_page(s0)
+        storage._batched_migrate(self.PG0, CacheLevel(1), GPU_LEVEL, [p0], update_src=True)
+        torch.cuda.synchronize()
+        # The race: a delayed write on a foreign ("forward") stream is still
+        # pending when the write-out is enqueued.
+        s1 = storage.take_gpu_sequence_slot(self.PG0, rng, 1)
+        sid1 = s1.slot_id
+        self._slot_floats(GPU_LEVEL, sid1).fill_(1.0)
+        torch.cuda.synchronize()
+        page = self._gpu_page(s1)
+        fwd = torch.cuda.Stream()
+        with torch.cuda.stream(fwd):
+            torch.cuda._sleep(100_000_000)
+            self._slot_floats(GPU_LEVEL, sid1).fill_(2.0)
+        prior = CachedCudaEvent(CudaStream(fwd.cuda_stream))
+        storage._batched_migrate(
+            self.PG0, CacheLevel(1), GPU_LEVEL, [page], update_src=True, extra_prior_event=prior
+        )
+        torch.cuda.synchronize()
+        host_data = self._slot_floats(CacheLevel(1), page.slot_id)
+        self.assertTrue(bool((host_data == 2.0).all().item()))
+        storage.free_gpu_sequence(self.PG0, rng, CachedCudaEvent.NULL)
+        self.assertEqual(storage.drain_gpu_reclaim(CachedCudaEvent.NULL, wait=True), 1)
+        for p in (p0, page):
+            storage.release_slot(self.LC0, CacheLevel(1), p)
+
     def test_onboard_explicit_destination(self) -> None:
         """§4.4 stale->active mechanics.
 
@@ -1248,6 +1289,55 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
         self.assertEqual(manager.drain_gpu_reclaim(CachedCudaEvent.NULL), 1)
         self.assertEqual(budget.used_pages, 0)
         self.assertEqual(self._host_used(), 2)
+
+    def test_suspend_orders_evacuation_after_forward_stream_writes(self) -> None:
+        """§4.5 write-out ordering vs the in-flight step.
+
+        A scheduler eviction can suspend a sequence whose current step is
+        still writing its tail block on the FORWARD stream; the sequence's
+        manager-stream events and the pages' ready events do not order
+        against it. The evacuation copies must wait on the caller-supplied
+        ``prior_event`` or the host copy captures the block pre-write and
+        resume restores stale bytes.
+        """
+        manager = self.manager
+        # Warm up the batched-copy kernel: its first-call module-load latency
+        # exceeds the race window below and would mask the assertion.
+        kv0 = manager.create_kv_cache(max_capacity=self.TPB)
+        with TemporaryCudaStream([]) as s0:
+            self.assertTrue(kv0.resume(CudaStream(s0.handle)))
+            self.assertTrue(kv0.resize(self.TPB))
+            kv0.suspend()
+        s0.take_finish_event().synchronize()
+        kv0.close()
+        torch.cuda.synchronize()
+        kv = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv.resume(stream))
+            self.assertTrue(kv.resize(2 * self.TPB))
+            old_indices = list(kv.get_base_page_indices(LifeCycleId(0)))
+            for idx in old_indices:
+                self._block_floats(idx).fill_(1.0)
+            torch.cuda.synchronize()
+            kv.commit([500 + i for i in range(self.TPB)])  # block 1 = uncommitted tail
+            # The in-flight "forward step": a delayed overwrite of the tail
+            # block on a separate stream, still pending when suspend() runs.
+            fwd = torch.cuda.Stream()
+            with torch.cuda.stream(fwd):
+                torch.cuda._sleep(50_000_000)
+                self._block_floats(old_indices[-1]).fill_(2.0)
+            kv.suspend(CachedCudaEvent(CudaStream(fwd.cuda_stream)))
+        torch.cuda.synchronize()
+        with TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv.resume(CudaStream(s2.handle)))
+            torch.cuda.synchronize()
+            indices = list(kv.get_base_page_indices(LifeCycleId(0)))
+            tail = self._block_floats(indices[-1])
+            self.assertTrue(bool((tail == 2.0).all().item()))
+            kv.close()
+        torch.cuda.synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL, wait=True)
 
     def test_suspend_drops_private_copies(self) -> None:
         """§4.5 x §4.4 interaction.

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -11,12 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the contiguous primary KV cache scaffold (DESIGN.md in
-``contiguous_primary_kvcache/``): the block-range allocator, int31 index-width
-check, sparse ``VirtMem`` mapping, and the ``SequenceArena`` demand-paging layer.
+"""Tests for the contiguous primary KV cache storage layer.
 
-The allocator / index-width / config tests are pure logic and always run. The
-sparse ``VirtMem`` and ``SequenceArena`` tests require a CUDA device.
+Covers (see ``contiguous_primary_kvcache/DESIGN.md``): the block-range
+allocator, int31 index-width check, page budget, sparse ``VirtMem`` mapping,
+the ``SequenceArena`` demand-paging layer, and the ``ArenaPoolGroup`` /
+``GpuArenaCacheLevelStorage`` storage seam.
+
+The allocator / index-width / budget / config tests are pure logic and always
+run. The sparse ``VirtMem``, ``SequenceArena``, and pool-group tests require a
+CUDA device.
 """
 
 import unittest
@@ -34,32 +38,35 @@ except ImportError:  # pragma: no cover
 if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
     from kv_cache_manager_v2 import ContiguousArenaConfig, WriteThroughPolicy
     from kv_cache_manager_v2._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
+    from kv_cache_manager_v2._exceptions import LogicError, OutOfPagesError
     from kv_cache_manager_v2._sequence_arena import (
         INT31_MAX,
         BlockRangeAllocator,
+        PageBudget,
         SequenceArena,
         check_index_width,
     )
+    from kv_cache_manager_v2._storage._core import ArenaPoolGroup, GpuArenaCacheLevelStorage
     from kv_cache_manager_v2._utils import CachedCudaEvent, init_cuda_once
 else:
-    from tensorrt_llm.runtime.kv_cache_manager_v2 import (
-        ContiguousArenaConfig,
-        WriteThroughPolicy,
-    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2 import ContiguousArenaConfig, WriteThroughPolicy
     from tensorrt_llm.runtime.kv_cache_manager_v2._cuda_virt_mem import (
         PooledPhysMemAllocator,
         VirtMem,
     )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import LogicError, OutOfPagesError
     from tensorrt_llm.runtime.kv_cache_manager_v2._sequence_arena import (
         INT31_MAX,
         BlockRangeAllocator,
+        PageBudget,
         SequenceArena,
         check_index_width,
     )
-    from tensorrt_llm.runtime.kv_cache_manager_v2._utils import (
-        CachedCudaEvent,
-        init_cuda_once,
+    from tensorrt_llm.runtime.kv_cache_manager_v2._storage._core import (
+        ArenaPoolGroup,
+        GpuArenaCacheLevelStorage,
     )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._utils import CachedCudaEvent, init_cuda_once
 
 MiB = 1 << 20
 requires_cuda = unittest.skipUnless(_CUDA_AVAILABLE, "requires CUDA")
@@ -301,6 +308,232 @@ class TestSequenceArena(unittest.TestCase):
             self.assertGreater(arena.mapped_pages, pages_a)
         finally:
             arena.destroy()
+
+
+class TestPageBudget(unittest.TestCase):
+    def test_consume_release(self) -> None:
+        b = PageBudget(4)
+        self.assertEqual(b.free_pages, 4)
+        b.consume(3)
+        self.assertEqual(b.used_pages, 3)
+        self.assertEqual(b.free_pages, 1)
+        b.release(2)
+        self.assertEqual(b.used_pages, 1)
+
+    def test_over_consume_raises_without_side_effects(self) -> None:
+        b = PageBudget(4)
+        b.consume(3)
+        with self.assertRaises(OutOfPagesError):
+            b.consume(2)
+        self.assertEqual(b.used_pages, 3)  # unchanged after the failed consume
+
+
+class TestMultiPoolAlignment(unittest.TestCase):
+    def test_alignment_is_lcm_across_pools(self) -> None:
+        # stride 1MiB -> align 2; stride 512KiB -> align 4; lcm = 4
+        a = BlockRangeAllocator(
+            capacity_blocks=64, record_stride=(1 * MiB, MiB // 2), phys_page_size=2 * MiB
+        )
+        self.assertEqual(a.align_blocks, 4)
+        # whole-page stride (align 1) with a half-page stride (align 2) -> 2
+        a = BlockRangeAllocator(
+            capacity_blocks=64, record_stride=(2 * MiB, 1 * MiB), phys_page_size=2 * MiB
+        )
+        self.assertEqual(a.align_blocks, 2)
+
+    def test_ranges_page_disjoint_in_every_pool(self) -> None:
+        strides = (1 * MiB, MiB // 2)
+        a = BlockRangeAllocator(capacity_blocks=64, record_stride=strides, phys_page_size=2 * MiB)
+        bases = [a.allocate(1) for _ in range(4)]
+        for base in bases:
+            for stride in strides:
+                self.assertEqual((base * stride) % (2 * MiB), 0)
+
+
+@requires_cuda
+class TestSequenceArenaMultiPool(unittest.TestCase):
+    def setUp(self) -> None:
+        init_cuda_once()
+        self.allocator = PooledPhysMemAllocator(2 * MiB)
+
+    def test_maps_all_pools(self) -> None:
+        # pool 0: 1 block = 1 page; pool 1: 2 blocks = 1 page
+        arena = SequenceArena(
+            block_capacity=8,
+            record_stride=(2 * MiB, 1 * MiB),
+            phys_mem_allocator=self.allocator,
+            map_ahead_pages=0,
+        )
+        try:
+            self.assertEqual(arena.num_pools, 2)
+            base = arena.reserve(4)
+            new_pages = arena.ensure_mapped(base, 4)
+            # pool 0: 4 pages, pool 1: 2 pages
+            self.assertEqual(new_pages, 6)
+            self.assertEqual(arena.mapped_pages, 6)
+            self.assertNotEqual(int(arena.base_address(0)), int(arena.base_address(1)))
+        finally:
+            arena.destroy()
+
+    def test_budget_enforced_atomically(self) -> None:
+        budget = PageBudget(4)
+        arena = SequenceArena(
+            block_capacity=8,
+            record_stride=(2 * MiB, 1 * MiB),
+            phys_mem_allocator=self.allocator,
+            map_ahead_pages=0,
+            page_budget=budget,
+        )
+        try:
+            base = arena.reserve(4)  # full mapping would need 6 pages > 4
+            with self.assertRaises(OutOfPagesError):
+                arena.ensure_mapped(base, 4)
+            # nothing was mapped or consumed by the failed call
+            self.assertEqual(arena.mapped_pages, 0)
+            self.assertEqual(budget.used_pages, 0)
+            # a smaller frontier fits: 2 blocks -> 2 + 1 = 3 pages
+            self.assertEqual(arena.ensure_mapped(base, 2), 3)
+            self.assertEqual(budget.used_pages, 3)
+            # reclaim returns the pages to the budget
+            arena.enqueue_free(base, CachedCudaEvent.NULL)
+            self.assertEqual(arena.drain_reclaim(), 1)
+            self.assertEqual(budget.used_pages, 0)
+        finally:
+            arena.destroy()
+
+
+@requires_cuda
+class TestArenaPoolGroup(unittest.TestCase):
+    PAGE = 2 * MiB
+
+    def setUp(self) -> None:
+        init_cuda_once()
+        self.allocator = PooledPhysMemAllocator(self.PAGE)
+        self.budget = PageBudget(64)
+
+    def _group(self, block_capacity: int = 16, map_ahead: int = 0) -> "ArenaPoolGroup":
+        return ArenaPoolGroup(
+            block_capacity=block_capacity,
+            slot_size_list=[2 * MiB, 1 * MiB],
+            shared_phys_mem_pool=self.allocator,
+            page_budget=self.budget,
+            map_ahead_pages=map_ahead,
+            page_index_scale=64,
+        )
+
+    def test_int31_check_wired_into_construction(self) -> None:
+        with self.assertRaises(ValueError):
+            ArenaPoolGroup(
+                block_capacity=INT31_MAX,
+                slot_size_list=[2 * MiB],
+                shared_phys_mem_pool=self.allocator,
+                page_budget=self.budget,
+                map_ahead_pages=0,
+                page_index_scale=2,
+            )
+
+    def test_sequence_slots_are_consecutive_and_addressable(self) -> None:
+        group = self._group()
+        try:
+            rng = group.reserve_sequence(4)
+            group.ensure_mapped(rng, 4)
+            slots = [group.take_slot(rng, j) for j in range(4)]
+            ids = [s.slot_id for s in slots]
+            self.assertEqual(ids, list(range(rng.base_block, rng.base_block + 4)))
+            for pool_idx, stride in enumerate((2 * MiB, 1 * MiB)):
+                addrs = [group._pools[pool_idx].slot_address(i) for i in ids]
+                deltas = [addrs[j + 1] - addrs[j] for j in range(len(addrs) - 1)]
+                self.assertEqual(deltas, [stride] * 3)  # contiguous in VA
+            for s in slots:
+                group.release(s)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(), 1)
+            self.assertEqual(group.mapped_pages, 0)
+            self.assertEqual(self.budget.used_pages, 0)
+        finally:
+            group.destroy()
+
+    def test_reclaim_gated_on_outstanding_slots(self) -> None:
+        group = self._group()
+        try:
+            rng = group.reserve_sequence(2)
+            group.ensure_mapped(rng, 2)
+            slot = group.take_slot(rng, 0)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            self.assertEqual(group.drain_reclaim(), 0)  # slot still outstanding
+            group.release(slot)
+            self.assertEqual(group.drain_reclaim(), 1)
+        finally:
+            group.destroy()
+
+    def test_scattered_allocation_retired(self) -> None:
+        group = self._group()
+        try:
+            with self.assertRaises(LogicError):
+                group.allocate()
+            with self.assertRaises(LogicError):
+                group.allocate_multiple(2)
+        finally:
+            group.destroy()
+
+    def test_va_exhaustion_raises_memory_error(self) -> None:
+        group = self._group(block_capacity=8)
+        try:
+            rng = group.reserve_sequence(8)
+            with self.assertRaises(MemoryError):
+                group.reserve_sequence(1)
+            group.free_sequence(rng, CachedCudaEvent.NULL)
+            group.drain_reclaim()
+        finally:
+            group.destroy()
+
+
+@requires_cuda
+class TestGpuArenaCacheLevelStorage(unittest.TestCase):
+    PAGE = 2 * MiB
+
+    def setUp(self) -> None:
+        init_cuda_once()
+
+    def test_budget_shared_across_pool_groups(self) -> None:
+        storage = GpuArenaCacheLevelStorage(
+            slot_size_lists=[[2 * MiB], [1 * MiB]],
+            block_capacity_list=[16, 16],
+            page_index_scale_list=[64, 32],
+            quota=8 * self.PAGE,
+            phys_page_size=self.PAGE,
+            map_ahead_pages=0,
+        )
+        try:
+            self.assertEqual(storage.page_budget.total_pages, 8)
+            g0 = storage.pool_group(0)
+            g1 = storage.pool_group(1)
+            r0 = g0.reserve_sequence(6)  # 6 pages in pool group 0
+            g0.ensure_mapped(r0, 6)
+            self.assertEqual(storage.page_budget.used_pages, 6)
+            r1 = g1.reserve_sequence(8)  # would need 4 pages; only 2 left
+            with self.assertRaises(OutOfPagesError):
+                g1.ensure_mapped(r1, 8)
+            g1.ensure_mapped(r1, 4)  # 2 pages fit
+            self.assertEqual(storage.page_budget.used_pages, 8)
+            # free the first sequence; the second can now finish mapping
+            g0.free_sequence(r0, CachedCudaEvent.NULL)
+            g1.free_sequence(r1, CachedCudaEvent.NULL)
+            self.assertEqual(storage.drain_reclaim(), 2)
+            self.assertEqual(storage.page_budget.used_pages, 0)
+        finally:
+            storage.destroy()
+
+    def test_int31_violation_fails_before_cuda_setup(self) -> None:
+        with self.assertRaises(ValueError):
+            GpuArenaCacheLevelStorage(
+                slot_size_lists=[[2 * MiB]],
+                block_capacity_list=[INT31_MAX],
+                page_index_scale_list=[2],
+                quota=8 * self.PAGE,
+                phys_page_size=self.PAGE,
+                map_ahead_pages=0,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1205,6 +1205,202 @@ class TestArenaKVCacheManagerEndToEnd(unittest.TestCase):
 
 
 @requires_cuda
+class TestArenaLazyRetention(unittest.TestCase):
+    """§4.4 phase 2 (P2): lazy GPU retention.
+
+    Freed ranges stay mapped on a retained LRU; reuse hits copy D2D from the
+    resident "ghost" bytes; pressure spills LRU-first; the resume gate counts
+    retained pages as available.
+    """
+
+    TPB = 16
+    WRITE_THROUGH = WriteThroughPolicy.ON_FREE
+
+    def setUp(self) -> None:
+        init_cuda_once()
+        cfg = _make_manager_config(gpu_quota=32 * MiB, host_quota=32 * MiB)
+        cfg.contiguous_arena = ContiguousArenaConfig(
+            map_ahead_pages=0, lazy_gpu_retention=True, write_through=self.WRITE_THROUGH
+        )
+        self.manager = KVCacheManager(cfg)
+
+    def tearDown(self) -> None:
+        self.manager.shutdown()
+        del self.manager
+
+    def _block_floats(self, page_index: int) -> "torch.Tensor":
+        addr = int(
+            self.manager._storage.slot_address(
+                GPU_LEVEL, PoolGroupIndex(0), page_index, PoolIndex(0)
+            )
+        )
+        return TestSparseVirtMem._tensor_at(addr, (4 * 8192) // 4)
+
+    def _host_floats(self, slot_id: int) -> "torch.Tensor":
+        import ctypes
+
+        addr = int(
+            self.manager._storage.slot_address(
+                CacheLevel(1), PoolGroupIndex(0), slot_id, PoolIndex(0)
+            )
+        )
+        buf = (ctypes.c_float * ((4 * 8192) // 4)).from_address(addr)
+        return torch.frombuffer(buf, dtype=torch.float32)
+
+    def _commit_and_close(self, tokens, value: float):
+        manager = self.manager
+        kv = manager.create_kv_cache(max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv.resume(stream))
+            self.assertTrue(kv.resize(2 * self.TPB))
+            for j, idx in enumerate(kv.get_base_page_indices(LifeCycleId(0))):
+                self._block_floats(idx).fill_(value + j)
+            torch.cuda.synchronize()
+            kv.commit(tokens)
+            kv.close()
+        s.take_finish_event().synchronize()
+
+    def test_retention_keeps_pages_utilization_reports_free(self) -> None:
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        tokens = [900 + i for i in range(2 * self.TPB)]
+        self._commit_and_close(tokens, 11.0)
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)  # parked, not unmapped
+        self.assertGreater(budget.used_pages, 0)
+        self.assertEqual(budget.retained_pages, budget.used_pages)
+        # retained pages count as available for the resume gate
+        self.assertEqual(manager._storage.get_utilization(GPU_LEVEL), [0.0])
+
+    def test_reuse_onboards_d2d_from_ghost(self) -> None:
+        manager = self.manager
+        tokens = [910 + i for i in range(2 * self.TPB)]
+        self._commit_and_close(tokens, 21.0)
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        # corrupt the HOST copies: if onboarding reads from host, the new
+        # sequence sees junk; correct data proves the D2D ghost path
+        kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        self.assertEqual(kv2.history_length, 2 * self.TPB)
+        for ordinal in range(2):
+            host_id = kv2._blocks[ordinal].pages[0][LifeCycleId(0)].page.slot_id
+            self._host_floats(host_id).fill_(-999.0)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv2.resume(stream))
+            torch.cuda.synchronize()
+            for j, idx in enumerate(kv2.get_base_page_indices(LifeCycleId(0))):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 21.0 + j).all().item()), f"block {j} not D2D")
+            kv2.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+
+    def test_pressure_spills_retained_and_falls_back_to_host(self) -> None:
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        tokens = [920 + i for i in range(2 * self.TPB)]
+        self._commit_and_close(tokens, 31.0)
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        retained_before = budget.retained_pages
+        self.assertGreater(retained_before, 0)
+        # a large fresh sequence needs (nearly) the whole 16-page budget:
+        # mapping must succeed by spilling the retained range
+        kv2 = manager.create_kv_cache(max_capacity=1024 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv2.resume(stream))
+            self.assertTrue(kv2.resize(1024 * self.TPB))
+            self.assertEqual(budget.retained_pages, 0)  # spilled
+            kv2.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+        # the ghost is gone; reuse now falls back to the (intact) host copy
+        kv3 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        self.assertEqual(kv3.history_length, 2 * self.TPB)
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv3.resume(stream2))
+            torch.cuda.synchronize()
+            for j, idx in enumerate(kv3.get_base_page_indices(LifeCycleId(0))):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 31.0 + j).all().item()))
+            kv3.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+
+    def test_private_copies_refresh_ghosts(self) -> None:
+        """Ghost refresh by private copies.
+
+        A hot prefix's D2D source must survive its original committer's range
+        being spilled: every closing user re-registers its private copy as
+        the (fresher) ghost.
+        """
+        manager = self.manager
+        budget = manager._storage.gpu_page_budget
+        tokens = [940 + i for i in range(2 * self.TPB)]
+        self._commit_and_close(tokens, 41.0)  # kv1: canonical + oldest ghost
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        # kv2 reuses (D2D) and closes: its private copies refresh the ghosts
+        kv2 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv2.resume(stream))
+            kv2.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)
+        # spill ONLY the LRU (kv1's) range; kv2's stays retained
+        self.assertGreater(manager._storage.spill_gpu_retained(1), 0)
+        self.assertGreater(budget.retained_pages, 0)
+        # corrupt host copies; correct data proves the refreshed D2D ghost
+        kv3 = manager.create_kv_cache(input_tokens=tokens, max_capacity=4 * self.TPB)
+        self.assertEqual(kv3.history_length, 2 * self.TPB)
+        for ordinal in range(2):
+            host_id = kv3._blocks[ordinal].pages[0][LifeCycleId(0)].page.slot_id
+            self._host_floats(host_id).fill_(-888.0)
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv3.resume(stream2))
+            torch.cuda.synchronize()
+            for j, idx in enumerate(kv3.get_base_page_indices(LifeCycleId(0))):
+                data = self._block_floats(idx)
+                self.assertTrue(bool((data == 41.0 + j).all().item()), f"block {j} lost ghost")
+            kv3.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+
+    def test_va_pressure_spills_retained(self) -> None:
+        manager = self.manager
+        # VA capacity is 8192 blocks; three 4096-block reservations only fit
+        # if the retained first range is spilled for its VA
+        blocks = 4096
+        kv1 = manager.create_kv_cache(max_capacity=blocks * self.TPB)
+        with TemporaryCudaStream([]) as s:
+            stream = CudaStream(s.handle)
+            self.assertTrue(kv1.resume(stream))
+            self.assertTrue(kv1.resize(2 * self.TPB))
+            kv1.close()
+        s.take_finish_event().synchronize()
+        self.assertEqual(manager.drain_gpu_reclaim(), 1)  # retained (holds VA)
+        kv2 = manager.create_kv_cache(max_capacity=blocks * self.TPB)
+        kv3 = manager.create_kv_cache(max_capacity=blocks * self.TPB)
+        with TemporaryCudaStream([]) as s2:
+            stream2 = CudaStream(s2.handle)
+            self.assertTrue(kv2.resume(stream2))
+            self.assertTrue(kv3.resume(stream2))  # requires spilling kv1's VA
+            kv2.close()
+            kv3.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim()
+
+
+@requires_cuda
+class TestArenaLazyRetentionOnCommit(TestArenaLazyRetention):
+    """P2 x §4.3 ON_COMMIT: adopted host copies register ghosts too."""
+
+    WRITE_THROUGH = WriteThroughPolicy.ON_COMMIT
+
+
+@requires_cuda
 class TestArenaWriteThroughOnCommit(TestArenaKVCacheManagerEndToEnd):
     """The §4.3 ON_COMMIT write-through policy.
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -49,12 +49,12 @@ if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
         WriteThroughPolicy,
         rawref,
     )
-    from kv_cache_manager_v2._common import GPU_LEVEL, CacheLevel, LayerId, Priority
+    from kv_cache_manager_v2._common import GPU_LEVEL, BlockOrdinal, CacheLevel, LayerId, Priority
     from kv_cache_manager_v2._copy_engine import CopyTask
     from kv_cache_manager_v2._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
     from kv_cache_manager_v2._exceptions import LogicError, OutOfPagesError
     from kv_cache_manager_v2._life_cycle_registry import LifeCycleId, LifeCycleRegistry
-    from kv_cache_manager_v2._page import Page
+    from kv_cache_manager_v2._page import CommittedPage, Page
     from kv_cache_manager_v2._sequence_arena import (
         INT31_MAX,
         BlockRangeAllocator,
@@ -87,6 +87,7 @@ else:
     )
     from tensorrt_llm.runtime.kv_cache_manager_v2._common import (
         GPU_LEVEL,
+        BlockOrdinal,
         CacheLevel,
         LayerId,
         Priority,
@@ -101,7 +102,7 @@ else:
         LifeCycleId,
         LifeCycleRegistry,
     )
-    from tensorrt_llm.runtime.kv_cache_manager_v2._page import Page
+    from tensorrt_llm.runtime.kv_cache_manager_v2._page import CommittedPage, Page
     from tensorrt_llm.runtime.kv_cache_manager_v2._sequence_arena import (
         INT31_MAX,
         BlockRangeAllocator,
@@ -2644,14 +2645,17 @@ class TestArenaPrefixAliasing(unittest.TestCase):
         self.assertEqual(budget.used_pages, 0)
 
     def test_dedup_remap_frees_commit_conflict_loser(self) -> None:
-        """P3 v2 pressure-time dedup at the manager seam: the loser shape.
+        """P3 v3 pressure-time dedup at the manager seam: the loser shape.
 
         A and B prefill the same tokens concurrently; A commits first
         (winner, owner-live span), B's commit takes the arena conflict
-        branch (sequence-private duplicates referencing A's tree blocks).
-        The dedup scan finds B, the remap re-backs B's prefix with A's
-        physical pages at the same VA -- B's holders, slots, and offsets
-        are untouched -- and the duplicates' budget charge is freed.
+        branch (sequence-private duplicates referencing A's tree blocks --
+        A is GPU-resident and span-covered, so mappability-weighted
+        resolution keeps A canonical) and flags B in the dedup dirty set.
+        hard_reclaim_gpu scans ONLY the flagged B (clearing the flag on the
+        attempt), the remap re-backs B's prefix with A's physical pages at
+        the same VA -- B's holders, slots, and offsets are untouched -- and
+        the duplicates' budget charge is freed.
         """
         manager = self.manager
         budget = manager._storage.gpu_page_budget
@@ -2675,15 +2679,20 @@ class TestArenaPrefixAliasing(unittest.TestCase):
             kv_a.commit(tokens)  # winner; owner-live span registers here
             kv_b.commit(tokens)  # loser -> private duplicates of A's blocks
             self.assertEqual(len(pg._canonical_spans), 1)
+            # R2: the commit-conflict loss to a MAPPABLE incumbent flagged
+            # exactly B in the dirty set; the winner is not flagged.
+            self.assertEqual(list(manager._arena_dedup_dirty.keys()), [id(kv_b)])
             used_before = budget.used_pages
             hits_before = pg.alias_hits
             misses_before = pg.alias_misses
 
-            freed = manager.dedup_remap_gpu(1 << 62)
+            freed = manager.hard_reclaim_gpu(1 << 62)
             self.assertEqual(freed, 1)  # 64 x 32KiB blocks = 1 chunk
             self.assertEqual(budget.used_pages, used_before - 1)
             self.assertEqual(pg.dedup_remapped_pages, 1)
             self.assertIsNotNone(kv_b._arena_ranges[PoolGroupIndex(0)]._alias_span_key)
+            # Clear-on-attempt: the scan consumed the flag.
+            self.assertEqual(len(manager._arena_dedup_dirty), 0)
             # The scan must not disturb the admission counters.
             self.assertEqual(pg.alias_hits, hits_before)
             self.assertEqual(pg.alias_misses, misses_before)
@@ -2692,8 +2701,10 @@ class TestArenaPrefixAliasing(unittest.TestCase):
             self._block_floats(a0).fill_(43.0)
             torch.cuda.synchronize()
             self.assertTrue(bool((self._block_floats(b0) == 43.0).all().item()))
-            # Idempotent: nothing left to dedup.
-            self.assertEqual(manager.dedup_remap_gpu(1 << 62), 0)
+            # Idempotent AND sync-free: the dirty set is empty, nothing is
+            # parked or pending, and the only span is owner-live (no
+            # registry excess) -- there is nothing to reclaim anywhere.
+            self.assertEqual(manager.hard_reclaim_gpu(1 << 62), 0)
             kv_b.close()
             kv_a.close()
         s.take_finish_event().synchronize()
@@ -2999,6 +3010,372 @@ class TestArenaSuspendHostExhaustion(unittest.TestCase):
             kv_b.close()
         s2.take_finish_event().synchronize()
         manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+
+
+class TestArenaV3HardReclaimAndPromotion(unittest.TestCase):
+    """P3 v3: hard-reclaim ladder + mappability-weighted promotion.
+
+    Covers the canonical-residency trap fix (once a canonical is evicted to
+    host and its span pin dies, every same-prefix admission would otherwise
+    copy from host forever), the destruction-ordered hard reclaim (dedup
+    before parked ranges), the dirty-set lifecycle, and the single-quiesce
+    discipline.
+    """
+
+    TPB = 16
+    PREFIX_BLOCKS = 64  # one full 2 MiB chunk of 32 KiB coalesced records
+
+    def setUp(self) -> None:
+        init_cuda_once()
+        cfg = _make_manager_config(gpu_quota=32 * MiB, host_quota=64 * MiB)
+        cfg.contiguous_arena = ContiguousArenaConfig(map_ahead_pages=0, prefix_aliasing=True)
+        self.manager = KVCacheManager(cfg)
+
+    def tearDown(self) -> None:
+        self.manager.shutdown()
+        del self.manager
+
+    def _block_floats(self, page_index: int) -> "torch.Tensor":
+        addr = int(
+            self.manager._storage.slot_address(
+                GPU_LEVEL, PoolGroupIndex(0), page_index, PoolIndex(0)
+            )
+        )
+        return TestSparseVirtMem._tensor_at(addr, (4 * 8192) // 4)
+
+    def _host_floats(self, slot_id: int) -> "torch.Tensor":
+        import ctypes
+
+        addr = int(
+            self.manager._storage.slot_address(
+                CacheLevel(1), PoolGroupIndex(0), slot_id, PoolIndex(0)
+            )
+        )
+        buf = (ctypes.c_float * ((4 * 8192) // 4)).from_address(addr)
+        return torch.frombuffer(buf, dtype=torch.float32)
+
+    def _pool_group(self):
+        return self.manager._storage._gpu_arena_storage().pool_group(PoolGroupIndex(0))
+
+    def _cap(self) -> int:
+        return (self.PREFIX_BLOCKS + 4) * self.TPB
+
+    def _spawn_owner_then_spill(self, tokens: "list[int]") -> "list[int]":
+        """A commits ``tokens`` and closes; then everything spillable is
+        spilled (parked range AND span pin), leaving the canonical entries
+        host-resident and UNMAPPABLE -- the trap precondition. Returns A's
+        host slot ids for the prefix, ordinal order.
+        """
+        manager = self.manager
+        kv_a = manager.create_kv_cache(max_capacity=self._cap())
+        with TemporaryCudaStream([]) as s:
+            self.assertTrue(kv_a.resume(CudaStream(s.handle)))
+            self.assertTrue(kv_a.resize(len(tokens)))
+            for j, idx in enumerate(list(kv_a.get_base_page_indices(LifeCycleId(0)))):
+                self._block_floats(idx).fill_(float(j))
+            torch.cuda.synchronize()
+            kv_a.commit(tokens)
+            blocks = [kv_a._get_tree_block(BlockOrdinal(o)) for o in range(self.PREFIX_BLOCKS)]
+            kv_a.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        torch.cuda.synchronize()
+        manager._storage.spill_gpu_retained(1 << 62)
+        pg = self._pool_group()
+        self.assertEqual(pg.canonical_span_pages, 0)  # span pin is gone
+        self.assertEqual(self.manager._storage.gpu_page_budget.used_pages, 0)
+        host_ids = []
+        for blk in blocks:
+            page = blk.storage[LifeCycleId(0)]()
+            self.assertIsNotNone(page)
+            self.assertNotEqual(page.cache_level, GPU_LEVEL)  # host-resident
+            host_ids.append(int(page.slot_id))
+        return host_ids
+
+    def test_onboard_promotion_breaks_canonical_residency_trap(self) -> None:
+        """The owner-found trap (P3 v3 R1(b)): A's canonicals are
+        host-resident with a dead span pin. C's admission copy-onboards --
+        and the promotion pass re-points every canonical entry to C's
+        GPU-resident copy, ADOPTING A's host slot (same slot id, no new
+        host allocation). C's context-end commit then registers a live
+        span over the promoted pages, so D ALIASES (zero-copy, proven by
+        corrupting the host bytes) instead of copying from host --
+        breaking the eternal-copy loop. C's close adopts the stolen slot
+        copy-free (the corrupted host bytes stay corrupted: no D2H copy
+        ran).
+        """
+        manager = self.manager
+        pg = self._pool_group()
+        n_tok = self.PREFIX_BLOCKS * self.TPB
+        tokens = [3000 + i for i in range(n_tok)]
+        a_host_ids = self._spawn_owner_then_spill(tokens)
+
+        kv_c = manager.create_kv_cache(input_tokens=tokens + [1, 2], max_capacity=self._cap())
+        self.assertEqual(kv_c.history_length, n_tok)
+        with TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv_c.resume(CudaStream(s2.handle)))
+            # Promotion: every prefix canonical is now C's GPU page...
+            c_indices = list(kv_c.get_base_page_indices(LifeCycleId(0)))[: self.PREFIX_BLOCKS]
+            for o in range(self.PREFIX_BLOCKS):
+                entry = kv_c._get_tree_block(BlockOrdinal(o)).storage[LifeCycleId(0)]()
+                self.assertIsNotNone(entry, f"block {o} canonical died")
+                self.assertEqual(entry.cache_level, GPU_LEVEL, f"block {o} not promoted")
+                self.assertEqual(int(entry.slot_id), int(c_indices[o]))
+                self.assertIs(type(entry), CommittedPage)
+            # ...whose host slots were ADOPTED, not freed (same ids)...
+            stash_ids = [
+                int(kv_c._write_through_slots[(o, 0)].slot_id) for o in range(self.PREFIX_BLOCKS)
+            ]
+            self.assertEqual(stash_ids, a_host_ids)
+            # ...and nothing was flagged dirty (promotion is a win).
+            self.assertEqual(len(manager._arena_dedup_dirty), 0)
+            torch.cuda.synchronize()
+            for j, idx in enumerate(c_indices):
+                self.assertTrue(bool((self._block_floats(idx) == float(j)).all().item()))
+            # Context-end commit registers a live span over promoted pages.
+            self.assertTrue(kv_c.resize(n_tok + self.TPB))
+            kv_c.commit([1] * self.TPB)  # delta: the matched prefix is committed
+            self.assertEqual(len(pg._canonical_spans), 1)
+            # Corrupt the (adopted) host copies: correct bytes at D can then
+            # only arrive through the alias mapping.
+            for slot_id in a_host_ids:
+                self._host_floats(slot_id).fill_(-777.0)
+            hits_before = pg.alias_hits
+            kv_d = manager.create_kv_cache(input_tokens=tokens + [5, 6], max_capacity=self._cap())
+            with TemporaryCudaStream([]) as s3:
+                self.assertTrue(kv_d.resume(CudaStream(s3.handle)))
+                self.assertEqual(pg.alias_hits, hits_before + 1)
+                torch.cuda.synchronize()
+                d_indices = list(kv_d.get_base_page_indices(LifeCycleId(0)))
+                for j in range(self.PREFIX_BLOCKS):
+                    self.assertTrue(
+                        bool((self._block_floats(d_indices[j]) == float(j)).all().item()),
+                        f"block {j} not aliased from the promoted canonical",
+                    )
+                kv_d.close()
+            s3.take_finish_event().synchronize()
+            kv_c.close()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        # Copy-free adoption at close: the host bytes are still the
+        # corruption pattern -- no D2H copy overwrote them.
+        for slot_id in a_host_ids:
+            self.assertTrue(bool((self._host_floats(slot_id) == -777.0).all().item()))
+        torch.cuda.synchronize()
+        manager._storage.spill_gpu_retained(1 << 62)
+
+    def test_commit_conflict_promotes_over_host_incumbent(self) -> None:
+        """P3 v3 R1(a), the staggered no-match arrival: C admitted before
+        A commits (empty tree, no reuse match) computes the same tokens
+        itself; by the time C commits, A has closed, offloaded, and its
+        span pin was spilled. C's commit conflicts with the HOST-resident
+        incumbent -- and wins: C's page becomes canonical, A's host slot
+        is adopted, C is NOT flagged dirty, and C's own commit burst
+        registers a live span that a follower aliases mid-C-life.
+        """
+        manager = self.manager
+        pg = self._pool_group()
+        n_tok = self.PREFIX_BLOCKS * self.TPB
+        tokens = [4000 + i for i in range(n_tok)]
+        kv_c = manager.create_kv_cache(max_capacity=self._cap())  # BEFORE any commit
+        a_host_ids = self._spawn_owner_then_spill(tokens)
+        with TemporaryCudaStream([]) as s:
+            self.assertTrue(kv_c.resume(CudaStream(s.handle)))
+            self.assertTrue(kv_c.resize(n_tok))
+            c_indices = list(kv_c.get_base_page_indices(LifeCycleId(0)))
+            for j, idx in enumerate(c_indices):
+                self._block_floats(idx).fill_(100.0 + j)
+            torch.cuda.synchronize()
+            kv_c.commit(tokens)  # conflicts with A's host-resident entries
+            for o in range(self.PREFIX_BLOCKS):
+                entry = kv_c._get_tree_block(BlockOrdinal(o)).storage[LifeCycleId(0)]()
+                self.assertIsNotNone(entry)
+                self.assertEqual(entry.cache_level, GPU_LEVEL, f"block {o} not promoted")
+                self.assertEqual(int(entry.slot_id), int(c_indices[o]))
+            stash_ids = [
+                int(kv_c._write_through_slots[(o, 0)].slot_id) for o in range(self.PREFIX_BLOCKS)
+            ]
+            self.assertEqual(stash_ids, a_host_ids)
+            self.assertEqual(len(manager._arena_dedup_dirty), 0)  # winner
+            # C's commit burst registered a live span over the promoted run.
+            self.assertEqual(len(pg._canonical_spans), 1)
+            hits_before = pg.alias_hits
+            kv_b = manager.create_kv_cache(input_tokens=tokens + [7, 8], max_capacity=self._cap())
+            with TemporaryCudaStream([]) as s2:
+                self.assertTrue(kv_b.resume(CudaStream(s2.handle)))
+                self.assertEqual(pg.alias_hits, hits_before + 1)
+                torch.cuda.synchronize()
+                b0 = list(kv_b.get_base_page_indices(LifeCycleId(0)))[0]
+                self.assertTrue(bool((self._block_floats(b0) == 100.0).all().item()))
+                kv_b.close()
+            s2.take_finish_event().synchronize()
+            kv_c.close()
+        s.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        torch.cuda.synchronize()
+        manager._storage.spill_gpu_retained(1 << 62)
+
+    def test_promotion_window_race_becomes_productive_dedup(self) -> None:
+        """P3 v3 R1 window self-heal: D onboards right after C promoted but
+        BEFORE C's commit registered the live span -- D's copy sources are
+        C's GPU-resident canonicals (mappable), so D is NOT promoted; it is
+        flagged dirty instead, and once C's span registers, hard_reclaim
+        remaps D's duplicates onto C's pages (the productive dedup case).
+        """
+        manager = self.manager
+        pg = self._pool_group()
+        n_tok = self.PREFIX_BLOCKS * self.TPB
+        tokens = [5000 + i for i in range(n_tok)]
+        self._spawn_owner_then_spill(tokens)
+        budget = manager._storage.gpu_page_budget
+
+        kv_c = manager.create_kv_cache(input_tokens=tokens + [1, 2], max_capacity=self._cap())
+        with TemporaryCudaStream([]) as s, TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv_c.resume(CudaStream(s.handle)))  # promotes
+            self.assertEqual(len(manager._arena_dedup_dirty), 0)
+            # D lands inside the window: canonical is C's live GPU page, no
+            # span registered yet -> D2D copy, not promoted, flagged dirty.
+            kv_d = manager.create_kv_cache(input_tokens=tokens + [3, 4], max_capacity=self._cap())
+            self.assertTrue(kv_d.resume(CudaStream(s2.handle)))
+            self.assertEqual(list(manager._arena_dedup_dirty.keys()), [id(kv_d)])
+            d_rng = kv_d._arena_ranges[PoolGroupIndex(0)]
+            self.assertIsNone(d_rng._alias_span_key)
+            # C's context-end commit registers the live span...
+            self.assertTrue(kv_c.resize(n_tok + self.TPB))
+            kv_c.commit([1] * self.TPB)  # delta: the matched prefix is committed
+            self.assertEqual(len(pg._canonical_spans), 1)
+            # ...and the hard reclaim dedups D onto it (clearing the flag).
+            used_before = budget.used_pages
+            freed = manager.hard_reclaim_gpu(1 << 62)
+            self.assertGreaterEqual(freed, 1)
+            self.assertEqual(budget.used_pages, used_before - freed)
+            self.assertEqual(len(manager._arena_dedup_dirty), 0)
+            self.assertIsNotNone(d_rng._alias_span_key)
+            self.assertGreaterEqual(pg.dedup_remapped_pages, 1)
+            kv_d.close()
+            kv_c.close()
+        s.take_finish_event().synchronize()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        torch.cuda.synchronize()
+        manager._storage.spill_gpu_retained(1 << 62)
+
+    def test_hard_reclaim_dedups_before_spilling_parked_ranges(self) -> None:
+        """Destruction order: a sufficient dedup harvest PRESERVES parked
+        ranges (they carry adoption/D2D value; duplicates carry none).
+        """
+        manager = self.manager
+        pg = self._pool_group()
+        n_tok = self.PREFIX_BLOCKS * self.TPB
+        tokens = [6000 + i for i in range(n_tok)]
+
+        # Winner A (live, span registered at commit) + loser B (dirty).
+        # Reserved BEFORE the parked range exists, so adoption cannot
+        # consume it.
+        kv_a = manager.create_kv_cache(max_capacity=self._cap())
+        kv_b = manager.create_kv_cache(max_capacity=self._cap())
+        with TemporaryCudaStream([]) as s, TemporaryCudaStream([]) as s2:
+            self.assertTrue(kv_a.resume(CudaStream(s.handle)))
+            self.assertTrue(kv_b.resume(CudaStream(s2.handle)))
+            self.assertTrue(kv_a.resize(n_tok))
+            self.assertTrue(kv_b.resize(n_tok))
+
+            # Z: an unrelated closed sequence -> a parked (retained) range.
+            pg._range_adoption = True  # park instead of unmapping on drain
+            kv_z = manager.create_kv_cache(max_capacity=self._cap())
+            with TemporaryCudaStream([]) as s0:
+                self.assertTrue(kv_z.resume(CudaStream(s0.handle)))
+                self.assertTrue(kv_z.resize(2 * self.TPB))
+                kv_z.commit([9000 + i for i in range(2 * self.TPB)])
+                kv_z.close()
+            s0.take_finish_event().synchronize()
+            manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+            self.assertGreaterEqual(len(pg._retained), 1)
+            spilled_before = pg.spilled_ranges
+
+            torch.cuda.synchronize()
+            kv_a.commit(tokens)
+            kv_b.commit(tokens)  # loser: flagged dirty
+            self.assertEqual(list(manager._arena_dedup_dirty.keys()), [id(kv_b)])
+            freed = manager.hard_reclaim_gpu(1)
+            self.assertGreaterEqual(freed, 1)
+            # The dedup satisfied the request: parked range untouched.
+            self.assertEqual(pg.spilled_ranges, spilled_before)
+            self.assertGreaterEqual(len(pg._retained), 1)
+            self.assertGreaterEqual(pg.dedup_remapped_pages, 1)
+            kv_b.close()
+            kv_a.close()
+        s.take_finish_event().synchronize()
+        s2.take_finish_event().synchronize()
+        manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+        torch.cuda.synchronize()
+        manager._storage.spill_gpu_retained(1 << 62)
+
+    def test_hard_reclaim_sync_discipline(self) -> None:
+        """No-sync guarantee + single-quiesce guarantee: with nothing to
+        reclaim anywhere, hard_reclaim syncs ZERO times; with a dedup batch
+        AND multiple parked ranges to spill, it syncs EXACTLY ONCE (the old
+        ladder quiesced per range).
+        """
+        import sys
+
+        storage_core = sys.modules[ArenaPoolGroup.__module__]
+        manager = self.manager
+        pg = self._pool_group()
+        n_tok = self.PREFIX_BLOCKS * self.TPB
+        counter = {"n": 0}
+        real_quiesce = storage_core.quiesce_before_unmap
+
+        def counting_quiesce() -> None:
+            counter["n"] += 1
+            real_quiesce()
+
+        storage_core.quiesce_before_unmap = counting_quiesce
+        try:
+            # Nothing anywhere: zero syncs.
+            self.assertEqual(manager.hard_reclaim_gpu(1 << 62), 0)
+            self.assertEqual(counter["n"], 0)
+
+            # Build work: one dirty loser + two parked ranges (A/B reserved
+            # first so adoption cannot consume the parked ranges).
+            tokens = [9500 + i for i in range(n_tok)]
+            kv_a = manager.create_kv_cache(max_capacity=self._cap())
+            kv_b = manager.create_kv_cache(max_capacity=self._cap())
+            with TemporaryCudaStream([]) as s, TemporaryCudaStream([]) as s2:
+                self.assertTrue(kv_a.resume(CudaStream(s.handle)))
+                self.assertTrue(kv_b.resume(CudaStream(s2.handle)))
+                self.assertTrue(kv_a.resize(n_tok))
+                self.assertTrue(kv_b.resize(n_tok))
+                pg._range_adoption = True  # park instead of unmapping
+                for base in (7000, 8000):
+                    kv_z = manager.create_kv_cache(max_capacity=self._cap())
+                    with TemporaryCudaStream([]) as s0:
+                        self.assertTrue(kv_z.resume(CudaStream(s0.handle)))
+                        self.assertTrue(kv_z.resize(2 * self.TPB))
+                        kv_z.commit([base + i for i in range(2 * self.TPB)])
+                        kv_z.close()
+                    s0.take_finish_event().synchronize()
+                manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+                self.assertGreaterEqual(len(pg._retained), 2)
+                torch.cuda.synchronize()
+                kv_a.commit(tokens)
+                kv_b.commit(tokens)  # dirty loser
+                counter["n"] = 0
+                # Demand everything: dedup + spill BOTH parked ranges, one
+                # quiesce total (per-range re-sync eliminated).
+                freed = manager.hard_reclaim_gpu(1 << 62)
+                self.assertGreaterEqual(freed, 3)  # 1 dedup chunk + 2 parked
+                self.assertEqual(counter["n"], 1)
+                self.assertEqual(len(pg._retained), 0)
+                kv_b.close()
+                kv_a.close()
+            s.take_finish_event().synchronize()
+            s2.take_finish_event().synchronize()
+            manager.drain_gpu_reclaim(CachedCudaEvent.NULL)
+            torch.cuda.synchronize()
+            manager._storage.spill_gpu_retained(1 << 62)
+        finally:
+            storage_core.quiesce_before_unmap = real_quiesce
 
 
 if __name__ == "__main__":

--- a/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py
@@ -1127,21 +1127,78 @@ class TestArenaPoolGroup(unittest.TestCase):
             self.assertEqual(adopted.base_block, rng_a.base_block)
             self.assertEqual(adopted._alias_span_key, (key, 2))
 
-            # Spill the registry: pins drop, lookups miss, aliases keep bytes.
+            # Refcount-gated spill (P3): rng_b and the adopted range both still
+            # alias this span, so pressure must NOT spill it -- dropping the pin
+            # would free nothing (the aliases keep the handles resident) and
+            # evict a still-usable prefix from the reuse lookup. It stays
+            # discoverable and the bytes stay valid through the live aliases.
             torch.cuda.synchronize()
-            self.assertEqual(group.spill_canonical_spans(1 << 62), 3)
-            self.assertIsNone(group.lookup_canonical_span(canon[0], canon))
+            self.assertEqual(group.spill_canonical_spans(1 << 62), 0)
+            self.assertEqual(group.spilled_spans, 0)
+            self.assertIsNotNone(group.lookup_canonical_span(canon[0], canon))
             tb2 = TestSparseVirtMem._tensor_at(int(addr_b), n)
             self.assertTrue(bool((tb2 == 11.5).all().item()))
 
+            # Free every live range and reclaim; unmapping the parked aliaser
+            # ranges returns the span's chunks to the registry pin alone, so it
+            # finally spills and leaves the lookup.
             for base, rng in list(group._ranges.items()):
                 if not rng._freed:
                     group.free_sequence(rng, CachedCudaEvent.NULL)
             group.drain_reclaim(CachedCudaEvent.NULL)
             torch.cuda.synchronize()
             group.spill_retained(1 << 62)
+            self.assertEqual(group.spill_canonical_spans(1 << 62), 3)
+            self.assertIsNone(group.lookup_canonical_span(canon[0], canon))
             self.assertEqual(self.budget.used_pages, 0)
             self.assertEqual(group.mapped_pages, 0)
+        finally:
+            group.destroy()
+
+    def test_spill_skips_span_with_live_alias(self) -> None:
+        """A span a live sequence still aliases is never spilled (P3).
+
+        It stays in the reuse lookup and becomes spillable only once its last
+        aliaser frees: spilling it would free no physical pages (the alias
+        keeps the handles resident) and would only force a later re-copy.
+        """
+        group = self._group()
+        group._prefix_aliasing = True
+        try:
+            # Owner A registers a 2-block (3-page) span, then closes: the span
+            # is registry-charged with no live alias (refcount == registry pin).
+            rng_a = group.reserve_sequence(4)
+            self.assertEqual(group.ensure_mapped(rng_a, 4), 6)
+            canon = [self._FakeCanonicalPage(), self._FakeCanonicalPage()]
+            group.register_canonical_span(rng_a, canon, CachedCudaEvent.NULL)
+            group.free_sequence(rng_a, CachedCudaEvent.NULL)
+            group.drain_reclaim(CachedCudaEvent.NULL)
+            group.spill_retained(1 << 62)  # unmap A's parked range
+            torch.cuda.synchronize()
+
+            # Admission B aliases the whole span into a fresh range.
+            hit = group.lookup_canonical_span(canon[0], canon)
+            self.assertIsNotNone(hit)
+            rng_b = group.reserve_sequence(4)
+            self.assertEqual(group.alias_span_into_range(rng_b, hit[0], hit[1], hit[2]), 3)
+
+            # Now the span has a live alias: pressure must skip it. It stays
+            # charged and in the reuse lookup, and spills nothing.
+            self.assertEqual(group.canonical_span_pages, 3)
+            self.assertEqual(group.spill_canonical_spans(1 << 62), 0)
+            self.assertEqual(group.spilled_spans, 0)
+            self.assertIsNotNone(group.lookup_canonical_span(canon[0], canon))
+
+            # B frees: its alias ref drops, the span returns to the registry
+            # pin alone and is spillable again.
+            group.free_sequence(rng_b, CachedCudaEvent.NULL)
+            group.drain_reclaim(CachedCudaEvent.NULL)
+            torch.cuda.synchronize()
+            group.spill_retained(1 << 62)  # unmap B's parked range -> drop ref
+            self.assertEqual(group.spill_canonical_spans(1 << 62), 3)
+            self.assertEqual(group.spilled_spans, 1)
+            self.assertIsNone(group.lookup_canonical_span(canon[0], canon))
+            self.assertEqual(self.budget.used_pages, 0)
         finally:
             group.destroy()
 


### PR DESCRIPTION
## Summary

Prototype implementation (P0) of the **contiguous primary KV cache** for `KVCacheManagerV2`: each sequence's active KV blocks are contiguous in virtual memory, backed by physical pages mapped on demand via CUDA VMM, while reusable (stale) state lives in the host tier.

Flag-gated end to end: `KvCacheConfig(use_contiguous_kv_arena=True)` (prototype status). Default behavior is untouched — with the flag off, no code path changes.

### Design

- One large VA reservation ("arena") per (pool group, pool); each sequence gets a contiguous, page-aligned block-index range sized for its per-request maximum, so `slot_id = base + ordinal` and the sequence's kernel-visible page indices are consecutive. Arena base = pool base pointer → **zero kernel changes**, CUDA-graph safe.
- Physical 2 MiB pages (configurable super-pages) map on demand against a level-wide page budget; freed ranges are **parked still-mapped and adopted whole by the next admitted sequence** (default ON), so steady state performs zero `cuMemMap`/`cuMemUnmap`; unmaps happen only under real pressure (spill) or teardown, behind a device quiesce.
- Active→stale: committed blocks copy out to the host tier on free, or eagerly via an opt-in write-through-on-commit policy that makes the free path copy-free (adoption of the pre-copied host slot).
- Stale→active: a reuse hit copies the matched prefix into the new sequence's range as sequence-private pages; canonical radix entries are untouched. Suspend/resume evacuates and re-onboards through the same paths.
- **Prefix aliasing (opt-in, `prefix_aliasing` / `TRTLLM_KV_ARENA_PREFIX_ALIASING=1`)**: a closing canonical owner's fully-committed prefix pages are pinned (refcounted) in a canonical-span registry, and later same-prefix admissions `cuMemMap` the SAME physical pages into their own ranges — zero-copy, zero-budget reuse, with **prefix-affine adoption** (parked ranges carry an `(span, extent)` signature and are only handed to admissions matching it, since adoption overwrites page content). This recovers paged's refcount-sharing economics for the arena layout.
- Capacity planning (`clamp_max_seq_len_for_mem`, scheduler backpressure) moves from slot counts to physical pages; the v2 scheduler needed no changes.

Full design doc, VMM microbenchmarks (H100 + GH200), and per-commit work log are tracked in the development directory (`contiguous_primary_kvcache/DESIGN.md`); can be attached or moved into `docs/` on request.

### P0 scope gates (fail loudly, lifted in later phases)

Sliding-window/VSWA layers, SSM, SWA scratch reuse, partial-block reuse matches, seq rebasing, beam search (unsupported in v2 anyway), FlashInfer-style dense pool views (`get_buffers`), disaggregated serving.

### Correctness campaign (8B scale): three distinct bugs, all root-caused and fixed

Scaling validation from 1B to Llama-3.1-8B exposed an intermittent illegal-memory-access that turned out to be **three independent bugs** (two of which also affect or inform `main`):

| # | Bug | Class | Fix |
|---|-----|-------|-----|
| a | KV block-offset staging race: the offset-gather kernel could read pinned staging buffers already overwritten by the next iteration under the overlap scheduler → stale offsets → IMA (arena) / silent wrong reads (classic) | CPU-side buffer reuse (nvbug-6293536 class); **affects `main`** | `4d49f1d66e` here; standalone `main` fix in PR #16088 |
| b | Scheduler capacity deadlock: arena frees are event- and fence-gated, and the fence was only assigned after scheduling — pages freed by the scheduler's own evictions were unreclaimable in-pass → suspension cascade → guard raise | Arena-specific capacity model | `4fefc34db5` — blocking fenced drain inside the pass + allocation retry |
| c | `cuMemUnmap` racing in-flight kernels: unmapping a VA range that running kernels concurrently read intermittently produces a Warp MMU fault | Driver-level; being escalated to the driver team with a repro matrix | `b271d635fd` (freed-range adoption removes steady-state unmaps entirely); `TRTLLM_KV_ARENA_SYNC_BEFORE_UNMAP` (default ON) quiesces the rare pressure/teardown unmaps |

Evidence for (c), with (a) and (b) fixed: on a deterministic pressure reproducer (`free_gpu_memory_fraction=0.42` ≈ 2.4× KV oversubscription @ conc 256), no-quiesce crashes ~4/7 across mapping margins (growth maps exonerated), while sync-before-unmap runs 6/6 clean (p ≈ 0.6% against the ~57% base rate). Two further ordering fixes landed from the same campaign: arena write-outs (suspend/close) are now ordered after the in-flight forward step via a caller-supplied prior event (`52a311ed99` — silent stale-tail restore, proven both directions), and on-demand mapping (margin=1) was restored as the default (`53f7167405`) after pre-mapping proved to be a ~3-point stopgap for what was mostly bug (a).

A fourth bug was root-caused and fixed after the table above (`51e092e3ed`): **host-tier exhaustion during suspension**. The host tier legitimately fills with already-suspended sequences' HELD pages (which LRU eviction correctly refuses to drop at the last level), and `suspend()` mutated sequence state before its fallible host allocation — so exhaustion either escaped as a process-fatal `OutOfPagesError` or, raced by the in-flight overlap step against the half-suspended state, poisoned the device as an IMA. Fix: an atomic pre-flight host reservation in `suspend()` (failure leaves the sequence fully intact) plus graceful degradation to v1-style **drop-and-recompute** through the adapter, scheduler, and executor (surviving canonical prefixes still shorten the re-prefill). Discriminator (Llama-3.1-8B, 0.42 quota, 4 GiB host ≈ 10× under suspension demand, conc 256): unfixed **4/4 dead** (2 IMA + 2 clean FATAL — two faces of the same trigger); fixed **8/8 clean** at 300/300 with 40+ drop-and-recompute cycles per run.

Endurance under production defaults on the pressure reproducer: 300-req ×3 + 2500-req runs all clean — zero IMA, zero deadlock.

### Testing

- `tests/unittest/kv_cache_manager_v2_tests/test_contiguous_arena.py`: 108 tests — allocator/budget/int31 pure logic, sparse VirtMem, arena storage seam, manager-level end-to-end (growth, reuse round-trip with data verification, suspend/resume byte-identical restore, page-exhaustion backoff, page-based capacity planning), lazy-retention matrix, batched-sweep charging, freed-range adoption semantics, blocking-drain deadlock terminal state, host-exhaustion suspension atomicity (HELD-pinned raise + DROPPABLE churn), prefix aliasing (refcount matrix, zero-charge accounting, registry roundtrip, and two manager-level end-to-ends where zero-copy is proven by corrupting every host copy — including the partial-span shape where the owner's chain outlives a shorter adopter's match, and the pressure window where the registry spills between an admission's lookup and its first resume — dead spans fall back to the host-copy path), and write-out ordering (with explicit copy-kernel warmups — the first batchedCopy call pays ~200 ms module load and masks races otherwise), run under both write-through policies via class inheritance. Newest additions: span-spill protection (floor survives full-pressure spill while parked ranges die, excess spills oldest-first, fraction=0 restores unprotected spilling), map-ahead margin degradation (frontier-only mapping at the budget edge, deterministic batched-sweep charge replay, delta-degrade excess release), and owner-live aliasing (owner-charged span lifecycle at the pool-group seam; a manager-level end-to-end where the consumer admits while the owner is mid-generation and physical sharing is proven by writing through the owner's VA and reading the change through the consumer's).
- `tests/unittest/_torch/executor/test_kv_cache_v2_contiguous_arena.py`: 12 adapter tests (config field/validator, env knobs, real adapter construction, physical capacity accounting, request lifecycle, terminal-state allocation retry, drop-and-recompute fallback).
- `tests/unittest/_torch/executor/test_kv_block_offset_overlap_race_v2.py`: regression test for the offset-staging race (a).
- v2 regression suite: 219 passed / 12 skipped (211 inherited + 8 added), identical to `main` before/after every commit.
- `api_stability` 61/61; existing executor v2 tests 201/201.

### Throughput benchmarks — Llama-3.1-8B (H100, solo runs on an idle node)

`trtllm-bench throughput`, 2500 requests, ISL/OSL 1024/1024, concurrency 256, v2 manager + block reuse + 64 GiB host tier, prefix-sharing dataset (15 shared system prompts, avg 512 tokens). Arena = production defaults (adoption ON, on-demand mapping, `on_free`, 16 MiB pages, linear kernels off).

**Memory-equalized runs** (both backends at ~52.5–52.9 GiB KV quota — a `total_quota` accounting bug that silently granted the arena ~8 GiB more than paged was found and fixed, `c645628fcc`):

| config | tok/s | vs paged |
|---|---|---|
| paged v2 (baseline) | 8,563 | — |
| arena (adoption) | 7,746 | −9.5% |
| arena + prefix aliasing | 7,816 / 7,844 | −8.6% |
| arena + aliasing + **span-spill protection** (+ margin degrade, owner-live, dedup remap) | 8,125–8,278 over 7 runs | **−4.5% ± 0.5** (paged 8,617–8,631, ±0.05%) |

At this quota the shared-prefix workload sits exactly at the arena's capacity edge even WITH aliasing ((3,385 pages − 60 registry)/13 charged pages/seq = 256), so pressure spills thrashed the canonical-span registry: alias hit rate dropped to ~9% and all 15 spans got spilled — aliasing recovered only ~0.9 points. **Span-spill protection** (`463f45cee9`) fixes this: the registry is exempt from pressure spills up to `protected_span_fraction` of the page budget (default 5%; the excess stays spillable LRU-first), and the resume-utilization gate stops counting protected pages as reclaimable. Re-run at the same equalized quota: **zero spans spilled, 2,278 alias hits with zero lookup misses**, recovering ~4 points (−8.6% → −4.5%). An error-bar note on that row: an interleaved A/B bisect across the night's runs showed the ARENA config wanders ~±0.7% across time windows on an otherwise idle node while paged holds ±0.05%, so the honest pooled number for the full stack is **−4.5% ± 0.5** — single run-pairs at this scale cannot resolve sub-point deltas. Within that resolution the three follow-on commits are individually throughput-neutral at this benchmark shape, each by an understood mechanism: **best-effort map-ahead margin** (`812ef73a32`) converts capacity-edge growth failures into frontier-only mappings (this workload rarely hits that path); **owner-live aliasing** (`35260d6afc`) registers spans at context-end commit rather than close — at saturated concurrency admissions happen exactly at closes, so close-time registration was already timely, and its win shape is staggered/bursty same-prompt arrivals; **pressure-time dedup remap** (`530da2a633`) frees duplicate private prefix copies (commit-conflict losers, pre-span copy-onboards) by remapping their VA onto the canonical physical pages, as a reclaim-ladder rung between the parked-range spill and the registry-excess spill — one device quiesce per batch, paid only when the alternative is a preemption; the benchmark's steady state never reaches that rung (every admission aliases, so nothing is duplicated).

**Capacity sensitivity** (the same runs before the quota fix, i.e. arena inadvertently at 60.8 GiB — retained as the headroom data point):

| config | tok/s | vs paged (52.5 GiB) |
|---|---|---|
| arena (adoption) | 8,051 / 8,058 | −6.1% |
| arena + prefix aliasing | 8,471 / 8,461 | −1.3% (87% alias hit rate) |
| arena + aliasing + linear kernels | 8,434 / 8,439 | −1.6% |

Read together: the aliasing **mechanism** works — with ~8 GiB of headroom the spans stay resident and it recovers the full duplication gap (−1.3%, beating the −1.6% reuse-off bound) — but the current **spill policy** forfeits it exactly when memory is tight: the registry is only ~1 GB, and spilling it costs ~5 points. Attribution (reuse-off discriminator, identical footprint both modes): the arena-vs-paged gap is dominated by prefix duplication (paged refcount-shares and fits the quota eviction-free; arena's private copies oversubscribe it), with −1.6% of sharing-independent overhead underneath. Follow-ups: span-aware spill protection, map-ahead-margin degradation, and **owner-live aliasing** have all since **landed** (`463f45cee9`, `812ef73a32`, `35260d6afc` — see the equalized table above). Owner-live registration pins the span at the owner's context-end commit (matching paged, which shares context blocks the moment they commit), so same-prefix admissions alias while the owner is still generating; the entry stays owner-charged (no registry charge, spill-exempt) until the owner's `free_sequence` flips it to the registry-charged state. **Pressure-time dedup remap** (`530da2a633`) has also landed: a stateless scan over live sequences finds committed prefixes held as private duplicates of a registered span and re-backs their VA with the canonical physical pages (same-VA swap — slot ids, offsets, and page holders are untouched, since page objects are slot-indexed), freeing the duplicates' budget charge from LIVE sequences with zero information loss before the reclaim ladder resorts to spilling the registry or preempting.

Aliasing status: **prototype, default OFF** (`ContiguousArenaConfig.prefix_aliasing` / `TRTLLM_KV_ARENA_PREFIX_ALIASING=1`). Correctness-validated at production-shaped load (multiple 2×2500 runs, zero errors) and across a pressure discriminator matrix (adoption-off, tight-quota-only, registry-spill fallback). One rare first-wave IMA on the extreme pressure reproducer (2.4× KV oversubscription + 10× undersized host tier) remains under investigation — a dedicated 84-round multi-GPU grind reproduced it on BOTH arms, with the **no-alias arm crashing at 5× the aliasing arm's rate** (8/36 vs 2/48; the no-alias crashers fire with an empty registry and zero drop/OutOfPages events), confirming it is **not the aliasing machinery** but a rare residual of the pre-hardening IMA class (the driver-interference family being escalated separately).

Gap trajectory as the campaign's fixes landed (same workload; node-shared runs up to adoption, solo after; memory-equalized from `c645628fcc`): pre-map default −12.8% → margin=18 −9.4% → margin=1 −7.4% → adoption −6.8% → equalized adoption −9.5% → + prefix aliasing −8.6% → **+ span-spill protection (and follow-ons) −4.5% ± 0.5** (−1.3% with 8 GiB of KV headroom).

### Throughput benchmarks — Llama-3.2-1B (H100)

5000 requests, ISL/OSL 1024/1024, concurrency 256, v2 manager + block reuse + 8 GiB host tier in all runs. Two datasets: **shared** (every prompt prefixed by one of 15 shared system prompts, avg 512 tokens — maximizes prefix reuse) and **unique** (fully unique prompts — isolates intrinsic overhead). Note both are cache-oversubscribed: ~320k committed blocks vs a ~65k-block GPU quota, so classic paged also offloads D2H at steady state (it runs copy-free only for the first ~15% of requests); copy *volume* is comparable between modes.

| dataset | paged v2 | arena on_free / 16 MiB | arena on_commit / 16 MiB | arena on_free / 2 MiB |
|---|---|---|---|---|
| unique | 30,908 tok/s | **30,785 (−0.4%)** | 28,147 (−8.9%) | — |
| shared | 33,885 tok/s | **31,987 (−5.6%)** | 30,423 (−10.2%) | 28,689 (−15.3%) |

Findings:

- **Arena reaches parity with paged (−0.4%, noise) on the unique-prompt workload with the default `on_free` policy and 16 MiB super-pages.** Demand paging, VA management, deferred reclaim, and write-out volume are all in the noise at this scale.
- The apparent "intrinsic" −8.9% was entirely the `on_commit` write-through's per-block dispatch granularity (~320k small migrations vs classic's large batched evictions) — the rate-limiting concern the design flags as risk #4. `on_free` (the default) batches per request. A batched/async write-through dispatcher is the P1 fix before `on_commit` is recommendable.
- All runs completed 5000/5000 requests — sustained stress of demand paging, deferred reclaim, and the page budget at high concurrency.
- With policy and page size held at their best settings: **arena is at parity (−0.4%) without prefix sharing and −4.4% to −5.6% behind with heavy sharing** (−4.4% with 256 system prompts and a 64 GiB host tier); 2 MiB paging adds ~10 points of churn at this request rate (16 MiB super-pages recommended); `on_commit` write-through as currently implemented adds ~5-8 points of per-block dispatch (`on_free` is the default).

### Attributing the residual gap (P2 + ablations)

The branch also implements **P2 lazy GPU retention** (§4.4 phase 2, opt-in): freed ranges stay mapped on a retained LRU, reuse hits copy D2D from the resident bytes (private copies re-register as fresh sources so hot prefixes survive LRU spills), and the page budget reclaims retained ranges only under pressure — plus the **§4.2 batched map sweep** (opt-in): growth maps charge the budget at resize time but execute in one batched pass per iteration. (Freed-range adoption, above, grew out of this parking machinery and is now default-ON in all modes.)

Three controlled ablations on the prefix-heavy workload all came back **null**, which bounds the residual precisely:

| ablation | mechanism tested | result |
|---|---|---|
| lazy retention | reuse copy *transfer* (99.7% D2D hit rate measured) | no change |
| batched sweep | driver-call *placement* | no change |
| map-ahead | driver-call *count* (1 `cuMemSetAccess`/seq) | no change |

Together with py-spy profiles (arena-vs-paged on identical workloads), the residual ~5% is **distributed host-side Python bookkeeping across the arena's per-request paths** (onboarding, close write-out, reclaim scans) plus associated GPU-wait — no concentrated sink. Both benchmark modes ran the pure-Python v2 package; the arena executes more Python per request, so **mypyc compilation is the largest remaining lever**, followed by moving the (now single-point) map flush to a helper thread. The sweep defaults off until then. The P1 linear-addressing kernels remain the upside this storage layout exists to enable. Profiles and per-run reports are archived with the work log.

### Super-page size curve and follow-up optimizations

Sweeping `TRTLLM_KV_ARENA_PHYS_PAGE_SIZE_MB` on the prefix-heavy (shared) workload shows page *count* — not map-call count — scales several per-request costs at once (teardown unmap chunks, budget arithmetic, mapped-range scans):

| super-page size | vs paged | mapped/seq (68-block range) | tail waste @ 256 seqs |
|---|---|---|---|
| 16 MiB | −5.6% | 80 MiB | ~3 GB |
| 32 MiB | **−3.5%** | 96 MiB | ~7 GB |
| 64 MiB | −3.0% | 128 MiB | ~15 GB |

**Recommended default for this workload shape: 32 MiB** (16→32 gains 2.1 points; 32→64 only 0.5 more while doubling tail waste). Long-context workloads can go larger, memory-tight deployments smaller. (With adoption ON, steady-state map traffic is zero, so page size matters mainly for spill/teardown and tail waste.)

Follow-ups landed since:

- **Per-range mapped high-water frontier** (`Track per-range mapped frontier in contiguous KV arenas`): `ensure_mapped` previously rescanned each range from its start on every growth call (O(blocks × pages) per sequence of pure-Python `is_mapped` checks — the inefficiency the page-size curve exposed). Ranges now track a mapped high-water frontier, making growth planning, retained-page counts, and reclaim O(1)/single-unmap. Recovers ~0.8 points at 16 MiB (−5.6% → −4.8% against a same-node paged baseline) without 32 MiB's tail-waste cost, and removes the two scanning helpers outright (net −18 lines).
- **mypyc compilation** (the biggest lever per profiling): `main` no longer mypyc-compiles at all; PR #15990 restores compilability (pre-existing issues, separate PR), and this branch carries the arena-side typing fixes. With the package hybrid-compiled (20/22 modules; two excluded for mypyc codegen bugs documented in #15990), both modes speed up (paged +2.3%, arena +2.8%) and the gap narrows to **−4.3%**. That is a lower bound on full compilation's effect: the single hottest module (`_core/_kv_cache.py`, resize/commit per token) is one of the two still interpreted.
- **P1 linear-addressing kernels** (opt-in, `TRTLLM_KV_ARENA_LINEAR_KERNELS`): XQA reads KV pages by linear arithmetic instead of table loads. E2e: **+1.8% at short sequences** (ISL/OSL 256/256, the µbench sweet spot), null at 1024/1024 — including under prefix aliasing in the KV-headroom regime (8,436 vs 8,466, −0.35%), so deduplicated, L2-friendlier prefix reads do not change the verdict. Graduation case is short-context serving regimes; default off.

Benchmarking also surfaced and fixed an arena-mode crash (commit "Handle intra-batch commit conflicts"): two in-flight requests committing the same system-prompt block asserted, since seq rebasing is disabled in arena mode; the loser now keeps its own pages as sequence-private committed copies referencing the existing tree block, and `commit()`'s block loop tolerates mid-loop virtual stops (hardening the classic path as well).

### Hard-reclaim redesign + mappability-weighted canonical promotion (P3 v3)

Two commits (`c9ac413fae`, `7fd533b628`) rework pressure-time reclaim and fix a pathology in how the reuse tree tracks residency.

**The canonical-residency trap.** Once a canonical block is evicted to host and its span pin dies, every later same-prefix admission copy-onboards from host, holds a sequence-private duplicate, and the tree never re-learns that a GPU copy exists — the prompt class copies from host forever. Fix: **mappability-weighted promotion** at both duplicate-creating seams (commit-conflict and onboarding). If the incumbent canonical is unmappable (no live registered span identity-covers it) and droppable, the GPU-resident challenger becomes the canonical instead of a private duplicate, and it **adopts the incumbent's host slot** as its pre-valid host backing — a future eviction is copy-free (verified byte-level: a corruption pattern written to the host copy survives the promoted owner's close, proving no D2H copy ran). The first descendant pays the copy once; its context-end commit registers a live span; every later descendant aliases.

**Hard reclaim.** `hard_reclaim_gpu(min_pages)` replaces the ladder's three lower rungs: a sync-free exit when nothing is reclaimable anywhere, otherwise ONE device quiesce under which everything harvestable is taken in destruction order — dedup remap of ALL flagged sequences first (duplicates have zero retention value), then parked terminated ranges, then registry excess above the protection floor; pausing stays the caller's fallback. A per-request dirty set (flagged at the duplicate-creating sites, cleared on scan attempt) gates the scan at O(1). The old ladder short-circuited at the first progressing rung, so the dedup rung never fired on any real workload, and the parked-range spill re-quiesced per range; both are gone (a unit test pins the discipline: zero syncs when idle, exactly one per harvest).

**Validation (Llama-3.1-8B, H100, solo, interleaved):**

| shape | config | throughput | dedup remapped pages |
|---|---|---|---|
| capacity edge (`free_gpu_memory_fraction=0.7`) | pre-v3 arena+aliasing | 7763.6 / 7785.9 | 0 / 0 |
| capacity edge (0.7) | **v3** arena+aliasing | **7852.9 / 7839.7 / 7885.3** (**+0.9..1.4%**) | **187 / 184 / 150** |
| saturated honest memory (0.85) | paged | 8593.1 / 8583.1 | — |
| saturated honest memory (0.85) | **v3** arena+aliasing | 8210.0 / 8198.9 (−4.47%, = pre-v3 pooled −4.5%±0.5) | 31 / 24 |

Net: **wins at the capacity edge where reclaim pressure is real, neutral at saturation**; zero IMA / drops / alias misses across all runs. The second commit fixes a probe bug found during validation: the promotion mappability check originally reused the admission-path span lookup, whose verify loop invalidates a span on identity mismatch — probe chains legitimately diverge from the span owner's path past the shared prefix, so live spans were sporadically forfeited (47/2279 admissions missed). The probe is now a non-destructive O(1) identity check.

### Mean-batch gap at saturation: root cause and fix (map-ahead margin)

Per-iteration instrumentation of the saturated 0.85 shape (scheduler batch, page-budget composition, and admission-refusal sites, correlated per iteration) decomposed the arena's −4.4% against paged into an admission-capacity story:

- New context requests are admitted through `resume()`, whose utilization gate (`max_util_for_resume`, default 0.95) refuses while `(used − reclaimable)/total > 0.95`. On refusing iterations the gate-visible utilization sits exactly at 0.951 — the system is a regulator pinned at its setpoint, holding the arena at ~234 active sequences while paged (whose evictable blocks reclaim via synchronous free-list ops and whose gate essentially never fires — 566 checks failed in a whole run vs ~197k) runs client-bound at 256.
- Of the 212 MB charged per active sequence at the pin, 187 MB is true KV capacity; the rest is the demand-paging **map-ahead margin** plus super-page rounding. The margin is charged to the page budget per sequence, so at the utilization ceiling it converts one-for-one into fewer admitted sequences — while its latency-hiding value does not measure, because at super-page granularity a sequence crosses a page boundary only every `page_size/bytes_per_token` tokens (128 tokens at 16 MiB for an 8B model).
- Steady-phase means (excluding the identical ramp/drain phases, which had masked the effect) on Llama-3.1-8B, H100, 2500×(1024/1024)@conc 256, 0.85 fraction, 64 GiB host, prefix aliasing on:

| config | steady mean batch | at 256 cap | throughput |
|---|---|---|---|
| paged | 232.9 | 77.8% | 8615–8621 |
| arena+aliasing, margin 1 (old default) | 218.5–218.8 | 13% | 8238–8251 |
| arena+aliasing, **margin 0** | 228.3 | 14% | **8383 (+1.7%)** |
| arena+aliasing, margin 0 + `max_util_for_resume: 0.98` | **232.9** | **77.9%** | **8473 / 8485 (+2.8%)** |

**This PR flips the map-ahead default to 0** (`TRTLLM_KV_ARENA_MAP_AHEAD_PAGES`, `ContiguousArenaConfig.map_ahead_pages`; the knob remains). Margin 0 is already routinely exercised — the mapping planner degrades the margin to 0 under pressure before failing a charge — and the flip also *reduces* pressure-machinery activity (gate refusals drop 4×, −5.4% iterations to completion, allocation failures unchanged, zero IMA across all runs).

With the margin honest, raising `max_util_for_resume` to 0.98 in the serving config makes the arena client-bound with the same steady batch and cap-residency as paged, leaving **−1.6%**, which profiling attributes to per-step host bookkeeping (the mypyc item above), with no capacity component. Note the ordering matters: 0.98 *without* the margin fix ran the pressure machinery hot (5× dedup harvests, ~1000 iterations with blocking mid-scheduling drains) and measured *slower* (−1.4%); the gate default is therefore left at 0.95 and 0.98 is a recommended config for arena workloads rather than a default change (the field is shared with classic v2).

### Status

Ready for review. Since the last body update: **P3 v3 hard-reclaim redesign + mappability-weighted canonical promotion** (`c9ac413fae` + probe fix `7fd533b628`), and the **saturation mean-batch root cause + map-ahead default flip** (`a4fa141fe7`, sections above; the flip closes the batch gap's dominant term and combined with `max_util_for_resume: 0.98` in serving configs reaches batch parity with paged). Remaining follow-ups tracked for later phases: batched `on_commit` dispatcher (its write-through prior-event is on the manager stream — needs the same forward-stream treatment as `52a311ed99` before default use), helper-thread map flush, partial-block reuse, VSWA/SSM support, disaggregated serving (P2), driver-team escalation of the unmap-vs-in-flight-kernels fault (repro matrix ready).
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental contiguous KV arena mode for KV cache management.
  * Introduced new arena-aware capacity, mapping, reclaim, and write-through behaviors.
  * Added public configuration options and APIs for arena-backed cache handling.

* **Bug Fixes**
  * Improved handling of cache lifecycle operations in arena mode, including resume, suspend, close, and capacity growth.
  * Tightened validation to prevent unsupported configuration combinations when arena mode is enabled.

* **Tests**
  * Added extensive CUDA unit coverage for contiguous arena allocation, mapping, reclamation, and end-to-end cache workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

