### PR TITLE
[https://nvbugs/6114139][test] Unwaive test_workers_kv_cache_events

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -125,7 +125,6 @@ disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_llama_context
 disaggregated/test_workers.py::test_workers_conversation_router[TinyLlama-1.1B-Chat-v1.0] SKIP (https://nvbugs/6162322)
 disaggregated/test_workers.py::test_workers_kv_cache_aware_router_deepseek_v3_lite_bf16[DeepSeek-V3-Lite-bf16] SKIP (https://nvbugs/6162322)
 disaggregated/test_workers.py::test_workers_kv_cache_aware_router_eviction[TinyLlama-1.1B-Chat-v1.0] SKIP (https://nvbugs/6162322)
-disaggregated/test_workers.py::test_workers_kv_cache_events[TinyLlama-1.1B-Chat-v1.0] SKIP (https://nvbugs/6114139)
 examples/test_bert.py::test_llm_bert_general[compare_hf-enable_remove_input_padding-disable_attention_plugin-disable_context_fmha-tp:2-pp:1-float16-RobertaForSequenceClassification-bert/twitter-roberta-base-emotion] SKIP (https://nvbugs/5234058)
 examples/test_bert.py::test_llm_bert_general[compare_hf-enable_remove_input_padding-use_attention_plugin-enable_context_fmha-tp:2-pp:1-float16-BertForSequenceClassification-bert/bert-base-uncased-yelp-polarity] SKIP (https://nvbugs/5234058)
 examples/test_bert.py::test_llm_bert_general[compare_hf-enable_remove_input_padding-use_attention_plugin-enable_context_fmha-tp:2-pp:1-float16-RobertaForQuestionAnswering-bert/roberta-base-squad2] SKIP (https://nvbugs/5234058)


### PR DESCRIPTION
## Description

Re-enables `disaggregated/test_workers.py::test_workers_kv_cache_events[TinyLlama-1.1B-Chat-v1.0]`, previously waived under NVBug 6114139.

The test was reproduced on a healthy GB300 (aarch64, sm_103, IMEX active) using a 1.3.0rc20 release container, and it **passes** with fabric memory active (`mUseFabricMemory:1`) and the NIXL/UCX cache transceiver. The original failure — `tcp_ep ... send() failed: Input/output error` → `AgentConnection::send failed` → `kNETWORK_ERROR` — was an environment-specific UCX TCP KV-cache transfer failure (consistent with strict `rp_filter` on the failing node), not a code defect. Re-enabling so CI can validate.

## Test Coverage

- `disaggregated/test_workers.py::test_workers_kv_cache_events[TinyLlama-1.1B-Chat-v1.0]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an outdated test waiver from the integration test list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->