### PR TITLE
[https://nvbugs/6208457][fix] Harden spawn proxy HMAC key env variable handling

### DIFF
--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import ctypes
 import os
 import sys
 import threading
@@ -29,6 +30,33 @@ class LlmLauncherEnvs(StrEnum):
     TLLM_EXECUTOR_PERIODICAL_RESP_IN_AWAIT = "TLLM_EXECUTOR_PERIODICAL_RESP_IN_AWAIT"
 
 
+_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY: bytes | None = None
+
+
+def _set_process_non_dumpable() -> None:
+    if sys.platform != "linux":
+        return
+
+    pr_set_dumpable = 4
+    suid_dump_disable = 0
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(pr_set_dumpable, suid_dump_disable, 0, 0, 0) != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def _normalize_spawn_proxy_process_ipc_hmac_key(key: str) -> bytes:
+    try:
+        key_bytes = bytes.fromhex(key)
+    except ValueError as exc:
+        raise ValueError(
+            "IPC HMAC key must be a 64-character hex string.") from exc
+
+    if len(key_bytes) != 32:
+        raise ValueError("IPC HMAC key must be 32 bytes.")
+    return key_bytes
+
+
 def get_spawn_proxy_process_ipc_addr_env() -> str | None:
     ''' Get the IPC address for the spawn proxy process dynamically. '''
     return os.getenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_ADDR)
@@ -36,11 +64,21 @@ def get_spawn_proxy_process_ipc_addr_env() -> str | None:
 
 def get_spawn_proxy_process_ipc_hmac_key_env() -> bytes:
     ''' Get the HMAC key for the spawn proxy process dynamically. '''
-    key = os.getenv("TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY")
-    assert key is not None, (
-        f"{LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY} is not set. "
-        "HMAC encryption is required for IPC communication.")
-    return bytes.fromhex(key)
+    global _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY
+    if _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY is not None:
+        return _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY
+
+    _set_process_non_dumpable()
+    key = os.environ.pop(
+        LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, None)
+    if key is None:
+        raise RuntimeError(
+            f"{LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY} is not set. "
+            "HMAC encryption is required for IPC communication.")
+
+    _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY = (
+        _normalize_spawn_proxy_process_ipc_hmac_key(key))
+    return _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY
 
 
 def get_spawn_proxy_process_env() -> bool:

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -33,16 +33,15 @@ class LlmLauncherEnvs(StrEnum):
 _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY: bytes | None = None
 
 
-def _set_process_non_dumpable() -> None:
+def _scrub_process_env_value(key_name: str, value: str) -> None:
     if sys.platform != "linux":
         return
 
-    pr_set_dumpable = 4
-    suid_dump_disable = 0
     libc = ctypes.CDLL(None, use_errno=True)
-    if libc.prctl(pr_set_dumpable, suid_dump_disable, 0, 0, 0) != 0:
-        err = ctypes.get_errno()
-        raise OSError(err, os.strerror(err))
+    libc.getenv.restype = ctypes.c_void_p
+    value_ptr = libc.getenv(key_name.encode())
+    if value_ptr:
+        ctypes.memset(value_ptr, 0, len(value))
 
 
 def _normalize_spawn_proxy_process_ipc_hmac_key(key: str) -> bytes:
@@ -68,13 +67,14 @@ def get_spawn_proxy_process_ipc_hmac_key_env() -> bytes:
     if _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY is not None:
         return _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY
 
-    _set_process_non_dumpable()
-    key = os.environ.pop(
-        LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, None)
+    env_name = LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value
+    key = os.environ.get(env_name)
     if key is None:
         raise RuntimeError(
             f"{LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY} is not set. "
             "HMAC encryption is required for IPC communication.")
+    _scrub_process_env_value(env_name, key)
+    os.environ.pop(env_name, None)
 
     _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY = (
         _normalize_spawn_proxy_process_ipc_hmac_key(key))

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -1,7 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 import concurrent.futures
 import ctypes
 import os
+import re
 import sys
 import threading
 import traceback
@@ -31,6 +47,7 @@ class LlmLauncherEnvs(StrEnum):
 
 
 _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY: bytes | None = None
+_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
 
 
 def _scrub_process_env_value(key_name: str, value: str) -> None:
@@ -39,12 +56,15 @@ def _scrub_process_env_value(key_name: str, value: str) -> None:
 
     libc = ctypes.CDLL(None, use_errno=True)
     libc.getenv.restype = ctypes.c_void_p
-    value_ptr = libc.getenv(key_name.encode())
+    value_ptr = libc.getenv(os.fsencode(key_name))
     if value_ptr:
