### PR TITLE
[None][fix] Canonicalize small-M BF16 FC1 execution

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # --------------------------------------------------
 # Portions of this code were derived from DeepSeek‑V3:
 #   https://github.com/deepseek-ai/DeepSeek-V3
@@ -76,6 +91,17 @@ from ..utils import (AuxStreamType, EventType, Fp4QuantizedTensor,
 from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import (DecoderModel, EagerFusionConfig, filter_weights,
                              register_auto_model)
+
+_LAYER0_CANONICAL_SMALL_M_FC1_ROWS_ENV = \
+    "TLLM_DSV3_LAYER0_CANONICAL_SMALL_M_FC1_ROWS"
+
+
+def _get_layer0_canonical_small_m_fc1_rows(layer_idx: int) -> int:
+    value = os.environ.get(_LAYER0_CANONICAL_SMALL_M_FC1_ROWS_ENV, "0")
+    if value not in ("0", "16"):
+        raise ValueError(
+            f"{_LAYER0_CANONICAL_SMALL_M_FC1_ROWS_ENV} must be 0 or 16")
+    return int(value) if layer_idx == 0 else 0
 
 
 @triton.jit
@@ -1320,6 +1346,9 @@ class DeepseekV3DecoderLayer(DecoderLayer):
             self.mlp_tp_size = self._compute_mlp_tp_size(
                 config.intermediate_size, block_size)
 
+            small_m_fc1_pad_rows = \
+                _get_layer0_canonical_small_m_fc1_rows(layer_idx)
+
             has_mlp_tp = self.mlp_tp_size > 1
             self.fusion_config.PRE_MLP_FUSION = self.enable_fusion and has_mlp_tp and self.is_nvfp4
             self.fusion_config.POST_MLP_FUSION = self.enable_fusion and has_mlp_tp
@@ -1334,6 +1363,7 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                 reduce_output=has_mlp_tp,
                 use_cute_dsl_blockscaling_mm=model_config.
                 use_cute_dsl_blockscaling_mm,
+                small_m_fc1_pad_rows=small_m_fc1_pad_rows,
             )
 
         self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,

--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections.abc import Callable
 from typing import Optional, Union
 
@@ -18,6 +33,8 @@ from .swiglu import swiglu
 
 class GatedMLP(nn.Module):
 
+    _CANONICAL_FC1_UNPADDED_MAX_M = 8
+
     def __init__(
         self,
         *,
@@ -35,6 +52,7 @@ class GatedMLP(nn.Module):
         use_custom_cublas_mm: bool = False,
         is_shared_expert: bool = False,
         swiglu_limit: Optional[float] = None,
+        small_m_fc1_pad_rows: int = 0,
     ):
 
         super().__init__()
@@ -45,6 +63,9 @@ class GatedMLP(nn.Module):
         self.use_cute_dsl_blockscaling_mm = use_cute_dsl_blockscaling_mm
         self.swiglu_limit = float(
             swiglu_limit) if swiglu_limit is not None else None
