### PR TITLE
[None][test] Unwaive DeepSeekV3.2 nvfp4 mtp3_fp8kv_chunked test

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3470,8 +3470,9 @@ class PyExecutor:
         if not getattr(self, 'use_spec_decode', True):
             return
 
+        model_engine = getattr(self, 'model_engine', None)
         if (self.drafter is None
-                and getattr(self.model_engine, 'spec_config', None) is None):
+                and getattr(model_engine, 'spec_config', None) is None):
             return
 
         for request in self.active_requests:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2977,21 +2977,13 @@ class PyExecutor:
             logger.debug(f"Use spec decode: {self.use_spec_decode}")
             self.model_engine.enable_spec_decode = self.use_spec_decode
 
-            # Set up draft_tokens in active_requests, because they could be used in the scheduling stage.
-            for request in self.active_requests:
-                if request.state not in (
-                        LlmRequestState.GENERATION_IN_PROGRESS,
-                        LlmRequestState.DISAGG_GENERATION_INIT):
-                    continue
-                request.draft_tokens = [
-                    0
-                ] * self.max_total_draft_tokens if self.max_total_draft_tokens > 0 else []
-
             # If speculation is off, this function sets py_draft_tokens to []
             # for all active requests. If it's on, we initialize py_draft_tokens
             # with dummy draft tokens to make the scheduler aware of the fact
             # that speculation is about to happen.
             self._prepare_draft_requests()
+
+        self._prepare_scheduler_draft_tokens()
 
         scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._schedule(
         )
@@ -3463,6 +3455,28 @@ class PyExecutor:
             error_msg = str(e)
             logger.error(f"Encountered an error in decode: {error_msg}")
             self._handle_errors(error_msg)
+
+    def _prepare_scheduler_draft_tokens(self) -> None:
+        """Reserve speculative generation tokens in the micro-batch budget.
+
+        One-engine speculative decoders such as MTP_EAGLE_ONE_MODEL keep their
+        draft model inside ``ModelEngine`` instead of exposing an executor-level
+        ``Drafter``.  In overlap mode, their next draft tokens are produced by
+        the previous batch and may not have been copied to the C++ request when
+        the next scheduling pass starts.  The model still consumes the full
+        speculative step, so expose placeholder draft tokens to the scheduler
+        for every speculative decoder, not only executor-level drafters.
+        """
+        if (self.drafter is None
+                and getattr(self.model_engine, 'spec_config', None) is None):
+            return
+
+        for request in self.active_requests:
+            if request.state not in (LlmRequestState.GENERATION_IN_PROGRESS,
+                                     LlmRequestState.DISAGG_GENERATION_INIT):
+                continue
+            request.draft_tokens = ([0] * self.max_total_draft_tokens
+                                    if self.max_total_draft_tokens > 0 else [])
 
     def _handle_control_request(self):
         """Fire the next pending control action at the next step boundary.

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3467,6 +3467,9 @@ class PyExecutor:
         speculative step, so expose placeholder draft tokens to the scheduler
         for every speculative decoder, not only executor-level drafters.
         """
