### PR TITLE
[None][perf] template NVLink A2A fault tolerance checks

### DIFF
--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -213,13 +213,8 @@ __device__ __forceinline__ int compute_target_rank_id(int expert_id, int base, i
 // Test bit `rank` in a kRankMaskWords-wide little-endian uint64 bitmask.
 // Word 0 covers ranks 0..63, word 1 covers ranks 64..127, etc.
 // `rank >> 6` and `rank & 63` divide / modulo by 64.
-template <bool ENABLE_FAULT_TOLERANCE>
-__host__ __device__ __forceinline__ bool is_rank_active(uint64_t const* mask, int rank)
+__device__ __forceinline__ bool is_rank_active(uint64_t const* mask, int rank)
 {
-    if constexpr (!ENABLE_FAULT_TOLERANCE)
-    {
-        return true;
-    }
     return (mask[rank >> 6] >> (rank & 63)) & 1ULL;
 }
 
@@ -445,11 +440,16 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
             // Supports the non-divisible case where num_experts % ep_size != 0.
             int target_rank = compute_target_rank_id(expert_id, ep_base, ep_remainder);
 
-            // Skip duplicate target ranks. Runtime routing is expected to avoid inactive ranks.
             int const mask_word = target_rank >> 6;
             uint64_t const mask_bit = 1ULL << (target_rank & 63);
             bool const target_already_copied = (already_copied[mask_word] & mask_bit) != 0;
-            if (target_already_copied)
+            bool skip_target = target_already_copied;
+            if constexpr (ENABLE_FAULT_TOLERANCE)
+            {
+                // Do not dispatch routes to inactive ranks; their symmetric memory may be inaccessible.
+                skip_target = skip_target || !is_rank_active(ptrs.active_rank_mask, target_rank);
+            }
+            if (skip_target)
             {
                 if (thread_idx == 0)
                 {
@@ -531,9 +531,12 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
 #pragma unroll 1 // No unroll as one iter is typically enough
             for (int target_rank = lane_id; target_rank < ep_size; target_rank += warpSize)
             {
-                // Do not write counters into inactive ranks' symmetric workspace.
-                if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, target_rank))
-                    continue;
+                if constexpr (ENABLE_FAULT_TOLERANCE)
+                {
+                    // Do not write counters into inactive ranks' symmetric workspace.
+                    if (!is_rank_active(ptrs.active_rank_mask, target_rank))
+                        continue;
+                }
                 int send_count = ptrs.send_counters[target_rank];
                 ptrs.recv_counters[target_rank][rank_id] = send_count;
             }
@@ -544,9 +547,12 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
 #pragma unroll 1
                 for (int target_rank = 0; target_rank < ep_size; ++target_rank)
                 {
-                    // Do not publish EPLB stats into inactive ranks' symmetric workspace.
-                    if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, target_rank))
-                        continue;
+                    if constexpr (ENABLE_FAULT_TOLERANCE)
+                    {
+                        // Do not publish EPLB stats into inactive ranks' symmetric workspace.
+                        if (!is_rank_active(ptrs.active_rank_mask, target_rank))
+                            continue;
+                    }
                     int* target_stats = ptrs.eplb_gathered_stats[target_rank];
                     for (int expert_id = lane_id; expert_id < eplb_stats_num_experts; expert_id += warpSize)
                     {
@@ -568,9 +574,12 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
 #pragma unroll 1 // No unroll as one iter is typically enough
             for (int target_rank = lane_id; target_rank < ep_size; target_rank += warpSize)
             {
-                // Do not signal inactive peers; their flag memory may be unreachable.
-                if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, target_rank))
-                    continue;
+                if constexpr (ENABLE_FAULT_TOLERANCE)
+                {
+                    // Do not signal inactive peers; their flag memory may be unreachable.
+                    if (!is_rank_active(ptrs.active_rank_mask, target_rank))
+                        continue;
+                }
                 uint32_t* flag_addr = &ptrs.completion_flags[target_rank][rank_id];
                 asm volatile("st.relaxed.sys.u32 [%0], %1;" ::"l"(flag_addr), "r"(expected_value));
 
@@ -583,9 +592,12 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
 #pragma unroll 1 // No unroll
             for (int peer_rank = lane_id; peer_rank < ep_size; peer_rank += warpSize)
             {
-                // Do not wait on inactive peers; they will not signal this collective.
-                if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, peer_rank))
-                    continue;
+                if constexpr (ENABLE_FAULT_TOLERANCE)
+                {
+                    // Do not wait on inactive peers; they will not signal this collective.
+                    if (!is_rank_active(ptrs.active_rank_mask, peer_rank))
+                        continue;
+                }
                 bool flag_set = false;
                 auto s = clock64();
                 do
@@ -710,7 +722,7 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params)
 // Unified path: load VEC_SIZE bytes, reinterpret as InT[elems_per_vec], accumulate as float32,
 // store as T.  Works for same-type (InT==T: half/bf16/float) and cross-type
 // (e.g. InT=fp8_e4m3, T=bf16).  sizeof(InT) must divide VEC_SIZE.
