### PR TITLE
[https://nvbugs/6418912][fix] Prevent BufferIndexHolder test deadlock

### DIFF
--- a/cpp/tests/unit_tests/batch_manager/bufferIndexHolderTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/bufferIndexHolderTest.cpp
@@ -70,6 +70,10 @@ protected:
     void SetUp() override
     {
         setenv("TRTLLM_USE_UCX_KVCACHE", "1", 1);
+        // Move-assignment coverage requires two simultaneously held indices from either pool.
+        setenv("TRTLLM_REQUEST_KV_CACHE_CONCURRENT", "1", 1);
+        setenv("TRTLLM_KVCACHE_RECV_BUFFER_COUNT", "2", 1);
+        setenv("TRTLLM_KVCACHE_SEND_MAX_CONCURRENCY_NUM", "2", 1);
 
         int constexpr numLayers = 2;
         int constexpr numHeads = 2;
@@ -249,6 +253,7 @@ TEST_P(BufferIndexHolderLifecycleTest, MoveConstructTransfersOwnership)
 TEST_P(BufferIndexHolderLifecycleTest, MoveAssignReleasesPriorThenTransfers)
 {
     int const before = inUse();
+    ASSERT_GE(isRecv() ? mgr().getRecvBufferCount() : mgr().getSendBufferCount(), 2);
     auto firstIdx = acquire();
     auto secondIdx = acquire();
     ASSERT_TRUE(firstIdx.has_value());


### PR DESCRIPTION
## Summary

- Configure `BufferIndexHolderLifecycleTest` with two send and receive slots so move-assignment coverage can hold both the source and destination indices simultaneously.
- Assert the two-slot precondition before acquiring indices, turning any future fixture regression into an immediate failure instead of a one-hour timeout.

## Root cause

`MoveAssignReleasesPriorThenTransfers` acquired two buffer indices before constructing either RAII holder. Both pools default to one slot, so the second acquisition waited indefinitely on the pool condition variable and the move assignment was never exercised.

This was reported by NVBUG 6418912 in `A30-CPP-Post-Merge-2`; both the send and receive variants timed out.

## Why this escaped earlier

PR #14768 added the test, but its recorded pre-merge runs did not execute the A30 C++ post-merge stage. The final PR head used `/bot skip` after separate performance verification in #14916. The fixture also depended implicitly on CI-provided concurrency environment values, so it could appear healthy anywhere those values provided at least two slots.

This change makes the required capacity explicit and removes that environment dependence.

## Validation

- `pre-commit run --files cpp/tests/unit_tests/batch_manager/bufferIndexHolderTest.cpp`
- Combined validation PR #16019 included this PR together with #16011, #16012, and the independent sequence-link fix in #16037.
- [Targeted `A30-CPP-1` pipeline #46619](http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=46619) completed **SUCCESS** on integration head `1248a186`.
- The batch-manager report completed 525 gtests with 0 failures; the BufferIndexHolder cases no longer timed out.
- #16037 documents the final end-to-end evidence and fixes the unrelated `FillKvCacheWithRequestsAndCompleteOneByOne/5` crash exposed after this timeout was removed.

Earlier standalone pipelines #46503, #46532, and #46562 did not contain all companion fixes, so their later KV-cache failures do not invalidate this BufferIndexHolder fix.