### PR TITLE
[None][chore] Enable acc for disagg multi node stress test on qa side

### DIFF
--- a/tests/scripts/perf/disaggregated/gb200_wideep_stress-deepseek-r1-fp4_1k1k_ctx2_gen1_dep16_bs128_eplb288_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_wideep_stress-deepseek-r1-fp4_1k1k_ctx2_gen1_dep16_bs128_eplb288_mtp3_ccb-NIXL.yaml
@@ -46,7 +46,7 @@ environment:
 profiling:
   nsys_on: false
 accuracy:
-  enable_accuracy_test: false
+  enable_accuracy_test: true
   env_var:
     HF_HOME: <hf_home_path>
   tasks:

--- a/tests/scripts/perf/disaggregated/gb200_wideep_stress-deepseek-r1-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_wideep_stress-deepseek-r1-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_ccb-NIXL.yaml
@@ -46,7 +46,7 @@ environment:
 profiling:
   nsys_on: false
 accuracy:
-  enable_accuracy_test: false
+  enable_accuracy_test: true
   env_var:
     HF_HOME: <hf_home_path>
   tasks:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled accuracy checks for two performance test configurations.
  * Test runs now include accuracy validation alongside the existing benchmark settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Enable acc for disagg multi node stress test on qa side

