### PR TITLE
[https://nvbugs/6401921][fix] Add `if shutil.which("ffmpeg"): return` guard at the top of `_visual_gen_deps`…

### DIFF
--- a/tests/integration/defs/examples/visual_gen/test_visual_gen.py
+++ b/tests/integration/defs/examples/visual_gen/test_visual_gen.py
@@ -235,7 +235,10 @@ def _visual_gen_deps(llm_venv):
     """Install av + diffusers + ffmpeg once per session (shared by all video-gen fixtures)."""
     llm_venv.run_cmd(["-m", "pip", "install", "av"])
     llm_venv.run_cmd(["-m", "pip", "install", "diffusers>=0.37.0"])
-    # Install ffmpeg system package required by save_video() for MP4 encoding
+    # Skip apt-get when ffmpeg is already present: it is typically preinstalled in
+    # the container image, and apt-get requires root which is not always available.
+    if shutil.which("ffmpeg"):
+        return
     check_call(["apt-get", "update", "-y"], shell=False)
     check_call(["apt-get", "install", "-y", "ffmpeg"], shell=False)
 


### PR DESCRIPTION
## Summary
- **Root cause**: `_visual_gen_deps` fixture unconditionally invoked `apt-get` even when ffmpeg was already installed, aborting fixture setup as non-root before the LPIPS gate could run
- **Fix**: Add `if shutil.which("ffmpeg"): return` guard at the top of `_visual_gen_deps` before the apt-get calls, making the fixture idempotent while preserving apt-get fallback behavior for containers that lack ffmpeg
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6401921


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the visual generation test setup by reusing an existing `ffmpeg` installation when available, reducing unnecessary package installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->