### PR TITLE
[TRTLLM-13969][feat] Support MiniMax M3 for Disaggregated Serving

### DIFF
--- a/cpp/include/tensorrt_llm/executor/transferAgent.h
+++ b/cpp/include/tensorrt_llm/executor/transferAgent.h
@@ -221,8 +221,11 @@ struct VmmDescSplitter
     /// min(srcPiece, dstPiece, remaining). Pairs are sorted by src address, and adjacent pieces
     /// whose src AND dst are both contiguous (same deviceId) are merged — but a merged desc never
     /// crosses a chunk boundary on either side, and never spans two distinct regions, so every
-    /// output desc stays within a single registered memory region. Non-kVRAM descs pass through
-    /// unchanged (no region info is available to bound the merge).
+    /// output desc stays within a single registered memory region. Merging requires region
+    /// metadata: a piece whose address misses the region map on either side is never merged,
+    /// because two unknown regions are indistinguishable and a merge could cross a chunk or
+    /// registration boundary. With no region metadata the result is split-only. Non-kVRAM descs
+    /// pass through unchanged (no region info is available to bound the merge).
     /// @param enableCoalesce When false, only split at chunk boundaries without merging pieces.
     [[nodiscard]] static std::pair<MemoryDescs, MemoryDescs> splitAndCoalesceTransferDescs(MemoryDescs const& srcDescs,
         MemoryDescs const& dstDescs, VramRegionMap const& localRegionMap, VramRegionMap const& remoteRegionMap,

--- a/cpp/include/tensorrt_llm/executor/transferAgent.h
+++ b/cpp/include/tensorrt_llm/executor/transferAgent.h
@@ -216,12 +216,17 @@ struct VmmDescSplitter
     /// For non-VRAM or addresses not in the map, descs pass through unchanged.
     [[nodiscard]] static MemoryDescs splitDescsWithRegionMap(MemoryDescs const& descs, VramRegionMap const& regionMap);
 
-    /// @brief Split paired src/dst descs using local and remote region maps.
-    /// src is split by localRegionMap, dst is split by remoteRegionMap.
-    /// The final piece size is min(srcPiece, dstPiece, remaining).
-    [[nodiscard]] static std::pair<MemoryDescs, MemoryDescs> splitTransferDescsWithRegionMaps(
-        MemoryDescs const& srcDescs, MemoryDescs const& dstDescs, VramRegionMap const& localRegionMap,
-        VramRegionMap const& remoteRegionMap);
+    /// @brief Split paired src/dst descs at chunk boundaries, then coalesce contiguous pieces.
+    /// src is split by localRegionMap, dst is split by remoteRegionMap; each piece size is
+    /// min(srcPiece, dstPiece, remaining). Pairs are sorted by src address, and adjacent pieces
+    /// whose src AND dst are both contiguous (same deviceId) are merged — but a merged desc never
+    /// crosses a chunk boundary on either side, and never spans two distinct regions, so every
+    /// output desc stays within a single registered memory region. Non-kVRAM descs pass through
+    /// unchanged (no region info is available to bound the merge).
+    /// @param enableCoalesce When false, only split at chunk boundaries without merging pieces.
+    [[nodiscard]] static std::pair<MemoryDescs, MemoryDescs> splitAndCoalesceTransferDescs(MemoryDescs const& srcDescs,
+        MemoryDescs const& dstDescs, VramRegionMap const& localRegionMap, VramRegionMap const& remoteRegionMap,
+        bool enableCoalesce = true);
 
     /// @brief Split VRAM descs at VMM chunk boundaries detected via cuMemGetAddressRange.
     /// For cudaMalloc memory (single allocation), descs pass through unchanged.

--- a/cpp/tensorrt_llm/common/envUtils.cpp
+++ b/cpp/tensorrt_llm/common/envUtils.cpp
@@ -517,10 +517,10 @@ uint16_t getEnvNixlPort()
     return nixlPort;
 }
 
-bool getEnvNixlEnableCoalesce()
+bool getEnvNixlDisableCoalesce()
 {
-    static bool const enableCoalesce = getBoolEnv("TRTLLM_NIXL_ENABLE_COALESCE");
-    return enableCoalesce;
+    static bool const disableCoalesce = getBoolEnv("TRTLLM_NIXL_DISABLE_COALESCE");
+    return disableCoalesce;
 }
 
 bool getEnvDisaggBenchmarkGenOnly()

--- a/cpp/tensorrt_llm/common/envUtils.h
+++ b/cpp/tensorrt_llm/common/envUtils.h
@@ -151,7 +151,8 @@ bool getEnvKVCachePoolUseFabricMemory();
 
 uint16_t getEnvNixlPort();
 
-bool getEnvNixlEnableCoalesce();
+// Whether to disable coalescing of contiguous NIXL transfer descriptors (coalescing is on by default).
+bool getEnvNixlDisableCoalesce();
 
 bool getEnvDisaggBenchmarkGenOnly();
 

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
@@ -646,7 +646,10 @@ void NixlTransferAgent::invalidateRemoteAgent(std::string const& name)
     // contiguous pieces. A coalesced descriptor never crosses a chunk boundary or a registered
     // region boundary on either side, so every descriptor still falls within a single registered
     // memory region on both local and remote sides. Set TRTLLM_NIXL_DISABLE_COALESCE=1 to fall back
-    // to split-only descriptors. Find remote agent's region map (empty map if not found).
+    // to split-only descriptors. Find remote agent's region map (empty map if not found — e.g. the
+    // peer's AgentDesc carried no region info; addresses missing from a map are never coalesced,
+    // so an empty remote map degrades to split-only rather than risking merges across unknown
+    // remote chunk/registration boundaries).
     static VramRegionMap const kEmptyMap;
     auto remoteIt = mRemoteVramRegionInfo.find(request.getRemoteName());
     auto const& remoteRegionMap = (remoteIt != mRemoteVramRegionInfo.end()) ? remoteIt->second : kEmptyMap;

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
@@ -347,164 +347,6 @@ NixlTransferStatus::~NixlTransferStatus() noexcept
     }
 }
 
-[[nodiscard]] MemoryDescs NixlHelper::coalesceMemoryDescs(MemoryDescs const& descs)
-{
-    auto const& descVec = descs.getDescs();
-
-    // If empty or single element, return as-is
-    if (descVec.size() <= 1)
-    {
-        return descs;
-    }
-
-    size_t const numDescs = descVec.size();
-
-    // Create index array and sort by address
-    std::vector<size_t> sortedIndices(numDescs);
-    std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
-
-    std::sort(sortedIndices.begin(), sortedIndices.end(),
-        [&descVec](size_t lhs, size_t rhs)
-        {
-            // Sort by deviceId first, then by address
-            if (descVec[lhs].getDeviceId() != descVec[rhs].getDeviceId())
-            {
-                return descVec[lhs].getDeviceId() < descVec[rhs].getDeviceId();
-            }
-            return descVec[lhs].getAddr() < descVec[rhs].getAddr();
-        });
-
-    std::vector<MemoryDesc> coalesced;
-    coalesced.reserve(numDescs);
-
-    // Start with the first entry
-    size_t firstIdx = sortedIndices[0];
-    uintptr_t currentAddr = descVec[firstIdx].getAddr();
-    size_t currentLen = descVec[firstIdx].getLen();
-    uint32_t currentDeviceId = descVec[firstIdx].getDeviceId();
-
-    for (size_t idx = 1; idx < numDescs; ++idx)
-    {
-        size_t sortedIdx = sortedIndices[idx];
-        auto const& desc = descVec[sortedIdx];
-
-        // Check if current can be coalesced with previous
-        bool isContiguous = (currentAddr + currentLen == desc.getAddr()) && (currentDeviceId == desc.getDeviceId());
-
-        if (isContiguous)
-        {
-            // Coalesce: extend the current region
-            currentLen += desc.getLen();
-        }
-        else
-        {
-            // Cannot coalesce: save the current region and start a new one
-            coalesced.emplace_back(currentAddr, currentLen, currentDeviceId);
-
-            currentAddr = desc.getAddr();
-            currentLen = desc.getLen();
-            currentDeviceId = desc.getDeviceId();
-        }
-    }
-
-    // Add the last region
-    coalesced.emplace_back(currentAddr, currentLen, currentDeviceId);
-
-    TLLM_LOG_DEBUG("NixlHelper::coalesceMemoryDescs: coalesced %zu -> %zu entries", descVec.size(), coalesced.size());
-
-    return MemoryDescs{descs.getType(), std::move(coalesced)};
-}
-
-[[nodiscard]] std::pair<MemoryDescs, MemoryDescs> NixlHelper::coalesceTransferDescs(
-    TransferDescs const& srcDescs, TransferDescs const& dstDescs)
-{
-    auto const& srcVec = srcDescs.getDescs();
-    auto const& dstVec = dstDescs.getDescs();
-
-    // If sizes don't match or empty, return as-is
-    if (srcVec.size() != dstVec.size() || srcVec.empty())
-    {
-        return {srcDescs, dstDescs};
-    }
-
-    size_t const numDescs = srcVec.size();
-
-    // Create index array and sort by src address
-    // This allows us to find contiguous regions even if the original order is scattered
-    std::vector<size_t> sortedIndices(numDescs);
-    std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
-
-    std::sort(sortedIndices.begin(), sortedIndices.end(),
-        [&srcVec](size_t lhs, size_t rhs)
-        {
-            // Sort by deviceId first, then by address
-            if (srcVec[lhs].getDeviceId() != srcVec[rhs].getDeviceId())
-            {
-                return srcVec[lhs].getDeviceId() < srcVec[rhs].getDeviceId();
-            }
-            return srcVec[lhs].getAddr() < srcVec[rhs].getAddr();
-        });
-
-    std::vector<MemoryDesc> coalescedSrc;
-    std::vector<MemoryDesc> coalescedDst;
-    coalescedSrc.reserve(numDescs);
-    coalescedDst.reserve(numDescs);
-
-    // Start with the first entry (using sorted order)
-    size_t firstIdx = sortedIndices[0];
-    uintptr_t currentSrcAddr = srcVec[firstIdx].getAddr();
-    size_t currentSrcLen = srcVec[firstIdx].getLen();
-    uint32_t currentSrcDeviceId = srcVec[firstIdx].getDeviceId();
-
-    uintptr_t currentDstAddr = dstVec[firstIdx].getAddr();
-    size_t currentDstLen = dstVec[firstIdx].getLen();
-    uint32_t currentDstDeviceId = dstVec[firstIdx].getDeviceId();
-
-    for (size_t idx = 1; idx < numDescs; ++idx)
-    {
-        size_t sortedIdx = sortedIndices[idx];
-        auto const& src = srcVec[sortedIdx];
-        auto const& dst = dstVec[sortedIdx];
-
-        // Check if current src and dst can be coalesced with previous
-        bool srcContiguous
-            = (currentSrcAddr + currentSrcLen == src.getAddr()) && (currentSrcDeviceId == src.getDeviceId());
-        bool dstContiguous
-            = (currentDstAddr + currentDstLen == dst.getAddr()) && (currentDstDeviceId == dst.getDeviceId());
-
-        if (srcContiguous && dstContiguous)
-        {
-            // Coalesce: extend the current region
-            currentSrcLen += src.getLen();
-            currentDstLen += dst.getLen();
-        }
-        else
-        {
-            // Cannot coalesce: save the current region and start a new one
-            coalescedSrc.emplace_back(currentSrcAddr, currentSrcLen, currentSrcDeviceId);
-            coalescedDst.emplace_back(currentDstAddr, currentDstLen, currentDstDeviceId);
-
-            currentSrcAddr = src.getAddr();
-            currentSrcLen = src.getLen();
-            currentSrcDeviceId = src.getDeviceId();
-
-            currentDstAddr = dst.getAddr();
-            currentDstLen = dst.getLen();
-            currentDstDeviceId = dst.getDeviceId();
-        }
-    }
-
-    // Don't forget to add the last region
-    coalescedSrc.emplace_back(currentSrcAddr, currentSrcLen, currentSrcDeviceId);
-    coalescedDst.emplace_back(currentDstAddr, currentDstLen, currentDstDeviceId);
-
-    TLLM_LOG_DEBUG(
-        "NixlHelper::coalesceTransferDescs: coalesced %zu -> %zu transfer entries", srcVec.size(), coalescedSrc.size());
-
-    return {MemoryDescs{srcDescs.getType(), std::move(coalescedSrc)},
-        MemoryDescs{dstDescs.getType(), std::move(coalescedDst)}};
-}
-
 TransferState NixlTransferStatus::wait(int64_t timeout_ms) const
 {
     auto startTime = std::chrono::steady_clock::now();
@@ -693,12 +535,8 @@ void NixlTransferAgent::registerMemory(RegisterDescs const& descs)
     auto detectedRegionMap = VmmDescSplitter::detectVramRegionMap(descs);
     mLocalVramRegionInfo.merge(detectedRegionMap);
 
-    // Coalesce contiguous memory regions to reduce registration overhead (disabled by default)
-    // Set TRTLLM_NIXL_ENABLE_COALESCE=1 to enable this optimization
-    auto coalescedDescs = common::getEnvNixlEnableCoalesce() ? NixlHelper::coalesceMemoryDescs(splitDescs) : splitDescs;
-
     nixl_status_t status;
-    status = mRawAgent->registerMem(NixlHelper::convertRegDlist(coalescedDescs), &mExtraParams);
+    status = mRawAgent->registerMem(NixlHelper::convertRegDlist(splitDescs), &mExtraParams);
     TLLM_CHECK(status == NIXL_SUCCESS);
 
     std::string localMD;
@@ -713,12 +551,8 @@ void NixlTransferAgent::deregisterMemory(RegisterDescs const& descs)
     // Split using per-region registry info to match what was registered
     auto splitDescs = VmmDescSplitter::splitDescsWithRegionMap(descs, mLocalVramRegionInfo);
 
-    // Coalesce contiguous memory regions to match what was registered (disabled by default)
-    // Set TRTLLM_NIXL_ENABLE_COALESCE=1 to enable this optimization
-    auto coalescedDescs = common::getEnvNixlEnableCoalesce() ? NixlHelper::coalesceMemoryDescs(splitDescs) : splitDescs;
-
     nixl_status_t status;
-    status = mRawAgent->deregisterMem(NixlHelper::convertRegDlist(coalescedDescs), &mExtraParams);
+    status = mRawAgent->deregisterMem(NixlHelper::convertRegDlist(splitDescs), &mExtraParams);
     TLLM_CHECK(status == NIXL_SUCCESS);
 
     // Remove entries from registry
@@ -743,7 +577,7 @@ void NixlTransferAgent::loadRemoteAgent(std::string const& name, AgentDesc const
         name == remoteName, "loadRemoteAgent gets error agent name: %s != %s", name.c_str(), remoteName.c_str());
 
     // Store remote VMM region info for chunk boundary calculations in
-    // VmmDescSplitter::splitTransferDescsWithRegionMaps. Per-agent map because different remote agents may have
+    // VmmDescSplitter::splitAndCoalesceTransferDescs. Per-agent map because different remote agents may have
     // overlapping virtual addresses.
     auto const& regions = agentDesc.getVramRegions();
     if (!regions.empty())
@@ -764,14 +598,13 @@ AgentDesc NixlTransferAgent::getLocalAgentDesc()
     nixl_status_t status = mRawAgent->getLocalMD(nixlBlob);
     TLLM_CHECK(status == NIXL_SUCCESS);
 
-    // Pack local VMM region info so remote agents can compute chunk boundaries.
+    // Pack ALL local region info (VMM multi-chunk and single-allocation alike) so remote agents can
+    // compute chunk boundaries and never coalesce transfer descs across separately registered regions.
     std::vector<VramRegionMeta> regions;
+    regions.reserve(mLocalVramRegionInfo.size());
     for (auto const& [base, info] : mLocalVramRegionInfo)
     {
-        if (info.chunkSize > 0)
-        {
-            regions.push_back({base, info.totalLen, info.chunkSize});
-        }
+        regions.push_back({base, info.totalLen, info.chunkSize});
     }
 
     return AgentDesc{nixlBlob, std::move(regions)};
@@ -809,32 +642,22 @@ void NixlTransferAgent::invalidateRemoteAgent(std::string const& name)
     {
         reqParams.hasNotif = false;
     }
-    // Split transfer descriptors at VMM chunk boundaries to match registered memory.
-    // Both src and dst are split at chunk boundaries to ensure each descriptor
-    // falls within a single registered memory region on both local and remote sides.
-    // Find remote agent's VMM region map (empty map if not found).
+    // Split transfer descriptors at VMM chunk boundaries to match registered memory, then coalesce
+    // contiguous pieces. A coalesced descriptor never crosses a chunk boundary or a registered
+    // region boundary on either side, so every descriptor still falls within a single registered
+    // memory region on both local and remote sides. Set TRTLLM_NIXL_DISABLE_COALESCE=1 to fall back
+    // to split-only descriptors. Find remote agent's region map (empty map if not found).
     static VramRegionMap const kEmptyMap;
     auto remoteIt = mRemoteVramRegionInfo.find(request.getRemoteName());
     auto const& remoteRegionMap = (remoteIt != mRemoteVramRegionInfo.end()) ? remoteIt->second : kEmptyMap;
 
-    auto [splitSrc, splitDst] = VmmDescSplitter::splitTransferDescsWithRegionMaps(
-        request.getSrcDescs(), request.getDstDescs(), mLocalVramRegionInfo, remoteRegionMap);
+    auto [xferSrc, xferDst] = VmmDescSplitter::splitAndCoalesceTransferDescs(request.getSrcDescs(),
+        request.getDstDescs(), mLocalVramRegionInfo, remoteRegionMap, !common::getEnvNixlDisableCoalesce());
 
-    // Coalesce contiguous memory regions to reduce transfer count (disabled by default)
-    // This matches the coalescing done during registerMemory()
-    // Set TRTLLM_NIXL_ENABLE_COALESCE=1 to enable this optimization
-    if (common::getEnvNixlEnableCoalesce())
     {
-        NVTX3_SCOPED_RANGE(coalesceTransferDescs_CreateXferReq);
-        auto [coalescedSrc, coalescedDst] = NixlHelper::coalesceTransferDescs(splitSrc, splitDst);
-        status
-            = mRawAgent->createXferReq(NixlHelper::convert(request.getOp()), NixlHelper::convertXferDist(coalescedSrc),
-                NixlHelper::convertXferDist(coalescedDst), request.getRemoteName(), handle, &reqParams);
-    }
-    else
-    {
-        status = mRawAgent->createXferReq(NixlHelper::convert(request.getOp()), NixlHelper::convertXferDist(splitSrc),
-            NixlHelper::convertXferDist(splitDst), request.getRemoteName(), handle, &reqParams);
+        NVTX3_SCOPED_RANGE(createXferReq);
+        status = mRawAgent->createXferReq(NixlHelper::convert(request.getOp()), NixlHelper::convertXferDist(xferSrc),
+            NixlHelper::convertXferDist(xferDst), request.getRemoteName(), handle, &reqParams);
     }
 
     TLLM_CHECK_WITH_INFO(status == NIXL_SUCCESS,

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
@@ -39,21 +39,6 @@ struct NixlHelper
     [[nodiscard]] static nixl_xfer_dlist_t convertXferDist(FileDescs const& descs);
     static void posixGpuToFileFallback(MemoryDescs const& memoryDesc, FileDescs const& fileDescs);
     static void posixFileToGpuFallback(MemoryDescs const& memoryDesc, FileDescs const& fileDescs);
-
-    /// @brief Coalesce contiguous memory regions to reduce memory registration overhead.
-    /// Adjacent memory regions with the same deviceId will be merged into a single region.
-    /// @param descs Memory descriptors to coalesce
-    /// @return Coalesced MemoryDescs
-    [[nodiscard]] static MemoryDescs coalesceMemoryDescs(MemoryDescs const& descs);
-
-    /// @brief Coalesce contiguous memory regions in src and dst to reduce transfer count.
-    /// If src[i] and src[i+1] are contiguous, and dst[i] and dst[i+1] are also contiguous
-    /// (with same deviceId), they will be merged into a single transfer.
-    /// @param srcDescs Source memory descriptors
-    /// @param dstDescs Destination memory descriptors
-    /// @return Pair of coalesced (src, dst) MemoryDescs
-    [[nodiscard]] static std::pair<MemoryDescs, MemoryDescs> coalesceTransferDescs(
-        TransferDescs const& srcDescs, TransferDescs const& dstDescs);
 };
 
 class NixlTransferStatus final : public TransferStatus

--- a/cpp/tensorrt_llm/executor/cache_transmission/transferAgent.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/transferAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +19,10 @@
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/serializeUtils.h"
 
+#include <algorithm>
 #include <cuda.h>
 #include <dlfcn.h>
+#include <numeric>
 #include <sstream>
 
 namespace tensorrt_llm::executor::kv_cache
@@ -152,8 +154,9 @@ MemoryDescs VmmDescSplitter::splitDescsWithRegionMap(MemoryDescs const& descs, V
     return MemoryDescs{descs.getType(), std::move(result)};
 }
 
-std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitTransferDescsWithRegionMaps(MemoryDescs const& srcDescs,
-    MemoryDescs const& dstDescs, VramRegionMap const& localRegionMap, VramRegionMap const& remoteRegionMap)
+std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitAndCoalesceTransferDescs(MemoryDescs const& srcDescs,
+    MemoryDescs const& dstDescs, VramRegionMap const& localRegionMap, VramRegionMap const& remoteRegionMap,
+    bool enableCoalesce)
 {
     if (srcDescs.getType() != MemoryType::kVRAM)
         return {srcDescs, dstDescs};
@@ -161,54 +164,138 @@ std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitTransferDescsWithRegio
     auto const& srcVec = srcDescs.getDescs();
     auto const& dstVec = dstDescs.getDescs();
     TLLM_CHECK(srcVec.size() == dstVec.size());
+    if (srcVec.empty())
+        return {srcDescs, dstDescs};
 
-    std::vector<MemoryDesc> splitSrc, splitDst;
-    splitSrc.reserve(srcVec.size());
-    splitDst.reserve(dstVec.size());
-
-    for (size_t i = 0; i < srcVec.size(); ++i)
+    // Sort pair indices by (src deviceId, src addr) so pairs that are contiguous in memory become
+    // adjacent, maximizing coalescing regardless of input order. Pairs are independent transfers,
+    // so reordering is safe. The sort only serves coalescing; with it disabled, keep input order.
+    std::vector<size_t> order(srcVec.size());
+    std::iota(order.begin(), order.end(), 0);
+    if (enableCoalesce)
     {
-        auto [srcChunkSize, srcBase] = lookupChunkInfo(srcVec[i].getAddr(), localRegionMap);
-        auto [dstChunkSize, dstBase] = lookupChunkInfo(dstVec[i].getAddr(), remoteRegionMap);
+        std::sort(order.begin(), order.end(),
+            [&srcVec](size_t lhs, size_t rhs)
+            {
+                if (srcVec[lhs].getDeviceId() != srcVec[rhs].getDeviceId())
+                {
+                    return srcVec[lhs].getDeviceId() < srcVec[rhs].getDeviceId();
+                }
+                return srcVec[lhs].getAddr() < srcVec[rhs].getAddr();
+            });
+    }
 
-        // If neither side is multi-chunk VMM, no splitting is needed.
-        if (srcChunkSize == 0 && dstChunkSize == 0)
+    std::vector<MemoryDesc> outSrc, outDst;
+    outSrc.reserve(srcVec.size());
+    outDst.reserve(dstVec.size());
+
+    // Region info of the last emitted piece. Invariant: every emitted desc lies within a single
+    // chunk on both sides, so a merge is legal iff the new piece is contiguous, in the same region,
+    // and does not start on a chunk boundary (starting on a boundary means the merge would cross it).
+    size_t prevSrcChunkSize = 0, prevDstChunkSize = 0;
+    uintptr_t prevSrcBase = 0, prevDstBase = 0;
+
+    auto emitPiece = [&](uintptr_t srcAddr, uintptr_t dstAddr, size_t len, uint32_t srcDev, uint32_t dstDev,
+                         size_t srcChunkSize, uintptr_t srcBase, size_t dstChunkSize, uintptr_t dstBase)
+    {
+        if (enableCoalesce && !outSrc.empty())
         {
-            splitSrc.push_back(srcVec[i]);
-            splitDst.push_back(dstVec[i]);
-            continue;
+            auto const& lastSrc = outSrc.back();
+            auto const& lastDst = outDst.back();
+            bool contiguous = lastSrc.getAddr() + lastSrc.getLen() == srcAddr && lastSrc.getDeviceId() == srcDev
+                && lastDst.getAddr() + lastDst.getLen() == dstAddr && lastDst.getDeviceId() == dstDev;
+            bool sameSrcRegion = srcChunkSize == prevSrcChunkSize && srcBase == prevSrcBase;
+            bool sameDstRegion = dstChunkSize == prevDstChunkSize && dstBase == prevDstBase;
+            bool srcWithinChunk = srcChunkSize == 0 || (srcAddr - srcBase) % srcChunkSize != 0;
+            bool dstWithinChunk = dstChunkSize == 0 || (dstAddr - dstBase) % dstChunkSize != 0;
+            if (contiguous && sameSrcRegion && sameDstRegion && srcWithinChunk && dstWithinChunk)
+            {
+                outSrc.back() = MemoryDesc{lastSrc.getAddr(), lastSrc.getLen() + len, srcDev};
+                outDst.back() = MemoryDesc{lastDst.getAddr(), lastDst.getLen() + len, dstDev};
+                return;
+            }
         }
+        outSrc.emplace_back(srcAddr, len, srcDev);
+        outDst.emplace_back(dstAddr, len, dstDev);
+        prevSrcChunkSize = srcChunkSize;
+        prevSrcBase = srcBase;
+        prevDstChunkSize = dstChunkSize;
+        prevDstBase = dstBase;
+    };
 
-        uintptr_t srcAddr = srcVec[i].getAddr();
-        uintptr_t dstAddr = dstVec[i].getAddr();
-        size_t remaining = srcVec[i].getLen();
+    // One-entry region cache per side: after sorting, consecutive pairs almost always fall in the
+    // same region (typically one KV pool), so the O(log R) map lookup is skipped on cache hits.
+    struct RegionCache
+    {
+        uintptr_t base = 0;
+        size_t totalLen = 0;
+        size_t chunkSize = 0;
+        bool valid = false;
+    };
+
+    auto cachedLookup = [](uintptr_t addr, VramRegionMap const& regionMap, RegionCache& cache)
+    {
+        if (cache.valid && addr >= cache.base && addr - cache.base < cache.totalLen)
+        {
+            return std::pair<size_t, uintptr_t>{cache.chunkSize, cache.base};
+        }
+        auto it = regionMap.upper_bound(addr);
+        if (it != regionMap.begin())
+        {
+            --it;
+            if (addr >= it->first && addr - it->first < it->second.totalLen)
+            {
+                cache = {it->first, it->second.totalLen, it->second.chunkSize, true};
+                return std::pair<size_t, uintptr_t>{cache.chunkSize, cache.base};
+            }
+        }
+        return std::pair<size_t, uintptr_t>{0, 0};
+    };
+
+    RegionCache srcCache, dstCache;
+    size_t numPieces = 0;
+    for (size_t idx : order)
+    {
+        auto const& src = srcVec[idx];
+        auto const& dst = dstVec[idx];
+        auto [srcChunkSize, srcBase] = cachedLookup(src.getAddr(), localRegionMap, srcCache);
+        auto [dstChunkSize, dstBase] = cachedLookup(dst.getAddr(), remoteRegionMap, dstCache);
+
+        uintptr_t srcAddr = src.getAddr();
+        uintptr_t dstAddr = dst.getAddr();
+        size_t remaining = src.getLen();
 
         while (remaining > 0)
         {
             size_t srcPieceSize = remaining;
             if (srcChunkSize > 0)
             {
-                size_t srcOffsetInChunk = static_cast<size_t>((srcAddr - srcBase) % srcChunkSize);
-                srcPieceSize = srcChunkSize - srcOffsetInChunk;
+                srcPieceSize = srcChunkSize - static_cast<size_t>((srcAddr - srcBase) % srcChunkSize);
             }
 
             size_t dstPieceSize = remaining;
             if (dstChunkSize > 0)
             {
-                size_t dstOffsetInChunk = static_cast<size_t>((dstAddr - dstBase) % dstChunkSize);
-                dstPieceSize = dstChunkSize - dstOffsetInChunk;
+                dstPieceSize = dstChunkSize - static_cast<size_t>((dstAddr - dstBase) % dstChunkSize);
             }
 
             size_t pieceSize = std::min({remaining, srcPieceSize, dstPieceSize});
-            splitSrc.emplace_back(srcAddr, pieceSize, srcVec[i].getDeviceId());
-            splitDst.emplace_back(dstAddr, pieceSize, dstVec[i].getDeviceId());
+            emitPiece(srcAddr, dstAddr, pieceSize, src.getDeviceId(), dst.getDeviceId(), srcChunkSize, srcBase,
+                dstChunkSize, dstBase);
             srcAddr += pieceSize;
             dstAddr += pieceSize;
             remaining -= pieceSize;
+            ++numPieces;
         }
     }
 
-    return {MemoryDescs{srcDescs.getType(), std::move(splitSrc)}, MemoryDescs{dstDescs.getType(), std::move(splitDst)}};
+    if (outSrc.size() != srcVec.size())
+    {
+        TLLM_LOG_DEBUG("VmmDescSplitter::splitAndCoalesceTransferDescs: %zu pairs -> %zu pieces -> %zu transfers",
+            srcVec.size(), numPieces, outSrc.size());
+    }
+
+    return {MemoryDescs{srcDescs.getType(), std::move(outSrc)}, MemoryDescs{dstDescs.getType(), std::move(outDst)}};
 }
 
 MemoryDescs VmmDescSplitter::splitVmmDescs(MemoryDescs const& descs, size_t& detectedChunkSize)

--- a/cpp/tensorrt_llm/executor/cache_transmission/transferAgent.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/transferAgent.cpp
@@ -24,6 +24,7 @@
 #include <dlfcn.h>
 #include <numeric>
 #include <sstream>
+#include <tuple>
 
 namespace tensorrt_llm::executor::kv_cache
 {
@@ -195,10 +196,11 @@ std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitAndCoalesceTransferDes
     size_t prevSrcChunkSize = 0, prevDstChunkSize = 0;
     uintptr_t prevSrcBase = 0, prevDstBase = 0;
 
-    auto emitPiece = [&](uintptr_t srcAddr, uintptr_t dstAddr, size_t len, uint32_t srcDev, uint32_t dstDev,
-                         size_t srcChunkSize, uintptr_t srcBase, size_t dstChunkSize, uintptr_t dstBase)
+    auto emitPiece
+        = [&](uintptr_t srcAddr, uintptr_t dstAddr, size_t len, uint32_t srcDev, uint32_t dstDev, size_t srcChunkSize,
+              uintptr_t srcBase, size_t dstChunkSize, uintptr_t dstBase, bool regionsKnown)
     {
-        if (enableCoalesce && !outSrc.empty())
+        if (enableCoalesce && regionsKnown && !outSrc.empty())
         {
             auto const& lastSrc = outSrc.back();
             auto const& lastDst = outDst.back();
@@ -233,11 +235,15 @@ std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitAndCoalesceTransferDes
         bool valid = false;
     };
 
+    // Returns {chunkSize, regionBase, found}. A miss means the address is not covered by any
+    // region metadata (e.g. the peer did not send its region info). Two misses both look like
+    // {0, 0} yet may belong to two distinct regions, so pieces with a missed lookup on either
+    // side are never merged — a merge could silently cross a chunk or registration boundary.
     auto cachedLookup = [](uintptr_t addr, VramRegionMap const& regionMap, RegionCache& cache)
     {
         if (cache.valid && addr >= cache.base && addr - cache.base < cache.totalLen)
         {
-            return std::pair<size_t, uintptr_t>{cache.chunkSize, cache.base};
+            return std::tuple<size_t, uintptr_t, bool>{cache.chunkSize, cache.base, true};
         }
         auto it = regionMap.upper_bound(addr);
         if (it != regionMap.begin())
@@ -246,10 +252,10 @@ std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitAndCoalesceTransferDes
             if (addr >= it->first && addr - it->first < it->second.totalLen)
             {
                 cache = {it->first, it->second.totalLen, it->second.chunkSize, true};
-                return std::pair<size_t, uintptr_t>{cache.chunkSize, cache.base};
+                return std::tuple<size_t, uintptr_t, bool>{cache.chunkSize, cache.base, true};
             }
         }
-        return std::pair<size_t, uintptr_t>{0, 0};
+        return std::tuple<size_t, uintptr_t, bool>{0, 0, false};
     };
 
     RegionCache srcCache, dstCache;
@@ -258,8 +264,8 @@ std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitAndCoalesceTransferDes
     {
         auto const& src = srcVec[idx];
         auto const& dst = dstVec[idx];
-        auto [srcChunkSize, srcBase] = cachedLookup(src.getAddr(), localRegionMap, srcCache);
-        auto [dstChunkSize, dstBase] = cachedLookup(dst.getAddr(), remoteRegionMap, dstCache);
+        auto [srcChunkSize, srcBase, srcFound] = cachedLookup(src.getAddr(), localRegionMap, srcCache);
+        auto [dstChunkSize, dstBase, dstFound] = cachedLookup(dst.getAddr(), remoteRegionMap, dstCache);
 
         uintptr_t srcAddr = src.getAddr();
         uintptr_t dstAddr = dst.getAddr();
@@ -281,7 +287,7 @@ std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitAndCoalesceTransferDes
 
             size_t pieceSize = std::min({remaining, srcPieceSize, dstPieceSize});
             emitPiece(srcAddr, dstAddr, pieceSize, src.getDeviceId(), dst.getDeviceId(), srcChunkSize, srcBase,
-                dstChunkSize, dstBase);
+                dstChunkSize, dstBase, srcFound && dstFound);
             srcAddr += pieceSize;
             dstAddr += pieceSize;
             remaining -= pieceSize;

--- a/cpp/tests/unit_tests/executor/CMakeLists.txt
+++ b/cpp/tests/unit_tests/executor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION &
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION &
 # AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -24,6 +24,7 @@ add_gtest(executorTensorTest tensorTest.cpp)
 add_gtest(serializeUtilsTest serializeUtilsTest.cpp)
 add_gtest(requestWithIdTest requestWithIdTest.cpp)
 add_gtest(loraConfigTest loraConfigTest.cpp)
+add_gtest(coalesceTest coalesceTest.cpp)
 add_gtest(genUniqueAgentNameTest genUniqueAgentNameTest.cpp)
 target_link_libraries(genUniqueAgentNameTest PRIVATE ${Python3_LIBRARIES})
 add_gtest(ucxCommTest ucxCommTest.cpp)
@@ -46,10 +47,6 @@ if(NIXL_ROOT OR (MOONCAKE_ROOT AND NOT IS_ROCKY8))
                                                 ${Python3_LIBRARIES})
     target_compile_definitions(transferAgentTest PRIVATE TEST_NIXL_BACKEND=1)
     target_compile_definitions(agentCommTest PRIVATE TEST_NIXL_BACKEND=1)
-
-    add_gtest(coalesceTest coalesceTest.cpp)
-    target_link_libraries(coalesceTest PRIVATE tensorrt_llm_nixl_wrapper
-                                               NIXL::nixl)
   endif()
 
   if(MOONCAKE_ROOT)

--- a/cpp/tests/unit_tests/executor/coalesceTest.cpp
+++ b/cpp/tests/unit_tests/executor/coalesceTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,154 +15,50 @@
  * limitations under the License.
  */
 
-#include "tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h"
+#include "tensorrt_llm/executor/transferAgent.h"
 #include <gtest/gtest.h>
 
 using namespace tensorrt_llm::executor::kv_cache;
 
-// ==================== coalesceMemoryDescs tests ====================
-
-TEST(CoalesceMemoryDescsTest, EmptyInput)
+namespace
 {
-    MemoryDescs descs{MemoryType::kVRAM, {}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    EXPECT_EQ(result.getDescs().size(), 0);
-}
+VramRegionMap const kEmptyMap;
 
-TEST(CoalesceMemoryDescsTest, SingleEntry)
+std::pair<MemoryDescs, MemoryDescs> run(TransferDescs const& src, TransferDescs const& dst,
+    VramRegionMap const& localMap = kEmptyMap, VramRegionMap const& remoteMap = kEmptyMap)
 {
-    MemoryDescs descs{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 1);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 256);
-    EXPECT_EQ(result.getDescs()[0].getDeviceId(), 0);
+    return VmmDescSplitter::splitAndCoalesceTransferDescs(src, dst, localMap, remoteMap);
 }
+} // namespace
 
-TEST(CoalesceMemoryDescsTest, TwoContiguous)
-{
-    // [0x1000, 256) then [0x1100, 256) — adjacent, should merge into one
-    MemoryDescs descs{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 1);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 512);
-    EXPECT_EQ(result.getDescs()[0].getDeviceId(), 0);
-}
+// ==================== pure coalescing (no region maps) ====================
 
-TEST(CoalesceMemoryDescsTest, TwoNonContiguous)
-{
-    // Gap between blocks — should stay as two
-    MemoryDescs descs{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x2000, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 2);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 256);
-    EXPECT_EQ(result.getDescs()[1].getAddr(), 0x2000);
-    EXPECT_EQ(result.getDescs()[1].getLen(), 256);
-}
-
-TEST(CoalesceMemoryDescsTest, ThreeContiguous)
-{
-    MemoryDescs descs{
-        MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1200, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 1);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 768);
-}
-
-TEST(CoalesceMemoryDescsTest, UnsortedInput)
-{
-    // Same three contiguous blocks but in reverse order — sorting should fix it
-    MemoryDescs descs{
-        MemoryType::kVRAM, {MemoryDesc{0x1200, 256, 0}, MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 1);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 768);
-}
-
-TEST(CoalesceMemoryDescsTest, DifferentDevices)
-{
-    // Contiguous addresses but different devices — should NOT merge
-    MemoryDescs descs{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 1}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 2);
-}
-
-TEST(CoalesceMemoryDescsTest, MixedContiguousAndGaps)
-{
-    // First two are contiguous, then a gap before the third
-    MemoryDescs descs{
-        MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x3000, 128, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 2);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 512);
-    EXPECT_EQ(result.getDescs()[1].getAddr(), 0x3000);
-    EXPECT_EQ(result.getDescs()[1].getLen(), 128);
-}
-
-TEST(CoalesceMemoryDescsTest, MultipleDevicesEachContiguous)
-{
-    // Two contiguous on device 0, two contiguous on device 1
-    MemoryDescs descs{MemoryType::kVRAM,
-        {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x2000, 128, 1},
-            MemoryDesc{0x2080, 128, 1}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 2);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 512);
-    EXPECT_EQ(result.getDescs()[0].getDeviceId(), 0);
-    EXPECT_EQ(result.getDescs()[1].getAddr(), 0x2000);
-    EXPECT_EQ(result.getDescs()[1].getLen(), 256);
-    EXPECT_EQ(result.getDescs()[1].getDeviceId(), 1);
-}
-
-TEST(CoalesceMemoryDescsTest, PreservesMemoryType)
-{
-    MemoryDescs descs{MemoryType::kDRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    EXPECT_EQ(result.getType(), MemoryType::kDRAM);
-}
-
-TEST(CoalesceMemoryDescsTest, AllSeparate)
-{
-    // Nothing can be merged — all have gaps
-    MemoryDescs descs{MemoryType::kVRAM,
-        {MemoryDesc{0x1000, 100, 0}, MemoryDesc{0x2000, 100, 0}, MemoryDesc{0x3000, 100, 0},
-            MemoryDesc{0x4000, 100, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 4);
-}
-
-// ==================== coalesceTransferDescs tests ====================
-
-TEST(CoalesceTransferDescsTest, EmptyInput)
+TEST(SplitAndCoalesceTest, EmptyInput)
 {
     TransferDescs src{MemoryType::kVRAM, {}};
     TransferDescs dst{MemoryType::kVRAM, {}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     EXPECT_EQ(resSrc.getDescs().size(), 0);
     EXPECT_EQ(resDst.getDescs().size(), 0);
 }
 
-TEST(CoalesceTransferDescsTest, SinglePair)
+TEST(SplitAndCoalesceTest, SinglePair)
 {
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x5000);
 }
 
-TEST(CoalesceTransferDescsTest, BothSidesContiguous)
+TEST(SplitAndCoalesceTest, BothSidesContiguous)
 {
     // src contiguous AND dst contiguous — should merge into one transfer
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
@@ -171,98 +67,79 @@ TEST(CoalesceTransferDescsTest, BothSidesContiguous)
     EXPECT_EQ(resDst.getDescs()[0].getLen(), 512);
 }
 
-TEST(CoalesceTransferDescsTest, SrcContiguousDstNot)
+TEST(SplitAndCoalesceTest, SrcContiguousDstNot)
 {
-    // src is contiguous but dst has a gap — can't merge
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x6000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
 
-TEST(CoalesceTransferDescsTest, DstContiguousSrcNot)
+TEST(SplitAndCoalesceTest, DstContiguousSrcNot)
 {
-    // dst is contiguous but src has a gap — can't merge
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x2000, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
 
-TEST(CoalesceTransferDescsTest, DifferentDevicesOnSrc)
+TEST(SplitAndCoalesceTest, DifferentDevicesOnSrc)
 {
-    // src addresses look contiguous but are on different devices — can't merge
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 1}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 0}, MemoryDesc{0x5100, 256, 0}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
 
-TEST(CoalesceTransferDescsTest, DifferentDevicesOnDst)
+TEST(SplitAndCoalesceTest, DifferentDevicesOnDst)
 {
-    // dst addresses look contiguous but are on different devices — can't merge
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 0}, MemoryDesc{0x5100, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
 
-TEST(CoalesceTransferDescsTest, MismatchedSizes)
-{
-    // src has 2 entries, dst has 1 — sizes don't match, return as-is
-    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
-    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
-    ASSERT_EQ(resSrc.getDescs().size(), 2);
-    ASSERT_EQ(resDst.getDescs().size(), 1);
-}
-
-TEST(CoalesceTransferDescsTest, ThreePairsAllContiguous)
+TEST(SplitAndCoalesceTest, ThreePairsAllContiguous)
 {
     TransferDescs src{
         MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1200, 256, 0}}};
     TransferDescs dst{
         MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}, MemoryDesc{0x5200, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getLen(), 768);
     EXPECT_EQ(resDst.getDescs()[0].getLen(), 768);
 }
 
-TEST(CoalesceTransferDescsTest, PartialMerge)
+TEST(SplitAndCoalesceTest, PartialMerge)
 {
-    // First two pairs: both sides contiguous — merge
-    // Third pair: src contiguous but dst has gap — stays separate
+    // First two pairs merge; third pair's dst has a gap — stays separate
     TransferDescs src{
         MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1200, 256, 0}}};
     TransferDescs dst{
         MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}, MemoryDesc{0x9000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
-    // Merged pair
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
     EXPECT_EQ(resSrc.getDescs()[0].getLen(), 512);
     EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x5000);
     EXPECT_EQ(resDst.getDescs()[0].getLen(), 512);
-    // Separate pair
     EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x1200);
-    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 256);
     EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0x9000);
-    EXPECT_EQ(resDst.getDescs()[1].getLen(), 256);
 }
 
-TEST(CoalesceTransferDescsTest, UnsortedInput)
+TEST(SplitAndCoalesceTest, UnsortedInput)
 {
-    // Same as BothSidesContiguous but in reverse order — sorting should fix it
+    // Same as BothSidesContiguous but in reverse order — sorting by src addr should fix it
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1000, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5100, 256, 1}, MemoryDesc{0x5000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
@@ -271,11 +148,224 @@ TEST(CoalesceTransferDescsTest, UnsortedInput)
     EXPECT_EQ(resDst.getDescs()[0].getLen(), 512);
 }
 
-TEST(CoalesceTransferDescsTest, PreservesMemoryType)
+TEST(SplitAndCoalesceTest, NonVramPassthrough)
 {
-    TransferDescs src{MemoryType::kDRAM, {MemoryDesc{0x1000, 256, 0}}};
-    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 0}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    // Non-kVRAM descs pass through unchanged: no region info exists to bound a merge
+    TransferDescs src{MemoryType::kDRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
+    TransferDescs dst{MemoryType::kDRAM, {MemoryDesc{0x5000, 256, 0}, MemoryDesc{0x5100, 256, 0}}};
+    auto [resSrc, resDst] = run(src, dst);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
     EXPECT_EQ(resSrc.getType(), MemoryType::kDRAM);
-    EXPECT_EQ(resDst.getType(), MemoryType::kVRAM);
+}
+
+// ==================== chunk-boundary-constrained coalescing ====================
+
+TEST(SplitAndCoalesceTest, MergeStopsAtSrcChunkBoundary)
+{
+    // Local VMM region: base=0x100000, 4MB total, 2MB chunks → boundary at 0x300000.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x400000, 0x200000};
+
+    // Four contiguous 1MB pairs covering 4MB on both sides; dst has no region info.
+    std::vector<MemoryDesc> srcVec, dstVec;
+    for (size_t i = 0; i < 4; ++i)
+    {
+        srcVec.emplace_back(0x100000 + i * 0x100000, 0x100000, 0);
+        dstVec.emplace_back(0x900000 + i * 0x100000, 0x100000, 1);
+    }
+    TransferDescs src{MemoryType::kVRAM, srcVec};
+    TransferDescs dst{MemoryType::kVRAM, dstVec};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    // Merged per src chunk: two 2MB transfers, split exactly at the chunk boundary.
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x200000);
+    EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x300000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x200000);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x900000);
+    EXPECT_EQ(resDst.getDescs()[0].getLen(), 0x200000);
+    EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0xB00000);
+    EXPECT_EQ(resDst.getDescs()[1].getLen(), 0x200000);
+}
+
+TEST(SplitAndCoalesceTest, MergeStopsAtDstChunkBoundary)
+{
+    // Remote VMM region: base=0x800000, 1MB chunks → boundary at 0x900000.
+    VramRegionMap remoteMap;
+    remoteMap[0x800000] = {0x400000, 0x100000};
+
+    // Two contiguous pairs whose dst junction sits exactly on the remote chunk boundary.
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 0x80000, 0}, MemoryDesc{0x81000, 0x80000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x880000, 0x80000, 1}, MemoryDesc{0x900000, 0x80000, 1}}};
+
+    // Without the remote map they would merge into one transfer...
+    {
+        auto [resSrc, resDst] = run(src, dst);
+        ASSERT_EQ(resSrc.getDescs().size(), 1);
+        ASSERT_EQ(resDst.getDescs().size(), 1);
+    }
+    // ...but the dst chunk boundary must block the merge.
+    auto [resSrc, resDst] = run(src, dst, kEmptyMap, remoteMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x880000);
+    EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0x900000);
+}
+
+TEST(SplitAndCoalesceTest, SplitPiecesAreNotRemerged)
+{
+    // A single pair spanning two src chunks stays split even though the pieces are contiguous.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x400000, 0x100000};
+
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x200000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x200000, 1}}};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x100000);
+}
+
+TEST(SplitAndCoalesceTest, UnalignedRegionBaseBoundary)
+{
+    // Chunk boundaries are relative to the region base, not absolute alignment.
+    // base=0x180000, 1MB chunks → boundaries at 0x280000, 0x380000, ...
+    VramRegionMap localMap;
+    localMap[0x180000] = {0x300000, 0x100000};
+
+    // Three contiguous 512KB pairs: first two share the first chunk, third starts a new chunk.
+    std::vector<MemoryDesc> srcVec, dstVec;
+    for (size_t i = 0; i < 3; ++i)
+    {
+        srcVec.emplace_back(0x180000 + i * 0x80000, 0x80000, 0);
+        dstVec.emplace_back(0x900000 + i * 0x80000, 0x80000, 1);
+    }
+    TransferDescs src{MemoryType::kVRAM, srcVec};
+    TransferDescs dst{MemoryType::kVRAM, dstVec};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x180000);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x280000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x80000);
+}
+
+TEST(SplitAndCoalesceTest, NoMergeAcrossRegions)
+{
+    // Two VA-adjacent but distinct local regions (cudaMalloc-style, chunkSize=0):
+    // contiguous descs must not merge across the region boundary.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x100000, 0};
+    localMap[0x200000] = {0x100000, 0};
+
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x100000, 0}, MemoryDesc{0x200000, 0x100000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x100000, 1}, MemoryDesc{0xA00000, 0x100000, 1}}};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+}
+
+TEST(SplitAndCoalesceTest, MergeWithinSingleRegion)
+{
+    // Control for NoMergeAcrossRegions: same layout as one region (chunkSize=0) merges freely.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x200000, 0};
+
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x100000, 0}, MemoryDesc{0x200000, 0x100000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x100000, 1}, MemoryDesc{0xA00000, 0x100000, 1}}};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 1);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x200000);
+    EXPECT_EQ(resDst.getDescs()[0].getLen(), 0x200000);
+}
+
+TEST(SplitAndCoalesceTest, NoMergeAcrossRemoteRegions)
+{
+    // The remote side registered two discrete but VA-adjacent buffers (chunkSize=0 each):
+    // contiguous dst descs must not merge across the remote registration boundary.
+    VramRegionMap remoteMap;
+    remoteMap[0x900000] = {0x100000, 0};
+    remoteMap[0xA00000] = {0x100000, 0};
+
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x100000, 0}, MemoryDesc{0x200000, 0x100000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x100000, 1}, MemoryDesc{0xA00000, 0x100000, 1}}};
+
+    auto [resSrc, resDst] = run(src, dst, kEmptyMap, remoteMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+}
+
+TEST(SplitAndCoalesceTest, CoalesceDisabledSplitsOnly)
+{
+    // With coalescing disabled, contiguous pairs stay separate and chunk splitting still applies.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x400000, 0x100000};
+
+    // Two contiguous 512KB pairs within one chunk plus one pair spanning a chunk boundary.
+    TransferDescs src{MemoryType::kVRAM,
+        {MemoryDesc{0x100000, 0x80000, 0}, MemoryDesc{0x180000, 0x80000, 0}, MemoryDesc{0x200000, 0x200000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM,
+        {MemoryDesc{0x900000, 0x80000, 1}, MemoryDesc{0x980000, 0x80000, 1}, MemoryDesc{0xA00000, 0x200000, 1}}};
+
+    auto [resSrc, resDst]
+        = VmmDescSplitter::splitAndCoalesceTransferDescs(src, dst, localMap, kEmptyMap, /*enableCoalesce=*/false);
+    // No merging: pair 1, pair 2, and pair 3 split into two chunk pieces → 4 descs.
+    ASSERT_EQ(resSrc.getDescs().size(), 4);
+    ASSERT_EQ(resDst.getDescs().size(), 4);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x80000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x80000);
+    EXPECT_EQ(resSrc.getDescs()[2].getLen(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[3].getLen(), 0x100000);
+}
+
+TEST(SplitAndCoalesceTest, CoalesceDisabledPreservesInputOrder)
+{
+    // With coalescing disabled there is no sorting either: descs come out in input order,
+    // matching the historical split-only behavior.
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x2000, 256, 0}, MemoryDesc{0x1000, 256, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x6000, 256, 1}, MemoryDesc{0x5000, 256, 1}}};
+
+    auto [resSrc, resDst]
+        = VmmDescSplitter::splitAndCoalesceTransferDescs(src, dst, kEmptyMap, kEmptyMap, /*enableCoalesce=*/false);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x2000);
+    EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x1000);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x6000);
+    EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0x5000);
+}
+
+TEST(SplitAndCoalesceTest, SplitAndMergeScatteredBlocks)
+{
+    // Scattered input order + chunked src region: blocks are sorted, merged per chunk.
+    // base=0x100000, 1MB chunks; four 512KB blocks given out of order.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x400000, 0x100000};
+
+    std::vector<size_t> perm{2, 0, 3, 1};
+    std::vector<MemoryDesc> srcVec, dstVec;
+    for (size_t i : perm)
+    {
+        srcVec.emplace_back(0x100000 + i * 0x80000, 0x80000, 0);
+        dstVec.emplace_back(0x900000 + i * 0x80000, 0x80000, 1);
+    }
+    TransferDescs src{MemoryType::kVRAM, srcVec};
+    TransferDescs dst{MemoryType::kVRAM, dstVec};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    // 2MB of contiguous data over two 1MB chunks → one transfer per chunk.
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x200000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x100000);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x900000);
+    EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0xA00000);
 }

--- a/cpp/tests/unit_tests/executor/coalesceTest.cpp
+++ b/cpp/tests/unit_tests/executor/coalesceTest.cpp
@@ -24,6 +24,16 @@ namespace
 {
 VramRegionMap const kEmptyMap;
 
+// Merging requires region metadata: an address that misses its region map is never coalesced.
+// Tests exercising merge behavior therefore provide maps covering their addresses; a flat
+// region (chunkSize=0) imposes no chunk boundaries within it.
+VramRegionMap flatRegion(uintptr_t base, size_t len)
+{
+    VramRegionMap map;
+    map[base] = {len, 0};
+    return map;
+}
+
 std::pair<MemoryDescs, MemoryDescs> run(TransferDescs const& src, TransferDescs const& dst,
     VramRegionMap const& localMap = kEmptyMap, VramRegionMap const& remoteMap = kEmptyMap)
 {
@@ -31,7 +41,7 @@ std::pair<MemoryDescs, MemoryDescs> run(TransferDescs const& src, TransferDescs 
 }
 } // namespace
 
-// ==================== pure coalescing (no region maps) ====================
+// ==================== coalescing within flat regions (chunkSize=0) ====================
 
 TEST(SplitAndCoalesceTest, EmptyInput)
 {
@@ -55,10 +65,10 @@ TEST(SplitAndCoalesceTest, SinglePair)
 
 TEST(SplitAndCoalesceTest, BothSidesContiguous)
 {
-    // src contiguous AND dst contiguous — should merge into one transfer
+    // src contiguous AND dst contiguous within known regions — should merge into one transfer
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}}};
-    auto [resSrc, resDst] = run(src, dst);
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x1000, 0x1000), flatRegion(0x5000, 0x1000));
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
@@ -71,7 +81,7 @@ TEST(SplitAndCoalesceTest, SrcContiguousDstNot)
 {
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x6000, 256, 1}}};
-    auto [resSrc, resDst] = run(src, dst);
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x1000, 0x1000), flatRegion(0x5000, 0x2000));
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
@@ -80,7 +90,7 @@ TEST(SplitAndCoalesceTest, DstContiguousSrcNot)
 {
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x2000, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}}};
-    auto [resSrc, resDst] = run(src, dst);
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x1000, 0x2000), flatRegion(0x5000, 0x1000));
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
@@ -89,7 +99,7 @@ TEST(SplitAndCoalesceTest, DifferentDevicesOnSrc)
 {
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 1}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 0}, MemoryDesc{0x5100, 256, 0}}};
-    auto [resSrc, resDst] = run(src, dst);
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x1000, 0x1000), flatRegion(0x5000, 0x1000));
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
@@ -98,7 +108,7 @@ TEST(SplitAndCoalesceTest, DifferentDevicesOnDst)
 {
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 0}, MemoryDesc{0x5100, 256, 1}}};
-    auto [resSrc, resDst] = run(src, dst);
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x1000, 0x1000), flatRegion(0x5000, 0x1000));
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
@@ -109,7 +119,7 @@ TEST(SplitAndCoalesceTest, ThreePairsAllContiguous)
         MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1200, 256, 0}}};
     TransferDescs dst{
         MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}, MemoryDesc{0x5200, 256, 1}}};
-    auto [resSrc, resDst] = run(src, dst);
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x1000, 0x1000), flatRegion(0x5000, 0x1000));
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getLen(), 768);
@@ -123,7 +133,7 @@ TEST(SplitAndCoalesceTest, PartialMerge)
         MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1200, 256, 0}}};
     TransferDescs dst{
         MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}, MemoryDesc{0x9000, 256, 1}}};
-    auto [resSrc, resDst] = run(src, dst);
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x1000, 0x1000), flatRegion(0x5000, 0x8000));
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
@@ -139,7 +149,7 @@ TEST(SplitAndCoalesceTest, UnsortedInput)
     // Same as BothSidesContiguous but in reverse order — sorting by src addr should fix it
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1000, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5100, 256, 1}, MemoryDesc{0x5000, 256, 1}}};
-    auto [resSrc, resDst] = run(src, dst);
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x1000, 0x1000), flatRegion(0x5000, 0x1000));
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
@@ -159,6 +169,40 @@ TEST(SplitAndCoalesceTest, NonVramPassthrough)
     EXPECT_EQ(resSrc.getType(), MemoryType::kDRAM);
 }
 
+// ==================== unknown regions never merge ====================
+
+TEST(SplitAndCoalesceTest, NoMergeWithoutRegionMetadata)
+{
+    // Contiguous on both sides, but neither map covers the addresses: two unknown regions are
+    // indistinguishable (both look up as a miss), so merging is disabled and pairs stay separate.
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}}};
+    auto [resSrc, resDst] = run(src, dst);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+}
+
+TEST(SplitAndCoalesceTest, NoMergeWhenRemoteRegionUnknown)
+{
+    // Local map covers src, but the remote side sent no region info (e.g. an older peer):
+    // dst lookups miss, so nothing merges even though both sides are contiguous.
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}}};
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x1000, 0x1000));
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+}
+
+TEST(SplitAndCoalesceTest, NoMergeWhenLocalRegionUnknown)
+{
+    // Remote map covers dst, but src addresses miss the local map: no merging.
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}}};
+    auto [resSrc, resDst] = run(src, dst, kEmptyMap, flatRegion(0x5000, 0x1000));
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+}
+
 // ==================== chunk-boundary-constrained coalescing ====================
 
 TEST(SplitAndCoalesceTest, MergeStopsAtSrcChunkBoundary)
@@ -167,7 +211,7 @@ TEST(SplitAndCoalesceTest, MergeStopsAtSrcChunkBoundary)
     VramRegionMap localMap;
     localMap[0x100000] = {0x400000, 0x200000};
 
-    // Four contiguous 1MB pairs covering 4MB on both sides; dst has no region info.
+    // Four contiguous 1MB pairs covering 4MB on both sides; dst is one flat remote region.
     std::vector<MemoryDesc> srcVec, dstVec;
     for (size_t i = 0; i < 4; ++i)
     {
@@ -177,7 +221,7 @@ TEST(SplitAndCoalesceTest, MergeStopsAtSrcChunkBoundary)
     TransferDescs src{MemoryType::kVRAM, srcVec};
     TransferDescs dst{MemoryType::kVRAM, dstVec};
 
-    auto [resSrc, resDst] = run(src, dst, localMap);
+    auto [resSrc, resDst] = run(src, dst, localMap, flatRegion(0x900000, 0x400000));
     // Merged per src chunk: two 2MB transfers, split exactly at the chunk boundary.
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
@@ -198,17 +242,18 @@ TEST(SplitAndCoalesceTest, MergeStopsAtDstChunkBoundary)
     remoteMap[0x800000] = {0x400000, 0x100000};
 
     // Two contiguous pairs whose dst junction sits exactly on the remote chunk boundary.
+    auto localMap = flatRegion(0x1000, 0x100000);
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 0x80000, 0}, MemoryDesc{0x81000, 0x80000, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x880000, 0x80000, 1}, MemoryDesc{0x900000, 0x80000, 1}}};
 
-    // Without the remote map they would merge into one transfer...
+    // With a flat remote region they would merge into one transfer...
     {
-        auto [resSrc, resDst] = run(src, dst);
+        auto [resSrc, resDst] = run(src, dst, localMap, flatRegion(0x800000, 0x400000));
         ASSERT_EQ(resSrc.getDescs().size(), 1);
         ASSERT_EQ(resDst.getDescs().size(), 1);
     }
     // ...but the dst chunk boundary must block the merge.
-    auto [resSrc, resDst] = run(src, dst, kEmptyMap, remoteMap);
+    auto [resSrc, resDst] = run(src, dst, localMap, remoteMap);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
     EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x880000);
@@ -224,7 +269,7 @@ TEST(SplitAndCoalesceTest, SplitPiecesAreNotRemerged)
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x200000, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x200000, 1}}};
 
-    auto [resSrc, resDst] = run(src, dst, localMap);
+    auto [resSrc, resDst] = run(src, dst, localMap, flatRegion(0x900000, 0x400000));
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
     EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x100000);
@@ -248,7 +293,7 @@ TEST(SplitAndCoalesceTest, UnalignedRegionBaseBoundary)
     TransferDescs src{MemoryType::kVRAM, srcVec};
     TransferDescs dst{MemoryType::kVRAM, dstVec};
 
-    auto [resSrc, resDst] = run(src, dst, localMap);
+    auto [resSrc, resDst] = run(src, dst, localMap, flatRegion(0x900000, 0x300000));
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x180000);
     EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x100000);
@@ -267,7 +312,7 @@ TEST(SplitAndCoalesceTest, NoMergeAcrossRegions)
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x100000, 0}, MemoryDesc{0x200000, 0x100000, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x100000, 1}, MemoryDesc{0xA00000, 0x100000, 1}}};
 
-    auto [resSrc, resDst] = run(src, dst, localMap);
+    auto [resSrc, resDst] = run(src, dst, localMap, flatRegion(0x900000, 0x200000));
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
@@ -281,7 +326,7 @@ TEST(SplitAndCoalesceTest, MergeWithinSingleRegion)
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x100000, 0}, MemoryDesc{0x200000, 0x100000, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x100000, 1}, MemoryDesc{0xA00000, 0x100000, 1}}};
 
-    auto [resSrc, resDst] = run(src, dst, localMap);
+    auto [resSrc, resDst] = run(src, dst, localMap, flatRegion(0x900000, 0x200000));
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x200000);
     EXPECT_EQ(resDst.getDescs()[0].getLen(), 0x200000);
@@ -298,7 +343,7 @@ TEST(SplitAndCoalesceTest, NoMergeAcrossRemoteRegions)
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x100000, 0}, MemoryDesc{0x200000, 0x100000, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x100000, 1}, MemoryDesc{0xA00000, 0x100000, 1}}};
 
-    auto [resSrc, resDst] = run(src, dst, kEmptyMap, remoteMap);
+    auto [resSrc, resDst] = run(src, dst, flatRegion(0x100000, 0x200000), remoteMap);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
@@ -359,7 +404,7 @@ TEST(SplitAndCoalesceTest, SplitAndMergeScatteredBlocks)
     TransferDescs src{MemoryType::kVRAM, srcVec};
     TransferDescs dst{MemoryType::kVRAM, dstVec};
 
-    auto [resSrc, resDst] = run(src, dst, localMap);
+    auto [resSrc, resDst] = run(src, dst, localMap, flatRegion(0x900000, 0x400000));
     // 2MB of contiguous data over two 1MB chunks → one transfer per chunk.
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x100000);

--- a/cpp/tests/unit_tests/executor/transferAgentTest.cpp
+++ b/cpp/tests/unit_tests/executor/transferAgentTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -702,8 +702,7 @@ TEST(VmmDescSplitterTest, SplitTransferDescsDifferentChunkSizes)
     MemoryDescs srcInput{MemoryType::kVRAM, srcDescs};
     MemoryDescs dstInput{MemoryType::kVRAM, dstDescs};
 
-    auto [splitSrc, splitDst]
-        = VmmDescSplitter::splitTransferDescsWithRegionMaps(srcInput, dstInput, localMap, remoteMap);
+    auto [splitSrc, splitDst] = VmmDescSplitter::splitAndCoalesceTransferDescs(srcInput, dstInput, localMap, remoteMap);
 
     // dst has smaller chunks (512KB), so we get 4 pieces: 512K, 512K, 512K, 512K
     ASSERT_EQ(splitSrc.getDescs().size(), 4);
@@ -735,8 +734,7 @@ TEST(VmmDescSplitterTest, SplitTransferDescsUnalignedBothSides)
     MemoryDescs srcInput{MemoryType::kVRAM, srcDescs};
     MemoryDescs dstInput{MemoryType::kVRAM, dstDescs};
 
-    auto [splitSrc, splitDst]
-        = VmmDescSplitter::splitTransferDescsWithRegionMaps(srcInput, dstInput, localMap, remoteMap);
+    auto [splitSrc, splitDst] = VmmDescSplitter::splitAndCoalesceTransferDescs(srcInput, dstInput, localMap, remoteMap);
 
     // src has 4MB chunks starting at srcBase → 1 piece from src side
     // dst has 2MB chunks starting at dstBase → 2 pieces from dst side
@@ -760,7 +758,7 @@ TEST(VmmDescSplitterTest, SplitTransferDescsNoDstRegion)
     MemoryDescs dstInput{MemoryType::kVRAM, dstDescs};
 
     auto [splitSrc, splitDst]
-        = VmmDescSplitter::splitTransferDescsWithRegionMaps(srcInput, dstInput, localMap, emptyRemoteMap);
+        = VmmDescSplitter::splitAndCoalesceTransferDescs(srcInput, dstInput, localMap, emptyRemoteMap);
 
     // Only src boundaries: 2 pieces of 1MB each
     ASSERT_EQ(splitSrc.getDescs().size(), 2);

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """KV cache management for MiniMax-M3 sparse attention.
 
 Provides:
@@ -18,18 +30,12 @@ from typing import List, Optional, Sequence
 import torch
 
 from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
-from tensorrt_llm._utils import (
-    TensorWrapper,
-    binding_to_torch_dtype,
-    convert_to_torch_tensor,
-    prefer_pinned,
-)
+from tensorrt_llm._utils import TensorWrapper, binding_to_torch_dtype, convert_to_torch_tensor
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
-from tensorrt_llm.runtime.kv_cache_manager_v2 import BufferConfig, LayerId
+from tensorrt_llm.runtime.kv_cache_manager_v2 import BufferConfig
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
-from tensorrt_llm.runtime.kv_cache_manager_v2._utils import typed_range
 
 from ....pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2, Role
 
@@ -278,12 +284,12 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
 
         The base :meth:`KVCacheManagerV2.get_buffers` produces a
         ``[num_pages, kv_factor, ...]`` view with contiguous strides
-        that assume each slot contains exactly K+V. With INDEX_KEY
-        registered, sparse layers may have ``scale > 2`` per-slot
-        buffers (e.g. M3 TP=8 coalesces K, V, INDEX_K into one pool
-        where ``scale == 3 * num_sparse + 2 * num_dense``), and the
-        base view's dim-0 stride no longer reaches the next slot's K
-        for this layer.
+        that assume the slot holds exactly one layer's K+V. In M3's
+        pool the slot packs K+V for *all* layers of the group
+        (``scale >= 2 * num_layers_in_group``), so the base view's
+        dim-0 stride does not reach the next slot's K for this layer.
+        (When INDEX_KEY's per-block size coincides with K/V's, it is
+        coalesced into the same pool and contributes to ``scale`` too.)
 
         The override builds a ``[num_slots, scale, ...]`` view rooted
         at K's base, then slices ``[:, :2]`` to extract K+V. The slice
@@ -359,75 +365,20 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         full_view = convert_to_torch_tensor(TensorWrapper(addr_key, torch_dtype, full_slot_shape))
         return full_view[:, :2]
 
-    def _build_pool_mapping_tensors(self):
-        """Compute pool-mapping offsets from layer position in the pool group.
+    def _kv_pool_mapping_offset(self, layer_id, layer_group_id, key_base_addr) -> int:
+        """Pool-mapping offset from layer position in the pool group.
 
-        The base method does ``exact_div(addr_offset, key_bytes *
-        kv_factor * tokens_per_block)``, which assumes each layer
-        contributes exactly K+V. When INDEX_KEY coincidentally shares
-        the same per-block size as K/V (M3 production at TP=8: all
-        three are 256 B/token), V2 coalesces all three into one pool
-        and the per-layer stride becomes ``3 * single_buffer_size`` —
-        the base ``exact_div`` then asserts.
-
-        Compute ``offset`` directly from
-        ``self.impl.layer_grouping[group_id]`` so the formula stays
-        correct regardless of how many extra buffers coalesce with
-        K/V. The M3 forward path uses :meth:`get_buffers` /
+        The base formula ``exact_div(addr_offset, key_bytes * kv_factor *
+        tokens_per_block)`` assumes each layer contributes exactly K+V to
+        its pool slot. When index-K coalesces into the K/V pool the layer
+        stride is non-uniform (sparse layers add an INDEX_KEY sub-page),
+        so derive ``offset`` from ``self.impl.layer_grouping`` instead.
+        The M3 forward path uses :meth:`get_buffers` /
         :meth:`get_index_k_buffer` rather than this mapping, so the
         offset just needs to be consistent (layer position in group).
         """
-        kv_cache_pool_pointers = torch.tensor(
-            [
-                [
-                    self.impl.get_mem_pool_base_address(
-                        self.impl.layer_grouping[pool_id][0], Role.KEY
-                    ),
-                    0,
-                ]
-                for pool_id in range(self.num_pools)
-            ],
-            dtype=torch.int64,
-            device="cpu",
-            pin_memory=prefer_pinned(),
-        )
-
-        if self.dtype == DataType.NVFP4:
-            kv_cache_pool_pointers = torch.stack(
-                [
-                    kv_cache_pool_pointers,
-                    torch.tensor(
-                        [
-                            [
-                                self.impl.get_mem_pool_base_address(
-                                    self.impl.layer_grouping[pool_id][0], Role.KEY_BLOCK_SCALE
-                                ),
-                                0,
-                            ]
-                            for pool_id in range(self.num_pools)
-                        ],
-                        dtype=torch.int64,
-                        device="cpu",
-                        pin_memory=prefer_pinned(),
-                    ),
-                ],
-                dim=-1,
-            )
-
-        kv_cache_pool_mapping_list = []
-        for layer_id in typed_range(LayerId(self.num_local_layers)):
-            layer_group_id = self.impl.get_layer_group_id(layer_id)
-            layers_in_group = list(self.impl.layer_grouping[int(layer_group_id)])
-            offset = layers_in_group.index(int(layer_id))
-            kv_cache_pool_mapping_list.append([int(layer_group_id), offset])
-
-        kv_cache_pool_mapping = torch.tensor(
-            kv_cache_pool_mapping_list,
-            dtype=torch.int32,
-            device="cpu",
-            pin_memory=prefer_pinned(),
-        )
-        return kv_cache_pool_pointers, kv_cache_pool_mapping
+        layers_in_group = list(self.impl.layer_grouping[int(layer_group_id)])
+        return layers_in_group.index(int(layer_id))
 
     def _get_batch_cache_indices_by_pool_id(
         self,
@@ -441,10 +392,10 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
 
         The base method converts slot ids to V1-style block ids via
         ``base_idx * index_scales[pool_id] // kv_factor``, which is
-        only correct when each layer contributes exactly K+V. With
-        INDEX_KEY-coalesced sparse pools (M3 production), the scale
-        breaks the V1 conversion and produces out-of-bounds block ids
-        during V2 warmup.
+        only correct when each layer contributes exactly K+V. M3's slot
+        packs K+V for all layers of the group, so the scale breaks the
+        V1 conversion and produces out-of-bounds block ids during V2
+        warmup.
 
         Bypass the conversion: the M3 forward path indexes paged
         views (built by :meth:`get_buffers` /

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Sequence
 
 import torch
 
+from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._utils import (
     TensorWrapper,
     binding_to_torch_dtype,
@@ -27,14 +28,10 @@ from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
 from tensorrt_llm.runtime.kv_cache_manager_v2 import BufferConfig, LayerId
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX
+from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
 from tensorrt_llm.runtime.kv_cache_manager_v2._utils import typed_range
 
-from ....pyexecutor.kv_cache_manager_v2 import (
-    DisaggCacheLayout,
-    DisaggPoolViewConfig,
-    KVCacheManagerV2,
-    Role,
-)
+from ....pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2, Role
 
 
 class MiniMaxM3SparseIndexCache:
@@ -226,12 +223,12 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
             if layer_id in self.layer_offsets
         }
 
-    def get_disagg_pool_view_config(self) -> DisaggPoolViewConfig:
+    def get_disagg_role_mapper_kinds(self) -> dict[DataRole, MapperKind]:
         """Declare MiniMax M3's token-major K/V and replicated index-K."""
-        return DisaggPoolViewConfig(
-            sharded_layout=DisaggCacheLayout.NHD,
-            replicated_roles=frozenset({Role.INDEX_KEY}),
-        )
+        return {
+            Role.ALL: MapperKind.NHD,
+            Role.INDEX_KEY: MapperKind.REPLICATED,
+        }
 
     def _compute_num_total_slots(self) -> int:
         """Total token slots across all blocks in the main K pool.

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
@@ -387,6 +387,7 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         pool_id: int = 0,
         is_kv_aggregate: bool = True,
         num_blocks_per_seq: Optional[Sequence[int]] = None,
+        index_scale: Optional[int] = None,
     ):
         """Return page indices; padded entries remain ``BAD_PAGE_INDEX`` (-1).
 
@@ -412,6 +413,9 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
             num_blocks_per_seq: Optional per-request truncation limits. When
                 omitted, preserve the full padded width required by MiniMax
                 CUDA-graph metadata initialization.
+            index_scale: Kept for compatibility with the base virtual method;
+                M3 bypasses the V1 block-id conversion entirely, so any
+                caller-supplied scale is ignored alongside ``index_scales``.
         """
         res = []
         for req_idx, req_id in enumerate(request_ids):

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
@@ -33,7 +33,7 @@ from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._utils import TensorWrapper, binding_to_torch_dtype, convert_to_torch_tensor
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
-from tensorrt_llm.runtime.kv_cache_manager_v2 import BufferConfig
+from tensorrt_llm.runtime.kv_cache_manager_v2 import BufferConfig, PageIndexMode
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
 
@@ -366,19 +366,29 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         return full_view[:, :2]
 
     def _kv_pool_mapping_offset(self, layer_id, layer_group_id, key_base_addr) -> int:
-        """Pool-mapping offset from layer position in the pool group.
+        """Pool-mapping offset from the layer's physical position in its pool.
 
         The base formula ``exact_div(addr_offset, key_bytes * kv_factor *
         tokens_per_block)`` assumes each layer contributes exactly K+V to
         its pool slot. When index-K coalesces into the K/V pool the layer
         stride is non-uniform (sparse layers add an INDEX_KEY sub-page),
-        so derive ``offset`` from ``self.impl.layer_grouping`` instead.
-        The M3 forward path uses :meth:`get_buffers` /
-        :meth:`get_index_k_buffer` rather than this mapping, so the
-        offset just needs to be consistent (layer position in group).
+        so no uniform-stride offset exists. The M3 forward path uses
+        :meth:`get_buffers` / :meth:`get_index_k_buffer` rather than this
+        mapping, so the offset just needs to be a consistent per-layer
+        position. Rank the group's layers by their K base address instead
+        of by ``layer_grouping`` iteration order: the ordering of
+        ``layer_grouping`` is not a V2 API contract, while the address
+        rank always reflects the physical slot layout (and keeps the
+        NVFP4 ``block_scale_offset == offset`` cross-check in the base
+        pool-mapping loop meaningful).
         """
-        layers_in_group = list(self.impl.layer_grouping[int(layer_group_id)])
-        return layers_in_group.index(int(layer_id))
+        layers_by_addr = sorted(
+            self.impl.layer_grouping[int(layer_group_id)],
+            key=lambda lid: self.impl.get_mem_pool_base_address(
+                lid, Role.KEY, PageIndexMode.SHARED
+            ),
+        )
+        return layers_by_addr.index(int(layer_id))
 
     def _get_batch_cache_indices_by_pool_id(
         self,

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
@@ -29,7 +29,12 @@ from tensorrt_llm.runtime.kv_cache_manager_v2 import BufferConfig, LayerId
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX
 from tensorrt_llm.runtime.kv_cache_manager_v2._utils import typed_range
 
-from ....pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2, Role
+from ....pyexecutor.kv_cache_manager_v2 import (
+    DisaggCacheLayout,
+    DisaggPoolViewConfig,
+    KVCacheManagerV2,
+    Role,
+)
 
 
 class MiniMaxM3SparseIndexCache:
@@ -176,6 +181,15 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
 
         super().__init__(*args, **kwargs)
 
+        index_v_layer_ids = set(self.sparse_layer_ids) - self.disable_index_value_layer_ids
+        if self.is_disagg and index_v_layer_ids:
+            raise ValueError(
+                "MiniMax M3 disaggregated serving requires disable_index_value=True "
+                "for every sparse layer because the optional test-only index-V cache "
+                "is not managed or transferred by KVCacheManagerV2; enabled layers="
+                f"{sorted(index_v_layer_ids)}"
+            )
+
         # Optional plain-tensor index-V cache for non-disabled sparse
         # layers (test-only; production has disable_index_value=True
         # on every sparse layer).
@@ -211,6 +225,13 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
             for layer_id in self.sparse_layer_ids
             if layer_id in self.layer_offsets
         }
+
+    def get_disagg_pool_view_config(self) -> DisaggPoolViewConfig:
+        """Declare MiniMax M3's token-major K/V and replicated index-K."""
+        return DisaggPoolViewConfig(
+            sharded_layout=DisaggCacheLayout.NHD,
+            replicated_roles=frozenset({Role.INDEX_KEY}),
+        )
 
     def _compute_num_total_slots(self) -> int:
         """Total token slots across all blocks in the main K pool.
@@ -418,9 +439,8 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         pool_id: int = 0,
         is_kv_aggregate: bool = True,
         num_blocks_per_seq: Optional[Sequence[int]] = None,
-        index_scale: Optional[int] = None,
     ):
-        """Return per-request slot ids in ``[0, num_slots)`` directly.
+        """Return page indices; padded entries remain ``BAD_PAGE_INDEX`` (-1).
 
         The base method converts slot ids to V1-style block ids via
         ``base_idx * index_scales[pool_id] // kv_factor``, which is
@@ -429,36 +449,30 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         breaks the V1 conversion and produces out-of-bounds block ids
         during V2 warmup.
 
-        ``index_scale`` (per-layer scale supplied by the base
-        :meth:`get_batch_cache_indices`) is accepted for
-        signature compatibility but intentionally ignored: this
-        override bypasses the scale conversion entirely.
-
         Bypass the conversion: the M3 forward path indexes paged
         views (built by :meth:`get_buffers` /
         :meth:`get_index_k_buffer`) directly by slot id.
-        ``BAD_PAGE_INDEX`` slots stay as 0 to match the legacy
-        padding contract.
+        ``BAD_PAGE_INDEX`` slots remain ``-1`` here because disaggregation's
+        :class:`KVRegionExtractorV1` filters ``region_ids >= 0``.
+        :meth:`get_block_ids_per_seq` maps them to zero for the attention
+        metadata's padded tensor.
 
-        ``num_blocks_per_seq``, when provided by the base
-        :meth:`get_batch_cache_indices`, truncates each request's slot
-        ids to the blocks it actually owns (matching the base method's
-        contract); the padded tail is discarded by attention callers.
+        Args:
+            request_ids: Request IDs whose page-index rows are returned.
+            pool_id: V2 pool whose page indices are requested.
+            is_kv_aggregate: Kept for compatibility with the base virtual method.
+            num_blocks_per_seq: Optional per-request truncation limits. When
+                omitted, preserve the full padded width required by MiniMax
+                CUDA-graph metadata initialization.
         """
         res = []
         for req_idx, req_id in enumerate(request_ids):
-            idx_tensor = torch.as_tensor(self.kv_cache_map[req_id].get_base_page_indices(pool_id))
+            kv_cache = self.kv_cache_map[req_id]
+            base_page_indices = kv_cache.get_base_page_indices(pool_id)
             if num_blocks_per_seq is not None:
-                idx_tensor = idx_tensor[: num_blocks_per_seq[req_idx]]
-            res.append(
-                (
-                    torch.where(
-                        idx_tensor != BAD_PAGE_INDEX,
-                        idx_tensor,
-                        torch.full_like(idx_tensor, BAD_PAGE_INDEX),
-                    )
-                ).tolist()
-            )
+                num_blocks = min(kv_cache.num_blocks, num_blocks_per_seq[req_idx])
+                base_page_indices = base_page_indices[:num_blocks]
+            res.append(list(base_page_indices))
         return res
 
     def get_block_ids_per_seq(self, request_ids):

--- a/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
@@ -1,4 +1,19 @@
-from dataclasses import dataclass
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -11,266 +26,71 @@ from tensorrt_llm._torch.disaggregation.base.region import (
 )
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
 from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
-from tensorrt_llm._torch.disaggregation.resource.utils import get_pool_view_mapper_kinds
 from tensorrt_llm._utils import nvtx_range
 
 
-@dataclass(frozen=True)
-class PoolBufferMapping:
-    """One logical buffer mapped between two physical pool slots."""
-
-    src_offset: int
-    dst_offset: int
-    src_bytes: int
-    dst_bytes: int
-    mapper_kind: MapperKind
-
-
-class IdentityMapper(RegionMapperBase):
+class IntactMapper(RegionMapperBase):
     """
-    ---- mapper_identity ----
+    ---- mapper_intact ----
 
-    Pass-through mapping. Do not change pointers or sizes.
+    Copy the selected layers' class regions between slots. Consumes slot-base
+    pointers from the extractor and expands them with slot-relative per-layer
+    byte offsets taken from the logical view's buffer entries, so it handles
+    non-uniform layer strides (a slot may interleave other role classes
+    between this class's layers).
 
-    src_ptrs: [ S0 ] [ S1 ] [ S2 ] ...
-                |      |      |
-                v      v      v
-    dst_ptrs: [ D0 ] [ D1 ] [ D2 ] ...
+    src slot: [ base ]--+off(L2)--> [L2 region] --+off(L3)--> [L3 region] ...
+    dst slot: [ base ]--+off'(L2)-> [L2 region] --+off'(L3)-> [L3 region] ...
+
+    Layers whose regions are contiguous on BOTH sides are merged into one
+    fragment, so a fully contiguous class (e.g. K/V in a dedicated pool)
+    degrades to a single whole-region copy per block.
     """
 
     def __init__(
         self,
-        self_region_bytes: int | None = None,
-        peer_region_bytes: int | None = None,
+        src_layer_offsets: Sequence[int] | np.ndarray,
+        dst_layer_offsets: Sequence[int] | np.ndarray,
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
         *,
-        mapper_name: str = "Identity",
+        mapper_name: str = "Intact",
     ) -> None:
-        if self_region_bytes is not None and peer_region_bytes is not None:
-            if self_region_bytes != peer_region_bytes:
-                raise ValueError(
-                    f"{mapper_name} cache region size mismatch: "
-                    f"local={self_region_bytes}, peer={peer_region_bytes}"
-                )
-
-    @nvtx_range("IdentityMapper.map")
-    def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
-        src_group = src_regions.memory
-        dst_group = dst_regions.memory
-        if src_group.ptrs.size != dst_group.ptrs.size:
+        if self_bytes_per_layer != peer_bytes_per_layer:
             raise ValueError(
-                f"Number of regions of src({src_group.ptrs.size}) and "
-                f"dst({dst_group.ptrs.size}) must match"
+                f"{mapper_name} cache region size mismatch: "
+                f"local={self_bytes_per_layer}, peer={peer_bytes_per_layer}"
             )
-        return SpecRegionPair(
-            src=SpecRegion(memory=src_group, spec=src_regions.spec),
-            dst=SpecRegion(memory=dst_group, spec=dst_regions.spec),
-        )
-
-
-class ReplicatedMapper(IdentityMapper):
-    """Copy a replicated cache region without KV-head remapping.
-
-    Every TP rank holds identical bytes (for example, MiniMax M3 index-key),
-    so mapping is an identity copy plus a strict source/destination size check.
-    """
-
-    def __init__(self, self_region_bytes: int, peer_region_bytes: int) -> None:
-        super().__init__(self_region_bytes, peer_region_bytes, mapper_name="Replicated")
-
-
-class PoolBufferMapper(RegionMapperBase):
-    """Map heterogeneous logical buffers inside one physical pool view.
-
-    Matching physical layouts with equal heads retain the whole-pool identity
-    path. Otherwise, per-buffer offsets select NHD head slices, replicated
-    buffers, or legacy HND buffers without expanding the page table per layer.
-    """
-
-    def __init__(
-        self,
-        *,
-        mappings: list[PoolBufferMapping],
-        self_ri: RankInfo,
-        peer_ri: RankInfo,
-        self_region_bytes: int,
-        peer_region_bytes: int,
-        full_region_identity: bool,
-        include_sharded: bool,
-        include_replicated: bool,
-    ) -> None:
-        head_match = (
-            self_ri.attention.is_mla
-            or self_ri.attention.kv_heads_per_rank == peer_ri.attention.kv_heads_per_rank
-        )
-        all_mappings_included = all(
-            include_replicated if mapping.mapper_kind == MapperKind.REPLICATED else include_sharded
-            for mapping in mappings
-        )
-        self._identity = (
-            IdentityMapper(self_region_bytes, peer_region_bytes, mapper_name="PoolBuffer")
-            if full_region_identity and head_match and all_mappings_included
-            else None
-        )
-        self._plans = self._build_plans(
-            mappings=mappings,
-            self_ri=self_ri,
-            peer_ri=peer_ri,
-            include_sharded=include_sharded,
-            include_replicated=include_replicated,
-        )
+        src = np.asarray(src_layer_offsets, dtype=np.int64)
+        dst = np.asarray(dst_layer_offsets, dtype=np.int64)
+        if src.size == 0 or src.size != dst.size:
+            raise ValueError(
+                f"{mapper_name} layer offsets must be non-empty and equal-length: "
+                f"src={src.size}, dst={dst.size}"
+            )
+        self._runs = self._merge_contiguous(src, dst, self_bytes_per_layer)
 
     @staticmethod
-    def _exact_div(numerator: int, denominator: int, *, what: str) -> int:
-        if denominator <= 0 or numerator % denominator != 0:
-            raise ValueError(
-                f"{what} is not evenly divisible: numerator={numerator}, denominator={denominator}"
-            )
-        return numerator // denominator
-
-    @classmethod
-    def _build_plans(
-        cls,
-        *,
-        mappings: list[PoolBufferMapping],
-        self_ri: RankInfo,
-        peer_ri: RankInfo,
-        include_sharded: bool,
-        include_replicated: bool,
-    ) -> list[tuple[np.ndarray, np.ndarray, int]]:
-        head_match = (
-            self_ri.attention.is_mla
-            or self_ri.attention.kv_heads_per_rank == peer_ri.attention.kv_heads_per_rank
-        )
-        self_heads = self_ri.attention.kv_heads_per_rank
-        peer_heads = peer_ri.attention.kv_heads_per_rank
-        self_tpb = self_ri.attention.tokens_per_block
-        peer_tpb = peer_ri.attention.tokens_per_block
-        offsets_by_size: dict[int, tuple[list[int], list[int]]] = {}
-
-        def append_offsets(size: int, src_offsets, dst_offsets) -> None:
-            src_list, dst_list = offsets_by_size.setdefault(size, ([], []))
-            src_list.extend(int(offset) for offset in src_offsets)
-            dst_list.extend(int(offset) for offset in dst_offsets)
-
-        for mapping in mappings:
-            kind = mapping.mapper_kind
-            if kind == MapperKind.REPLICATED:
-                if not include_replicated:
-                    continue
-            elif not include_sharded:
-                continue
-
-            if head_match or kind == MapperKind.REPLICATED:
-                if mapping.src_bytes != mapping.dst_bytes:
-                    raise ValueError(
-                        "Pool buffer size mismatch: "
-                        f"local={mapping.src_bytes}, peer={mapping.dst_bytes}, "
-                        f"mapper={kind.name}"
-                    )
-                append_offsets(
-                    mapping.src_bytes,
-                    [mapping.src_offset],
-                    [mapping.dst_offset],
+    def _merge_contiguous(
+        src: np.ndarray, dst: np.ndarray, bytes_per_layer: int
+    ) -> list[tuple[int, int, int]]:
+        runs: list[tuple[int, int, int]] = []
+        run_start = 0
+        for i in range(1, src.size + 1):
+            if (
+                i == src.size
+                or src[i] != src[i - 1] + bytes_per_layer
+                or dst[i] != dst[i - 1] + bytes_per_layer
+            ):
+                run_layers = i - run_start
+                runs.append(
+                    (int(src[run_start]), int(dst[run_start]), run_layers * bytes_per_layer)
                 )
-                continue
+                run_start = i
+        return runs
 
-            if kind == MapperKind.NHD:
-                if self_tpb != peer_tpb:
-                    raise ValueError(
-                        "NHD pool buffer mapping requires equal tokens_per_block: "
-                        f"local={self_tpb}, peer={peer_tpb}"
-                    )
-                self_bytes_per_token_head = cls._exact_div(
-                    mapping.src_bytes,
-                    self_tpb * self_heads,
-                    what="local NHD buffer bytes",
-                )
-                peer_bytes_per_token_head = cls._exact_div(
-                    mapping.dst_bytes,
-                    peer_tpb * peer_heads,
-                    what="peer NHD buffer bytes",
-                )
-                if self_bytes_per_token_head != peer_bytes_per_token_head:
-                    raise ValueError(
-                        "NHD bytes per token/head mismatch: "
-                        f"local={self_bytes_per_token_head}, "
-                        f"peer={peer_bytes_per_token_head}"
-                    )
-                src_head_off, dst_head_off = HeadMismatchMapper._compute_head_offsets(
-                    self_ri.tp_size_per_dp_group,
-                    peer_ri.tp_size_per_dp_group,
-                    self_ri.tp_rank,
-                    peer_ri.tp_rank,
-                    self_kv_heads=self_heads,
-                    peer_kv_heads=peer_heads,
-                    bytes_per_head=self_bytes_per_token_head,
-                )
-                transfer_bytes = min(self_heads, peer_heads) * self_bytes_per_token_head
-                token_indices = np.arange(self_tpb, dtype=np.int64)
-                append_offsets(
-                    transfer_bytes,
-                    mapping.src_offset
-                    + token_indices * self_heads * self_bytes_per_token_head
-                    + src_head_off,
-                    mapping.dst_offset
-                    + token_indices * peer_heads * peer_bytes_per_token_head
-                    + dst_head_off,
-                )
-                continue
-
-            if kind == MapperKind.INDEXED:
-                self_bytes_per_head = cls._exact_div(
-                    mapping.src_bytes,
-                    self_heads,
-                    what="local HND buffer bytes",
-                )
-                peer_bytes_per_head = cls._exact_div(
-                    mapping.dst_bytes,
-                    peer_heads,
-                    what="peer HND buffer bytes",
-                )
-                if self_bytes_per_head != peer_bytes_per_head:
-                    raise ValueError(
-                        "HND bytes per head mismatch: "
-                        f"local={self_bytes_per_head}, peer={peer_bytes_per_head}"
-                    )
-                src_head_off, dst_head_off = HeadMismatchMapper._compute_head_offsets(
-                    self_ri.tp_size_per_dp_group,
-                    peer_ri.tp_size_per_dp_group,
-                    self_ri.tp_rank,
-                    peer_ri.tp_rank,
-                    self_kv_heads=self_heads,
-                    peer_kv_heads=peer_heads,
-                    bytes_per_head=self_bytes_per_head,
-                )
-                transfer_bytes = min(self_heads, peer_heads) * self_bytes_per_head
-                append_offsets(
-                    transfer_bytes,
-                    [mapping.src_offset + src_head_off],
-                    [mapping.dst_offset + dst_head_off],
-                )
-                continue
-
-            raise ValueError(f"Unsupported per-buffer mapper kind: {kind.name}")
-
-        return [
-            (
-                np.asarray(src_offsets, dtype=np.int64),
-                np.asarray(dst_offsets, dtype=np.int64),
-                size,
-            )
-            for size, (src_offsets, dst_offsets) in offsets_by_size.items()
-        ]
-
-    @nvtx_range("PoolBufferMapper.map")
-    def map(
-        self,
-        src_regions: SpecRegion,
-        dst_regions: SpecRegion,
-    ) -> SpecRegionPair | list[SpecRegionPair]:
-        if self._identity is not None:
-            return self._identity.map(src_regions, dst_regions)
-
+    @nvtx_range("IntactMapper.map")
+    def map(self, src_regions: SpecRegion, dst_regions: SpecRegion):
         src_group = src_regions.memory
         dst_group = dst_regions.memory
         if src_group.ptrs.size != dst_group.ptrs.size:
@@ -278,104 +98,55 @@ class PoolBufferMapper(RegionMapperBase):
                 f"Number of regions of src({src_group.ptrs.size}) and "
                 f"dst({dst_group.ptrs.size}) must match"
             )
-
-        results = []
-        for src_offsets, dst_offsets, transfer_bytes in self._plans:
-            src_ptrs = np.add.outer(src_group.ptrs, src_offsets).ravel()
-            dst_ptrs = np.add.outer(dst_group.ptrs, dst_offsets).ravel()
-            results.append(
-                SpecRegionPair(
-                    src=SpecRegion(
-                        memory=MemRegionGroup(src_ptrs, transfer_bytes),
-                        spec=src_regions.spec,
+        pairs = [
+            SpecRegionPair(
+                src=SpecRegion(
+                    memory=MemRegionGroup(
+                        ptrs=src_group.ptrs + src_off, bytes_per_region=run_bytes
                     ),
-                    dst=SpecRegion(
-                        memory=MemRegionGroup(dst_ptrs, transfer_bytes),
-                        spec=dst_regions.spec,
+                    spec=src_regions.spec,
+                ),
+                dst=SpecRegion(
+                    memory=MemRegionGroup(
+                        ptrs=dst_group.ptrs + dst_off, bytes_per_region=run_bytes
                     ),
-                )
+                    spec=dst_regions.spec,
+                ),
             )
-        return results
+            for src_off, dst_off, run_bytes in self._runs
+        ]
+        return pairs[0] if len(pairs) == 1 else pairs
 
 
-class HeadMatchMapper(RegionMapperBase):
-    """
-    ---- mapper_head_match ----
+class ReplicatedMapper(IntactMapper):
+    """Copy TP-replicated per-layer regions without KV-head remapping.
 
-    Move/copy entire contiguous block(s) (multi-layer fragment) as a single chunk.
-    Align by whole fragment size (frag_size) and apply a constant source/destination block offset.
-
-    src_ptrs:  [ S0 ]         [ S1 ]          ...
-                 |              |
-              + src_off      + src_off
-                 |              |
-          [ S0 + src_off ] [ S1 + src_off ]   ->  (each points to a frag of size frag_size)
-                   copy whole frag
-                 |              |
-                 v              v
-          [ D0 + dst_off ] [ D1 + dst_off ]   ->  (destination frags)
-
-    Contiguous-layer assumption:
-        This mapper assumes that ``transfer_layers`` consecutive layers
-        starting at ``src_layer_off`` (and ``dst_layer_off``) are laid out
-        contiguously within each slot.  This holds because
-        ``buffer_attributes()`` in the storage config assigns buffer
-        offsets sequentially from 0 for each layer_group (life cycle),
-        and each PoolDescriptor only contains layers belonging to a single
-        layer_group.  Even when multiple layer_groups share the same
-        physical storage pool_group, each layer_group independently
-        occupies the full slot (offsets start from 0), so the contiguous
-        layout is preserved.
+    Every TP rank holds identical bytes per layer (MiniMax M3 index-key, DSA
+    indexer K), so no head slicing applies. Layer selection under partial PP
+    overlap happens through the per-layer offsets, and fan-in routing (one
+    owning sender per destination) is decided upstream by
+    ``PeerRegistrar.should_send_pool``.
     """
 
     def __init__(
         self,
-        transfer_layers: int,
-        src_layer_off: int,
-        dst_layer_off: int,
-        self_ri: RankInfo,
-        peer_ri: RankInfo,
-        slot_size_per_layer: int,
-    ):
-        if not isinstance(slot_size_per_layer, int):
-            raise TypeError(
-                f"slot_size_per_layer must be int, got {type(slot_size_per_layer).__name__} "
-                f"(value={slot_size_per_layer}). Use // instead of / for integer division."
-            )
-        self._kv_factor = self_ri.attention.kv_factor
-        self._frag_size = self._block_size(transfer_layers, slot_size_per_layer=slot_size_per_layer)
-        self._src_block_off = self._block_size(
-            src_layer_off, slot_size_per_layer=slot_size_per_layer
-        )
-        self._dst_block_off = self._block_size(
-            dst_layer_off, slot_size_per_layer=slot_size_per_layer
+        src_layer_offsets: Sequence[int] | np.ndarray,
+        dst_layer_offsets: Sequence[int] | np.ndarray,
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
+    ) -> None:
+        super().__init__(
+            src_layer_offsets,
+            dst_layer_offsets,
+            self_bytes_per_layer,
+            peer_bytes_per_layer,
+            mapper_name="Replicated",
         )
 
-    @nvtx_range("HeadMatchMapper.map")
-    def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
-        src_group = src_regions.memory
-        dst_group = dst_regions.memory
-        if src_group.ptrs.size != dst_group.ptrs.size:
-            raise ValueError(
-                f"Number of regions of src({src_group.ptrs.size}) and "
-                f"dst({dst_group.ptrs.size}) must match"
-            )
-        new_src_ptrs = src_group.ptrs + self._src_block_off
-        new_dst_ptrs = dst_group.ptrs + self._dst_block_off
-        new_src = MemRegionGroup(ptrs=new_src_ptrs, bytes_per_region=self._frag_size)
-        new_dst = MemRegionGroup(ptrs=new_dst_ptrs, bytes_per_region=self._frag_size)
-        return SpecRegionPair(
-            src=SpecRegion(memory=new_src, spec=src_regions.spec),
-            dst=SpecRegion(memory=new_dst, spec=dst_regions.spec),
-        )
 
-    def _block_size(self, layer_num: int, slot_size_per_layer: int) -> int:
-        return layer_num * slot_size_per_layer
-
-
-class HeadMismatchMapper(RegionMapperBase):
+class HNDHeadMismatchMapper(RegionMapperBase):
     """
-    ---- mapper_head_mismatch ----
+    ---- mapper_hnd_head_mismatch ----
 
     Fine-grained mapping when head counts or TP/DP partitioning differ.
     Split layers into per-head (or contiguous-heads) fragments and map them individually.
@@ -397,26 +168,60 @@ class HeadMismatchMapper(RegionMapperBase):
 
     def __init__(
         self,
-        transfer_layers: int,
-        src_layer_off: int,
-        peer_layer_off: int,
+        *,
+        src_layer_offsets: "Sequence[int] | np.ndarray",
+        dst_layer_offsets: "Sequence[int] | np.ndarray",
         self_ri: RankInfo,
         peer_ri: RankInfo,
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
+        self_buffers_per_layer: int,
+        peer_buffers_per_layer: int,
     ):
         self._ri = self_ri
         self._peer_ri = peer_ri
 
-        kv_factor = self_ri.attention.kv_factor
         self_tp_per_dp = self_ri.tp_size_per_dp_group
         peer_tp_per_dp = peer_ri.tp_size_per_dp_group
         self_tp_rank = self_ri.tp_rank
         peer_tp_rank = peer_ri.tp_rank
 
-        bytes_per_head = (
-            self._ri.attention.tokens_per_block
-            * self._ri.attention.dims_per_head
-            * self._ri.attention.element_bytes
+        if self_buffers_per_layer != peer_buffers_per_layer:
+            raise ValueError(
+                "HND buffer count per layer mismatch: "
+                f"local={self_buffers_per_layer}, peer={peer_buffers_per_layer}"
+            )
+        src_offsets = np.asarray(src_layer_offsets, dtype=np.int64)
+        dst_offsets = np.asarray(dst_layer_offsets, dtype=np.int64)
+        if src_offsets.size == 0 or src_offsets.size != dst_offsets.size:
+            raise ValueError(
+                "HND layer offsets must be non-empty and equal-length: "
+                f"src={src_offsets.size}, dst={dst_offsets.size}"
+            )
+
+        # Byte geometry is derived from the per-layer region size registered
+        # by storage (always whole bytes) rather than element_bytes x dims
+        # arithmetic, so sub-byte dtypes (e.g. NVFP4) stay exact-integer.
+        src_buffer_bytes = self._bytes_per_buffer(
+            bytes_per_layer=self_bytes_per_layer,
+            buffers_per_layer=self_buffers_per_layer,
+            side="local",
         )
+        dst_buffer_bytes = self._bytes_per_buffer(
+            bytes_per_layer=peer_bytes_per_layer,
+            buffers_per_layer=peer_buffers_per_layer,
+            side="peer",
+        )
+        bytes_per_head = self._bytes_per_head(
+            src_buffer_bytes, self._ri.attention.kv_heads_per_rank, side="local"
+        )
+        peer_bytes_per_head = self._bytes_per_head(
+            dst_buffer_bytes, peer_ri.attention.kv_heads_per_rank, side="peer"
+        )
+        if bytes_per_head != peer_bytes_per_head:
+            raise ValueError(
+                f"HND bytes per head mismatch: local={bytes_per_head}, peer={peer_bytes_per_head}"
+            )
         self._bytes_cont_heads = (
             min(self._ri.attention.kv_heads_per_rank, peer_ri.attention.kv_heads_per_rank)
             * bytes_per_head
@@ -431,63 +236,47 @@ class HeadMismatchMapper(RegionMapperBase):
             peer_kv_heads=peer_ri.attention.kv_heads_per_rank,
             bytes_per_head=bytes_per_head,
         )
-        self._peer_layer_off = peer_layer_off
 
-        # --- Pre-compute flat 1D offset arrays ---
-        #
-        # Each KV cache block (slot) is laid out as:
-        #
-        #   block_base ──► [layer_0 kv_0] [layer_0 kv_1] [layer_1 kv_0] [layer_1 kv_1] ...
-        #                   ◄─ layer_kv ─► ◄─ layer_kv ─►
-        #                   ◄────── layer_num (= layer_kv * kv_factor) ──────►
-        #
-        # To address fragment (layer=j, kv=k) within a block at base_ptr:
-        #
-        #   frag_ptr = base_ptr
-        #            + layer_num * (layer_off + j)    # skip to the right layer
-        #            + layer_kv  * k                  # skip to key or value
-        #            + head_off                       # head offset for TP mismatch
-        #
-        # The original code computed this as a 3D broadcast in map():
-        #   bases[:, None, None] + layer_offsets[None, :, None]
-        #                        + kv_offsets[None, None, :] + head_off
-        # producing shape (n_blocks, transfer_layers, kv_factor) then .ravel().
-        #
-        # Optimization: since the (layer, kv) offsets are independent of the
-        # per-call block base pointers, we pre-compute them here as a flat 1D
-        # array of length (transfer_layers * kv_factor).  At map() time we only
-        # need np.add.outer(bases, flat_offsets).ravel(), which produces the
-        # same result in the same C-order traversal (blocks outer, offsets inner)
-        # but with fewer intermediate allocations.
-        layer_indices = np.arange(transfer_layers, dtype=np.int64)
-        kv_indices = np.arange(kv_factor, dtype=np.int64)
+        # Pre-compute flat 1D offset arrays: one fragment per (layer, buffer)
+        # where buffers are the layer's K/V (or scale) buffers laid out
+        # back-to-back within the layer's region. Layer starts come from the
+        # view's buffer entries, so interleaved role classes (non-uniform
+        # layer strides) are handled the same way as everywhere else. At
+        # map() time a single np.add.outer(bases, flat_offsets) expands the
+        # per-block base pointers.
+        self._src_flat_offsets = self._build_flat_offsets(
+            layer_offsets=src_offsets,
+            buffers_per_layer=self_buffers_per_layer,
+            buffer_bytes=src_buffer_bytes,
+            head_offset=self._src_head_off,
+        )
+        self._dst_flat_offsets = self._build_flat_offsets(
+            layer_offsets=dst_offsets,
+            buffers_per_layer=peer_buffers_per_layer,
+            buffer_bytes=dst_buffer_bytes,
+            head_offset=self._dst_head_off,
+        )
 
-        src_layer_kv_num = self._get_layer_kv_num(self._ri)
-        src_layer_num = src_layer_kv_num * kv_factor
-        # Shape (transfer_layers, kv_factor) → ravel to 1D
-        self._src_flat_offsets = (
-            src_layer_num * (src_layer_off + layer_indices)[:, None]
-            + src_layer_kv_num * kv_indices[None, :]
-            + self._src_head_off
+    @staticmethod
+    def _build_flat_offsets(
+        *,
+        layer_offsets: np.ndarray,
+        buffers_per_layer: int,
+        buffer_bytes: int,
+        head_offset: int,
+    ) -> np.ndarray:
+        buffer_indices = np.arange(buffers_per_layer, dtype=np.int64)
+        return (
+            layer_offsets[:, None] + buffer_bytes * buffer_indices[None, :] + head_offset
         ).ravel()
 
-        dst_layer_kv_num = self._get_layer_kv_num(self._peer_ri)
-        dst_layer_num = dst_layer_kv_num * kv_factor
-        self._dst_flat_offsets = (
-            dst_layer_num * (peer_layer_off + layer_indices)[:, None]
-            + dst_layer_kv_num * kv_indices[None, :]
-            + self._dst_head_off
-        ).ravel()
-
-    @nvtx_range("HeadMismatchMapper.map")
+    @nvtx_range("HNDHeadMismatchMapper.map")
     def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
         src_group = src_regions.memory
         dst_group = dst_regions.memory
-        if src_group.ptrs.size != dst_group.ptrs.size:
-            raise ValueError(
-                f"Number of regions of src({src_group.ptrs.size}) and "
-                f"dst({dst_group.ptrs.size}) must match"
-            )
+        assert src_group.ptrs.size == dst_group.ptrs.size, (
+            f"Number of regions of src({src_group.ptrs.size}) and dst({dst_group.ptrs.size}) must match"
+        )
         # np.add.outer(ptrs, offsets) produces every (base + offset) combination:
         #   shape (n_blocks, transfer_layers * kv_factor)
         # .ravel() flattens in C-order: for each block, emit all layer×kv fragments.
@@ -526,19 +315,36 @@ class HeadMismatchMapper(RegionMapperBase):
             return 0, dst_head_idx * bytes_per_head
 
     @staticmethod
-    def _get_layer_kv_num(ri: RankInfo) -> int:
-        return (
-            ri.attention.kv_heads_per_rank
-            * ri.attention.tokens_per_block
-            * ri.attention.dims_per_head
-            * ri.attention.element_bytes
-        )
+    def _bytes_per_buffer(*, bytes_per_layer: int, buffers_per_layer: int, side: str) -> int:
+        """Bytes of one buffer (K or V) within a layer's region."""
+        if buffers_per_layer <= 0 or bytes_per_layer % buffers_per_layer != 0:
+            raise ValueError(
+                f"HND layer geometry is not evenly divisible ({side}): "
+                f"bytes_per_layer={bytes_per_layer}, buffers_per_layer={buffers_per_layer}"
+            )
+        return bytes_per_layer // buffers_per_layer
+
+    @staticmethod
+    def _bytes_per_head(layer_kv_bytes: int, heads: int, *, side: str) -> int:
+        """Bytes of one head's rows within a K/V buffer.
+
+        Byte-granular head slicing is only valid when a head lands on a byte
+        boundary; sub-byte dtypes (e.g. NVFP4) satisfy this whenever the
+        per-head element count covers whole bytes, which this divisibility
+        check enforces without any fractional arithmetic.
+        """
+        if heads <= 0 or layer_kv_bytes % heads != 0:
+            raise ValueError(
+                f"HND head slicing is not byte-aligned ({side}): "
+                f"layer_kv_bytes={layer_kv_bytes}, kv_heads={heads}"
+            )
+        return layer_kv_bytes // heads
 
 
-class NHDHeadMismatchMapper(HeadMismatchMapper):
+class NHDHeadMismatchMapper(HNDHeadMismatchMapper):
     """Map heterogeneous KV heads stored token-major as ``[N, H, D]``.
 
-    ``HeadMismatchMapper`` selects one contiguous head range per K/V buffer,
+    ``HNDHeadMismatchMapper`` selects one contiguous head range per K/V buffer,
     which is correct for HND storage. In NHD storage, the selected head range
     is contiguous only within one token, so this mapper emits one fragment per
     ``(layer, K/V, token)``. Only offset precomputation differs from the
@@ -548,19 +354,17 @@ class NHDHeadMismatchMapper(HeadMismatchMapper):
 
     def __init__(
         self,
-        transfer_layers: int,
-        src_layer_off: int,
-        peer_layer_off: int,
+        *,
+        src_layer_offsets: Sequence[int] | np.ndarray,
+        dst_layer_offsets: Sequence[int] | np.ndarray,
         self_ri: RankInfo,
         peer_ri: RankInfo,
-        self_region_bytes: int,
-        peer_region_bytes: int,
-        self_pool_num_layers: int,
-        peer_pool_num_layers: int,
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
         self_buffers_per_layer: int,
         peer_buffers_per_layer: int,
     ) -> None:
-        # Deliberately do not call HeadMismatchMapper.__init__: its offsets
+        # Deliberately do not call HNDHeadMismatchMapper.__init__: its offsets
         # assume HND-contiguous heads. Initialize the three attributes consumed
         # by the inherited map() with NHD token-granular geometry instead.
         self_tpb = self_ri.attention.tokens_per_block
@@ -578,17 +382,22 @@ class NHDHeadMismatchMapper(HeadMismatchMapper):
                 "NHD buffer count per layer mismatch: "
                 f"local={self_buffers_per_layer}, peer={peer_buffers_per_layer}"
             )
+        src_offsets = np.asarray(src_layer_offsets, dtype=np.int64)
+        dst_offsets = np.asarray(dst_layer_offsets, dtype=np.int64)
+        if src_offsets.size == 0 or src_offsets.size != dst_offsets.size:
+            raise ValueError(
+                "NHD layer offsets must be non-empty and equal-length: "
+                f"src={src_offsets.size}, dst={dst_offsets.size}"
+            )
 
         self_bytes_per_token_head = self._bytes_per_token_head(
-            region_bytes=self_region_bytes,
-            num_layers=self_pool_num_layers,
+            bytes_per_layer=self_bytes_per_layer,
             buffers_per_layer=self_buffers_per_layer,
             tokens_per_block=self_tpb,
             heads=self_heads,
         )
         peer_bytes_per_token_head = self._bytes_per_token_head(
-            region_bytes=peer_region_bytes,
-            num_layers=peer_pool_num_layers,
+            bytes_per_layer=peer_bytes_per_layer,
             buffers_per_layer=peer_buffers_per_layer,
             tokens_per_block=peer_tpb,
             heads=peer_heads,
@@ -600,7 +409,7 @@ class NHDHeadMismatchMapper(HeadMismatchMapper):
             )
         self._bytes_cont_heads = min(self_heads, peer_heads) * self_bytes_per_token_head
 
-        src_head_off, dst_head_off = HeadMismatchMapper._compute_head_offsets(
+        src_head_off, dst_head_off = HNDHeadMismatchMapper._compute_head_offsets(
             self_ri.tp_size_per_dp_group,
             peer_ri.tp_size_per_dp_group,
             self_ri.tp_rank,
@@ -611,8 +420,7 @@ class NHDHeadMismatchMapper(HeadMismatchMapper):
         )
 
         self._src_flat_offsets = self._build_flat_offsets(
-            transfer_layers=transfer_layers,
-            layer_offset=src_layer_off,
+            layer_offsets=src_offsets,
             buffers_per_layer=self_buffers_per_layer,
             tokens_per_block=self_tpb,
             heads=self_heads,
@@ -620,8 +428,7 @@ class NHDHeadMismatchMapper(HeadMismatchMapper):
             head_offset=src_head_off,
         )
         self._dst_flat_offsets = self._build_flat_offsets(
-            transfer_layers=transfer_layers,
-            layer_offset=peer_layer_off,
+            layer_offsets=dst_offsets,
             buffers_per_layer=peer_buffers_per_layer,
             tokens_per_block=peer_tpb,
             heads=peer_heads,
@@ -632,91 +439,42 @@ class NHDHeadMismatchMapper(HeadMismatchMapper):
     @staticmethod
     def _bytes_per_token_head(
         *,
-        region_bytes: int,
-        num_layers: int,
+        bytes_per_layer: int,
         buffers_per_layer: int,
         tokens_per_block: int,
         heads: int,
     ) -> int:
-        denominator = num_layers * buffers_per_layer * tokens_per_block * heads
-        if denominator <= 0 or region_bytes % denominator != 0:
+        denominator = buffers_per_layer * tokens_per_block * heads
+        if denominator <= 0 or bytes_per_layer % denominator != 0:
             raise ValueError(
                 "NHD region geometry is not evenly divisible: "
-                f"region_bytes={region_bytes}, layers={num_layers}, "
+                f"bytes_per_layer={bytes_per_layer}, "
                 f"buffers_per_layer={buffers_per_layer}, "
                 f"tokens_per_block={tokens_per_block}, kv_heads={heads}, "
                 f"denominator={denominator}"
             )
-        return region_bytes // denominator
+        return bytes_per_layer // denominator
 
     @staticmethod
     def _build_flat_offsets(
         *,
-        transfer_layers: int,
-        layer_offset: int,
+        layer_offsets: np.ndarray,
         buffers_per_layer: int,
         tokens_per_block: int,
         heads: int,
         bytes_per_token_head: int,
         head_offset: int,
     ) -> np.ndarray:
-        layer_indices = np.arange(transfer_layers, dtype=np.int64)
         buffer_indices = np.arange(buffers_per_layer, dtype=np.int64)
         token_indices = np.arange(tokens_per_block, dtype=np.int64)
         token_bytes = heads * bytes_per_token_head
         buffer_bytes = tokens_per_block * token_bytes
-        layer_bytes = buffers_per_layer * buffer_bytes
         return (
-            layer_bytes * (layer_offset + layer_indices)[:, None, None]
+            layer_offsets[:, None, None]
             + buffer_bytes * buffer_indices[None, :, None]
             + token_bytes * token_indices[None, None, :]
             + head_offset
         ).ravel()
-
-
-class IndexerKCacheHeadMatchMapper(RegionMapperBase):
-    """
-    Mapper for indexer K cache when head counts match.
-
-    Moves contiguous block(s) as a single chunk, aligned by block_size_per_layer,
-    with constant source/destination block offsets.
-    """
-
-    def __init__(
-        self,
-        transfer_layers: int,
-        src_layer_off: int,
-        dst_layer_off: int,
-        self_ri: RankInfo,
-        peer_ri: RankInfo,
-        block_size_per_layer: int,
-    ):
-        if not isinstance(block_size_per_layer, int):
-            raise TypeError(
-                f"block_size_per_layer must be int, got {type(block_size_per_layer).__name__} "
-                f"(value={block_size_per_layer}). Use // instead of / for integer division."
-            )
-        self._frag_size = block_size_per_layer * transfer_layers
-        self._src_block_off = block_size_per_layer * src_layer_off
-        self._dst_block_off = block_size_per_layer * dst_layer_off
-
-    @nvtx_range("IndexerKCacheHeadMatchMapper.map")
-    def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
-        src_group = src_regions.memory
-        dst_group = dst_regions.memory
-        if src_group.ptrs.size != dst_group.ptrs.size:
-            raise ValueError(
-                f"Number of regions of src({src_group.ptrs.size}) and "
-                f"dst({dst_group.ptrs.size}) must match"
-            )
-        new_src_ptrs = src_group.ptrs + self._src_block_off
-        new_dst_ptrs = dst_group.ptrs + self._dst_block_off
-        new_src = MemRegionGroup(ptrs=new_src_ptrs, bytes_per_region=self._frag_size)
-        new_dst = MemRegionGroup(ptrs=new_dst_ptrs, bytes_per_region=self._frag_size)
-        return SpecRegionPair(
-            src=SpecRegion(memory=new_src, spec=src_regions.spec),
-            dst=SpecRegion(memory=new_dst, spec=dst_regions.spec),
-        )
 
 
 class AttentionPolicy:
@@ -743,23 +501,12 @@ class AttentionPolicy:
 
     @staticmethod
     def _uses_exact_tpb_mapper(ri: RankInfo) -> bool:
+        """NHD / replicated pools address bytes inside a block, so their
+        geometry only lines up when both sides use the same tokens_per_block."""
         if ri.page_table is None:
             return False
         return any(
-            bool(get_pool_view_mapper_kinds(pool_view) & {MapperKind.NHD, MapperKind.REPLICATED})
-            for layer_group in ri.page_table.layer_groups
-            for pool_view in getattr(layer_group, "pool_views", ())
-        )
-
-    @staticmethod
-    def _uses_legacy_subbyte_mapper(ri: RankInfo) -> bool:
-        element_bytes = ri.attention.element_bytes
-        if float(element_bytes).is_integer():
-            return False
-        if ri.page_table is None:
-            return True
-        return any(
-            bool(get_pool_view_mapper_kinds(pool_view) - {MapperKind.NHD, MapperKind.REPLICATED})
+            pool_view.mapper_kind in (MapperKind.NHD, MapperKind.REPLICATED)
             for layer_group in ri.page_table.layer_groups
             for pool_view in getattr(layer_group, "pool_views", ())
         )
@@ -770,7 +517,7 @@ class AttentionPolicy:
         if self._uses_exact_tpb_mapper(self._ri) or self._uses_exact_tpb_mapper(peer_ri):
             logger.warning(
                 "AttentionPolicy: incompatible: tokens_per_block mismatch for "
-                "NHD/replicated logical pools; local=%d peer=%d",
+                "NHD/replicated pools; local=%d peer=%d",
                 local,
                 peer,
             )
@@ -806,13 +553,11 @@ class AttentionPolicy:
             or self._mismatch("element_bytes", a.element_bytes, b.element_bytes)
             or self._fail_if(
                 not self.head_match(peer_ri)[0]
-                and (
-                    self._uses_legacy_subbyte_mapper(self._ri)
-                    or self._uses_legacy_subbyte_mapper(peer_ri)
-                ),
-                "sub-byte cache dtype requires geometry-aware NHD/replicated pools",
-                local_element_bytes=a.element_bytes,
-                peer_element_bytes=b.element_bytes,
+                and not float(a.tokens_per_block * a.dims_per_head * a.element_bytes).is_integer(),
+                "sub-byte head slicing is not byte-aligned",
+                tokens_per_block=a.tokens_per_block,
+                dims_per_head=a.dims_per_head,
+                element_bytes=a.element_bytes,
             )
             or self._tpb_check(a.tokens_per_block, b.tokens_per_block, peer_ri)
             or self._mismatch("dims_per_head", a.dims_per_head, b.dims_per_head)
@@ -852,74 +597,66 @@ class AttentionPolicy:
         *,
         peer_ri: RankInfo,
         mapper_kind: MapperKind,
-        transfer_layers: int,
-        self_layer_offset: int,
-        peer_layer_offset: int,
-        self_pool_num_layers: int,
-        peer_pool_num_layers: int,
-        self_buffers_per_layer: int,
-        peer_buffers_per_layer: int,
-        self_pool_slot_bytes: int,
-        peer_pool_slot_bytes: int,
+        self_layer_offsets: "Sequence[int] | np.ndarray",
+        peer_layer_offsets: "Sequence[int] | np.ndarray",
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
+        self_buffers_per_layer: int = 1,
+        peer_buffers_per_layer: int = 1,
     ) -> RegionMapperBase:
+        """Pick the mapper for one view pair.
+
+        Every view is entries-driven: layer selection always uses explicit
+        slot-relative per-layer byte offsets, never positional arithmetic
+        (other role classes may interleave between this class's layers).
+        The kind only decides the two irreducible semantic differences:
+
+        - REPLICATED skips head matching entirely (bytes are identical on
+          every TP rank; fan-in ownership is decided upstream).
+        - Under head mismatch, HND (INDEXED) slices one contiguous head
+          range per K/V buffer, while NHD must slice inside every token.
+
+        Head-matched views of any kind collapse into IntactMapper,
+        whose run merging degrades to a single whole-region copy per block
+        when the selected layers are contiguous on both sides.
+        """
         if mapper_kind == MapperKind.REPLICATED:
-            return ReplicatedMapper(self_pool_slot_bytes, peer_pool_slot_bytes)
-
-        head_match, _ = self.head_match(peer_ri)
-
-        if head_match and transfer_layers == self_pool_num_layers == peer_pool_num_layers:
-            return IdentityMapper(self_pool_slot_bytes, peer_pool_slot_bytes)
-
-        if head_match:
-            if mapper_kind == MapperKind.FLAT:
-                block_size_per_layer = self_pool_slot_bytes // self_pool_num_layers
-                return IndexerKCacheHeadMatchMapper(
-                    transfer_layers=transfer_layers,
-                    src_layer_off=self_layer_offset,
-                    dst_layer_off=peer_layer_offset,
-                    self_ri=self._ri,
-                    peer_ri=peer_ri,
-                    block_size_per_layer=block_size_per_layer,
-                )
-
-            slot_size_per_layer = self_pool_slot_bytes // self_pool_num_layers
-            peer_size_per_layer = peer_pool_slot_bytes // peer_pool_num_layers
-            if slot_size_per_layer != peer_size_per_layer:
-                raise ValueError(
-                    f"slot_size_per_layer mismatch between self ({slot_size_per_layer}) "
-                    f"and peer ({peer_size_per_layer}) for HeadMatchMapper"
-                )
-            return HeadMatchMapper(
-                transfer_layers=transfer_layers,
-                src_layer_off=self_layer_offset,
-                dst_layer_off=peer_layer_offset,
-                self_ri=self._ri,
-                peer_ri=peer_ri,
-                slot_size_per_layer=slot_size_per_layer,
+            return ReplicatedMapper(
+                self_layer_offsets,
+                peer_layer_offsets,
+                self_bytes_per_layer,
+                peer_bytes_per_layer,
             )
 
-        if mapper_kind == MapperKind.FLAT:
-            raise ValueError("IndexerKCacheHeadMatchMapper is not supported for head mismatch case")
+        head_match, _ = self.head_match(peer_ri)
+        if head_match:
+            return IntactMapper(
+                self_layer_offsets,
+                peer_layer_offsets,
+                self_bytes_per_layer,
+                peer_bytes_per_layer,
+                mapper_name=mapper_kind.name,
+            )
 
         if mapper_kind == MapperKind.NHD:
             return NHDHeadMismatchMapper(
-                transfer_layers=transfer_layers,
-                src_layer_off=self_layer_offset,
-                peer_layer_off=peer_layer_offset,
+                src_layer_offsets=self_layer_offsets,
+                dst_layer_offsets=peer_layer_offsets,
                 self_ri=self._ri,
                 peer_ri=peer_ri,
-                self_region_bytes=self_pool_slot_bytes,
-                peer_region_bytes=peer_pool_slot_bytes,
-                self_pool_num_layers=self_pool_num_layers,
-                peer_pool_num_layers=peer_pool_num_layers,
+                self_bytes_per_layer=self_bytes_per_layer,
+                peer_bytes_per_layer=peer_bytes_per_layer,
                 self_buffers_per_layer=self_buffers_per_layer,
                 peer_buffers_per_layer=peer_buffers_per_layer,
             )
 
-        return HeadMismatchMapper(
-            transfer_layers=transfer_layers,
-            src_layer_off=self_layer_offset,
-            peer_layer_off=peer_layer_offset,
+        return HNDHeadMismatchMapper(
+            src_layer_offsets=self_layer_offsets,
+            dst_layer_offsets=peer_layer_offsets,
             self_ri=self._ri,
             peer_ri=peer_ri,
+            self_bytes_per_layer=self_bytes_per_layer,
+            peer_bytes_per_layer=peer_bytes_per_layer,
+            self_buffers_per_layer=self_buffers_per_layer,
+            peer_buffers_per_layer=peer_buffers_per_layer,
         )

--- a/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import numpy as np
 
 from tensorrt_llm import logger
@@ -9,7 +11,19 @@ from tensorrt_llm._torch.disaggregation.base.region import (
 )
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
 from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
+from tensorrt_llm._torch.disaggregation.resource.utils import get_pool_view_mapper_kinds
 from tensorrt_llm._utils import nvtx_range
+
+
+@dataclass(frozen=True)
+class PoolBufferMapping:
+    """One logical buffer mapped between two physical pool slots."""
+
+    src_offset: int
+    dst_offset: int
+    src_bytes: int
+    dst_bytes: int
+    mapper_kind: MapperKind
 
 
 class IdentityMapper(RegionMapperBase):
@@ -62,6 +76,226 @@ class ReplicatedMapper(IdentityMapper):
 
     def __init__(self, self_region_bytes: int, peer_region_bytes: int) -> None:
         super().__init__(self_region_bytes, peer_region_bytes, mapper_name="Replicated")
+
+
+class PoolBufferMapper(RegionMapperBase):
+    """Map heterogeneous logical buffers inside one physical pool view.
+
+    Matching physical layouts with equal heads retain the whole-pool identity
+    path. Otherwise, per-buffer offsets select NHD head slices, replicated
+    buffers, or legacy HND buffers without expanding the page table per layer.
+    """
+
+    def __init__(
+        self,
+        *,
+        mappings: list[PoolBufferMapping],
+        self_ri: RankInfo,
+        peer_ri: RankInfo,
+        self_region_bytes: int,
+        peer_region_bytes: int,
+        full_region_identity: bool,
+        include_sharded: bool,
+        include_replicated: bool,
+    ) -> None:
+        head_match = (
+            self_ri.attention.is_mla
+            or self_ri.attention.kv_heads_per_rank == peer_ri.attention.kv_heads_per_rank
+        )
+        all_mappings_included = all(
+            include_replicated if mapping.mapper_kind == MapperKind.REPLICATED else include_sharded
+            for mapping in mappings
+        )
+        self._identity = (
+            IdentityMapper(self_region_bytes, peer_region_bytes, mapper_name="PoolBuffer")
+            if full_region_identity and head_match and all_mappings_included
+            else None
+        )
+        self._plans = self._build_plans(
+            mappings=mappings,
+            self_ri=self_ri,
+            peer_ri=peer_ri,
+            include_sharded=include_sharded,
+            include_replicated=include_replicated,
+        )
+
+    @staticmethod
+    def _exact_div(numerator: int, denominator: int, *, what: str) -> int:
+        if denominator <= 0 or numerator % denominator != 0:
+            raise ValueError(
+                f"{what} is not evenly divisible: numerator={numerator}, denominator={denominator}"
+            )
+        return numerator // denominator
+
+    @classmethod
+    def _build_plans(
+        cls,
+        *,
+        mappings: list[PoolBufferMapping],
+        self_ri: RankInfo,
+        peer_ri: RankInfo,
+        include_sharded: bool,
+        include_replicated: bool,
+    ) -> list[tuple[np.ndarray, np.ndarray, int]]:
+        head_match = (
+            self_ri.attention.is_mla
+            or self_ri.attention.kv_heads_per_rank == peer_ri.attention.kv_heads_per_rank
+        )
+        self_heads = self_ri.attention.kv_heads_per_rank
+        peer_heads = peer_ri.attention.kv_heads_per_rank
+        self_tpb = self_ri.attention.tokens_per_block
+        peer_tpb = peer_ri.attention.tokens_per_block
+        offsets_by_size: dict[int, tuple[list[int], list[int]]] = {}
+
+        def append_offsets(size: int, src_offsets, dst_offsets) -> None:
+            src_list, dst_list = offsets_by_size.setdefault(size, ([], []))
+            src_list.extend(int(offset) for offset in src_offsets)
+            dst_list.extend(int(offset) for offset in dst_offsets)
+
+        for mapping in mappings:
+            kind = mapping.mapper_kind
+            if kind == MapperKind.REPLICATED:
+                if not include_replicated:
+                    continue
+            elif not include_sharded:
+                continue
+
+            if head_match or kind == MapperKind.REPLICATED:
+                if mapping.src_bytes != mapping.dst_bytes:
+                    raise ValueError(
+                        "Pool buffer size mismatch: "
+                        f"local={mapping.src_bytes}, peer={mapping.dst_bytes}, "
+                        f"mapper={kind.name}"
+                    )
+                append_offsets(
+                    mapping.src_bytes,
+                    [mapping.src_offset],
+                    [mapping.dst_offset],
+                )
+                continue
+
+            if kind == MapperKind.NHD:
+                if self_tpb != peer_tpb:
+                    raise ValueError(
+                        "NHD pool buffer mapping requires equal tokens_per_block: "
+                        f"local={self_tpb}, peer={peer_tpb}"
+                    )
+                self_bytes_per_token_head = cls._exact_div(
+                    mapping.src_bytes,
+                    self_tpb * self_heads,
+                    what="local NHD buffer bytes",
+                )
+                peer_bytes_per_token_head = cls._exact_div(
+                    mapping.dst_bytes,
+                    peer_tpb * peer_heads,
+                    what="peer NHD buffer bytes",
+                )
+                if self_bytes_per_token_head != peer_bytes_per_token_head:
+                    raise ValueError(
+                        "NHD bytes per token/head mismatch: "
+                        f"local={self_bytes_per_token_head}, "
+                        f"peer={peer_bytes_per_token_head}"
+                    )
+                src_head_off, dst_head_off = HeadMismatchMapper._compute_head_offsets(
+                    self_ri.tp_size_per_dp_group,
+                    peer_ri.tp_size_per_dp_group,
+                    self_ri.tp_rank,
+                    peer_ri.tp_rank,
+                    self_kv_heads=self_heads,
+                    peer_kv_heads=peer_heads,
+                    bytes_per_head=self_bytes_per_token_head,
+                )
+                transfer_bytes = min(self_heads, peer_heads) * self_bytes_per_token_head
+                token_indices = np.arange(self_tpb, dtype=np.int64)
+                append_offsets(
+                    transfer_bytes,
+                    mapping.src_offset
+                    + token_indices * self_heads * self_bytes_per_token_head
+                    + src_head_off,
+                    mapping.dst_offset
+                    + token_indices * peer_heads * peer_bytes_per_token_head
+                    + dst_head_off,
+                )
+                continue
+
+            if kind == MapperKind.INDEXED:
+                self_bytes_per_head = cls._exact_div(
+                    mapping.src_bytes,
+                    self_heads,
+                    what="local HND buffer bytes",
+                )
+                peer_bytes_per_head = cls._exact_div(
+                    mapping.dst_bytes,
+                    peer_heads,
+                    what="peer HND buffer bytes",
+                )
+                if self_bytes_per_head != peer_bytes_per_head:
+                    raise ValueError(
+                        "HND bytes per head mismatch: "
+                        f"local={self_bytes_per_head}, peer={peer_bytes_per_head}"
+                    )
+                src_head_off, dst_head_off = HeadMismatchMapper._compute_head_offsets(
+                    self_ri.tp_size_per_dp_group,
+                    peer_ri.tp_size_per_dp_group,
+                    self_ri.tp_rank,
+                    peer_ri.tp_rank,
+                    self_kv_heads=self_heads,
+                    peer_kv_heads=peer_heads,
+                    bytes_per_head=self_bytes_per_head,
+                )
+                transfer_bytes = min(self_heads, peer_heads) * self_bytes_per_head
+                append_offsets(
+                    transfer_bytes,
+                    [mapping.src_offset + src_head_off],
+                    [mapping.dst_offset + dst_head_off],
+                )
+                continue
+
+            raise ValueError(f"Unsupported per-buffer mapper kind: {kind.name}")
+
+        return [
+            (
+                np.asarray(src_offsets, dtype=np.int64),
+                np.asarray(dst_offsets, dtype=np.int64),
+                size,
+            )
+            for size, (src_offsets, dst_offsets) in offsets_by_size.items()
+        ]
+
+    @nvtx_range("PoolBufferMapper.map")
+    def map(
+        self,
+        src_regions: SpecRegion,
+        dst_regions: SpecRegion,
+    ) -> SpecRegionPair | list[SpecRegionPair]:
+        if self._identity is not None:
+            return self._identity.map(src_regions, dst_regions)
+
+        src_group = src_regions.memory
+        dst_group = dst_regions.memory
+        if src_group.ptrs.size != dst_group.ptrs.size:
+            raise ValueError(
+                f"Number of regions of src({src_group.ptrs.size}) and "
+                f"dst({dst_group.ptrs.size}) must match"
+            )
+
+        results = []
+        for src_offsets, dst_offsets, transfer_bytes in self._plans:
+            src_ptrs = np.add.outer(src_group.ptrs, src_offsets).ravel()
+            dst_ptrs = np.add.outer(dst_group.ptrs, dst_offsets).ravel()
+            results.append(
+                SpecRegionPair(
+                    src=SpecRegion(
+                        memory=MemRegionGroup(src_ptrs, transfer_bytes),
+                        spec=src_regions.spec,
+                    ),
+                    dst=SpecRegion(
+                        memory=MemRegionGroup(dst_ptrs, transfer_bytes),
+                        spec=dst_regions.spec,
+                    ),
+                )
+            )
+        return results
 
 
 class HeadMatchMapper(RegionMapperBase):
@@ -512,7 +746,7 @@ class AttentionPolicy:
         if ri.page_table is None:
             return False
         return any(
-            pool_view.mapper_kind in (MapperKind.NHD, MapperKind.REPLICATED)
+            bool(get_pool_view_mapper_kinds(pool_view) & {MapperKind.NHD, MapperKind.REPLICATED})
             for layer_group in ri.page_table.layer_groups
             for pool_view in getattr(layer_group, "pool_views", ())
         )
@@ -525,7 +759,7 @@ class AttentionPolicy:
         if ri.page_table is None:
             return True
         return any(
-            pool_view.mapper_kind not in (MapperKind.NHD, MapperKind.REPLICATED)
+            bool(get_pool_view_mapper_kinds(pool_view) - {MapperKind.NHD, MapperKind.REPLICATED})
             for layer_group in ri.page_table.layer_groups
             for pool_view in getattr(layer_group, "pool_views", ())
         )

--- a/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
@@ -24,17 +24,44 @@ class IdentityMapper(RegionMapperBase):
     dst_ptrs: [ D0 ] [ D1 ] [ D2 ] ...
     """
 
+    def __init__(
+        self,
+        self_region_bytes: int | None = None,
+        peer_region_bytes: int | None = None,
+        *,
+        mapper_name: str = "Identity",
+    ) -> None:
+        if self_region_bytes is not None and peer_region_bytes is not None:
+            if self_region_bytes != peer_region_bytes:
+                raise ValueError(
+                    f"{mapper_name} cache region size mismatch: "
+                    f"local={self_region_bytes}, peer={peer_region_bytes}"
+                )
+
     @nvtx_range("IdentityMapper.map")
     def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
         src_group = src_regions.memory
         dst_group = dst_regions.memory
-        assert src_group.ptrs.size == dst_group.ptrs.size, (
-            f"Number of regions of src({src_group.ptrs.size}) and dst({dst_group.ptrs.size}) must match"
-        )
+        if src_group.ptrs.size != dst_group.ptrs.size:
+            raise ValueError(
+                f"Number of regions of src({src_group.ptrs.size}) and "
+                f"dst({dst_group.ptrs.size}) must match"
+            )
         return SpecRegionPair(
             src=SpecRegion(memory=src_group, spec=src_regions.spec),
             dst=SpecRegion(memory=dst_group, spec=dst_regions.spec),
         )
+
+
+class ReplicatedMapper(IdentityMapper):
+    """Copy a replicated cache region without KV-head remapping.
+
+    Every TP rank holds identical bytes (for example, MiniMax M3 index-key),
+    so mapping is an identity copy plus a strict source/destination size check.
+    """
+
+    def __init__(self, self_region_bytes: int, peer_region_bytes: int) -> None:
+        super().__init__(self_region_bytes, peer_region_bytes, mapper_name="Replicated")
 
 
 class HeadMatchMapper(RegionMapperBase):
@@ -94,9 +121,11 @@ class HeadMatchMapper(RegionMapperBase):
     def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
         src_group = src_regions.memory
         dst_group = dst_regions.memory
-        assert src_group.ptrs.size == dst_group.ptrs.size, (
-            f"Number of regions of src({src_group.ptrs.size}) and dst({dst_group.ptrs.size}) must match"
-        )
+        if src_group.ptrs.size != dst_group.ptrs.size:
+            raise ValueError(
+                f"Number of regions of src({src_group.ptrs.size}) and "
+                f"dst({dst_group.ptrs.size}) must match"
+            )
         new_src_ptrs = src_group.ptrs + self._src_block_off
         new_dst_ptrs = dst_group.ptrs + self._dst_block_off
         new_src = MemRegionGroup(ptrs=new_src_ptrs, bytes_per_region=self._frag_size)
@@ -220,9 +249,11 @@ class HeadMismatchMapper(RegionMapperBase):
     def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
         src_group = src_regions.memory
         dst_group = dst_regions.memory
-        assert src_group.ptrs.size == dst_group.ptrs.size, (
-            f"Number of regions of src({src_group.ptrs.size}) and dst({dst_group.ptrs.size}) must match"
-        )
+        if src_group.ptrs.size != dst_group.ptrs.size:
+            raise ValueError(
+                f"Number of regions of src({src_group.ptrs.size}) and "
+                f"dst({dst_group.ptrs.size}) must match"
+            )
         # np.add.outer(ptrs, offsets) produces every (base + offset) combination:
         #   shape (n_blocks, transfer_layers * kv_factor)
         # .ravel() flattens in C-order: for each block, emit all layer×kv fragments.
@@ -270,6 +301,145 @@ class HeadMismatchMapper(RegionMapperBase):
         )
 
 
+class NHDHeadMismatchMapper(HeadMismatchMapper):
+    """Map heterogeneous KV heads stored token-major as ``[N, H, D]``.
+
+    ``HeadMismatchMapper`` selects one contiguous head range per K/V buffer,
+    which is correct for HND storage. In NHD storage, the selected head range
+    is contiguous only within one token, so this mapper emits one fragment per
+    ``(layer, K/V, token)``. Only offset precomputation differs from the
+    parent; the inherited :meth:`map` consumes ``_src_flat_offsets``,
+    ``_dst_flat_offsets``, and ``_bytes_cont_heads``.
+    """
+
+    def __init__(
+        self,
+        transfer_layers: int,
+        src_layer_off: int,
+        peer_layer_off: int,
+        self_ri: RankInfo,
+        peer_ri: RankInfo,
+        self_region_bytes: int,
+        peer_region_bytes: int,
+        self_pool_num_layers: int,
+        peer_pool_num_layers: int,
+        self_buffers_per_layer: int,
+        peer_buffers_per_layer: int,
+    ) -> None:
+        # Deliberately do not call HeadMismatchMapper.__init__: its offsets
+        # assume HND-contiguous heads. Initialize the three attributes consumed
+        # by the inherited map() with NHD token-granular geometry instead.
+        self_tpb = self_ri.attention.tokens_per_block
+        peer_tpb = peer_ri.attention.tokens_per_block
+        if self_tpb != peer_tpb:
+            raise ValueError(
+                "NHDHeadMismatchMapper requires equal tokens_per_block; "
+                f"local={self_tpb}, peer={peer_tpb}"
+            )
+
+        self_heads = self_ri.attention.kv_heads_per_rank
+        peer_heads = peer_ri.attention.kv_heads_per_rank
+        if self_buffers_per_layer != peer_buffers_per_layer:
+            raise ValueError(
+                "NHD buffer count per layer mismatch: "
+                f"local={self_buffers_per_layer}, peer={peer_buffers_per_layer}"
+            )
+
+        self_bytes_per_token_head = self._bytes_per_token_head(
+            region_bytes=self_region_bytes,
+            num_layers=self_pool_num_layers,
+            buffers_per_layer=self_buffers_per_layer,
+            tokens_per_block=self_tpb,
+            heads=self_heads,
+        )
+        peer_bytes_per_token_head = self._bytes_per_token_head(
+            region_bytes=peer_region_bytes,
+            num_layers=peer_pool_num_layers,
+            buffers_per_layer=peer_buffers_per_layer,
+            tokens_per_block=peer_tpb,
+            heads=peer_heads,
+        )
+        if self_bytes_per_token_head != peer_bytes_per_token_head:
+            raise ValueError(
+                "NHD bytes per token/head mismatch: "
+                f"local={self_bytes_per_token_head}, peer={peer_bytes_per_token_head}"
+            )
+        self._bytes_cont_heads = min(self_heads, peer_heads) * self_bytes_per_token_head
+
+        src_head_off, dst_head_off = HeadMismatchMapper._compute_head_offsets(
+            self_ri.tp_size_per_dp_group,
+            peer_ri.tp_size_per_dp_group,
+            self_ri.tp_rank,
+            peer_ri.tp_rank,
+            self_kv_heads=self_heads,
+            peer_kv_heads=peer_heads,
+            bytes_per_head=self_bytes_per_token_head,
+        )
+
+        self._src_flat_offsets = self._build_flat_offsets(
+            transfer_layers=transfer_layers,
+            layer_offset=src_layer_off,
+            buffers_per_layer=self_buffers_per_layer,
+            tokens_per_block=self_tpb,
+            heads=self_heads,
+            bytes_per_token_head=self_bytes_per_token_head,
+            head_offset=src_head_off,
+        )
+        self._dst_flat_offsets = self._build_flat_offsets(
+            transfer_layers=transfer_layers,
+            layer_offset=peer_layer_off,
+            buffers_per_layer=peer_buffers_per_layer,
+            tokens_per_block=peer_tpb,
+            heads=peer_heads,
+            bytes_per_token_head=peer_bytes_per_token_head,
+            head_offset=dst_head_off,
+        )
+
+    @staticmethod
+    def _bytes_per_token_head(
+        *,
+        region_bytes: int,
+        num_layers: int,
+        buffers_per_layer: int,
+        tokens_per_block: int,
+        heads: int,
+    ) -> int:
+        denominator = num_layers * buffers_per_layer * tokens_per_block * heads
+        if denominator <= 0 or region_bytes % denominator != 0:
+            raise ValueError(
+                "NHD region geometry is not evenly divisible: "
+                f"region_bytes={region_bytes}, layers={num_layers}, "
+                f"buffers_per_layer={buffers_per_layer}, "
+                f"tokens_per_block={tokens_per_block}, kv_heads={heads}, "
+                f"denominator={denominator}"
+            )
+        return region_bytes // denominator
+
+    @staticmethod
+    def _build_flat_offsets(
+        *,
+        transfer_layers: int,
+        layer_offset: int,
+        buffers_per_layer: int,
+        tokens_per_block: int,
+        heads: int,
+        bytes_per_token_head: int,
+        head_offset: int,
+    ) -> np.ndarray:
+        layer_indices = np.arange(transfer_layers, dtype=np.int64)
+        buffer_indices = np.arange(buffers_per_layer, dtype=np.int64)
+        token_indices = np.arange(tokens_per_block, dtype=np.int64)
+        token_bytes = heads * bytes_per_token_head
+        buffer_bytes = tokens_per_block * token_bytes
+        layer_bytes = buffers_per_layer * buffer_bytes
+        return (
+            layer_bytes * (layer_offset + layer_indices)[:, None, None]
+            + buffer_bytes * buffer_indices[None, :, None]
+            + token_bytes * token_indices[None, None, :]
+            + head_offset
+        ).ravel()
+
+
 class IndexerKCacheHeadMatchMapper(RegionMapperBase):
     """
     Mapper for indexer K cache when head counts match.
@@ -300,9 +470,11 @@ class IndexerKCacheHeadMatchMapper(RegionMapperBase):
     def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
         src_group = src_regions.memory
         dst_group = dst_regions.memory
-        assert src_group.ptrs.size == dst_group.ptrs.size, (
-            f"Number of regions of src({src_group.ptrs.size}) and dst({dst_group.ptrs.size}) must match"
-        )
+        if src_group.ptrs.size != dst_group.ptrs.size:
+            raise ValueError(
+                f"Number of regions of src({src_group.ptrs.size}) and "
+                f"dst({dst_group.ptrs.size}) must match"
+            )
         new_src_ptrs = src_group.ptrs + self._src_block_off
         new_dst_ptrs = dst_group.ptrs + self._dst_block_off
         new_src = MemRegionGroup(ptrs=new_src_ptrs, bytes_per_region=self._frag_size)
@@ -335,9 +507,40 @@ class AttentionPolicy:
             local != peer, f"{field} mismatch", field=field, local=local, peer=peer
         )
 
-    def _tpb_check(self, local: int, peer: int) -> bool:
+    @staticmethod
+    def _uses_exact_tpb_mapper(ri: RankInfo) -> bool:
+        if ri.page_table is None:
+            return False
+        return any(
+            pool_view.mapper_kind in (MapperKind.NHD, MapperKind.REPLICATED)
+            for layer_group in ri.page_table.layer_groups
+            for pool_view in getattr(layer_group, "pool_views", ())
+        )
+
+    @staticmethod
+    def _uses_legacy_subbyte_mapper(ri: RankInfo) -> bool:
+        element_bytes = ri.attention.element_bytes
+        if float(element_bytes).is_integer():
+            return False
+        if ri.page_table is None:
+            return True
+        return any(
+            pool_view.mapper_kind not in (MapperKind.NHD, MapperKind.REPLICATED)
+            for layer_group in ri.page_table.layer_groups
+            for pool_view in getattr(layer_group, "pool_views", ())
+        )
+
+    def _tpb_check(self, local: int, peer: int, peer_ri: RankInfo) -> bool:
         if local == peer:
             return False
+        if self._uses_exact_tpb_mapper(self._ri) or self._uses_exact_tpb_mapper(peer_ri):
+            logger.warning(
+                "AttentionPolicy: incompatible: tokens_per_block mismatch for "
+                "NHD/replicated logical pools; local=%d peer=%d",
+                local,
+                peer,
+            )
+            return True
         larger, smaller = max(local, peer), min(local, peer)
         if larger % smaller != 0:
             logger.warning(
@@ -367,7 +570,17 @@ class AttentionPolicy:
                 peer=peer_ri.cp_size,
             )
             or self._mismatch("element_bytes", a.element_bytes, b.element_bytes)
-            or self._tpb_check(a.tokens_per_block, b.tokens_per_block)
+            or self._fail_if(
+                not self.head_match(peer_ri)[0]
+                and (
+                    self._uses_legacy_subbyte_mapper(self._ri)
+                    or self._uses_legacy_subbyte_mapper(peer_ri)
+                ),
+                "sub-byte cache dtype requires geometry-aware NHD/replicated pools",
+                local_element_bytes=a.element_bytes,
+                peer_element_bytes=b.element_bytes,
+            )
+            or self._tpb_check(a.tokens_per_block, b.tokens_per_block, peer_ri)
             or self._mismatch("dims_per_head", a.dims_per_head, b.dims_per_head)
             or self._fail_if(
                 a.is_mla and (a.kv_heads_per_rank != 1 or b.kv_heads_per_rank != 1),
@@ -410,13 +623,18 @@ class AttentionPolicy:
         peer_layer_offset: int,
         self_pool_num_layers: int,
         peer_pool_num_layers: int,
+        self_buffers_per_layer: int,
+        peer_buffers_per_layer: int,
         self_pool_slot_bytes: int,
         peer_pool_slot_bytes: int,
     ) -> RegionMapperBase:
+        if mapper_kind == MapperKind.REPLICATED:
+            return ReplicatedMapper(self_pool_slot_bytes, peer_pool_slot_bytes)
+
         head_match, _ = self.head_match(peer_ri)
 
         if head_match and transfer_layers == self_pool_num_layers == peer_pool_num_layers:
-            return IdentityMapper()
+            return IdentityMapper(self_pool_slot_bytes, peer_pool_slot_bytes)
 
         if head_match:
             if mapper_kind == MapperKind.FLAT:
@@ -432,10 +650,11 @@ class AttentionPolicy:
 
             slot_size_per_layer = self_pool_slot_bytes // self_pool_num_layers
             peer_size_per_layer = peer_pool_slot_bytes // peer_pool_num_layers
-            assert slot_size_per_layer == peer_size_per_layer, (
-                f"slot_size_per_layer mismatch between self ({slot_size_per_layer}) "
-                f"and peer ({peer_size_per_layer}) for HeadMatchMapper"
-            )
+            if slot_size_per_layer != peer_size_per_layer:
+                raise ValueError(
+                    f"slot_size_per_layer mismatch between self ({slot_size_per_layer}) "
+                    f"and peer ({peer_size_per_layer}) for HeadMatchMapper"
+                )
             return HeadMatchMapper(
                 transfer_layers=transfer_layers,
                 src_layer_off=self_layer_offset,
@@ -447,6 +666,21 @@ class AttentionPolicy:
 
         if mapper_kind == MapperKind.FLAT:
             raise ValueError("IndexerKCacheHeadMatchMapper is not supported for head mismatch case")
+
+        if mapper_kind == MapperKind.NHD:
+            return NHDHeadMismatchMapper(
+                transfer_layers=transfer_layers,
+                src_layer_off=self_layer_offset,
+                peer_layer_off=peer_layer_offset,
+                self_ri=self._ri,
+                peer_ri=peer_ri,
+                self_region_bytes=self_pool_slot_bytes,
+                peer_region_bytes=peer_pool_slot_bytes,
+                self_pool_num_layers=self_pool_num_layers,
+                peer_pool_num_layers=peer_pool_num_layers,
+                self_buffers_per_layer=self_buffers_per_layer,
+                peer_buffers_per_layer=peer_buffers_per_layer,
+            )
 
         return HeadMismatchMapper(
             transfer_layers=transfer_layers,

--- a/tensorrt_llm/_torch/disaggregation/native/mixers/attention/spec.py
+++ b/tensorrt_llm/_torch/disaggregation/native/mixers/attention/spec.py
@@ -7,7 +7,7 @@ class AttentionInfo:
     kv_heads_per_rank: int
     tokens_per_block: int
     dims_per_head: int
-    element_bytes: int
+    element_bytes: int | float
     enable_attention_dp: bool
     is_mla: bool
 

--- a/tensorrt_llm/_torch/disaggregation/native/mixers/attention/spec.py
+++ b/tensorrt_llm/_torch/disaggregation/native/mixers/attention/spec.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import asdict, dataclass
 
 

--- a/tensorrt_llm/_torch/disaggregation/native/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/peer.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
@@ -31,9 +32,7 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
 from tensorrt_llm._torch.disaggregation.resource.utils import (
     get_layer_byte_ranges,
     get_layer_to_layer_group,
-    get_num_buffer_entries,
     get_pool_view_global_layer_ids,
-    get_pool_view_num_layers,
 )
 
 # Type alias for (lg_idx, pool_idx) pair
@@ -165,6 +164,13 @@ class PeerRegistrar:
         Layer-overlap is required: a peer pool with the same pool_role but
         zero layer overlap with self is *not* a match — the two pools cover
         disjoint layers and have nothing to transfer.
+
+        A self layer group never matches multiple peer layer groups, so the
+        result is one peer pool per self pool. Layer groups partition each
+        rank's layers by attention/life-cycle class, which both sides derive
+        from the same model config; PP only changes which layers overlap (the
+        fan-out across peer PP ranks is handled by calling this method once
+        per peer rank). Step 1 raises if this invariant is ever violated.
         """
         key = self._unique_key(peer_ri.instance_name, peer_ri.instance_rank)
         if key in self._lg_pool_mapping_cache:
@@ -196,13 +202,31 @@ class PeerRegistrar:
                 if not pv_global_ids:
                     continue
 
-                # Step 1: find peer layer_group via any overlapping global_layer_id.
-                peer_lg_idx = next(
-                    (peer_layer_to_group[g] for g in pv_global_ids if g in peer_layer_to_group),
-                    None,
-                )
-                if peer_lg_idx is None:
+                # Step 1: find the peer layer_group via overlapping global_layer_ids.
+                # A self layer group (hence each of its pool views) never matches
+                # multiple peer layer groups: layer groups partition a rank's
+                # layers by attention/life-cycle class, both sides derive that
+                # class from the same model config, and global ids are
+                # PP-invariant. So PP only changes WHICH layers overlap — layers
+                # the peer doesn't hold are a legal skip (PP slices, one-sided
+                # MTP layers) — never how many peer LGs they land in; the PP
+                # fan-out is handled by per-peer-rank calls of this method. A
+                # multi-LG hit therefore means the two peers group layers
+                # differently (unsupported topology), and we fail loudly instead
+                # of silently transferring only the first LG's overlap.
+                peer_lg_indices = {
+                    peer_layer_to_group[g] for g in pv_global_ids if g in peer_layer_to_group
+                }
+                if not peer_lg_indices:
                     continue
+                if len(peer_lg_indices) > 1:
+                    raise ValueError(
+                        "PeerRegistrar.get_pool_mapping: pool view "
+                        f"(lg={self_lg_idx}, pool={self_pi}) spans multiple peer "
+                        f"layer groups {sorted(peer_lg_indices)}; mismatched layer "
+                        "grouping between peers is not supported"
+                    )
+                peer_lg_idx = next(iter(peer_lg_indices))
                 peer_lg = peer_pt.layer_groups[peer_lg_idx]
 
                 # Step 2: pick the first peer pool with the same pool_role
@@ -283,8 +307,6 @@ class PeerRegistrar:
         # entries. Layer selection is explicit, so mappers never assume a
         # uniform layer stride (other role classes may interleave), and no
         # convention about global-id/byte-offset ordering is needed.
-        self_num_layers = get_pool_view_num_layers(self_pv)
-        peer_num_layers = get_pool_view_num_layers(peer_pv)
         self_global_ids = get_pool_view_global_layer_ids(self_pv, self_lg)
         peer_global_ids = get_pool_view_global_layer_ids(peer_pv, peer_lg)
         overlapping_layers = sorted(set(self_global_ids) & set(peer_global_ids))
@@ -303,13 +325,11 @@ class PeerRegistrar:
         # layer's region); head-mismatch mappers slice heads inside each.
         self_buffers_per_layer = self._get_buffers_per_layer(
             self_pv,
-            self_num_layers,
             layer_group_id=self_lg_idx,
             pool_idx=self_pi,
         )
         peer_buffers_per_layer = self._get_buffers_per_layer(
             peer_pv,
-            peer_num_layers,
             layer_group_id=peer_lg_idx,
             pool_idx=peer_pi,
         )
@@ -331,21 +351,31 @@ class PeerRegistrar:
     @staticmethod
     def _get_buffers_per_layer(
         pool_view: PoolView,
-        num_layers: int,
         *,
         layer_group_id: int,
         pool_idx: int,
     ) -> int:
-        num_entries = get_num_buffer_entries(pool_view)
-        if num_entries == 0:
+        """Per-layer buffer count of a view (e.g. K+V -> 2, key-only -> 1).
+
+        Views are bucketed per (layer group, pool, mapper kind) at page-table
+        build time, so every layer in a view carries the same role set and
+        hence the same entry count — a skewed distribution should never occur.
+        Still verify it per layer rather than via total-count divisibility:
+        e.g. 1 + 3 entries over two layers passes ``total % layers == 0`` yet
+        would make head-slicing mappers split every layer at wrong offsets.
+        """
+        entries = pool_view.buffer_entries
+        if len(entries) == 0:
             return 1
-        if num_layers <= 0 or num_entries % num_layers != 0:
+        counts = Counter(int(e["local_layer_id"]) for e in entries)
+        distinct = set(counts.values())
+        if len(distinct) != 1:
             raise ValueError(
                 "PoolView buffer entries are not evenly distributed across layers: "
                 f"layer_group={layer_group_id}, pool={pool_idx}, "
-                f"entries={num_entries}, layers={num_layers}"
+                f"per-layer entry counts={sorted(counts.items())}"
             )
-        return num_entries // num_layers
+        return distinct.pop()
 
     @staticmethod
     def _find_overlap(self_val, peer_val, self_rank, peer_rank=None):

--- a/tensorrt_llm/_torch/disaggregation/native/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/peer.py
@@ -309,7 +309,15 @@ class PeerRegistrar:
         # convention about global-id/byte-offset ordering is needed.
         self_global_ids = get_pool_view_global_layer_ids(self_pv, self_lg)
         peer_global_ids = get_pool_view_global_layer_ids(peer_pv, peer_lg)
-        overlapping_layers = sorted(set(self_global_ids) & set(peer_global_ids))
+        # Iterate the overlap in self's physical slot order (not sorted by
+        # global id) so that layers whose regions are contiguous on both
+        # sides stay adjacent in the offset arrays and the mappers can merge
+        # them into one fragment even when global-id order diverges from the
+        # physical layout. Order only affects run merging (a perf property):
+        # each layer's byte offset is looked up explicitly below, so any
+        # iteration order transfers correct bytes.
+        overlap = set(self_global_ids) & set(peer_global_ids)
+        overlapping_layers = [gid for gid in self_global_ids if gid in overlap]
 
         self_starts, self_bytes_per_layer = get_layer_byte_ranges(self_pv)
         peer_starts, peer_bytes_per_layer = get_layer_byte_ranges(peer_pv)

--- a/tensorrt_llm/_torch/disaggregation/native/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/peer.py
@@ -6,11 +6,16 @@ from tensorrt_llm._torch.disaggregation.base.region import RegionMapperBase
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import AttentionPolicy
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
-from tensorrt_llm._torch.disaggregation.resource.page import AttentionLayerGroup, MapperKind
+from tensorrt_llm._torch.disaggregation.resource.page import (
+    AttentionLayerGroup,
+    MapperKind,
+    PoolView,
+)
 from tensorrt_llm._torch.disaggregation.resource.utils import (
     get_global_layer_ids,
     get_layer_group_num_layers,
     get_layer_to_layer_group,
+    get_num_buffer_entries,
     get_physical_pool,
     get_pool_view_global_layer_ids,
     get_pool_view_num_layers,
@@ -56,6 +61,33 @@ class PeerRegistrar:
         peer_ri = self.get_peer_rank_info(peer_name, peer_rank)
         extractor = KVRegionExtractorV1(peer_ri.page_table)
         self._peer_ext_cache[key] = extractor
+
+        head_match, _ = self._attention_policy.head_match(peer_ri)
+        if not head_match:
+            self_page_table = self._self_ext_cache.page_table
+            nhd_fragments_per_token = sum(
+                get_num_buffer_entries(
+                    self_page_table.layer_groups[layer_group_id].pool_views[pool_idx]
+                )
+                for layer_group_id, pool_idx in self.get_pool_mapping(peer_ri)
+                if self_page_table.layer_groups[layer_group_id].pool_views[pool_idx].mapper_kind
+                == MapperKind.NHD
+            )
+            if nhd_fragments_per_token:
+                local_heads = self._ri.attention.kv_heads_per_rank
+                peer_heads = peer_ri.attention.kv_heads_per_rank
+                logger.warning_once(
+                    "NHD head-mismatched disaggregated KV transfer has no "
+                    "contiguous staging path and will emit approximately "
+                    f"{nhd_fragments_per_token} NIXL descriptors per transferred "
+                    "token per peer, excluding block-level replicated pools "
+                    f"(local_kv_heads={local_heads}, peer_kv_heads={peer_heads}). "
+                    "Long-context TEP/DEP transfers may have high latency.",
+                    key=(
+                        "native-nhd-head-mismatch-"
+                        f"{local_heads}-{peer_heads}-{nhd_fragments_per_token}"
+                    ),
+                )
 
     def peer_extractor(self, peer_name: str, peer_rank: int) -> KVRegionExtractorV1:
         return self._peer_ext_cache[self._unique_key(peer_name, peer_rank)]
@@ -297,6 +329,23 @@ class PeerRegistrar:
         self_phys = get_physical_pool(self_pt, self_lg_idx, self_pv.pool_idx)
         peer_phys = get_physical_pool(peer_pt, peer_lg_idx, peer_pv.pool_idx)
 
+        self_region_bytes = self_pv.bytes_per_region or self_phys.slot_bytes
+        peer_region_bytes = peer_pv.bytes_per_region or peer_phys.slot_bytes
+        if self_pv.mapper_kind == MapperKind.NHD:
+            self_buffers_per_layer = self._get_buffers_per_layer(
+                self_pv,
+                self_num_layers,
+                layer_group_id=self_lg_idx,
+                pool_idx=self_pi,
+            )
+            peer_buffers_per_layer = self._get_buffers_per_layer(
+                peer_pv,
+                peer_num_layers,
+                layer_group_id=peer_lg_idx,
+                pool_idx=peer_pi,
+            )
+        else:
+            self_buffers_per_layer = peer_buffers_per_layer = 1
         mapper = self._attention_policy.build_kv_mapper(
             peer_ri=peer_ri,
             mapper_kind=self_pv.mapper_kind,
@@ -305,12 +354,33 @@ class PeerRegistrar:
             peer_layer_offset=peer_layer_offset,
             self_pool_num_layers=self_num_layers,
             peer_pool_num_layers=peer_num_layers,
-            self_pool_slot_bytes=self_phys.slot_bytes,
-            peer_pool_slot_bytes=peer_phys.slot_bytes,
+            self_buffers_per_layer=self_buffers_per_layer,
+            peer_buffers_per_layer=peer_buffers_per_layer,
+            self_pool_slot_bytes=self_region_bytes,
+            peer_pool_slot_bytes=peer_region_bytes,
         )
 
         self._kv_map_cache[cache_key] = mapper
         return mapper
+
+    @staticmethod
+    def _get_buffers_per_layer(
+        pool_view: PoolView,
+        num_layers: int,
+        *,
+        layer_group_id: int,
+        pool_idx: int,
+    ) -> int:
+        num_entries = get_num_buffer_entries(pool_view)
+        if num_entries == 0:
+            return 1
+        if num_layers <= 0 or num_entries % num_layers != 0:
+            raise ValueError(
+                "PoolView buffer entries are not evenly distributed across layers: "
+                f"layer_group={layer_group_id}, pool={pool_idx}, "
+                f"entries={num_entries}, layers={num_layers}"
+            )
+        return num_entries // num_layers
 
     @staticmethod
     def _find_overlap(self_val, peer_val, self_rank, peer_rank=None):
@@ -393,13 +463,45 @@ class PeerRegistrar:
             self_tp_rank_in_dp_group % dup_head_factor
         )
 
+    def _owns_tp_fan_in(self, peer_rank_info: RankInfo) -> bool:
+        """Elect one owner when replicated bytes fan in across TP ranks.
+
+        A peer with fewer TP shards receives identical replicated data from
+        several local ranks. Elect the first local rank in each peer-sized
+        fan-in group so exactly one copy reaches each destination.
+        """
+        ratio = max(
+            1,
+            self._ri.tp_size_per_dp_group // peer_rank_info.tp_size_per_dp_group,
+        )
+        self_tp_rank = self._ri.tp_rank % self._ri.tp_size_per_dp_group
+        return self_tp_rank % ratio == 0
+
+    def should_send_pool(
+        self,
+        peer_overlap: PeerOverlap,
+        peer_rank_info: RankInfo,
+        layer_group_id: int,
+        pool_idx: int,
+    ) -> bool:
+        """Return whether this rank owns the transfer for one logical pool.
+
+        Normal KV pools retain head-duplication routing. Replicated side-cache
+        pools use one sender per fan-in group so TEP->DEP does not race several
+        identical INDEX_KEY copies into the same destination.
+        """
+        layer_group = self._self_ext_cache.page_table.layer_groups[layer_group_id]
+        pool_view = layer_group.pool_views[pool_idx]
+        if pool_view.mapper_kind != MapperKind.REPLICATED:
+            return self.should_send_kv(peer_overlap, peer_rank_info)
+
+        return self._owns_tp_fan_in(peer_rank_info)
+
     def should_send_aux(self, peer_rank_info: RankInfo) -> bool:
         # to ensure the transfer aux is not duplicated
 
         # TP: only the first rank in each peer-TP-sized group sends aux
-        ratio = max(1, self._ri.tp_size_per_dp_group // peer_rank_info.tp_size_per_dp_group)
-        self_tp_rank_in_dp_group = self._ri.tp_rank % self._ri.tp_size_per_dp_group
-        should_send_in_tp = self_tp_rank_in_dp_group % ratio == 0
+        should_send_in_tp = self._owns_tp_fan_in(peer_rank_info)
 
         # PP: only the first self-PP rank whose layers overlap with the peer's PP rank sends aux.
         # All tp/pp ranks have the same aux data, so pick the first overlapping one to avoid duplication.

--- a/tensorrt_llm/_torch/disaggregation/native/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/peer.py
@@ -1,13 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
+import numpy as np
+
 from tensorrt_llm import logger
 from tensorrt_llm._torch.disaggregation.base.region import RegionMapperBase
-from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import (
-    AttentionPolicy,
-    PoolBufferMapper,
-    PoolBufferMapping,
-)
+from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import AttentionPolicy
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
 from tensorrt_llm._torch.disaggregation.resource.page import (
@@ -16,19 +29,15 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     PoolView,
 )
 from tensorrt_llm._torch.disaggregation.resource.utils import (
-    get_buffer_mapper_kinds,
-    get_global_layer_ids,
-    get_layer_group_num_layers,
+    get_layer_byte_ranges,
     get_layer_to_layer_group,
     get_num_buffer_entries,
-    get_physical_pool,
     get_pool_view_global_layer_ids,
     get_pool_view_num_layers,
 )
 
 # Type alias for (lg_idx, pool_idx) pair
 LGPoolKey = Tuple[int, int]
-PoolPair = Tuple[LGPoolKey, LGPoolKey]
 
 
 @dataclass
@@ -52,7 +61,9 @@ class PeerRegistrar:
         self._self_ext_cache = self_extractor
         self._peer_ext_cache: Dict[str, KVRegionExtractorV1] = {}
         self._overlap_cache: Dict[str, PeerOverlap] = {}
-        self._lg_pool_mapping_cache: Dict[str, List[PoolPair]] = {}
+        self._lg_pool_mapping_cache: Dict[
+            str, Dict[LGPoolKey, LGPoolKey]
+        ] = {}  # peer_key -> {(self_lg, self_pi) -> (peer_lg, peer_pi)}
 
     def register(self, peer_name: str, peer_rank: int, peer_ri: RankInfo):
         assert self._self_ext_cache is not None
@@ -69,17 +80,13 @@ class PeerRegistrar:
         head_match, _ = self._attention_policy.head_match(peer_ri)
         if not head_match:
             self_page_table = self._self_ext_cache.page_table
-            mapped_self_pools = {
-                self_pool_key for self_pool_key, _ in self.get_pool_mapping(peer_ri)
-            }
             nhd_fragments_per_token = sum(
-                sum(
-                    kind == MapperKind.NHD
-                    for kind in get_buffer_mapper_kinds(
-                        self_page_table.layer_groups[layer_group_id].pool_views[pool_idx]
-                    )
+                len(
+                    self_page_table.layer_groups[layer_group_id].pool_views[pool_idx].buffer_entries
                 )
-                for layer_group_id, pool_idx in mapped_self_pools
+                for layer_group_id, pool_idx in self.get_pool_mapping(peer_ri)
+                if self_page_table.layer_groups[layer_group_id].pool_views[pool_idx].mapper_kind
+                == MapperKind.NHD
             )
             if nhd_fragments_per_token:
                 local_heads = self._ri.attention.kv_heads_per_rank
@@ -146,52 +153,24 @@ class PeerRegistrar:
 
         return True
 
-    @staticmethod
-    def _buffer_records(
-        pool_view: PoolView,
-        layer_group: AttentionLayerGroup,
-    ) -> dict[tuple[int, str], tuple[int, int, MapperKind]]:
-        """Map ``(global_layer_id, role)`` to ``(offset, size, kind)``."""
-        if not pool_view.buffer_roles:
-            return {}
-        local_to_global = {
-            layer.local_layer_id: layer.global_layer_id for layer in layer_group.local_layers
-        }
-        mapper_kinds = get_buffer_mapper_kinds(pool_view)
-        records = {}
-        for entry, role, mapper_kind in zip(
-            pool_view.buffer_entries,
-            pool_view.buffer_roles,
-            mapper_kinds,
-        ):
-            local_layer_id = int(entry["local_layer_id"])
-            if local_layer_id not in local_to_global:
-                raise ValueError(
-                    "PoolView references a layer outside its layer group: "
-                    f"local_layer_id={local_layer_id}"
-                )
-            buffer_key = (local_to_global[local_layer_id], role)
-            if buffer_key in records:
-                raise ValueError(f"Duplicate PoolView buffer metadata for {buffer_key!r}")
-            records[buffer_key] = (
-                int(entry["offset"]),
-                int(entry["size"]),
-                mapper_kind,
-            )
-        return records
+    def get_pool_mapping(self, peer_ri: RankInfo) -> Dict[LGPoolKey, LGPoolKey]:
+        """Get mapping from (self_lg_idx, self_pool_idx) -> (peer_lg_idx, peer_pool_idx).
 
-    def get_pool_mapping(self, peer_ri: RankInfo) -> List[PoolPair]:
-        """Return physical pool pairs that share logical layer/role buffers.
+        Two-step matching:
+        1. Find peer layer_group via layer_to_layer_group (global_layer_id -> lg_idx).
+        2. Within the matched peer layer_group, find the unique peer pool whose
+           ``PoolView.pool_role`` equals self's and whose global_layer_ids
+           overlap.
 
-        New V2 page tables carry per-buffer roles, so a coalesced local pool
-        may map to multiple peer pools when topology changes pool grouping.
-        Legacy page tables retain the original one-to-one role-set matching.
+        Layer-overlap is required: a peer pool with the same pool_role but
+        zero layer overlap with self is *not* a match — the two pools cover
+        disjoint layers and have nothing to transfer.
         """
         key = self._unique_key(peer_ri.instance_name, peer_ri.instance_rank)
         if key in self._lg_pool_mapping_cache:
             return self._lg_pool_mapping_cache[key]
 
-        mapping: List[PoolPair] = []
+        mapping: Dict[LGPoolKey, LGPoolKey] = {}
         self_pt = self._self_ext_cache.page_table
         peer_pt = peer_ri.page_table
 
@@ -208,71 +187,57 @@ class PeerRegistrar:
             if not isinstance(self_lg, AttentionLayerGroup):
                 continue
             for self_pi, self_pv in enumerate(self_lg.pool_views):
-                # The only place mapper_kind affects pool matching:
-                #   INDEXED → pool may cover a subset of the LG; read
-                #             buffer_entries to find the exact layer set.
-                #   FLAT    → pool covers the entire LG by convention;
-                #             use the LG's layer ids directly.
-                self_is_flat = self_pv.mapper_kind == MapperKind.FLAT
-                pv_global_ids = (
-                    get_global_layer_ids(self_lg)
-                    if self_is_flat
-                    else get_pool_view_global_layer_ids(self_pv, self_lg)
-                )
+                # Every view carries buffer_entries, so a view's exact layer
+                # set always comes from its entries (a view may cover a
+                # subset of the LG when V2 splits an LG into multiple pools
+                # by buffer-size class, or when a role class exists only on
+                # some layers, e.g. sparse-layer index-K).
+                pv_global_ids = get_pool_view_global_layer_ids(self_pv, self_lg)
                 if not pv_global_ids:
                     continue
 
-                # One physical pool may span layers that land in different
-                # peer PP layer groups. Preserve their order while visiting
-                # every overlapping group.
-                peer_lg_indices = list(
-                    dict.fromkeys(
-                        peer_layer_to_group[g] for g in pv_global_ids if g in peer_layer_to_group
-                    )
+                # Step 1: find peer layer_group via any overlapping global_layer_id.
+                peer_lg_idx = next(
+                    (peer_layer_to_group[g] for g in pv_global_ids if g in peer_layer_to_group),
+                    None,
                 )
-                if not peer_lg_indices:
+                if peer_lg_idx is None:
                     continue
-                self_records = self._buffer_records(self_pv, self_lg)
+                peer_lg = peer_pt.layer_groups[peer_lg_idx]
+
+                # Step 2: pick the first peer pool with the same pool_role
+                # whose layers overlap self's (zero-overlap pools cover
+                # disjoint layers — nothing to transfer).
+                #
+                # Uniqueness assumption: at most one peer pool can match on
+                # both ``pool_role`` (frozenset equality) and layer overlap.
+                # We do *not* assume ``pool_role`` is unique within a peer LG
+                # — V2 may split an LG into multiple same-role pools by
+                # buffer-size class (e.g. VSWA). What we rely on is that both
+                # peers run the same pool-grouping logic, so for every self_pv
+                # there is exactly one peer pool with the same role *and* an
+                # overlapping layer set; other same-role peer pools cover
+                # disjoint layers and fall out via the overlap filter.
                 self_layer_set = set(pv_global_ids)
-                for peer_lg_idx in peer_lg_indices:
-                    peer_lg = peer_pt.layer_groups[peer_lg_idx]
-                    for peer_pi, peer_pv in enumerate(peer_lg.pool_views):
-                        peer_global_ids = (
-                            get_global_layer_ids(peer_lg)
-                            if peer_pv.mapper_kind == MapperKind.FLAT
-                            else get_pool_view_global_layer_ids(peer_pv, peer_lg)
+                matched_peer_pi = None
+                for peer_pi, peer_pv in enumerate(peer_lg.pool_views):
+                    if peer_pv.pool_role != self_pv.pool_role:
+                        continue
+                    peer_global_ids = get_pool_view_global_layer_ids(peer_pv, peer_lg)
+                    if not set(peer_global_ids) & self_layer_set:
+                        continue
+                    if peer_pv.mapper_kind != self_pv.mapper_kind:
+                        raise ValueError(
+                            "PeerRegistrar.get_pool_mapping: incompatible mapper "
+                            f"kinds for pool role {sorted(self_pv.pool_role)} "
+                            f"(local={self_pv.mapper_kind.name}, "
+                            f"peer={peer_pv.mapper_kind.name}, peer_pool={peer_pi})"
                         )
-                        if not set(peer_global_ids) & self_layer_set:
-                            continue
+                    matched_peer_pi = peer_pi
+                    break
 
-                        peer_records = self._buffer_records(peer_pv, peer_lg)
-                        if self_records and peer_records:
-                            overlapping_keys = self_records.keys() & peer_records.keys()
-                            if not overlapping_keys:
-                                continue
-                            for buffer_key in overlapping_keys:
-                                self_kind = self_records[buffer_key][2]
-                                peer_kind = peer_records[buffer_key][2]
-                                if self_kind != peer_kind:
-                                    raise ValueError(
-                                        "PeerRegistrar.get_pool_mapping: incompatible mapper "
-                                        f"kinds for buffer {buffer_key!r} "
-                                        f"(local={self_kind.name}, peer={peer_kind.name})"
-                                    )
-                            mapping.append(((self_lg_idx, self_pi), (peer_lg_idx, peer_pi)))
-                            continue
-
-                        if peer_pv.pool_role != self_pv.pool_role:
-                            continue
-                        if peer_pv.mapper_kind != self_pv.mapper_kind:
-                            raise ValueError(
-                                "PeerRegistrar.get_pool_mapping: incompatible mapper "
-                                f"kinds for pool role {sorted(self_pv.pool_role)} "
-                                f"(local={self_pv.mapper_kind.name}, "
-                                f"peer={peer_pv.mapper_kind.name}, peer_pool={peer_pi})"
-                            )
-                        mapping.append(((self_lg_idx, self_pi), (peer_lg_idx, peer_pi)))
-                        break
+                if matched_peer_pi is not None:
+                    mapping[(self_lg_idx, self_pi)] = (peer_lg_idx, matched_peer_pi)
 
         self._lg_pool_mapping_cache[key] = mapping
         return mapping
@@ -305,145 +270,59 @@ class PeerRegistrar:
         peer_lg = peer_pt.layer_groups[peer_lg_idx]
         self_pv = self_lg.pool_views[self_pi]
         peer_pv = peer_lg.pool_views[peer_pi]
-        self_phys = get_physical_pool(self_pt, self_lg_idx, self_pv.pool_idx)
-        peer_phys = get_physical_pool(peer_pt, peer_lg_idx, peer_pv.pool_idx)
 
         assert self._ri.attention is not None
-        assert isinstance(self_lg, AttentionLayerGroup)
-        assert isinstance(peer_lg, AttentionLayerGroup)
-        self_records = self._buffer_records(self_pv, self_lg)
-        peer_records = self._buffer_records(peer_pv, peer_lg)
-        if self_records and peer_records:
-            overlapping_keys = [key for key in self_records if key in peer_records]
-            mappings = []
-            for buffer_key in overlapping_keys:
-                self_offset, self_size, self_kind = self_records[buffer_key]
-                peer_offset, peer_size, peer_kind = peer_records[buffer_key]
-                if self_kind != peer_kind:
-                    raise ValueError(
-                        "PeerRegistrar.get_kv_map: incompatible mapper kinds "
-                        f"for buffer {buffer_key!r} "
-                        f"(local={self_kind.name}, peer={peer_kind.name})"
-                    )
-                mappings.append(
-                    PoolBufferMapping(
-                        src_offset=self_offset,
-                        dst_offset=peer_offset,
-                        src_bytes=self_size,
-                        dst_bytes=peer_size,
-                        mapper_kind=self_kind,
-                    )
-                )
-
-            full_region_identity = len(overlapping_keys) == len(self_records) == len(
-                peer_records
-            ) and all(
-                self_records[buffer_key] == peer_records[buffer_key]
-                for buffer_key in overlapping_keys
-            )
-            targets = self.get_peer_overlap(peer_ri, peer_ri.dp_rank)
-            mapper = PoolBufferMapper(
-                mappings=mappings,
-                self_ri=self._ri,
-                peer_ri=peer_ri,
-                self_region_bytes=self_phys.slot_bytes,
-                peer_region_bytes=peer_phys.slot_bytes,
-                full_region_identity=full_region_identity,
-                include_sharded=self.should_send_kv(targets, peer_ri),
-                include_replicated=self._owns_tp_fan_in(peer_ri),
-            )
-            self._kv_map_cache[cache_key] = mapper
-            return mapper
-
         if self_pv.mapper_kind != peer_pv.mapper_kind:
             raise ValueError(
                 "PeerRegistrar.get_kv_map: incompatible mapper kinds "
                 f"(local={self_pv.mapper_kind.name}, peer={peer_pv.mapper_kind.name})"
             )
 
-        # Order both layer-id lists by physical slot position so that a layer's
-        # index in the list *is* its slot offset. The KV transfer maps layers
-        # positionally (byte offset = index * per-layer stride) and the mappers
-        # copy one contiguous ``[offset, offset + transfer_layers)`` fragment, so
-        # the order must reflect the actual physical layout. We derive it from
-        # the KV-cache manager's layout rather than assuming ``global_layer_id``
-        # is monotonic with the layer's byte offset in the slot:
-        #   INDEXED: ``get_pool_view_global_layer_ids`` orders layers by their
-        #            ``buffer_entries`` offsets (the V2 pool-view layout).
-        #   FLAT:    the pool has no per-buffer layer info; it packs the whole
-        #            layer group equal-sized in ``local_layers`` order, so that
-        #            order already *is* the physical order.
-        if self_pv.mapper_kind == MapperKind.FLAT:
-            self_global_ids = get_global_layer_ids(self_lg)
-            peer_global_ids = get_global_layer_ids(peer_lg)
-            self_num_layers = get_layer_group_num_layers(self_lg)
-            peer_num_layers = get_layer_group_num_layers(peer_lg)
-        elif self_pv.mapper_kind == MapperKind.INDEXED:
-            self_global_ids = get_pool_view_global_layer_ids(self_pv, self_lg)
-            peer_global_ids = get_pool_view_global_layer_ids(peer_pv, peer_lg)
-            self_num_layers = get_pool_view_num_layers(self_pv)
-            peer_num_layers = get_pool_view_num_layers(peer_pv)
-        else:
-            raise ValueError(
-                f"PeerRegistrar.get_kv_map: unexpected mapper kind {self_pv.mapper_kind!r}"
-            )
+        # Every view is entries-driven: resolve the overlap layers to
+        # slot-relative byte offsets on each side from the views' buffer
+        # entries. Layer selection is explicit, so mappers never assume a
+        # uniform layer stride (other role classes may interleave), and no
+        # convention about global-id/byte-offset ordering is needed.
+        self_num_layers = get_pool_view_num_layers(self_pv)
+        peer_num_layers = get_pool_view_num_layers(peer_pv)
+        self_global_ids = get_pool_view_global_layer_ids(self_pv, self_lg)
+        peer_global_ids = get_pool_view_global_layer_ids(peer_pv, peer_lg)
+        overlapping_layers = sorted(set(self_global_ids) & set(peer_global_ids))
 
-        overlap = set(self_global_ids) & set(peer_global_ids)
-        transfer_layers = len(overlap)
+        self_starts, self_bytes_per_layer = get_layer_byte_ranges(self_pv)
+        peer_starts, peer_bytes_per_layer = get_layer_byte_ranges(peer_pv)
+        self_g2l = {ll.global_layer_id: ll.local_layer_id for ll in self_lg.local_layers}
+        peer_g2l = {ll.global_layer_id: ll.local_layer_id for ll in peer_lg.local_layers}
+        self_layer_offsets = np.array(
+            [self_starts[self_g2l[gid]] for gid in overlapping_layers], dtype=np.int64
+        )
+        peer_layer_offsets = np.array(
+            [peer_starts[peer_g2l[gid]] for gid in overlapping_layers], dtype=np.int64
+        )
+        # Per-layer buffer count (K and V are separate buffers within a
+        # layer's region); head-mismatch mappers slice heads inside each.
+        self_buffers_per_layer = self._get_buffers_per_layer(
+            self_pv,
+            self_num_layers,
+            layer_group_id=self_lg_idx,
+            pool_idx=self_pi,
+        )
+        peer_buffers_per_layer = self._get_buffers_per_layer(
+            peer_pv,
+            peer_num_layers,
+            layer_group_id=peer_lg_idx,
+            pool_idx=peer_pi,
+        )
 
-        if transfer_layers > 0:
-            # Anchor on the overlap layer that comes first in self's physical
-            # order and locate the *same* global layer in peer's physical order.
-            # Since the mapper copies a single contiguous fragment, the shared
-            # layers must occupy an aligned, contiguous run of slots on both
-            # peers. Validate that here instead of relying on a global-layer-id
-            # ordering convention and silently transferring the wrong bytes.
-            first_overlap_layer = next(g for g in self_global_ids if g in overlap)
-            self_layer_offset = self_global_ids.index(first_overlap_layer)
-            peer_layer_offset = peer_global_ids.index(first_overlap_layer)
-            self_run = self_global_ids[self_layer_offset : self_layer_offset + transfer_layers]
-            peer_run = peer_global_ids[peer_layer_offset : peer_layer_offset + transfer_layers]
-            if set(self_run) != overlap or self_run != peer_run:
-                raise ValueError(
-                    "PeerRegistrar.get_kv_map: shared layers do not form an "
-                    "aligned contiguous run of physical slots on both peers "
-                    f"(self={self_global_ids}, peer={peer_global_ids}, "
-                    f"overlap={sorted(overlap)}); the KV transfer requires shared "
-                    "layers to occupy matching contiguous slot ranges."
-                )
-        else:
-            self_layer_offset = 0
-            peer_layer_offset = 0
-
-        self_region_bytes = self_pv.bytes_per_region or self_phys.slot_bytes
-        peer_region_bytes = peer_pv.bytes_per_region or peer_phys.slot_bytes
-        if self_pv.mapper_kind == MapperKind.NHD:
-            self_buffers_per_layer = self._get_buffers_per_layer(
-                self_pv,
-                self_num_layers,
-                layer_group_id=self_lg_idx,
-                pool_idx=self_pi,
-            )
-            peer_buffers_per_layer = self._get_buffers_per_layer(
-                peer_pv,
-                peer_num_layers,
-                layer_group_id=peer_lg_idx,
-                pool_idx=peer_pi,
-            )
-        else:
-            self_buffers_per_layer = peer_buffers_per_layer = 1
         mapper = self._attention_policy.build_kv_mapper(
             peer_ri=peer_ri,
             mapper_kind=self_pv.mapper_kind,
-            transfer_layers=transfer_layers,
-            self_layer_offset=self_layer_offset,
-            peer_layer_offset=peer_layer_offset,
-            self_pool_num_layers=self_num_layers,
-            peer_pool_num_layers=peer_num_layers,
+            self_layer_offsets=self_layer_offsets,
+            peer_layer_offsets=peer_layer_offsets,
+            self_bytes_per_layer=self_bytes_per_layer,
+            peer_bytes_per_layer=peer_bytes_per_layer,
             self_buffers_per_layer=self_buffers_per_layer,
             peer_buffers_per_layer=peer_buffers_per_layer,
-            self_pool_slot_bytes=self_region_bytes,
-            peer_pool_slot_bytes=peer_region_bytes,
         )
 
         self._kv_map_cache[cache_key] = mapper
@@ -553,15 +432,18 @@ class PeerRegistrar:
         """Elect one owner when replicated bytes fan in across TP ranks.
 
         A peer with fewer TP shards receives identical replicated data from
-        several local ranks. Elect the first local rank in each peer-sized
-        fan-in group so exactly one copy reaches each destination.
+        several local ranks. Rotate the elected owner by the destination's
+        DP rank (mirroring ``should_send_kv``'s head-duplication pairing) so
+        that with a multi-DP-group generation side the extra replicated
+        traffic spreads across local ranks instead of always landing on the
+        first rank of each fan-in group.
         """
         ratio = max(
             1,
             self._ri.tp_size_per_dp_group // peer_rank_info.tp_size_per_dp_group,
         )
         self_tp_rank = self._ri.tp_rank % self._ri.tp_size_per_dp_group
-        return self_tp_rank % ratio == 0
+        return self_tp_rank % ratio == peer_rank_info.dp_rank % ratio
 
     def should_send_pool(
         self,
@@ -569,41 +451,28 @@ class PeerRegistrar:
         peer_rank_info: RankInfo,
         layer_group_id: int,
         pool_idx: int,
-        peer_layer_group_id: int,
-        peer_pool_idx: int,
     ) -> bool:
-        """Return whether this rank owns any logical buffer in a pool pair.
+        """Return whether this rank owns the transfer of one view pair.
 
-        Normal KV buffers retain head-duplication routing. Replicated side
-        caches use one sender per fan-in group. A mixed physical pool is sent
-        when this rank owns at least one of its overlapping logical buffers;
-        PoolBufferMapper filters the remaining entries.
+        ``pool_idx`` indexes the layer group's ``pool_views`` list (one view
+        per role class; several views may share a physical pool). Each view
+        is kind-homogeneous, so ownership is a single per-view decision:
+        replicated views use one sender per fan-in group, sharded views
+        retain head-duplication routing.
         """
         layer_group = self._self_ext_cache.page_table.layer_groups[layer_group_id]
         pool_view = layer_group.pool_views[pool_idx]
-        peer_layer_group = peer_rank_info.page_table.layer_groups[peer_layer_group_id]
-        peer_pool_view = peer_layer_group.pool_views[peer_pool_idx]
-        self_records = self._buffer_records(pool_view, layer_group)
-        peer_records = self._buffer_records(peer_pool_view, peer_layer_group)
-        if self_records and peer_records:
-            kinds = {
-                self_records[buffer_key][2]
-                for buffer_key in self_records.keys() & peer_records.keys()
-            }
-        else:
-            kinds = {pool_view.mapper_kind}
-
-        owns_sharded = any(kind != MapperKind.REPLICATED for kind in kinds) and self.should_send_kv(
-            peer_overlap, peer_rank_info
-        )
-        owns_replicated = MapperKind.REPLICATED in kinds and self._owns_tp_fan_in(peer_rank_info)
-        return owns_sharded or owns_replicated
+        if pool_view.mapper_kind == MapperKind.REPLICATED:
+            return self._owns_tp_fan_in(peer_rank_info)
+        return self.should_send_kv(peer_overlap, peer_rank_info)
 
     def should_send_aux(self, peer_rank_info: RankInfo) -> bool:
         # to ensure the transfer aux is not duplicated
 
         # TP: only the first rank in each peer-TP-sized group sends aux
-        should_send_in_tp = self._owns_tp_fan_in(peer_rank_info)
+        ratio = max(1, self._ri.tp_size_per_dp_group // peer_rank_info.tp_size_per_dp_group)
+        self_tp_rank_in_dp_group = self._ri.tp_rank % self._ri.tp_size_per_dp_group
+        should_send_in_tp = self_tp_rank_in_dp_group % ratio == 0
 
         # PP: only the first self-PP rank whose layers overlap with the peer's PP rank sends aux.
         # All tp/pp ranks have the same aux data, so pick the first overlapping one to avoid duplication.

--- a/tensorrt_llm/_torch/disaggregation/native/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/peer.py
@@ -3,7 +3,11 @@ from typing import Dict, List, Tuple
 
 from tensorrt_llm import logger
 from tensorrt_llm._torch.disaggregation.base.region import RegionMapperBase
-from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import AttentionPolicy
+from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import (
+    AttentionPolicy,
+    PoolBufferMapper,
+    PoolBufferMapping,
+)
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
 from tensorrt_llm._torch.disaggregation.resource.page import (
@@ -12,6 +16,7 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     PoolView,
 )
 from tensorrt_llm._torch.disaggregation.resource.utils import (
+    get_buffer_mapper_kinds,
     get_global_layer_ids,
     get_layer_group_num_layers,
     get_layer_to_layer_group,
@@ -23,6 +28,7 @@ from tensorrt_llm._torch.disaggregation.resource.utils import (
 
 # Type alias for (lg_idx, pool_idx) pair
 LGPoolKey = Tuple[int, int]
+PoolPair = Tuple[LGPoolKey, LGPoolKey]
 
 
 @dataclass
@@ -46,9 +52,7 @@ class PeerRegistrar:
         self._self_ext_cache = self_extractor
         self._peer_ext_cache: Dict[str, KVRegionExtractorV1] = {}
         self._overlap_cache: Dict[str, PeerOverlap] = {}
-        self._lg_pool_mapping_cache: Dict[
-            str, Dict[LGPoolKey, LGPoolKey]
-        ] = {}  # peer_key -> {(self_lg, self_pi) -> (peer_lg, peer_pi)}
+        self._lg_pool_mapping_cache: Dict[str, List[PoolPair]] = {}
 
     def register(self, peer_name: str, peer_rank: int, peer_ri: RankInfo):
         assert self._self_ext_cache is not None
@@ -65,13 +69,17 @@ class PeerRegistrar:
         head_match, _ = self._attention_policy.head_match(peer_ri)
         if not head_match:
             self_page_table = self._self_ext_cache.page_table
+            mapped_self_pools = {
+                self_pool_key for self_pool_key, _ in self.get_pool_mapping(peer_ri)
+            }
             nhd_fragments_per_token = sum(
-                get_num_buffer_entries(
-                    self_page_table.layer_groups[layer_group_id].pool_views[pool_idx]
+                sum(
+                    kind == MapperKind.NHD
+                    for kind in get_buffer_mapper_kinds(
+                        self_page_table.layer_groups[layer_group_id].pool_views[pool_idx]
+                    )
                 )
-                for layer_group_id, pool_idx in self.get_pool_mapping(peer_ri)
-                if self_page_table.layer_groups[layer_group_id].pool_views[pool_idx].mapper_kind
-                == MapperKind.NHD
+                for layer_group_id, pool_idx in mapped_self_pools
             )
             if nhd_fragments_per_token:
                 local_heads = self._ri.attention.kv_heads_per_rank
@@ -138,24 +146,52 @@ class PeerRegistrar:
 
         return True
 
-    def get_pool_mapping(self, peer_ri: RankInfo) -> Dict[LGPoolKey, LGPoolKey]:
-        """Get mapping from (self_lg_idx, self_pool_idx) -> (peer_lg_idx, peer_pool_idx).
+    @staticmethod
+    def _buffer_records(
+        pool_view: PoolView,
+        layer_group: AttentionLayerGroup,
+    ) -> dict[tuple[int, str], tuple[int, int, MapperKind]]:
+        """Map ``(global_layer_id, role)`` to ``(offset, size, kind)``."""
+        if not pool_view.buffer_roles:
+            return {}
+        local_to_global = {
+            layer.local_layer_id: layer.global_layer_id for layer in layer_group.local_layers
+        }
+        mapper_kinds = get_buffer_mapper_kinds(pool_view)
+        records = {}
+        for entry, role, mapper_kind in zip(
+            pool_view.buffer_entries,
+            pool_view.buffer_roles,
+            mapper_kinds,
+        ):
+            local_layer_id = int(entry["local_layer_id"])
+            if local_layer_id not in local_to_global:
+                raise ValueError(
+                    "PoolView references a layer outside its layer group: "
+                    f"local_layer_id={local_layer_id}"
+                )
+            buffer_key = (local_to_global[local_layer_id], role)
+            if buffer_key in records:
+                raise ValueError(f"Duplicate PoolView buffer metadata for {buffer_key!r}")
+            records[buffer_key] = (
+                int(entry["offset"]),
+                int(entry["size"]),
+                mapper_kind,
+            )
+        return records
 
-        Two-step matching:
-        1. Find peer layer_group via layer_to_layer_group (global_layer_id -> lg_idx).
-        2. Within the matched peer layer_group, find the unique peer pool whose
-           ``PoolView.pool_role`` equals self's and whose global_layer_ids
-           overlap.
+    def get_pool_mapping(self, peer_ri: RankInfo) -> List[PoolPair]:
+        """Return physical pool pairs that share logical layer/role buffers.
 
-        Layer-overlap is required: a peer pool with the same pool_role but
-        zero layer overlap with self is *not* a match — the two pools cover
-        disjoint layers and have nothing to transfer.
+        New V2 page tables carry per-buffer roles, so a coalesced local pool
+        may map to multiple peer pools when topology changes pool grouping.
+        Legacy page tables retain the original one-to-one role-set matching.
         """
         key = self._unique_key(peer_ri.instance_name, peer_ri.instance_rank)
         if key in self._lg_pool_mapping_cache:
             return self._lg_pool_mapping_cache[key]
 
-        mapping: Dict[LGPoolKey, LGPoolKey] = {}
+        mapping: List[PoolPair] = []
         self_pt = self._self_ext_cache.page_table
         peer_pt = peer_ri.page_table
 
@@ -186,52 +222,57 @@ class PeerRegistrar:
                 if not pv_global_ids:
                     continue
 
-                # Step 1: find peer layer_group via any overlapping global_layer_id.
-                peer_lg_idx = next(
-                    (peer_layer_to_group[g] for g in pv_global_ids if g in peer_layer_to_group),
-                    None,
-                )
-                if peer_lg_idx is None:
-                    continue
-                peer_lg = peer_pt.layer_groups[peer_lg_idx]
-
-                # Step 2: pick the first peer pool with the same pool_role
-                # whose layers overlap self's (zero-overlap pools cover
-                # disjoint layers — nothing to transfer).
-                #
-                # Uniqueness assumption: at most one peer pool can match on
-                # both ``pool_role`` (frozenset equality) and layer overlap.
-                # We do *not* assume ``pool_role`` is unique within a peer LG
-                # — V2 may split an LG into multiple same-role pools by
-                # buffer-size class (e.g. VSWA). What we rely on is that both
-                # peers run the same pool-grouping logic, so for every self_pv
-                # there is exactly one peer pool with the same role *and* an
-                # overlapping layer set; other same-role peer pools cover
-                # disjoint layers and fall out via the overlap filter.
-                self_layer_set = set(pv_global_ids)
-                matched_peer_pi = None
-                for peer_pi, peer_pv in enumerate(peer_lg.pool_views):
-                    if peer_pv.pool_role != self_pv.pool_role:
-                        continue
-                    peer_global_ids = (
-                        get_global_layer_ids(peer_lg)
-                        if peer_pv.mapper_kind == MapperKind.FLAT
-                        else get_pool_view_global_layer_ids(peer_pv, peer_lg)
+                # One physical pool may span layers that land in different
+                # peer PP layer groups. Preserve their order while visiting
+                # every overlapping group.
+                peer_lg_indices = list(
+                    dict.fromkeys(
+                        peer_layer_to_group[g] for g in pv_global_ids if g in peer_layer_to_group
                     )
-                    if not set(peer_global_ids) & self_layer_set:
-                        continue
-                    if peer_pv.mapper_kind != self_pv.mapper_kind:
-                        raise ValueError(
-                            "PeerRegistrar.get_pool_mapping: incompatible mapper "
-                            f"kinds for pool role {sorted(self_pv.pool_role)} "
-                            f"(local={self_pv.mapper_kind.name}, "
-                            f"peer={peer_pv.mapper_kind.name}, peer_pool={peer_pi})"
+                )
+                if not peer_lg_indices:
+                    continue
+                self_records = self._buffer_records(self_pv, self_lg)
+                self_layer_set = set(pv_global_ids)
+                for peer_lg_idx in peer_lg_indices:
+                    peer_lg = peer_pt.layer_groups[peer_lg_idx]
+                    for peer_pi, peer_pv in enumerate(peer_lg.pool_views):
+                        peer_global_ids = (
+                            get_global_layer_ids(peer_lg)
+                            if peer_pv.mapper_kind == MapperKind.FLAT
+                            else get_pool_view_global_layer_ids(peer_pv, peer_lg)
                         )
-                    matched_peer_pi = peer_pi
-                    break
+                        if not set(peer_global_ids) & self_layer_set:
+                            continue
 
-                if matched_peer_pi is not None:
-                    mapping[(self_lg_idx, self_pi)] = (peer_lg_idx, matched_peer_pi)
+                        peer_records = self._buffer_records(peer_pv, peer_lg)
+                        if self_records and peer_records:
+                            overlapping_keys = self_records.keys() & peer_records.keys()
+                            if not overlapping_keys:
+                                continue
+                            for buffer_key in overlapping_keys:
+                                self_kind = self_records[buffer_key][2]
+                                peer_kind = peer_records[buffer_key][2]
+                                if self_kind != peer_kind:
+                                    raise ValueError(
+                                        "PeerRegistrar.get_pool_mapping: incompatible mapper "
+                                        f"kinds for buffer {buffer_key!r} "
+                                        f"(local={self_kind.name}, peer={peer_kind.name})"
+                                    )
+                            mapping.append(((self_lg_idx, self_pi), (peer_lg_idx, peer_pi)))
+                            continue
+
+                        if peer_pv.pool_role != self_pv.pool_role:
+                            continue
+                        if peer_pv.mapper_kind != self_pv.mapper_kind:
+                            raise ValueError(
+                                "PeerRegistrar.get_pool_mapping: incompatible mapper "
+                                f"kinds for pool role {sorted(self_pv.pool_role)} "
+                                f"(local={self_pv.mapper_kind.name}, "
+                                f"peer={peer_pv.mapper_kind.name}, peer_pool={peer_pi})"
+                            )
+                        mapping.append(((self_lg_idx, self_pi), (peer_lg_idx, peer_pi)))
+                        break
 
         self._lg_pool_mapping_cache[key] = mapping
         return mapping
@@ -264,8 +305,56 @@ class PeerRegistrar:
         peer_lg = peer_pt.layer_groups[peer_lg_idx]
         self_pv = self_lg.pool_views[self_pi]
         peer_pv = peer_lg.pool_views[peer_pi]
+        self_phys = get_physical_pool(self_pt, self_lg_idx, self_pv.pool_idx)
+        peer_phys = get_physical_pool(peer_pt, peer_lg_idx, peer_pv.pool_idx)
 
         assert self._ri.attention is not None
+        assert isinstance(self_lg, AttentionLayerGroup)
+        assert isinstance(peer_lg, AttentionLayerGroup)
+        self_records = self._buffer_records(self_pv, self_lg)
+        peer_records = self._buffer_records(peer_pv, peer_lg)
+        if self_records and peer_records:
+            overlapping_keys = [key for key in self_records if key in peer_records]
+            mappings = []
+            for buffer_key in overlapping_keys:
+                self_offset, self_size, self_kind = self_records[buffer_key]
+                peer_offset, peer_size, peer_kind = peer_records[buffer_key]
+                if self_kind != peer_kind:
+                    raise ValueError(
+                        "PeerRegistrar.get_kv_map: incompatible mapper kinds "
+                        f"for buffer {buffer_key!r} "
+                        f"(local={self_kind.name}, peer={peer_kind.name})"
+                    )
+                mappings.append(
+                    PoolBufferMapping(
+                        src_offset=self_offset,
+                        dst_offset=peer_offset,
+                        src_bytes=self_size,
+                        dst_bytes=peer_size,
+                        mapper_kind=self_kind,
+                    )
+                )
+
+            full_region_identity = len(overlapping_keys) == len(self_records) == len(
+                peer_records
+            ) and all(
+                self_records[buffer_key] == peer_records[buffer_key]
+                for buffer_key in overlapping_keys
+            )
+            targets = self.get_peer_overlap(peer_ri, peer_ri.dp_rank)
+            mapper = PoolBufferMapper(
+                mappings=mappings,
+                self_ri=self._ri,
+                peer_ri=peer_ri,
+                self_region_bytes=self_phys.slot_bytes,
+                peer_region_bytes=peer_phys.slot_bytes,
+                full_region_identity=full_region_identity,
+                include_sharded=self.should_send_kv(targets, peer_ri),
+                include_replicated=self._owns_tp_fan_in(peer_ri),
+            )
+            self._kv_map_cache[cache_key] = mapper
+            return mapper
+
         if self_pv.mapper_kind != peer_pv.mapper_kind:
             raise ValueError(
                 "PeerRegistrar.get_kv_map: incompatible mapper kinds "
@@ -325,9 +414,6 @@ class PeerRegistrar:
         else:
             self_layer_offset = 0
             peer_layer_offset = 0
-
-        self_phys = get_physical_pool(self_pt, self_lg_idx, self_pv.pool_idx)
-        peer_phys = get_physical_pool(peer_pt, peer_lg_idx, peer_pv.pool_idx)
 
         self_region_bytes = self_pv.bytes_per_region or self_phys.slot_bytes
         peer_region_bytes = peer_pv.bytes_per_region or peer_phys.slot_bytes
@@ -483,19 +569,35 @@ class PeerRegistrar:
         peer_rank_info: RankInfo,
         layer_group_id: int,
         pool_idx: int,
+        peer_layer_group_id: int,
+        peer_pool_idx: int,
     ) -> bool:
-        """Return whether this rank owns the transfer for one logical pool.
+        """Return whether this rank owns any logical buffer in a pool pair.
 
-        Normal KV pools retain head-duplication routing. Replicated side-cache
-        pools use one sender per fan-in group so TEP->DEP does not race several
-        identical INDEX_KEY copies into the same destination.
+        Normal KV buffers retain head-duplication routing. Replicated side
+        caches use one sender per fan-in group. A mixed physical pool is sent
+        when this rank owns at least one of its overlapping logical buffers;
+        PoolBufferMapper filters the remaining entries.
         """
         layer_group = self._self_ext_cache.page_table.layer_groups[layer_group_id]
         pool_view = layer_group.pool_views[pool_idx]
-        if pool_view.mapper_kind != MapperKind.REPLICATED:
-            return self.should_send_kv(peer_overlap, peer_rank_info)
+        peer_layer_group = peer_rank_info.page_table.layer_groups[peer_layer_group_id]
+        peer_pool_view = peer_layer_group.pool_views[peer_pool_idx]
+        self_records = self._buffer_records(pool_view, layer_group)
+        peer_records = self._buffer_records(peer_pool_view, peer_layer_group)
+        if self_records and peer_records:
+            kinds = {
+                self_records[buffer_key][2]
+                for buffer_key in self_records.keys() & peer_records.keys()
+            }
+        else:
+            kinds = {pool_view.mapper_kind}
 
-        return self._owns_tp_fan_in(peer_rank_info)
+        owns_sharded = any(kind != MapperKind.REPLICATED for kind in kinds) and self.should_send_kv(
+            peer_overlap, peer_rank_info
+        )
+        owns_replicated = MapperKind.REPLICATED in kinds and self._owns_tp_fan_in(peer_rank_info)
+        return owns_sharded or owns_replicated
 
     def should_send_aux(self, peer_rank_info: RankInfo) -> bool:
         # to ensure the transfer aux is not duplicated

--- a/tensorrt_llm/_torch/disaggregation/native/rank_info.py
+++ b/tensorrt_llm/_torch/disaggregation/native/rank_info.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import asdict, dataclass
 from typing import List, Optional
 

--- a/tensorrt_llm/_torch/disaggregation/native/rank_info.py
+++ b/tensorrt_llm/_torch/disaggregation/native/rank_info.py
@@ -60,6 +60,14 @@ class RankInfo:
         kvm = kv_cache_manager
         enable_attention_dp = m.enable_attention_dp
         kv_heads_per_rank = next((h for h in kvm.num_kv_heads_per_layer if h > 0), 0)
+        # Eight is the smallest element count guaranteed to occupy whole bytes
+        # for every supported sub-byte cache dtype (including NVFP4).
+        bytes_for_eight_elements = get_size_in_bytes(8, kvm.dtype)
+        element_bytes = (
+            bytes_for_eight_elements // 8
+            if bytes_for_eight_elements % 8 == 0
+            else bytes_for_eight_elements / 8
+        )
         return cls(
             instance_name=instance_name,
             instance_rank=m.rank,
@@ -81,7 +89,7 @@ class RankInfo:
                 kv_heads_per_rank=kv_heads_per_rank,
                 tokens_per_block=kvm.tokens_per_block,
                 dims_per_head=kvm.head_dim,
-                element_bytes=get_size_in_bytes(1, kvm.dtype),
+                element_bytes=element_bytes,
                 enable_attention_dp=enable_attention_dp,
                 is_mla=kvm.kv_factor == 1,
             ),

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import os
@@ -28,7 +43,6 @@ from tensorrt_llm._torch.disaggregation.base.agent import (
     RegMemoryDescs,
     TransferOp,
     TransferRequest,
-    use_pure_python_transfer_agent,
 )
 from tensorrt_llm._torch.disaggregation.base.transfer import (
     KVSlice,
@@ -49,6 +63,7 @@ from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
 from tensorrt_llm._torch.disaggregation.native.utils import get_local_ip
 from tensorrt_llm._torch.disaggregation.nixl.agent import NixlTransferAgent
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
+from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.disaggregation.resource.utils import get_unique_pool_memory_descs
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
@@ -260,7 +275,6 @@ class Sender(SenderBase):
     # RecvReqInfo that never gets consumed.  Entries older than this
     # are evicted during periodic sweeps.
     _STALE_REQ_INFO_TTL_S = 120.0
-    _LARGE_DESCRIPTOR_WARNING_THRESHOLD = 100_000
 
     def __init__(
         self,
@@ -467,14 +481,6 @@ class Sender(SenderBase):
                 f"{write_meta.sizes.size=}"
             )
         n = write_meta.src_ptrs.size
-        if n >= Sender._LARGE_DESCRIPTOR_WARNING_THRESHOLD and use_pure_python_transfer_agent():
-            logger.warning_once(
-                "Pure-Python NIXL transfer-agent fallback is converting "
-                f"{n:,} descriptors through Python lists for one transfer. "
-                "Install/use the C++ transfer-agent binding for long-context "
-                "head-mismatched disaggregated serving.",
-                key="native-large-python-nixl-descriptor-transfer",
-            )
         if write_meta.meta_type == WriteMetaType.AUX:
             src_dev, dst_dev, mem_type = 0, 0, MemoryType.DRAM
         else:
@@ -752,74 +758,6 @@ class Sender(SenderBase):
             return block_ids.size
         return max(0, block_ids.size - (beam_width - 1))
 
-    @staticmethod
-    def _prepare_kv_blocks_for_transfer(
-        src_block_ids: np.ndarray,
-        dst_block_ids: np.ndarray,
-        *,
-        tokens_per_block: int,
-        slice_end: int,
-        beam_width: int,
-        dst_start_token: Optional[int],
-        sliding_window_size: Optional[int],
-        prompt_len: Optional[int],
-    ) -> tuple[np.ndarray, np.ndarray]:
-        """Normalize and align one layer-group pair's source/destination blocks.
-
-        Each block list is a suffix of the logical blocks covering
-        ``[0, slice_end)``; its omitted prefix is inferred from list length.
-        ``prompt_len`` can exceed ``slice_end`` for non-final context chunks,
-        so SWA staleness is derived from the full prompt, not the slice.
-        """
-        # Both sides trim block lists to ceil(prompt_len / tpb) in
-        # _create_kv_slice, so dst must never exceed src. A smaller dst
-        # (generation prefix-cache reuse) is handled via dst_start below.
-        block_diff = dst_block_ids.size - src_block_ids.size
-        if block_diff > 0:
-            raise ValueError(
-                f"src/dst block count mismatch: {src_block_ids.size} vs "
-                f"{dst_block_ids.size} (dst must not exceed src)"
-            )
-
-        total_blocks = (slice_end + tokens_per_block - 1) // tokens_per_block
-        src_beam0_blocks = Sender._beam0_block_count(src_block_ids, total_blocks, beam_width)
-        dst_beam0_blocks = Sender._beam0_block_count(dst_block_ids, total_blocks, beam_width)
-        if src_beam0_blocks > total_blocks:
-            raise ValueError(
-                f"src beam-0 block list ({src_beam0_blocks}) exceeds total slice "
-                f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tokens_per_block}"
-            )
-        if dst_beam0_blocks > total_blocks:
-            raise ValueError(
-                f"dst beam-0 block list ({dst_beam0_blocks}) exceeds total slice "
-                f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tokens_per_block}"
-            )
-
-        src_start = (total_blocks - src_beam0_blocks) * tokens_per_block
-        dst_start = (total_blocks - dst_beam0_blocks) * tokens_per_block
-        if dst_start_token is not None:
-            dst_start = max(dst_start, dst_start_token)
-        if sliding_window_size is not None:
-            if prompt_len is None:
-                raise ValueError(
-                    "SWA layer requires session.prompt_len; "
-                    "set TxSession(prompt_len=request.prompt_len)."
-                )
-            stale_end = max(
-                0,
-                (prompt_len + 1 - sliding_window_size) // tokens_per_block,
-            )
-            src_start = max(stale_end * tokens_per_block, src_start)
-            dst_start = max(stale_end * tokens_per_block, dst_start)
-
-        return Sender._align_kv_blocks(
-            src_block_ids,
-            dst_block_ids,
-            src_token_start=src_start,
-            dst_token_start=dst_start,
-            tokens_per_block=tokens_per_block,
-        )
-
     @nvtx_range("_build_kv_write_meta")
     def _build_kv_write_meta(self, task: KVSendTask, req_info: RecvReqInfo) -> WriteMeta:
         peer_ri = self._registrar.get_peer_rank_info(req_info.instance_name, req_info.instance_rank)
@@ -848,38 +786,70 @@ class Sender(SenderBase):
         dst_block_ids_per_groups = req_info.block_ids_per_layer_groups
         src_block_ids_per_groups = task._slice.block_ids_per_layer_groups
 
-        aligned_blocks_by_layer_groups: dict[tuple[int, int], tuple[np.ndarray, np.ndarray]] = {}
-
         # Aggregate fragments from all matching pools using numpy concatenation.
-        # Ownership is decided per logical pool because replicated side caches
-        # have different fan-in rules from head-sharded K/V.
-        for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping:
-            if not self._registrar.should_send_pool(
-                targets,
-                peer_ri,
-                self_lg,
-                self_pi,
-                peer_lg,
-                peer_pi,
-            ):
+        # Send ownership is per pool: replicated pools elect one fan-in
+        # owner, sharded pools keep head-duplication routing.
+        for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
+            if not self._registrar.should_send_pool(targets, peer_ri, self_lg, self_pi):
                 continue
-            layer_group_pair = (self_lg, peer_lg)
-            if layer_group_pair not in aligned_blocks_by_layer_groups:
-                token_range = task._slice.token_range
-                lg_info = extractor.page_table.layer_groups[self_lg]
-                aligned_blocks_by_layer_groups[layer_group_pair] = (
-                    Sender._prepare_kv_blocks_for_transfer(
-                        src_block_ids_per_groups[self_lg],
-                        dst_block_ids_per_groups[peer_lg],
-                        tokens_per_block=extractor.page_table.tokens_per_block,
-                        slice_end=token_range.end if token_range is not None else 0,
-                        beam_width=task._beam_width,
-                        dst_start_token=req_info.dst_start_token,
-                        sliding_window_size=getattr(lg_info, "sliding_window_size", None),
-                        prompt_len=task._prompt_len,
-                    )
+            src_block_ids = src_block_ids_per_groups[self_lg]
+            dst_block_ids = dst_block_ids_per_groups[peer_lg]
+
+            # Both sides trim block lists to ceil(prompt_len / tpb) in
+            # _create_kv_slice, so dst must never exceed src. A smaller dst
+            # (generation prefix-cache reuse) is handled via dst_start below.
+            block_diff = dst_block_ids.size - src_block_ids.size
+            if block_diff > 0:
+                raise ValueError(
+                    f"src/dst block count mismatch: {src_block_ids.size} vs "
+                    f"{dst_block_ids.size} (dst must not exceed src)"
                 )
-            src_block_ids, dst_block_ids = aligned_blocks_by_layer_groups[layer_group_pair]
+            tpb = extractor.page_table.tokens_per_block
+            token_range = task._slice.token_range
+            lg_info = extractor.page_table.layer_groups[self_lg]
+            window_size = getattr(lg_info, "sliding_window_size", None)
+
+            # Block lists are the suffix of [..., slice_end); cached prefix
+            # is implicit in their size. token_start = (total_blocks - n) * tpb.
+            slice_end = token_range.end if token_range is not None else 0
+            total_blocks = (slice_end + tpb - 1) // tpb
+            src_beam0_blocks = Sender._beam0_block_count(
+                src_block_ids, total_blocks, task._beam_width
+            )
+            dst_beam0_blocks = Sender._beam0_block_count(
+                dst_block_ids, total_blocks, task._beam_width
+            )
+            assert src_beam0_blocks <= total_blocks, (
+                f"src beam-0 block list ({src_beam0_blocks}) exceeds total slice "
+                f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
+            )
+            assert dst_beam0_blocks <= total_blocks, (
+                f"dst beam-0 block list ({dst_beam0_blocks}) exceeds total slice "
+                f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
+            )
+            src_start = (total_blocks - src_beam0_blocks) * tpb
+            dst_start = (total_blocks - dst_beam0_blocks) * tpb
+            if req_info.dst_start_token is not None:
+                dst_start = max(dst_start, req_info.dst_start_token)
+            if window_size is not None:
+                # SWA stale_end uses the request prompt_len (not slice_end —
+                # they differ for non-final slices). prompt_len must be plumbed
+                # via the session; falling back to slice_end is wrong on
+                # non-final slices.
+                assert task._prompt_len is not None, (
+                    "SWA layer requires session.prompt_len; "
+                    "set TxSession(prompt_len=request.prompt_len)."
+                )
+                stale_end = max(0, (task._prompt_len + 1 - window_size) // tpb)
+                src_start = max(stale_end * tpb, src_start)
+                dst_start = max(stale_end * tpb, dst_start)
+            src_block_ids, dst_block_ids = Sender._align_kv_blocks(
+                src_block_ids,
+                dst_block_ids,
+                src_token_start=src_start,
+                dst_token_start=dst_start,
+                tokens_per_block=tpb,
+            )
 
             src_region = extractor.extract(src_block_ids, layer_group_id=self_lg, pool_idx=self_pi)
             dst_region = peer_extractor.extract(
@@ -1577,6 +1547,14 @@ class Receiver(ReceiverBase):
             lpp = getattr(peer_ri, "layer_num_per_pp", None)
             if not lpp or len(lpp) < overlap.overlap_pp_size or len(set(lpp)) != 1:
                 return False
+        # Replicated pools (e.g. MiniMax M3 index-key) are sent by one elected
+        # fan-in owner only, so with multiple writers their contributions
+        # differ in size and the equal split is invalid.
+        if len(overlap.ranks) > 1 and peer_ri.page_table is not None:
+            for layer_group in peer_ri.page_table.layer_groups:
+                for pool_view in getattr(layer_group, "pool_views", ()):
+                    if pool_view.mapper_kind == MapperKind.REPLICATED:
+                        return False
         return True
 
     def dispatch_task(self, task: KVRecvTask):
@@ -1678,10 +1656,10 @@ class Receiver(ReceiverBase):
             finally:
                 messenger.stop()
 
-            rank_info_bytes = self._registrar.self_rank_info.to_bytes()
             for endpoint in sender_info.sender_endpoints:
                 dealer = self._get_or_connect_dealer(endpoint)
-                dealer.send([MessageType.REGISTER_RANK_INFO, rank_info_bytes])
+                rank_info = self._registrar.self_rank_info
+                dealer.send([MessageType.REGISTER_RANK_INFO, rank_info.to_bytes()])
 
             self._sender_ep_instance_map[info_endpoint] = sender_info
             return sender_info
@@ -2288,9 +2266,7 @@ class TransferWorker:
 
     def _setup_peer_infrastructure(self, kvm: KVCacheManager):
         self._rank_info_server = RankInfoServer(self._rank_info) if kvm.mapping.rank == 0 else None
-        if self._rank_info.page_table is None:
-            raise RuntimeError("RankInfo page table must be initialized before peer setup")
-        self._kv_extractor = KVRegionExtractorV1(self._rank_info.page_table)
+        self._kv_extractor = KVRegionExtractorV1(kvm)
         self._peer_registrar = PeerRegistrar(self._rank_info, self._kv_extractor)
 
     def _setup_transfer_engine(self):

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -853,8 +853,15 @@ class Sender(SenderBase):
         # Aggregate fragments from all matching pools using numpy concatenation.
         # Ownership is decided per logical pool because replicated side caches
         # have different fan-in rules from head-sharded K/V.
-        for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
-            if not self._registrar.should_send_pool(targets, peer_ri, self_lg, self_pi):
+        for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping:
+            if not self._registrar.should_send_pool(
+                targets,
+                peer_ri,
+                self_lg,
+                self_pi,
+                peer_lg,
+                peer_pi,
+            ):
                 continue
             layer_group_pair = (self_lg, peer_lg)
             if layer_group_pair not in aligned_blocks_by_layer_groups:

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -28,6 +28,7 @@ from tensorrt_llm._torch.disaggregation.base.agent import (
     RegMemoryDescs,
     TransferOp,
     TransferRequest,
+    use_pure_python_transfer_agent,
 )
 from tensorrt_llm._torch.disaggregation.base.transfer import (
     KVSlice,
@@ -259,6 +260,7 @@ class Sender(SenderBase):
     # RecvReqInfo that never gets consumed.  Entries older than this
     # are evicted during periodic sweeps.
     _STALE_REQ_INFO_TTL_S = 120.0
+    _LARGE_DESCRIPTOR_WARNING_THRESHOLD = 100_000
 
     def __init__(
         self,
@@ -465,6 +467,14 @@ class Sender(SenderBase):
                 f"{write_meta.sizes.size=}"
             )
         n = write_meta.src_ptrs.size
+        if n >= Sender._LARGE_DESCRIPTOR_WARNING_THRESHOLD and use_pure_python_transfer_agent():
+            logger.warning_once(
+                "Pure-Python NIXL transfer-agent fallback is converting "
+                f"{n:,} descriptors through Python lists for one transfer. "
+                "Install/use the C++ transfer-agent binding for long-context "
+                "head-mismatched disaggregated serving.",
+                key="native-large-python-nixl-descriptor-transfer",
+            )
         if write_meta.meta_type == WriteMetaType.AUX:
             src_dev, dst_dev, mem_type = 0, 0, MemoryType.DRAM
         else:
@@ -742,6 +752,74 @@ class Sender(SenderBase):
             return block_ids.size
         return max(0, block_ids.size - (beam_width - 1))
 
+    @staticmethod
+    def _prepare_kv_blocks_for_transfer(
+        src_block_ids: np.ndarray,
+        dst_block_ids: np.ndarray,
+        *,
+        tokens_per_block: int,
+        slice_end: int,
+        beam_width: int,
+        dst_start_token: Optional[int],
+        sliding_window_size: Optional[int],
+        prompt_len: Optional[int],
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Normalize and align one layer-group pair's source/destination blocks.
+
+        Each block list is a suffix of the logical blocks covering
+        ``[0, slice_end)``; its omitted prefix is inferred from list length.
+        ``prompt_len`` can exceed ``slice_end`` for non-final context chunks,
+        so SWA staleness is derived from the full prompt, not the slice.
+        """
+        # Both sides trim block lists to ceil(prompt_len / tpb) in
+        # _create_kv_slice, so dst must never exceed src. A smaller dst
+        # (generation prefix-cache reuse) is handled via dst_start below.
+        block_diff = dst_block_ids.size - src_block_ids.size
+        if block_diff > 0:
+            raise ValueError(
+                f"src/dst block count mismatch: {src_block_ids.size} vs "
+                f"{dst_block_ids.size} (dst must not exceed src)"
+            )
+
+        total_blocks = (slice_end + tokens_per_block - 1) // tokens_per_block
+        src_beam0_blocks = Sender._beam0_block_count(src_block_ids, total_blocks, beam_width)
+        dst_beam0_blocks = Sender._beam0_block_count(dst_block_ids, total_blocks, beam_width)
+        if src_beam0_blocks > total_blocks:
+            raise ValueError(
+                f"src beam-0 block list ({src_beam0_blocks}) exceeds total slice "
+                f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tokens_per_block}"
+            )
+        if dst_beam0_blocks > total_blocks:
+            raise ValueError(
+                f"dst beam-0 block list ({dst_beam0_blocks}) exceeds total slice "
+                f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tokens_per_block}"
+            )
+
+        src_start = (total_blocks - src_beam0_blocks) * tokens_per_block
+        dst_start = (total_blocks - dst_beam0_blocks) * tokens_per_block
+        if dst_start_token is not None:
+            dst_start = max(dst_start, dst_start_token)
+        if sliding_window_size is not None:
+            if prompt_len is None:
+                raise ValueError(
+                    "SWA layer requires session.prompt_len; "
+                    "set TxSession(prompt_len=request.prompt_len)."
+                )
+            stale_end = max(
+                0,
+                (prompt_len + 1 - sliding_window_size) // tokens_per_block,
+            )
+            src_start = max(stale_end * tokens_per_block, src_start)
+            dst_start = max(stale_end * tokens_per_block, dst_start)
+
+        return Sender._align_kv_blocks(
+            src_block_ids,
+            dst_block_ids,
+            src_token_start=src_start,
+            dst_token_start=dst_start,
+            tokens_per_block=tokens_per_block,
+        )
+
     @nvtx_range("_build_kv_write_meta")
     def _build_kv_write_meta(self, task: KVSendTask, req_info: RecvReqInfo) -> WriteMeta:
         peer_ri = self._registrar.get_peer_rank_info(req_info.instance_name, req_info.instance_rank)
@@ -766,85 +844,47 @@ class Sender(SenderBase):
         peer_extractor = self._registrar.peer_extractor(
             peer_ri.instance_name, peer_ri.instance_rank
         )
-        if self._registrar.should_send_kv(targets, peer_ri):
-            pool_mapping = self._registrar.get_pool_mapping(peer_ri)
-            dst_block_ids_per_groups = req_info.block_ids_per_layer_groups
-            src_block_ids_per_groups = task._slice.block_ids_per_layer_groups
+        pool_mapping = self._registrar.get_pool_mapping(peer_ri)
+        dst_block_ids_per_groups = req_info.block_ids_per_layer_groups
+        src_block_ids_per_groups = task._slice.block_ids_per_layer_groups
 
-            # Aggregate fragments from all matching pools using numpy concatenation
-            for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
-                src_block_ids = src_block_ids_per_groups[self_lg]
-                dst_block_ids = dst_block_ids_per_groups[peer_lg]
+        aligned_blocks_by_layer_groups: dict[tuple[int, int], tuple[np.ndarray, np.ndarray]] = {}
 
-                # Both sides trim block lists to ceil(prompt_len / tpb) in
-                # _create_kv_slice, so dst must never exceed src. A smaller dst
-                # (generation prefix-cache reuse) is handled via dst_start below.
-                block_diff = dst_block_ids.size - src_block_ids.size
-                if block_diff > 0:
-                    raise ValueError(
-                        f"src/dst block count mismatch: {src_block_ids.size} vs "
-                        f"{dst_block_ids.size} (dst must not exceed src)"
-                    )
-                tpb = extractor.page_table.tokens_per_block
+        # Aggregate fragments from all matching pools using numpy concatenation.
+        # Ownership is decided per logical pool because replicated side caches
+        # have different fan-in rules from head-sharded K/V.
+        for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
+            if not self._registrar.should_send_pool(targets, peer_ri, self_lg, self_pi):
+                continue
+            layer_group_pair = (self_lg, peer_lg)
+            if layer_group_pair not in aligned_blocks_by_layer_groups:
                 token_range = task._slice.token_range
                 lg_info = extractor.page_table.layer_groups[self_lg]
-                window_size = getattr(lg_info, "sliding_window_size", None)
-
-                # Block lists are the suffix of [..., slice_end); cached prefix
-                # is implicit in their size. token_start = (total_blocks - n) * tpb.
-                slice_end = token_range.end if token_range is not None else 0
-                total_blocks = (slice_end + tpb - 1) // tpb
-                src_beam0_blocks = Sender._beam0_block_count(
-                    src_block_ids, total_blocks, task._beam_width
-                )
-                dst_beam0_blocks = Sender._beam0_block_count(
-                    dst_block_ids, total_blocks, task._beam_width
-                )
-                assert src_beam0_blocks <= total_blocks, (
-                    f"src beam-0 block list ({src_beam0_blocks}) exceeds total slice "
-                    f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
-                )
-                assert dst_beam0_blocks <= total_blocks, (
-                    f"dst beam-0 block list ({dst_beam0_blocks}) exceeds total slice "
-                    f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
-                )
-                src_start = (total_blocks - src_beam0_blocks) * tpb
-                dst_start = (total_blocks - dst_beam0_blocks) * tpb
-                if req_info.dst_start_token is not None:
-                    dst_start = max(dst_start, req_info.dst_start_token)
-                if window_size is not None:
-                    # SWA stale_end uses the request prompt_len (not slice_end —
-                    # they differ for non-final slices). prompt_len must be plumbed
-                    # via the session; falling back to slice_end is wrong on
-                    # non-final slices.
-                    assert task._prompt_len is not None, (
-                        "SWA layer requires session.prompt_len; "
-                        "set TxSession(prompt_len=request.prompt_len)."
+                aligned_blocks_by_layer_groups[layer_group_pair] = (
+                    Sender._prepare_kv_blocks_for_transfer(
+                        src_block_ids_per_groups[self_lg],
+                        dst_block_ids_per_groups[peer_lg],
+                        tokens_per_block=extractor.page_table.tokens_per_block,
+                        slice_end=token_range.end if token_range is not None else 0,
+                        beam_width=task._beam_width,
+                        dst_start_token=req_info.dst_start_token,
+                        sliding_window_size=getattr(lg_info, "sliding_window_size", None),
+                        prompt_len=task._prompt_len,
                     )
-                    stale_end = max(0, (task._prompt_len + 1 - window_size) // tpb)
-                    src_start = max(stale_end * tpb, src_start)
-                    dst_start = max(stale_end * tpb, dst_start)
-                src_block_ids, dst_block_ids = Sender._align_kv_blocks(
-                    src_block_ids,
-                    dst_block_ids,
-                    src_token_start=src_start,
-                    dst_token_start=dst_start,
-                    tokens_per_block=tpb,
                 )
+            src_block_ids, dst_block_ids = aligned_blocks_by_layer_groups[layer_group_pair]
 
-                src_region = extractor.extract(
-                    src_block_ids, layer_group_id=self_lg, pool_idx=self_pi
-                )
-                dst_region = peer_extractor.extract(
-                    dst_block_ids, layer_group_id=peer_lg, pool_idx=peer_pi
-                )
-                mapper = self._registrar.get_kv_map(peer_ri, (self_lg, self_pi), (peer_lg, peer_pi))
-                region_pair = mapper.map(src_region, dst_region)
-                region_pairs = region_pair if isinstance(region_pair, list) else [region_pair]
-                for rp in region_pairs:
-                    src_frag_parts.append(rp.src.memory.ptrs)
-                    dst_frag_parts.append(rp.dst.memory.ptrs)
-                    size_specs.append((rp.src.memory.ptrs.size, rp.src.memory.bytes_per_region))
+            src_region = extractor.extract(src_block_ids, layer_group_id=self_lg, pool_idx=self_pi)
+            dst_region = peer_extractor.extract(
+                dst_block_ids, layer_group_id=peer_lg, pool_idx=peer_pi
+            )
+            mapper = self._registrar.get_kv_map(peer_ri, (self_lg, self_pi), (peer_lg, peer_pi))
+            region_pair = mapper.map(src_region, dst_region)
+            region_pairs = region_pair if isinstance(region_pair, list) else [region_pair]
+            for rp in region_pairs:
+                src_frag_parts.append(rp.src.memory.ptrs)
+                dst_frag_parts.append(rp.dst.memory.ptrs)
+                size_specs.append((rp.src.memory.ptrs.size, rp.src.memory.bytes_per_region))
 
         if src_frag_parts:
             src_frags = np.concatenate(src_frag_parts)
@@ -1631,10 +1671,10 @@ class Receiver(ReceiverBase):
             finally:
                 messenger.stop()
 
+            rank_info_bytes = self._registrar.self_rank_info.to_bytes()
             for endpoint in sender_info.sender_endpoints:
                 dealer = self._get_or_connect_dealer(endpoint)
-                rank_info = self._registrar.self_rank_info
-                dealer.send([MessageType.REGISTER_RANK_INFO, rank_info.to_bytes()])
+                dealer.send([MessageType.REGISTER_RANK_INFO, rank_info_bytes])
 
             self._sender_ep_instance_map[info_endpoint] = sender_info
             return sender_info
@@ -2241,7 +2281,9 @@ class TransferWorker:
 
     def _setup_peer_infrastructure(self, kvm: KVCacheManager):
         self._rank_info_server = RankInfoServer(self._rank_info) if kvm.mapping.rank == 0 else None
-        self._kv_extractor = KVRegionExtractorV1(kvm)
+        if self._rank_info.page_table is None:
+            raise RuntimeError("RankInfo page table must be initialized before peer setup")
+        self._kv_extractor = KVRegionExtractorV1(self._rank_info.page_table)
         self._peer_registrar = PeerRegistrar(self._rank_info, self._kv_extractor)
 
     def _setup_transfer_engine(self):

--- a/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Dict, List
 
 import numpy as np
@@ -20,13 +35,20 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     PhysicalPoolGroup,
     PoolView,
 )
-from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool
+from tensorrt_llm._torch.disaggregation.resource.utils import (
+    compute_layer_byte_ranges,
+    get_physical_pool,
+)
 from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import Role
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import MambaHybridCacheManager
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._utils import get_size_in_bytes, nvtx_range
 from tensorrt_llm.bindings import DataType
 
+# Mapper kinds a V2 manager may declare via get_disagg_role_mapper_kinds().
+# A physical pool may mix kinds (V2 storage coalesces buffers purely by
+# size within a life cycle); the page-table builder emits one PoolView per
+# (pool, kind) so each view stays kind-homogeneous.
 _V2_ROLE_MAPPER_KINDS = frozenset(
     {
         MapperKind.INDEXED,
@@ -37,10 +59,11 @@ _V2_ROLE_MAPPER_KINDS = frozenset(
 
 
 class KVRegionExtractorV1(RegionExtractorBase):
-    """Extract descriptors and regions from KV cache pools.
+    """
+    Descriptor and region extractor for KV cache pool managed by
+    KVCacheManager, KVCacheManagerV2, or described by a KVCachePageTable.
 
-    Supports pools managed by KVCacheManager or KVCacheManagerV2, as well as
-    pools described directly by a KVCachePageTable.
+    Provides region descriptors for adapting block-wise view.
     """
 
     def __init__(self, kv_arg):
@@ -62,11 +85,15 @@ class KVRegionExtractorV1(RegionExtractorBase):
         layer_group_id: int = 0,
         pool_idx: int = 0,
     ) -> SpecRegion:
-        """Return the memory regions for the provided block or slot IDs.
+        """
+        Given a list of region_ids (block IDs or slot IDs), returns a single
+        SpecRegion whose memory is a MemRegionGroup containing all blocks
+        described by region_ids.
 
-        Each pointer is ``base_address + slot_id * slot_bytes`` and addresses
-        the selected logical view within a slot. The slot contains entries for
-        all layers in this layer group laid out contiguously from offset zero.
+        For KV cache: each ptr = base_address + slot_id * slot_bytes, pointing
+        to the start of a full slot. Sub-slot selection (layers, role classes,
+        heads) is the mappers' responsibility; logical views carry that
+        geometry in their buffer entries.
 
         Args:
             layer_group_id: The layer group index (= life cycle index).
@@ -76,14 +103,13 @@ class KVRegionExtractorV1(RegionExtractorBase):
         pv = lg.pool_views[pool_idx]
         pool = get_physical_pool(self._page_table, layer_group_id, pv.pool_idx)
 
-        base_ptr = pool.base_address + pv.byte_offset
-        block_stride = pool.slot_bytes
-        region_size = pv.bytes_per_region if pv.bytes_per_region is not None else pool.slot_bytes
+        base_ptr = pool.base_address
+        block_size = pool.slot_bytes
 
         # KV cache: filter out invalid block_ids (BAD_PAGE_INDEX = -1)
         valid = region_ids >= 0
-        ptrs = base_ptr + block_stride * region_ids[valid]
-        memory = MemRegionGroup(ptrs=ptrs, bytes_per_region=region_size)
+        ptrs = base_ptr + block_size * region_ids[valid]
+        memory = MemRegionGroup(ptrs=ptrs, bytes_per_region=block_size)
         return SpecRegion(memory=memory)
 
 
@@ -199,11 +225,15 @@ def build_page_table(kv_cache_manager: KVCacheManager) -> KVCachePageTable:
             buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE),
             pool_role=frozenset(kv_role_names),
             mapper_kind=MapperKind.INDEXED,
+            bytes_per_layer=stride,
         )
         physical_pools = [kv_physical]
         pool_views = [kv_view]
 
-        # Indexer K cache support
+        # Indexer K cache support. The DSA indexer K cache is identical on
+        # every TP rank (single index head), so its view is REPLICATED with
+        # one synthesized buffer entry per local layer: the slot packs the
+        # layers equal-sized in local-layer order.
         if getattr(kv_cache_manager, "enable_indexer_k_cache", False):
             indexer_pool = kv_cache_manager.impl.get_indexer_k_cache_pool()
             # indexer_pool shape: (numBlocks, numLayers, kvFactor, blockSize), dtype=UINT8
@@ -217,11 +247,19 @@ def build_page_table(kv_cache_manager: KVCacheManager) -> KVCachePageTable:
                 slot_bytes=indexer_slot_bytes,
                 num_slots=num_blocks,
             )
+            indexer_bytes_per_layer = indexer_slot_bytes // len(local_layer_ids)
             indexer_view = PoolView(
                 pool_idx=1,
-                buffer_entries=np.array([], dtype=BUFFER_ENTRY_DTYPE),
+                buffer_entries=np.array(
+                    [
+                        (lid, i * indexer_bytes_per_layer, indexer_bytes_per_layer)
+                        for i, lid in enumerate(local_layer_ids)
+                    ],
+                    dtype=BUFFER_ENTRY_DTYPE,
+                ),
                 pool_role=frozenset({"indexer_k"}),
-                mapper_kind=MapperKind.FLAT,
+                mapper_kind=MapperKind.REPLICATED,
+                bytes_per_layer=indexer_bytes_per_layer,
             )
             physical_pools.append(indexer_physical)
             pool_views.append(indexer_view)
@@ -319,25 +357,8 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
             gpu_level = level_idx
             break
 
-    # Collect buffer IDs keyed by (life_cycle_id, pool_idx). PoolView stays at
-    # physical-pool granularity; per-buffer roles, offsets, and mapper kinds
-    # let the mapper handle heterogeneous layouts within the pool.
-    buffer_ids_by_lc_pool: Dict[tuple, list] = defaultdict(list)
-    native_roles_by_pool: Dict[tuple, set] = defaultdict(set)
-
-    for buffer_id, attr in storage._buffer_attr.items():
-        layer_id, role = buffer_id
-        lc_id = attr.life_cycle_id
-        pool_idx = attr.pool_index
-        pool_key = (int(lc_id), pool_idx)
-        buffer_ids_by_lc_pool[pool_key].append(buffer_id)
-        native_roles_by_pool[pool_key].add(str(role))
-
     # Every V2 manager declares how native roles map to the closed set of
-    # disaggregation mappers. Role.ALL is the fallback for future/native roles
-    # unknown to this shared extractor. An all-INDEXED mapping preserves the
-    # legacy whole-slot behavior. Heterogeneous declarations are recorded per
-    # buffer while retaining one PoolView per physical pool.
+    # disaggregation mapper kinds; Role.ALL is the required fallback.
     role_mapper_kinds = manager.get_disagg_role_mapper_kinds()
     if Role.ALL not in role_mapper_kinds:
         raise ValueError("Disaggregation role mapping must define Role.ALL")
@@ -352,11 +373,35 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
                 f"Unsupported V2 disaggregation mapper kind {mapper_kind.name} "
                 f"for role {role!s}; supported kinds: {supported}"
             )
-    if MapperKind.INDEXED in role_mapper_kinds.values() and role_mapper_kinds != {
-        Role.ALL: MapperKind.INDEXED
-    }:
-        raise ValueError("MapperKind.INDEXED is only valid as the sole Role.ALL mapping")
+        # INDEXED is the whole-manager legacy default, not a per-role
+        # choice: it may only appear as the Role.ALL fallback. Side-cache
+        # roles (e.g. INDEX_KEY) may declare their own non-INDEXED kind
+        # alongside it.
+        if mapper_kind is MapperKind.INDEXED and role != Role.ALL:
+            raise ValueError(
+                f"MapperKind.INDEXED is only valid as the Role.ALL mapping; "
+                f"got it for role {role!s}"
+            )
     default_mapper_kind = role_mapper_kinds[Role.ALL]
+
+    # Bucket buffer entries by (life_cycle, pool, mapper kind). One PoolView
+    # is emitted per bucket and spans every layer of that role class, so the
+    # view count per layer group is bounded by the number of role classes —
+    # never by the layer count. A physical pool may hold several classes
+    # (V2 storage coalesces buffers purely by size within a life cycle, so
+    # e.g. MiniMax M3's index-K shares the K/V pool when their per-block
+    # sizes coincide); each class still gets its own view, which keeps peer
+    # matching independent of that physical coalescing decision.
+    # ``pool_role`` stays the manager-supplied equivalence label used for
+    # peer matching without enumerating role names.
+    bucket_entries: Dict[tuple, list] = defaultdict(list)
+    bucket_roles: Dict[tuple, set] = defaultdict(set)
+    for buffer_id, attr in storage._buffer_attr.items():
+        layer_id, role = buffer_id
+        kind = role_mapper_kinds.get(role, default_mapper_kind)
+        bucket_key = (int(attr.life_cycle_id), int(attr.pool_index), kind)
+        bucket_entries[bucket_key].append((int(layer_id), int(attr.offset), int(attr.size)))
+        bucket_roles[bucket_key].add(str(role))
 
     # Iterate over life cycles (layer groups), not storage pool groups.
     # Multiple layer_groups can share the same storage pool_group when their
@@ -407,42 +452,49 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
             for iid, gid in zip(all_internal_layer_ids, all_global_layer_ids)
         ]
 
+        # Emit this life cycle's views: one per bucket, i.e. per
+        # (life_cycle, pool, mapper kind) — the life-cycle component is
+        # fixed by the enclosing loop, so within this group it reads as
+        # one view per (pool, mapper-kind class of roles). Roles sharing a
+        # kind share a view (KEY+VALUE); roles with different kinds in the
+        # same physical pool get separate views (M3 coalesced index-K).
+        # The life-cycle filter also handles pool-group sharing: multiple
+        # life cycles may draw slots from the same storage pool group, and
+        # each group only picks up buckets holding its own buffers.
+        # All ordering below is canonicalization — the page table is
+        # serialized and matched against peers, so view order (pool, then
+        # lowest slot offset), entry order (slot offset), and role text
+        # must not depend on dict/set iteration order.
         pool_views = []
-        for pool_idx in range(num_pools):
-            pool_key = (lc_idx, pool_idx)
-            buffer_ids = sorted(
-                buffer_ids_by_lc_pool.get(pool_key, []),
-                key=lambda buffer_id: int(storage._buffer_attr[buffer_id].offset),
+        lc_bucket_keys = sorted(
+            (key for key in bucket_entries if key[0] == lc_idx),
+            key=lambda key: (key[1], min(entry[1] for entry in bucket_entries[key])),
+        )
+        for bucket_key in lc_bucket_keys:
+            _, pool_idx, mapper_kind = bucket_key
+            roles = frozenset(bucket_roles[bucket_key])
+            entries = np.array(
+                sorted(bucket_entries[bucket_key], key=lambda entry: entry[1]),
+                dtype=BUFFER_ENTRY_DTYPE,
             )
-
-            # Skip pools that have no buffers for this layer group.
-            # Multiple life cycles may share the same storage pool group;
-            # only include pools that actually belong to this life cycle.
-            if not buffer_ids:
-                continue
-
-            entries = [
-                (
-                    int(buffer_id[0]),
-                    int(storage._buffer_attr[buffer_id].offset),
-                    int(storage._buffer_attr[buffer_id].size),
-                )
-                for buffer_id in buffer_ids
-            ]
-            buffer_mapper_kinds = tuple(
-                role_mapper_kinds.get(buffer_id[1], default_mapper_kind) for buffer_id in buffer_ids
-            )
-            mapper_kind = (
-                buffer_mapper_kinds[0] if len(set(buffer_mapper_kinds)) == 1 else MapperKind.MIXED
+            # Fail fast on invalid geometry and record the uniform per-layer
+            # region size on the wire. Every kind is entries-driven, so the
+            # contiguous-layer-region / uniform-size invariants apply to all
+            # views uniformly.
+            _, bytes_per_layer = compute_layer_byte_ranges(
+                entries,
+                context=(
+                    f"View(life_cycle={lc_idx}, pool={pool_idx}, "
+                    f"kind={mapper_kind.name}, role={sorted(roles)})"
+                ),
             )
             pool_views.append(
                 PoolView(
                     pool_idx=pool_idx,
-                    buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE),
-                    pool_role=frozenset(native_roles_by_pool[pool_key]),
+                    buffer_entries=entries,
+                    pool_role=roles,
                     mapper_kind=mapper_kind,
-                    buffer_roles=tuple(str(buffer_id[1]) for buffer_id in buffer_ids),
-                    buffer_mapper_kinds=buffer_mapper_kinds,
+                    bytes_per_layer=bytes_per_layer,
                 )
             )
 

--- a/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
@@ -21,10 +21,15 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     PoolView,
 )
 from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import DisaggCacheLayout
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import MambaHybridCacheManager
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._utils import get_size_in_bytes, nvtx_range
 from tensorrt_llm.bindings import DataType
+
+_LAYOUT_TO_MAPPER = {
+    DisaggCacheLayout.NHD: MapperKind.NHD,
+}
 
 
 class KVRegionExtractorV1(RegionExtractorBase):
@@ -71,13 +76,14 @@ class KVRegionExtractorV1(RegionExtractorBase):
         pv = lg.pool_views[pool_idx]
         pool = get_physical_pool(self._page_table, layer_group_id, pv.pool_idx)
 
-        base_ptr = pool.base_address
-        block_size = pool.slot_bytes
+        base_ptr = pool.base_address + pv.byte_offset
+        block_stride = pool.slot_bytes
+        region_size = pv.bytes_per_region or pool.slot_bytes
 
         # KV cache: filter out invalid block_ids (BAD_PAGE_INDEX = -1)
         valid = region_ids >= 0
-        ptrs = base_ptr + block_size * region_ids[valid]
-        memory = MemRegionGroup(ptrs=ptrs, bytes_per_region=block_size)
+        ptrs = base_ptr + block_stride * region_ids[valid]
+        memory = MemRegionGroup(ptrs=ptrs, bytes_per_region=region_size)
         return SpecRegion(memory=memory)
 
 
@@ -288,109 +294,198 @@ def _compute_global_layer_ids(manager, lg_idx: int) -> List[int]:
 def _build_page_table_v2(manager) -> KVCachePageTable:
     """Build a KVCachePageTable from a KVCacheManagerV2.
 
-    Uses KVCacheManagerV2's public pool_group_descs layout API. A physical
-    pool group may be shared by several layer groups; layer_groups remains
-    indexed by layer_group_id while pool_group_idx points at the shared
-    physical pool group entry.
+    Uses the V2 storage layer APIs (pool.slot_address, pool.slot_size,
+    pool.num_slots) for accurate pool metadata, and stamps each PoolView
+    with the manager's native role-name strings (``pool_role``) plus the
+    closed-set ``mapper_kind`` discriminator used by ``build_kv_mapper``.
 
-    Each PoolView is stamped with the manager's native role-name strings
-    (``pool_role``) plus the closed-set ``mapper_kind`` discriminator used
-    by ``build_kv_mapper``.
+    Important: iterates over life cycles (layer groups), not storage pool
+    groups.  Multiple life cycles with different sliding-window sizes may
+    share the same underlying storage pool group when their buffer sizes
+    are identical.  The page table must reflect life cycles so that
+    per-window transfer logic works correctly.
     """
-    config = manager.impl.init_config
-    pool_group_descs = manager.impl.pool_group_descs
+    from collections import defaultdict
 
-    def _window_size_for_layer(internal_layer_id: int):
-        if internal_layer_id < len(config.layers):
-            return getattr(config.layers[internal_layer_id], "window_size", None)
+    from tensorrt_llm.runtime.kv_cache_manager_v2 import CacheTier
 
-        if hasattr(manager, "_layer_attn_to_layer_id"):
-            for (model_layer, _attn_type), layer_id in manager._layer_attn_to_layer_id.items():
-                if layer_id != internal_layer_id:
-                    continue
-                local_layer = manager.layer_offsets.get(model_layer)
-                if local_layer is not None and local_layer < len(config.layers):
-                    return getattr(config.layers[local_layer], "window_size", None)
-                if model_layer < len(config.layers):
-                    return getattr(config.layers[model_layer], "window_size", None)
+    storage = manager.impl._storage
+    config = manager.impl._init_config
 
-        raise ValueError(f"Cannot resolve layer config for internal layer {internal_layer_id}")
+    # Find GPU level
+    gpu_level = 0
+    for level_idx, cache_tier_config in enumerate(config.cache_tiers):
+        if cache_tier_config.tier == CacheTier.GPU_MEM:
+            gpu_level = level_idx
+            break
+
+    # Collect buffer entries keyed by (life_cycle_id, pool_idx).
+    # Also collect the set of native role-name strings per pool — used as
+    # ``PoolView.pool_role``, the manager-supplied equivalence label that
+    # disagg uses to match pools across peers without enumerating roles.
+    buffer_by_lc_pool: Dict[tuple, list] = defaultdict(list)
+    buffer_ids_by_lc_layer: Dict[tuple, list] = defaultdict(list)
+    native_roles_by_pool: Dict[tuple, set] = defaultdict(set)
+
+    for buffer_id, attr in storage._buffer_attr.items():
+        layer_id, role = buffer_id
+        lc_id = attr.life_cycle_id
+        pool_idx = attr.pool_index
+        pool_key = (int(lc_id), pool_idx)
+        buffer_by_lc_pool[pool_key].append((layer_id, attr.offset, attr.size))
+        buffer_ids_by_lc_layer[(int(lc_id), int(layer_id))].append(buffer_id)
+        native_roles_by_pool[pool_key].add(str(role))
+
+    # V2 managers opt into model-specific logical views through
+    # get_disagg_pool_view_config()/DisaggPoolViewConfig. This keeps shared
+    # disaggregation independent of private model attributes and role names,
+    # and ensures dense-only PP ranks use the same scheme as sparse ranks even
+    # when no replicated role is locally allocated.
+    view_config = manager.get_disagg_pool_view_config()
+    sharded_mapper_kind = None
+    if view_config is not None:
+        sharded_mapper_kind = _LAYOUT_TO_MAPPER.get(view_config.sharded_layout)
+        if sharded_mapper_kind is None:
+            supported = ", ".join(layout.value for layout in _LAYOUT_TO_MAPPER)
+            raise ValueError(
+                "Unsupported disaggregation sharded layout "
+                f"{view_config.sharded_layout!r}; supported layouts: {supported}"
+            )
+    replicated_roles = view_config.replicated_roles if view_config is not None else frozenset()
+
+    # Iterate over life cycles (layer groups), not storage pool groups.
+    # Multiple layer_groups can share the same storage pool_group when their
+    # slot_size_list (coalesced buffer sizes) are identical.  In that case,
+    # different layer_groups draw slots from the same physical pool, but a
+    # slot is exclusively allocated to one layer_group at a time (managed by
+    # SlotAllocator).  Within a slot, each layer_group's buffer offsets start
+    # from 0 independently — the memory is reused, not concatenated.
+    # Therefore, slot_bytes / num_layers_for_this_layer_group correctly gives
+    # the per-layer size, and buffer offsets within a slot are contiguous for
+    # each layer_group.
+    num_life_cycles = storage.num_life_cycles
+    pool_group_storage = storage._levels[gpu_level].storage._pool_groups
 
     pool_groups: List[PhysicalPoolGroup] = []
     storage_pg_to_list_idx: Dict[int, int] = {}
-    layer_groups_by_id: List[LayerGroup | None] = [None] * len(manager.impl.layer_grouping)
+    layer_groups: List[LayerGroup] = []
 
-    for pg_desc in pool_group_descs:
-        storage_pg_idx = int(pg_desc.pool_group_index)
-        storage_pg_to_list_idx[storage_pg_idx] = len(pool_groups)
-        pool_groups.append(
-            PhysicalPoolGroup(
-                pools=[
-                    PhysicalPool(
-                        base_address=int(pool.base_address),
-                        slot_bytes=int(pool.slot_bytes),
-                        num_slots=int(pg_desc.num_slots),
-                    )
-                    for pool in pg_desc.pools
-                ]
-            )
-        )
+    for lc_idx in range(num_life_cycles):
+        # Resolve the storage pool group for this life cycle.
+        # storage_pg_idx may be the same for multiple lc_idx values.
+        storage_pg_idx = storage.get_pool_group_index(lc_idx)
+        pool_group = pool_group_storage[storage_pg_idx]
+        num_pools = pool_group.num_pools
 
-        for variant in pg_desc.slot_desc.variants:
-            layer_group_id = int(variant.layer_group_id)
-            all_internal_layer_ids = list(manager.impl.layer_grouping[layer_group_id])
-            all_global_layer_ids = _compute_global_layer_ids(manager, layer_group_id)
-
-            local_layers = [
-                LocalLayer(local_layer_id=int(iid), global_layer_id=int(gid))
-                for iid, gid in zip(all_internal_layer_ids, all_global_layer_ids)
-            ]
-
-            pool_views = []
-            for pool_idx, coalesced_buffer in enumerate(variant.coalesced_buffers):
-                entries = []
-                # Native role-name strings for this pool — used as
-                # ``PoolView.pool_role``, the manager-supplied equivalence
-                # label that disagg uses to match pools across peers without
-                # enumerating roles.
-                native_roles: set = set()
-                offset = 0
-                single_buffer_size = int(coalesced_buffer.single_buffer_size)
-                for buffer_id in coalesced_buffer.buffer_ids:
-                    entries.append((int(buffer_id.layer_id), offset, single_buffer_size))
-                    native_roles.add(str(buffer_id.role))
-                    offset += single_buffer_size
-
-                if entries:
-                    pool_views.append(
-                        PoolView(
-                            pool_idx=pool_idx,
-                            buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE),
-                            pool_role=frozenset(native_roles),
-                            mapper_kind=MapperKind.INDEXED,
+        # Build PhysicalPoolGroup once per unique storage pool group.
+        if storage_pg_idx not in storage_pg_to_list_idx:
+            storage_pg_to_list_idx[storage_pg_idx] = len(pool_groups)
+            pool_groups.append(
+                PhysicalPoolGroup(
+                    pools=[
+                        PhysicalPool(
+                            base_address=int(pool_group._pools[pi].slot_address(0)),
+                            slot_bytes=int(pool_group._pools[pi].slot_size),
+                            num_slots=int(pool_group._pools[pi].num_slots),
                         )
+                        for pi in range(num_pools)
+                    ]
+                )
+            )
+
+        # Compute group-level global layer IDs and internal layer IDs
+        all_internal_layer_ids = list(manager.impl.layer_grouping[lc_idx])
+        all_global_layer_ids = _compute_global_layer_ids(manager, lc_idx)
+
+        local_layers = [
+            LocalLayer(local_layer_id=int(iid), global_layer_id=int(gid))
+            for iid, gid in zip(all_internal_layer_ids, all_global_layer_ids)
+        ]
+
+        pool_views = []
+        if view_config is not None:
+            # Depending on topology, replicated side caches may occupy their
+            # own physical pools or be coalesced with sharded K/V. Describe
+            # each layer and role class as a logical byte range so matching is
+            # independent of that physical coalescing decision.
+            physical_pools = pool_groups[storage_pg_to_list_idx[storage_pg_idx]].pools
+            for layer_id in all_internal_layer_ids:
+                layer_buffers = buffer_ids_by_lc_layer.get((lc_idx, int(layer_id)), [])
+                standard_buffers = [b for b in layer_buffers if b[1] not in replicated_roles]
+                replicated_buffers = [b for b in layer_buffers if b[1] in replicated_roles]
+
+                for buffers, mapper_kind in (
+                    (standard_buffers, sharded_mapper_kind),
+                    (replicated_buffers, MapperKind.REPLICATED),
+                ):
+                    if not buffers:
+                        continue
+                    for desc in manager.impl.get_aggregated_pages(buffers):
+                        desc_buffer_ids = [expanded.id for expanded in desc.buffers]
+                        first_attr = storage._buffer_attr[desc_buffer_ids[0]]
+                        pool_idx = int(first_attr.pool_index)
+                        pool_base = physical_pools[pool_idx].base_address
+                        entries = [
+                            (
+                                int(buffer_id[0]),
+                                int(storage._buffer_attr[buffer_id].offset),
+                                int(storage._buffer_attr[buffer_id].size),
+                            )
+                            for buffer_id in desc_buffer_ids
+                        ]
+                        pool_views.append(
+                            PoolView(
+                                pool_idx=pool_idx,
+                                buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE),
+                                pool_role=frozenset(
+                                    str(buffer_id[1]) for buffer_id in desc_buffer_ids
+                                ),
+                                mapper_kind=mapper_kind,
+                                byte_offset=int(desc.base) - pool_base,
+                                bytes_per_region=int(desc.size),
+                            )
+                        )
+        else:
+            for pool_idx in range(num_pools):
+                pool_key = (lc_idx, pool_idx)
+                buffers_info = buffer_by_lc_pool.get(pool_key, [])
+
+                # Skip pools that have no buffers for this layer group.
+                # Multiple life cycles may share the same storage pool group;
+                # only include pools that actually belong to this life cycle.
+                if not buffers_info:
+                    continue
+
+                pool_views.append(
+                    PoolView(
+                        pool_idx=pool_idx,
+                        buffer_entries=np.array(buffers_info, dtype=BUFFER_ENTRY_DTYPE),
+                        pool_role=frozenset(native_roles_by_pool[pool_key]),
+                        mapper_kind=MapperKind.INDEXED,
                     )
+                )
 
-            first_local_layer = all_internal_layer_ids[0]
-            if first_local_layer < len(manager.num_kv_heads_per_layer):
-                num_kv_heads = manager.num_kv_heads_per_layer[first_local_layer]
-            else:
-                num_kv_heads = manager.num_kv_heads_per_layer[0]
-            sliding_window_size = _window_size_for_layer(first_local_layer)
+        # Determine layer group metadata.
+        # For managers with virtual layers, internal layer_ids
+        # may exceed the length of num_kv_heads_per_layer. Use index 0 as all
+        # layers within a pool group share the same kv_heads count.
+        first_local_layer = all_internal_layer_ids[0]
+        if first_local_layer < len(manager.num_kv_heads_per_layer):
+            num_kv_heads = manager.num_kv_heads_per_layer[first_local_layer]
+        else:
+            num_kv_heads = manager.num_kv_heads_per_layer[0]
+        life_cycle = manager.impl._life_cycles[lc_idx]
+        sliding_window_size = life_cycle.window_size
 
-            layer_groups_by_id[layer_group_id] = AttentionLayerGroup(
+        layer_groups.append(
+            AttentionLayerGroup(
                 pool_group_idx=storage_pg_to_list_idx[storage_pg_idx],
                 kv_head_num_per_rank=num_kv_heads,
                 sliding_window_size=sliding_window_size,
                 local_layers=local_layers,
                 pool_views=pool_views,
             )
-
-    layer_groups: List[LayerGroup] = []
-    for layer_group_id, layer_group in enumerate(layer_groups_by_id):
-        if layer_group is None:
-            raise ValueError(f"Missing V2 layer group descriptor for layer group {layer_group_id}")
-        layer_groups.append(layer_group)
+        )
 
     if isinstance(manager, MambaHybridCacheManager):
         mamba_layer_group_idx = len(pool_groups)

--- a/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
@@ -319,12 +319,10 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
             gpu_level = level_idx
             break
 
-    # Collect buffer entries keyed by (life_cycle_id, pool_idx).
-    # Also collect the set of native role-name strings per pool — used as
-    # ``PoolView.pool_role``, the manager-supplied equivalence label that
-    # disagg uses to match pools across peers without enumerating roles.
-    buffer_by_lc_pool: Dict[tuple, list] = defaultdict(list)
-    buffer_ids_by_lc_layer: Dict[tuple, list] = defaultdict(list)
+    # Collect buffer IDs keyed by (life_cycle_id, pool_idx). PoolView stays at
+    # physical-pool granularity; per-buffer roles, offsets, and mapper kinds
+    # let the mapper handle heterogeneous layouts within the pool.
+    buffer_ids_by_lc_pool: Dict[tuple, list] = defaultdict(list)
     native_roles_by_pool: Dict[tuple, set] = defaultdict(set)
 
     for buffer_id, attr in storage._buffer_attr.items():
@@ -332,16 +330,14 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
         lc_id = attr.life_cycle_id
         pool_idx = attr.pool_index
         pool_key = (int(lc_id), pool_idx)
-        buffer_by_lc_pool[pool_key].append((layer_id, attr.offset, attr.size))
-        buffer_ids_by_lc_layer[(int(lc_id), int(layer_id))].append(buffer_id)
+        buffer_ids_by_lc_pool[pool_key].append(buffer_id)
         native_roles_by_pool[pool_key].add(str(role))
 
     # Every V2 manager declares how native roles map to the closed set of
     # disaggregation mappers. Role.ALL is the fallback for future/native roles
     # unknown to this shared extractor. An all-INDEXED mapping preserves the
-    # legacy whole-slot page table; any logical mapper opts every PP rank into
-    # per-layer views, even when that rank has no local buffer of the overriding
-    # role (for example, a dense-only MiniMax rank without INDEX_KEY).
+    # legacy whole-slot behavior. Heterogeneous declarations are recorded per
+    # buffer while retaining one PoolView per physical pool.
     role_mapper_kinds = manager.get_disagg_role_mapper_kinds()
     if Role.ALL not in role_mapper_kinds:
         raise ValueError("Disaggregation role mapping must define Role.ALL")
@@ -361,8 +357,6 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
     }:
         raise ValueError("MapperKind.INDEXED is only valid as the sole Role.ALL mapping")
     default_mapper_kind = role_mapper_kinds[Role.ALL]
-    mapper_kind_order = list(dict.fromkeys(role_mapper_kinds.values()))
-    use_logical_views = any(kind != MapperKind.INDEXED for kind in mapper_kind_order)
 
     # Iterate over life cycles (layer groups), not storage pool groups.
     # Multiple layer_groups can share the same storage pool_group when their
@@ -414,67 +408,43 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
         ]
 
         pool_views = []
-        if use_logical_views:
-            # Depending on topology, replicated side caches may occupy their
-            # own physical pools or be coalesced with sharded K/V. Describe
-            # each layer and role class as a logical byte range so matching is
-            # independent of that physical coalescing decision.
-            physical_pools = pool_groups[storage_pg_to_list_idx[storage_pg_idx]].pools
-            for layer_id in all_internal_layer_ids:
-                layer_buffers = buffer_ids_by_lc_layer.get((lc_idx, int(layer_id)), [])
-                buffers_by_mapper_kind: Dict[MapperKind, list] = defaultdict(list)
-                for buffer_id in layer_buffers:
-                    mapper_kind = role_mapper_kinds.get(buffer_id[1], default_mapper_kind)
-                    buffers_by_mapper_kind[mapper_kind].append(buffer_id)
+        for pool_idx in range(num_pools):
+            pool_key = (lc_idx, pool_idx)
+            buffer_ids = sorted(
+                buffer_ids_by_lc_pool.get(pool_key, []),
+                key=lambda buffer_id: int(storage._buffer_attr[buffer_id].offset),
+            )
 
-                for mapper_kind in mapper_kind_order:
-                    buffers = buffers_by_mapper_kind.get(mapper_kind, [])
-                    if not buffers:
-                        continue
-                    for desc in manager.impl.get_aggregated_pages(buffers):
-                        desc_buffer_ids = [expanded.id for expanded in desc.buffers]
-                        first_attr = storage._buffer_attr[desc_buffer_ids[0]]
-                        pool_idx = int(first_attr.pool_index)
-                        pool_base = physical_pools[pool_idx].base_address
-                        entries = [
-                            (
-                                int(buffer_id[0]),
-                                int(storage._buffer_attr[buffer_id].offset),
-                                int(storage._buffer_attr[buffer_id].size),
-                            )
-                            for buffer_id in desc_buffer_ids
-                        ]
-                        pool_views.append(
-                            PoolView(
-                                pool_idx=pool_idx,
-                                buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE),
-                                pool_role=frozenset(
-                                    str(buffer_id[1]) for buffer_id in desc_buffer_ids
-                                ),
-                                mapper_kind=mapper_kind,
-                                byte_offset=int(desc.base) - pool_base,
-                                bytes_per_region=int(desc.size),
-                            )
-                        )
-        else:
-            for pool_idx in range(num_pools):
-                pool_key = (lc_idx, pool_idx)
-                buffers_info = buffer_by_lc_pool.get(pool_key, [])
+            # Skip pools that have no buffers for this layer group.
+            # Multiple life cycles may share the same storage pool group;
+            # only include pools that actually belong to this life cycle.
+            if not buffer_ids:
+                continue
 
-                # Skip pools that have no buffers for this layer group.
-                # Multiple life cycles may share the same storage pool group;
-                # only include pools that actually belong to this life cycle.
-                if not buffers_info:
-                    continue
-
-                pool_views.append(
-                    PoolView(
-                        pool_idx=pool_idx,
-                        buffer_entries=np.array(buffers_info, dtype=BUFFER_ENTRY_DTYPE),
-                        pool_role=frozenset(native_roles_by_pool[pool_key]),
-                        mapper_kind=MapperKind.INDEXED,
-                    )
+            entries = [
+                (
+                    int(buffer_id[0]),
+                    int(storage._buffer_attr[buffer_id].offset),
+                    int(storage._buffer_attr[buffer_id].size),
                 )
+                for buffer_id in buffer_ids
+            ]
+            buffer_mapper_kinds = tuple(
+                role_mapper_kinds.get(buffer_id[1], default_mapper_kind) for buffer_id in buffer_ids
+            )
+            mapper_kind = (
+                buffer_mapper_kinds[0] if len(set(buffer_mapper_kinds)) == 1 else MapperKind.MIXED
+            )
+            pool_views.append(
+                PoolView(
+                    pool_idx=pool_idx,
+                    buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE),
+                    pool_role=frozenset(native_roles_by_pool[pool_key]),
+                    mapper_kind=mapper_kind,
+                    buffer_roles=tuple(str(buffer_id[1]) for buffer_id in buffer_ids),
+                    buffer_mapper_kinds=buffer_mapper_kinds,
+                )
+            )
 
         # Determine layer group metadata.
         # For managers with virtual layers, internal layer_ids

--- a/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
@@ -33,11 +33,10 @@ _LAYOUT_TO_MAPPER = {
 
 
 class KVRegionExtractorV1(RegionExtractorBase):
-    """
-    Descriptor and region extractor for KV cache pool managed by
-    KVCacheManager, KVCacheManagerV2, or described by a KVCachePageTable.
+    """Extract descriptors and regions from KV cache pools.
 
-    Provides region descriptors for adapting block-wise view.
+    Supports pools managed by KVCacheManager or KVCacheManagerV2, as well as
+    pools described directly by a KVCachePageTable.
     """
 
     def __init__(self, kv_arg):
@@ -59,14 +58,11 @@ class KVRegionExtractorV1(RegionExtractorBase):
         layer_group_id: int = 0,
         pool_idx: int = 0,
     ) -> SpecRegion:
-        """
-        Given a list of region_ids (block IDs or slot IDs), returns a single
-        SpecRegion whose memory is a MemRegionGroup containing all blocks
-        described by region_ids.
+        """Return the memory regions for the provided block or slot IDs.
 
-        For KV cache: each ptr = base_address + slot_id * slot_bytes, pointing
-        to the start of a full slot.  The slot contains buffer entries for all
-        layers in this layer_group laid out contiguously from offset 0.
+        Each pointer is ``base_address + slot_id * slot_bytes`` and addresses
+        the selected logical view within a slot. The slot contains entries for
+        all layers in this layer group laid out contiguously from offset zero.
 
         Args:
             layer_group_id: The layer group index (= life cycle index).
@@ -78,7 +74,7 @@ class KVRegionExtractorV1(RegionExtractorBase):
 
         base_ptr = pool.base_address + pv.byte_offset
         block_stride = pool.slot_bytes
-        region_size = pv.bytes_per_region or pool.slot_bytes
+        region_size = pv.bytes_per_region if pv.bytes_per_region is not None else pool.slot_bytes
 
         # KV cache: filter out invalid block_ids (BAD_PAGE_INDEX = -1)
         valid = region_ids >= 0

--- a/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 from typing import Dict, List
 
 import numpy as np
@@ -332,30 +333,20 @@ def _compute_global_layer_ids(manager, lg_idx: int) -> List[int]:
 def _build_page_table_v2(manager) -> KVCachePageTable:
     """Build a KVCachePageTable from a KVCacheManagerV2.
 
-    Uses the V2 storage layer APIs (pool.slot_address, pool.slot_size,
-    pool.num_slots) for accurate pool metadata, and stamps each PoolView
-    with the manager's native role-name strings (``pool_role``) plus the
-    closed-set ``mapper_kind`` discriminator used by ``build_kv_mapper``.
+    Uses KVCacheManagerV2's public ``pool_group_descs`` layout API and
+    stamps each PoolView with the manager's native role-name strings
+    (``pool_role``) plus the closed-set ``mapper_kind`` discriminator used
+    by ``build_kv_mapper``.
 
-    Important: iterates over life cycles (layer groups), not storage pool
-    groups.  Multiple life cycles with different sliding-window sizes may
-    share the same underlying storage pool group when their buffer sizes
-    are identical.  The page table must reflect life cycles so that
-    per-window transfer logic works correctly.
+    A physical pool group may be shared by several layer groups (life
+    cycles whose coalesced-buffer sizes are identical); each layer group
+    is exactly one ``SlotDescVariant`` of one pool group, so iterating
+    variants visits every layer group once. ``layer_groups`` stays indexed
+    by layer_group_id while ``pool_group_idx`` points at the shared
+    physical pool group entry, so per-window transfer logic keeps working.
     """
-    from collections import defaultdict
-
-    from tensorrt_llm.runtime.kv_cache_manager_v2 import CacheTier
-
-    storage = manager.impl._storage
-    config = manager.impl._init_config
-
-    # Find GPU level
-    gpu_level = 0
-    for level_idx, cache_tier_config in enumerate(config.cache_tiers):
-        if cache_tier_config.tier == CacheTier.GPU_MEM:
-            gpu_level = level_idx
-            break
+    config = manager.impl.init_config
+    pool_group_descs = manager.impl.pool_group_descs
 
     # Every V2 manager declares how native roles map to the closed set of
     # disaggregation mapper kinds; Role.ALL is the required fallback.
@@ -384,141 +375,149 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
             )
     default_mapper_kind = role_mapper_kinds[Role.ALL]
 
-    # Bucket buffer entries by (life_cycle, pool, mapper kind). One PoolView
-    # is emitted per bucket and spans every layer of that role class, so the
-    # view count per layer group is bounded by the number of role classes —
-    # never by the layer count. A physical pool may hold several classes
-    # (V2 storage coalesces buffers purely by size within a life cycle, so
-    # e.g. MiniMax M3's index-K shares the K/V pool when their per-block
-    # sizes coincide); each class still gets its own view, which keeps peer
-    # matching independent of that physical coalescing decision.
-    # ``pool_role`` stays the manager-supplied equivalence label used for
-    # peer matching without enumerating role names.
-    bucket_entries: Dict[tuple, list] = defaultdict(list)
-    bucket_roles: Dict[tuple, set] = defaultdict(set)
-    for buffer_id, attr in storage._buffer_attr.items():
-        layer_id, role = buffer_id
-        kind = role_mapper_kinds.get(role, default_mapper_kind)
-        bucket_key = (int(attr.life_cycle_id), int(attr.pool_index), kind)
-        bucket_entries[bucket_key].append((int(layer_id), int(attr.offset), int(attr.size)))
-        bucket_roles[bucket_key].add(str(role))
+    def _window_size_for_layer(internal_layer_id: int):
+        if internal_layer_id < len(config.layers):
+            return getattr(config.layers[internal_layer_id], "window_size", None)
 
-    # Iterate over life cycles (layer groups), not storage pool groups.
-    # Multiple layer_groups can share the same storage pool_group when their
-    # slot_size_list (coalesced buffer sizes) are identical.  In that case,
-    # different layer_groups draw slots from the same physical pool, but a
-    # slot is exclusively allocated to one layer_group at a time (managed by
-    # SlotAllocator).  Within a slot, each layer_group's buffer offsets start
-    # from 0 independently — the memory is reused, not concatenated.
-    # Therefore, slot_bytes / num_layers_for_this_layer_group correctly gives
-    # the per-layer size, and buffer offsets within a slot are contiguous for
-    # each layer_group.
-    num_life_cycles = storage.num_life_cycles
-    pool_group_storage = storage._levels[gpu_level].storage._pool_groups
+        if hasattr(manager, "_layer_attn_to_layer_id"):
+            for (model_layer, _attn_type), layer_id in manager._layer_attn_to_layer_id.items():
+                if layer_id != internal_layer_id:
+                    continue
+                local_layer = manager.layer_offsets.get(model_layer)
+                if local_layer is not None and local_layer < len(config.layers):
+                    return getattr(config.layers[local_layer], "window_size", None)
+                if model_layer < len(config.layers):
+                    return getattr(config.layers[model_layer], "window_size", None)
+
+        raise ValueError(f"Cannot resolve layer config for internal layer {internal_layer_id}")
 
     pool_groups: List[PhysicalPoolGroup] = []
     storage_pg_to_list_idx: Dict[int, int] = {}
-    layer_groups: List[LayerGroup] = []
+    layer_groups_by_id: List[LayerGroup | None] = [None] * len(manager.impl.layer_grouping)
 
-    for lc_idx in range(num_life_cycles):
-        # Resolve the storage pool group for this life cycle.
-        # storage_pg_idx may be the same for multiple lc_idx values.
-        storage_pg_idx = storage.get_pool_group_index(lc_idx)
-        pool_group = pool_group_storage[storage_pg_idx]
-        num_pools = pool_group.num_pools
-
-        # Build PhysicalPoolGroup once per unique storage pool group.
-        if storage_pg_idx not in storage_pg_to_list_idx:
-            storage_pg_to_list_idx[storage_pg_idx] = len(pool_groups)
-            pool_groups.append(
-                PhysicalPoolGroup(
-                    pools=[
-                        PhysicalPool(
-                            base_address=int(pool_group._pools[pi].slot_address(0)),
-                            slot_bytes=int(pool_group._pools[pi].slot_size),
-                            num_slots=int(pool_group._pools[pi].num_slots),
-                        )
-                        for pi in range(num_pools)
-                    ]
-                )
+    for pg_desc in pool_group_descs:
+        storage_pg_idx = int(pg_desc.pool_group_index)
+        storage_pg_to_list_idx[storage_pg_idx] = len(pool_groups)
+        pool_groups.append(
+            PhysicalPoolGroup(
+                pools=[
+                    PhysicalPool(
+                        base_address=int(pool.base_address),
+                        slot_bytes=int(pool.slot_bytes),
+                        num_slots=int(pg_desc.num_slots),
+                    )
+                    for pool in pg_desc.pools
+                ]
             )
-
-        # Compute group-level global layer IDs and internal layer IDs
-        all_internal_layer_ids = list(manager.impl.layer_grouping[lc_idx])
-        all_global_layer_ids = _compute_global_layer_ids(manager, lc_idx)
-
-        local_layers = [
-            LocalLayer(local_layer_id=int(iid), global_layer_id=int(gid))
-            for iid, gid in zip(all_internal_layer_ids, all_global_layer_ids)
-        ]
-
-        # Emit this life cycle's views: one per bucket, i.e. per
-        # (life_cycle, pool, mapper kind) — the life-cycle component is
-        # fixed by the enclosing loop, so within this group it reads as
-        # one view per (pool, mapper-kind class of roles). Roles sharing a
-        # kind share a view (KEY+VALUE); roles with different kinds in the
-        # same physical pool get separate views (M3 coalesced index-K).
-        # The life-cycle filter also handles pool-group sharing: multiple
-        # life cycles may draw slots from the same storage pool group, and
-        # each group only picks up buckets holding its own buffers.
-        # All ordering below is canonicalization — the page table is
-        # serialized and matched against peers, so view order (pool, then
-        # lowest slot offset), entry order (slot offset), and role text
-        # must not depend on dict/set iteration order.
-        pool_views = []
-        lc_bucket_keys = sorted(
-            (key for key in bucket_entries if key[0] == lc_idx),
-            key=lambda key: (key[1], min(entry[1] for entry in bucket_entries[key])),
         )
-        for bucket_key in lc_bucket_keys:
-            _, pool_idx, mapper_kind = bucket_key
-            roles = frozenset(bucket_roles[bucket_key])
-            entries = np.array(
-                sorted(bucket_entries[bucket_key], key=lambda entry: entry[1]),
-                dtype=BUFFER_ENTRY_DTYPE,
+
+        # Each variant is one layer group (life cycle) drawing slots from
+        # this pool group. Multiple layer groups share a pool group when
+        # their coalesced-buffer sizes are identical; within a slot, each
+        # layer group's buffer offsets start from 0 independently — the
+        # memory is reused, not concatenated.
+        for variant in pg_desc.slot_desc.variants:
+            layer_group_id = int(variant.layer_group_id)
+            all_internal_layer_ids = list(manager.impl.layer_grouping[layer_group_id])
+            all_global_layer_ids = _compute_global_layer_ids(manager, layer_group_id)
+
+            local_layers = [
+                LocalLayer(local_layer_id=int(iid), global_layer_id=int(gid))
+                for iid, gid in zip(all_internal_layer_ids, all_global_layer_ids)
+            ]
+
+            # Bucket buffer entries by (pool, mapper kind). One PoolView is
+            # emitted per bucket and spans every layer of that role class,
+            # so the view count per layer group is bounded by the number of
+            # role classes — never by the layer count. A physical pool may
+            # hold several classes (V2 storage coalesces buffers purely by
+            # size within a layer group, so e.g. MiniMax M3's index-K shares
+            # the K/V pool when their per-block sizes coincide); each class
+            # still gets its own view, which keeps peer matching independent
+            # of that physical coalescing decision. ``pool_role`` stays the
+            # manager-supplied equivalence label used for peer matching
+            # without enumerating role names. Buffer offsets within a slot
+            # follow ``buffer_ids`` order: the i-th buffer of a coalesced
+            # buffer lives at ``i * single_buffer_size``.
+            bucket_entries: Dict[tuple, list] = defaultdict(list)
+            bucket_roles: Dict[tuple, set] = defaultdict(set)
+            for pool_idx, coalesced_buffer in enumerate(variant.coalesced_buffers):
+                single_buffer_size = int(coalesced_buffer.single_buffer_size)
+                offset = 0
+                for buffer_id in coalesced_buffer.buffer_ids:
+                    kind = role_mapper_kinds.get(buffer_id.role, default_mapper_kind)
+                    bucket_key = (pool_idx, kind)
+                    bucket_entries[bucket_key].append(
+                        (int(buffer_id.layer_id), offset, single_buffer_size)
+                    )
+                    bucket_roles[bucket_key].add(str(buffer_id.role))
+                    offset += single_buffer_size
+
+            # Emit this layer group's views: one per (pool, mapper-kind
+            # class of roles). Roles sharing a kind share a view
+            # (KEY+VALUE); roles with different kinds in the same physical
+            # pool get separate views (M3 coalesced index-K).
+            # All ordering below is canonicalization — the page table is
+            # serialized and matched against peers, so view order (pool,
+            # then lowest slot offset), entry order (slot offset), and role
+            # text must not depend on dict/set iteration order.
+            pool_views = []
+            lg_bucket_keys = sorted(
+                bucket_entries,
+                key=lambda key: (key[0], min(entry[1] for entry in bucket_entries[key])),
             )
-            # Fail fast on invalid geometry and record the uniform per-layer
-            # region size on the wire. Every kind is entries-driven, so the
-            # contiguous-layer-region / uniform-size invariants apply to all
-            # views uniformly.
-            _, bytes_per_layer = compute_layer_byte_ranges(
-                entries,
-                context=(
-                    f"View(life_cycle={lc_idx}, pool={pool_idx}, "
-                    f"kind={mapper_kind.name}, role={sorted(roles)})"
-                ),
-            )
-            pool_views.append(
-                PoolView(
-                    pool_idx=pool_idx,
-                    buffer_entries=entries,
-                    pool_role=roles,
-                    mapper_kind=mapper_kind,
-                    bytes_per_layer=bytes_per_layer,
+            for bucket_key in lg_bucket_keys:
+                pool_idx, mapper_kind = bucket_key
+                roles = frozenset(bucket_roles[bucket_key])
+                entries = np.array(
+                    sorted(bucket_entries[bucket_key], key=lambda entry: entry[1]),
+                    dtype=BUFFER_ENTRY_DTYPE,
                 )
-            )
+                # Fail fast on invalid geometry and record the uniform
+                # per-layer region size on the wire. Every kind is
+                # entries-driven, so the contiguous-layer-region /
+                # uniform-size invariants apply to all views uniformly.
+                _, bytes_per_layer = compute_layer_byte_ranges(
+                    entries,
+                    context=(
+                        f"View(layer_group={layer_group_id}, pool={pool_idx}, "
+                        f"kind={mapper_kind.name}, role={sorted(roles)})"
+                    ),
+                )
+                pool_views.append(
+                    PoolView(
+                        pool_idx=pool_idx,
+                        buffer_entries=entries,
+                        pool_role=roles,
+                        mapper_kind=mapper_kind,
+                        bytes_per_layer=bytes_per_layer,
+                    )
+                )
 
-        # Determine layer group metadata.
-        # For managers with virtual layers, internal layer_ids
-        # may exceed the length of num_kv_heads_per_layer. Use index 0 as all
-        # layers within a pool group share the same kv_heads count.
-        first_local_layer = all_internal_layer_ids[0]
-        if first_local_layer < len(manager.num_kv_heads_per_layer):
-            num_kv_heads = manager.num_kv_heads_per_layer[first_local_layer]
-        else:
-            num_kv_heads = manager.num_kv_heads_per_layer[0]
-        life_cycle = manager.impl._life_cycles[lc_idx]
-        sliding_window_size = life_cycle.window_size
+            # Determine layer group metadata.
+            # For managers with virtual layers, internal layer_ids
+            # may exceed the length of num_kv_heads_per_layer. Use index 0 as
+            # all layers within a pool group share the same kv_heads count.
+            first_local_layer = all_internal_layer_ids[0]
+            if first_local_layer < len(manager.num_kv_heads_per_layer):
+                num_kv_heads = manager.num_kv_heads_per_layer[first_local_layer]
+            else:
+                num_kv_heads = manager.num_kv_heads_per_layer[0]
+            sliding_window_size = _window_size_for_layer(first_local_layer)
 
-        layer_groups.append(
-            AttentionLayerGroup(
+            layer_groups_by_id[layer_group_id] = AttentionLayerGroup(
                 pool_group_idx=storage_pg_to_list_idx[storage_pg_idx],
                 kv_head_num_per_rank=num_kv_heads,
                 sliding_window_size=sliding_window_size,
                 local_layers=local_layers,
                 pool_views=pool_views,
             )
-        )
+
+    layer_groups: List[LayerGroup] = []
+    for layer_group_id, layer_group in enumerate(layer_groups_by_id):
+        if layer_group is None:
+            raise ValueError(f"Missing V2 layer group descriptor for layer group {layer_group_id}")
+        layer_groups.append(layer_group)
 
     if isinstance(manager, MambaHybridCacheManager):
         mamba_layer_group_idx = len(pool_groups)

--- a/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
@@ -21,15 +21,19 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     PoolView,
 )
 from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool
-from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import DisaggCacheLayout
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import Role
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import MambaHybridCacheManager
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._utils import get_size_in_bytes, nvtx_range
 from tensorrt_llm.bindings import DataType
 
-_LAYOUT_TO_MAPPER = {
-    DisaggCacheLayout.NHD: MapperKind.NHD,
-}
+_V2_ROLE_MAPPER_KINDS = frozenset(
+    {
+        MapperKind.INDEXED,
+        MapperKind.REPLICATED,
+        MapperKind.NHD,
+    }
+)
 
 
 class KVRegionExtractorV1(RegionExtractorBase):
@@ -332,22 +336,33 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
         buffer_ids_by_lc_layer[(int(lc_id), int(layer_id))].append(buffer_id)
         native_roles_by_pool[pool_key].add(str(role))
 
-    # V2 managers opt into model-specific logical views through
-    # get_disagg_pool_view_config()/DisaggPoolViewConfig. This keeps shared
-    # disaggregation independent of private model attributes and role names,
-    # and ensures dense-only PP ranks use the same scheme as sparse ranks even
-    # when no replicated role is locally allocated.
-    view_config = manager.get_disagg_pool_view_config()
-    sharded_mapper_kind = None
-    if view_config is not None:
-        sharded_mapper_kind = _LAYOUT_TO_MAPPER.get(view_config.sharded_layout)
-        if sharded_mapper_kind is None:
-            supported = ", ".join(layout.value for layout in _LAYOUT_TO_MAPPER)
+    # Every V2 manager declares how native roles map to the closed set of
+    # disaggregation mappers. Role.ALL is the fallback for future/native roles
+    # unknown to this shared extractor. An all-INDEXED mapping preserves the
+    # legacy whole-slot page table; any logical mapper opts every PP rank into
+    # per-layer views, even when that rank has no local buffer of the overriding
+    # role (for example, a dense-only MiniMax rank without INDEX_KEY).
+    role_mapper_kinds = manager.get_disagg_role_mapper_kinds()
+    if Role.ALL not in role_mapper_kinds:
+        raise ValueError("Disaggregation role mapping must define Role.ALL")
+    for role, mapper_kind in role_mapper_kinds.items():
+        if not isinstance(mapper_kind, MapperKind):
             raise ValueError(
-                "Unsupported disaggregation sharded layout "
-                f"{view_config.sharded_layout!r}; supported layouts: {supported}"
+                f"Invalid disaggregation mapper kind {mapper_kind!r} for role {role!s}"
             )
-    replicated_roles = view_config.replicated_roles if view_config is not None else frozenset()
+        if mapper_kind not in _V2_ROLE_MAPPER_KINDS:
+            supported = ", ".join(kind.name for kind in sorted(_V2_ROLE_MAPPER_KINDS))
+            raise ValueError(
+                f"Unsupported V2 disaggregation mapper kind {mapper_kind.name} "
+                f"for role {role!s}; supported kinds: {supported}"
+            )
+    if MapperKind.INDEXED in role_mapper_kinds.values() and role_mapper_kinds != {
+        Role.ALL: MapperKind.INDEXED
+    }:
+        raise ValueError("MapperKind.INDEXED is only valid as the sole Role.ALL mapping")
+    default_mapper_kind = role_mapper_kinds[Role.ALL]
+    mapper_kind_order = list(dict.fromkeys(role_mapper_kinds.values()))
+    use_logical_views = any(kind != MapperKind.INDEXED for kind in mapper_kind_order)
 
     # Iterate over life cycles (layer groups), not storage pool groups.
     # Multiple layer_groups can share the same storage pool_group when their
@@ -399,7 +414,7 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
         ]
 
         pool_views = []
-        if view_config is not None:
+        if use_logical_views:
             # Depending on topology, replicated side caches may occupy their
             # own physical pools or be coalesced with sharded K/V. Describe
             # each layer and role class as a logical byte range so matching is
@@ -407,13 +422,13 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
             physical_pools = pool_groups[storage_pg_to_list_idx[storage_pg_idx]].pools
             for layer_id in all_internal_layer_ids:
                 layer_buffers = buffer_ids_by_lc_layer.get((lc_idx, int(layer_id)), [])
-                standard_buffers = [b for b in layer_buffers if b[1] not in replicated_roles]
-                replicated_buffers = [b for b in layer_buffers if b[1] in replicated_roles]
+                buffers_by_mapper_kind: Dict[MapperKind, list] = defaultdict(list)
+                for buffer_id in layer_buffers:
+                    mapper_kind = role_mapper_kinds.get(buffer_id[1], default_mapper_kind)
+                    buffers_by_mapper_kind[mapper_kind].append(buffer_id)
 
-                for buffers, mapper_kind in (
-                    (standard_buffers, sharded_mapper_kind),
-                    (replicated_buffers, MapperKind.REPLICATED),
-                ):
+                for mapper_kind in mapper_kind_order:
+                    buffers = buffers_by_mapper_kind.get(mapper_kind, [])
                     if not buffers:
                         continue
                     for desc in manager.impl.get_aggregated_pages(buffers):

--- a/tensorrt_llm/_torch/disaggregation/resource/page.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/page.py
@@ -36,6 +36,9 @@ class MapperKind(IntEnum):
         token-major ``[token, head, dim]``. Heterogeneous-head transfer must
         select the corresponding head slice inside every token rather than a
         single contiguous head-major range.
+    MIXED: PoolView describes one physical V2 pool whose individual buffer
+        entries use different mapper kinds. ``buffer_mapper_kinds`` carries
+        the per-entry kinds; managers cannot declare MIXED directly.
 
     INDEXED and FLAT retain the legacy full-slot byte arithmetic unless a
     PoolView supplies a logical ``byte_offset`` / ``bytes_per_region``.
@@ -49,6 +52,7 @@ class MapperKind(IntEnum):
     FLAT = 1
     REPLICATED = 2
     NHD = 3
+    MIXED = 4
 
 
 @dataclass
@@ -123,6 +127,11 @@ class PoolView:
             are equal. Disagg never enumerates the role-name vocabulary —
             adding a new role on the manager side requires no disagg change.
         mapper_kind: Closed-set discriminator for picking the Mapper family.
+        buffer_roles: Native role string for each ``buffer_entries`` item.
+            Empty for legacy page tables whose view is homogeneous.
+        buffer_mapper_kinds: Mapper kind for each ``buffer_entries`` item.
+            Empty for legacy page tables, where ``mapper_kind`` applies to
+            the complete view.
         byte_offset: Byte offset of this logical view from the physical pool's
             slot base. Defaults to zero for legacy full-slot views.
         bytes_per_region: Number of bytes transferred from each slot. ``None``
@@ -133,8 +142,23 @@ class PoolView:
     buffer_entries: np.ndarray  # dtype=BUFFER_ENTRY_DTYPE
     pool_role: FrozenSet[str] = field(default_factory=frozenset)
     mapper_kind: MapperKind = MapperKind.INDEXED
+    buffer_roles: tuple[str, ...] = ()
+    buffer_mapper_kinds: tuple[MapperKind, ...] = ()
     byte_offset: int = 0
     bytes_per_region: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        num_entries = len(self.buffer_entries)
+        if self.buffer_roles and len(self.buffer_roles) != num_entries:
+            raise ValueError(
+                "PoolView buffer_roles must align with buffer_entries: "
+                f"roles={len(self.buffer_roles)}, entries={num_entries}"
+            )
+        if self.buffer_mapper_kinds and len(self.buffer_mapper_kinds) != num_entries:
+            raise ValueError(
+                "PoolView buffer_mapper_kinds must align with buffer_entries: "
+                f"kinds={len(self.buffer_mapper_kinds)}, entries={num_entries}"
+            )
 
     def to_dict(self) -> dict:
         return {
@@ -142,6 +166,8 @@ class PoolView:
             "buffer_entries": self.buffer_entries.tolist(),
             "pool_role": sorted(self.pool_role),
             "mapper_kind": int(self.mapper_kind),
+            "buffer_roles": list(self.buffer_roles),
+            "buffer_mapper_kinds": [int(kind) for kind in self.buffer_mapper_kinds],
             "byte_offset": int(self.byte_offset),
             "bytes_per_region": (
                 int(self.bytes_per_region) if self.bytes_per_region is not None else None
@@ -161,6 +187,10 @@ class PoolView:
             ),
             pool_role=frozenset(data["pool_role"]),
             mapper_kind=MapperKind(int(data["mapper_kind"])),
+            buffer_roles=tuple(data.get("buffer_roles", ())),
+            buffer_mapper_kinds=tuple(
+                MapperKind(int(kind)) for kind in data.get("buffer_mapper_kinds", ())
+            ),
             byte_offset=int(data.get("byte_offset", 0)),
             bytes_per_region=(
                 int(data["bytes_per_region"]) if data.get("bytes_per_region") is not None else None

--- a/tensorrt_llm/_torch/disaggregation/resource/page.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/page.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -16,32 +31,38 @@ BUFFER_ENTRY_DTYPE = np.dtype(
 
 
 class MapperKind(IntEnum):
-    """Slot metadata shape — selects how disagg derives the pool's layer set.
+    """Transfer semantics of one physical pool's bytes.
 
-    INDEXED: PoolView.buffer_entries lists ``(local_layer_id, offset, size)``
-        per buffer. Disagg reads ``local_layer_id`` to know *which* layers
-        from the LG live in this pool (a pool may cover a subset when V2
-        splits an LG into multiple pools by buffer-size class). The
-        ``offset`` / ``size`` columns are carried for future use but are not
-        currently consumed at byte-transfer time.
-    FLAT:    PoolView.buffer_entries is empty. Disagg assumes the pool
-        covers *all* layers of the LG, packed equal-sized in
-        ``local_layers`` order. Used today by the DSA (DeepSeek Sparse
-        Attention, v3.2) indexer K cache pool, whose slot layout is a dense
-        ``(numLayers, kvFactor, blockSize)`` array.
-    REPLICATED: PoolView describes an indexed logical byte range that is
-        replicated across TP ranks. It is copied without KV-head remapping,
-        and fan-in routing selects one owning sender per destination group.
-    NHD: PoolView describes ordinary K/V whose per-buffer storage is
-        token-major ``[token, head, dim]``. Heterogeneous-head transfer must
-        select the corresponding head slice inside every token rather than a
-        single contiguous head-major range.
-    MIXED: PoolView describes one physical V2 pool whose individual buffer
-        entries use different mapper kinds. ``buffer_mapper_kinds`` carries
-        the per-entry kinds; managers cannot declare MIXED directly.
+    Every PoolView carries ``buffer_entries`` listing
+    ``(local_layer_id, offset, size)`` per buffer; the view's exact layer
+    set always comes from those entries (a view may cover a subset of the
+    LG when V2 splits an LG into multiple pools by buffer-size class, or
+    when a role class exists only on some layers). The kind selects how
+    bytes move between heterogeneous topologies:
 
-    INDEXED and FLAT retain the legacy full-slot byte arithmetic unless a
-    PoolView supplies a logical ``byte_offset`` / ``bytes_per_region``.
+    INDEXED: Head-major (HND) K/V — the layout written by the TRTLLM
+        attention kernels and the default for V1 and standard V2 managers.
+        Heterogeneous-head transfer selects one contiguous head-major range
+        per K/V buffer.
+    REPLICATED: The pool holds bytes that are identical on every TP rank
+        (MiniMax M3 index-key, DSA indexer K). Copied without KV-head
+        remapping using per-layer strides; fan-in routing elects one owning
+        sender per destination so each peer receives exactly one copy.
+    NHD: Ordinary K/V whose per-buffer storage is token-major
+        ``[token, head, dim]``. Heterogeneous-head transfer must select the
+        corresponding head slice inside every token rather than a single
+        contiguous head-major range.
+
+    A physical pool may hold roles of different kinds: V2 storage coalesces
+    buffers purely by ``(life_cycle, buffer size)``, so e.g. MiniMax M3's
+    replicated index-K shares the K/V pool at TP degrees where their
+    per-block sizes coincide. The page-table builder therefore emits one
+    PoolView per ``(physical pool, mapper kind)`` — a view covers exactly
+    the bytes of one role class, and its per-layer byte ranges come from
+    ``buffer_entries`` (offsets are per layer because another class may
+    interleave between layers; only the per-layer size is uniform, recorded
+    in ``bytes_per_layer``). View count per layer group is bounded by the
+    number of role classes, never by layer count.
 
     Mamba state pools do not use this enum: Mamba's transfer is dispatched
     through :class:`MambaPolicy` which hard-codes the ``is_conv`` switch and
@@ -49,10 +70,8 @@ class MapperKind(IntEnum):
     """
 
     INDEXED = 0
-    FLAT = 1
-    REPLICATED = 2
-    NHD = 3
-    MIXED = 4
+    REPLICATED = 1
+    NHD = 2
 
 
 @dataclass
@@ -119,7 +138,7 @@ class PoolView:
         pool_idx: Index of the physical pool within its pool group.
         buffer_entries: Structured array using ``BUFFER_ENTRY_DTYPE``. Each
             entry records a buffer's ``local_layer_id`` and its byte ``offset``
-            and ``size`` within the pool slot. FLAT pools have no entries.
+            and ``size`` within the pool slot.
         pool_role: Set of native role-name strings (whatever the cache manager
             uses, e.g. ``"key"`` / ``"value"`` / ``"deepseek_v4_swa"``) that
             live in this pool. Used as the *equivalence label* for peer-to-peer
@@ -127,38 +146,19 @@ class PoolView:
             are equal. Disagg never enumerates the role-name vocabulary —
             adding a new role on the manager side requires no disagg change.
         mapper_kind: Closed-set discriminator for picking the Mapper family.
-        buffer_roles: Native role string for each ``buffer_entries`` item.
-            Empty for legacy page tables whose view is homogeneous.
-        buffer_mapper_kinds: Mapper kind for each ``buffer_entries`` item.
-            Empty for legacy page tables, where ``mapper_kind`` applies to
-            the complete view.
-        byte_offset: Byte offset of this logical view from the physical pool's
-            slot base. Defaults to zero for legacy full-slot views.
-        bytes_per_region: Number of bytes transferred from each slot. ``None``
-            means the full physical slot for backward compatibility.
+        bytes_per_layer: Uniform byte size of one layer's region within the
+            slot. The per-layer *offsets* live in ``buffer_entries``; only
+            the size is uniform, because a slot may interleave other role
+            classes between layers, making the layer stride non-uniform.
+            Set for every kind; ``None`` only in tables serialized by older
+            builders, where consumers re-derive it from the entries.
     """
 
     pool_idx: int
     buffer_entries: np.ndarray  # dtype=BUFFER_ENTRY_DTYPE
     pool_role: FrozenSet[str] = field(default_factory=frozenset)
     mapper_kind: MapperKind = MapperKind.INDEXED
-    buffer_roles: tuple[str, ...] = ()
-    buffer_mapper_kinds: tuple[MapperKind, ...] = ()
-    byte_offset: int = 0
-    bytes_per_region: Optional[int] = None
-
-    def __post_init__(self) -> None:
-        num_entries = len(self.buffer_entries)
-        if self.buffer_roles and len(self.buffer_roles) != num_entries:
-            raise ValueError(
-                "PoolView buffer_roles must align with buffer_entries: "
-                f"roles={len(self.buffer_roles)}, entries={num_entries}"
-            )
-        if self.buffer_mapper_kinds and len(self.buffer_mapper_kinds) != num_entries:
-            raise ValueError(
-                "PoolView buffer_mapper_kinds must align with buffer_entries: "
-                f"kinds={len(self.buffer_mapper_kinds)}, entries={num_entries}"
-            )
+    bytes_per_layer: Optional[int] = None
 
     def to_dict(self) -> dict:
         return {
@@ -166,11 +166,8 @@ class PoolView:
             "buffer_entries": self.buffer_entries.tolist(),
             "pool_role": sorted(self.pool_role),
             "mapper_kind": int(self.mapper_kind),
-            "buffer_roles": list(self.buffer_roles),
-            "buffer_mapper_kinds": [int(kind) for kind in self.buffer_mapper_kinds],
-            "byte_offset": int(self.byte_offset),
-            "bytes_per_region": (
-                int(self.bytes_per_region) if self.bytes_per_region is not None else None
+            "bytes_per_layer": (
+                int(self.bytes_per_layer) if self.bytes_per_layer is not None else None
             ),
         }
 
@@ -187,13 +184,8 @@ class PoolView:
             ),
             pool_role=frozenset(data["pool_role"]),
             mapper_kind=MapperKind(int(data["mapper_kind"])),
-            buffer_roles=tuple(data.get("buffer_roles", ())),
-            buffer_mapper_kinds=tuple(
-                MapperKind(int(kind)) for kind in data.get("buffer_mapper_kinds", ())
-            ),
-            byte_offset=int(data.get("byte_offset", 0)),
-            bytes_per_region=(
-                int(data["bytes_per_region"]) if data.get("bytes_per_region") is not None else None
+            bytes_per_layer=(
+                int(data["bytes_per_layer"]) if data.get("bytes_per_layer") is not None else None
             ),
         )
 

--- a/tensorrt_llm/_torch/disaggregation/resource/page.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/page.py
@@ -29,10 +29,16 @@ class MapperKind(IntEnum):
         ``local_layers`` order. Used today by the DSA (DeepSeek Sparse
         Attention, v3.2) indexer K cache pool, whose slot layout is a dense
         ``(numLayers, kvFactor, blockSize)`` array.
+    REPLICATED: PoolView describes an indexed logical byte range that is
+        replicated across TP ranks. It is copied without KV-head remapping,
+        and fan-in routing selects one owning sender per destination group.
+    NHD: PoolView describes ordinary K/V whose per-buffer storage is
+        token-major ``[token, head, dim]``. Heterogeneous-head transfer must
+        select the corresponding head slice inside every token rather than a
+        single contiguous head-major range.
 
-    Byte arithmetic is the same for both kinds: per-layer stride is
-    ``slot_bytes // num_layers``. The kind only affects how disagg discovers
-    the pool's layer set during pool matching.
+    INDEXED and FLAT retain the legacy full-slot byte arithmetic unless a
+    PoolView supplies a logical ``byte_offset`` / ``bytes_per_region``.
 
     Mamba state pools do not use this enum: Mamba's transfer is dispatched
     through :class:`MambaPolicy` which hard-codes the ``is_conv`` switch and
@@ -41,6 +47,8 @@ class MapperKind(IntEnum):
 
     INDEXED = 0
     FLAT = 1
+    REPLICATED = 2
+    NHD = 3
 
 
 @dataclass
@@ -115,12 +123,18 @@ class PoolView:
             are equal. Disagg never enumerates the role-name vocabulary —
             adding a new role on the manager side requires no disagg change.
         mapper_kind: Closed-set discriminator for picking the Mapper family.
+        byte_offset: Byte offset of this logical view from the physical pool's
+            slot base. Defaults to zero for legacy full-slot views.
+        bytes_per_region: Number of bytes transferred from each slot. ``None``
+            means the full physical slot for backward compatibility.
     """
 
     pool_idx: int
     buffer_entries: np.ndarray  # dtype=BUFFER_ENTRY_DTYPE
     pool_role: FrozenSet[str] = field(default_factory=frozenset)
     mapper_kind: MapperKind = MapperKind.INDEXED
+    byte_offset: int = 0
+    bytes_per_region: Optional[int] = None
 
     def to_dict(self) -> dict:
         return {
@@ -128,6 +142,10 @@ class PoolView:
             "buffer_entries": self.buffer_entries.tolist(),
             "pool_role": sorted(self.pool_role),
             "mapper_kind": int(self.mapper_kind),
+            "byte_offset": int(self.byte_offset),
+            "bytes_per_region": (
+                int(self.bytes_per_region) if self.bytes_per_region is not None else None
+            ),
         }
 
     @staticmethod
@@ -143,6 +161,10 @@ class PoolView:
             ),
             pool_role=frozenset(data["pool_role"]),
             mapper_kind=MapperKind(int(data["mapper_kind"])),
+            byte_offset=int(data.get("byte_offset", 0)),
+            bytes_per_region=(
+                int(data["bytes_per_region"]) if data.get("bytes_per_region") is not None else None
+            ),
         )
 
 

--- a/tensorrt_llm/_torch/disaggregation/resource/utils.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/utils.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from typing import Dict, List, Set
@@ -31,6 +46,64 @@ def get_slot_address(pool: PhysicalPool, slot_id: int) -> int:
 # -------------------------------------------------------------------------
 # PoolView helpers
 # -------------------------------------------------------------------------
+
+
+def compute_layer_byte_ranges(
+    buffer_entries,
+    *,
+    declared_bytes_per_layer: "int | None" = None,
+    context: str = "PoolView",
+) -> tuple[Dict[int, int], int]:
+    """Per-layer slot-relative byte offsets from raw buffer entries.
+
+    Returns ``({local_layer_id: start_offset}, bytes_per_layer)``. A layer's
+    region is the concatenation of its buffer entries, which must be
+    contiguous within the slot; the region size must be uniform across
+    layers (the slot may interleave other role classes between layers, so
+    only the *size* is uniform — offsets are per layer). ``context`` labels
+    error messages; ``declared_bytes_per_layer`` cross-checks a size that
+    was recorded elsewhere.
+    """
+    starts: Dict[int, int] = {}
+    totals: Dict[int, int] = {}
+    entries_by_layer: Dict[int, list] = {}
+    for entry in buffer_entries:
+        entries_by_layer.setdefault(int(entry["local_layer_id"]), []).append(
+            (int(entry["offset"]), int(entry["size"]))
+        )
+    if not entries_by_layer:
+        raise ValueError(f"{context} has no buffer entries; per-layer byte ranges are undefined")
+    for layer_id, spans in entries_by_layer.items():
+        spans.sort()
+        for (off, size), (next_off, _) in zip(spans, spans[1:]):
+            if off + size != next_off:
+                raise ValueError(
+                    f"{context} layer {layer_id} buffers are "
+                    f"not contiguous: [{off}, {off + size}) is followed by offset {next_off}"
+                )
+        starts[layer_id] = spans[0][0]
+        totals[layer_id] = sum(size for _, size in spans)
+    distinct_totals = set(totals.values())
+    if len(distinct_totals) != 1:
+        raise ValueError(
+            f"{context} per-layer region sizes are not uniform: {sorted(totals.items())}"
+        )
+    bytes_per_layer = distinct_totals.pop()
+    if declared_bytes_per_layer is not None and declared_bytes_per_layer != bytes_per_layer:
+        raise ValueError(
+            f"{context} declares bytes_per_layer={declared_bytes_per_layer} but buffer "
+            f"entries sum to {bytes_per_layer} per layer"
+        )
+    return starts, bytes_per_layer
+
+
+def get_layer_byte_ranges(pool_view: PoolView) -> tuple[Dict[int, int], int]:
+    """Per-layer byte ranges of a view; see :func:`compute_layer_byte_ranges`."""
+    return compute_layer_byte_ranges(
+        pool_view.buffer_entries,
+        declared_bytes_per_layer=pool_view.bytes_per_layer,
+        context=f"PoolView(pool_idx={pool_view.pool_idx}, role={sorted(pool_view.pool_role)})",
+    )
 
 
 def get_unique_layers(pool_view: PoolView) -> Set[int]:

--- a/tensorrt_llm/_torch/disaggregation/resource/utils.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/utils.py
@@ -17,14 +17,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Set
 
-from .page import (
-    AttentionLayerGroup,
-    KVCachePageTable,
-    MambaLayerGroup,
-    MapperKind,
-    PhysicalPool,
-    PoolView,
-)
+from .page import AttentionLayerGroup, KVCachePageTable, MambaLayerGroup, PhysicalPool, PoolView
 
 # -------------------------------------------------------------------------
 # PhysicalPool helpers
@@ -114,23 +107,6 @@ def get_unique_layers(pool_view: PoolView) -> Set[int]:
 def get_num_buffer_entries(pool_view: PoolView) -> int:
     """Number of buffer entries."""
     return len(pool_view.buffer_entries)
-
-
-def get_buffer_mapper_kinds(pool_view: PoolView) -> tuple[MapperKind, ...]:
-    """Return one mapper kind per buffer entry.
-
-    Legacy page tables omit ``buffer_mapper_kinds`` and use the view-level
-    ``mapper_kind`` for every entry.
-    """
-    if pool_view.buffer_mapper_kinds:
-        return pool_view.buffer_mapper_kinds
-    return (pool_view.mapper_kind,) * len(pool_view.buffer_entries)
-
-
-def get_pool_view_mapper_kinds(pool_view: PoolView) -> frozenset[MapperKind]:
-    """Return all mapper kinds represented by a pool view."""
-    kinds = get_buffer_mapper_kinds(pool_view)
-    return frozenset(kinds) if kinds else frozenset({pool_view.mapper_kind})
 
 
 def get_pool_view_num_layers(pool_view: PoolView) -> int:

--- a/tensorrt_llm/_torch/disaggregation/resource/utils.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/utils.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from typing import Dict, List, Set
 
-from .page import AttentionLayerGroup, KVCachePageTable, MambaLayerGroup, PhysicalPool, PoolView
+from .page import (
+    AttentionLayerGroup,
+    KVCachePageTable,
+    MambaLayerGroup,
+    MapperKind,
+    PhysicalPool,
+    PoolView,
+)
 
 # -------------------------------------------------------------------------
 # PhysicalPool helpers
@@ -34,6 +41,23 @@ def get_unique_layers(pool_view: PoolView) -> Set[int]:
 def get_num_buffer_entries(pool_view: PoolView) -> int:
     """Number of buffer entries."""
     return len(pool_view.buffer_entries)
+
+
+def get_buffer_mapper_kinds(pool_view: PoolView) -> tuple[MapperKind, ...]:
+    """Return one mapper kind per buffer entry.
+
+    Legacy page tables omit ``buffer_mapper_kinds`` and use the view-level
+    ``mapper_kind`` for every entry.
+    """
+    if pool_view.buffer_mapper_kinds:
+        return pool_view.buffer_mapper_kinds
+    return (pool_view.mapper_kind,) * len(pool_view.buffer_entries)
+
+
+def get_pool_view_mapper_kinds(pool_view: PoolView) -> frozenset[MapperKind]:
+    """Return all mapper kinds represented by a pool view."""
+    kinds = get_buffer_mapper_kinds(pool_view)
+    return frozenset(kinds) if kinds else frozenset({pool_view.mapper_kind})
 
 
 def get_pool_view_num_layers(pool_view: PoolView) -> int:

--- a/tensorrt_llm/_torch/disaggregation/resource/utils.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/utils.py
@@ -217,13 +217,24 @@ def get_unique_pool_memory_descs(
 
 def get_layer_to_layer_group(page_table: KVCachePageTable) -> Dict[int, int]:
     """
-    Build ``{global_layer_id: lg_idx}`` mapping
+    Build ``{global_layer_id: lg_idx}`` mapping.
+
+    Layer groups must partition a rank's attention layers: every
+    global_layer_id belongs to exactly one group. Peer matching relies on
+    this, so a duplicate raises instead of silently keeping the last group.
     """
     out: Dict[int, int] = {}
     for lg_idx, lg in enumerate(page_table.layer_groups):
         if isinstance(lg, AttentionLayerGroup):
             for ll in lg.local_layers:
-                out[int(ll.global_layer_id)] = int(lg_idx)
+                gid = int(ll.global_layer_id)
+                if gid in out:
+                    raise ValueError(
+                        f"global_layer_id {gid} appears in layer groups "
+                        f"{out[gid]} and {lg_idx}; layer groups must partition "
+                        "a rank's attention layers"
+                    )
+                out[gid] = int(lg_idx)
     return out
 
 

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -236,6 +236,15 @@ class DisaggPoolViewConfig(NamedTuple):
 
     Returning this capability asks the generic page-table builder to expose
     per-layer, per-role-class logical views instead of opaque whole-slot views.
+
+    Scope: ``sharded_layout`` asserts what the manager's *paired attention
+    backend* actually writes; the pool memory itself is layout-agnostic (see
+    :meth:`KVCacheManagerV2.get_buffers`). Declaring it statically is only
+    valid when the manager and backend form a fixed pair with one layout
+    (e.g. MiniMax M3's sparse backend, always token-major). A manager whose
+    backend selects the layout at runtime (e.g. FlashInfer NHD/HND) must
+    derive this value from the backend configuration instead of hardcoding
+    it.
     """
 
     sharded_layout: DisaggCacheLayout

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -24,6 +24,7 @@ import numpy as np
 import torch
 from strenum import StrEnum
 
+from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.distributed.communicator import Distributed, ReduceOp
 from tensorrt_llm._utils import (
     TensorWrapper,
@@ -218,37 +219,6 @@ class ConversationManager:
     def clear(self) -> None:
         """Clear state after reusable KV-cache blocks have been cleared."""
         self._conversation_states.clear()
-
-
-class DisaggCacheLayout(StrEnum):
-    NHD = "NHD"
-
-
-class DisaggPoolViewConfig(NamedTuple):
-    """Describe model-specific V2 cache views to native disaggregation.
-
-    ``sharded_layout`` describes non-replicated storage; ``NHD`` means
-    token-major ``[token, head, dim]`` bytes and requires token-granular head
-    remapping when peer topologies differ. ``replicated_roles`` identifies
-    side caches that contain the same bytes on every TP rank. Those regions
-    use a strict 1:1 byte copy with no KV-head remapping, and
-    :meth:`PeerRegistrar.should_send_pool` elects one sender during TP fan-in.
-
-    Returning this capability asks the generic page-table builder to expose
-    per-layer, per-role-class logical views instead of opaque whole-slot views.
-
-    Scope: ``sharded_layout`` asserts what the manager's *paired attention
-    backend* actually writes; the pool memory itself is layout-agnostic (see
-    :meth:`KVCacheManagerV2.get_buffers`). Declaring it statically is only
-    valid when the manager and backend form a fixed pair with one layout
-    (e.g. MiniMax M3's sparse backend, always token-major). A manager whose
-    backend selects the layout at runtime (e.g. FlashInfer NHD/HND) must
-    derive this value from the backend configuration instead of hardcoding
-    it.
-    """
-
-    sharded_layout: DisaggCacheLayout
-    replicated_roles: frozenset[DataRole]
 
 
 def _estimate_full_attn_size_per_token(
@@ -1836,16 +1806,23 @@ class KVCacheManagerV2(BaseResourceManager):
         """
         return None
 
-    def get_disagg_pool_view_config(self) -> Optional[DisaggPoolViewConfig]:
-        """Return an explicit logical-pool contract for disaggregation.
+    def get_disagg_role_mapper_kinds(self) -> dict[DataRole, MapperKind]:
+        """Map native cache roles to disaggregation mapper kinds.
 
-        The default ``None`` preserves the legacy whole-slot page table.
-        Model-specific managers may return :class:`DisaggPoolViewConfig`
-        without requiring the shared extractor to inspect private attributes
-        or role names. MiniMax M3, for example, declares NHD K/V plus a
-        replicated index-key side cache.
+        ``Role.ALL`` is the required fallback for roles without an explicit
+        entry. The default preserves the legacy whole-slot ``INDEXED`` page
+        table. Model-specific managers may declare logical layouts without
+        requiring the shared extractor to inspect private attributes or role
+        names. MiniMax M3, for example, maps ordinary K/V to ``NHD`` and its
+        replicated index-key side cache to ``REPLICATED``.
+
+        Pool memory is layout-agnostic; this declaration describes what the
+        manager's paired attention backend actually writes. A static mapping
+        is valid only for a fixed manager/backend pair. A manager whose backend
+        selects the layout at runtime must derive the mapping from that
+        backend's configuration.
         """
-        return None
+        return {Role.ALL: MapperKind.INDEXED}
 
     @property
     def blocks_in_primary_pool(self) -> int:

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -220,6 +220,28 @@ class ConversationManager:
         self._conversation_states.clear()
 
 
+class DisaggCacheLayout(StrEnum):
+    NHD = "NHD"
+
+
+class DisaggPoolViewConfig(NamedTuple):
+    """Describe model-specific V2 cache views to native disaggregation.
+
+    ``sharded_layout`` describes non-replicated storage; ``NHD`` means
+    token-major ``[token, head, dim]`` bytes and requires token-granular head
+    remapping when peer topologies differ. ``replicated_roles`` identifies
+    side caches that contain the same bytes on every TP rank. Those regions
+    use a strict 1:1 byte copy with no KV-head remapping, and
+    :meth:`PeerRegistrar.should_send_pool` elects one sender during TP fan-in.
+
+    Returning this capability asks the generic page-table builder to expose
+    per-layer, per-role-class logical views instead of opaque whole-slot views.
+    """
+
+    sharded_layout: DisaggCacheLayout
+    replicated_roles: frozenset[DataRole]
+
+
 def _estimate_full_attn_size_per_token(
     layer_sizes: Sequence[int], attention_windows: Sequence[Optional[int]]
 ) -> int:
@@ -1155,12 +1177,49 @@ class KVCacheManagerV2(BaseResourceManager):
 
         self._log_kv_cache_pool_lifecycle_mapping()
 
-    def _build_pool_mapping_tensors(self):
-        """Build the (kv_cache_pool_pointers, kv_cache_pool_mapping) tensors.
+    def _prepare_page_table_tensor(self, index_mapper_capacity: int) -> None:
+        # Sparse managers can add roles whose physical pool stride does not
+        # follow the base K/V-only formula, so keep mapping construction virtual.
+        (self.kv_cache_pool_pointers, self.kv_cache_pool_mapping) = (
+            self._build_pool_mapping_tensors()
+        )
 
-        An overridable hook for subclasses whose pools coalesce extra
-        per-layer buffers alongside K/V.
-        """
+        self.index_scales = torch.empty(
+            self.num_pools, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
+        )
+        self.kv_offset = torch.empty(
+            self.num_pools, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
+        )
+        for pool_id in range(self.num_pools):
+            layer_id = self.impl.layer_grouping[pool_id][0]
+            self.index_scales[pool_id] = self.impl.get_page_index_scale(layer_id, Role.KEY)
+            if self.kv_cache_type != CacheTypeCpp.SELFKONLY:
+                self.kv_offset[pool_id] = exact_div(
+                    self.impl.get_mem_pool_base_address(layer_id, Role.VALUE, PageIndexMode.SHARED)
+                    - self.impl.get_mem_pool_base_address(layer_id, Role.KEY, PageIndexMode.SHARED),
+                    self.impl.get_page_stride(layer_id, Role.KEY),
+                )
+            else:
+                self.kv_offset[pool_id] = 0
+        # Plain-int mirror of index_scales so the per-step block-table build
+        # does not index a tensor per request (see get_batch_cache_indices*).
+        self._index_scale_ints: List[int] = self.index_scales.tolist()
+
+        # Keep unused block offsets as safe block index 0.
+        self.host_kv_cache_block_offsets = torch.zeros(
+            self.num_pools,
+            index_mapper_capacity * self.max_beam_width,
+            2,  # key and value
+            self.max_blocks_per_seq,
+            dtype=torch.int32,
+            pin_memory=prefer_pinned(),
+            device="cpu",
+        )
+        if self.enable_swa_scratch_reuse:
+            self._prepare_swa_scratch_copy_tensors(index_mapper_capacity)
+
+    def _build_pool_mapping_tensors(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build the default K/V pool pointers and per-layer pool offsets."""
         kv_cache_pool_pointers_list = []
         kv_cache_pool_mapping_list = []
         block_scale_pool_pointers_list = []
@@ -1271,42 +1330,6 @@ class KVCacheManagerV2(BaseResourceManager):
             pin_memory=prefer_pinned(),
         )
         return kv_cache_pool_pointers, kv_cache_pool_mapping
-
-    def _prepare_page_table_tensor(self, index_mapper_capacity: int) -> None:
-        self.kv_cache_pool_pointers, self.kv_cache_pool_mapping = self._build_pool_mapping_tensors()
-        self.index_scales = torch.empty(
-            self.num_pools, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
-        )
-        self.kv_offset = torch.empty(
-            self.num_pools, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
-        )
-        for pool_id in range(self.num_pools):
-            layer_id = self.impl.layer_grouping[pool_id][0]
-            self.index_scales[pool_id] = self.impl.get_page_index_scale(layer_id, Role.KEY)
-            if self.kv_cache_type != CacheTypeCpp.SELFKONLY:
-                self.kv_offset[pool_id] = exact_div(
-                    self.impl.get_mem_pool_base_address(layer_id, Role.VALUE, PageIndexMode.SHARED)
-                    - self.impl.get_mem_pool_base_address(layer_id, Role.KEY, PageIndexMode.SHARED),
-                    self.impl.get_page_stride(layer_id, Role.KEY),
-                )
-            else:
-                self.kv_offset[pool_id] = 0
-        # Plain-int mirror of index_scales so the per-step block-table build
-        # does not index a tensor per request (see get_batch_cache_indices*).
-        self._index_scale_ints: List[int] = self.index_scales.tolist()
-
-        # Keep unused block offsets as safe block index 0.
-        self.host_kv_cache_block_offsets = torch.zeros(
-            self.num_pools,
-            index_mapper_capacity * self.max_beam_width,
-            2,  # key and value
-            self.max_blocks_per_seq,
-            dtype=torch.int32,
-            pin_memory=prefer_pinned(),
-            device="cpu",
-        )
-        if self.enable_swa_scratch_reuse:
-            self._prepare_swa_scratch_copy_tensors(index_mapper_capacity)
 
     def _get_runtime_cache_size_layer_components(self) -> tuple[List[int], List[Optional[int]]]:
         layer_sizes = []
@@ -1801,6 +1824,17 @@ class KVCacheManagerV2(BaseResourceManager):
         buffers built in :meth:`_build_base_config`. The block storage
         groups buffers by lifecycle and size with an opaque role key, so
         new roles do not require C++ changes.
+        """
+        return None
+
+    def get_disagg_pool_view_config(self) -> Optional[DisaggPoolViewConfig]:
+        """Return an explicit logical-pool contract for disaggregation.
+
+        The default ``None`` preserves the legacy whole-slot page table.
+        Model-specific managers may return :class:`DisaggPoolViewConfig`
+        without requiring the shared extractor to inspect private attributes
+        or role names. MiniMax M3, for example, declares NHD K/V plus a
+        replicated index-key side cache.
         """
         return None
 

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1157,48 +1157,6 @@ class KVCacheManagerV2(BaseResourceManager):
         self._log_kv_cache_pool_lifecycle_mapping()
 
     def _prepare_page_table_tensor(self, index_mapper_capacity: int) -> None:
-        # Sparse managers can add roles whose physical pool stride does not
-        # follow the base K/V-only formula, so keep mapping construction virtual.
-        (self.kv_cache_pool_pointers, self.kv_cache_pool_mapping) = (
-            self._build_pool_mapping_tensors()
-        )
-
-        self.index_scales = torch.empty(
-            self.num_pools, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
-        )
-        self.kv_offset = torch.empty(
-            self.num_pools, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
-        )
-        for pool_id in range(self.num_pools):
-            layer_id = self.impl.layer_grouping[pool_id][0]
-            self.index_scales[pool_id] = self.impl.get_page_index_scale(layer_id, Role.KEY)
-            if self.kv_cache_type != CacheTypeCpp.SELFKONLY:
-                self.kv_offset[pool_id] = exact_div(
-                    self.impl.get_mem_pool_base_address(layer_id, Role.VALUE, PageIndexMode.SHARED)
-                    - self.impl.get_mem_pool_base_address(layer_id, Role.KEY, PageIndexMode.SHARED),
-                    self.impl.get_page_stride(layer_id, Role.KEY),
-                )
-            else:
-                self.kv_offset[pool_id] = 0
-        # Plain-int mirror of index_scales so the per-step block-table build
-        # does not index a tensor per request (see get_batch_cache_indices*).
-        self._index_scale_ints: List[int] = self.index_scales.tolist()
-
-        # Keep unused block offsets as safe block index 0.
-        self.host_kv_cache_block_offsets = torch.zeros(
-            self.num_pools,
-            index_mapper_capacity * self.max_beam_width,
-            2,  # key and value
-            self.max_blocks_per_seq,
-            dtype=torch.int32,
-            pin_memory=prefer_pinned(),
-            device="cpu",
-        )
-        if self.enable_swa_scratch_reuse:
-            self._prepare_swa_scratch_copy_tensors(index_mapper_capacity)
-
-    def _build_pool_mapping_tensors(self) -> tuple[torch.Tensor, torch.Tensor]:
-        """Build the default K/V pool pointers and per-layer pool offsets."""
         kv_cache_pool_pointers_list = []
         kv_cache_pool_mapping_list = []
         block_scale_pool_pointers_list = []
@@ -1245,23 +1203,11 @@ class KVCacheManagerV2(BaseResourceManager):
 
             for layer_id in typed_range(LayerId(self.num_local_layers)):
                 layer_group_id = self.impl.get_layer_group_id(layer_id)
-                if self.dtype != DataType.NVFP4:
-                    key_base_addr = kv_cache_pool_pointers_list[layer_group_id][0]
-                    addr_offset = (
-                        self.impl.get_mem_pool_base_address(
-                            layer_id, Role.KEY, PageIndexMode.SHARED
-                        )
-                        - key_base_addr
-                    )
-                else:
-                    key_base_addr = kv_cache_pool_pointers_list[layer_group_id][0]
+                key_base_addr = kv_cache_pool_pointers_list[layer_group_id][0]
+                offset = self._kv_pool_mapping_offset(layer_id, layer_group_id, key_base_addr)
+
+                if self.dtype == DataType.NVFP4:
                     block_scale_base_addr = block_scale_pool_pointers_list[layer_group_id][0]
-                    addr_offset = (
-                        self.impl.get_mem_pool_base_address(
-                            layer_id, Role.KEY, PageIndexMode.SHARED
-                        )
-                        - key_base_addr
-                    )
                     block_scale_addr_offset = (
                         self.impl.get_mem_pool_base_address(
                             layer_id, Role.KEY_BLOCK_SCALE, PageIndexMode.SHARED
@@ -1274,14 +1220,6 @@ class KVCacheManagerV2(BaseResourceManager):
                         * self.kv_factor
                         * self.tokens_per_block,
                     )
-                offset = exact_div(
-                    addr_offset,
-                    self.get_layer_bytes_per_token(layer_id, Role.KEY)
-                    * self.kv_factor
-                    * self.tokens_per_block,
-                )
-
-                if self.dtype == DataType.NVFP4:
                     assert block_scale_offset == offset, (
                         "Block scale offset and offset should be the same"
                     )
@@ -1296,19 +1234,74 @@ class KVCacheManagerV2(BaseResourceManager):
                     [pool_pointers[1], block_scale_pool_pointers[1]],
                 ]
 
-        kv_cache_pool_pointers = torch.tensor(
+        self.kv_cache_pool_pointers = torch.tensor(
             kv_cache_pool_pointers_list,
             dtype=torch.int64,
             device="cpu",
             pin_memory=prefer_pinned(),
         )
-        kv_cache_pool_mapping = torch.tensor(
+        self.kv_cache_pool_mapping = torch.tensor(
             kv_cache_pool_mapping_list,
             dtype=torch.int32,
             device="cpu",
             pin_memory=prefer_pinned(),
         )
-        return kv_cache_pool_pointers, kv_cache_pool_mapping
+        self.index_scales = torch.empty(
+            self.num_pools, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
+        )
+        self.kv_offset = torch.empty(
+            self.num_pools, dtype=torch.int32, pin_memory=prefer_pinned(), device="cpu"
+        )
+        for pool_id in range(self.num_pools):
+            layer_id = self.impl.layer_grouping[pool_id][0]
+            self.index_scales[pool_id] = self.impl.get_page_index_scale(layer_id, Role.KEY)
+            if self.kv_cache_type != CacheTypeCpp.SELFKONLY:
+                self.kv_offset[pool_id] = exact_div(
+                    self.impl.get_mem_pool_base_address(layer_id, Role.VALUE, PageIndexMode.SHARED)
+                    - self.impl.get_mem_pool_base_address(layer_id, Role.KEY, PageIndexMode.SHARED),
+                    self.impl.get_page_stride(layer_id, Role.KEY),
+                )
+            else:
+                self.kv_offset[pool_id] = 0
+        # Plain-int mirror of index_scales so the per-step block-table build
+        # does not index a tensor per request (see get_batch_cache_indices*).
+        self._index_scale_ints: List[int] = self.index_scales.tolist()
+
+        # Keep unused block offsets as safe block index 0.
+        self.host_kv_cache_block_offsets = torch.zeros(
+            self.num_pools,
+            index_mapper_capacity * self.max_beam_width,
+            2,  # key and value
+            self.max_blocks_per_seq,
+            dtype=torch.int32,
+            pin_memory=prefer_pinned(),
+            device="cpu",
+        )
+        if self.enable_swa_scratch_reuse:
+            self._prepare_swa_scratch_copy_tensors(index_mapper_capacity)
+
+    def _kv_pool_mapping_offset(
+        self, layer_id: LayerId, layer_group_id: int, key_base_addr: int
+    ) -> int:
+        """Per-layer offset recorded in ``kv_cache_pool_mapping``.
+
+        The default derives the layer's position within its pool from the K
+        base address, assuming every layer contributes exactly K(+V) to the
+        pool slot so the layer stride is uniform. Managers whose pool slots
+        may interleave extra per-layer buffers between layers (non-uniform
+        layer strides — e.g. MiniMax M3 when the index-K buffer coalesces
+        into the K/V pool) must override this with a positional formula.
+        """
+        addr_offset = (
+            self.impl.get_mem_pool_base_address(layer_id, Role.KEY, PageIndexMode.SHARED)
+            - key_base_addr
+        )
+        return exact_div(
+            addr_offset,
+            self.get_layer_bytes_per_token(layer_id, Role.KEY)
+            * self.kv_factor
+            * self.tokens_per_block,
+        )
 
     def _get_runtime_cache_size_layer_components(self) -> tuple[List[int], List[Optional[int]]]:
         layer_sizes = []
@@ -1810,11 +1803,25 @@ class KVCacheManagerV2(BaseResourceManager):
         """Map native cache roles to disaggregation mapper kinds.
 
         ``Role.ALL`` is the required fallback for roles without an explicit
-        entry. The default preserves the legacy whole-slot ``INDEXED`` page
-        table. Model-specific managers may declare logical layouts without
-        requiring the shared extractor to inspect private attributes or role
-        names. MiniMax M3, for example, maps ordinary K/V to ``NHD`` and its
-        replicated index-key side cache to ``REPLICATED``.
+        entry. The default is the head-major (HND) ``INDEXED`` layout written
+        by the TRTLLM attention kernels — correct for V1 and standard V2
+        managers. ``Role.INDEX_KEY`` defaults to ``REPLICATED``: every
+        index-key side cache shipped so far (DSA indexer-K on V1, MiniMax M3
+        on V2) computes its projection replicated across TP ranks, so the
+        cache bytes are identical per rank; the entry is inert unless a
+        subclass actually registers ``INDEX_KEY`` buffers via
+        ``_extra_buffers_per_layer``. Model-specific managers may declare
+        logical layouts without requiring the shared extractor to inspect
+        private attributes or role names. MiniMax M3, for example, maps
+        ordinary K/V to ``NHD`` and keeps index-key ``REPLICATED``.
+
+        This declaration does not influence storage pooling: V2 storage
+        coalesces buffers purely by ``(life_cycle, buffer size)``, so roles
+        with different transfer semantics may share a pool slot when their
+        per-block sizes coincide (e.g. MiniMax M3 at TP degrees where
+        K == V == INDEX_KEY bytes per block). The disagg page-table builder
+        splits each physical pool into one logical view per mapper kind, so
+        transfer correctness never depends on the coalescing outcome.
 
         Pool memory is layout-agnostic; this declaration describes what the
         manager's paired attention backend actually writes. A static mapping
@@ -1822,7 +1829,7 @@ class KVCacheManagerV2(BaseResourceManager):
         selects the layout at runtime must derive the mapping from that
         backend's configuration.
         """
-        return {Role.ALL: MapperKind.INDEXED}
+        return {Role.ALL: MapperKind.INDEXED, Role.INDEX_KEY: MapperKind.REPLICATED}
 
     @property
     def blocks_in_primary_pool(self) -> int:

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -307,6 +307,9 @@ class KVCacheManager(BaseResourceManager):
         self.mapping = mapping
         self.dtype = dtype
         self.kv_cache_type = kv_cache_type
+        # Consumed by the disaggregation page-table builder to expose the DSA
+        # indexer K cache pool as a REPLICATED pool view.
+        self.enable_indexer_k_cache = enable_indexer_k_cache
         self.spec_config = spec_config
         self.pp_layers, self.num_layers = get_pp_layers(
             num_layers,

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -72,6 +72,7 @@ l0_a10:
   - unittest/disaggregated/test_cluster_storage.py
   - unittest/disaggregated/test_extractor.py
   - unittest/disaggregated/test_peer.py
+  - unittest/disaggregated/test_cache_reuse_adapter.py
   - unittest/disaggregated/test_bounce.py
   - unittest/disaggregated/region/test_block.py
   - unittest/disaggregated/test_mamba_transfer.py

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -86,6 +86,7 @@ l0_h100:
   - unittest/disaggregated/test_request_id.py
   - unittest/disaggregated/test_kv_transfer.py
   - unittest/disaggregated/test_kv_transfer_mp.py
+  - unittest/disaggregated/test_minimax_m3_kv_transfer.py
   # Split the large cache transceiver parametrization into readable chunks.
   # Main transfer matrix.
   - unittest/disaggregated/test_cache_transceiver_single_process.py::test_cache_transceiver -k "v1 and no_window"

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -86,6 +86,9 @@ l0_h100:
   - unittest/disaggregated/test_request_id.py
   - unittest/disaggregated/test_kv_transfer.py
   - unittest/disaggregated/test_kv_transfer_mp.py
+  - unittest/disaggregated/test_transceiver_bounded_polling.py
+  - unittest/disaggregated/test_pool_matching.py
+  - unittest/disaggregated/test_deepseek_v4_kv_transfer.py
   - unittest/disaggregated/test_minimax_m3_kv_transfer.py
   # Split the large cache transceiver parametrization into readable chunks.
   # Main transfer matrix.
@@ -101,6 +104,8 @@ l0_h100:
   # Boundary request lengths.
   - unittest/disaggregated/test_cache_transceiver_single_process.py::test_cache_transceiver_boundary_lengths -k "v1"
   - unittest/disaggregated/test_cache_transceiver_single_process.py::test_cache_transceiver_boundary_lengths -k "v2"
+  # DSA indexer-K side cache (V1, REPLICATED).
+  - unittest/disaggregated/test_cache_transceiver_single_process.py::test_cache_transceiver_v1_dsa_indexer
   - unittest/disaggregated/test_cache_transceiver_harness_report.py
   - unittest/disaggregated/test_cache_transceiver_harness.py
   - unittest/others/test_kv_cache_transceiver.py::test_kv_cache_transceiver_single_process[PYTHON-mha-ctx_fp16_gen_fp16]

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -1280,7 +1280,7 @@ class TestDeepseekV4CacheManager:
 
             pool_mapping = registrar.get_pool_mapping(ctx_rank_info)
             assert pool_mapping
-            for self_pool_key, peer_pool_key in pool_mapping:
+            for self_pool_key, peer_pool_key in pool_mapping.items():
                 registrar.get_kv_map(ctx_rank_info, self_pool_key, peer_pool_key)
         finally:
             ctx_cache_manager.shutdown()

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -1280,7 +1280,7 @@ class TestDeepseekV4CacheManager:
 
             pool_mapping = registrar.get_pool_mapping(ctx_rank_info)
             assert pool_mapping
-            for self_pool_key, peer_pool_key in pool_mapping.items():
+            for self_pool_key, peer_pool_key in pool_mapping:
                 registrar.get_kv_map(ctx_rank_info, self_pool_key, peer_pool_key)
         finally:
             ctx_cache_manager.shutdown()

--- a/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
@@ -1,5 +1,17 @@
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from dataclasses import dataclass, field
 from types import SimpleNamespace
@@ -8,17 +20,10 @@ from unittest.mock import patch
 import pytest
 import torch
 
-import tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 as kv_cache_manager_v2_module
-from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
-from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import (
-    BlockReusePolicy,
-    KVCacheManagerV2,
-    Role,
-)
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import BlockReusePolicy, KVCacheManagerV2
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal.batch_manager import CacheType
-from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
 from tensorrt_llm.conversation_params import ConversationParams
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
@@ -505,54 +510,17 @@ def test_per_conversation_policy_ignores_overlapping_request(
         _free_if_active(manager, request_a)
 
 
-class _PoolMappingOverride(KVCacheManagerV2):
-    def _build_pool_mapping_tensors(self):
-        self.pool_mapping_override_called = True
-        return self.expected_pool_pointers, self.expected_pool_mapping
-
-
-class _FakePoolImpl:
-    layer_grouping = [[0]]
-
-    @staticmethod
-    def get_page_index_scale(_layer_id, _role):
-        return 1
-
-    @staticmethod
-    def get_mem_pool_base_address(_layer_id, role, _page_index_mode):
-        return 16 if role == Role.VALUE else 0
-
-    @staticmethod
-    def get_page_stride(_layer_id, _role):
-        return 16
-
-
-def test_prepare_page_table_uses_subclass_pool_mapping(monkeypatch):
-    """Keep sparse-manager pool mapping overrides on the initialization path."""
-    monkeypatch.setattr(kv_cache_manager_v2_module, "prefer_pinned", lambda: False)
-
-    manager = object.__new__(_PoolMappingOverride)
-    manager.expected_pool_pointers = torch.tensor([[11, 0]], dtype=torch.int64)
-    manager.expected_pool_mapping = torch.tensor([[0, 7]], dtype=torch.int32)
-    manager.pool_mapping_override_called = False
-    manager.num_pools = 1
-    manager.max_beam_width = 1
-    manager.max_blocks_per_seq = 4
-    manager.kv_cache_type = CacheTypeCpp.SELF
-    manager.enable_swa_scratch_reuse = False
-    manager.impl = _FakePoolImpl()
-
-    manager._prepare_page_table_tensor(index_mapper_capacity=2)
-
-    assert manager.pool_mapping_override_called
-    assert manager.kv_cache_pool_pointers is manager.expected_pool_pointers
-    assert manager.kv_cache_pool_mapping is manager.expected_pool_mapping
-    assert manager.index_scales.tolist() == [1]
-    assert manager.kv_offset.tolist() == [1]
-    assert manager.host_kv_cache_block_offsets.shape == (1, 2, 2, 4)
-
-
 def test_disagg_role_mapper_kinds_default_to_indexed():
+    from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
+    from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import Role
+
     manager = object.__new__(KVCacheManagerV2)
 
-    assert manager.get_disagg_role_mapper_kinds() == {Role.ALL: MapperKind.INDEXED}
+    # K/V default to the TRTLLM head-major layout; the index-key side cache
+    # defaults to REPLICATED (every shipped index-K — DSA V1, MiniMax M3 —
+    # is TP-replicated). The INDEX_KEY entry is inert unless a subclass
+    # registers such buffers.
+    assert manager.get_disagg_role_mapper_kinds() == {
+        Role.ALL: MapperKind.INDEXED,
+        Role.INDEX_KEY: MapperKind.REPLICATED,
+    }

--- a/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 import tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 as kv_cache_manager_v2_module
+from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import (
     BlockReusePolicy,
     KVCacheManagerV2,
@@ -551,7 +552,7 @@ def test_prepare_page_table_uses_subclass_pool_mapping(monkeypatch):
     assert manager.host_kv_cache_block_offsets.shape == (1, 2, 2, 4)
 
 
-def test_disagg_pool_view_capability_defaults_to_none():
+def test_disagg_role_mapper_kinds_default_to_indexed():
     manager = object.__new__(KVCacheManagerV2)
 
-    assert manager.get_disagg_pool_view_config() is None
+    assert manager.get_disagg_role_mapper_kinds() == {Role.ALL: MapperKind.INDEXED}

--- a/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
@@ -8,10 +8,16 @@ from unittest.mock import patch
 import pytest
 import torch
 
-from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import BlockReusePolicy, KVCacheManagerV2
+import tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 as kv_cache_manager_v2_module
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import (
+    BlockReusePolicy,
+    KVCacheManagerV2,
+    Role,
+)
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal.batch_manager import CacheType
+from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
 from tensorrt_llm.conversation_params import ConversationParams
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
@@ -496,3 +502,56 @@ def test_per_conversation_policy_ignores_overlapping_request(
         _free_if_active(manager, request_old_prompt)
         _free_if_active(manager, request_b)
         _free_if_active(manager, request_a)
+
+
+class _PoolMappingOverride(KVCacheManagerV2):
+    def _build_pool_mapping_tensors(self):
+        self.pool_mapping_override_called = True
+        return self.expected_pool_pointers, self.expected_pool_mapping
+
+
+class _FakePoolImpl:
+    layer_grouping = [[0]]
+
+    @staticmethod
+    def get_page_index_scale(_layer_id, _role):
+        return 1
+
+    @staticmethod
+    def get_mem_pool_base_address(_layer_id, role, _page_index_mode):
+        return 16 if role == Role.VALUE else 0
+
+    @staticmethod
+    def get_page_stride(_layer_id, _role):
+        return 16
+
+
+def test_prepare_page_table_uses_subclass_pool_mapping(monkeypatch):
+    """Keep sparse-manager pool mapping overrides on the initialization path."""
+    monkeypatch.setattr(kv_cache_manager_v2_module, "prefer_pinned", lambda: False)
+
+    manager = object.__new__(_PoolMappingOverride)
+    manager.expected_pool_pointers = torch.tensor([[11, 0]], dtype=torch.int64)
+    manager.expected_pool_mapping = torch.tensor([[0, 7]], dtype=torch.int32)
+    manager.pool_mapping_override_called = False
+    manager.num_pools = 1
+    manager.max_beam_width = 1
+    manager.max_blocks_per_seq = 4
+    manager.kv_cache_type = CacheTypeCpp.SELF
+    manager.enable_swa_scratch_reuse = False
+    manager.impl = _FakePoolImpl()
+
+    manager._prepare_page_table_tensor(index_mapper_capacity=2)
+
+    assert manager.pool_mapping_override_called
+    assert manager.kv_cache_pool_pointers is manager.expected_pool_pointers
+    assert manager.kv_cache_pool_mapping is manager.expected_pool_mapping
+    assert manager.index_scales.tolist() == [1]
+    assert manager.kv_offset.tolist() == [1]
+    assert manager.host_kv_cache_block_offsets.shape == (1, 2, 2, 4)
+
+
+def test_disagg_pool_view_capability_defaults_to_none():
+    manager = object.__new__(KVCacheManagerV2)
+
+    assert manager.get_disagg_pool_view_config() is None

--- a/tests/unittest/disaggregated/kv_transfer_harness.py
+++ b/tests/unittest/disaggregated/kv_transfer_harness.py
@@ -1,0 +1,514 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Threaded single-process NIXL harness for V2 disaggregated KV transfer tests.
+
+Creates one ``KvCacheTransceiverV2`` per rank inside a single process using
+threads plus a Barrier-based ``Distributed`` mock, then drives a full
+ctx-send / gen-receive transfer and hands verification back to the caller.
+Model specifics (cache-manager construction, pool initialization, post-transfer
+verification) are injected as hooks; see ``test_deepseek_v4_kv_transfer.py``
+and ``test_minimax_m3_kv_transfer.py`` for the two current users.
+"""
+
+import os
+import threading
+import uuid
+from typing import Dict, List, Optional, Protocol, Sequence, TypeVar
+
+import tensorrt_llm
+import tensorrt_llm.bindings
+import tensorrt_llm.tensorrt_llm_transfer_agent_binding  # noqa: F401
+from tensorrt_llm import DisaggregatedParams, Mapping, SamplingParams
+from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestType
+from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
+from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig
+
+# Reduce NIXL threads for unit test: default 8 threads per agent causes heavy
+# contention when creating multiple agents on a single GPU in the same process.
+os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
+
+
+# ---------------------------------------------------------------------------
+# Harness-scale constants shared by all model-specific manager factories
+# ---------------------------------------------------------------------------
+TOKENS_PER_BLOCK = 128
+MAX_SEQ_LEN = 512
+MAX_BATCH_SIZE = 16
+VOCAB_SIZE = 129280
+
+_CacheManagerT = TypeVar("_CacheManagerT", bound=KVCacheManagerV2)
+_CacheManagerT_co = TypeVar("_CacheManagerT_co", bound=KVCacheManagerV2, covariant=True)
+_CacheManagerT_contra = TypeVar("_CacheManagerT_contra", bound=KVCacheManagerV2, contravariant=True)
+
+
+class ManagerFactory(Protocol[_CacheManagerT_co]):
+    """Build one cache manager per rank of a (tp x pp) instance.
+
+    Model-specific knobs (dtype, compress ratios, sparse layers, ...) are
+    closed over by the caller rather than threaded through the harness.
+    """
+
+    def __call__(
+        self,
+        tp: int,
+        pp: int,
+        enable_dp: bool,
+        /,
+    ) -> Sequence[_CacheManagerT_co]: ...
+
+
+class CacheInitializer(Protocol[_CacheManagerT_contra]):
+    def __call__(
+        self,
+        managers: Sequence[_CacheManagerT_contra],
+        tp: int,
+        /,
+        *,
+        seed_base: int = 0,
+        fill_random: bool = True,
+    ) -> None: ...
+
+
+class CacheVerifier(Protocol[_CacheManagerT_contra]):
+    def __call__(
+        self,
+        *,
+        request_lengths: List[int],
+        ctx_managers: Sequence[_CacheManagerT_contra],
+        gen_managers: Sequence[_CacheManagerT_contra],
+        ctx_tp: int,
+        ctx_pp: int,
+        gen_tp: int,
+        gen_pp: int,
+        ctx_enable_dp: bool,
+        gen_enable_dp: bool,
+        ctx_request_ids: List[int],
+        gen_request_ids: List[int],
+    ) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# ThreadSafeDistributed: threading.Barrier-based Distributed mock
+# ---------------------------------------------------------------------------
+class ThreadSafeDistributed:
+    """Distributed mock using threading.Barrier for single-process multi-rank testing.
+
+    Provides the same interface as TorchDistributedWrapper from test_py_cache_transceiver_mp.py
+    but uses Barrier + Lock + shared dict instead of torch.distributed.
+    """
+
+    def __init__(
+        self,
+        local_rank: int,
+        world_size: int,
+        tp_size: int,
+        pp_size: int,
+        tp_rank: int,
+        pp_rank: int,
+        shared: dict,
+    ):
+        self.rank = local_rank
+        self._world_size = world_size
+        self._tp_size = tp_size
+        self._pp_size = pp_size
+        self._tp_rank = tp_rank
+        self._pp_rank = pp_rank
+        self._s = shared
+        self._bcast_idx = 0
+        self._ag_idx = 0
+        self._pp_ag_idx = 0
+        self._tp_ag_idx = 0
+
+    @property
+    def tp_size(self):
+        return self._tp_size
+
+    @property
+    def pp_size(self):
+        return self._pp_size
+
+    @property
+    def world_size(self):
+        return self._world_size
+
+    def broadcast(self, obj, root=0):
+        idx = self._bcast_idx
+        self._bcast_idx += 1
+        key = f"bcast_{idx}"
+        if self.rank == root:
+            self._s[key] = obj
+        self._s["barrier"].wait()
+        result = self._s[key]
+        self._s["barrier"].wait()
+        return result
+
+    def allgather(self, obj):
+        idx = self._ag_idx
+        self._ag_idx += 1
+        key = f"ag_{idx}"
+        with self._s["lock"]:
+            if key not in self._s:
+                self._s[key] = [None] * self._world_size
+            self._s[key][self.rank] = obj
+        self._s["barrier"].wait()
+        result = list(self._s[key])
+        self._s["barrier"].wait()
+        return result
+
+    def pp_allgather(self, obj):
+        idx = self._pp_ag_idx
+        self._pp_ag_idx += 1
+        key = f"pp_ag_{idx}_tp{self._tp_rank}"
+        with self._s["lock"]:
+            if key not in self._s:
+                self._s[key] = [None] * self._pp_size
+            self._s[key][self._pp_rank] = obj
+        self._s["barrier"].wait()
+        result = list(self._s[key])
+        self._s["barrier"].wait()
+        return result
+
+    def tp_allgather(self, obj):
+        idx = self._tp_ag_idx
+        self._tp_ag_idx += 1
+        key = f"tp_ag_{idx}_pp{self._pp_rank}"
+        with self._s["lock"]:
+            if key not in self._s:
+                self._s[key] = [None] * self._tp_size
+            self._s[key][self._tp_rank] = obj
+        self._s["barrier"].wait()
+        result = list(self._s[key])
+        self._s["barrier"].wait()
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Threading helpers
+# ---------------------------------------------------------------------------
+def run_concurrent(items, fn):
+    """Run fn(item) for each item concurrently in threads and propagate errors."""
+    errors = [None] * len(items)
+    results = [None] * len(items)
+
+    def _worker(idx, item):
+        try:
+            results[idx] = fn(item)
+        except Exception as e:
+            errors[idx] = e
+
+    threads = [threading.Thread(target=_worker, args=(i, item)) for i, item in enumerate(items)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    for i, err in enumerate(errors):
+        if err is not None:
+            raise err
+    return results
+
+
+def _create_transceiver_in_thread(rank, mapping, cache_manager, dist_mock, config, results, errors):
+    """Thread target: create one KvCacheTransceiverV2."""
+    try:
+        tc = KvCacheTransceiverV2(
+            mapping=mapping,
+            dist=dist_mock,
+            kv_cache_manager=cache_manager,
+            cache_transceiver_config=config,
+        )
+        results[rank] = tc
+    except Exception as e:
+        errors[rank] = e
+
+
+def create_instance_transceivers(
+    tp: int,
+    pp: int,
+    enable_dp: bool,
+    cache_managers: Sequence[KVCacheManagerV2],
+    config: CacheTransceiverConfig,
+) -> List[KvCacheTransceiverV2]:
+    """Create KvCacheTransceiverV2 for all ranks via threaded init."""
+    world_size = tp * pp
+    shared = {"barrier": threading.Barrier(world_size), "lock": threading.Lock()}
+    results = [None] * world_size
+    errors = [None] * world_size
+    threads = []
+
+    for rank in range(world_size):
+        pp_rank = rank // tp
+        tp_rank = rank % tp
+        mapping = Mapping(
+            world_size=world_size,
+            rank=rank,
+            tp_size=tp,
+            pp_size=pp,
+            enable_attention_dp=enable_dp,
+        )
+        dist_mock = ThreadSafeDistributed(rank, world_size, tp, pp, tp_rank, pp_rank, shared)
+        t = threading.Thread(
+            target=_create_transceiver_in_thread,
+            args=(
+                rank,
+                mapping,
+                cache_managers[rank],
+                dist_mock,
+                config,
+                results,
+                errors,
+            ),
+        )
+        threads.append(t)
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for rank, err in enumerate(errors):
+        if err is not None:
+            raise err
+
+    return results
+
+
+def get_ctx_info_endpoint(tc: KvCacheTransceiverV2) -> Optional[str]:
+    """Extract the context_info_endpoint from a transceiver's disaggregated params."""
+    endpoints = tc.get_disaggregated_params().get("ctx_info_endpoint") or []
+    return endpoints[0] if endpoints else None
+
+
+def get_layers_per_pp(num_layers: int, pp_size: int) -> List[int]:
+    """Return a list of layer counts per PP rank (mirrors C++ getLayerNumPPRank).
+
+    When num_layers is not evenly divisible by pp_size, the first
+    (num_layers % pp_size) ranks get one extra layer.
+    Matches Mapping.pp_layers / torch.tensor_split behaviour.
+    """
+    base = num_layers // pp_size
+    extra = num_layers % pp_size
+    return [base + (1 if r < extra else 0) for r in range(pp_size)]
+
+
+def run_kv_transfer_test(
+    ctx_tp: int,
+    ctx_pp: int,
+    gen_tp: int,
+    gen_pp: int,
+    ctx_enable_dp: bool,
+    gen_enable_dp: bool,
+    update_before_transfer: bool = True,
+    *,
+    manager_factory: ManagerFactory[_CacheManagerT],
+    init_fn: CacheInitializer[_CacheManagerT],
+    verify_fn: CacheVerifier[_CacheManagerT],
+) -> None:
+    """Run one ctx->gen KV transfer with injectable model-specific cache hooks."""
+    ctx_world = ctx_tp * ctx_pp
+    gen_world = gen_tp * gen_pp
+
+    # Mix of block-aligned and non-aligned lengths for boundary testing.
+    # TOKENS_PER_BLOCK=128: 65=half+1, 256=2x exact, 129=1x+1, 383=3x-1
+    request_lengths = [65, 256, 129, 383]
+
+    # ===== 1. Create cache managers =====
+    ctx_managers = list(manager_factory(ctx_tp, ctx_pp, ctx_enable_dp))
+    gen_managers = list(manager_factory(gen_tp, gen_pp, gen_enable_dp))
+
+    # ===== 2. Initialize data =====
+    # ctx: random data, seed=pp_rank (same across TP, different across PP)
+    init_fn(ctx_managers, ctx_tp, seed_base=1000, fill_random=True)
+    # gen: zeros
+    init_fn(gen_managers, gen_tp, fill_random=False)
+
+    # ===== 3. Create KvCacheTransceiverV2 instances (threaded init) =====
+    config = CacheTransceiverConfig(
+        backend="NIXL",
+        transceiver_runtime="PYTHON",
+        max_tokens_in_buffer=512,
+    )
+    ctx_tcs = create_instance_transceivers(ctx_tp, ctx_pp, ctx_enable_dp, ctx_managers, config)
+    gen_tcs = create_instance_transceivers(gen_tp, gen_pp, gen_enable_dp, gen_managers, config)
+
+    try:
+        ctx_info_endpoint = get_ctx_info_endpoint(ctx_tcs[0])
+
+        # ===== 4. Create requests and determine handle map =====
+        # handle_map: rank -> [(req_idx, ctx_request, gen_request)]
+        ctx_handle_map: Dict[int, List] = {r: [] for r in range(ctx_world)}
+        gen_handle_map: Dict[int, List] = {r: [] for r in range(gen_world)}
+        ctx_request_ids: List[int] = []
+        gen_request_ids: List[int] = []
+
+        sampling_params = SamplingParams()
+
+        for req_idx, req_len in enumerate(request_lengths):
+            unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
+            ctx_rid = req_idx * 2
+            gen_rid = req_idx * 2 + 1
+            ctx_request_ids.append(ctx_rid)
+            gen_request_ids.append(gen_rid)
+
+            ctx_dp_rank = req_idx % ctx_tp if ctx_enable_dp else 0
+
+            ctx_request = LlmRequest(
+                request_id=ctx_rid,
+                max_new_tokens=1,
+                input_tokens=list(range(req_len)),
+                sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                    sampling_params._get_sampling_config()
+                ),
+                is_streaming=False,
+                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
+            )
+            ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
+
+            gen_request = LlmRequest(
+                request_id=gen_rid,
+                max_new_tokens=1,
+                input_tokens=list(range(req_len)),
+                sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                    sampling_params._get_sampling_config()
+                ),
+                is_streaming=False,
+                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+            )
+            gen_request.py_disaggregated_params = DisaggregatedParams(
+                ctx_request_id=ctx_rid,
+                ctx_dp_rank=ctx_dp_rank,
+                ctx_info_endpoint=ctx_info_endpoint,
+                disagg_request_id=unique_rid,
+            )
+
+            for rank in range(ctx_world):
+                tp_rank = rank % ctx_tp
+                should_handle = (not ctx_enable_dp) or (req_idx % ctx_tp == tp_rank)
+                if should_handle:
+                    ctx_handle_map[rank].append((req_idx, ctx_request))
+
+            for rank in range(gen_world):
+                tp_rank = rank % gen_tp
+                should_handle = (not gen_enable_dp) or (req_idx % gen_tp == tp_rank)
+                if should_handle:
+                    gen_handle_map[rank].append((req_idx, gen_request))
+
+        # ===== 5. Allocate KV cache for all ranks =====
+        # prepare_resources is a no-op for non-draft KVCacheManagerV2.
+        # All ranks must allocate BEFORE mutating shared request objects
+        # (add_new_token changes is_first_context_chunk).
+        #
+        # Gen ranks take the disagg-gen-init path: prepare_disagg_gen_init
+        # sizes the cache for the full prompt and pre-declares
+        # history_length=prompt_len, matching what the V2 scheduler's
+        # _try_schedule_disagg_gen_init does in production so the
+        # transceiver's TRANS_COMPLETE contract check is satisfied.
+        # Ctx ranks take the regular prefill path (prepare_context +
+        # resize_context).
+        gen_batches: Dict[int, ScheduledRequests] = {}
+        for rank in range(gen_world):
+            reqs = [req for _, req in gen_handle_map[rank]]
+            if reqs:
+                batch = ScheduledRequests()
+                batch.context_requests_last_chunk = reqs
+                for req in reqs:
+                    gen_managers[rank].prepare_disagg_gen_init(req)
+                gen_batches[rank] = batch
+
+        ctx_batches: Dict[int, ScheduledRequests] = {}
+        for rank in range(ctx_world):
+            reqs = [req for _, req in ctx_handle_map[rank]]
+            if reqs:
+                batch = ScheduledRequests()
+                batch.context_requests_last_chunk = reqs
+                for req in reqs:
+                    ctx_managers[rank].prepare_context(req)
+                    ctx_managers[rank].resize_context(req, req.context_chunk_size)
+                ctx_batches[rank] = batch
+
+        # ===== 5.5. context_current_position + add_new_token =====
+        # Set position on each unique request once (needed for transfer metadata).
+        seen: set = set()
+        for rank in range(ctx_world):
+            for _, req in ctx_handle_map[rank]:
+                if req.py_request_id not in seen:
+                    req.context_current_position = req.prompt_len
+                    req.add_new_token(req.prompt_len, 0)
+                    seen.add(req.py_request_id)
+
+        seen = set()
+        for rank in range(gen_world):
+            for _, req in gen_handle_map[rank]:
+                if req.py_request_id not in seen:
+                    req.context_current_position = req.prompt_len
+                    req.add_new_token(req.prompt_len, 0)
+                    seen.add(req.py_request_id)
+
+        # ===== 5.6. update_resources BEFORE transfer (mode: update_before) =====
+        if update_before_transfer:
+            for rank, batch in ctx_batches.items():
+                ctx_managers[rank].update_resources(batch)
+            for rank, batch in gen_batches.items():
+                gen_managers[rank].update_resources(batch)
+
+        # ===== 6. gen receive + ctx send =====
+        for rank in range(gen_world):
+            for _, req in gen_handle_map[rank]:
+                gen_tcs[rank].request_and_receive_async(req)
+        for rank in range(ctx_world):
+            for _, req in ctx_handle_map[rank]:
+                ctx_tcs[rank].respond_and_send_async(req)
+
+        # ===== 7. Wait for completion (threaded, dist calls inside) =====
+        run_concurrent(
+            ctx_tcs, lambda tc: tc.check_context_transfer_status(None, mark_complete=True)
+        )
+        run_concurrent(gen_tcs, lambda tc: tc.check_gen_transfer_status(None))
+
+        # ===== 7.5. update_resources AFTER transfer (mode: update_after) =====
+        if not update_before_transfer:
+            for rank, batch in ctx_batches.items():
+                ctx_managers[rank].update_resources(batch)
+            for rank, batch in gen_batches.items():
+                gen_managers[rank].update_resources(batch)
+
+        # ===== 8. Verify =====
+        verify_fn(
+            request_lengths=request_lengths,
+            ctx_managers=ctx_managers,
+            gen_managers=gen_managers,
+            ctx_tp=ctx_tp,
+            ctx_pp=ctx_pp,
+            gen_tp=gen_tp,
+            gen_pp=gen_pp,
+            ctx_enable_dp=ctx_enable_dp,
+            gen_enable_dp=gen_enable_dp,
+            ctx_request_ids=ctx_request_ids,
+            gen_request_ids=gen_request_ids,
+        )
+
+    finally:
+        for tc in ctx_tcs + gen_tcs:
+            try:
+                tc.shutdown()
+            except Exception:
+                pass
+        for mgr in ctx_managers + gen_managers:
+            try:
+                mgr.shutdown()
+            except Exception:
+                pass

--- a/tests/unittest/disaggregated/kv_transfer_harness.py
+++ b/tests/unittest/disaggregated/kv_transfer_harness.py
@@ -38,9 +38,16 @@ from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestTyp
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig
 
-# Reduce NIXL threads for unit test: default 8 threads per agent causes heavy
-# contention when creating multiple agents on a single GPU in the same process.
-os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
+# This harness builds real NIXL transfer agents, so force a known-good
+# transport config *unconditionally* rather than deferring to inherited env:
+# a poisoned developer/CI environment must not be able to destabilize the
+# transport or oversubscribe CPUs.
+#   - One NIXL worker thread per agent: the default (8) causes heavy contention
+#     when many agents are created on a single GPU in the same process.
+#   - ``^ib,gdr_copy`` disables InfiniBand and GDR copy, which are unavailable
+#     (and flaky) in the single-process threaded harness.
+os.environ["TRTLLM_NIXL_NUM_THREADS"] = "1"
+os.environ["UCX_TLS"] = "^ib,gdr_copy"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/disaggregated/region/test_block.py
+++ b/tests/unittest/disaggregated/region/test_block.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 
 from tensorrt_llm._torch.disaggregation.base.region import (
@@ -6,9 +21,8 @@ from tensorrt_llm._torch.disaggregation.base.region import (
     SpecRegionPair,
 )
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import (
-    HeadMatchMapper,
-    HeadMismatchMapper,
-    IdentityMapper,
+    HNDHeadMismatchMapper,
+    IntactMapper,
 )
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.spec import AttentionInfo
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
@@ -81,12 +95,13 @@ def test_spec_region_and_spec_region_pair():
     assert pair.dst.spec == "spec_dst"
 
 
-def test_identity_mapper():
+def test_intact_mapper_identity_degenerate():
+    """Full contiguous overlap degrades to a whole-region pass-through copy."""
     src_group = MemRegionGroup(ptrs=np.array([100, 200], dtype=np.int64), bytes_per_region=32)
     dst_group = MemRegionGroup(ptrs=np.array([300, 400], dtype=np.int64), bytes_per_region=32)
     src_spec = SpecRegion(memory=src_group, spec="a")
     dst_spec = SpecRegion(memory=dst_group, spec="b")
-    mapper = IdentityMapper()
+    mapper = IntactMapper([0, 16], [0, 16], 16, 16)
     result = mapper.map(src_spec, dst_spec)
     assert isinstance(result, SpecRegionPair)
     np.testing.assert_array_equal(result.src.memory.ptrs, [100, 200])
@@ -95,14 +110,11 @@ def test_identity_mapper():
     assert result.dst.memory.bytes_per_region == 32
 
 
-def test_head_match_mapper():
+def test_intact_mapper_partial_layers():
+    """Selecting a contiguous layer subset yields one shifted fragment."""
     self_ri = make_rankinfo(kv_heads_per_rank=2)
-    peer_ri = make_rankinfo(kv_heads_per_rank=2)
-    transfer_layers = 2
-    src_layer_off = 1
-    dst_layer_off = 1
-    # slot_size_per_layer = kv_factor * kv_heads * tokens_per_block * dims_per_head * element_bytes
-    slot_size_per_layer = (
+    # bytes_per_layer = kv_factor * kv_heads * tokens_per_block * dims_per_head * element_bytes
+    bytes_per_layer = (
         self_ri.attention.kv_factor
         * self_ri.attention.kv_heads_per_rank
         * self_ri.attention.tokens_per_block
@@ -113,39 +125,43 @@ def test_head_match_mapper():
     dst_group = MemRegionGroup(ptrs=np.array([30, 40], dtype=np.int64), bytes_per_region=1)
     src_spec = SpecRegion(memory=src_group, spec="srcspec")
     dst_spec = SpecRegion(memory=dst_group, spec="dstspec")
-    mapper = HeadMatchMapper(
-        transfer_layers,
-        src_layer_off,
-        dst_layer_off,
-        self_ri,
-        peer_ri,
-        slot_size_per_layer=slot_size_per_layer,
-    )
+    # Layers 1..2 of a 3-layer slot on both sides.
+    offsets = [bytes_per_layer, 2 * bytes_per_layer]
+    mapper = IntactMapper(offsets, offsets, bytes_per_layer, bytes_per_layer)
     result = mapper.map(src_spec, dst_spec)
-    expected_off = transfer_layers * slot_size_per_layer
+    expected_bytes = 2 * bytes_per_layer
     np.testing.assert_array_equal(
-        result.src.memory.ptrs, [10 + mapper._src_block_off, 20 + mapper._src_block_off]
+        result.src.memory.ptrs, [10 + bytes_per_layer, 20 + bytes_per_layer]
     )
     np.testing.assert_array_equal(
-        result.dst.memory.ptrs, [30 + mapper._dst_block_off, 40 + mapper._dst_block_off]
+        result.dst.memory.ptrs, [30 + bytes_per_layer, 40 + bytes_per_layer]
     )
-    assert result.src.memory.bytes_per_region == expected_off
-    assert result.dst.memory.bytes_per_region == expected_off
+    assert result.src.memory.bytes_per_region == expected_bytes
+    assert result.dst.memory.bytes_per_region == expected_bytes
 
 
 def test_head_mismatch_mapper():
     self_ri = make_rankinfo(kv_heads_per_rank=2, tp_size=2, tp_rank=1)
     peer_ri = make_rankinfo(kv_heads_per_rank=4, tp_size=4, tp_rank=2)
-    transfer_layers = 1
-    src_layer_off = 0
-    peer_layer_off = 1
+    # buffer bytes = heads * tokens_per_block * dims_per_head * element_bytes
+    self_bytes_per_layer = 2 * (2 * 4 * 2 * 1)  # kv_factor x K-buffer bytes
+    peer_bytes_per_layer = 2 * (4 * 4 * 2 * 1)
     src_group = MemRegionGroup(ptrs=np.array([111], dtype=np.int64), bytes_per_region=32)
     dst_group = MemRegionGroup(ptrs=np.array([222], dtype=np.int64), bytes_per_region=32)
     src_spec = SpecRegion(memory=src_group, spec="srcspec")
     dst_spec = SpecRegion(memory=dst_group, spec="dstspec")
-    mapper = HeadMismatchMapper(transfer_layers, src_layer_off, peer_layer_off, self_ri, peer_ri)
+    mapper = HNDHeadMismatchMapper(
+        src_layer_offsets=[0],
+        dst_layer_offsets=[peer_bytes_per_layer],  # layer 1 on the peer side
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_bytes_per_layer=self_bytes_per_layer,
+        peer_bytes_per_layer=peer_bytes_per_layer,
+        self_buffers_per_layer=2,
+        peer_buffers_per_layer=2,
+    )
     result = mapper.map(src_spec, dst_spec)
-    expected_frag_count = self_ri.attention.kv_factor * transfer_layers
+    expected_frag_count = 2  # one fragment per (layer, K/V buffer)
     assert isinstance(result, SpecRegionPair)
     assert len(result.src.memory.ptrs) == expected_frag_count
     assert len(result.dst.memory.ptrs) == expected_frag_count

--- a/tests/unittest/disaggregated/region/test_block.py
+++ b/tests/unittest/disaggregated/region/test_block.py
@@ -125,50 +125,81 @@ def test_intact_mapper_partial_layers():
     dst_group = MemRegionGroup(ptrs=np.array([30, 40], dtype=np.int64), bytes_per_region=1)
     src_spec = SpecRegion(memory=src_group, spec="srcspec")
     dst_spec = SpecRegion(memory=dst_group, spec="dstspec")
-    # Layers 1..2 of a 3-layer slot on both sides.
-    offsets = [bytes_per_layer, 2 * bytes_per_layer]
-    mapper = IntactMapper(offsets, offsets, bytes_per_layer, bytes_per_layer)
+    # Self selects layers 1..2 of its slot; the peer stores the same class at
+    # layers 2..3. Distinct src/dst layer offsets make the test fail if the
+    # mapper ever applies one side's offset to the other.
+    src_offsets = [bytes_per_layer, 2 * bytes_per_layer]
+    dst_offsets = [2 * bytes_per_layer, 3 * bytes_per_layer]
+    mapper = IntactMapper(src_offsets, dst_offsets, bytes_per_layer, bytes_per_layer)
     result = mapper.map(src_spec, dst_spec)
+    # Both sides are internally contiguous, so the two layers merge into a
+    # single fragment shifted by each side's own first-layer offset.
     expected_bytes = 2 * bytes_per_layer
     np.testing.assert_array_equal(
         result.src.memory.ptrs, [10 + bytes_per_layer, 20 + bytes_per_layer]
     )
     np.testing.assert_array_equal(
-        result.dst.memory.ptrs, [30 + bytes_per_layer, 40 + bytes_per_layer]
+        result.dst.memory.ptrs, [30 + 2 * bytes_per_layer, 40 + 2 * bytes_per_layer]
     )
     assert result.src.memory.bytes_per_region == expected_bytes
     assert result.dst.memory.bytes_per_region == expected_bytes
 
 
 def test_head_mismatch_mapper():
+    # Self holds 2 KV heads at TP=2; the peer holds 4 KV heads at TP=4. Using
+    # peer tp_rank=1 (not 2) forces a *nonzero* source-side head offset, so an
+    # incorrect head-offset computation cannot pass silently.
     self_ri = make_rankinfo(kv_heads_per_rank=2, tp_size=2, tp_rank=1)
-    peer_ri = make_rankinfo(kv_heads_per_rank=4, tp_size=4, tp_rank=2)
+    peer_ri = make_rankinfo(kv_heads_per_rank=4, tp_size=4, tp_rank=1)
+    buffers_per_layer = 2  # K and V
     # buffer bytes = heads * tokens_per_block * dims_per_head * element_bytes
-    self_bytes_per_layer = 2 * (2 * 4 * 2 * 1)  # kv_factor x K-buffer bytes
-    peer_bytes_per_layer = 2 * (4 * 4 * 2 * 1)
-    src_group = MemRegionGroup(ptrs=np.array([111], dtype=np.int64), bytes_per_region=32)
-    dst_group = MemRegionGroup(ptrs=np.array([222], dtype=np.int64), bytes_per_region=32)
+    self_buffer_bytes = 2 * 4 * 2 * 1
+    peer_buffer_bytes = 4 * 4 * 2 * 1
+    self_bytes_per_layer = buffers_per_layer * self_buffer_bytes  # kv_factor x K-buffer bytes
+    peer_bytes_per_layer = buffers_per_layer * peer_buffer_bytes
+    bytes_per_head = self_buffer_bytes // self_ri.attention.kv_heads_per_rank  # equals peer side
+    src_base, dst_base = 111, 222
+    src_group = MemRegionGroup(ptrs=np.array([src_base], dtype=np.int64), bytes_per_region=32)
+    dst_group = MemRegionGroup(ptrs=np.array([dst_base], dtype=np.int64), bytes_per_region=32)
     src_spec = SpecRegion(memory=src_group, spec="srcspec")
     dst_spec = SpecRegion(memory=dst_group, spec="dstspec")
+    peer_layer_off = peer_bytes_per_layer  # copy targets layer 1 on the peer side
     mapper = HNDHeadMismatchMapper(
         src_layer_offsets=[0],
-        dst_layer_offsets=[peer_bytes_per_layer],  # layer 1 on the peer side
+        dst_layer_offsets=[peer_layer_off],
         self_ri=self_ri,
         peer_ri=peer_ri,
         self_bytes_per_layer=self_bytes_per_layer,
         peer_bytes_per_layer=peer_bytes_per_layer,
-        self_buffers_per_layer=2,
-        peer_buffers_per_layer=2,
+        self_buffers_per_layer=buffers_per_layer,
+        peer_buffers_per_layer=buffers_per_layer,
     )
     result = mapper.map(src_spec, dst_spec)
-    expected_frag_count = 2  # one fragment per (layer, K/V buffer)
     assert isinstance(result, SpecRegionPair)
-    assert len(result.src.memory.ptrs) == expected_frag_count
-    assert len(result.dst.memory.ptrs) == expected_frag_count
     assert isinstance(result.src.memory.ptrs, np.ndarray)
     assert isinstance(result.dst.memory.ptrs, np.ndarray)
-    assert result.src.memory.bytes_per_region == mapper._bytes_cont_heads
-    assert result.dst.memory.bytes_per_region == mapper._bytes_cont_heads
+    # Source head offset for self rank 1 slicing into the peer's 4-head layout:
+    #   (peer_tp_rank * self_kv_heads * self_tp) // peer_tp % self_kv_heads
+    #   = (1 * 2 * 2) // 4 % 2 = 1 head -> 1 * bytes_per_head. The peer side is
+    # the coarser layout, so its head offset is 0.
+    src_head_off = 1 * bytes_per_head
+    # One fragment per (layer, K/V buffer), buffers back-to-back within a layer.
+    # Source layer offset is 0; the peer layer offset is nonzero.
+    expected_src_ptrs = [
+        src_base + src_head_off + buf * self_buffer_bytes for buf in range(buffers_per_layer)
+    ]
+    expected_dst_ptrs = [
+        dst_base + peer_layer_off + buf * peer_buffer_bytes for buf in range(buffers_per_layer)
+    ]
+    np.testing.assert_array_equal(result.src.memory.ptrs, expected_src_ptrs)
+    np.testing.assert_array_equal(result.dst.memory.ptrs, expected_dst_ptrs)
+    # Each fragment copies min(self_heads, peer_heads) contiguous heads.
+    cont_heads_bytes = (
+        min(self_ri.attention.kv_heads_per_rank, peer_ri.attention.kv_heads_per_rank)
+        * bytes_per_head
+    )
+    assert result.src.memory.bytes_per_region == cont_heads_bytes
+    assert result.dst.memory.bytes_per_region == cont_heads_bytes
 
 
 def test_rankinfo_kv_factor():

--- a/tests/unittest/disaggregated/region/test_page.py
+++ b/tests/unittest/disaggregated/region/test_page.py
@@ -6,6 +6,7 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     KVCachePageTable,
     LayerGroup,
     LocalLayer,
+    MapperKind,
     PhysicalPool,
     PhysicalPoolGroup,
     PoolView,
@@ -47,6 +48,30 @@ def test_pool_view_roundtrip():
     assert len(restored.buffer_entries) == 2
     assert restored.buffer_entries[0]["offset"] == 0
     assert restored.buffer_entries[1]["offset"] == 128
+
+
+def test_logical_pool_view_roundtrip_and_legacy_defaults():
+    entries = _make_buffer_entries()
+    view = PoolView(
+        pool_idx=2,
+        buffer_entries=entries,
+        pool_role=frozenset({"index_key"}),
+        mapper_kind=MapperKind.REPLICATED,
+        byte_offset=768,
+        bytes_per_region=256,
+    )
+
+    restored = PoolView.from_dict(view.to_dict())
+    assert restored.mapper_kind == MapperKind.REPLICATED
+    assert restored.byte_offset == 768
+    assert restored.bytes_per_region == 256
+
+    legacy = view.to_dict()
+    del legacy["byte_offset"]
+    del legacy["bytes_per_region"]
+    restored_legacy = PoolView.from_dict(legacy)
+    assert restored_legacy.byte_offset == 0
+    assert restored_legacy.bytes_per_region is None
 
 
 def test_local_layer_roundtrip():

--- a/tests/unittest/disaggregated/region/test_page.py
+++ b/tests/unittest/disaggregated/region/test_page.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 
 from tensorrt_llm._torch.disaggregation.resource.page import (
@@ -50,39 +65,22 @@ def test_pool_view_roundtrip():
     assert restored.buffer_entries[1]["offset"] == 128
 
 
-def test_logical_pool_view_roundtrip_and_legacy_defaults():
+def test_pool_view_kind_roundtrip():
+    """REPLICATED / NHD kinds survive serialization; default stays INDEXED."""
     entries = _make_buffer_entries()
-    view = PoolView(
-        pool_idx=2,
-        buffer_entries=entries,
-        pool_role=frozenset({"index_key"}),
-        mapper_kind=MapperKind.REPLICATED,
-        buffer_roles=("index_key", "index_key"),
-        buffer_mapper_kinds=(MapperKind.REPLICATED, MapperKind.REPLICATED),
-        byte_offset=768,
-        bytes_per_region=256,
-    )
+    for kind in (MapperKind.REPLICATED, MapperKind.NHD):
+        view = PoolView(
+            pool_idx=2,
+            buffer_entries=entries,
+            pool_role=frozenset({"index_key"}),
+            mapper_kind=kind,
+        )
+        restored = PoolView.from_dict(view.to_dict())
+        assert restored.mapper_kind == kind
+        assert restored.pool_role == frozenset({"index_key"})
 
-    restored = PoolView.from_dict(view.to_dict())
-    assert restored.mapper_kind == MapperKind.REPLICATED
-    assert restored.buffer_roles == ("index_key", "index_key")
-    assert restored.buffer_mapper_kinds == (
-        MapperKind.REPLICATED,
-        MapperKind.REPLICATED,
-    )
-    assert restored.byte_offset == 768
-    assert restored.bytes_per_region == 256
-
-    legacy = view.to_dict()
-    del legacy["byte_offset"]
-    del legacy["bytes_per_region"]
-    del legacy["buffer_roles"]
-    del legacy["buffer_mapper_kinds"]
-    restored_legacy = PoolView.from_dict(legacy)
-    assert restored_legacy.byte_offset == 0
-    assert restored_legacy.bytes_per_region is None
-    assert restored_legacy.buffer_roles == ()
-    assert restored_legacy.buffer_mapper_kinds == ()
+    legacy = PoolView(pool_idx=0, buffer_entries=entries).to_dict()
+    assert PoolView.from_dict(legacy).mapper_kind == MapperKind.INDEXED
 
 
 def test_local_layer_roundtrip():
@@ -136,3 +134,94 @@ def test_kv_cache_page_table_roundtrip():
     assert len(restored.layer_groups) == 1
     assert len(restored.pool_groups) == 1
     assert restored.pool_groups[0].pools[0].base_address == 0x10000
+
+
+# ---------------------------------------------------------------------------
+# bytes_per_layer serialization and get_layer_byte_ranges geometry
+# ---------------------------------------------------------------------------
+
+
+def test_pool_view_bytes_per_layer_roundtrip():
+    entries = _make_buffer_entries()
+    view = PoolView(
+        pool_idx=1,
+        buffer_entries=entries,
+        pool_role=frozenset({"key", "value"}),
+        mapper_kind=MapperKind.NHD,
+        bytes_per_layer=256,
+    )
+    restored = PoolView.from_dict(view.to_dict())
+    assert restored.bytes_per_layer == 256
+
+    # None (INDEXED views) survives the roundtrip too.
+    legacyless = PoolView(pool_idx=0, buffer_entries=entries)
+    assert PoolView.from_dict(legacyless.to_dict()).bytes_per_layer is None
+
+
+def _view(entries, bytes_per_layer=None):
+    return PoolView(
+        pool_idx=0,
+        buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE),
+        pool_role=frozenset({"key", "value"}),
+        mapper_kind=MapperKind.NHD,
+        bytes_per_layer=bytes_per_layer,
+    )
+
+
+def test_layer_byte_ranges_uniform_stride():
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    # Dedicated K/V pool: dense layers, uniform stride.
+    starts, bytes_per_layer = get_layer_byte_ranges(
+        _view([(0, 0, 128), (0, 128, 128), (1, 256, 128), (1, 384, 128)])
+    )
+    assert starts == {0: 0, 1: 256}
+    assert bytes_per_layer == 256
+
+
+def test_layer_byte_ranges_non_uniform_stride():
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    # Coalesced slot: another role class interleaves 64B after layer 0,
+    # so the layer stride is non-uniform while sizes stay uniform.
+    starts, bytes_per_layer = get_layer_byte_ranges(
+        _view([(0, 0, 128), (0, 128, 128), (1, 320, 128), (1, 448, 128)])
+    )
+    assert starts == {0: 0, 1: 320}
+    assert bytes_per_layer == 256
+
+
+def test_layer_byte_ranges_noncontiguous_layer_raises():
+    import pytest
+
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    with pytest.raises(ValueError, match="not contiguous"):
+        get_layer_byte_ranges(_view([(0, 0, 128), (0, 192, 128)]))
+
+
+def test_layer_byte_ranges_nonuniform_size_raises():
+    import pytest
+
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    with pytest.raises(ValueError, match="not uniform"):
+        get_layer_byte_ranges(_view([(0, 0, 128), (1, 128, 64)]))
+
+
+def test_layer_byte_ranges_declared_size_mismatch_raises():
+    import pytest
+
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    with pytest.raises(ValueError, match="declares bytes_per_layer"):
+        get_layer_byte_ranges(_view([(0, 0, 128)], bytes_per_layer=256))
+
+
+def test_layer_byte_ranges_empty_view_raises():
+    import pytest
+
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    with pytest.raises(ValueError, match="no buffer entries"):
+        get_layer_byte_ranges(_view([]))

--- a/tests/unittest/disaggregated/region/test_page.py
+++ b/tests/unittest/disaggregated/region/test_page.py
@@ -57,21 +57,32 @@ def test_logical_pool_view_roundtrip_and_legacy_defaults():
         buffer_entries=entries,
         pool_role=frozenset({"index_key"}),
         mapper_kind=MapperKind.REPLICATED,
+        buffer_roles=("index_key", "index_key"),
+        buffer_mapper_kinds=(MapperKind.REPLICATED, MapperKind.REPLICATED),
         byte_offset=768,
         bytes_per_region=256,
     )
 
     restored = PoolView.from_dict(view.to_dict())
     assert restored.mapper_kind == MapperKind.REPLICATED
+    assert restored.buffer_roles == ("index_key", "index_key")
+    assert restored.buffer_mapper_kinds == (
+        MapperKind.REPLICATED,
+        MapperKind.REPLICATED,
+    )
     assert restored.byte_offset == 768
     assert restored.bytes_per_region == 256
 
     legacy = view.to_dict()
     del legacy["byte_offset"]
     del legacy["bytes_per_region"]
+    del legacy["buffer_roles"]
+    del legacy["buffer_mapper_kinds"]
     restored_legacy = PoolView.from_dict(legacy)
     assert restored_legacy.byte_offset == 0
     assert restored_legacy.bytes_per_region is None
+    assert restored_legacy.buffer_roles == ()
+    assert restored_legacy.buffer_mapper_kinds == ()
 
 
 def test_local_layer_roundtrip():

--- a/tests/unittest/disaggregated/test_bounce.py
+++ b/tests/unittest/disaggregated/test_bounce.py
@@ -196,13 +196,19 @@ def test_fanin_bounce_safe_gate():
     expected_transfers) must fall back to the per-fragment path.
     """
     tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
+    from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
+
     safe = tfr.Receiver._fanin_bounce_safe
 
-    def ov(dup, pp):
-        return SimpleNamespace(duplicate_head_factor=dup, overlap_pp_size=pp)
+    def ov(dup, pp, ranks=(0,)):
+        return SimpleNamespace(duplicate_head_factor=dup, overlap_pp_size=pp, ranks=list(ranks))
 
-    def ri(lpp):
-        return SimpleNamespace(layer_num_per_pp=lpp)
+    def ri(lpp, page_table=None):
+        return SimpleNamespace(layer_num_per_pp=lpp, page_table=page_table)
+
+    def pt(mapper_kind):
+        view = SimpleNamespace(mapper_kind=mapper_kind)
+        return SimpleNamespace(layer_groups=[SimpleNamespace(pool_views=[view])])
 
     # single PP stage (overlap_pp_size <= 1): only duplicate_head_factor matters
     assert safe(ov(1, 1), ri([24])) is True
@@ -216,6 +222,12 @@ def test_fanin_bounce_safe_gate():
     assert safe(ov(1, 4), ri([20])) is False
     # duplicate heads blocks even an otherwise-even PP split
     assert safe(ov(2, 4), ri([20, 20, 20, 20])) is False
+    # replicated views (one elected sender per destination) make multi-writer
+    # contributions unequal -> fall back; single-writer overlap stays safe,
+    # and sharded-only view schemes are unaffected
+    assert safe(ov(1, 1, ranks=(0, 1)), ri([24], pt(MapperKind.REPLICATED))) is False
+    assert safe(ov(1, 1, ranks=(0,)), ri([24], pt(MapperKind.REPLICATED))) is True
+    assert safe(ov(1, 1, ranks=(0, 1)), ri([24], pt(MapperKind.NHD))) is True
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unittest/disaggregated/test_cache_reuse_adapter.py
+++ b/tests/unittest/disaggregated/test_cache_reuse_adapter.py
@@ -694,8 +694,14 @@ class TestPrepareKvBlocksForTransfer:
         np.testing.assert_array_equal(src, [11, 12])
         np.testing.assert_array_equal(dst, [20, 21])
 
+    def test_shorter_destination_trims_source_to_shared_suffix(self):
+        src, dst = self._prepare([10, 11, 12], [20, 21])
+
+        np.testing.assert_array_equal(src, [11, 12])
+        np.testing.assert_array_equal(dst, [20, 21])
+
     def test_swa_requires_prompt_length(self):
-        with pytest.raises(ValueError, match="requires session.prompt_len"):
+        with pytest.raises(ValueError, match=r"requires session\.prompt_len"):
             self._prepare(
                 [10, 11],
                 [20, 21],

--- a/tests/unittest/disaggregated/test_cache_reuse_adapter.py
+++ b/tests/unittest/disaggregated/test_cache_reuse_adapter.py
@@ -20,8 +20,9 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+import tensorrt_llm._torch.disaggregation.native.transfer as transfer_module
 from tensorrt_llm._torch.disaggregation.base.transfer import TokenRange
-from tensorrt_llm._torch.disaggregation.native.transfer import Sender
+from tensorrt_llm._torch.disaggregation.native.transfer import Sender, WriteMeta
 from tensorrt_llm._torch.disaggregation.resource.cache_reuse import (
     CacheReuseAdapter,
     _CacheReuseAdapterV1,
@@ -651,6 +652,101 @@ class TestSenderTokenStarts:
         )
         # total_blocks for slice = 2 → raw start = 16; clamped = max(16, 16) = 16.
         assert (src_start, dst_start) == (16, 16)
+
+
+class TestPrepareKvBlocksForTransfer:
+    """Exercise the complete pure block-normalization helper."""
+
+    @staticmethod
+    def _prepare(src, dst, **kwargs):
+        defaults = dict(
+            tokens_per_block=8,
+            slice_end=24,
+            beam_width=1,
+            dst_start_token=None,
+            sliding_window_size=None,
+            prompt_len=None,
+        )
+        defaults.update(kwargs)
+        return Sender._prepare_kv_blocks_for_transfer(
+            np.asarray(src, dtype=np.int64),
+            np.asarray(dst, dtype=np.int64),
+            **defaults,
+        )
+
+    def test_trims_one_extra_draft_destination_block(self):
+        src, dst = self._prepare([10, 11, 12], [20, 21, 22, 23])
+
+        np.testing.assert_array_equal(src, [10, 11, 12])
+        np.testing.assert_array_equal(dst, [20, 21, 22])
+
+    def test_rejects_more_than_one_extra_destination_block(self):
+        with pytest.raises(ValueError, match="expected diff <= 1"):
+            self._prepare([10], [20, 21, 22])
+
+    def test_destination_prefix_start_trims_source(self):
+        src, dst = self._prepare(
+            [10, 11, 12],
+            [20, 21, 22],
+            dst_start_token=8,
+        )
+
+        np.testing.assert_array_equal(src, [11, 12])
+        np.testing.assert_array_equal(dst, [20, 21])
+
+    def test_swa_requires_prompt_length(self):
+        with pytest.raises(ValueError, match="requires session.prompt_len"):
+            self._prepare(
+                [10, 11],
+                [20, 21],
+                slice_end=16,
+                sliding_window_size=8,
+            )
+
+    def test_swa_clamps_both_sides_to_live_window(self):
+        src, dst = self._prepare(
+            [10, 11],
+            [20, 21],
+            slice_end=32,
+            sliding_window_size=16,
+            prompt_len=32,
+        )
+
+        # CacheReuseAdapter has already removed the two stale blocks. The
+        # helper assigns both suffixes the live-window origin (token 16), so
+        # neither side is trimmed a second time during alignment.
+        np.testing.assert_array_equal(src, [10, 11])
+        np.testing.assert_array_equal(dst, [20, 21])
+
+
+def test_large_python_nixl_descriptor_transfer_warns_once(monkeypatch):
+    warnings = []
+    monkeypatch.setattr(Sender, "_LARGE_DESCRIPTOR_WARNING_THRESHOLD", 2)
+    monkeypatch.setattr(transfer_module, "use_pure_python_transfer_agent", lambda: True)
+    monkeypatch.setattr(
+        transfer_module.logger,
+        "warning_once",
+        lambda *message, key: warnings.append((" ".join(map(str, message)), key)),
+    )
+    write_meta = WriteMeta(
+        task=SimpleNamespace(),
+        expected_transfers=1,
+        peer_name="peer0",
+        peer_rank=0,
+        peer_endpoint="tcp://peer",
+        unique_rid=1,
+        src_ptrs=np.array([1000, 2000], dtype=np.int64),
+        dst_ptrs=np.array([3000, 4000], dtype=np.int64),
+        sizes=np.array([64, 64], dtype=np.int64),
+        dst_device_id=0,
+    )
+
+    Sender._make_agent_request(write_meta, device_id=0)
+
+    assert len(warnings) == 1
+    message, key = warnings[0]
+    assert "2 descriptors through Python lists" in message
+    assert key == "native-large-python-nixl-descriptor-transfer"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/disaggregated/test_cache_reuse_adapter.py
+++ b/tests/unittest/disaggregated/test_cache_reuse_adapter.py
@@ -117,10 +117,16 @@ class TestPackedBeamBlockLayout:
 
             def __init__(self):
                 self.beam_width = None
+                self.pool_indices_window = None
 
             def get_batch_cache_indices(self, request_ids, layer_idx=None, beam_width=1):
                 self.beam_width = beam_width
                 return [[10, 11, 12, 13]]
+
+            def get_memory_pool_block_indices(self, block_ids, window_size):
+                # Identity translation: nothing offloaded, block_id == pool slot.
+                self.pool_indices_window = window_size
+                return block_ids
 
         req = _FakeReq(prompt_len=7)
         req.py_request_id = 1
@@ -128,9 +134,10 @@ class TestPackedBeamBlockLayout:
         req.sampling_config = _FakeSamplingConfig(beam_width=1)
         mgr = _FakeMgr()
 
-        block_ids = _CacheReuseAdapterV1(mgr).get_block_ids(req, 0, _lg())
+        block_ids = _CacheReuseAdapterV1(mgr).get_block_ids(req, 0, _lg(window=512))
 
         assert mgr.beam_width == 4
+        assert mgr.pool_indices_window == 512
         np.testing.assert_array_equal(block_ids, [10, 11, 12, 13])
 
     def test_pack_beam_cache_indices_single_block_prompt_keeps_all_beams(self):

--- a/tests/unittest/disaggregated/test_cache_reuse_adapter.py
+++ b/tests/unittest/disaggregated/test_cache_reuse_adapter.py
@@ -20,9 +20,8 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
-import tensorrt_llm._torch.disaggregation.native.transfer as transfer_module
 from tensorrt_llm._torch.disaggregation.base.transfer import TokenRange
-from tensorrt_llm._torch.disaggregation.native.transfer import Sender, WriteMeta
+from tensorrt_llm._torch.disaggregation.native.transfer import Sender
 from tensorrt_llm._torch.disaggregation.resource.cache_reuse import (
     CacheReuseAdapter,
     _CacheReuseAdapterV1,
@@ -652,107 +651,6 @@ class TestSenderTokenStarts:
         )
         # total_blocks for slice = 2 → raw start = 16; clamped = max(16, 16) = 16.
         assert (src_start, dst_start) == (16, 16)
-
-
-class TestPrepareKvBlocksForTransfer:
-    """Exercise the complete pure block-normalization helper."""
-
-    @staticmethod
-    def _prepare(src, dst, **kwargs):
-        defaults = dict(
-            tokens_per_block=8,
-            slice_end=24,
-            beam_width=1,
-            dst_start_token=None,
-            sliding_window_size=None,
-            prompt_len=None,
-        )
-        defaults.update(kwargs)
-        return Sender._prepare_kv_blocks_for_transfer(
-            np.asarray(src, dtype=np.int64),
-            np.asarray(dst, dtype=np.int64),
-            **defaults,
-        )
-
-    def test_trims_one_extra_draft_destination_block(self):
-        src, dst = self._prepare([10, 11, 12], [20, 21, 22, 23])
-
-        np.testing.assert_array_equal(src, [10, 11, 12])
-        np.testing.assert_array_equal(dst, [20, 21, 22])
-
-    def test_rejects_more_than_one_extra_destination_block(self):
-        with pytest.raises(ValueError, match="expected diff <= 1"):
-            self._prepare([10], [20, 21, 22])
-
-    def test_destination_prefix_start_trims_source(self):
-        src, dst = self._prepare(
-            [10, 11, 12],
-            [20, 21, 22],
-            dst_start_token=8,
-        )
-
-        np.testing.assert_array_equal(src, [11, 12])
-        np.testing.assert_array_equal(dst, [20, 21])
-
-    def test_shorter_destination_trims_source_to_shared_suffix(self):
-        src, dst = self._prepare([10, 11, 12], [20, 21])
-
-        np.testing.assert_array_equal(src, [11, 12])
-        np.testing.assert_array_equal(dst, [20, 21])
-
-    def test_swa_requires_prompt_length(self):
-        with pytest.raises(ValueError, match=r"requires session\.prompt_len"):
-            self._prepare(
-                [10, 11],
-                [20, 21],
-                slice_end=16,
-                sliding_window_size=8,
-            )
-
-    def test_swa_clamps_both_sides_to_live_window(self):
-        src, dst = self._prepare(
-            [10, 11],
-            [20, 21],
-            slice_end=32,
-            sliding_window_size=16,
-            prompt_len=32,
-        )
-
-        # CacheReuseAdapter has already removed the two stale blocks. The
-        # helper assigns both suffixes the live-window origin (token 16), so
-        # neither side is trimmed a second time during alignment.
-        np.testing.assert_array_equal(src, [10, 11])
-        np.testing.assert_array_equal(dst, [20, 21])
-
-
-def test_large_python_nixl_descriptor_transfer_warns_once(monkeypatch):
-    warnings = []
-    monkeypatch.setattr(Sender, "_LARGE_DESCRIPTOR_WARNING_THRESHOLD", 2)
-    monkeypatch.setattr(transfer_module, "use_pure_python_transfer_agent", lambda: True)
-    monkeypatch.setattr(
-        transfer_module.logger,
-        "warning_once",
-        lambda *message, key: warnings.append((" ".join(map(str, message)), key)),
-    )
-    write_meta = WriteMeta(
-        task=SimpleNamespace(),
-        expected_transfers=1,
-        peer_name="peer0",
-        peer_rank=0,
-        peer_endpoint="tcp://peer",
-        unique_rid=1,
-        src_ptrs=np.array([1000, 2000], dtype=np.int64),
-        dst_ptrs=np.array([3000, 4000], dtype=np.int64),
-        sizes=np.array([64, 64], dtype=np.int64),
-        dst_device_id=0,
-    )
-
-    Sender._make_agent_request(write_meta, device_id=0)
-
-    assert len(warnings) == 1
-    message, key = warnings[0]
-    assert "2 descriptors through Python lists" in message
-    assert key == "native-large-python-nixl-descriptor-transfer"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
+++ b/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Single-process test for KVCacheManager (V1/V2) + KvCacheTransceiverV2.
 
 Uses threading + ThreadSafeDistributed to create KvCacheTransceiverV2 instances
@@ -47,6 +62,7 @@ os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
 # Constants
 # ---------------------------------------------------------------------------
 NUM_LAYERS = 4
+INDEXER_HEAD_DIM = 128
 NUM_KV_HEADS = 4  # 1 for MLA
 HEAD_DIM = 128
 TOKENS_PER_BLOCK = 8
@@ -309,8 +325,10 @@ def _create_cache_manager(
     max_attention_window_vec: Optional[List[int]] = None,
     num_layers: int = NUM_LAYERS,
     max_batch_size: int = MAX_BATCH_SIZE,
+    enable_indexer_k_cache: bool = False,
 ) -> "KVCacheManager | KVCacheManagerV2":
     """Create a KVCacheManager (V1) or KVCacheManagerV2 for the given mapping."""
+    assert not (enable_indexer_k_cache and use_v2), "DSA indexer K cache is V1-only"
     num_kv_heads = 1 if is_mla else NUM_KV_HEADS
     cache_type = CacheTypeCpp.SELFKONLY if is_mla else CacheTypeCpp.SELF
 
@@ -377,6 +395,9 @@ def _create_cache_manager(
             mapping=mapping,
             dtype=DataType.FLOAT,
             model_config=model_config,
+            enable_indexer_k_cache=enable_indexer_k_cache,
+            indexer_k_cache_quant_block_size=128,
+            indexer_k_cache_index_head_dim=INDEXER_HEAD_DIM if enable_indexer_k_cache else 0,
         )
 
 
@@ -389,6 +410,7 @@ def _create_managers_for_instance(
     max_attention_window_vec: Optional[List[int]] = None,
     num_layers: int = NUM_LAYERS,
     max_batch_size: int = MAX_BATCH_SIZE,
+    enable_indexer_k_cache: bool = False,
 ) -> List:
     """Create cache managers for all ranks in an instance."""
     managers = []
@@ -404,7 +426,13 @@ def _create_managers_for_instance(
             )
             managers.append(
                 _create_cache_manager(
-                    mapping, is_mla, use_v2, max_attention_window_vec, num_layers, max_batch_size
+                    mapping,
+                    is_mla,
+                    use_v2,
+                    max_attention_window_vec,
+                    num_layers,
+                    max_batch_size,
+                    enable_indexer_k_cache,
                 )
             )
     return managers
@@ -438,6 +466,27 @@ def _init_pool_data_v1(
             pool_tensor.copy_(random_values)
         else:
             pool_tensor.zero_()
+
+        if getattr(mgr, "enable_indexer_k_cache", False):
+            # DSA indexer K is TP-replicated: seed by PP stage only so every
+            # TP rank of a stage holds identical bytes.
+            indexer_pool = mgr.impl.get_indexer_k_cache_pool().view(torch.uint8)
+            if fill_random:
+                generator = torch.Generator(device=indexer_pool.device).manual_seed(
+                    seed_base + 7000 + pp_rank
+                )
+                indexer_pool.copy_(
+                    torch.randint(
+                        0,
+                        256,
+                        indexer_pool.shape,
+                        dtype=torch.uint8,
+                        device=indexer_pool.device,
+                        generator=generator,
+                    )
+                )
+            else:
+                indexer_pool.zero_()
 
 
 def _init_pool_data_v2(
@@ -816,6 +865,77 @@ def verify_all_requests(
             )
 
 
+def _get_indexer_block_data(mgr, request_id, layer_idx, num_layers, pp, tp, enable_dp, req_idx):
+    """Per-request indexer-K bytes for one global layer on the owning rank.
+
+    Indexer K is TP-replicated, so any TP rank of the layer's PP stage works;
+    with attention DP only the request's DP group holds the request.
+    """
+    pp_rank = _pp_rank_of_layer(layer_idx, num_layers, pp)
+    tp_rank = req_idx % tp if enable_dp else 0
+    owner = mgr[pp_rank * tp + tp_rank]
+    block_indices = owner.get_batch_cache_indices([request_id], layer_idx)[0]
+    valid = [idx for idx in block_indices if idx >= 0]
+    if not valid:
+        return None
+    local_layer = layer_idx - _pp_layer_start(pp_rank, num_layers, pp)
+    # Pool shape: (numBlocks, numLayers, kvFactor, blockSize), dtype uint8.
+    pool = owner.impl.get_indexer_k_cache_pool().view(torch.uint8)
+    return pool[valid, local_layer]
+
+
+def _verify_indexer_k_all_requests(
+    request_lengths: List[int],
+    ctx_managers: List,
+    gen_managers: List,
+    ctx_tp: int,
+    ctx_pp: int,
+    gen_tp: int,
+    gen_pp: int,
+    ctx_enable_dp: bool,
+    gen_enable_dp: bool,
+    ctx_request_ids: List[int],
+    gen_request_ids: List[int],
+    num_layers: int,
+):
+    """Compare the transferred DSA indexer K bytes for every request/layer."""
+    for req_idx, _req_len in enumerate(request_lengths):
+        for layer_idx in range(num_layers):
+            ctx_data = _get_indexer_block_data(
+                ctx_managers,
+                ctx_request_ids[req_idx],
+                layer_idx,
+                num_layers,
+                ctx_pp,
+                ctx_tp,
+                ctx_enable_dp,
+                req_idx,
+            )
+            gen_data = _get_indexer_block_data(
+                gen_managers,
+                gen_request_ids[req_idx],
+                layer_idx,
+                num_layers,
+                gen_pp,
+                gen_tp,
+                gen_enable_dp,
+                req_idx,
+            )
+            if ctx_data is None or gen_data is None:
+                continue
+            assert ctx_data.shape == gen_data.shape, (
+                f"Indexer shape mismatch at req={req_idx} layer={layer_idx}: "
+                f"ctx={ctx_data.shape} gen={gen_data.shape}"
+            )
+            torch.testing.assert_close(
+                gen_data,
+                ctx_data,
+                rtol=0,
+                atol=0,
+                msg=lambda m: (f"Indexer data mismatch at req={req_idx} layer={layer_idx}: {m}"),
+            )
+
+
 # ---------------------------------------------------------------------------
 # Main test orchestrator
 # ---------------------------------------------------------------------------
@@ -831,6 +951,7 @@ def run_transfer_test(
     max_attention_window_vec: Optional[List[int]] = None,
     num_layers: int = NUM_LAYERS,
     request_lengths: Optional[List[int]] = None,
+    enable_indexer_k_cache: bool = False,
 ):
     """Run a full KV transfer test using KvCacheTransceiverV2."""
     if request_lengths is None:
@@ -849,6 +970,7 @@ def run_transfer_test(
         max_attention_window_vec,
         num_layers,
         max_batch_size,
+        enable_indexer_k_cache,
     )
     gen_managers = _create_managers_for_instance(
         gen_tp,
@@ -859,6 +981,7 @@ def run_transfer_test(
         max_attention_window_vec,
         num_layers,
         max_batch_size,
+        enable_indexer_k_cache,
     )
 
     # 2. Initialize data: random for ctx, zeros for gen
@@ -987,6 +1110,21 @@ def run_transfer_test(
             max_attention_window_vec=max_attention_window_vec,
             num_layers=num_layers,
         )
+        if enable_indexer_k_cache:
+            _verify_indexer_k_all_requests(
+                request_lengths=request_lengths,
+                ctx_managers=ctx_managers,
+                gen_managers=gen_managers,
+                ctx_tp=ctx_tp,
+                ctx_pp=ctx_pp,
+                gen_tp=gen_tp,
+                gen_pp=gen_pp,
+                ctx_enable_dp=ctx_enable_dp,
+                gen_enable_dp=gen_enable_dp,
+                ctx_request_ids=ctx_request_ids,
+                gen_request_ids=gen_request_ids,
+                num_layers=num_layers,
+            )
 
         # 9. Cleanup
         if use_v2:
@@ -1309,6 +1447,50 @@ def test_cache_transceiver_boundary_lengths(
     )
 
     print("PASSED")
+
+
+# DSA (DeepSeek V3.2) indexer K cache: V1-only, MLA, TP-replicated single
+# index head. Covers the REPLICATED pool view end to end through the real
+# python transceiver: fan-in owner election, fan-out, and PP layer subsets
+# (layer-strided ReplicatedMapper offsets).
+DSA_INDEXER_CONFIGS = [
+    # (ctx_tp, ctx_pp, gen_tp, gen_pp, ctx_dp, gen_dp, test_id)
+    (1, 1, 1, 1, False, False, "tp1_to_tp1"),
+    (2, 1, 1, 1, False, False, "tp2_to_tp1_fanin"),
+    (1, 1, 2, 1, False, False, "tp1_to_tp2_fanout"),
+    (1, 2, 1, 1, False, False, "pp2_to_pp1"),
+    (1, 1, 1, 2, False, False, "pp1_to_pp2"),
+    (2, 2, 1, 1, False, False, "tp2pp2_to_tp1"),
+    (2, 1, 2, 1, False, True, "tp2_to_dep2"),
+]
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,gen_tp,gen_pp,ctx_enable_dp,gen_enable_dp",
+    [c[:6] for c in DSA_INDEXER_CONFIGS],
+    ids=[c[6] for c in DSA_INDEXER_CONFIGS],
+)
+def test_cache_transceiver_v1_dsa_indexer(
+    ctx_tp,
+    ctx_pp,
+    gen_tp,
+    gen_pp,
+    ctx_enable_dp,
+    gen_enable_dp,
+):
+    """V1 KVCacheManager + DSA indexer K cache through KvCacheTransceiverV2."""
+    run_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        is_mla=True,
+        use_v2=False,
+        enable_indexer_k_cache=True,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
@@ -8,7 +8,7 @@ different TP/PP/DP configurations.
 import os
 import threading
 import uuid
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import pytest
 import torch
@@ -600,8 +600,12 @@ def run_deepseek_v4_transfer_test(
     gen_enable_dp: bool,
     compress_ratios: List[int],
     update_before_transfer: bool = True,
+    *,
+    manager_factory: Callable = _create_managers_for_instance,
+    init_fn: Callable = _init_pool_data,
+    verify_fn: Callable = verify_all_requests,
 ):
-    """Run a full DeepSeek-V4 KV transfer test."""
+    """Run a KV transfer test with injectable model-specific cache hooks."""
     ctx_world = ctx_tp * ctx_pp
     gen_world = gen_tp * gen_pp
 
@@ -610,14 +614,14 @@ def run_deepseek_v4_transfer_test(
     request_lengths = [65, 256, 129, 383]
 
     # ===== 1. Create DeepseekV4CacheManagers =====
-    ctx_managers = _create_managers_for_instance(ctx_tp, ctx_pp, ctx_enable_dp, compress_ratios)
-    gen_managers = _create_managers_for_instance(gen_tp, gen_pp, gen_enable_dp, compress_ratios)
+    ctx_managers = manager_factory(ctx_tp, ctx_pp, ctx_enable_dp, compress_ratios)
+    gen_managers = manager_factory(gen_tp, gen_pp, gen_enable_dp, compress_ratios)
 
     # ===== 2. Initialize data =====
     # ctx: random data, seed=pp_rank (same across TP, different across PP)
-    _init_pool_data(ctx_managers, ctx_tp, seed_base=1000, fill_random=True)
+    init_fn(ctx_managers, ctx_tp, seed_base=1000, fill_random=True)
     # gen: zeros
-    _init_pool_data(gen_managers, gen_tp, fill_random=False)
+    init_fn(gen_managers, gen_tp, fill_random=False)
 
     # ===== 3. Create KvCacheTransceiverV2 instances (threaded init) =====
     config = CacheTransceiverConfig(
@@ -770,7 +774,7 @@ def run_deepseek_v4_transfer_test(
                 gen_managers[rank].update_resources(batch)
 
         # ===== 8. Verify =====
-        verify_all_requests(
+        verify_fn(
             request_lengths=request_lengths,
             compress_ratios=compress_ratios,
             ctx_managers=ctx_managers,

--- a/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
@@ -1,22 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Test KV Transfer for DeepseekV4CacheManager with KvCacheTransceiverV2.
 
-Uses threading + ThreadSafeDistributed to create KvCacheTransceiverV2 instances
-in a single process. Validates all DeepseekV4AttentionType cache transfers across
-different TP/PP/DP configurations.
+Drives the shared threaded single-process harness (``kv_transfer_harness``)
+with DeepSeek-V4 cache managers. Validates all DeepseekV4AttentionType cache
+transfers across different TP/PP/DP configurations.
 """
 
-import os
-import threading
-import uuid
-from typing import Dict, List, Optional, Protocol, Sequence, Tuple, TypeVar
+import functools
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import pytest
 import torch
+from kv_transfer_harness import (
+    MAX_BATCH_SIZE,
+    MAX_SEQ_LEN,
+    TOKENS_PER_BLOCK,
+    VOCAB_SIZE,
+    get_layers_per_pp,
+    run_kv_transfer_test,
+)
 
-import tensorrt_llm
-import tensorrt_llm.bindings
-import tensorrt_llm.tensorrt_llm_transfer_agent_binding  # noqa: F401
-from tensorrt_llm import DisaggregatedParams, Mapping, SamplingParams
+from tensorrt_llm import Mapping
 from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4 import DeepseekV4CacheManager
 from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4.deepseek_v4 import (
     DEEPSEEK_V4_OVERLAP_COMPRESSOR_RATIO,
@@ -25,23 +43,10 @@ from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4.deepseek_v4 import
 )
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
 from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool, get_pool_bytes
-from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
-from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
-from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestType
-from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
-from tensorrt_llm.llmapi.llm_args import (
-    CacheTransceiverConfig,
-    DeepSeekV4SparseAttentionConfig,
-    KvCacheConfig,
-)
-
-# Reduce NIXL threads for unit test: default 8 threads per agent causes heavy
-# contention when creating multiple agents on a single GPU in the same process.
-os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
-
+from tensorrt_llm.llmapi.llm_args import DeepSeekV4SparseAttentionConfig, KvCacheConfig
 
 # ---------------------------------------------------------------------------
 # Constants matching DeepseekV4CacheManager defaults
@@ -49,247 +54,11 @@ os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
 HEAD_DIM = 256  # Reduced from 512: test validates transfer, not attention correctness
 INDEX_HEAD_DIM = 128
 WINDOW_SIZE = 128
-TOKENS_PER_BLOCK = 128
-MAX_SEQ_LEN = 512
-MAX_BATCH_SIZE = 16
-VOCAB_SIZE = 129280
 NUM_KV_HEADS = 1
-
-_CacheManagerT = TypeVar("_CacheManagerT", bound=KVCacheManagerV2)
-_CacheManagerT_co = TypeVar("_CacheManagerT_co", bound=KVCacheManagerV2, covariant=True)
-_CacheManagerT_contra = TypeVar("_CacheManagerT_contra", bound=KVCacheManagerV2, contravariant=True)
-
-
-class _ManagerFactory(Protocol[_CacheManagerT_co]):
-    def __call__(
-        self,
-        tp: int,
-        pp: int,
-        enable_dp: bool,
-        model_config: List[int],
-        /,
-    ) -> Sequence[_CacheManagerT_co]: ...
-
-
-class _CacheInitializer(Protocol[_CacheManagerT_contra]):
-    def __call__(
-        self,
-        managers: Sequence[_CacheManagerT_contra],
-        tp: int,
-        /,
-        *,
-        seed_base: int = 0,
-        fill_random: bool = True,
-    ) -> None: ...
-
-
-class _CacheVerifier(Protocol[_CacheManagerT_contra]):
-    def __call__(
-        self,
-        *,
-        request_lengths: List[int],
-        compress_ratios: List[int],
-        ctx_managers: Sequence[_CacheManagerT_contra],
-        gen_managers: Sequence[_CacheManagerT_contra],
-        ctx_tp: int,
-        ctx_pp: int,
-        gen_tp: int,
-        gen_pp: int,
-        ctx_enable_dp: bool,
-        gen_enable_dp: bool,
-        ctx_request_ids: List[int],
-        gen_request_ids: List[int],
-    ) -> None: ...
-
 
 # DeepSeek-V4 specific ratios (mirrors module constants)
 SPARSE_RATIO = DEEPSEEK_V4_SPARSE_RATIO
 OVERLAP_COMPRESSOR_RATIO = DEEPSEEK_V4_OVERLAP_COMPRESSOR_RATIO
-
-
-# ---------------------------------------------------------------------------
-# ThreadSafeDistributed: threading.Barrier-based Distributed mock
-# ---------------------------------------------------------------------------
-class ThreadSafeDistributed:
-    """Distributed mock using threading.Barrier for single-process multi-rank testing.
-
-    Provides the same interface as TorchDistributedWrapper from test_py_cache_transceiver_mp.py
-    but uses Barrier + Lock + shared dict instead of torch.distributed.
-    """
-
-    def __init__(
-        self,
-        local_rank: int,
-        world_size: int,
-        tp_size: int,
-        pp_size: int,
-        tp_rank: int,
-        pp_rank: int,
-        shared: dict,
-    ):
-        self.rank = local_rank
-        self._world_size = world_size
-        self._tp_size = tp_size
-        self._pp_size = pp_size
-        self._tp_rank = tp_rank
-        self._pp_rank = pp_rank
-        self._s = shared
-        self._bcast_idx = 0
-        self._ag_idx = 0
-        self._pp_ag_idx = 0
-        self._tp_ag_idx = 0
-
-    @property
-    def tp_size(self):
-        return self._tp_size
-
-    @property
-    def pp_size(self):
-        return self._pp_size
-
-    @property
-    def world_size(self):
-        return self._world_size
-
-    def broadcast(self, obj, root=0):
-        idx = self._bcast_idx
-        self._bcast_idx += 1
-        key = f"bcast_{idx}"
-        if self.rank == root:
-            self._s[key] = obj
-        self._s["barrier"].wait()
-        result = self._s[key]
-        self._s["barrier"].wait()
-        return result
-
-    def allgather(self, obj):
-        idx = self._ag_idx
-        self._ag_idx += 1
-        key = f"ag_{idx}"
-        with self._s["lock"]:
-            if key not in self._s:
-                self._s[key] = [None] * self._world_size
-            self._s[key][self.rank] = obj
-        self._s["barrier"].wait()
-        result = list(self._s[key])
-        self._s["barrier"].wait()
-        return result
-
-    def pp_allgather(self, obj):
-        idx = self._pp_ag_idx
-        self._pp_ag_idx += 1
-        key = f"pp_ag_{idx}_tp{self._tp_rank}"
-        with self._s["lock"]:
-            if key not in self._s:
-                self._s[key] = [None] * self._pp_size
-            self._s[key][self._pp_rank] = obj
-        self._s["barrier"].wait()
-        result = list(self._s[key])
-        self._s["barrier"].wait()
-        return result
-
-    def tp_allgather(self, obj):
-        idx = self._tp_ag_idx
-        self._tp_ag_idx += 1
-        key = f"tp_ag_{idx}_pp{self._pp_rank}"
-        with self._s["lock"]:
-            if key not in self._s:
-                self._s[key] = [None] * self._tp_size
-            self._s[key][self._tp_rank] = obj
-        self._s["barrier"].wait()
-        result = list(self._s[key])
-        self._s["barrier"].wait()
-        return result
-
-
-# ---------------------------------------------------------------------------
-# Threading helpers
-# ---------------------------------------------------------------------------
-def run_concurrent(items, fn):
-    """Run fn(item) for each item concurrently in threads and propagate errors."""
-    errors = [None] * len(items)
-    results = [None] * len(items)
-
-    def _worker(idx, item):
-        try:
-            results[idx] = fn(item)
-        except Exception as e:
-            errors[idx] = e
-
-    threads = [threading.Thread(target=_worker, args=(i, item)) for i, item in enumerate(items)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-    for i, err in enumerate(errors):
-        if err is not None:
-            raise err
-    return results
-
-
-def _create_transceiver_in_thread(rank, mapping, cache_manager, dist_mock, config, results, errors):
-    """Thread target: create one KvCacheTransceiverV2."""
-    try:
-        tc = KvCacheTransceiverV2(
-            mapping=mapping,
-            dist=dist_mock,
-            kv_cache_manager=cache_manager,
-            cache_transceiver_config=config,
-        )
-        results[rank] = tc
-    except Exception as e:
-        errors[rank] = e
-
-
-def create_instance_transceivers(
-    tp: int,
-    pp: int,
-    enable_dp: bool,
-    cache_managers: Sequence[KVCacheManagerV2],
-    config: CacheTransceiverConfig,
-) -> List[KvCacheTransceiverV2]:
-    """Create KvCacheTransceiverV2 for all ranks via threaded init."""
-    world_size = tp * pp
-    shared = {"barrier": threading.Barrier(world_size), "lock": threading.Lock()}
-    results = [None] * world_size
-    errors = [None] * world_size
-    threads = []
-
-    for rank in range(world_size):
-        pp_rank = rank // tp
-        tp_rank = rank % tp
-        mapping = Mapping(
-            world_size=world_size,
-            rank=rank,
-            tp_size=tp,
-            pp_size=pp,
-            enable_attention_dp=enable_dp,
-        )
-        dist_mock = ThreadSafeDistributed(rank, world_size, tp, pp, tp_rank, pp_rank, shared)
-        t = threading.Thread(
-            target=_create_transceiver_in_thread,
-            args=(
-                rank,
-                mapping,
-                cache_managers[rank],
-                dist_mock,
-                config,
-                results,
-                errors,
-            ),
-        )
-        threads.append(t)
-
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
-    for rank, err in enumerate(errors):
-        if err is not None:
-            raise err
-
-    return results
 
 
 # ---------------------------------------------------------------------------
@@ -641,12 +410,6 @@ def verify_all_requests(
 # ---------------------------------------------------------------------------
 # Main test function
 # ---------------------------------------------------------------------------
-def _get_ctx_info_endpoint(tc: KvCacheTransceiverV2) -> Optional[str]:
-    """Extract the context_info_endpoint from a transceiver's disaggregated params."""
-    endpoints = tc.get_disaggregated_params().get("ctx_info_endpoint") or []
-    return endpoints[0] if endpoints else None
-
-
 def run_deepseek_v4_transfer_test(
     ctx_tp: int,
     ctx_pp: int,
@@ -656,206 +419,22 @@ def run_deepseek_v4_transfer_test(
     gen_enable_dp: bool,
     compress_ratios: List[int],
     update_before_transfer: bool = True,
-    *,
-    manager_factory: _ManagerFactory[_CacheManagerT] = _create_managers_for_instance,
-    init_fn: _CacheInitializer[_CacheManagerT] = _init_pool_data,
-    verify_fn: _CacheVerifier[_CacheManagerT] = verify_all_requests,
 ) -> None:
-    """Run a KV transfer test with injectable model-specific cache hooks."""
-    ctx_world = ctx_tp * ctx_pp
-    gen_world = gen_tp * gen_pp
-
-    # Mix of block-aligned and non-aligned lengths for boundary testing.
-    # TOKENS_PER_BLOCK=128: 65=half+1, 256=2x exact, 129=1x+1, 383=3x-1
-    request_lengths = [65, 256, 129, 383]
-
-    # ===== 1. Create DeepseekV4CacheManagers =====
-    ctx_managers = list(manager_factory(ctx_tp, ctx_pp, ctx_enable_dp, compress_ratios))
-    gen_managers = list(manager_factory(gen_tp, gen_pp, gen_enable_dp, compress_ratios))
-
-    # ===== 2. Initialize data =====
-    # ctx: random data, seed=pp_rank (same across TP, different across PP)
-    init_fn(ctx_managers, ctx_tp, seed_base=1000, fill_random=True)
-    # gen: zeros
-    init_fn(gen_managers, gen_tp, fill_random=False)
-
-    # ===== 3. Create KvCacheTransceiverV2 instances (threaded init) =====
-    config = CacheTransceiverConfig(
-        backend="NIXL",
-        transceiver_runtime="PYTHON",
-        max_tokens_in_buffer=512,
+    """Run the shared transfer harness with DeepSeek-V4 cache hooks."""
+    run_kv_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        update_before_transfer=update_before_transfer,
+        manager_factory=lambda tp, pp, enable_dp: _create_managers_for_instance(
+            tp, pp, enable_dp, compress_ratios
+        ),
+        init_fn=_init_pool_data,
+        verify_fn=functools.partial(verify_all_requests, compress_ratios=compress_ratios),
     )
-    ctx_tcs = create_instance_transceivers(ctx_tp, ctx_pp, ctx_enable_dp, ctx_managers, config)
-    gen_tcs = create_instance_transceivers(gen_tp, gen_pp, gen_enable_dp, gen_managers, config)
-
-    try:
-        ctx_info_endpoint = _get_ctx_info_endpoint(ctx_tcs[0])
-
-        # ===== 4. Create requests and determine handle map =====
-        # handle_map: rank -> [(req_idx, ctx_request, gen_request)]
-        ctx_handle_map: Dict[int, List] = {r: [] for r in range(ctx_world)}
-        gen_handle_map: Dict[int, List] = {r: [] for r in range(gen_world)}
-        ctx_request_ids: List[int] = []
-        gen_request_ids: List[int] = []
-
-        sampling_params = SamplingParams()
-
-        for req_idx, req_len in enumerate(request_lengths):
-            unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
-            ctx_rid = req_idx * 2
-            gen_rid = req_idx * 2 + 1
-            ctx_request_ids.append(ctx_rid)
-            gen_request_ids.append(gen_rid)
-
-            ctx_dp_rank = req_idx % ctx_tp if ctx_enable_dp else 0
-
-            ctx_request = LlmRequest(
-                request_id=ctx_rid,
-                max_new_tokens=1,
-                input_tokens=list(range(req_len)),
-                sampling_config=tensorrt_llm.bindings.SamplingConfig(
-                    sampling_params._get_sampling_config()
-                ),
-                is_streaming=False,
-                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
-            )
-            ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
-
-            gen_request = LlmRequest(
-                request_id=gen_rid,
-                max_new_tokens=1,
-                input_tokens=list(range(req_len)),
-                sampling_config=tensorrt_llm.bindings.SamplingConfig(
-                    sampling_params._get_sampling_config()
-                ),
-                is_streaming=False,
-                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
-            )
-            gen_request.py_disaggregated_params = DisaggregatedParams(
-                ctx_request_id=ctx_rid,
-                ctx_dp_rank=ctx_dp_rank,
-                ctx_info_endpoint=ctx_info_endpoint,
-                disagg_request_id=unique_rid,
-            )
-
-            for rank in range(ctx_world):
-                tp_rank = rank % ctx_tp
-                should_handle = (not ctx_enable_dp) or (req_idx % ctx_tp == tp_rank)
-                if should_handle:
-                    ctx_handle_map[rank].append((req_idx, ctx_request))
-
-            for rank in range(gen_world):
-                tp_rank = rank % gen_tp
-                should_handle = (not gen_enable_dp) or (req_idx % gen_tp == tp_rank)
-                if should_handle:
-                    gen_handle_map[rank].append((req_idx, gen_request))
-
-        # ===== 5. Allocate KV cache for all ranks =====
-        # prepare_resources is a no-op for non-draft KVCacheManagerV2.
-        # All ranks must allocate BEFORE mutating shared request objects
-        # (add_new_token changes is_first_context_chunk).
-        #
-        # Gen ranks take the disagg-gen-init path: prepare_disagg_gen_init
-        # sizes the cache for the full prompt and pre-declares
-        # history_length=prompt_len, matching what the V2 scheduler's
-        # _try_schedule_disagg_gen_init does in production so the
-        # transceiver's TRANS_COMPLETE contract check is satisfied.
-        # Ctx ranks take the regular prefill path (prepare_context +
-        # resize_context).
-        gen_batches: Dict[int, ScheduledRequests] = {}
-        for rank in range(gen_world):
-            reqs = [req for _, req in gen_handle_map[rank]]
-            if reqs:
-                batch = ScheduledRequests()
-                batch.context_requests_last_chunk = reqs
-                for req in reqs:
-                    gen_managers[rank].prepare_disagg_gen_init(req)
-                gen_batches[rank] = batch
-
-        ctx_batches: Dict[int, ScheduledRequests] = {}
-        for rank in range(ctx_world):
-            reqs = [req for _, req in ctx_handle_map[rank]]
-            if reqs:
-                batch = ScheduledRequests()
-                batch.context_requests_last_chunk = reqs
-                for req in reqs:
-                    ctx_managers[rank].prepare_context(req)
-                    ctx_managers[rank].resize_context(req, req.context_chunk_size)
-                ctx_batches[rank] = batch
-
-        # ===== 5.5. context_current_position + add_new_token =====
-        # Set position on each unique request once (needed for transfer metadata).
-        seen: set = set()
-        for rank in range(ctx_world):
-            for _, req in ctx_handle_map[rank]:
-                if req.py_request_id not in seen:
-                    req.context_current_position = req.prompt_len
-                    req.add_new_token(req.prompt_len, 0)
-                    seen.add(req.py_request_id)
-
-        seen = set()
-        for rank in range(gen_world):
-            for _, req in gen_handle_map[rank]:
-                if req.py_request_id not in seen:
-                    req.context_current_position = req.prompt_len
-                    req.add_new_token(req.prompt_len, 0)
-                    seen.add(req.py_request_id)
-
-        # ===== 5.6. update_resources BEFORE transfer (mode: update_before) =====
-        if update_before_transfer:
-            for rank, batch in ctx_batches.items():
-                ctx_managers[rank].update_resources(batch)
-            for rank, batch in gen_batches.items():
-                gen_managers[rank].update_resources(batch)
-
-        # ===== 6. gen receive + ctx send =====
-        for rank in range(gen_world):
-            for _, req in gen_handle_map[rank]:
-                gen_tcs[rank].request_and_receive_async(req)
-        for rank in range(ctx_world):
-            for _, req in ctx_handle_map[rank]:
-                ctx_tcs[rank].respond_and_send_async(req)
-
-        # ===== 7. Wait for completion (threaded, dist calls inside) =====
-        run_concurrent(
-            ctx_tcs, lambda tc: tc.check_context_transfer_status(None, mark_complete=True)
-        )
-        run_concurrent(gen_tcs, lambda tc: tc.check_gen_transfer_status(None))
-
-        # ===== 7.5. update_resources AFTER transfer (mode: update_after) =====
-        if not update_before_transfer:
-            for rank, batch in ctx_batches.items():
-                ctx_managers[rank].update_resources(batch)
-            for rank, batch in gen_batches.items():
-                gen_managers[rank].update_resources(batch)
-
-        # ===== 8. Verify =====
-        verify_fn(
-            request_lengths=request_lengths,
-            compress_ratios=compress_ratios,
-            ctx_managers=ctx_managers,
-            gen_managers=gen_managers,
-            ctx_tp=ctx_tp,
-            ctx_pp=ctx_pp,
-            gen_tp=gen_tp,
-            gen_pp=gen_pp,
-            ctx_enable_dp=ctx_enable_dp,
-            gen_enable_dp=gen_enable_dp,
-            ctx_request_ids=ctx_request_ids,
-            gen_request_ids=gen_request_ids,
-        )
-
-    finally:
-        for tc in ctx_tcs + gen_tcs:
-            try:
-                tc.shutdown()
-            except Exception:
-                pass
-        for mgr in ctx_managers + gen_managers:
-            try:
-                mgr.shutdown()
-            except Exception:
-                pass
 
 
 # ---------------------------------------------------------------------------
@@ -927,21 +506,6 @@ def test_deepseek_v4_kv_transfer(
 
 
 # ---------------------------------------------------------------------------
-# PP layer distribution helpers (mirrors C++ getLayerNumPPRank)
-# ---------------------------------------------------------------------------
-def _get_layers_per_pp(num_layers: int, pp_size: int) -> List[int]:
-    """Return a list of layer counts per PP rank.
-
-    When num_layers is not evenly divisible by pp_size, the first
-    (num_layers % pp_size) ranks get one extra layer.
-    Matches Mapping.pp_layers / torch.tensor_split behaviour.
-    """
-    base = num_layers // pp_size
-    extra = num_layers % pp_size
-    return [base + (1 if r < extra else 0) for r in range(pp_size)]
-
-
-# ---------------------------------------------------------------------------
 # Uneven PP layer test configurations
 # ---------------------------------------------------------------------------
 # compress_ratios templates for different num_layers (covering ratios 1, 4, 128)
@@ -1009,8 +573,8 @@ def test_deepseek_v4_kv_transfer_uneven_pp(
         f"ctx_tp={ctx_tp} ctx_pp={ctx_pp} gen_tp={gen_tp} gen_pp={gen_pp} "
         f"ctx_dp={ctx_enable_dp} gen_dp={gen_enable_dp} "
         f"num_layers={num_layers} compress_ratios={compress_ratios} "
-        f"layers_per_pp(ctx)={_get_layers_per_pp(num_layers, ctx_pp)} "
-        f"layers_per_pp(gen)={_get_layers_per_pp(num_layers, gen_pp)}"
+        f"layers_per_pp(ctx)={get_layers_per_pp(num_layers, ctx_pp)} "
+        f"layers_per_pp(gen)={get_layers_per_pp(num_layers, gen_pp)}"
     )
 
     run_deepseek_v4_transfer_test(

--- a/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
@@ -8,7 +8,7 @@ different TP/PP/DP configurations.
 import os
 import threading
 import uuid
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Protocol, Sequence, Tuple, TypeVar
 
 import pytest
 import torch
@@ -26,6 +26,7 @@ from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4.deepseek_v4 import
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
 from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool, get_pool_bytes
 from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestType
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
@@ -53,6 +54,52 @@ MAX_SEQ_LEN = 512
 MAX_BATCH_SIZE = 16
 VOCAB_SIZE = 129280
 NUM_KV_HEADS = 1
+
+_CacheManagerT = TypeVar("_CacheManagerT", bound=KVCacheManagerV2)
+_CacheManagerT_co = TypeVar("_CacheManagerT_co", bound=KVCacheManagerV2, covariant=True)
+_CacheManagerT_contra = TypeVar("_CacheManagerT_contra", bound=KVCacheManagerV2, contravariant=True)
+
+
+class _ManagerFactory(Protocol[_CacheManagerT_co]):
+    def __call__(
+        self,
+        tp: int,
+        pp: int,
+        enable_dp: bool,
+        model_config: List[int],
+        /,
+    ) -> Sequence[_CacheManagerT_co]: ...
+
+
+class _CacheInitializer(Protocol[_CacheManagerT_contra]):
+    def __call__(
+        self,
+        managers: Sequence[_CacheManagerT_contra],
+        tp: int,
+        /,
+        *,
+        seed_base: int = 0,
+        fill_random: bool = True,
+    ) -> None: ...
+
+
+class _CacheVerifier(Protocol[_CacheManagerT_contra]):
+    def __call__(
+        self,
+        *,
+        request_lengths: List[int],
+        compress_ratios: List[int],
+        ctx_managers: Sequence[_CacheManagerT_contra],
+        gen_managers: Sequence[_CacheManagerT_contra],
+        ctx_tp: int,
+        ctx_pp: int,
+        gen_tp: int,
+        gen_pp: int,
+        ctx_enable_dp: bool,
+        gen_enable_dp: bool,
+        ctx_request_ids: List[int],
+        gen_request_ids: List[int],
+    ) -> None: ...
 
 
 # DeepSeek-V4 specific ratios (mirrors module constants)
@@ -195,7 +242,11 @@ def _create_transceiver_in_thread(rank, mapping, cache_manager, dist_mock, confi
 
 
 def create_instance_transceivers(
-    tp: int, pp: int, enable_dp: bool, cache_managers: List, config: CacheTransceiverConfig
+    tp: int,
+    pp: int,
+    enable_dp: bool,
+    cache_managers: Sequence[KVCacheManagerV2],
+    config: CacheTransceiverConfig,
 ) -> List[KvCacheTransceiverV2]:
     """Create KvCacheTransceiverV2 for all ranks via threaded init."""
     world_size = tp * pp
@@ -301,7 +352,12 @@ def _create_managers_for_instance(
     return managers
 
 
-def _init_pool_data(managers: List, tp: int, seed_base: int = 0, fill_random: bool = True):
+def _init_pool_data(
+    managers: Sequence[DeepseekV4CacheManager],
+    tp: int,
+    seed_base: int = 0,
+    fill_random: bool = True,
+) -> None:
     """Initialize pool data for all managers.
 
     Uses half-precision view of pool memory for initialization.
@@ -470,7 +526,7 @@ def _read_cache_data(
 
 def _find_ctx_rank_for_layer(
     layer_idx: int,
-    ctx_managers: List[DeepseekV4CacheManager],
+    ctx_managers: Sequence[DeepseekV4CacheManager],
     ctx_tp: int,
     ctx_enable_dp: bool,
     req_idx: int,
@@ -495,8 +551,8 @@ def _find_ctx_rank_for_layer(
 def verify_all_requests(
     request_lengths: List[int],
     compress_ratios: List[int],
-    ctx_managers: List[DeepseekV4CacheManager],
-    gen_managers: List[DeepseekV4CacheManager],
+    ctx_managers: Sequence[DeepseekV4CacheManager],
+    gen_managers: Sequence[DeepseekV4CacheManager],
     ctx_tp: int,
     ctx_pp: int,
     gen_tp: int,
@@ -601,10 +657,10 @@ def run_deepseek_v4_transfer_test(
     compress_ratios: List[int],
     update_before_transfer: bool = True,
     *,
-    manager_factory: Callable = _create_managers_for_instance,
-    init_fn: Callable = _init_pool_data,
-    verify_fn: Callable = verify_all_requests,
-):
+    manager_factory: _ManagerFactory[_CacheManagerT] = _create_managers_for_instance,
+    init_fn: _CacheInitializer[_CacheManagerT] = _init_pool_data,
+    verify_fn: _CacheVerifier[_CacheManagerT] = verify_all_requests,
+) -> None:
     """Run a KV transfer test with injectable model-specific cache hooks."""
     ctx_world = ctx_tp * ctx_pp
     gen_world = gen_tp * gen_pp
@@ -614,8 +670,8 @@ def run_deepseek_v4_transfer_test(
     request_lengths = [65, 256, 129, 383]
 
     # ===== 1. Create DeepseekV4CacheManagers =====
-    ctx_managers = manager_factory(ctx_tp, ctx_pp, ctx_enable_dp, compress_ratios)
-    gen_managers = manager_factory(gen_tp, gen_pp, gen_enable_dp, compress_ratios)
+    ctx_managers = list(manager_factory(ctx_tp, ctx_pp, ctx_enable_dp, compress_ratios))
+    gen_managers = list(manager_factory(gen_tp, gen_pp, gen_enable_dp, compress_ratios))
 
     # ===== 2. Initialize data =====
     # ctx: random data, seed=pp_rank (same across TP, different across PP)

--- a/tests/unittest/disaggregated/test_extractor.py
+++ b/tests/unittest/disaggregated/test_extractor.py
@@ -5,6 +5,7 @@ from tensorrt_llm._torch.disaggregation.base.region import MemRegionGroup, SpecR
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import (
     KVRegionExtractorV1,
     build_page_table,
+    build_page_table_from_manager,
 )
 from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.disaggregation.resource.utils import (
@@ -14,6 +15,11 @@ from tensorrt_llm._torch.disaggregation.resource.utils import (
     get_num_layers,
     get_physical_pool,
     get_unique_layers,
+)
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import (
+    DisaggCacheLayout,
+    DisaggPoolViewConfig,
+    Role,
 )
 from tensorrt_llm._torch.pyexecutor.resource_manager import (
     CacheTypeCpp,
@@ -230,6 +236,184 @@ def test_layer_group_meta_serialization():
     assert restored_lg.kv_head_num_per_rank == 4
     assert len(restored_lg.local_layers) == 2
     assert len(restored_lg.pool_views[0].buffer_entries) == 2
+
+
+def test_extract_logical_pool_view_uses_physical_stride():
+    from tensorrt_llm._torch.disaggregation.resource.page import (
+        BUFFER_ENTRY_DTYPE,
+        AttentionLayerGroup,
+        KVCachePageTable,
+        LocalLayer,
+        PhysicalPool,
+        PhysicalPoolGroup,
+        PoolView,
+    )
+
+    page_table = KVCachePageTable(
+        tokens_per_block=16,
+        layer_groups=[
+            AttentionLayerGroup(
+                pool_group_idx=0,
+                kv_head_num_per_rank=1,
+                local_layers=[LocalLayer(0, 0)],
+                pool_views=[
+                    PoolView(
+                        pool_idx=0,
+                        buffer_entries=np.array([(0, 256, 128)], dtype=BUFFER_ENTRY_DTYPE),
+                        pool_role=frozenset({"index_key"}),
+                        mapper_kind=MapperKind.REPLICATED,
+                        byte_offset=256,
+                        bytes_per_region=128,
+                    )
+                ],
+            )
+        ],
+        pool_groups=[
+            PhysicalPoolGroup(pools=[PhysicalPool(base_address=1000, slot_bytes=384, num_slots=4)])
+        ],
+    )
+
+    region = KVRegionExtractorV1(page_table).extract(np.array([0, -1, 2], dtype=np.int64))
+    np.testing.assert_array_equal(region.memory.ptrs, np.array([1256, 2024]))
+    assert region.memory.bytes_per_region == 128
+
+
+def test_v2_index_key_builder_emits_per_layer_logical_views():
+    from types import SimpleNamespace
+
+    from tensorrt_llm.runtime.kv_cache_manager_v2 import CacheTier
+
+    base = 0x1000
+    slot_bytes = 640
+    attrs = {
+        (0, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=0, size=128),
+        (0, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=128, size=128),
+        (0, Role.INDEX_KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=256, size=128),
+        (1, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=384, size=128),
+        (1, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=512, size=128),
+    }
+
+    class FakePool:
+        slot_size = slot_bytes
+        num_slots = 4
+
+        @staticmethod
+        def slot_address(slot):
+            return base + slot * slot_bytes
+
+    class FakeImpl:
+        layer_grouping = ((0, 1),)
+        _life_cycles = [SimpleNamespace(window_size=None)]
+        _init_config = SimpleNamespace(
+            cache_tiers=[SimpleNamespace(tier=CacheTier.GPU_MEM)], tokens_per_block=16
+        )
+        _storage = SimpleNamespace(
+            _buffer_attr=attrs,
+            num_life_cycles=1,
+            get_pool_group_index=lambda _lc: 0,
+            _levels=[
+                SimpleNamespace(
+                    storage=SimpleNamespace(
+                        _pool_groups=[SimpleNamespace(num_pools=1, _pools=[FakePool()])]
+                    )
+                )
+            ],
+        )
+
+        def get_aggregated_pages(self, buffers):
+            local_attrs = self._storage._buffer_attr
+            ordered = sorted(buffers, key=lambda b: local_attrs[b].offset)
+            first = local_attrs[ordered[0]]
+            size = sum(local_attrs[b].size for b in ordered)
+            return [
+                SimpleNamespace(
+                    base=base + first.offset,
+                    size=size,
+                    stride=slot_bytes,
+                    buffers=[SimpleNamespace(id=b) for b in ordered],
+                )
+            ]
+
+    manager = SimpleNamespace(
+        impl=FakeImpl(),
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+        get_disagg_pool_view_config=lambda: DisaggPoolViewConfig(
+            sharded_layout=DisaggCacheLayout.NHD,
+            replicated_roles=frozenset({Role.INDEX_KEY}),
+        ),
+    )
+
+    page_table = build_page_table_from_manager(manager)
+    views = page_table.layer_groups[0].pool_views
+    assert [view.pool_role for view in views] == [
+        frozenset({"key", "value"}),
+        frozenset({"index_key"}),
+        frozenset({"key", "value"}),
+    ]
+    assert [view.mapper_kind for view in views] == [
+        MapperKind.NHD,
+        MapperKind.REPLICATED,
+        MapperKind.NHD,
+    ]
+    assert [view.byte_offset for view in views] == [0, 256, 384]
+    assert [view.bytes_per_region for view in views] == [256, 128, 256]
+
+    # A dense-only PP rank has no local INDEX_KEY entry, but model-level sparse
+    # metadata must still force per-layer views so it can interoperate with a
+    # peer PP rank that also owns sparse layers.
+    dense_impl = FakeImpl()
+    dense_impl._storage = SimpleNamespace(
+        _buffer_attr={key: attr for key, attr in attrs.items() if key[1] != Role.INDEX_KEY},
+        num_life_cycles=1,
+        get_pool_group_index=lambda _lc: 0,
+        _levels=FakeImpl._storage._levels,
+    )
+    dense_manager = SimpleNamespace(
+        impl=dense_impl,
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+        get_disagg_pool_view_config=manager.get_disagg_pool_view_config,
+    )
+    dense_views = build_page_table_from_manager(dense_manager).layer_groups[0].pool_views
+    assert len(dense_views) == 2
+    assert [get_unique_layers(view) for view in dense_views] == [{0}, {1}]
+
+    # A private attribute with a coincidental name must not opt a manager into
+    # model-specific logical views.
+    accidental_manager = SimpleNamespace(
+        impl=FakeImpl(),
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+        sparse_layer_ids=[3],
+        get_disagg_pool_view_config=lambda: None,
+    )
+    accidental_views = build_page_table_from_manager(accidental_manager).layer_groups[0].pool_views
+    assert len(accidental_views) == 1
+    assert accidental_views[0].mapper_kind == MapperKind.INDEXED
+
+    # V2 managers must expose the capability method explicitly. A missing
+    # method is a programming error rather than an invitation to guess from
+    # private attributes.
+    missing_capability_manager = SimpleNamespace(
+        impl=FakeImpl(),
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+    )
+    with pytest.raises(AttributeError, match="get_disagg_pool_view_config"):
+        build_page_table_from_manager(missing_capability_manager)
+
+    invalid_layout_manager = SimpleNamespace(
+        impl=FakeImpl(),
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+        get_disagg_pool_view_config=lambda: DisaggPoolViewConfig(
+            sharded_layout="HND",
+            replicated_roles=frozenset({Role.INDEX_KEY}),
+        ),
+    )
+    with pytest.raises(ValueError, match="Unsupported disaggregation sharded layout 'HND'"):
+        build_page_table_from_manager(invalid_layout_manager)
 
 
 def test_mamba_layer_group_serialization():

--- a/tests/unittest/disaggregated/test_extractor.py
+++ b/tests/unittest/disaggregated/test_extractor.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import pytest
 
@@ -10,6 +25,7 @@ from tensorrt_llm._torch.disaggregation.resource.kv_extractor import (
 from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.disaggregation.resource.utils import (
     get_global_layer_ids,
+    get_layer_byte_ranges,
     get_layer_to_layer_group,
     get_num_layer_groups,
     get_num_layers,
@@ -189,6 +205,142 @@ def test_build_page_table():
     manager.shutdown()
 
 
+def _make_v1_dsa_manager(pp_size: int = 1, pp_rank: int = 0) -> KVCacheManager:
+    """V1 KVCacheManager with the DSA indexer K cache enabled (MLA-style)."""
+    return KVCacheManager(
+        kv_cache_config=KvCacheConfig(
+            max_tokens=512,
+            enable_block_reuse=False,
+            event_buffer_max_size=0,
+        ),
+        kv_cache_type=CacheTypeCpp.SELFKONLY,
+        num_layers=4,
+        num_kv_heads=1,
+        head_dim=64,
+        tokens_per_block=32,
+        max_seq_len=256,
+        max_batch_size=2,
+        mapping=Mapping(world_size=pp_size, rank=pp_rank, tp_size=1, pp_size=pp_size),
+        dtype=DataType.HALF,
+        enable_indexer_k_cache=True,
+        indexer_k_cache_quant_block_size=128,
+        indexer_k_cache_index_head_dim=128,
+    )
+
+
+def _byte_view(ptr: int, nbytes: int):
+    from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
+
+    return convert_to_torch_tensor(TensorWrapper(int(ptr), DataType.INT8, [int(nbytes)]))
+
+
+@pytest.mark.cuda
+def test_v1_dsa_indexer_page_table_is_replicated_with_per_layer_entries():
+    manager = _make_v1_dsa_manager()
+    try:
+        page_table = build_page_table(manager)
+        lg = page_table.layer_groups[0]
+        assert len(lg.pool_views) == 2
+
+        kv_view, idx_view = lg.pool_views
+        assert kv_view.mapper_kind == MapperKind.INDEXED
+        assert idx_view.mapper_kind == MapperKind.REPLICATED
+        assert idx_view.pool_role == frozenset({"indexer_k"})
+
+        # One synthesized entry per LG layer, equal-sized, contiguous from 0.
+        assert get_unique_layers(idx_view) == get_unique_layers(kv_view)
+        idx_pool = get_physical_pool(page_table, 0, idx_view.pool_idx)
+        sizes = {int(entry["size"]) for entry in idx_view.buffer_entries}
+        assert len(sizes) == 1
+        per_layer = sizes.pop()
+        assert per_layer * len(idx_view.buffer_entries) == idx_pool.slot_bytes
+        offsets = sorted(int(entry["offset"]) for entry in idx_view.buffer_entries)
+        assert offsets == [i * per_layer for i in range(len(offsets))]
+    finally:
+        manager.shutdown()
+
+
+@pytest.mark.cuda
+def test_v1_dsa_indexer_replicated_transfer_across_pp():
+    """PP1 ctx sends the DSA indexer K cache into two PP2 gen ranks.
+
+    Exercises the full python path on real V1 managers: page-table build,
+    role-set matching, ReplicatedMapper layer-strided offsets, and a
+    byte-level copy that must land each gen rank's layer subset at the
+    right offsets.
+    """
+    import torch
+
+    from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import ReplicatedMapper
+    from tensorrt_llm._torch.disaggregation.native.peer import PeerRegistrar
+    from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
+
+    ctx = _make_v1_dsa_manager()
+    gens = [_make_v1_dsa_manager(pp_size=2, pp_rank=r) for r in range(2)]
+    try:
+        ctx_extractor = KVRegionExtractorV1(ctx)
+        ctx_ri = RankInfo.from_kv_cache_manager("ctx", ctx, device_id=0)
+        registrar = PeerRegistrar(ctx_ri, ctx_extractor)
+
+        # Fill ctx indexer pool with position-dependent bytes; zero gen pools.
+        ctx_pool_tensor = ctx.impl.get_indexer_k_cache_pool()
+        flat = ctx_pool_tensor.view(torch.uint8).flatten()
+        flat.copy_(torch.arange(flat.numel(), dtype=torch.int64, device=flat.device) % 251)
+        for gen in gens:
+            gen.impl.get_indexer_k_cache_pool().view(torch.uint8).zero_()
+
+        block_ids = np.array([0, 2, 3], dtype=np.int64)
+        ctx_pt = ctx_extractor.page_table
+        idx_pool = get_physical_pool(ctx_pt, 0, 1)
+        layers_per_gen = 2
+        per_layer = idx_pool.slot_bytes // 4
+
+        for gen_pp_rank, gen in enumerate(gens):
+            gen_ri = RankInfo.from_kv_cache_manager("gen", gen, device_id=0)
+            registrar.register("gen", gen_ri.instance_rank, gen_ri)
+            mapping = registrar.get_pool_mapping(gen_ri)
+            # KV pool and indexer pool each match 1:1.
+            assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
+
+            mapper = registrar.get_kv_map(gen_ri, (0, 1), (0, 1))
+            assert isinstance(mapper, ReplicatedMapper)
+
+            gen_extractor = registrar.peer_extractor("gen", gen_ri.instance_rank)
+            pair = mapper.map(
+                ctx_extractor.extract(block_ids, layer_group_id=0, pool_idx=1),
+                gen_extractor.extract(block_ids, layer_group_id=0, pool_idx=1),
+            )
+            # This gen rank holds 2 of the 4 layers; the fragment is the
+            # contiguous 2-layer range at this PP stage's offset within
+            # the ctx slot.
+            assert pair.src.memory.bytes_per_region == layers_per_gen * per_layer
+            expected_src_off = gen_pp_rank * layers_per_gen * per_layer
+            base_ptrs = idx_pool.base_address + block_ids * idx_pool.slot_bytes
+            np.testing.assert_array_equal(pair.src.memory.ptrs, base_ptrs + expected_src_off)
+
+            # Emulate the transfer with raw byte copies, then verify content.
+            for src_ptr, dst_ptr in zip(pair.src.memory.ptrs, pair.dst.memory.ptrs):
+                _byte_view(dst_ptr, pair.dst.memory.bytes_per_region).copy_(
+                    _byte_view(src_ptr, pair.src.memory.bytes_per_region)
+                )
+
+            gen_pool_tensor = gen.impl.get_indexer_k_cache_pool()
+            gen_bytes = gen_pool_tensor.view(torch.uint8).reshape(gen_pool_tensor.shape[0], -1)
+            ctx_bytes = ctx_pool_tensor.view(torch.uint8).reshape(ctx_pool_tensor.shape[0], -1)
+            src_lo = gen_pp_rank * layers_per_gen * per_layer
+            src_hi = src_lo + layers_per_gen * per_layer
+            torch.testing.assert_close(
+                gen_bytes[block_ids],
+                ctx_bytes[block_ids, src_lo:src_hi],
+                rtol=0,
+                atol=0,
+            )
+    finally:
+        ctx.shutdown()
+        for gen in gens:
+            gen.shutdown()
+
+
 def test_layer_group_meta_serialization():
     import numpy as np
 
@@ -234,57 +386,93 @@ def test_layer_group_meta_serialization():
     assert len(restored_lg.pool_views[0].buffer_entries) == 2
 
 
-@pytest.mark.parametrize(
-    ("bytes_per_region", "expected_region_size"),
-    [(128, 128), (0, 0), (None, 384)],
-)
-def test_extract_logical_pool_view_uses_physical_stride(bytes_per_region, expected_region_size):
-    from tensorrt_llm._torch.disaggregation.resource.page import (
-        BUFFER_ENTRY_DTYPE,
-        AttentionLayerGroup,
-        KVCachePageTable,
-        LocalLayer,
-        PhysicalPool,
-        PhysicalPoolGroup,
-        PoolView,
-    )
-
-    page_table = KVCachePageTable(
-        tokens_per_block=16,
-        layer_groups=[
-            AttentionLayerGroup(
-                pool_group_idx=0,
-                kv_head_num_per_rank=1,
-                local_layers=[LocalLayer(0, 0)],
-                pool_views=[
-                    PoolView(
-                        pool_idx=0,
-                        buffer_entries=np.array([(0, 256, 128)], dtype=BUFFER_ENTRY_DTYPE),
-                        pool_role=frozenset({"index_key"}),
-                        mapper_kind=MapperKind.REPLICATED,
-                        byte_offset=256,
-                        bytes_per_region=bytes_per_region,
-                    )
-                ],
-            )
-        ],
-        pool_groups=[
-            PhysicalPoolGroup(pools=[PhysicalPool(base_address=1000, slot_bytes=384, num_slots=4)])
-        ],
-    )
-
-    region = KVRegionExtractorV1(page_table).extract(np.array([0, -1, 2], dtype=np.int64))
-    np.testing.assert_array_equal(region.memory.ptrs, np.array([1256, 2024]))
-    assert region.memory.bytes_per_region == expected_region_size
-
-
-def test_v2_index_key_builder_keeps_pool_level_view():
+def _make_fake_v2_manager(attrs, role_mapper_kinds, *, num_pools=1, slot_bytes_list=(640,)):
+    """Build a minimal duck-typed KVCacheManagerV2 for _build_page_table_v2."""
     from types import SimpleNamespace
 
     from tensorrt_llm.runtime.kv_cache_manager_v2 import CacheTier
 
     base = 0x1000
-    slot_bytes = 640
+
+    def _make_pool(slot_bytes):
+        return SimpleNamespace(
+            slot_size=slot_bytes,
+            num_slots=4,
+            slot_address=lambda slot, _sb=slot_bytes: base + slot * _sb,
+        )
+
+    impl = SimpleNamespace(
+        layer_grouping=((0, 1),),
+        _life_cycles=[SimpleNamespace(window_size=None)],
+        _init_config=SimpleNamespace(
+            cache_tiers=[SimpleNamespace(tier=CacheTier.GPU_MEM)], tokens_per_block=16
+        ),
+        _storage=SimpleNamespace(
+            _buffer_attr=attrs,
+            num_life_cycles=1,
+            get_pool_group_index=lambda _lc: 0,
+            _levels=[
+                SimpleNamespace(
+                    storage=SimpleNamespace(
+                        _pool_groups=[
+                            SimpleNamespace(
+                                num_pools=num_pools,
+                                _pools=[_make_pool(sb) for sb in slot_bytes_list],
+                            )
+                        ]
+                    )
+                )
+            ],
+        ),
+    )
+    return SimpleNamespace(
+        impl=impl,
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+        get_disagg_role_mapper_kinds=lambda: role_mapper_kinds,
+    )
+
+
+def test_v2_builder_stamps_homogeneous_pool_kinds():
+    """Split KV / INDEX_KEY pools get NHD and REPLICATED views respectively."""
+    from types import SimpleNamespace
+
+    attrs = {
+        (0, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=0, size=128),
+        (0, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=128, size=128),
+        (1, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=256, size=128),
+        (1, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=384, size=128),
+        (1, Role.INDEX_KEY): SimpleNamespace(life_cycle_id=0, pool_index=1, offset=0, size=128),
+    }
+    manager = _make_fake_v2_manager(
+        attrs,
+        {Role.ALL: MapperKind.NHD, Role.INDEX_KEY: MapperKind.REPLICATED},
+        num_pools=2,
+        slot_bytes_list=(512, 128),
+    )
+
+    views = build_page_table_from_manager(manager).layer_groups[0].pool_views
+    assert len(views) == 2
+    assert views[0].pool_role == frozenset({"key", "value"})
+    assert views[0].mapper_kind == MapperKind.NHD
+    assert get_unique_layers(views[0]) == {0, 1}
+    assert views[1].pool_role == frozenset({"index_key"})
+    assert views[1].mapper_kind == MapperKind.REPLICATED
+    assert get_unique_layers(views[1]) == {1}
+
+
+def test_v2_builder_splits_mixed_kind_pool_into_per_class_views():
+    """A pool coalescing several role classes yields one view per class.
+
+    Miniature of the MiniMax M3 layout at TP degrees where
+    K == V == INDEX_KEY bytes per block: V2 storage coalesces all three
+    into one pool and the slot interleaves the sparse layer's INDEX_KEY
+    between the layers' K/V regions. The builder must split the pool into
+    a NHD K/V view (non-uniform layer offsets, uniform per-layer size)
+    and a REPLICATED INDEX_KEY view covering only the sparse layer.
+    """
+    from types import SimpleNamespace
+
     attrs = {
         (0, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=0, size=128),
         (0, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=128, size=128),
@@ -292,142 +480,87 @@ def test_v2_index_key_builder_keeps_pool_level_view():
         (1, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=384, size=128),
         (1, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=512, size=128),
     }
-
-    class FakePool:
-        slot_size = slot_bytes
-        num_slots = 4
-
-        @staticmethod
-        def slot_address(slot):
-            return base + slot * slot_bytes
-
-    class FakeImpl:
-        layer_grouping = ((0, 1),)
-        _life_cycles = [SimpleNamespace(window_size=None)]
-        _init_config = SimpleNamespace(
-            cache_tiers=[SimpleNamespace(tier=CacheTier.GPU_MEM)], tokens_per_block=16
-        )
-        _storage = SimpleNamespace(
-            _buffer_attr=attrs,
-            num_life_cycles=1,
-            get_pool_group_index=lambda _lc: 0,
-            _levels=[
-                SimpleNamespace(
-                    storage=SimpleNamespace(
-                        _pool_groups=[SimpleNamespace(num_pools=1, _pools=[FakePool()])]
-                    )
-                )
-            ],
-        )
-
-    manager = SimpleNamespace(
-        impl=FakeImpl(),
-        pp_layers=[0, 1],
-        num_kv_heads_per_layer=[1, 1],
-        get_disagg_role_mapper_kinds=lambda: {
-            Role.ALL: MapperKind.NHD,
-            Role.INDEX_KEY: MapperKind.REPLICATED,
-        },
+    manager = _make_fake_v2_manager(
+        attrs,
+        {Role.ALL: MapperKind.NHD, Role.INDEX_KEY: MapperKind.REPLICATED},
     )
 
-    page_table = build_page_table_from_manager(manager)
-    views = page_table.layer_groups[0].pool_views
+    views = build_page_table_from_manager(manager).layer_groups[0].pool_views
+    assert len(views) == 2
+    kv_view, idx_view = views
+    # Both views address the same physical pool.
+    assert kv_view.pool_idx == idx_view.pool_idx == 0
+
+    assert kv_view.pool_role == frozenset({"key", "value"})
+    assert kv_view.mapper_kind == MapperKind.NHD
+    assert get_unique_layers(kv_view) == {0, 1}
+    assert kv_view.bytes_per_layer == 256
+    kv_starts, kv_bytes_per_layer = get_layer_byte_ranges(kv_view)
+    # Layer stride is non-uniform: INDEX_KEY interleaves after layer 0.
+    assert kv_starts == {0: 0, 1: 384}
+    assert kv_bytes_per_layer == 256
+
+    assert idx_view.pool_role == frozenset({"index_key"})
+    assert idx_view.mapper_kind == MapperKind.REPLICATED
+    assert get_unique_layers(idx_view) == {0}
+    assert idx_view.bytes_per_layer == 128
+    idx_starts, _ = get_layer_byte_ranges(idx_view)
+    assert idx_starts == {0: 256}
+
+
+def test_v2_builder_validates_role_mapper_declaration():
+    from types import SimpleNamespace
+
+    attrs = {
+        (0, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=0, size=128),
+        (0, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=128, size=128),
+        (1, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=256, size=128),
+        (1, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=384, size=128),
+    }
+
+    # Default INDEXED declaration keeps the whole-slot HND view.
+    views = (
+        build_page_table_from_manager(_make_fake_v2_manager(attrs, {Role.ALL: MapperKind.INDEXED}))
+        .layer_groups[0]
+        .pool_views
+    )
     assert len(views) == 1
-    assert views[0].pool_role == frozenset({"key", "value", "index_key"})
-    assert views[0].mapper_kind == MapperKind.MIXED
-    assert views[0].buffer_roles == ("key", "value", "index_key", "key", "value")
-    assert views[0].buffer_mapper_kinds == (
-        MapperKind.NHD,
-        MapperKind.NHD,
-        MapperKind.REPLICATED,
-        MapperKind.NHD,
-        MapperKind.NHD,
-    )
-    assert views[0].byte_offset == 0
-    assert views[0].bytes_per_region is None
+    assert views[0].mapper_kind == MapperKind.INDEXED
 
-    # A dense-only PP rank has no local INDEX_KEY entry, so its one physical
-    # pool view is homogeneous NHD.
-    dense_impl = FakeImpl()
-    dense_impl._storage = SimpleNamespace(
-        _buffer_attr={key: attr for key, attr in attrs.items() if key[1] != Role.INDEX_KEY},
-        num_life_cycles=1,
-        get_pool_group_index=lambda _lc: 0,
-        _levels=FakeImpl._storage._levels,
-    )
-    dense_manager = SimpleNamespace(
-        impl=dense_impl,
-        pp_layers=[0, 1],
-        num_kv_heads_per_layer=[1, 1],
-        get_disagg_role_mapper_kinds=manager.get_disagg_role_mapper_kinds,
-    )
-    dense_views = build_page_table_from_manager(dense_manager).layer_groups[0].pool_views
-    assert len(dense_views) == 1
-    assert get_unique_layers(dense_views[0]) == {0, 1}
-    assert dense_views[0].mapper_kind == MapperKind.NHD
-
-    # A private attribute with a coincidental name must not opt a manager into
-    # model-specific logical views.
-    accidental_manager = SimpleNamespace(
-        impl=FakeImpl(),
-        pp_layers=[0, 1],
-        num_kv_heads_per_layer=[1, 1],
-        sparse_layer_ids=[3],
-        get_disagg_role_mapper_kinds=lambda: {Role.ALL: MapperKind.INDEXED},
-    )
-    accidental_views = build_page_table_from_manager(accidental_manager).layer_groups[0].pool_views
-    assert len(accidental_views) == 1
-    assert accidental_views[0].mapper_kind == MapperKind.INDEXED
-
-    # V2 managers must expose the capability method explicitly. A missing
-    # method is a programming error rather than an invitation to guess from
-    # private attributes.
-    missing_capability_manager = SimpleNamespace(
-        impl=FakeImpl(),
-        pp_layers=[0, 1],
-        num_kv_heads_per_layer=[1, 1],
-    )
+    # V2 managers must expose the capability method explicitly.
+    missing_capability = _make_fake_v2_manager(attrs, {Role.ALL: MapperKind.INDEXED})
+    del missing_capability.get_disagg_role_mapper_kinds
     with pytest.raises(AttributeError, match="get_disagg_role_mapper_kinds"):
-        build_page_table_from_manager(missing_capability_manager)
+        build_page_table_from_manager(missing_capability)
 
-    missing_default_manager = SimpleNamespace(
-        impl=FakeImpl(),
-        pp_layers=[0, 1],
-        num_kv_heads_per_layer=[1, 1],
-        get_disagg_role_mapper_kinds=lambda: {Role.INDEX_KEY: MapperKind.REPLICATED},
-    )
     with pytest.raises(ValueError, match="must define Role.ALL"):
-        build_page_table_from_manager(missing_default_manager)
+        build_page_table_from_manager(
+            _make_fake_v2_manager(attrs, {Role.INDEX_KEY: MapperKind.REPLICATED})
+        )
 
-    invalid_mapper_manager = SimpleNamespace(
-        impl=FakeImpl(),
-        pp_layers=[0, 1],
-        num_kv_heads_per_layer=[1, 1],
-        get_disagg_role_mapper_kinds=lambda: {Role.ALL: "HND"},
-    )
     with pytest.raises(ValueError, match="Invalid disaggregation mapper kind 'HND'"):
-        build_page_table_from_manager(invalid_mapper_manager)
+        build_page_table_from_manager(_make_fake_v2_manager(attrs, {Role.ALL: "HND"}))
 
-    unsupported_mapper_manager = SimpleNamespace(
-        impl=FakeImpl(),
-        pp_layers=[0, 1],
-        num_kv_heads_per_layer=[1, 1],
-        get_disagg_role_mapper_kinds=lambda: {Role.ALL: MapperKind.FLAT},
-    )
-    with pytest.raises(ValueError, match="Unsupported V2 disaggregation mapper kind FLAT"):
-        build_page_table_from_manager(unsupported_mapper_manager)
+    with pytest.raises(ValueError, match="INDEXED is only valid as the Role.ALL mapping"):
+        build_page_table_from_manager(
+            _make_fake_v2_manager(attrs, {Role.ALL: MapperKind.NHD, Role.KEY: MapperKind.INDEXED})
+        )
 
-    mixed_indexed_manager = SimpleNamespace(
-        impl=FakeImpl(),
-        pp_layers=[0, 1],
-        num_kv_heads_per_layer=[1, 1],
-        get_disagg_role_mapper_kinds=lambda: {
-            Role.ALL: MapperKind.NHD,
-            Role.KEY: MapperKind.INDEXED,
-        },
+    # INDEXED as the Role.ALL fallback coexists with side-cache roles that
+    # declare their own kind (the base-manager default for INDEX_KEY); with
+    # no INDEX_KEY buffers registered the declaration is inert.
+    views = (
+        build_page_table_from_manager(
+            _make_fake_v2_manager(
+                attrs,
+                {Role.ALL: MapperKind.INDEXED, Role.INDEX_KEY: MapperKind.REPLICATED},
+            )
+        )
+        .layer_groups[0]
+        .pool_views
     )
-    with pytest.raises(ValueError, match="INDEXED is only valid as the sole Role.ALL mapping"):
-        build_page_table_from_manager(mixed_indexed_manager)
+    assert len(views) == 1
+    assert views[0].mapper_kind == MapperKind.INDEXED
 
 
 def test_mamba_layer_group_serialization():

--- a/tests/unittest/disaggregated/test_extractor.py
+++ b/tests/unittest/disaggregated/test_extractor.py
@@ -16,11 +16,7 @@ from tensorrt_llm._torch.disaggregation.resource.utils import (
     get_physical_pool,
     get_unique_layers,
 )
-from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import (
-    DisaggCacheLayout,
-    DisaggPoolViewConfig,
-    Role,
-)
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import Role
 from tensorrt_llm._torch.pyexecutor.resource_manager import (
     CacheTypeCpp,
     DataType,
@@ -342,10 +338,10 @@ def test_v2_index_key_builder_emits_per_layer_logical_views():
         impl=FakeImpl(),
         pp_layers=[0, 1],
         num_kv_heads_per_layer=[1, 1],
-        get_disagg_pool_view_config=lambda: DisaggPoolViewConfig(
-            sharded_layout=DisaggCacheLayout.NHD,
-            replicated_roles=frozenset({Role.INDEX_KEY}),
-        ),
+        get_disagg_role_mapper_kinds=lambda: {
+            Role.ALL: MapperKind.NHD,
+            Role.INDEX_KEY: MapperKind.REPLICATED,
+        },
     )
 
     page_table = build_page_table_from_manager(manager)
@@ -377,7 +373,7 @@ def test_v2_index_key_builder_emits_per_layer_logical_views():
         impl=dense_impl,
         pp_layers=[0, 1],
         num_kv_heads_per_layer=[1, 1],
-        get_disagg_pool_view_config=manager.get_disagg_pool_view_config,
+        get_disagg_role_mapper_kinds=manager.get_disagg_role_mapper_kinds,
     )
     dense_views = build_page_table_from_manager(dense_manager).layer_groups[0].pool_views
     assert len(dense_views) == 2
@@ -390,7 +386,7 @@ def test_v2_index_key_builder_emits_per_layer_logical_views():
         pp_layers=[0, 1],
         num_kv_heads_per_layer=[1, 1],
         sparse_layer_ids=[3],
-        get_disagg_pool_view_config=lambda: None,
+        get_disagg_role_mapper_kinds=lambda: {Role.ALL: MapperKind.INDEXED},
     )
     accidental_views = build_page_table_from_manager(accidental_manager).layer_groups[0].pool_views
     assert len(accidental_views) == 1
@@ -404,20 +400,47 @@ def test_v2_index_key_builder_emits_per_layer_logical_views():
         pp_layers=[0, 1],
         num_kv_heads_per_layer=[1, 1],
     )
-    with pytest.raises(AttributeError, match="get_disagg_pool_view_config"):
+    with pytest.raises(AttributeError, match="get_disagg_role_mapper_kinds"):
         build_page_table_from_manager(missing_capability_manager)
 
-    invalid_layout_manager = SimpleNamespace(
+    missing_default_manager = SimpleNamespace(
         impl=FakeImpl(),
         pp_layers=[0, 1],
         num_kv_heads_per_layer=[1, 1],
-        get_disagg_pool_view_config=lambda: DisaggPoolViewConfig(
-            sharded_layout="HND",
-            replicated_roles=frozenset({Role.INDEX_KEY}),
-        ),
+        get_disagg_role_mapper_kinds=lambda: {Role.INDEX_KEY: MapperKind.REPLICATED},
     )
-    with pytest.raises(ValueError, match="Unsupported disaggregation sharded layout 'HND'"):
-        build_page_table_from_manager(invalid_layout_manager)
+    with pytest.raises(ValueError, match="must define Role.ALL"):
+        build_page_table_from_manager(missing_default_manager)
+
+    invalid_mapper_manager = SimpleNamespace(
+        impl=FakeImpl(),
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+        get_disagg_role_mapper_kinds=lambda: {Role.ALL: "HND"},
+    )
+    with pytest.raises(ValueError, match="Invalid disaggregation mapper kind 'HND'"):
+        build_page_table_from_manager(invalid_mapper_manager)
+
+    unsupported_mapper_manager = SimpleNamespace(
+        impl=FakeImpl(),
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+        get_disagg_role_mapper_kinds=lambda: {Role.ALL: MapperKind.FLAT},
+    )
+    with pytest.raises(ValueError, match="Unsupported V2 disaggregation mapper kind FLAT"):
+        build_page_table_from_manager(unsupported_mapper_manager)
+
+    mixed_indexed_manager = SimpleNamespace(
+        impl=FakeImpl(),
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+        get_disagg_role_mapper_kinds=lambda: {
+            Role.ALL: MapperKind.NHD,
+            Role.KEY: MapperKind.INDEXED,
+        },
+    )
+    with pytest.raises(ValueError, match="INDEXED is only valid as the sole Role.ALL mapping"):
+        build_page_table_from_manager(mixed_indexed_manager)
 
 
 def test_mamba_layer_group_serialization():

--- a/tests/unittest/disaggregated/test_extractor.py
+++ b/tests/unittest/disaggregated/test_extractor.py
@@ -278,7 +278,7 @@ def test_extract_logical_pool_view_uses_physical_stride(bytes_per_region, expect
     assert region.memory.bytes_per_region == expected_region_size
 
 
-def test_v2_index_key_builder_emits_per_layer_logical_views():
+def test_v2_index_key_builder_keeps_pool_level_view():
     from types import SimpleNamespace
 
     from tensorrt_llm.runtime.kv_cache_manager_v2 import CacheTier
@@ -320,20 +320,6 @@ def test_v2_index_key_builder_emits_per_layer_logical_views():
             ],
         )
 
-        def get_aggregated_pages(self, buffers):
-            local_attrs = self._storage._buffer_attr
-            ordered = sorted(buffers, key=lambda b: local_attrs[b].offset)
-            first = local_attrs[ordered[0]]
-            size = sum(local_attrs[b].size for b in ordered)
-            return [
-                SimpleNamespace(
-                    base=base + first.offset,
-                    size=size,
-                    stride=slot_bytes,
-                    buffers=[SimpleNamespace(id=b) for b in ordered],
-                )
-            ]
-
     manager = SimpleNamespace(
         impl=FakeImpl(),
         pp_layers=[0, 1],
@@ -346,22 +332,22 @@ def test_v2_index_key_builder_emits_per_layer_logical_views():
 
     page_table = build_page_table_from_manager(manager)
     views = page_table.layer_groups[0].pool_views
-    assert [view.pool_role for view in views] == [
-        frozenset({"key", "value"}),
-        frozenset({"index_key"}),
-        frozenset({"key", "value"}),
-    ]
-    assert [view.mapper_kind for view in views] == [
+    assert len(views) == 1
+    assert views[0].pool_role == frozenset({"key", "value", "index_key"})
+    assert views[0].mapper_kind == MapperKind.MIXED
+    assert views[0].buffer_roles == ("key", "value", "index_key", "key", "value")
+    assert views[0].buffer_mapper_kinds == (
+        MapperKind.NHD,
         MapperKind.NHD,
         MapperKind.REPLICATED,
         MapperKind.NHD,
-    ]
-    assert [view.byte_offset for view in views] == [0, 256, 384]
-    assert [view.bytes_per_region for view in views] == [256, 128, 256]
+        MapperKind.NHD,
+    )
+    assert views[0].byte_offset == 0
+    assert views[0].bytes_per_region is None
 
-    # A dense-only PP rank has no local INDEX_KEY entry, but model-level sparse
-    # metadata must still force per-layer views so it can interoperate with a
-    # peer PP rank that also owns sparse layers.
+    # A dense-only PP rank has no local INDEX_KEY entry, so its one physical
+    # pool view is homogeneous NHD.
     dense_impl = FakeImpl()
     dense_impl._storage = SimpleNamespace(
         _buffer_attr={key: attr for key, attr in attrs.items() if key[1] != Role.INDEX_KEY},
@@ -376,8 +362,9 @@ def test_v2_index_key_builder_emits_per_layer_logical_views():
         get_disagg_role_mapper_kinds=manager.get_disagg_role_mapper_kinds,
     )
     dense_views = build_page_table_from_manager(dense_manager).layer_groups[0].pool_views
-    assert len(dense_views) == 2
-    assert [get_unique_layers(view) for view in dense_views] == [{0}, {1}]
+    assert len(dense_views) == 1
+    assert get_unique_layers(dense_views[0]) == {0, 1}
+    assert dense_views[0].mapper_kind == MapperKind.NHD
 
     # A private attribute with a coincidental name must not opt a manager into
     # model-specific logical views.

--- a/tests/unittest/disaggregated/test_extractor.py
+++ b/tests/unittest/disaggregated/test_extractor.py
@@ -238,7 +238,11 @@ def test_layer_group_meta_serialization():
     assert len(restored_lg.pool_views[0].buffer_entries) == 2
 
 
-def test_extract_logical_pool_view_uses_physical_stride():
+@pytest.mark.parametrize(
+    ("bytes_per_region", "expected_region_size"),
+    [(128, 128), (0, 0), (None, 384)],
+)
+def test_extract_logical_pool_view_uses_physical_stride(bytes_per_region, expected_region_size):
     from tensorrt_llm._torch.disaggregation.resource.page import (
         BUFFER_ENTRY_DTYPE,
         AttentionLayerGroup,
@@ -263,7 +267,7 @@ def test_extract_logical_pool_view_uses_physical_stride():
                         pool_role=frozenset({"index_key"}),
                         mapper_kind=MapperKind.REPLICATED,
                         byte_offset=256,
-                        bytes_per_region=128,
+                        bytes_per_region=bytes_per_region,
                     )
                 ],
             )
@@ -275,7 +279,7 @@ def test_extract_logical_pool_view_uses_physical_stride():
 
     region = KVRegionExtractorV1(page_table).extract(np.array([0, -1, 2], dtype=np.int64))
     np.testing.assert_array_equal(region.memory.ptrs, np.array([1256, 2024]))
-    assert region.memory.bytes_per_region == 128
+    assert region.memory.bytes_per_region == expected_region_size
 
 
 def test_v2_index_key_builder_emits_per_layer_logical_views():

--- a/tests/unittest/disaggregated/test_extractor.py
+++ b/tests/unittest/disaggregated/test_extractor.py
@@ -387,43 +387,58 @@ def test_layer_group_meta_serialization():
 
 
 def _make_fake_v2_manager(attrs, role_mapper_kinds, *, num_pools=1, slot_bytes_list=(640,)):
-    """Build a minimal duck-typed KVCacheManagerV2 for _build_page_table_v2."""
-    from types import SimpleNamespace
+    """Build a minimal duck-typed KVCacheManagerV2 for _build_page_table_v2.
 
-    from tensorrt_llm.runtime.kv_cache_manager_v2 import CacheTier
+    ``attrs`` keeps the storage-layer shape ``{(layer_id, role):
+    (life_cycle_id, pool_index, offset, size)}``; the fake synthesizes the
+    public ``pool_group_descs`` view from it. Buffer order within a
+    coalesced buffer follows ascending offset, mirroring how the real
+    storage config assigns offsets in ``buffer_ids`` order.
+    """
+    from types import SimpleNamespace
 
     base = 0x1000
 
-    def _make_pool(slot_bytes):
-        return SimpleNamespace(
-            slot_size=slot_bytes,
-            num_slots=4,
-            slot_address=lambda slot, _sb=slot_bytes: base + slot * _sb,
+    per_pool: dict[int, list] = {}
+    for (layer_id, role), attr in attrs.items():
+        per_pool.setdefault(int(attr.pool_index), []).append(
+            (int(attr.offset), layer_id, role, int(attr.size))
         )
+
+    coalesced_buffers = []
+    for pool_idx in range(num_pools):
+        buffers = sorted(per_pool.get(pool_idx, []))
+        sizes = {size for _, _, _, size in buffers}
+        assert len(sizes) == 1, "buffers in a coalesced buffer are uniform-size by construction"
+        coalesced_buffers.append(
+            SimpleNamespace(
+                single_buffer_size=sizes.pop(),
+                buffer_ids=[
+                    SimpleNamespace(layer_id=layer_id, role=role)
+                    for _, layer_id, role, _ in buffers
+                ],
+            )
+        )
+
+    pg_desc = SimpleNamespace(
+        pool_group_index=0,
+        num_slots=4,
+        pools=[
+            SimpleNamespace(pool_index=pi, base_address=base, slot_bytes=sb)
+            for pi, sb in enumerate(slot_bytes_list)
+        ],
+        slot_desc=SimpleNamespace(
+            variants=[SimpleNamespace(layer_group_id=0, coalesced_buffers=coalesced_buffers)]
+        ),
+    )
 
     impl = SimpleNamespace(
         layer_grouping=((0, 1),),
-        _life_cycles=[SimpleNamespace(window_size=None)],
-        _init_config=SimpleNamespace(
-            cache_tiers=[SimpleNamespace(tier=CacheTier.GPU_MEM)], tokens_per_block=16
+        init_config=SimpleNamespace(
+            tokens_per_block=16,
+            layers=[SimpleNamespace(window_size=None), SimpleNamespace(window_size=None)],
         ),
-        _storage=SimpleNamespace(
-            _buffer_attr=attrs,
-            num_life_cycles=1,
-            get_pool_group_index=lambda _lc: 0,
-            _levels=[
-                SimpleNamespace(
-                    storage=SimpleNamespace(
-                        _pool_groups=[
-                            SimpleNamespace(
-                                num_pools=num_pools,
-                                _pools=[_make_pool(sb) for sb in slot_bytes_list],
-                            )
-                        ]
-                    )
-                )
-            ],
-        ),
+        pool_group_descs=[pg_desc],
     )
     return SimpleNamespace(
         impl=impl,

--- a/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
@@ -1,18 +1,34 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """MiniMax M3 heterogeneous-topology KV transfer tests.
 
-This reuses the threaded NIXL harness from the DeepSeek-V4 V2 transfer test,
-but supplies MiniMax M3 cache managers and validates both ordinary K/V and the
-replicated INDEX_KEY cache. The TP=2 TEP layout coalesces K/V/INDEX_KEY in one
-physical pool, while attention-DP keeps INDEX_KEY in a separate pool.
+This drives the shared threaded NIXL harness (``kv_transfer_harness``) with
+MiniMax M3 cache managers and validates both ordinary K/V and the
+replicated INDEX_KEY cache. V2 storage coalesces buffers purely by (life
+cycle, size), so at TP degrees where K == V == INDEX_KEY bytes per block the
+index-K cache shares the K/V pool and the slot interleaves per layer; at
+other degrees it gets its own pool. The disagg page-table builder splits each
+pool into per-mapper-kind views, so both layouts (and transfers between them)
+are exercised by the topology matrix below.
 """
 
 from collections.abc import Sequence
 
+import kv_transfer_harness as transfer_harness
 import pytest
-import test_deepseek_v4_kv_transfer as transfer_harness
 import torch
 
 from tensorrt_llm import Mapping
@@ -71,7 +87,10 @@ def test_minimax_cache_indices_support_block_count_limit() -> None:
 def test_v2_disagg_role_mapper_kind_defaults() -> None:
     manager = object.__new__(KVCacheManagerV2)
 
-    assert manager.get_disagg_role_mapper_kinds() == {Role.ALL: MapperKind.INDEXED}
+    assert manager.get_disagg_role_mapper_kinds() == {
+        Role.ALL: MapperKind.INDEXED,
+        Role.INDEX_KEY: MapperKind.REPLICATED,
+    }
 
 
 def test_minimax_disagg_role_mapper_kinds() -> None:
@@ -102,7 +121,9 @@ def test_minimax_disagg_rejects_unmanaged_index_value(monkeypatch) -> None:
         )
 
 
-def _create_manager(mapping: Mapping, dtype: DataType) -> MiniMaxM3KVCacheManagerV2:
+def _create_manager(
+    mapping: Mapping, dtype: DataType, sparse_layers: list[int] | None = None
+) -> MiniMaxM3KVCacheManagerV2:
     max_num_tokens = 2048
     kv_cache_dtype = {
         DataType.FP8: "fp8",
@@ -126,18 +147,72 @@ def _create_manager(mapping: Mapping, dtype: DataType) -> MiniMaxM3KVCacheManage
         dtype=dtype,
         vocab_size=transfer_harness.VOCAB_SIZE,
         max_num_tokens=max_num_tokens,
-        sparse_layer_ids=SPARSE_LAYERS,
-        disable_index_value_layer_ids=SPARSE_LAYERS,
+        sparse_layer_ids=sparse_layers if sparse_layers is not None else SPARSE_LAYERS,
+        disable_index_value_layer_ids=sparse_layers if sparse_layers is not None else SPARSE_LAYERS,
         sparse_index_dim=INDEX_DIM,
     )
+
+
+def test_minimax_m3_pool_view_scheme_coalesced_vs_separate() -> None:
+    """Pool composition varies with TP; the view scheme must not.
+
+    TP=2 makes kv_heads_per_rank == 1, so K == V == INDEX_KEY bytes per
+    block and V2 coalesces all three into one pool whose slot interleaves
+    the sparse layer's index-K between K/V regions (non-uniform layer
+    stride). TP=1 doubles K/V, so index-K gets its own pool and strides are
+    uniform. Both layouts must yield the same two per-class views.
+    """
+    from tensorrt_llm._torch.disaggregation.resource.kv_extractor import (
+        build_page_table_from_manager,
+    )
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    # --- TP=2: coalesced, interleaved slot ---
+    manager = _create_manager(
+        Mapping(world_size=2, rank=0, tp_size=2, pp_size=1), DataType.BF16, sparse_layers=[1]
+    )
+    try:
+        lg = build_page_table_from_manager(manager).layer_groups[0]
+        assert len(lg.pool_views) == 2
+        kv_view = next(pv for pv in lg.pool_views if pv.mapper_kind == MapperKind.NHD)
+        idx_view = next(pv for pv in lg.pool_views if pv.mapper_kind == MapperKind.REPLICATED)
+        assert kv_view.pool_role == frozenset({str(Role.KEY), str(Role.VALUE)})
+        assert idx_view.pool_role == frozenset({str(Role.INDEX_KEY)})
+        # Coalesced: both views address the same physical pool.
+        assert kv_view.pool_idx == idx_view.pool_idx
+        starts, bytes_per_layer = get_layer_byte_ranges(kv_view)
+        unit = bytes_per_layer // 2  # one K or V buffer per block
+        # Slot: L0K L0V L1K L1V L1IDX L2K L2V L3K L3V — the sparse layer's
+        # index-K makes the K/V layer stride non-uniform.
+        assert starts == {0: 0, 1: 2 * unit, 2: 5 * unit, 3: 7 * unit}
+        idx_starts, idx_bytes_per_layer = get_layer_byte_ranges(idx_view)
+        assert idx_starts == {1: 4 * unit}
+        assert idx_bytes_per_layer == unit
+    finally:
+        manager.shutdown()
+
+    # --- TP=1: separate pools, uniform strides ---
+    manager = _create_manager(
+        Mapping(world_size=1, rank=0, tp_size=1, pp_size=1), DataType.BF16, sparse_layers=[1]
+    )
+    try:
+        lg = build_page_table_from_manager(manager).layer_groups[0]
+        assert len(lg.pool_views) == 2
+        kv_view = next(pv for pv in lg.pool_views if pv.mapper_kind == MapperKind.NHD)
+        idx_view = next(pv for pv in lg.pool_views if pv.mapper_kind == MapperKind.REPLICATED)
+        assert kv_view.pool_idx != idx_view.pool_idx
+        starts, bytes_per_layer = get_layer_byte_ranges(kv_view)
+        assert starts == {i: i * bytes_per_layer for i in range(NUM_LAYERS)}
+    finally:
+        manager.shutdown()
 
 
 def _create_managers(
     tp: int,
     pp: int,
     enable_dp: bool,
-    _unused_layout: list[int],
     dtype: DataType = DataType.BF16,
+    sparse_layers: list[int] | None = None,
 ) -> list[MiniMaxM3KVCacheManagerV2]:
     return [
         _create_manager(
@@ -149,6 +224,7 @@ def _create_managers(
                 enable_attention_dp=enable_dp,
             ),
             dtype,
+            sparse_layers,
         )
         for rank in range(tp * pp)
     ]
@@ -177,10 +253,15 @@ def _get_nvfp4_scale_view(
     scale_roles = frozenset({"key_block_scale", "value_block_scale"})
     for layer_group_id, layer_group in enumerate(page_table.layer_groups):
         for pool_view in getattr(layer_group, "pool_views", ()):
+            # Scale buffers land in their own pool (smaller size class), so
+            # selecting the pool by role set suffices; every entry for the
+            # layer inside that pool is a scale buffer.
+            if not (pool_view.pool_role & scale_roles):
+                continue
             matching_entries = [
                 entry
-                for entry, role in zip(pool_view.buffer_entries, pool_view.buffer_roles)
-                if int(entry["local_layer_id"]) == local_layer_id and role in scale_roles
+                for entry in pool_view.buffer_entries
+                if int(entry["local_layer_id"]) == local_layer_id
             ]
             if not matching_entries:
                 continue
@@ -322,7 +403,6 @@ def _initialize_cache(
 
 def _verify_cache(
     request_lengths: list[int],
-    compress_ratios: list[int],
     ctx_managers: Sequence[MiniMaxM3KVCacheManagerV2],
     gen_managers: Sequence[MiniMaxM3KVCacheManagerV2],
     ctx_tp: int,
@@ -334,7 +414,7 @@ def _verify_cache(
     ctx_request_ids: list[int],
     gen_request_ids: list[int],
 ) -> None:
-    del compress_ratios, ctx_pp
+    del ctx_pp
 
     for req_idx, _request_length in enumerate(request_lengths):
         gen_request_id = gen_request_ids[req_idx]
@@ -481,17 +561,56 @@ def test_minimax_m3_kv_transfer(
     cache_dtype,
     update_before_transfer,
 ) -> None:
-    transfer_harness.run_deepseek_v4_transfer_test(
+    transfer_harness.run_kv_transfer_test(
         ctx_tp=ctx_tp,
         ctx_pp=ctx_pp,
         gen_tp=gen_tp,
         gen_pp=gen_pp,
         ctx_enable_dp=ctx_enable_dp,
         gen_enable_dp=gen_enable_dp,
-        compress_ratios=[1] * NUM_LAYERS,
         update_before_transfer=update_before_transfer,
-        manager_factory=lambda tp, pp, enable_dp, layout: _create_managers(
-            tp, pp, enable_dp, layout, cache_dtype
+        manager_factory=lambda tp, pp, enable_dp: _create_managers(tp, pp, enable_dp, cache_dtype),
+        init_fn=_initialize_cache,
+        verify_fn=_verify_cache,
+    )
+
+
+# Multiple sparse layers spread across PP stages: the replicated index-key
+# pool overlaps only partially between peers, exercising the layer-strided
+# ReplicatedMapper offsets (a single-sparse-layer model always fully
+# overlaps and would degenerate to a whole-slot copy).
+MULTI_SPARSE_LAYERS = [1, 2, 3]
+
+
+@pytest.mark.cuda
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,ctx_enable_dp,gen_tp,gen_pp,gen_enable_dp",
+    [
+        (1, 1, True, 1, 2, False),  # ctx full index pool -> per-PP-stage subsets
+        (1, 2, False, 1, 1, True),  # per-PP-stage subsets -> full index pool
+        (2, 1, False, 1, 2, False),  # TEP fan-in + PP subset on the same transfer
+    ],
+    ids=["dep1_to_tp1pp2", "tp1pp2_to_dep1", "tep2_to_tp1pp2"],
+)
+def test_minimax_m3_multi_sparse_layer_pp_transfer(
+    ctx_tp,
+    ctx_pp,
+    ctx_enable_dp,
+    gen_tp,
+    gen_pp,
+    gen_enable_dp,
+) -> None:
+    transfer_harness.run_kv_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        update_before_transfer=True,
+        manager_factory=lambda tp, pp, enable_dp: _create_managers(
+            tp, pp, enable_dp, DataType.BF16, sparse_layers=MULTI_SPARSE_LAYERS
         ),
         init_fn=_initialize_cache,
         verify_fn=_verify_cache,

--- a/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
@@ -18,12 +18,9 @@ import torch
 from tensorrt_llm import Mapping
 from tensorrt_llm._torch.attention_backend.sparse.minimax_m3 import MiniMaxM3KVCacheManagerV2
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
+from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool, get_pool_bytes
-from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import (
-    DisaggCacheLayout,
-    KVCacheManagerV2,
-    Role,
-)
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2, Role
 from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
@@ -71,13 +68,21 @@ def test_minimax_cache_indices_support_block_count_limit() -> None:
     ]
 
 
-def test_minimax_disagg_pool_view_capability() -> None:
+def test_v2_disagg_role_mapper_kind_defaults() -> None:
+    manager = object.__new__(KVCacheManagerV2)
+
+    assert manager.get_disagg_role_mapper_kinds() == {Role.ALL: MapperKind.INDEXED}
+
+
+def test_minimax_disagg_role_mapper_kinds() -> None:
     manager = object.__new__(MiniMaxM3KVCacheManagerV2)
 
-    config = manager.get_disagg_pool_view_config()
+    role_mapper_kinds = manager.get_disagg_role_mapper_kinds()
 
-    assert config.sharded_layout is DisaggCacheLayout.NHD
-    assert config.replicated_roles == frozenset({Role.INDEX_KEY})
+    assert role_mapper_kinds == {
+        Role.ALL: MapperKind.NHD,
+        Role.INDEX_KEY: MapperKind.REPLICATED,
+    }
 
 
 def test_minimax_disagg_rejects_unmanaged_index_value(monkeypatch) -> None:

--- a/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
@@ -1,0 +1,480 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MiniMax M3 heterogeneous-topology KV transfer tests.
+
+This reuses the threaded NIXL harness from the DeepSeek-V4 V2 transfer test,
+but supplies MiniMax M3 cache managers and validates both ordinary K/V and the
+replicated INDEX_KEY cache. The TP=2 TEP layout coalesces K/V/INDEX_KEY in one
+physical pool, while attention-DP keeps INDEX_KEY in a separate pool.
+"""
+
+import pytest
+import test_deepseek_v4_kv_transfer as transfer_harness
+import torch
+
+from tensorrt_llm import Mapping
+from tensorrt_llm._torch.attention_backend.sparse.minimax_m3 import MiniMaxM3KVCacheManagerV2
+from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
+from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool, get_pool_bytes
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import (
+    DisaggCacheLayout,
+    KVCacheManagerV2,
+    Role,
+)
+from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
+from tensorrt_llm.bindings import DataType
+from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+NUM_LAYERS = 4
+NUM_KV_HEADS = 2
+HEAD_DIM = 128
+INDEX_DIM = 128
+TOKENS_PER_BLOCK = transfer_harness.TOKENS_PER_BLOCK
+SPARSE_LAYERS = [3]
+
+
+class _FakeKVCache:
+    num_blocks = 3
+
+    @staticmethod
+    def get_base_page_indices(_pool_id):
+        return [4, 5, 6, -1]
+
+
+class _ShortFakeKVCache:
+    num_blocks = 2
+
+    @staticmethod
+    def get_base_page_indices(_pool_id):
+        return [7, 8, -1, -1]
+
+
+def test_minimax_cache_indices_support_block_count_limit() -> None:
+    manager = object.__new__(MiniMaxM3KVCacheManagerV2)
+    manager.kv_cache_map = {7: _FakeKVCache(), 8: _ShortFakeKVCache()}
+
+    assert manager._get_batch_cache_indices_by_pool_id([7]) == [[4, 5, 6, -1]]
+    assert manager._get_batch_cache_indices_by_pool_id([7], num_blocks_per_seq=[2]) == [[4, 5]]
+    assert manager._get_batch_cache_indices_by_pool_id([7], num_blocks_per_seq=[99]) == [[4, 5, 6]]
+    assert manager._get_batch_cache_indices_by_pool_id([7, 8]) == [
+        [4, 5, 6, -1],
+        [7, 8, -1, -1],
+    ]
+    assert manager.get_block_ids_per_seq([7]).tolist() == [[4, 5, 6, 0]]
+    assert manager.get_block_ids_per_seq([7, 8]).tolist() == [
+        [4, 5, 6, 0],
+        [7, 8, 0, 0],
+    ]
+
+
+def test_minimax_disagg_pool_view_capability() -> None:
+    manager = object.__new__(MiniMaxM3KVCacheManagerV2)
+
+    config = manager.get_disagg_pool_view_config()
+
+    assert config.sharded_layout is DisaggCacheLayout.NHD
+    assert config.replicated_roles == frozenset({Role.INDEX_KEY})
+
+
+def test_minimax_disagg_rejects_unmanaged_index_value(monkeypatch) -> None:
+    def fake_base_init(self, *args, **kwargs):
+        self.is_disagg = kwargs.get("is_disagg", False)
+        self.layer_offsets = {layer_id: layer_id for layer_id in range(kwargs["num_layers"])}
+
+    monkeypatch.setattr(KVCacheManagerV2, "__init__", fake_base_init)
+
+    with pytest.raises(ValueError, match="requires disable_index_value=True"):
+        MiniMaxM3KVCacheManagerV2(
+            num_layers=4,
+            sparse_layer_ids=[3],
+            disable_index_value_layer_ids=[],
+            sparse_index_dim=INDEX_DIM,
+            is_disagg=True,
+        )
+
+
+def _create_manager(mapping: Mapping, dtype: DataType) -> MiniMaxM3KVCacheManagerV2:
+    max_num_tokens = 2048
+    return MiniMaxM3KVCacheManagerV2(
+        kv_cache_config=KvCacheConfig(
+            enable_block_reuse=False,
+            max_tokens=max_num_tokens,
+            event_buffer_max_size=0,
+            dtype="nvfp4" if dtype == DataType.NVFP4 else "auto",
+        ),
+        kv_cache_type=CacheTypeCpp.SELF,
+        num_layers=NUM_LAYERS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        tokens_per_block=TOKENS_PER_BLOCK,
+        max_seq_len=transfer_harness.MAX_SEQ_LEN,
+        max_batch_size=transfer_harness.MAX_BATCH_SIZE,
+        mapping=mapping,
+        dtype=dtype,
+        vocab_size=transfer_harness.VOCAB_SIZE,
+        max_num_tokens=max_num_tokens,
+        sparse_layer_ids=SPARSE_LAYERS,
+        disable_index_value_layer_ids=SPARSE_LAYERS,
+        sparse_index_dim=INDEX_DIM,
+    )
+
+
+def _create_managers(
+    tp: int,
+    pp: int,
+    enable_dp: bool,
+    _unused_layout: list[int],
+    dtype: DataType = DataType.BF16,
+) -> list[MiniMaxM3KVCacheManagerV2]:
+    return [
+        _create_manager(
+            Mapping(
+                world_size=tp * pp,
+                rank=rank,
+                tp_size=tp,
+                pp_size=pp,
+                enable_attention_dp=enable_dp,
+            ),
+            dtype,
+        )
+        for rank in range(tp * pp)
+    ]
+
+
+def _zero_physical_pools(manager: MiniMaxM3KVCacheManagerV2) -> None:
+    page_table = KVRegionExtractorV1(manager).page_table
+    unique_pools = {}
+    for pool_group in page_table.pool_groups:
+        for pool in pool_group.pools:
+            unique_pools[pool.base_address] = max(
+                unique_pools.get(pool.base_address, 0), get_pool_bytes(pool)
+            )
+    for base_address, size in unique_pools.items():
+        tensor = convert_to_torch_tensor(TensorWrapper(base_address, DataType.INT8, [size]))
+        tensor.zero_()
+
+
+def _get_nvfp4_scale_view(
+    manager: MiniMaxM3KVCacheManagerV2, layer_idx: int
+) -> torch.Tensor | None:
+    if manager.dtype != DataType.NVFP4:
+        return None
+    page_table = KVRegionExtractorV1(manager).page_table
+    local_layer_id = manager.layer_offsets[layer_idx]
+    scale_roles = frozenset({"key_block_scale", "value_block_scale"})
+    for layer_group_id, layer_group in enumerate(page_table.layer_groups):
+        for pool_view in getattr(layer_group, "pool_views", ()):
+            if pool_view.pool_role != scale_roles:
+                continue
+            if local_layer_id not in pool_view.buffer_entries["local_layer_id"]:
+                continue
+            pool = get_physical_pool(page_table, layer_group_id, pool_view.pool_idx)
+            raw_slots = convert_to_torch_tensor(
+                TensorWrapper(
+                    pool.base_address,
+                    DataType.INT8,
+                    [pool.num_slots, pool.slot_bytes],
+                )
+            )
+            end = pool_view.byte_offset + pool_view.bytes_per_region
+            return raw_slots[:, pool_view.byte_offset : end]
+    raise AssertionError(f"missing NVFP4 scale view for layer {layer_idx}")
+
+
+def _fill_position_dependent(
+    tensor: torch.Tensor,
+    *,
+    layer_idx: int,
+    first_global_head: int,
+) -> None:
+    """Fill ``[block, role, token, head, dim]`` with exact small integers."""
+    block = torch.arange(tensor.shape[0], device=tensor.device)[:, None, None, None, None]
+    role = torch.arange(tensor.shape[1], device=tensor.device)[None, :, None, None, None]
+    token = torch.arange(tensor.shape[2], device=tensor.device)[None, None, :, None, None]
+    head = (first_global_head + torch.arange(tensor.shape[3], device=tensor.device))[
+        None, None, None, :, None
+    ]
+    dim = torch.arange(tensor.shape[4], device=tensor.device)[None, None, None, None, :]
+    values = (layer_idx * 17 + block * 11 + role * 13 + token * 3 + head * 19 + dim) % 97
+    tensor.copy_(values.to(tensor.dtype))
+
+
+def _as_nvfp4_scale_tensor(
+    manager: MiniMaxM3KVCacheManagerV2,
+    layer_idx: int,
+) -> torch.Tensor | None:
+    scale_view = _get_nvfp4_scale_view(manager, layer_idx)
+    if scale_view is None:
+        return None
+    local_layer_id = manager.layer_offsets[layer_idx]
+    local_heads = manager.num_kv_heads_per_layer[local_layer_id]
+    bytes_per_token_head = HEAD_DIM // 16
+    return scale_view.view(
+        scale_view.shape[0],
+        2,
+        TOKENS_PER_BLOCK,
+        local_heads,
+        bytes_per_token_head,
+    )
+
+
+def _valid_indices(
+    manager: MiniMaxM3KVCacheManagerV2,
+    request_id: int,
+    layer_idx: int,
+) -> list[int]:
+    return [
+        index for index in manager.get_batch_cache_indices([request_id], layer_idx)[0] if index >= 0
+    ]
+
+
+def _first_global_head(manager: MiniMaxM3KVCacheManagerV2) -> int:
+    """Map a TP rank to its first logical head, including duplicated heads."""
+    if manager.mapping.enable_attention_dp:
+        return 0
+    return manager.mapping.tp_rank * NUM_KV_HEADS // manager.mapping.tp_size
+
+
+def _find_ctx_source(
+    ctx_managers: list[MiniMaxM3KVCacheManagerV2],
+    *,
+    ctx_tp: int,
+    ctx_enable_dp: bool,
+    request_idx: int,
+    layer_idx: int,
+    global_head: int,
+) -> tuple[MiniMaxM3KVCacheManagerV2, int]:
+    """Return the context manager/local head that owns one logical KV head."""
+    for manager in ctx_managers:
+        if layer_idx not in manager.pp_layers:
+            continue
+        tp_rank = manager.mapping.tp_rank
+        local_layer_id = manager.layer_offsets[layer_idx]
+        local_heads = manager.num_kv_heads_per_layer[local_layer_id]
+        if ctx_enable_dp:
+            if tp_rank == request_idx % ctx_tp:
+                return manager, global_head
+            continue
+        first_global_head = _first_global_head(manager)
+        if first_global_head <= global_head < first_global_head + local_heads:
+            return manager, global_head - first_global_head
+    raise AssertionError(
+        f"missing context source for request={request_idx}, layer={layer_idx}, "
+        f"global_head={global_head}"
+    )
+
+
+def _initialize_cache(
+    managers: list[MiniMaxM3KVCacheManagerV2],
+    _tp: int,
+    seed_base: int = 0,
+    fill_random: bool = True,
+) -> None:
+    del seed_base
+    for manager in managers:
+        _zero_physical_pools(manager)
+        if not fill_random:
+            continue
+
+        for layer_idx in manager.pp_layers:
+            kv = manager.get_buffers(layer_idx, kv_layout="NHD")
+            first_global_head = _first_global_head(manager)
+            _fill_position_dependent(
+                kv,
+                layer_idx=layer_idx,
+                first_global_head=first_global_head,
+            )
+
+            index_key = manager.get_index_k_buffer(layer_idx)
+            if index_key is not None:
+                index_tensor = index_key.unsqueeze(1)
+                _fill_position_dependent(
+                    index_tensor,
+                    layer_idx=layer_idx,
+                    first_global_head=0,
+                )
+
+            scale_tensor = _as_nvfp4_scale_tensor(manager, layer_idx)
+            if scale_tensor is not None:
+                _fill_position_dependent(
+                    scale_tensor,
+                    layer_idx=layer_idx,
+                    first_global_head=first_global_head,
+                )
+
+
+def _verify_cache(
+    request_lengths,
+    compress_ratios,
+    ctx_managers,
+    gen_managers,
+    ctx_tp,
+    ctx_pp,
+    gen_tp,
+    gen_pp,
+    ctx_enable_dp,
+    gen_enable_dp,
+    ctx_request_ids,
+    gen_request_ids,
+) -> None:
+    del compress_ratios, ctx_pp
+
+    for req_idx, _request_length in enumerate(request_lengths):
+        gen_request_id = gen_request_ids[req_idx]
+        for gen_rank, manager in enumerate(gen_managers):
+            tp_rank = gen_rank % gen_tp
+            if gen_enable_dp and req_idx % gen_tp != tp_rank:
+                continue
+
+            for layer_idx in manager.pp_layers:
+                gen_indices = _valid_indices(manager, gen_request_id, layer_idx)
+                assert gen_indices
+
+                gen_kv = manager.get_buffers(layer_idx, kv_layout="NHD")[gen_indices]
+                local_heads = gen_kv.shape[3]
+                first_global_head = _first_global_head(manager)
+                for kv_idx in range(2):
+                    for local_head in range(local_heads):
+                        global_head = first_global_head + local_head
+                        ctx_manager, ctx_local_head = _find_ctx_source(
+                            ctx_managers,
+                            ctx_tp=ctx_tp,
+                            ctx_enable_dp=ctx_enable_dp,
+                            request_idx=req_idx,
+                            layer_idx=layer_idx,
+                            global_head=global_head,
+                        )
+                        ctx_indices = _valid_indices(
+                            ctx_manager, ctx_request_ids[req_idx], layer_idx
+                        )
+                        ctx_kv = ctx_manager.get_buffers(layer_idx, kv_layout="NHD")
+                        torch.testing.assert_close(
+                            gen_kv[:, kv_idx, :, local_head, :],
+                            ctx_kv[ctx_indices, kv_idx, :, ctx_local_head, :],
+                            rtol=0,
+                            atol=0,
+                        )
+
+                index_key = manager.get_index_k_buffer(layer_idx)
+                if index_key is not None:
+                    ctx_manager, _ = _find_ctx_source(
+                        ctx_managers,
+                        ctx_tp=ctx_tp,
+                        ctx_enable_dp=ctx_enable_dp,
+                        request_idx=req_idx,
+                        layer_idx=layer_idx,
+                        global_head=0,
+                    )
+                    ctx_indices = _valid_indices(ctx_manager, ctx_request_ids[req_idx], layer_idx)
+                    ctx_index_key = ctx_manager.get_index_k_buffer(layer_idx)
+                    assert ctx_index_key is not None
+                    torch.testing.assert_close(
+                        index_key[gen_indices],
+                        ctx_index_key[ctx_indices],
+                        rtol=0,
+                        atol=0,
+                    )
+
+                gen_scales = _as_nvfp4_scale_tensor(manager, layer_idx)
+                if gen_scales is not None:
+                    for local_head in range(local_heads):
+                        global_head = first_global_head + local_head
+                        ctx_manager, ctx_local_head = _find_ctx_source(
+                            ctx_managers,
+                            ctx_tp=ctx_tp,
+                            ctx_enable_dp=ctx_enable_dp,
+                            request_idx=req_idx,
+                            layer_idx=layer_idx,
+                            global_head=global_head,
+                        )
+                        ctx_indices = _valid_indices(
+                            ctx_manager, ctx_request_ids[req_idx], layer_idx
+                        )
+                        ctx_scales = _as_nvfp4_scale_tensor(ctx_manager, layer_idx)
+                        assert ctx_scales is not None
+                        torch.testing.assert_close(
+                            gen_scales[gen_indices, :, :, local_head, :],
+                            ctx_scales[ctx_indices, :, :, ctx_local_head, :],
+                            rtol=0,
+                            atol=0,
+                        )
+
+
+# Production is expected to use TEP/DEP context and DEP generation. Bias the
+# committed matrix toward head-matched layouts while retaining representative
+# head-mismatch, degree-8 duplication, fan-in/fan-out, and PP2 coverage.
+HEAD_MATCHED_BF16_TOPOLOGIES = [
+    (1, 1, True, 1, 1, True, "dep1_to_dep1"),
+    (2, 1, True, 2, 1, True, "dep2_to_dep2"),
+    (4, 1, True, 4, 1, True, "dep4_to_dep4"),
+    (8, 1, True, 8, 1, True, "dep8_to_dep8"),
+    (1, 1, True, 8, 1, True, "dep1_to_dep8"),
+    (8, 1, True, 1, 1, True, "dep8_to_dep1"),
+    (1, 1, False, 4, 1, True, "tep1_to_dep4"),
+    (1, 1, False, 8, 1, True, "tep1_to_dep8"),
+    (1, 2, False, 2, 1, True, "tp1pp2_to_dep2"),
+]
+
+HEAD_MISMATCHED_BF16_TOPOLOGIES = [
+    (2, 1, False, 2, 1, True, "tep2_to_dep2"),
+    (4, 1, False, 4, 1, True, "tep4_to_dep4"),
+    (8, 1, False, 8, 1, True, "tep8_to_dep8"),
+    (8, 1, False, 1, 1, True, "tep8_to_dep1"),
+]
+
+BF16_TOPOLOGIES = HEAD_MATCHED_BF16_TOPOLOGIES + HEAD_MISMATCHED_BF16_TOPOLOGIES
+
+# A smaller NVFP4 set covers packed K/V and scale-view geometry across the
+# same production directions without repeating the BF16 topology matrix.
+NVFP4_TOPOLOGIES = [
+    (4, 1, True, 4, 1, True, "nvfp4_dep4_to_dep4"),
+    (8, 1, True, 1, 1, True, "nvfp4_dep8_to_dep1"),
+    (1, 1, False, 8, 1, True, "nvfp4_tep1_to_dep8"),
+    (4, 1, False, 4, 1, True, "nvfp4_tep4_to_dep4"),
+    (8, 1, False, 1, 1, True, "nvfp4_tep8_to_dep1"),
+]
+
+CACHE_CASES = [(*topology[:6], DataType.BF16, topology[6]) for topology in BF16_TOPOLOGIES] + [
+    (*topology[:6], DataType.NVFP4, topology[6]) for topology in NVFP4_TOPOLOGIES
+]
+
+
+@pytest.mark.cuda
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,ctx_enable_dp,gen_tp,gen_pp,gen_enable_dp,cache_dtype",
+    [case[:7] for case in CACHE_CASES],
+    ids=[case[7] for case in CACHE_CASES],
+)
+@pytest.mark.parametrize(
+    "update_before_transfer",
+    [True, False],
+    ids=["update_before", "update_after"],
+)
+def test_minimax_m3_kv_transfer(
+    ctx_tp,
+    ctx_pp,
+    ctx_enable_dp,
+    gen_tp,
+    gen_pp,
+    gen_enable_dp,
+    cache_dtype,
+    update_before_transfer,
+) -> None:
+    transfer_harness.run_deepseek_v4_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        compress_ratios=[1] * NUM_LAYERS,
+        update_before_transfer=update_before_transfer,
+        manager_factory=lambda tp, pp, enable_dp, layout: _create_managers(
+            tp, pp, enable_dp, layout, cache_dtype
+        ),
+        init_fn=_initialize_cache,
+        verify_fn=_verify_cache,
+    )

--- a/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
@@ -104,12 +104,16 @@ def test_minimax_disagg_rejects_unmanaged_index_value(monkeypatch) -> None:
 
 def _create_manager(mapping: Mapping, dtype: DataType) -> MiniMaxM3KVCacheManagerV2:
     max_num_tokens = 2048
+    kv_cache_dtype = {
+        DataType.FP8: "fp8",
+        DataType.NVFP4: "nvfp4",
+    }.get(dtype, "auto")
     return MiniMaxM3KVCacheManagerV2(
         kv_cache_config=KvCacheConfig(
             enable_block_reuse=False,
             max_tokens=max_num_tokens,
             event_buffer_max_size=0,
-            dtype="nvfp4" if dtype == DataType.NVFP4 else "auto",
+            dtype=kv_cache_dtype,
         ),
         kv_cache_type=CacheTypeCpp.SELF,
         num_layers=NUM_LAYERS,
@@ -173,9 +177,12 @@ def _get_nvfp4_scale_view(
     scale_roles = frozenset({"key_block_scale", "value_block_scale"})
     for layer_group_id, layer_group in enumerate(page_table.layer_groups):
         for pool_view in getattr(layer_group, "pool_views", ()):
-            if pool_view.pool_role != scale_roles:
-                continue
-            if local_layer_id not in pool_view.buffer_entries["local_layer_id"]:
+            matching_entries = [
+                entry
+                for entry, role in zip(pool_view.buffer_entries, pool_view.buffer_roles)
+                if int(entry["local_layer_id"]) == local_layer_id and role in scale_roles
+            ]
+            if not matching_entries:
                 continue
             pool = get_physical_pool(page_table, layer_group_id, pool_view.pool_idx)
             raw_slots = convert_to_torch_tensor(
@@ -185,8 +192,9 @@ def _get_nvfp4_scale_view(
                     [pool.num_slots, pool.slot_bytes],
                 )
             )
-            end = pool_view.byte_offset + pool_view.bytes_per_region
-            return raw_slots[:, pool_view.byte_offset : end]
+            start = min(int(entry["offset"]) for entry in matching_entries)
+            end = max(int(entry["offset"] + entry["size"]) for entry in matching_entries)
+            return raw_slots[:, start:end]
     raise AssertionError(f"missing NVFP4 scale view for layer {layer_idx}")
 
 
@@ -433,18 +441,21 @@ HEAD_MISMATCHED_BF16_TOPOLOGIES = [
 
 BF16_TOPOLOGIES = HEAD_MATCHED_BF16_TOPOLOGIES + HEAD_MISMATCHED_BF16_TOPOLOGIES
 
-# A smaller NVFP4 set covers packed K/V and scale-view geometry across the
-# same production directions without repeating the BF16 topology matrix.
-NVFP4_TOPOLOGIES = [
-    (4, 1, True, 4, 1, True, "nvfp4_dep4_to_dep4"),
-    (8, 1, True, 1, 1, True, "nvfp4_dep8_to_dep1"),
-    (1, 1, False, 8, 1, True, "nvfp4_tep1_to_dep8"),
-    (4, 1, False, 4, 1, True, "nvfp4_tep4_to_dep4"),
-    (8, 1, False, 1, 1, True, "nvfp4_tep8_to_dep1"),
+# Smaller quantized-cache sets cover packed K/V geometry across the same
+# production directions without repeating the BF16 topology matrix. NVFP4
+# additionally exercises its block-scale pools.
+QUANTIZED_TOPOLOGIES = [
+    (4, 1, True, 4, 1, True, "dep4_to_dep4"),
+    (8, 1, True, 1, 1, True, "dep8_to_dep1"),
+    (1, 1, False, 8, 1, True, "tep1_to_dep8"),
+    (4, 1, False, 4, 1, True, "tep4_to_dep4"),
+    (8, 1, False, 1, 1, True, "tep8_to_dep1"),
 ]
 
 CACHE_CASES = [(*topology[:6], DataType.BF16, topology[6]) for topology in BF16_TOPOLOGIES] + [
-    (*topology[:6], DataType.NVFP4, topology[6]) for topology in NVFP4_TOPOLOGIES
+    (*topology[:6], dtype, f"{prefix}_{topology[6]}")
+    for dtype, prefix in ((DataType.FP8, "fp8"), (DataType.NVFP4, "nvfp4"))
+    for topology in QUANTIZED_TOPOLOGIES
 ]
 
 

--- a/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
@@ -9,6 +9,8 @@ replicated INDEX_KEY cache. The TP=2 TEP layout coalesces K/V/INDEX_KEY in one
 physical pool, while attention-DP keeps INDEX_KEY in a separate pool.
 """
 
+from collections.abc import Sequence
+
 import pytest
 import test_deepseek_v4_kv_transfer as transfer_harness
 import torch
@@ -267,7 +269,7 @@ def _find_ctx_source(
 
 
 def _initialize_cache(
-    managers: list[MiniMaxM3KVCacheManagerV2],
+    managers: Sequence[MiniMaxM3KVCacheManagerV2],
     _tp: int,
     seed_base: int = 0,
     fill_random: bool = True,
@@ -306,18 +308,18 @@ def _initialize_cache(
 
 
 def _verify_cache(
-    request_lengths,
-    compress_ratios,
-    ctx_managers,
-    gen_managers,
-    ctx_tp,
-    ctx_pp,
-    gen_tp,
-    gen_pp,
-    ctx_enable_dp,
-    gen_enable_dp,
-    ctx_request_ids,
-    gen_request_ids,
+    request_lengths: list[int],
+    compress_ratios: list[int],
+    ctx_managers: Sequence[MiniMaxM3KVCacheManagerV2],
+    gen_managers: Sequence[MiniMaxM3KVCacheManagerV2],
+    ctx_tp: int,
+    ctx_pp: int,
+    gen_tp: int,
+    gen_pp: int,
+    ctx_enable_dp: bool,
+    gen_enable_dp: bool,
+    ctx_request_ids: list[int],
+    gen_request_ids: list[int],
 ) -> None:
     del compress_ratios, ctx_pp
 

--- a/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
@@ -121,6 +121,36 @@ def test_minimax_disagg_rejects_unmanaged_index_value(monkeypatch) -> None:
         )
 
 
+class _StubGroupingImpl:
+    """Stub ``manager.impl`` exposing only what ``_kv_pool_mapping_offset`` reads."""
+
+    def __init__(self, grouping, key_addrs):
+        self.layer_grouping = grouping
+        self._key_addrs = key_addrs
+
+    def get_mem_pool_base_address(self, layer_id, role, index_mode=None):
+        assert role == Role.KEY
+        return self._key_addrs[int(layer_id)]
+
+
+def test_minimax_kv_pool_mapping_offset_ignores_layer_grouping_order() -> None:
+    """Offsets must rank layers by physical K address, not grouping order.
+
+    ``layer_grouping``'s iteration order is not a V2 API contract; here it
+    deliberately disagrees with the physical slot layout (addresses put the
+    layers in order 0, 2, 1) and the offsets must follow the addresses.
+    """
+    manager = object.__new__(MiniMaxM3KVCacheManagerV2)
+    manager.impl = _StubGroupingImpl(
+        grouping=((2, 0, 1),),
+        key_addrs={0: 0x1000, 1: 0x3000, 2: 0x2000},
+    )
+
+    offsets = {layer_id: manager._kv_pool_mapping_offset(layer_id, 0, 0) for layer_id in (0, 1, 2)}
+
+    assert offsets == {0: 0, 2: 1, 1: 2}
+
+
 def _create_manager(
     mapping: Mapping, dtype: DataType, sparse_layers: list[int] | None = None
 ) -> MiniMaxM3KVCacheManagerV2:

--- a/tests/unittest/disaggregated/test_peer.py
+++ b/tests/unittest/disaggregated/test_peer.py
@@ -1,10 +1,14 @@
 import numpy as np
 import pytest
 
+import tensorrt_llm._torch.disaggregation.native.peer as peer_module
+from tensorrt_llm._torch.disaggregation.base.region import MemRegionGroup, SpecRegion
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import (
     HeadMatchMapper,
     HeadMismatchMapper,
     IdentityMapper,
+    NHDHeadMismatchMapper,
+    ReplicatedMapper,
 )
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.spec import AttentionInfo
 from tensorrt_llm._torch.disaggregation.native.peer import PeerOverlap, PeerRegistrar
@@ -16,6 +20,7 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     KVCachePageTable,
     LocalLayer,
     MambaLayerGroup,
+    MapperKind,
     PhysicalPool,
     PhysicalPoolGroup,
     PoolView,
@@ -456,6 +461,148 @@ def test_peer_registrar_get_kv_map_rejects_non_contiguous_overlap():
         reg.get_kv_map(peer_ri, (0, 0), (0, 0))
 
 
+def test_nhd_head_mismatch_mapper_slices_each_token():
+    self_ri = make_rankinfo(
+        instance_name="local",
+        tp_size=2,
+        tp_rank=0,
+        dp_size=2,
+        dp_rank=0,
+        kv_heads_per_rank=2,
+        tokens_per_block=2,
+        dims_per_head=2,
+        element_bytes=2,
+        enable_attention_dp=True,
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=2,
+        tp_rank=0,
+        kv_heads_per_rank=1,
+        tokens_per_block=2,
+        dims_per_head=2,
+        element_bytes=2,
+    )
+    mapper = NHDHeadMismatchMapper(
+        transfer_layers=1,
+        src_layer_off=0,
+        peer_layer_off=0,
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_region_bytes=32,
+        peer_region_bytes=16,
+        self_pool_num_layers=1,
+        peer_pool_num_layers=1,
+        self_buffers_per_layer=2,
+        peer_buffers_per_layer=2,
+    )
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=32)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=16)),
+    )
+
+    # Source NHD has two heads per token: select head 0 at offsets 0 and 8
+    # for K, then 16 and 24 for V. Destination has one head per token.
+    assert pair.src.memory.ptrs.tolist() == [1000, 1008, 1016, 1024]
+    assert pair.dst.memory.ptrs.tolist() == [2000, 2004, 2008, 2012]
+    assert pair.src.memory.bytes_per_region == 4
+    assert pair.dst.memory.bytes_per_region == 4
+
+
+def test_nhd_head_mismatch_mapper_uses_scale_pool_geometry():
+    self_ri = make_rankinfo(
+        tp_size=2,
+        kv_heads_per_rank=2,
+        tokens_per_block=2,
+        dims_per_head=128,
+        element_bytes=0.5,
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=1,
+        kv_heads_per_rank=1,
+        tokens_per_block=2,
+        dims_per_head=128,
+        element_bytes=0.5,
+    )
+    mapper = NHDHeadMismatchMapper(
+        transfer_layers=1,
+        src_layer_off=0,
+        peer_layer_off=0,
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_region_bytes=8,
+        peer_region_bytes=4,
+        self_pool_num_layers=1,
+        peer_pool_num_layers=1,
+        self_buffers_per_layer=2,
+        peer_buffers_per_layer=2,
+    )
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=8)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=4)),
+    )
+
+    assert pair.src.memory.ptrs.tolist() == [1000, 1002, 1004, 1006]
+    assert pair.dst.memory.ptrs.tolist() == [2000, 2001, 2002, 2003]
+    assert pair.src.memory.bytes_per_region == 1
+    assert pair.dst.memory.bytes_per_region == 1
+
+
+def test_replicated_mapper_ignores_kv_head_mismatch():
+    self_pt = make_page_table(global_layer_ids=[0])
+    peer_pt = make_page_table(global_layer_ids=[0])
+    for page_table in (self_pt, peer_pt):
+        view = page_table.layer_groups[0].pool_views[0]
+        view.pool_role = frozenset({"index_key"})
+        view.mapper_kind = MapperKind.REPLICATED
+        view.bytes_per_region = 256
+
+    self_rankinfo = make_rankinfo(instance_name="local", kv_heads_per_rank=1, page_table=self_pt)
+    reg = _make_peer_registrar(self_rankinfo)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        instance_rank=3,
+        tp_size=1,
+        kv_heads_per_rank=8,
+        layer_num_per_pp=[1],
+        page_table=peer_pt,
+    )
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+    assert isinstance(mapper, ReplicatedMapper)
+
+
+def test_replicated_pool_has_single_owner_on_tp_fan_in():
+    page_table = make_page_table(global_layer_ids=[0])
+    view = page_table.layer_groups[0].pool_views[0]
+    view.mapper_kind = MapperKind.REPLICATED
+
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=8,
+        dp_size=8,
+        enable_attention_dp=True,
+        page_table=page_table,
+        layer_num_per_pp=[1],
+    )
+    overlap = PeerOverlap()
+    ownership = []
+    for tp_rank in range(8):
+        self_ri = make_rankinfo(
+            instance_name="local",
+            tp_size=8,
+            tp_rank=tp_rank,
+            page_table=page_table,
+            layer_num_per_pp=[1],
+        )
+        reg = _make_peer_registrar(self_ri)
+        ownership.append(reg.should_send_pool(overlap, peer_ri, 0, 0))
+
+    assert ownership == [True, False, False, False, False, False, False, False]
+
+
 def test_peer_registrar_tpb_divisible_warns_but_compatible():
     # local=16, peer=32: 32 % 16 == 0 → compatible with warning, register succeeds
     self_rankinfo = make_rankinfo(instance_name="local", tokens_per_block=16)
@@ -484,3 +631,192 @@ def test_peer_registrar_tpb_not_divisible_raises():
     )
     with pytest.raises(ValueError):
         reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+
+@pytest.mark.parametrize("mapper_kind", [MapperKind.NHD, MapperKind.REPLICATED])
+def test_peer_registrar_exact_tpb_mapper_rejects_divisible_mismatch(mapper_kind):
+    self_pt = make_page_table()
+    peer_pt = make_page_table()
+    self_pt.layer_groups[0].pool_views[0].mapper_kind = mapper_kind
+    peer_pt.layer_groups[0].pool_views[0].mapper_kind = mapper_kind
+    self_ri = make_rankinfo(page_table=self_pt, tokens_per_block=16)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        instance_rank=7,
+        page_table=peer_pt,
+        tokens_per_block=32,
+    )
+    reg = _make_peer_registrar(self_ri)
+
+    with pytest.raises(ValueError):
+        reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+
+def test_identity_mapper_region_size_mismatch_raises():
+    with pytest.raises(ValueError, match="Identity cache region size mismatch"):
+        IdentityMapper(256, 128)
+
+
+def test_replicated_mapper_region_size_mismatch_raises():
+    with pytest.raises(ValueError, match="Replicated cache region size mismatch"):
+        ReplicatedMapper(256, 128)
+
+
+def test_nhd_mapper_rejects_non_divisible_region_geometry():
+    self_ri = make_rankinfo(kv_heads_per_rank=2, tokens_per_block=2)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=1,
+        kv_heads_per_rank=4,
+        tokens_per_block=2,
+    )
+
+    with pytest.raises(ValueError, match="not evenly divisible"):
+        NHDHeadMismatchMapper(
+            transfer_layers=1,
+            src_layer_off=0,
+            peer_layer_off=0,
+            self_ri=self_ri,
+            peer_ri=peer_ri,
+            self_region_bytes=17,
+            peer_region_bytes=32,
+            self_pool_num_layers=1,
+            peer_pool_num_layers=1,
+            self_buffers_per_layer=2,
+            peer_buffers_per_layer=2,
+        )
+
+
+def test_nhd_mapper_rejects_tokens_per_block_mismatch():
+    self_ri = make_rankinfo(tokens_per_block=2)
+    peer_ri = make_rankinfo(instance_name="peer", tokens_per_block=4)
+
+    with pytest.raises(ValueError, match="requires equal tokens_per_block"):
+        NHDHeadMismatchMapper(
+            transfer_layers=1,
+            src_layer_off=0,
+            peer_layer_off=0,
+            self_ri=self_ri,
+            peer_ri=peer_ri,
+            self_region_bytes=32,
+            peer_region_bytes=64,
+            self_pool_num_layers=1,
+            peer_pool_num_layers=1,
+            self_buffers_per_layer=2,
+            peer_buffers_per_layer=2,
+        )
+
+
+def test_get_buffers_per_layer_rejects_non_uniform_nhd_entries():
+    pool_view = PoolView(
+        pool_idx=0,
+        buffer_entries=np.array(
+            [(0, 0, 16), (0, 16, 16), (1, 32, 16)],
+            dtype=BUFFER_ENTRY_DTYPE,
+        ),
+        mapper_kind=MapperKind.NHD,
+    )
+
+    with pytest.raises(ValueError, match="layer_group=3, pool=4"):
+        PeerRegistrar._get_buffers_per_layer(
+            pool_view,
+            2,
+            layer_group_id=3,
+            pool_idx=4,
+        )
+
+
+def test_indexed_mapper_ignores_non_uniform_buffer_entry_geometry():
+    """Legacy/DSV4 indexed pools do not need NHD buffer geometry."""
+    entries = np.array(
+        [(0, 0, 16), (0, 16, 16), (1, 32, 16)],
+        dtype=BUFFER_ENTRY_DTYPE,
+    )
+    self_pt = make_page_table()
+    peer_pt = make_page_table()
+    self_pt.layer_groups[0].pool_views[0].buffer_entries = entries
+    peer_pt.layer_groups[0].pool_views[0].buffer_entries = entries.copy()
+    self_ri = make_rankinfo(page_table=self_pt)
+    peer_ri = make_rankinfo(instance_name="peer", page_table=peer_pt)
+    reg = _make_peer_registrar(self_ri)
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+
+    assert isinstance(mapper, IdentityMapper)
+
+
+def test_peer_registrar_rejects_legacy_subbyte_head_mismatch():
+    self_ri = make_rankinfo(
+        element_bytes=0.5,
+        kv_heads_per_rank=2,
+        tp_size=2,
+        page_table=make_page_table(),
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        element_bytes=0.5,
+        kv_heads_per_rank=4,
+        tp_size=1,
+        page_table=make_page_table(block_bytes=[2048]),
+    )
+    reg = _make_peer_registrar(self_ri)
+
+    with pytest.raises(ValueError):
+        reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+
+def test_peer_registrar_dispatches_nhd_mapper():
+    self_pt = make_page_table()
+    peer_pt = make_page_table(block_bytes=[2048])
+    self_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    peer_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    self_ri = make_rankinfo(
+        kv_heads_per_rank=2,
+        tp_size=2,
+        page_table=self_pt,
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        kv_heads_per_rank=4,
+        tp_size=1,
+        page_table=peer_pt,
+    )
+    reg = _make_peer_registrar(self_ri)
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+
+    assert isinstance(mapper, NHDHeadMismatchMapper)
+
+
+def test_peer_registrar_warns_for_nhd_head_mismatch(monkeypatch):
+    self_pt = make_page_table()
+    peer_pt = make_page_table(block_bytes=[2048])
+    self_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    peer_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    self_ri = make_rankinfo(kv_heads_per_rank=2, tp_size=2, page_table=self_pt)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        kv_heads_per_rank=4,
+        tp_size=1,
+        page_table=peer_pt,
+    )
+    warnings = []
+    monkeypatch.setattr(
+        peer_module.logger,
+        "warning_once",
+        lambda *message, key: warnings.append((" ".join(map(str, message)), key)),
+    )
+
+    _make_peer_registrar(self_ri).register(
+        peer_ri.instance_name,
+        peer_ri.instance_rank,
+        peer_ri,
+    )
+
+    assert len(warnings) == 1
+    message, key = warnings[0]
+    assert "4 NIXL descriptors per transferred token per peer" in message
+    assert "local_kv_heads=2, peer_kv_heads=4" in message
+    assert key == "native-nhd-head-mismatch-2-4-4"

--- a/tests/unittest/disaggregated/test_peer.py
+++ b/tests/unittest/disaggregated/test_peer.py
@@ -826,7 +826,6 @@ def test_get_buffers_per_layer_rejects_non_uniform_nhd_entries():
     with pytest.raises(ValueError, match="layer_group=3, pool=4"):
         PeerRegistrar._get_buffers_per_layer(
             pool_view,
-            2,
             layer_group_id=3,
             pool_idx=4,
         )

--- a/tests/unittest/disaggregated/test_peer.py
+++ b/tests/unittest/disaggregated/test_peer.py
@@ -1,19 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import pytest
 
 import tensorrt_llm._torch.disaggregation.native.peer as peer_module
-from tensorrt_llm._torch.disaggregation.base.region import (
-    MemRegionGroup,
-    SpecRegion,
-    SpecRegionPair,
-)
+from tensorrt_llm._torch.disaggregation.base.region import MemRegionGroup, SpecRegion
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import (
-    HeadMatchMapper,
-    HeadMismatchMapper,
-    IdentityMapper,
+    HNDHeadMismatchMapper,
+    IntactMapper,
     NHDHeadMismatchMapper,
-    PoolBufferMapper,
-    PoolBufferMapping,
     ReplicatedMapper,
 )
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.spec import AttentionInfo
@@ -42,21 +50,22 @@ def make_page_table(pool_ptrs=None, block_bytes=None, global_layer_ids=None):
     if global_layer_ids is None:
         global_layer_ids = [0, 1]
 
-    # Build buffer entries: K + V per local layer
-    buffer_size = 256  # bytes per buffer entry (arbitrary for tests)
-    entries = []
-    for i in range(len(global_layer_ids)):
-        base_offset = i * buffer_size * 2
-        entries.append((i, base_offset, buffer_size))
-        entries.append((i, base_offset + buffer_size, buffer_size))
-    buffer_entries = np.array(entries, dtype=BUFFER_ENTRY_DTYPE)
-
     local_layers = [
         LocalLayer(local_layer_id=i, global_layer_id=gid) for i, gid in enumerate(global_layer_ids)
     ]
-    pool_views = [
-        PoolView(pool_idx=pi, buffer_entries=buffer_entries) for pi in range(len(pool_ptrs))
-    ]
+    # Build buffer entries: K + V per local layer, sized so the layers fill
+    # the pool slot (keeps entry geometry consistent with slot_bytes).
+    pool_views = []
+    for pi, bs in enumerate(block_bytes):
+        buffer_size = bs // (len(global_layer_ids) * 2)
+        entries = []
+        for i in range(len(global_layer_ids)):
+            base_offset = i * buffer_size * 2
+            entries.append((i, base_offset, buffer_size))
+            entries.append((i, base_offset + buffer_size, buffer_size))
+        pool_views.append(
+            PoolView(pool_idx=pi, buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE))
+        )
     physical_pools = [
         PhysicalPool(base_address=ptr, slot_bytes=bs, num_slots=128)
         for ptr, bs in zip(pool_ptrs, block_bytes)
@@ -370,7 +379,15 @@ def test_peer_registrar_get_kv_map_identity():
     )
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
     mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
-    assert isinstance(mapper, IdentityMapper)
+    # Full contiguous overlap: one whole-region fragment per block.
+    assert isinstance(mapper, IntactMapper)
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=1024)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=1024)),
+    )
+    assert not isinstance(pair, list)
+    assert pair.src.memory.ptrs.tolist() == [1000]
+    assert pair.src.memory.bytes_per_region == 1024
 
 
 def test_peer_registrar_get_kv_map_head_match():
@@ -391,12 +408,23 @@ def test_peer_registrar_get_kv_map_head_match():
     )
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
     mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
-    assert isinstance(mapper, HeadMatchMapper)
+    # Partial layer overlap with matching heads: a single shifted fragment.
+    assert isinstance(mapper, IntactMapper)
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=1024)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=512)),
+    )
+    # Overlap is global layer 1: self slot holds layers [0, 1] (512B each),
+    # peer slot holds only layer 1.
+    assert pair.src.memory.ptrs.tolist() == [1512]
+    assert pair.dst.memory.ptrs.tolist() == [2000]
+    assert pair.src.memory.bytes_per_region == 512
 
 
 def test_peer_registrar_get_kv_map_head_mismatch():
     self_rankinfo = make_rankinfo(instance_name="local", page_table=make_page_table())
     reg = _make_peer_registrar(self_rankinfo)
+    # Twice the KV heads per rank -> twice the slot bytes on the peer side.
     peer_ri = make_rankinfo(
         instance_name="peer",
         instance_rank=3,
@@ -408,20 +436,21 @@ def test_peer_registrar_get_kv_map_head_mismatch():
         tokens_per_block=16,
         dims_per_head=8,
         layer_num_per_pp=[2],
-        page_table=make_page_table(),
+        page_table=make_page_table(block_bytes=[2048]),
     )
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
     mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
-    assert isinstance(mapper, HeadMismatchMapper)
+    assert isinstance(mapper, HNDHeadMismatchMapper)
 
 
 def test_peer_registrar_get_kv_map_uses_physical_offset_order():
-    """The layer slot offset must follow physical buffer order, not sorted global id.
+    """The layer byte offset must follow physical buffer order, not sorted global id.
 
     ``self`` lays out its two global layers in physical order ``[5, 3]`` (layer 3
     sits at physical slot 1); ``peer`` holds only layer 3. The transfer must copy
-    ``self``'s slot at offset 1 -- a sort-by-global-id would wrongly pick offset 0
-    (layer 5's bytes).
+    ``self``'s slot at byte offset 512 -- a sort-by-global-id would wrongly pick
+    offset 0 (layer 5's bytes). The entries-driven mapper resolves each layer's
+    offset from the view's buffer entries, so no ordering convention is involved.
     """
     self_pt = make_page_table(global_layer_ids=[5, 3])
     peer_pt = make_page_table(global_layer_ids=[3], block_bytes=[512])
@@ -436,22 +465,28 @@ def test_peer_registrar_get_kv_map_uses_physical_offset_order():
     )
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
     mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
-    assert isinstance(mapper, HeadMatchMapper)
-    # slot_size_per_layer = 1024 // 2 = 512; layer 3 is at physical slot 1 on
-    # self and slot 0 on peer.
-    assert mapper._src_block_off == 512
-    assert mapper._dst_block_off == 0
+    assert isinstance(mapper, IntactMapper)
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=1024)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=512)),
+    )
+    # Layer 3 (512B) sits at physical slot 1 on self and slot 0 on peer.
+    assert pair.src.memory.ptrs.tolist() == [1512]
+    assert pair.dst.memory.ptrs.tolist() == [2000]
+    assert pair.src.memory.bytes_per_region == 512
 
 
-def test_peer_registrar_get_kv_map_rejects_non_contiguous_overlap():
-    """Shared layers that are not an aligned contiguous slot run must be rejected.
+def test_peer_registrar_get_kv_map_non_contiguous_overlap_splits_fragments():
+    """Shared layers that are not a contiguous slot run transfer as separate fragments.
 
     ``self`` holds layers ``[0, 1, 2]`` and ``peer`` holds ``[0, 2]``: the overlap
     ``{0, 2}`` is not contiguous within ``self``'s slot, so a single contiguous
-    fragment transfer would corrupt layer 1's bytes. ``get_kv_map`` must raise
-    rather than emit a wrong mapping.
+    fragment transfer would corrupt layer 1's bytes. The entries-driven mapper
+    selects layers by explicit per-layer byte offsets, so it must emit one
+    correctly-shifted fragment per contiguous run instead of rejecting (or
+    silently corrupting) the transfer.
     """
-    self_pt = make_page_table(global_layer_ids=[0, 1, 2])
+    self_pt = make_page_table(global_layer_ids=[0, 1, 2], block_bytes=[1536])
     peer_pt = make_page_table(global_layer_ids=[0, 2])
 
     self_rankinfo = make_rankinfo(instance_name="local", page_table=self_pt)
@@ -463,8 +498,17 @@ def test_peer_registrar_get_kv_map_rejects_non_contiguous_overlap():
         page_table=peer_pt,
     )
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
-    with pytest.raises(ValueError, match="aligned contiguous run"):
-        reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+    assert isinstance(mapper, IntactMapper)
+    pairs = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=1536)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=1024)),
+    )
+    # Layer 0: self offset 0 -> peer offset 0; layer 2: self offset 1024 ->
+    # peer offset 512. Non-adjacent on self, so two fragments.
+    assert [p.src.memory.ptrs.tolist() for p in pairs] == [[1000], [2024]]
+    assert [p.dst.memory.ptrs.tolist() for p in pairs] == [[2000], [2512]]
+    assert [p.src.memory.bytes_per_region for p in pairs] == [512, 512]
 
 
 def test_nhd_head_mismatch_mapper_slices_each_token():
@@ -490,15 +534,12 @@ def test_nhd_head_mismatch_mapper_slices_each_token():
         element_bytes=2,
     )
     mapper = NHDHeadMismatchMapper(
-        transfer_layers=1,
-        src_layer_off=0,
-        peer_layer_off=0,
+        src_layer_offsets=[0],
+        dst_layer_offsets=[0],
         self_ri=self_ri,
         peer_ri=peer_ri,
-        self_region_bytes=32,
-        peer_region_bytes=16,
-        self_pool_num_layers=1,
-        peer_pool_num_layers=1,
+        self_bytes_per_layer=32,
+        peer_bytes_per_layer=16,
         self_buffers_per_layer=2,
         peer_buffers_per_layer=2,
     )
@@ -533,15 +574,12 @@ def test_nhd_head_mismatch_mapper_uses_scale_pool_geometry():
         element_bytes=0.5,
     )
     mapper = NHDHeadMismatchMapper(
-        transfer_layers=1,
-        src_layer_off=0,
-        peer_layer_off=0,
+        src_layer_offsets=[0],
+        dst_layer_offsets=[0],
         self_ri=self_ri,
         peer_ri=peer_ri,
-        self_region_bytes=8,
-        peer_region_bytes=4,
-        self_pool_num_layers=1,
-        peer_pool_num_layers=1,
+        self_bytes_per_layer=8,
+        peer_bytes_per_layer=4,
         self_buffers_per_layer=2,
         peer_buffers_per_layer=2,
     )
@@ -557,77 +595,6 @@ def test_nhd_head_mismatch_mapper_uses_scale_pool_geometry():
     assert pair.dst.memory.bytes_per_region == 1
 
 
-def test_pool_buffer_mapper_uses_whole_pool_identity_for_equal_layout():
-    self_ri = make_rankinfo(instance_name="local", kv_heads_per_rank=2)
-    peer_ri = make_rankinfo(instance_name="peer", kv_heads_per_rank=2)
-    mapper = PoolBufferMapper(
-        mappings=[
-            PoolBufferMapping(0, 0, 256, 256, MapperKind.NHD),
-            PoolBufferMapping(256, 256, 128, 128, MapperKind.REPLICATED),
-        ],
-        self_ri=self_ri,
-        peer_ri=peer_ri,
-        self_region_bytes=384,
-        peer_region_bytes=384,
-        full_region_identity=True,
-        include_sharded=True,
-        include_replicated=True,
-    )
-
-    pair = mapper.map(
-        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000, 2000]), bytes_per_region=384)),
-        SpecRegion(memory=MemRegionGroup(ptrs=np.array([3000, 4000]), bytes_per_region=384)),
-    )
-
-    assert isinstance(pair, SpecRegionPair)
-    assert pair.src.memory.ptrs.size == 2  # One descriptor per input block.
-    assert pair.src.memory.ptrs.tolist() == [1000, 2000]
-    assert pair.dst.memory.ptrs.tolist() == [3000, 4000]
-    assert pair.src.memory.bytes_per_region == 384
-
-
-def test_pool_buffer_mapper_uses_entry_offsets_for_head_mismatch():
-    self_ri = make_rankinfo(
-        instance_name="local",
-        tp_size=2,
-        kv_heads_per_rank=2,
-        tokens_per_block=2,
-        dims_per_head=2,
-        element_bytes=2,
-    )
-    peer_ri = make_rankinfo(
-        instance_name="peer",
-        tp_size=1,
-        kv_heads_per_rank=1,
-        tokens_per_block=2,
-        dims_per_head=2,
-        element_bytes=2,
-    )
-    mapper = PoolBufferMapper(
-        mappings=[
-            PoolBufferMapping(0, 0, 16, 8, MapperKind.NHD),
-            PoolBufferMapping(16, 8, 4, 4, MapperKind.REPLICATED),
-        ],
-        self_ri=self_ri,
-        peer_ri=peer_ri,
-        self_region_bytes=20,
-        peer_region_bytes=12,
-        full_region_identity=False,
-        include_sharded=True,
-        include_replicated=True,
-    )
-
-    pairs = mapper.map(
-        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=20)),
-        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=12)),
-    )
-
-    assert len(pairs) == 1
-    assert pairs[0].src.memory.ptrs.tolist() == [1000, 1008, 1016]
-    assert pairs[0].dst.memory.ptrs.tolist() == [2000, 2004, 2008]
-    assert pairs[0].src.memory.bytes_per_region == 4
-
-
 def test_replicated_mapper_ignores_kv_head_mismatch():
     self_pt = make_page_table(global_layer_ids=[0])
     peer_pt = make_page_table(global_layer_ids=[0])
@@ -635,7 +602,6 @@ def test_replicated_mapper_ignores_kv_head_mismatch():
         view = page_table.layer_groups[0].pool_views[0]
         view.pool_role = frozenset({"index_key"})
         view.mapper_kind = MapperKind.REPLICATED
-        view.bytes_per_region = 256
 
     self_rankinfo = make_rankinfo(instance_name="local", kv_heads_per_rank=1, page_table=self_pt)
     reg = _make_peer_registrar(self_rankinfo)
@@ -651,7 +617,13 @@ def test_replicated_mapper_ignores_kv_head_mismatch():
     assert isinstance(mapper, ReplicatedMapper)
 
 
-def test_replicated_pool_has_single_owner_on_tp_fan_in():
+@pytest.mark.parametrize("peer_dp_rank", [0, 1, 3, 7])
+def test_replicated_pool_owner_rotates_by_destination_dp_rank(peer_dp_rank):
+    """Exactly one owner per fan-in group, rotated by destination DP rank.
+
+    Mirrors the C++ MLACacheFormatter::needSendCache pairing so the
+    replicated traffic spreads across local ranks for multi-DP generation.
+    """
     page_table = make_page_table(global_layer_ids=[0])
     view = page_table.layer_groups[0].pool_views[0]
     view.mapper_kind = MapperKind.REPLICATED
@@ -660,6 +632,7 @@ def test_replicated_pool_has_single_owner_on_tp_fan_in():
         instance_name="peer",
         tp_size=8,
         dp_size=8,
+        dp_rank=peer_dp_rank,
         enable_attention_dp=True,
         page_table=page_table,
         layer_num_per_pp=[1],
@@ -675,9 +648,12 @@ def test_replicated_pool_has_single_owner_on_tp_fan_in():
             layer_num_per_pp=[1],
         )
         reg = _make_peer_registrar(self_ri)
-        ownership.append(reg.should_send_pool(overlap, peer_ri, 0, 0, 0, 0))
+        ownership.append(reg.should_send_pool(overlap, peer_ri, 0, 0))
 
-    assert ownership == [True, False, False, False, False, False, False, False]
+    # ratio = self_tp(8) / peer_tp_per_dp(1) = 8: exactly one owner, at the
+    # slot selected by the destination dp rank.
+    assert sum(ownership) == 1
+    assert ownership.index(True) == peer_dp_rank % 8
 
 
 def test_peer_registrar_tpb_divisible_warns_but_compatible():
@@ -729,14 +705,73 @@ def test_peer_registrar_exact_tpb_mapper_rejects_divisible_mismatch(mapper_kind)
         reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
 
 
-def test_identity_mapper_region_size_mismatch_raises():
-    with pytest.raises(ValueError, match="Identity cache region size mismatch"):
-        IdentityMapper(256, 128)
+def test_intact_mapper_region_size_mismatch_raises():
+    with pytest.raises(ValueError, match="cache region size mismatch"):
+        IntactMapper([0], [0], 256, 128)
 
 
-def test_replicated_mapper_region_size_mismatch_raises():
+def test_replicated_mapper_per_layer_size_mismatch_raises():
     with pytest.raises(ValueError, match="Replicated cache region size mismatch"):
-        ReplicatedMapper(256, 128)
+        ReplicatedMapper(
+            src_layer_offsets=[0, 128],
+            dst_layer_offsets=[0, 64],
+            self_bytes_per_layer=128,
+            peer_bytes_per_layer=64,
+        )
+
+
+def test_replicated_mapper_selects_partial_layer_range():
+    """PP mismatch selects the overlap layers via explicit offsets.
+
+    The peer slot holds a superset of layers; only the overlap moves, and
+    contiguous layers on both sides merge into one fragment.
+    """
+    mapper = ReplicatedMapper(
+        src_layer_offsets=[0, 128],  # self slot: 2 layers x 128B
+        dst_layer_offsets=[128, 256],  # peer slot: 3 layers x 128B, overlap at 1..2
+        self_bytes_per_layer=128,
+        peer_bytes_per_layer=128,
+    )
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=256)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=384)),
+    )
+
+    assert pair.src.memory.ptrs.tolist() == [1000]
+    assert pair.dst.memory.ptrs.tolist() == [2128]
+    assert pair.src.memory.bytes_per_region == 256
+    assert pair.dst.memory.bytes_per_region == 256
+
+
+def test_intact_mapper_splits_non_contiguous_runs():
+    """Interleaved slots (another role class between layers) split runs.
+
+    Source layers sit at non-uniform strides (something interleaves after
+    layer 0); destination is densely packed. Runs must break where either
+    side is discontiguous, and each fragment must carry the run's bytes.
+    """
+    mapper = IntactMapper(
+        src_layer_offsets=[0, 192, 320],  # gap after layer 0 (64B interleaved)
+        dst_layer_offsets=[0, 128, 256],  # dense
+        self_bytes_per_layer=128,
+        peer_bytes_per_layer=128,
+    )
+
+    pairs = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=448)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=384)),
+    )
+
+    assert isinstance(pairs, list) and len(pairs) == 2
+    # Run 1: layer 0 alone (src gap breaks the run).
+    assert pairs[0].src.memory.ptrs.tolist() == [1000]
+    assert pairs[0].dst.memory.ptrs.tolist() == [2000]
+    assert pairs[0].src.memory.bytes_per_region == 128
+    # Run 2: layers 1-2 contiguous on both sides -> merged.
+    assert pairs[1].src.memory.ptrs.tolist() == [1192]
+    assert pairs[1].dst.memory.ptrs.tolist() == [2128]
+    assert pairs[1].src.memory.bytes_per_region == 256
 
 
 def test_nhd_mapper_rejects_non_divisible_region_geometry():
@@ -750,15 +785,12 @@ def test_nhd_mapper_rejects_non_divisible_region_geometry():
 
     with pytest.raises(ValueError, match="not evenly divisible"):
         NHDHeadMismatchMapper(
-            transfer_layers=1,
-            src_layer_off=0,
-            peer_layer_off=0,
+            src_layer_offsets=[0],
+            dst_layer_offsets=[0],
             self_ri=self_ri,
             peer_ri=peer_ri,
-            self_region_bytes=17,
-            peer_region_bytes=32,
-            self_pool_num_layers=1,
-            peer_pool_num_layers=1,
+            self_bytes_per_layer=17,
+            peer_bytes_per_layer=32,
             self_buffers_per_layer=2,
             peer_buffers_per_layer=2,
         )
@@ -770,15 +802,12 @@ def test_nhd_mapper_rejects_tokens_per_block_mismatch():
 
     with pytest.raises(ValueError, match="requires equal tokens_per_block"):
         NHDHeadMismatchMapper(
-            transfer_layers=1,
-            src_layer_off=0,
-            peer_layer_off=0,
+            src_layer_offsets=[0],
+            dst_layer_offsets=[0],
             self_ri=self_ri,
             peer_ri=peer_ri,
-            self_region_bytes=32,
-            peer_region_bytes=64,
-            self_pool_num_layers=1,
-            peer_pool_num_layers=1,
+            self_bytes_per_layer=32,
+            peer_bytes_per_layer=64,
             self_buffers_per_layer=2,
             peer_buffers_per_layer=2,
         )
@@ -803,8 +832,13 @@ def test_get_buffers_per_layer_rejects_non_uniform_nhd_entries():
         )
 
 
-def test_indexed_mapper_ignores_non_uniform_buffer_entry_geometry():
-    """Legacy/DSV4 indexed pools do not need NHD buffer geometry."""
+def test_non_uniform_view_geometry_rejected_for_all_kinds():
+    """Entries-driven views require uniform per-layer regions for every kind.
+
+    Under the unified contract INDEXED views are no longer exempt: a view
+    whose layers have different region sizes cannot be addressed per layer
+    and must fail loudly instead of transferring garbage.
+    """
     entries = np.array(
         [(0, 0, 16), (0, 16, 16), (1, 32, 16)],
         dtype=BUFFER_ENTRY_DTYPE,
@@ -818,12 +852,15 @@ def test_indexed_mapper_ignores_non_uniform_buffer_entry_geometry():
     reg = _make_peer_registrar(self_ri)
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
 
-    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+    with pytest.raises(ValueError, match="not uniform"):
+        reg.get_kv_map(peer_ri, (0, 0), (0, 0))
 
-    assert isinstance(mapper, IdentityMapper)
 
+def test_peer_registrar_allows_byte_aligned_subbyte_head_mismatch():
+    """Byte-aligned sub-byte head slicing is allowed on the HND path.
 
-def test_peer_registrar_rejects_legacy_subbyte_head_mismatch():
+    Per-head bytes are integral here: tpb=16 x dims=8 x 0.5B = 64B.
+    """
     self_ri = make_rankinfo(
         element_bytes=0.5,
         kv_heads_per_rank=2,
@@ -834,6 +871,36 @@ def test_peer_registrar_rejects_legacy_subbyte_head_mismatch():
         instance_name="peer",
         element_bytes=0.5,
         kv_heads_per_rank=4,
+        tp_size=1,
+        page_table=make_page_table(block_bytes=[2048]),
+    )
+    reg = _make_peer_registrar(self_ri)
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+
+    assert isinstance(mapper, HNDHeadMismatchMapper)
+
+
+def test_peer_registrar_rejects_misaligned_subbyte_head_mismatch():
+    """Head slicing that lands mid-byte must fail at registration.
+
+    tpb=1 x dims=1 x 0.5B = 0.5B per head is not byte-aligned.
+    """
+    self_ri = make_rankinfo(
+        element_bytes=0.5,
+        kv_heads_per_rank=2,
+        tokens_per_block=1,
+        dims_per_head=1,
+        tp_size=2,
+        page_table=make_page_table(),
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        element_bytes=0.5,
+        kv_heads_per_rank=4,
+        tokens_per_block=1,
+        dims_per_head=1,
         tp_size=1,
         page_table=make_page_table(block_bytes=[2048]),
     )
@@ -897,3 +964,100 @@ def test_peer_registrar_warns_for_nhd_head_mismatch(monkeypatch):
     assert "4 NIXL descriptors per transferred token per peer" in message
     assert "local_kv_heads=2, peer_kv_heads=4" in message
     assert key == "native-nhd-head-mismatch-2-4-4"
+
+
+def test_peer_registrar_nhd_head_match_uses_intact_mapper():
+    """NHD + equal heads takes the merged-run fast path, not per-token slicing.
+
+    With a dedicated (non-interleaved) K/V pool the run merge collapses the
+    whole class region into a single fragment per block — the fragment-count
+    budget for separate layouts.
+    """
+    self_pt = make_page_table()
+    peer_pt = make_page_table()
+    self_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    peer_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    self_ri = make_rankinfo(page_table=self_pt)
+    peer_ri = make_rankinfo(instance_name="peer", instance_rank=9, page_table=peer_pt)
+    reg = _make_peer_registrar(self_ri)
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+    assert isinstance(mapper, IntactMapper)
+    assert not isinstance(mapper, NHDHeadMismatchMapper)
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000, 5000]), bytes_per_region=1024)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000, 6000]), bytes_per_region=1024)),
+    )
+    # Fully contiguous on both sides -> exactly one fragment per block.
+    assert not isinstance(pair, list)
+    assert pair.src.memory.ptrs.tolist() == [1000, 5000]
+    assert pair.dst.memory.ptrs.tolist() == [2000, 6000]
+    assert pair.src.memory.bytes_per_region == 1024
+
+
+def test_indexed_head_mismatch_subbyte_geometry_is_entries_derived():
+    """HND head-mismatch byte math comes from slot bytes, never element_bytes.
+
+    Emulates an NVFP4-like cache: element_bytes is fractional (0.5), but the
+    slot size registered by storage is whole bytes, so every derived offset
+    and fragment size must be an exact integer.
+    """
+    # self: 2 kv heads/rank, per-head bytes = 16 tokens x 8 dims x 0.5B = 64.
+    self_ri = make_rankinfo(
+        tp_size=1,
+        tp_rank=0,
+        kv_heads_per_rank=2,
+        tokens_per_block=16,
+        dims_per_head=8,
+        element_bytes=0.5,
+    )
+    # peer: twice the TP -> 1 kv head/rank, half the slot bytes.
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=2,
+        tp_rank=1,
+        kv_heads_per_rank=1,
+        tokens_per_block=16,
+        dims_per_head=8,
+        element_bytes=0.5,
+    )
+    mapper = HNDHeadMismatchMapper(
+        src_layer_offsets=[0, 256],  # 2 layers x 256B/layer (kv_factor 2 x 128B)
+        dst_layer_offsets=[0, 128],  # 2 layers x 128B/layer (kv_factor 2 x 64B)
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_bytes_per_layer=256,
+        peer_bytes_per_layer=128,
+        self_buffers_per_layer=2,
+        peer_buffers_per_layer=2,
+    )
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=512)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=256)),
+    )
+    # peer tp_rank=1 selects head 1 inside self's per-rank pair of heads:
+    # src_head_off = 1 x 64B; fragments = (layer, k/v) x 2 layers.
+    assert pair.src.memory.ptrs.tolist() == [1064, 1192, 1320, 1448]
+    assert pair.dst.memory.ptrs.tolist() == [2000, 2064, 2128, 2192]
+    assert pair.src.memory.bytes_per_region == 64
+    assert pair.src.memory.ptrs.dtype == np.int64
+    assert pair.dst.memory.ptrs.dtype == np.int64
+
+
+def test_indexed_head_mismatch_inconsistent_slot_geometry_raises():
+    self_ri = make_rankinfo(tp_size=1, kv_heads_per_rank=2)
+    peer_ri = make_rankinfo(instance_name="peer", tp_size=2, kv_heads_per_rank=1)
+    with pytest.raises(ValueError, match="HND bytes per head mismatch"):
+        HNDHeadMismatchMapper(
+            src_layer_offsets=[0, 256],
+            dst_layer_offsets=[0, 256],
+            self_ri=self_ri,
+            peer_ri=peer_ri,
+            self_bytes_per_layer=256,
+            peer_bytes_per_layer=256,  # should be 128 for half the heads
+            self_buffers_per_layer=2,
+            peer_buffers_per_layer=2,
+        )

--- a/tests/unittest/disaggregated/test_peer.py
+++ b/tests/unittest/disaggregated/test_peer.py
@@ -2,12 +2,18 @@ import numpy as np
 import pytest
 
 import tensorrt_llm._torch.disaggregation.native.peer as peer_module
-from tensorrt_llm._torch.disaggregation.base.region import MemRegionGroup, SpecRegion
+from tensorrt_llm._torch.disaggregation.base.region import (
+    MemRegionGroup,
+    SpecRegion,
+    SpecRegionPair,
+)
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import (
     HeadMatchMapper,
     HeadMismatchMapper,
     IdentityMapper,
     NHDHeadMismatchMapper,
+    PoolBufferMapper,
+    PoolBufferMapping,
     ReplicatedMapper,
 )
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.spec import AttentionInfo
@@ -551,6 +557,77 @@ def test_nhd_head_mismatch_mapper_uses_scale_pool_geometry():
     assert pair.dst.memory.bytes_per_region == 1
 
 
+def test_pool_buffer_mapper_uses_whole_pool_identity_for_equal_layout():
+    self_ri = make_rankinfo(instance_name="local", kv_heads_per_rank=2)
+    peer_ri = make_rankinfo(instance_name="peer", kv_heads_per_rank=2)
+    mapper = PoolBufferMapper(
+        mappings=[
+            PoolBufferMapping(0, 0, 256, 256, MapperKind.NHD),
+            PoolBufferMapping(256, 256, 128, 128, MapperKind.REPLICATED),
+        ],
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_region_bytes=384,
+        peer_region_bytes=384,
+        full_region_identity=True,
+        include_sharded=True,
+        include_replicated=True,
+    )
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000, 2000]), bytes_per_region=384)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([3000, 4000]), bytes_per_region=384)),
+    )
+
+    assert isinstance(pair, SpecRegionPair)
+    assert pair.src.memory.ptrs.size == 2  # One descriptor per input block.
+    assert pair.src.memory.ptrs.tolist() == [1000, 2000]
+    assert pair.dst.memory.ptrs.tolist() == [3000, 4000]
+    assert pair.src.memory.bytes_per_region == 384
+
+
+def test_pool_buffer_mapper_uses_entry_offsets_for_head_mismatch():
+    self_ri = make_rankinfo(
+        instance_name="local",
+        tp_size=2,
+        kv_heads_per_rank=2,
+        tokens_per_block=2,
+        dims_per_head=2,
+        element_bytes=2,
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=1,
+        kv_heads_per_rank=1,
+        tokens_per_block=2,
+        dims_per_head=2,
+        element_bytes=2,
+    )
+    mapper = PoolBufferMapper(
+        mappings=[
+            PoolBufferMapping(0, 0, 16, 8, MapperKind.NHD),
+            PoolBufferMapping(16, 8, 4, 4, MapperKind.REPLICATED),
+        ],
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_region_bytes=20,
+        peer_region_bytes=12,
+        full_region_identity=False,
+        include_sharded=True,
+        include_replicated=True,
+    )
+
+    pairs = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=20)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=12)),
+    )
+
+    assert len(pairs) == 1
+    assert pairs[0].src.memory.ptrs.tolist() == [1000, 1008, 1016]
+    assert pairs[0].dst.memory.ptrs.tolist() == [2000, 2004, 2008]
+    assert pairs[0].src.memory.bytes_per_region == 4
+
+
 def test_replicated_mapper_ignores_kv_head_mismatch():
     self_pt = make_page_table(global_layer_ids=[0])
     peer_pt = make_page_table(global_layer_ids=[0])
@@ -598,7 +675,7 @@ def test_replicated_pool_has_single_owner_on_tp_fan_in():
             layer_num_per_pp=[1],
         )
         reg = _make_peer_registrar(self_ri)
-        ownership.append(reg.should_send_pool(overlap, peer_ri, 0, 0))
+        ownership.append(reg.should_send_pool(overlap, peer_ri, 0, 0, 0, 0))
 
     assert ownership == [True, False, False, False, False, False, False, False]
 

--- a/tests/unittest/disaggregated/test_peer.py
+++ b/tests/unittest/disaggregated/test_peer.py
@@ -511,6 +511,39 @@ def test_peer_registrar_get_kv_map_non_contiguous_overlap_splits_fragments():
     assert [p.src.memory.bytes_per_region for p in pairs] == [512, 512]
 
 
+def test_peer_registrar_get_kv_map_merges_non_monotonic_contiguous_layout():
+    """Physically contiguous layers merge into one fragment despite global-id order.
+
+    Both peers lay out global layers in physical order ``[5, 3]``: byte-contiguous
+    on both sides, just not monotonic in global id. Iterating the overlap in
+    self's physical order keeps the offset arrays adjacent, so the mapper merges
+    the two layers into a single 1024B fragment; a sorted-by-global-id iteration
+    would visit offsets ``[512, 0]`` and split the copy into two fragments.
+    """
+    self_pt = make_page_table(global_layer_ids=[5, 3])
+    peer_pt = make_page_table(global_layer_ids=[5, 3])
+
+    self_rankinfo = make_rankinfo(instance_name="local", page_table=self_pt)
+    reg = _make_peer_registrar(self_rankinfo)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        instance_rank=2,
+        layer_num_per_pp=[2],
+        page_table=peer_pt,
+    )
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+    assert isinstance(mapper, IntactMapper)
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=1024)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=1024)),
+    )
+    assert not isinstance(pair, list)
+    assert pair.src.memory.ptrs.tolist() == [1000]
+    assert pair.dst.memory.ptrs.tolist() == [2000]
+    assert pair.src.memory.bytes_per_region == 1024
+
+
 def test_nhd_head_mismatch_mapper_slices_each_token():
     self_ri = make_rankinfo(
         instance_name="local",

--- a/tests/unittest/disaggregated/test_pool_matching.py
+++ b/tests/unittest/disaggregated/test_pool_matching.py
@@ -15,7 +15,8 @@
 
 """Golden tests for ``PeerRegistrar.get_pool_mapping``.
 
-Covers pool-level and legacy disagg matching across representative scenarios:
+Locks the current (pre-refactor) behavior of disagg pool matching across the
+representative scenarios that the refactor must keep working:
 
   * single KV pool, full layer overlap (basic MHA)
   * MLA (kv_factor=1, KEY-only pool)
@@ -25,8 +26,9 @@ Covers pool-level and legacy disagg matching across representative scenarios:
   * Two pools with same role but different layer sets within a peer LG
     (DSv4 virtual-layer scenario, exercises ``best_overlap``)
 
-New V2 views carry per-buffer roles and mapper kinds. Legacy views without
-that metadata retain role-set matching.
+The refactor (PoolRole -> PoolMatchKey + TransferLayout) must keep these
+results stable. If a test needs updating, the change should be deliberate and
+called out in the refactor commit message.
 """
 
 import numpy as np
@@ -80,8 +82,6 @@ def _pool_view(pool_idx, layer_role_pairs, *, pool_role=None, mapper_kind=Mapper
         buffer_entries=_entries(layer_role_pairs),
         pool_role=pool_role,
         mapper_kind=mapper_kind,
-        buffer_roles=tuple(role for _, role in layer_role_pairs),
-        buffer_mapper_kinds=(mapper_kind,) * len(layer_role_pairs),
     )
 
 
@@ -206,7 +206,7 @@ def test_kv_only_full_overlap():
     peer_ri = _rank_info(name="peer", rank=1, page_table=_page_table([peer_lg]))
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == [((0, 0), (0, 0))]
+    assert mapping == {(0, 0): (0, 0)}
 
 
 def test_mla_kv_only_full_overlap():
@@ -218,7 +218,7 @@ def test_mla_kv_only_full_overlap():
     peer_ri = _rank_info(name="peer", rank=1, page_table=_page_table([peer_lg]), is_mla=True)
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == [((0, 0), (0, 0))]
+    assert mapping == {(0, 0): (0, 0)}
 
 
 def test_kv_and_block_scale_in_same_lg():
@@ -240,7 +240,7 @@ def test_kv_and_block_scale_in_same_lg():
     peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt)
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == [((0, 0), (0, 0)), ((0, 1), (0, 1))]
+    assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
 
 
 def test_kv_and_indexer_in_same_lg():
@@ -263,48 +263,7 @@ def test_kv_and_indexer_in_same_lg():
     peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt)
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == [((0, 0), (0, 0)), ((0, 1), (0, 1))]
-
-
-def test_minimax_pool_views_match_across_physical_coalescing():
-    """One coalesced TEP pool maps to two role-separated DEP pools."""
-    dep_kv = _pool_view(
-        0,
-        [(0, "key"), (0, "value")],
-        mapper_kind=MapperKind.NHD,
-    )
-    dep_index = _pool_view(
-        1,
-        [(0, "index_key")],
-        mapper_kind=MapperKind.REPLICATED,
-    )
-    tep_mixed = PoolView(
-        pool_idx=0,
-        buffer_entries=_entries([(0, "key"), (0, "value"), (0, "index_key")]),
-        pool_role=frozenset({"key", "value", "index_key"}),
-        mapper_kind=MapperKind.MIXED,
-        buffer_roles=("key", "value", "index_key"),
-        buffer_mapper_kinds=(MapperKind.NHD, MapperKind.NHD, MapperKind.REPLICATED),
-    )
-
-    dep_lg = _attn_lg(0, [(0, 10)], [dep_kv, dep_index])
-    tep_lg = _attn_lg(0, [(0, 10)], [tep_mixed])
-    dep_pt = _page_table([dep_lg], pool_specs={0: [(256, 64, 0x1000), (128, 64, 0x2000)]})
-    tep_pt = _page_table([tep_lg], pool_specs={0: [(384, 64, 0x3000)]})
-
-    reg = _registrar(dep_pt, kv_heads=8)
-    peer_ri = _rank_info(name="peer", rank=1, page_table=tep_pt, kv_heads=1)
-    assert reg.get_pool_mapping(peer_ri) == [
-        ((0, 0), (0, 0)),
-        ((0, 1), (0, 0)),
-    ]
-
-    reverse_reg = _registrar(tep_pt, kv_heads=1)
-    reverse_peer_ri = _rank_info(name="peer", rank=1, page_table=dep_pt, kv_heads=8)
-    assert reverse_reg.get_pool_mapping(reverse_peer_ri) == [
-        ((0, 0), (0, 0)),
-        ((0, 0), (0, 1)),
-    ]
+    assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
 
 
 def test_minimax_split_kv_and_replicated_index_pools_match():
@@ -370,27 +329,7 @@ def test_pp_partial_layer_overlap():
     )
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == [((0, 0), (0, 0))]
-
-
-def test_pool_view_maps_across_multiple_peer_pp_layer_groups():
-    """One local physical pool can overlap multiple peer PP life cycles."""
-    self_lg = _attn_lg(0, [(0, 10), (1, 11)], [_kv_pool_view(0, [0, 1])])
-    peer_lg0 = _attn_lg(0, [(0, 10)], [_kv_pool_view(0, [0])])
-    peer_lg1 = _attn_lg(1, [(1, 11)], [_kv_pool_view(0, [1])])
-
-    reg = _registrar(_page_table([self_lg]), layer_num_per_pp=[2])
-    peer_ri = _rank_info(
-        name="peer",
-        rank=1,
-        page_table=_page_table([peer_lg0, peer_lg1]),
-        layer_num_per_pp=[1, 1],
-    )
-
-    assert reg.get_pool_mapping(peer_ri) == [
-        ((0, 0), (0, 0)),
-        ((0, 0), (1, 0)),
-    ]
+    assert mapping == {(0, 0): (0, 0)}
 
 
 def test_two_pools_distinct_roles_in_same_lg():
@@ -416,7 +355,7 @@ def test_two_pools_distinct_roles_in_same_lg():
     peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt)
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == [((0, 0), (0, 0)), ((0, 1), (0, 1))]
+    assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
 
 
 def test_same_role_pools_disambiguated_by_layer_overlap():
@@ -445,7 +384,7 @@ def test_same_role_pools_disambiguated_by_layer_overlap():
     peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt, layer_num_per_pp=[3])
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == [((0, 0), (0, 1))]
+    assert mapping == {(0, 0): (0, 1)}
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/disaggregated/test_pool_matching.py
+++ b/tests/unittest/disaggregated/test_pool_matching.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Golden tests for ``PeerRegistrar.get_pool_mapping``.
 
 Covers pool-level and legacy disagg matching across representative scenarios:
@@ -5,7 +20,7 @@ Covers pool-level and legacy disagg matching across representative scenarios:
   * single KV pool, full layer overlap (basic MHA)
   * MLA (kv_factor=1, KEY-only pool)
   * KV + block-scale pools coexisting in one LG
-  * KV + FLAT pools coexisting in one LG (FLAT has empty buffer_entries)
+  * KV + REPLICATED indexer pools coexisting in one LG
   * PP partial layer overlap (Step-1 LG match by global_layer_id)
   * Two pools with same role but different layer sets within a peer LG
     (DSv4 virtual-layer scenario, exercises ``best_overlap``)
@@ -70,13 +85,13 @@ def _pool_view(pool_idx, layer_role_pairs, *, pool_role=None, mapper_kind=Mapper
     )
 
 
-def _empty_pool_view(pool_idx, *, pool_role=frozenset({"indexer_k"})):
-    """Pool view with no buffer entries — FLAT pool convention."""
-    return PoolView(
-        pool_idx=pool_idx,
-        buffer_entries=np.array([], dtype=BUFFER_ENTRY_DTYPE),
+def _indexer_pool_view(pool_idx, local_layer_ids, *, pool_role=frozenset({"indexer_k"})):
+    """Replicated indexer pool view: one synthesized entry per local layer."""
+    return _pool_view(
+        pool_idx,
+        [(lid, "indexer_k") for lid in local_layer_ids],
         pool_role=pool_role,
-        mapper_kind=MapperKind.FLAT,
+        mapper_kind=MapperKind.REPLICATED,
     )
 
 
@@ -229,16 +244,16 @@ def test_kv_and_block_scale_in_same_lg():
 
 
 def test_kv_and_indexer_in_same_lg():
-    """KV pool + FLAT pool. FLAT has empty buffer_entries; matches by role."""
+    """KV pool + replicated indexer pool match independently by role."""
     self_lg = _attn_lg(
         0,
         [(0, 0), (1, 1)],
-        [_kv_pool_view(0, [0, 1]), _empty_pool_view(1)],
+        [_kv_pool_view(0, [0, 1]), _indexer_pool_view(1, [0, 1])],
     )
     peer_lg = _attn_lg(
         0,
         [(0, 0), (1, 1)],
-        [_kv_pool_view(0, [0, 1]), _empty_pool_view(1)],
+        [_kv_pool_view(0, [0, 1]), _indexer_pool_view(1, [0, 1])],
     )
 
     self_pt = _page_table([self_lg], pool_specs={0: [(1024, 64, 0x1000), (512, 64, 0x2000)]})
@@ -292,6 +307,58 @@ def test_minimax_pool_views_match_across_physical_coalescing():
     ]
 
 
+def test_minimax_split_kv_and_replicated_index_pools_match():
+    """MiniMax M3 shape: NHD KV pool + REPLICATED index-key pool.
+
+    coalescing_group derivation keeps INDEX_KEY in its own pool on every
+    topology, so both sides always present the same two role sets and
+    role-set matching pairs them 1:1 with kinds intact.
+    """
+
+    def _lg():
+        return _attn_lg(
+            0,
+            [(0, 0), (1, 1)],
+            [
+                _pool_view(
+                    0,
+                    [(lid, role) for lid in (0, 1) for role in ("key", "value")],
+                    mapper_kind=MapperKind.NHD,
+                ),
+                _pool_view(
+                    1, [(0, "index_key"), (1, "index_key")], mapper_kind=MapperKind.REPLICATED
+                ),
+            ],
+        )
+
+    self_pt = _page_table([_lg()], pool_specs={0: [(512, 64, 0x1000), (256, 64, 0x2000)]})
+    peer_pt = _page_table([_lg()], pool_specs={0: [(512, 64, 0x3000), (256, 64, 0x4000)]})
+
+    reg = _registrar(self_pt)
+    peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt)
+
+    mapping = reg.get_pool_mapping(peer_ri)
+    assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
+
+
+def test_mismatched_view_kinds_raise():
+    """Kind disagreement on one role set must fail loudly.
+
+    Same role set but different kinds on the two sides is a version or
+    configuration inconsistency.
+    """
+    self_lg = _attn_lg(
+        0, [(0, 0)], [_pool_view(0, [(0, "index_key")], mapper_kind=MapperKind.REPLICATED)]
+    )
+    peer_lg = _attn_lg(0, [(0, 0)], [_pool_view(0, [(0, "index_key")], mapper_kind=MapperKind.NHD)])
+
+    reg = _registrar(_page_table([self_lg]))
+    peer_ri = _rank_info(name="peer", rank=1, page_table=_page_table([peer_lg]))
+
+    with pytest.raises(ValueError, match="incompatible mapper"):
+        reg.get_pool_mapping(peer_ri)
+
+
 def test_pp_partial_layer_overlap():
     """Self covers global layers {10,11}, peer covers {11,12}. Match via overlap on layer 11."""
     self_lg = _attn_lg(0, [(0, 10), (1, 11)], [_kv_pool_view(0, [0, 1])])
@@ -335,11 +402,11 @@ def test_two_pools_distinct_roles_in_same_lg():
     pool with the same pool_role.
     """
     self_kv = _kv_pool_view(0, [0, 1])
-    self_indexer = _empty_pool_view(1)
+    self_indexer = _indexer_pool_view(1, [0, 1])
     self_lg = _attn_lg(0, [(0, 10), (1, 11)], [self_kv, self_indexer])
 
     peer_kv = _kv_pool_view(0, [0, 1])
-    peer_indexer = _empty_pool_view(1)
+    peer_indexer = _indexer_pool_view(1, [0, 1])
     peer_lg = _attn_lg(0, [(0, 10), (1, 11)], [peer_kv, peer_indexer])
 
     self_pt = _page_table([self_lg], pool_specs={0: [(1024, 64, 0x1000), (512, 64, 0x2000)]})
@@ -384,20 +451,19 @@ def test_same_role_pools_disambiguated_by_layer_overlap():
 @pytest.mark.parametrize(
     ("self_mapper_kind", "peer_mapper_kind"),
     [
-        (MapperKind.FLAT, MapperKind.INDEXED),
-        (MapperKind.INDEXED, MapperKind.FLAT),
+        (MapperKind.REPLICATED, MapperKind.INDEXED),
+        (MapperKind.INDEXED, MapperKind.REPLICATED),
     ],
 )
 def test_mixed_mapper_kinds_are_rejected(self_mapper_kind, peer_mapper_kind):
     """Pool layouts must use the same mapper kind on both peers."""
 
     def _indexer_view(mapper_kind):
-        if mapper_kind == MapperKind.FLAT:
-            return _empty_pool_view(0)
         return _pool_view(
             0,
             [(0, "indexer_k"), (1, "indexer_k")],
             pool_role=frozenset({"indexer_k"}),
+            mapper_kind=mapper_kind,
         )
 
     self_lg = _attn_lg(0, [(0, 10), (1, 11)], [_indexer_view(self_mapper_kind)])

--- a/tests/unittest/disaggregated/test_pool_matching.py
+++ b/tests/unittest/disaggregated/test_pool_matching.py
@@ -251,6 +251,37 @@ def test_kv_and_indexer_in_same_lg():
     assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
 
 
+def test_minimax_logical_views_match_across_physical_coalescing():
+    """DEP split pools and TEP coalesced pools match by logical role/layer."""
+    dep_kv = _pool_view(0, [(0, "key"), (0, "value")])
+    dep_kv.bytes_per_region = 512
+    dep_index = _pool_view(
+        1,
+        [(0, "index_key")],
+        mapper_kind=MapperKind.REPLICATED,
+    )
+    dep_index.bytes_per_region = 128
+
+    tep_kv = _pool_view(0, [(0, "key"), (0, "value")])
+    tep_kv.bytes_per_region = 128
+    tep_index = _pool_view(
+        0,
+        [(0, "index_key")],
+        mapper_kind=MapperKind.REPLICATED,
+    )
+    tep_index.byte_offset = 128
+    tep_index.bytes_per_region = 128
+
+    dep_lg = _attn_lg(0, [(0, 10)], [dep_kv, dep_index])
+    tep_lg = _attn_lg(0, [(0, 10)], [tep_kv, tep_index])
+    dep_pt = _page_table([dep_lg], pool_specs={0: [(512, 64, 0x1000), (128, 64, 0x2000)]})
+    tep_pt = _page_table([tep_lg], pool_specs={0: [(256, 64, 0x3000)]})
+
+    reg = _registrar(dep_pt, kv_heads=8)
+    peer_ri = _rank_info(name="peer", rank=1, page_table=tep_pt, kv_heads=1)
+    assert reg.get_pool_mapping(peer_ri) == {(0, 0): (0, 0), (0, 1): (0, 1)}
+
+
 def test_pp_partial_layer_overlap():
     """Self covers global layers {10,11}, peer covers {11,12}. Match via overlap on layer 11."""
     self_lg = _attn_lg(0, [(0, 10), (1, 11)], [_kv_pool_view(0, [0, 1])])

--- a/tests/unittest/disaggregated/test_pool_matching.py
+++ b/tests/unittest/disaggregated/test_pool_matching.py
@@ -1,7 +1,6 @@
 """Golden tests for ``PeerRegistrar.get_pool_mapping``.
 
-Locks the current (pre-refactor) behavior of disagg pool matching across the
-representative scenarios that the refactor must keep working:
+Covers pool-level and legacy disagg matching across representative scenarios:
 
   * single KV pool, full layer overlap (basic MHA)
   * MLA (kv_factor=1, KEY-only pool)
@@ -11,9 +10,8 @@ representative scenarios that the refactor must keep working:
   * Two pools with same role but different layer sets within a peer LG
     (DSv4 virtual-layer scenario, exercises ``best_overlap``)
 
-The refactor (PoolRole -> PoolMatchKey + TransferLayout) must keep these
-results stable. If a test needs updating, the change should be deliberate and
-called out in the refactor commit message.
+New V2 views carry per-buffer roles and mapper kinds. Legacy views without
+that metadata retain role-set matching.
 """
 
 import numpy as np
@@ -67,6 +65,8 @@ def _pool_view(pool_idx, layer_role_pairs, *, pool_role=None, mapper_kind=Mapper
         buffer_entries=_entries(layer_role_pairs),
         pool_role=pool_role,
         mapper_kind=mapper_kind,
+        buffer_roles=tuple(role for _, role in layer_role_pairs),
+        buffer_mapper_kinds=(mapper_kind,) * len(layer_role_pairs),
     )
 
 
@@ -191,7 +191,7 @@ def test_kv_only_full_overlap():
     peer_ri = _rank_info(name="peer", rank=1, page_table=_page_table([peer_lg]))
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == {(0, 0): (0, 0)}
+    assert mapping == [((0, 0), (0, 0))]
 
 
 def test_mla_kv_only_full_overlap():
@@ -203,7 +203,7 @@ def test_mla_kv_only_full_overlap():
     peer_ri = _rank_info(name="peer", rank=1, page_table=_page_table([peer_lg]), is_mla=True)
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == {(0, 0): (0, 0)}
+    assert mapping == [((0, 0), (0, 0))]
 
 
 def test_kv_and_block_scale_in_same_lg():
@@ -225,7 +225,7 @@ def test_kv_and_block_scale_in_same_lg():
     peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt)
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
+    assert mapping == [((0, 0), (0, 0)), ((0, 1), (0, 1))]
 
 
 def test_kv_and_indexer_in_same_lg():
@@ -248,38 +248,48 @@ def test_kv_and_indexer_in_same_lg():
     peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt)
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
+    assert mapping == [((0, 0), (0, 0)), ((0, 1), (0, 1))]
 
 
-def test_minimax_logical_views_match_across_physical_coalescing():
-    """DEP split pools and TEP coalesced pools match by logical role/layer."""
-    dep_kv = _pool_view(0, [(0, "key"), (0, "value")])
-    dep_kv.bytes_per_region = 512
+def test_minimax_pool_views_match_across_physical_coalescing():
+    """One coalesced TEP pool maps to two role-separated DEP pools."""
+    dep_kv = _pool_view(
+        0,
+        [(0, "key"), (0, "value")],
+        mapper_kind=MapperKind.NHD,
+    )
     dep_index = _pool_view(
         1,
         [(0, "index_key")],
         mapper_kind=MapperKind.REPLICATED,
     )
-    dep_index.bytes_per_region = 128
-
-    tep_kv = _pool_view(0, [(0, "key"), (0, "value")])
-    tep_kv.bytes_per_region = 128
-    tep_index = _pool_view(
-        0,
-        [(0, "index_key")],
-        mapper_kind=MapperKind.REPLICATED,
+    tep_mixed = PoolView(
+        pool_idx=0,
+        buffer_entries=_entries([(0, "key"), (0, "value"), (0, "index_key")]),
+        pool_role=frozenset({"key", "value", "index_key"}),
+        mapper_kind=MapperKind.MIXED,
+        buffer_roles=("key", "value", "index_key"),
+        buffer_mapper_kinds=(MapperKind.NHD, MapperKind.NHD, MapperKind.REPLICATED),
     )
-    tep_index.byte_offset = 128
-    tep_index.bytes_per_region = 128
 
     dep_lg = _attn_lg(0, [(0, 10)], [dep_kv, dep_index])
-    tep_lg = _attn_lg(0, [(0, 10)], [tep_kv, tep_index])
-    dep_pt = _page_table([dep_lg], pool_specs={0: [(512, 64, 0x1000), (128, 64, 0x2000)]})
-    tep_pt = _page_table([tep_lg], pool_specs={0: [(256, 64, 0x3000)]})
+    tep_lg = _attn_lg(0, [(0, 10)], [tep_mixed])
+    dep_pt = _page_table([dep_lg], pool_specs={0: [(256, 64, 0x1000), (128, 64, 0x2000)]})
+    tep_pt = _page_table([tep_lg], pool_specs={0: [(384, 64, 0x3000)]})
 
     reg = _registrar(dep_pt, kv_heads=8)
     peer_ri = _rank_info(name="peer", rank=1, page_table=tep_pt, kv_heads=1)
-    assert reg.get_pool_mapping(peer_ri) == {(0, 0): (0, 0), (0, 1): (0, 1)}
+    assert reg.get_pool_mapping(peer_ri) == [
+        ((0, 0), (0, 0)),
+        ((0, 1), (0, 0)),
+    ]
+
+    reverse_reg = _registrar(tep_pt, kv_heads=1)
+    reverse_peer_ri = _rank_info(name="peer", rank=1, page_table=dep_pt, kv_heads=8)
+    assert reverse_reg.get_pool_mapping(reverse_peer_ri) == [
+        ((0, 0), (0, 0)),
+        ((0, 0), (0, 1)),
+    ]
 
 
 def test_pp_partial_layer_overlap():
@@ -293,7 +303,27 @@ def test_pp_partial_layer_overlap():
     )
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == {(0, 0): (0, 0)}
+    assert mapping == [((0, 0), (0, 0))]
+
+
+def test_pool_view_maps_across_multiple_peer_pp_layer_groups():
+    """One local physical pool can overlap multiple peer PP life cycles."""
+    self_lg = _attn_lg(0, [(0, 10), (1, 11)], [_kv_pool_view(0, [0, 1])])
+    peer_lg0 = _attn_lg(0, [(0, 10)], [_kv_pool_view(0, [0])])
+    peer_lg1 = _attn_lg(1, [(1, 11)], [_kv_pool_view(0, [1])])
+
+    reg = _registrar(_page_table([self_lg]), layer_num_per_pp=[2])
+    peer_ri = _rank_info(
+        name="peer",
+        rank=1,
+        page_table=_page_table([peer_lg0, peer_lg1]),
+        layer_num_per_pp=[1, 1],
+    )
+
+    assert reg.get_pool_mapping(peer_ri) == [
+        ((0, 0), (0, 0)),
+        ((0, 0), (1, 0)),
+    ]
 
 
 def test_two_pools_distinct_roles_in_same_lg():
@@ -319,7 +349,7 @@ def test_two_pools_distinct_roles_in_same_lg():
     peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt)
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
+    assert mapping == [((0, 0), (0, 0)), ((0, 1), (0, 1))]
 
 
 def test_same_role_pools_disambiguated_by_layer_overlap():
@@ -348,7 +378,7 @@ def test_same_role_pools_disambiguated_by_layer_overlap():
     peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt, layer_num_per_pp=[3])
 
     mapping = reg.get_pool_mapping(peer_ri)
-    assert mapping == {(0, 0): (0, 1)}
+    assert mapping == [((0, 0), (0, 1))]
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/disaggregated/test_pool_matching.py
+++ b/tests/unittest/disaggregated/test_pool_matching.py
@@ -48,6 +48,7 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     PhysicalPoolGroup,
     PoolView,
 )
+from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_to_layer_group
 
 # ---------------------------------------------------------------------------
 # Builders
@@ -330,6 +331,47 @@ def test_pp_partial_layer_overlap():
 
     mapping = reg.get_pool_mapping(peer_ri)
     assert mapping == {(0, 0): (0, 0)}
+
+
+def test_pool_view_spanning_multiple_peer_lgs_raises():
+    """A self pool view spanning two peer LGs must fail loudly.
+
+    Mismatched layer grouping between peers is an unsupported topology;
+    silently transferring only the first LG's overlap would drop layers.
+    """
+    self_lg = _attn_lg(0, [(0, 10), (1, 11)], [_kv_pool_view(0, [0, 1])])
+    # Peer holds the same global layers but split across two layer groups.
+    peer_lg0 = _attn_lg(0, [(0, 10)], [_kv_pool_view(0, [0])])
+    peer_lg1 = _attn_lg(1, [(0, 11)], [_kv_pool_view(0, [0])])
+
+    reg = _registrar(_page_table([self_lg]))
+    peer_ri = _rank_info(name="peer", rank=1, page_table=_page_table([peer_lg0, peer_lg1]))
+
+    with pytest.raises(ValueError, match="multiple peer layer groups"):
+        reg.get_pool_mapping(peer_ri)
+
+
+def test_skewed_buffer_entries_per_layer_raises():
+    """A skewed per-layer entry distribution must raise.
+
+    1 + 3 entries over two layers passes ``total % layers == 0`` (4 % 2)
+    but is not a uniform per-layer layout — must raise, not return 2.
+    """
+    view = _pool_view(0, [(0, "key"), (1, "key"), (1, "key"), (1, "key")])
+    with pytest.raises(ValueError, match="not evenly distributed"):
+        PeerRegistrar._get_buffers_per_layer(view, layer_group_id=0, pool_idx=0)
+
+
+def test_duplicate_global_layer_id_across_lgs_raises():
+    """Layer groups must partition a rank's attention layers.
+
+    The same global_layer_id in two LGs would silently corrupt peer matching.
+    """
+    lg0 = _attn_lg(0, [(0, 10)], [_kv_pool_view(0, [0])])
+    lg1 = _attn_lg(1, [(0, 10)], [_kv_pool_view(0, [0])])
+
+    with pytest.raises(ValueError, match="layer groups must partition"):
+        get_layer_to_layer_group(_page_table([lg0, lg1]))
 
 
 def test_two_pools_distinct_roles_in_same_lg():

--- a/tests/unittest/disaggregated/test_rank_info.py
+++ b/tests/unittest/disaggregated/test_rank_info.py
@@ -21,6 +21,7 @@ from tensorrt_llm import bindings
 from tensorrt_llm._torch.disaggregation.native import rank_info as rank_info_module
 from tensorrt_llm._torch.disaggregation.native.auxiliary import AuxBufferMeta
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
+from tensorrt_llm.bindings import DataType
 
 
 def test_rank_info_construction():
@@ -122,3 +123,31 @@ def test_from_kv_cache_manager_uses_first_nonzero_kv_head_count(monkeypatch) -> 
     info = RankInfo.from_kv_cache_manager("ctx", manager, device_id=0)
 
     assert info.attention.kv_heads_per_rank == 8
+
+
+def test_rank_info_represents_subbyte_nvfp4_cache(monkeypatch):
+    monkeypatch.setattr(rank_info_module, "build_page_table_from_manager", lambda _manager: None)
+    manager = SimpleNamespace(
+        mapping=SimpleNamespace(
+            rank=0,
+            tp_size=2,
+            tp_rank=0,
+            pp_size=1,
+            pp_rank=0,
+            dp_size=1,
+            cp_size=1,
+            cp_rank=0,
+            enable_attention_dp=False,
+        ),
+        pp_layers=[0],
+        num_kv_heads_per_layer=[4],
+        tokens_per_block=64,
+        head_dim=128,
+        dtype=DataType.NVFP4,
+        kv_factor=2,
+    )
+
+    rank_info = RankInfo.from_kv_cache_manager("ctx", manager, device_id=0)
+
+    assert rank_info.attention.element_bytes == 0.5
+    assert RankInfo.from_bytes(rank_info.to_bytes()).attention.element_bytes == 0.5

--- a/tests/unittest/disaggregated/test_rank_info.py
+++ b/tests/unittest/disaggregated/test_rank_info.py
@@ -16,6 +16,7 @@
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 from tensorrt_llm import bindings
 from tensorrt_llm._torch.disaggregation.native import rank_info as rank_info_module
@@ -125,7 +126,13 @@ def test_from_kv_cache_manager_uses_first_nonzero_kv_head_count(monkeypatch) -> 
     assert info.attention.kv_heads_per_rank == 8
 
 
-def test_rank_info_represents_subbyte_nvfp4_cache(monkeypatch):
+@pytest.mark.parametrize(
+    ("dtype", "expected_element_bytes", "expected_type"),
+    [(DataType.NVFP4, 0.5, float), (DataType.HALF, 2, int)],
+)
+def test_rank_info_represents_cache_element_bytes(
+    monkeypatch, dtype, expected_element_bytes, expected_type
+):
     monkeypatch.setattr(rank_info_module, "build_page_table_from_manager", lambda _manager: None)
     manager = SimpleNamespace(
         mapping=SimpleNamespace(
@@ -143,11 +150,15 @@ def test_rank_info_represents_subbyte_nvfp4_cache(monkeypatch):
         num_kv_heads_per_layer=[4],
         tokens_per_block=64,
         head_dim=128,
-        dtype=DataType.NVFP4,
+        dtype=dtype,
         kv_factor=2,
     )
 
     rank_info = RankInfo.from_kv_cache_manager("ctx", manager, device_id=0)
 
-    assert rank_info.attention.element_bytes == 0.5
-    assert RankInfo.from_bytes(rank_info.to_bytes()).attention.element_bytes == 0.5
+    assert rank_info.attention.element_bytes == expected_element_bytes
+    assert isinstance(rank_info.attention.element_bytes, expected_type)
+
+    restored = RankInfo.from_bytes(rank_info.to_bytes())
+    assert restored.attention.element_bytes == expected_element_bytes
+    assert isinstance(restored.attention.element_bytes, expected_type)

--- a/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
+++ b/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from typing import Optional
 from unittest.mock import Mock
 
+import pytest
+
 from tensorrt_llm._torch.disaggregation.base.transfer import SessionStatus, WaitResult
 from tensorrt_llm._torch.disaggregation.native.transfer import TaskStatus, TxSession
 from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
@@ -267,6 +269,48 @@ def test_consensus_outcome_uses_single_batched_allgather() -> None:
     assert new_cancelled == [1]  # union of cancelled across ranks
     assert new_failed == [2, 99]  # union of failed across ranks
     assert new_completed == [7]  # intersection only (8 is completed on the peer only)
+
+
+@pytest.mark.skip(
+    reason="ctx idle fast-path was dropped from this branch. TODO: when the "
+    "fast-path is reintroduced, its terminal-count reduction must mirror "
+    "_ctx_consensus()'s communicator scope (TP group, then PP group; TP "
+    "skipped under attention DP) — a WORLD-scoped allreduce hangs under "
+    "ADP+PP because independent attention-DP lanes poll on their own "
+    "schedules. Re-enable this test and add scoped mock coverage for the "
+    "TP+PP and ADP+PP configurations plus real-collective MP tests."
+)
+def test_ctx_consensus_fastpath_skips_when_idle(monkeypatch) -> None:
+    # With the fast-path enabled, an all-zero terminal count (one fixed-size
+    # allreduce) makes every rank skip the variable-length consensus; a non-zero
+    # count falls through to the normal consensus path.
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.disaggregation.transceiver._CTX_CONSENSUS_FASTPATH", True
+    )
+    transceiver = object.__new__(KvCacheTransceiverV2)
+    transceiver._ever_had_send_session = True
+    transceiver._ctx_need_tp_sync = True
+    transceiver._ctx_need_pp_sync = False
+    transceiver._send_sessions = {}
+    transceiver._send_reqs = {}
+    transceiver._dist = Mock()
+    transceiver._dist.allreduce = Mock(return_value=0)
+    transceiver._ctx_consensus = Mock(return_value=[])
+    transceiver._build_to_process = Mock(return_value=[])
+    transceiver._ctx_consensus_outcome = Mock(return_value=([], [], [], []))
+    transceiver._transfer_worker = _FakeTransferWorker()
+    transceiver._close_failed_sessions = Mock()
+
+    completed, failed = transceiver.check_context_transfer_status(at_least_request_num=0)
+
+    assert completed == [] and failed == []
+    transceiver._dist.allreduce.assert_called_once()
+    transceiver._ctx_consensus.assert_not_called()  # idle fast-path skipped the consensus
+
+    # Non-zero global terminal count => fast-path does not skip; consensus runs.
+    transceiver._dist.allreduce = Mock(return_value=2)
+    transceiver.check_context_transfer_status(at_least_request_num=0)
+    transceiver._ctx_consensus.assert_called_once()
 
 
 def test_tx_session_wait_complete_defaults_to_blocking() -> None:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

### Dev Engineer Review

**Correctness / API consistency**
- **MiniMax M3 disaggregated serving (KV Cache Manager V2 / NIXL)**:
  - Added disaggregation role→mapper-kind declarations via `get_disagg_role_mapper_kinds` (both `KVCacheManagerV2` and MiniMax M3 sparse manager V2).
  - Enforced disaggregated sparse policy by computing sparse layers that would enable index-value and **rejecting disaggregated serving if any such sparse layer exists** (i.e., requires `disable_index_value=True` for all sparse layers in disagg mode).
  - Updated disaggregation page-table semantics by expanding `MapperKind` to **`INDEXED`, `REPLICATED`, `NHD`** (removed `FLAT`) and extended `PoolView` with optional `bytes_per_layer` to support geometry-aware views.
  - Strengthened paging/indexing + geometry handling:
    - MiniMax M3 `_get_batch_cache_indices_by_pool_id` now supports `num_blocks_per_seq` by directly returning base page indices from `kv_cache.get_base_page_indices(pool_id)` and truncating per-request indices (preserving `BAD_PAGE_INDEX` entries).
    - MiniMax M3 `_kv_pool_mapping_offset` now computes consistent per-layer offsets based on **physical K base address ordering** rather than `layer_grouping` iteration order.
- **Native disaggregation peer attention mapping**:
  - Replaced previous head-match/identity mapping behavior with `IntactMapper` (fragments only the selected contiguous per-layer regions) and routed mapper dispatch by `MapperKind`:
    - `ReplicatedMapper` (specialized `IntactMapper`) for `MapperKind.REPLICATED`
    - `HNDHeadMismatchMapper` and new `NHDHeadMismatchMapper` for head-mismatch cases with NHD’s token-major layout invariants.
  - Converted mapping validity checks from assertions to deterministic `ValueError`s for region/byte/alignment/buffer-count invariants (including sub-byte head alignment requirements).
  - Updated `PeerRegistrar`:
    - Simplified global-layer mapping by using `get_pool_view_global_layer_ids` on both sides.
    - Reworked `get_kv_map` to compute overlap layers and offsets from explicit per-layer byte ranges and validated per-layer buffer entry distribution.
    - Updated replicated send ownership selection to avoid multi-writer fan-in issues (`_owns_tp_fan_in`).
- **Transfer / NIXL transport**
  - Updated disaggregation sender logic to decide pool eligibility **per (self pool view, peer pool view) pair** and tightened bounce/fan-in safety for replicated pools in the peer page table.
  - C++ NIXL descriptor shaping refactor:
    - Renamed/expanded `VmmDescSplitter` API to `splitAndCoalesceTransferDescs(..., enableCoalesce=true)` and updated call sites.
    - Removed older standalone NIXL coalescing helpers; coalescing is now controlled by the new env accessor and remote region metadata availability.
  - **Environment knob rename/inversion**:
    - `getEnvNixlEnableCoalesce()` → `getEnvNixlDisableCoalesce()`
    - `TRTLLM_NIXL_ENABLE_COALESCE` → `TRTLLM_NIXL_DISABLE_COALESCE`
- **Config/spec robustness**
  - Disaggregation attention spec + rank info now correctly represent `element_bytes` as an `int | float`-typed quantity, with unit tests added to lock expected typing/value behavior.

**Tests / validation additions**
- Added/expanded unit tests for:
  - `PoolView` roundtrip of `mapper_kind` and `bytes_per_layer`.
  - `compute_layer_byte_ranges` / `get_layer_byte_ranges` validation and failure modes.
  - Mapper constructor and mapping behavior for `IntactMapper`, `ReplicatedMapper`, `HNDHeadMismatchMapper`, `NHDHeadMismatchMapper`.
  - `KVCacheManagerV2.get_disagg_role_mapper_kinds()` defaults.
  - V1 DSA indexer-K replicated page-table/transfer behavior.
  - Disaggregated KV transfer harness and a MiniMax M3 disaggregated transfer matrix, including new ordering/indexing/validation cases.
- **CI note**: multiple CI runs were repeatedly triggered and some merge-request pipeline runs failed, with follow-up reruns requested after author fixes.

### QA Engineer Review

**Test list changes (tests/integration/test_lists)**
- **Modified:** `tests/integration/test_lists/test-db/l0_h100.yml`
  - **Added:**
    - `unittest/disaggregated/test_transceiver_bounded_polling.py`
    - `unittest/disaggregated/test_pool_matching.py`
    - `unittest/disaggregated/test_deepseek_v4_kv_transfer.py`
    - `unittest/disaggregated/test_minimax_m3_kv_transfer.py`
  - **Added under DSA indexer-K comment:**
    - `unittest/disaggregated/test_cache_transceiver_single_process.py::test_cache_transceiver_v1_dsa_indexer`
- **Modified:** `tests/integration/test_lists/test-db/l0_a10.yml`
  - **Added:**
    - `unittest/disaggregated/test_cache_reuse_adapter.py`
- **Verdict:** needs follow-up (test-db list updates cover the newly added/modified disaggregated tests, but broader CBTS/CI coverage data was not provided).

**Test code changes (files under tests/, outside test-list files)**
- **Added / expanded:**
  - `tests/unittest/_torch/executor/test_kv_cache_manager_v2.py` — `test_disagg_role_mapper_kinds_default_to_indexed`
  - `tests/unittest/disaggregated/region/test_page.py` — `PoolView` kind/`bytes_per_layer` roundtrip + multiple `get_layer_byte_ranges` validation tests
  - `tests/unittest/disaggregated/test_cache_reuse_adapter.py` — extended request window propagation assertion
  - `tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py` — refactor to use `kv_transfer_harness.run_kv_transfer_test` and tightened typing
  - `tests/unittest/disaggregated/test_extractor.py` — added V1 DSA indexer-K and V2 page-table builder tests + validation cases
  - `tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py` — new MiniMax M3 disaggregated transfer matrix + multiple unit validations
  - `tests/unittest/disaggregated/test_peer.py` — expanded mapper/registrar dispatch + geometry/alignment/buffer validation tests
  - `tests/unittest/disaggregated/test_pool_matching.py` — added/updated golden/unit coverage for pool mapping rules and validation errors
  - `tests/unittest/disaggregated/test_rank_info.py` — dtype-dependent `element_bytes` numeric/type tests
  - `tests/unittest/disaggregated/test_cache_transceiver_single_process.py` — new V1 DSA indexer-K transfer test and harness plumbing
  - `tests/unittest/disaggregated/test_transceiver_bounded_polling.py` — new skipped unit test `test_ctx_consensus_fastpath_skips_when_idle`
  - `tests/unittest/disaggregated/kv_transfer_harness.py` — added threaded single-process NIXL/V2 KV transfer harness
  - `tests/unittest/disaggregated/test_bounce.py`, `tests/unittest/disaggregated/region/test_block.py` — updated mapper/region coverage and fan-in safety assertions
- **Integration coverage mapping:** all the above are intended to be exercised by the newly added entries in `tests/integration/test_lists/test-db/l0_h100.yml` and `l0_a10.yml` (where applicable), but full per-test CBTS linkage/coverage data is not provided.
- **Verdict:** needs follow-up (major test additions outside test lists; CI coverage mapping beyond the listed entries was not provided).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Enables MiniMax M3 with native NIXL disaggregated serving using KV Cache Manager V2.

  MiniMax M3 requires model-specific KV-cache handling because it uses token-major NHD K/V storage and a replicated sparse-attention index-key cache. This PR:

  - Adds a manager-declared disaggregation layout capability instead of MiniMax-specific checks in shared code.
  - Exposes K/V and index-key as logical V2 pool views.
  - Adds NHD head remapping for heterogeneous TEP/DEP topologies.
  - Transfers replicated index-key data with single-owner routing.
  - Rejects disaggregation when unmanaged index-value caching is enabled.
  - Adds validation for incompatible cache geometry and block alignment.
  - Preserves the existing DeepSeek-V4 indexed-cache path.
  - Warns about expensive head-mismatched transfers and the pure-Python NIXL fallback.

  Known limitation: long-context head-mismatched TEP↔DEP transfers remain functionally correct but require a future gather/staging/scatter path for production performance.

## Test Coverage
- Committed MiniMax matrix: 39 passed
- 3 capability/validation tests
- Covers both update orders, BF16 and NVFP4 KV caches, TEP/DEP→DEP, degree-8 duplication/fan-in/fan-out, and PP2.


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
