### PR TITLE
[None][feat] Support MiniCPM-V 4.6 (image + video) on the PyTorch bac…

### DIFF
--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -33,6 +33,7 @@ The following is a table of supported models for the PyTorch backend:
 | `LagunaForCausalLM`                  | Laguna-XS                          | `poolside/laguna-XS.2`                       |
 | `LlamaForCausalLM`                   | Llama 3.1, Llama 3, Llama 2, LLaMA | `meta-llama/Meta-Llama-3.1-70B`              |
 | `Llama4ForConditionalGeneration`     | Llama 4                            | `meta-llama/Llama-4-Scout-17B-16E-Instruct`  |
+| `MiniCPMV4_6ForConditionalGeneration` [^14]| MiniCPM-V 4.6                    | `openbmb/MiniCPM-V-4.6`                      |
 | `MiniMaxM2ForCausalLM` [^5]          | MiniMax M2/M2.1/M2.7              | `MiniMaxAI/MiniMax-M2.7`                    |
 | `MiniMaxM3SparseForConditionalGeneration` [^12]| MiniMax-M3                       | `MiniMaxAI/MiniMax-M3`                      |
 | `MistralForCausalLM`                 | Mistral                            | `mistralai/Mistral-7B-v0.1`                  |
@@ -92,6 +93,7 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 [^11]: DeepSeek-V4 is only supported on Blackwell GPUs (`SM100+`). See the [DeepSeek-V4 example README](../../../examples/models/core/deepseek_v4/README.md) for setup and parallelism.
 [^12]: Supports text, image, and video inputs over the block-sparse attention path. The published MXFP8 checkpoint is dequantized on load so the runtime sees an effectively BF16 model. The text decoder is also usable standalone (text-only) via the `MiniMaxM3SparseForCausalLM` architecture. KV cache reuse and MTP are not supported on the sparse-attention path in this release.
 [^13]: The Cosmos 3 family also supports visual generation through the VisualGen API. See [Visual Generation Models](#visual-generation-models).
+[^14]: Requires `transformers>=5.7.0`: MiniCPM-V 4.6 was upstreamed into transformers as a native model type (`minicpmv4_6`) and the checkpoint ships no remote code (`auto_map`) to fall back on. The Qwen3.5-hybrid text tower runs in BF16. Image, video, and text inputs are supported in this release (video reuses the same NaViT-packed vision path as image via `MiniCPMV4_6InputProcessor`).
 
 # Multimodal Feature Support Matrix (PyTorch Backend)
 
@@ -105,6 +107,7 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 | `LlavaLlamaModel (VILA)`             | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I + V |
 | `LlavaNextForConditionalGeneration`  | Yes               | Yes        | Yes             | Yes           | Yes              | Yes            | Yes                   | Yes                       | L + I     |
 | `Llama4ForConditionalGeneration`     | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I     |
+| `MiniCPMV4_6ForConditionalGeneration` [^14] | Yes               | Untested   | Untested        | Yes           | Untested         | Untested       | Untested              | No                        | L + I + V |
 | `Mistral3ForConditionalGeneration`   | Yes               | Yes        | Yes             | Yes           | Yes              | Yes            | Yes                   | No                        | L + I     |
 | `NemotronH_Nano_VL_V2`               | Yes               | Yes        | Yes             | Yes           | Yes              | N/A            | Yes                   | Yes                       | L + I + V + A [^10] |
 | `Phi4MMForCausalLM`                  | Yes               | Yes        | Yes             | Yes           | Yes              | Yes            | Yes                   | No                        | L + I + A |

--- a/tensorrt_llm/_torch/configs/__init__.py
+++ b/tensorrt_llm/_torch/configs/__init__.py
@@ -8,6 +8,7 @@ from tensorrt_llm._torch.configs.gemma4_unified import (
     Gemma4UnifiedVisionConfig,
 )
 from tensorrt_llm._torch.configs.laguna import LagunaConfig
+from tensorrt_llm._torch.configs.minicpmv4_6 import MiniCPMV4_6Config, MiniCPMV4_6VisionConfig
 
 
 def _register_custom_configs_with_transformers() -> None:
@@ -37,6 +38,10 @@ def _register_custom_configs_with_transformers() -> None:
         "kimi_k2": DeepseekV3Config,
         "deepseek_v4": DeepseekV4Config,
         "laguna": LagunaConfig,
+        # minicpmv4_6 is only registered in transformers>=5.7.0; register our
+        # own composite config so AutoTokenizer.from_pretrained works on older
+        # releases (the model itself is built via load_pretrained_config).
+        "minicpmv4_6": MiniCPMV4_6Config,
         "gemma4_unified": Gemma4UnifiedConfig,
         "gemma4_unified_text": Gemma4UnifiedTextConfig,
         "gemma4_unified_vision": Gemma4UnifiedVisionConfig,
@@ -64,4 +69,6 @@ __all__ = [
     "Gemma4UnifiedTextConfig",
     "Gemma4UnifiedVisionConfig",
     "LagunaConfig",
+    "MiniCPMV4_6Config",
+    "MiniCPMV4_6VisionConfig",
 ]

--- a/tensorrt_llm/_torch/configs/minicpmv4_6.py
+++ b/tensorrt_llm/_torch/configs/minicpmv4_6.py
@@ -11,6 +11,19 @@ the HF fields we consume, and build them from ``config.json`` inside
 The inner text config is normalized separately into a ``Qwen3NextConfig`` (the
 runtime model that backs the Qwen3.5 dense text tower) via the shared Qwen3.5
 compatibility shim; it is passed in already constructed.
+
+.. note::
+    This is a transitional import/registration-safety shim, **not** a way to
+    avoid the ``transformers>=5.7.0`` runtime requirement: actually running the
+    model still needs the native ``MiniCPMV4_6Processor`` for image/video
+    preprocessing (see ``_ensure_transformers_supports_minicpmv4_6`` in
+    ``modeling_minicpmv4_6``).  Its only job is to keep ``import tensorrt_llm``,
+    ``AutoConfig``/``AutoTokenizer`` and CI unit-test collection working on the
+    repo's currently-pinned transformers 5.5.4.
+
+    TODO: remove this module once the repo pins ``transformers>=5.7.0`` and
+    switch ``_build_minicpmv4_6_config`` to the native
+    ``transformers.MiniCPMV4_6Config``.
 """
 
 from transformers import PretrainedConfig

--- a/tensorrt_llm/_torch/configs/minicpmv4_6.py
+++ b/tensorrt_llm/_torch/configs/minicpmv4_6.py
@@ -60,8 +60,7 @@ class MiniCPMV4_6VisionConfig(PretrainedConfig):
 
     @property
     def window_intermediate_size(self) -> int:
-        return (self.intermediate_size * self.window_kernel_size[0] *
-                self.window_kernel_size[1])
+        return self.intermediate_size * self.window_kernel_size[0] * self.window_kernel_size[1]
 
 
 class MiniCPMV4_6Config(PretrainedConfig):

--- a/tensorrt_llm/_torch/configs/minicpmv4_6.py
+++ b/tensorrt_llm/_torch/configs/minicpmv4_6.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Self-contained config classes for MiniCPM-V 4.6.
+
+The composite ``minicpmv4_6`` HF config is only registered in
+``transformers>=5.7.0``.  TRT-LLM must load the model on older transformers
+releases too, so we ship lightweight ``PretrainedConfig`` subclasses that mirror
+the HF fields we consume, and build them from ``config.json`` inside
+``pyexecutor.config_utils.load_pretrained_config`` (bypassing ``AutoConfig``).
+
+The inner text config is normalized separately into a ``Qwen3NextConfig`` (the
+runtime model that backs the Qwen3.5 dense text tower) via the shared Qwen3.5
+compatibility shim; it is passed in already constructed.
+"""
+
+from transformers import PretrainedConfig
+
+__all__ = ["MiniCPMV4_6Config", "MiniCPMV4_6VisionConfig"]
+
+
+class MiniCPMV4_6VisionConfig(PretrainedConfig):
+    """SigLIP2-style variable-resolution ViT config for MiniCPM-V 4.6."""
+
+    model_type = "minicpmv4_6_vision"
+    base_config_key = "vision_config"
+
+    def __init__(
+        self,
+        hidden_size: int = 1152,
+        intermediate_size: int = 4304,
+        num_hidden_layers: int = 27,
+        num_attention_heads: int = 16,
+        num_channels: int = 3,
+        image_size: int = 980,
+        patch_size: int = 14,
+        hidden_act: str = "gelu_pytorch_tanh",
+        layer_norm_eps: float = 1e-6,
+        attention_dropout: float = 0.0,
+        insert_layer_id: int = 6,
+        window_kernel_size=(2, 2),
+        **kwargs,
+    ):
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_channels = num_channels
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.hidden_act = hidden_act
+        self.layer_norm_eps = layer_norm_eps
+        self.attention_dropout = attention_dropout
+        self.insert_layer_id = insert_layer_id
+        self.window_kernel_size = tuple(window_kernel_size)
+        super().__init__(**kwargs)
+
+    @property
+    def window_hidden_size(self) -> int:
+        return self.hidden_size * self.window_kernel_size[0] * self.window_kernel_size[1]
+
+    @property
+    def window_intermediate_size(self) -> int:
+        return (self.intermediate_size * self.window_kernel_size[0] *
+                self.window_kernel_size[1])
+
+
+class MiniCPMV4_6Config(PretrainedConfig):
+    """Composite config: SigLIP2 vision tower + Qwen3.5 dense text tower."""
+
+    model_type = "minicpmv4_6"
+    sub_configs = {"vision_config": MiniCPMV4_6VisionConfig}
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        insert_layer_id: int = 6,
+        image_size: int = 448,
+        drop_vision_last_layer: bool = False,
+        image_token_id=None,
+        video_token_id=None,
+        downsample_mode: str = "16x",
+        merge_kernel_size=(2, 2),
+        merger_times: int = 1,
+        tie_word_embeddings: bool = False,
+        **kwargs,
+    ):
+        if isinstance(vision_config, dict):
+            vision_config = dict(vision_config)
+            vision_config.pop("model_type", None)
+            vision_config = MiniCPMV4_6VisionConfig(**vision_config)
+        elif vision_config is None:
+            vision_config = MiniCPMV4_6VisionConfig()
+        self.vision_config = vision_config
+        self.vision_config.insert_layer_id = insert_layer_id
+
+        # The loader passes an already-constructed Qwen3NextConfig. When
+        # AutoConfig builds this class from a raw dict (e.g. AutoTokenizer),
+        # keep the dict as-is; only the loader path needs a real text config.
+        self.text_config = text_config
+
+        self.insert_layer_id = insert_layer_id
+        self.image_size = image_size
+        self.drop_vision_last_layer = drop_vision_last_layer
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.downsample_mode = downsample_mode
+        self.merge_kernel_size = tuple(merge_kernel_size)
+        self.merger_times = merger_times
+        self.patch_size = self.vision_config.patch_size
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -33,6 +33,7 @@ from .modeling_kimi_k25 import KimiK25ForConditionalGeneration
 from .modeling_laguna import LagunaForCausalLM
 from .modeling_llama import LlamaForCausalLM
 from .modeling_llava_next import LlavaNextModel
+from .modeling_minicpmv4_6 import MiniCPMV4_6Model
 from .modeling_minimaxm2 import MiniMaxM2ForCausalLM
 from .modeling_minimaxm3 import (MiniMaxM3ForCausalLM,
                                  MiniMaxM3VLForConditionalGeneration)