+        if small_m_fc1_pad_rows not in (0, 16):
+            raise ValueError("small_m_fc1_pad_rows must be 0 or 16")
+        self.small_m_fc1_pad_rows = small_m_fc1_pad_rows
 
         config = config or ModelConfig()
         use_cute_dsl_bf16_gemm = getattr(config, "use_cute_dsl_bf16_gemm",
@@ -260,6 +281,37 @@ class GatedMLP(nn.Module):
     # because the CTA tile height exceeds the output allocation.
     _FP4OUT_MIN_M = 128
 
+    def _run_gate_up_proj(
+            self, x: Union[torch.Tensor, Fp4QuantizedTensor]) -> torch.Tensor:
+        if (self.small_m_fc1_pad_rows and isinstance(x, torch.Tensor)
+                and x.ndim == 2 and x.dtype == torch.bfloat16
+                and not self.gate_up_proj.has_any_quant):
+            num_rows = x.shape[0]
+            if torch.compiler.is_compiling():
+                # Keep the decision inside one compiled graph while avoiding
+                # a zero-pad clone for M<=8 and M>=16.
+                def padded_gate_up(value: torch.Tensor) -> torch.Tensor:
+                    rows = value.shape[0]
+                    zero_rows = rows - rows
+                    pad_rows = torch.sym_max(self.small_m_fc1_pad_rows - rows,
+                                             zero_rows)
+                    padded_value = F.pad(value, (0, 0, 0, pad_rows))
+                    return self.gate_up_proj(padded_value)[:rows]
+
+                should_pad = (num_rows > self._CANONICAL_FC1_UNPADDED_MAX_M) & (
+                    num_rows < self.small_m_fc1_pad_rows)
+                return torch.cond(should_pad, padded_gate_up, self.gate_up_proj,
+                                  (x, ))
+            if (self._CANONICAL_FC1_UNPADDED_MAX_M < num_rows <
+                    self.small_m_fc1_pad_rows):
+                # M=9..15 uses a shape-dependent cuBLAS reduction tactic.
+                # Padding only that range to M=16 preserves the established
+                # target-only arithmetic for M<=8.
+                padded_x = F.pad(
+                    x, (0, 0, 0, self.small_m_fc1_pad_rows - num_rows))
+                return self.gate_up_proj(padded_x)[:num_rows]
+        return self.gate_up_proj(x)
+
     def forward(
         self,
         x: Union[torch.Tensor, Fp4QuantizedTensor],
@@ -289,7 +341,7 @@ class GatedMLP(nn.Module):
         elif self._can_fuse_gate_up_swiglu():
             h2 = self._fused_gate_up_swiglu(x)
         else:
-            h1 = self.gate_up_proj(x)
+            h1 = self._run_gate_up_proj(x)
             h2 = self._apply_activation(h1)
 
         output = self.down_proj(h2,
@@ -307,7 +359,7 @@ class GatedMLP(nn.Module):
         assert lora_params is not None
         assert self.layer_idx is not None, "layer_idx is required for lora"
 
-        h1 = self.gate_up_proj(x)
+        h1 = self._run_gate_up_proj(x)
 
         h1_lora = self.splitted_gate_up_lora(x, lora_params, self.layer_idx)
 

--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv3.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv3.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.models import modeling_deepseekv3
+
+
+class _RecordingGatedMLP(nn.Module):
+    def __init__(self, *, small_m_fc1_pad_rows: int, **_: object) -> None:
+        super().__init__()
+        self.small_m_fc1_pad_rows = small_m_fc1_pad_rows
+
+
+@pytest.mark.parametrize(
+    ("value", "layer_idx", "expected"), [(None, 0, 0), ("0", 0, 0), ("16", 0, 16), ("16", 1, 0)]
+)
+def test_layer0_canonical_small_m_fc1_rows_environment(
+    monkeypatch: pytest.MonkeyPatch, value: str | None, layer_idx: int, expected: int
+) -> None:
+    name = "TLLM_DSV3_LAYER0_CANONICAL_SMALL_M_FC1_ROWS"
+    if value is None:
+        monkeypatch.delenv(name, raising=False)
+    else:
+        monkeypatch.setenv(name, value)
+
+    assert modeling_deepseekv3._get_layer0_canonical_small_m_fc1_rows(layer_idx) == expected
+
+
+@pytest.mark.parametrize("value", ["true", "8", "17"])
+def test_layer0_canonical_small_m_fc1_rows_rejects_invalid_environment(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("TLLM_DSV3_LAYER0_CANONICAL_SMALL_M_FC1_ROWS", value)
+
+    with pytest.raises(
+        ValueError, match="TLLM_DSV3_LAYER0_CANONICAL_SMALL_M_FC1_ROWS must be 0 or 16"
+    ):
+        modeling_deepseekv3._get_layer0_canonical_small_m_fc1_rows(0)
+
+
+@pytest.mark.parametrize(("layer_idx", "expected"), [(0, 16), (1, 0)])
+def test_decoder_layer_threads_layer0_canonical_small_m_fc1_rows(
+    monkeypatch: pytest.MonkeyPatch, layer_idx: int, expected: int
+) -> None:
+    monkeypatch.setenv("TLLM_DSV3_LAYER0_CANONICAL_SMALL_M_FC1_ROWS", "16")
+    monkeypatch.setattr(modeling_deepseekv3, "GatedMLP", _RecordingGatedMLP)
+    monkeypatch.setattr(
+        modeling_deepseekv3,
+        "DeepseekV3Attention",
+        lambda *_args, **_kwargs: nn.Identity(),
+    )
+    monkeypatch.setattr(
+        modeling_deepseekv3,
+        "RMSNorm",
+        lambda *_args, **_kwargs: nn.Identity(),
+    )
+    monkeypatch.setattr(modeling_deepseekv3, "can_access_peer", lambda _mapping: False)
+
+    quant_config = SimpleNamespace(
+        group_size=None,
+        layer_quant_mode=SimpleNamespace(has_nvfp4=lambda: False),
+        quant_algo=None,
+        is_module_excluded_from_quantization=lambda _name: False,
+    )
+    config = SimpleNamespace(
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=64,
+        n_routed_experts=None,
+        n_shared_experts=0,
+        num_experts_per_tok=0,
+        model_type="deepseek_v3",
+        torch_dtype=torch.bfloat16,
+        rms_norm_eps=1e-5,
+    )
+    mapping = SimpleNamespace(
+        enable_attention_dp=False,
+        tp_size=1,
+        gpus_per_node=1,
+        has_tp=lambda: False,
+    )
+    model_config = SimpleNamespace(
+        pretrained_config=config,
+        mapping=mapping,
+        quant_config=quant_config,
+        allreduce_strategy=None,
+        use_cute_dsl_blockscaling_mm=False,
+    )
+    aux_stream_dict = {modeling_deepseekv3.AuxStreamType.Attention: None}
+
+    layer = modeling_deepseekv3.DeepseekV3DecoderLayer(model_config, layer_idx, aux_stream_dict)
+
+    assert isinstance(layer.mlp, _RecordingGatedMLP)
+    assert layer.mlp.small_m_fc1_pad_rows == expected

--- a/tests/unittest/_torch/modules/test_gated_mlp.py
+++ b/tests/unittest/_torch/modules/test_gated_mlp.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+
+import pytest
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.modules.gated_mlp import GatedMLP
+
+
+class _RecordingProjection(nn.Module):
+    def __init__(self, has_any_quant: bool = False) -> None:
+        super().__init__()
+        self.has_any_quant = has_any_quant
+        self.last_input_shape: tuple[int, ...] | None = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self.last_input_shape = tuple(x.shape)
+        return torch.cat((x, x), dim=-1)
+
+
+class _CompiledProjection(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.has_any_quant = False
+        self.linear = nn.Linear(32, 64, bias=False, dtype=torch.bfloat16)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+class _GateUpProjectionWrapper(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.mlp = _make_test_mlp()
+        self.mlp.gate_up_proj = _CompiledProjection()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.mlp._run_gate_up_proj(x)
+
+
+def _make_test_mlp(*, pad_rows: int = 16, has_any_quant: bool = False) -> GatedMLP:
+    mlp = GatedMLP.__new__(GatedMLP)
+    nn.Module.__init__(mlp)
+    mlp.small_m_fc1_pad_rows = pad_rows
+    mlp.gate_up_proj = _RecordingProjection(has_any_quant=has_any_quant)
+    return mlp
+
+
+@pytest.mark.parametrize(
+    ("num_rows", "expected_projection_rows"),
+    [(1, 1), (8, 8), (9, 16), (12, 16), (15, 16), (16, 16), (17, 17)],
+)
+def test_small_m_bf16_fc1_padding(num_rows: int, expected_projection_rows: int) -> None:
+    mlp = _make_test_mlp()
+    x = torch.randn(num_rows, 32, dtype=torch.bfloat16)
+
+    output = mlp._run_gate_up_proj(x)
+
+    assert mlp.gate_up_proj.last_input_shape == (expected_projection_rows, 32)
+    assert output.shape == (num_rows, 64)
+    torch.testing.assert_close(output, torch.cat((x, x), dim=-1))
+
+
+@pytest.mark.parametrize(
+    ("dtype", "has_any_quant"),
+    [(torch.float16, False), (torch.bfloat16, True)],
+)
+def test_small_m_fc1_padding_skips_other_paths(dtype: torch.dtype, has_any_quant: bool) -> None:
+    mlp = _make_test_mlp(has_any_quant=has_any_quant)
+    x = torch.randn(12, 32, dtype=dtype)
+
+    output = mlp._run_gate_up_proj(x)
+
+    assert mlp.gate_up_proj.last_input_shape == (12, 32)
+    assert output.shape == (12, 64)
+
+
+@pytest.mark.parametrize("pad_rows", [-1, 8, 15, 17])
+def test_small_m_fc1_padding_rejects_invalid_configuration(pad_rows: int) -> None:
+    with pytest.raises(ValueError, match="small_m_fc1_pad_rows must be 0 or 16"):
+        GatedMLP(hidden_size=32, intermediate_size=64, bias=False, small_m_fc1_pad_rows=pad_rows)
+
+
+def test_small_m_fc1_padding_uses_one_dynamic_compiled_graph() -> None:
+    compile_count = 0
+
+    def backend(
+        graph: torch.fx.GraphModule, _example_inputs: list[torch.Tensor]
+    ) -> Callable[..., torch.Tensor]:
+        nonlocal compile_count
+        compile_count += 1
+        return graph.forward
+
+    compiled = torch.compile(
+        _GateUpProjectionWrapper(), backend=backend, dynamic=True, fullgraph=True
+    )
+    for num_rows in (8, 9, 12, 15, 16, 17):
+        x = torch.randn(num_rows, 32, dtype=torch.bfloat16)
+        output = compiled(x)
+        assert output.shape == (num_rows, 64)
+
+    assert compile_count == 1


### PR DESCRIPTION
@coderabbitai summary

## Description

Speculative verification evaluates `K + 1` rows in one target forward. For
small draft widths, this gives the unquantized BF16 gate/up projection an
`M` dimension between 9 and 15, where cuBLAS can use a different reduction
tactic from target-only decoding. The resulting row-wise BF16 difference can
be large enough to change deterministic greedy logits.

This change adds an opt-in FC1 canonicalization path to `GatedMLP`. When
enabled, an unquantized, two-dimensional BF16 input with 9-15 rows is padded
to 16 rows for the gate/up projection and trimmed immediately afterward. The
DeepSeek V3 family enables the behavior only for the experimentally validated
first dense layer through
`TLLM_DSV3_LAYER0_CANONICAL_SMALL_M_FC1_ROWS=16`.

Compiled execution uses `torch.cond`, avoiding separate graphs at the 8/9/16
row boundaries without cloning inputs on the unpadded paths.

The default remains disabled. Quantized projections, non-BF16 inputs, and
other row counts retain their existing behavior.

## Test Coverage

- Focused module and DeepSeek configuration tests
  - 23 passed in a TensorRT-LLM runtime environment
  - Includes decoder-constructor wiring checks for layer 0 and layer 1
- Dynamic `torch.compile(fullgraph=True)` test verifies one graph across
  M=8,9,12,15,16,17
- Dynamic Inductor compilation passed across the same boundary values
- `python -m py_compile` for both modified modules and the new test
- Full repository pre-commit suite passed on all four changed files
- `git diff --check origin/main...HEAD`
- Runtime validation: the enabled path reproduced the deterministic
  target-only 256-token response under speculative verification; a matched
  16-request panel retained exact target-equivalent outputs.

## PR Checklist

- [x] The description explains the issue and the narrowly scoped solution.
- [x] The change follows the TensorRT-LLM coding guidelines.
- [x] Focused tests cover padded and bypassed paths.
- [x] No new dependencies, ownership changes, or architecture updates are
  required.

## GitHub Bot Help

To see a list of available CI bot commands, comment `/bot help`.
