### PR TITLE
Draft: [None][feat] Integrate M3 sparse attention kernels form MSA

### DIFF
--- a/docs/source/deployment-guide/deployment-guide-for-minimax-m3-on-trtllm.md
+++ b/docs/source/deployment-guide/deployment-guide-for-minimax-m3-on-trtllm.md
@@ -60,6 +60,7 @@ Both checkpoints ship their own chat template (`chat_template.jinja`), which is 
 * **`max_seq_len` must be capped for CUDA graphs.** The dense GQA expansion in the first few attention layers and the per-Q FP32 expansion in the sparse decode kernel allocate temporary tensors whose size grows linearly with the warmup decode's `max_k`. If `max_seq_len` is left at the checkpoint default, that `max_k` follows `max_position_embeddings` (1M for MXFP8, 512K for BF16) and the resulting gigabyte-scale single-allocation request exceeds the caching allocator's CUDA-graph-safe path, so capture fails with `cudaErrorStreamCaptureUnsupported` / OOM. The curated YAML therefore sets `max_seq_len` to a small value just above ISL+OSL (`2068` for the 1k/1k benchmark) so CUDA graphs can capture cleanly. Raise it for longer-context workloads, but expect a corresponding cut in `max_batch_size`.
 * **Parallelism.** MoE experts run with expert parallelism. The attention layers support both Tensor-Expert Parallelism (TEP) and Data-Expert Parallelism (DEP, via `enable_attention_dp: true`). The overlap scheduler is enabled by default.
 * **Multimodal.** `MiniMaxM3SparseForConditionalGeneration` supports text, image, and video inputs. The text decoder is also usable standalone (text-only) via the `MiniMaxM3SparseForCausalLM` architecture.
