### PR TITLE
[None][test] keep MXFP4 block-scale unswizzle on GPU in create_weights

### DIFF
--- a/tests/unittest/_torch/modules/moe/quantize_utils.py
+++ b/tests/unittest/_torch/modules/moe/quantize_utils.py
@@ -2011,21 +2011,21 @@ class MXFP4MXFP8QuantizeUtil(BaseQuantizeUtil):
                 w1_weight, None, scaling_vector_size, True
             )
             w1_sf_block_unswizzled = torch.ops.trtllm.block_scale_interleave_reverse(
-                w1_sf_block.cpu().view(intermediate_size, -1)
+                w1_sf_block.view(intermediate_size, -1)
             )
 
             w2_weight_mxfp4, w2_sf_block = torch.ops.trtllm.fp4_quantize(
                 w2_weight, None, scaling_vector_size, True
             )
             w2_sf_block_unswizzled = torch.ops.trtllm.block_scale_interleave_reverse(
-                w2_sf_block.cpu().view(hidden_size_out, -1)
+                w2_sf_block.view(hidden_size_out, -1)
             )
 
             w3_weight_mxfp4, w3_sf_block = torch.ops.trtllm.fp4_quantize(
                 w3_weight, None, scaling_vector_size, True
             )
             w3_sf_block_unswizzled = torch.ops.trtllm.block_scale_interleave_reverse(
-                w3_sf_block.cpu().view(intermediate_size, -1)
+                w3_sf_block.view(intermediate_size, -1)
             )
 
             weights[f"{expert_id}.w1.weight"] = w1_weight_mxfp4


### PR DESCRIPTION
## Summary
- Remove redundant `.cpu()` before `block_scale_interleave_reverse` in `MXFP4MXFP8QuantizeUtil.create_weights` (and inherited `MXFP4FP8QuantizeUtil`).
- `fp4_quantize` already produces GPU block scales; `block_scale_interleave_reverse` supports CUDA tensors, matching `W4A8NVFP4FP8QuantizeUtil`.

## Test plan
- [x] OCI GB200: `test_moe_backend` filtered to W4A8_MXFP4_* quant algos
- [x] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved quantization test coverage for block-scale handling.
  * Updated scale reshaping behavior to better match expected results during weight processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->