### PR TITLE
[None][feat] Support externally provided MPI sessions with explicit ownership

### DIFF
--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -1240,7 +1240,28 @@ def init_pp_comm(mapping):
     global _pp_comm
     if mpi_disabled():
         _pp_comm = PPCommTorch(mapping)
+    elif isinstance(_pp_comm, PPCommNCCL) and \
+            _pp_comm.mapping.world_size == mapping.world_size:
+        # Reuse the existing world NCCL communicator across LLM instances that
+        # share the same worker processes (e.g. a reused MpiPoolSession). The
+        # underlying comm depends only on (world_size, rank) -- it is a world
+        # communicator, independent of the pp/tp/ep layout -- so only the
+        # routing mapping needs refreshing. Recreating it would drop the old
+        # comm and trigger a collective ncclCommDestroy at an unsynchronized
+        # point during the next model build, which can deadlock on reused
+        # workers. Single-LLM (production) runs are unaffected: _pp_comm starts
+        # as None, so the first call still constructs a fresh PPCommNCCL.
+        _pp_comm.mapping = mapping
     else:
+        if _pp_comm is not None:
+            # Rebinding drops the old comm; its ncclCommDestroy runs at an
+            # unsynchronized point and can deadlock on reused worker processes
+            # (see the reuse branch above). Surface it instead of hanging
+            # silently -- pools sharing workers must keep one world_size.
+            logger.warning(
+                "init_pp_comm: replacing existing PP comm (world_size "
+                f"{_pp_comm.mapping.world_size} -> {mapping.world_size}) on a "
+                "live process; this can deadlock on reused MPI workers.")
         _pp_comm = PPCommNCCL(mapping)
     init_helix_cp_comm(mapping)
 

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -652,7 +652,7 @@ class GenerationExecutor(ABC):
             return GenerationExecutor._create_ipc_executor(
                 worker_kwargs,
                 model_world_size=model_world_size,
-                mpi_session=None,  # use mpi4py
+                mpi_session=mpi_session,
                 postproc_worker_config=postproc_worker_config,
                 is_llm_executor=is_llm_executor,
                 use_worker=False)
@@ -662,13 +662,17 @@ class GenerationExecutor(ABC):
             mpi_session = ProcessPoolExecutorSession(n_workers=1,
                                                      mp_context=ctx)
             # TODO: add rpc worker here
-            return GenerationExecutor._create_ipc_executor(
+            executor = GenerationExecutor._create_ipc_executor(
                 worker_kwargs,
                 model_world_size=model_world_size,
                 mpi_session=mpi_session,
                 postproc_worker_config=postproc_worker_config,
                 is_llm_executor=is_llm_executor,
                 use_worker=False)
+            # The session was created right here with no outer owner, so the
+            # proxy must shut it down despite it arriving as "external".
+            executor._owns_mpi_session = True
+            return executor
 
     def wait_first_completed(
         self, futures: List[GenerationResult]

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -29,7 +29,8 @@ from tensorrt_llm.logger import logger
 
 from .._utils import customized_gc_thresholds, mpi_rank, nvtx_range_debug
 from ..llmapi.mpi_session import (MpiCommSession, MpiPoolSession, MpiSession,
-                                  RemoteMpiCommSessionClient)
+                                  RemoteMpiCommSessionClient,
+                                  validate_session_world_size)
 from ..llmapi.tracer import enable_llm_tracer, get_tracer, global_tracer
 from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
                             enable_llm_debug, logger_debug, print_colored)
@@ -117,6 +118,7 @@ class GenerationExecutorProxy(GenerationExecutor):
         self.worker_cls = worker_cls
 
         mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
+        self._owns_mpi_session = mpi_session is None
 
         if mpi_session is None:
             if mpi_process_pre_spawned:
@@ -126,6 +128,10 @@ class GenerationExecutorProxy(GenerationExecutor):
                 logger_debug('create pool session ...\n', "yellow")
                 self.mpi_session = MpiPoolSession(n_workers=model_world_size)
         else:
+            # submit() launches one worker task per pool worker, so an
+            # external session must match the model's world size exactly;
+            # fail loudly instead of starting the wrong number of executors.
+            validate_session_world_size(mpi_session, model_world_size)
             logger_debug('using external mpi session ...\n', "yellow")
             self.mpi_session = mpi_session
 
@@ -406,11 +412,11 @@ class GenerationExecutorProxy(GenerationExecutor):
         return self._resource_governor_queue
 
     def abort_request(self, request_id: int) -> None:
