### PR TITLE
[TRTLLM-13973][fix] Restrict MiniMax M3 dense SDPA backends

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_minimaxm3.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm3.py
@@ -27,6 +27,7 @@ from typing import Mapping as TMapping
 
 import torch
 from torch import nn
+from torch.nn.attention import SDPBackend, sdpa_kernel
 from transformers import PretrainedConfig
 
 from tensorrt_llm.functional import AllReduceStrategy, PositionEmbeddingType
@@ -45,6 +46,11 @@ from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
 from ..utils import ActivationType, AuxStreamType, EventType
 from .modeling_utils import DecoderModel, DecoderModelForCausalLM, ModelConfig, register_auto_model
+
+# Dense layers use SDPA with non-contiguous Q/K/V and a bool attn_mask.
+# Limit backends to memory-efficient and math; cuDNN SDPA fails for this layout,
+# and flash SDPA does not accept attn_mask.
+_DENSE_SDPA_BACKENDS = [SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]
 
 # ---------------------------------------------------------------------------
 # Config normalization helpers
@@ -948,14 +954,15 @@ class MiniMaxM3Attention(Attention):
                 v_b = v_padded[b].transpose(0, 1).unsqueeze(0)  # [1, H, k, d]
                 mask_b = valid[start:end].unsqueeze(0).unsqueeze(0)  # [1, 1, q, k]
                 # SDPA: when attn_mask is a bool tensor, True = attend, False = mask.
-                out_b = torch.nn.functional.scaled_dot_product_attention(
-                    q_b.to(q.dtype),
-                    k_b.to(q.dtype),
-                    v_b.to(q.dtype),
-                    attn_mask=mask_b,
-                    dropout_p=0.0,
-                    is_causal=False,
-                )  # [1, H, q, d]
+                with sdpa_kernel(_DENSE_SDPA_BACKENDS):
+                    out_b = torch.nn.functional.scaled_dot_product_attention(
+                        q_b.to(q.dtype),
+                        k_b.to(q.dtype),
+                        v_b.to(q.dtype),
+                        attn_mask=mask_b,
+                        dropout_p=0.0,
+                        is_causal=False,
+                    )  # [1, H, q, d]
                 attn_outputs.append(out_b.squeeze(0).transpose(0, 1))  # [q, H, d]
             o = (
                 torch.cat(attn_outputs, dim=0)
@@ -977,14 +984,15 @@ class MiniMaxM3Attention(Attention):
             k_b = k_padded.transpose(1, 2)  # [batch, H, k, d]
             v_b = v_padded.transpose(1, 2)  # [batch, H, k, d]
             mask_b = valid.unsqueeze(1).unsqueeze(1)  # [batch, 1, 1, k]
-            out_b = torch.nn.functional.scaled_dot_product_attention(
-                q_b.to(q.dtype),
-                k_b.to(q.dtype),
-                v_b.to(q.dtype),
-                attn_mask=mask_b,
-                dropout_p=0.0,
-                is_causal=False,
-            )  # [batch, H, 1, d]
+            with sdpa_kernel(_DENSE_SDPA_BACKENDS):
+                out_b = torch.nn.functional.scaled_dot_product_attention(
+                    q_b.to(q.dtype),
+                    k_b.to(q.dtype),
+                    v_b.to(q.dtype),
+                    attn_mask=mask_b,
+                    dropout_p=0.0,
+                    is_causal=False,
+                )  # [batch, H, 1, d]
             # Drop the singleton Q-length axis. The result is already the
             # ``[batch, num_heads, head_dim]`` layout the prefill branch
             # produces, so the shared flatten on line below is sufficient.


### PR DESCRIPTION
## Description

**_Background:_**
PyTorch SDPA auto-dispatch can pick the cuDNN backend for MiniMax-M3 dense layers, which fails at runtime with non-contiguous Q/K/V and a bool attn_mask.

**_Fix:_**
Wrap dense-layer scaled_dot_product_attention calls in sdpa_kernel() limited to memory-efficient and math backends.

## Test Coverage
```
$ pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8 -s -v
```
## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention handling for dense model layers to use a more consistent backend selection during both initial and generation-time processing.
  * This helps prevent backend-related issues and can improve reliability of model execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->