### PR TITLE
[TRTLLM-13639][perf] Migrate Kimi perf-sanity tests to Transceiver v2

### DIFF
--- a/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_1k1k_con2048_ctx1_dep4_gen1_dep32_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_1k1k_con2048_ctx1_dep4_gen1_dep32_eplb0_mtp0_ccb-NIXL.yaml
@@ -63,6 +63,8 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
+      kv_cache_bounce_size_mb: 384
     disable_overlap_scheduler: true
     trust_remote_code: true
     num_postprocess_workers: 4
@@ -88,5 +90,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
+      kv_cache_bounce_size_mb: 384
     disable_overlap_scheduler: true
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_1k1k_con4096_ctx1_dep4_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_1k1k_con4096_ctx1_dep4_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     trust_remote_code: true
     num_postprocess_workers: 4
@@ -88,5 +89,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_1k1k_con4_ctx1_dep4_gen1_tep4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_1k1k_con4_ctx1_dep4_gen1_tep4_eplb0_mtp0_ccb-NIXL.yaml
@@ -61,6 +61,8 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
+      kv_cache_bounce_size_mb: 384
     disable_overlap_scheduler: true
     trust_remote_code: true
     num_postprocess_workers: 4
@@ -86,5 +88,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
+      kv_cache_bounce_size_mb: 384
     disable_overlap_scheduler: true
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: Eagle
@@ -96,6 +97,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     trust_remote_code: true
@@ -89,6 +90,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: Eagle
@@ -92,6 +93,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_1k1k_con2048_ctx1_dep4_gen1_dep32_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_1k1k_con2048_ctx1_dep4_gen1_dep32_eplb0_mtp0_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     trust_remote_code: true
     num_postprocess_workers: 4
@@ -88,5 +89,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_1k1k_con4096_ctx1_dep4_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_1k1k_con4096_ctx1_dep4_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     trust_remote_code: true
     num_postprocess_workers: 4
@@ -88,5 +89,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_1k1k_con4_ctx1_dep4_gen1_tep4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_1k1k_con4_ctx1_dep4_gen1_tep4_eplb0_mtp0_ccb-NIXL.yaml
@@ -61,6 +61,8 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
+      kv_cache_bounce_size_mb: 384
     disable_overlap_scheduler: true
     trust_remote_code: true
     num_postprocess_workers: 4
@@ -86,5 +88,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
+      kv_cache_bounce_size_mb: 384
     disable_overlap_scheduler: true
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: Eagle
@@ -96,6 +97,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     trust_remote_code: true
     num_postprocess_workers: 4
@@ -88,5 +89,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,8 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
+      kv_cache_bounce_size_mb: 384
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: Eagle
@@ -92,6 +94,8 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
+      kv_cache_bounce_size_mb: 384
     disable_overlap_scheduler: true
     speculative_config: *id001
     trust_remote_code: true


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This pull request updates several performance sanity test YAML configurations for disaggregated worker setups, primarily to enhance the `cache_transceiver_config` section. The main changes introduce a new runtime and adjust memory settings for the cache transceiver, which will impact how cache data is managed and transferred during tests.

**Cache transceiver configuration updates:**