-        ''' Abort a request by sending a cancelling request to the request queue.
+        """Abort a request by sending a cancelling request to the request queue.
 
         Args:
             request_id (int): The id of the request to abort.
-        '''
+        """
         # NOTE, it just sends a cancelling request to the request queue, but it
         # may take a while for the request to be cancelled in the worker and
         # send back a finished result.
@@ -543,7 +549,10 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         if ready_signal != GenerationExecutorProxy.READY_SIGNAL:
             logger.error(f"Executor worker initialization error: {error_trace}")
-            self.mpi_session.shutdown_abort(reason=ready_signal)
+            # Only abort a session this proxy created; an externally owned
+            # (shared) session must stay alive for its owner to tear down.
+            if self._owns_mpi_session:
+                self.mpi_session.shutdown_abort(reason=ready_signal)
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
@@ -630,7 +639,8 @@ class GenerationExecutorProxy(GenerationExecutor):
             self._resource_governor_queue.close()
 
         self.workers_started = False
-        self.mpi_session.shutdown()
+        if self._owns_mpi_session:
+            self.mpi_session.shutdown()
 
         # Process the errors in-case error during shutting down the threads
         self._handle_background_error()

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -16,7 +16,8 @@ import json
 import threading
 from typing import List, Optional, Union
 
-from ..llmapi.mpi_session import MpiPoolSession, MpiSession
+from ..llmapi.mpi_session import (MpiPoolSession, MpiSession,
+                                  validate_session_world_size)
 from ..llmapi.utils import logger_debug, print_colored
 from ..logger import logger
 from .executor import GenerationExecutor
@@ -42,13 +43,12 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         postproc_worker_config: Optional[PostprocWorkerConfig] = None,
         is_llm_executor: Optional[bool] = None,
     ):
-        """
-        Args:
-            worker_kwargs: kwargs for the rpc worker
-            model_world_size: the world size of the model
-            mpi_session: the mpi session to use
-            postproc_worker_config: the postproc worker config
-            is_llm_executor: whether this is an llm executor
+        """Args:
+        worker_kwargs: kwargs for the rpc worker
+        model_world_size: the world size of the model
+        mpi_session: the mpi session to use
+        postproc_worker_config: the postproc worker config
+        is_llm_executor: whether this is an llm executor
         """
         GenerationExecutorRpcProxy.INSTANCE_COUNTER += 1
         self.init_rpc_executor()
@@ -81,11 +81,13 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         self._setup_mainloop_with_tasks()
 
     def launch_workers(self):
-        logger.debug(f"Launching workers")
+        logger.debug("Launching workers")
         assert self.mpi_session is not None
