### PR TITLE
[https://nvbugs/6418912][fix] Clear detached KV cache sequence links

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -3182,9 +3182,16 @@ std::optional<KVCacheBlock::IdType> WindowBlockManager::releaseBlocks(
         // mRefCount==0 and are silently ignored by EvictionPolicy::releaseBlock().
         if (!block->hasRefs())
         {
+            auto const isDetached = block->isDetached();
+            if (isDetached)
+            {
+                // Detached blocks have no reusable hash chain. Drop the stale owning link before recycling the block;
+                // otherwise front-queue reuse can join completed request chains into an unbounded ownership chain.
+                block->setPrevBlockInSeq(nullptr);
+            }
             // Send block to front of free queue if it has no reusable state,
             // so detached blocks are evicted before blocks cached for reuse.
-            mEvictionPolicy->releaseBlock(block, /*toFront = */ block->isDetached());
+            mEvictionPolicy->releaseBlock(block, /*toFront=*/isDetached);
         }
     }
     // Remove stored block ids in sequence

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -219,6 +219,11 @@ TEST_F(KVCacheManagerTest, BlockManagerTest)
     EXPECT_EQ(idSet.size(), occupiedBlocks);
     blockManager.releaseBlocks(seq0);
     EXPECT_EQ(blockManager.getNumFreeBlocks(), blocksInPrimaryPool);
+    for (auto const blockId : idSet)
+    {
+        auto const block = blockManager.getBlockById(blockId, maxAttentionWindow);
+        EXPECT_EQ(block->getPrevBlockInSeq(), nullptr);
+    }
 
     // Test: last block shared (inputLength aligned to tokensPerBlock)
     auto inputTokensAligned = makeInputTokens(numTokens);


### PR DESCRIPTION
## Summary

- clear stale `mPrevBlockInSeq` ownership links when detached KV-cache blocks are released
- retain predecessor links for blocks that remain attached to the reuse tree
- add a focused assertion that released detached blocks no longer retain their prior sequence chain

## Root cause

PR #11685 began returning detached blocks to the front of the free queue. Those blocks still retained strong `mPrevBlockInSeq` links. Reusing a subset of each completed request's blocks could therefore join otherwise completed request chains; the large `FillKvCacheWithRequestsAndCompleteOneByOne/5` fixture eventually tears down an unbounded shared-ownership chain and segfaults.

Detached blocks have no reusable hash chain, so their predecessor link is obsolete once their reference count reaches zero. Reusable radix-tree blocks are unchanged.

## Validation

Local:

- pre-commit on both modified C++ files
- `git diff --check`
- focused invariant assertion that released detached blocks no longer retain their old predecessor

Targeted CI through combined integration PR #16019:

- exact integration head: `1248a1862d69a3ef8c2e9bca0a2207f383ba31bd`
- [CI invocation](https://github.com/NVIDIA/TensorRT-LLM/pull/16019#issuecomment-4900140778)
- `PR_Github #57931` → `L0_MergeRequest_PR #46619`: **SUCCESS**
- only selected stage: `A30-CPP-1`
- only selected pytest: `cpp/test_unit_tests.py::test_unit_tests[batch_manager-80]`
- pytest result: **1 passed**, 16,431 deselected, 9 warnings in 644.08s
- batch-manager gtest report: **525 tests, 0 failures** (6 disabled, 2 skipped)
- formerly crashing `FillKvCacheAndCompleteRequestsTest.FillKvCacheWithRequestsAndCompleteOneByOne/5`: **OK** in 1,739 ms
- no retry, segfault, timeout, or test waiver

## Regression evidence

The preceding integration run, pipeline #46583 on head `656e9e6`, reproduced the exact `/5` segfault twice (initial run and CTest rerun). All other concrete gtests in `batch_manager-80`, including the nine partial-copy variants, passed. The only code delta in the successful integration rerun is this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block recycling so detached blocks no longer keep stale sequence links when returned to reuse.
  * Improved block cleanup to better prevent incorrect ownership/back-pointer relationships.
  * Added test coverage to verify occupied blocks do not retain a previous-block link in the non-shared case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->