* Added `transceiver_runtime: PYTHON` to all affected YAML files, switching the cache transceiver to use the Python runtime for improved flexibility and compatibility. [[1]](diffhunk://#diff-e418b4ab6d23940503a23a6654cbdf2d6be0936cf233d80a5478a821e0610611R66-R67) [[2]](diffhunk://#diff-e418b4ab6d23940503a23a6654cbdf2d6be0936cf233d80a5478a821e0610611R93-R94) [[3]](diffhunk://#diff-3df8e9d4f2c01ca3ede7dc92d800c1bb1556d929f4a8e8b04a84bfe4eb960440R66) [[4]](diffhunk://#diff-3df8e9d4f2c01ca3ede7dc92d800c1bb1556d929f4a8e8b04a84bfe4eb960440R92) [[5]](diffhunk://#diff-937b6c5144dab8d43b27af70a480f0abc1696ed44f93667e1a97481522efcbedR64-R65) [[6]](diffhunk://#diff-937b6c5144dab8d43b27af70a480f0abc1696ed44f93667e1a97481522efcbedR91-R92) [[7]](diffhunk://#diff-2ece6bef6dfa529f00cc196c47ed4dec7034f20ed01ecfb57e0b775a0996eac4R69) [[8]](diffhunk://#diff-2ece6bef6dfa529f00cc196c47ed4dec7034f20ed01ecfb57e0b775a0996eac4R100) [[9]](diffhunk://#diff-c6269d52b778551659e43a0e5e5e3fb186024a403a148179dff7dbd662d5d028R66) [[10]](diffhunk://#diff-c6269d52b778551659e43a0e5e5e3fb186024a403a148179dff7dbd662d5d028R93) [[11]](diffhunk://#diff-57e489f3d21da4a768815c702f8c1d2b87de45f08ed6b3df368e2c91b4320543R64) [[12]](diffhunk://#diff-57e489f3d21da4a768815c702f8c1d2b87de45f08ed6b3df368e2c91b4320543R96) [[13]](diffhunk://#diff-c0d61f66260f91cee0f7843ab7dcfb46b9c5622bd141a51d4b3008d00ed7bb01R66) [[14]](diffhunk://#diff-c0d61f66260f91cee0f7843ab7dcfb46b9c5622bd141a51d4b3008d00ed7bb01R92) [[15]](diffhunk://#diff-d00bc7b2754e365cb44292ef32942308d5097eb532325d06ebbf9132c7157280R66) [[16]](diffhunk://#diff-d00bc7b2754e365cb44292ef32942308d5097eb532325d06ebbf9132c7157280R92) [[17]](diffhunk://#diff-7a25e715b8c47ddbf08d299f8820a1ad7be1b8d7e92f779ebebe5f42c276babbR64-R65) [[18]](diffhunk://#diff-7a25e715b8c47ddbf08d299f8820a1ad7be1b8d7e92f779ebebe5f42c276babbR91-R92) [[19]](diffhunk://#diff-4b4293a2b730ae4b2ba858ac7f020f1123bae5b8d4885aa41be25defbdd098caR69) [[20]](diffhunk://#diff-4b4293a2b730ae4b2ba858ac7f020f1123bae5b8d4885aa41be25defbdd098caR100) [[21]](diffhunk://#diff-2a50310e5710ff15ef3445cf45c4cb5e50a4a5cd2731c06acb03a89623c4d5a6R66) [[22]](diffhunk://#diff-2a50310e5710ff15ef3445cf45c4cb5e50a4a5cd2731c06acb03a89623c4d5a6R92) [[23]](diffhunk://#diff-a6546e8cf7a1794c937be123be9ff7a6c5c53c9bea0dd9d9806e664ebf417e70R64-R65) [[24]](diffhunk://#diff-a6546e8cf7a1794c937be123be9ff7a6c5c53c9bea0dd9d9806e664ebf417e70R97-R98)
* Added `kv_cache_bounce_size_mb: 384` to selected YAML files, increasing the key-value cache bounce buffer size to 384 MB for improved cache transfer performance in relevant test scenarios. [[1]](diffhunk://#diff-e418b4ab6d23940503a23a6654cbdf2d6be0936cf233d80a5478a821e0610611R66-R67) [[2]](diffhunk://#diff-e418b4ab6d23940503a23a6654cbdf2d6be0936cf233d80a5478a821e0610611R93-R94) [[3]](diffhunk://#diff-937b6c5144dab8d43b27af70a480f0abc1696ed44f93667e1a97481522efcbedR64-R65) [[4]](diffhunk://#diff-937b6c5144dab8d43b27af70a480f0abc1696ed44f93667e1a97481522efcbedR91-R92) [[5]](diffhunk://#diff-7a25e715b8c47ddbf08d299f8820a1ad7be1b8d7e92f779ebebe5f42c276babbR64-R65) [[6]](diffhunk://#diff-7a25e715b8c47ddbf08d299f8820a1ad7be1b8d7e92f779ebebe5f42c276babbR91-R92) [[7]](diffhunk://#diff-a6546e8cf7a1794c937be123be9ff7a6c5c53c9bea0dd9d9806e664ebf417e70R64-R65) [[8]](diffhunk://#diff-a6546e8cf7a1794c937be123be9ff7a6c5c53c9bea0dd9d9806e664ebf417e70R97-R98)

No other functional or logic changes were made; these updates are limited to configuration improvements for the test scripts.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated several performance sanity test configurations to use explicit cache and runtime settings.
  * Standardized test setup across multiple GB200 and GB300 benchmark scenarios.
  * Improved consistency of benchmark runs by removing reliance on implicit defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->