### PR TITLE
[None][test] Add coverage for DeepseekV3DecoderLayer.forward_mlp

### DIFF
--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -14,6 +14,7 @@ l0_b200:
       stage: pre_merge
       backend: pytorch
   tests:
+  - unittest/_torch/modeling/test_modeling_deepseekv3.py::test_forward_mlp_pre_mlp_fusion_fallback_no_nvfp4
   # ------------- PyTorch tests ---------------
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8B::test_nvfp4
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8B::test_nvfp4_streaming[stream_interval_4]

--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv3.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv3.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.distributed import AllReduceFusionOp
+from tensorrt_llm._torch.utils import Fp4QuantizedTensor
+
+
+@pytest.fixture
+def mock_decoder_layer():
+    """Create a mock DeepseekV3DecoderLayer with the real forward_mlp method."""
+    from tensorrt_llm._torch.models.modeling_deepseekv3 import DeepseekV3DecoderLayer
+
+    layer = MagicMock(spec=DeepseekV3DecoderLayer)
+
+    # Bind the real forward_mlp method to our mock
+    layer.forward_mlp = DeepseekV3DecoderLayer.forward_mlp.__get__(layer, DeepseekV3DecoderLayer)
+
+    return layer
+
+
+@pytest.mark.parametrize("has_nvfp4", [True, False], ids=["nvfp4_enabled", "nvfp4_disabled"])
+def test_forward_mlp_pre_mlp_fusion_fallback_no_nvfp4(mock_decoder_layer, has_nvfp4):
+    """Test that forward_mlp selects the correct AllReduceFusionOp based on
+    mlp.gate_up_proj.has_nvfp4 when PRE_MLP_FUSION is enabled.
+
+    When has_nvfp4 is True: uses RESIDUAL_RMS_NORM_QUANT_NVFP4
+    When has_nvfp4 is False: falls back to RESIDUAL_RMS_NORM
+    """
+    layer = mock_decoder_layer
+
+    # Setup fusion_config with PRE_MLP_FUSION enabled, POST_MLP_FUSION disabled
+    layer.fusion_config = MagicMock()
+    layer.fusion_config.PRE_MLP_FUSION = True
+    layer.fusion_config.POST_MLP_FUSION = False
+
+    # Setup mlp mock
+    layer.mlp = MagicMock()
+    layer.mlp.gate_up_proj = MagicMock()
+    layer.mlp.gate_up_proj.has_nvfp4 = has_nvfp4
+    layer.mlp.gate_up_proj.input_scale = torch.tensor(1.0)
+
+    # Setup post_attention_layernorm mock
+    layer.post_attention_layernorm = MagicMock()
+    layer.post_attention_layernorm.weight = torch.ones(16)
+    layer.post_attention_layernorm.variance_epsilon = 1e-6
+
+    # Setup next_layer_layernorm mock
+    layer.next_layer_layernorm = MagicMock()
+    layer.next_layer_layernorm.weight = torch.ones(16)
+    layer.next_layer_layernorm.variance_epsilon = 1e-6
+
+    # Setup mlp_tp_size
+    layer.mlp_tp_size = 1
+
+    # Track allreduce calls
+    captured_params = []
+
+    def mock_allreduce(hidden_states, all_reduce_params=None):
+        captured_params.append(all_reduce_params)
+        if all_reduce_params.fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4:
+            # Return (act_fp4, act_sf, residual) tuple for nvfp4 path
+            act_fp4 = torch.zeros(4, dtype=torch.uint8)
+            act_sf = torch.ones(1)
+            residual = torch.ones(16)
+            return act_fp4, act_sf, residual
+        else:
+            # Return (hidden_states, residual) tuple for non-nvfp4 path
+            return torch.ones(16), torch.ones(16)
+
+    layer.allreduce = mock_allreduce
+
+    # Setup mlp to return a tensor
+    mlp_output = torch.ones(16)
+    layer.mlp.return_value = mlp_output
+
+    # Setup next_layer_layernorm to return (hidden, residual)
+    layer.next_layer_layernorm.return_value = (torch.ones(16), torch.ones(16))
+
+    # Input tensors
+    hidden_states = torch.randn(16)
+    residual = torch.randn(16)
+
+    # Call forward_mlp
+    result_hidden, result_residual = layer.forward_mlp(
+        hidden_states=hidden_states,
+        residual=residual,
+        spec_metadata=None,
+    )
+
+    # Verify the first allreduce call (PRE_MLP_FUSION path)
+    assert len(captured_params) >= 1, "allreduce should have been called at least once"
+
+    first_params = captured_params[0]
+
+    if has_nvfp4:
+        # Should use RESIDUAL_RMS_NORM_QUANT_NVFP4
+        assert first_params.fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4, (
+            f"Expected RESIDUAL_RMS_NORM_QUANT_NVFP4 when has_nvfp4=True, got {first_params.fusion_op}"
+        )
+        # Verify scale is passed
+        assert first_params.scale is not None, (
+            "scale should be set when using RESIDUAL_RMS_NORM_QUANT_NVFP4"
+        )
+        # Verify mlp was called with Fp4QuantizedTensor
+        mlp_call_args = layer.mlp.call_args
+        assert mlp_call_args is not None, "mlp should have been called"
+        first_arg = (
+            mlp_call_args[0][0] if mlp_call_args[0] else mlp_call_args[1].get("hidden_states")
+        )
+        assert isinstance(first_arg, Fp4QuantizedTensor), (
+            f"mlp input should be Fp4QuantizedTensor when has_nvfp4=True, got {type(first_arg)}"
+        )
+    else:
+        # Should fall back to RESIDUAL_RMS_NORM
+        assert first_params.fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM, (
+            f"Expected RESIDUAL_RMS_NORM when has_nvfp4=False, got {first_params.fusion_op}"
+        )
+        # Verify that RESIDUAL_RMS_NORM_QUANT_NVFP4 was NOT used
+        assert first_params.fusion_op != AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4, (
+            "RESIDUAL_RMS_NORM_QUANT_NVFP4 should NOT be used when has_nvfp4=False"
+        )
+        # Verify mlp was NOT called with Fp4QuantizedTensor
+        mlp_call_args = layer.mlp.call_args
+        assert mlp_call_args is not None, "mlp should have been called"
+        first_arg = (
+            mlp_call_args[0][0] if mlp_call_args[0] else mlp_call_args[1].get("hidden_states")
+        )
+        assert not isinstance(first_arg, Fp4QuantizedTensor), (
+            f"mlp input should NOT be Fp4QuantizedTensor when has_nvfp4=False, got {type(first_arg)}"
+        )


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Adds `tests/unittest/_torch/modeling/test_modeling_deepseekv3.py::test_forward_mlp_pre_mlp_fusion_fallback_no_nvfp4` to cover: When PRE_MLP_FUSION is enabled but the dense layer (mlp.gate_up_proj) does not have nvfp4 quantization (has_nvfp4 is False), the code now falls back to RESIDUAL_RMS_NORM fusion instead of RESIDUAL_RMS_NORM_QUANT_NVFP4. This is specifically for GLM-5.1 NVFP4 where dense layers are unquantized.

> Prepared by LLM Gap Fixer as a draft PR. Human review is required before merge.

## Test Coverage

- [Jenkins #8](https://prod.blsm.nvidia.com/swqa-tensorrt-qa-test/job/LLM_PATCH_CHECKER/8/) — `SUCCESS`
- `unittest/_torch/modeling/test_modeling_deepseekv3.py::test_forward_mlp_pre_mlp_fusion_fallback_no_nvfp4`

## Gap Fixer Validation

- Patch review: The patch correctly tests the forward_mlp branching logic for has_nvfp4 with PRE_MLP_FUSION enabled, uses verified APIs, and follows repository conventions for placement and registration.
- Gap Fixer job: `#15`
- Analyzed source commit: `70c5e430c8544638f95d0c8dd20cb3cf862a0331`
- Validated patch commit: `7dae66006360873e76c9347e714f471d9a1ac057`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
