### PR TITLE
[None][fix] trtllm-serve VisualGen: bind HTTP port only on rank 0 in multi-rank launch

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -605,6 +605,16 @@ def launch_visual_gen_server(
         visual_gen_args: Optional validated VisualGenArgs for model configuration.
         metadata_server_cfg: Optional metadata server configuration.
     """
+    # Only global rank 0 serves HTTP; in external multi-rank launch ranks > 0
+    # must become workers before binding, else every rank on a multi-GPU node
+    # races the same port and all but one die EADDRINUSE. VisualGen() on a
+    # worker rank never returns (sys.exit in __init__).
+    from tensorrt_llm._torch.visual_gen.executor import _detect_external_launch
+    ext = _detect_external_launch()
+    if ext is not None and ext[0] != 0:
+        VisualGen(model=model, args=visual_gen_args)
+        return
+
     # Reserve the listening (host, port) by binding the socket *before*
     # constructing the VisualGen pipeline, then hand the bound socket to
     # uvicorn. VisualGen initialization can take many minutes; if we deferred


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup reliability when running in multi-rank launch setups.
  * Non-primary ranks now avoid trying to bind the same network port, reducing startup conflicts and race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

In external multi-rank launch (`torchrun` / `srun`), `launch_visual_gen_server` binds the HTTP socket before constructing `VisualGen`, but rank>0 processes only exit into worker mode inside `VisualGen.__init__`. On a multi-GPU node every local rank therefore races to bind the same `host:port` and all but one die with `EADDRINUSE`, so no server ever becomes ready. This is a regression from #14355 (nvbugs/6143883), which moved the bind ahead of the minutes-long pipeline init to reserve the port; that is correct for a single server rank but makes every rank bind under multi-rank-per-node launch.

Fix: before the early bind, detect external launch and let rank>0 construct `VisualGen` (which dispatches to the worker loop and never returns) and return without touching the port. Rank 0 and single-node (`mp.Process`) keep the early-bind behavior unchanged.

## Test Coverage

Verified on a 16-GPU (4 nodes × 4) LTX-2 distributed serve on GB200 (NVFP4, cfg2 × ulysses8, VAE-parallel 8): before the fix all 16 ranks fail with `[Errno 98] Address already in use`; after the fix rank 0 binds, ranks 1-15 become workers, and the server reaches `Application startup complete` and serves generations.

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