+* **Optional accelerated MSA kernels.** By default the sparse-attention layers run on the in-tree Triton reference path, which needs no extra packages. For higher performance on NVIDIA Blackwell (SM100) GPUs you can enable the MiniMax Sparse Attention (MSA) kernels by installing the external `fmha_sm100` package and setting `sparse_attention_config.sparse_use_msa: true`. This package is MIT-licensed, SM100-only, and not published on PyPI, so it is **not** installed with TensorRT LLM and must be installed manually — see [Optional: Accelerated MSA Attention Kernels](#optional-accelerated-msa-attention-kernels-fmha_sm100).
 
 ## Deployment Steps
 
@@ -77,6 +78,43 @@ Note:
 
 * See <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/tags> for all available containers. Containers published in the main branch weekly have an `rcN` suffix, while the monthly release with QA tests has no `rcN` suffix. Use the `rc` release to get the latest model and feature support.
 * If you want to use the latest main branch, you can build from source: [https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source.html](https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source.html)
+
+### Optional: Accelerated MSA Attention Kernels (`fmha_sm100`)
+
+By default the MiniMax-M3 sparse-attention layers run on the in-tree Triton reference path, which requires no additional packages. On NVIDIA Blackwell (SM100) GPUs — including the GB200 target of this guide — you can optionally switch the sparse path to the **MiniMax Sparse Attention (MSA)** kernels for higher performance.
+
+The MSA kernels ship in the external `fmha_sm100` package (MSA: <https://github.com/MiniMax-AI/MSA>). This package is MIT-licensed, SM100-only, and **not published on PyPI**, so it is intentionally not a dependency of TensorRT LLM and is not installed by `pip install tensorrt-llm` or bundled in the NGC container. If you want the MSA path, install it yourself.
+
+**Prerequisites**
+
+* An NVIDIA Blackwell (SM100) GPU (e.g., B200 / GB200). The kernels are compiled and dispatched only for SM100.
+* A CUDA toolkit with `nvcc` on `PATH`. The MSA `csrc` kernels are JIT-compiled on first use, so the compiler must be available at runtime (it is present in the NGC TensorRT LLM container).
+* `git` (the package and its vendored CUTLASS headers are fetched from GitHub).
+
+**Install**
+
+Install the package into the same environment that runs the server (on every node, since each rank imports it). Pin the commit that matches your TensorRT LLM version:
+
+```bash
+pip install "git+https://github.com/MiniMax-AI/MSA.git@e2ebe7656649f619af0ad1d457b534283034655e"
+```
+
+This pulls MSA's own runtime dependencies (`nvidia-cutlass-dsl`, `quack-kernels`, `apache-tvm-ffi`, `ninja`, `pybind11`, `cuda-python`, `jinja2`) and fetches the CUTLASS headers via git submodule.
+
+**Enable**
+
+Set `sparse_use_msa: true` in the `sparse_attention_config` block of your `--extra_llm_api_options` YAML, and make sure the KV-cache block size matches the MSA sparse block size of 128 (`kv_cache_config.tokens_per_block: 128`):
+
+```yaml
+sparse_attention_config:
+  algorithm: minimax_m3
+  sparse_use_msa: true
+kv_cache_config:
+  enable_block_reuse: false
+  tokens_per_block: 128
+```
+
+If `sparse_use_msa: true` is set but `fmha_sm100` is not installed (or the GPU is not SM100), the server raises a descriptive error the first time a sparse layer dispatches, instructing you to install the package or unset the flag to fall back to the Triton reference path.
 
 ### Recommended Performance Settings
 
@@ -150,6 +188,10 @@ Must be set to `minimax_m3`. There is no dense fallback for the MiniMax-M3 spars
 ##### `kv_cache_config.enable_block_reuse`
 
 Must be `false`. The sparse-attention path does not support KV cache block reuse across requests with shared prefixes.
+
+##### `sparse_attention_config.sparse_use_msa` (optional)
+
+Defaults to `false` (the in-tree Triton reference path). Set to `true` to route the sparse-attention layers through the accelerated MSA kernels. This requires the external `fmha_sm100` package and an SM100 GPU, and requires `kv_cache_config.tokens_per_block: 128` (the MSA sparse block size). See [Optional: Accelerated MSA Attention Kernels](#optional-accelerated-msa-attention-kernels-fmha_sm100) for installation and prerequisites.
 
 ## Testing API Endpoint
 

--- a/tensorrt_llm/_torch/attention_backend/fmha/__init__.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/__init__.py
@@ -16,6 +16,7 @@
 from .fallback import FallbackFmha
 from .flashinfer_trtllm_gen import FlashInferTrtllmGenFmha
 from .interface import Fmha
+from .msa_sparse_gqa import MsaSparseGqaFmha
 from .phased import FmhaParams, PhasedFmha
 from .registry import DEFAULT_FMHA_LIBS, FMHA_LIBS, FmhaCls, get_enabled_fmha_lib_classes
 
@@ -27,6 +28,7 @@ __all__ = [
     "Fmha",
     "FmhaCls",
     "FmhaParams",
+    "MsaSparseGqaFmha",
     "PhasedFmha",
     "get_enabled_fmha_lib_classes",
 ]

--- a/tensorrt_llm/_torch/attention_backend/fmha/msa_sparse_gqa.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/msa_sparse_gqa.py
@@ -1,0 +1,309 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Block-sparse GQA FMHA backed by MSA's `fmha_sm100` kernel.
+
+`MsaSparseGqaFmha` wraps MSA's `fmha_sm100` paged sparse GQA kernel and
+participates in the standard `TrtllmAttention.forward` dispatch loop. The
+owning `MiniMaxM3MSATrtllmAttention` layer runs an `MsaIndexer` to select
+the per-query KV blocks and publishes them on
+`forward_args.sparse_prediction`; this class attends over them.
+
+The kernel is SM100-only and `fmha_sm100` is an optional external
+dependency (https://github.com/MiniMax-AI/MSA); `is_available` returns
+False when it or an SM100 device is missing. `run_msa_sparse_gqa` is
+importable for focused unit tests that drive the kernel directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from tensorrt_llm.logger import logger
+
+from .interface import Fmha
+
+if TYPE_CHECKING:
+    from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
+    from tensorrt_llm._torch.attention_backend.trtllm import (
+        TrtllmAttention,
+        TrtllmAttentionMetadata,
+    )
+
+
+def _msa_metadata_cls() -> type:
+    """The concrete metadata class that drives `MsaSparseGqaFmha`.
+
+    Resolved lazily (the class is built inside a factory with a deferred
+    `trtllm` import) so importing this module during attention-backend
+    package init does not form an import cycle.
+    """
+    from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.msa_backend import (
+        get_minimax_m3_msa_attention_backend_cls,
+    )
+
+    return get_minimax_m3_msa_attention_backend_cls().Metadata
+
+
+def run_msa_sparse_gqa(
+    q: torch.Tensor,
+    k_paged: torch.Tensor,
+    v_paged: torch.Tensor,
+    kv_block_indexes: torch.Tensor,
+    *,
+    qo_lens_cpu: torch.Tensor,
+    kv_lens_cpu: torch.Tensor,
+    qo_offset_cpu: Optional[torch.Tensor],
+    kv_indices: torch.Tensor,
+    sm_scale: float,
+    causal: bool,
+    head_dim: int = 128,
+) -> torch.Tensor:
+    """Single kernel core: `fmha_sm100` block-sparse paged GQA.
+
+    Follows MSA's two-call pattern: `fmha_sm100_plan` builds the per-shape
+    sparse plan (with `kv_block_num` derived from
+    `kv_block_indexes.shape[-1]`), then `fmha_sm100` runs the kernel with
+    the block indices threaded through. Returns
+    `[total_q, num_qo_heads, head_dim]` bfloat16.
+    """
+    # Imported here, not at module top, so the registry can still
+    # advertise the class on hosts where fmha_sm100 is absent.
+    # is_available() handles the off-host case.
+    import fmha_sm100
+
+    if q.dim() != 3:
+        raise ValueError(
+            "MsaSparseGqaFmha expects q with shape [total_q, num_qo_heads, head_dim]; "
+            f"got {tuple(q.shape)}."
+        )
+    if q.shape[-1] != head_dim:
+        raise NotImplementedError(
+            f"MsaSparseGqaFmha currently supports head_dim={head_dim}; got {q.shape[-1]}."
+        )
+    if k_paged.dim() != 4 or v_paged.dim() != 4:
+        raise ValueError(
+            "MsaSparseGqaFmha expects paged KV with shape "
+            "[num_pages, num_kv_heads, page_size, head_dim]; "
+            f"got k={tuple(k_paged.shape)}, v={tuple(v_paged.shape)}."
+        )
+    if k_paged.shape != v_paged.shape:
+        raise ValueError(
+            f"MsaSparseGqaFmha requires k and v to share shape; "
+            f"got k={tuple(k_paged.shape)}, v={tuple(v_paged.shape)}."
+        )
+    if k_paged.shape[-1] != head_dim:
+        raise NotImplementedError(
+            f"MsaSparseGqaFmha currently supports head_dim={head_dim}; "
+            f"got k_paged head_dim={k_paged.shape[-1]}."
+        )
+
+    num_qo_heads = int(q.shape[1])
+    num_kv_heads = int(k_paged.shape[1])
+    page_size = int(k_paged.shape[2])
+
+    sparse_plan = fmha_sm100.fmha_sm100_plan(
+        qo_lens_cpu,
+        kv_lens_cpu,
+        num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        qo_offset=qo_offset_cpu,
+        page_size=page_size,
+        kv_block_num=int(kv_block_indexes.shape[-1]),
+        causal=causal,
+        num_kv_splits=1,
+    )
+    out, _ = fmha_sm100.fmha_sm100(
+        q,
+        k_paged,
+        v_paged,
+        sparse_plan,
+        kv_indices=kv_indices,
+        kv_block_indexes=kv_block_indexes,
+        sm_scale=sm_scale,
+        output_maxscore=False,
+    )
+    return out
+
+
+def _sm100_fmha_available(class_name: str) -> bool:
+    """Shared availability probe for the MSA `fmha_sm100` backend.
+
+    Probes with `importlib.util.find_spec` instead of importing:
+    `fmha_sm100`'s import side effects (an early `tvm_ffi` import plus
+    global-func registration) can corrupt the flashinfer dense-attention
+    path when pulled in at layer-construction time. The real import
+    happens at first kernel use.
+    """
+    if importlib.util.find_spec("fmha_sm100") is None:
+        logger.debug(f"{class_name} is unavailable: fmha_sm100 package not installed.")
+        return False
+    if not torch.cuda.is_available():
+        logger.debug(f"{class_name} is unavailable: no CUDA device.")
+        return False
+    try:
+        major, _ = torch.cuda.get_device_capability()
+    except RuntimeError:
+        return False
+    if major != 10:
+        logger.debug(
+            f"{class_name} is unavailable: requires SM100 (compute capability 10.x), "
+            f"got compute capability {major}.x."
+        )
+        return False
+    return True
+
+
+class MsaSparseGqaFmha(Fmha):
+    """SM100 block-sparse GQA FMHA powered by MSA's `fmha_sm100` kernel.
+
+    Consumes the indexer's selected KV block indices on
+    `forward_args.sparse_prediction.sparse_attn_indices` and runs paged GQA
+    over them; `is_supported` claims only M3 MSA sparse requests. Inherits
+    `Fmha` rather than `PhasedFmha` because the indexer, plan, and block
+    indices span the whole batch and `fmha_sm100` handles mixed
+    decode/prefill varlen batches in one call, so there is no
+    context/generation split to reuse and `forward` dispatches the whole
+    batch at once. Requires head_dim 128 and 4-D HND paged K/V.
+    """
+
+    HEAD_DIM = 128
+    REQUIRES_PAGED_KV = True
+
+    def __init__(self, attn: "TrtllmAttention"):
+        # kv_factor and the out-head sizes mirror the other FMHA libs for
+        # parity; the whole-batch path does not read them.
+        super().__init__(attn)
+        self.kv_factor = 2
+        self.generation_out_head_size = self.HEAD_DIM
+        self.context_out_head_size = self.HEAD_DIM
+
+    @classmethod
+    def is_available(cls, attn: Optional["TrtllmAttention"] = None) -> bool:
+        return _sm100_fmha_available(cls.__name__)
+
+    def is_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: "AttentionForwardArgs",
+    ) -> bool:
+        # Only claim MiniMax-M3 MSA sparse requests: the indexer must have
+        # populated the per-query selected block indices via
+        # sparse_attn_predict, and the metadata must be the M3 MSA
+        # metadata that carries the pre-staged plans.
+        sparse_prediction = getattr(forward_args, "sparse_prediction", None)
+        if sparse_prediction is None:
+            return False
+        if getattr(sparse_prediction, "sparse_attn_indices", None) is None:
+            return False
+        return isinstance(metadata, _msa_metadata_cls())
+
+    def _sm_scale(self) -> float:
+        attn = self.attn
+        q_scaling = getattr(attn, "q_scaling", 1.0) or 1.0
+        return (self.HEAD_DIM**-0.5) / float(q_scaling)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: "AttentionForwardArgs",
+    ) -> None:
+        from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.common import (
+            msa_paged_kv,
+            write_msa_main_kv,
+        )
+        from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.msa_backend import (
+            _whole_batch_lens,
+            run_msa_sparse_decode,
+        )
+
+        attn = self.attn
+        config = attn.m3_config
+        layer_idx = attn.layer_idx
+        kv_cache_manager = metadata.kv_cache_manager
+        m3_meta = metadata.m3_meta
+        output = forward_args.output
+        if output is None:
+            raise RuntimeError(f"{type(self).__name__} requires output.")
+
+        # fmha_sm100 reads the paged K/V cache directly, so (unlike the
+        # standard C++ FMHA path) the new-token K/V must be written into
+        # the cache here before the sparse GQA runs. The index-K write is
+        # done by the indexer via sparse_attn_predict.
+        if k is not None and v is not None:
+            write_msa_main_kv(kv_cache_manager, layer_idx, metadata.m3_out_cache_loc, k, v)
+
+        sparse_prediction = getattr(forward_args, "sparse_prediction", None)
+        kv_block_indexes = (
+            getattr(sparse_prediction, "sparse_attn_indices", None)
+            if sparse_prediction is not None
+            else None
+        )
+        if kv_block_indexes is None:
+            raise RuntimeError(
+                "MsaSparseGqaFmha invoked without sparse_attn_indices; "
+                "MiniMaxM3MSATrtllmAttention.sparse_attn_predict must populate them."
+            )
+
+        num_tokens = int(q.shape[0])
+        q3 = q.view(num_tokens, attn.num_heads, self.HEAD_DIM)
+        out_view = output.view(num_tokens, attn.num_heads, self.HEAD_DIM)
+        sm_scale = self._sm_scale()
+
+        if m3_meta.is_prefill:
+            # Context or mixed batch: eager fmha_sm100 (not graph captured).
+            k_paged, v_paged = msa_paged_kv(kv_cache_manager, layer_idx)
+            qo_lens_cpu, kv_lens_cpu, qo_offset_cpu, kv_indices = _whole_batch_lens(
+                m3_meta, config.block_size
+            )
+            out = run_msa_sparse_gqa(
+                q3,
+                k_paged,
+                v_paged,
+                kv_block_indexes,
+                qo_lens_cpu=qo_lens_cpu,
+                kv_lens_cpu=kv_lens_cpu,
+                qo_offset_cpu=qo_offset_cpu,
+                kv_indices=kv_indices,
+                sm_scale=sm_scale,
+                causal=True,
+                head_dim=self.HEAD_DIM,
+            )
+        else:
+            # Pure decode: CUDA-graph captured, so route through the
+            # graph-safe in-tree decode kernels rather than the
+            # graph-hostile eager fmha_sm100_plan path.
+            out = run_msa_sparse_decode(
+                config,
+                kv_cache_manager,
+                layer_idx,
+                m3_meta,
+                q3,
+                kv_block_indexes,
+                sm_scale,
+            )
+        out_view.copy_(out.view_as(out_view))
+
+
+__all__ = ["MsaSparseGqaFmha", "run_msa_sparse_gqa"]

--- a/tensorrt_llm/_torch/attention_backend/fmha/registry.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/registry.py
@@ -19,12 +19,14 @@ from typing import TypeAlias
 from .fallback import FallbackFmha
 from .flashinfer_trtllm_gen import FlashInferTrtllmGenFmha
 from .interface import Fmha
+from .msa_sparse_gqa import MsaSparseGqaFmha
 
 FmhaCls: TypeAlias = type[Fmha]
 
 FMHA_LIBS: dict[str, FmhaCls] = {
     "flashinfer_trtllm_gen": FlashInferTrtllmGenFmha,
     "fallback": FallbackFmha,
+    "msa_sparse_gqa": MsaSparseGqaFmha,
 }
 DEFAULT_FMHA_LIBS: tuple[str, ...] = tuple(FMHA_LIBS)
 

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/__init__.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/__init__.py
@@ -56,8 +56,8 @@ from .metadata import (
     allocate_minimax_m3_static_buffers,
     build_runtime_metadata_from_kv_manager,
     get_minimax_m3_attention_metadata_cls,
-    replace_metadata,
 )
+from .msa_backend import get_minimax_m3_msa_attention_backend_cls
 
 __all__ = [
     "MiniMaxM3KVCacheManagerV2",
@@ -70,7 +70,7 @@ __all__ = [
     "get_minimax_m3_attention_backend_cls",
     "get_minimax_m3_attention_metadata_cls",
     "get_minimax_m3_kv_cache_manager_cls",
+    "get_minimax_m3_msa_attention_backend_cls",
     "minimax_m3_sparse_decode",
     "minimax_m3_sparse_prefill",
-    "replace_metadata",
 ]

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
@@ -13,7 +13,7 @@ Provides:
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import torch
 
@@ -151,10 +151,11 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         **kwargs,
     ):
         # Resolve M3 sparse-layer metadata from explicit kwargs first,
-        # then from ``sparse_attn_config``, then from the M3 checkpoint
-        # convention (layers 0..2 dense, 3..N-1 sparse,
-        # disable_index_value=True, sparse_index_dim=128).
-        sparse_attn_config = kwargs.get("sparse_attn_config")
+        # then from `sparse_attention_config` (the name the pyexecutor
+        # passes), then from the M3 checkpoint convention (layers 0..2
+        # dense, 3..N-1 sparse, disable_index_value=True,
+        # sparse_index_dim=128).
+        sparse_attn_config = kwargs.get("sparse_attention_config")
         num_layers = kwargs.get("num_layers")
 
         if sparse_index_dim is None:
@@ -173,6 +174,11 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         self.sparse_layer_ids = sorted(int(i) for i in sparse_layer_ids)
         self.disable_index_value_layer_ids = set(int(i) for i in disable_index_value_layer_ids)
         self.sparse_index_dim = int(sparse_index_dim)
+        # Surface whether the runtime dispatches through the MSA-backed
+        # (`fmha_sm100`) path so `prepare()` can pre-build the MSA plans
+        # outside the CUDA graph capture window. The config's
+        # `sparse_use_msa` field is the single source of truth.
+        self.use_msa = bool(getattr(sparse_attn_config, "sparse_use_msa", False))
 
         super().__init__(*args, **kwargs)
 
@@ -417,6 +423,7 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         *,
         pool_id: int = 0,
         is_kv_aggregate: bool = True,
+        num_blocks_per_seq: Optional[Sequence[int]] = None,
     ):
         """Return per-request slot ids in ``[0, num_slots)`` directly.
 
@@ -434,8 +441,10 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         padding contract.
         """
         res = []
-        for req_id in request_ids:
+        for req_idx, req_id in enumerate(request_ids):
             idx_tensor = torch.as_tensor(self.kv_cache_map[req_id].get_base_page_indices(pool_id))
+            if num_blocks_per_seq is not None:
+                idx_tensor = idx_tensor[: num_blocks_per_seq[req_idx]]
             res.append(
                 (
                     torch.where(

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/common.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/common.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared, backend-neutral helpers for MiniMax-M3 sparse attention.
+
+Hosts the pure-torch primitives that both the Triton reference backend
+and the MSA (`fmha_sm100`) backend rely on, so the MSA path does not
+import Triton-backend internals:
+
+  * KV-slot writers (paged and flat-slot aware).
+  * Init/local block-priority sentinels.
+  * MSA cache-layout adapters (pool NHD to `fmha_sm100` HND).
+  * Per-query valid-block counting and torch top-k block selection.
+  * The lazy `fmha_sm100` import guard and kernel precondition constants.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import torch
+
+if TYPE_CHECKING:
+    from .metadata import MiniMaxM3SparseAttentionMetadata
+
+
+# Sentinel block score for blocks that init / local priority forces into
+# the top-k regardless of their numerical score.
+_INIT_SCORE = 1e30
+_LOCAL_SCORE = 1e29
+
+# fmha_sm100 only ships head_dim=128 variants, and the in-tree
+# block-selection/driver geometry is validated for topk=16 (the
+# MiniMax-M3 checkpoint value). Callers enforce these preconditions early
+# so layer construction fails with a clear message rather than a cryptic
+# shape error from inside the MSA JIT.
+_MSA_REQUIRED_TOPK = 16
+_MSA_REQUIRED_HEAD_DIM = 128
+
+
+def require_msa_module():
+    """Lazy-import `fmha_sm100` and raise a clear error on failure.
+
+    Returns the imported module. The import is guarded so the MSA backend
+    can be advertised in the config schema even where MSA is not
+    installed; the error only fires when a sparse layer actually
+    dispatches the MSA path.
+    """
+    try:
+        import fmha_sm100  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - install-time error
+        raise RuntimeError(
+            "MiniMax-M3 MSA backend requires the external `fmha_sm100` "
+            "package (MSA: https://github.com/MiniMax-AI/MSA; not on "
+            "PyPI). Install it with `pip install "
+            "'git+https://github.com/MiniMax-AI/MSA.git'`, or unset "
+            "`sparse_use_msa` in the sparse attention config to fall "
+            "back to the Triton reference path."
+        ) from exc
+    return fmha_sm100
+
+
+# ---------------------------------------------------------------------------
+# Paged / flat-slot KV writers
+# ---------------------------------------------------------------------------
+
+
+def write_main_kv_slots(
+    cache: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    values: torch.Tensor,
+) -> None:
+    """Layout-aware writer for K (or V / index-K) caches.
+
+    Supports two layouts:
+
+      * 3-D flat-slot `[num_slots, num_heads, channel]`: index_copy_
+        writes propagate because the tensor is the storage (unit tests).
+      * 4-D paged `[num_pages, tokens_per_block, num_heads, channel]`: a
+        view of `kv_pool[:, 0]` / `kv_pool[:, 1]` (or the paged index-K
+        view). The view is non-contiguous, so index_copy_ would silently
+        fork a copy and lose the write; instead decompose the flat slot id
+        into (page, within) and use multi-dim fancy assignment so the
+        write propagates to the pool.
+    """
+    # KV-cache writes never need autograd; wrap in no_grad so callers with
+    # an active grad context (unit tests without inference_mode) do not
+    # trip the in-place autograd guard on the cache view chain.
+    with torch.no_grad():
+        if cache.ndim >= 4:
+            tokens_per_block = int(cache.shape[1])
+            out_long = out_cache_loc.to(torch.long)
+            page = out_long // tokens_per_block
+            within = out_long % tokens_per_block
+            cache[page, within] = values.to(cache.dtype)
+        else:
+            cache.index_copy_(0, out_cache_loc.to(torch.long), values.to(cache.dtype))
+
+
+# ---------------------------------------------------------------------------
+# MSA cache-layout adapters (pool NHD -> fmha_sm100 HND)
+# ---------------------------------------------------------------------------
+#
+# TRT-LLM's KVCacheManagerV2 stores the main K/V cache as a 5-D pool
+# [num_pages, kv_factor, tokens_per_block, num_kv_heads, head_dim] (NHD).
+# fmha_sm100 expects paged K/V tensors with layout
+# [num_pages, num_kv_heads, page_size, head_dim] (HND). The side index-K
+# cache is [num_slots, 1, sparse_index_dim] (flat) or the 4-D paged
+# variant [num_pages, tokens_per_block, 1, sparse_index_dim].
+#
+# The helpers below produce MSA-compatible views without mutating the
+# pool's storage; they permute and call .contiguous() once per call.
+
+
+def cache_view_to_msa_paged(cache_view: torch.Tensor) -> torch.Tensor:
+    """Convert `[num_pages, page_size, num_kv_heads, head_dim]` to HND.
+
+    A flat-slot 3-D cache (unit tests) is treated as a single virtual
+    page of size `num_slots`, giving `[1, num_kv_heads, num_slots,
+    head_dim]`. The side index-K cache shares this layout with a single
+    replicated head (`num_kv_heads == 1`), so it uses the same adapter.
+    """
+    if cache_view.dim() == 4:
+        return cache_view.permute(0, 2, 1, 3).contiguous()
+    if cache_view.dim() == 3:
+        return cache_view.permute(1, 0, 2).unsqueeze(0).contiguous()
+    raise ValueError(
+        f"Unsupported cache view rank {cache_view.dim()} for MSA paged conversion; "
+        f"expected 3 (flat-slot) or 4 (paged multi-dim)."
+    )
+
+
+def msa_paged_kv(kv_cache_manager, layer_idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-layer paged K/V in `fmha_sm100` HND layout.
+
+    Reads the coalesced K+V slot view from the KV cache manager and
+    converts each half to `[num_pages, num_kv_heads, page_size, head_dim]`.
+    """
+    buffers = kv_cache_manager.get_buffers(layer_idx)
+    return cache_view_to_msa_paged(buffers[:, 0]), cache_view_to_msa_paged(buffers[:, 1])
+
+
+def write_msa_main_kv(
+    kv_cache_manager,
+    layer_idx: int,
+    out_cache_loc: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> None:
+    """Write new-token K/V into the paged main cache at `out_cache_loc`.
+
+    `fmha_sm100` reads the paged cache directly, so (unlike the standard
+    C++ FMHA path) the new-token K/V must be written into the cache before
+    the sparse GQA runs.
+    """
+    buffers = kv_cache_manager.get_buffers(layer_idx)
+    k_view, v_view = buffers[:, 0], buffers[:, 1]
+    num_kv_heads = int(k_view.shape[2])
+    head_dim = int(k_view.shape[3])
+    num_tokens = int(k.shape[0])
+    write_main_kv_slots(k_view, out_cache_loc, k.reshape(num_tokens, num_kv_heads, head_dim))
+    write_main_kv_slots(v_view, out_cache_loc, v.reshape(num_tokens, num_kv_heads, head_dim))
+
+
+def build_kv_indices_and_lens(
+    metadata: "MiniMaxM3SparseAttentionMetadata",
+    page_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Build `kv_indices` and `kv_segment_lens` for `fmha_sm100`.
+
+    `kv_indices` is the flattened per-request page table
+    `concat([pages_of(seq_0), pages_of(seq_1), ...])` int32; a sequence's
+    pages come from `req_to_token[slot, ::page_size] // page_size`.
+    `kv_segment_lens` is the per-request effective KV length (already on
+    the cache device inside `metadata`).
+    """
+    device = metadata.req_to_token.device
+    slot_ids_long = metadata.slot_ids.to(torch.long)
+    req_rows = metadata.req_to_token.index_select(0, slot_ids_long).to(torch.long)
+    batch = int(req_rows.shape[0])
+    seq_lens_cpu = metadata.seq_lens_cpu.to(torch.long).tolist()
+
+    page_lists = []
+    for b in range(batch):
+        kv_len = int(seq_lens_cpu[b])
+        if kv_len <= 0:
+            continue
+        num_pages = (kv_len + page_size - 1) // page_size
+        # First slot of each page gives the global page id into the paged
+        # cache. Do NOT clamp to a per-request bound: block ids are
+        # global and non-contiguous in production, so clamping collapses
+        # the page table and corrupts the proxy FMHA reads.
+        page_starts = torch.arange(num_pages, device=device, dtype=torch.long) * page_size
+        page_ids = req_rows[b].gather(0, page_starts) // page_size
+        page_lists.append(page_ids.to(torch.int32))
+
+    if page_lists:
+        kv_indices = torch.cat(page_lists, dim=0)
+    else:
+        kv_indices = torch.empty(0, dtype=torch.int32, device=device)
+
+    return kv_indices, metadata.seq_lens.to(torch.int32)
+
+
+# ---------------------------------------------------------------------------
+# Block selection (per-query valid-block masking + torch top-k)
+# ---------------------------------------------------------------------------
+
+
+def per_token_valid_blocks(
+    qo_lens_cpu: torch.Tensor,
+    kv_lens_cpu: torch.Tensor,
+    qo_offset_cpu: Optional[torch.Tensor],
+    *,
+    causal: bool,
+    block_size: int,
+) -> torch.Tensor:
+    """Per-query number of valid KV blocks (causal-aware), on CPU.
+
+    Expands per-request lens/offsets to a per-token `[total_q]` tensor so
+    block selection can honour each query token's own causal extent.
+    """
+    qo = qo_lens_cpu.to(torch.long)
+    kv = kv_lens_cpu.to(torch.long)
+    batch = int(qo.shape[0])
+    total = int(qo.sum().item())
+    if total == 0:
+        return torch.zeros(0, dtype=torch.long)
+    batch_row = torch.repeat_interleave(torch.arange(batch, dtype=torch.long), qo)
+    starts = torch.zeros(batch, dtype=torch.long)
+    if batch > 1:
+        starts[1:] = torch.cumsum(qo, 0)[:-1]
+    intra = torch.arange(total, dtype=torch.long) - starts[batch_row]
+    kv_per = kv[batch_row]
+    if causal:
+        if qo_offset_cpu is not None:
+            off = qo_offset_cpu.to(torch.long)[batch_row]
+        else:
+            off = (kv - qo)[batch_row]
+        eff = torch.minimum(off + intra + 1, kv_per)
+    else:
+        eff = kv_per
+    return (eff + block_size - 1) // block_size
+
+
+def select_blocks_from_maxscore(
+    max_score_kv: torch.Tensor,
+    *,
+    topk: int,
+    n_valid_blocks: torch.Tensor,
+    init_blocks: int,
+    local_blocks: int,
+) -> torch.Tensor:
+    """Per-query block selection from per-KV-head block scores, in torch.
+
+    Mirrors the reference selection (init/local forced blocks, per-query
+    valid-block masking, top-k) on the amax-reduced per-KV-head scores
+    `[num_kv_heads, n_blocks, total_q]`. Returns `[total_q, num_kv_heads,
+    topk]` int32: ascending block indices with -1 tail padding.
+    """
+    num_kv_heads, n_blocks, total_q = max_score_kv.shape
+    device = max_score_kv.device
+    scores = max_score_kv.permute(2, 0, 1).to(torch.float32).clone()  # [q, kv, blk]
+    block_ids = torch.arange(n_blocks, device=device, dtype=torch.long)
+    nvb = n_valid_blocks.to(device=device, dtype=torch.long)  # [total_q]
+
+    if init_blocks > 0:
+        init_mask = block_ids.view(1, 1, -1) < init_blocks
+        scores = torch.where(init_mask, torch.full_like(scores, _INIT_SCORE), scores)
+    if local_blocks > 0:
+        local_start = (nvb - local_blocks).clamp_min(0)  # [total_q]
+        local_mask = (block_ids.view(1, -1) >= local_start.view(-1, 1)) & (
+            block_ids.view(1, -1) < nvb.view(-1, 1)
+        )  # [total_q, n_blocks]
+        scores = torch.where(local_mask.unsqueeze(1), torch.full_like(scores, _LOCAL_SCORE), scores)
+    # Per-query replacement for the kernel's scalar num_valid_pages clamp.
+    block_valid = block_ids.view(1, -1) < nvb.view(-1, 1)  # [total_q, n_blocks]
+    scores = scores.masked_fill(~block_valid.unsqueeze(1), float("-inf"))
+
+    k = min(topk, n_blocks)
+    vals, idx = scores.topk(k=k, dim=-1)  # [total_q, kv, k]
+    idx = torch.where(vals != float("-inf"), idx, torch.full_like(idx, -1))
+    sort_key = torch.where(idx < 0, torch.full_like(idx, n_blocks), idx)
+    sort_key, _ = torch.sort(sort_key, dim=-1)
+    idx = torch.where(sort_key >= n_blocks, torch.full_like(sort_key, -1), sort_key)
+    if k < topk:
+        pad = torch.full((total_q, num_kv_heads, topk - k), -1, dtype=idx.dtype, device=device)
+        idx = torch.cat([idx, pad], dim=-1)
+    return idx.to(torch.int32)
+
+
+__all__ = [
+    "_INIT_SCORE",
+    "_LOCAL_SCORE",
+    "_MSA_REQUIRED_HEAD_DIM",
+    "_MSA_REQUIRED_TOPK",
+    "build_kv_indices_and_lens",
+    "cache_view_to_msa_paged",
+    "msa_paged_kv",
+    "per_token_valid_blocks",
+    "require_msa_module",
+    "select_blocks_from_maxscore",
+    "write_main_kv_slots",
+    "write_msa_main_kv",
+]

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/decode_wrapper/__init__.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/decode_wrapper/__init__.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA-graph-safe decode wrapper for MiniMax-M3 sparse attention.
+
+Drives the external MSA (`fmha_sm100`) SM100 kernels with launch
+arguments assembled from device tensors, so decode steps can be captured
+into CUDA graphs and replayed correctly as sequence state advances.
+
+Public surface:
+
+* `M3DecodeGeometry`: compile/alloc-time geometry key for one layer family.
+* `M3DecodeState`: persistent decode buffers + compiled kernels, owned by
+  the attention metadata (no separate driver object).
+* `build_m3_decode_state` / `resolve_decode_state`: build the state (in the
+  metadata's `prepare()`) or return the one the metadata already owns.
+* `decode_proxy_max_score` / `decode_select_blocks` / `decode_sparse_attention`:
+  the proxy MQA, top-k block selection, and block-sparse GQA launches.
+"""
+
+from .dispatch import (
+    M3DecodeGeometry,
+    M3DecodeState,
+    build_m3_decode_state,
+    decode_proxy_max_score,
+    decode_select_blocks,
+    decode_sparse_attention,
+    resolve_decode_state,
+)
+
+__all__ = [
+    "M3DecodeGeometry",
+    "M3DecodeState",
+    "build_m3_decode_state",
+    "decode_proxy_max_score",
+    "decode_select_blocks",
+    "decode_sparse_attention",
+    "resolve_decode_state",
+]

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/decode_wrapper/dispatch.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/decode_wrapper/dispatch.py
@@ -1,0 +1,507 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Graph-safe decode kernels for MiniMax-M3 sparse attention.
+
+Replaces MSA's host-centric `fmha_sm100_plan` / `fmha_sm100` launch for
+the decode path while invoking the same JIT-compiled SM100 kernel
+binaries via `fmha_sm100.jit.get_fmha_variant`. MSA's plan bakes
+host-side values into the launch, which CUDA graph replays would freeze,
+so only the launch is replaced and the kernels are reused.
+
+The persistent buffers live in an `M3DecodeState` that the attention
+metadata builds once (outside capture) and owns, so their `data_ptr()`
+stays stable across CUDA graph replays. The kernel launches are the
+module-level `decode_*` functions that operate on that state.
+
+Design contract:
+
+* No plan/run split: every call assembles launch args directly.
+* Everything per-step-varying is a device tensor: `seq_lens`,
+  `kv_page_indptr`, `kv_indices`, `kv_block_indexes`, and the `max_score`
+  contents.
+* Host-baked values are geometry or per-batch-size constants only: head
+  counts, pack factor, page size, `max_k_tiles` capacity, and worklists
+  (a pure function of batch size for decode).
+* Every function is callable inside a CUDA graph capture and yields
+  correct results at replay: no `.item()`, `.cpu()`, or `.tolist()`.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from .topk import select_topk_blocks
+from .worklist import build_decode_worklist
+
+if TYPE_CHECKING:
+    from ..metadata import MiniMaxM3SparseConfig
+
+# Mirrors fmha_sm100.jit._PACK_FACTORS.
+_PACK_FACTORS = (1, 2, 4, 6, 8, 16)
+_QO_TILE_SIZE = 128
+_WORKSPACE_BYTES = 32 * 1024 * 1024
+
+
+def _compute_pack_factor(max_qo_len: int, num_qo_heads: int, num_kv_heads: int) -> int:
+    """Verbatim port of `fmha_sm100.api._compute_pack_factor`."""
+    if num_kv_heads == -1:
+        return 1
+    h_r = num_qo_heads // num_kv_heads
+    if h_r <= 1 or max_qo_len <= 0 or max_qo_len > 32:
+        return 1
+    max_pf = 128 // max_qo_len
+    for pf in reversed(_PACK_FACTORS):
+        if pf <= max_pf and pf <= h_r and h_r % pf == 0:
+            return pf
+    return 1
+
+
+def _max_k_tiles_capacity(max_kv_len: int) -> int:
+    """MSA's `max_k_tiles` formula at max capacity.
+
+    Number of 128-token KV blocks rounded up to a multiple of 128 (the
+    kernel's max-score tile stride granularity).
+    """
+    return math.ceil(math.ceil(max_kv_len / 128) / 128) * 128
+
+
+@dataclass(frozen=True)
+class M3DecodeGeometry:
+    """Compile/alloc-time constants for one M3 layer family (per rank)."""
+
+    num_q_heads: int
+    num_kv_heads: int
+    num_index_heads: int
+    head_dim: int
+    page_size: int
+    topk: int
+    init_blocks: int
+    local_blocks: int
+    max_batch: int
+    max_kv_len: int
+
+    def __post_init__(self):
+        if self.head_dim != 128 or self.page_size != 128:
+            raise NotImplementedError(
+                "MSA SM100 decode kernels require head_dim=128 and page_size=128; "
+                f"got head_dim={self.head_dim}, page_size={self.page_size}."
+            )
+        if self.num_q_heads % self.num_kv_heads != 0:
+            raise ValueError("num_q_heads must be divisible by num_kv_heads")
+        if self.num_index_heads % self.num_kv_heads != 0:
+            raise ValueError("num_index_heads must be divisible by num_kv_heads")
+
+    @classmethod
+    def from_config(
+        cls,
+        config: "MiniMaxM3SparseConfig",
+        *,
+        max_batch: int,
+        max_kv_len: int,
+        page_size: Optional[int] = None,
+    ) -> "M3DecodeGeometry":
+        """Build the decode alloc-time key from the layer config.
+
+        Adds the two runtime dims the driver needs to size its buffers
+        (`max_batch`, `max_kv_len`). `page_size` defaults to `block_size`.
+        """
+        return cls(
+            num_q_heads=int(config.num_q_heads),
+            num_kv_heads=int(config.num_kv_heads),
+            num_index_heads=int(config.num_index_heads),
+            head_dim=int(config.head_dim),
+            page_size=int(config.block_size if page_size is None else page_size),
+            topk=int(config.topk),
+            init_blocks=int(config.init_blocks),
+            local_blocks=int(config.local_blocks),
+            max_batch=int(max_batch),
+            max_kv_len=int(max_kv_len),
+        )
+
+
+@dataclass
+class M3DecodeState:
+    """Persistent decode buffers and compiled kernels for one geometry.
+
+    Data only: the kernel launches are the module-level `decode_*`
+    functions below. The attention metadata builds this once (outside
+    capture) and owns it, so every persistent buffer keeps a stable
+    `data_ptr()` across CUDA graph replays. Per-call views are prefix or
+    strided views of these buffers.
+    """
+
+    geom: M3DecodeGeometry
+    device: torch.device
+    pf_proxy: int
+    heads_packed_proxy: int
+    pf_sparse: int
+    heads_packed_sparse: int
+    max_k_tiles: int
+    num_ctas: int
+    proxy_module: object
+    sparse_module: object
+    workspace_buffer: torch.Tensor
+    max_score_flat: torch.Tensor
+    kv_block_indexes: torch.Tensor
+    out: torch.Tensor
+    kv_segment_offsets: torch.Tensor
+    valid_pages: torch.Tensor
+    qo_offset: torch.Tensor
+    # Per-batch-size host constants, built once per shape (outside capture,
+    # bounded by the distinct batch sizes seen: CUDA graph buckets + eager).
+    qo_const_cache: dict = field(default_factory=dict)
+    worklist_cache: dict = field(default_factory=dict)
+
+
+def build_m3_decode_state(geometry: M3DecodeGeometry, device: torch.device) -> M3DecodeState:
+    """Allocate the persistent decode buffers and compile the kernels.
+
+    Runs outside any CUDA graph capture (from the metadata's `prepare()`),
+    using the same JIT-compiled SM100 binaries as the MSA api path.
+    """
+    import fmha_sm100  # noqa: F401  (hard dependency of the decode kernels)
+    from fmha_sm100.jit import _dlpack_dtype_code, get_fmha_variant
+
+    g = geometry
+    # Pack factors and packed head counts (decode: qo_len == 1).
+    pf_proxy = _compute_pack_factor(1, g.num_index_heads, 1)
+    pf_sparse = _compute_pack_factor(1, g.num_q_heads, g.num_kv_heads)
+    max_k_tiles = _max_k_tiles_capacity(g.max_kv_len)
+    bf16_code = _dlpack_dtype_code(torch.bfloat16)
+    return M3DecodeState(
+        geom=g,
+        device=device,
+        pf_proxy=pf_proxy,
+        heads_packed_proxy=g.num_index_heads // pf_proxy,
+        pf_sparse=pf_sparse,
+        heads_packed_sparse=g.num_q_heads // pf_sparse,
+        max_k_tiles=max_k_tiles,
+        num_ctas=int(torch.cuda.get_device_properties(device).multi_processor_count),
+        # Proxy: OnlyScore (sparse_mode=2). Sparse GQA: Sparse (sparse_mode=0).
+        proxy_module=get_fmha_variant(
+            bf16_code, _QO_TILE_SIZE, True, 2, g.page_size, False, pf_proxy
+        ),
+        sparse_module=get_fmha_variant(
+            bf16_code, _QO_TILE_SIZE, True, 0, g.page_size, False, pf_sparse
+        ),
+        workspace_buffer=torch.empty(_WORKSPACE_BYTES, dtype=torch.uint8, device=device),
+        max_score_flat=torch.empty(
+            g.num_index_heads * max_k_tiles * g.max_batch, dtype=torch.float32, device=device
+        ),
+        kv_block_indexes=torch.full(
+            (g.max_batch, g.num_kv_heads, g.topk), -1, dtype=torch.int32, device=device
+        ),
+        out=torch.empty(
+            g.max_batch, g.num_q_heads, g.head_dim, dtype=torch.bfloat16, device=device
+        ),
+        kv_segment_offsets=torch.zeros(g.max_batch + 1, dtype=torch.int32, device=device),
+        valid_pages=torch.zeros(g.max_batch, dtype=torch.int32, device=device),
+        qo_offset=torch.zeros(g.max_batch, dtype=torch.int32, device=device),
+    )
+
+
+def resolve_decode_state(
+    m3_meta,
+    geometry: M3DecodeGeometry,
+    device: torch.device,
+) -> M3DecodeState:
+    """Return the decode state owning the CUDA-graph-stable buffers.
+
+    The attention metadata's `prepare()` builds and attaches the state as
+    `m3_meta.decode_state` (outside capture), so its buffers keep a stable
+    `data_ptr()` across replays. The eager and test paths may reach here
+    without one; there we build a per-call state and cache it on the
+    metadata for reuse.
+    """
+    state = getattr(m3_meta, "decode_state", None)
+    if state is not None and state.geom == geometry and state.device == device:
+        return state
+    state = build_m3_decode_state(geometry, device)
+    try:
+        m3_meta.decode_state = state
+    except AttributeError:
+        # Metadata forbids attribute assignment (e.g. a slotted/frozen
+        # test double); the eager path still works with a per-call state.
+        pass
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Cached per-batch-size constants (host work happens once per shape, outside
+# any capture; callers warm shapes up before capturing).
+# ---------------------------------------------------------------------------
+
+
+def _qo_consts(
+    state: M3DecodeState, batch: int, pack_factor: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """(qo_segment_lens, qo_segment_offsets) for packed decode lens."""
+    key = (batch, pack_factor)
+    cached = state.qo_const_cache.get(key)
+    if cached is None:
+        lens = torch.full((batch,), pack_factor, dtype=torch.int32, device=state.device)
+        offsets = (
+            (torch.arange(batch + 1, dtype=torch.int64) * pack_factor)
+            .to(torch.int32)
+            .to(state.device)
+        )
+        cached = (lens, offsets)
+        state.qo_const_cache[key] = cached
+    return cached
+
+
+def _worklist(
+    state: M3DecodeState, batch: int, num_packed_heads: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    key = (batch, num_packed_heads)
+    cached = state.worklist_cache.get(key)
+    if cached is None:
+        cached = build_decode_worklist(
+            batch_size=batch,
+            num_packed_heads=num_packed_heads,
+            num_ctas=state.num_ctas,
+            device=state.device,
+        )
+        state.worklist_cache[key] = cached
+    return cached
+
+
+def _kv_offsets_view(state: M3DecodeState, seq_lens: torch.Tensor, batch: int) -> torch.Tensor:
+    """Cumulative KV lengths into the persistent buffer (device op)."""
+    view = state.kv_segment_offsets[: batch + 1]
+    torch.cumsum(seq_lens, 0, dtype=torch.int32, out=view[1:])
+    return view
+
+
+def _qo_offset_view(state: M3DecodeState, seq_lens: torch.Tensor, batch: int) -> torch.Tensor:
+    """Per-request causal offset `kv_len - 1` (device op).
+
+    The kernel's causal bound is inclusive (attend positions
+    `<= offset + q_idx`); with one query token at position `kv_len - 1`
+    this unmasks exactly the `kv_len` cached positions. `kv_len` itself
+    would leak one stale slot from a partially-filled last page in sparse
+    mode, which has no secondary seqlen clip.
+    """
+    view = state.qo_offset[:batch]
+    torch.sub(seq_lens, 1, out=view)
+    return view
+
+
+# ---------------------------------------------------------------------------
+# Proxy MQA pass (indexer): per-KV-block max scores
+# ---------------------------------------------------------------------------
+
+
+def decode_proxy_max_score(
+    state: M3DecodeState,
+    idx_q: torch.Tensor,
+    idx_k_paged: torch.Tensor,
+    *,
+    seq_lens: torch.Tensor,
+    kv_page_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    sm_scale: float,
+) -> torch.Tensor:
+    """Dense MQA proxy pass, OnlyScore mode.
+
+    Parameters
+    ----------
+    idx_q : `[batch, num_index_heads, 128]` bf16 (decode: 1 token/req).
+    idx_k_paged : `[num_pages, 1, page_size, 128]` bf16 (HND).
+    seq_lens : `[batch]` int32 device; per-request KV length.
+    kv_page_indptr : `[batch + 1]` int32 device.
+    kv_indices : `[total_pages]` int32 device page table.
+    sm_scale : softmax scale (does not affect max-score ranking).
+
+    Returns
+    -------
+    `[num_index_heads, max_k_tiles, batch]` fp32 view into the persistent
+    max-score buffer; unwritten tiles are -inf.
+    """
+    g = state.geom
+    batch = idx_q.shape[0]
+    seq_lens = seq_lens[:batch]
+
+    max_score = torch.as_strided(
+        state.max_score_flat,
+        (g.num_index_heads, state.max_k_tiles, batch),
+        (state.max_k_tiles * batch, batch, 1),
+    )
+    max_score.fill_(float("-inf"))
+
+    qo_lens, qo_offsets = _qo_consts(state, batch, state.pf_proxy)
+    work_range, work_info = _worklist(state, batch, state.heads_packed_proxy)
+    kv_offsets = _kv_offsets_view(state, seq_lens, batch)
+    qo_offset = _qo_offset_view(state, seq_lens, batch)
+
+    state.proxy_module.run(
+        state.workspace_buffer,
+        idx_q,
+        idx_k_paged,
+        idx_k_paged,
+        qo_lens,
+        seq_lens,
+        qo_offsets,
+        kv_offsets,
+        work_range,
+        work_info,
+        None,  # out (OnlyScore)
+        float(sm_scale),
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        state.pf_proxy,  # max_qo_len after packing
+        qo_offset,  # kv_len - 1: inclusive causal bound = last cached pos
+        1,  # num_kv_splits
+        None,
+        None,
+        None,  # kv_tile_begin / end / split
+        None,
+        None,  # workspace_o / workspace_lse
+        None,  # num_kv_splits_per_row
+        _QO_TILE_SIZE,
+        kv_indices,
+        kv_page_indptr,
+        max_score,
+        state.max_k_tiles,
+        None,  # kv_block_indexes
+        state.pf_proxy,
+        True,  # qo_len_uniform
+        torch.cuda.current_stream().cuda_stream,
+    )
+    return max_score
+
+
+# ---------------------------------------------------------------------------
+# Top-k block selection (device-driven)
+# ---------------------------------------------------------------------------
+
+
+def decode_select_blocks(
+    state: M3DecodeState,
+    max_score: torch.Tensor,
+    *,
+    seq_lens: torch.Tensor,
+) -> torch.Tensor:
+    """Group-reduce index-head scores to KV heads and pick top-k blocks.
+
+    Returns `[batch, num_kv_heads, topk]` int32 view into the persistent
+    `kv_block_indexes` buffer.
+    """
+    g = state.geom
+    batch = max_score.shape[2]
+    seq_lens = seq_lens[:batch]
+
+    group = g.num_index_heads // g.num_kv_heads
+    if group > 1:
+        max_score_kv = max_score.view(g.num_kv_heads, group, max_score.shape[1], batch).amax(dim=1)
+    else:
+        max_score_kv = max_score
+
+    valid_pages = state.valid_pages[:batch]
+    torch.div(seq_lens + (g.page_size - 1), g.page_size, rounding_mode="floor", out=valid_pages)
+
+    out = state.kv_block_indexes[:batch]
+    return select_topk_blocks(
+        max_score_kv,
+        valid_pages,
+        topk=g.topk,
+        init_blocks=g.init_blocks,
+        local_blocks=g.local_blocks,
+        out=out,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sparse block-GQA main pass
+# ---------------------------------------------------------------------------
+
+
+def decode_sparse_attention(
+    state: M3DecodeState,
+    q: torch.Tensor,
+    k_paged: torch.Tensor,
+    v_paged: torch.Tensor,
+    kv_block_indexes: torch.Tensor,
+    *,
+    seq_lens: torch.Tensor,
+    kv_page_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    sm_scale: float,
+) -> torch.Tensor:
+    """Block-sparse paged GQA over the selected KV blocks.
+
+    Parameters
+    ----------
+    q : `[batch, num_q_heads, 128]` bf16.
+    k_paged / v_paged : `[num_pages, num_kv_heads, page_size, 128]` bf16.
+    kv_block_indexes : `[batch, num_kv_heads, topk]` int32 ascending,
+        -1 tail padded.
+    seq_lens / kv_page_indptr / kv_indices : as in `decode_proxy_max_score`.
+
+    Returns
+    -------
+    `[batch, num_q_heads, 128]` bf16 view into the persistent output buffer.
+    """
+    batch = q.shape[0]
+    seq_lens = seq_lens[:batch]
+
+    out = state.out[:batch]
+    qo_lens, qo_offsets = _qo_consts(state, batch, state.pf_sparse)
+    work_range, work_info = _worklist(state, batch, state.heads_packed_sparse)
+    kv_offsets = _kv_offsets_view(state, seq_lens, batch)
+    qo_offset = _qo_offset_view(state, seq_lens, batch)
+
+    state.sparse_module.run(
+        state.workspace_buffer,
+        q,
+        k_paged,
+        v_paged,
+        qo_lens,
+        seq_lens,
+        qo_offsets,
+        kv_offsets,
+        work_range,
+        work_info,
+        out,
+        float(sm_scale),
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        state.pf_sparse,  # max_qo_len after packing
+        qo_offset,  # kv_len - 1 (see _qo_offset_view)
+        1,  # num_kv_splits
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        _QO_TILE_SIZE,
+        kv_indices,
+        kv_page_indptr,
+        None,  # max_score
+        -1,  # max_k_tiles
+        kv_block_indexes,
+        state.pf_sparse,
+        True,  # qo_len_uniform
+        torch.cuda.current_stream().cuda_stream,
+    )
+    return out
+
+
+__all__ = [
+    "M3DecodeGeometry",
+    "M3DecodeState",
+    "build_m3_decode_state",
+    "resolve_decode_state",
+    "decode_proxy_max_score",
+    "decode_select_blocks",
+    "decode_sparse_attention",
+]

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/decode_wrapper/topk.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/decode_wrapper/topk.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Device-driven top-k KV-block selection for M3 sparse decode.
+
+Replaces `fmha_sm100.sparse_topk_select` on the decode path. The MSA
+kernel takes `num_valid_pages` as a single global host int (the max over
+the batch), which is both CUDA-graph-hostile (it varies per step) and
+imprecise for heterogeneous batches (the forced "local" window is
+anchored at the global last block instead of each row's own last valid
+block).
+
+This implementation reads per-row valid page counts from a device
+tensor, matching the in-tree Triton reference semantics: force the first
+`init_blocks` and last `local_blocks` valid blocks per row, mask invalid
+blocks, pick top-k, ascending indices, -1 tail padding. It stays pure
+torch ops and so is fully CUDA-graph-capturable.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+# Finite sentinel mirroring MSA's FLT_MAX forced-score marker; avoids
+# inf arithmetic edge cases in torch.topk.
+_FORCE_SCORE = torch.finfo(torch.float32).max
+# Sort key sentinel that pushes -1 (invalid) entries to the tail while
+# staying well inside int32.
+_PAD_KEY = 0x40000000
+
+
+def select_topk_blocks(
+    max_score_kv: torch.Tensor,
+    valid_pages: torch.Tensor,
+    *,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Select per-(token, kv-head) top-k KV block indices.
+
+    Parameters
+    ----------
+    max_score_kv : `[num_kv_heads, max_k_tiles, total_q]` float32.
+        Per-128-token-block max scores (already group-reduced to KV-head
+        granularity). Blocks beyond a row's valid count may hold any
+        value; they are masked here.
+    valid_pages : `[total_q]` int32/int64 device tensor.
+        Per-token count of valid KV blocks (`ceil(kv_len / page_size)`).
+    topk : number of blocks to select (M3: 16).
+    init_blocks : always include blocks `[0, init_blocks)`.
+    local_blocks : always include blocks `[valid - local_blocks, valid)`
+        (per row).
+    out : optional `[total_q, num_kv_heads, topk]` int32 buffer.
+
+    Returns
+    -------
+    `[total_q, num_kv_heads, topk]` int32, ascending block indices, -1
+    padded at the tail (the sparse FMHA kernel's `kv_block_indexes`
+    contract).
+    """
+    num_kv_heads, max_k_tiles, total_q = max_score_kv.shape
+    if max_k_tiles < topk:
+        raise ValueError(f"max_k_tiles ({max_k_tiles}) must be >= topk ({topk})")
+
+    scores = max_score_kv.permute(2, 0, 1)  # [total_q, H_kv, K]
+    k_idx = torch.arange(max_k_tiles, device=scores.device, dtype=torch.int64)
+    valid = valid_pages.to(torch.int64).view(total_q, 1, 1)
+
+    forced = k_idx < init_blocks
+    if local_blocks > 0:
+        forced = forced | ((k_idx >= valid - local_blocks) & (k_idx < valid))
+    else:
+        forced = forced.expand(total_q, 1, max_k_tiles)
+
+    scores = torch.where(forced, scores.new_full((), _FORCE_SCORE), scores)
+    scores = torch.where(k_idx >= valid, scores.new_full((), float("-inf")), scores)
+
+    top_scores, top_idx = torch.topk(scores, topk, dim=-1)
+    # Rows with fewer than topk valid blocks pick -inf slots: pad them.
+    top_idx = torch.where(top_scores == float("-inf"), -1, top_idx)
+
+    # Ascending by block index with -1 at the tail.
+    sort_key = torch.where(top_idx < 0, _PAD_KEY, top_idx)
+    sort_key, _ = torch.sort(sort_key, dim=-1)
+    result = torch.where(sort_key == _PAD_KEY, -1, sort_key).to(torch.int32)
+
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+__all__ = ["select_topk_blocks"]

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/decode_wrapper/worklist.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/decode_wrapper/worklist.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Static persistent-CTA worklists for the M3 sparse decode kernels.
+
+The MSA C++ SM100 FMHA kernel's `HostPrecomputedTileScheduler` walks a
+device worklist:
+
+* `packed_work_range[cta] = end << 32 | start`: the slice of
+  `packed_work_info` that CTA `cta` owns.
+* `packed_work_info[i] = qo_tile << 32 | (head & 0xFFFF) << 16 |
+  (batch & 0xFFFF)`: one (batch, packed-head, qo-tile) work item.
+
+MSA computes these with a device planner kernel parameterised by
+per-step KV lengths for load balancing. For decode (`qo_len == 1` per
+request, `num_kv_splits == 1`) the set of work items is a pure function
+of `(batch_size, num_packed_heads)`: KV lengths only affect which CTA
+runs which item, never whether an item exists, and each item reads its
+own KV bounds from device tensors at execution time. So the worklist is
+a per-batch-size constant: build it once on the host, keep it in a
+persistent device buffer, and CUDA graph replays stay correct for any KV
+lengths.
+
+Item order is batch-major then head; CTA assignment is contiguous chunks
+(equal cost per item is the decode regime). Per-item outputs are
+independent, so assignment differences from MSA's greedy planner change
+only load balance, not results.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+
+
+def build_decode_worklist(
+    *,
+    batch_size: int,
+    num_packed_heads: int,
+    num_ctas: int,
+    device: torch.device,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Build `(packed_work_range, packed_work_info)` for one decode shape.
+
+    Parameters
+    ----------
+    batch_size : number of requests (the work-item batch dim; for the
+        per-token-expanded sparse pass this equals `total_q`).
+    num_packed_heads : `num_qo_heads // pack_factor`, the head count the
+        kernel iterates after pack-GQA folding.
+    num_ctas : persistent grid width (SM count); also the length of
+        `packed_work_range`.
+    device : CUDA device for the returned buffers.
+
+    Returns
+    -------
+    (packed_work_range `[num_ctas]` int64, packed_work_info `[n]` int64)
+    with `n = batch_size * num_packed_heads` (every item has
+    `qo_tile == 0` because decode packs at most 128 q rows per tile).
+    """
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    if batch_size > 0xFFFF:
+        raise ValueError(f"batch_size {batch_size} exceeds the 16-bit work-item field")
+    if num_packed_heads <= 0 or num_packed_heads > 0xFFFF:
+        raise ValueError(f"num_packed_heads out of range: {num_packed_heads}")
+
+    n_items = batch_size * num_packed_heads
+
+    # Batch-major enumeration: item = b * H + h maps to head h, batch b.
+    batch_idx = torch.arange(n_items, dtype=torch.int64) // num_packed_heads
+    head_idx = torch.arange(n_items, dtype=torch.int64) % num_packed_heads
+    work_info = (head_idx << 16) | batch_idx  # qo_tile == 0
+
+    # Contiguous, maximally even split of [0, n_items) across CTAs.
+    # CTA c owns [c * n // C rounded, ...) via cumulative fair shares.
+    bounds = (torch.arange(num_ctas + 1, dtype=torch.int64) * n_items) // num_ctas
+    starts = bounds[:-1]
+    ends = bounds[1:]
+    work_range = (ends << 32) | starts
+
+    return work_range.to(device), work_info.to(device)
+
+
+__all__ = ["build_decode_worklist"]

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/indexer.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/indexer.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""MiniMax-M3 MSA sparse-attention indexer.
+
+Mirrors the DSA `Indexer` pattern: a submodule owned by the sparse
+backend that runs the predictor pass and produces the per-query selected
+KV block indices the main attention consumes. It calls `fmha_sm100`
+directly in `output_maxscore` mode (prefill) or the graph-safe in-tree
+decode kernels (`decode_wrapper.dispatch`, decode), reduces the
+per-index-head max score to KV-head granularity, and selects top-k blocks
+per query.
+
+Results are `[total_q, num_kv_heads, topk]` int32 (ascending, -1 padded),
+published on `forward_args.sparse_prediction.sparse_attn_indices` by the
+owning `sparse_attn_predict`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from .common import (
+    _MSA_REQUIRED_TOPK,
+    build_kv_indices_and_lens,
+    cache_view_to_msa_paged,
+    per_token_valid_blocks,
+    require_msa_module,
+    select_blocks_from_maxscore,
+)
+
+if TYPE_CHECKING:
+    from .metadata import MiniMaxM3SparseAttentionMetadata, MiniMaxM3SparseConfig
+
+
+def _proxy_max_score_direct(
+    idx_q: torch.Tensor,
+    idx_k_paged: torch.Tensor,
+    *,
+    qo_lens_cpu: torch.Tensor,
+    kv_lens_cpu: torch.Tensor,
+    qo_offset_cpu: Optional[torch.Tensor],
+    kv_indices: torch.Tensor,
+    sm_scale: float,
+    causal: bool,
+) -> torch.Tensor:
+    """Direct `fmha_sm100` MQA proxy pass (no Fmha-lib wrapper).
+
+    Follows MSA's two-call pattern: `fmha_sm100_plan` builds the plan with
+    `output_maxscore=True` and `num_kv_heads=1` (MQA), and `fmha_sm100`
+    runs with `output_o=False` so only the per-block max score is
+    materialized. Returns `[num_index_heads, max_k_tiles, total_q]`
+    float32.
+    """
+    fmha_sm100 = require_msa_module()
+
+    if idx_q.dim() != 3:
+        raise ValueError(
+            "MsaIndexer expects idx_q with shape [total_q, num_index_heads, head_dim]; "
+            f"got {tuple(idx_q.shape)}."
+        )
+    if idx_k_paged.dim() != 4 or idx_k_paged.shape[1] != 1:
+        raise ValueError(
+            "MsaIndexer expects MQA paged index-K [num_pages, 1, page_size, head_dim]; "
+            f"got {tuple(idx_k_paged.shape)}."
+        )
+
+    page_size = int(idx_k_paged.shape[2])
+    proxy_plan = fmha_sm100.fmha_sm100_plan(
+        qo_lens_cpu,
+        kv_lens_cpu,
+        idx_q.shape[1],  # num_index_heads (= num_qo_heads for the MQA proxy)
+        num_kv_heads=1,
+        qo_offset=qo_offset_cpu,
+        page_size=page_size,
+        output_maxscore=True,
+        causal=causal,
+        num_kv_splits=1,
+    )
+    _, max_score = fmha_sm100.fmha_sm100(
+        idx_q,
+        idx_k_paged,
+        idx_k_paged,  # v passthrough; proxy ignores V via output_o=False
+        proxy_plan,
+        kv_indices=kv_indices,
+        output_o=False,
+        output_maxscore=True,
+        sm_scale=sm_scale,
+    )
+    return max_score
+
+
+def _group_max_reduce(max_score: torch.Tensor, config: "MiniMaxM3SparseConfig") -> torch.Tensor:
+    """Reduce per-index-head max score to per-KV-head granularity (amax)."""
+    if config.num_index_heads % config.num_kv_heads != 0:
+        raise ValueError(
+            f"num_index_heads ({config.num_index_heads}) must be divisible by "
+            f"num_kv_heads ({config.num_kv_heads}) for MSA group-max reduction."
+        )
+    group = config.num_index_heads // config.num_kv_heads
+    if group > 1:
+        return max_score.view(
+            config.num_kv_heads, group, max_score.shape[1], max_score.shape[2]
+        ).amax(dim=1)
+    return max_score
+
+
+class MsaIndexer:
+    """Predictor submodule: proxy MQA and top-k block selection.
+
+    Owned by `MiniMaxM3MSATrtllmAttention`. Stateless: the decode path's
+    CUDA-graph-stable persistent buffers live in the attention metadata's
+    decode state (`m3_meta.decode_state`), built once in the metadata's
+    `prepare()` outside any capture.
+    """
+
+    def __init__(self, config: "MiniMaxM3SparseConfig"):
+        self.config = config
+
+    # prefill: eager, direct fmha_sm100
+
+    def select_blocks_prefill(
+        self,
+        idx_q: torch.Tensor,
+        idx_k_cache: torch.Tensor,
+        metadata: "MiniMaxM3SparseAttentionMetadata",
+        *,
+        idx_sm_scale: float,
+        qo_lens_cpu: torch.Tensor,
+        kv_lens_cpu: torch.Tensor,
+        qo_offset_cpu: Optional[torch.Tensor],
+        kv_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return `[total_q, num_kv_heads, topk]` selected block indices."""
+        config = self.config
+        idx_k_paged = cache_view_to_msa_paged(idx_k_cache)
+
+        max_score = _proxy_max_score_direct(
+            idx_q,
+            idx_k_paged,
+            qo_lens_cpu=qo_lens_cpu,
+            kv_lens_cpu=kv_lens_cpu,
+            qo_offset_cpu=qo_offset_cpu,
+            kv_indices=kv_indices,
+            sm_scale=idx_sm_scale,
+            causal=True,
+        )
+        max_score_kv = _group_max_reduce(max_score, config)
+
+        page_size = int(idx_k_paged.shape[2])
+        n_valid_blocks = per_token_valid_blocks(
+            qo_lens_cpu,
+            kv_lens_cpu,
+            qo_offset_cpu,
+            causal=True,
+            block_size=page_size,
+        )
+        if n_valid_blocks.numel() == 0 or int(n_valid_blocks.max().item()) <= 0:
+            return torch.full(
+                (idx_q.shape[0], config.num_kv_heads, _MSA_REQUIRED_TOPK),
+                -1,
+                dtype=torch.int32,
+                device=idx_q.device,
+            )
+        return select_blocks_from_maxscore(
+            max_score_kv,
+            topk=_MSA_REQUIRED_TOPK,
+            n_valid_blocks=n_valid_blocks,
+            init_blocks=config.init_blocks,
+            local_blocks=config.local_blocks,
+        )
+
+    # decode: CUDA-graph-safe in-tree driver
+
+    def select_blocks_decode(
+        self,
+        idx_q: torch.Tensor,
+        idx_k_cache: torch.Tensor,
+        metadata: "MiniMaxM3SparseAttentionMetadata",
+        *,
+        idx_sm_scale: float,
+        page_size: int,
+    ) -> torch.Tensor:
+        """Return `kv_block_indexes` via the graph-safe decode driver.
+
+        The driver runs the same `fmha_sm100` proxy binary and device-side
+        top-k with persistent buffers, so this path is CUDA-graph
+        capturable.
+        """
+        from .decode_wrapper.dispatch import (
+            M3DecodeGeometry,
+            decode_proxy_max_score,
+            decode_select_blocks,
+            resolve_decode_state,
+        )
+
+        config = self.config
+        idx_k_paged = cache_view_to_msa_paged(idx_k_cache)
+        batch = int(idx_q.shape[0])
+        seq_lens = metadata.seq_lens.to(torch.int32)
+
+        kv_indices = getattr(metadata, "msa_kv_indices", None)
+        if kv_indices is not None:
+            kv_page_indptr = metadata.msa_kv_page_indptr
+            max_batch = int(getattr(metadata, "msa_max_batch", 0) or 0)
+            max_kv_len = int(getattr(metadata, "msa_max_kv_len", 0) or 0)
+        else:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "MiniMax-M3 MSA decode reached the eager fallback during CUDA graph "
+                    "capture: metadata plan values were not pre-staged by prepare()."
+                )
+            kv_indices, _ = build_kv_indices_and_lens(metadata, page_size)
+            num_pages_cpu = (metadata.seq_lens_cpu.to(torch.long) + page_size - 1) // page_size
+            kv_page_indptr = torch.zeros(batch + 1, dtype=torch.int32)
+            kv_page_indptr[1:] = num_pages_cpu.to(torch.int32).cumsum(0)
+            kv_page_indptr = kv_page_indptr.to(idx_q.device, non_blocking=True)
+            max_batch = 0
+            max_kv_len = 0
+
+        if max_batch <= 0:
+            max_batch = max(64, 1 << (batch - 1).bit_length())
+        if max_kv_len <= 0:
+            max_kv_len = int(metadata.req_to_token.shape[1])
+
+        geometry = M3DecodeGeometry.from_config(
+            config,
+            max_batch=max_batch,
+            max_kv_len=max_kv_len,
+            page_size=page_size,
+        )
+        state = resolve_decode_state(metadata, geometry, idx_q.device)
+        max_score = decode_proxy_max_score(
+            state,
+            idx_q,
+            idx_k_paged,
+            seq_lens=seq_lens,
+            kv_page_indptr=kv_page_indptr,
+            kv_indices=kv_indices,
+            sm_scale=idx_sm_scale,
+        )
+        return decode_select_blocks(state, max_score, seq_lens=seq_lens)
+
+
+__all__ = ["MsaIndexer"]

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/metadata.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/metadata.py
@@ -27,7 +27,178 @@ from typing import List, Literal, Optional, Tuple
 
 import torch
 
+from tensorrt_llm.logger import logger
+
 from ..params import SparseParams
+
+# ---------------------------------------------------------------------------
+# MSA per-rank geometry and CUDA-graph-stable paged-KV table staging
+# ---------------------------------------------------------------------------
+
+# The per-rank sparse geometry needed to stage the MSA plans is the
+# layer-invariant `MiniMaxM3SparseConfig`. There is no separate geometry
+# struct: the config is the single source of truth, and the decode driver
+# derives its own alloc-time key (`M3DecodeGeometry`) from it.
+
+_GLOBAL_MSA_GEOMETRY: Optional["MiniMaxM3SparseConfig"] = None
+
+
+def set_global_msa_geometry(geometry: "MiniMaxM3SparseConfig") -> None:
+    """Register the per-rank M3 sparse config process-wide.
+
+    Called from the attention layer's constructor, before any forward and
+    so before any CUDA graph capture. Every metadata instance's prepare()
+    reads this to pre-build the MSA plans; registering at construction
+    ensures graph-capture metadata has a config and does not fall back to
+    in-forward planning that would freeze host values into each replay.
+
+    All sparse layers on a rank share one config; the first writer wins.
+    """
+    global _GLOBAL_MSA_GEOMETRY
+    if _GLOBAL_MSA_GEOMETRY is None:
+        _GLOBAL_MSA_GEOMETRY = geometry
+        logger.info("MiniMax-M3: using MSA (fmha_sm100) sparse attention kernels.")
+
+
+def get_global_msa_geometry() -> Optional["MiniMaxM3SparseConfig"]:
+    return _GLOBAL_MSA_GEOMETRY
+
+
+def build_stable_kv_indices(
+    *,
+    req_to_token: torch.Tensor,
+    slot_ids: torch.Tensor,
+    seq_lens: torch.Tensor,
+    seq_lens_cpu: torch.Tensor,
+    page_size: int,
+    dst: torch.Tensor,
+    kv_page_indptr_dst: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute the flat paged-KV page table into `dst`.
+
+    Computes the page table with vectorized ops into a preallocated
+    buffer whose `data_ptr()` is stable under CUDA graph replay.
+
+    Parameters
+    ----------
+    req_to_token : `[max_reqs, max_kv_len]` int32 on cache device.
+    slot_ids : `[batch]` int32 on cache device; `req_to_token` row
+        indices for the current batch.
+    seq_lens : `[batch]` int32 on cache device; per-request effective KV
+        length.
+    seq_lens_cpu : `[batch]` int32 or int64 on CPU; same values, used for
+        the CPU-side sizing math so we do not force a D2H sync.
+    page_size : int, must equal the `req_to_token` block width (the M3 KV
+        cache manager enforces this).
+    dst : preallocated int32 buffer sized `>= max_batch * max_pages`. The
+        output `kv_indices` view is `dst[:total_pages]`.
+    kv_page_indptr_dst : preallocated int32 buffer sized `>= batch + 1`.
+        The output `kv_page_indptr` view is `kv_page_indptr_dst[:batch+1]`.
+
+    Returns
+    -------
+    (kv_indices, kv_page_indptr) as views into `dst` / `kv_page_indptr_dst`.
+    Their `data_ptr()` is stable across calls because they alias the
+    destination buffers.
+    """
+    device = req_to_token.device
+    batch = int(seq_lens_cpu.shape[0])
+    max_kv_len = int(req_to_token.shape[1])
+    max_pages_per_seq = max_kv_len // page_size
+
+    if batch == 0:
+        return dst[:0], kv_page_indptr_dst[:1].zero_()
+
+    # Number of pages per request: ceil(seq_len / page_size). Do it on
+    # CPU so kv_page_indptr can be prepared as ints for the row/col
+    # gather without triggering a D2H sync on seq_lens.
+    seq_lens_cpu_long = seq_lens_cpu.to(torch.long).cpu()
+    num_pages_cpu = (seq_lens_cpu_long + page_size - 1) // page_size
+    num_pages_cpu = num_pages_cpu.clamp_min(0)
+    total_pages = int(num_pages_cpu.sum().item())
+    if total_pages > int(dst.shape[0]):
+        raise RuntimeError(
+            f"MSA kv_indices persistent buffer too small: capacity {int(dst.shape[0])} "
+            f"< total pages {total_pages}. Increase max_kv_indices on allocate()."
+        )
+
+    # Build kv_page_indptr on CPU then copy the prefix into the
+    # persistent buffer. Values are per-batch cumulative page counts,
+    # starting at 0.
+    kv_page_indptr_cpu = torch.empty(batch + 1, dtype=torch.int32)
+    kv_page_indptr_cpu[0] = 0
+    kv_page_indptr_cpu[1:].copy_(num_pages_cpu.to(torch.int32).cumsum(0))
+    kv_page_indptr_dst[: batch + 1].copy_(
+        kv_page_indptr_cpu.to(device=device, non_blocking=True), non_blocking=True
+    )
+
+    # Vectorized page-index gather:
+    #   req_rows = req_to_token[slot_ids] gives [batch, max_kv_len] slot
+    #   ids. For each request b, valid pages are indices 0..num_pages[b]-1;
+    #   the p-th page's first-slot column is p * page_size, and its page
+    #   id is req_rows[b, p*page_size] // page_size. We build a max-sized
+    #   (batch, max_pages_per_seq) grid, gather with clamped column
+    #   indices, then mask trailing invalid pages before packing into dst.
+    slot_ids_long = slot_ids.to(torch.long)
+    req_rows = req_to_token.index_select(0, slot_ids_long).to(torch.long)
+
+    max_valid_pages = max(1, max_pages_per_seq)
+    pages_grid = torch.arange(max_valid_pages, device=device, dtype=torch.long)
+    # Column index of the first slot of page p: p * page_size, clamped to
+    # max_kv_len - 1 for out-of-range pages so the gather does not fault.
+    # Out-of-range page ids are trimmed by the batch mask below.
+    col_idx = (pages_grid * page_size).clamp_max(max(0, max_kv_len - 1))
+    # Broadcast to [batch, max_pages_per_seq].
+    col_idx_b = col_idx.unsqueeze(0).expand(batch, -1)
+    # The gathered values are global page ids into the paged cache.
+    # req_rows holds valid slot ids by construction, so no value clamp is
+    # applied: clamping to the per-request page count would collapse the
+    # page table for any request whose global page ids exceed that count
+    # and corrupt every request after the first.
+    gathered = (req_rows.gather(1, col_idx_b) // page_size).to(torch.int32)
+
+    # Build a valid-page mask per request:
+    #   mask[b, p] = p < num_pages[b]
+    num_pages_dev = num_pages_cpu.to(device=device, dtype=torch.long, non_blocking=True)
+    mask = pages_grid.unsqueeze(0) < num_pages_dev.unsqueeze(1)  # [batch, max_pages_per_seq]
+
+    # Compact into the flat dst prefix using boolean indexing.
+    # torch.masked_select preserves row-major (batch, page) order, which
+    # matches the concat([pages_of(seq_0), pages_of(seq_1), ...]) layout
+    # kv_page_indptr encodes.
+    packed = torch.masked_select(gathered, mask)
+    dst[:total_pages].copy_(packed, non_blocking=True)
+
+    return dst[:total_pages], kv_page_indptr_dst[: batch + 1]
+
+
+def whole_batch_qo_lens(
+    m3_meta: "MiniMaxM3SparseAttentionMetadata",
+) -> Optional[Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]]:
+    """Per-request `(qo_lens_cpu, kv_lens_cpu, qo_offset_cpu)` for the whole batch.
+
+    Single source of truth for the CPU length/offset derivation shared by
+    the plan staging (`_build_msa_plans_for_metadata`) and the eager
+    whole-batch fallback (`msa_backend._whole_batch_lens`): prefill reads
+    the extend lengths and prefix offsets; decode is one query token per
+    request at position `kv_len - 1`. `kv_lens_cpu` is the per-request
+    effective KV length (int32, CPU).
+
+    Returns ``None`` when prefill metadata is incomplete (missing
+    `extend_seq_lens_cpu` / `prefix_lens`) so callers can choose to skip
+    staging or raise.
+    """
+    seq_lens_cpu = m3_meta.seq_lens_cpu.to(torch.int32)
+    if m3_meta.is_prefill:
+        if m3_meta.extend_seq_lens_cpu is None or m3_meta.prefix_lens is None:
+            return None
+        qo_lens_cpu = torch.tensor(m3_meta.extend_seq_lens_cpu, dtype=torch.int32)
+        qo_offset_cpu = m3_meta.prefix_lens.detach().to(device="cpu", dtype=torch.int32)
+    else:
+        batch = int(seq_lens_cpu.shape[0])
+        qo_lens_cpu = torch.ones(batch, dtype=torch.int32)
+        qo_offset_cpu = (seq_lens_cpu - 1).to(torch.int32)
+    return qo_lens_cpu, seq_lens_cpu, qo_offset_cpu
 
 
 @dataclass(frozen=True)
@@ -36,6 +207,13 @@ class MiniMaxM3SparseParams(SparseParams):
 
     algorithm: Literal["minimax_m3"] = field(init=False, default="minimax_m3")
     num_index_heads: int = 4
+    # Sparse index heads paired with each KV head
+    # (index_group = num_index_heads_global // num_kv_heads_global). Under
+    # TP a rank holding KV heads `[s, e)` scores with index heads
+    # `[s*index_group, e*index_group)`. `None` means "derive from the
+    # per-rank KV head count" (single-GPU / tests, where per-rank equals
+    # global).
+    index_group: Optional[int] = None
     sparse_index_dim: int = 128
     block_size: int = 128
     topk: int = 16
@@ -43,6 +221,24 @@ class MiniMaxM3SparseParams(SparseParams):
     local_blocks: int = 1
     score_type: str = "max"
     disable_index_value: bool = True
+    # When True, the layer dispatches the sparse forward through the
+    # MSA-backed FMHA runtime (`fmha_sm100` + `sparse_topk_select`)
+    # instead of the in-tree Triton + SDPA reference path. The MSA stack
+    # is only available on SM100 and requires the external
+    # `fmha_sm100` package; the layer raises a descriptive error if
+    # it is requested without those preconditions met.
+    use_msa: bool = False
+
+    @property
+    def indices_block_size(self) -> int:
+        """Block granularity of the sparse attention indices.
+
+        `TrtllmAttention.forward` reads this off the sparse params to
+        stamp `forward_args.sparse_prediction.sparse_attn_indices_block_size`.
+        For MiniMax-M3 the per-query selected indices are KV *block* indices,
+        so the granularity is the sparse block size.
+        """
+        return self.block_size
 
 
 @dataclass(frozen=True)
@@ -109,12 +305,32 @@ class MiniMaxM3SparseConfig:
     ) -> "MiniMaxM3SparseConfig":
         """Build a kernel param bundle from lowered ``MiniMaxM3SparseParams``
         and the per-rank model geometry.
+
+        The per-rank index-head count is `index_group` heads per local KV
+        head, so index head `i` stays paired with KV head `i` under TP
+        (the model layer slices `idx_q` with the matching offsets; see
+        `modeling_minimaxm3.py`). Selecting blocks from all index heads'
+        scores would give every KV head the union/max over all index heads
+        instead of its own head's top-k.
         """
+        index_group = sparse_params.index_group
+        if index_group is None:
+            # Single-GPU / tests: per-rank KV heads equal the global count.
+            if int(sparse_params.num_index_heads) % int(num_kv_heads) != 0:
+                raise ValueError(
+                    f"num_index_heads ({sparse_params.num_index_heads}) must be "
+                    f"divisible by num_kv_heads ({num_kv_heads})"
+                )
+            index_group = int(sparse_params.num_index_heads) // int(num_kv_heads)
+        index_group = int(index_group)
+        # Per-rank KV heads never exceed the global count, so this is just
+        # index_group heads per local KV head.
+        num_index_heads_local = index_group * int(num_kv_heads)
         return cls(
             num_q_heads=int(num_q_heads),
             num_kv_heads=int(num_kv_heads),
             head_dim=int(head_dim),
-            num_index_heads=int(sparse_params.num_index_heads),
+            num_index_heads=num_index_heads_local,
             sparse_index_dim=int(sparse_params.sparse_index_dim),
             block_size=int(sparse_params.block_size),
             topk=int(sparse_params.topk),
@@ -128,61 +344,17 @@ class MiniMaxM3SparseConfig:
 class MiniMaxM3SparseAttentionMetadata:
     """Per-forward metadata for MiniMax-M3 sparse attention.
 
-    Mirrors the shape of SGLang's
-    :class:`MiniMaxSparseAttnBackend`-side metadata but is constructed
-    from the paged-cache view that :class:`KVCacheManagerV2` exposes:
+    Built from the paged-cache view `KVCacheManagerV2` exposes
+    (`req_to_token[req_idx, pos] -> slot_id` plus `slot_ids[batch_idx]`).
+    `prepare()` fills the CUDA-graph-safe scalars `max_seqlen_q` /
+    `max_seqlen_k` and, for prefill, the `q_batch_row` / `q_positions`
+    tensors.
 
-      * ``req_to_token[req_idx, pos] -> slot_id``
-      * ``slot_ids[batch_idx]``  -- which ``req_to_token`` row the
-        ``batch_idx``-th sequence in this forward corresponds to.
-
-    Fields
-    ------
-    is_prefill : bool
-        ``True`` routes through the *extend* kernel
-        (``minimax_m3_sparse_prefill``), which handles both pure
-        prefill AND mixed prefill+decode batches — decode rows in a
-        mixed batch appear as 1-slot extends (``extend_seq_len=1``,
-        ``prefix_len=num_cached``).
-        ``False`` is a perf-only specialization for pure-decode
-        batches (``num_contexts == 0``); it is mathematically
-        equivalent to the ``True`` path with
-        ``extend_seq_len=[1]*batch``. See
-        ``test_iter131_metadata_prepare_mixed_batch_uses_extend_path``.
-    req_to_token : torch.Tensor
-        Paged ``[max_reqs, max_kv_len]`` int32 mapping from
-        ``(req_idx, pos)`` to slot index. Shared across layers.
-    slot_ids : torch.Tensor
-        ``[batch_size]`` int32 mapping from ``batch_idx`` to
-        ``req_to_token`` row index.
-    seq_lens : torch.Tensor
-        ``[batch_size]`` int32 total K length per sequence (prefix +
-        current chunk, or full context for decode).
-    prefix_lens : torch.Tensor or None
-        ``[batch_size]`` int32 prefix length per sequence; required for
-        prefill, ignored for decode.
-    cu_seqlens_q : torch.Tensor or None
-        ``[batch_size + 1]`` int32 cumulative Q-length offsets; required
-        for prefill, ignored for decode.
-    seq_lens_cpu : torch.Tensor
-        CPU mirror of ``seq_lens`` used by :meth:`prepare` to compute
-        :attr:`max_seqlen_k` without a GPU sync.
-    extend_seq_lens_cpu : list[int] or None
-        Per-sequence Q-length list (CPU) used by :meth:`prepare` to
-        compute :attr:`max_seqlen_q` for prefill without a GPU sync.
-        Ignored for decode (decode always has 1 Q token / sequence).
-    q_batch_row : torch.Tensor or None
-        ``[total_q_tokens]`` int32, only meaningful for prefill: for
-        each Q token, which batch row it belongs to. Built by
-        :meth:`prepare` from ``cu_seqlens_q``.
-    q_positions : torch.Tensor or None
-        ``[total_q_tokens]`` int32, only meaningful for prefill: each
-        Q token's K-side position (prefix_lens[b] + offset). Built by
-        :meth:`prepare` from ``cu_seqlens_q`` and ``prefix_lens``.
-    max_seqlen_q : int
-        Populated by :meth:`prepare`. CUDA-graph safe scalar.
-    max_seqlen_k : int
-        Populated by :meth:`prepare`. CUDA-graph safe scalar.
+    `is_prefill=True` routes through the extend kernel, which handles both
+    pure prefill and mixed prefill+decode batches (decode rows appear as
+    1-slot extends). `is_prefill=False` is a perf-only specialization for
+    pure-decode batches, mathematically equivalent to the extend path with
+    `extend_seq_len=[1]*batch`.
     """
 
     is_prefill: bool
@@ -197,6 +369,16 @@ class MiniMaxM3SparseAttentionMetadata:
     q_positions: Optional[torch.Tensor] = None
     max_seqlen_q: int = field(default=1)
     max_seqlen_k: int = field(default=1)
+    # MSA per-step plan values, written by `_build_msa_plans_for_metadata`
+    # when the KV cache manager has `use_msa=True` (None on the Triton
+    # path). The MSA decode kernels read them directly off this metadata.
+    msa_kv_indices: Optional[torch.Tensor] = None
+    msa_kv_page_indptr: Optional[torch.Tensor] = None
+    msa_qo_lens_cpu: Optional[torch.Tensor] = None
+    msa_kv_lens_cpu: Optional[torch.Tensor] = None
+    msa_qo_offset_cpu: Optional[torch.Tensor] = None
+    msa_max_batch: int = 0
+    msa_max_kv_len: int = 0
 
     def prepare(self) -> None:
         """Compute CUDA-graph-safe scalar max lengths from CPU tensors.
@@ -306,18 +488,6 @@ def ensure_metadata_on_device(
     )
 
 
-def replace_metadata(
-    metadata: MiniMaxM3SparseAttentionMetadata,
-    **changes,
-) -> MiniMaxM3SparseAttentionMetadata:
-    """Helper around :func:`dataclasses.replace` for ``metadata``.
-
-    Provided so callers can build a decode metadata from a prefill
-    metadata without manually re-typing every field.
-    """
-    return dataclasses.replace(metadata, **changes)
-
-
 def allocate_minimax_m3_static_buffers(
     *,
     max_num_sequences: int,
@@ -327,28 +497,17 @@ def allocate_minimax_m3_static_buffers(
 ) -> dict:
     """Allocate persistent per-graph buffers for MiniMax-M3 metadata.
 
-    Under CUDA-graph capture/replay every tensor the captured kernels
-    read must keep the same ``data_ptr()`` across replays. The default
-    :func:`build_runtime_metadata_from_kv_manager` path allocates fresh
-    tensors per call, which silently breaks graph replay: the captured
-    kernel keeps reading from the warmup tensor's freed memory, so the
-    enabled-graph run either produces wrong tokens (numerical drift) or
-    crashes inside ``index_select`` when the stale memory contains
-    out-of-bounds indices (``Indexing.cu:1515`` ``srcIndex <
-    srcSelectDimSize`` assert).
+    Under CUDA-graph replay every tensor the captured kernels read must
+    keep the same `data_ptr()`. Fresh per-call allocations break this: the
+    captured kernel reads freed warmup memory, producing wrong tokens or an
+    out-of-bounds `index_select` (`Indexing.cu:1515` `srcIndex <
+    srcSelectDimSize`). `build_runtime_metadata_from_kv_manager` writes
+    per-call values into these buffers in place via `.copy_()`.
 
-    The buffers returned here are sized for the largest batch the
-    captured graph will ever see: ``max_num_sequences`` requests with
-    up to ``max_kv_len`` cache slots, plus ``max_num_tokens`` total Q
-    tokens. They live on ``device`` so the forward path consumes them
-    without any device migration. ``build_runtime_metadata_from_kv_manager``
-    writes per-call values into these buffers in-place via ``.copy_()``
-    so the captured graph always sees the same addresses.
-
-    Returns a dict carrying the persistent tensors plus the geometry
-    parameters used at allocation time; callers compare those parameters
-    on subsequent prepare() calls to detect a geometry change (which
-    would be a workflow bug under fixed-batch CUDA graph).
+    The buffers are sized for the largest batch the graph will see
+    (`max_num_sequences` requests, `max_kv_len` cache slots, `max_num_tokens`
+    Q tokens) and live on `device`. The returned dict also carries the
+    allocation-time geometry so callers can detect a geometry change.
     """
     if max_num_sequences <= 0:
         raise ValueError("max_num_sequences must be positive")
@@ -405,6 +564,63 @@ def allocate_minimax_m3_static_buffers(
     }
 
 
+def m3_cache_device(meta) -> torch.device:
+    """Device hosting the paged KV buffers, else the current CUDA device.
+
+    Shared by both M3 metadata classes and the plan builder so the
+    cache-device probe lives in one place.
+    """
+    kv_cache_manager = meta.kv_cache_manager
+    if kv_cache_manager is not None:
+        try:
+            return kv_cache_manager.get_buffers(0).device
+        except Exception:
+            pass
+    return torch.device(f"cuda:{torch.cuda.current_device()}")
+
+
+def maybe_build_static_buffers_placeholder(
+    meta,
+    cache_device: torch.device,
+) -> Optional[dict]:
+    """Return the persistent M3 buffer dict when CUDA-graph stability is needed.
+
+    Shared by both M3 attention-metadata classes (the Triton
+    :class:`MiniMaxM3AttentionMetadata` and the MSA
+    ``MiniMaxM3MSATrtllmAttentionMetadata``). Manages ``meta._m3_static_buffers``
+    in place and returns:
+
+      * ``None`` when static buffers are not needed (eager-only paths that
+        rely on per-call allocations), OR
+      * a placeholder dict (only capacity hints) on first use, which
+        :func:`build_runtime_metadata_from_kv_manager` lazily fills with the
+        real persistent tensors once the current step's geometry is known,
+        OR
+      * the already-allocated buffer dict on subsequent steps.
+
+    Static buffers are used when either ``is_cuda_graph`` is set (captured
+    graph needs stable ``data_ptr()`` across replays) or a previous
+    prepare() already allocated them (so the algorithm keeps seeing the
+    same addresses when the engine alternates eager warmup and graph
+    replay).
+    """
+    existing = getattr(meta, "_m3_static_buffers", None)
+    need_static = bool(meta.is_cuda_graph) or existing is not None
+    if not need_static:
+        return None
+    if existing is not None and existing.get("device") == cache_device:
+        return existing
+
+    max_num_sequences_hint = int(meta.max_num_sequences or meta.max_num_requests)
+    placeholder: dict = {
+        "device": cache_device,
+        "max_num_sequences_hint": max_num_sequences_hint,
+        "max_num_tokens_hint": int(meta.max_num_tokens or max_num_sequences_hint),
+    }
+    meta._m3_static_buffers = placeholder
+    return placeholder
+
+
 def build_runtime_metadata_from_kv_manager(
     *,
     kv_cache_manager,
@@ -417,40 +633,19 @@ def build_runtime_metadata_from_kv_manager(
     device: Optional[torch.device] = None,
     static_buffers: Optional[dict] = None,
 ) -> Tuple[MiniMaxM3SparseAttentionMetadata, torch.Tensor]:
-    """Build a :class:`MiniMaxM3SparseAttentionMetadata` from a real
-    :class:`MiniMaxM3KVCacheManagerV2`.
+    """Build a `MiniMaxM3SparseAttentionMetadata` from a real
+    `MiniMaxM3KVCacheManagerV2`.
 
-    Returns the populated metadata plus an ``out_cache_loc`` tensor
-    ``[num_new_tokens]`` listing the per-new-token slot ids the caller
-    must write the projected K/V/idx_K to before calling the algorithm.
+    Returns the metadata plus an `out_cache_loc` tensor `[num_new_tokens]`
+    of the per-new-token slot ids the caller must write K/V/idx_K to. The
+    `req_to_token[req_idx, pos] -> slot_id` view is built by expanding each
+    of `get_block_ids_per_seq(request_ids)`'s block ids into a contiguous
+    range of `tokens_per_block` slot ids.
 
-    The slot view of the paged main K/V cache is built by combining
-    ``kv_cache_manager.get_block_ids_per_seq(request_ids)`` (per-request
-    block ids in order) with the configured ``tokens_per_block`` to
-    expand each block id into a contiguous range of ``tokens_per_block``
-    slot ids. The resulting ``req_to_token[req_idx, pos] -> slot_id``
-    matches the main cache's per-token addressing exactly.
-
-    ``device`` selects the placement of the returned tensors. Default
-    is ``seq_lens.device`` so existing callers (focused tests) keep
-    their behaviour; the production
-    :class:`MiniMaxM3AttentionMetadata.prepare` path passes the cache
-    device explicitly so the forward never needs a CPU->GPU copy.
-
-    ``static_buffers`` is the CUDA-graph-stable buffer dict produced by
-    :func:`allocate_minimax_m3_static_buffers`. When provided, this
-    function writes every per-call tensor into the persistent buffers
-    in-place (via ``.copy_()`` / slice assignment) and returns metadata
-    pointing into those persistent buffers. That keeps ``data_ptr()``
-    constant across replays, which is the contract the CUDA graph
-    runner expects. When omitted, the function falls back to fresh
-    per-call allocations (preserves existing focused-test behaviour).
-
-    This helper is the integration glue between the
-    pyexecutor-driven runtime metadata and the MiniMax-M3
-    algorithm's metadata shape. Tests can call it directly to verify
-    the end-to-end runtime path without going through the full LLM
-    forward.
+    `device` places the returned tensors (default `seq_lens.device`). When
+    `static_buffers` is provided, per-call values are written into those
+    persistent buffers in place so `data_ptr()` stays constant across CUDA
+    graph replays; otherwise fresh tensors are allocated per call.
     """
     tokens_per_block = int(kv_cache_manager.tokens_per_block)
     # block_ids_per_seq is a [batch_size, max_blocks_per_seq] tensor; row b
@@ -674,232 +869,236 @@ def build_runtime_metadata_from_kv_manager(
     return meta, out_cache_loc
 
 
+def _build_msa_plans_for_metadata(
+    *,
+    m3_meta: "MiniMaxM3SparseAttentionMetadata",
+    geometry: "MiniMaxM3SparseConfig",
+    cache_device: torch.device,
+    max_batch: int,
+    kv_indices_buf: Optional[torch.Tensor],
+    kv_page_indptr_buf: Optional[torch.Tensor],
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """Refresh the persistent paged-KV staging for one scheduler step.
+
+    Returns the persistent `(kv_indices_buf, kv_page_indptr_buf)` staging
+    buffers (stable `data_ptr()` across CUDA graph replays) so the caller
+    can retain them for the next step. The per-step plan values (the staged
+    page-table views plus the per-request CPU lens/offsets the forward path
+    consumes) are written directly onto `m3_meta`'s `msa_*` attributes.
+    """
+    # 1) Derive per-request CPU tensors via the shared helper (same values
+    #    the eager forward fallback in `msa_backend._whole_batch_lens`
+    #    produces).
+    lens = whole_batch_qo_lens(m3_meta)
+    if lens is None:
+        # Prefill metadata is incomplete; skip staging. The sparse
+        # forward's eager fallback builds the page table in-forward
+        # (safe when outside capture).
+        return kv_indices_buf, kv_page_indptr_buf
+    qo_lens_cpu, seq_lens_cpu, qo_offset_cpu = lens
+
+    # 2) Allocate the staging buffers lazily on the first call. Sizes
+    #    are picked so any padded batch up to `max_batch` (from
+    #    `AttentionMetadata.max_num_sequences`) fits. The first allocation
+    #    pins the buffer addresses for the rest of the metadata's
+    #    lifetime, so CUDA graph capture/replay keeps reading stable
+    #    `data_ptr()`s.
+    if kv_indices_buf is None:
+        # kv_indices is max_batch * max_pages_per_seq; page_size is the
+        # sparse config's block_size (128 for M3) so max_pages_per_seq
+        # comes from req_to_token's max_kv_len column dimension.  Use
+        # the current metadata's `req_to_token` as the size witness.
+        max_kv_len = int(m3_meta.req_to_token.shape[1])
+        max_pages_per_seq = max(1, max_kv_len // int(geometry.block_size))
+        max_kv_indices = max_batch * max_pages_per_seq
+        kv_indices_buf = torch.zeros(max_kv_indices, dtype=torch.int32, device=cache_device)
+        kv_page_indptr_buf = torch.zeros(max_batch + 1, dtype=torch.int32, device=cache_device)
+
+    # 3) Refresh the page table in-place into the persistent buffers.
+    kv_indices, kv_page_indptr = build_stable_kv_indices(
+        req_to_token=m3_meta.req_to_token,
+        slot_ids=m3_meta.slot_ids,
+        seq_lens=m3_meta.seq_lens,
+        seq_lens_cpu=m3_meta.seq_lens_cpu,
+        page_size=int(geometry.block_size),
+        dst=kv_indices_buf,
+        kv_page_indptr_dst=kv_page_indptr_buf,
+    )
+
+    # Write the per-step plan values directly onto the sparse attention
+    # metadata. The decode capacity constants stay stable across steps so
+    # the decode state's geometry key is constant.
+    m3_meta.msa_kv_indices = kv_indices
+    m3_meta.msa_kv_page_indptr = kv_page_indptr
+    m3_meta.msa_qo_lens_cpu = qo_lens_cpu
+    m3_meta.msa_kv_lens_cpu = seq_lens_cpu
+    m3_meta.msa_qo_offset_cpu = qo_offset_cpu
+    m3_meta.msa_max_batch = int(max_batch)
+    m3_meta.msa_max_kv_len = int(m3_meta.req_to_token.shape[1])
+    return kv_indices_buf, kv_page_indptr_buf
+
+
+def build_m3_sparse_metadata_and_plans(
+    meta,
+    *,
+    geometry: Optional["MiniMaxM3SparseConfig"],
+) -> Optional[dict]:
+    """Build the per-step MiniMax-M3 sparse attachment and MSA plans.
+
+    Backend-neutral so both the Triton and MSA metadata classes produce
+    the identical attachment without duplicating the logic. `meta` must
+    expose the standard attention-metadata attributes; `geometry` is the
+    layer-invariant `MiniMaxM3SparseConfig`.
+
+    All CUDA-graph-stable buffers are owned by `meta` (the static per-graph
+    buffers and the MSA paged-KV staging buffers). This function reads them
+    off `meta` and writes any newly allocated buffers back, so their
+    `data_ptr()` stays constant across replays.
+
+    Publishes the built per-forward sparse metadata as `meta.m3_sparse_metadata`
+    and the per-new-token slot ids as `meta.m3_out_cache_loc`, and returns the
+    sparse metadata (or None when the manager is not an M3 sparse cache or
+    the batch is empty).
+    """
+    kv_cache_manager = meta.kv_cache_manager
+    if kv_cache_manager is None or not hasattr(kv_cache_manager, "get_index_k_buffer"):
+        return None
+    request_ids = meta.request_ids
+    seq_lens = meta.seq_lens
+    if request_ids is None or seq_lens is None:
+        return None
+    num_contexts = int(meta.num_contexts or 0)
+    batch_size = int(seq_lens.shape[0])
+    if batch_size == 0:
+        return None
+
+    cache_device = m3_cache_device(meta)
+    # All graph-stable buffers live on the metadata; pull the current
+    # ones (allocated lazily on first use) so the builder can refresh
+    # them in place.
+    static_buffers = maybe_build_static_buffers_placeholder(meta, cache_device)
+    kv_indices_buf = getattr(meta, "_msa_kv_indices_buf", None)
+    kv_page_indptr_buf = getattr(meta, "_msa_kv_page_indptr_buf", None)
+
+    # `seq_lens_cpu` is a `TrtllmAttentionMetadata` field (the MSA metadata
+    # path) but not part of the base `AttentionMetadata` (the Triton path),
+    # so probe for it and fall back to a D2H copy.
+    seq_lens_cpu = getattr(meta, "seq_lens_cpu", None)
+    if seq_lens_cpu is None:
+        seq_lens_cpu = seq_lens.detach().to("cpu")
+
+    kv_cache_params = meta.kv_cache_params
+    num_cached_per_seq = (
+        kv_cache_params.num_cached_tokens_per_seq
+        if kv_cache_params is not None
+        else [0] * batch_size
+    )
+    kv_lens_cpu_list = [
+        int(num_cached_per_seq[b]) + int(seq_lens_cpu[b].item()) for b in range(batch_size)
+    ]
+    kv_lens_cpu = torch.tensor(kv_lens_cpu_list, dtype=torch.int32)
+    kv_lens_dev = kv_lens_cpu.to(device=cache_device, non_blocking=True)
+
+    use_msa = bool(getattr(kv_cache_manager, "use_msa", False))
+
+    is_extend = num_contexts > 0
+    if is_extend:
+        prefix_lens_list = [int(num_cached_per_seq[b]) for b in range(batch_size)]
+        extend_seq_lens_cpu = [kv_lens_cpu_list[b] - prefix_lens_list[b] for b in range(batch_size)]
+        prefix_lens = torch.tensor(prefix_lens_list, dtype=torch.int32, device=cache_device)
+        m3_meta, out_cache_loc = build_runtime_metadata_from_kv_manager(
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            seq_lens=kv_lens_dev,
+            seq_lens_cpu=kv_lens_cpu,
+            is_prefill=True,
+            prefix_lens=prefix_lens,
+            extend_seq_lens_cpu=extend_seq_lens_cpu,
+            device=cache_device,
+            static_buffers=static_buffers,
+        )
+    else:
+        # The MSA decode path assumes a single query token per request
+        # (decode_wrapper/dispatch.py packs qo_len=1). Speculative
+        # decoding emits multiple draft query tokens per generation step,
+        # which this path cannot represent, so reject it with a clear
+        # error rather than silently mis-staging out_cache_loc. The Triton
+        # reference path shares this builder but keeps its prior behavior,
+        # so gate the rejection on the MSA backend only.
+        if use_msa and batch_size > 0 and int(seq_lens_cpu[:batch_size].max().item()) > 1:
+            raise NotImplementedError(
+                "MiniMax-M3 MSA sparse attention does not support speculative "
+                "decoding (multiple query tokens per decode step). Disable "
+                "speculative decoding or use the non-MSA MiniMax-M3 backend."
+            )
+        m3_meta, out_cache_loc = build_runtime_metadata_from_kv_manager(
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+            seq_lens=kv_lens_dev,
+            seq_lens_cpu=kv_lens_cpu,
+            is_prefill=False,
+            device=cache_device,
+            static_buffers=static_buffers,
+        )
+
+    # Publish the built sparse metadata and per-new-token slot ids as
+    # direct attributes on the attention metadata.
+    meta.m3_sparse_metadata = m3_meta
+    meta.m3_out_cache_loc = out_cache_loc
+
+    if use_msa and geometry is not None:
+        max_batch = int(meta.max_num_sequences or meta.max_num_requests)
+        # Persist the (possibly first-allocated) staging buffers back onto
+        # the metadata so the next step reuses the same data_ptr(). The
+        # per-step plan values are written onto `m3_meta` by the helper.
+        meta._msa_kv_indices_buf, meta._msa_kv_page_indptr_buf = _build_msa_plans_for_metadata(
+            m3_meta=m3_meta,
+            geometry=geometry,
+            cache_device=cache_device,
+            max_batch=max_batch,
+            kv_indices_buf=kv_indices_buf,
+            kv_page_indptr_buf=kv_page_indptr_buf,
+        )
+    return m3_meta
+
+
 @functools.lru_cache(maxsize=1)
 def get_minimax_m3_attention_metadata_cls():
-    """Return :class:`MiniMaxM3AttentionMetadata` (lazy import).
-
-    The class extends :class:`AttentionMetadata` so the pyexecutor's
-    metadata-creation/prepare hooks (model_engine.py) drive M3 metadata
-    construction outside the CUDA-graph capture window. Building the
-    M3-sparse ``req_to_token`` / ``slot_ids`` / ``out_cache_loc``
-    tensors during ``prepare()`` lands them on the GPU **before** the
-    forward call; the forward path then reads from the pre-built
-    attachment and performs no CPU->GPU copies, which is required for
-    CUDA-graph capture safety (``cudaErrorStreamCaptureUnsupported``
-    fires for CPU->GPU ``memcpyAsync`` calls inside a captured stream).
-    """
+    """Return :class:`MiniMaxM3AttentionMetadata` (lazy import)."""
     from ...interface import AttentionMetadata
 
     class MiniMaxM3AttentionMetadata(AttentionMetadata):
         """:class:`AttentionMetadata` that pre-builds MiniMax-M3 metadata.
 
-        Overrides :meth:`prepare` so the M3-sparse
-        :class:`MiniMaxM3SparseAttentionMetadata` and the per-new-token
-        ``out_cache_loc`` are built **once per scheduler step**, on the
-        cache device, before the model forward runs.  The result is
-        stored as ``self.minimax_m3 = {"metadata": m3_meta,
-        "out_cache_loc": out_cache_loc}`` so the model layer's
-        ``_dense_forward`` and ``_sparse_forward`` can read it without
-        any device migration.
-
-        Test paths that build their own metadata can short-circuit by
-        attaching ``attn_metadata.minimax_m3`` directly before calling
-        the forward; those paths do not go through :meth:`prepare`.
+        `prepare()` builds the per-forward `MiniMaxM3SparseAttentionMetadata`
+        and per-new-token `out_cache_loc` once per scheduler step, outside
+        the CUDA-graph capture window, and publishes them as
+        `self.m3_sparse_metadata` / `self.m3_out_cache_loc` so the forward
+        reads them with no capture-time CPU->GPU copies. Test paths may set
+        those attributes directly instead of going through `prepare()`.
         """
 
-        minimax_m3: Optional[dict] = None
-        # Lazily allocated dict of persistent device buffers used to keep
-        # ``MiniMaxM3SparseAttentionMetadata`` tensor addresses stable
-        # across CUDA-graph capture/replay. None until the first
-        # ``prepare()`` call decides to use them (``is_cuda_graph`` /
-        # graph-stable mode).
+        m3_sparse_metadata: Optional["MiniMaxM3SparseAttentionMetadata"] = None
+        m3_out_cache_loc: Optional[torch.Tensor] = None
+        # Persistent buffers that keep the sparse-metadata tensor addresses
+        # stable across CUDA-graph replays (see
+        # allocate_minimax_m3_static_buffers); allocated lazily on first use.
         _m3_static_buffers: Optional[dict] = None
-
-        def _maybe_get_m3_static_buffers(
-            self, cache_device: torch.device, kv_cache_manager
-        ) -> Optional[dict]:
-            """Return persistent M3 buffers when graph stability is
-            required.
-
-            Allocates the persistent buffer dict the first time it is
-            needed and caches it on ``self._m3_static_buffers``. We
-            allocate the buffers under two conditions:
-
-              * ``self.is_cuda_graph`` is True -- the captured graph
-                requires stable ``data_ptr()`` across replays; OR
-              * the previous prepare() already allocated buffers --
-                we keep using them so the algorithm sees the same
-                addresses even between non-graph and graph-mode calls
-                (which can happen when the model engine alternates
-                between eager warmup and graph replay).
-
-            Returns ``None`` when no static buffers should be used (e.g.
-            eager-only test paths that rely on per-call allocations).
-            """
-            need_static = (
-                bool(getattr(self, "is_cuda_graph", False)) or self._m3_static_buffers is not None
-            )
-            if not need_static:
-                return None
-            if self._m3_static_buffers is not None:
-                bufs = self._m3_static_buffers
-                if bufs.get("device") == cache_device:
-                    return bufs
-
-            # First-time use: return an empty placeholder dict.
-            # ``build_runtime_metadata_from_kv_manager`` performs the
-            # actual allocation lazily on the first call where the
-            # current scheduler step's geometry (max_kv_len from the
-            # manager's block-id table, total_q from extend_seq_lens,
-            # actual batch size after CUDA-graph padding) is known.
-            # That removes the need to predict the warmup geometry up
-            # front. The first allocation pins the buffer addresses
-            # for the rest of this metadata instance's lifetime, so all
-            # subsequent prepare() calls reuse the same ``data_ptr()``s
-            # and CUDA graph capture/replay stays valid.
-            placeholder: dict = {
-                "device": cache_device,
-                # Caller-provided hints used by the lazy allocator below
-                # when it sizes the persistent buffers on the first real
-                # prepare() call.
-                "max_num_sequences_hint": int(
-                    getattr(self, "max_num_sequences", None) or self.max_num_requests
-                ),
-                "max_num_tokens_hint": int(
-                    getattr(self, "max_num_tokens", None)
-                    or (int(getattr(self, "max_num_sequences", None) or self.max_num_requests))
-                ),
-            }
-            self._m3_static_buffers = placeholder
-            return placeholder
+        # MSA paged-KV page-table staging buffers, allocated lazily when the
+        # cache manager has use_msa=True.
+        _msa_kv_indices_buf: Optional[torch.Tensor] = None
+        _msa_kv_page_indptr_buf: Optional[torch.Tensor] = None
 
         def prepare(self) -> None:
             super().prepare()
-
-            # Always rebuild the M3 metadata block on each prepare()
-            # call so it reflects the current scheduler step's seq_lens
-            # / request_ids / num_cached_tokens. Production
-            # ``model_engine`` invokes ``prepare()`` outside any CUDA
-            # graph capture window, so the (potentially expensive) build
-            # is safe to perform here.
-            #
-            # When CUDA graph is enabled the inner ``build_runtime_metadata_from_kv_manager``
-            # call writes into the persistent ``_m3_static_buffers`` so
-            # the captured graph keeps reading from stable ``data_ptr()``s
-            # across replays. Without this the captured ``index_select``
-            # over ``req_to_token``/``slot_ids`` reads from freed warmup
-            # memory and either produces wrong tokens or fires
-            # ``Indexing.cu:1515`` ``srcIndex < srcSelectDimSize``.
-            self.minimax_m3 = None
-
-            # Production path: build the M3 metadata from the standard
-            # AttentionMetadata fields. Requires kv_cache_manager + the
-            # M3 sparse-cache contract.
-            kv_cache_manager = getattr(self, "kv_cache_manager", None)
-            if kv_cache_manager is None or not hasattr(kv_cache_manager, "get_index_k_buffer"):
-                # Not an M3 KV cache manager: nothing to build. The
-                # forward path will raise a clear error if the M3
-                # backend ends up dispatched without the M3 cache.
-                return
-            request_ids = getattr(self, "request_ids", None)
-            seq_lens = self.seq_lens
-            if request_ids is None or seq_lens is None:
-                return
-            num_contexts = int(getattr(self, "num_contexts", 0) or 0)
-            batch_size = int(seq_lens.shape[0])
-            if batch_size == 0:
-                return
-
-            # The cache device hosts every paged buffer; this is the
-            # device the forward path consumes.
-            try:
-                layer_buf = kv_cache_manager.get_buffers(0)
-                cache_device = layer_buf.device
-            except Exception:
-                cache_device = torch.device(f"cuda:{torch.cuda.current_device()}")
-
-            seq_lens_cpu = (
-                getattr(self, "seq_lens_cpu", None)
-                if hasattr(self, "seq_lens_cpu")
-                else seq_lens.detach().to("cpu")
-            )
-            if seq_lens_cpu is None:
-                seq_lens_cpu = seq_lens.detach().to("cpu")
-
-            kv_cache_params = getattr(self, "kv_cache_params", None)
-            num_cached_per_seq = (
-                kv_cache_params.num_cached_tokens_per_seq
-                if kv_cache_params is not None
-                else [0] * batch_size
-            )
-
-            # ``attn_metadata.seq_lens`` from the PyExecutor is the
-            # per-step new-token count. The M3 sparse-attention algorithm
-            # consumes a *cumulative* kv length: ``minimax_m3_sparse_*``
-            # masks reads against ``metadata.seq_lens`` as the per-request
-            # K-side extent. Compute that cumulative kv length per request
-            # and feed it into the algorithm metadata builder.
-            kv_lens_cpu_list = [
-                int(num_cached_per_seq[b]) + int(seq_lens_cpu[b].item()) for b in range(batch_size)
-            ]
-            kv_lens_cpu = torch.tensor(kv_lens_cpu_list, dtype=torch.int32)
-            kv_lens_dev = kv_lens_cpu.to(device=cache_device, non_blocking=True)
-
-            static_buffers = self._maybe_get_m3_static_buffers(cache_device, kv_cache_manager)
-
-            # Any batch containing a context (prefill or chunked extend)
-            # request takes the extend path. For prefill rows
-            # ``num_cached_per_seq`` is ``prefix_lens`` and the full new
-            # chunk is ``extend_seq_len``; for decode rows
-            # ``num_cached`` is ``kv_len - 1`` and ``extend_seq_len`` is
-            # 1, so the same builder produces the correct one-slot
-            # entry. Pure-decode batches (``num_contexts == 0``) still
-            # take the decode optimization for CUDA-graph warmup
-            # geometry.
-            #
-            # Mixed prefill+decode batches always take the extend path:
-            # the prefill kernel handles decode rows as 1-slot extends.
-            # The decode branch below is a pure-decode-only perf
-            # specialization. (iter-131 regression: previously a wrong
-            # predicate routed mixed batches into the decode branch and
-            # crashed in index_copy_.)
-            is_extend = num_contexts > 0
-            if is_extend:
-                prefix_lens_list = [int(num_cached_per_seq[b]) for b in range(batch_size)]
-                extend_seq_lens_cpu = [
-                    kv_lens_cpu_list[b] - prefix_lens_list[b] for b in range(batch_size)
-                ]
-                prefix_lens = torch.tensor(
-                    prefix_lens_list,
-                    dtype=torch.int32,
-                    device=cache_device,
-                )
-                m3_meta, out_cache_loc = build_runtime_metadata_from_kv_manager(
-                    kv_cache_manager=kv_cache_manager,
-                    request_ids=request_ids,
-                    seq_lens=kv_lens_dev,
-                    seq_lens_cpu=kv_lens_cpu,
-                    is_prefill=True,
-                    prefix_lens=prefix_lens,
-                    extend_seq_lens_cpu=extend_seq_lens_cpu,
-                    device=cache_device,
-                    static_buffers=static_buffers,
-                )
-            else:
-                m3_meta, out_cache_loc = build_runtime_metadata_from_kv_manager(
-                    kv_cache_manager=kv_cache_manager,
-                    request_ids=request_ids,
-                    seq_lens=kv_lens_dev,
-                    seq_lens_cpu=kv_lens_cpu,
-                    is_prefill=False,
-                    device=cache_device,
-                    static_buffers=static_buffers,
-                )
-
-            self.minimax_m3 = {
-                "metadata": m3_meta,
-                "out_cache_loc": out_cache_loc,
-            }
+            # Rebuild the M3 metadata each step to reflect the current
+            # seq_lens / request_ids / num_cached_tokens. model_engine runs
+            # prepare() outside capture; the builder writes into the
+            # persistent static/staging buffers so the captured forward
+            # reads stable data_ptr()s across replays.
+            self.m3_sparse_metadata = None
+            self.m3_out_cache_loc = None
+            build_m3_sparse_metadata_and_plans(self, geometry=get_global_msa_geometry())
 
     return MiniMaxM3AttentionMetadata
 
@@ -908,8 +1107,11 @@ __all__ = [
     "MiniMaxM3SparseConfig",
     "MiniMaxM3SparseAttentionMetadata",
     "allocate_minimax_m3_static_buffers",
+    "build_m3_sparse_metadata_and_plans",
     "build_runtime_metadata_from_kv_manager",
+    "build_stable_kv_indices",
     "ensure_metadata_on_device",
+    "get_global_msa_geometry",
     "get_minimax_m3_attention_metadata_cls",
-    "replace_metadata",
+    "set_global_msa_geometry",
 ]

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""MSA-backed MiniMax-M3 sparse attention on the `TrtllmAttention` stack.
+
+Mimics `DSATrtllmAttention`:
+
+  * `MiniMaxM3MSATrtllmAttention` subclasses `TrtllmAttention` and reuses
+    its inherited `forward`, overriding only the sparse hooks
+    (`sparse_attn_predict`, `sparse_kv_predict`) and owning an `MsaIndexer`.
+  * The main sparse GQA runs through the registered `MsaSparseGqaFmha`.
+  * The indexer calls `fmha_sm100` directly (prefill) or the graph-safe
+    decode kernels (decode) to produce the per-query selected block
+    indices, which the model layer threads through
+    `forward_args.topk_indices`.
+  * `MiniMaxM3MSATrtllmAttentionMetadata` subclasses
+    `TrtllmAttentionMetadata` and owns the CUDA-graph-stable buffers and
+    the built sparse metadata.
+
+The classes are defined inside `get_minimax_m3_msa_attention_backend_cls`
+with a deferred `trtllm` import, avoiding a `trtllm` -> `fmha` ->
+`interface` import cycle at package init.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import torch
+
+from .common import (
+    _MSA_REQUIRED_HEAD_DIM,
+    _MSA_REQUIRED_TOPK,
+    build_kv_indices_and_lens,
+    msa_paged_kv,
+    write_main_kv_slots,
+)
+from .indexer import MsaIndexer
+from .metadata import (
+    MiniMaxM3SparseConfig,
+    build_m3_sparse_metadata_and_plans,
+    get_global_msa_geometry,
+    m3_cache_device,
+    whole_batch_qo_lens,
+)
+
+if TYPE_CHECKING:
+    from .metadata import MiniMaxM3SparseAttentionMetadata
+
+
+def _whole_batch_lens(
+    m3_meta: "MiniMaxM3SparseAttentionMetadata",
+    page_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    """Whole-batch `(qo_lens_cpu, kv_lens_cpu, qo_offset_cpu, kv_indices)`.
+
+    Prefers the pre-staged plan values on the metadata (CUDA-graph-stable
+    buffers) and falls back to an eager rebuild for focused tests and the
+    first eager warmup pass.
+    """
+    kv_indices = getattr(m3_meta, "msa_kv_indices", None)
+    if kv_indices is not None:
+        return (
+            m3_meta.msa_qo_lens_cpu,
+            m3_meta.msa_kv_lens_cpu,
+            m3_meta.msa_qo_offset_cpu,
+            kv_indices,
+        )
+    lens = whole_batch_qo_lens(m3_meta)
+    if lens is None:
+        raise RuntimeError("prefill metadata requires extend_seq_lens_cpu / prefix_lens")
+    qo_lens_cpu, kv_lens_cpu, qo_offset_cpu = lens
+    kv_indices, _ = build_kv_indices_and_lens(m3_meta, page_size)
+    return qo_lens_cpu, kv_lens_cpu, qo_offset_cpu, kv_indices
+
+
+def run_msa_sparse_decode(
+    config: "MiniMaxM3SparseConfig",
+    kv_cache_manager,
+    layer_idx: int,
+    m3_meta: "MiniMaxM3SparseAttentionMetadata",
+    q: torch.Tensor,
+    kv_block_indexes: torch.Tensor,
+    sm_scale: float,
+) -> torch.Tensor:
+    """CUDA-graph-safe decode sparse GQA via the in-tree driver.
+
+    Decode is CUDA-graph captured, so it must not go through the eager
+    `fmha_sm100_plan` host driver, which uses unpinned H2D staging,
+    per-call device allocations, and a device-side cost sweep. The staged
+    page tables come from the metadata's pre-built plan values. Returns
+    `[num_tokens, num_q_heads * head_dim]`.
+    """
+    from .decode_wrapper.dispatch import (
+        M3DecodeGeometry,
+        decode_sparse_attention,
+        resolve_decode_state,
+    )
+
+    kv_indices = getattr(m3_meta, "msa_kv_indices", None)
+    if kv_indices is None:
+        raise RuntimeError(
+            "MiniMax-M3 MSA decode requires pre-staged plan values; "
+            "prepare() did not build them (missing geometry / use_msa)."
+        )
+    kv_page_indptr = m3_meta.msa_kv_page_indptr
+    k_paged, v_paged = msa_paged_kv(kv_cache_manager, layer_idx)
+    page_size = int(k_paged.shape[2])
+    seq_lens = m3_meta.seq_lens.to(torch.int32)
+    batch = int(q.shape[0])
+    geometry = M3DecodeGeometry.from_config(
+        config,
+        max_batch=int(getattr(m3_meta, "msa_max_batch", 0))
+        or max(64, 1 << (batch - 1).bit_length()),
+        max_kv_len=int(getattr(m3_meta, "msa_max_kv_len", 0)) or int(m3_meta.req_to_token.shape[1]),
+        page_size=page_size,
+    )
+    state = resolve_decode_state(m3_meta, geometry, q.device)
+    out = decode_sparse_attention(
+        state,
+        q,
+        k_paged,
+        v_paged,
+        kv_block_indexes,
+        seq_lens=seq_lens,
+        kv_page_indptr=kv_page_indptr,
+        kv_indices=kv_indices,
+        sm_scale=sm_scale,
+    )
+    return out.reshape(batch, config.num_q_heads * config.head_dim)
+
+
+@functools.lru_cache(maxsize=1)
+def get_minimax_m3_msa_attention_backend_cls():
+    """Return `MiniMaxM3MSATrtllmAttention` (selection entry point)."""
+    from dataclasses import dataclass
+
+    from tensorrt_llm._torch.attention_backend.trtllm import (
+        TrtllmAttention,
+        TrtllmAttentionMetadata,
+    )
+
+    @dataclass(init=False)
+    class MiniMaxM3MSATrtllmAttentionMetadata(TrtllmAttentionMetadata):
+        """`TrtllmAttentionMetadata` for MiniMax-M3 MSA sparse layers.
+
+        Owns the CUDA-graph-stable buffers and the per-forward sparse
+        metadata; the paged K/V views and sparse GQA dispatch live in
+        `MsaSparseGqaFmha`.
+        """
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.m3_sparse_metadata = None
+            self.m3_out_cache_loc = None
+            self._m3_static_buffers: Optional[dict] = None
+            self._msa_kv_indices_buf = None
+            self._msa_kv_page_indptr_buf = None
+            # Persistent decode state holding the CUDA-graph-stable kernel
+            # buffers. This metadata persists across steps and graph replays
+            # for its batch-size bucket, so owning the state here keeps
+            # those buffers' data_ptr() stable across replays.
+            self._m3_decode_state = None
+
+        # lifecycle
+
+        def prepare(self) -> None:
+            super().prepare()
+            self.m3_sparse_metadata = None
+            self.m3_out_cache_loc = None
+            # The per-rank config (geometry) is registered process-wide by
+            # the attention layer's constructor, before any CUDA graph
+            # capture, so every metadata instance reads it here. The builder
+            # allocates and owns all graph-stable buffers on this metadata
+            # and publishes m3_sparse_metadata / m3_out_cache_loc.
+            geometry = get_global_msa_geometry()
+            m3_meta = build_m3_sparse_metadata_and_plans(self, geometry=geometry)
+            self._attach_decode_state(m3_meta, geometry, m3_cache_device(self))
+
+        def _attach_decode_state(self, m3_meta, config, cache_device) -> None:
+            """Build once and attach the persistent decode state.
+
+            Runs inside prepare(), outside any CUDA graph capture, so the
+            decode buffers are allocated before capture and reused across
+            replays. It is keyed by the decode geometry and rebuilt only
+            when that changes, which does not happen once a bucket's static
+            buffers are allocated. Only the pure-decode path uses it;
+            prefill / mixed batches run the eager fmha_sm100 path.
+            """
+            if m3_meta is None or config is None:
+                return
+            if getattr(m3_meta, "msa_kv_indices", None) is None or m3_meta.is_prefill:
+                return
+            from .decode_wrapper.dispatch import M3DecodeGeometry, build_m3_decode_state
+
+            decode_geometry = M3DecodeGeometry.from_config(
+                config,
+                max_batch=int(m3_meta.msa_max_batch),
+                max_kv_len=int(m3_meta.msa_max_kv_len),
+            )
+            state = self._m3_decode_state
+            if state is None or state.geom != decode_geometry or state.device != cache_device:
+                state = build_m3_decode_state(decode_geometry, cache_device)
+                self._m3_decode_state = state
+            m3_meta.decode_state = state
+
+        # internal accessors
+
+        @property
+        def m3_meta(self) -> "MiniMaxM3SparseAttentionMetadata":
+            if self.m3_sparse_metadata is None:
+                raise RuntimeError(
+                    "MiniMaxM3MSATrtllmAttentionMetadata.m3_sparse_metadata is not built; "
+                    "prepare() must run before the sparse forward."
+                )
+            return self.m3_sparse_metadata
+
+        # Index-K cache access + write, consumed by the MsaIndexer.
+
+        def msa_idx_k_cache(self, layer_idx: int) -> torch.Tensor:
+            """Raw paged index-K view for the indexer; HND conversion is done there."""
+            return self.kv_cache_manager.get_index_k_buffer(layer_idx)
+
+        def msa_write_idx_k(self, layer_idx: int, idx_k: torch.Tensor) -> None:
+            idx_cache = self.msa_idx_k_cache(layer_idx)
+            sparse_index_dim = int(idx_cache.shape[-1])
+            num_tokens = int(idx_k.shape[0])
+            write_main_kv_slots(
+                idx_cache, self.m3_out_cache_loc, idx_k.reshape(num_tokens, 1, sparse_index_dim)
+            )
+
+    class MiniMaxM3MSATrtllmAttention(TrtllmAttention):
+        """MSA-backed MiniMax-M3 sparse attention (mimics `DSATrtllmAttention`)."""
+
+        Metadata = MiniMaxM3MSATrtllmAttentionMetadata
+
+        def __init__(
+            self,
+            layer_idx: int,
+            num_heads: int,
+            head_dim: int,
+            num_kv_heads: Optional[int] = None,
+            quant_config=None,
+            *,
+            sparse_params,
+            **kwargs,
+        ):
+            TrtllmAttention.__init__(
+                self,
+                layer_idx,
+                num_heads,
+                head_dim,
+                num_kv_heads=num_kv_heads,
+                quant_config=quant_config,
+                sparse_params=sparse_params,
+                **kwargs,
+            )
+            self.m3_config = MiniMaxM3SparseConfig.from_sparse_params(
+                sparse_params,
+                num_q_heads=num_heads,
+                num_kv_heads=num_kv_heads or num_heads,
+                head_dim=head_dim,
+            )
+            self.disable_index_value = bool(sparse_params.disable_index_value)
+            self._validate_msa_preconditions()
+            self.indexer = MsaIndexer(self.m3_config)
+            self._register_global_geometry()
+
+        def _validate_msa_preconditions(self) -> None:
+            if not self.disable_index_value:
+                raise NotImplementedError(
+                    "MSA backend requires disable_index_value=True (MSA's proxy pass "
+                    "only consumes max_score; an index-V path is not implemented)."
+                )
+            if self.m3_config.head_dim != _MSA_REQUIRED_HEAD_DIM:
+                raise NotImplementedError(
+                    f"MSA backend requires head_dim={_MSA_REQUIRED_HEAD_DIM}, "
+                    f"got {self.m3_config.head_dim}."
+                )
+            if self.m3_config.sparse_index_dim != _MSA_REQUIRED_HEAD_DIM:
+                raise NotImplementedError(
+                    f"MSA backend requires sparse_index_dim={_MSA_REQUIRED_HEAD_DIM}, "
+                    f"got {self.m3_config.sparse_index_dim}."
+                )
+            if self.m3_config.topk != _MSA_REQUIRED_TOPK:
+                raise NotImplementedError(
+                    f"MSA backend requires topk={_MSA_REQUIRED_TOPK}, got {self.m3_config.topk}."
+                )
+
+        def _register_global_geometry(self) -> None:
+            # Register the config process-wide at construction, before any
+            # forward or CUDA graph capture, so every metadata's prepare()
+            # can pre-build the MSA plans.
+            from .metadata import set_global_msa_geometry
+
+            set_global_msa_geometry(self.m3_config)
+
+        @classmethod
+        def support_fused_rope(cls) -> bool:
+            # The MiniMax-M3 model layer applies partial RoPE to both the
+            # main and index branches explicitly.
+            return False
+
+        def create_fmha_libs(self) -> None:
+            # Restrict the dispatch loop to MsaSparseGqaFmha; the standard
+            # libs come first in the registry but cannot handle the M3
+            # sparse contract (unfused q/k/v plus selected block indices).
+            from tensorrt_llm._torch.attention_backend.fmha import MsaSparseGqaFmha
+
+            self.fmha_libs = [MsaSparseGqaFmha(self)]
+
+        # indexer entry point (called by the model layer, DSA-style)
+
+        def run_indexer(
+            self,
+            idx_q: torch.Tensor,
+            idx_k: torch.Tensor,
+            metadata,
+            *,
+            idx_sm_scale: Optional[float] = None,
+        ) -> torch.Tensor:
+            """Write the index-K cache and return the selected block indices.
+
+            Mirrors DSA's `indexer.sparse_attn_indexer`: the model layer
+            runs this before `forward` and threads the result through
+            `forward_args.topk_indices`. Returns `[total_q, num_kv_heads,
+            topk]`.
+            """
+            config = self.m3_config
+            idx_sm_scale = (
+                idx_sm_scale if idx_sm_scale is not None else config.sparse_index_dim**-0.5
+            )
+            num_tokens = int(idx_q.shape[0])
+            idx_q_view = idx_q.view(num_tokens, config.num_index_heads, config.sparse_index_dim)
+            idx_k_view = idx_k.view(num_tokens, 1, config.sparse_index_dim)
+
+            metadata.msa_write_idx_k(self.layer_idx, idx_k_view)
+            idx_k_cache = metadata.msa_idx_k_cache(self.layer_idx)
+            m3_meta = metadata.m3_meta
+            # The cache's tokens_per_block equals the sparse block size
+            # (enforced by the M3 KV cache manager), so read it from the
+            # config instead of the cache view.
+            page_size = self.m3_config.block_size
+
+            if m3_meta.is_prefill:
+                qo, kv, qo_off, kv_indices = _whole_batch_lens(m3_meta, page_size)
+                return self.indexer.select_blocks_prefill(
+                    idx_q_view,
+                    idx_k_cache,
+                    m3_meta,
+                    idx_sm_scale=idx_sm_scale,
+                    qo_lens_cpu=qo,
+                    kv_lens_cpu=kv,
+                    qo_offset_cpu=qo_off,
+                    kv_indices=kv_indices,
+                )
+            return self.indexer.select_blocks_decode(
+                idx_q_view,
+                idx_k_cache,
+                m3_meta,
+                idx_sm_scale=idx_sm_scale,
+                page_size=page_size,
+            )
+
+        # sparse hooks (consumed by inherited TrtllmAttention.forward)
+
+        def sparse_attn_predict(
+            self,
+            q: torch.Tensor,
+            k: Optional[torch.Tensor],
+            metadata,
+            forward_args,
+        ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+            # The model layer runs run_indexer() and passes the selected
+            # block indices through forward_args.topk_indices. Publish them
+            # as the sparse attention indices the MsaSparseGqaFmha reads.
+            return getattr(forward_args, "topk_indices", None), None
+
+        def sparse_kv_predict(
+            self,
+            q: torch.Tensor,
+            k: Optional[torch.Tensor],
+            metadata,
+            forward_args,
+        ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+            return None, None
+
+    return MiniMaxM3MSATrtllmAttention
+
+
+__all__ = [
+    "get_minimax_m3_msa_attention_backend_cls",
+]

--- a/tensorrt_llm/_torch/attention_backend/sparse/utils.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/utils.py
@@ -12,10 +12,10 @@ if TYPE_CHECKING:
     SparseAttentionConfig = Union[LlmSparseAttentionConfig,
                                   VisualGenSparseAttentionConfig]
 
-# Imports of the concrete backends / cache managers are kept local to each
-# function: they pull in ``trtllm`` and ``resource_manager``, which import
-# ``interface`` and would otherwise form an import cycle when this package is
-# loaded.
+# Imports of the concrete backends and cache managers are kept local to
+# each function: they pull in `trtllm` and `resource_manager`, which
+# import `interface` and would otherwise form an import cycle when this
+# package is loaded.
 
 
 def get_sparse_attn_kv_cache_manager(
@@ -42,14 +42,28 @@ def get_sparse_attn_kv_cache_manager(
         )
 
 
+def _resolve_minimax_m3_backend_cls(
+        sparse_params: "SparseParams") -> Type["AttentionBackend"]:
+    """Pick the Triton or MSA-backed M3 backend class.
+
+    Honours `use_msa` on the lowered `MiniMaxM3SparseParams` (populated
+    from the user-facing `sparse_use_msa` flag). Falls back to the Triton
+    reference path when the flag is unset.
+    """
+    from .minimax_m3 import (get_minimax_m3_attention_backend_cls,
+                             get_minimax_m3_msa_attention_backend_cls)
+    if getattr(sparse_params, "use_msa", False):
+        return get_minimax_m3_msa_attention_backend_cls()
+    return get_minimax_m3_attention_backend_cls()
+
+
 def get_vanilla_sparse_attn_attention_backend(
         sparse_params: "SparseParams") -> Type["AttentionBackend"]:
-    from .minimax_m3 import get_minimax_m3_attention_backend_cls
     from .rocket import RocketVanillaAttention
     if sparse_params.algorithm == "rocket":
         return RocketVanillaAttention
     elif sparse_params.algorithm == "minimax_m3":
-        return get_minimax_m3_attention_backend_cls()
+        return _resolve_minimax_m3_backend_cls(sparse_params)
     else:
         raise ValueError(
             f"Unsupported sparse attention algorithm in vanilla attention backend: {sparse_params.algorithm}"
@@ -62,7 +76,6 @@ def get_trtllm_sparse_attn_attention_backend(
 
     from .deepseek_v4 import DeepseekV4TrtllmAttention
     from .dsa import DSATrtllmAttention
-    from .minimax_m3 import get_minimax_m3_attention_backend_cls
     from .rocket import RocketTrtllmAttention
     if sparse_params.algorithm == "rocket":
         return RocketTrtllmAttention
@@ -78,7 +91,7 @@ def get_trtllm_sparse_attn_attention_backend(
         # `create_attention(...)` dispatch in `Attention.__init__`
         # returns an instantiable AttentionBackend under the trtllm
         # attention backend slot.
-        return get_minimax_m3_attention_backend_cls()
+        return _resolve_minimax_m3_backend_cls(sparse_params)
     else:
         raise ValueError(
             f"Unsupported sparse attention algorithm in trtllm attention backend: {sparse_params.algorithm}"
@@ -87,9 +100,8 @@ def get_trtllm_sparse_attn_attention_backend(
 
 def get_flashinfer_sparse_attn_attention_backend(
         sparse_params: "SparseParams") -> Type["AttentionBackend"]:
-    from .minimax_m3 import get_minimax_m3_attention_backend_cls
     if sparse_params.algorithm == "minimax_m3":
-        return get_minimax_m3_attention_backend_cls()
+        return _resolve_minimax_m3_backend_cls(sparse_params)
     raise ValueError(
         f"Unsupported sparse attention algorithm in flashinfer attention backend: {sparse_params.algorithm}"
     )

--- a/tensorrt_llm/_torch/models/modeling_minimaxm3.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm3.py
@@ -705,10 +705,41 @@ class MiniMaxM3Attention(Attention):
             self.sparse_local_block = int(sparse_cfg.get("sparse_local_block", 1))
             self.sparse_score_type = str(sparse_cfg.get("sparse_score_type", "max"))
 
-            # index_q_proj is **replicated** across TP ranks. The sparse
-            # forward reshapes idx_q to
-            # ``[num_tokens, sparse_num_index_heads, sparse_index_dim]``,
-            # which requires the rank-local idx_q to carry all heads.
+            # Index head i pairs 1:1 with KV head i in the reference
+            # model (SGLang/HF): KV head i's GQA group attends only to
+            # the blocks selected by index head i. Under TP the KV
+            # heads are sharded, so each rank must score with the
+            # index heads paired to its local KV heads. The sparse
+            # forward slices `idx_q` down to
+            # `[num_tokens, num_local_index_heads, sparse_index_dim]`
+            # with the offsets computed here. Scoring with all index heads
+            # and reducing would give every KV head the union/max over all
+            # index heads' selections.
+            num_kv_heads_global = int(config.num_key_value_heads)
+            if self.sparse_num_index_heads % num_kv_heads_global != 0:
+                raise ValueError(
+                    f"sparse_num_index_heads ({self.sparse_num_index_heads}) must be "
+                    f"divisible by num_key_value_heads ({num_kv_heads_global})"
+                )
+            index_group = self.sparse_num_index_heads // num_kv_heads_global
+            if self.tp_size <= num_kv_heads_global:
+                # Contiguous KV-head shard: rank r holds KV heads
+                # [r * local, (r + 1) * local), mirroring the qkv_proj
+                # column split.
+                kv_head_start = self.tp_rank * self.num_key_value_heads
+            else:
+                # KV heads duplicated across ranks (tp > global KV):
+                # rank r holds the single KV head r * kv // tp.
+                kv_head_start = (self.tp_rank * num_kv_heads_global) // self.tp_size
+            self.index_head_start = kv_head_start * index_group
+            self.num_local_index_heads = (
+                min(self.num_key_value_heads, num_kv_heads_global) * index_group
+            )
+
+            # index_q_proj stays **replicated** across TP ranks (the
+            # 4-head GEMM is negligible); the forward slices the local
+            # heads from its output, keeping checkpoint loading
+            # unchanged.
             index_q_total = self.sparse_num_index_heads * self.sparse_index_dim
             self.index_q_proj = Linear(
                 config.hidden_size,
@@ -863,8 +894,8 @@ class MiniMaxM3Attention(Attention):
           3. Apply partial RoPE.
           4. Pull the paged main K/V cache from the M3 cache manager.
           5. Read the pre-built :class:`MiniMaxM3SparseAttentionMetadata`
-             from ``attn_metadata.minimax_m3``. Production code paths
-             build this attachment in
+             from `attn_metadata.m3_sparse_metadata`. Production code paths
+             build this in
              :meth:`MiniMaxM3AttentionMetadata.prepare` (called by the
              pyexecutor outside any CUDA-graph capture window); test
              code paths attach it directly. The forward path **never**
@@ -928,17 +959,11 @@ class MiniMaxM3Attention(Attention):
         k_view = k.view(num_tokens, self.num_key_value_heads, self.head_dim)
         v_view = v.view(num_tokens, self.num_key_value_heads, self.head_dim)
 
-        # 4. Paged-block main K/V pool. Keep the multi-dim view (do not
-        # reshape) so writes propagate to the underlying pool storage:
-        # ``kv_pool[:, 0]`` is a non-contiguous view (its dim-0 stride
-        # is 2× the contiguous stride because dim 1 separates K from
-        # V), so reshaping to ``[-1, num_kv_heads, head_dim]`` silently
-        # forks a copy. Writing to the copy and then discarding it is
-        # exactly the bug that drove dense layer-0 decode attention to
-        # near-zero output: the next forward call would read zeros for
-        # the prefilled positions because the pool was never updated.
-        # Pass the 4-D view directly; the helpers below address slots
-        # via ``(page, within)`` fancy indexing.
+        # 4. Paged-block main K/V pool. Keep the 4-D view: kv_pool[:, 0] is
+        # non-contiguous (dim-0 stride is 2x because dim 1 separates K from
+        # V), so reshaping to [-1, num_kv_heads, head_dim] silently forks a
+        # copy and drops the cache write. The helpers address slots via
+        # (page, within) fancy indexing.
         kv_pool = kv_cache_manager.get_buffers(self.layer_idx)
         k_cache_view = kv_pool[:, 0]
         v_cache_view = kv_pool[:, 1]
@@ -946,17 +971,16 @@ class MiniMaxM3Attention(Attention):
         # 5. Read the pre-built M3 metadata. Building is the
         # responsibility of ``MiniMaxM3AttentionMetadata.prepare`` (or
         # the test path), so the forward stays CUDA-graph-capture safe.
-        m3_attachment = getattr(attn_metadata, "minimax_m3", None)
-        if m3_attachment is None:
+        m3_meta = getattr(attn_metadata, "m3_sparse_metadata", None)
+        if m3_meta is None:
             raise RuntimeError(
                 f"MiniMax-M3 dense forward (layer {self.layer_idx}) requires "
-                "attn_metadata.minimax_m3 to be pre-built by "
+                "attn_metadata.m3_sparse_metadata to be pre-built by "
                 "MiniMaxM3AttentionMetadata.prepare(); the model_engine "
                 "configures the M3 backend's Metadata class so this happens "
-                "automatically. Test callers must attach minimax_m3 manually."
+                "automatically. Test callers must set m3_sparse_metadata manually."
             )
-        m3_meta = m3_attachment["metadata"]
-        out_cache_loc = m3_attachment["out_cache_loc"]
+        out_cache_loc = attn_metadata.m3_out_cache_loc
 
         # 6. Write the new tokens' K/V to the pool. All inputs come
         # from prepare() which lands them on the cache device, so the
@@ -1068,17 +1092,10 @@ class MiniMaxM3Attention(Attention):
                     dropout_p=0.0,
                     is_causal=False,
                 )  # [batch, H, 1, d]
-            # Drop the singleton Q-length axis and write the resulting
-            # ``[batch, num_heads, head_dim]`` tensor into the final buffer.
-            # The prior ``.transpose(1, 2).reshape(batch, H, d)`` pattern
-            # was wrong: with ``H != head_dim`` (M3 TP=8 has H=8, d=128)
-            # the non-contiguous transpose forces ``reshape`` to copy the
-            # data in C-order under its current ``[batch, d, H]`` shape,
-            # then reinterpret as ``[batch, H, d]`` — which scrambles
-            # ``(head, head_dim)`` ordering and feeds permuted activations
-            # into ``o_proj``. Prefill is unaffected because its
-            # ``transpose(0, 1)`` runs between q-len and num_heads axes
-            # which the per-batch loop already laid out correctly.
+            # Drop the singleton Q-length axis. Use squeeze(2) + a
+            # [batch, num_heads, head_dim] view rather than
+            # transpose(1, 2).reshape, which (with H != head_dim) copies in
+            # C-order and scrambles the (head, head_dim) ordering into o_proj.
             output.view(batch, self.num_heads, self.head_dim).copy_(out_b.squeeze(2))
 
         return output
@@ -1153,12 +1170,13 @@ class MiniMaxM3Attention(Attention):
 
         Production callers (the LLM API path) drive
         :meth:`MiniMaxM3AttentionMetadata.prepare` outside any
-        CUDA-graph capture window; that method attaches a pre-built
-        :class:`MiniMaxM3SparseAttentionMetadata` and an
-        ``out_cache_loc`` tensor as ``attn_metadata.minimax_m3``. Test
-        callers attach the same dict manually.  This forward path
-        always reads the pre-built attachment and never builds metadata
-        itself — both would trigger
+        CUDA-graph capture window; that method publishes a pre-built
+        :class:`MiniMaxM3SparseAttentionMetadata` as
+        `attn_metadata.m3_sparse_metadata` and the per-new-token
+        `out_cache_loc` as `attn_metadata.m3_out_cache_loc`. Test callers
+        set the same attributes manually. This forward path always reads
+        the pre-built metadata and never builds it itself; both would
+        trigger
         ``cudaErrorStreamCaptureUnsupported`` for the
         ``cuda_graph=True`` hard path because the build does
         CPU->GPU copies.
@@ -1173,6 +1191,17 @@ class MiniMaxM3Attention(Attention):
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         idx_q = self.index_q_proj(hidden_states)
         idx_k = self.index_k_proj(hidden_states)
+        if self.num_local_index_heads != self.sparse_num_index_heads:
+            # Keep only the index heads paired with this rank's KV
+            # heads (1:1 pairing; see __init__). Slicing before the
+            # per-head norm and RoPE is equivalent and cheaper.
+            idx_q = (
+                idx_q.view(-1, self.sparse_num_index_heads, self.sparse_index_dim)[
+                    :, self.index_head_start : self.index_head_start + self.num_local_index_heads
+                ]
+                .reshape(idx_q.shape[0], self.num_local_index_heads * self.sparse_index_dim)
+                .contiguous()
+            )
 
         # 2. Per-head Gemma RMSNorm on both branches.
         q, k = self.apply_qk_norm(q, k)
@@ -1198,27 +1227,79 @@ class MiniMaxM3Attention(Attention):
         attn_metadata: AttentionMetadata,
         output: torch.Tensor,
     ) -> torch.Tensor:
-        """Run sparse cache updates and attention into ``output``."""
-        kv_cache_manager = getattr(attn_metadata, "kv_cache_manager", None)
+        """Run sparse cache updates and attention into `output`.
+
+        Dispatches to the MSA (`fmha_sm100`) backend when `self.attn` is a
+        :class:`MiniMaxM3MSATrtllmAttention` (`sparse_use_msa=True`), which
+        mimics `DSATrtllmAttention`: the indexer produces the selected block
+        indices and the inherited `TrtllmAttention.forward` runs the sparse
+        GQA through the registered `MsaSparseGqaFmha`. Otherwise falls back
+        to the Triton reference backend's keyword-driven `forward`.
+        """
+        kv_cache_manager = attn_metadata.kv_cache_manager
         if kv_cache_manager is None:
             raise RuntimeError(
                 f"MiniMax-M3 sparse forward (layer {self.layer_idx}) requires "
                 "attn_metadata.kv_cache_manager to be a MiniMaxM3KVCacheManagerV2."
             )
 
-        # 4. Get the paged-block main K/V cache + flat side index-K cache.
-        # The base KVCacheManagerV2 layout is
-        # ``[num_pages, kv_factor, tokens_per_block, num_kv_heads, head_dim]``
-        # with NHD layout. Pass the multi-dim view ``kv_pool[:, kv_index]``
-        # ``[num_pages, tokens_per_block, num_kv_heads, head_dim]`` directly:
-        # ``_gather_paged_batched`` decomposes the flat slot id into
-        # ``(page, within)`` for 4-D caches, and writes go through
-        # :func:`_write_main_kv_slots_to_pool` which uses multi-dim
-        # fancy assignment. The previously used reshape pattern
-        # silently copied the K (or V) slice because ``kv_pool[:, 0]``
-        # is non-contiguous, so writes never propagated to the pool —
-        # the bug that drove the dense layer-0 decode attention to
-        # near-zero output and produced the GSM8K-100 0.0 score.
+        from ..attention_backend.sparse.minimax_m3 import (
+            get_minimax_m3_attention_backend_cls,
+            get_minimax_m3_msa_attention_backend_cls,
+        )
+
+        if isinstance(self.attn, get_minimax_m3_msa_attention_backend_cls()):
+            return self._sparse_attention_core_msa(q, k, v, idx_q, idx_k, attn_metadata, output)
+        if isinstance(self.attn, get_minimax_m3_attention_backend_cls()):
+            return self._sparse_attention_core_triton(
+                q, k, v, idx_q, idx_k, attn_metadata, output, kv_cache_manager
+            )
+        raise RuntimeError(
+            f"MiniMax-M3 sparse forward (layer {self.layer_idx}) requires self.attn "
+            f"to be a MiniMax-M3 sparse backend, got {type(self.attn).__name__}. "
+            "Construct the model with "
+            "sparse_attention_config=MiniMaxM3SparseAttentionConfig(...) on ModelConfig."
+        )
+
+    def _sparse_attention_core_msa(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        idx_q: torch.Tensor,
+        idx_k: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        """MSA path: indexer + inherited `TrtllmAttention.forward` (DSA-style)."""
+        from ..attention_backend.interface import AttentionForwardArgs
+
+        # Indexer: proxy MQA + top-k block selection. Writes the index-K
+        # cache and returns [total_q, num_kv_heads, topk] selected blocks.
+        kv_block_indexes = self.attn.run_indexer(idx_q, idx_k, attn_metadata)
+        # Thread the selected blocks through forward_args.topk_indices; the
+        # backend's sparse_attn_predict publishes them as sparse_attn_indices,
+        # and MsaSparseGqaFmha writes K/V + runs the sparse GQA in place into
+        # `output`. attention_input_type defaults to mixed (ctx + gen).
+        forward_args = AttentionForwardArgs(output=output, topk_indices=kv_block_indexes)
+        self.attn.forward(q, k, v, attn_metadata, forward_args=forward_args)
+        return output
+
+    def _sparse_attention_core_triton(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        idx_q: torch.Tensor,
+        idx_k: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        output: torch.Tensor,
+        kv_cache_manager,
+    ) -> torch.Tensor:
+        """Triton reference path: keyword-driven `forward` with M3 caches."""
+        # Pass the 4-D pool views directly (kv_pool[:, 0] / [:, 1]); they are
+        # non-contiguous, so reshaping forks a copy and drops the cache write
+        # (see _dense_forward). The helpers address slots via (page, within).
         kv_pool = kv_cache_manager.get_buffers(self.layer_idx)
         # Index 0 = K, 1 = V on the kv_factor axis.
         k_cache = kv_pool[:, 0]
@@ -1239,17 +1320,16 @@ class MiniMaxM3Attention(Attention):
         # 5. Read the pre-built M3 metadata. Building is the
         # responsibility of ``MiniMaxM3AttentionMetadata.prepare`` (or
         # the test path), so the forward stays CUDA-graph-capture safe.
-        m3_attachment = getattr(attn_metadata, "minimax_m3", None)
-        if m3_attachment is None:
+        m3_meta = getattr(attn_metadata, "m3_sparse_metadata", None)
+        if m3_meta is None:
             raise RuntimeError(
                 f"MiniMax-M3 sparse forward (layer {self.layer_idx}) requires "
-                "attn_metadata.minimax_m3 to be pre-built by "
+                "attn_metadata.m3_sparse_metadata to be pre-built by "
                 "MiniMaxM3AttentionMetadata.prepare(); the model_engine "
                 "configures the M3 backend's Metadata class so this happens "
-                "automatically. Test callers must attach minimax_m3 manually."
+                "automatically. Test callers must set m3_sparse_metadata manually."
             )
-        m3_meta = m3_attachment["metadata"]
-        out_cache_loc = m3_attachment["out_cache_loc"]
+        out_cache_loc = attn_metadata.m3_out_cache_loc
 
         if not self.disable_index_value and idx_v_cache is not None:
             # The shared idx_v_proj is not part of the M3 checkpoint
@@ -1261,25 +1341,10 @@ class MiniMaxM3Attention(Attention):
                 "disable_index_value=True on every sparse layer)."
             )
 
-        # 6-7. Dispatch to the registered MiniMax-M3 sparse runtime
-        # backend, which executes the sparse path end-to-end including
-        # the cache writes. Production construction (LLM API with
-        # ``sparse_attention_config=MiniMaxM3SparseAttentionConfig()``)
-        # registers :class:`MiniMaxM3SparseRuntimeBackend` as
-        # ``self.attn``; any other backend on a sparse layer is a
-        # configuration error.
-        from ..attention_backend.sparse.minimax_m3 import get_minimax_m3_attention_backend_cls
-
-        m3_backend_cls = get_minimax_m3_attention_backend_cls()
-        if not isinstance(self.attn, m3_backend_cls):
-            raise RuntimeError(
-                f"MiniMax-M3 sparse forward (layer {self.layer_idx}) requires "
-                f"self.attn to be a MiniMaxM3SparseRuntimeBackend, got "
-                f"{type(self.attn).__name__}. Construct the model with "
-                "sparse_attention_config=MiniMaxM3SparseAttentionConfig(...) on "
-                "ModelConfig so the standard attention-backend dispatch selects "
-                "the M3 sparse runtime."
-            )
+        # 6-7. Dispatch to the Triton reference runtime backend, which
+        # executes the sparse path end-to-end including the cache writes.
+        # (Backend-type dispatch + geometry publication are handled by the
+        # caller `_sparse_attention_core`.)
         return self.attn.forward(
             q,
             k,

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -996,7 +996,17 @@ class KVCacheManagerV2(BaseResourceManager):
 
         self._log_kv_cache_pool_lifecycle_mapping()
 
-    def _prepare_page_table_tensor(self, index_mapper_capacity: int) -> None:
+    def _build_pool_mapping_tensors(self):
+        """Build the `(kv_cache_pool_pointers, kv_cache_pool_mapping)` tensors.
+
+        Extracted into an overridable hook: subclasses whose pools
+        coalesce extra per-layer buffers alongside K/V (e.g.
+        MiniMax-M3 merges `Role.INDEX_KEY` into the K/V pool) cannot
+        derive the per-layer mapping offset via `exact_div` of the
+        byte address delta, because a layer no longer contributes
+        exactly K+V. They override this method to compute the offset
+        from the layer's position within its pool group instead.
+        """
         kv_cache_pool_pointers_list = []
         kv_cache_pool_mapping_list = []
         block_scale_pool_pointers_list = []
@@ -1094,18 +1104,22 @@ class KVCacheManagerV2(BaseResourceManager):
                     [pool_pointers[1], block_scale_pool_pointers[1]],
                 ]
 
-        self.kv_cache_pool_pointers = torch.tensor(
+        kv_cache_pool_pointers = torch.tensor(
             kv_cache_pool_pointers_list,
             dtype=torch.int64,
             device="cpu",
             pin_memory=prefer_pinned(),
         )
-        self.kv_cache_pool_mapping = torch.tensor(
+        kv_cache_pool_mapping = torch.tensor(
             kv_cache_pool_mapping_list,
             dtype=torch.int32,
             device="cpu",
             pin_memory=prefer_pinned(),
         )
+        return kv_cache_pool_pointers, kv_cache_pool_mapping
+
+    def _prepare_page_table_tensor(self, index_mapper_capacity: int) -> None:
+        self.kv_cache_pool_pointers, self.kv_cache_pool_mapping = self._build_pool_mapping_tensors()
         self.index_scales = torch.empty(
             self.num_pools, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
         )

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -674,6 +674,15 @@ class MiniMaxM3SparseAttentionConfig(BaseSparseAttentionConfig):
         default=True,
         description="If True, skip the index V branch (M3 checkpoint default).",
     )
+    sparse_use_msa: bool = Field(
+        default=False,
+        description=("If True, route the sparse forward through the MSA-backed "
+                     "FMHA runtime (`fmha_sm100` and `sparse_topk_select`) "
+                     "instead of the in-tree Triton and SDPA reference path. "
+                     "Requires SM100 and the external `fmha_sm100` package "
+                     "(https://github.com/MiniMax-AI/MSA) to be importable."),
+        status="prototype",
+    )
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
@@ -685,8 +694,17 @@ class MiniMaxM3SparseAttentionConfig(BaseSparseAttentionConfig):
         from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.metadata import \
             MiniMaxM3SparseParams
 
+        # Sparse index heads paired with each KV head, used by the backend
+        # to localize index heads per TP rank. Derived from the
+        # checkpoint's global head counts; None if unavailable (the backend
+        # then falls back to the per-rank KV head count).
+        num_kv_heads_global = getattr(kwargs.get("pretrained_config"),
+                                      "num_key_value_heads", None)
+        index_group = (self.sparse_num_index_heads // int(num_kv_heads_global)
+                       if num_kv_heads_global else None)
         return MiniMaxM3SparseParams(
             num_index_heads=self.sparse_num_index_heads,
+            index_group=index_group,
             sparse_index_dim=self.sparse_index_dim,
             block_size=self.sparse_block_size,
             topk=self.sparse_topk_blocks,
@@ -694,6 +712,7 @@ class MiniMaxM3SparseAttentionConfig(BaseSparseAttentionConfig):
             local_blocks=self.sparse_local_blocks,
             score_type=self.sparse_score_type,
             disable_index_value=self.sparse_disable_index_value,
+            use_msa=self.sparse_use_msa,
         )
 
 

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -7614,8 +7614,9 @@ class TestMiniMaxM3(LlmapiAccuracyTestHarness):
 
     @pytest.mark.skip_less_device(4)
     @pytest.mark.skip_less_device_memory(140000)
-    @parametrize_with_ids("tp_size,ep_size", [(4, 4)])
-    def test_mxfp8(self, tp_size, ep_size):
+    @parametrize_with_ids("use_msa", [True, False])
+    def test_mxfp8(self, use_msa):
+        tp_size, ep_size = 4, 4
         # MXFP8 checkpoint: weights are MXFP8 (e4m3 + UE8M0 1x32 block
         # scales) with MXFP8 dynamic activations; the KV cache stays in
         # BF16 and the sparse attention path is unchanged from BF16.
@@ -7625,9 +7626,12 @@ class TestMiniMaxM3(LlmapiAccuracyTestHarness):
         # model + KV footprint; cap KV cache at 0.4 of free memory and
         # constrain batch / token budget so the runtime allocator stays
         # under the PyTorch cap.
+        # The MSA sparse kernel requires page_size == sparse_block_size(128).
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.4,
-                                        enable_block_reuse=False)
-        sparse_attention_config = MiniMaxM3SparseAttentionConfig()
+                                        enable_block_reuse=False,
+                                        tokens_per_block=128 if use_msa else 32)
+        sparse_attention_config = MiniMaxM3SparseAttentionConfig(
+            sparse_use_msa=use_msa)
         with LLM(model_path,
                  tensor_parallel_size=tp_size,
                  moe_expert_parallel_size=ep_size,
@@ -7643,15 +7647,19 @@ class TestMiniMaxM3(LlmapiAccuracyTestHarness):
             task = GSM8K(model_name)
             task.evaluate(llm)
 
-    @pytest.mark.skip_less_device(8)
+    @pytest.mark.skip_less_device(4)
     @pytest.mark.skip_less_device_memory(140000)
-    @parametrize_with_ids("tp_size,ep_size", [(8, 8)])
-    def test_mxfp8_piecewise_cuda_graph(self, tp_size, ep_size):
+    @parametrize_with_ids("use_msa", [True, False])
+    def test_mxfp8_piecewise_cuda_graph(self, use_msa):
+        tp_size, ep_size = 4, 4
         model_name = "MiniMaxAI/MiniMax-M3-MXFP8"
         model_path = f"{llm_models_root()}/MiniMax-M3-MXFP8"
+        # The MSA sparse kernel requires page_size == sparse_block_size(128).
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.5,
-                                        enable_block_reuse=False)
-        sparse_attention_config = MiniMaxM3SparseAttentionConfig()
+                                        enable_block_reuse=False,
+                                        tokens_per_block=128 if use_msa else 32)
+        sparse_attention_config = MiniMaxM3SparseAttentionConfig(
+            sparse_use_msa=use_msa)
         cuda_graph_config = CudaGraphConfig(
             enable_padding=True, batch_sizes=[1, 2, 4, 8, 12, 16, 24, 32])
         torch_compile_config = TorchCompileConfig(
@@ -7678,16 +7686,20 @@ class TestMiniMaxM3(LlmapiAccuracyTestHarness):
 
     @pytest.mark.skip_less_device(4)
     @pytest.mark.skip_less_device_memory(140000)
-    @parametrize_with_ids("tp_size,ep_size", [(4, 4)])
-    def test_nvfp4(self, tp_size, ep_size):
+    @parametrize_with_ids("use_msa", [True, False])
+    def test_nvfp4(self, use_msa):
+        tp_size, ep_size = 4, 4
         # NVFP4 checkpoint: MXFP8 base layers with NVFP4 routed experts
         # (MIXED_PRECISION checkpoint); the KV cache stays in BF16 and the
         # sparse attention path is unchanged from BF16.
         model_name = "nvidia/MiniMax-M3-NVFP4"
         model_path = f"{llm_models_root()}/MiniMax-M3-NVFP4"
+        # The MSA sparse kernel requires page_size == sparse_block_size(128)
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.6,
-                                        enable_block_reuse=False)
-        sparse_attention_config = MiniMaxM3SparseAttentionConfig()
+                                        enable_block_reuse=False,
+                                        tokens_per_block=128 if use_msa else 32)
+        sparse_attention_config = MiniMaxM3SparseAttentionConfig(
+            sparse_use_msa=use_msa)
         moe_config = MoeConfig(backend="CUTLASS")
         with LLM(model_path,
                  tensor_parallel_size=tp_size,

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -679,9 +679,9 @@ accuracy/test_llm_api_pytorch.py::TestLlama3_3_70BInstruct::test_nvfp4_tp4[torch
 accuracy/test_llm_api_pytorch.py::TestMiniMaxM2::test_4gpus[attention_dp=False-cuda_graph=True-overlap_scheduler=True-tp_size=4-ep_size=4]
 accuracy/test_llm_api_pytorch.py::TestMiniMaxM2_5::test_4gpus[attention_dp=False-cuda_graph=True-overlap_scheduler=True-tp_size=4-ep_size=4]
 accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_auto_dtype[tp_size=8-ep_size=8] TIMEOUT (180)
-accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8[tp_size=4-ep_size=4] TIMEOUT (180)
-accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8_piecewise_cuda_graph[tp_size=8-ep_size=8] TIMEOUT (180)
-accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[tp_size=4-ep_size=4] TIMEOUT (180)
+accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8[use_msa=False] TIMEOUT (180)
+accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8_piecewise_cuda_graph[use_msa=False] TIMEOUT (180)
+accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=False] TIMEOUT (180)
 accuracy/test_llm_api_pytorch.py::TestMinistral8BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestMinistral8BInstruct::test_fp8
 accuracy/test_llm_api_pytorch.py::TestMistralLarge3_675B::test_fp8[latency_moe_deepgemm]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -252,7 +252,6 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[fp4_indexer_dsl_mtp3] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus[baseline_pp4_mtp1] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gpus_chunked_prefill[baseline_fp8kv] TIMEOUT (60)
-  - accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8_piecewise_cuda_graph[tp_size=8-ep_size=8] TIMEOUT (180)
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8_attn_dp] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep8] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8] TIMEOUT (60)
@@ -353,6 +352,8 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention_4gpus[target_sparsity_0.9-fp8kv=True]
   - disaggregated/test_disaggregated.py::test_disaggregated_mamba_conc_greater_than_mbs[NVIDIA-Nemotron-3-Super-120B-A12B-FP8]
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_attn_multi_gpus TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8_piecewise_cuda_graph[use_msa=False] TIMEOUT (180)
+  - accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=False] TIMEOUT (180)
   # ---- FP8 per-tensor (QDQ) moved to post-merge; block-scale/W4A8 stay in pre ----
   - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_multi_gpu -k "CUTLASS and FP8 and not FP8_BLOCK_SCALES and not W4A8 and not MXFP8"
 # ------------- AutoDeploy Backend Stages ---------------

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -267,8 +267,6 @@ full:GB300/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_
 full:GB300/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=0-pp4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=False-torch_compile=False] SKIP (https://nvbugs/6388153)
 full:GB300/accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16_4gpus[pp4-attn_backend=FLASHINFER-torch_compile=False] SKIP (https://nvbugs/6385771)
 full:GB300/accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_fp8_4gpus[pp4-fp8kv=True-attn_backend=FLASHINFER-torch_compile=False] SKIP (https://nvbugs/6385771)
-full:GB300/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8[tp_size=4-ep_size=4] SKIP (https://nvbugs/6422502)
-full:GB300/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[tp_size=4-ep_size=4] SKIP (https://nvbugs/6422502)
 full:GB300/accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8_moe_dflash SKIP (https://nvbugs/6316985)
 full:GB300/accuracy/test_llm_api_pytorch_multimodal.py::TestExaone4_5_33B::test_auto_dtype[forced_chunked_prefill] SKIP (https://nvbugs/6422318)
 full:GB300/accuracy/test_llm_api_pytorch_multimodal.py::TestExaone4_5_33B::test_auto_dtype[full_budget] SKIP (https://nvbugs/6422318)

--- a/tests/unittest/_torch/attention/sparse/test_minimax_m3_decode_driver_vs_msa.py
+++ b/tests/unittest/_torch/attention/sparse/test_minimax_m3_decode_driver_vs_msa.py
@@ -1,0 +1,492 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Validation: in-tree decode kernels vs MSA api path, bit-exact.
+
+Runs the same JIT-compiled SM100 kernel binaries through (a) MSA's
+host-centric `fmha_sm100_plan` / `fmha_sm100` launch and (b) the in-tree
+graph-safe `dispatch.decode_*` functions over an `M3DecodeState`, on
+identical inputs, and asserts bit-equality:
+
+* proxy MQA max-score pass: uniform and heterogeneous KV lens;
+* top-k block selection: bit-diff vs `sparse_topk_select` on uniform lens
+  (global equals per-row there), reference-diff vs a pure Python
+  implementation on heterogeneous lens;
+* sparse block-GQA pass: same `kv_block_indexes` fed to both;
+* full pipeline under CUDA graph capture/replay with mutated lengths and
+  contents between replays (the property MSA's driver lacks).
+
+Requires SM100 + the `fmha_sm100` package (see requirements.txt).
+"""
+
+import math
+
+import pytest
+import torch
+
+# Full-model per-rank M3 geometry.
+NUM_Q_HEADS = 64
+NUM_KV_HEADS = 4
+NUM_INDEX_HEADS = 4
+HEAD_DIM = 128
+PAGE_SIZE = 128
+TOPK = 16
+INIT_BLOCKS = 0
+LOCAL_BLOCKS = 1
+MAX_KV_LEN = 2048  # 16 pages -> max_k_tiles rounds to 128, same as MSA's
+
+SM_SCALE = HEAD_DIM**-0.5
+IDX_SM_SCALE = HEAD_DIM**-0.5
+
+
+def _require_env():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    major, _ = torch.cuda.get_device_capability()
+    if major != 10:
+        pytest.skip("SM100 (Blackwell) required")
+    try:
+        import fmha_sm100  # noqa: F401
+    except ImportError:
+        pytest.skip("fmha_sm100 (MSA) not importable")
+
+
+def _geometry(max_batch):
+    from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.decode_wrapper.dispatch import (  # noqa: E501
+        M3DecodeGeometry,
+    )
+
+    return M3DecodeGeometry(
+        num_q_heads=NUM_Q_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        num_index_heads=NUM_INDEX_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=PAGE_SIZE,
+        topk=TOPK,
+        init_blocks=INIT_BLOCKS,
+        local_blocks=LOCAL_BLOCKS,
+        max_batch=max_batch,
+        max_kv_len=MAX_KV_LEN,
+    )
+
+
+def _make_inputs(kv_lens, seed=0, pool_pages=None):
+    """Build synthetic paged caches + decode Q for the given KV lengths.
+
+    `pool_pages` fixes the physical page-pool size so tensors keep
+    identical shapes across calls (required by the CUDA graph test's
+    in-place refreshes).
+    """
+    device = torch.device("cuda")
+    gen = torch.Generator(device="cuda").manual_seed(seed)
+    batch = len(kv_lens)
+    kv_lens_t = torch.tensor(kv_lens, dtype=torch.int32)
+    num_pages = [(kv_len + PAGE_SIZE - 1) // PAGE_SIZE for kv_len in kv_lens]
+    total_pages = sum(num_pages)
+    if pool_pages is None:
+        pool_pages = max(total_pages, 1)
+    assert pool_pages >= total_pages, "pool too small for requested kv_lens"
+
+    def r(*shape, dtype=torch.bfloat16, scale=1.0):
+        return (torch.randn(*shape, generator=gen, device=device, dtype=torch.float32) * scale).to(
+            dtype
+        )
+
+    q = r(batch, NUM_Q_HEADS, HEAD_DIM, scale=0.5)
+    idx_q = r(batch, NUM_INDEX_HEADS, HEAD_DIM, scale=0.5)
+    k_paged = r(pool_pages, NUM_KV_HEADS, PAGE_SIZE, HEAD_DIM, scale=0.5)
+    v_paged = r(pool_pages, NUM_KV_HEADS, PAGE_SIZE, HEAD_DIM, scale=0.5)
+    idx_k_paged = r(pool_pages, 1, PAGE_SIZE, HEAD_DIM, scale=0.5)
+
+    # Shuffled physical page assignment (exercises kv_indices gather).
+    perm = torch.randperm(pool_pages, generator=gen, device=device)[:total_pages]
+    kv_indices = perm.to(torch.int32)
+    kv_page_indptr = torch.zeros(batch + 1, dtype=torch.int32, device=device)
+    kv_page_indptr[1:] = torch.cumsum(torch.tensor(num_pages, dtype=torch.int32, device=device), 0)
+
+    return {
+        "batch": batch,
+        "q": q,
+        "idx_q": idx_q,
+        "k_paged": k_paged,
+        "v_paged": v_paged,
+        "idx_k_paged": idx_k_paged,
+        "kv_indices": kv_indices,
+        "kv_page_indptr": kv_page_indptr,
+        "kv_lens_cpu": kv_lens_t,
+        "seq_lens_dev": kv_lens_t.to(device),
+    }
+
+
+# ---------------------------------------------------------------------------
+# MSA reference path (mirrors msa_backend.py decode exactly)
+# ---------------------------------------------------------------------------
+
+
+def _msa_proxy_max_score(inp):
+    import fmha_sm100
+
+    batch = inp["batch"]
+    qo_lens_cpu = torch.ones(batch, dtype=torch.int32)
+    qo_offset_cpu = (inp["kv_lens_cpu"] - 1).to(torch.int32)
+    plan = fmha_sm100.fmha_sm100_plan(
+        qo_lens_cpu,
+        inp["kv_lens_cpu"],
+        NUM_INDEX_HEADS,
+        num_kv_heads=1,
+        qo_offset=qo_offset_cpu,
+        page_size=PAGE_SIZE,
+        output_maxscore=True,
+        causal=False,
+        num_kv_splits=1,
+    )
+    _, max_score = fmha_sm100.fmha_sm100(
+        inp["idx_q"],
+        inp["idx_k_paged"],
+        inp["idx_k_paged"],
+        plan,
+        kv_indices=inp["kv_indices"],
+        output_o=False,
+        output_maxscore=True,
+        sm_scale=IDX_SM_SCALE,
+    )
+    return max_score
+
+
+def _msa_topk(max_score, kv_lens_cpu):
+    import fmha_sm100
+
+    max_valid = int(((kv_lens_cpu + PAGE_SIZE - 1) // PAGE_SIZE).max().item())
+    return fmha_sm100.sparse_topk_select(
+        max_score.contiguous(),
+        TOPK,
+        num_valid_pages=max_valid,
+        force_begin_blocks=INIT_BLOCKS,
+        force_end_blocks=LOCAL_BLOCKS,
+    )
+
+
+def _msa_sparse(inp, kv_block_indexes, causal=False):
+    """MSA reference sparse pass.
+
+    `causal=False` is the production decode configuration: MSA then
+    overwrites `qo_offset` with the global `max_kv_len`, which in sparse
+    mode (no secondary seqlen clip) lets short requests attend stale
+    positions inside forced/OOB blocks, a real MSA hetero-batch defect.
+    `causal=True` keeps the per-request `kv_len - 1` offsets and is the
+    exact-semantics reference the in-tree driver implements; both agree on
+    uniform batches.
+    """
+    import fmha_sm100
+
+    batch = inp["batch"]
+    qo_lens_cpu = torch.ones(batch, dtype=torch.int32)
+    qo_offset_cpu = (inp["kv_lens_cpu"] - 1).to(torch.int32)
+    plan = fmha_sm100.fmha_sm100_plan(
+        qo_lens_cpu,
+        inp["kv_lens_cpu"],
+        NUM_Q_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        qo_offset=qo_offset_cpu,
+        page_size=PAGE_SIZE,
+        kv_block_num=TOPK,
+        causal=causal,
+        num_kv_splits=1,
+    )
+    out, _ = fmha_sm100.fmha_sm100(
+        inp["q"],
+        inp["k_paged"],
+        inp["v_paged"],
+        plan,
+        kv_indices=inp["kv_indices"],
+        kv_block_indexes=kv_block_indexes,
+        sm_scale=SM_SCALE,
+        output_maxscore=False,
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# In-tree driver path
+# ---------------------------------------------------------------------------
+
+
+def _decode_state(max_batch):
+    from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.decode_wrapper.dispatch import (  # noqa: E501
+        build_m3_decode_state,
+    )
+
+    return build_m3_decode_state(_geometry(max_batch), torch.device("cuda"))
+
+
+def _intree_proxy(state, inp):
+    from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.decode_wrapper.dispatch import (  # noqa: E501
+        decode_proxy_max_score,
+    )
+
+    return decode_proxy_max_score(
+        state,
+        inp["idx_q"],
+        inp["idx_k_paged"],
+        seq_lens=inp["seq_lens_dev"],
+        kv_page_indptr=inp["kv_page_indptr"],
+        kv_indices=inp["kv_indices"],
+        sm_scale=IDX_SM_SCALE,
+    )
+
+
+def _intree_select(state, max_score, seq_lens):
+    from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.decode_wrapper.dispatch import (  # noqa: E501
+        decode_select_blocks,
+    )
+
+    return decode_select_blocks(state, max_score, seq_lens=seq_lens)
+
+
+def _intree_sparse(state, inp, kv_block_indexes):
+    from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.decode_wrapper.dispatch import (  # noqa: E501
+        decode_sparse_attention,
+    )
+
+    return decode_sparse_attention(
+        state,
+        inp["q"],
+        inp["k_paged"],
+        inp["v_paged"],
+        kv_block_indexes,
+        seq_lens=inp["seq_lens_dev"],
+        kv_page_indptr=inp["kv_page_indptr"],
+        kv_indices=inp["kv_indices"],
+        sm_scale=SM_SCALE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python top-k reference (per-row semantics)
+# ---------------------------------------------------------------------------
+
+
+def _reference_topk(max_score_kv, kv_lens):
+    """Per-(token, kv-head) reference: force init/local, top-k, ascending."""
+    num_kv_heads, max_k_tiles, total_q = max_score_kv.shape
+    scores = max_score_kv.float().cpu().numpy()
+    out = torch.full((total_q, num_kv_heads, TOPK), -1, dtype=torch.int32)
+    for t in range(total_q):
+        valid = (int(kv_lens[t]) + PAGE_SIZE - 1) // PAGE_SIZE
+        for h in range(num_kv_heads):
+            row = scores[h, :, t].copy()
+            row[valid:] = -math.inf
+            for k in range(min(INIT_BLOCKS, valid)):
+                row[k] = math.inf
+            for k in range(max(valid - LOCAL_BLOCKS, 0), valid):
+                row[k] = math.inf
+            order = sorted(range(max_k_tiles), key=lambda i: (-row[i], i))[:TOPK]
+            picked = sorted(i for i in order if row[i] != -math.inf)
+            for j, blk in enumerate(picked):
+                out[t, h, j] = blk
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+UNIFORM_LENS = [512] * 8
+HETERO_LENS = [1, 130, 257, 128, 511, 1024, 33, 900]
+
+
+@pytest.mark.parametrize("kv_lens", [UNIFORM_LENS, HETERO_LENS], ids=["uniform", "hetero"])
+def test_proxy_max_score_bitdiff(kv_lens):
+    _require_env()
+    inp = _make_inputs(kv_lens)
+    state = _decode_state(max_batch=len(kv_lens))
+
+    ms_ref = _msa_proxy_max_score(inp)
+    ms_new = _intree_proxy(state, inp)
+    torch.cuda.synchronize()
+
+    assert ms_ref.shape == ms_new.shape, f"{ms_ref.shape} vs {ms_new.shape}"
+    same = ms_ref == ms_new
+    both_neginf = torch.isinf(ms_ref) & torch.isinf(ms_new) & (ms_ref == ms_new)
+    mismatch = (~same & ~both_neginf).sum().item()
+    assert mismatch == 0, f"proxy max_score mismatches: {mismatch}/{ms_ref.numel()}"
+
+
+def test_topk_bitdiff_uniform():
+    _require_env()
+    inp = _make_inputs(UNIFORM_LENS)
+    state = _decode_state(max_batch=len(UNIFORM_LENS))
+
+    ms = _msa_proxy_max_score(inp)
+    blocks_ref = _msa_topk(ms, inp["kv_lens_cpu"])
+    blocks_new = _intree_select(state, ms, inp["seq_lens_dev"])
+    torch.cuda.synchronize()
+
+    assert torch.equal(blocks_ref, blocks_new), (
+        f"topk mismatch rows: {(blocks_ref != blocks_new).any(dim=-1).nonzero()[:8].tolist()}"
+    )
+
+
+def test_topk_reference_hetero():
+    _require_env()
+    inp = _make_inputs(HETERO_LENS)
+    state = _decode_state(max_batch=len(HETERO_LENS))
+
+    ms = _intree_proxy(state, inp)
+    blocks_new = _intree_select(state, ms, inp["seq_lens_dev"]).cpu()
+    torch.cuda.synchronize()
+    blocks_ref = _reference_topk(ms, HETERO_LENS)
+
+    assert torch.equal(blocks_ref, blocks_new), (
+        f"per-row topk mismatch, first rows: ref={blocks_ref[:2].tolist()} "
+        f"new={blocks_new[:2].tolist()}"
+    )
+
+
+@pytest.mark.parametrize(
+    "kv_lens",
+    [UNIFORM_LENS, [130] * 8, HETERO_LENS],
+    ids=["uniform", "uniform_partial_page", "hetero"],
+)
+def test_sparse_gqa_bitdiff(kv_lens):
+    _require_env()
+    inp = _make_inputs(kv_lens)
+    state = _decode_state(max_batch=len(kv_lens))
+
+    # Use MSA's own block selection for both sides to isolate the
+    # sparse kernel and driver comparison. Heterogeneous batches need
+    # the causal=True reference (per-request offsets; see _msa_sparse
+    # docstring); uniform batches match the production causal=False
+    # path bit-exactly as well.
+    ms = _msa_proxy_max_score(inp)
+    blocks = _msa_topk(ms, inp["kv_lens_cpu"])
+
+    # causal=True reference whenever MSA's causal=False global-offset
+    # shortcut would attend stale positions (hetero lens, or a
+    # partially filled last page).
+    needs_exact_ref = len(set(kv_lens)) > 1 or any(kv_len % PAGE_SIZE for kv_len in kv_lens)
+    out_ref = _msa_sparse(inp, blocks, causal=needs_exact_ref)
+    out_new = _intree_sparse(state, inp, blocks)
+    torch.cuda.synchronize()
+
+    assert out_ref.shape == out_new.shape
+    assert torch.equal(out_ref, out_new), (
+        f"sparse out mismatch: max abs diff "
+        f"{(out_ref.float() - out_new.float()).abs().max().item()}"
+    )
+
+
+def test_full_pipeline_bitdiff_uniform():
+    _require_env()
+    inp = _make_inputs(UNIFORM_LENS)
+    state = _decode_state(max_batch=len(UNIFORM_LENS))
+
+    ms_ref = _msa_proxy_max_score(inp)
+    blocks_ref = _msa_topk(ms_ref, inp["kv_lens_cpu"])
+    out_ref = _msa_sparse(inp, blocks_ref)
+
+    ms_new = _intree_proxy(state, inp)
+    blocks_new = _intree_select(state, ms_new, inp["seq_lens_dev"])
+    out_new = _intree_sparse(state, inp, blocks_new)
+    torch.cuda.synchronize()
+
+    assert torch.equal(blocks_ref, blocks_new)
+    assert torch.equal(out_ref, out_new)
+
+
+def test_cuda_graph_replay_tracks_device_state():
+    """Capture once, mutate lengths + contents, replay: must match eager.
+
+    This is exactly the failure mode of the MSA driver (frozen plan): the
+    in-tree driver must produce bit-identical results to its own eager
+    execution for every replay.
+    """
+    _require_env()
+    batch = 8
+    state = _decode_state(max_batch=batch)
+
+    # Persistent input buffers the graph will read.
+    pool_pages = batch * (MAX_KV_LEN // PAGE_SIZE)
+    inp0 = _make_inputs([256] * batch, seed=1, pool_pages=pool_pages)
+    seq_lens = inp0["seq_lens_dev"].clone()
+    kv_page_indptr = inp0["kv_page_indptr"].clone()
+    kv_indices_buf = torch.zeros(
+        batch * (MAX_KV_LEN // PAGE_SIZE), dtype=torch.int32, device="cuda"
+    )
+    n0 = inp0["kv_indices"].shape[0]
+    kv_indices_buf[:n0] = inp0["kv_indices"]
+    q = inp0["q"].clone()
+    idx_q = inp0["idx_q"].clone()
+    k_paged = inp0["k_paged"].clone()
+    v_paged = inp0["v_paged"].clone()
+    idx_k_paged = inp0["idx_k_paged"].clone()
+
+    def run_pipeline():
+        from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.decode_wrapper.dispatch import (  # noqa: E501
+            decode_proxy_max_score,
+            decode_select_blocks,
+            decode_sparse_attention,
+        )
+
+        ms = decode_proxy_max_score(
+            state,
+            idx_q,
+            idx_k_paged,
+            seq_lens=seq_lens,
+            kv_page_indptr=kv_page_indptr,
+            kv_indices=kv_indices_buf,
+            sm_scale=IDX_SM_SCALE,
+        )
+        blocks = decode_select_blocks(state, ms, seq_lens=seq_lens)
+        return decode_sparse_attention(
+            state,
+            q,
+            k_paged,
+            v_paged,
+            blocks,
+            seq_lens=seq_lens,
+            kv_page_indptr=kv_page_indptr,
+            kv_indices=kv_indices_buf,
+            sm_scale=SM_SCALE,
+        )
+
+    # Warm up (JIT + shape caches + allocator) then capture.
+    out_view = run_pipeline()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out_view = run_pipeline()
+
+    for step, lens in enumerate(
+        [[256] * batch, [384] * batch, [128, 512, 1920, 256, 640, 64, 2048, 300]]
+    ):
+        # Refresh device state in place (as prepare() would).
+        inp = _make_inputs(lens, seed=10 + step, pool_pages=pool_pages)
+        seq_lens.copy_(inp["seq_lens_dev"])
+        kv_page_indptr.copy_(inp["kv_page_indptr"])
+        n = inp["kv_indices"].shape[0]
+        kv_indices_buf.zero_()
+        kv_indices_buf[:n] = inp["kv_indices"]
+        q.copy_(inp["q"])
+        idx_q.copy_(inp["idx_q"])
+        k_paged.copy_(inp["k_paged"])
+        v_paged.copy_(inp["v_paged"])
+        idx_k_paged.copy_(inp["idx_k_paged"])
+
+        graph.replay()
+        torch.cuda.synchronize()
+        replay_out = out_view.clone()
+
+        eager_out = run_pipeline()
+        torch.cuda.synchronize()
+
+        assert torch.equal(replay_out, eager_out), (
+            f"replay step {step} (lens={lens[:4]}...) diverges from eager: "
+            f"max abs diff "
+            f"{(replay_out.float() - eager_out.float()).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-x"]))

--- a/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_backend.py
+++ b/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_backend.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MSA-backed MiniMax-M3 sparse attention runtime.
+
+The MSA stack (`fmha_sm100` package) is SM100-only and not installed in
+the standard CI runners, so these tests are GPU-free structural checks:
+
+  * config to params to backend-class wiring (`sparse_use_msa`),
+  * the MSA backend is a `TrtllmAttention` subclass and does not inherit
+    the Triton reference backend,
+  * the backend-neutral helpers in `common` (cache-layout adapters,
+    per-request page-table and length derivation),
+  * the FMHA wiring: `MsaSparseGqaFmha` is a dispatch-participating `Fmha`
+    registered under `msa_sparse_gqa`,
+  * regression guards that the removed proxy-wrapper and duplicate-resolver
+    symbols stay gone.
+
+End-to-end kernel parity is covered by the MiniMax-M3 integration
+accuracy test (SM100 + fmha_sm100 + weights).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+import torch
+
+# Module-under-test imports are kept lazy so the file imports cleanly on
+# hosts where heavy TRT-LLM C++ extensions are absent.
+sparse_minimax_m3 = pytest.importorskip("tensorrt_llm._torch.attention_backend.sparse.minimax_m3")
+common = pytest.importorskip("tensorrt_llm._torch.attention_backend.sparse.minimax_m3.common")
+msa_backend = pytest.importorskip(
+    "tensorrt_llm._torch.attention_backend.sparse.minimax_m3.msa_backend"
+)
+
+
+# ---------------------------------------------------------------------------
+# Param + config plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_sparse_attention_config_threads_use_msa_into_params():
+    """`sparse_use_msa=True` must land on the lowered SparseParams."""
+    from tensorrt_llm.llmapi.llm_args import MiniMaxM3SparseAttentionConfig
+
+    cfg = MiniMaxM3SparseAttentionConfig(sparse_use_msa=True)
+    assert cfg.to_sparse_params().use_msa is True
+    assert MiniMaxM3SparseAttentionConfig().to_sparse_params().use_msa is False
+
+
+def test_backend_dispatch_picks_msa_when_flag_set():
+    """`utils._resolve_minimax_m3_backend_cls` honours sparse_use_msa."""
+    from tensorrt_llm._torch.attention_backend.sparse.utils import _resolve_minimax_m3_backend_cls
+    from tensorrt_llm.llmapi.llm_args import MiniMaxM3SparseAttentionConfig
+
+    triton_cls = sparse_minimax_m3.get_minimax_m3_attention_backend_cls()
+    msa_cls = sparse_minimax_m3.get_minimax_m3_msa_attention_backend_cls()
+
+    # _resolve_minimax_m3_backend_cls consumes the lowered
+    # MiniMaxM3SparseParams (.use_msa), not the user-facing config.
+    triton_params = MiniMaxM3SparseAttentionConfig(sparse_use_msa=False).to_sparse_params()
+    msa_params = MiniMaxM3SparseAttentionConfig(sparse_use_msa=True).to_sparse_params()
+    assert _resolve_minimax_m3_backend_cls(triton_params) is triton_cls
+    assert _resolve_minimax_m3_backend_cls(msa_params) is msa_cls
+
+
+def test_msa_backend_is_trtllm_subclass_not_triton_subclass():
+    """The MSA backend mimics DSATrtllmAttention.
+
+    It must subclass `TrtllmAttention` (to reuse the FMHA dispatch loop)
+    and must not inherit the Triton reference backend.
+    """
+    from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttention
+
+    msa_cls = sparse_minimax_m3.get_minimax_m3_msa_attention_backend_cls()
+    triton_cls = sparse_minimax_m3.get_minimax_m3_attention_backend_cls()
+
+    assert issubclass(msa_cls, TrtllmAttention)
+    assert not issubclass(msa_cls, triton_cls)
+    # Its metadata rides the TrtllmAttentionMetadata stack.
+    from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttentionMetadata
+
+    assert issubclass(msa_cls.Metadata, TrtllmAttentionMetadata)
+
+
+def test_duplicate_resolver_helper_removed():
+    """The duplicate `get_..._with_msa` resolver must be gone (single resolver)."""
+    assert not hasattr(msa_backend, "get_minimax_m3_attention_backend_cls_with_msa")
+    assert not hasattr(sparse_minimax_m3, "get_minimax_m3_attention_backend_cls_with_msa")
+
+
+# ---------------------------------------------------------------------------
+# Cache layout adapters (backend-neutral helpers in common.py)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_view_to_msa_paged_4d_layout():
+    num_pages, tokens_per_block, num_kv_heads, head_dim = 3, 128, 2, 128
+    cache_view = torch.randn(
+        num_pages, tokens_per_block, num_kv_heads, head_dim, dtype=torch.bfloat16
+    )
+    paged = common.cache_view_to_msa_paged(cache_view)
+    assert paged.shape == (num_pages, num_kv_heads, tokens_per_block, head_dim)
+    assert paged.is_contiguous()
+    assert torch.equal(paged, cache_view.permute(0, 2, 1, 3).contiguous())
+
+
+def test_cache_view_to_msa_paged_3d_flat_slot_layout():
+    num_slots, num_kv_heads, head_dim = 64, 2, 128
+    cache_view = torch.randn(num_slots, num_kv_heads, head_dim, dtype=torch.bfloat16)
+    paged = common.cache_view_to_msa_paged(cache_view)
+    assert paged.shape == (1, num_kv_heads, num_slots, head_dim)
+    assert torch.equal(paged, cache_view.permute(1, 0, 2).unsqueeze(0).contiguous())
+
+
+def test_cache_view_to_msa_paged_rejects_other_ranks():
+    with pytest.raises(ValueError, match="rank"):
+        common.cache_view_to_msa_paged(torch.empty(4, 8))
+    with pytest.raises(ValueError, match="rank"):
+        common.cache_view_to_msa_paged(torch.empty(2))
+
+
+# ---------------------------------------------------------------------------
+# Metadata derivation (whole-batch lens + page table)
+# ---------------------------------------------------------------------------
+
+
+def _build_metadata_for_test(
+    *,
+    is_prefill: bool,
+    seq_lens: List[int],
+    extend_seq_lens: List[int] | None = None,
+    page_size: int = 128,
+):
+    """Construct a minimal `MiniMaxM3SparseAttentionMetadata`."""
+    from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.metadata import (
+        MiniMaxM3SparseAttentionMetadata,
+    )
+
+    batch = len(seq_lens)
+    max_kv_len = max(((s + page_size - 1) // page_size) * page_size for s in seq_lens)
+    req_to_token = torch.arange(batch * max_kv_len, dtype=torch.int32).view(batch, max_kv_len)
+    slot_ids = torch.arange(batch, dtype=torch.int32)
+    seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32)
+
+    if is_prefill:
+        assert extend_seq_lens is not None
+        prefix_lens = torch.tensor(
+            [seq_lens[b] - extend_seq_lens[b] for b in range(batch)], dtype=torch.int32
+        )
+        cu_q = [0]
+        for x in extend_seq_lens:
+            cu_q.append(cu_q[-1] + x)
+        meta = MiniMaxM3SparseAttentionMetadata(
+            is_prefill=True,
+            req_to_token=req_to_token,
+            slot_ids=slot_ids,
+            seq_lens=seq_lens_t,
+            seq_lens_cpu=seq_lens_t,
+            prefix_lens=prefix_lens,
+            cu_seqlens_q=torch.tensor(cu_q, dtype=torch.int32),
+            extend_seq_lens_cpu=list(extend_seq_lens),
+        )
+    else:
+        meta = MiniMaxM3SparseAttentionMetadata(
+            is_prefill=False,
+            req_to_token=req_to_token,
+            slot_ids=slot_ids,
+            seq_lens=seq_lens_t,
+            seq_lens_cpu=seq_lens_t,
+        )
+    meta.prepare()
+    return meta
+
+
+def test_whole_batch_lens_prefill_uses_extend_lens_and_prefix():
+    meta = _build_metadata_for_test(
+        is_prefill=True, seq_lens=[256, 384], extend_seq_lens=[128, 128]
+    )
+    qo, kv, qo_off, _ = msa_backend._whole_batch_lens(meta, 128)
+    assert qo.dtype == torch.int32
+    assert qo.tolist() == [128, 128]
+    assert kv.tolist() == [256, 384]
+    assert qo_off.tolist() == [128, 256]
+
+
+def test_whole_batch_lens_decode_uses_unit_q_and_kv_minus_one():
+    meta = _build_metadata_for_test(is_prefill=False, seq_lens=[200, 300])
+    qo, kv, qo_off, _ = msa_backend._whole_batch_lens(meta, 128)
+    assert qo.tolist() == [1, 1]
+    assert kv.tolist() == [200, 300]
+    assert qo_off.tolist() == [199, 299]
+
+
+def test_build_kv_indices_packs_per_request_pages():
+    page_size = 128
+    meta = _build_metadata_for_test(
+        is_prefill=False,
+        seq_lens=[page_size * 2, page_size * 3 - 5],
+        page_size=page_size,
+    )
+    kv_indices, kv_lens = common.build_kv_indices_and_lens(meta, page_size)
+    assert kv_indices.dtype == torch.int32
+    assert kv_indices.tolist() == [0, 1, 3, 4, 5]
+    assert kv_lens.tolist() == [256, 379]
+
+
+# ---------------------------------------------------------------------------
+# FMHA wiring: MsaSparseGqaFmha as a registered Fmha
+# ---------------------------------------------------------------------------
+
+
+def test_msa_sparse_gqa_registered_as_fmha():
+    """The block-sparse main FMHA is a registered dispatch-participating Fmha.
+
+    It inherits `Fmha` directly (not `PhasedFmha`): MSA does its own
+    whole-batch dispatch, so there is no ctx/gen phase split to reuse.
+    """
+    from tensorrt_llm._torch.attention_backend.fmha import FMHA_LIBS, MsaSparseGqaFmha, PhasedFmha
+    from tensorrt_llm._torch.attention_backend.fmha.interface import Fmha
+
+    assert "msa_sparse_gqa" in FMHA_LIBS
+    assert FMHA_LIBS["msa_sparse_gqa"] is MsaSparseGqaFmha
+    assert issubclass(MsaSparseGqaFmha, Fmha)
+    assert not issubclass(MsaSparseGqaFmha, PhasedFmha)
+
+
+def test_msa_sparse_gqa_is_supported_gates_on_sparse_prediction():
+    """is_supported must reject non-M3-MSA requests (no sparse block indices)."""
+    from tensorrt_llm._torch.attention_backend.fmha import MsaSparseGqaFmha
+
+    class _DummyAttn:
+        layer_idx = 0
+        num_heads = 8
+
+    fmha = MsaSparseGqaFmha(_DummyAttn())
+    # No forward_args / no sparse_prediction -> not an MSA sparse request.
+    assert fmha.is_supported(None, None, None, None, None) is False
+
+
+def test_proxy_wrapper_and_block_sparse_bases_removed():
+    """The Fmha-lib proxy wrapper + opt-out bases must be gone (indexer calls fmha_sm100 directly)."""
+    import tensorrt_llm._torch.attention_backend.fmha as fmha_pkg
+
+    for removed in ("MsaProxyMqaFmha", "IndexerProxyFmha", "BlockSparseFmha"):
+        assert not hasattr(fmha_pkg, removed), f"{removed} should have been removed"
+    from tensorrt_llm._torch.attention_backend.fmha import FMHA_LIBS
+
+    assert "msa_proxy_mqa" not in FMHA_LIBS
+
+
+# ---------------------------------------------------------------------------
+# Lazy fmha_sm100 import guard
+# ---------------------------------------------------------------------------
+
+
+def _make_import_blocklist(blocked, *, fallback):
+    def _shim(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in blocked or name.split(".")[0] in blocked:
+            raise ImportError(f"blocked: {name}")
+        return fallback(name, globals, locals, fromlist, level)
+
+    return _shim
+
+
+def test_require_msa_module_raises_when_absent(monkeypatch):
+    """The lazy import wrapper produces a descriptive error."""
+    import sys
+
+    original = sys.modules.pop("fmha_sm100", None)
+    try:
+        monkeypatch.setattr(
+            "builtins.__import__",
+            _make_import_blocklist({"fmha_sm100"}, fallback=__import__),
+        )
+        with pytest.raises(RuntimeError, match="fmha_sm100"):
+            common.require_msa_module()
+    finally:
+        if original is not None:
+            sys.modules["fmha_sm100"] = original


### PR DESCRIPTION
## Description

This MR integrates Minimax's MSA kernels to support Minimax M3. Original MR by @WeiHaocheng :
https://github.com/NVIDIA/TensorRT-LLM/pull/15809

## Test Coverage

```
$ pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=True]
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional MSA-backed sparse attention support for MiniMax-M3, including new backend selection and runtime paths.
  * Improved sparse decode/prefill to support preallocated output buffers and CUDA-graph-safe execution.

* **Bug Fixes**
  * Better handles attention metadata, cache planning, and backend cleanup for more stable graph replay and sparse execution.
  * Added support for clearing cached piecewise CUDA graphs during model teardown.

* **Tests**
  * Added coverage for new sparse attention flows, backend selection, and CUDA graph replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->