### PR TITLE
[None][ci] reuse MPI pools for eligible PyTorch cases

### DIFF
--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -1,6 +1,5 @@
 import atexit
 import faulthandler
-import multiprocessing
 import platform
 import signal
 import traceback
@@ -39,7 +38,7 @@ from .postproc_worker import PostprocParams, PostprocWorkerConfig
 from .request import (DEFAULT_REQUEST_PRIORITY, GenerationRequest, LoRARequest,
                       PromptAdapterRequest)
 from .result import GenerationResult, IterationResult
-from .utils import IntraProcessQueue, ProcessPoolExecutorSession, RequestError
+from .utils import IntraProcessQueue, RequestError
 
 if TYPE_CHECKING:
     from .proxy import GenerationExecutorProxy
@@ -632,35 +631,22 @@ class GenerationExecutor(ABC):
         # Partition the workload to multiple processes for streaming performance.
         # While this requires users to protect their entrypoint to
         # `if __name__ == "__main__":`.
-        if not platform.system() == 'Windows':
-            if orchestrator_is_rpc:
-                return GenerationExecutor._create_rpc_executor(
-                    worker_kwargs,
-                    model_world_size=model_world_size,
-                    mpi_session=mpi_session,
-                    postproc_worker_config=postproc_worker_config,
-                    is_llm_executor=is_llm_executor)
-
-            return GenerationExecutor._create_ipc_executor(
-                worker_kwargs,
-                model_world_size=model_world_size,
-                mpi_session=None,  # use mpi4py
-                postproc_worker_config=postproc_worker_config,
-                is_llm_executor=is_llm_executor,
-                use_worker=False)
-        else:
-            ctx = multiprocessing.get_context("spawn")
-            # The ProcessPoolExecutorSession is used to support Windows, as mpi4py cannot.
-            mpi_session = ProcessPoolExecutorSession(n_workers=1,
-                                                     mp_context=ctx)
-            # TODO: add rpc worker here
-            return GenerationExecutor._create_ipc_executor(
+        if orchestrator_is_rpc and platform.system() != "Windows":
+            return GenerationExecutor._create_rpc_executor(
                 worker_kwargs,
                 model_world_size=model_world_size,
                 mpi_session=mpi_session,
                 postproc_worker_config=postproc_worker_config,
-                is_llm_executor=is_llm_executor,
-                use_worker=False)
+                is_llm_executor=is_llm_executor)
+
+        # TODO: add rpc worker on Windows.
+        return GenerationExecutor._create_ipc_executor(
+            worker_kwargs,
+            model_world_size=model_world_size,
+            mpi_session=mpi_session,
+            postproc_worker_config=postproc_worker_config,
+            is_llm_executor=is_llm_executor,
+            use_worker=False)
 
     def wait_first_completed(
         self, futures: List[GenerationResult]

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -28,7 +28,7 @@ import zmq.asyncio
 from tensorrt_llm.logger import logger
 
 from .._utils import customized_gc_thresholds, mpi_rank, nvtx_range_debug
-from ..llmapi.mpi_session import (MpiCommSession, MpiPoolSession, MpiSession,
+from ..llmapi.mpi_session import (MpiCommSession, MpiSession,
                                   RemoteMpiCommSessionClient)
 from ..llmapi.tracer import enable_llm_tracer, get_tracer, global_tracer
 from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
@@ -41,8 +41,7 @@ from .result import GenerationResult, IterationResult
 from .rpc import RPCClient
 from .rpc.rpc_common import RPCError, get_unique_ipc_addr
 from .utils import (ErrorResponse, RequestError, WorkerCommIpcAddrs,
-                    create_mpi_comm_session, get_spawn_proxy_process_env,
-                    is_llm_response, print_alive_threads)
+                    get_mpi_session, is_llm_response, print_alive_threads)
 from .worker import GenerationExecutorWorker, worker_main
 
 __all__ = [
@@ -97,18 +96,8 @@ class GenerationExecutorProxy(GenerationExecutor):
         self.workers_started = False
         self.worker_cls = worker_cls
 
-        mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
-
-        if mpi_session is None:
-            if mpi_process_pre_spawned:
-                logger_debug('create comm session ...\n', "yellow")
-                self.mpi_session = create_mpi_comm_session(model_world_size)
-            else:
-                logger_debug('create pool session ...\n', "yellow")
-                self.mpi_session = MpiPoolSession(n_workers=model_world_size)
-        else:
-            logger_debug('using external mpi session ...\n', "yellow")
-            self.mpi_session = mpi_session
+        self.mpi_session, self._owns_mpi_session = get_mpi_session(
+            model_world_size, mpi_session)
 
         if isinstance(self.mpi_session,
                       (MpiCommSession, RemoteMpiCommSessionClient)):
@@ -435,14 +424,30 @@ class GenerationExecutorProxy(GenerationExecutor):
                 break
             if any(fut.done() for fut in self.mpi_futures):
                 logger.error("Executor worker died during initialization.")
+                if not self._owns_mpi_session:
+                    self._cleanup_startup_workers()
                 raise RuntimeError("Executor worker died during initialization")
             self._handle_background_error()
 
         if ready_signal != GenerationExecutorProxy.READY_SIGNAL:
             logger.error(f"Executor worker initialization error: {error_trace}")
-            self.mpi_session.shutdown_abort(reason=ready_signal)
+            if self._owns_mpi_session:
+                self.mpi_session.shutdown_abort(reason=ready_signal)
+            else:
+                self._cleanup_startup_workers()
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
+
+    def _cleanup_startup_workers(self):
+        """Stop workers after a failed startup without closing a borrowed pool."""
+        if not self.workers_started:
+            return
+        try:
+            self.shutdown()
+        except Exception as cleanup_error:
+            logger.warning(
+                f"Failed to fully clean executor startup workers: {cleanup_error}"
+            )
 
     def _abort_all_requests(self):
         # The results can be finished during this loop, so self._results may be changed.
@@ -527,7 +532,8 @@ class GenerationExecutorProxy(GenerationExecutor):
             self._resource_governor_queue.close()
 
         self.workers_started = False
-        self.mpi_session.shutdown()
+        if self._owns_mpi_session:
+            self.mpi_session.shutdown()
 
         # Process the errors in-case error during shutting down the threads
         self._handle_background_error()
@@ -720,7 +726,12 @@ class GenerationExecutorProxy(GenerationExecutor):
         return self._iter_kv_events_result
 
     def __del__(self):
-        self.shutdown()
+        try:
+            self.shutdown()
+        except Exception:
+            # Destructors must not mask the original constructor or shutdown
+            # error. Explicit shutdown still reports failures to the caller.
+            pass
 
     def __enter__(self):
         return self

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -16,7 +16,7 @@ import json
 import threading
 from typing import List, Optional, Union
 
-from ..llmapi.mpi_session import MpiPoolSession, MpiSession
+from ..llmapi.mpi_session import MpiSession
 from ..llmapi.utils import logger_debug, print_colored
 from ..logger import logger
 from .executor import GenerationExecutor
@@ -25,7 +25,7 @@ from .proxy import _check_collective_rpc_guard
 from .result import IterationResult
 from .rpc_proxy_mixin import RpcExecutorMixin
 from .rpc_worker import RpcWorker
-from .utils import create_mpi_comm_session, get_spawn_proxy_process_env
+from .utils import get_mpi_session
 
 
 class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
@@ -64,7 +64,8 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         )
 
         self.model_world_size = model_world_size
-        self._create_mpi_session(model_world_size, mpi_session)
+        self.mpi_session, self._owns_mpi_session = get_mpi_session(
+            model_world_size, mpi_session)
 
         # Inject the generated HMAC key into worker_kwargs for workers
         worker_kwargs['hmac_key'] = self.hmac_key
@@ -82,9 +83,9 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
     def launch_workers(self):
         logger.debug(f"Launching workers")
         assert self.mpi_session is not None
-        self.mpi_session.submit(RpcWorker.main_task,
-                                rpc_addr=self.rpc_addr,
-                                **self.worker_kwargs)
+        self.worker_futures = self.mpi_session.submit(RpcWorker.main_task,
+                                                      rpc_addr=self.rpc_addr,
+                                                      **self.worker_kwargs)
 
     def _setup_mainloop_with_tasks(self):
         """Setup mainloop with tasks needed for RpcProxy.
@@ -251,8 +252,15 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         logger_debug(f"Shutting down GenerationExecutorRpcProxy",
                      color="yellow")
 
+        shutdown_error = None
+
         # 1. shutdown the rpc server (PyExecutor Rank 0 + RPC server)
-        self.shutdown_remote()
+        try:
+            if self.rpc_client is not None:
+                self.shutdown_remote()
+        except Exception as e:
+            shutdown_error = e
+            logger.warning(f"Failed to shut down the remote RPC server: {e}")
 
         # 2. stop the main loop, so that no new rpc requests
         if self.main_loop and self.main_loop_task_obj:
@@ -276,29 +284,48 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         # 3. shutdown the mpi session, this should wait until all the PyExecutor
         # processes are shutdown
         if self.mpi_session is not None:
-            logger_debug(f"Shutting down mpi session", color="yellow")
-            self.mpi_session.shutdown()
+            if self._owns_mpi_session:
+                logger_debug(f"Shutting down mpi session", color="yellow")
+                try:
+                    self.mpi_session.shutdown()
+                except Exception as e:
+                    shutdown_error = shutdown_error or e
+                    logger.warning(f"Failed to shut down mpi session: {e}")
+            else:
+                # A borrowed pool must stay alive, but this executor's RPC
+                # worker tasks must finish before the pool is reused.
+                for future in getattr(self, "worker_futures", []):
+                    try:
+                        future.result()
+                    except Exception as e:
+                        shutdown_error = shutdown_error or e
+                        logger.warning(
+                            f"RPC worker task raised during shutdown: {e}")
             logger_debug(f"Mpi session shutdown", color="yellow")
             self.mpi_session = None
 
-        self.rpc_client.close()
+        if self.rpc_client is not None:
+            try:
+                self.rpc_client.close()
+            except Exception as e:
+                shutdown_error = shutdown_error or e
+                logger.warning(f"Failed to close the RPC client: {e}")
+            finally:
+                self.rpc_client = None
+
+        if shutdown_error is not None:
+            raise shutdown_error
+
+    def __del__(self):
+        try:
+            self.shutdown()
+        except Exception:
+            # Destructors must not mask the original constructor or shutdown
+            # error. Explicit shutdown still reports failures to the caller.
+            pass
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.shutdown()
-
-    def _create_mpi_session(self, model_world_size: int,
-                            mpi_session: Optional[MpiSession]):
-        mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
-        if mpi_session is None:
-            if mpi_process_pre_spawned:
-                logger_debug('[proxy] create comm session ...\n', "yellow")
-                self.mpi_session = create_mpi_comm_session(model_world_size)
-            else:
-                logger_debug('[proxy] create pool session ...\n', "yellow")
-                self.mpi_session = MpiPoolSession(n_workers=model_world_size)
-        else:
-            logger_debug('[proxy] using external mpi session ...\n', "yellow")
-            self.mpi_session = mpi_session

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -1,6 +1,8 @@
 import asyncio
 import concurrent.futures
+import multiprocessing
 import os
+import platform
 import sys
 import threading
 import traceback
@@ -11,7 +13,7 @@ from typing import Any, Callable, List, NamedTuple, Optional
 from strenum import StrEnum
 
 from tensorrt_llm._utils import mpi_rank
-from tensorrt_llm.llmapi.utils import enable_llm_debug, logger_debug
+from tensorrt_llm.llmapi.utils import enable_llm_debug
 
 from ..llmapi.mpi_session import (MpiCommSession, MpiPoolSession, MpiSession,
                                   RemoteMpiCommSessionClient)
@@ -156,8 +158,43 @@ class ProcessPoolExecutorSession(MpiSession):
         ]
         return [future.result() for future in futures]
 
-    def shutdown(self):
-        self.mpi_pool.shutdown(wait=True)
+    def shutdown(self, wait=True):
+        self.mpi_pool.shutdown(wait=wait)
+
+    def abort(self):
+        self.mpi_pool.shutdown(wait=False, cancel_futures=True)
+
+
+def get_mpi_session(
+    n_workers: int,
+    mpi_session: Optional[MpiSession] = None,
+) -> tuple[MpiSession, bool]:
+    """Return an MPI session and whether the caller owns it.
+
+    A supplied session is borrowed.  Otherwise this function creates the
+    platform-appropriate session and transfers ownership to the caller.
+    """
+    if mpi_session is not None:
+        external_workers = getattr(mpi_session, "n_workers", None)
+        if (external_workers is not None and external_workers != n_workers):
+            raise ValueError(
+                f"MPI session has {external_workers} workers but the model "
+                f"needs world_size={n_workers}.")
+        logger_debug('using external mpi session ...\n', "yellow")
+        return mpi_session, False
+
+    if platform.system() == "Windows":
+        # mpi4py cannot be used on Windows.
+        ctx = multiprocessing.get_context("spawn")
+        return ProcessPoolExecutorSession(n_workers=n_workers,
+                                          mp_context=ctx), True
+
+    if get_spawn_proxy_process_env():
+        logger_debug('create comm session ...\n', "yellow")
+        return create_mpi_comm_session(n_workers), True
+
+    logger_debug('create pool session ...\n', "yellow")
+    return MpiPoolSession(n_workers=n_workers), True
 
 
 class ErrorResponse(NamedTuple):

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -314,6 +314,11 @@ class BaseLLM:
         logger_debug(f"LLM.args.mpi_session: {self.args.mpi_session}\n",
                      "yellow")
         self.mpi_session = self.args.mpi_session
+        # Keep ownership on LLM. The session object is removed from args
+        # before args are sent to model/executor workers because MpiSession is
+        # not pickleable.
+        self._owns_mpi_session = False
+        self.args.mpi_session = None
 
         # Build this LLM's post-processing hook for the in-proxy detok path (each
         # postproc worker builds its own). Resolving here fails fast on a bad
@@ -333,7 +338,7 @@ class BaseLLM:
             logger.info(
                 f'start MpiSession with {self.args.parallel_config.world_size} workers'
             )
-            if not self.mpi_session:
+            if self.mpi_session is None:
                 mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
                 if not mpi_process_pre_spawned:
                     logger_debug("LLM create MpiPoolSession\n", "yellow")
@@ -343,6 +348,7 @@ class BaseLLM:
                     logger_debug("LLM create MpiCommSession\n", "yellow")
                     self.mpi_session = create_mpi_comm_session(
                         self.args.parallel_config.world_size)
+                self._owns_mpi_session = True
 
         try:
             # Due to the Executor can only accept a engine path, we need to save the engine to a directory
@@ -365,8 +371,15 @@ class BaseLLM:
             self._build_model()
 
         except Exception:
-            if self.mpi_session is not None:
-                self.mpi_session.shutdown()
+            if self.mpi_session is not None and self._owns_mpi_session:
+                mpi_session = self.mpi_session
+                self.mpi_session = None
+                try:
+                    mpi_session.shutdown()
+                except Exception as shutdown_error:
+                    logger.error(
+                        f"Failed to shut down MPI session after construction failure: {shutdown_error}"
+                    )
             raise
 
         # --- Usage telemetry (fail-silent) ---
@@ -1472,18 +1485,36 @@ class BaseLLM:
 
     @set_api_status("beta")
     def shutdown(self) -> None:
-        if hasattr(self, "_executor") and self._executor is not None:
-            self._executor.shutdown()
-            self._executor = None
+        shutdown_error = None
 
-        if hasattr(self,
-                   "_encoder_executor") and self._encoder_executor is not None:
-            self._encoder_executor.shutdown()
-            self._encoder_executor = None
+        for executor_attr in ("_executor", "_encoder_executor"):
+            executor = getattr(self, executor_attr, None)
+            if executor is None:
+                continue
+            try:
+                executor.shutdown()
+            except Exception as e:
+                # Do not skip owned MPI-session cleanup when an executor
+                # reports a fatal worker error during shutdown.
+                shutdown_error = shutdown_error or e
+                logger.error(f"Failed to shut down {executor_attr}: {e}")
+            finally:
+                setattr(self, executor_attr, None)
 
-        if hasattr(self, 'mpi_session') and self.mpi_session is not None:
-            self.mpi_session.shutdown()
-            self.mpi_session = None
+        owns_mpi_session = getattr(self, "_owns_mpi_session", False)
+        mpi_session = getattr(self, "mpi_session", None)
+        if mpi_session is not None:
+            try:
+                if owns_mpi_session:
+                    mpi_session.shutdown()
+            except Exception as e:
+                shutdown_error = shutdown_error or e
+                logger.error(f"Failed to shut down MPI session: {e}")
+            finally:
+                self.mpi_session = None
+
+        if shutdown_error is not None:
+            raise shutdown_error
 
     def _check_health(self) -> bool:
         """Check if the LLM is healthy.
@@ -1564,7 +1595,7 @@ class _TrtLLM(BaseLLM):
         if self._engine_dir.absolute() == os.path.abspath(engine_dir):
             return
 
-        if not self.mpi_session or not self.mpi_session.is_comm_session():
+        if self.mpi_session is None or not self.mpi_session.is_comm_session():
             shutil.copytree(self._engine_dir, engine_dir, dirs_exist_ok=True)
         else:
             # NFS is fragile, so we copy files one by one

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -23,6 +23,8 @@ import torch
 from datasets import load_dataset
 from defs.conftest import get_sm_version, is_sm_100f
 from mpi4py.futures import MPIPoolExecutor
+from test_common.grouped_test_utils import (SharedMpiSessionRegistry,
+                                            share_torch_llm_mpi_sessions)
 
 from tensorrt_llm import LLM
 from tensorrt_llm._torch.model_config import MoeLoadBalancerConfig
@@ -46,6 +48,19 @@ from ..conftest import (check_device_contain, get_device_count, llm_models_root,
 from .accuracy_core import (GSM8K, MMLU, CnnDailymail, GPQADiamond,
                             JsonModeEval, LlmapiAccuracyTestHarness,
                             LongBenchV1, LongBenchV2)
+
+pytestmark = pytest.mark.threadleak(enabled=False)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _shared_mpi_pools():
+    """Reuse spawned PyTorch worker pools within this accuracy module."""
+    registry = SharedMpiSessionRegistry()
+    try:
+        with share_torch_llm_mpi_sessions(registry):
+            yield
+    finally:
+        registry.shutdown()
 
 
 # Keep helper definitions below imports so new imports do not need E402

--- a/tests/test_common/grouped_test_utils.py
+++ b/tests/test_common/grouped_test_utils.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Helpers for tests that reuse one MPI worker pool across LLM instances."""
+
+import os
+from contextlib import contextmanager
+from functools import wraps
+
+
+class SharedMpiSessionRegistry:
+    """Own lazily-created MPI pools keyed by worker count and layout."""
+
+    def __init__(self):
+        self._sessions = {}
+
+    def get(self, n_workers: int, key=()):
+        from tensorrt_llm._utils import mpi_disabled
+
+        if mpi_disabled():
+            return None
+
+        session_key = (n_workers, key)
+        if session_key not in self._sessions:
+            from tensorrt_llm.llmapi.mpi_session import MpiPoolSession
+
+            self._sessions[session_key] = MpiPoolSession(n_workers=n_workers)
+        return self._sessions[session_key]
+
+    def shutdown(self):
+        sessions = list(self._sessions.values())
+        self._sessions.clear()
+        shutdown_error = None
+        for session in reversed(sessions):
+            try:
+                session.shutdown()
+            except Exception as error:
+                shutdown_error = shutdown_error or error
+        if shutdown_error is not None:
+            raise shutdown_error
+
+
+@contextmanager
+def share_torch_llm_mpi_sessions(registry):
+    """Inject borrowed registry pools into eligible PyTorch ``LLM`` objects."""
+    from tensorrt_llm.llmapi.llm import BaseLLM, _TorchLLM
+    from tensorrt_llm.llmapi.mpi_session import MpiPoolSession, external_mpi_comm_available
+
+    original_init = BaseLLM.__init__
+
+    def environment_key():
+        prefixes = ("CUDA_", "NCCL_", "PYTORCH_", "RAY_", "TLLM_", "TRTLLM_", "UCX_")
+        return tuple(
+            sorted((name, value) for name, value in os.environ.items() if name.startswith(prefixes))
+        )
+
+    default_environment = environment_key()
+    default_pool_launcher = MpiPoolSession._start_mpi_pool
+
+    def get_pool_config(llm, tensor_parallel_size, kwargs):
+        if not isinstance(llm, _TorchLLM):
+            return None
+        if kwargs.get("backend", "pytorch") != "pytorch":
+            return None
+        if kwargs.get("orchestrator_type") is not None:
+            return None
+        if kwargs.get("_mpi_session") is not None:
+            return None
+        if kwargs.get("executor_cls") is not None:
+            return None
+        if kwargs.get("env_overrides") is not None:
+            return None
+        if kwargs.get("encode_only") or kwargs.get("mm_encoder_only"):
+            return None
+
+        # These modes do not use the MPI worker pool.
+        if os.environ.get("TLLM_DISABLE_MPI") == "1":
+            return None
+        if os.environ.get("TLLM_WORKER_USE_SINGLE_PROCESS") == "1":
+            return None
+        if os.environ.get("TLLM_SPAWN_PROXY_PROCESS") == "1":
+            return None
+        if os.environ.get("RAY_LOCAL_WORLD_SIZE") is not None:
+            return None
+        if environment_key() != default_environment:
+            return None
+        if MpiPoolSession._start_mpi_pool is not default_pool_launcher:
+            return None
+
+        pipeline_parallel_size = kwargs.get("pipeline_parallel_size", 1)
+        context_parallel_size = kwargs.get("context_parallel_size", 1)
+        world_size = tensor_parallel_size * pipeline_parallel_size * context_parallel_size
+        if world_size <= 0 or external_mpi_comm_available(world_size):
+            return None
+
+        # These paths may select the single-process executor.
+        build_config = kwargs.get("build_config")
+        if kwargs.get("gather_generation_logits") or getattr(
+            build_config, "gather_context_logits", False
+        ):
+            return None
+
+        # The worker process keeps its PP communicator globally. Reuse a pool
+        # only when the TP/PP/CP layout is unchanged.
+        layout = (tensor_parallel_size, pipeline_parallel_size, context_parallel_size)
+        return world_size, layout
+
+    @wraps(original_init)
+    def patched_init(
+        self,
+        model,
+        tokenizer=None,
+        tokenizer_mode="auto",
+        skip_tokenizer_init=False,
+        trust_remote_code=False,
+        tensor_parallel_size=1,
+        dtype="auto",
+        revision=None,
+        tokenizer_revision=None,
+        **kwargs,
+    ):
+        pool_config = get_pool_config(self, tensor_parallel_size, kwargs)
+        if pool_config is not None:
+            world_size, layout = pool_config
+            kwargs = dict(kwargs)
+            kwargs["_mpi_session"] = registry.get(world_size, key=layout)
+        return original_init(
+            self,
+            model,
+            tokenizer,
+            tokenizer_mode,
+            skip_tokenizer_init,
+            trust_remote_code,
+            tensor_parallel_size,
+            dtype,
+            revision,
+            tokenizer_revision,
+            **kwargs,
+        )
+
+    BaseLLM.__init__ = patched_init
+    try:
+        yield
+    finally:
+        BaseLLM.__init__ = original_init

--- a/tests/unittest/llmapi/conftest.py
+++ b/tests/unittest/llmapi/conftest.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared MPI-pool support for eligible LLM API unit tests."""
+
+import pytest
+from test_common.grouped_test_utils import SharedMpiSessionRegistry, share_torch_llm_mpi_sessions
+
+
+def pytest_collection_modifyitems(items):
+    # The shared pool deliberately keeps its manager thread alive until the
+    # session fixture tears down.
+    for item in items:
+        item.add_marker(pytest.mark.threadleak(enabled=False))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _shared_mpi_pools():
+    registry = SharedMpiSessionRegistry()
+    try:
+        with share_torch_llm_mpi_sessions(registry):
+            yield
+    finally:
+        registry.shutdown()

--- a/tests/unittest/llmapi/test_mpi_session_ownership.py
+++ b/tests/unittest/llmapi/test_mpi_session_ownership.py
@@ -1,0 +1,56 @@
+from unittest.mock import Mock
+
+import pytest
+
+from tensorrt_llm.executor.utils import get_mpi_session
+from tensorrt_llm.llmapi.llm import BaseLLM
+
+
+def _llm_for_shutdown(executor, mpi_session, owns_mpi_session):
+    llm = object.__new__(BaseLLM)
+    llm._executor = executor
+    llm._encoder_executor = None
+    llm.mpi_session = mpi_session
+    llm._owns_mpi_session = owns_mpi_session
+    return llm
+
+
+def test_owned_session_is_cleaned_when_executor_shutdown_fails():
+    executor = Mock()
+    executor.shutdown.side_effect = RuntimeError("worker failed")
+    session = Mock()
+    llm = _llm_for_shutdown(executor, session, owns_mpi_session=True)
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        llm.shutdown()
+
+    executor.shutdown.assert_called_once_with()
+    session.shutdown.assert_called_once_with()
+    assert llm._executor is None
+    assert llm.mpi_session is None
+
+
+def test_borrowed_session_is_not_shutdown_by_llm():
+    executor = Mock()
+    session = Mock()
+    llm = _llm_for_shutdown(executor, session, owns_mpi_session=False)
+
+    llm.shutdown()
+
+    executor.shutdown.assert_called_once_with()
+    session.shutdown.assert_not_called()
+    assert llm._executor is None
+    assert llm.mpi_session is None
+
+
+def test_external_session_is_borrowed_and_validated():
+    session = Mock()
+    session.n_workers = 2
+
+    returned_session, owns_session = get_mpi_session(2, session)
+
+    assert returned_session is session
+    assert owns_session is False
+
+    with pytest.raises(ValueError, match="needs world_size=4"):
+        get_mpi_session(4, session)


### PR DESCRIPTION
Reuse one caller-owned MPI worker pool across eligible LLM API tests.

The optimization applies to PyTorch LLM cases using the default MPI executor with the same world size and TP/PP/CP layout, under the default environment and without custom executors, env overrides, or encoder-only modes. It covers tests/unittest/llmapi, including test_llm.py and test_llm_multi_gpu_pytorch.py through the shared conftest, and tests/integration/defs/accuracy/test_llm_api_pytorch.py through its module fixture.

RPC/Ray, special-environment, single-process, logits-gathering, custom-executor, and different-layout cases keep their existing private lifecycle. External MPI session ownership is explicit so executors borrow caller-owned pools and clean up worker tasks without shutting down the pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MPI session sharing and reuse across LLM workloads and tests.
  * Added support for safer session ownership tracking during execution and shutdown.

* **Bug Fixes**
  * Prevented accidental shutdown of externally provided MPI sessions.
  * Made executor and session cleanup more resilient to startup or shutdown failures.
  * Improved Windows compatibility for worker/session setup.

* **Tests**
  * Added broader coverage for MPI session ownership, compatibility checks, and shared-pool test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
