### PR TITLE
[https://nvbugs/6418103][fix] Clamp the post-allreduce quota by the pre-allreduce quota (`quota = min(quota…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -823,7 +823,11 @@ class KVCacheManagerV2(BaseResourceManager):
             # inf max_tokens means all layers are SWA and every rank quota can
             # fit all SWA fixed cache.
             if not math.isinf(max_tokens):
-                quota = self._get_quota_from_max_tokens(max_tokens)
+                # allreduce(MIN) must never increase the local quota. The
+                # token↔quota round-trip is not identity when SWA layers
+                # dominate (full_attn_size_per_token==0), so clamp to guard
+                # against a bogus inflation (nvbugs/6418103).
+                quota = min(quota, self._get_quota_from_max_tokens(max_tokens))
 
         logger.info(f"KV cache manager v2 device quota set to {quota / (1 << 30)}GiB")
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -4,7 +4,6 @@ accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype_with
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype_with_helix[fifo_v2-cudagraph:with_padding-pp2tp1cp2] SKIP (https://nvbugs/6427411)
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_guided_decoding[llguidance-mtp_nextn=0] SKIP (https://nvbugs/6426865)
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_guided_decoding[llguidance-mtp_nextn=2] SKIP (https://nvbugs/6075533)
-accuracy/test_disaggregated_serving.py::TestGPTOSS::test_kv_cache_v2_nixl_python[cache_mgr_v2] SKIP (https://nvbugs/6418103)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=2] SKIP (https://nvbugs/6427411)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=4] SKIP (https://nvbugs/6428069)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=2-ctx_pp=2] SKIP (https://nvbugs/6427411)


### PR DESCRIPTION
## Summary
- **Root cause**: `_get_max_tokens_from_quota` and `_get_quota_from_max_tokens` are not inverses when `full_attn_size_per_token == 0` (all layers SWA per test's `max_attention_window=[128, 32768]`), so the intended cross-rank normalization inflates the KV cache GPU quota ~10× (115.83 → 1156.5 GiB) and cuMemCreate OOMs.
- **Fix**: Clamp the post-allreduce quota by the pre-allreduce quota (`quota = min(quota, _get_quota_from_max_tokens(max_tokens))`) — allreduce(MIN) must never raise the local quota. Also remove the corresponding waiver from `tests/integration/test_lists/waives.txt`.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6418103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU memory quota calculation for cache management to better handle mixed layer configurations and avoid quota over-allocation.
  * Added safeguards so available token capacity is capped more conservatively, improving stability in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->