### PR TITLE
[https://nvbugs/6418912][test] Fix KV cache reuse accounting tests

### DIFF
--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -6858,8 +6858,8 @@ TEST(KVCacheManagerReuseAccountingTest, CountReusableBlocksPartialMatch)
         = kvCacheManager->getNeededBlocksOneStep(req1, /*twoStepsLookAhead=*/false, onlyWindowSize);
     EXPECT_EQ(neededOneStep, promptLength / tokensPerBlock); // All 4 context blocks
 
-    // Blocks are free (released via removeSequence), so onlyAllocated=true yields 0 reusable blocks.
-    EXPECT_EQ(req1.getEstimatedReusableTokens(), 0);
+    // Free-but-cached blocks still consume free-pool capacity, but their tokens do not require recomputation.
+    EXPECT_EQ(req1.getEstimatedReusableTokens(), summaryShared.reusableBlocksAll * tokensPerBlock);
 }
 
 TEST(KVCacheManagerReuseAccountingTest, GetRemainingBlocksToCompletionWithPartialReuse)
@@ -6976,7 +6976,7 @@ TEST(KVCacheManagerReuseAccountingTest, GetNeededBlocksOneStepWithFullReuse)
     tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(req0);
     kvCacheManager->removeSequence(req0.mRequestId, req0);
 
-    // Second request with identical tokens - all context blocks should be reusable
+    // Second request with identical tokens - the recoverable cached prefix should be reusable
     auto req1 = LlmRequest{
         1,
         maxNewTokens,
@@ -6989,11 +6989,12 @@ TEST(KVCacheManagerReuseAccountingTest, GetNeededBlocksOneStepWithFullReuse)
     // getNeededBlocksOneStep must NOT subtract free reusable blocks.
     auto const neededOneStep
         = kvCacheManager->getNeededBlocksOneStep(req1, /*twoStepsLookAhead=*/false, onlyWindowSize);
-    auto const numSharedBlocks = promptLength / tokensPerBlock; // 3 blocks
-    EXPECT_EQ(neededOneStep, numSharedBlocks);                  // All 3 context blocks
+    auto const numContextBlocks = promptLength / tokensPerBlock; // 3 blocks
+    EXPECT_EQ(neededOneStep, numContextBlocks);                  // All 3 context blocks
 
-    // Blocks are free (released via removeSequence), so onlyAllocated=true yields 0 reusable blocks.
-    EXPECT_EQ(req1.getEstimatedReusableTokens(), 0);
+    // Sequence insertion omits the final prompt token, so only the preceding full blocks are recoverable.
+    auto const expectedReusableBlocks = (promptLength - 1) / tokensPerBlock;
+    EXPECT_EQ(req1.getEstimatedReusableTokens(), expectedReusableBlocks * tokensPerBlock);
 }
 
 TEST(KVCacheManagerReuseAccountingTest, ReuseDisabledReturnsFullBlockCount)
@@ -7131,8 +7132,8 @@ TEST(KVCacheManagerReuseAccountingTest, MultipleRequestsWithSharedPrefix)
         = kvCacheManager->getNeededBlocksOneStep(req1, /*twoStepsLookAhead=*/false, onlyWindowSize);
     EXPECT_EQ(neededOneStep, promptLength / tokensPerBlock); // All 4 context blocks
 
-    // Blocks are free (released via removeSequence), so onlyAllocated=true yields 0 reusable blocks.
-    EXPECT_EQ(req1.getEstimatedReusableTokens(), 0);
+    // Free-but-cached blocks still consume free-pool capacity, but their tokens do not require recomputation.
+    EXPECT_EQ(req1.getEstimatedReusableTokens(), summaryPrefix.reusableBlocksAll * tokensPerBlock);
 
     // getRemainingBlocksToCompletion: 4 context + 1 gen = 5 blocks (no subtraction; blocks are free)
     auto const remaining = kvCacheManager->getRemainingBlocksToCompletion(req1, onlyWindowSize);

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -4402,6 +4402,7 @@ def launchTestJobs(pipeline, testFilter)
         "A30-PyTorch-1": ["a30", "l0_a30", 1, 2],
         "A30-PyTorch-2": ["a30", "l0_a30", 2, 2],
         "A10-CPP-1": ["a10", "l0_a10", 1, 1],