-        ctypes.memset(value_ptr, 0, len(value))
+        ctypes.memset(value_ptr, 0, len(os.fsencode(value)))
 
 
 def _normalize_spawn_proxy_process_ipc_hmac_key(key: str) -> bytes:
+    if not _SPAWN_PROXY_PROCESS_IPC_HMAC_KEY_PATTERN.fullmatch(key):
+        raise ValueError("IPC HMAC key must be a 64-character hex string.")
+
     try:
         key_bytes = bytes.fromhex(key)
     except ValueError as exc:

--- a/tensorrt_llm/llmapi/trtllm-llmapi-launch
+++ b/tensorrt_llm/llmapi/trtllm-llmapi-launch
@@ -40,9 +40,10 @@ function maybe_export_free_tcp_addr_for_spawn_proxy_process {
 export tllm_mpi_size=$(mpi_world_size)
 log_stderr "tllm_mpi_size: $tllm_mpi_size"
 
-export TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY=$(openssl rand -hex 32)
+unset TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY
 
 if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
+    export TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY=$(openssl rand -hex 32)
 
     # IPC only works on localhost and in MPI rank0 process
     maybe_export_free_tcp_addr_for_spawn_proxy_process

--- a/tensorrt_llm/llmapi/trtllm-llmapi-launch
+++ b/tensorrt_llm/llmapi/trtllm-llmapi-launch
@@ -43,7 +43,15 @@ log_stderr "tllm_mpi_size: $tllm_mpi_size"
 unset TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY
 
 if [ -z "$mpi_rank" ] || [ "$mpi_rank" -eq 0 ]; then
-    export TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY=$(openssl rand -hex 32)
+    if ! hmac_key=$(openssl rand -hex 32); then
+        log_stderr "Failed to generate TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY"
+        exit 1
+    fi
+    if [[ ! "$hmac_key" =~ ^[0-9a-fA-F]{64}$ ]]; then
+        log_stderr "Generated invalid TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY"
+        exit 1
+    fi
+    export TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY="$hmac_key"
 
     # IPC only works on localhost and in MPI rank0 process
     maybe_export_free_tcp_addr_for_spawn_proxy_process

--- a/tests/unittest/executor/test_launcher_envs.py
+++ b/tests/unittest/executor/test_launcher_envs.py
@@ -12,26 +12,30 @@ def reset_ipc_hmac_key_env(monkeypatch):
     monkeypatch.delenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, raising=False)
 
 
-def _mock_non_dumpable(monkeypatch):
+def _mock_env_scrub(monkeypatch):
     calls = []
-    monkeypatch.setattr(executor_utils, "_set_process_non_dumpable", lambda: calls.append(True))
+    monkeypatch.setattr(
+        executor_utils,
+        "_scrub_process_env_value",
+        lambda key_name, value: calls.append((key_name, value)),
+    )
     return calls
 
 
 def test_get_spawn_proxy_process_ipc_hmac_key_from_env(monkeypatch):
-    calls = _mock_non_dumpable(monkeypatch)
+    calls = _mock_env_scrub(monkeypatch)
     key_hex = "01" * 32
     monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, key_hex)
 
     key = executor_utils.get_spawn_proxy_process_ipc_hmac_key_env()
 
     assert key == bytes.fromhex(key_hex)
-    assert calls == [True]
+    assert calls == [(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, key_hex)]
     assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ
 
 
 def test_get_spawn_proxy_process_ipc_hmac_key_caches_env_key(monkeypatch):
-    calls = _mock_non_dumpable(monkeypatch)
+    calls = _mock_env_scrub(monkeypatch)
     key_hex = "02" * 32
     monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, key_hex)
 
@@ -39,20 +43,20 @@ def test_get_spawn_proxy_process_ipc_hmac_key_caches_env_key(monkeypatch):
 
     assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ
     assert executor_utils.get_spawn_proxy_process_ipc_hmac_key_env() == key
-    assert calls == [True]
+    assert calls == [(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, key_hex)]
 
 
 def test_get_spawn_proxy_process_ipc_hmac_key_missing(monkeypatch):
-    calls = _mock_non_dumpable(monkeypatch)
+    calls = _mock_env_scrub(monkeypatch)
 
     with pytest.raises(RuntimeError, match="HMAC encryption is required"):
         executor_utils.get_spawn_proxy_process_ipc_hmac_key_env()
 
-    assert calls == [True]
+    assert calls == []
 
 
 def test_get_spawn_proxy_process_ipc_hmac_key_rejects_invalid_hex(monkeypatch):