-        self.mpi_session.submit(RpcWorker.main_task,
-                                rpc_addr=self.rpc_addr,
-                                **self.worker_kwargs)
+        # Keep the futures: on an externally owned (shared) session, shutdown
+        # waits on them so worker teardown finishes before the pool is reused.
+        self.worker_futures = self.mpi_session.submit(RpcWorker.main_task,
+                                                      rpc_addr=self.rpc_addr,
+                                                      **self.worker_kwargs)
 
     def _setup_mainloop_with_tasks(self):
         """Setup mainloop with tasks needed for RpcProxy.
@@ -256,7 +258,7 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         return self.rpc_client.setup_engine().remote(need_response=True)
 
     def shutdown_remote(self):
-        logger_debug(f"Shutting down rpc remote", color="yellow")
+        logger_debug("Shutting down rpc remote", color="yellow")
         self.rpc_client.shutdown().remote(need_response=False)
 
     def abort_request(self, request_id: int) -> None:
@@ -266,8 +268,7 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         if self._shutdown_event.is_set():
             return
         self._shutdown_event.set()
-        logger_debug(f"Shutting down GenerationExecutorRpcProxy",
-                     color="yellow")
+        logger_debug("Shutting down GenerationExecutorRpcProxy", color="yellow")
 
         # 1. shutdown the rpc server (PyExecutor Rank 0 + RPC server)
         self.shutdown_remote()
@@ -294,9 +295,24 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         # 3. shutdown the mpi session, this should wait until all the PyExecutor
         # processes are shutdown
         if self.mpi_session is not None:
-            logger_debug(f"Shutting down mpi session", color="yellow")
-            self.mpi_session.shutdown()
-            logger_debug(f"Mpi session shutdown", color="yellow")
+            if self._owns_mpi_session:
+                logger_debug("Shutting down mpi session", color="yellow")
+                self.mpi_session.shutdown()
+            else:
+                # Externally owned (shared) session: leave the pool alive, but
+                # wait for this executor's worker tasks to finish so the next
+                # LLM on the pool doesn't race with PyExecutor teardown. Block
+                # without a timeout, mirroring the owned path above
+                # (mpi_session.shutdown() also waits indefinitely); a timeout
+                # that expires would just reintroduce the race it prevents.
+                for future in getattr(self, "worker_futures", []):
+                    try:
+                        future.result()
+                    except Exception as e:
+                        logger.warning(
+                            f"RPC worker task raised during shutdown on "
+                            f"shared MPI session: {e}")
+            logger_debug("Mpi session shutdown", color="yellow")
             self.mpi_session = None
 
         self.rpc_client.close()
@@ -309,8 +325,12 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
 
     def _create_mpi_session(self, model_world_size: int,
                             mpi_session: Optional[MpiSession]):
+        # Ownership is decided here, next to the create-vs-adopt branch: a
+        # session this proxy created is shut down by it; an external one is
+        # owned (and shut down) by the caller.
         mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
         if mpi_session is None:
+            self._owns_mpi_session = True
             if mpi_process_pre_spawned:
                 logger_debug('[proxy] create comm session ...\n', "yellow")
                 self.mpi_session = create_mpi_comm_session(model_world_size)
@@ -318,5 +338,7 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
                 logger_debug('[proxy] create pool session ...\n', "yellow")
                 self.mpi_session = MpiPoolSession(n_workers=model_world_size)
         else:
+            validate_session_world_size(mpi_session, model_world_size)
+            self._owns_mpi_session = False
             logger_debug('[proxy] using external mpi session ...\n', "yellow")
             self.mpi_session = mpi_session

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -314,6 +314,10 @@ class BaseLLM:
         logger_debug(f"LLM.args.mpi_session: {self.args.mpi_session}\n",
                      "yellow")
         self.mpi_session = self.args.mpi_session
+        # Keep the live session on LLM only. LLM args are passed to model-build
+        # tasks and executor workers, and MpiSession objects are not pickleable.
+        self.args.mpi_session = None
+        self._owns_mpi_session = self.mpi_session is None
 
         # Build this LLM's post-processing hook for the in-proxy detok path (each
         # postproc worker builds its own). Resolving here fails fast on a bad
@@ -333,6 +337,8 @@ class BaseLLM:
             logger.info(
                 f'start MpiSession with {self.args.parallel_config.world_size} workers'
             )
+            # _owns_mpi_session is already True here: this branch only runs
+            # when no external session was supplied.
             if not self.mpi_session:
                 mpi_process_pre_spawned: bool = get_spawn_proxy_process_env()
                 if not mpi_process_pre_spawned:
@@ -365,7 +371,9 @@ class BaseLLM:
             self._build_model()
 
         except Exception:
-            if self.mpi_session is not None:
+            # _owns_mpi_session is assigned before this try block, so it is
+            # always present here.
+            if self.mpi_session is not None and self._owns_mpi_session:
                 self.mpi_session.shutdown()
             raise
 
@@ -1500,7 +1508,8 @@ class BaseLLM:
             self._encoder_executor.shutdown()
             self._encoder_executor = None
 
-        if hasattr(self, 'mpi_session') and self.mpi_session is not None:
+        if (hasattr(self, 'mpi_session') and self.mpi_session is not None
+                and getattr(self, "_owns_mpi_session", True)):
             self.mpi_session.shutdown()
             self.mpi_session = None
 

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -28,7 +28,7 @@ T = TypeVar("T")
 
 
 class MPINodeState:
-    ''' MPINodeState acts as a central global state shares between tasks on MPI node.
+    """MPINodeState acts as a central global state shares between tasks on MPI node.
 
     An example:
         def task():
@@ -45,7 +45,7 @@ class MPINodeState:
         This should produce the following output:
         - [1, 1, 1, 1]
         - [2, 2, 2, 2]
