### PR TITLE
[TRTLLM-13235][feat] Support bad_words in TorchSampler

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -1190,6 +1190,13 @@ def executor_request_to_llm_request(
                                        "py_logprobs_simple_format", False),
     )
 
+    # Bad-words list for the TorchSampler path, kept in its native
+    # list[list[int]] form (single- and multi-token words). This is the
+    # TorchSampler's own input and is independent of any other sampler.
+    llm_request.py_bad_words = [
+        list(word) for word in executor_request.bad_words
+    ] if executor_request.bad_words else None
+
     llm_request.py_original_end_id = getattr(executor_request,
                                              "py_original_end_id",
                                              llm_request.py_end_id)

--- a/tensorrt_llm/_torch/pyexecutor/sampler/ops/flashinfer.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler/ops/flashinfer.py
@@ -15,7 +15,12 @@
 """FlashInfer-accelerated sampling kernels.
 
 These ops depend on flashinfer; the import is guarded so the module stays
-importable without it.
+importable without it (sampling_utils imports it unconditionally, and the
+vanilla/TRTLLM sampler paths must keep working without flashinfer). Without
+flashinfer, calling any op raises an ImportError with installation guidance.
+Components that will invoke these ops are expected to fail fast at startup
+instead of relying on that call-time error: TorchSampler enforces flashinfer
+availability in its constructor.
 
 Randomness can be supplied either way (flashinfer accepts both in one
 signature; explicit ``seed``/``offset`` take precedence over ``generator``):
@@ -27,7 +32,7 @@ signature; explicit ``seed``/``offset`` take precedence over ``generator``):
   random values).
 """
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 
@@ -35,6 +40,19 @@ from tensorrt_llm._torch.flashinfer_utils import IS_FLASHINFER_AVAILABLE, get_en
 
 if IS_FLASHINFER_AVAILABLE:
     import flashinfer.sampling
+else:
+
+    class _FlashInferUnavailable:
+        """Placeholder that raises on first use instead of a bare NameError."""
+
+        def __getattr__(self, name: str) -> Any:
+            raise ImportError(
+                "flashinfer is required for the FlashInfer sampling ops but is "
+                "not installed; please install the version pinned in "
+                "requirements.txt."
+            )
+
+    flashinfer = _FlashInferUnavailable()  # type: ignore[assignment]
 
 SeedOrTensor = Union[int, torch.Tensor]
 

--- a/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
@@ -2414,6 +2414,22 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             None
         ] * self.max_num_sequences
 
