### PR TITLE
[None][infra] expand MoE CODEOWNERS coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -275,18 +275,42 @@
 /cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe @NVIDIA/trt-llm-moe-devs
 /cpp/tensorrt_llm/thop/*Moe* @NVIDIA/trt-llm-moe-devs
 /cpp/tensorrt_llm/thop/moe* @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/cutlass_extensions/include/cutlass_extensions/gemm/kernel/*moe* @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/communicationKernels/moe* @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/cuteDslKernels/moe* @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_util_kernels.h @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/internal_cutlass_kernels/include/moe_gemm_kernels.h @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/internal_cutlass_kernels/include/moe_kernels.h @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/llama4MinLatencyKernels/*Moe* @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/marlin/*moe* @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/kernels/trtllmGenKernels/batchedGemm @NVIDIA/trt-llm-kernels-devs @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/nanobind/runtime/moe* @NVIDIA/trt-llm-moe-devs
+/cpp/tensorrt_llm/runtime/moeLoadBalancer @NVIDIA/trt-llm-moe-devs
 /tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm @NVIDIA/trt-llm-moe-devs
 /tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4 @NVIDIA/trt-llm-moe-devs
+/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py @NVIDIA/trt-llm-moe-devs
 /tensorrt_llm/_torch/distributed/moe_alltoall.py @NVIDIA/trt-llm-moe-devs
 /tensorrt_llm/_torch/expert_statistic.py @NVIDIA/trt-llm-moe-devs
 /tensorrt_llm/_torch/modules/fused_moe @NVIDIA/trt-llm-moe-devs
 /tensorrt_llm/_torch/modules/fused_shared_expert.py @NVIDIA/trt-llm-moe-devs
+/tensorrt_llm/deep_ep @NVIDIA/trt-llm-moe-devs
+/tests/microbenchmarks/bench_moe @NVIDIA/trt-llm-moe-devs
+/tests/microbenchmarks/bench_moe_comm.py @NVIDIA/trt-llm-moe-devs
+/tests/microbenchmarks/compare_moe_comm.py @NVIDIA/trt-llm-moe-devs
 /tests/scripts/cute_dsl_kernels/moe_as_dense_gemm @NVIDIA/trt-llm-moe-devs
 /tests/scripts/cute_dsl_kernels/moe_workload_generator.py @NVIDIA/trt-llm-moe-devs
+/tests/unittest/_torch/modules/dwdp/test_dwdp_fixup_moe_backends.py @NVIDIA/trt-llm-moe-devs
 /tests/unittest/_torch/modules/fused_moe @NVIDIA/trt-llm-moe-devs
 /tests/unittest/_torch/modules/moe @NVIDIA/trt-llm-moe-devs
+/tests/unittest/_torch/modules/test_fused_moe.py @NVIDIA/trt-llm-moe-devs
+/tests/unittest/_torch/modules/test_fused_shared_expert.py @NVIDIA/trt-llm-moe-devs
+/tests/unittest/_torch/modules/test_moe_*.py @NVIDIA/trt-llm-moe-devs
+/tests/unittest/_torch/multi_gpu/test_moe_a2a.py @NVIDIA/trt-llm-moe-devs
 /tests/unittest/_torch/thop/parallel/*moe* @NVIDIA/trt-llm-moe-devs
 /tests/unittest/_torch/thop/serial/*moe* @NVIDIA/trt-llm-moe-devs
+/tests/unittest/bindings/test_bindings_moe.py @NVIDIA/trt-llm-moe-devs
 
 # ===== VisualGen / AIGV =====
 /cpp/tensorrt_llm/thop/fusedDiT* @NVIDIA/trt-llm-torch-visual-gen-devs


### PR DESCRIPTION
## Summary
Expand the MoE section of .github/CODEOWNERS so @NVIDIA/trt-llm-moe-devs covers MoE code that the current globs miss. Derived by tracing every configurable_moe backend call-chain (cutlass / cutedsl / deepgemm / trtllmgen / densegemm / marlin / megamoe) from backend through quantization down to the underlying kernels/cubin, plus tests and microbenchmarks.

## Added (previously uncovered)
- C++ kernels in subdirs / other top-level dirs: cutlass_extensions gemm kernel `*moe*`, `communicationKernels/moe*` (MoE comm kernels), `cuteDslKernels/moe*`, `cutlass_kernels/include/moe_*`, `internal_cutlass_kernels/include/moe_*`, `llama4MinLatencyKernels/*Moe*`, `marlin/*moe*`, `nanobind/runtime/moe*`, `runtime/moeLoadBalancer`.
- Python: `_torch/custom_ops/cute_dsl_megamoe_custom_op.py`, `/tensorrt_llm/deep_ep` (python bindings).
- Tests: `test_fused_moe.py`, `test_fused_shared_expert.py`, `test_moe_*.py`, `dwdp/test_dwdp_fixup_moe_backends.py`, `multi_gpu/test_moe_a2a.py`, `bindings/test_bindings_moe.py`.
- Microbenchmarks: `bench_moe`, `bench_moe_comm.py`, `compare_moe_comm.py`.

## Co-owner
- `trtllmGenKernels/batchedGemm` holds the TRTLLMGen MoE cubin but is shared with the non-MoE fp8BatchedGemmTrtllmGen op, so it is set as co-owner: `@NVIDIA/trt-llm-kernels-devs @NVIDIA/trt-llm-moe-devs`.

## Excluded intentionally
- LoRA is a general PEFT mechanism (attention / MLP / mamba also use LoraLayer); only MoE-specific LoRA would belong here.
- Legacy TRT MoE path (plugins/mixtureOfExperts, layers/moe.py, trt unittests).

## Test plan
- CODEOWNERS-only change; no code/runtime impact. Relies on GitHub CODEOWNERS syntax validation.