-    '''
+    """
 
     state = None
     # Global MPICommExecutor instance to be reused across multiple MpiCommSession instances
@@ -59,9 +59,9 @@ class MPINodeState:
 
 
 def external_mpi_comm_available(model_world_size: int) -> bool:
-    ''' Check if the current process is launched by mpirun and does not use MPIPoolExecutor to spawn processes.
+    """Check if the current process is launched by mpirun and does not use MPIPoolExecutor to spawn processes.
     e.g. mpirun -np 4 python script.py
-    '''
+    """
     if ENABLE_MULTI_DEVICE:
         return (get_mpi_world_size() == model_world_size
                 and model_world_size > 1) or (global_mpi_size()
@@ -71,7 +71,7 @@ def external_mpi_comm_available(model_world_size: int) -> bool:
 
 
 def need_spawn_mpi_workers(model_world_size: int) -> bool:
-    ''' Check if the current process needs to spawn MPI workers. '''
+    """Check if the current process needs to spawn MPI workers."""
     if ENABLE_MULTI_DEVICE:
         return get_mpi_world_size() == 1 and model_world_size > 1
     else:
@@ -83,6 +83,20 @@ def set_mpi_session_cpp(comm):
         comm_fortran = comm.py2f()
         from tensorrt_llm.bindings import MpiComm
         MpiComm.set_raw_mpi_session_by_fortran_handle(comm_fortran)
+
+
+def validate_session_world_size(mpi_session, model_world_size: int) -> None:
+    """Fail loudly when an external session cannot serve ``model_world_size``.
+
+    ``submit()`` launches one worker task per pool worker, so an externally
+    provided session must match the model's world size exactly; otherwise the
+    wrong number of executors would start.
+    """
+    external_workers = getattr(mpi_session, "n_workers", None)
+    if external_workers is not None and external_workers != model_world_size:
+        raise ValueError(
+            f"External MPI session has {external_workers} workers but "
+            f"the model needs world_size={model_world_size}.")
 
 
 class MpiSession(abc.ABC):
@@ -220,13 +234,13 @@ class MpiCommSession(MpiSession):
 
     def submit(self, task: Callable[..., T], *args,
                **kwargs) -> List[Future[T]]:
-        ''' Submit a task to MPI workers.
+        """Submit a task to MPI workers.
 
         Args:
             task: The task to be submitted.
             args: Positional arguments for the task.
             kwargs: Keyword arguments for the task.
-        '''
+        """
         assert self.mpi_pool is not None, 'MPI session not started'
         worker_futures = [
             self.mpi_pool.submit(task, *args, **kwargs)
@@ -281,7 +295,7 @@ class MpiCommSession(MpiSession):
             self.owns_mpi_pool = False
         else:
             logger_debug(
-                f"_start_mpi_pool: Creating new MPICommExecutor (not COMM_WORLD or ENABLE_MULTI_DEVICE=False)\n",
+                "_start_mpi_pool: Creating new MPICommExecutor (not COMM_WORLD or ENABLE_MULTI_DEVICE=False)\n",
                 "grey")
             # For non-COMM_WORLD communicators, create a new executor
             comm_executor = MPICommExecutor(self.comm)
@@ -323,12 +337,11 @@ class RemoteWorkerDeath(NamedTuple):
 
 
 class RemoteMpiCommSessionClient(MpiSession):
-    '''
-    RemoteMpiCommSessionClient is a variant of MpiCommSession that is used to connect to a remote MPI pool.
+    """RemoteMpiCommSessionClient is a variant of MpiCommSession that is used to connect to a remote MPI pool.
 
     Note: This class uses a global singleton pattern because ZeroMQ PAIR sockets only support
     one connection at a time. Multiple LLM instances will reuse the same client connection.
-    '''
+    """
     _global_instance = None
     _global_instance_lock = threading.Lock()
 
@@ -374,7 +387,7 @@ class RemoteMpiCommSessionClient(MpiSession):
                *args,
                sync: bool = False,
                **kwargs) -> list:
-        ''' Submit a task to the remote MPI pool. '''
+        """Submit a task to the remote MPI pool."""
         if self._is_shutdown:
             logger_debug("RemoteMpiCommSessionClient is already shut down\n",
                          "yellow")
@@ -388,7 +401,7 @@ class RemoteMpiCommSessionClient(MpiSession):
     SYNC_IDLE_INTERVAL = 8
 
     def submit_sync(self, task, *args, **kwargs) -> List[T]:
-        ''' Submit a task to the remote MPI pool and wait for task completion. '''
+        """Submit a task to the remote MPI pool and wait for task completion."""
         self.submit(task, *args, sync=True, **kwargs)
 
         while not ((res := self.poll()) or self._is_shutdown):
@@ -405,10 +418,11 @@ class RemoteMpiCommSessionClient(MpiSession):
         return res
 
     def poll(self) -> bool:
-        ''' Poll the queue for a response.
+        """Poll the queue for a response.
+
         Returns:
             True if a response is received, False otherwise.
-        '''
+        """
         if self._is_shutdown:
             return False
         if self._pending_responses:
@@ -447,7 +461,7 @@ class RemoteMpiCommSessionClient(MpiSession):
         # LLM instances. Marking it as shutdown would prevent subsequent LLM instances from
         # using it. The connection stays open for the entire lifetime of the mgmn setup.
         logger_debug(
-            f"RemoteMpiCommSessionClient.shutdown() called (no-op for singleton)\n",
+            "RemoteMpiCommSessionClient.shutdown() called (no-op for singleton)\n",
             "grey")
 
     def shutdown_abort(self, grace: float = 60, reason=None):
@@ -455,14 +469,13 @@ class RemoteMpiCommSessionClient(MpiSession):
 
 
 class RemoteMpiCommSessionServer():
-    '''
-    RemoteMpiCommSessionServer is a variant of MpiCommSession that is used to create a remote MPI pool.
-    '''
+    """RemoteMpiCommSessionServer is a variant of MpiCommSession that is used to create a remote MPI pool.
+    """
 
     def __init__(self,
                  hmac_key: bytes,
                  n_workers: int = 0,
-                 addr: str = f'tcp://127.0.0.1:*',
+                 addr: str = 'tcp://127.0.0.1:*',
                  comm=None,
                  is_comm: bool = False):
         # FIXME: this is a hack to avoid circular import, resolve later
@@ -612,7 +625,7 @@ class RemoteMpiCommSessionServer():
             "grey")
         if len(self.results) == self.num_results:
             logger_debug(
-                f"RemoteMpiCommSessionServer received all results, sending to client\n",
+                "RemoteMpiCommSessionServer received all results, sending to client\n",
                 "green")
             try:
                 self.queue.put_noblock(self.results, retry=2)