+    @staticmethod
+    def _is_draft_batch(requests: list[LlmRequest]) -> bool:
+        """Whether this batch belongs to the draft model.
+
+        Batches are homogeneous by construction: ModelDrafter builds all-draft
+        batches for its sample_async/update_requests calls on this shared
+        sampler, and PyExecutor's batches are all-target. The pending-steps
+        accounting relies on this to skip draft batches wholesale; assert it so
+        a mixed batch fails loudly instead of silently corrupting the counters.
+        """
+        is_draft: bool = requests[0].py_is_draft
+        assert all(r.py_is_draft == is_draft for r in requests), (
+            "sampler batch must be homogeneous (all-draft or all-target)"
+        )
+        return is_draft
+
     def get_generator(self, device: torch.device) -> torch.Generator:
         """Get a deterministic generator for the specified device.
 
@@ -3632,7 +3648,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         if not state.requests:
             return
 
-        if self._track_pending_steps and not state.requests[0].py_is_draft:
+        if self._track_pending_steps and not self._is_draft_batch(state.requests):
             for req in state.requests:
                 slot = req.py_seq_slot
                 if slot is not None and self._pending_steps[slot] > 0:
@@ -3798,7 +3814,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             num_context_logits_prefix_sum,
         )
 
-        if self._track_pending_steps and requests and not requests[0].py_is_draft:
+        if self._track_pending_steps and requests and not self._is_draft_batch(requests):
             for r in requests:
                 assert r.py_seq_slot is not None
                 self._pending_steps[r.py_seq_slot] += 1
@@ -4831,7 +4847,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
         if any(getattr(r, "py_bad_words", None) for r in sampling_requests):
             stale_by_one: list[bool] | None = None
-            if self._track_pending_steps and not sampling_requests[0].py_is_draft:
+            if self._track_pending_steps and not self._is_draft_batch(sampling_requests):
                 pending = [
                     self._pending_steps[r.py_seq_slot] if r.py_seq_slot is not None else 0
                     for r in sampling_requests

--- a/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
@@ -4339,6 +4339,74 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             logits.index_put_((row_idx, col_idx), neg_inf, accumulate=False)
 
     @staticmethod
+    @torch.inference_mode()
+    def _apply_bad_words(
+        logits: torch.Tensor,
+        requests: list[LlmRequest],
+        num_steps: list[int],
+        num_beams: list[int],
+    ) -> None:
+        """Inplace ban "bad words" by masking their final token's logit to -inf.
+
+        A single-token word is banned unconditionally; a multi-token word
+        ``[t0, ..., t_{k-1}]`` bans its final token ``t_{k-1}`` only when the
+        ``k-1`` most recently generated tokens exactly match the prefix
+        ``[t0, ..., t_{k-2}]``.
+
+        Args:
+            logits: Flattened ``[total_rows, vocab]`` logits; rows are packed per
+                request as ``num_steps * num_beams`` consecutive entries, in
+                beam-major / step-minor order (same layout as
+                ``_apply_min_length_penalty``). Modified in-place.
+            requests: The requests, aligned with the packed logits rows.
+            num_steps: Number of steps per request.
+            num_beams: Number of beams per request.
+        """
+        rows: list[int] = []
+        cols: list[int] = []
+        current_offset = 0
+        for index, r in enumerate(requests):
+            request_offset = current_offset
+            # Advance to the next request's rows before any early continue.
+            current_offset += num_steps[index] * num_beams[index]
+
+            bad_words = getattr(r, "py_bad_words", None)
+            if not bad_words:
+                continue
+
+            for beam_idx in range(num_beams[index]):
+                # Full token sequence for this beam (prompt + generated), so a
+                # bad-word prefix ending inside the prompt is also matched.
+                context = r.get_tokens(beam_idx)
+                for word in bad_words:
+                    k = len(word)
+                    if k == 0:
+                        continue
+                    if k == 1:
+                        # Single-token word: banned unconditionally.
+                        col = word[0]
+                    elif len(context) >= k - 1 and context[-(k - 1) :] == word[:-1]:
+                        # Multi-token word: ban the final token only when the
+                        # generated suffix matches the word prefix.
+                        col = word[-1]
+                    else:
+                        continue
+                    # Apply to every step row of this beam.
+                    for step in range(num_steps[index]):
+                        rows.append(request_offset + num_steps[index] * beam_idx + step)
+                        cols.append(col)
+
+        if rows:
+            neg_inf = torch.full((), float("-inf"), dtype=logits.dtype, device=logits.device)
+            row_idx = torch.tensor(rows, dtype=torch.long, pin_memory=prefer_pinned()).to(
+                logits.device, non_blocking=True
+            )
+            col_idx = torch.tensor(cols, dtype=torch.long, pin_memory=prefer_pinned()).to(
+                logits.device, non_blocking=True
+            )
+            logits.index_put_((row_idx, col_idx), neg_inf, accumulate=False)
+
+    @staticmethod
     def _select_generated_logits(
         scheduled_requests: ScheduledRequests,
         raw_logits_cuda: torch.Tensor,
@@ -4649,6 +4717,14 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             sampling_requests_metadata.req_num_steps,
             sampling_requests_metadata.req_num_beams,
         )
+
+        if any(getattr(r, "py_bad_words", None) for r in sampling_requests):
+            self._apply_bad_words(
+                logits_cuda,
+                sampling_requests,
+                sampling_requests_metadata.req_num_steps.tolist(),
+                sampling_requests_metadata.req_num_beams.tolist(),
+            )
 
         # Fast path for greedy sampling
         if self._can_use_fast_greedy_path(sampling_requests):

--- a/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
@@ -2343,7 +2343,6 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         # to decide whether the newest token must be read device-side.
         self._track_pending_steps = not args.disable_overlap_scheduler
         self._pending_steps = [0] * self.max_num_sequences
-        self._warned_stale_bad_words = False
         self.NEW_TOKENS_SHAPE = (self.max_tokens, self.max_num_sequences, self.max_beam_width)
         self.CACHE_INDIRECTION_SHAPE = (
             self.max_num_sequences,
@@ -4855,17 +4854,17 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 if any(pending):
                     if self.max_tokens == 1 and self.max_beam_width == 1 and max(pending) == 1:
                         stale_by_one = [p > 0 for p in pending]
-                    elif not self._warned_stale_bad_words:
+                    else:
                         # Speculative decoding / beam search under overlap:
                         # the missing host tokens cannot be reconstructed with
                         # the single-token device-side check; multi-token bad
                         # words may be applied one step late.
-                        self._warned_stale_bad_words = True
-                        logger.warning(
+                        logger.warning_once(
                             "bad_words with the overlap scheduler and speculative "
                             "decoding or beam search: multi-token bad words are "
                             "matched against a host token history that lags the "
-                            "device state and may be enforced inexactly."
+                            "device state and may be enforced inexactly.",
+                            key="bad_words_stale_overlap",
                         )
             self._apply_bad_words(
                 logits_cuda,

--- a/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
@@ -2336,6 +2336,14 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         if args.max_total_draft_tokens > 0 and args.max_beam_width > 1:
             raise ValueError("TorchSampler does not support beam search with speculative decoding")
         self.max_num_sequences = args.max_num_sequences
+        # With the overlap scheduler, sample_async for step i runs before
+        # update_requests for step i-1, so the host-side token lists lag the
+        # device state. Track, per seq slot, how many sampled steps have not
+        # been folded back into the request yet; bad-words handling uses this
+        # to decide whether the newest token must be read device-side.
+        self._track_pending_steps = not args.disable_overlap_scheduler
+        self._pending_steps = [0] * self.max_num_sequences
+        self._warned_stale_bad_words = False
         self.NEW_TOKENS_SHAPE = (self.max_tokens, self.max_num_sequences, self.max_beam_width)
         self.CACHE_INDIRECTION_SHAPE = (
             self.max_num_sequences,
@@ -3624,6 +3632,12 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         if not state.requests:
             return
 
+        if self._track_pending_steps and not state.requests[0].py_is_draft:
+            for req in state.requests:
+                slot = req.py_seq_slot
+                if slot is not None and self._pending_steps[slot] > 0:
+                    self._pending_steps[slot] -= 1
+
         assert state.host is not None
         new_tokens = state.host.new_tokens
         finish_reasons = state.host.finish_reasons_list()
@@ -3758,6 +3772,16 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         self.setup_sampler_step(scheduled_requests)
         new_tokens = self.store.new_tokens
 
+        if self._track_pending_steps:
+            # A context request claims a (possibly reused) slot: clear any
+            # counter leaked by a prior occupant that never got its final
+            # update_requests. Must happen before _process_requests, which
+            # reads the counters for bad-words staleness.
+            for r in scheduled_requests.context_requests:
+                if not r.py_is_draft:
+                    assert r.py_seq_slot is not None
+                    self._pending_steps[r.py_seq_slot] = 0
+
         # seq_slots_cuda / seq_lens_cuda are cast once inside
         # _process_requests and shared with the beam-search metadata builder.
         (
@@ -3773,6 +3797,11 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             new_tokens,
             num_context_logits_prefix_sum,
         )
+
+        if self._track_pending_steps and requests and not requests[0].py_is_draft:
+            for r in requests:
+                assert r.py_seq_slot is not None
+                self._pending_steps[r.py_seq_slot] += 1
 
         finish_reasons_host: torch.Tensor | None = None
         first_finish_reasons_host: torch.Tensor | None = None
@@ -4345,6 +4374,9 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         requests: list[LlmRequest],
         num_steps: list[int],
         num_beams: list[int],
+        *,
+        new_tokens_cuda: torch.Tensor | None = None,
+        stale_by_one: list[bool] | None = None,
     ) -> None:
         """Inplace ban "bad words" by masking their final token's logit to -inf.
 
