### PR TITLE
[None][fix] Fix Qwen2-VL Transformers 5 compatibility

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 from torch.nn import functional as F
 from transformers import (AutoProcessor, AutoTokenizer, PretrainedConfig,
                           PreTrainedModel)
+from transformers.modeling_outputs import BaseModelOutputWithPooling
 from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
     Qwen2_5_VisionPatchEmbed, Qwen2_5_VisionTransformerPretrainedModel)
 from transformers.models.qwen2_vl.modeling_qwen2_vl import \
@@ -1080,11 +1081,15 @@ class Qwen2VisionModelBase(nn.Module):
         embeds = []
         if pixel_values is not None:
             embed = self.visual(pixel_values, grid_thw=image_grid_thw)
+            if isinstance(embed, BaseModelOutputWithPooling):
+                embed = embed.pooler_output
             embeds.append(embed)
 
         if pixel_values_videos is not None:
-            embeds.append(
-                self.visual(pixel_values_videos, grid_thw=video_grid_thw))
+            embed = self.visual(pixel_values_videos, grid_thw=video_grid_thw)
+            if isinstance(embed, BaseModelOutputWithPooling):
+                embed = embed.pooler_output
+            embeds.append(embed)
         return embeds
 
 
@@ -1948,7 +1953,8 @@ class Qwen2VLModel(Qwen2VLModelBase):
         return [
             "image.pixel_values", "image.image_grid_thw",
             "video.pixel_values_videos", "video.video_grid_thw",
-            "multimodal_embedding"
+            "multimodal_embedding", "mrope_config.mrope_position_ids",
+            "mrope_config.mrope_position_deltas"
         ]
 
     def load_weights(self, weights, weight_mapper: BaseWeightMapper):

--- a/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
@@ -13,12 +13,18 @@ from test_modeling_multimodal import MultimodalScenario, TestModelingMultimodal
 from transformers import Qwen2_5_VLConfig
 from transformers import \
     Qwen2_5_VLForConditionalGeneration as HFQwen2_5_VLForConditionalLM
+from transformers import Qwen2VLConfig
+from transformers.modeling_outputs import BaseModelOutputWithPooling
+from transformers.models.qwen2_vl.modeling_qwen2_vl import \
+    Qwen2VisionTransformerPretrainedModel
 from utils.llm_data import llm_models_root
 
+from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.checkpoints.hf.qwen2vl_weight_mapper import \
     Qwen2VLHfWeightMapper
 from tensorrt_llm._torch.models.modeling_qwen2vl import (
-    Qwen2_5_VLModel, Qwen2VLInputProcessorBase, _prepare_qwen_vl_mrope_config)
+    Qwen2_5_VLModel, Qwen2VisionModelBase, Qwen2VLInputProcessorBase,
+    Qwen2VLModel, _prepare_qwen_vl_mrope_config)
 from tensorrt_llm._torch.models.modeling_qwen3vl import \
     Qwen3VLInputProcessorBase
 from tensorrt_llm._utils import get_sm_version
@@ -348,6 +354,66 @@ class _FakeRotaryEmbedding:
                            dtype=torch.float32).reshape(1, num_tokens,
                                                         self.rotary_dim)
         return cos, cos + 1000
+
+
+def test_qwen2_vision_adapter_extracts_pooler_output():
+    """The real Transformers 5.x Qwen2 encoder wraps LLM features in pooler_output."""
+    config = Qwen2VLConfig(dtype="float32",
+                           vision_config={
+                               "depth": 1,
+                               "embed_dim": 32,
+                               "hidden_size": 64,
+                               "num_heads": 4,
+                               "mlp_ratio": 2,
+                               "patch_size": 2,
+                               "spatial_merge_size": 2,
+                               "temporal_patch_size": 1,
+                               "in_channels": 3,
+                           })
+    vision_model = Qwen2VisionModelBase(
+        ModelConfig(pretrained_config=config),
+        Qwen2VisionTransformerPretrainedModel).eval()
+    # Set to eager to make the test CPU-only.
+    vision_model.visual.config._attn_implementation = "eager"
+    multimodal_params = [
+        MultimodalParams(
+            multimodal_data={
+                "image": {
+                    "pixel_values": torch.randn(16, 12),
+                    "image_grid_thw": torch.tensor([[1, 4, 4]]),
+                }
+            })
+    ]
+    image = multimodal_params[0].multimodal_data["image"]
+    encoder_output = vision_model.visual(image["pixel_values"],
+                                         grid_thw=image["image_grid_thw"])
+
+    result = vision_model(multimodal_params)
+
+    assert isinstance(encoder_output, BaseModelOutputWithPooling)
+    assert len(result) == 1
+    torch.testing.assert_close(result[0], encoder_output.pooler_output)
+
+
+def test_qwen2_vl_device_paths_move_mrope_tensors_to_cuda():
+    multimodal_params = MultimodalParams(
+        multimodal_data={
+            "mrope_config": {
+                "mrope_position_ids":
+                torch.arange(6, dtype=torch.int32).reshape(3, 1, 2),
+                "mrope_position_deltas":
+                torch.tensor([[2]], dtype=torch.int32),
+            }
+        })
+    device_paths = Qwen2VLModel.multimodal_data_device_paths.fget(None)
+    multimodal_params.to_device("multimodal_data",
+                                "cuda",
+                                target_keywords=device_paths)
+
+    mrope_config = multimodal_params.multimodal_data["mrope_config"]
+
+    assert mrope_config["mrope_position_ids"].is_cuda
+    assert mrope_config["mrope_position_deltas"].is_cuda
 
 
 def _mrope_param(delta: int) -> MultimodalParams:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multimodal vision handling so pooled outputs from vision encoders are supported correctly for both image and video inputs.
  * Ensured additional multimodal position tensors are moved to the right device during distributed execution.

* **Tests**
  * Added coverage for pooled vision outputs.
  * Added coverage for device placement of multimodal position data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

* Why?

Transformers 5.x returns vision features in a pooling wrapper, and MRoPE position tensors must be on the model device for inference.

* What?

Extract pooled vision embeddings, transfer MRoPE tensors with multimodal data, and add regression coverage for both paths.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
