### PR TITLE
[TRTLLM-14040][fix] VisualGen shared-tensor handle: same-process (external-launch) handoff

### DIFF
--- a/tensorrt_llm/_torch/shared_tensor/shared_tensor.py
+++ b/tensorrt_llm/_torch/shared_tensor/shared_tensor.py
@@ -1,6 +1,9 @@
 import base64
+import itertools
 import logging
-from typing import Any, Callable, Dict, Tuple
+import os
+import threading
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import torch
 from torch.multiprocessing import get_sharing_strategy, set_sharing_strategy
@@ -11,6 +14,35 @@ from torch.multiprocessing.reductions import (rebuild_cuda_tensor,
                                               reduce_storage, reduce_tensor)
 
 logger = logging.getLogger(__name__)
+
+
+class _LocalTensorStore:
+    """Process-local stash for same-process tensor handoff.
+
+    CUDA IPC handles (reduce_tensor / cudaIpc) cannot be opened by the exporting
+    process, so cross-process sharing fails when producer and consumer are threads
+    of one process (e.g. external-launch VisualGen: rank 0's worker and the response
+    coordinator share a process). The producer stashes the live tensor here and the
+    same-process consumer looks it up by token -- the token survives the pickled
+    handle round-trip, the tensor does not.
+    """
+
+    _store: Dict[int, torch.Tensor] = {}
+    _lock = threading.Lock()
+    _counter = itertools.count()
+
+    @classmethod
+    def stash(cls, tensor: torch.Tensor) -> int:
+        token = next(cls._counter)
+        with cls._lock:
+            cls._store[token] = tensor
+        return token
+
+    @classmethod
+    def pop(cls, token: int) -> Optional[torch.Tensor]:
+        with cls._lock:
+            return cls._store.pop(token, None)
+
 
 DTYPE_MAPPING = {
     'torch.float32': torch.float32,
@@ -48,6 +80,7 @@ class _SharedTensorRebuildMethodRegistry:
     # Fixed keys for common rebuild methods
     REBUILD_CUDA = 1
     REBUILD_CPU = 2
+    REBUILD_LOCAL = 3
 
     _registry: Dict[int, Callable] = {}
 
@@ -310,7 +343,7 @@ class SharedTensorContainer:
             raise ValueError(f"Failed to deserialize tensor information: {e}")
 
     @classmethod
-    def from_tensor(cls, tensor: torch.Tensor) -> 'SharedTensorContainer':
+    def from_tensor(cls, tensor: torch.Tensor, local: bool = False) -> 'SharedTensorContainer':
         """Create a SharedTensorContainer from a local tensor (Producer side).
 
         This method is called by the producer process to prepare a tensor for sharing
@@ -326,6 +359,10 @@ class SharedTensorContainer:
         Returns:
             SharedTensorContainer instance that can be serialized later for IPC
         """
+        if local:
+            token = _LocalTensorStore.stash(tensor)
+            return cls(_SharedTensorRebuildMethodRegistry.REBUILD_LOCAL,
+                       {"local_token": token, "producer_pid": os.getpid()})
         rebuild_method, tensor_handle = reduce_tensor(tensor)
         method_key = _SharedTensorRebuildMethodRegistry.register(rebuild_method)
         return cls(method_key, tensor_handle)
@@ -348,6 +385,11 @@ class SharedTensorContainer:
             ValueError: If the method_key is not supported
         """
         method_key = tensor_info['method_key']
+        if method_key == _SharedTensorRebuildMethodRegistry.REBUILD_LOCAL:
+            return cls(method_key, {
+                "local_token": tensor_info["local_token"],
+                "producer_pid": tensor_info["producer_pid"],
+            })
         if method_key == _SharedTensorRebuildMethodRegistry.REBUILD_CUDA:
             tensor_handle = SharedTensorContainer.dict_to_cuda_handle(
                 tensor_info)
@@ -368,6 +410,16 @@ class SharedTensorContainer:
         Returns:
             The reconstructed tensor
         """
+        if self.method_key == _SharedTensorRebuildMethodRegistry.REBUILD_LOCAL:
+            if self.tensor_handle["producer_pid"] != os.getpid():
+                raise RuntimeError(
+                    "REBUILD_LOCAL handle crossed a process boundary; it is only "
+                    "valid within the producing process.")
+            tensor = _LocalTensorStore.pop(self.tensor_handle["local_token"])
+            if tensor is None:
+                raise RuntimeError(
+                    "REBUILD_LOCAL tensor missing from same-process registry.")
+            return tensor
         rebuild_method = _SharedTensorRebuildMethodRegistry.get_method(
             self.method_key)
         return rebuild_method(*self.tensor_handle)
@@ -381,6 +433,12 @@ class SharedTensorContainer:
         Returns:
             Dictionary containing the serialized tensor information
         """
+        if self.method_key == _SharedTensorRebuildMethodRegistry.REBUILD_LOCAL:
+            return {
+                "method_key": self.method_key,
+                "local_token": self.tensor_handle["local_token"],
+                "producer_pid": self.tensor_handle["producer_pid"],
+            }
         if self.method_key == _SharedTensorRebuildMethodRegistry.REBUILD_CUDA:
             tensor_dict = SharedTensorContainer.cuda_handle_to_dict(
                 self.tensor_handle)

--- a/tensorrt_llm/_torch/shared_tensor/shared_tensor.py
+++ b/tensorrt_llm/_torch/shared_tensor/shared_tensor.py
@@ -343,7 +343,9 @@ class SharedTensorContainer:
             raise ValueError(f"Failed to deserialize tensor information: {e}")
 
     @classmethod
-    def from_tensor(cls, tensor: torch.Tensor, local: bool = False) -> 'SharedTensorContainer':
+    def from_tensor(cls,
+                    tensor: torch.Tensor,
+                    local: bool = False) -> 'SharedTensorContainer':
         """Create a SharedTensorContainer from a local tensor (Producer side).
 
         This method is called by the producer process to prepare a tensor for sharing
@@ -355,14 +357,20 @@ class SharedTensorContainer:
 
         Args:
             tensor: The tensor to share
+            local: When True, keep the tensor in a process-local store and
+                skip the cross-process IPC handle, for a consumer in the same
+                process (e.g. external-launch where producer and consumer are
+                threads of one process). CUDA IPC handles are invalid same-process.
 
         Returns:
             SharedTensorContainer instance that can be serialized later for IPC
         """
         if local:
             token = _LocalTensorStore.stash(tensor)
-            return cls(_SharedTensorRebuildMethodRegistry.REBUILD_LOCAL,
-                       {"local_token": token, "producer_pid": os.getpid()})
+            return cls(_SharedTensorRebuildMethodRegistry.REBUILD_LOCAL, {
+                "local_token": token,
+                "producer_pid": os.getpid()
+            })
         rebuild_method, tensor_handle = reduce_tensor(tensor)
         method_key = _SharedTensorRebuildMethodRegistry.register(rebuild_method)
         return cls(method_key, tensor_handle)
@@ -386,10 +394,11 @@ class SharedTensorContainer:
         """
         method_key = tensor_info['method_key']
         if method_key == _SharedTensorRebuildMethodRegistry.REBUILD_LOCAL:
-            return cls(method_key, {
-                "local_token": tensor_info["local_token"],
-                "producer_pid": tensor_info["producer_pid"],
-            })
+            return cls(
+                method_key, {
+                    "local_token": tensor_info["local_token"],
+                    "producer_pid": tensor_info["producer_pid"],
+                })
         if method_key == _SharedTensorRebuildMethodRegistry.REBUILD_CUDA:
             tensor_handle = SharedTensorContainer.dict_to_cuda_handle(
                 tensor_info)

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -435,7 +435,10 @@ class DiffusionExecutor:
             output = self.pipeline.infer(req)
             generation = time.perf_counter() - generation_start  # seconds
             if self.rank == 0:
-                output.to_handle()
+                # External launch co-locates this worker with the coordinator in one
+                # process; to_handle(local=True) hands the tensor over in-process
+                # instead of cross-process CUDA IPC (invalid same-process).
+                output.to_handle(local=_detect_external_launch() is not None)
                 self.response_queue.put(
                     DiffusionResponse(
                         request_id=req.request_id,

--- a/tensorrt_llm/_torch/visual_gen/output.py
+++ b/tensorrt_llm/_torch/visual_gen/output.py
@@ -86,7 +86,9 @@ class PipelineOutput:
         for f in fields(self):
             t = getattr(self, f.name)
             if isinstance(t, torch.Tensor):
-                setattr(self, f.name, SharedTensorContainer.from_tensor(t, local=local).dump_to_dict())
+                setattr(
+                    self, f.name, SharedTensorContainer.from_tensor(t, local=local).dump_to_dict()
+                )
 
     def to_tensor(self) -> None:
         """Rebuild media tensors from handle dicts, in place. ``clone()`` so the client

--- a/tensorrt_llm/_torch/visual_gen/output.py
+++ b/tensorrt_llm/_torch/visual_gen/output.py
@@ -78,12 +78,15 @@ class PipelineOutput:
     denoise: float = 0.0
     post_denoise: float = 0.0
 
-    def to_handle(self) -> None:
-        """Replace media tensors with handle dicts in place (avoids pickling the full blob over IPC)."""
+    def to_handle(self, local: bool = False) -> None:
+        """Replace media tensors with handle dicts in place (avoids pickling the full blob over IPC).
+
+        ``local=True`` (producer and consumer share a process, e.g. external launch)
+        keeps the tensor in-process instead of using cross-process CUDA IPC."""
         for f in fields(self):
             t = getattr(self, f.name)
             if isinstance(t, torch.Tensor):
-                setattr(self, f.name, SharedTensorContainer.from_tensor(t).dump_to_dict())
+                setattr(self, f.name, SharedTensorContainer.from_tensor(t, local=local).dump_to_dict())
 
     def to_tensor(self) -> None:
         """Rebuild media tensors from handle dicts, in place. ``clone()`` so the client

--- a/tests/unittest/visual_gen/test_executor_shared_tensor_ipc.py
+++ b/tests/unittest/visual_gen/test_executor_shared_tensor_ipc.py
@@ -79,6 +79,20 @@ class TestExecutorSharedTensorIPC(unittest.TestCase):
             resp.output.to_tensor()
         self.assertEqual(resp.output, {"status": "READY"})
 
+    def test_roundtrip_local_same_process(self):
+        """Same-process handoff: media stays in-process (local=True), not cross-process IPC."""
+        video = torch.arange(2 * 3 * 4 * 5 * 3, dtype=torch.uint8).reshape(2, 3, 4, 5, 3)
+        audio = torch.randn(2, 2, 100)
+        output = PipelineOutput(video=video, audio=audio, frame_rate=24.0)
+        output.to_handle(local=True)
+        self.assertIsInstance(output.video, dict)
+        self.assertIsInstance(output.audio, dict)
+        resp = DiffusionResponse(request_id=2, output=output)
+        resp.output.to_tensor()
+        self.assertTrue(torch.equal(resp.output.video, video))
+        self.assertTrue(torch.equal(resp.output.audio, audio))
+        self.assertEqual(resp.output.frame_rate, 24.0)
+
 
 if __name__ == "__main__":
     mp.set_start_method("spawn", force=True)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for same-process tensor handoff in cross-thread workflows.
  * Output handling can now preserve in-memory tensors when producer and consumer run in the same process.

* **Bug Fixes**
  * Improved tensor transfer behavior for externally launched distributed runs by avoiding unnecessary cross-process sharing.
  * Added safeguards to prevent using same-process tensor handles across different processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

#15834 shares decoded media between the worker and the server via a `SharedTensorContainer` handle (CUDA IPC for GPU tensors). CUDA cannot open an IPC handle exported by the same process. In external launch (`torchrun` / `srun`) rank 0's worker runs as a background thread inside the coordinator process, so the handle is produced and consumed within one process and `cudaIpcOpenMemHandle` fails with `cudaErrorDeviceUninitialized`, crashing the server right after the first generation completes. Single-node (`mp.Process` workers) is unaffected because the workers are genuinely separate processes.

Fix: add a same-process handoff path to `SharedTensorContainer` (`REBUILD_LOCAL`). When producer and consumer share a process, the producer stashes the live tensor in a process-local registry and passes only a small `{local_token, producer_pid}` dict over IPC; the same-process consumer retrieves the tensor directly, with no CUDA IPC and no media blob serialized over ZMQ. The VisualGen executor selects this path via `to_handle(local=_detect_external_launch() is not None)`. Cross-process (single-node) behavior is byte-for-byte unchanged.

## Test Coverage

Verified on a 16-GPU LTX-2 distributed serve on GB200: before the fix the server crashes on the first request with `cudaErrorDeviceUninitialized`; after the fix the video is delivered and the server serves multiple requests. The same-process path also lowers end-to-end latency vs. a host-copy fallback (5.45s vs 6.29s per request at 768×1280 / 121f / 40 steps) because the ~357MB media blob no longer crosses ZMQ, preserving #15834's optimization for the co-located case.

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
