### PR TITLE
[None][build] Add --yes flag to build_wheel.py to skip interactive prompt

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -135,8 +135,10 @@ def create_venv(project_dir: Path):
     return venv_prefix
 
 
-def setup_venv(project_dir: Path, requirements_file: Path,
-               no_venv: bool) -> tuple[Path, Path]:
+def setup_venv(project_dir: Path,
+               requirements_file: Path,
+               no_venv: bool,
+               yes: bool = False) -> tuple[Path, Path]:
     """Creates/updates a venv and installs requirements.
 
     Args:
@@ -170,7 +172,8 @@ def setup_venv(project_dir: Path, requirements_file: Path,
                 f"`build_wheel.py` can recreate a virtual environment using container-provided PyTorch installation."
             )
             print("^^^^^^^^^^ IMPORTANT WARNING ^^^^^^^^^^", file=sys.stderr)
-            input("Press Ctrl+C to stop, any key to continue...\n")
+            if not yes:
+                input("Press Ctrl+C to stop, any key to continue...\n")
 
         # Ensure inherited PyTorch version is compatible
         try:
@@ -511,7 +514,8 @@ def main(*,
          nvrtc_dynamic_linking: bool = False,
          mypyc: bool = False,
          require_dynamic_attributions: bool = False,
-         plat_name: Optional[str] = None):
+         plat_name: Optional[str] = None,
+         yes: bool = False):
 
     if clean:
         clean_wheel = True
@@ -535,7 +539,8 @@ def main(*,
     # Setup venv and install requirements
     venv_python, venv_conan = setup_venv(project_dir,
                                          project_dir / requirements_filename,
-                                         no_venv)
+                                         no_venv,
+                                         yes=yes)
 
     # Ensure base TRT is installed (check inside the venv)
     try:
@@ -1324,6 +1329,14 @@ def add_arguments(parser: ArgumentParser):
         type=_plat_name_type,
         help=
         "Wheel platform tag passed to bdist_wheel --plat-name (e.g. linux_x86_64, manylinux_2_28_x86_64)"
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        default=False,
+        help=
+        "Skip interactive confirmation prompts (useful for non-interactive builds)",
     )
 
 


### PR DESCRIPTION
## Summary

- `build_wheel.py` blocks indefinitely on an interactive `input()` prompt when it detects PyPI PyTorch inside an NVIDIA container venv. This blocks non-interactive builds that run inside a pseudo-TTY (e.g. via `script(1)`), since `isatty()` returns True in that case.
- Add `--yes` / `-y` flag to `build_wheel.py` (and thread it through `setup_venv`) to skip the prompt while still printing the warning.

## Test plan

- [x] Run `build_wheel.py --yes --install ...` in a container with an existing `.venv` that has PyPI PyTorch — confirm it prints the warning but does not block.
- [x] Run without `--yes` in an interactive shell — confirm the prompt still appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--yes` / `-y` option to run builds without interactive confirmation prompts.
  * Non-interactive builds now continue automatically when a compatibility warning appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->