@@ -623,7 +636,7 @@ class RemoteMpiCommSessionServer():
                 else:
                     raise e
 
-            logger_debug(f"RemoteMpiCommSessionServer sent results to client\n",
+            logger_debug("RemoteMpiCommSessionServer sent results to client\n",
                          "green")
             self.results.clear()
 
@@ -653,8 +666,7 @@ def get_mpi_world_size() -> int:
 
 
 def split_mpi_env(mpi_env_keys: List[str] | None = None) -> Tuple[dict, dict]:
-    '''
-    Splits the environment variables into MPI-related and non-MPI-related dictionaries.
+    """Splits the environment variables into MPI-related and non-MPI-related dictionaries.
 
     Args:
         mpi_env_keys: Additional environment variables to be considered as MPI-related.
@@ -663,7 +675,7 @@ def split_mpi_env(mpi_env_keys: List[str] | None = None) -> Tuple[dict, dict]:
         Tuple[dict, dict]: (non_mpi_env, mpi_env)
             - non_mpi_env: Environment dictionary without MPI-related variables
             - mpi_env: Environment dictionary containing only MPI-related variables
-    '''
+    """
     current_env = os.environ.copy()
 
     # Identify MPI-related variables


### PR DESCRIPTION
## Summary

Core MPI session lifecycle only (split out of #15777 per review):

- **Accept an externally created MPI session**: `GenerationExecutorProxy` / `GenerationExecutorRpcProxy` adopt a caller-provided `MpiPoolSession`; its size is validated against the model world size via a shared `validate_session_world_size()` in `mpi_session.py` (an external session must match exactly, else the wrong number of executor workers would start).
- **Owned vs borrowed**: `_owns_mpi_session` in `llm.py`, `proxy.py`, `rpc_proxy.py`. Borrowed sessions are never shut down by the LLM or the executor — on normal or exceptional paths; `shutdown_abort` is equally gated. The rpc_proxy non-owning shutdown blocks on outstanding worker futures for parity with the owned path.
- **Minimal communicator change for reused workers**: `init_pp_comm` reuses the existing `PPCommNCCL` when world size is unchanged, and warns when replacing a live comm of a different world size.

No test-specific optimization and no weight-loader behavior in this PR.

## Companion PRs

- HF weight-loader cache: #16054
- Test-side automatic session reuse: #16055

Each is independently mergeable; together they supersede #15777.

## Test plan

- [x] Exercised end-to-end by the test-side companion PR's validation on B200 (multi-GPU suite 15 passed with shared sessions; DeepSeek-V3-Lite accuracy 4 layouts at reference)
- [x] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MPI session handling so existing sessions are reused more safely during model startup and shutdown.
  * Added validation to catch mismatches between session size and model size earlier, preventing incorrect executor launches.
  * Fixed cleanup behavior so externally managed sessions are no longer shut down unexpectedly.
  * Improved shutdown coordination for worker processes to reduce hangs and deadlock risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->