### PR TITLE
[https://nvbugs/6418006][fix] Mirror the test_medusa pattern from commit b08ce26ac1 — replace test_whisper's…

### DIFF
--- a/tests/integration/defs/triton_server/test_triton.py
+++ b/tests/integration/defs/triton_server/test_triton.py
@@ -312,15 +312,16 @@ def test_eagle(tritonserver_test_root, test_name, llm_root, model_path,
 
 
 @pytest.mark.parametrize("test_name", ["whisper"], indirect=True)
-def test_whisper(tritonserver_test_root, test_name, llm_root, model_path,
-                 engine_dir):
-    build_model(test_name, llm_root, tritonserver_test_root)
-    tokenizer_type = "auto"
-    decoder_path = f"{engine_dir}/decoder"
-    encoder_path = f"{engine_dir}/encoder"
-    run_shell_command(
-        f"cd {tritonserver_test_root} && ./test.sh {test_name} {decoder_path} {model_path} {tokenizer_type} skip skip {encoder_path}",
-        llm_root)
+def test_whisper(tritonserver_test_root, test_name, llm_root):
+    # examples/models/core/whisper/convert_checkpoint.py was removed with the
+    # legacy TensorRT-backend cleanup; guard against silent reintroduction.
+    whisper_convert_script = os.path.join(llm_root, "examples", "models",
+                                          "core", "whisper",
+                                          "convert_checkpoint.py")
+    assert not os.path.exists(whisper_convert_script), (
+        f"{whisper_convert_script} was reintroduced; update this test or "
+        "restore the Triton whisper build pipeline in build_model.sh and "
+        "test.sh.")
 
 
 @pytest.mark.parametrize("test_name", ["t5-ib"], indirect=True)


### PR DESCRIPTION
## Summary
- **Root cause**: PR #15763 deleted examples/models/core/whisper/, but build_model.sh's whisper branch still pushd's into it and invokes convert_checkpoint.py, aborting with CalledProcessError under `set -e`.
- **Fix**: Mirror the test_medusa pattern from commit b08ce26ac1 — replace test_whisper's body with an assertion that the removed convert_checkpoint.py has not been reintroduced. Keeps pytest node id resolvable while removing the broken build/test.sh invocation.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6418006


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Whisper integration coverage to validate the expected file layout and fail clearly if a removed script reappears.
  * Simplified the test setup by removing unused build and execution steps from this check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->