-    _mock_non_dumpable(monkeypatch)
+    _mock_env_scrub(monkeypatch)
     monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, "not-a-hex-key")
 
     with pytest.raises(ValueError, match="IPC HMAC key must be a 64-character hex string"):
@@ -62,7 +66,7 @@ def test_get_spawn_proxy_process_ipc_hmac_key_rejects_invalid_hex(monkeypatch):
 
 
 def test_get_spawn_proxy_process_ipc_hmac_key_rejects_wrong_length(monkeypatch):
-    _mock_non_dumpable(monkeypatch)
+    _mock_env_scrub(monkeypatch)
     monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, "01")
 
     with pytest.raises(ValueError, match="IPC HMAC key must be 32 bytes"):

--- a/tests/unittest/executor/test_launcher_envs.py
+++ b/tests/unittest/executor/test_launcher_envs.py
@@ -1,4 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ctypes
 import os
+import sys
 
 import pytest
 
@@ -7,13 +24,13 @@ from tensorrt_llm.executor.utils import LlmLauncherEnvs
 
 
 @pytest.fixture(autouse=True)
-def reset_ipc_hmac_key_env(monkeypatch):
+def reset_ipc_hmac_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(executor_utils, "_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY", None)
     monkeypatch.delenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, raising=False)
 
 
-def _mock_env_scrub(monkeypatch):
-    calls = []
+def _mock_env_scrub(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    calls: list[tuple[str, str]] = []
     monkeypatch.setattr(
         executor_utils,
         "_scrub_process_env_value",
@@ -22,7 +39,7 @@ def _mock_env_scrub(monkeypatch):
     return calls
 
 
-def test_get_spawn_proxy_process_ipc_hmac_key_from_env(monkeypatch):
+def test_get_spawn_proxy_process_ipc_hmac_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = _mock_env_scrub(monkeypatch)
     key_hex = "01" * 32
     monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, key_hex)
@@ -34,7 +51,9 @@ def test_get_spawn_proxy_process_ipc_hmac_key_from_env(monkeypatch):
     assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ
 
 
-def test_get_spawn_proxy_process_ipc_hmac_key_caches_env_key(monkeypatch):
+def test_get_spawn_proxy_process_ipc_hmac_key_caches_env_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls = _mock_env_scrub(monkeypatch)
     key_hex = "02" * 32
     monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, key_hex)
@@ -46,7 +65,7 @@ def test_get_spawn_proxy_process_ipc_hmac_key_caches_env_key(monkeypatch):
     assert calls == [(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, key_hex)]
 
 
-def test_get_spawn_proxy_process_ipc_hmac_key_missing(monkeypatch):
+def test_get_spawn_proxy_process_ipc_hmac_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = _mock_env_scrub(monkeypatch)
 
     with pytest.raises(RuntimeError, match="HMAC encryption is required"):
@@ -55,7 +74,9 @@ def test_get_spawn_proxy_process_ipc_hmac_key_missing(monkeypatch):
     assert calls == []
 
 
-def test_get_spawn_proxy_process_ipc_hmac_key_rejects_invalid_hex(monkeypatch):
+def test_get_spawn_proxy_process_ipc_hmac_key_rejects_invalid_hex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _mock_env_scrub(monkeypatch)
     monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, "not-a-hex-key")
 
@@ -65,11 +86,45 @@ def test_get_spawn_proxy_process_ipc_hmac_key_rejects_invalid_hex(monkeypatch):
     assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ
 
 
-def test_get_spawn_proxy_process_ipc_hmac_key_rejects_wrong_length(monkeypatch):
+def test_get_spawn_proxy_process_ipc_hmac_key_rejects_wrong_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _mock_env_scrub(monkeypatch)
     monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, "01")
 
-    with pytest.raises(ValueError, match="IPC HMAC key must be 32 bytes"):
+    with pytest.raises(ValueError, match="IPC HMAC key must be a 64-character hex string"):
         executor_utils.get_spawn_proxy_process_ipc_hmac_key_env()
 
     assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ
+
+
+def test_get_spawn_proxy_process_ipc_hmac_key_rejects_hex_with_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_env_scrub(monkeypatch)
+    monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, "01 " * 32)
+
+    with pytest.raises(ValueError, match="IPC HMAC key must be a 64-character hex string"):
+        executor_utils.get_spawn_proxy_process_ipc_hmac_key_env()
+
+    assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="requires libc getenv")
+def test_scrub_process_env_value_zeroes_real_libc_env_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env_name = "TRTLLM_TEST_SCRUB_PROCESS_ENV_VALUE"
+    env_value = "bad-\u00e9-value"
+    env_value_bytes = os.fsencode(env_value)
+    monkeypatch.setenv(env_name, env_value)
+
+    libc = ctypes.CDLL(None)
+    libc.getenv.restype = ctypes.c_void_p
+    value_ptr = libc.getenv(os.fsencode(env_name))
+    assert value_ptr
+    assert ctypes.string_at(value_ptr, len(env_value_bytes)) == env_value_bytes
+
+    executor_utils._scrub_process_env_value(env_name, env_value)
+
+    assert ctypes.string_at(value_ptr, len(env_value_bytes)) == b"\0" * len(env_value_bytes)

