### PR TITLE
[TRTLLM-13977][fix] Fix NT3 NVFP4 perf regression in Blackwell

### DIFF
--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -161,7 +161,9 @@ class Mamba2Mixer(nn.Module):
         # TODO: Update head_dims once flashinfer is updated.
         # Nemotron-v2-Nano (mamba_head_dim=80) is not supported by flashinfer yet.
         supported_head_dims = [64, 128]
-        supported_head_group_ratios = [1, 8, 16]
+        # flashinfer supports some head group ratios:
+        # https://github.com/flashinfer-ai/flashinfer/blob/v0.6.14/include/flashinfer/mamba/kernel_selective_state_update_stp.cuh#L1338
+        supported_head_group_ratios = [1, 2, 4, 8, 16, 32, 64]
         supported_d_states = [64, 128, 256]
         head_group_ratio = (self.tp_nheads //
                             self.tp_ngroups if self.tp_ngroups > 0 else 0)

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -161,12 +161,8 @@ class Mamba2Mixer(nn.Module):
         # TODO: Update head_dims once flashinfer is updated.
         # Nemotron-v2-Nano (mamba_head_dim=80) is not supported by flashinfer yet.
         supported_head_dims = [64, 128]
-        supported_head_group_ratios = [1, 8, 16]
         supported_d_states = [64, 128, 256]
-        head_group_ratio = (self.tp_nheads //
-                            self.tp_ngroups if self.tp_ngroups > 0 else 0)
-        self._use_flashinfer = (head_dim in supported_head_dims and
-                                head_group_ratio in supported_head_group_ratios
+        self._use_flashinfer = (head_dim in supported_head_dims
                                 and d_state in supported_d_states)
 
         self._stochastic_rounding_for_replay = (

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -161,8 +161,12 @@ class Mamba2Mixer(nn.Module):
         # TODO: Update head_dims once flashinfer is updated.
         # Nemotron-v2-Nano (mamba_head_dim=80) is not supported by flashinfer yet.
         supported_head_dims = [64, 128]
+        supported_head_group_ratios = [1, 8, 16]
         supported_d_states = [64, 128, 256]
-        self._use_flashinfer = (head_dim in supported_head_dims
+        head_group_ratio = (self.tp_nheads //
+                            self.tp_ngroups if self.tp_ngroups > 0 else 0)
+        self._use_flashinfer = (head_dim in supported_head_dims and
+                                head_group_ratio in supported_head_group_ratios
                                 and d_state in supported_d_states)
 
         self._stochastic_rounding_for_replay = (


### PR DESCRIPTION
This PR fixes the perf regression of NT3 in Blackwell introduced by #13476. That PR adds constraints about `head_group_ratio` to enable `flashinfer`. In this PR, we relax the constraints ti align upstream `flashinfer` so that NT model family could harness faster kernels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for an optimized state-update path so it can be used in more valid model configurations.
  * Reduced unnecessary fallbacks in supported setups, which may improve runtime behavior and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