-template <int VEC_SIZE, int TOP_K, typename ThreadingPolicy, typename T, typename InT = T>
+template <int VEC_SIZE, int TOP_K, typename ThreadingPolicy, typename T, bool ENABLE_FAULT_TOLERANCE, typename InT = T>
 __device__ void vectorized_combine_impl(T* dst_typed_base, int size_per_token, int stride_per_token, int rank_id,
     int max_tokens_per_rank, CombineKernelPointers const& ptrs)
 {
@@ -739,7 +751,13 @@ __device__ void vectorized_combine_impl(T* dst_typed_base, int size_per_token, i
         {
             int target_rank = ptrs.topk_target_ranks[local_token_idx * TOP_K + k];
             int dst_idx = ptrs.topk_send_indices[local_token_idx * TOP_K + k];
-            if (dst_idx < 0)
+            bool skip_payload = dst_idx < 0;
+            if constexpr (ENABLE_FAULT_TOLERANCE)
+            {
+                // Do not read payloads from inactive ranks; their remote buffer may be inaccessible.
+                skip_payload = skip_payload || !is_rank_active(ptrs.active_rank_mask, target_rank);
+            }
+            if (skip_payload)
             {
                 acc[k].fill(0.0f);
                 continue;
@@ -764,6 +782,18 @@ __device__ void vectorized_combine_impl(T* dst_typed_base, int size_per_token, i
 #pragma unroll
         for (int k = 0; k < TOP_K; ++k)
         {
+            int target_rank = ptrs.topk_target_ranks[local_token_idx * TOP_K + k];
+            int dst_idx = ptrs.topk_send_indices[local_token_idx * TOP_K + k];
+            bool skip_payload = dst_idx < 0;
+            if constexpr (ENABLE_FAULT_TOLERANCE)
+            {
+                // Inactive payloads were zero-filled above; do not reinterpret them as input elements.
+                skip_payload = skip_payload || !is_rank_active(ptrs.active_rank_mask, target_rank);
+            }
+            if (skip_payload)
+            {
+                continue;
+            }
 #pragma unroll
             for (int j = elems_per_vec - 1; j >= 0; --j)
                 acc[k][j] = static_cast<float>(reinterpret_cast<InT const*>(&acc[k])[j]);
@@ -955,7 +985,7 @@ __device__ void vectorized_combine_impl(T* dst_typed_base, int size_per_token, i
 // stride_per_token: byte distance between tokens in the recv buffer (may differ from
 // size_per_token when FP8 in-place uses BF16-stride workspace with FP8-sized payload).
 // InT: input element type in recv buffer (defaults to T for same-type accumulation)
-template <int TOP_K, typename ThreadingPolicy, typename T, typename InT = T>
+template <int TOP_K, typename ThreadingPolicy, typename T, bool ENABLE_FAULT_TOLERANCE, typename InT = T>
 __device__ void vectorized_combine(T* dst_typed_base, int size_per_token, int stride_per_token, int rank_id,
     int max_tokens_per_rank, CombineKernelPointers const& ptrs)
 {
@@ -966,31 +996,31 @@ __device__ void vectorized_combine(T* dst_typed_base, int size_per_token, int st
     if (size_per_token % 16 == 0)
     {
         if constexpr (static_cast<int>(sizeof(InT)) <= 16)
-            vectorized_combine_impl<16, TOP_K, ThreadingPolicy, T, InT>(
+            vectorized_combine_impl<16, TOP_K, ThreadingPolicy, T, ENABLE_FAULT_TOLERANCE, InT>(
                 dst_typed_base, size_per_token, stride_per_token, rank_id, max_tokens_per_rank, ptrs);
     }
     else if (size_per_token % 8 == 0)
     {
         if constexpr (static_cast<int>(sizeof(InT)) <= 8)
-            vectorized_combine_impl<8, TOP_K, ThreadingPolicy, T, InT>(
+            vectorized_combine_impl<8, TOP_K, ThreadingPolicy, T, ENABLE_FAULT_TOLERANCE, InT>(
                 dst_typed_base, size_per_token, stride_per_token, rank_id, max_tokens_per_rank, ptrs);
     }
     else if (size_per_token % 4 == 0)
     {
         if constexpr (static_cast<int>(sizeof(InT)) <= 4)
-            vectorized_combine_impl<4, TOP_K, ThreadingPolicy, T, InT>(
+            vectorized_combine_impl<4, TOP_K, ThreadingPolicy, T, ENABLE_FAULT_TOLERANCE, InT>(
                 dst_typed_base, size_per_token, stride_per_token, rank_id, max_tokens_per_rank, ptrs);
     }
     else if (size_per_token % 2 == 0)
     {
         if constexpr (static_cast<int>(sizeof(InT)) <= 2)
-            vectorized_combine_impl<2, TOP_K, ThreadingPolicy, T, InT>(
+            vectorized_combine_impl<2, TOP_K, ThreadingPolicy, T, ENABLE_FAULT_TOLERANCE, InT>(
                 dst_typed_base, size_per_token, stride_per_token, rank_id, max_tokens_per_rank, ptrs);
     }
     else
     {
         if constexpr (static_cast<int>(sizeof(InT)) <= 1)
-            vectorized_combine_impl<1, TOP_K, ThreadingPolicy, T, InT>(
+            vectorized_combine_impl<1, TOP_K, ThreadingPolicy, T, ENABLE_FAULT_TOLERANCE, InT>(
                 dst_typed_base, size_per_token, stride_per_token, rank_id, max_tokens_per_rank, ptrs);
     }
 }
@@ -1190,14 +1220,16 @@ __global__ void moeA2ACombineKernel(
 
         if (blockIdx.x == 0)
         {
-            // Signal readiness to all active peers; skip dead ranks (their symmetric memory
-            // is unreachable).
+            // Signal readiness to peers.
 #pragma unroll 1 // No unroll
             for (int peer_rank = lane_id; peer_rank < ep_size; peer_rank += warpSize)
             {
-                // Do not signal inactive peers; their flag memory may be unreachable.
-                if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, peer_rank))
-                    continue;
+                if constexpr (ENABLE_FAULT_TOLERANCE)
+                {
+                    // Do not signal inactive peers; their flag memory may be unreachable.
+                    if (!is_rank_active(ptrs.active_rank_mask, peer_rank))
+                        continue;
+                }
                 uint32_t* flag_addr = &ptrs.completion_flags[peer_rank][rank_id];
                 asm volatile("st.relaxed.sys.u32 [%0], %1;" ::"l"(flag_addr), "r"(expected_value));
 #if ENABLE_DEBUG_PRINT
@@ -1210,9 +1242,12 @@ __global__ void moeA2ACombineKernel(
 #pragma unroll 1 // No unroll
         for (int peer_rank = lane_id; peer_rank < ep_size; peer_rank += warpSize)
         {
-            // Do not wait on inactive peers; they will not signal this collective.
-            if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, peer_rank))
-                continue;
+            if constexpr (ENABLE_FAULT_TOLERANCE)
+            {
+                // Do not wait on inactive peers; they will not signal this collective.
+                if (!is_rank_active(ptrs.active_rank_mask, peer_rank))
+                    continue;
+            }
             bool flag_set = false;
             auto s = clock64();
             do
@@ -1258,7 +1293,7 @@ __global__ void moeA2ACombineKernel(
         // src_data_ptrs[0] points to a BF16 output buffer (set by moeA2ACombineOp)
         auto* token_output
             = reinterpret_cast<__nv_bfloat16*>(ptrs.src_data_ptrs[0]) + local_token_idx * elements_per_token;
-        vectorized_combine<TOP_K, ThreadingPolicy, __nv_bfloat16, __nv_fp8_e4m3>(
+        vectorized_combine<TOP_K, ThreadingPolicy, __nv_bfloat16, ENABLE_FAULT_TOLERANCE, __nv_fp8_e4m3>(
             token_output, size_per_token, stride_per_token, rank_id, max_tokens_per_rank, ptrs);
     }
     else
@@ -1266,7 +1301,7 @@ __global__ void moeA2ACombineKernel(
         // Get output location for this token (using src_data_ptrs[0] as output)
         T* token_output = static_cast<T*>(ptrs.src_data_ptrs[0]) + local_token_idx * elements_per_token;
         // Accumulate across ranks in registers, then store once per segment
-        vectorized_combine<TOP_K, ThreadingPolicy, T>(
+        vectorized_combine<TOP_K, ThreadingPolicy, T, ENABLE_FAULT_TOLERANCE>(
             token_output, size_per_token, stride_per_token, rank_id, max_tokens_per_rank, ptrs);
     }
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))

--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -213,8 +213,13 @@ __device__ __forceinline__ int compute_target_rank_id(int expert_id, int base, i
 // Test bit `rank` in a kRankMaskWords-wide little-endian uint64 bitmask.
 // Word 0 covers ranks 0..63, word 1 covers ranks 64..127, etc.
 // `rank >> 6` and `rank & 63` divide / modulo by 64.
-__device__ __forceinline__ bool is_rank_active(uint64_t const* mask, int rank)
+template <bool ENABLE_FAULT_TOLERANCE>
+__host__ __device__ __forceinline__ bool is_rank_active(uint64_t const* mask, int rank)
 {
+    if constexpr (!ENABLE_FAULT_TOLERANCE)
+    {
+        return true;
+    }
     return (mask[rank >> 6] >> (rank & 63)) & 1ULL;
 }
 
@@ -392,7 +397,7 @@ __global__ void moeA2APrepareDispatchKernel(
 // Dispatch Kernels
 // ============================================================================
 
-template <typename ThreadingPolicy, int TOP_K, bool ENABLE_EPLB>
+template <typename ThreadingPolicy, int TOP_K, bool ENABLE_EPLB, bool ENABLE_FAULT_TOLERANCE>
 __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [local_num_tokens, TOP_K]
     const DispatchKernelPointers ptrs,                                      // Struct containing all kernel pointers
     int num_payloads,                                                       // Number of payloads
@@ -440,15 +445,11 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
             // Supports the non-divisible case where num_experts % ep_size != 0.
             int target_rank = compute_target_rank_id(expert_id, ep_base, ep_remainder);
 
-            // Skip duplicates AND dead ranks: both produce the same -1 sentinel that combine
-            // checks via topk_send_indices[k] < 0. A token whose only target is dead is dropped
-            // from this collective; higher-layer logic (EPLB redistribution) is responsible
-            // for re-routing such tokens on subsequent iterations.
+            // Skip duplicate target ranks. Runtime routing is expected to avoid inactive ranks.
             int const mask_word = target_rank >> 6;
             uint64_t const mask_bit = 1ULL << (target_rank & 63);
-            bool const target_already_copied = already_copied[mask_word] & mask_bit;
-            bool const target_dead = !is_rank_active(ptrs.active_rank_mask, target_rank);
-            if (target_already_copied || target_dead)
+            bool const target_already_copied = (already_copied[mask_word] & mask_bit) != 0;
+            if (target_already_copied)
             {
                 if (thread_idx == 0)
                 {
@@ -527,12 +528,11 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
 
         if (is_last_token)
         {
-// Store send_counters to recv_counters.
-// Skip masked target ranks: their symmetric memory may be inaccessible.
 #pragma unroll 1 // No unroll as one iter is typically enough
             for (int target_rank = lane_id; target_rank < ep_size; target_rank += warpSize)
             {
-                if (!is_rank_active(ptrs.active_rank_mask, target_rank))
+                // Do not write counters into inactive ranks' symmetric workspace.
+                if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, target_rank))
                     continue;
                 int send_count = ptrs.send_counters[target_rank];
                 ptrs.recv_counters[target_rank][rank_id] = send_count;
@@ -541,11 +541,11 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
             if constexpr (ENABLE_EPLB)
             {
                 // Write local stats into peer buffers before the release fence below.
-                // Skip masked target ranks for the same reason as above.
 #pragma unroll 1
                 for (int target_rank = 0; target_rank < ep_size; ++target_rank)
                 {
-                    if (!is_rank_active(ptrs.active_rank_mask, target_rank))
+                    // Do not publish EPLB stats into inactive ranks' symmetric workspace.
+                    if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, target_rank))
                         continue;
                     int* target_stats = ptrs.eplb_gathered_stats[target_rank];
                     for (int expert_id = lane_id; expert_id < eplb_stats_num_experts; expert_id += warpSize)
@@ -565,12 +565,11 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
 #else
             asm volatile("fence.acq_rel.sys;");
 #endif
-            // Signal completion to all active peers; skip dead ranks (their symmetric memory
-            // is unreachable).
 #pragma unroll 1 // No unroll as one iter is typically enough
             for (int target_rank = lane_id; target_rank < ep_size; target_rank += warpSize)
             {
-                if (!is_rank_active(ptrs.active_rank_mask, target_rank))
+                // Do not signal inactive peers; their flag memory may be unreachable.
+                if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, target_rank))
                     continue;
                 uint32_t* flag_addr = &ptrs.completion_flags[target_rank][rank_id];
                 asm volatile("st.relaxed.sys.u32 [%0], %1;" ::"l"(flag_addr), "r"(expected_value));
@@ -581,12 +580,11 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
 #endif
             }
 
-            // Wait for all active peers to signal; skip dead ranks (otherwise we would
-            // spin forever — this is the bug the rank-mask is here to prevent).
 #pragma unroll 1 // No unroll
             for (int peer_rank = lane_id; peer_rank < ep_size; peer_rank += warpSize)
             {
-                if (!is_rank_active(ptrs.active_rank_mask, peer_rank))
+                // Do not wait on inactive peers; they will not signal this collective.
+                if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, peer_rank))
                     continue;
                 bool flag_set = false;
                 auto s = clock64();
@@ -636,10 +634,7 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params)
     TLLM_CHECK(params.ep_rank >= 0 && params.ep_rank < params.ep_size);
     TLLM_CHECK(params.local_num_tokens >= 0);
     TLLM_CHECK(params.num_payloads > 0 && params.num_payloads <= kMaxPayloads);
-    // The local rank must always be marked active in its own view of the mask;
-    // otherwise the kernel itself would be running on a "dead" rank.
-    TLLM_CHECK_WITH_INFO((params.active_rank_mask[params.ep_rank >> 6] >> (params.ep_rank & 63)) & 1ULL,
-        "active_rank_mask must mark the local ep_rank (%d) as active", params.ep_rank);
+    bool const enable_fault_tolerance = params.enable_fault_tolerance;
 
     // Prepare kernel pointers struct
     DispatchKernelPointers kernel_ptrs = {};
@@ -693,12 +688,15 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params)
         grid_size = 1;
     }
     int shared_bytes = 2 * params.top_k * (int) sizeof(int);
-    SWITCH_BOOL(params.enable_eplb, EPLB_STATS, SWITCH_TOP_K(params.top_k, TOP_K, {
-        auto kernel_fn = moeA2ADispatchKernel<BlockPolicy, TOP_K, EPLB_STATS>;
-        launchWithPdlWhenEnabled("moeA2ADispatchKernel", kernel_fn, grid_size, kBlockSize, shared_bytes, params.stream,
-            params.token_selected_experts, kernel_ptrs, params.num_payloads, params.max_tokens_per_rank,
-            params.local_num_tokens, params.ep_rank, params.ep_size, params.num_experts, params.eplb_stats_num_experts);
-    }))
+    SWITCH_BOOL(enable_fault_tolerance, ENABLE_FAULT_TOLERANCE, {SWITCH_BOOL(params.enable_eplb, EPLB_STATS, {
+        SWITCH_TOP_K(params.top_k, TOP_K, {
+            auto kernel_fn = moeA2ADispatchKernel<BlockPolicy, TOP_K, EPLB_STATS, ENABLE_FAULT_TOLERANCE>;
+            launchWithPdlWhenEnabled("moeA2ADispatchKernel", kernel_fn, grid_size, kBlockSize, shared_bytes,
+                params.stream, params.token_selected_experts, kernel_ptrs, params.num_payloads,
+                params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank, params.ep_size, params.num_experts,
+                params.eplb_stats_num_experts);
+        });
+    })})
 }
 
 // ============================================================================
@@ -741,7 +739,7 @@ __device__ void vectorized_combine_impl(T* dst_typed_base, int size_per_token, i
         {
             int target_rank = ptrs.topk_target_ranks[local_token_idx * TOP_K + k];
             int dst_idx = ptrs.topk_send_indices[local_token_idx * TOP_K + k];
-            if (dst_idx < 0 || !is_rank_active(ptrs.active_rank_mask, target_rank))
+            if (dst_idx < 0)
             {
                 acc[k].fill(0.0f);
                 continue;
@@ -766,12 +764,6 @@ __device__ void vectorized_combine_impl(T* dst_typed_base, int size_per_token, i
 #pragma unroll
         for (int k = 0; k < TOP_K; ++k)
         {
-            int target_rank = ptrs.topk_target_ranks[local_token_idx * TOP_K + k];
-            int dst_idx = ptrs.topk_send_indices[local_token_idx * TOP_K + k];
-            if (dst_idx < 0 || !is_rank_active(ptrs.active_rank_mask, target_rank))
-            {
-                continue; // acc[k] already holds 0.0f from fill() above
-            }
 #pragma unroll
             for (int j = elems_per_vec - 1; j >= 0; --j)
                 acc[k][j] = static_cast<float>(reinterpret_cast<InT const*>(&acc[k])[j]);
@@ -1158,7 +1150,7 @@ __global__ void moeA2APrepareCombineKernel(uint8_t* recv_buffer_bytes, void cons
 // Generic Combine Kernel Implementation (Templated by data type)
 // ============================================================================
 
-template <typename T, typename ThreadingPolicy, int TOP_K>
+template <typename T, typename ThreadingPolicy, int TOP_K, bool ENABLE_FAULT_TOLERANCE>
 __global__ void moeA2ACombineKernel(
     const CombineKernelPointers ptrs, // Combine-specific struct, src_data_ptrs[0] is output
     int max_tokens_per_rank, int elements_per_token, int local_num_tokens, int rank_id, int ep_size,
@@ -1203,7 +1195,8 @@ __global__ void moeA2ACombineKernel(
 #pragma unroll 1 // No unroll
             for (int peer_rank = lane_id; peer_rank < ep_size; peer_rank += warpSize)
             {
-                if (!is_rank_active(ptrs.active_rank_mask, peer_rank))
+                // Do not signal inactive peers; their flag memory may be unreachable.
+                if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, peer_rank))
                     continue;
                 uint32_t* flag_addr = &ptrs.completion_flags[peer_rank][rank_id];
                 asm volatile("st.relaxed.sys.u32 [%0], %1;" ::"l"(flag_addr), "r"(expected_value));
@@ -1214,12 +1207,11 @@ __global__ void moeA2ACombineKernel(
             }
         }
 
-        // Wait for all active peers to signal; skip dead ranks (otherwise we would spin
-        // forever — this is the bug the rank-mask is here to prevent).
 #pragma unroll 1 // No unroll
         for (int peer_rank = lane_id; peer_rank < ep_size; peer_rank += warpSize)
         {
-            if (!is_rank_active(ptrs.active_rank_mask, peer_rank))
+            // Do not wait on inactive peers; they will not signal this collective.
+            if (!is_rank_active<ENABLE_FAULT_TOLERANCE>(ptrs.active_rank_mask, peer_rank))
                 continue;
             bool flag_set = false;
             auto s = clock64();
@@ -1327,10 +1319,7 @@ void moe_a2a_combine_launch(MoeA2ACombineParams const& params)
     TLLM_CHECK(params.ep_rank >= 0 && params.ep_rank < params.ep_size);
     TLLM_CHECK(params.local_num_tokens >= 0);
     TLLM_CHECK(params.elements_per_token > 0);
-    // The local rank must always be marked active in its own view of the mask;
-    // otherwise the kernel itself would be running on a "dead" rank.
-    TLLM_CHECK_WITH_INFO((params.active_rank_mask[params.ep_rank >> 6] >> (params.ep_rank & 63)) & 1ULL,
-        "active_rank_mask must mark the local ep_rank (%d) as active", params.ep_rank);
+    bool const enable_fault_tolerance = params.enable_fault_tolerance;
 
     // Configure kernel launch (one block per token).
     int const kBlockSize = tensorrt_llm::common::getEnvMoeA2ACombineBlockSize();
@@ -1385,14 +1374,16 @@ void moe_a2a_combine_launch(MoeA2ACombineParams const& params)
     auto const effective_dtype = params.use_low_precision ? nvinfer1::DataType::kFP8 : params.dtype;
 
     // Launch appropriate kernel with compact macros
-    SWITCH_DTYPE(effective_dtype, TKernelType, {
-        SWITCH_TOP_K(params.top_k, TOP_K, {
-            auto kernel_fn = moeA2ACombineKernel<TKernelType, BlockPolicy, TOP_K>;
-            launchWithPdlWhenEnabled("moeA2ACombineKernel", kernel_fn, grid, kBlockSize, 0, params.stream, kernel_ptrs,
-                params.max_tokens_per_rank, params.elements_per_token, params.local_num_tokens, params.ep_rank,
-                params.ep_size, stride_per_token);
+    SWITCH_BOOL(enable_fault_tolerance, ENABLE_FAULT_TOLERANCE, {
+        SWITCH_DTYPE(effective_dtype, TKernelType, {
+            SWITCH_TOP_K(params.top_k, TOP_K, {
+                auto kernel_fn = moeA2ACombineKernel<TKernelType, BlockPolicy, TOP_K, ENABLE_FAULT_TOLERANCE>;
+                launchWithPdlWhenEnabled("moeA2ACombineKernel", kernel_fn, grid, kBlockSize, 0, params.stream,
+                    kernel_ptrs, params.max_tokens_per_rank, params.elements_per_token, params.local_num_tokens,
+                    params.ep_rank, params.ep_size, stride_per_token);
+            });
         });
-    });
+    })
 }
 
 // Kernel to sanitize expert ids for invalid tokens

--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h
@@ -70,9 +70,9 @@ struct DispatchKernelPointers
     int* eplb_gathered_stats[kMaxRanks]; // [ep_size, eplb_stats_num_experts] per rank
 
     // Active-rank bitmask: bit i set => rank i is alive and participates in this collective.
-    // Word 0 covers ranks 0..63; word 1 covers ranks 64..127. Tokens routed to a masked
-    // rank are dropped (topk_*[k] = -1); flag writes/waits to/from masked peers are skipped.
-    // The local rank's own bit must always be set; this is checked at launch time.
+    // Word 0 covers ranks 0..63; word 1 covers ranks 64..127. Routing is expected to avoid
+    // inactive ranks; the kernel uses this mask only for peer counters, stats, and completion
+    // flag writes/waits.
     uint64_t active_rank_mask[kRankMaskWords];
 };
 
@@ -93,8 +93,7 @@ struct CombineKernelPointers
     int const* topk_send_indices; // dst index per k, -1 for duplicates
 
     // Active-rank bitmask: see DispatchKernelPointers::active_rank_mask. Combine skips flag
-    // writes/waits to/from masked peers and also skips per-token accumulation for ranks that
-    // become inactive between dispatch and combine.
+    // writes/waits to/from masked peers.
     uint64_t active_rank_mask[kRankMaskWords];
 };
 
@@ -139,9 +138,11 @@ struct MoeA2ADispatchParams
     int const* eplb_local_stats;         // [eplb_stats_num_experts]
     int* eplb_gathered_stats[kMaxRanks]; // [ep_size, eplb_stats_num_experts] per rank
 
-    // Active-rank bitmask: see DispatchKernelPointers::active_rank_mask. The launch function
-    // copies these words into the kernel pointers struct. Defaults to all-ones for
-    // backwards-compatible "no masking" behavior.
+    // Whether to instantiate kernels with active-rank checks enabled.
+    bool enable_fault_tolerance{false};
+
+    // Active-rank bitmask: see DispatchKernelPointers::active_rank_mask. Used only when
+    // enable_fault_tolerance is true; defaults to all-ones for backwards-compatible behavior.
     uint64_t active_rank_mask[kRankMaskWords] = {~uint64_t{0}, ~uint64_t{0}};
 
     // CUDA stream
@@ -189,9 +190,11 @@ struct MoeA2ACombineParams
                                            // rank has signaled the target rank
     void const* recv_buffers[kMaxRanks];   // Per-rank receive buffers (only for single payload)
 
-    // Active-rank bitmask: see DispatchKernelPointers::active_rank_mask. The launch function
-    // copies these words into the kernel pointers struct. Defaults to all-ones for
-    // backwards-compatible "no masking" behavior.
+    // Whether to instantiate kernels with active-rank checks enabled.
+    bool enable_fault_tolerance{false};
+
+    // Active-rank bitmask: see DispatchKernelPointers::active_rank_mask. Used only when
+    // enable_fault_tolerance is true; defaults to all-ones for backwards-compatible behavior.
     uint64_t active_rank_mask[kRankMaskWords] = {~uint64_t{0}, ~uint64_t{0}};
 
     // CUDA stream

--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h
@@ -62,17 +62,16 @@ struct DispatchKernelPointers
     int* local_token_counter;      // Atomic counter for completed tokens
 
     // Top-K compact routing info per local token (size: [local_num_tokens, top_k])
-    int* topk_target_ranks; // target rank per k, -1 for duplicates
-    int* topk_send_indices; // dst index per k, -1 for duplicates
+    int* topk_target_ranks; // target rank per k, -1 for invalid or duplicate routes
+    int* topk_send_indices; // dst index per k, -1 for invalid or duplicate routes
 
     // Optional: Statistics for EPLB
     int const* eplb_local_stats;         // [eplb_stats_num_experts]
     int* eplb_gathered_stats[kMaxRanks]; // [ep_size, eplb_stats_num_experts] per rank
 
     // Active-rank bitmask: bit i set => rank i is alive and participates in this collective.
-    // Word 0 covers ranks 0..63; word 1 covers ranks 64..127. Routing is expected to avoid
-    // inactive ranks; the kernel uses this mask only for peer counters, stats, and completion
-    // flag writes/waits.
+    // Word 0 covers ranks 0..63; word 1 covers ranks 64..127. The FT kernel uses this mask to
+    // reject inactive route targets and to skip peer counters, stats, and completion flags.
     uint64_t active_rank_mask[kRankMaskWords];
 };
 
@@ -89,11 +88,11 @@ struct CombineKernelPointers
     uint32_t* flag_val;                    // The value of the flag for this round (stored on the local rank)
 
     // Top-K compact routing info per local token (size: [local_num_tokens, top_k])
-    int const* topk_target_ranks; // target rank per k, -1 for duplicates
-    int const* topk_send_indices; // dst index per k, -1 for duplicates
+    int const* topk_target_ranks; // target rank per k, -1 for invalid or duplicate routes
+    int const* topk_send_indices; // dst index per k, -1 for invalid or duplicate routes
 
-    // Active-rank bitmask: see DispatchKernelPointers::active_rank_mask. Combine skips flag
-    // writes/waits to/from masked peers.
+    // Active-rank bitmask: see DispatchKernelPointers::active_rank_mask. The FT kernel skips
+    // payload reads and completion flag writes/waits involving inactive peers.
     uint64_t active_rank_mask[kRankMaskWords];
 };
 

--- a/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
@@ -79,6 +79,11 @@ inline void resolveActiveRankMask(torch::optional<torch::Tensor> const& maskTens
         ") as active");
 }
 
+inline bool hasActiveRankMask(torch::optional<torch::Tensor> const& maskTensor)
+{
+    return maskTensor.has_value() && maskTensor.value().defined();
+}
+
 // Calculate auxiliary data offsets
 MoeA2ADataOffsets calculateOffsets(int epSize, int maxNumTokens, int eplbStatsNumExperts)
 {
@@ -403,9 +408,11 @@ std::tuple<std::vector<torch::Tensor>, int64_t, torch::Tensor> moeA2ADispatchOp(
         params.eplb_local_stats = nullptr;
     }
 
-    // Resolve the optional active-rank mask. Default (no mask) = all bits set, which
-    // exactly reproduces the pre-fault-tolerance kernel behavior.
-    resolveActiveRankMask(activeRankMask, epRank, params.active_rank_mask);
+    params.enable_fault_tolerance = hasActiveRankMask(activeRankMask);
+    if (params.enable_fault_tolerance)
+    {
+        resolveActiveRankMask(activeRankMask, epRank, params.active_rank_mask);
+    }
 
     params.stream = at::cuda::getCurrentCUDAStream();
 
@@ -570,8 +577,11 @@ torch::Tensor moeA2ACombineOp(torch::Tensor const& payload, int64_t localNumToke
         params.recv_buffers[target_rank] = target_workspace_ptr + combinePayloadOffset;
     }
 
-    // Resolve the optional active-rank mask. Default (no mask) = all bits set.
-    resolveActiveRankMask(activeRankMask, epRank, params.active_rank_mask);
+    params.enable_fault_tolerance = hasActiveRankMask(activeRankMask);
+    if (params.enable_fault_tolerance)
+    {
+        resolveActiveRankMask(activeRankMask, epRank, params.active_rank_mask);
+    }
 
     params.stream = at::cuda::getCurrentCUDAStream();
 

--- a/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
@@ -79,11 +79,6 @@ inline void resolveActiveRankMask(torch::optional<torch::Tensor> const& maskTens
         ") as active");
 }
 
-inline bool hasActiveRankMask(torch::optional<torch::Tensor> const& maskTensor)
-{
-    return maskTensor.has_value() && maskTensor.value().defined();
-}
-
 // Calculate auxiliary data offsets
 MoeA2ADataOffsets calculateOffsets(int epSize, int maxNumTokens, int eplbStatsNumExperts)
 {
@@ -227,7 +222,7 @@ std::tuple<std::vector<torch::Tensor>, int64_t, torch::Tensor> moeA2ADispatchOp(
     torch::Tensor const& tokenSelectedExperts, std::vector<torch::Tensor> const& inputPayloads,
     torch::Tensor const& workspace, torch::Tensor const& metainfo, int64_t runtimeMaxTokensPerRank, int64_t epRank,
     int64_t epSize, int64_t topK, int64_t numExperts, torch::optional<torch::Tensor> eplbLocalStats,
-    torch::optional<torch::Tensor> activeRankMask)
+    bool enableFaultTolerance, torch::optional<torch::Tensor> activeRankMask)
 {
     using tensorrt_llm::kernels::moe_comm::PayloadDescriptor;
     using tensorrt_llm::kernels::moe_comm::MoeA2ADispatchParams;
@@ -408,10 +403,15 @@ std::tuple<std::vector<torch::Tensor>, int64_t, torch::Tensor> moeA2ADispatchOp(
         params.eplb_local_stats = nullptr;
     }
 
-    params.enable_fault_tolerance = hasActiveRankMask(activeRankMask);
+    params.enable_fault_tolerance = enableFaultTolerance;
     if (params.enable_fault_tolerance)
     {
         resolveActiveRankMask(activeRankMask, epRank, params.active_rank_mask);
+    }
+    else
+    {
+        TORCH_CHECK(!activeRankMask.has_value() || !activeRankMask.value().defined(),
+            "active_rank_mask requires enable_fault_tolerance=True");
     }
 
     params.stream = at::cuda::getCurrentCUDAStream();
@@ -467,7 +467,7 @@ std::tuple<std::vector<torch::Tensor>, int64_t, torch::Tensor> moeA2ADispatchOp(
 // In both cases, the combine kernel reads from the workspace at 'combinePayloadOffset'.
 torch::Tensor moeA2ACombineOp(torch::Tensor const& payload, int64_t localNumTokens, torch::Tensor const& workspace,
     torch::Tensor const& metainfo, int64_t runtimeMaxTokensPerRank, int64_t epRank, int64_t epSize, int64_t topK,
-    int64_t combinePayloadOffset, bool payloadInWorkspace, bool useLowPrecision = false,
+    int64_t combinePayloadOffset, bool payloadInWorkspace, bool useLowPrecision, bool enableFaultTolerance,
     torch::optional<torch::Tensor> activeRankMask = torch::nullopt)
 {
     using tensorrt_llm::kernels::moe_comm::MoeA2ACombineParams;
@@ -577,10 +577,15 @@ torch::Tensor moeA2ACombineOp(torch::Tensor const& payload, int64_t localNumToke
         params.recv_buffers[target_rank] = target_workspace_ptr + combinePayloadOffset;
     }
 
-    params.enable_fault_tolerance = hasActiveRankMask(activeRankMask);
+    params.enable_fault_tolerance = enableFaultTolerance;
     if (params.enable_fault_tolerance)
     {
         resolveActiveRankMask(activeRankMask, epRank, params.active_rank_mask);
+    }
+    else
+    {
+        TORCH_CHECK(!activeRankMask.has_value() || !activeRankMask.value().defined(),
+            "active_rank_mask requires enable_fault_tolerance=True");
     }
 
     params.stream = at::cuda::getCurrentCUDAStream();
@@ -677,13 +682,13 @@ TORCH_LIBRARY_FRAGMENT(trtllm, module)
         "Tensor(a!->*) workspace, Tensor metainfo, int runtime_max_tokens_per_rank, "
         "int ep_rank, int ep_size, int top_k, int num_experts, "
         "Tensor? eplb_local_stats=None, "
-        "Tensor? active_rank_mask=None) -> (Tensor(a!)[], int, Tensor(a!))");
+        "bool enable_fault_tolerance=False, Tensor? active_rank_mask=None) -> (Tensor(a!)[], int, Tensor(a!))");
     module.def(
         "moe_a2a_combine(Tensor(a) payload, int local_num_tokens,"
         "Tensor(a!) workspace, Tensor metainfo, int runtime_max_tokens_per_rank, "
         "int ep_rank, int ep_size, int top_k, int combine_payload_offset, "
         "bool payload_in_workspace, bool use_low_precision=False, "
-        "Tensor? active_rank_mask=None) -> Tensor");
+        "bool enable_fault_tolerance=False, Tensor? active_rank_mask=None) -> Tensor");
     module.def(
         "moe_a2a_initialize(Tensor(a!) workspace, int ep_rank, int ep_size, int max_num_tokens_per_rank, "
         "int? eplb_stats_num_experts=None) -> Tensor");

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -496,6 +496,7 @@ def _register_fake():
         top_k: int,
         num_experts: int,
         eplb_local_stats: Optional[torch.Tensor] = None,
+        enable_fault_tolerance: bool = False,
         active_rank_mask: Optional[torch.Tensor] = None,
     ) -> Tuple[List[torch.Tensor], int, torch.Tensor]:
         recv_tensors: List[torch.Tensor] = []
@@ -527,6 +528,7 @@ def _register_fake():
         combine_payload_offset: int,
         payload_in_workspace: bool,
         use_low_precision: bool = False,
+        enable_fault_tolerance: bool = False,
         active_rank_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return payload.new_empty((local_num_tokens, payload.shape[2]))

--- a/tensorrt_llm/_torch/distributed/moe_alltoall.py
+++ b/tensorrt_llm/_torch/distributed/moe_alltoall.py
@@ -322,6 +322,7 @@ class MoeAlltoAll:
             self.top_k,
             self.num_experts,
             eplb_local_stats,
+            self.ep_group_health is not None,
             active_rank_mask,
         )
         self._watchdog_coordinator.watch_collective(self._alltoall_watchdog,
@@ -384,7 +385,8 @@ class MoeAlltoAll:
             payload, self._state.local_num_tokens, self.workspace,
             self.metainfo, runtime_max_tokens_per_rank, self.ep_rank,
             self.ep_size, self.top_k, self._state.combine_payload_offset,
-            payload_in_workspace, use_low_precision_combine, active_rank_mask)
+            payload_in_workspace, use_low_precision_combine,
+            self.ep_group_health is not None, active_rank_mask)
         self._watchdog_coordinator.watch_collective(self._alltoall_watchdog,
                                                     "combine", active_rank_mask)
 

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
@@ -429,8 +429,8 @@ class NVLinkOneSided(Communication):
             **kwargs: Strategy-specific arguments. In fault-tolerance mode, ``active_rank_mask`` may override
                 the committed membership for dispatch. Without an override, the committed mask and generation
                 are captured together; combine reuses that mask and fails closed if the generation changes first.
-                Routing must exclude inactive ranks before dispatch; this kernel does not drop or rewrite routes
-                whose target rank is inactive.
+                In fault-tolerance mode, dispatch marks routes to inactive ranks invalid, and combine omits their
+                payloads.
 
         Returns:
             Tuple of (hidden_states, hidden_states_sf, token_selected_slots, token_final_scales)

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
@@ -489,6 +489,7 @@ class NVLinkOneSided(Communication):
                 self.top_k,
                 self.num_experts,
                 eplb_local_stats,
+                self.ep_group_health is not None,
                 active_rank_mask,
             )
         )
@@ -628,6 +629,7 @@ class NVLinkOneSided(Communication):
             int(combine_payload_offset),
             bool(self.payload_in_workspace),
             bool(self.use_low_precision_combine),
+            self.ep_group_health is not None,
             active_rank_mask,
         )
         self._watchdog_coordinator.watch_collective(

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
@@ -182,8 +182,9 @@ class NVLinkOneSided(Communication):
             use_low_precision_combine: If True, quantize the combine payload to FP8 for NVLink
                 transfer (halves NVLink bandwidth usage, output precision is preserved).
                 Corresponds to model_config.use_low_precision_moe_combine.
-            ep_group_health: Optional read-only committed EP membership. When present, its mask is passed to
-                the CUDA kernels and defines the peers expected by the watchdog. Timeout detection never mutates it.
+            ep_group_health: Optional read-only committed EP membership. When present, fault tolerance is enabled,
+                and its mask is passed to the CUDA kernels and defines the peers expected by the watchdog.
+                Timeout detection never mutates it.
             alltoall_watchdog_timeout_s: Optional timeout for the host-side AlltoAll watchdog. If None, the
                 watchdog is disabled.
             alltoall_watchdog_poll_interval_s: Poll interval for the watchdog thread.
@@ -425,9 +426,11 @@ class NVLinkOneSided(Communication):
             token_final_scales: Router weights [local_num_tokens, top_k]
             all_rank_num_tokens: Token counts per rank [ep_size]
             use_dp_padding: Whether to use DP padding (optional)
-            **kwargs: Strategy-specific arguments. ``active_rank_mask`` may override the committed membership
-                for dispatch. Without an override, the committed mask and generation are captured together;
-                combine reuses that mask and fails closed if the generation changes first.
+            **kwargs: Strategy-specific arguments. In fault-tolerance mode, ``active_rank_mask`` may override
+                the committed membership for dispatch. Without an override, the committed mask and generation
+                are captured together; combine reuses that mask and fails closed if the generation changes first.
+                Routing must exclude inactive ranks before dispatch; this kernel does not drop or rewrite routes
+                whose target rank is inactive.
 
         Returns:
             Tuple of (hidden_states, hidden_states_sf, token_selected_slots, token_final_scales)
@@ -458,9 +461,20 @@ class NVLinkOneSided(Communication):
             assert eplb_local_stats.size(0) == self.eplb_stats_num_experts, (
                 "eplb_local_stats size must match eplb_stats_num_experts"
             )
-        active_rank_mask_snapshot = self._watchdog_coordinator.capture_active_rank_mask(
-            kwargs.get("active_rank_mask")
-        )
+        requested_active_rank_mask = kwargs.get("active_rank_mask")
+        if self.ep_group_health is None:
+            if requested_active_rank_mask is not None:
+                raise ValueError(
+                    "active_rank_mask requires NVLinkOneSided fault tolerance to be enabled"
+                )
+            active_rank_mask_snapshot = ActiveRankMaskSnapshot(
+                active_rank_mask=None,
+                committed_generation=None,
+            )
+        else:
+            active_rank_mask_snapshot = self._watchdog_coordinator.capture_active_rank_mask(
+                requested_active_rank_mask
+            )
         active_rank_mask = active_rank_mask_snapshot.active_rank_mask
 
         recv_buffers, combine_payload_offset, eplb_gathered_stats = (
@@ -550,9 +564,9 @@ class NVLinkOneSided(Communication):
             final_hidden_states: Output from MoE computation
                 Shape: [ep_size, max_tokens_per_rank, hidden_size] or
                        [ep_size * max_tokens_per_rank, hidden_size] (will be reshaped)
-            **kwargs: Strategy-specific arguments. If ``active_rank_mask`` is supplied, it must match the mask
-                captured by dispatch for this collective. A committed-generation change since dispatch aborts
-                the collective epoch.
+            **kwargs: Strategy-specific arguments. In fault-tolerance mode, ``active_rank_mask`` must match
+                the mask captured by dispatch for this collective when supplied. A committed-generation change
+                since dispatch aborts the collective epoch.
 
         Returns:
             Combined output tensor [local_num_tokens, hidden_size]
@@ -590,10 +604,18 @@ class NVLinkOneSided(Communication):
         active_rank_mask_snapshot = self._dispatch_state.get("active_rank_mask_snapshot")
         if not isinstance(active_rank_mask_snapshot, ActiveRankMaskSnapshot):
             raise RuntimeError("combine called but dispatch rank-mask snapshot is missing")
-        active_rank_mask = self._watchdog_coordinator.active_rank_mask_for_combine(
-            active_rank_mask_snapshot,
-            kwargs.get("active_rank_mask"),
-        )
+        requested_active_rank_mask = kwargs.get("active_rank_mask")
+        if self.ep_group_health is None:
+            if requested_active_rank_mask is not None:
+                raise ValueError(
+                    "active_rank_mask requires NVLinkOneSided fault tolerance to be enabled"
+                )
+            active_rank_mask = None
+        else:
+            active_rank_mask = self._watchdog_coordinator.active_rank_mask_for_combine(
+                active_rank_mask_snapshot,
+                requested_active_rank_mask,
+            )
         output = torch.ops.trtllm.moe_a2a_combine(
             final_hidden_states,
             int(local_num_tokens),

--- a/tests/unittest/_torch/modules/moe/test_moe_comm.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_comm.py
@@ -267,6 +267,7 @@ def _run_nvlink_rank_mask_dispatch(
     token_selected_experts: torch.Tensor,
     payload: torch.Tensor,
     runtime_max_tokens_per_rank: int,
+    enable_fault_tolerance: bool,
     active_rank_mask: Optional[torch.Tensor],
 ) -> Tuple[List[torch.Tensor], int, torch.Tensor, torch.Tensor]:
     """Run raw NVLink one-sided dispatch with an optional active rank mask."""
@@ -281,6 +282,7 @@ def _run_nvlink_rank_mask_dispatch(
         comm.top_k,
         comm.num_experts,
         None,  # eplb_local_stats
+        enable_fault_tolerance,
         active_rank_mask,
     )
 
@@ -303,6 +305,7 @@ def _run_nvlink_rank_mask_combine(
     local_num_tokens: int,
     runtime_max_tokens_per_rank: int,
     combine_payload_offset: int,
+    enable_fault_tolerance: bool,
     active_rank_mask: Optional[torch.Tensor],
 ) -> torch.Tensor:
     """Run raw NVLink one-sided combine with an optional active rank mask."""
@@ -318,6 +321,7 @@ def _run_nvlink_rank_mask_combine(
         combine_payload_offset,
         False,  # payload_in_workspace
         False,  # use_low_precision
+        enable_fault_tolerance,
         active_rank_mask,
     )
 
@@ -327,6 +331,7 @@ def _run_nvlink_rank_mask_dispatch_combine(
     token_selected_experts: torch.Tensor,
     payload: torch.Tensor,
     runtime_max_tokens_per_rank: int,
+    enable_fault_tolerance: bool,
     active_rank_mask: Optional[torch.Tensor],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Run raw NVLink one-sided dispatch/combine with an optional active rank mask."""
@@ -335,6 +340,7 @@ def _run_nvlink_rank_mask_dispatch_combine(
         token_selected_experts,
         payload,
         runtime_max_tokens_per_rank,
+        enable_fault_tolerance,
         active_rank_mask,
     )
     combined = _run_nvlink_rank_mask_combine(
@@ -343,6 +349,7 @@ def _run_nvlink_rank_mask_dispatch_combine(
         token_selected_experts.size(0),
         runtime_max_tokens_per_rank,
         combine_payload_offset,
+        enable_fault_tolerance,
         active_rank_mask,
     )
     return combined.cpu(), topk_target_ranks
@@ -1214,6 +1221,7 @@ def _worker_rank_mask_all_active_matches_no_mask(config: CommTestConfig) -> dict
             token_selected_experts,
             payload,
             local_num_tokens,
+            enable_fault_tolerance=False,
             active_rank_mask=None,
         )
         out_all_active, topk_all_active = _run_nvlink_rank_mask_dispatch_combine(
@@ -1221,6 +1229,7 @@ def _worker_rank_mask_all_active_matches_no_mask(config: CommTestConfig) -> dict
             token_selected_experts,
             payload,
             local_num_tokens,
+            enable_fault_tolerance=True,
             active_rank_mask=_ep_mask_words(config.ep_size, dead_ranks=set()),
         )
 
@@ -1293,6 +1302,7 @@ def _worker_rank_mask_one_rank_masked(
             token_selected_experts,
             payload,
             local_num_tokens,
+            enable_fault_tolerance=True,
             active_rank_mask=mask,
         )
         expected_target_ranks = _expected_target_ranks(
@@ -1352,6 +1362,7 @@ def _worker_rank_mask_inactive_before_combine(
                 token_selected_experts,
                 payload,
                 local_num_tokens,
+                enable_fault_tolerance=True,
                 active_rank_mask=_ep_mask_words(config.ep_size, dead_ranks=set()),
             )
         )
@@ -1376,6 +1387,7 @@ def _worker_rank_mask_inactive_before_combine(
             local_num_tokens,
             local_num_tokens,
             combine_payload_offset,
+            enable_fault_tolerance=True,
             active_rank_mask=_ep_mask_words(config.ep_size, dead_ranks=dead_ranks),
         ).cpu()
 


### PR DESCRIPTION
## Summary
- Compile-time specialize NVLink one-sided A2A dispatch and combine kernels with `ENABLE_FAULT_TOLERANCE`.
- Keep `is_rank_active()` as a plain bit-test helper and place every call inside `if constexpr (ENABLE_FAULT_TOLERANCE)`, so non-FT kernels contain no active-rank checks.
- Preserve FT route and payload protection while the runtime does not yet guarantee that routing excludes inactive ranks.
- Scope inactive-peer handling for counters, EPLB stats, completion signaling, and completion waits to the FT kernel instantiations.
- Pass an explicit `enable_fault_tolerance` mode from the construction-time `ep_group_health` state; `active_rank_mask` is validated and copied only after the mode is selected and no longer chooses the kernel specialization.

CUDA-graph lifecycle handling for changing active-rank masks remains follow-up work and is not addressed by this PR.

## Testing
- `pre-commit run --files` for all changed C++, CUDA, Python, and test files
- `python -m py_compile` for the changed Python files
- `git diff --check`

Not run: GPU/MPI tests locally.