--- a/tests/unittest/executor/test_launcher_envs.py
+++ b/tests/unittest/executor/test_launcher_envs.py
@@ -1,0 +1,71 @@
+import os
+
+import pytest
+
+import tensorrt_llm.executor.utils as executor_utils
+from tensorrt_llm.executor.utils import LlmLauncherEnvs
+
+
+@pytest.fixture(autouse=True)
+def reset_ipc_hmac_key_env(monkeypatch):
+    monkeypatch.setattr(executor_utils, "_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY", None)
+    monkeypatch.delenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, raising=False)
+
+
+def _mock_non_dumpable(monkeypatch):
+    calls = []
+    monkeypatch.setattr(executor_utils, "_set_process_non_dumpable", lambda: calls.append(True))
+    return calls
+
+
+def test_get_spawn_proxy_process_ipc_hmac_key_from_env(monkeypatch):
+    calls = _mock_non_dumpable(monkeypatch)
+    key_hex = "01" * 32
+    monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, key_hex)
+
+    key = executor_utils.get_spawn_proxy_process_ipc_hmac_key_env()
+
+    assert key == bytes.fromhex(key_hex)
+    assert calls == [True]
+    assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ
+
+
+def test_get_spawn_proxy_process_ipc_hmac_key_caches_env_key(monkeypatch):
+    calls = _mock_non_dumpable(monkeypatch)
+    key_hex = "02" * 32
+    monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, key_hex)
+
+    key = executor_utils.get_spawn_proxy_process_ipc_hmac_key_env()
+
+    assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ
+    assert executor_utils.get_spawn_proxy_process_ipc_hmac_key_env() == key
+    assert calls == [True]
+
+
+def test_get_spawn_proxy_process_ipc_hmac_key_missing(monkeypatch):
+    calls = _mock_non_dumpable(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="HMAC encryption is required"):
+        executor_utils.get_spawn_proxy_process_ipc_hmac_key_env()
+
+    assert calls == [True]
+
+
+def test_get_spawn_proxy_process_ipc_hmac_key_rejects_invalid_hex(monkeypatch):
+    _mock_non_dumpable(monkeypatch)
+    monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, "not-a-hex-key")
+
+    with pytest.raises(ValueError, match="IPC HMAC key must be a 64-character hex string"):
+        executor_utils.get_spawn_proxy_process_ipc_hmac_key_env()
+
+    assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ
+
+
+def test_get_spawn_proxy_process_ipc_hmac_key_rejects_wrong_length(monkeypatch):
+    _mock_non_dumpable(monkeypatch)
+    monkeypatch.setenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value, "01")
+
+    with pytest.raises(ValueError, match="IPC HMAC key must be 32 bytes"):
+        executor_utils.get_spawn_proxy_process_ipc_hmac_key_env()
+
+    assert LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY.value not in os.environ


### PR DESCRIPTION
## Summary
- scrub the spawn-proxy HMAC value from the C process environment before popping it from os.environ
- cache and validate the HMAC key without making CUDA-active processes non-dumpable
- scope HMAC key export to rank 0 in trtllm-llmapi-launch
- add focused launcher env tests

Reasons for why we need additional step to clear `TLLM_SPAWN_PROXY_PROCESS_IPC_HMAC_KEY`:
- os.environ.pop() = logical removal from Python/libc environment.
- memset(getenv(...)) = physical overwrite of the secret bytes that may still be visible through /proc/<pid>/environ.

## Testing
- SKIP=type-check,clang-format,ruff-legacy pre-commit run -a
- python3 -m py_compile tensorrt_llm/executor/utils.py tests/unittest/executor/test_launcher_envs.py
- targeted pytest could not run in the host venv because pluggy is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the IPC HMAC key by validating its format, removing it from the environment after use, and caching the parsed value for reuse.
  * Added safer cleanup of the key in Linux environments to reduce the chance of it lingering in process memory.
  * Updated launcher behavior so the random key is cleared first and only generated by the primary process.
* **Tests**
  * Added coverage for valid, missing, invalid, and wrong-length key handling, including cache behavior and environment cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->