+        if not getattr(self, 'use_spec_decode', True):
+            return
+
         if (self.drafter is None
                 and getattr(self.model_engine, 'spec_config', None) is None):
             return

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -52,7 +52,6 @@ accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[h
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp3_no_adp] SKIP (https://nvbugs/6384357)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[baseline] SKIP (https://nvbugs/6384136)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_chunked_prefill[latency] SKIP (https://nvbugs/6276981)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_piecewise_cuda_graph[mtp3_fp8kv_chunked] SKIP (https://nvbugs/5989920)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=True-overlap_scheduler=True-torch_compile=True-enable_chunked_prefill=False-v2_kv_cache=False] SKIP (https://nvbugs/6305365)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=True-overlap_scheduler=True-torch_compile=True-enable_chunked_prefill=False-v2_kv_cache=True] SKIP (https://nvbugs/6305365)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=True-cuda_graph=False-overlap_scheduler=False-torch_compile=True-enable_chunked_prefill=False-v2_kv_cache=True] SKIP (https://nvbugs/6305404)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -26,7 +26,6 @@ accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[latency_
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp] SKIP (https://nvbugs/6481323)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp1] SKIP (https://nvbugs/6384357)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp3_no_adp] SKIP (https://nvbugs/6384357)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_piecewise_cuda_graph[mtp3_fp8kv_chunked] SKIP (https://nvbugs/5989920)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_4gpus[ep4-mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=False] SKIP (https://nvbugs/6517844)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_4gpus[ep4-mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=True] SKIP (https://nvbugs/6402058)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_4gpus[pp4-mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False] SKIP (https://nvbugs/6278337)

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -22,7 +22,7 @@ from tensorrt_llm._torch.pyexecutor.executor_request_queue import (
     SHUTDOWN_REQUEST_ID,
     RequestQueueItem,
 )
-from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestState, SamplingConfig
 from tensorrt_llm._torch.pyexecutor.py_executor import DisaggTransferAdmissionController, PyExecutor
 from tensorrt_llm._torch.pyexecutor.scheduler import (
     FCFSWaitingQueue,
@@ -344,6 +344,50 @@ def _make_gen_request(num_draft_tokens=0):
     req = Mock()
     req.num_draft_tokens = num_draft_tokens
     return req
+
+
+def test_prepare_and_schedule_reserves_one_engine_spec_decode_tokens():
+    """One-engine MTP reserves draft tokens before invoking the scheduler."""
+    executor = PyExecutor.__new__(PyExecutor)
+    executor.drafter = None
+    executor.model_engine = types.SimpleNamespace(spec_config=object())
+    executor.max_total_draft_tokens = 3
+
+    generation_request = LlmRequest(
+        request_id=1,
+        max_new_tokens=8,
+        input_tokens=[1],
+        sampling_config=SamplingConfig(1),
+        is_streaming=False,
+    )
+    generation_request.state = LlmRequestState.GENERATION_IN_PROGRESS
+    context_request = types.SimpleNamespace(state=LlmRequestState.CONTEXT_INIT, draft_tokens=[123])
+    executor.active_requests = [generation_request, context_request]
+
+    executor._fetch_and_activate_new_requests = Mock(return_value=[])
+    executor.is_shutdown = False
+    executor.waiting_queue = []
+    executor._handle_control_request = Mock()
+    executor.kv_cache_transceiver = None
+    executor.enable_iter_perf_stats = False
+    executor._pad_attention_dp_dummy_request = Mock()
+    executor._prefetch_for_context_requests = Mock()
+
+    scheduled_batch = ScheduledRequests()
+
+    def schedule():
+        assert generation_request.draft_tokens == [0, 0, 0]
+        assert generation_request.num_draft_tokens == 3
+        assert context_request.draft_tokens == [123]
+        return scheduled_batch, [], 0
+
+    executor._schedule = Mock(side_effect=schedule)
+
+    result, iter_stats = executor._prepare_and_schedule_batch()
+
+    assert result is scheduled_batch
+    assert iter_stats is None
+    executor._schedule.assert_called_once_with()
 
 
 def _make_disagg_transfer_request(


### PR DESCRIPTION
## Description

Unwaives `accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_piecewise_cuda_graph[mtp3_fp8kv_chunked]` (NVBug 5989920).

Two separate defects kept this test failing; both are fixed elsewhere:

1. **Scheduler token budget** — `total_num_tokens (8195) should be <= max_num_tokens (8192)` under one-model MTP with chunked prefill + overlap scheduler. Fixed on `main` by #16101.
2. **Stale CUDA graph pool** — with torch.compile enabled, `Backend._graph_pool_handle` is class state shared by every engine in the process. Engine teardown resets the graphs captured into that pool, dropping its `use_count` to zero, but the caching allocator only erases the entry once the pool has no blocks left. The next engine in the same worker process then captured into the retired handle and hit `it->second->use_count > 0 INTERNAL ASSERT FAILED` in `beginAllocateToPool`. Fixed by **#16952**, which removes the shared class handle entirely and lets each capture create its own private pool.

**This PR depends on #16952 landing first.** Verified on 8x B200 that with that class of fix applied, running `[baseline]` and `[mtp3_fp8kv_chunked]` back to back in one pytest session goes from `1 failed, 1 passed` to `2 passed`. Without it the test still fails, because the CI stage runs `[baseline]` first and the MPI workers are reused across both — which is also why the test passes when run standalone.

## Test Coverage

`accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_piecewise_cuda_graph[mtp3_fp8kv_chunked]`, re-enabled by this PR, runs in `DGX_B200-8_GPUs-PyTorch-*`.

Post-fix accuracy measured on 8x B200: MMLU 87.865 (reference 87.200), GSM8K 95.072 (reference 95.600).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