@@ -4352,6 +4384,17 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         ``[t0, ..., t_{k-1}]`` bans its final token ``t_{k-1}`` only when the
         ``k-1`` most recently generated tokens exactly match the prefix
         ``[t0, ..., t_{k-2}]``.
+
+        With the overlap scheduler, ``sample_async`` for step ``i`` runs before
+        ``update_requests`` for step ``i-1``, so ``r.get_tokens()`` is missing
+        exactly the previous step's token; that token still lives device-side in
+        ``new_tokens_cuda``. For requests flagged in ``stale_by_one``, the
+        prefix match is therefore split: the first ``k-2`` prefix tokens are
+        matched on the host against the (complete up to there) host context, and
+        the final prefix token is compared on the GPU against
+        ``new_tokens_cuda[0, seq_slot, 0]``, without any device-to-host
+        synchronization. This path only supports ``num_steps == 1`` and
+        ``num_beams == 1`` (no speculation, no beam search).
 
         Args:
             logits: Flattened ``[total_rows, vocab]`` logits; rows are packed per
@@ -4361,9 +4404,19 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             requests: The requests, aligned with the packed logits rows.
             num_steps: Number of steps per request.
             num_beams: Number of beams per request.
+            new_tokens_cuda: Device buffer holding the previous step's sampled
+                tokens, shape ``[max_tokens, max_num_sequences, max_beam_width]``.
+                Required when any entry of ``stale_by_one`` is True.
+            stale_by_one: Per-request flag; True when the host token list lags
+                the device state by exactly one token (overlap scheduler).
         """
         rows: list[int] = []
         cols: list[int] = []
+        # Overlap path: bans whose last prefix token must be compared on-device.
+        cond_rows: list[int] = []
+        cond_cols: list[int] = []
+        cond_slots: list[int] = []
+        cond_expected: list[int] = []
         current_offset = 0
         for index, r in enumerate(requests):
             request_offset = current_offset
@@ -4372,6 +4425,37 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
             bad_words = getattr(r, "py_bad_words", None)
             if not bad_words:
+                continue
+
+            if stale_by_one is not None and stale_by_one[index]:
+                assert num_steps[index] == 1 and num_beams[index] == 1, (
+                    "stale-host bad-words path only supports a single step and beam"
+                )
+                assert r.py_seq_slot is not None
+                # Host context is missing the previous step's token; the true
+                # sequence is context + [new_tokens_cuda[0, seq_slot, 0]].
+                context = r.get_tokens(0)
+                for word in bad_words:
+                    k = len(word)
+                    if k == 0:
+                        continue
+                    if k == 1:
+                        # Single-token word: banned unconditionally.
+                        rows.append(request_offset)
+                        cols.append(word[0])
+                        continue
+                    # True sequence length is len(context) + 1; need >= k - 1.
+                    if len(context) < k - 2:
+                        continue
+                    # Host part: all prefix tokens except the newest one.
+                    if k > 2 and context[-(k - 2) :] != word[: k - 2]:
+                        continue
+                    # Device part: the previous step's token must equal the
+                    # last prefix token; resolved on the GPU below.
+                    cond_rows.append(request_offset)
+                    cond_cols.append(word[-1])
+                    cond_slots.append(r.py_seq_slot)
+                    cond_expected.append(word[k - 2])
                 continue
 
             for beam_idx in range(num_beams[index]):
@@ -4405,6 +4489,33 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 logits.device, non_blocking=True
             )
             logits.index_put_((row_idx, col_idx), neg_inf, accumulate=False)
+
+        if cond_rows:
+            assert new_tokens_cuda is not None
+            device = logits.device
+            cond_row_idx = torch.tensor(cond_rows, dtype=torch.long, pin_memory=prefer_pinned()).to(
+                device, non_blocking=True
+            )
+            cond_col_idx = torch.tensor(cond_cols, dtype=torch.long, pin_memory=prefer_pinned()).to(
+                device, non_blocking=True
+            )
+            slot_idx = torch.tensor(cond_slots, dtype=torch.long, pin_memory=prefer_pinned()).to(
+                device, non_blocking=True
+            )
+            expected = torch.tensor(
+                cond_expected, dtype=new_tokens_cuda.dtype, pin_memory=prefer_pinned()
+            ).to(device, non_blocking=True)
+            # Previous step's token per request (single step, single beam).
+            prev_tokens = new_tokens_cuda[0].index_select(0, slot_idx)[:, 0]
+            # -inf where the device-side prefix token matches, 0 otherwise.
+            # Additive update keeps the op shape-static (boolean-mask indexing
+            # would force a device-to-host sync).
+            penalty = torch.where(
+                prev_tokens == expected,
+                torch.full((), float("-inf"), dtype=logits.dtype, device=device),
+                torch.zeros((), dtype=logits.dtype, device=device),
+            )
+            logits.index_put_((cond_row_idx, cond_col_idx), penalty, accumulate=True)
 
     @staticmethod
     def _select_generated_logits(
@@ -4719,11 +4830,34 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         )
 
         if any(getattr(r, "py_bad_words", None) for r in sampling_requests):
+            stale_by_one: list[bool] | None = None
+            if self._track_pending_steps and not sampling_requests[0].py_is_draft:
+                pending = [
+                    self._pending_steps[r.py_seq_slot] if r.py_seq_slot is not None else 0
+                    for r in sampling_requests
+                ]
+                if any(pending):
+                    if self.max_tokens == 1 and self.max_beam_width == 1 and max(pending) == 1:
+                        stale_by_one = [p > 0 for p in pending]
+                    elif not self._warned_stale_bad_words:
+                        # Speculative decoding / beam search under overlap:
+                        # the missing host tokens cannot be reconstructed with
+                        # the single-token device-side check; multi-token bad
+                        # words may be applied one step late.
+                        self._warned_stale_bad_words = True
+                        logger.warning(
+                            "bad_words with the overlap scheduler and speculative "
+                            "decoding or beam search: multi-token bad words are "
+                            "matched against a host token history that lags the "
+                            "device state and may be enforced inexactly."
+                        )
             self._apply_bad_words(
                 logits_cuda,
                 sampling_requests,
                 sampling_requests_metadata.req_num_steps.tolist(),
                 sampling_requests_metadata.req_num_beams.tolist(),
+                new_tokens_cuda=new_tokens_cuda,
+                stale_by_one=stale_by_one,
             )
 
         # Fast path for greedy sampling

--- a/tensorrt_llm/_torch/pyexecutor/sampler/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler/sampling_utils.py
@@ -31,47 +31,49 @@ from tensorrt_llm._torch.pyexecutor.sampler.ops import flashinfer, vanilla
 # These op wrappers are safe to import without flashinfer installed; they are
 # only called on the flashinfer sampler / speculative-worker paths.
 from tensorrt_llm._torch.pyexecutor.sampler.ops.flashinfer import (
-    sampling_from_probs_op as sampling_from_probs_op,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.flashinfer import softmax_op as softmax_op
-from tensorrt_llm._torch.pyexecutor.sampler.ops.flashinfer import (
-    top_k_mask_logits_op as top_k_mask_logits_op,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.flashinfer import (
-    top_k_sampling_from_probs_op as top_k_sampling_from_probs_op,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.flashinfer import (
-    top_k_top_p_sampling_from_logits_op as top_k_top_p_sampling_from_logits_op,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.flashinfer import (
-    top_p_renorm_probs_op as top_p_renorm_probs_op,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.flashinfer import (
-    top_p_sampling_from_probs_op as top_p_sampling_from_probs_op,
+    sampling_from_probs_op,
+    softmax_op,
+    top_k_mask_logits_op,
+    top_k_sampling_from_probs_op,
+    top_k_top_p_sampling_from_logits_op,
+    top_p_renorm_probs_op,
+    top_p_sampling_from_probs_op,
 )
 from tensorrt_llm._torch.pyexecutor.sampler.ops.vanilla import (
-    GREEDY_TEMPERATURE_THRESHOLD as GREEDY_TEMPERATURE_THRESHOLD,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.vanilla import (
-    BeamSearchMetadata as BeamSearchMetadata,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.vanilla import Fusions as Fusions
-from tensorrt_llm._torch.pyexecutor.sampler.ops.vanilla import StrategyMetadata as StrategyMetadata
-from tensorrt_llm._torch.pyexecutor.sampler.ops.vanilla import (
-    beam_search_sampling_batch as beam_search_sampling_batch,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.vanilla import (
-    get_rejected_indices as get_rejected_indices,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.vanilla import (
-    greedy_search_sampling_batch as greedy_search_sampling_batch,
-)
-from tensorrt_llm._torch.pyexecutor.sampler.ops.vanilla import sample_rejected as sample_rejected
-from tensorrt_llm._torch.pyexecutor.sampler.ops.vanilla import (
-    top_k_top_p_sampling_batch as top_k_top_p_sampling_batch,
+    GREEDY_TEMPERATURE_THRESHOLD,
+    BeamSearchMetadata,
+    Fusions,
+    StrategyMetadata,
+    beam_search_sampling_batch,
+    get_rejected_indices,
+    greedy_search_sampling_batch,
+    sample_rejected,
+    top_k_top_p_sampling_batch,
 )
 from tensorrt_llm._utils import prefer_pinned
 from tensorrt_llm.sampling_params import SamplingParams
+
+# Ops imported above are re-exported for dependent modules (sampler, drafting
+# loops, tests). mypy runs in strict mode (no implicit re-export), so they must
+# be listed here.
+__all__ = [
+    "GREEDY_TEMPERATURE_THRESHOLD",
+    "BeamSearchMetadata",
+    "Fusions",
+    "StrategyMetadata",
+    "beam_search_sampling_batch",
+    "get_rejected_indices",
+    "greedy_search_sampling_batch",
+    "sample_rejected",
+    "sampling_from_probs_op",
+    "softmax_op",
+    "top_k_mask_logits_op",
+    "top_k_sampling_from_probs_op",
+    "top_k_top_p_sampling_batch",
+    "top_k_top_p_sampling_from_logits_op",
+    "top_p_renorm_probs_op",
+    "top_p_sampling_from_probs_op",
+]
 
 if sys.version_info[:2] >= (3, 12):
     from typing import override
@@ -824,9 +826,6 @@ class FlashInferGroupedStrategySampler:
         return next_tokens, softmax, strategy_impl.get_temperature()
 
 
-# Re-export the torch greedy op (used by drafting_loops and speculative/interface).
-greedy = greedy_search_sampling_batch
-
 # ---------------------------------------------------------------------------
 # Spec-decoding interface: compute_probs_from_logits (per-request tensor params)
 # ---------------------------------------------------------------------------
@@ -842,7 +841,7 @@ def sanitize_top_k(top_k: torch.Tensor, vocab_size: int) -> torch.Tensor:
     ``vocab_size`` (== keep all tokens), leaving genuine top_k values
     untouched.
     """