@@ -89,6 +90,7 @@ __all__ = [
     "KimiK25ForConditionalGeneration",
     "LlamaForCausalLM",
     "LlavaNextModel",
+    "MiniCPMV4_6Model",
     "Mistral3VLM",
     "MistralForCausalLM",
     "MixtralForCausalLM",

--- a/tensorrt_llm/_torch/models/modeling_minicpmv4_6.py
+++ b/tensorrt_llm/_torch/models/modeling_minicpmv4_6.py
@@ -409,7 +409,9 @@ class MiniCPMV4_6DownsampleMLP(nn.Module):
         super().__init__()
         dtype = model_config.pretrained_config.vision_config.torch_dtype
         mapping = model_config.mapping
-        merged_hidden_size = hidden_size * 4
+        merge_kernel_size = tuple(model_config.pretrained_config.merge_kernel_size)
+        merge_factor = merge_kernel_size[0] * merge_kernel_size[1]
+        merged_hidden_size = hidden_size * merge_factor
         self.pre_norm = LayerNorm(hidden_size=merged_hidden_size, eps=1e-6, dtype=dtype)
         self.linear_1 = Linear(
             merged_hidden_size,

--- a/tensorrt_llm/_torch/models/modeling_minicpmv4_6.py
+++ b/tensorrt_llm/_torch/models/modeling_minicpmv4_6.py
@@ -22,25 +22,29 @@ model does *not* use mRoPE).
 """
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import transformers
 from packaging.version import Version
-from transformers import (AutoProcessor, AutoTokenizer, PretrainedConfig,
-                          PreTrainedModel)
+from transformers import AutoProcessor, AutoTokenizer, PretrainedConfig, PreTrainedModel
 
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 from tensorrt_llm.mapping import Mapping
 
 from ..._utils import nvtx_range
-from ...inputs import (BaseMultimodalDummyInputsBuilder,
-                       BaseMultimodalInputProcessor, ContentFormat,
-                       ExtraProcessedInputs, MultimodalPlaceholderMetadata,
-                       MultimodalPlaceholderPlacement, TextPrompt,
-                       register_input_processor)
+from ...inputs import (
+    BaseMultimodalDummyInputsBuilder,
+    BaseMultimodalInputProcessor,
+    ContentFormat,
+    ExtraProcessedInputs,
+    MultimodalPlaceholderMetadata,
+    MultimodalPlaceholderPlacement,
+    TextPrompt,
+    register_input_processor,
+)
 from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
 from ..attention_backend.interface import PredefinedAttentionMask
@@ -53,12 +57,14 @@ from ..modules.mlp import MLP
 from .checkpoints.base_weight_mapper import BaseWeightMapper
 from .checkpoints.hf.qwen3_5_weight_mapper import Qwen3_5MoeHfWeightMapper
 from .modeling_auto import AutoModelForCausalLM
-from .modeling_multimodal_utils import (_is_mm_disagg, find_input_mm_embeds,
-                                        fuse_input_embeds,
-                                        get_multimodal_embeddings)
+from .modeling_multimodal_utils import (
+    _is_mm_disagg,
+    find_input_mm_embeds,
+    fuse_input_embeds,
+    get_multimodal_embeddings,
+)
 from .modeling_qwen2vl import _prepare_qwen_vl_vision_attn_metadata
-from .modeling_utils import (QuantConfig, _load_weights_impl,
-                             register_auto_model)
+from .modeling_utils import QuantConfig, _load_weights_impl, register_auto_model
 
 
 def _gelu_tanh(x: torch.Tensor) -> torch.Tensor:
@@ -84,7 +90,8 @@ def _ensure_transformers_supports_minicpmv4_6() -> None:
             f"(installed: {installed}). This model was upstreamed into "
             f"transformers and ships no remote code to fall back on. Please "
             f"upgrade, e.g. `pip install 'transformers>="
-            f"{_MINICPMV4_6_MIN_TRANSFORMERS}'`.")
+            f"{_MINICPMV4_6_MIN_TRANSFORMERS}'`."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -114,12 +121,9 @@ class MiniCPMV4_6VisionEmbeddings(nn.Module):
         )
         self.num_patches_per_side = self.image_size // self.patch_size
         self.num_positions = self.num_patches_per_side**2
-        self.position_embedding = nn.Embedding(self.num_positions,
-                                               self.embed_dim,
-                                               dtype=dtype)
+        self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim, dtype=dtype)
 
-    def forward(self, pixel_values: torch.Tensor,
-                target_sizes: torch.Tensor) -> torch.Tensor:
+    def forward(self, pixel_values: torch.Tensor, target_sizes: torch.Tensor) -> torch.Tensor:
         # pixel_values: NaViT-packed [1, C, patch_size, total_patch_axis]
         patch_embeds = self.patch_embedding(pixel_values)
         embeddings = patch_embeds.flatten(2).transpose(1, 2)  # [1, T, D]
@@ -132,19 +136,16 @@ class MiniCPMV4_6VisionEmbeddings(nn.Module):
             h, w = int(target_size[0]), int(target_size[1])
             fractional_coords_h = torch.arange(0, 1 - 1e-6, 1 / h)
             fractional_coords_w = torch.arange(0, 1 - 1e-6, 1 / w)
-            bucket_coords_h = torch.bucketize(fractional_coords_h,
-                                              boundaries,
-                                              right=True)
-            bucket_coords_w = torch.bucketize(fractional_coords_w,
-                                              boundaries,
-                                              right=True)
-            pos_ids = (bucket_coords_h[:, None] * nps +
-                       bucket_coords_w).flatten().to(
-                           self.position_embedding.weight.device)
+            bucket_coords_h = torch.bucketize(fractional_coords_h, boundaries, right=True)
+            bucket_coords_w = torch.bucketize(fractional_coords_w, boundaries, right=True)
+            pos_ids = (
+                (bucket_coords_h[:, None] * nps + bucket_coords_w)
+                .flatten()
+                .to(self.position_embedding.weight.device)
+            )
             position_embeddings.append(self.position_embedding(pos_ids))
 
-        position_embeddings = torch.concat(position_embeddings,
-                                           dim=0).unsqueeze(0)
+        position_embeddings = torch.concat(position_embeddings, dim=0).unsqueeze(0)
         return embeddings + position_embeddings
 
 
@@ -156,8 +157,7 @@ class MiniCPMV4_6VisionAttention(Attention):
     custom forward that skips the generic RoPE path. Runs replicated (tp=1).
     """
 
-    def __init__(self, model_config: ModelConfig[PretrainedConfig],
-                 layer_idx: int):
+    def __init__(self, model_config: ModelConfig[PretrainedConfig], layer_idx: int):
         config = model_config.pretrained_config.vision_config
         text_config = model_config.pretrained_config.text_config
         super().__init__(
@@ -178,8 +178,7 @@ class MiniCPMV4_6VisionAttention(Attention):
         # compiled LM region); unregister so `forward_impl` uses the eager path
         # with the vision-local `attn_metadata` instead of the LM's.
         if self.register_to_config:
-            model_config.extra_attrs.get("attn_layers",
-                                         {}).pop(self.layer_idx_str, None)
+            model_config.extra_attrs.get("attn_layers", {}).pop(self.layer_idx_str, None)
             self.register_to_config = False
 
     def forward(
@@ -203,8 +202,7 @@ class MiniCPMV4_6VisionAttention(Attention):
         )
         return self.o_proj(output, layer_idx=self.layer_idx)
 
-    def forward_window(self, hidden_states: torch.Tensor,
-                       window_len: int) -> torch.Tensor:
+    def forward_window(self, hidden_states: torch.Tensor, window_len: int) -> torch.Tensor:
         """Fixed-size window self-attention via batched SDPA.
 
         The ViT window merger reorders tokens into consecutive, equal-length
@@ -223,21 +221,18 @@ class MiniCPMV4_6VisionAttention(Attention):
 
         def to_windows(x: torch.Tensor) -> torch.Tensor:
             # [num_windows * window_len, H*D] -> [num_windows, H, window_len, D]
-            return x.view(num_windows, window_len, self.num_heads,
-                          self.head_dim).transpose(1, 2)
+            return x.view(num_windows, window_len, self.num_heads, self.head_dim).transpose(1, 2)
 
         q, k, v = to_windows(q), to_windows(k), to_windows(v)
         output = F.scaled_dot_product_attention(q, k, v)
-        output = output.transpose(1, 2).reshape(
-            num_tokens, self.num_heads * self.head_dim)
+        output = output.transpose(1, 2).reshape(num_tokens, self.num_heads * self.head_dim)
         return self.o_proj(output, layer_idx=self.layer_idx)
 
 
 class MiniCPMV4_6VisionMLP(MLP):
     """ViT feed-forward (``fc1`` -> gelu_tanh -> ``fc2``) on TRT-LLM ``MLP``."""
 
-    def __init__(self, model_config: ModelConfig[PretrainedConfig],
-                 layer_idx: int):
+    def __init__(self, model_config: ModelConfig[PretrainedConfig], layer_idx: int):
         config = model_config.pretrained_config.vision_config
         super().__init__(
             hidden_size=config.hidden_size,
@@ -251,23 +246,22 @@ class MiniCPMV4_6VisionMLP(MLP):
 
 
 class MiniCPMV4_6VisionEncoderLayer(nn.Module):
-
-    def __init__(self, model_config: ModelConfig[PretrainedConfig],
-                 layer_idx: int):
+    def __init__(self, model_config: ModelConfig[PretrainedConfig], layer_idx: int):
         super().__init__()
         config = model_config.pretrained_config.vision_config
         dtype = config.torch_dtype
-        self.layer_norm1 = LayerNorm(hidden_size=config.hidden_size,
-                                     eps=config.layer_norm_eps,
-                                     dtype=dtype)
+        self.layer_norm1 = LayerNorm(
+            hidden_size=config.hidden_size, eps=config.layer_norm_eps, dtype=dtype
+        )
         self.self_attn = MiniCPMV4_6VisionAttention(model_config, layer_idx)
-        self.layer_norm2 = LayerNorm(hidden_size=config.hidden_size,
-                                     eps=config.layer_norm_eps,
-                                     dtype=dtype)
+        self.layer_norm2 = LayerNorm(
+            hidden_size=config.hidden_size, eps=config.layer_norm_eps, dtype=dtype
+        )
         self.mlp = MiniCPMV4_6VisionMLP(model_config, layer_idx)
 
-    def forward(self, hidden_states: torch.Tensor,
-                attn_metadata: AttentionMetadata) -> torch.Tensor:
+    def forward(
+        self, hidden_states: torch.Tensor, attn_metadata: AttentionMetadata
+    ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.layer_norm1(hidden_states)
         hidden_states = self.self_attn(hidden_states, attn_metadata)
@@ -281,14 +275,15 @@ class MiniCPMV4_6VisionEncoderLayer(nn.Module):
 
 
 class MiniCPMV4_6VisionEncoder(nn.Module):
-
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
         super().__init__()
         config = model_config.pretrained_config.vision_config
-        self.layers = nn.ModuleList([
-            MiniCPMV4_6VisionEncoderLayer(model_config, layer_idx)
-            for layer_idx in range(config.num_hidden_layers)
-        ])
+        self.layers = nn.ModuleList(
+            [
+                MiniCPMV4_6VisionEncoderLayer(model_config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
 
 
 class MiniCPMV4_6ViTWindowAttentionMerger(nn.Module):
@@ -309,25 +304,30 @@ class MiniCPMV4_6ViTWindowAttentionMerger(nn.Module):
         mapping = model_config.mapping
 
         self.self_attn = MiniCPMV4_6VisionAttention(
-            model_config, layer_idx=config.num_hidden_layers)
-        self.layer_norm1 = LayerNorm(hidden_size=self.embed_dim,
-                                     eps=config.layer_norm_eps,
-                                     dtype=dtype)
-        self.pre_norm = LayerNorm(hidden_size=config.window_hidden_size,
-                                  eps=config.layer_norm_eps,
-                                  dtype=dtype)
-        self.linear_1 = Linear(config.window_hidden_size,
-                               config.window_intermediate_size,
-                               bias=True,
-                               dtype=dtype,
-                               mapping=mapping,
-                               tensor_parallel_mode=None)
-        self.linear_2 = Linear(config.window_intermediate_size,
-                               self.embed_dim,
-                               bias=True,
-                               dtype=dtype,
-                               mapping=mapping,
-                               tensor_parallel_mode=None)
+            model_config, layer_idx=config.num_hidden_layers
+        )
+        self.layer_norm1 = LayerNorm(
+            hidden_size=self.embed_dim, eps=config.layer_norm_eps, dtype=dtype
+        )
+        self.pre_norm = LayerNorm(
+            hidden_size=config.window_hidden_size, eps=config.layer_norm_eps, dtype=dtype
+        )
+        self.linear_1 = Linear(
+            config.window_hidden_size,
+            config.window_intermediate_size,
+            bias=True,
+            dtype=dtype,
+            mapping=mapping,
+            tensor_parallel_mode=None,
+        )
+        self.linear_2 = Linear(
+            config.window_intermediate_size,
+            self.embed_dim,
+            bias=True,
+            dtype=dtype,
+            mapping=mapping,
+            tensor_parallel_mode=None,
+        )
 
     def get_window_index(
         self, target_sizes: torch.Tensor
@@ -343,18 +343,16 @@ class MiniCPMV4_6ViTWindowAttentionMerger(nn.Module):
             if height % window_h != 0 or width % window_w != 0:
                 raise ValueError(
                     f"height={height}, width={width} must be divisible by "
-                    f"window size {self.window_kernel_size}")
+                    f"window size {self.window_kernel_size}"
+                )
             index = torch.arange(height * width).reshape(height, width)
             num_windows_h = height // window_h
             num_windows_w = width // window_w
             num_windows = num_windows_h * num_windows_w
-            index = index.reshape(num_windows_h, window_h, num_windows_w,
-                                  window_w)
-            index = index.permute(0, 2, 1, 3).reshape(num_windows,
-                                                       window_h * window_w)
+            index = index.reshape(num_windows_h, window_h, num_windows_w, window_w)
+            index = index.permute(0, 2, 1, 3).reshape(num_windows, window_h * window_w)
             window_index_list.append(index.reshape(-1) + token_offset)
-            cu_this = torch.arange(1, num_windows + 1) * (
-                window_h * window_w) + cu_seqlens[-1]
+            cu_this = torch.arange(1, num_windows + 1) * (window_h * window_w) + cu_seqlens[-1]
             cu_seqlens.extend(cu_this.tolist())
             token_offset += height * width
 
@@ -362,8 +360,9 @@ class MiniCPMV4_6ViTWindowAttentionMerger(nn.Module):
         cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32)
         return window_index, cu_seqlens, max_seqlens
 
-    def forward(self, hidden_states: torch.Tensor, target_sizes: torch.Tensor,
-                cu_seqlens: List[int]) -> torch.Tensor:
+    def forward(
+        self, hidden_states: torch.Tensor, target_sizes: torch.Tensor, cu_seqlens: List[int]
+    ) -> torch.Tensor:
         # hidden_states: [T, D]
         residual = hidden_states
         hidden_states = self.layer_norm1(hidden_states)
@@ -385,15 +384,15 @@ class MiniCPMV4_6ViTWindowAttentionMerger(nn.Module):
         merged = []
         for i in range(len(target_sizes)):
             height, width = int(target_sizes[i][0]), int(target_sizes[i][1])
-            patch = hidden_states[cu_seqlens[i]:cu_seqlens[i + 1], :]
+            patch = hidden_states[cu_seqlens[i] : cu_seqlens[i + 1], :]
             merged_h, merged_w = height // window_h, width // window_w
-            patch_5d = patch.view(merged_h, window_h, merged_w, window_w,
-                                  embed_dim).permute(0, 2, 1, 3, 4)
-            hidden_state = patch_5d.reshape(merged_h * merged_w,
-                                            window_h * window_w * embed_dim)
-            mean_residual = patch_5d.reshape(merged_h * merged_w,
-                                             window_h * window_w,
-                                             embed_dim).mean(dim=1)
+            patch_5d = patch.view(merged_h, window_h, merged_w, window_w, embed_dim).permute(
+                0, 2, 1, 3, 4
+            )
+            hidden_state = patch_5d.reshape(merged_h * merged_w, window_h * window_w * embed_dim)
+            mean_residual = patch_5d.reshape(
+                merged_h * merged_w, window_h * window_w, embed_dim
+            ).mean(dim=1)
             hidden_state = self.pre_norm(hidden_state)
             hidden_state = self.linear_1(hidden_state)
             hidden_state = _gelu_tanh(hidden_state)
@@ -406,31 +405,31 @@ class MiniCPMV4_6ViTWindowAttentionMerger(nn.Module):
 class MiniCPMV4_6DownsampleMLP(nn.Module):
     """2x2 spatial-merge projection (``pre_norm`` -> ``linear_1`` -> GELU -> ``linear_2``)."""
 
-    def __init__(self, model_config: ModelConfig[PretrainedConfig],
-                 hidden_size: int, out_dim: int):
+    def __init__(self, model_config: ModelConfig[PretrainedConfig], hidden_size: int, out_dim: int):
         super().__init__()
         dtype = model_config.pretrained_config.vision_config.torch_dtype
         mapping = model_config.mapping
         merged_hidden_size = hidden_size * 4
-        self.pre_norm = LayerNorm(hidden_size=merged_hidden_size,
-                                  eps=1e-6,
-                                  dtype=dtype)
-        self.linear_1 = Linear(merged_hidden_size,
-                               merged_hidden_size,
-                               bias=True,
-                               dtype=dtype,
-                               mapping=mapping,
-                               tensor_parallel_mode=None)
-        self.linear_2 = Linear(merged_hidden_size,
-                               out_dim,
-                               bias=True,
-                               dtype=dtype,
-                               mapping=mapping,
-                               tensor_parallel_mode=None)
+        self.pre_norm = LayerNorm(hidden_size=merged_hidden_size, eps=1e-6, dtype=dtype)
+        self.linear_1 = Linear(
+            merged_hidden_size,
+            merged_hidden_size,
+            bias=True,
+            dtype=dtype,
+            mapping=mapping,
+            tensor_parallel_mode=None,
+        )
+        self.linear_2 = Linear(
+            merged_hidden_size,
+            out_dim,
+            bias=True,
+            dtype=dtype,
+            mapping=mapping,
+            tensor_parallel_mode=None,
+        )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        hidden_states = self.pre_norm(hidden_states).view(
-            -1, self.linear_1.in_features)
+        hidden_states = self.pre_norm(hidden_states).view(-1, self.linear_1.in_features)
         hidden_states = self.linear_1(hidden_states)
         hidden_states = F.gelu(hidden_states)
         hidden_states = self.linear_2(hidden_states)
@@ -451,12 +450,12 @@ class MiniCPMV4_6Merger(nn.Module):
             MiniCPMV4_6DownsampleMLP(model_config, hidden_size, hidden_size)
             for _ in range(self.merger_times - 1)
         ]
-        mlps.append(
-            MiniCPMV4_6DownsampleMLP(model_config, hidden_size, llm_embed_dim))
+        mlps.append(MiniCPMV4_6DownsampleMLP(model_config, hidden_size, llm_embed_dim))
         self.mlp = nn.ModuleList(mlps)
 
-    def forward(self, hidden_states: torch.Tensor,
-                target_sizes: torch.Tensor) -> List[torch.Tensor]:
+    def forward(
+        self, hidden_states: torch.Tensor, target_sizes: torch.Tensor
+    ) -> List[torch.Tensor]:
         merge_h, merge_w = self.merge_kernel_size
         start = 0
         processed_features = []
@@ -465,22 +464,23 @@ class MiniCPMV4_6Merger(nn.Module):
             num_patches = height * width
             embed_dim = hidden_states.shape[-1]
             merged_h, merged_w = height // merge_h, width // merge_w
-            hidden_state = (hidden_states[start:start + num_patches, :].view(
-                merged_h, merge_h, merged_w, merge_w,
-                embed_dim).permute(0, 2, 1, 3,
-                                   4).reshape(merged_h * merged_w,
-                                              merge_h * merge_w * embed_dim))
+            hidden_state = (
+                hidden_states[start : start + num_patches, :]
+                .view(merged_h, merge_h, merged_w, merge_w, embed_dim)
+                .permute(0, 2, 1, 3, 4)
+                .reshape(merged_h * merged_w, merge_h * merge_w * embed_dim)
+            )
             hidden_state = self.mlp[0](hidden_state)
             for j in range(1, self.merger_times):
                 height = height // merge_h
                 width = width // merge_w
                 inner_dim = hidden_state.shape[-1]
                 merged_h, merged_w = height // merge_h, width // merge_w
-                hidden_state = (hidden_state.view(
-                    merged_h, merge_h, merged_w, merge_w,
-                    inner_dim).permute(0, 2, 1, 3,
-                                       4).reshape(merged_h * merged_w,
-                                                  merge_h * merge_w * inner_dim))
+                hidden_state = (
+                    hidden_state.view(merged_h, merge_h, merged_w, merge_w, inner_dim)
+                    .permute(0, 2, 1, 3, 4)
+                    .reshape(merged_h * merged_w, merge_h * merge_w * inner_dim)
+                )
                 hidden_state = self.mlp[j](hidden_state)
             start += num_patches
             processed_features.append(hidden_state)
@@ -514,24 +514,23 @@ class MiniCPMV4_6VisionModel(nn.Module):
         # dataclasses.replace gives a fresh extra_attrs (init=False), so the
         # vision attention's transient layer registration can't collide with
         # the LLM's.
-        vision_model_config = dataclasses.replace(model_config,
-                                                  quant_config=QuantConfig(),
-                                                  mapping=Mapping())
+        vision_model_config = dataclasses.replace(
+            model_config, quant_config=QuantConfig(), mapping=Mapping()
+        )
         self.model_config = vision_model_config
         self.config = self.vision_config
 
-        self.embeddings = MiniCPMV4_6VisionEmbeddings(self.vision_config,
-                                                      self.dtype)
+        self.embeddings = MiniCPMV4_6VisionEmbeddings(self.vision_config, self.dtype)
         self.encoder = MiniCPMV4_6VisionEncoder(vision_model_config)
-        self.post_layernorm = LayerNorm(hidden_size=self.vision_config.hidden_size,
-                                        eps=self.vision_config.layer_norm_eps,
-                                        dtype=self.dtype)
-        self.vit_merger = MiniCPMV4_6ViTWindowAttentionMerger(
-            vision_model_config)
+        self.post_layernorm = LayerNorm(
+            hidden_size=self.vision_config.hidden_size,
+            eps=self.vision_config.layer_norm_eps,
+            dtype=self.dtype,
+        )
+        self.vit_merger = MiniCPMV4_6ViTWindowAttentionMerger(vision_model_config)
         self.merger = MiniCPMV4_6Merger(vision_model_config)
 
-        self.metadata_cls = get_attention_backend(
-            model_config.attn_backend).Metadata
+        self.metadata_cls = get_attention_backend(model_config.attn_backend).Metadata
 
     def _make_attn_metadata(self, seq_lens: List[int]) -> AttentionMetadata:
         num_segments = len(seq_lens)
@@ -550,31 +549,27 @@ class MiniCPMV4_6VisionModel(nn.Module):
     def _grid_cu_seqlens(target_sizes: torch.Tensor) -> List[int]:
         cu = [0]
         for i in range(len(target_sizes)):
-            cu.append(cu[-1] +
-                      int(target_sizes[i][0]) * int(target_sizes[i][1]))
+            cu.append(cu[-1] + int(target_sizes[i][0]) * int(target_sizes[i][1]))
         return cu
 
-    def _get_image_features(self, pixel_values: torch.Tensor,
-                            target_sizes: torch.Tensor) -> List[torch.Tensor]:
+    def _get_image_features(
+        self, pixel_values: torch.Tensor, target_sizes: torch.Tensor
+    ) -> List[torch.Tensor]:
         pixel_values = pixel_values.to(self.dtype)
         hidden_states = self.embeddings(pixel_values, target_sizes).squeeze(0)
 
         use_vit_merger = self.downsample_mode != "4x"
         if use_vit_merger and self.insert_layer_id >= 0:
-            attn_metadata = self._make_attn_metadata(
-                self._grid_seq_lens(target_sizes))
+            attn_metadata = self._make_attn_metadata(self._grid_seq_lens(target_sizes))
             for layer_index, encoder_layer in enumerate(self.encoder.layers):
                 hidden_states = encoder_layer(hidden_states, attn_metadata)
                 if layer_index == self.insert_layer_id:
                     cu_seqlens = self._grid_cu_seqlens(target_sizes)
-                    hidden_states = self.vit_merger(hidden_states, target_sizes,
-                                                    cu_seqlens)
+                    hidden_states = self.vit_merger(hidden_states, target_sizes, cu_seqlens)
                     target_sizes = target_sizes // 2
-                    attn_metadata = self._make_attn_metadata(
-                        self._grid_seq_lens(target_sizes))
+                    attn_metadata = self._make_attn_metadata(self._grid_seq_lens(target_sizes))
         else:
-            attn_metadata = self._make_attn_metadata(
-                self._grid_seq_lens(target_sizes))
+            attn_metadata = self._make_attn_metadata(self._grid_seq_lens(target_sizes))
             for encoder_layer in self.encoder.layers:
                 hidden_states = encoder_layer(hidden_states, attn_metadata)
 
@@ -583,8 +578,7 @@ class MiniCPMV4_6VisionModel(nn.Module):
 
     @torch.inference_mode()
     @nvtx_range("MiniCPMV4_6 vision encoder")
-    def forward(self,
-                multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
+    def forward(self, multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
         pixel_values_list = []
         target_sizes_list = []
         for param in multimodal_params:
@@ -602,10 +596,16 @@ class MiniCPMV4_6VisionModel(nn.Module):
             return []
 
         # NaViT packing: concat along the packed patch axis; target grids stack.
-        pixel_values = (torch.cat(pixel_values_list, dim=-1)
-                        if len(pixel_values_list) > 1 else pixel_values_list[0])
-        target_sizes = (torch.cat(target_sizes_list, dim=0)
-                        if len(target_sizes_list) > 1 else target_sizes_list[0])
+        pixel_values = (
+            torch.cat(pixel_values_list, dim=-1)
+            if len(pixel_values_list) > 1
+            else pixel_values_list[0]
+        )
+        target_sizes = (
+            torch.cat(target_sizes_list, dim=0)
+            if len(target_sizes_list) > 1
+            else target_sizes_list[0]
+        )
         target_sizes = target_sizes.to("cpu")
 
         features = self._get_image_features(pixel_values, target_sizes)
@@ -615,10 +615,9 @@ class MiniCPMV4_6VisionModel(nn.Module):
         converted_weights = {}
         for key, value in weights.items():
             if key.startswith("model.vision_tower."):
-                converted_weights[key[len("model.vision_tower."):]] = value
+                converted_weights[key[len("model.vision_tower.") :]] = value
             elif key.startswith("model.merger."):
-                converted_weights["merger." +
-                                  key[len("model.merger."):]] = value
+                converted_weights["merger." + key[len("model.merger.") :]] = value
 
         # q/k/v -> qkv_proj fusion is handled by _load_weights_impl's params_map;
         # only the projection / MLP renames need explicit regex substitutions.
@@ -633,39 +632,40 @@ class MiniCPMV4_6VisionModel(nn.Module):
 # ---------------------------------------------------------------------------
 # Input processor
 # ---------------------------------------------------------------------------
-class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor,
-                                BaseMultimodalDummyInputsBuilder):
+class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInputsBuilder):
     """Runs the HF MiniCPM-V processor and rewrites image tokens to the OOV
     sentinel expected by ``fuse_input_embeds``."""
 
-    def __init__(self,
-                 model_path: str,
-                 config: PretrainedConfig,
-                 tokenizer: AutoTokenizer,
-                 trust_remote_code: bool = True,
-                 **kwargs):
+    def __init__(
+        self,
+        model_path: str,
+        config: PretrainedConfig,
+        tokenizer: AutoTokenizer,
+        trust_remote_code: bool = True,
+        **kwargs,
+    ):
         _ensure_transformers_supports_minicpmv4_6()
-        super().__init__(model_path=model_path,
-                         config=config,
-                         tokenizer=tokenizer,
-                         trust_remote_code=trust_remote_code,
-                         **kwargs)
+        super().__init__(
+            model_path=model_path,
+            config=config,
+            tokenizer=tokenizer,
+            trust_remote_code=trust_remote_code,
+            **kwargs,
+        )
         self._config = config
         self._model_path = model_path
-        self._tokenizer = tokenizer if tokenizer is not None else \
-            AutoTokenizer.from_pretrained(model_path,
-                                          trust_remote_code=trust_remote_code)
+        self._tokenizer = (
+            tokenizer
+            if tokenizer is not None
+            else AutoTokenizer.from_pretrained(model_path, trust_remote_code=trust_remote_code)
+        )
         self._processor = AutoProcessor.from_pretrained(
-            model_path,
-            use_fast=self.use_fast,
-            trust_remote_code=trust_remote_code)
-        self._dtype = (config.torch_dtype or config.text_config.torch_dtype
-                       or torch.bfloat16)
+            model_path, use_fast=self.use_fast, trust_remote_code=trust_remote_code
+        )
+        self._dtype = config.torch_dtype or config.text_config.torch_dtype or torch.bfloat16
         self.tllm_multimodal_token_id = self.get_vocab_size() + 1
-        self.image_token_str = getattr(self._processor, "image_token",
-                                       "<|image_pad|>")
-        self.video_token_str = getattr(self._processor, "video_token",
-                                       "<|video_pad|>")
+        self.image_token_str = getattr(self._processor, "image_token", "<|image_pad|>")
+        self.video_token_str = getattr(self._processor, "video_token", "<|video_pad|>")
 
     def get_vocab_size(self) -> int:
         return self.config.text_config.vocab_size
@@ -692,22 +692,21 @@ class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor,
 
     def _mm_token_ids(self) -> List[int]:
         return [
-            tid for attr in ("image_token_id", "video_token_id")
+            tid
+            for attr in ("image_token_id", "video_token_id")
             if (tid := getattr(self.config, attr, None)) is not None
         ]
 
     def _postprocess(self, input_ids: torch.IntTensor) -> torch.IntTensor:
         token_ids = self._mm_token_ids()
         if token_ids:
-            ids_tensor = torch.tensor(token_ids,
-                                      device=input_ids.device,
-                                      dtype=input_ids.dtype)
-            input_ids[torch.isin(input_ids,
-                                 ids_tensor)] = self.tllm_multimodal_token_id
+            ids_tensor = torch.tensor(token_ids, device=input_ids.device, dtype=input_ids.dtype)
+            input_ids[torch.isin(input_ids, ids_tensor)] = self.tllm_multimodal_token_id
         return input_ids
 
-    def _preprocess(self, text_prompt: str, images, videos, video_metadata,
-                    mm_processor_kwargs: Dict):
+    def _preprocess(
+        self, text_prompt: str, images, videos, video_metadata, mm_processor_kwargs: Dict
+    ):
         do_rescale = True
         if images and isinstance(images[0], torch.Tensor):
             do_rescale = False
@@ -715,11 +714,13 @@ class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor,
         # the HF rescale (x / 255) must be skipped for video.
         if videos and isinstance(videos[0][0], torch.Tensor):
             do_rescale = False
-        call_kwargs = dict(text=[text_prompt],
-                           images=images,
-                           do_rescale=do_rescale,
-                           return_tensors="pt",
-                           **mm_processor_kwargs)
+        call_kwargs = dict(
+            text=[text_prompt],
+            images=images,
+            do_rescale=do_rescale,
+            return_tensors="pt",
+            **mm_processor_kwargs,
+        )
         if videos is not None:
             # Frames are already sampled by TRT-LLM's load_video, so disable the
             # HF processor's own frame sampling (which would otherwise require
@@ -731,29 +732,24 @@ class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor,
 
     def get_num_tokens_per_image(self, *, image, **kwargs) -> int:
         do_rescale = not isinstance(image, torch.Tensor)
-        processed = self.processor(text=[self.image_token_str],
-                                   images=[image],
-                                   do_rescale=do_rescale,
-                                   return_tensors="pt")
+        processed = self.processor(
+            text=[self.image_token_str], images=[image], do_rescale=do_rescale, return_tensors="pt"
+        )
         input_ids = processed["input_ids"][0]
         return int((input_ids == self.config.image_token_id).sum().item())
 
-    def get_num_tokens_per_video(self,
-                                 *,
-                                 video,
-                                 video_metadata=None,
-                                 **kwargs) -> int:
+    def get_num_tokens_per_video(self, *, video, video_metadata=None, **kwargs) -> int:
         # `video` is the list of pre-sampled frames (see find_mm_token_lengths).
         frames = video
         do_rescale = not (frames and isinstance(frames[0], torch.Tensor))
         processed = self.processor(
             text=[self.video_token_str],
             videos=[frames],
-            video_metadata=[video_metadata]
-            if video_metadata is not None else None,
+            video_metadata=[video_metadata] if video_metadata is not None else None,
             do_sample_frames=False,
             do_rescale=do_rescale,
-            return_tensors="pt")
+            return_tensors="pt",
+        )
         input_ids = processed["input_ids"][0]
         return int((input_ids == self.config.video_token_id).sum().item())
 
@@ -769,8 +765,7 @@ class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor,
         mm_processor_kwargs = inputs.get("mm_processor_kwargs", {}) or {}
 
         if not mm_data:
-            input_ids = self.tokenizer(text_prompt,
-                                       return_tensors="pt").input_ids
+            input_ids = self.tokenizer(text_prompt, return_tensors="pt").input_ids
             return input_ids[0].to(torch.int32).tolist(), None
 
         images = mm_data.get("image")
@@ -780,11 +775,10 @@ class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor,
             # Each item is a VideoData (frames + decode metadata) from
             # load_video, mirroring the Qwen-VL input processor.
             videos = [vd.frames for vd in video_datas]
-            video_metadata = [
-                getattr(vd, "metadata", None) for vd in video_datas
-            ]
-        processed_inputs = self._preprocess(text_prompt, images, videos,
-                                            video_metadata, mm_processor_kwargs)
+            video_metadata = [getattr(vd, "metadata", None) for vd in video_datas]
+        processed_inputs = self._preprocess(
+            text_prompt, images, videos, video_metadata, mm_processor_kwargs
+        )
 
         multimodal_data = {}
         pixel_values = processed_inputs.get("pixel_values")
@@ -830,9 +824,7 @@ class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor,
     ),
 )
 class MiniCPMV4_6Model(PreTrainedModel):
-
-    def __init__(self, model_config: ModelConfig[PretrainedConfig], *args,
-                 **kwargs):
+    def __init__(self, model_config: ModelConfig[PretrainedConfig], *args, **kwargs):
         config = model_config.pretrained_config
         super().__init__(config)
         if hasattr(self, "llm"):
@@ -841,14 +833,14 @@ class MiniCPMV4_6Model(PreTrainedModel):
         if _is_mm_disagg():
             raise NotImplementedError(
                 "MiniCPMV4_6 does not support disaggregated multimodal serving "
-                "yet. Unset TLLM_MULTIMODAL_DISAGGREGATED or set it to '0'.")
+                "yet. Unset TLLM_MULTIMODAL_DISAGGREGATED or set it to '0'."
+            )
 
         self.model_config = model_config
         self.mm_encoder = MiniCPMV4_6VisionModel(model_config).eval()
 
         # Inner LLM resolved from text_config (Qwen3_5ForCausalLM, hybrid).
-        llm_model_config = dataclasses.replace(
-            model_config, pretrained_config=config.text_config)
+        llm_model_config = dataclasses.replace(model_config, pretrained_config=config.text_config)
         # Share the wrapper's extra_attrs so the LM's attention layers register
         # into the same dict the engine binds via with_model_extra_attrs (needed
         # for the compiled / piecewise-CUDA-graph LM path). dataclasses.replace
@@ -890,25 +882,24 @@ class MiniCPMV4_6Model(PreTrainedModel):
                 encoder_forward_fn=self.mm_encoder.forward,
                 multimodal_params=multimodal_params[:num_context_requests],
             )
-            mm_embeds = find_input_mm_embeds(
-                mm_embeds, multimodal_params[:num_context_requests])
+            mm_embeds = find_input_mm_embeds(mm_embeds, multimodal_params[:num_context_requests])
 
         input_ids, inputs_embeds = fuse_input_embeds(
-            self.llm.model.embed_tokens, input_ids, mm_embeds, **kwargs)
-        return self.llm.forward(attn_metadata=attn_metadata,
-                                input_ids=input_ids,
-                                position_ids=position_ids,
-                                inputs_embeds=inputs_embeds,
-                                return_context_logits=return_context_logits)
+            self.llm.model.embed_tokens, input_ids, mm_embeds, **kwargs
+        )
+        return self.llm.forward(
+            attn_metadata=attn_metadata,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            return_context_logits=return_context_logits,
+        )
 
     @property
     def multimodal_data_device_paths(self) -> List[str]:
-        return [
-            "image.pixel_values", "video.pixel_values", "multimodal_embedding"
-        ]
+        return ["image.pixel_values", "video.pixel_values", "multimodal_embedding"]
 
-    def load_weights(self, weights: Dict[str, torch.Tensor],
-                     weight_mapper: BaseWeightMapper):
+    def load_weights(self, weights: Dict[str, torch.Tensor], weight_mapper: BaseWeightMapper):
         if self.mm_encoder is not None:
             self.mm_encoder.load_weights(weights)
             if hasattr(weights, "mark_consumed"):
@@ -917,11 +908,7 @@ class MiniCPMV4_6Model(PreTrainedModel):
 
         llm_weight_mapper = Qwen3_5MoeHfWeightMapper()
         llm_weight_mapper.init_model_and_config(self.llm, self.model_config)
-        llm_weights = {
-            k: v
-            for k, v in weights.items()
-            if k.startswith("model.language_model.")
-        }
+        llm_weights = {k: v for k, v in weights.items() if k.startswith("model.language_model.")}
         self.llm.load_weights(llm_weights, llm_weight_mapper)
         if hasattr(weights, "mark_consumed"):
             weights.mark_consumed("model.language_model")

--- a/tensorrt_llm/_torch/models/modeling_minicpmv4_6.py
+++ b/tensorrt_llm/_torch/models/modeling_minicpmv4_6.py
@@ -1,0 +1,927 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""MiniCPM-V 4.6 (openbmb/MiniCPM-V-4.6) for the TRT-LLM PyTorch backend.
+
+Composition:
+  * A SigLIP2-style variable-resolution ViT (NaViT-packed) with an intermediate
+    window-attention merger and a final 2x2 downsample-MLP merger, ported to
+    TRT-LLM modules (``Attention`` / ``Linear`` / ``LayerNorm`` / ``MLP``).
+  * A Qwen3.5 dense hybrid (linear + full attention) text tower, resolved from
+    ``text_config`` through TRT-LLM's ``AutoModelForCausalLM`` (Qwen3_5ForCausalLM).
+
+Both image and video modalities are wired up. Video reuses the exact same
+NaViT-packed vision path: the HF processor packs every frame/slice into
+``pixel_values_videos`` / ``target_sizes_videos`` with the same layout as image
+inputs, and HF's ``get_video_features`` is (for batch/beam == 1) an identity
+repack of ``get_image_features`` -- so the ported ``_get_image_features`` is
+correct for video too.
+
+The vision tower uses learned (interpolated) absolute position embeddings and no
+rotary embedding, so the text tower's standard 1-D RoPE path is untouched (this
+model does *not* use mRoPE).
+"""
+
+import dataclasses
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import transformers
+from packaging.version import Version
+from transformers import (AutoProcessor, AutoTokenizer, PretrainedConfig,
+                          PreTrainedModel)
+
+from tensorrt_llm.inputs.multimodal import MultimodalParams
+from tensorrt_llm.mapping import Mapping
+
+from ..._utils import nvtx_range
+from ...inputs import (BaseMultimodalDummyInputsBuilder,
+                       BaseMultimodalInputProcessor, ContentFormat,
+                       ExtraProcessedInputs, MultimodalPlaceholderMetadata,
+                       MultimodalPlaceholderPlacement, TextPrompt,
+                       register_input_processor)
+from ...sampling_params import SamplingParams
+from ..attention_backend import AttentionMetadata
+from ..attention_backend.interface import PredefinedAttentionMask
+from ..attention_backend.utils import get_attention_backend
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.layer_norm import LayerNorm
+from ..modules.linear import Linear
+from ..modules.mlp import MLP
+from .checkpoints.base_weight_mapper import BaseWeightMapper
+from .checkpoints.hf.qwen3_5_weight_mapper import Qwen3_5MoeHfWeightMapper
+from .modeling_auto import AutoModelForCausalLM
+from .modeling_multimodal_utils import (_is_mm_disagg, find_input_mm_embeds,
+                                        fuse_input_embeds,
+                                        get_multimodal_embeddings)
+from .modeling_qwen2vl import _prepare_qwen_vl_vision_attn_metadata
+from .modeling_utils import (QuantConfig, _load_weights_impl,
+                             register_auto_model)
+
+
+def _gelu_tanh(x: torch.Tensor) -> torch.Tensor:
+    """``gelu_pytorch_tanh`` activation used by the ViT encoder / window merger."""
+    return F.gelu(x, approximate="tanh")
+
+
+# MiniCPM-V 4.6 was upstreamed into transformers as a native model
+# (``minicpmv4_6``); its processor/config classes only ship in >=5.7.0, and the
+# checkpoint carries no remote code (``auto_map``) to fall back on. The TRT-LLM
+# model/config code is import-safe on older releases, so only the input
+# processor (which loads the native ``MiniCPMV4_6Processor``) hard-requires it.
+_MINICPMV4_6_MIN_TRANSFORMERS = "5.7.0"
+
+
+def _ensure_transformers_supports_minicpmv4_6() -> None:
+    """Raise a clear error if transformers is too old for the HF processor."""
+    installed = transformers.__version__
+    if Version(installed) < Version(_MINICPMV4_6_MIN_TRANSFORMERS):
+        raise RuntimeError(
+            f"MiniCPM-V 4.6 requires transformers>="
+            f"{_MINICPMV4_6_MIN_TRANSFORMERS} for its native processor/config "
+            f"(installed: {installed}). This model was upstreamed into "
+            f"transformers and ships no remote code to fall back on. Please "
+            f"upgrade, e.g. `pip install 'transformers>="
+            f"{_MINICPMV4_6_MIN_TRANSFORMERS}'`.")
+
+
+# ---------------------------------------------------------------------------
+# Vision tower
+# ---------------------------------------------------------------------------
+class MiniCPMV4_6VisionEmbeddings(nn.Module):
+    """Conv2d patch embedding + interpolated absolute position embeddings.
+
+    Adapted from SigLIP's NaViT variant: images keep their native aspect ratio,
+    so position ids are bucketized per (h, w) grid rather than looked up from a
+    fixed square grid.
+    """
+
+    def __init__(self, config: PretrainedConfig, dtype: torch.dtype):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.patch_size = config.patch_size
+        self.image_size = config.image_size
+
+        self.patch_embedding = nn.Conv2d(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            padding="valid",
+            dtype=dtype,
+        )
+        self.num_patches_per_side = self.image_size // self.patch_size
+        self.num_positions = self.num_patches_per_side**2
+        self.position_embedding = nn.Embedding(self.num_positions,
+                                               self.embed_dim,
+                                               dtype=dtype)
+
+    def forward(self, pixel_values: torch.Tensor,
+                target_sizes: torch.Tensor) -> torch.Tensor:
+        # pixel_values: NaViT-packed [1, C, patch_size, total_patch_axis]
+        patch_embeds = self.patch_embedding(pixel_values)
+        embeddings = patch_embeds.flatten(2).transpose(1, 2)  # [1, T, D]
+
+        nps = self.num_patches_per_side
+        boundaries = torch.arange(1 / nps, 1.0, 1 / nps)
+        position_embeddings = []
+        # target_sizes lives on CPU (used for integer arithmetic here).
+        for target_size in target_sizes:
+            h, w = int(target_size[0]), int(target_size[1])
+            fractional_coords_h = torch.arange(0, 1 - 1e-6, 1 / h)
+            fractional_coords_w = torch.arange(0, 1 - 1e-6, 1 / w)
+            bucket_coords_h = torch.bucketize(fractional_coords_h,
+                                              boundaries,
+                                              right=True)
+            bucket_coords_w = torch.bucketize(fractional_coords_w,
+                                              boundaries,
+                                              right=True)
+            pos_ids = (bucket_coords_h[:, None] * nps +
+                       bucket_coords_w).flatten().to(
+                           self.position_embedding.weight.device)
+            position_embeddings.append(self.position_embedding(pos_ids))
+
+        position_embeddings = torch.concat(position_embeddings,
+                                           dim=0).unsqueeze(0)
+        return embeddings + position_embeddings
+
+
+class MiniCPMV4_6VisionAttention(Attention):
+    """Variable-length full self-attention (no RoPE) for the ViT tower.
+
+    Mirrors ``Qwen2_5_VLVisionAttention``: fused ``qkv_proj`` / ``o_proj``, a
+    per-segment ``attn_metadata`` (cu_seqlens) built by the caller, and a
+    custom forward that skips the generic RoPE path. Runs replicated (tp=1).
+    """
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig],
+                 layer_idx: int):
+        config = model_config.pretrained_config.vision_config
+        text_config = model_config.pretrained_config.text_config
+        super().__init__(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=config.num_attention_heads,
+            max_position_embeddings=text_config.max_position_embeddings,
+            bias=True,
+            pos_embd_params=None,
+            rope_fusion=False,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            config=model_config,
+            reduce_output=False,
+            head_dim=config.hidden_size // config.num_attention_heads,
+        )
+        # Vision attention runs eagerly from the VL wrapper (outside the
+        # compiled LM region); unregister so `forward_impl` uses the eager path
+        # with the vision-local `attn_metadata` instead of the LM's.
+        if self.register_to_config:
+            model_config.extra_attrs.get("attn_layers",
+                                         {}).pop(self.layer_idx_str, None)
+            self.register_to_config = False
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        qkv = self.qkv_proj(hidden_states)
+        q, k, v = self.split_qkv(qkv, None, None)
+        q, k, v = self.convert_qkv(q, k, v)
+        output = self.forward_impl(
+            q=q,
+            k=k,
+            v=v,
+            attn_metadata=attn_metadata,
+            attention_mask=PredefinedAttentionMask.FULL,
+            attention_window_size=None,
+            attention_mask_data=None,
+            mrope_config=None,
+            attention_sinks=None,
+        )
+        return self.o_proj(output, layer_idx=self.layer_idx)
+
+    def forward_window(self, hidden_states: torch.Tensor,
+                       window_len: int) -> torch.Tensor:
+        """Fixed-size window self-attention via batched SDPA.
+
+        The ViT window merger reorders tokens into consecutive, equal-length
+        windows (``window_h * window_w`` tokens each) that never attend across
+        window boundaries. Running this as one variable-length fused-attention
+        call produces one segment per window; with many frames/slices the
+        segment count is large enough to overflow the fused-attention kernel's
+        launch limits. Because every window is the *same* small length, it maps
+        exactly onto a regular batched attention instead -- which is both
+        cheaper and free of that segment-count ceiling.
+        """
+        num_tokens = hidden_states.shape[0]
+        num_windows = num_tokens // window_len
+        qkv = self.qkv_proj(hidden_states)
+        q, k, v = self.split_qkv(qkv)
+
+        def to_windows(x: torch.Tensor) -> torch.Tensor:
+            # [num_windows * window_len, H*D] -> [num_windows, H, window_len, D]
+            return x.view(num_windows, window_len, self.num_heads,
+                          self.head_dim).transpose(1, 2)
+
+        q, k, v = to_windows(q), to_windows(k), to_windows(v)
+        output = F.scaled_dot_product_attention(q, k, v)
+        output = output.transpose(1, 2).reshape(
+            num_tokens, self.num_heads * self.head_dim)
+        return self.o_proj(output, layer_idx=self.layer_idx)
+
+
+class MiniCPMV4_6VisionMLP(MLP):
+    """ViT feed-forward (``fc1`` -> gelu_tanh -> ``fc2``) on TRT-LLM ``MLP``."""
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig],
+                 layer_idx: int):
+        config = model_config.pretrained_config.vision_config
+        super().__init__(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            bias=True,
+            activation=_gelu_tanh,
+            dtype=config.torch_dtype,
+            config=model_config,
+            layer_idx=layer_idx,
+        )
+
+
+class MiniCPMV4_6VisionEncoderLayer(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig],
+                 layer_idx: int):
+        super().__init__()
+        config = model_config.pretrained_config.vision_config
+        dtype = config.torch_dtype
+        self.layer_norm1 = LayerNorm(hidden_size=config.hidden_size,
+                                     eps=config.layer_norm_eps,
+                                     dtype=dtype)
+        self.self_attn = MiniCPMV4_6VisionAttention(model_config, layer_idx)
+        self.layer_norm2 = LayerNorm(hidden_size=config.hidden_size,
+                                     eps=config.layer_norm_eps,
+                                     dtype=dtype)
+        self.mlp = MiniCPMV4_6VisionMLP(model_config, layer_idx)
+
+    def forward(self, hidden_states: torch.Tensor,
+                attn_metadata: AttentionMetadata) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states = self.self_attn(hidden_states, attn_metadata)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class MiniCPMV4_6VisionEncoder(nn.Module):
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig]):
+        super().__init__()
+        config = model_config.pretrained_config.vision_config
+        self.layers = nn.ModuleList([
+            MiniCPMV4_6VisionEncoderLayer(model_config, layer_idx)
+            for layer_idx in range(config.num_hidden_layers)
+        ])
+
+
+class MiniCPMV4_6ViTWindowAttentionMerger(nn.Module):
+    """Intermediate window self-attention + 2x2 window merge (inserted mid-ViT).
+
+    Reorders tokens into 2x2 windows, runs window-local self-attention, then
+    merges every 2x2 window into one token (with a mean-pool residual) through a
+    block-structured MLP (``linear_1`` -> gelu_tanh -> ``linear_2``). Halves the
+    per-axis patch grid.
+    """
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig]):
+        super().__init__()
+        config = model_config.pretrained_config.vision_config
+        dtype = config.torch_dtype
+        self.window_kernel_size = tuple(config.window_kernel_size)
+        self.embed_dim = config.hidden_size
+        mapping = model_config.mapping
+
+        self.self_attn = MiniCPMV4_6VisionAttention(
+            model_config, layer_idx=config.num_hidden_layers)
+        self.layer_norm1 = LayerNorm(hidden_size=self.embed_dim,
+                                     eps=config.layer_norm_eps,
+                                     dtype=dtype)
+        self.pre_norm = LayerNorm(hidden_size=config.window_hidden_size,
+                                  eps=config.layer_norm_eps,
+                                  dtype=dtype)
+        self.linear_1 = Linear(config.window_hidden_size,
+                               config.window_intermediate_size,
+                               bias=True,
+                               dtype=dtype,
+                               mapping=mapping,
+                               tensor_parallel_mode=None)
+        self.linear_2 = Linear(config.window_intermediate_size,
+                               self.embed_dim,
+                               bias=True,
+                               dtype=dtype,
+                               mapping=mapping,
+                               tensor_parallel_mode=None)
+
+    def get_window_index(
+        self, target_sizes: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, int]:
+        window_h, window_w = self.window_kernel_size
+        max_seqlens = window_h * window_w
+
+        window_index_list = []
+        cu_seqlens = [0]
+        token_offset = 0
+        for height, width in target_sizes:
+            height, width = int(height), int(width)
+            if height % window_h != 0 or width % window_w != 0:
+                raise ValueError(
+                    f"height={height}, width={width} must be divisible by "
+                    f"window size {self.window_kernel_size}")
+            index = torch.arange(height * width).reshape(height, width)
+            num_windows_h = height // window_h
+            num_windows_w = width // window_w
+            num_windows = num_windows_h * num_windows_w
+            index = index.reshape(num_windows_h, window_h, num_windows_w,
+                                  window_w)
+            index = index.permute(0, 2, 1, 3).reshape(num_windows,
+                                                       window_h * window_w)
+            window_index_list.append(index.reshape(-1) + token_offset)
+            cu_this = torch.arange(1, num_windows + 1) * (
+                window_h * window_w) + cu_seqlens[-1]
+            cu_seqlens.extend(cu_this.tolist())
+            token_offset += height * width
+
+        window_index = torch.cat(window_index_list)
+        cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32)
+        return window_index, cu_seqlens, max_seqlens
+
+    def forward(self, hidden_states: torch.Tensor, target_sizes: torch.Tensor,
+                cu_seqlens: List[int]) -> torch.Tensor:
+        # hidden_states: [T, D]
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        device = hidden_states.device
+
+        window_index, _, window_len = self.get_window_index(target_sizes)
+        window_index = window_index.to(device)
+
+        # Every window is exactly `window_len` (= window_h*window_w) tokens, so
+        # the window self-attention is a regular batched attention rather than a
+        # variable-length one (see MiniCPMV4_6VisionAttention.forward_window).
+        hidden_states = hidden_states[window_index, :]
+        hidden_states = self.self_attn.forward_window(hidden_states, window_len)
+        hidden_states = hidden_states[torch.argsort(window_index), :]
+        hidden_states = residual + hidden_states
+
+        window_h, window_w = self.window_kernel_size
+        embed_dim = hidden_states.shape[-1]
+        merged = []
+        for i in range(len(target_sizes)):
+            height, width = int(target_sizes[i][0]), int(target_sizes[i][1])
+            patch = hidden_states[cu_seqlens[i]:cu_seqlens[i + 1], :]
+            merged_h, merged_w = height // window_h, width // window_w
+            patch_5d = patch.view(merged_h, window_h, merged_w, window_w,
+                                  embed_dim).permute(0, 2, 1, 3, 4)
+            hidden_state = patch_5d.reshape(merged_h * merged_w,
+                                            window_h * window_w * embed_dim)
+            mean_residual = patch_5d.reshape(merged_h * merged_w,
+                                             window_h * window_w,
+                                             embed_dim).mean(dim=1)
+            hidden_state = self.pre_norm(hidden_state)
+            hidden_state = self.linear_1(hidden_state)
+            hidden_state = _gelu_tanh(hidden_state)
+            hidden_state = self.linear_2(hidden_state)
+            merged.append(hidden_state + mean_residual)
+
+        return torch.concat(merged, dim=0)
+
+
+class MiniCPMV4_6DownsampleMLP(nn.Module):
+    """2x2 spatial-merge projection (``pre_norm`` -> ``linear_1`` -> GELU -> ``linear_2``)."""
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig],
+                 hidden_size: int, out_dim: int):
+        super().__init__()
+        dtype = model_config.pretrained_config.vision_config.torch_dtype
+        mapping = model_config.mapping
+        merged_hidden_size = hidden_size * 4
+        self.pre_norm = LayerNorm(hidden_size=merged_hidden_size,
+                                  eps=1e-6,
+                                  dtype=dtype)
+        self.linear_1 = Linear(merged_hidden_size,
+                               merged_hidden_size,
+                               bias=True,
+                               dtype=dtype,
+                               mapping=mapping,
+                               tensor_parallel_mode=None)
+        self.linear_2 = Linear(merged_hidden_size,
+                               out_dim,
+                               bias=True,
+                               dtype=dtype,
+                               mapping=mapping,
+                               tensor_parallel_mode=None)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.pre_norm(hidden_states).view(
+            -1, self.linear_1.in_features)
+        hidden_states = self.linear_1(hidden_states)
+        hidden_states = F.gelu(hidden_states)
+        hidden_states = self.linear_2(hidden_states)
+        return hidden_states
+
+
+class MiniCPMV4_6Merger(nn.Module):
+    """Final per-image/frame 2x2 merge into the LLM embedding space."""
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig]):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.merge_kernel_size = tuple(config.merge_kernel_size)
+        self.merger_times = config.merger_times
+        hidden_size = config.vision_config.hidden_size
+        llm_embed_dim = config.text_config.hidden_size
+        mlps = [
+            MiniCPMV4_6DownsampleMLP(model_config, hidden_size, hidden_size)
+            for _ in range(self.merger_times - 1)
+        ]
+        mlps.append(
+            MiniCPMV4_6DownsampleMLP(model_config, hidden_size, llm_embed_dim))
+        self.mlp = nn.ModuleList(mlps)
+
+    def forward(self, hidden_states: torch.Tensor,
+                target_sizes: torch.Tensor) -> List[torch.Tensor]:
+        merge_h, merge_w = self.merge_kernel_size
+        start = 0
+        processed_features = []
+        for i in range(len(target_sizes)):
+            height, width = int(target_sizes[i][0]), int(target_sizes[i][1])
+            num_patches = height * width
+            embed_dim = hidden_states.shape[-1]
+            merged_h, merged_w = height // merge_h, width // merge_w
+            hidden_state = (hidden_states[start:start + num_patches, :].view(
+                merged_h, merge_h, merged_w, merge_w,
+                embed_dim).permute(0, 2, 1, 3,
+                                   4).reshape(merged_h * merged_w,
+                                              merge_h * merge_w * embed_dim))
+            hidden_state = self.mlp[0](hidden_state)
+            for j in range(1, self.merger_times):
+                height = height // merge_h
+                width = width // merge_w
+                inner_dim = hidden_state.shape[-1]
+                merged_h, merged_w = height // merge_h, width // merge_w
+                hidden_state = (hidden_state.view(
+                    merged_h, merge_h, merged_w, merge_w,
+                    inner_dim).permute(0, 2, 1, 3,
+                                       4).reshape(merged_h * merged_w,
+                                                  merge_h * merge_w * inner_dim))
+                hidden_state = self.mlp[j](hidden_state)
+            start += num_patches
+            processed_features.append(hidden_state)
+        return processed_features
+
+
+class MiniCPMV4_6VisionModel(nn.Module):
+    """Full vision tower: embeddings -> encoder (+window merger) -> merger.
+
+    Consumes a batch of :class:`MultimodalParams`, concatenates every request's
+    NaViT-packed ``pixel_values`` / ``target_sizes`` into one packed sequence
+    (Contract 4), and returns a single ``[total_mm_tokens, llm_hidden]`` tensor.
+    Runs replicated on every rank (tp=1); the vision encoder is excluded from
+    quantization.
+    """
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig]):
+        super().__init__()
+        config = model_config.pretrained_config
+        self.vision_config = config.vision_config
+        # Authoritative model dtype (set by ModelConfig.from_pretrained on the
+        # composite; the raw config.json omits torch_dtype, so fall back to
+        # bf16 which matches the released checkpoint). Mirror it onto the
+        # vision sub-config so ported modules pick up a concrete dtype.
+        self.dtype = config.torch_dtype or torch.bfloat16
+        self.vision_config.torch_dtype = self.dtype
+        self.downsample_mode = config.downsample_mode
+        self.insert_layer_id = self.vision_config.insert_layer_id
+
+        # Replicated, unquantized ModelConfig for the vision sub-modules.
+        # dataclasses.replace gives a fresh extra_attrs (init=False), so the
+        # vision attention's transient layer registration can't collide with
+        # the LLM's.
+        vision_model_config = dataclasses.replace(model_config,
+                                                  quant_config=QuantConfig(),
+                                                  mapping=Mapping())
+        self.model_config = vision_model_config
+        self.config = self.vision_config
+
+        self.embeddings = MiniCPMV4_6VisionEmbeddings(self.vision_config,
+                                                      self.dtype)
+        self.encoder = MiniCPMV4_6VisionEncoder(vision_model_config)
+        self.post_layernorm = LayerNorm(hidden_size=self.vision_config.hidden_size,
+                                        eps=self.vision_config.layer_norm_eps,
+                                        dtype=self.dtype)
+        self.vit_merger = MiniCPMV4_6ViTWindowAttentionMerger(
+            vision_model_config)
+        self.merger = MiniCPMV4_6Merger(vision_model_config)
+
+        self.metadata_cls = get_attention_backend(
+            model_config.attn_backend).Metadata
+
+    def _make_attn_metadata(self, seq_lens: List[int]) -> AttentionMetadata:
+        num_segments = len(seq_lens)
+        attn_metadata = self.metadata_cls(
+            max_num_requests=num_segments + 1,
+            max_num_tokens=sum(seq_lens) + 1,
+            kv_cache_manager=None,
+        )
+        return _prepare_qwen_vl_vision_attn_metadata(seq_lens, attn_metadata)
+
+    @staticmethod
+    def _grid_seq_lens(target_sizes: torch.Tensor) -> List[int]:
+        return (target_sizes[:, 0] * target_sizes[:, 1]).tolist()
+
+    @staticmethod
+    def _grid_cu_seqlens(target_sizes: torch.Tensor) -> List[int]:
+        cu = [0]
+        for i in range(len(target_sizes)):
+            cu.append(cu[-1] +
+                      int(target_sizes[i][0]) * int(target_sizes[i][1]))
+        return cu
+
+    def _get_image_features(self, pixel_values: torch.Tensor,
+                            target_sizes: torch.Tensor) -> List[torch.Tensor]:
+        pixel_values = pixel_values.to(self.dtype)
+        hidden_states = self.embeddings(pixel_values, target_sizes).squeeze(0)
+
+        use_vit_merger = self.downsample_mode != "4x"
+        if use_vit_merger and self.insert_layer_id >= 0:
+            attn_metadata = self._make_attn_metadata(
+                self._grid_seq_lens(target_sizes))
+            for layer_index, encoder_layer in enumerate(self.encoder.layers):
+                hidden_states = encoder_layer(hidden_states, attn_metadata)
+                if layer_index == self.insert_layer_id:
+                    cu_seqlens = self._grid_cu_seqlens(target_sizes)
+                    hidden_states = self.vit_merger(hidden_states, target_sizes,
+                                                    cu_seqlens)
+                    target_sizes = target_sizes // 2
+                    attn_metadata = self._make_attn_metadata(
+                        self._grid_seq_lens(target_sizes))
+        else:
+            attn_metadata = self._make_attn_metadata(
+                self._grid_seq_lens(target_sizes))
+            for encoder_layer in self.encoder.layers:
+                hidden_states = encoder_layer(hidden_states, attn_metadata)
+
+        hidden_states = self.post_layernorm(hidden_states)
+        return self.merger(hidden_states, target_sizes)
+
+    @torch.inference_mode()
+    @nvtx_range("MiniCPMV4_6 vision encoder")
+    def forward(self,
+                multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
+        pixel_values_list = []
+        target_sizes_list = []
+        for param in multimodal_params:
+            # Image and video share the NaViT-packed vision path; a request may
+            # carry either (or both). Concatenate in image-then-video order to
+            # match the placeholder order the input processor emits.
+            for modality in ("image", "video"):
+                modality_data = param.multimodal_data.get(modality)
+                if modality_data is None:
+                    continue
+                pixel_values_list.append(modality_data["pixel_values"])
+                target_sizes_list.append(modality_data["target_sizes"])
+
+        if not pixel_values_list:
+            return []
+
+        # NaViT packing: concat along the packed patch axis; target grids stack.
+        pixel_values = (torch.cat(pixel_values_list, dim=-1)
+                        if len(pixel_values_list) > 1 else pixel_values_list[0])
+        target_sizes = (torch.cat(target_sizes_list, dim=0)
+                        if len(target_sizes_list) > 1 else target_sizes_list[0])
+        target_sizes = target_sizes.to("cpu")
+
+        features = self._get_image_features(pixel_values, target_sizes)
+        return [torch.cat(features, dim=0)]
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        converted_weights = {}
+        for key, value in weights.items():
+            if key.startswith("model.vision_tower."):
+                converted_weights[key[len("model.vision_tower."):]] = value
+            elif key.startswith("model.merger."):
+                converted_weights["merger." +
+                                  key[len("model.merger."):]] = value
+
+        # q/k/v -> qkv_proj fusion is handled by _load_weights_impl's params_map;
+        # only the projection / MLP renames need explicit regex substitutions.
+        pattern_mapping = {
+            r"(.*?)self_attn\.out_proj\.(.*)": r"\1self_attn.o_proj.\2",
+            r"(.*?)mlp\.fc1\.(.*)": r"\1mlp.up_proj.\2",
+            r"(.*?)mlp\.fc2\.(.*)": r"\1mlp.down_proj.\2",
+        }
+        _load_weights_impl(self, converted_weights, params_map=pattern_mapping)
+
+
+# ---------------------------------------------------------------------------
+# Input processor
+# ---------------------------------------------------------------------------
+class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor,
+                                BaseMultimodalDummyInputsBuilder):
+    """Runs the HF MiniCPM-V processor and rewrites image tokens to the OOV
+    sentinel expected by ``fuse_input_embeds``."""
+
+    def __init__(self,
+                 model_path: str,
+                 config: PretrainedConfig,
+                 tokenizer: AutoTokenizer,
+                 trust_remote_code: bool = True,
+                 **kwargs):
+        _ensure_transformers_supports_minicpmv4_6()
+        super().__init__(model_path=model_path,
+                         config=config,
+                         tokenizer=tokenizer,
+                         trust_remote_code=trust_remote_code,
+                         **kwargs)
+        self._config = config
+        self._model_path = model_path
+        self._tokenizer = tokenizer if tokenizer is not None else \
+            AutoTokenizer.from_pretrained(model_path,
+                                          trust_remote_code=trust_remote_code)
+        self._processor = AutoProcessor.from_pretrained(
+            model_path,
+            use_fast=self.use_fast,
+            trust_remote_code=trust_remote_code)
+        self._dtype = (config.torch_dtype or config.text_config.torch_dtype
+                       or torch.bfloat16)
+        self.tllm_multimodal_token_id = self.get_vocab_size() + 1
+        self.image_token_str = getattr(self._processor, "image_token",
+                                       "<|image_pad|>")
+        self.video_token_str = getattr(self._processor, "video_token",
+                                       "<|video_pad|>")
+
+    def get_vocab_size(self) -> int:
+        return self.config.text_config.vocab_size
+
+    @property
+    def config(self) -> PretrainedConfig:
+        return self._config
+
+    @property
+    def tokenizer(self) -> AutoTokenizer:
+        return self._tokenizer
+
+    @property
+    def model_path(self) -> str:
+        return self._model_path
+
+    @property
+    def processor(self) -> AutoProcessor:
+        return self._processor
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    def _mm_token_ids(self) -> List[int]:
+        return [
+            tid for attr in ("image_token_id", "video_token_id")
+            if (tid := getattr(self.config, attr, None)) is not None
+        ]
+
+    def _postprocess(self, input_ids: torch.IntTensor) -> torch.IntTensor:
+        token_ids = self._mm_token_ids()
+        if token_ids:
+            ids_tensor = torch.tensor(token_ids,
+                                      device=input_ids.device,
+                                      dtype=input_ids.dtype)
+            input_ids[torch.isin(input_ids,
+                                 ids_tensor)] = self.tllm_multimodal_token_id
+        return input_ids
+
+    def _preprocess(self, text_prompt: str, images, videos, video_metadata,
+                    mm_processor_kwargs: Dict):
+        do_rescale = True
+        if images and isinstance(images[0], torch.Tensor):
+            do_rescale = False
+        # load_video hands us CHW float frames already scaled to [0, 1], so
+        # the HF rescale (x / 255) must be skipped for video.
+        if videos and isinstance(videos[0][0], torch.Tensor):
+            do_rescale = False
+        call_kwargs = dict(text=[text_prompt],
+                           images=images,
+                           do_rescale=do_rescale,
+                           return_tensors="pt",
+                           **mm_processor_kwargs)
+        if videos is not None:
+            # Frames are already sampled by TRT-LLM's load_video, so disable the
+            # HF processor's own frame sampling (which would otherwise require
+            # full metadata and re-index against the original frame count).
+            call_kwargs["videos"] = videos
+            call_kwargs["video_metadata"] = video_metadata
+            call_kwargs["do_sample_frames"] = False
+        return self.processor(**call_kwargs)
+
+    def get_num_tokens_per_image(self, *, image, **kwargs) -> int:
+        do_rescale = not isinstance(image, torch.Tensor)
+        processed = self.processor(text=[self.image_token_str],
+                                   images=[image],
+                                   do_rescale=do_rescale,
+                                   return_tensors="pt")
+        input_ids = processed["input_ids"][0]
+        return int((input_ids == self.config.image_token_id).sum().item())
+
+    def get_num_tokens_per_video(self,
+                                 *,
+                                 video,
+                                 video_metadata=None,
+                                 **kwargs) -> int:
+        # `video` is the list of pre-sampled frames (see find_mm_token_lengths).
+        frames = video
+        do_rescale = not (frames and isinstance(frames[0], torch.Tensor))
+        processed = self.processor(
+            text=[self.video_token_str],
+            videos=[frames],
+            video_metadata=[video_metadata]
+            if video_metadata is not None else None,
+            do_sample_frames=False,
+            do_rescale=do_rescale,
+            return_tensors="pt")
+        input_ids = processed["input_ids"][0]
+        return int((input_ids == self.config.video_token_id).sum().item())
+
+    @nvtx_range("MiniCPMV4_6InputProcessor call_with_text_prompt")
+    @torch.inference_mode()
+    def call_with_text_prompt(
+        self,
+        inputs: TextPrompt,
+        sampling_params: SamplingParams,
+    ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
+        text_prompt = inputs.get("prompt")
+        mm_data = inputs.get("multi_modal_data", {})
+        mm_processor_kwargs = inputs.get("mm_processor_kwargs", {}) or {}
+
+        if not mm_data:
+            input_ids = self.tokenizer(text_prompt,
+                                       return_tensors="pt").input_ids
+            return input_ids[0].to(torch.int32).tolist(), None
+
+        images = mm_data.get("image")
+        video_datas = mm_data.get("video")
+        videos = video_metadata = None
+        if video_datas is not None:
+            # Each item is a VideoData (frames + decode metadata) from
+            # load_video, mirroring the Qwen-VL input processor.
+            videos = [vd.frames for vd in video_datas]
+            video_metadata = [
+                getattr(vd, "metadata", None) for vd in video_datas
+            ]
+        processed_inputs = self._preprocess(text_prompt, images, videos,
+                                            video_metadata, mm_processor_kwargs)
+
+        multimodal_data = {}
+        pixel_values = processed_inputs.get("pixel_values")
+        if pixel_values is not None:
+            multimodal_data["image"] = {
+                # target_sizes stays on CPU: the vision encoder uses it for
+                # integer window/grid arithmetic (not listed in
+                # multimodal_data_device_paths).
+                "pixel_values": pixel_values.to(self.dtype),
+                "target_sizes": processed_inputs.get("target_sizes"),
+            }
+        # Video is packed identically to image (pixel_values_videos is a NaViT
+        # [1, C, patch, seq] tensor); store it under the "video" key so the
+        # vision tower runs the shared encoder path on it.
+        pixel_values_videos = processed_inputs.get("pixel_values_videos")
+        if pixel_values_videos is not None:
+            multimodal_data["video"] = {
+                "pixel_values": pixel_values_videos.to(self.dtype),
+                "target_sizes": processed_inputs.get("target_sizes_videos"),
+            }
+
+        fused_input_ids = self._postprocess(processed_inputs["input_ids"][0])
+        return fused_input_ids.to(torch.int32).tolist(), {
+            "multimodal_data": multimodal_data,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Top-level VLM wrapper
+# ---------------------------------------------------------------------------
+@register_auto_model("MiniCPMV4_6ForConditionalGeneration")
+@register_input_processor(
+    MiniCPMV4_6InputProcessor,
+    model_type="minicpmv4_6",
+    placeholder_metadata=MultimodalPlaceholderMetadata(
+        placeholder_map={
+            "image": "<|image_pad|>",
+            "video": "<|video_pad|>",
+        },
+        placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+        placeholders_separator="\n",
+        content_format=ContentFormat.STRING,
+    ),
+)
+class MiniCPMV4_6Model(PreTrainedModel):
+
+    def __init__(self, model_config: ModelConfig[PretrainedConfig], *args,
+                 **kwargs):
+        config = model_config.pretrained_config
+        super().__init__(config)
+        if hasattr(self, "llm"):
+            return
+
+        if _is_mm_disagg():
+            raise NotImplementedError(
+                "MiniCPMV4_6 does not support disaggregated multimodal serving "
+                "yet. Unset TLLM_MULTIMODAL_DISAGGREGATED or set it to '0'.")
+
+        self.model_config = model_config
+        self.mm_encoder = MiniCPMV4_6VisionModel(model_config).eval()
+
+        # Inner LLM resolved from text_config (Qwen3_5ForCausalLM, hybrid).
+        llm_model_config = dataclasses.replace(
+            model_config, pretrained_config=config.text_config)
+        # Share the wrapper's extra_attrs so the LM's attention layers register
+        # into the same dict the engine binds via with_model_extra_attrs (needed
+        # for the compiled / piecewise-CUDA-graph LM path). dataclasses.replace
+        # would otherwise give a fresh (init=False) extra_attrs.
+        llm_model_config.extra_attrs = model_config.extra_attrs
+        self.llm = AutoModelForCausalLM.from_config(llm_model_config)
+
+        self.image_token_id = config.image_token_id
+        self.post_config()
+
+    def post_config(self):
+        # Downstream (KV cache manager, engine) expects the LLM-shaped config.
+        self.config = self.llm.config
+        self.model_config.pretrained_config = self.llm.config
+
+    @property
+    def vocab_size_padded(self) -> int:
+        return self.llm.vocab_size_padded
+
+    def infer_max_seq_len(self) -> int:
+        return self.llm.infer_max_seq_len()
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: Optional[torch.IntTensor] = None,
+        position_ids: Optional[torch.IntTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        return_context_logits: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        num_context_requests = attn_metadata.num_contexts
+        multimodal_params = kwargs.get("multimodal_params", [])
+
+        mm_embeds = []
+        if len(multimodal_params) > 0 and not _is_mm_disagg():
+            mm_embeds = get_multimodal_embeddings(
+                encoder_forward_fn=self.mm_encoder.forward,
+                multimodal_params=multimodal_params[:num_context_requests],
+            )
+            mm_embeds = find_input_mm_embeds(
+                mm_embeds, multimodal_params[:num_context_requests])
+
+        input_ids, inputs_embeds = fuse_input_embeds(
+            self.llm.model.embed_tokens, input_ids, mm_embeds, **kwargs)
+        return self.llm.forward(attn_metadata=attn_metadata,
+                                input_ids=input_ids,
+                                position_ids=position_ids,
+                                inputs_embeds=inputs_embeds,
+                                return_context_logits=return_context_logits)
+
+    @property
+    def multimodal_data_device_paths(self) -> List[str]:
+        return [
+            "image.pixel_values", "video.pixel_values", "multimodal_embedding"
+        ]
+
+    def load_weights(self, weights: Dict[str, torch.Tensor],
+                     weight_mapper: BaseWeightMapper):
+        if self.mm_encoder is not None:
+            self.mm_encoder.load_weights(weights)
+            if hasattr(weights, "mark_consumed"):
+                weights.mark_consumed("model.vision_tower")
+                weights.mark_consumed("model.merger")
+
+        llm_weight_mapper = Qwen3_5MoeHfWeightMapper()
+        llm_weight_mapper.init_model_and_config(self.llm, self.model_config)
+        llm_weights = {
+            k: v
+            for k, v in weights.items()
+            if k.startswith("model.language_model.")
+        }
+        self.llm.load_weights(llm_weights, llm_weight_mapper)
+        if hasattr(weights, "mark_consumed"):
+            weights.mark_consumed("model.language_model")

--- a/tensorrt_llm/_torch/models/modeling_minicpmv4_6.py
+++ b/tensorrt_llm/_torch/models/modeling_minicpmv4_6.py
@@ -516,6 +516,14 @@ class MiniCPMV4_6VisionModel(nn.Module):
         # dataclasses.replace gives a fresh extra_attrs (init=False), so the
         # vision attention's transient layer registration can't collide with
         # the LLM's.
+        # NOTE: mapping=Mapping() (tp=1) is load-bearing for correctness, not
+        # just perf. It makes the whole vision tower run REPLICATED on every
+        # rank (all vision Linears use tensor_parallel_mode=None and vision
+        # attention uses reduce_output=False). Under TP that means every rank
+        # computes identical vision embeds from the broadcast multimodal data;
+        # do NOT switch this to the LLM's real mapping -- a row-parallel
+        # projection would then all-reduce data that was never sharded across
+        # ranks and produce wrong output.
         vision_model_config = dataclasses.replace(
             model_config, quant_config=QuantConfig(), mapping=Mapping()
         )
@@ -568,7 +576,10 @@ class MiniCPMV4_6VisionModel(nn.Module):
                 if layer_index == self.insert_layer_id:
                     cu_seqlens = self._grid_cu_seqlens(target_sizes)
                     hidden_states = self.vit_merger(hidden_states, target_sizes, cu_seqlens)
-                    target_sizes = target_sizes // 2
+                    window_h, window_w = self.vit_merger.window_kernel_size
+                    target_sizes = target_sizes // torch.tensor(
+                        [window_h, window_w], dtype=target_sizes.dtype
+                    )
                     attn_metadata = self._make_attn_metadata(self._grid_seq_lens(target_sizes))
         else:
             attn_metadata = self._make_attn_metadata(self._grid_seq_lens(target_sizes))
@@ -584,9 +595,11 @@ class MiniCPMV4_6VisionModel(nn.Module):
         pixel_values_list = []
         target_sizes_list = []
         for param in multimodal_params:
-            # Image and video share the NaViT-packed vision path; a request may
-            # carry either (or both). Concatenate in image-then-video order to
-            # match the placeholder order the input processor emits.
+            # Image and video share the NaViT-packed vision path. A request
+            # carries at most one modality (the input processor rejects mixed
+            # image+video requests), so the fixed image-then-video iteration
+            # order here is unambiguous and matches the placeholder order in
+            # `input_ids`.
             for modality in ("image", "video"):
                 modality_data = param.multimodal_data.get(modality)
                 if modality_data is None:
@@ -611,7 +624,30 @@ class MiniCPMV4_6VisionModel(nn.Module):
         target_sizes = target_sizes.to("cpu")
 
         features = self._get_image_features(pixel_values, target_sizes)
-        return [torch.cat(features, dim=0)]
+        fused = torch.cat(features, dim=0)
+
+        # Contract-4 invariants (this forward returns ONE pre-concatenated
+        # tensor that find_input_mm_embeds / _cache_multimodal_embeddings slice
+        # back per request):
+        #   I.  Order -- `features` are concatenated in `multimodal_params`
+        #       order; the loop above and the per-grid merger both preserve it,
+        #       which is exactly the order the downstream slicers assume. (Not
+        #       assertable cheaply -- covered by the multi-request E2E test.)
+        #   II. Count -- the produced row count must equal the sum of each
+        #       request's placeholder count (`total_embeds_in_request`). A
+        #       mismatch means the vision output and the fused `input_ids` will
+        #       misalign, so fail loudly here instead of silently scattering
+        #       wrong rows downstream. Only checked when every request carries
+        #       runtime counts (absent on some warmup / JIT paths).
+        runtimes = [p.multimodal_runtime for p in multimodal_params]
+        if all(r is not None and r.total_embeds_in_request is not None for r in runtimes):
+            expected = sum(r.total_embeds_in_request for r in runtimes)
+            assert fused.shape[0] == expected, (
+                f"MiniCPMV4_6 vision produced {fused.shape[0]} embedding rows "
+                f"but the batch's per-request placeholder counts sum to "
+                f"{expected}; vision output would misalign with input_ids."
+            )
+        return [fused]
 
     def load_weights(self, weights: Dict[str, torch.Tensor]):
         converted_weights = {}
@@ -772,6 +808,22 @@ class MiniCPMV4_6InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDumm
 
         images = mm_data.get("image")
         video_datas = mm_data.get("video")
+        # Single-modality-per-request guard. `_postprocess` rewrites both the
+        # image and video placeholders to the same sentinel
+        # (`tllm_multimodal_token_id`), so once fused into `input_ids` the two
+        # modalities are indistinguishable and their relative order is lost.
+        # The vision tower, meanwhile, always concatenates embeddings in a
+        # fixed image-then-video order. A request that interleaves image and
+        # video placeholders would therefore misalign embeddings with their
+        # placeholder positions. Until order-preserving fusion is implemented,
+        # reject mixed image+video requests instead of producing silently
+        # wrong output (single-modality requests are unaffected).
+        if images and video_datas:
+            raise ValueError(
+                "MiniCPM-V 4.6 supports only a single modality (image OR "
+                "video) per request, but this request carries both. Please "
+                "split the image and video content into separate requests."
+            )
         videos = video_metadata = None
         if video_datas is not None:
             # Each item is a VideoData (frames + decode metadata) from
@@ -902,11 +954,10 @@ class MiniCPMV4_6Model(PreTrainedModel):
         return ["image.pixel_values", "video.pixel_values", "multimodal_embedding"]
 
     def load_weights(self, weights: Dict[str, torch.Tensor], weight_mapper: BaseWeightMapper):
-        if self.mm_encoder is not None:
-            self.mm_encoder.load_weights(weights)
-            if hasattr(weights, "mark_consumed"):
-                weights.mark_consumed("model.vision_tower")
-                weights.mark_consumed("model.merger")
+        self.mm_encoder.load_weights(weights)
+        if hasattr(weights, "mark_consumed"):
+            weights.mark_consumed("model.vision_tower")
+            weights.mark_consumed("model.merger")
 
         llm_weight_mapper = Qwen3_5MoeHfWeightMapper()
         llm_weight_mapper.init_model_and_config(self.llm, self.model_config)

--- a/tensorrt_llm/_torch/pyexecutor/config_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/config_utils.py
@@ -369,6 +369,77 @@ def is_qwen_image_bench_config(config_dict: dict) -> bool:
             and required_multimodal_token_ids.issubset(config_dict))
 
 
+def _resolve_composite_torch_dtype(*config_dicts: dict) -> torch.dtype:
+    """Resolve a concrete torch dtype from one or more raw config dicts.
+
+    Respects an explicit ``torch_dtype``/``dtype`` declaration (string or
+    ``torch.dtype``) from the first dict that provides one, and otherwise falls
+    back to ``bfloat16`` (TensorRT-LLM's default, matching the checkpoint).
+    """
+    for config_dict in config_dicts:
+        for key in ("torch_dtype", "dtype"):
+            coerced = _coerce_torch_dtype(config_dict.get(key))
+            if coerced is not None:
+                return coerced
+    return torch.bfloat16
+
+
+def _build_minicpmv4_6_config(
+        config_dict: dict) -> transformers.PretrainedConfig:
+    """Build the composite MiniCPM-V 4.6 config from a raw config.json dict.
+
+    The top-level ``minicpmv4_6`` model_type is only known to
+    ``transformers>=5.7.0``; rebuild it locally so the PyTorch backend loads on
+    older releases.  The inner text tower is normalized into a
+    ``Qwen3NextConfig`` through the shared ``Qwen35ConfigCompat`` shim (the same
+    path standalone Qwen3.5 dense uses), and the top-level ``model_type`` is kept
+    as ``minicpmv4_6`` so ``MULTIMODAL_PLACEHOLDER_REGISTRY`` lookup succeeds.
+
+    TODO: this local builder is a transition path for the repo's pinned
+    transformers 5.5.4.  Once the pin is bumped to ``>=5.7.0``, drop the
+    ``MiniCPMV4_6Config`` shim and build the config from the native
+    ``transformers.MiniCPMV4_6Config`` instead.
+    """
+    from tensorrt_llm._torch.configs.minicpmv4_6 import MiniCPMV4_6Config
+    from tensorrt_llm._torch.models.modeling_qwen3_5 import Qwen35ConfigCompat
+
+    # Extract + normalize the Qwen3.5 dense text tower (rope flatten,
+    # quantization inheritance, architectures -> Qwen3_5ForCausalLM). MiniCPM-V
+    # 4.6 always nests its language model under ``text_config``, so force
+    # extraction of that nested config (same path Qwen-Image-Bench uses).
+    text_dict = Qwen35ConfigCompat.normalize(config_dict,
+                                             require_text_config=True)
+    text_config = transformers.Qwen3NextConfig.from_dict(text_dict)
+
+    # MiniCPM-V 4.6's config.json declares no torch_dtype/dtype (neither at the
+    # top level nor inside text_config).  Several engine-build paths read
+    # ``pretrained_config.torch_dtype`` directly with no fallback -- the hybrid
+    # (mamba) KV-cache byte sizing and ``validate_and_set_mamba_ssm_cache_dtype``
+    # -- so a ``None`` dtype crashes with ``None.itemsize``.  Pin a concrete
+    # dtype on both the text tower and the composite config so every downstream
+    # consumer (config validation before model build, and the post_config swap
+    # that replaces pretrained_config with the inner text_config) agrees.
+    resolved_dtype = _resolve_composite_torch_dtype(config_dict, text_dict)
+    text_config.torch_dtype = resolved_dtype
+
+    composite_config = MiniCPMV4_6Config(
+        text_config=text_config,
+        vision_config=config_dict.get("vision_config"),
+        insert_layer_id=config_dict.get("insert_layer_id", 6),
+        image_size=config_dict.get("image_size", 448),
+        drop_vision_last_layer=config_dict.get("drop_vision_last_layer", False),
+        image_token_id=config_dict.get("image_token_id"),
+        video_token_id=config_dict.get("video_token_id"),
+        downsample_mode=config_dict.get("downsample_mode", "16x"),
+        merge_kernel_size=config_dict.get("merge_kernel_size", (2, 2)),
+        merger_times=config_dict.get("merger_times", 1),
+        tie_word_embeddings=config_dict.get("tie_word_embeddings", False),
+        architectures=config_dict.get("architectures"),
+    )
+    composite_config.torch_dtype = resolved_dtype
+    return composite_config
+
+
 # TODO: remove this once the transformers can support all of those models in _CONFIG_REGISTRY
 class LazyConfigDict(dict):
 
@@ -452,6 +523,10 @@ def load_pretrained_config(model_name_or_path: str,
         config_class = _CONFIG_REGISTRY[model_type]
         model_config = config_class.from_pretrained(model_name_or_path,
                                                     **kwargs)
+    elif model_type == "minicpmv4_6" or (
+            architectures
+            and architectures[0] == "MiniCPMV4_6ForConditionalGeneration"):
+        model_config = _build_minicpmv4_6_config(config_dict)
     elif model_type in ("qwen3_5", "qwen3_5_text", "qwen3_5_moe",
                         "qwen3_5_moe_text") or (
                             architectures and architectures[0] in (

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -28,6 +28,7 @@ l0_a10:
   - unittest/_torch/modeling/test_modeling_parakeet.py
   - unittest/_torch/modeling/test_modeling_radio.py
   - unittest/_torch/modeling/test_modeling_step3p7.py
+  - unittest/_torch/modeling/test_modeling_minicpmv4_6.py
   - unittest/_torch/modeling/test_multimodal_encoder_mixin.py
   - unittest/_torch/sampler/test_trtllm_sampler.py
   - unittest/_torch/executor/test_async_transfer_manager.py

--- a/tests/unittest/_torch/modeling/test_modeling_minicpmv4_6.py
+++ b/tests/unittest/_torch/modeling/test_modeling_minicpmv4_6.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for MiniCPM-V 4.6 config loading on the PyTorch backend.
+
+These tests are intentionally CPU-only and do not require model weights or a
+native ``minicpmv4_6`` transformers release, so they run (and protect the fix)
+on the repo's currently-pinned ``transformers==5.5.4`` CI as well as on
+``>=5.7.0``:
+
+* ``_resolve_composite_torch_dtype`` dtype resolution.
+* ``_build_minicpmv4_6_config`` / ``load_pretrained_config`` composite-config
+  construction, including the regression guard for the checkpoint that declares
+  **no** ``torch_dtype`` (which used to crash the hybrid mamba KV-cache paths
+  with ``None.itemsize``).
+* The self-contained ``MiniCPMV4_6VisionConfig`` window helpers.
+* The runtime ``transformers>=5.7.0`` guard used by the input processor.
+
+A single ``transformers>=5.7.0``-gated test asserts the native config is present
+once the pin is bumped (at which point the local shim can be removed).
+"""
+
+import copy
+import json
+
+import pytest
+import torch
+import transformers
+from packaging.version import Version
+
+from tensorrt_llm._torch.configs.minicpmv4_6 import (MiniCPMV4_6Config,
+                                                     MiniCPMV4_6VisionConfig)
+from tensorrt_llm._torch.pyexecutor.config_utils import (
+    _build_minicpmv4_6_config, _resolve_composite_torch_dtype,
+    load_pretrained_config)
+
+_MIN_TRANSFORMERS = "5.7.0"
+
+requires_native_minicpmv4_6 = pytest.mark.skipif(
+    Version(transformers.__version__) < Version(_MIN_TRANSFORMERS),
+    reason=f"native minicpmv4_6 requires transformers>={_MIN_TRANSFORMERS}",
+)
+
+
+def _minicpmv4_6_config_dict() -> dict:
+    """A faithful, minimal ``config.json`` for openbmb/MiniCPM-V-4.6.
+
+    Mirrors the real checkpoint: composite ``minicpmv4_6`` with a SigLIP2 vision
+    tower and a Qwen3.5 dense hybrid text tower, and crucially **no**
+    ``torch_dtype``/``dtype`` at any level.
+    """
+    return copy.deepcopy({
+        "architectures": ["MiniCPMV4_6ForConditionalGeneration"],
+        "model_type": "minicpmv4_6",
+        "drop_vision_last_layer": False,
+        "image_size": 1120,
+        "insert_layer_id": 6,
+        "image_token_id": 248056,
+        "video_token_id": 248057,
+        "tie_word_embeddings": True,
+        "vision_config": {
+            "model_type": "minicpmv4_6_vision",
+            "hidden_act": "gelu_pytorch_tanh",
+            "hidden_size": 1152,
+            "image_size": 980,
+            "intermediate_size": 4304,
+            "layer_norm_eps": 1e-06,
+            "num_attention_heads": 16,
+            "num_channels": 3,
+            "num_hidden_layers": 27,
+            "patch_size": 14,
+        },
+        "text_config": {
+            "model_type": "qwen3_5_text",
+            "attention_bias": False,
+            "full_attention_interval": 4,
+            "head_dim": 256,
+            "hidden_act": "silu",
+            "hidden_size": 1024,
+            "intermediate_size": 3584,
+            "linear_conv_kernel_dim": 4,
+            "linear_key_head_dim": 128,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 16,
+            "linear_value_head_dim": 128,
+            "max_position_embeddings": 262144,
+            "num_attention_heads": 8,
+            "num_hidden_layers": 24,
+            "num_key_value_heads": 2,
+            "partial_rotary_factor": 0.25,
+            "rms_norm_eps": 1e-06,
+            "rope_parameters": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 10000000,
+                "rope_type": "default",
+            },
+            "vocab_size": 248094,
+            "tie_word_embeddings": True,
+        },
+    })
+
+
+# ---------------------------------------------------------------------------
+# _resolve_composite_torch_dtype
+# ---------------------------------------------------------------------------
+class TestResolveCompositeTorchDtype:
+
+    def test_defaults_to_bfloat16_when_absent(self):
+        assert _resolve_composite_torch_dtype({}, {}) is torch.bfloat16
+
+    def test_respects_explicit_string(self):
+        assert _resolve_composite_torch_dtype({"torch_dtype":
+                                               "float16"}) is torch.float16
+
+    def test_respects_dtype_alias_key(self):
+        assert _resolve_composite_torch_dtype({"dtype":
+                                               "float32"}) is torch.float32
+
+    def test_respects_torch_dtype_object(self):
+        assert _resolve_composite_torch_dtype(
+            {"torch_dtype": torch.float16}) is torch.float16
+
+    def test_auto_and_none_are_skipped(self):
+        assert _resolve_composite_torch_dtype(
+            {"torch_dtype": "auto"},
+            {"dtype": None},
+            {"torch_dtype": "float16"},
+        ) is torch.float16
+
+    def test_first_declaration_wins(self):
+        assert _resolve_composite_torch_dtype(
+            {"torch_dtype": "bfloat16"},
+            {"torch_dtype": "float16"},
+        ) is torch.bfloat16
+
+
+# ---------------------------------------------------------------------------
+# _build_minicpmv4_6_config
+# ---------------------------------------------------------------------------
+class TestBuildMiniCPMV46Config:
+
+    def test_pins_bfloat16_when_checkpoint_declares_none(self):
+        # Regression: the real checkpoint declares no torch_dtype anywhere, which
+        # crashed the hybrid mamba KV-cache byte sizing (None.itemsize). Both the
+        # composite config and the inner text tower must carry a concrete dtype.
+        cfg = _build_minicpmv4_6_config(_minicpmv4_6_config_dict())
+        assert cfg.torch_dtype is torch.bfloat16
+        assert cfg.text_config.torch_dtype is torch.bfloat16
+
+    def test_respects_explicit_dtype(self):
+        raw = _minicpmv4_6_config_dict()
+        raw["torch_dtype"] = "float16"
+        cfg = _build_minicpmv4_6_config(raw)
+        assert cfg.torch_dtype is torch.float16
+        assert cfg.text_config.torch_dtype is torch.float16
+
+    def test_keeps_top_level_model_type(self):
+        # Needed for MULTIMODAL_PLACEHOLDER_REGISTRY lookup; otherwise requests
+        # fail with "Unknown modality".
+        cfg = _build_minicpmv4_6_config(_minicpmv4_6_config_dict())
+        assert cfg.model_type == "minicpmv4_6"
+
+    def test_normalizes_text_tower_to_qwen3next(self):
+        cfg = _build_minicpmv4_6_config(_minicpmv4_6_config_dict())
+        assert isinstance(cfg.text_config, transformers.Qwen3NextConfig)
+        assert cfg.text_config.architectures == ["Qwen3_5ForCausalLM"]
+        assert cfg.text_config.num_hidden_layers == 24
+
+    def test_preserves_multimodal_token_ids(self):
+        cfg = _build_minicpmv4_6_config(_minicpmv4_6_config_dict())
+        assert cfg.image_token_id == 248056
+        assert cfg.video_token_id == 248057
+
+    def test_propagates_insert_layer_id_to_vision(self):
+        cfg = _build_minicpmv4_6_config(_minicpmv4_6_config_dict())
+        assert cfg.insert_layer_id == 6
+        assert cfg.vision_config.insert_layer_id == 6
+        assert cfg.vision_config.hidden_size == 1152
+        assert cfg.vision_config.num_hidden_layers == 27
+
+
+# ---------------------------------------------------------------------------
+# load_pretrained_config routing (offline, via a temp config.json)
+# ---------------------------------------------------------------------------
+class TestLoadPretrainedConfigRouting:
+
+    def _write_config(self, tmp_path) -> str:
+        (tmp_path / "config.json").write_text(
+            json.dumps(_minicpmv4_6_config_dict()))
+        return str(tmp_path)
+
+    def test_routes_minicpmv4_6_by_model_type(self, tmp_path):
+        cfg = load_pretrained_config(self._write_config(tmp_path))
+        assert isinstance(cfg, MiniCPMV4_6Config)
+        assert cfg.model_type == "minicpmv4_6"
+        assert cfg.torch_dtype is torch.bfloat16
+
+    def test_routes_when_only_architecture_present(self, tmp_path):
+        raw = _minicpmv4_6_config_dict()
+        raw.pop("model_type")
+        (tmp_path / "config.json").write_text(json.dumps(raw))
+        cfg = load_pretrained_config(str(tmp_path))
+        assert isinstance(cfg, MiniCPMV4_6Config)
+
+
+# ---------------------------------------------------------------------------
+# MiniCPMV4_6VisionConfig helpers
+# ---------------------------------------------------------------------------
+class TestVisionConfig:
+
+    def test_window_helpers_scale_by_kernel(self):
+        vc = MiniCPMV4_6VisionConfig(hidden_size=1152,
+                                     intermediate_size=4304,
+                                     window_kernel_size=(2, 2))
+        assert vc.window_kernel_size == (2, 2)
+        assert vc.window_hidden_size == 1152 * 2 * 2
+        assert vc.window_intermediate_size == 4304 * 2 * 2
+
+    def test_window_kernel_size_is_tuple(self):
+        # Accept list from JSON but expose a tuple.
+        vc = MiniCPMV4_6VisionConfig(window_kernel_size=[2, 2])
+        assert vc.window_kernel_size == (2, 2)
+
+
+# ---------------------------------------------------------------------------
+# transformers>=5.7.0 runtime guard (used by the input processor)
+# ---------------------------------------------------------------------------
+class TestTransformersGuard:
+
+    @pytest.mark.parametrize("version", ["5.5.4", "5.6.9"])
+    def test_raises_on_old_transformers(self, monkeypatch, version):
+        from tensorrt_llm._torch.models import modeling_minicpmv4_6 as mod
+        monkeypatch.setattr(transformers, "__version__", version)
+        with pytest.raises(RuntimeError, match="transformers>="):
+            mod._ensure_transformers_supports_minicpmv4_6()
+
+    @pytest.mark.parametrize("version", ["5.7.0", "5.8.1", "5.12.1"])
+    def test_passes_on_supported_transformers(self, monkeypatch, version):
+        from tensorrt_llm._torch.models import modeling_minicpmv4_6 as mod
+        monkeypatch.setattr(transformers, "__version__", version)
+        mod._ensure_transformers_supports_minicpmv4_6()
+
+
+# ---------------------------------------------------------------------------
+# Native transformers config (only once the pin is bumped to >=5.7.0)
+# ---------------------------------------------------------------------------
+@requires_native_minicpmv4_6
+def test_native_minicpmv4_6_config_available():
+    # Once transformers>=5.7.0 is pinned, the local MiniCPMV4_6Config shim can
+    # be dropped in favor of this native config.
+    from transformers import MiniCPMV4_6Config as HFMiniCPMV4_6Config
+    assert HFMiniCPMV4_6Config.model_type == "minicpmv4_6"

--- a/tests/unittest/_torch/modeling/test_modeling_minicpmv4_6.py
+++ b/tests/unittest/_torch/modeling/test_modeling_minicpmv4_6.py
@@ -39,11 +39,12 @@ import torch
 import transformers
 from packaging.version import Version
 
-from tensorrt_llm._torch.configs.minicpmv4_6 import (MiniCPMV4_6Config,
-                                                     MiniCPMV4_6VisionConfig)
+from tensorrt_llm._torch.configs.minicpmv4_6 import MiniCPMV4_6Config, MiniCPMV4_6VisionConfig
 from tensorrt_llm._torch.pyexecutor.config_utils import (
-    _build_minicpmv4_6_config, _resolve_composite_torch_dtype,
-    load_pretrained_config)
+    _build_minicpmv4_6_config,
+    _resolve_composite_torch_dtype,
+    load_pretrained_config,
+)
 
 _MIN_TRANSFORMERS = "5.7.0"
 
@@ -60,96 +61,99 @@ def _minicpmv4_6_config_dict() -> dict:
     tower and a Qwen3.5 dense hybrid text tower, and crucially **no**
     ``torch_dtype``/``dtype`` at any level.
     """
-    return copy.deepcopy({
-        "architectures": ["MiniCPMV4_6ForConditionalGeneration"],
-        "model_type": "minicpmv4_6",
-        "drop_vision_last_layer": False,
-        "image_size": 1120,
-        "insert_layer_id": 6,
-        "image_token_id": 248056,
-        "video_token_id": 248057,
-        "tie_word_embeddings": True,
-        "vision_config": {
-            "model_type": "minicpmv4_6_vision",
-            "hidden_act": "gelu_pytorch_tanh",
-            "hidden_size": 1152,
-            "image_size": 980,
-            "intermediate_size": 4304,
-            "layer_norm_eps": 1e-06,
-            "num_attention_heads": 16,
-            "num_channels": 3,
-            "num_hidden_layers": 27,
-            "patch_size": 14,
-        },
-        "text_config": {
-            "model_type": "qwen3_5_text",
-            "attention_bias": False,
-            "full_attention_interval": 4,
-            "head_dim": 256,
-            "hidden_act": "silu",
-            "hidden_size": 1024,
-            "intermediate_size": 3584,
-            "linear_conv_kernel_dim": 4,
-            "linear_key_head_dim": 128,
-            "linear_num_key_heads": 16,
-            "linear_num_value_heads": 16,
-            "linear_value_head_dim": 128,
-            "max_position_embeddings": 262144,
-            "num_attention_heads": 8,
-            "num_hidden_layers": 24,
-            "num_key_value_heads": 2,
-            "partial_rotary_factor": 0.25,
-            "rms_norm_eps": 1e-06,
-            "rope_parameters": {
-                "partial_rotary_factor": 0.25,
-                "rope_theta": 10000000,
-                "rope_type": "default",
-            },
-            "vocab_size": 248094,
+    return copy.deepcopy(
+        {
+            "architectures": ["MiniCPMV4_6ForConditionalGeneration"],
+            "model_type": "minicpmv4_6",
+            "drop_vision_last_layer": False,
+            "image_size": 1120,
+            "insert_layer_id": 6,
+            "image_token_id": 248056,
+            "video_token_id": 248057,
             "tie_word_embeddings": True,
-        },
-    })
+            "vision_config": {
+                "model_type": "minicpmv4_6_vision",
+                "hidden_act": "gelu_pytorch_tanh",
+                "hidden_size": 1152,
+                "image_size": 980,
+                "intermediate_size": 4304,
+                "layer_norm_eps": 1e-06,
+                "num_attention_heads": 16,
+                "num_channels": 3,
+                "num_hidden_layers": 27,
+                "patch_size": 14,
+            },
+            "text_config": {
+                "model_type": "qwen3_5_text",
+                "attention_bias": False,
+                "full_attention_interval": 4,
+                "head_dim": 256,
+                "hidden_act": "silu",
+                "hidden_size": 1024,
+                "intermediate_size": 3584,
+                "linear_conv_kernel_dim": 4,
+                "linear_key_head_dim": 128,
+                "linear_num_key_heads": 16,
+                "linear_num_value_heads": 16,
+                "linear_value_head_dim": 128,
+                "max_position_embeddings": 262144,
+                "num_attention_heads": 8,
+                "num_hidden_layers": 24,
+                "num_key_value_heads": 2,
+                "partial_rotary_factor": 0.25,
+                "rms_norm_eps": 1e-06,
+                "rope_parameters": {
+                    "partial_rotary_factor": 0.25,
+                    "rope_theta": 10000000,
+                    "rope_type": "default",
+                },
+                "vocab_size": 248094,
+                "tie_word_embeddings": True,
+            },
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
 # _resolve_composite_torch_dtype
 # ---------------------------------------------------------------------------
 class TestResolveCompositeTorchDtype:
-
     def test_defaults_to_bfloat16_when_absent(self):
         assert _resolve_composite_torch_dtype({}, {}) is torch.bfloat16
 
     def test_respects_explicit_string(self):
-        assert _resolve_composite_torch_dtype({"torch_dtype":
-                                               "float16"}) is torch.float16
+        assert _resolve_composite_torch_dtype({"torch_dtype": "float16"}) is torch.float16
 
     def test_respects_dtype_alias_key(self):
-        assert _resolve_composite_torch_dtype({"dtype":
-                                               "float32"}) is torch.float32
+        assert _resolve_composite_torch_dtype({"dtype": "float32"}) is torch.float32
 
     def test_respects_torch_dtype_object(self):
-        assert _resolve_composite_torch_dtype(
-            {"torch_dtype": torch.float16}) is torch.float16
+        assert _resolve_composite_torch_dtype({"torch_dtype": torch.float16}) is torch.float16
 
     def test_auto_and_none_are_skipped(self):
-        assert _resolve_composite_torch_dtype(
-            {"torch_dtype": "auto"},
-            {"dtype": None},
-            {"torch_dtype": "float16"},
-        ) is torch.float16
+        assert (
+            _resolve_composite_torch_dtype(
+                {"torch_dtype": "auto"},
+                {"dtype": None},
+                {"torch_dtype": "float16"},
+            )
+            is torch.float16
+        )
 
     def test_first_declaration_wins(self):
-        assert _resolve_composite_torch_dtype(
-            {"torch_dtype": "bfloat16"},
-            {"torch_dtype": "float16"},
-        ) is torch.bfloat16
+        assert (
+            _resolve_composite_torch_dtype(
+                {"torch_dtype": "bfloat16"},
+                {"torch_dtype": "float16"},
+            )
+            is torch.bfloat16
+        )
 
 
 # ---------------------------------------------------------------------------
 # _build_minicpmv4_6_config
 # ---------------------------------------------------------------------------
 class TestBuildMiniCPMV46Config:
-
     def test_pins_bfloat16_when_checkpoint_declares_none(self):
         # Regression: the real checkpoint declares no torch_dtype anywhere, which
         # crashed the hybrid mamba KV-cache byte sizing (None.itemsize). Both the
@@ -194,10 +198,8 @@ class TestBuildMiniCPMV46Config:
 # load_pretrained_config routing (offline, via a temp config.json)
 # ---------------------------------------------------------------------------
 class TestLoadPretrainedConfigRouting:
-
     def _write_config(self, tmp_path) -> str:
-        (tmp_path / "config.json").write_text(
-            json.dumps(_minicpmv4_6_config_dict()))
+        (tmp_path / "config.json").write_text(json.dumps(_minicpmv4_6_config_dict()))
         return str(tmp_path)
 
     def test_routes_minicpmv4_6_by_model_type(self, tmp_path):
@@ -218,11 +220,10 @@ class TestLoadPretrainedConfigRouting:
 # MiniCPMV4_6VisionConfig helpers
 # ---------------------------------------------------------------------------
 class TestVisionConfig:
-
     def test_window_helpers_scale_by_kernel(self):
-        vc = MiniCPMV4_6VisionConfig(hidden_size=1152,
-                                     intermediate_size=4304,
-                                     window_kernel_size=(2, 2))
+        vc = MiniCPMV4_6VisionConfig(
+            hidden_size=1152, intermediate_size=4304, window_kernel_size=(2, 2)
+        )
         assert vc.window_kernel_size == (2, 2)
         assert vc.window_hidden_size == 1152 * 2 * 2
         assert vc.window_intermediate_size == 4304 * 2 * 2
@@ -237,10 +238,10 @@ class TestVisionConfig:
 # transformers>=5.7.0 runtime guard (used by the input processor)
 # ---------------------------------------------------------------------------
 class TestTransformersGuard:
-
     @pytest.mark.parametrize("version", ["5.5.4", "5.6.9"])
     def test_raises_on_old_transformers(self, monkeypatch, version):
         from tensorrt_llm._torch.models import modeling_minicpmv4_6 as mod
+
         monkeypatch.setattr(transformers, "__version__", version)
         with pytest.raises(RuntimeError, match="transformers>="):
             mod._ensure_transformers_supports_minicpmv4_6()
@@ -248,6 +249,7 @@ class TestTransformersGuard:
     @pytest.mark.parametrize("version", ["5.7.0", "5.8.1", "5.12.1"])
     def test_passes_on_supported_transformers(self, monkeypatch, version):
         from tensorrt_llm._torch.models import modeling_minicpmv4_6 as mod
+
         monkeypatch.setattr(transformers, "__version__", version)
         mod._ensure_transformers_supports_minicpmv4_6()
 
@@ -260,4 +262,5 @@ def test_native_minicpmv4_6_config_available():
     # Once transformers>=5.7.0 is pinned, the local MiniCPMV4_6Config shim can
     # be dropped in favor of this native config.
     from transformers import MiniCPMV4_6Config as HFMiniCPMV4_6Config
+
     assert HFMiniCPMV4_6Config.model_type == "minicpmv4_6"


### PR DESCRIPTION
## Description

Adds support for `openbmb/MiniCPM-V-4.6` (image + video) to the TensorRT-LLM
PyTorch backend. The model is a SigLIP2-style variable-resolution ViT
(NaViT-packed, with an intermediate window-attention merger and a 2x2
downsample merger) on top of a Qwen3.5 dense hybrid (linear + full attention)
text tower (`Qwen3_5ForCausalLM`).

What this PR does:

- **New model / input processor.** `MiniCPMV4_6Model` fuses vision embeddings
  into the Qwen3.5 causal LM. The input processor wraps the native HF
  `MiniCPMV4_6Processor` and rewrites image/video placeholders to the OOV
  multimodal sentinel. Image and video share one NaViT-packed vision path; the
  fixed-size 2x2 window self-attention runs as a batched SDPA so it does not
  overflow the fused variable-length attention kernel's launch limits with many
  video frames/slices.
- **Composite config normalization** (`config_utils.py`). The top-level
  `minicpmv4_6` `model_type` is preserved (needed for
  `MULTIMODAL_PLACEHOLDER_REGISTRY` lookup) while the inner text tower is
  normalized to `Qwen3NextConfig`. A concrete `torch_dtype` is pinned because
  the released checkpoint declares none at any level, which otherwise crashes
  the hybrid mamba KV-cache byte sizing and cache-manager creation with
  `None.itemsize`.
- **transformers dependency.** Running the model requires
  `transformers>=5.7.0`: MiniCPM-V 4.6 was upstreamed into transformers as a
  native model type (`minicpmv4_6`) and the checkpoint ships no `auto_map`
  remote code to fall back on, so image/video preprocessing goes through the
  native `MiniCPMV4_6Processor` which only exists in `>=5.7.0`. A runtime guard
  raises a clear error on older releases. The small `MiniCPMV4_6Config` shim is
  a **transitional import/registration-safety layer** so `import tensorrt_llm`,
  `AutoConfig`/`AutoTokenizer` and unit-test collection stay green on the repo's
  currently-pinned `transformers==5.5.4`; it carries a TODO to remove once the
  pin is bumped to `>=5.7.0` (then switch to the native
  `transformers.MiniCPMV4_6Config`). This PR intentionally does not change the
  global `requirements.txt` pin.

Scope: image + video, PyTorch backend only (no changes to the legacy TensorRT
backend).

## Test Coverage

**Unit tests** — `tests/unittest/_torch/modeling/test_modeling_minicpmv4_6.py`
(CPU-only, no weights; safe to collect and run on the CI-pinned
`transformers==5.5.4`):

- `_resolve_composite_torch_dtype`: default `bfloat16`, explicit dtype
  (string / `torch.dtype` / `dtype` alias), `"auto"`/`None` skipping,
  first-declaration-wins.
- `_build_minicpmv4_6_config` / `load_pretrained_config`: composite-config
  construction, including a **regression guard** for the checkpoint that
  declares no `torch_dtype` (pins `bfloat16` on both the composite config and
  the inner text tower); top-level `model_type` preserved; text tower
  normalized to `Qwen3NextConfig` (`Qwen3_5ForCausalLM`); multimodal token IDs
  preserved; `insert_layer_id` propagated to the vision config; routing by both
  `model_type` and `architectures`.
- `MiniCPMV4_6VisionConfig` window helpers.
- The `transformers>=5.7.0` runtime guard (`_ensure_transformers_supports_minicpmv4_6`).
- One `transformers>=5.7.0`-gated test asserting the native config is present
  (auto-skipped below that version).

Results: **22 passed** on `transformers==5.7.0`; **21 passed + 1 skipped** on
`transformers==5.5.4` (native-config test gated; collection stays green).

**End-to-end** — validated on RTX 4090 (sm_89), TP1, `transformers==5.7.0`, via
`examples/llm-api/quickstart_multimodal.py` on `openbmb/MiniCPM-V-4.6`:

- Image (`--modality image`): produces a correct, coherent description of the
  input image.
- Video (`--modality video --num_frames 8`): produces a correct, coherent
  description of the input video.

> Note: automated E2E/integration tests are not included because the input
> processor requires `transformers>=5.7.0`, above the repo's current pin; a
> version-gated E2E test can be added as a follow-up once the pin is bumped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Dev Engineer Review

- Updated `ThinkingBudgetLogitsProcessor` to track per-request, per-beam reasoning-end progress, preventing duplicated end tags when the overlap scheduler exposes stale token views.
- Supports multi-token reasoning-end sequences and resets tracking after the reasoning block closes.
- Preserves stream handling while explicitly ignoring `client_id`.
- No public API or configuration changes.

### QA Engineer Review

- Added regression coverage for stale token views and multi-token reasoning-end progress in `tests/unittest/llmapi/test_sampling_params.py`.
- No test-list changes were identified; coverage is not listed in `tests/integration/test_lists/`.
- **Verdict: needs follow-up** for CI/manual test-list coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