+        "A30-CPP-1": ["a30", "l0_a30", 1, 1],
         "A30-AutoDeploy-1": ["a30", "l0_a30", 1, 1],
         "A100X-PyTorch-1": ["a100x", "l0_a100", 1, 1],
         "L40S-PyTorch-1": ["l40s", "l0_l40s", 1, 2],

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -38,11 +38,25 @@ l0_a30:
       - '*a30*'
       linux_distribution_name: ubuntu*
     terms:
-      stage: post_merge
+      stage: pre_merge
       backend: cpp
   tests:
   # ------------- CPP tests ---------------
   - cpp/test_unit_tests.py::test_unit_tests[batch_manager-80]
+- condition:
+    ranges:
+      system_gpu_count:
+        gte: 1
+        lte: 1
+    wildcards:
+      gpu:
+      - '*a30*'
+      linux_distribution_name: ubuntu*
+    terms:
+      stage: post_merge
+      backend: cpp
+  tests:
+  # ------------- CPP tests ---------------
   - cpp/test_unit_tests.py::test_unit_tests[common-80]
   - cpp/test_unit_tests.py::test_unit_tests[executor-80]
   - cpp/test_unit_tests.py::test_unit_tests[kernels-80]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reusable cache accounting so released-but-cached blocks continue to count toward reuse calculations.
  * Refined handling for shared-prefix and full-reuse cases, improving consistency in token budgeting and recomputation estimates.

* **Tests**
  * Adjusted automated coverage to match the updated reuse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

PR #15066 separated two reuse budgets: block-capacity accounting only discounts currently allocated reusable blocks, while `estimatedReusableTokens` credits every cached prefix block because those tokens do not need recomputation. Three existing tests still conflate those budgets and expect zero reusable tokens after the cached blocks are released.

Update the assertions and comments to expect two recoverable cached blocks, or 32 tokens. Production behavior is unchanged.

Following reviewer feedback, move `cpp/test_unit_tests.py::test_unit_tests[batch_manager-80]` from A30 post-merge coverage to a dedicated `A30-CPP-1` pre-merge stage so active KV-cache development is gated before landing.

This was exposed while validating NVBUG 6418912 / PR #15994, but is independent of the BufferIndexHolder fix.

### Affected tests

- `KVCacheManagerReuseAccountingTest.CountReusableBlocksPartialMatch`
- `KVCacheManagerReuseAccountingTest.GetNeededBlocksOneStepWithFullReuse`
- `KVCacheManagerReuseAccountingTest.MultipleRequestsWithSharedPrefix`

## Test Coverage

- `pre-commit run --files cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp jenkins/L0_Test.groovy tests/integration/test_lists/test-db/l0_a30.yml`
- `scripts/check_test_list.py --validate`: 2,217 unique entries validated
- Stage mapping: `batch_manager-80` resolves exclusively to `A30-CPP-1`
- Combined validation PR #16019 included this PR together with #15994, #16011, and the independent sequence-link fix in #16037.
- [Targeted `A30-CPP-1` pipeline #46619](http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=46619) completed **SUCCESS** on integration head `1248a186`.
- The exact pre-merge wrapper passed: 1 pytest passed, and its batch-manager report completed 525 gtests with 0 failures.
- #16037 documents the final end-to-end evidence; its formerly crashing `FillKvCacheWithRequestsAndCompleteOneByOne/5` case passed in 1,739 ms.

## Merge dependency

Because this PR activates `batch_manager-80` in pre-merge, merge it after #15994, #16011, and #16037. Its earlier standalone pipeline #46561 lacked those fixes and is therefore not a valid final merge gate.