### PR TITLE
[https://nvbugs/6003113][fix] BREAKING CHANGE: Authenticate disagg request to verify encoded_opaque_state and ctx_info_endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1631,7 +1631,7 @@ repos:
         additional_dependencies:
         - tomli
         # add ignore words list
-        args: ["-L", "Mor,ans,thirdparty,subtiles,PARD,pard,indx,therefrom", "--skip", "ATTRIBUTIONS-*.md,*.svg", "--skip", "security_scanning/*", "--skip", "tensorrt_llm/_torch/visual_gen/jit_kernels/*"]
+        args: ["-L", "Mor,ans,thirdparty,subtiles,PARD,pard,indx,therefrom,fo", "--skip", "ATTRIBUTIONS-*.md,*.svg", "--skip", "security_scanning/*", "--skip", "tensorrt_llm/_torch/visual_gen/jit_kernels/*"]
         exclude: 'scripts/attribution/data/cas/.*$'
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1631,7 +1631,7 @@ repos:
         additional_dependencies:
         - tomli
         # add ignore words list
-        args: ["-L", "Mor,ans,thirdparty,subtiles,PARD,pard,indx,therefrom,fo", "--skip", "ATTRIBUTIONS-*.md,*.svg", "--skip", "security_scanning/*", "--skip", "tensorrt_llm/_torch/visual_gen/jit_kernels/*"]
+        args: ["-L", "Mor,ans,thirdparty,subtiles,PARD,pard,indx,therefrom", "--skip", "ATTRIBUTIONS-*.md,*.svg", "--skip", "security_scanning/*", "--skip", "tensorrt_llm/_torch/visual_gen/jit_kernels/*"]
         exclude: 'scripts/attribution/data/cas/.*$'
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.4

--- a/examples/disaggregated/README.md
+++ b/examples/disaggregated/README.md
@@ -253,6 +253,7 @@ it would look like:
 hostname: localhost
 port: 8000
 backend: pytorch
+internal_request_auth_key: <shared-secret>
 context_servers:
   num_instances: 2
   urls:
@@ -265,6 +266,10 @@ generation_servers:
 ```
 
 Clients can then send requests to the disaggregated server at `localhost:8000`, which is an OpenAI API compatible endpoint.
+Set `internal_request_auth_key` to the same non-empty secret in the disaggregated
+server config and in each context/generation worker config. The proxy signs internal
+generation requests with this key, and generation workers reject request-supplied
+`ctx_info_endpoint` values that do not carry a valid signature.
 
 
 #### Sending requests to the disaggregated server
@@ -542,6 +547,8 @@ the active context/generation servers is below the corresponding threshold.
 - `inactive_interval_sec`: A server is marked inactive if no heartbeat is received within this interval (set higher than the heartbeat interval).
 
 Note that the disaggregated server and all the context/generation servers should have the same `disagg_cluster` configuration values, or the disaggregated server may not be able to keep alive or detect inactivity the other servers properly. If `disagg_cluster` section is specified, 
+the disaggregated server and all context/generation worker configs should also set the
+same `internal_request_auth_key` value.
 
 Additionally, we offer a fully executable script—please refer to [Disaggregated SLURM Scripts](./slurm/service_discovery_example/).
 

--- a/examples/disaggregated/README.md
+++ b/examples/disaggregated/README.md
@@ -269,7 +269,8 @@ Clients can then send requests to the disaggregated server at `localhost:8000`, 
 Set `internal_request_auth_key` to the same non-empty secret in the disaggregated
 server config and in each context/generation worker config. The proxy signs internal
 generation requests with this key, and generation workers reject request-supplied
-`ctx_info_endpoint` values that do not carry a valid signature.
+disaggregated metadata such as `ctx_info_endpoint` or `encoded_opaque_state` when
+the internal handoff does not carry a valid signature.
 
 
 #### Sending requests to the disaggregated server

--- a/examples/disaggregated/slurm/service_discovery_example/launch.slurm
+++ b/examples/disaggregated/slurm/service_discovery_example/launch.slurm
@@ -11,6 +11,7 @@ enable_etcd="${enable_etcd:-0}"
 disagg_port="8000"
 ctx_port="8001"
 gen_port="8002"
+internal_request_auth_key="${internal_request_auth_key:-$(python3 -c 'import secrets; print(secrets.token_hex(32))')}"
 
 # use the first node as the disaggregated server node
 disagg_server_node=$(head -n 1 <(scontrol show hostnames $SLURM_JOB_NODELIST))
@@ -33,6 +34,7 @@ cat >${work_path}/disagg_config.yaml << EOL
 hostname: localhost
 port: ${disagg_port}
 backend: pytorch
+internal_request_auth_key: ${internal_request_auth_key}
 disagg_cluster:
   cluster_uri: ${disagg_cluster_uri}
   cluster_name: example_cluster
@@ -40,12 +42,14 @@ EOL
 
 cat >${work_path}/ctx_config.yaml << EOL
 disable_overlap_scheduler: True
+internal_request_auth_key: ${internal_request_auth_key}
 cache_transceiver_config:
   backend: UCX
   max_tokens_in_buffer: 2048
 EOL
 
 cat >${work_path}/gen_config.yaml << EOL
+internal_request_auth_key: ${internal_request_auth_key}
 cache_transceiver_config:
   backend: UCX
   max_tokens_in_buffer: 2048

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -1646,10 +1646,12 @@ class Receiver(ReceiverBase):
         return
 
     @staticmethod
-    def _extract_info_endpoint(params: DisaggregatedParams) -> Optional[str]:
+    def _extract_info_endpoint(params: DisaggregatedParams) -> str:
         ep = params.ctx_info_endpoint
         if isinstance(ep, list):
-            return ep[0] if ep else None
+            ep = ep[0] if ep else None
+        if ep is None:
+            raise ValueError("ctx_info_endpoint is required")
         return ep  # str (backward compat)
 
     def _should_register_peer(self, params: DisaggregatedParams) -> bool:

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
 
 AttentionTypeCpp = tensorrt_llm.bindings.internal.batch_manager.AttentionType
 LlmRequestType = tensorrt_llm.bindings.internal.batch_manager.LlmRequestType
+
 # Number of worker threads for KV transfer queues (default: 1)
 KV_TRANSFER_NUM_THREADS = int(os.environ.get("TRTLLM_KV_TRANSFER_NUM_THREADS", "1"))
 
@@ -1655,10 +1656,6 @@ class Receiver(ReceiverBase):
         endpoint = self._extract_info_endpoint(params)
         return endpoint not in self._sender_ep_instance_map
 
-    def _validate_info_endpoint(self, endpoint: Optional[str]) -> None:
-        if endpoint is None:
-            raise ValueError("Receiver: ctx_info_endpoint is required")
-
     def _get_or_connect_dealer(self, endpoint: Optional[str]):
         if endpoint is None:
             raise ValueError("Receiver: peer endpoint is None; peer may not have registered yet")
@@ -1668,7 +1665,6 @@ class Receiver(ReceiverBase):
 
     def _get_sender_info(self, params: DisaggregatedParams) -> RankInfo:
         info_endpoint = self._extract_info_endpoint(params)
-        self._validate_info_endpoint(info_endpoint)
         if self._should_register_peer(params):
             logger.info(f"Registering peer in first request to endpoint '{info_endpoint}'")
             messenger = ZMQMessenger(mode="DEALER", endpoint=info_endpoint)

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -75,7 +75,6 @@ if TYPE_CHECKING:
 
 AttentionTypeCpp = tensorrt_llm.bindings.internal.batch_manager.AttentionType
 LlmRequestType = tensorrt_llm.bindings.internal.batch_manager.LlmRequestType
-
 # Number of worker threads for KV transfer queues (default: 1)
 KV_TRANSFER_NUM_THREADS = int(os.environ.get("TRTLLM_KV_TRANSFER_NUM_THREADS", "1"))
 
@@ -1656,6 +1655,10 @@ class Receiver(ReceiverBase):
         endpoint = self._extract_info_endpoint(params)
         return endpoint not in self._sender_ep_instance_map
 
+    def _validate_info_endpoint(self, endpoint: Optional[str]) -> None:
+        if endpoint is None:
+            raise ValueError("Receiver: ctx_info_endpoint is required")
+
     def _get_or_connect_dealer(self, endpoint: Optional[str]):
         if endpoint is None:
             raise ValueError("Receiver: peer endpoint is None; peer may not have registered yet")
@@ -1665,6 +1668,7 @@ class Receiver(ReceiverBase):
 
     def _get_sender_info(self, params: DisaggregatedParams) -> RankInfo:
         info_endpoint = self._extract_info_endpoint(params)
+        self._validate_info_endpoint(info_endpoint)
         if self._should_register_peer(params):
             logger.info(f"Registering peer in first request to endpoint '{info_endpoint}'")
             messenger = ZMQMessenger(mode="DEALER", endpoint=info_endpoint)

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -2095,7 +2095,12 @@ def _serve_coordinator_and_fleet(disagg_cfg, config_file,
     #    ZMQ ingest server, started once here).
     def _client_factory(router, role, max_retries=1):
         from tensorrt_llm.serve.openai_client import OpenAIHttpClient
-        return OpenAIHttpClient(router, role, request_timeout, max_retries)
+        return OpenAIHttpClient(
+            router,
+            role,
+            request_timeout,
+            max_retries,
+            internal_disagg_auth_key=disagg_cfg.internal_request_auth_key)
 
     coordinator = DisaggCoordinatorService(
         disagg_cfg,

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -65,6 +65,16 @@ def _pop_bool_config_option(config: dict[str, Any], key: str) -> bool:
     return validate_config_bool(config.pop(key, False), key)
 
 
+def _pop_optional_str_config_option(config: dict[str, Any],
+                                    key: str) -> Optional[str]:
+    value = config.pop(key, None)
+    if value is None:
+        return None
+    if isinstance(value, str) and value:
+        return value
+    raise ValueError(f"{key} must be a non-empty string")
+
+
 def _apply_fastapi_middlewares(app, middlewares: Sequence[str]) -> None:
     """Import and register middleware objects on a FastAPI app."""
     for middleware in middlewares:
@@ -529,7 +539,8 @@ def launch_server(
         allow_request_chat_template: bool = False,
         num_input_processor_workers: int = 8,
         num_media_load_workers: int = 8,
-        multi_frontend_enabled: bool = True):
+        multi_frontend_enabled: bool = True,
+        internal_disagg_auth_key: Optional[str] = None):
 
     backend = llm_args["backend"]
     model = served_model_name or llm_args["model"]
@@ -605,7 +616,8 @@ def launch_server(
                 chat_template=chat_template,
                 allow_request_chat_template=allow_request_chat_template,
                 input_processor_workers=num_input_processor_workers,
-                media_load_workers=num_media_load_workers)
+                media_load_workers=num_media_load_workers,
+                internal_disagg_auth_key=internal_disagg_auth_key)
             _apply_fastapi_middlewares(server.app, middleware)
 
             # Optionally disable GC (default: not disabled)
@@ -1395,6 +1407,8 @@ def serve(model: str, tokenizer: Optional[str], custom_tokenizer: Optional[str],
             llm_args_extra_dict, "allow_request_chat_template")
         allow_request_chat_template = (allow_request_chat_template
                                        or extra_allow_request_chat_template)
+        internal_disagg_auth_key = _pop_optional_str_config_option(
+            llm_args_extra_dict, "internal_request_auth_key")
         llm_args = update_llm_args_with_extra_dict(
             llm_args, llm_args_extra_dict, explicit_cli_keys=explicit_cli_keys)
 
@@ -1449,6 +1463,8 @@ def serve(model: str, tokenizer: Optional[str], custom_tokenizer: Optional[str],
                 "allow_request_chat_template":
                 allow_request_chat_template
                 if allow_request_chat_template else None,
+                "internal_request_auth_key":
+                internal_disagg_auth_key,
                 "metadata_server_config_file":
                 metadata_server_config_file,
                 "server_role":
@@ -1482,7 +1498,8 @@ def serve(model: str, tokenizer: Optional[str], custom_tokenizer: Optional[str],
                 served_model_name=served_model_name,
                 allow_request_chat_template=allow_request_chat_template,
                 num_input_processor_workers=num_input_processor_workers,
-                num_media_load_workers=num_media_load_workers)
+                num_media_load_workers=num_media_load_workers,
+                internal_disagg_auth_key=internal_disagg_auth_key)
 
     def _serve_visual_gen():
         parsed_visual_gen_args = (VisualGenArgs.from_yaml(visual_gen_args)
@@ -2350,13 +2367,21 @@ def _launch_disaggregated_server(disagg_config_file: str, llm_args: dict):
     logger.info(
         f"rank {mpi_rank()} for index {instance_idx} launch the disagg server")
 
-    launch_server(
-        host=server_cfg.hostname,
-        port=server_cfg.port,
-        llm_args=llm_args,
-        allow_request_chat_template=disagg_config.allow_request_chat_template,
+    launch_kwargs = {
+        "allow_request_chat_template":
+        disagg_config.allow_request_chat_template,
         # Disagg ctx/gen MPI workers must not enter multi-frontend mode.
-        multi_frontend_enabled=False)
+        "multi_frontend_enabled": False,
+    }
+    internal_disagg_auth_key = getattr(disagg_config,
+                                       "internal_request_auth_key", None)
+    if internal_disagg_auth_key is not None:
+        launch_kwargs["internal_disagg_auth_key"] = internal_disagg_auth_key
+
+    launch_server(host=server_cfg.hostname,
+                  port=server_cfg.port,
+                  llm_args=llm_args,
+                  **launch_kwargs)
 
 
 def _launch_disaggregated_leader(sub_comm, instance_idx: int, config_file: str,

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -736,8 +736,9 @@ class GenerationExecutorProxy(GenerationExecutor):
         Unlinking ipc socket paths does not disturb established zmq
         connections; it only prevents new connects.
         """
-        if self._multi_frontend_ipc_dir is not None:
-            shutil.rmtree(self._multi_frontend_ipc_dir, ignore_errors=True)
+        ipc_dir = getattr(self, "_multi_frontend_ipc_dir", None)
+        if ipc_dir is not None:
+            shutil.rmtree(ipc_dir, ignore_errors=True)
             self._multi_frontend_ipc_dir = None
 
     def shutdown(self):

--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -182,7 +182,6 @@ def parse_disagg_config_file(yaml_config_file: str):
     with open(yaml_config_file, 'r') as file:
 
         config = yaml.safe_load(file)
-
         disagg_server_config = extract_disagg_cfg(**config)
 
         return disagg_server_config
@@ -276,9 +275,9 @@ def extract_disagg_cfg(hostname: str = 'localhost',
     config.gen_tokids_ctxbytes = gen_tokids_ctxbytes
     config.num_workers = num_workers
     config.disagg_coordinator_url = disagg_coordinator_url
-    if internal_request_auth_key is not None and not isinstance(
-            internal_request_auth_key, str):
-        raise ValueError("internal_request_auth_key must be a string")
+    if internal_request_auth_key is not None and (not isinstance(
+            internal_request_auth_key, str) or not internal_request_auth_key):
+        raise ValueError("internal_request_auth_key must be a non-empty string")
     config.internal_request_auth_key = internal_request_auth_key
     return config
 

--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -31,6 +31,42 @@ def validate_config_bool(value: Any, field_name: str) -> bool:
         f"{field_name} must be a boolean, got {type(value).__name__}")
 
 
+def _validate_internal_request_auth_key(value: Optional[str]) -> Optional[str]:
+    if value is not None and (not isinstance(value, str) or not value):
+        raise ValueError("internal_request_auth_key must be a non-empty string")
+    return value
+
+
+def _extract_internal_request_auth_key(
+        top_level_key: Optional[str], context_servers: dict,
+        generation_servers: dict) -> Optional[str]:
+    top_level_key = _validate_internal_request_auth_key(top_level_key)
+    section_keys = []
+    for server_type, servers in (("context_servers", context_servers),
+                                 ("generation_servers", generation_servers)):
+        section_key = servers.pop("internal_request_auth_key", None)
+        if section_key is None:
+            continue
+        section_keys.append(
+            (server_type, _validate_internal_request_auth_key(section_key)))
+
+    for server_type, section_key in section_keys:
+        if top_level_key is not None and section_key != top_level_key:
+            raise ValueError(
+                "internal_request_auth_key must match between the top-level "
+                f"config and {server_type}")
+
+    if top_level_key is None and section_keys:
+        unique_keys = {section_key for _, section_key in section_keys}
+        if len(unique_keys) != 1:
+            raise ValueError(
+                "internal_request_auth_key must match between context_servers "
+                "and generation_servers")
+        top_level_key = section_keys[0][1]
+
+    return top_level_key
+
+
 class ServerRole(IntEnum):
     CONTEXT = 0
     GENERATION = 1
@@ -211,6 +247,8 @@ def extract_disagg_cfg(hostname: str = 'localhost',
                        **kwargs: Any) -> DisaggServerConfig:
     context_servers = context_servers or {}
     generation_servers = generation_servers or {}
+    internal_request_auth_key = _extract_internal_request_auth_key(
+        internal_request_auth_key, context_servers, generation_servers)
 
     inherited_args = dict(kwargs)
 
@@ -275,9 +313,6 @@ def extract_disagg_cfg(hostname: str = 'localhost',
     config.gen_tokids_ctxbytes = gen_tokids_ctxbytes
     config.num_workers = num_workers
     config.disagg_coordinator_url = disagg_coordinator_url
-    if internal_request_auth_key is not None and (not isinstance(
-            internal_request_auth_key, str) or not internal_request_auth_key):
-        raise ValueError("internal_request_auth_key must be a non-empty string")
     config.internal_request_auth_key = internal_request_auth_key
     return config
 

--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -117,6 +117,7 @@ class DisaggServerConfig():
     # fleet delegates to it; when absent, num_workers>1 starts an implicit in-process
     # coordinator and num_workers==1 runs a single self-contained server.
     disagg_coordinator_url: Optional[str] = None
+    internal_request_auth_key: Optional[str] = None
 
 
 @dataclass
@@ -207,6 +208,7 @@ def extract_disagg_cfg(hostname: str = 'localhost',
                        gen_tokids_ctxbytes: bool = False,
                        num_workers: int = 1,
                        disagg_coordinator_url: Optional[str] = None,
+                       internal_request_auth_key: Optional[str] = None,
                        **kwargs: Any) -> DisaggServerConfig:
     context_servers = context_servers or {}
     generation_servers = generation_servers or {}
@@ -274,6 +276,10 @@ def extract_disagg_cfg(hostname: str = 'localhost',
     config.gen_tokids_ctxbytes = gen_tokids_ctxbytes
     config.num_workers = num_workers
     config.disagg_coordinator_url = disagg_coordinator_url
+    if internal_request_auth_key is not None and not isinstance(
+            internal_request_auth_key, str):
+        raise ValueError("internal_request_auth_key must be a string")
+    config.internal_request_auth_key = internal_request_auth_key
     return config
 
 

--- a/tensorrt_llm/serve/disagg_auth.py
+++ b/tensorrt_llm/serve/disagg_auth.py
@@ -33,7 +33,10 @@ def request_requires_internal_disagg_auth(request: UCompletionRequest) -> bool:
 
 def _auth_payload(request: UCompletionRequest) -> bytes:
     disaggregated_params = request.disaggregated_params
-    payload = disaggregated_params.model_dump(mode="json", exclude_none=False)
+    payload = {
+        "ctx_info_endpoint": disaggregated_params.ctx_info_endpoint,
+        "encoded_opaque_state": disaggregated_params.encoded_opaque_state,
+    }
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 

--- a/tensorrt_llm/serve/disagg_auth.py
+++ b/tensorrt_llm/serve/disagg_auth.py
@@ -15,7 +15,7 @@
 import hashlib
 import hmac
 import json
-from typing import Mapping, Optional
+from typing import Any, Mapping, Optional
 
 from tensorrt_llm.serve.openai_protocol import UCompletionRequest
 
@@ -31,10 +31,16 @@ def request_requires_internal_disagg_auth(request: UCompletionRequest) -> bool:
     )
 
 
+def _canonical_ctx_info_endpoint(endpoint: Any) -> Any:
+    if isinstance(endpoint, list):
+        return endpoint[0] if endpoint else None
+    return endpoint
+
+
 def _auth_payload(request: UCompletionRequest) -> bytes:
     disaggregated_params = request.disaggregated_params
     payload = {
-        "ctx_info_endpoint": disaggregated_params.ctx_info_endpoint,
+        "ctx_info_endpoint": _canonical_ctx_info_endpoint(disaggregated_params.ctx_info_endpoint),
         "encoded_opaque_state": disaggregated_params.encoded_opaque_state,
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/tensorrt_llm/serve/disagg_auth.py
+++ b/tensorrt_llm/serve/disagg_auth.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import hmac
+import json
+from typing import Mapping, Optional
+
+from tensorrt_llm.serve.openai_protocol import UCompletionRequest
+
+INTERNAL_DISAGG_AUTH_HEADER = "x-trtllm-disagg-auth"
+_SIGNATURE_PREFIX = "sha256="
+
+
+def request_requires_internal_disagg_auth(request: UCompletionRequest) -> bool:
+    disaggregated_params = getattr(request, "disaggregated_params", None)
+    return disaggregated_params is not None and (
+        disaggregated_params.encoded_opaque_state is not None
+        or disaggregated_params.ctx_info_endpoint is not None
+    )
+
+
+def _auth_payload(request: UCompletionRequest) -> bytes:
+    disaggregated_params = request.disaggregated_params
+    payload = disaggregated_params.model_dump(mode="json", exclude_none=False)
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sign_request(internal_disagg_auth_key: str, request: UCompletionRequest) -> str:
+    signature = hmac.new(
+        internal_disagg_auth_key.encode("utf-8"), _auth_payload(request), hashlib.sha256
+    ).hexdigest()
+    return f"{_SIGNATURE_PREFIX}{signature}"
+
+
+def build_internal_disagg_auth_headers(
+    internal_disagg_auth_key: Optional[str], request: UCompletionRequest
+) -> dict[str, str]:
+    if not request_requires_internal_disagg_auth(request):
+        return {}
+    if not internal_disagg_auth_key:
+        raise ValueError(
+            "Internal disaggregated authentication key is required for protected disaggregated request fields"
+        )
+    return {INTERNAL_DISAGG_AUTH_HEADER: _sign_request(internal_disagg_auth_key, request)}
+
+
+def validate_internal_disagg_request(
+    internal_disagg_auth_key: Optional[str],
+    request: UCompletionRequest,
+    headers: Optional[Mapping[str, str]],
+) -> None:
+    if not request_requires_internal_disagg_auth(request):
+        return
+    if not internal_disagg_auth_key:
+        raise ValueError(
+            "Protected disaggregated request fields require authenticated disaggregated request forwarding"
+        )
+
+    expected = _sign_request(internal_disagg_auth_key, request)
+    provided = None if headers is None else headers.get(INTERNAL_DISAGG_AUTH_HEADER)
+    if provided is None or not hmac.compare_digest(provided, expected):
+        raise ValueError("Invalid internal disaggregated request authentication")

--- a/tensorrt_llm/serve/disagg_auth.py
+++ b/tensorrt_llm/serve/disagg_auth.py
@@ -22,6 +22,7 @@ from tensorrt_llm.serve.openai_protocol import UCompletionRequest
 
 INTERNAL_DISAGG_AUTH_HEADER = "x-trtllm-disagg-auth"
 _SIGNATURE_PREFIX = "sha256="
+_INTERNAL_DISAGG_AUTH_FIELDS = ("encoded_opaque_state", "ctx_info_endpoint")
 _MISSING_AUTH_KEY_WARNING = (
     "Internal disaggregated authentication key is required for protected "
     "disaggregated request fields. In a future release the requirement to "
@@ -30,15 +31,19 @@ _MISSING_AUTH_KEY_WARNING = (
 )
 
 
+def get_internal_disagg_auth_fields() -> tuple[str, ...]:
+    return _INTERNAL_DISAGG_AUTH_FIELDS
+
+
 def _warn_missing_auth_key() -> None:
     warnings.warn(_MISSING_AUTH_KEY_WARNING, FutureWarning, stacklevel=2)
 
 
 def request_requires_internal_disagg_auth(request: UCompletionRequest) -> bool:
     disaggregated_params = getattr(request, "disaggregated_params", None)
-    return disaggregated_params is not None and (
-        disaggregated_params.encoded_opaque_state is not None
-        or disaggregated_params.ctx_info_endpoint is not None
+    return disaggregated_params is not None and any(
+        getattr(disaggregated_params, field_name) is not None
+        for field_name in get_internal_disagg_auth_fields()
     )
 
 
@@ -51,8 +56,11 @@ def _canonical_ctx_info_endpoint(endpoint: Any) -> Any:
 def _auth_payload(request: UCompletionRequest) -> bytes:
     disaggregated_params = request.disaggregated_params
     payload = {
-        "ctx_info_endpoint": _canonical_ctx_info_endpoint(disaggregated_params.ctx_info_endpoint),
-        "encoded_opaque_state": disaggregated_params.encoded_opaque_state,
+        field_name: _canonical_ctx_info_endpoint(value)
+        if field_name == "ctx_info_endpoint"
+        else value
+        for field_name in get_internal_disagg_auth_fields()
+        for value in [getattr(disaggregated_params, field_name)]
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
@@ -65,7 +73,8 @@ def _sign_request(internal_disagg_auth_key: str, request: UCompletionRequest) ->
 
 
 def build_internal_disagg_auth_headers(
-    internal_disagg_auth_key: Optional[str], request: UCompletionRequest
+    internal_disagg_auth_key: Optional[str],
+    request: UCompletionRequest,
 ) -> dict[str, str]:
     if not request_requires_internal_disagg_auth(request):
         return {}

--- a/tensorrt_llm/serve/disagg_auth.py
+++ b/tensorrt_llm/serve/disagg_auth.py
@@ -15,12 +15,23 @@
 import hashlib
 import hmac
 import json
+import warnings
 from typing import Any, Mapping, Optional
 
 from tensorrt_llm.serve.openai_protocol import UCompletionRequest
 
 INTERNAL_DISAGG_AUTH_HEADER = "x-trtllm-disagg-auth"
 _SIGNATURE_PREFIX = "sha256="
+_MISSING_AUTH_KEY_WARNING = (
+    "Internal disaggregated authentication key is required for protected "
+    "disaggregated request fields. In a future release the requirement to "
+    "use internal_request_auth_key will be enforced. Please update workflow "
+    "accordingly."
+)
+
+
+def _warn_missing_auth_key() -> None:
+    warnings.warn(_MISSING_AUTH_KEY_WARNING, FutureWarning, stacklevel=2)
 
 
 def request_requires_internal_disagg_auth(request: UCompletionRequest) -> bool:
@@ -59,9 +70,8 @@ def build_internal_disagg_auth_headers(
     if not request_requires_internal_disagg_auth(request):
         return {}
     if not internal_disagg_auth_key:
-        raise ValueError(
-            "Internal disaggregated authentication key is required for protected disaggregated request fields"
-        )
+        _warn_missing_auth_key()
+        return {}
     return {INTERNAL_DISAGG_AUTH_HEADER: _sign_request(internal_disagg_auth_key, request)}
 
 
@@ -73,9 +83,8 @@ def validate_internal_disagg_request(
     if not request_requires_internal_disagg_auth(request):
         return
     if not internal_disagg_auth_key:
-        raise ValueError(
-            "Protected disaggregated request fields require authenticated disaggregated request forwarding"
-        )
+        _warn_missing_auth_key()
+        return
 
     expected = _sign_request(internal_disagg_auth_key, request)
     provided = None if headers is None else headers.get(INTERNAL_DISAGG_AUTH_HEADER)

--- a/tensorrt_llm/serve/openai_client.py
+++ b/tensorrt_llm/serve/openai_client.py
@@ -24,6 +24,10 @@ import aiohttp
 
 from tensorrt_llm.llmapi.disagg_utils import ServerRole
 from tensorrt_llm.logger import logger
+from tensorrt_llm.serve.disagg_auth import (
+    build_internal_disagg_auth_headers,
+    request_requires_internal_disagg_auth,
+)
 from tensorrt_llm.serve.openai_protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -142,6 +146,7 @@ class OpenAIHttpClient(OpenAIClient):
         session: Optional[aiohttp.ClientSession] = None,
         disagg_id_generator: Optional[Callable[[], Awaitable[int]]] = None,
         request_perf_metrics: bool = False,
+        internal_disagg_auth_key: Optional[str] = None,
     ):
         self._router = router
         self._role = role
@@ -161,6 +166,14 @@ class OpenAIHttpClient(OpenAIClient):
         self._retry_interval_sec = retry_interval_sec
         self._disagg_id_generator = disagg_id_generator
         self._request_perf_metrics = request_perf_metrics
+        self._internal_disagg_auth_key = internal_disagg_auth_key
+
+    def _get_request_headers(self, request: UCompletionRequest) -> Dict[str, str]:
+        if self._role != ServerRole.GENERATION:
+            return {}
+        if not request_requires_internal_disagg_auth(request):
+            return {}
+        return build_internal_disagg_auth_headers(self._internal_disagg_auth_key, request)
 
     async def _send_request(
         self,
@@ -236,19 +249,20 @@ class OpenAIHttpClient(OpenAIClient):
                 # subtypes); the X-TRTLLM-Msgpack header tells the worker's
                 # Request.json() to decode with msgspec instead of stdlib json.
                 body = _msgpack_encoder.encode(request.model_dump(mode="json", exclude_unset=True))
-                req_headers = {"Content-Type": "application/json", "X-TRTLLM-Msgpack": "1"}
+                headers = {"Content-Type": "application/json", "X-TRTLLM-Msgpack": "1"}
             else:
                 body = request.model_dump_json(exclude_unset=True)
-                req_headers = {"Content-Type": "application/json"}
+                headers = {"Content-Type": "application/json"}
             if self._request_perf_metrics:
-                req_headers[RETURN_METRICS_HEADER] = "1"
+                headers[RETURN_METRICS_HEADER] = "1"
+            headers.update(self._get_request_headers(request))
             try:
                 lines_yielded = 0
                 start_time = get_steady_clock_now_in_seconds()
                 async with self._session.post(
                     url,
                     data=body,
-                    headers=req_headers,
+                    headers=headers,
                 ) as http_response:
                     content_type = http_response.headers.get("Content-Type", "")
                     if self._request_perf_metrics:

--- a/tensorrt_llm/serve/openai_client.py
+++ b/tensorrt_llm/serve/openai_client.py
@@ -168,7 +168,7 @@ class OpenAIHttpClient(OpenAIClient):
         self._request_perf_metrics = request_perf_metrics
         self._internal_disagg_auth_key = internal_disagg_auth_key
 
-    def _get_request_headers(self, request: UCompletionRequest) -> Dict[str, str]:
+    def _get_request_headers(self, request: UCompletionRequest) -> dict[str, str]:
         if self._role != ServerRole.GENERATION:
             return {}
         if not request_requires_internal_disagg_auth(request):

--- a/tensorrt_llm/serve/openai_disagg_server.py
+++ b/tensorrt_llm/serve/openai_disagg_server.py
@@ -256,7 +256,6 @@ class OpenAIDisaggServer:
             disagg_id_generator=disagg_id_generator,
             request_perf_metrics=self._collect_perf_metrics,
             internal_disagg_auth_key=self._config.internal_request_auth_key)
-        self._perf_metrics_collector.add_client(client)
         return client
 
     def register_routes(self):

--- a/tensorrt_llm/serve/openai_disagg_server.py
+++ b/tensorrt_llm/serve/openai_disagg_server.py
@@ -251,10 +251,13 @@ class OpenAIDisaggServer:
     def _create_client(self, router: Router, role: ServerRole, max_retries: int = 1) -> OpenAIClient:
         async def disagg_id_generator():
             return await self._coordinator.get_disagg_request_id()
-        return OpenAIHttpClient(
+        client = OpenAIHttpClient(
             router, role, self._req_timeout_secs, max_retries,
             disagg_id_generator=disagg_id_generator,
-            request_perf_metrics=self._collect_perf_metrics)
+            request_perf_metrics=self._collect_perf_metrics,
+            internal_disagg_auth_key=self._config.internal_request_auth_key)
+        self._perf_metrics_collector.add_client(client)
+        return client
 
     def register_routes(self):
         # The disagg service owns only the request-serving endpoints (/v1/*) and

--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -128,7 +128,8 @@ class OpenAIDisaggregatedService(OpenAIService):
         # handshake. Keep the ID used to reserve the generation server separate
         # so its coordinator-side load is released under the original key.
         gen_reservation_id = disagg_request_id if gen_server else None
-        need_ctx = need_ctx and not await self._check_gen_only_disagg(request)
+        benchmark_gen_only = await self._check_gen_only_disagg(request)
+        need_ctx = need_ctx and not benchmark_gen_only
         ctx_response = None
         gen_req = request
         if need_ctx:
@@ -160,14 +161,10 @@ class OpenAIDisaggregatedService(OpenAIService):
                 raise
         else:
             # When need_ctx=False the gen server handles full generation and
-            # must not see a stale request_type="context_only".
-            # _check_gen_only_disagg already sets proper generation_only
-            # params when applicable.
-            if (
-                gen_req.disaggregated_params is not None
-                and gen_req.disaggregated_params.request_type == "context_only"
-            ):
-                gen_req.disaggregated_params = None
+            # must not see client-supplied disaggregated handoff params. The
+            # benchmark-only path above is the only trusted source here.
+            if not benchmark_gen_only:
+                gen_req = request.model_copy(update={"disaggregated_params": None})
         if ctx_response is None or self._need_gen(ctx_response):
             if not gen_server:
                 gen_server, _ = await self._gen_router.get_next_server(

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -63,7 +63,8 @@ from tensorrt_llm.serve.chat_utils import (load_chat_template,
                                            resolve_top_level_model_type)
 from tensorrt_llm.serve.cluster_storage import create_cluster_storage_client
 from tensorrt_llm.serve.conversation_id import resolve_request_conversation_id
-from tensorrt_llm.serve.disagg_auth import validate_internal_disagg_request
+from tensorrt_llm.serve.disagg_auth import (
+    request_requires_internal_disagg_auth, validate_internal_disagg_request)
 from tensorrt_llm.serve.disagg_auto_scaling import DisaggClusterWorker
 from tensorrt_llm.serve.encode_batcher import (EncodeBatcher, InputTooLongError,
                                                QueueFullError)
@@ -510,11 +511,6 @@ class OpenAIServer(_VideoRoutesMixin):
         self.media_storage_path.mkdir(exist_ok=True, parents=True)
         self.video_gen_tasks = {}
 
-    def _validate_internal_disagg_request(self, request, raw_request) -> None:
-        headers = {} if raw_request is None else raw_request.headers
-        validate_internal_disagg_request(
-            getattr(self, "_internal_disagg_auth_key", None), request, headers)
-
     def _init_llm(self, chat_template: Optional[str] = None):
         self.tokenizer = self.generator.tokenizer
         hf_tokenizer_path = self.generator._hf_model_dir
@@ -639,9 +635,22 @@ class OpenAIServer(_VideoRoutesMixin):
 
     def _validate_internal_disagg_request(
             self, request, raw_request: Optional[Request]) -> None:
+        if (request_requires_internal_disagg_auth(request)
+                and not self._has_cache_transceiver_config()):
+            raise ValueError("Protected disaggregated request fields require "
+                             "cache_transceiver_config to be configured")
         headers = None if raw_request is None else raw_request.headers
         validate_internal_disagg_request(
             getattr(self, "_internal_disagg_auth_key", None), request, headers)
+
+    def _has_cache_transceiver_config(self) -> bool:
+        cache_transceiver_config = getattr(
+            getattr(self.generator, "args", None), "cache_transceiver_config",
+            None)
+        if isinstance(cache_transceiver_config, dict):
+            return cache_transceiver_config.get("backend") is not None
+        return (cache_transceiver_config is not None and getattr(
+            cache_transceiver_config, "backend", None) is not None)
 
     def _log_config_info_metrics(self) -> None:
         """Extract configuration from generator args and log as Prometheus info gauges."""

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -63,6 +63,7 @@ from tensorrt_llm.serve.chat_utils import (load_chat_template,
                                            resolve_top_level_model_type)
 from tensorrt_llm.serve.cluster_storage import create_cluster_storage_client
 from tensorrt_llm.serve.conversation_id import resolve_request_conversation_id
+from tensorrt_llm.serve.disagg_auth import validate_internal_disagg_request
 from tensorrt_llm.serve.disagg_auto_scaling import DisaggClusterWorker
 from tensorrt_llm.serve.encode_batcher import (EncodeBatcher, InputTooLongError,
                                                QueueFullError)
@@ -269,7 +270,8 @@ class OpenAIServer(_VideoRoutesMixin):
             embedding_max_queue_delay: float = 0.005,
             embedding_max_queue_size: int = 2048,
             input_processor_workers: int = 8,
-            media_load_workers: int = 8):
+            media_load_workers: int = 8,
+            internal_disagg_auth_key: Optional[str] = None):
         self.generator = generator
         self._is_visual_gen = isinstance(generator, VisualGen)
         self._embedding_max_queue_delay = embedding_max_queue_delay
@@ -293,6 +295,7 @@ class OpenAIServer(_VideoRoutesMixin):
                 cfg.media_io_kwargs = merged
                 self.multimodal_server_config = cfg
         self.allow_request_chat_template = allow_request_chat_template
+        self._internal_disagg_auth_key = internal_disagg_auth_key
         self.server_role = server_role
         # Will be set in __call__
         self.binding_addr = None
@@ -507,6 +510,11 @@ class OpenAIServer(_VideoRoutesMixin):
         self.media_storage_path.mkdir(exist_ok=True, parents=True)
         self.video_gen_tasks = {}
 
+    def _validate_internal_disagg_request(self, request, raw_request) -> None:
+        headers = {} if raw_request is None else raw_request.headers
+        validate_internal_disagg_request(self._internal_disagg_auth_key,
+                                         request, headers)
+
     def _init_llm(self, chat_template: Optional[str] = None):
         self.tokenizer = self.generator.tokenizer
         hf_tokenizer_path = self.generator._hf_model_dir
@@ -628,6 +636,12 @@ class OpenAIServer(_VideoRoutesMixin):
             if vocab_size is not None:
                 return int(vocab_size)
         return int(self.tokenizer.tokenizer.vocab_size)
+
+    def _validate_internal_disagg_request(
+            self, request, raw_request: Optional[Request]) -> None:
+        headers = None if raw_request is None else raw_request.headers
+        validate_internal_disagg_request(self._internal_disagg_auth_key,
+                                         request, headers)
 
     def _log_config_info_metrics(self) -> None:
         """Extract configuration from generator args and log as Prometheus info gauges."""
@@ -1476,6 +1490,7 @@ class OpenAIServer(_VideoRoutesMixin):
                     if strict_guided is not None:
                         sampling_params.guided_decoding = strict_guided
             postproc_args = ChatPostprocArgs.from_request(request)
+            self._validate_internal_disagg_request(request, raw_request)
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)
 
@@ -1869,6 +1884,7 @@ class OpenAIServer(_VideoRoutesMixin):
             # TODO: better way to enable metrics
             if len(os.getenv("TRTLLM_KVCACHE_TIME_OUTPUT_PATH", "")) > 0:
                 sampling_params.return_perf_metrics = True
+            self._validate_internal_disagg_request(request, raw_request)
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)
             resolve_request_conversation_id(
@@ -2027,6 +2043,7 @@ class OpenAIServer(_VideoRoutesMixin):
             # for header or JSONL output.
             if len(os.getenv("TRTLLM_KVCACHE_TIME_OUTPUT_PATH", "")) > 0:
                 sampling_params.return_perf_metrics = True
+            self._validate_internal_disagg_request(request, raw_request)
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)
             trace_headers = (None if raw_request is None else

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -512,8 +512,8 @@ class OpenAIServer(_VideoRoutesMixin):
 
     def _validate_internal_disagg_request(self, request, raw_request) -> None:
         headers = {} if raw_request is None else raw_request.headers
-        validate_internal_disagg_request(self._internal_disagg_auth_key,
-                                         request, headers)
+        validate_internal_disagg_request(
+            getattr(self, "_internal_disagg_auth_key", None), request, headers)
 
     def _init_llm(self, chat_template: Optional[str] = None):
         self.tokenizer = self.generator.tokenizer
@@ -640,8 +640,8 @@ class OpenAIServer(_VideoRoutesMixin):
     def _validate_internal_disagg_request(
             self, request, raw_request: Optional[Request]) -> None:
         headers = None if raw_request is None else raw_request.headers
-        validate_internal_disagg_request(self._internal_disagg_auth_key,
-                                         request, headers)
+        validate_internal_disagg_request(
+            getattr(self, "_internal_disagg_auth_key", None), request, headers)
 
     def _log_config_info_metrics(self) -> None:
         """Extract configuration from generator args and log as Prometheus info gauges."""

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -5,6 +5,7 @@ import itertools
 import json
 import os
 import re
+import secrets
 import subprocess
 import tempfile
 import time
@@ -207,12 +208,24 @@ def launch_disaggregated_llm(
         "generation_servers": num_gen_instances
     }
 
+    internal_request_auth_key = secrets.token_hex(32)
+
     # Inject disagg_cluster into server config (for minimal_instances and is_ready check)
     disaggregated_server_config["disagg_cluster"] = disagg_cluster
+    disaggregated_server_config["internal_request_auth_key"] = (
+        internal_request_auth_key)
 
     # Inject into worker configs
-    ctx_server_config = {**ctx_server_config, "disagg_cluster": disagg_cluster}
-    gen_server_config = {**gen_server_config, "disagg_cluster": disagg_cluster}
+    ctx_server_config = {
+        **ctx_server_config,
+        "disagg_cluster": disagg_cluster,
+        "internal_request_auth_key": internal_request_auth_key,
+    }
+    gen_server_config = {
+        **gen_server_config,
+        "disagg_cluster": disagg_cluster,
+        "internal_request_auth_key": internal_request_auth_key,
+    }
 
     with open(disaggregated_serving_config_path, "w") as f:
         yaml.dump(disaggregated_server_config, f)

--- a/tests/integration/defs/disaggregated/disagg_test_utils.py
+++ b/tests/integration/defs/disaggregated/disagg_test_utils.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import os
+import secrets
 import shutil
 import subprocess
 import tempfile
@@ -477,7 +478,13 @@ def disagg_cluster_config(service_discovery):
 
 
 @pytest.fixture
-def disagg_server_config(disagg_cluster_config, router, disagg_port):
+def internal_request_auth_key():
+    """Create one internal auth key shared by proxy and workers."""
+    return secrets.token_hex(32)
+
+
+@pytest.fixture
+def disagg_server_config(disagg_cluster_config, router, disagg_port, internal_request_auth_key):
     """Create disaggregated server configuration."""
     return {
         "hostname": "localhost",
@@ -485,14 +492,16 @@ def disagg_server_config(disagg_cluster_config, router, disagg_port):
         "disagg_cluster": disagg_cluster_config,
         "context_servers": {"router": {"type": router}},
         "generation_servers": {"router": {"type": router}},
+        "internal_request_auth_key": internal_request_auth_key,
     }
 
 
 @pytest.fixture
-def worker_config(disagg_cluster_config):
+def worker_config(disagg_cluster_config, internal_request_auth_key):
     """Create worker configuration."""
     return {
         "disagg_cluster": disagg_cluster_config,
+        "internal_request_auth_key": internal_request_auth_key,
         "disable_overlap_scheduler": True,
         "cache_transceiver_config": {"backend": "DEFAULT"},
         "kv_cache_config": {

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -18,6 +18,7 @@ import json
 import os
 import platform
 import re
+import secrets
 import shutil
 import subprocess
 import tempfile
@@ -727,8 +728,12 @@ def setup_disagg_cluster(
                     gen_servers.get("context_parallel_size", 1))
 
     # Build worker configs
+    internal_request_auth_key = config.get(
+        "internal_request_auth_key") or secrets.token_hex(32)
     ctx_worker_config = build_worker_config(config, ctx_servers, disagg_cluster)
     gen_worker_config = build_worker_config(config, gen_servers, disagg_cluster)
+    ctx_worker_config["internal_request_auth_key"] = internal_request_auth_key
+    gen_worker_config["internal_request_auth_key"] = internal_request_auth_key
 
     # Launch workers
     model = model_name or config.get("model")
@@ -805,6 +810,8 @@ def setup_disagg_cluster(
             config.get("perf_metrics_output_dir", None),
             "return_perf_metrics":
             config.get("return_perf_metrics", False),
+            "internal_request_auth_key":
+            internal_request_auth_key,
         }
         if schedule_style:
             server_config["schedule_style"] = schedule_style

--- a/tests/integration/defs/disaggregated/test_workers.py
+++ b/tests/integration/defs/disaggregated/test_workers.py
@@ -18,6 +18,7 @@ import copy
 import json
 import os
 import platform
+import secrets
 import tempfile
 from typing import List
 
@@ -33,6 +34,7 @@ from disagg_test_utils import (HEARTBEAT_INTERVAL, INACTIVE_TIMEOUT,
 from transformers import AutoTokenizer
 
 from tensorrt_llm import logger
+from tensorrt_llm.serve.disagg_auth import build_internal_disagg_auth_headers
 from tensorrt_llm.serve.openai_client import OpenAIHttpClient
 from tensorrt_llm.serve.openai_protocol import (CompletionRequest,
                                                 ConversationParams,
@@ -140,11 +142,13 @@ class BasicWorkerTester:
                  ctx_servers: List[str],
                  gen_servers: List[str],
                  req_timeout_secs: int = DEFAULT_TIMEOUT_REQUEST,
-                 server_start_timeout_secs: int = DEFAULT_TIMEOUT_SERVER_START):
+                 server_start_timeout_secs: int = DEFAULT_TIMEOUT_SERVER_START,
+                 internal_request_auth_key: str | None = None):
         self.ctx_servers = ctx_servers
         self.gen_servers = gen_servers
         self.req_timeout_secs = req_timeout_secs
         self.server_start_timeout_secs = server_start_timeout_secs
+        self.internal_request_auth_key = internal_request_auth_key
 
     async def new_session(self):
         session = aiohttp.ClientSession(
@@ -155,11 +159,15 @@ class BasicWorkerTester:
                                            self.server_start_timeout_secs)
         return session
 
-    async def send_request(self, session: aiohttp.ClientSession, url: str,
-                           request: dict) -> dict:
+    async def send_request(self,
+                           session: aiohttp.ClientSession,
+                           url: str,
+                           request: dict,
+                           headers: dict | None = None) -> dict:
         # TODO: streaming support
         async with session.post(url + "/v1/completions",
-                                json=request) as response:
+                                json=request,
+                                headers=headers) as response:
             content_type = response.headers.get("Content-Type", "")
             if "text/event-stream" in content_type:
                 raise ValueError(
@@ -185,7 +193,11 @@ class BasicWorkerTester:
         gen_request["disaggregated_params"] = ctx_response["choices"][0][
             "disaggregated_params"]
         gen_request["disaggregated_params"]["request_type"] = "generation_only"
-        gen_response = await self.send_request(session, gen_url, gen_request)
+        headers = build_internal_disagg_auth_headers(
+            self.internal_request_auth_key,
+            CompletionRequest.model_validate(gen_request))
+        gen_response = await self.send_request(session, gen_url, gen_request,
+                                               headers)
         return gen_response
 
     async def query_kv_cache_events(self, session: aiohttp.ClientSession,
@@ -219,9 +231,10 @@ class ConditionalWorkerTester(BasicWorkerTester):
                  gen_servers: List[str],
                  req_timeout_secs: int = DEFAULT_TIMEOUT_REQUEST,
                  server_start_timeout_secs: int = DEFAULT_TIMEOUT_SERVER_START,
-                 model_name: str = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"):
+                 model_name: str = "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+                 internal_request_auth_key: str | None = None):
         super().__init__(ctx_servers, gen_servers, req_timeout_secs,
-                         server_start_timeout_secs)
+                         server_start_timeout_secs, internal_request_auth_key)
         self.model_name = model_name
 
     async def multi_round_request(self, session: aiohttp.ClientSession,
@@ -272,9 +285,10 @@ class KvCacheEventWorkerTester(BasicWorkerTester):
                  gen_servers: List[str],
                  req_timeout_secs: int = DEFAULT_TIMEOUT_REQUEST,
                  server_start_timeout_secs: int = DEFAULT_TIMEOUT_SERVER_START,
-                 model_name: str = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"):
+                 model_name: str = "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+                 internal_request_auth_key: str | None = None):
         super().__init__(ctx_servers, gen_servers, req_timeout_secs,
-                         server_start_timeout_secs)
+                         server_start_timeout_secs, internal_request_auth_key)
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)
         self.model_name = model_name
         self.kv_cache_block_maps: dict[str, KvCacheAwareServerState] = {}
@@ -289,9 +303,12 @@ class KvCacheEventWorkerTester(BasicWorkerTester):
                     gen_server)
                 self.kv_cache_event_maps[gen_server] = []
 
-    async def send_request(self, session: aiohttp.ClientSession, url: str,
-                           request: dict) -> dict:
-        response = await super().send_request(session, url, request)
+    async def send_request(self,
+                           session: aiohttp.ClientSession,
+                           url: str,
+                           request: dict,
+                           headers: dict | None = None) -> dict:
+        response = await super().send_request(session, url, request, headers)
         events = await self.query_kv_cache_events(session, url)
         async with self.kv_cache_block_maps[url]._lock:
             self.kv_cache_block_maps[url].update_with_events(events)
@@ -390,9 +407,10 @@ class KvCacheAwareRouterTester(BasicWorkerTester):
                  req_timeout_secs: int = DEFAULT_TIMEOUT_REQUEST,
                  server_start_timeout_secs: int = DEFAULT_TIMEOUT_SERVER_START,
                  model_name: str = "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-                 tokens_per_block: int = 32):
+                 tokens_per_block: int = 32,
+                 internal_request_auth_key: str | None = None):
         super().__init__(ctx_servers, gen_servers, req_timeout_secs,
-                         server_start_timeout_secs)
+                         server_start_timeout_secs, internal_request_auth_key)
         self.ctx_router = KvCacheAwareRouter(server_role=ServerRole.CONTEXT,
                                              servers=ctx_servers,
                                              tokens_per_block=tokens_per_block)
@@ -585,6 +603,9 @@ def background_workers(llm_venv, config_file: str):
                                             disagg_cluster)
     gen_worker_config = build_worker_config(config, gen_server_cfg,
                                             disagg_cluster)
+    internal_request_auth_key = secrets.token_hex(32)
+    ctx_worker_config["internal_request_auth_key"] = internal_request_auth_key
+    gen_worker_config["internal_request_auth_key"] = internal_request_auth_key
 
     gpus_per_ctx = (ctx_server_cfg.get("tensor_parallel_size", 1) *
                     ctx_server_cfg.get("pipeline_parallel_size", 1))
@@ -634,6 +655,7 @@ def background_workers(llm_venv, config_file: str):
         "generation_servers": {
             "router": gen_server_cfg.get("router", {})
         },
+        "internal_request_auth_key": internal_request_auth_key,
     }
     disagg_server = run_disagg_server(server_config,
                                       work_dir,
@@ -642,7 +664,7 @@ def background_workers(llm_venv, config_file: str):
 
     try:
         asyncio.run(wait_for_disagg_server_ready(disagg_port))
-        yield ctx_urls, gen_urls, disagg_port
+        yield ctx_urls, gen_urls, disagg_port, internal_request_auth_key
     except Exception:
         logger.error("-------- Service discovery workers error --------")
         raise
@@ -661,8 +683,12 @@ def test_workers_conditional_disaggregation(disaggregated_test_root,
     prepare_llama_model(llama_model_root, llm_venv)
 
     with background_workers(llm_venv,
-                            config_file) as (ctx_servers, gen_servers, _):
-        tester = ConditionalWorkerTester(ctx_servers, gen_servers)
+                            config_file) as (ctx_servers, gen_servers, _,
+                                             internal_request_auth_key):
+        tester = ConditionalWorkerTester(
+            ctx_servers,
+            gen_servers,
+            internal_request_auth_key=internal_request_auth_key)
         prompts = load_default_prompts(disaggregated_example_root)
         asyncio.run(tester.test_multi_round_request(prompts))
 
@@ -685,8 +711,12 @@ def test_workers_conditional_disaggregation_deepseek_v3_lite_bf16(
             os.symlink(src, dst, target_is_directory=True)
 
     with background_workers(llm_venv,
-                            config_file) as (ctx_servers, gen_servers, _):
-        tester = ConditionalWorkerTester(ctx_servers, gen_servers)
+                            config_file) as (ctx_servers, gen_servers, _,
+                                             internal_request_auth_key):
+        tester = ConditionalWorkerTester(
+            ctx_servers,
+            gen_servers,
+            internal_request_auth_key=internal_request_auth_key)
         prompts = load_default_prompts(disaggregated_example_root)
         asyncio.run(tester.test_multi_round_request(prompts))
 
@@ -701,8 +731,12 @@ def test_workers_kv_cache_events(disaggregated_test_root,
     prepare_llama_model(llama_model_root, llm_venv)
 
     with background_workers(llm_venv,
-                            config_file) as (ctx_servers, gen_servers, _):
-        tester = KvCacheEventWorkerTester(ctx_servers, gen_servers)
+                            config_file) as (ctx_servers, gen_servers, _,
+                                             internal_request_auth_key):
+        tester = KvCacheEventWorkerTester(
+            ctx_servers,
+            gen_servers,
+            internal_request_auth_key=internal_request_auth_key)
         prompts = load_default_prompts(disaggregated_example_root)
         asyncio.run(tester.test_multi_round_request(prompts, 6))
 
@@ -718,8 +752,12 @@ def test_workers_kv_cache_aware_router(disaggregated_test_root,
     prepare_llama_model(llama_model_root, llm_venv)
 
     with background_workers(llm_venv,
-                            config_file) as (ctx_servers, gen_servers, _):
-        tester = KvCacheAwareRouterTester(ctx_servers, gen_servers)
+                            config_file) as (ctx_servers, gen_servers, _,
+                                             internal_request_auth_key):
+        tester = KvCacheAwareRouterTester(
+            ctx_servers,
+            gen_servers,
+            internal_request_auth_key=internal_request_auth_key)
         prompts = load_default_prompts(disaggregated_example_root)
         asyncio.run(tester.test_multi_round_request(prompts, 16, 4))
 
@@ -743,11 +781,14 @@ def test_workers_kv_cache_aware_router_deepseek_v3_lite_bf16(
             os.symlink(src, dst, target_is_directory=True)
 
     with background_workers(llm_venv,
-                            config_file) as (ctx_servers, gen_servers, _):
-        tester = KvCacheAwareRouterTester(ctx_servers,
-                                          gen_servers,
-                                          model_name="DeepSeek-V3-Lite/bf16",
-                                          tokens_per_block=64)
+                            config_file) as (ctx_servers, gen_servers, _,
+                                             internal_request_auth_key):
+        tester = KvCacheAwareRouterTester(
+            ctx_servers,
+            gen_servers,
+            model_name="DeepSeek-V3-Lite/bf16",
+            tokens_per_block=64,
+            internal_request_auth_key=internal_request_auth_key)
         prompts = load_default_prompts(disaggregated_example_root)
         asyncio.run(tester.test_multi_round_request(prompts, 8, 4))
 
@@ -762,8 +803,12 @@ def test_workers_kv_cache_aware_router_eviction(disaggregated_test_root,
     prepare_llama_model(llama_model_root, llm_venv)
 
     with background_workers(llm_venv,
-                            config_file) as (ctx_servers, gen_servers, _):
-        tester = KvCacheAwareRouterTester(ctx_servers, gen_servers)
+                            config_file) as (ctx_servers, gen_servers, _,
+                                             internal_request_auth_key):
+        tester = KvCacheAwareRouterTester(
+            ctx_servers,
+            gen_servers,
+            internal_request_auth_key=internal_request_auth_key)
         asyncio.run(tester.test_eviction())
 
 
@@ -776,9 +821,10 @@ class ConversationRouterTester(BasicWorkerTester):
                  gen_servers: List[str],
                  req_timeout_secs: int = DEFAULT_TIMEOUT_REQUEST,
                  server_start_timeout_secs: int = DEFAULT_TIMEOUT_SERVER_START,
-                 model_name: str = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"):
+                 model_name: str = "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+                 internal_request_auth_key: str | None = None):
         super().__init__(ctx_servers, gen_servers, req_timeout_secs,
-                         server_start_timeout_secs)
+                         server_start_timeout_secs, internal_request_auth_key)
         self.disagg_url = disagg_url
         self.model_name = model_name
         self.ctx_router = ConversationRouter(server_role=ServerRole.CONTEXT,
@@ -963,10 +1009,20 @@ def test_workers_conversation_router(disaggregated_test_root,
         'test_configs/disagg_config_conversation_workers.yaml')
     prepare_llama_model(llama_model_root, llm_venv)
 
-    with background_workers(llm_venv, config_file) as (ctx_servers, gen_servers,
-                                                       disagg_port):
+    with background_workers(llm_venv,
+                            config_file) as (ctx_servers, gen_servers,
+                                             disagg_port,
+                                             internal_request_auth_key):
         disagg_url = f"http://localhost:{disagg_port}"
-        tester = ConversationRouterTester(disagg_url, ctx_servers, gen_servers)
+        tester = ConversationRouterTester(
+            disagg_url,
+            ctx_servers,
+            gen_servers,
+            internal_request_auth_key=internal_request_auth_key)
         asyncio.run(tester.test_explicit_conversation_id())
-        tester = ConversationRouterTester(disagg_url, ctx_servers, gen_servers)
+        tester = ConversationRouterTester(
+            disagg_url,
+            ctx_servers,
+            gen_servers,
+            internal_request_auth_key=internal_request_auth_key)
         asyncio.run(tester.test_implicit_conversation_matching())

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -1213,6 +1213,7 @@ class DisaggTestCmds(NamedTuple):
     output_dir: str
     test_output_dir: str
     model_name: str = ""
+    internal_request_auth_key: str = ""
     client_configs: Dict[int, List["ClientConfig"]] = {}
     # Per-server-index ServerConfig triples (ctx_config, gen_config, disagg_config).
     # Used by run_cmd() to merge per-config env vars into the appropriate
@@ -2134,6 +2135,7 @@ class PerfSanityTestConfig:
             output_dir=output_dir,
             test_output_dir=test_output_dir,
             model_name=disagg_config.model_name,
+            internal_request_auth_key=disagg_config.internal_request_auth_key,
             client_configs=self.server_client_configs,
             server_configs=list(self.server_configs),
         )

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -19,6 +19,7 @@ import fcntl
 import glob
 import os
 import re
+import secrets
 import shutil
 import socket
 import subprocess
@@ -1069,6 +1070,7 @@ class DisaggConfig:
         model_name: str,
         hardware: dict,
         server_env_var: str,
+        internal_request_auth_key: str | None = None,
     ):
         self.name = name
         self.disagg_serving_type = disagg_serving_type
@@ -1079,6 +1081,7 @@ class DisaggConfig:
         self.model_name = model_name
         self.hardware = hardware
         self.server_env_var = server_env_var
+        self.internal_request_auth_key = internal_request_auth_key
         self.num_ctx_servers = hardware.get("num_ctx_servers", 0)
         self.num_gen_servers = hardware.get("num_gen_servers", 0)
 
@@ -1274,6 +1277,7 @@ class DisaggTestCmds(NamedTuple):
             "hostname": self.hostname,
             "port": disagg_server_port,
             "backend": "pytorch",
+            "internal_request_auth_key": self.internal_request_auth_key,
             "context_servers": {
                 "num_instances": self.num_ctx_servers,
                 "urls": ctx_hostnames,
@@ -1892,6 +1896,7 @@ class PerfSanityTestConfig:
         )
         server_env_var = environment.get("server_env_var", "")
         client_env_var = environment.get("client_env_var", "")
+        internal_request_auth_key = config.get("internal_request_auth_key") or secrets.token_hex(32)
 
         # Parse concurrency_list - can be string or list
         concurrency_str = benchmark.get("concurrency_list", "1")
@@ -1933,6 +1938,7 @@ class PerfSanityTestConfig:
         else:
             # For e2e and gen_only modes - create ctx and gen server configs
             ctx_server_config_data = {
+                "internal_request_auth_key": internal_request_auth_key,
                 "concurrency": concurrency_values[0],
                 "name": f"{benchmark_mode}-{config_file_base_name}",
                 "model_name": model_name,
@@ -1942,6 +1948,7 @@ class PerfSanityTestConfig:
             }
 
             gen_server_config_data = {
+                "internal_request_auth_key": internal_request_auth_key,
                 "concurrency": concurrency_values[0],
                 "name": f"{benchmark_mode}-{config_file_base_name}",
                 "model_name": model_name,
@@ -1963,6 +1970,7 @@ class PerfSanityTestConfig:
                 model_name=model_name,
                 hardware=hardware,
                 server_env_var=server_env_var,
+                internal_request_auth_key=internal_request_auth_key,
             )
 
             # server_configs is a list with one element (tuple of ctx, gen, disagg config)

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -1897,7 +1897,7 @@ class PerfSanityTestConfig:
         )
         server_env_var = environment.get("server_env_var", "")
         client_env_var = environment.get("client_env_var", "")
-        internal_request_auth_key = config.get("internal_request_auth_key") or secrets.token_hex(32)
+        internal_request_auth_key = self._resolve_internal_request_auth_key(config)
 
         # Parse concurrency_list - can be string or list
         concurrency_str = benchmark.get("concurrency_list", "1")
@@ -2022,6 +2022,32 @@ class PerfSanityTestConfig:
             client_configs.append(client_config)
 
         self.server_client_configs = {0: client_configs}
+
+    def _resolve_internal_request_auth_key(self, config: dict) -> str:
+        explicit_key = config.get("internal_request_auth_key")
+        if explicit_key:
+            return explicit_key
+
+        test_output_dir = os.path.join(self._output_dir, self._test_param_labels)
+        os.makedirs(test_output_dir, exist_ok=True)
+        key_path = os.path.join(test_output_dir, "internal_request_auth_key.txt")
+        lock_path = f"{key_path}.lock"
+
+        with open(lock_path, "w") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                if os.path.exists(key_path):
+                    with open(key_path, "r") as key_file:
+                        internal_request_auth_key = key_file.read().strip()
+                    if internal_request_auth_key:
+                        return internal_request_auth_key
+
+                internal_request_auth_key = secrets.token_hex(32)
+                with open(key_path, "w") as key_file:
+                    key_file.write(f"{internal_request_auth_key}\n")
+                return internal_request_auth_key
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
 
     def get_commands(self):
         """Get commands based on runtime and benchmark_mode."""

--- a/tests/unittest/disaggregated/test_coordinator_e2e.py
+++ b/tests/unittest/disaggregated/test_coordinator_e2e.py
@@ -300,6 +300,7 @@ def _write_config(path, ctx_url, gen_url, public_port, num_workers=1):
         "hostname": "127.0.0.1",
         "port": public_port,
         "num_workers": num_workers,
+        "internal_request_auth_key": "test-internal-disagg-auth-key",
         "context_servers": {
             "num_instances": 1,
             "urls": [ctx_url],

--- a/tests/unittest/disaggregated/test_disagg_internal_auth.py
+++ b/tests/unittest/disaggregated/test_disagg_internal_auth.py
@@ -40,6 +40,15 @@ def _make_request(
     )
 
 
+def _with_raw_ctx_info_endpoint(
+    request: CompletionRequest, ctx_info_endpoint: object
+) -> CompletionRequest:
+    request.disaggregated_params = request.disaggregated_params.model_copy(
+        update={"ctx_info_endpoint": ctx_info_endpoint}
+    )
+    return request
+
+
 def test_unprotected_request_does_not_require_internal_auth():
     request = _make_request()
 
@@ -90,6 +99,21 @@ def test_protected_fields_accept_valid_header_after_wire_roundtrip():
 
     wire_request = CompletionRequest.model_validate_json(
         request.model_dump_json(exclude_unset=True)
+    )
+
+    validate_internal_disagg_request("secret", wire_request, headers)
+
+
+def test_ctx_info_endpoint_list_sender_matches_validated_string_receiver():
+    request = _with_raw_ctx_info_endpoint(
+        _make_request(encoded_opaque_state="b3BhcXVl"),
+        ["tcp://10.0.0.1:5000"],
+    )
+    headers = build_internal_disagg_auth_headers("secret", request)
+
+    wire_request = _make_request(
+        encoded_opaque_state="b3BhcXVl",
+        ctx_info_endpoint="tcp://10.0.0.1:5000",
     )
 
     validate_internal_disagg_request("secret", wire_request, headers)

--- a/tests/unittest/disaggregated/test_disagg_internal_auth.py
+++ b/tests/unittest/disaggregated/test_disagg_internal_auth.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from tensorrt_llm.serve.disagg_auth import (
+    INTERNAL_DISAGG_AUTH_HEADER,
+    build_internal_disagg_auth_headers,
+    request_requires_internal_disagg_auth,
+    validate_internal_disagg_request,
+)
+from tensorrt_llm.serve.openai_protocol import CompletionRequest, DisaggregatedParams
+
+
+def _make_request(
+    *, encoded_opaque_state: str | None = None, ctx_info_endpoint: str | None = None
+) -> CompletionRequest:
+    return CompletionRequest(
+        model="test-model",
+        prompt="hello",
+        stream=False,
+        disaggregated_params=DisaggregatedParams(
+            request_type="generation_only",
+            ctx_request_id=1,
+            disagg_request_id=2,
+            encoded_opaque_state=encoded_opaque_state,
+            ctx_info_endpoint=ctx_info_endpoint,
+        ),
+    )
+
+
+def test_unprotected_request_does_not_require_internal_auth():
+    request = _make_request()
+
+    assert not request_requires_internal_disagg_auth(request)
+    assert build_internal_disagg_auth_headers(None, request) == {}
+    validate_internal_disagg_request(None, request, {})
+
+
+@pytest.mark.parametrize(
+    "completion_request",
+    [
+        _make_request(encoded_opaque_state="b3BhcXVl"),
+        _make_request(ctx_info_endpoint="tcp://10.0.0.1:5000"),
+        _make_request(encoded_opaque_state="b3BhcXVl", ctx_info_endpoint="tcp://10.0.0.1:5000"),
+    ],
+)
+def test_protected_fields_require_internal_auth_key(completion_request):
+    assert request_requires_internal_disagg_auth(completion_request)
+
+    with pytest.raises(ValueError, match="authentication key"):
+        build_internal_disagg_auth_headers(None, completion_request)
+    with pytest.raises(ValueError, match="require authenticated"):
+        validate_internal_disagg_request(None, completion_request, {})
+
+
+@pytest.mark.parametrize(
+    "completion_request",
+    [
+        _make_request(encoded_opaque_state="b3BhcXVl"),
+        _make_request(ctx_info_endpoint="tcp://10.0.0.1:5000"),
+        _make_request(encoded_opaque_state="b3BhcXVl", ctx_info_endpoint="tcp://10.0.0.1:5000"),
+    ],
+)
+def test_protected_fields_accept_valid_internal_auth_header(completion_request):
+    headers = build_internal_disagg_auth_headers("secret", completion_request)
+
+    assert headers[INTERNAL_DISAGG_AUTH_HEADER].startswith("sha256=")
+    validate_internal_disagg_request("secret", completion_request, headers)
+
+
+def test_opaque_state_rejects_tampered_payload():
+    request = _make_request(encoded_opaque_state="b3BhcXVl")
+    headers = build_internal_disagg_auth_headers("secret", request)
+    request.disaggregated_params.encoded_opaque_state = "dGFtcGVyZWQ="
+
+    with pytest.raises(ValueError, match="Invalid internal"):
+        validate_internal_disagg_request("secret", request, headers)
+
+
+def test_ctx_info_endpoint_rejects_tampered_payload():
+    request = _make_request(ctx_info_endpoint="tcp://10.0.0.1:5000")
+    headers = build_internal_disagg_auth_headers("secret", request)
+    request.disaggregated_params.ctx_info_endpoint = "tcp://10.0.0.2:5000"
+
+    with pytest.raises(ValueError, match="Invalid internal"):
+        validate_internal_disagg_request("secret", request, headers)
+
+
+def test_protected_fields_reject_missing_auth_header():
+    request = _make_request(ctx_info_endpoint="tcp://10.0.0.1:5000")
+
+    with pytest.raises(ValueError, match="Invalid internal"):
+        validate_internal_disagg_request("secret", request, {})

--- a/tests/unittest/disaggregated/test_disagg_internal_auth.py
+++ b/tests/unittest/disaggregated/test_disagg_internal_auth.py
@@ -80,6 +80,29 @@ def test_protected_fields_accept_valid_internal_auth_header(completion_request):
     validate_internal_disagg_request("secret", completion_request, headers)
 
 
+def test_protected_fields_accept_valid_header_after_wire_roundtrip():
+    request = _make_request(
+        encoded_opaque_state="b3BhcXVl",
+        ctx_info_endpoint="tcp://10.0.0.1:5000",
+    )
+    request.disaggregated_params.conversation_id = "conversation-1"
+    headers = build_internal_disagg_auth_headers("secret", request)
+
+    wire_request = CompletionRequest.model_validate_json(
+        request.model_dump_json(exclude_unset=True)
+    )
+
+    validate_internal_disagg_request("secret", wire_request, headers)
+
+
+def test_unprotected_disagg_fields_do_not_invalidate_internal_auth_header():
+    request = _make_request(ctx_info_endpoint="tcp://10.0.0.1:5000")
+    headers = build_internal_disagg_auth_headers("secret", request)
+    request.disaggregated_params.conversation_id = "conversation-1"
+
+    validate_internal_disagg_request("secret", request, headers)
+
+
 def test_opaque_state_rejects_tampered_payload():
     request = _make_request(encoded_opaque_state="b3BhcXVl")
     headers = build_internal_disagg_auth_headers("secret", request)

--- a/tests/unittest/disaggregated/test_disagg_internal_auth.py
+++ b/tests/unittest/disaggregated/test_disagg_internal_auth.py
@@ -17,10 +17,12 @@ import pytest
 from tensorrt_llm.serve.disagg_auth import (
     INTERNAL_DISAGG_AUTH_HEADER,
     build_internal_disagg_auth_headers,
+    get_internal_disagg_auth_fields,
     request_requires_internal_disagg_auth,
     validate_internal_disagg_request,
 )
 from tensorrt_llm.serve.openai_protocol import CompletionRequest, DisaggregatedParams
+from tensorrt_llm.serve.openai_server import OpenAIServer
 
 
 def _make_request(
@@ -57,12 +59,22 @@ def test_unprotected_request_does_not_require_internal_auth():
     validate_internal_disagg_request(None, request, {})
 
 
+def test_protected_fields_come_from_protocol_metadata():
+    assert set(get_internal_disagg_auth_fields()) == {
+        "ctx_info_endpoint",
+        "encoded_opaque_state",
+    }
+
+
 @pytest.mark.parametrize(
     "completion_request",
     [
         _make_request(encoded_opaque_state="b3BhcXVl"),
         _make_request(ctx_info_endpoint="tcp://10.0.0.1:5000"),
-        _make_request(encoded_opaque_state="b3BhcXVl", ctx_info_endpoint="tcp://10.0.0.1:5000"),
+        _make_request(
+            encoded_opaque_state="b3BhcXVl",
+            ctx_info_endpoint="tcp://10.0.0.1:5000",
+        ),
     ],
 )
 def test_protected_fields_allow_missing_internal_auth_key_with_warning(
@@ -84,7 +96,10 @@ def test_protected_fields_allow_missing_internal_auth_key_with_warning(
     [
         _make_request(encoded_opaque_state="b3BhcXVl"),
         _make_request(ctx_info_endpoint="tcp://10.0.0.1:5000"),
-        _make_request(encoded_opaque_state="b3BhcXVl", ctx_info_endpoint="tcp://10.0.0.1:5000"),
+        _make_request(
+            encoded_opaque_state="b3BhcXVl",
+            ctx_info_endpoint="tcp://10.0.0.1:5000",
+        ),
     ],
 )
 def test_protected_fields_accept_valid_internal_auth_header(completion_request):
@@ -155,3 +170,25 @@ def test_protected_fields_reject_missing_auth_header():
 
     with pytest.raises(ValueError, match="Invalid internal"):
         validate_internal_disagg_request("secret", request, {})
+
+
+def test_worker_rejects_protected_fields_without_cache_transceiver_config():
+    request = _make_request(ctx_info_endpoint="tcp://10.0.0.1:5000")
+    server = object.__new__(OpenAIServer)
+    server.generator = type(
+        "Generator",
+        (),
+        {
+            "args": type(
+                "Args",
+                (),
+                {
+                    "cache_transceiver_config": None,
+                },
+            )(),
+        },
+    )()
+    server._internal_disagg_auth_key = "secret"
+
+    with pytest.raises(ValueError, match="cache_transceiver_config"):
+        server._validate_internal_disagg_request(request, raw_request=None)

--- a/tests/unittest/disaggregated/test_disagg_internal_auth.py
+++ b/tests/unittest/disaggregated/test_disagg_internal_auth.py
@@ -65,12 +65,17 @@ def test_unprotected_request_does_not_require_internal_auth():
         _make_request(encoded_opaque_state="b3BhcXVl", ctx_info_endpoint="tcp://10.0.0.1:5000"),
     ],
 )
-def test_protected_fields_require_internal_auth_key(completion_request):
+def test_protected_fields_allow_missing_internal_auth_key_with_warning(
+    completion_request,
+):
     assert request_requires_internal_disagg_auth(completion_request)
 
-    with pytest.raises(ValueError, match="authentication key"):
-        build_internal_disagg_auth_headers(None, completion_request)
-    with pytest.raises(ValueError, match="require authenticated"):
+    warning_message = (
+        "In a future release the requirement to use internal_request_auth_key will be enforced"
+    )
+    with pytest.warns(FutureWarning, match=warning_message):
+        assert build_internal_disagg_auth_headers(None, completion_request) == {}
+    with pytest.warns(FutureWarning, match=warning_message):
         validate_internal_disagg_request(None, completion_request, {})
 
 

--- a/tests/unittest/disaggregated/test_disagg_openai_client.py
+++ b/tests/unittest/disaggregated/test_disagg_openai_client.py
@@ -131,13 +131,10 @@ class TestOpenAIHttpClient:
         ):
             OpenAIHttpClient(router=mock_router, role=ServerRole.GENERATION)
 
-        assert session.call_args.kwargs[
-            "max_field_size"] == _PERF_METRICS_HEADER_BUDGET_BYTES
+        assert session.call_args.kwargs["max_field_size"] == _PERF_METRICS_HEADER_BUDGET_BYTES
 
     @pytest.mark.asyncio
-    async def test_generation_request_with_opaque_state_is_signed(
-        self, mock_router, mock_session
-    ):
+    async def test_generation_request_with_opaque_state_is_signed(self, mock_router, mock_session):
         """Opaque state forwarded to generation workers gets internal auth."""
         _reset_prometheus_registry()
         client = OpenAIHttpClient(

--- a/tests/unittest/disaggregated/test_disagg_openai_client.py
+++ b/tests/unittest/disaggregated/test_disagg_openai_client.py
@@ -173,10 +173,10 @@ class TestOpenAIHttpClient:
         assert headers[INTERNAL_DISAGG_AUTH_HEADER].startswith("sha256=")
 
     @pytest.mark.asyncio
-    async def test_generation_request_with_opaque_state_requires_key(
+    async def test_generation_request_with_opaque_state_without_key_warns(
         self, mock_router, mock_session
     ):
-        """The proxy refuses to forward opaque state without auth configured."""
+        """Opaque state without auth key emits a transitional warning."""
         _reset_prometheus_registry()
         client = OpenAIHttpClient(
             router=mock_router,
@@ -185,6 +185,14 @@ class TestOpenAIHttpClient:
             max_retries=0,
             session=mock_session,
         )
+        mock_response = self.dummy_response()
+        mock_http_response = AsyncMock()
+        mock_http_response.status = 200
+        mock_http_response.headers = {"Content-Type": "application/json"}
+        mock_http_response.json = AsyncMock(return_value=mock_response.model_dump())
+        mock_http_response.__aenter__ = AsyncMock(return_value=mock_http_response)
+        mock_http_response.__aexit__ = AsyncMock()
+        mock_session.post.return_value = mock_http_response
         request = CompletionRequest(
             model="test-model",
             prompt="Hello, world!",
@@ -195,9 +203,12 @@ class TestOpenAIHttpClient:
             ),
         )
 
-        with pytest.raises(ValueError, match="authentication key"):
+        warning_message = "In a future release the requirement to use internal_request_auth_key"
+        with pytest.warns(FutureWarning, match=warning_message):
             await client.send_request(request)
-        mock_session.post.assert_not_called()
+
+        headers = mock_session.post.call_args.kwargs["headers"]
+        assert INTERNAL_DISAGG_AUTH_HEADER not in headers
 
     @pytest.mark.asyncio
     async def test_non_streaming_completion_request(
@@ -423,7 +434,7 @@ class TestOpenAIHttpClient:
         assert headers is not None
         assert INTERNAL_DISAGG_AUTH_HEADER in headers
 
-    def test_generation_request_with_ctx_info_endpoint_requires_key(
+    def test_generation_request_with_ctx_info_endpoint_without_key_warns(
         self, mock_router, mock_session
     ):
         _reset_prometheus_registry()
@@ -443,8 +454,11 @@ class TestOpenAIHttpClient:
             ),
         )
 
-        with pytest.raises(ValueError, match="authentication key is required"):
-            client._get_request_headers(request)
+        warning_message = "In a future release the requirement to use internal_request_auth_key"
+        with pytest.warns(FutureWarning, match=warning_message):
+            headers = client._get_request_headers(request)
+
+        assert INTERNAL_DISAGG_AUTH_HEADER not in headers
 
 
 class TestHttpErrorBodyPreservation:

--- a/tests/unittest/disaggregated/test_disagg_openai_client.py
+++ b/tests/unittest/disaggregated/test_disagg_openai_client.py
@@ -18,6 +18,7 @@ import aiohttp
 import pytest
 
 from tensorrt_llm.llmapi.disagg_utils import ServerRole
+from tensorrt_llm.serve.disagg_auth import INTERNAL_DISAGG_AUTH_HEADER
 from tensorrt_llm.serve.openai_client import OpenAIHttpClient
 from tensorrt_llm.serve.openai_protocol import (
     CompletionRequest,
@@ -29,6 +30,13 @@ from tensorrt_llm.serve.openai_protocol import (
 from tensorrt_llm.serve.perf_metrics import _PERF_METRICS_HEADER_BUDGET_BYTES, SSE_METRICS_EVENT
 from tensorrt_llm.serve.responses_utils import ResponseHooks
 from tensorrt_llm.serve.router import Router
+
+
+def _reset_prometheus_registry():
+    from prometheus_client.registry import REGISTRY
+
+    REGISTRY._names_to_collectors = {}
+    REGISTRY._collector_to_names = {}
 
 
 @pytest.fixture
@@ -51,10 +59,7 @@ def mock_session():
 def openai_client(mock_router, mock_session):
     """Create an OpenAIHttpClient instance."""
     # uninitialize the prometheus metrics collector or it will raise a duplicate metric error
-    from prometheus_client.registry import REGISTRY
-
-    REGISTRY._names_to_collectors = {}
-    REGISTRY._collector_to_names = {}
+    _reset_prometheus_registry()
     return OpenAIHttpClient(
         router=mock_router,
         role=ServerRole.CONTEXT,
@@ -126,7 +131,73 @@ class TestOpenAIHttpClient:
         ):
             OpenAIHttpClient(router=mock_router, role=ServerRole.GENERATION)
 
-        assert session.call_args.kwargs["max_field_size"] == _PERF_METRICS_HEADER_BUDGET_BYTES
+        assert session.call_args.kwargs[
+            "max_field_size"] == _PERF_METRICS_HEADER_BUDGET_BYTES
+
+    @pytest.mark.asyncio
+    async def test_generation_request_with_opaque_state_is_signed(
+        self, mock_router, mock_session
+    ):
+        """Opaque state forwarded to generation workers gets internal auth."""
+        _reset_prometheus_registry()
+        client = OpenAIHttpClient(
+            router=mock_router,
+            role=ServerRole.GENERATION,
+            timeout_secs=300,
+            max_retries=0,
+            session=mock_session,
+            internal_disagg_auth_key="secret",
+        )
+        mock_response = self.dummy_response()
+        mock_http_response = AsyncMock()
+        mock_http_response.status = 200
+        mock_http_response.headers = {"Content-Type": "application/json"}
+        mock_http_response.json = AsyncMock(return_value=mock_response.model_dump())
+        mock_http_response.__aenter__ = AsyncMock(return_value=mock_http_response)
+        mock_http_response.__aexit__ = AsyncMock()
+        mock_session.post.return_value = mock_http_response
+
+        request = CompletionRequest(
+            model="test-model",
+            prompt="Hello, world!",
+            stream=False,
+            disaggregated_params=DisaggregatedParams(
+                request_type="generation_only",
+                encoded_opaque_state="b3BhcXVl",
+            ),
+        )
+
+        await client.send_request(request)
+
+        headers = mock_session.post.call_args.kwargs["headers"]
+        assert headers[INTERNAL_DISAGG_AUTH_HEADER].startswith("sha256=")
+
+    @pytest.mark.asyncio
+    async def test_generation_request_with_opaque_state_requires_key(
+        self, mock_router, mock_session
+    ):
+        """The proxy refuses to forward opaque state without auth configured."""
+        _reset_prometheus_registry()
+        client = OpenAIHttpClient(
+            router=mock_router,
+            role=ServerRole.GENERATION,
+            timeout_secs=300,
+            max_retries=0,
+            session=mock_session,
+        )
+        request = CompletionRequest(
+            model="test-model",
+            prompt="Hello, world!",
+            stream=False,
+            disaggregated_params=DisaggregatedParams(
+                request_type="generation_only",
+                encoded_opaque_state="b3BhcXVl",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="authentication key"):
+            await client.send_request(request)
+        mock_session.post.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_non_streaming_completion_request(
@@ -327,6 +398,53 @@ class TestOpenAIHttpClient:
         """Test handling of invalid request type."""
         with pytest.raises(ValueError, match="Invalid request type"):
             await openai_client.send_request("invalid_request")
+
+    def test_generation_request_with_ctx_info_endpoint_is_signed(self, mock_router, mock_session):
+        _reset_prometheus_registry()
+        client = OpenAIHttpClient(
+            router=mock_router,
+            role=ServerRole.GENERATION,
+            session=mock_session,
+            internal_disagg_auth_key="secret",
+        )
+        request = CompletionRequest(
+            model="test-model",
+            prompt="Hello, world!",
+            disaggregated_params=DisaggregatedParams(
+                request_type="generation_only",
+                ctx_request_id=1,
+                disagg_request_id=2,
+                ctx_info_endpoint="tcp://10.0.0.1:5000",
+            ),
+        )
+
+        headers = client._get_request_headers(request)
+
+        assert headers is not None
+        assert INTERNAL_DISAGG_AUTH_HEADER in headers
+
+    def test_generation_request_with_ctx_info_endpoint_requires_key(
+        self, mock_router, mock_session
+    ):
+        _reset_prometheus_registry()
+        client = OpenAIHttpClient(
+            router=mock_router,
+            role=ServerRole.GENERATION,
+            session=mock_session,
+        )
+        request = CompletionRequest(
+            model="test-model",
+            prompt="Hello, world!",
+            disaggregated_params=DisaggregatedParams(
+                request_type="generation_only",
+                ctx_request_id=1,
+                disagg_request_id=2,
+                ctx_info_endpoint="tcp://10.0.0.1:5000",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="authentication key is required"):
+            client._get_request_headers(request)
 
 
 class TestHttpErrorBodyPreservation:

--- a/tests/unittest/disaggregated/test_disagg_utils.py
+++ b/tests/unittest/disaggregated/test_disagg_utils.py
@@ -149,6 +149,17 @@ def test_extract_disagg_cfg_rejects_out_of_range_node_id(node_id):
         extract_disagg_cfg(node_id=node_id)
 
 
+@pytest.mark.parametrize("sample_yaml_config", [""], indirect=True)
+def test_extract_disagg_cfg_internal_request_auth_key(sample_yaml_config):
+    sample_yaml_config["internal_request_auth_key"] = "test-secret"
+
+    config = extract_disagg_cfg(**sample_yaml_config)
+
+    assert config.internal_request_auth_key == "test-secret"
+    assert "internal_request_auth_key" not in config.server_configs[
+        0].other_args
+
+
 def test_extract_ctx_gen_cfgs():
     configs = extract_ctx_gen_cfgs(
         type="ctx",

--- a/tests/unittest/disaggregated/test_disagg_utils.py
+++ b/tests/unittest/disaggregated/test_disagg_utils.py
@@ -160,6 +160,20 @@ def test_extract_disagg_cfg_internal_request_auth_key(sample_yaml_config):
         0].other_args
 
 
+def test_extract_disagg_cfg_rejects_invalid_internal_request_auth_key():
+    with pytest.raises(
+            ValueError,
+            match="internal_request_auth_key must be a non-empty string"):
+        extract_disagg_cfg(internal_request_auth_key="")
+
+
+def test_extract_disagg_cfg_rejects_non_string_internal_request_auth_key():
+    with pytest.raises(
+            ValueError,
+            match="internal_request_auth_key must be a non-empty string"):
+        extract_disagg_cfg(internal_request_auth_key=123)
+
+
 def test_extract_ctx_gen_cfgs():
     configs = extract_ctx_gen_cfgs(
         type="ctx",

--- a/tests/unittest/disaggregated/test_disagg_utils.py
+++ b/tests/unittest/disaggregated/test_disagg_utils.py
@@ -160,6 +160,33 @@ def test_extract_disagg_cfg_internal_request_auth_key(sample_yaml_config):
         0].other_args
 
 
+@pytest.mark.parametrize("sample_yaml_config", [""], indirect=True)
+def test_extract_disagg_cfg_accepts_matching_section_auth_keys(
+        sample_yaml_config):
+    sample_yaml_config["context_servers"][
+        "internal_request_auth_key"] = "test-secret"
+    sample_yaml_config["generation_servers"][
+        "internal_request_auth_key"] = "test-secret"
+
+    config = extract_disagg_cfg(**sample_yaml_config)
+
+    assert config.internal_request_auth_key == "test-secret"
+    assert "internal_request_auth_key" not in config.server_configs[
+        0].other_args
+
+
+@pytest.mark.parametrize("sample_yaml_config", [""], indirect=True)
+def test_extract_disagg_cfg_rejects_mismatched_section_auth_keys(
+        sample_yaml_config):
+    sample_yaml_config["context_servers"][
+        "internal_request_auth_key"] = "ctx-secret"
+    sample_yaml_config["generation_servers"][
+        "internal_request_auth_key"] = "gen-secret"
+
+    with pytest.raises(ValueError, match="must match"):
+        extract_disagg_cfg(**sample_yaml_config)
+
+
 def test_extract_disagg_cfg_rejects_invalid_internal_request_auth_key():
     with pytest.raises(
             ValueError,

--- a/tests/unittest/disaggregated/test_disaggregated_params.py
+++ b/tests/unittest/disaggregated/test_disaggregated_params.py
@@ -26,6 +26,8 @@ def test_receiver_ctx_info_endpoint_required():
 
     with pytest.raises(ValueError, match="ctx_info_endpoint is required"):
         Receiver._extract_info_endpoint(DisaggregatedParams())
+    with pytest.raises(ValueError, match="ctx_info_endpoint is required"):
+        Receiver._extract_info_endpoint(DisaggregatedParams(ctx_info_endpoint=[]))
     assert (
         Receiver._extract_info_endpoint(
             DisaggregatedParams(ctx_info_endpoint="tcp://10.0.0.1:5000")

--- a/tests/unittest/disaggregated/test_disaggregated_params.py
+++ b/tests/unittest/disaggregated/test_disaggregated_params.py
@@ -24,11 +24,14 @@ def test_disaggregated_params_ctx_info_endpoint():
 def test_receiver_ctx_info_endpoint_required():
     from tensorrt_llm._torch.disaggregation.native.transfer import Receiver
 
-    receiver = object.__new__(Receiver)
-
     with pytest.raises(ValueError, match="ctx_info_endpoint is required"):
-        receiver._validate_info_endpoint(None)
-    receiver._validate_info_endpoint("tcp://10.0.0.1:5000")
+        Receiver._extract_info_endpoint(DisaggregatedParams())
+    assert (
+        Receiver._extract_info_endpoint(
+            DisaggregatedParams(ctx_info_endpoint="tcp://10.0.0.1:5000")
+        )
+        == "tcp://10.0.0.1:5000"
+    )
 
 
 @patch("tensorrt_llm.disaggregated_params.tllme")

--- a/tests/unittest/disaggregated/test_disaggregated_params.py
+++ b/tests/unittest/disaggregated/test_disaggregated_params.py
@@ -21,6 +21,16 @@ def test_disaggregated_params_ctx_info_endpoint():
     assert params.ctx_info_endpoint == ["tcp://10.0.0.1:5000", "tcp://10.0.0.2:5000"]
 
 
+def test_receiver_ctx_info_endpoint_required():
+    from tensorrt_llm._torch.disaggregation.native.transfer import Receiver
+
+    receiver = object.__new__(Receiver)
+
+    with pytest.raises(ValueError, match="ctx_info_endpoint is required"):
+        receiver._validate_info_endpoint(None)
+    receiver._validate_info_endpoint("tcp://10.0.0.1:5000")
+
+
 @patch("tensorrt_llm.disaggregated_params.tllme")
 def test_get_context_phase_params(mock_tllme):
     mock_ctx_params = MagicMock()
@@ -126,6 +136,19 @@ def test_disaggregated_params_conversation_id():
     llm_params = to_llm_disaggregated_params(openai_params)
     assert llm_params.conversation_id == "conv-roundtrip"
     assert to_disaggregated_params(llm_params).conversation_id == "conv-roundtrip"
+
+
+def test_opaque_state_round_trips_through_openai_protocol():
+    from tensorrt_llm.serve.openai_protocol import (
+        to_disaggregated_params,
+        to_llm_disaggregated_params,
+    )
+
+    openai_params = to_disaggregated_params(
+        DisaggregatedParams(request_type="context_only", opaque_state=b"opaque")
+    )
+    assert openai_params.encoded_opaque_state == "b3BhcXVl"
+    assert to_llm_disaggregated_params(openai_params).opaque_state == b"opaque"
 
 
 @patch("tensorrt_llm.disaggregated_params.tllme")

--- a/tests/unittest/disaggregated/test_openai_disagg_server.py
+++ b/tests/unittest/disaggregated/test_openai_disagg_server.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import Request
 from starlette.datastructures import Headers
 
-from tensorrt_llm.llmapi.disagg_utils import extract_disagg_cfg
+from tensorrt_llm.llmapi.disagg_utils import ServerRole, extract_disagg_cfg
 from tensorrt_llm.serve.openai_disagg_server import OpenAIDisaggServer
 from tensorrt_llm.serve.openai_protocol import (
     CompletionRequest,
@@ -62,6 +62,21 @@ async def test_http_cluster_storage_request_is_proxied_to_coordinator():
     )
     assert response.status_code == 200
     assert response.body == b'{"result":true}'
+
+
+def test_create_client_does_not_register_with_server_metrics_collector():
+    server = OpenAIDisaggServer.__new__(OpenAIDisaggServer)
+    server._coordinator = SimpleNamespace(get_disagg_request_id=AsyncMock(return_value=1))
+    server._req_timeout_secs = 30
+    server._collect_perf_metrics = True
+    server._config = SimpleNamespace(internal_request_auth_key="key")
+    server._perf_metrics_collector = SimpleNamespace()
+
+    with patch("tensorrt_llm.serve.openai_disagg_server.OpenAIHttpClient") as mock_client:
+        client = server._create_client(SimpleNamespace(), ServerRole.GENERATION, max_retries=2)
+
+    assert client is mock_client.return_value
+    mock_client.assert_called_once()
 
 
 def test_extract_conversation_id_from_headers():

--- a/tests/unittest/disaggregated/test_openai_disagg_service.py
+++ b/tests/unittest/disaggregated/test_openai_disagg_service.py
@@ -102,6 +102,42 @@ async def test_conditional_disagg_uses_selected_server_match_length():
     assert need_context is False
 
 
+@pytest.mark.asyncio
+async def test_conditional_disagg_bypass_strips_client_disagg_params(monkeypatch):
+    monkeypatch.delenv("TRTLLM_DISAGG_BENCHMARK_GEN_ONLY", raising=False)
+    service = _make_service("context_first")
+    service._config.conditional_disagg_config = ConditionalDisaggConfig(max_local_prefill_length=32)
+    router = KvCacheAwareRouter(server_role=ServerRole.GENERATION, servers=[])
+    router.get_next_server = AsyncMock(
+        return_value=(
+            "gen:8000",
+            {
+                "match_length": 64,
+                "num_tokens": 96,
+            },
+        )
+    )
+    service._gen_router = router
+    service._gen_client = AsyncMock()
+    service._gen_client.send_request = AsyncMock(
+        return_value=_make_completion_response("ok", finish_reason="stop")
+    )
+    request = CompletionRequest(
+        model="model",
+        prompt=[1] * 96,
+        disaggregated_params=DisaggregatedParams(
+            request_type="generation_only",
+            ctx_info_endpoint="tcp://attacker:5000",
+            encoded_opaque_state="attacker-state",
+        ),
+    )
+
+    await service._send_disagg_request_ctx_first(request)
+
+    gen_req = service._gen_client.send_request.call_args.args[0]
+    assert gen_req.disaggregated_params is None
+
+
 def _make_completion_response(
     text: str,
     finish_reason: str,

--- a/tests/unittest/llmapi/apps/test_disagg_serving_perf_metrics.py
+++ b/tests/unittest/llmapi/apps/test_disagg_serving_perf_metrics.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 from typing import Tuple
 
 import openai
@@ -67,10 +68,18 @@ def disagg_cluster_config(disagg_port: int):
     }
 
 
-def worker_config(model_name: str, disagg_cluster_config: dict, perf_metrics_output_dir):
+@pytest.fixture
+def internal_request_auth_key():
+    return secrets.token_hex(32)
+
+
+def worker_config(model_name: str, disagg_cluster_config: dict,
+                  perf_metrics_output_dir,
+                  internal_request_auth_key: str):
     return {
         "model": model_name,
         "disagg_cluster": disagg_cluster_config,
+        "internal_request_auth_key": internal_request_auth_key,
         "cache_transceiver_config": {
             "backend": "DEFAULT",
         },
@@ -93,9 +102,12 @@ def workers(
     ctx_port: int,
     gen_port: int,
     perf_metrics_output_dir,
+    internal_request_auth_key: str,
 ):
     model_path = get_model_path(model_name)
-    extra_config = worker_config(model_name, disagg_cluster_config, perf_metrics_output_dir)
+    extra_config = worker_config(model_name, disagg_cluster_config,
+                                 perf_metrics_output_dir,
+                                 internal_request_auth_key)
 
     def worker(server_role: str, port: int):
         return RemoteOpenAIServer(
@@ -114,11 +126,18 @@ def workers(
 
 
 @pytest.fixture
-def disagg_server(disagg_cluster_config: dict, workers, disagg_port: int, perf_metrics_output_dir):
+def disagg_server(
+    disagg_cluster_config: dict,
+    workers,
+    disagg_port: int,
+    perf_metrics_output_dir,
+    internal_request_auth_key: str,
+):
     disagg_config = {
         "hostname": "localhost",
         "port": disagg_port,
         "disagg_cluster": disagg_cluster_config,
+        "internal_request_auth_key": internal_request_auth_key,
         "perf_metrics_max_requests": 1000,
         "return_perf_metrics": True,
         "perf_metrics_output_dir": str(perf_metrics_output_dir),

--- a/tests/unittest/llmapi/apps/test_disagg_serving_perf_metrics.py
+++ b/tests/unittest/llmapi/apps/test_disagg_serving_perf_metrics.py
@@ -73,9 +73,12 @@ def internal_request_auth_key():
     return secrets.token_hex(32)
 
 
-def worker_config(model_name: str, disagg_cluster_config: dict,
-                  perf_metrics_output_dir,
-                  internal_request_auth_key: str):
+def worker_config(
+    model_name: str,
+    disagg_cluster_config: dict,
+    perf_metrics_output_dir,
+    internal_request_auth_key: str,
+):
     return {
         "model": model_name,
         "disagg_cluster": disagg_cluster_config,
@@ -105,9 +108,9 @@ def workers(
     internal_request_auth_key: str,
 ):
     model_path = get_model_path(model_name)
-    extra_config = worker_config(model_name, disagg_cluster_config,
-                                 perf_metrics_output_dir,
-                                 internal_request_auth_key)
+    extra_config = worker_config(
+        model_name, disagg_cluster_config, perf_metrics_output_dir, internal_request_auth_key
+    )
 
     def worker(server_role: str, port: int):
         return RemoteOpenAIServer(


### PR DESCRIPTION
## Summary
This change protects disaggregated serving’s internal proxy-to-worker handoff by requiring an internal authentication signature on requests that carry trusted handoff fields `ctx_info_endpoint` and `encoded_opaque_state`. The goal is to prevent external clients from directly injecting those internal fields while preserving normal proxy-generated disaggregated requests. This PR fixes [6003113](https://nvbugs/6003113) opaque-state and [6030763](https://nvbugs/6030763) ctx_info_endpoint protections behind one internal disaggregated HMAC auth path.

## Validation
- Updated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional authentication for internal disaggregated serving requests.
  - Protected internal request metadata is signed and validated between the proxy and workers.
  - Added configuration support for sharing an authentication key across disaggregated servers and workers.
  - Requests with missing or invalid authentication are rejected.

- **Documentation**
  - Updated disaggregated serving examples with authentication and dynamic scaling configuration guidance.

- **Tests**
  - Added coverage for signing, validation, tampering, missing keys, and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->