-    return torch.where(top_k > 0, top_k, torch.full_like(top_k, vocab_size)).clamp(max=vocab_size)
+    return top_k.clamp(max=vocab_size).masked_fill_(top_k <= 0, vocab_size)
 
 
 @torch.compile(options={"max-autotune": True})

--- a/tensorrt_llm/_torch/speculative/drafting_loops.py
+++ b/tensorrt_llm/_torch/speculative/drafting_loops.py
@@ -15,7 +15,8 @@ from typing import Optional, final
 import torch
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
-from tensorrt_llm._torch.pyexecutor.sampler.sampling_utils import greedy
+from tensorrt_llm._torch.pyexecutor.sampler.sampling_utils import \
+    greedy_search_sampling_batch
 from tensorrt_llm._torch.speculative.eagle3 import Eagle3SpecMetadata
 from tensorrt_llm._torch.speculative.interface import SpecMetadata
 from tensorrt_llm._torch.speculative.spec_tree_manager import SpecTreeManager
@@ -150,7 +151,7 @@ class LinearDraftingLoopWrapper(BaseDraftingLoopWrapper):
 
     def sample(self, logits: torch.Tensor) -> torch.Tensor:
         # TODO: inject the sampler here so we can support non-greedy
-        tokens, _ = greedy(logits, return_probs=False)
+        tokens, _ = greedy_search_sampling_batch(logits, return_probs=False)
         if hasattr(self.draft_model.model, "d2t"):
             d2t = self.draft_model.model.d2t.data
             return tokens + d2t[tokens]

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -42,7 +42,8 @@ if IS_FLASHINFER_AVAILABLE:
     import flashinfer
 
 from ..pyexecutor.sampler.sampling_utils import (
-    compute_probs_from_logits, greedy, sampling_batch_spec_dec_one_model,
+    compute_probs_from_logits, greedy_search_sampling_batch,
+    sampling_batch_spec_dec_one_model,
     sampling_batch_spec_dec_one_model_for_rejection)
 
 
