### PR TITLE
[None][fix] Ignore valid Faroese code in codespell

### DIFF
--- a/triton_backend/all_models/whisper/whisper_bls/1/tokenizer.py
+++ b/triton_backend/all_models/whisper/whisper_bls/1/tokenizer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -98,7 +98,7 @@ LANGUAGES = {
     "yi": "yiddish",
     "lo": "lao",
     "uz": "uzbek",
-    "fo": "faroese",
+    "fo": "faroese",  # codespell:ignore
     "ht": "haitian creole",
     "ps": "pashto",
     "tk": "turkmen",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated copyright year information in the affected file.
  * Added a spelling-ignore note for one language entry to reduce false-positive linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fix the Release-Check codespell failure observed in #15929. `fo` is the valid ISO 639-1 language code for Faroese, so this change suppresses codespell on that dictionary entry without changing runtime behavior.

The copyright year is also updated as required for the modified file.

## Test Coverage

- `pre-commit run codespell --all-files`
- Commit-time pre-commit hooks

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
