### PR TITLE
[https://nvbugs/6417978][fix] Mirror the medusa/whisper precedent: replace test_gptj's body with an…

### DIFF
--- a/tests/integration/defs/triton_server/test_triton.py
+++ b/tests/integration/defs/triton_server/test_triton.py
@@ -132,13 +132,14 @@ def test_mistral(tritonserver_test_root, test_name, llm_root, model_path,
 
 
 @pytest.mark.parametrize("test_name", ["gptj"], indirect=True)
-def test_gptj(tritonserver_test_root, test_name, llm_root, model_path,
-              engine_dir):
-    build_model(test_name, llm_root, tritonserver_test_root)
-    tokenizer_type = "auto"
-    run_shell_command(
-        f"cd {tritonserver_test_root} && ./test.sh {test_name} {engine_dir} {model_path} {tokenizer_type}",
-        llm_root)
+def test_gptj(tritonserver_test_root, test_name, llm_root):
+    # examples/models/contrib/gptj was removed with the legacy TensorRT-backend
+    # cleanup; guard against silent reintroduction.
+    gptj_example_dir = os.path.join(llm_root, "examples", "models", "contrib",
+                                    "gptj")
+    assert not os.path.exists(gptj_example_dir), (
+        f"{gptj_example_dir} was reintroduced; update this test or restore "
+        "the Triton gptj build pipeline in build_model.sh and test.sh.")
 
 
 @pytest.mark.parametrize("test_name", ["mistral-ib"], indirect=True)


### PR DESCRIPTION
## Summary
- **Root cause**: PR #15763 removed examples/models/contrib/gptj/, but build_model.sh still runs `pushd examples/models/contrib/gptj` for the gptj target, so `set -e` propagates the failure to pytest.
- **Fix**: Mirror the medusa/whisper precedent: replace test_gptj's body with an `os.path.exists` assertion on `examples/models/contrib/gptj/` and drop the now-unused model_path/engine_dir fixture params.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6417978


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Triton integration test suite to verify the legacy GPT-J example directory is no longer present.
  * Improved the failure message so any reintroduction of that legacy example is flagged clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->