@@ -1703,7 +1704,8 @@ class SpecWorkerBase(nn.Module, ABC):
         Returns:
             draft_tokens: [num_tokens] - Sampled draft token ids (int32)
         """
-        draft_tokens = greedy(logits, return_probs=False)[0]
+        draft_tokens = greedy_search_sampling_batch(logits,
+                                                    return_probs=False)[0]
 
         # Apply the cached draft->target vocab offset map.
         if self._d2t is not None:

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -2634,12 +2634,13 @@ class TestApplyBadWords:
     class MockLlmRequest:
         """Minimal stub exposing the attributes _apply_bad_words reads."""
 
-        def __init__(self, tokens, *, bad_words=None, prompt_len=0):
+        def __init__(self, tokens, *, bad_words=None, prompt_len=0, seq_slot=None):
             # get_tokens(beam) returns the full token sequence (prompt +
             # generated); py_orig_prompt_len marks where generation starts.
             self.py_orig_prompt_len = prompt_len
             self._tokens = list(tokens)
             self.py_bad_words = bad_words
+            self.py_seq_slot = seq_slot
 
         def get_tokens(self, beam_idx):
             return self._tokens
@@ -2679,3 +2680,79 @@ class TestApplyBadWords:
         req = self.MockLlmRequest(tokens=[1, 9], bad_words=[[9, 2]], prompt_len=2)
         logits = self._run([req], num_steps=[1], num_beams=[1])
         assert self._banned_cols(logits[0]) == {2}
+
+    # --- Overlap-scheduler (stale-host) path -------------------------------
+    #
+    # With the overlap scheduler the host token list lags the device state by
+    # one token; the newest token is read from new_tokens_cuda[0, seq_slot, 0]
+    # on the GPU. These tests drive _apply_bad_words with stale_by_one set.
+
+    NUM_SLOTS = 4
+
+    def _new_tokens_cuda(self, slot_tokens):
+        buf = torch.full((1, self.NUM_SLOTS, 1), -1, dtype=torch.int32, device="cuda")
+        for slot, tok in slot_tokens.items():
+            buf[0, slot, 0] = tok
+        return buf
+
+    def _run_stale(self, requests, stale_by_one, slot_tokens):
+        total_rows = len(requests)
+        logits = torch.zeros(total_rows, self.VOCAB, device="cuda")
+        TorchSampler._apply_bad_words(
+            logits,
+            cast(list[LlmRequest], requests),
+            [1] * len(requests),
+            [1] * len(requests),
+            new_tokens_cuda=self._new_tokens_cuda(slot_tokens),
+            stale_by_one=stale_by_one,
+        )
+        return logits
+
+    def test_stale_two_token_device_hit(self):
+        # Host context [1]; device holds the pending token 9; word [9, 2]
+        # completes its prefix on the device side -> ban token 2.
+        req = self.MockLlmRequest(tokens=[1], bad_words=[[9, 2]], seq_slot=0)
+        logits = self._run_stale([req], [True], {0: 9})
+        assert self._banned_cols(logits[0]) == {2}
+
+    def test_stale_two_token_device_miss(self):
+        # Device token is 3, not the required prefix 9 -> nothing banned.
+        req = self.MockLlmRequest(tokens=[1], bad_words=[[9, 2]], seq_slot=0)
+        logits = self._run_stale([req], [True], {0: 3})
+        assert self._banned_cols(logits[0]) == set()
+
+    def test_stale_three_token_host_and_device_hit(self):
+        # Word [5, 9, 2]: host suffix must be [5], device token must be 9.
+        req = self.MockLlmRequest(tokens=[1, 5], bad_words=[[5, 9, 2]], seq_slot=1)
+        logits = self._run_stale([req], [True], {1: 9})
+        assert self._banned_cols(logits[0]) == {2}
+
+    def test_stale_three_token_host_miss(self):
+        # Host suffix [3] does not match the word prefix [5]; the device token
+        # matching is irrelevant -> nothing banned.
+        req = self.MockLlmRequest(tokens=[1, 3], bad_words=[[5, 9, 2]], seq_slot=1)
+        logits = self._run_stale([req], [True], {1: 9})
+        assert self._banned_cols(logits[0]) == set()
+
+    def test_stale_single_token_unconditional(self):
+        # Single-token words are banned regardless of the device token.
+        req = self.MockLlmRequest(tokens=[1], bad_words=[[7]], seq_slot=0)
+        logits = self._run_stale([req], [True], {0: 3})
+        assert self._banned_cols(logits[0]) == {7}
+
+    def test_stale_and_fresh_requests_mixed(self):
+        # Request 0 (stale) matches via the device token; request 1 (fresh)
+        # matches via the host context, as on the regular path.
+        stale_req = self.MockLlmRequest(tokens=[1], bad_words=[[9, 2]], seq_slot=0)
+        fresh_req = self.MockLlmRequest(tokens=[1, 9], bad_words=[[9, 4]], seq_slot=1)
+        logits = self._run_stale([stale_req, fresh_req], [True, False], {0: 9})
+        assert self._banned_cols(logits[0]) == {2}
+        assert self._banned_cols(logits[1]) == {4}
+
+    def test_stale_conditional_and_unconditional_same_cell(self):
+        # An unconditional single-token ban and a device-conditional ban on the
+        # same logit must combine to -inf (no NaN from -inf + -inf).
+        req = self.MockLlmRequest(tokens=[1], bad_words=[[2], [9, 2]], seq_slot=0)
+        logits = self._run_stale([req], [True], {0: 9})
+        assert self._banned_cols(logits[0]) == {2}
+        assert not torch.isnan(logits).any()

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -2618,3 +2618,64 @@ class TestBatchedSampling:
                 input_offset += steps
 
         run_test_with_warmup(_uut_provider, max_sync_s=0.2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+class TestApplyBadWords:
+    """Unit tests for TorchSampler._apply_bad_words.
+
+    Single-token words are banned unconditionally; multi-token words ban their
+    final token only when the token suffix (prompt + generated) matches the
+    word prefix.
+    """
+
+    VOCAB = 16
+
+    class MockLlmRequest:
+        """Minimal stub exposing the attributes _apply_bad_words reads."""
+
+        def __init__(self, tokens, *, bad_words=None, prompt_len=0):
+            # get_tokens(beam) returns the full token sequence (prompt +
+            # generated); py_orig_prompt_len marks where generation starts.
+            self.py_orig_prompt_len = prompt_len
+            self._tokens = list(tokens)
+            self.py_bad_words = bad_words
+
+        def get_tokens(self, beam_idx):
+            return self._tokens
+
+    def _run(self, requests, num_steps, num_beams):
+        total_rows = sum(s * b for s, b in zip(num_steps, num_beams))
+        logits = torch.zeros(total_rows, self.VOCAB, device="cuda")
+        TorchSampler._apply_bad_words(
+            logits, cast(list[LlmRequest], requests), num_steps, num_beams
+        )
+        return logits
+
+    @staticmethod
+    def _banned_cols(logits_row):
+        return set(torch.nonzero(torch.isinf(logits_row)).flatten().tolist())
+
+    def test_single_token_unconditional(self):
+        req = self.MockLlmRequest(tokens=[3, 4], bad_words=[[7]])
+        logits = self._run([req], num_steps=[1], num_beams=[1])
+        assert self._banned_cols(logits[0]) == {7}
+
+    def test_multi_token_prefix_hit(self):
+        # tokens end with [9]; word [9, 2] -> ban token 2.
+        req = self.MockLlmRequest(tokens=[1, 9], bad_words=[[9, 2]])
+        logits = self._run([req], num_steps=[1], num_beams=[1])
+        assert self._banned_cols(logits[0]) == {2}
+
+    def test_multi_token_prefix_miss(self):
+        # tokens end with [3]; word [9, 2] prefix [9] does not match.
+        req = self.MockLlmRequest(tokens=[1, 3], bad_words=[[9, 2]])
+        logits = self._run([req], num_steps=[1], num_beams=[1])
+        assert self._banned_cols(logits[0]) == set()
+
+    def test_multi_token_prefix_in_prompt(self):
+        # The prefix [9] lies in the prompt (nothing generated yet); the word
+        # [9, 2] must still ban token 2.
+        req = self.MockLlmRequest(tokens=[1, 9], bad_words=[[9, 2]], prompt_len=2)
+        logits = self._run([req], num_steps=[1], num_beams=[1])
+        assert self._banned_cols(logits[0]) == {2}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of blocked words during text generation, making sampling respect user-provided forbidden words more consistently.
  * Multi-token blocked phrases now suppress the final token only when the recent context matches, reducing unintended matches.
  * Added coverage to verify blocked-word behavior in sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->
## Description

`TorchSampler` previously ignored `bad_words` / `bad_token_ids` (only the C++ `TRTLLMSampler` applied them). This PR adds enforcement, including correct behavior under the overlap scheduler.

### Bad-words masking in TorchSampler
- `llm_request.py`: mirror the executor request's `bad_words` as `py_bad_words`.
- `sampler.py`: add `TorchSampler._apply_bad_words` — single-token words are banned unconditionally; a multi-token word bans its final token only when the generated suffix matches the word prefix (matches C++ `ban_bad_words` semantics). Speculative steps reconstruct per-step context from `py_draft_tokens`.

### Overlap scheduler support
Under overlap, `sample_async(i)` runs before `update_requests(i-1)`, so the host token list lags the device by one token — multi-token prefix matching could miss or misapply bans. Fix, with no added device-to-host sync:
- Split the match: first `k-2` prefix tokens on the host, the newest token compared on-GPU against `store.new_tokens[0, seq_slot, 0]`; conditional ban applied via additive shape-static `index_put_`.
- Track per-slot pending (sampled-but-not-updated) steps to detect staleness; draft batches excluded.
- GPU path triggers only for overlap + no speculation + no beam search; spec/beam under overlap keeps prior behavior with a one-time warning. Non-overlap path unchanged.

### Post-merge review follow-ups for #16365 (@ixlmar)
- `ops/flashinfer.py`: missing flashinfer now raises an actionable `ImportError` on op use (module stays importable; startup enforcement stays in `TorchSampler.__init__`).
- `sampling_utils.py`: replace `import y as y` re-exports with plain imports + `__all__`; drop the `greedy` alias (callers use `greedy_search_sampling_batch`); `sanitize_top_k` uses `clamp(...).masked_fill_(...)`.

### Follow-up (out of scope)
Batched device-side bad-words matching via the stop-words machinery (`past_tokens_cuda`) would remove the host loop and cover spec/beam under overlap natively.

## Test Coverage
- `test_torch_sampler.py::TestApplyBadWords` (11 cases): regular path (single/multi-token hit/miss, prefix in prompt) and overlap path (device-side hit/miss, host+device combined, mixed stale/fresh batches, overlapping bans → no NaN).
- Full `test_torch_sampler.py` suite: 207 passed, no regressions (B200; skips are Ampere-gated).


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
