### PR TITLE
[None][feat] Add an opt-in raw-weight cache to the HF weight loader

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -15,6 +15,8 @@
 import glob
 import multiprocessing
 import os
+import threading
+from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List
 
@@ -33,6 +35,15 @@ from tensorrt_llm._utils import (ENABLE_MULTI_DEVICE, local_mpi_barrier,
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
+_WEIGHT_CACHE_ENV = "TRTLLM_HF_WEIGHT_CACHE"
+_WEIGHT_CACHE_MAX_ENTRIES_ENV = "TRTLLM_HF_WEIGHT_CACHE_MAX_ENTRIES"
+# Default to a single cached checkpoint: each entry pins a full copy of the
+# raw weights in CPU RAM, so callers wanting cross-model caching must opt in
+# via TRTLLM_HF_WEIGHT_CACHE_MAX_ENTRIES.
+_DEFAULT_WEIGHT_CACHE_MAX_ENTRIES = 1
+_WEIGHT_CACHE_LOCK = threading.Lock()
+_WEIGHT_CACHE: OrderedDict[tuple, dict[str, Any]] = OrderedDict()
+
 
 @register_checkpoint_weight_loader("MX")
 @register_checkpoint_weight_loader("mistral")
@@ -42,6 +53,75 @@ class HfWeightLoader(BaseWeightLoader):
     """
     Loads weights from SafeTensors/bin/pth files.
     """
+
+    @staticmethod
+    def _is_weight_cache_enabled() -> bool:
+        return os.environ.get(_WEIGHT_CACHE_ENV,
+                              "0").lower() in ("1", "true", "yes", "on")
+
+    @staticmethod
+    def _weight_cache_max_entries() -> int:
+        try:
+            return max(
+                0,
+                int(
+                    os.environ.get(_WEIGHT_CACHE_MAX_ENTRIES_ENV,
+                                   _DEFAULT_WEIGHT_CACHE_MAX_ENTRIES)))
+        except ValueError:
+            logger.warning(
+                f"Invalid {_WEIGHT_CACHE_MAX_ENTRIES_ENV} value; disabling HF weight cache."
+            )
+            return 0
+
+    @staticmethod
+    def _weight_files_cache_key(weight_files: List[str],
+                                use_consolidated: bool) -> tuple:
+        file_fingerprint = []
+        for file_name in sorted(weight_files):
+            stat = os.stat(file_name)
+            file_fingerprint.append(
+                (os.path.abspath(file_name), stat.st_size, stat.st_mtime_ns))
+        return (tuple(file_fingerprint), use_consolidated)
+
+    @classmethod
+    def _clear_weight_cache(cls) -> None:
+        with _WEIGHT_CACHE_LOCK:
+            _WEIGHT_CACHE.clear()
+
+    @staticmethod
+    def _evict_to_make_room() -> None:
+        """Evict LRU entries on a miss BEFORE the new load, so CPU never holds
+        the old (cached) and new (loading) weights at once (a ~2x peak)."""
+        max_entries = HfWeightLoader._weight_cache_max_entries()
+        if max_entries <= 0:
+            return
+        with _WEIGHT_CACHE_LOCK:
+            while len(_WEIGHT_CACHE) >= max_entries:
+                _WEIGHT_CACHE.popitem(last=False)
+
+    @staticmethod
+    def _cache_loaded_weights(cache_key: tuple,
+                              loaded_weights: dict[str, Any]) -> None:
+        max_entries = HfWeightLoader._weight_cache_max_entries()
+        if max_entries <= 0:
+            return
+
+        HfWeightLoader._evict_to_make_room()
+        with _WEIGHT_CACHE_LOCK:
+            _WEIGHT_CACHE[cache_key] = dict(loaded_weights)
+
+    @staticmethod
+    def _get_cached_weights(cache_key: tuple) -> ConsumableWeightsDict | None:
+        with _WEIGHT_CACHE_LOCK:
+            weights = _WEIGHT_CACHE.get(cache_key)
+            if weights is None:
+                return None
+            _WEIGHT_CACHE.move_to_end(cache_key)
+            # Return a fresh dict wrapper because model loaders call
+            # mark_consumed(). Tensor values are intentionally shared: this
+            # cache targets read-only raw checkpoint tensors, not per-config
+            # materialized module weights.
+            return ConsumableWeightsDict(dict(weights))
 
     @staticmethod
     def _get_local_available_host_memory() -> int:
@@ -61,6 +141,36 @@ class HfWeightLoader(BaseWeightLoader):
                                               op=_MPI.MIN)
         return available_host_memory
 
+    def _with_weight_cache(self, weight_files: List[str],
+                           use_consolidated: bool, barrier_on_hit: bool,
+                           load_fn) -> ConsumableWeightsDict:
+        """Wrap ``load_fn`` with the optional raw-weight cache.
+
+        Key -> hit (optionally joining the local barrier the miss path is
+        about to enter) -> evict-before-load (so CPU never holds the old
+        cached and the new loading weights at once) -> load -> store.
+        """
+        cache_key = self._weight_files_cache_key(
+            weight_files,
+            use_consolidated) if self._is_weight_cache_enabled() else None
+        if cache_key is not None:
+            cached_weights = self._get_cached_weights(cache_key)
+            if cached_weights is not None:
+                logger.info("Reusing cached HF checkpoint weights.")
+                if barrier_on_hit:
+                    # The safetensors miss path has a local barrier before
+                    # deserialization. Cache hits must participate as well:
+                    # rank-local caches can diverge after eviction, and a hit
+                    # on one rank must not skip a barrier that a miss on
+                    # another rank is about to enter.
+                    local_mpi_barrier()
+                return cached_weights
+            self._evict_to_make_room()
+        weights = load_fn()
+        if cache_key is not None:
+            self._cache_loaded_weights(cache_key, weights)
+        return weights
+
     def load_weights(self,
                      checkpoint_dir: str,
                      mapping: Mapping,
@@ -77,41 +187,53 @@ class HfWeightLoader(BaseWeightLoader):
         if len(filtered_weight_files) > 0:
             weight_files = filtered_weight_files
         if weight_files:
-            # Prefetch the weight files to CPU memory if the size is less than 90% of the available memory.
-            # This is a heuristic to avoid prefetching files that are too large and causing file cache thrashing.
-            prefetch_size = sum(os.path.getsize(file) for file in weight_files)
-            # If the layer number is overridden, it indicates that only a subset of layers are loaded.
-            # Prefetching all layers is unnecessary.
-            num_layers = int(os.environ.get("TLLM_OVERRIDE_LAYER_NUM", "0"))
-            enable_prefetch = (prefetch_size
-                               < self._get_local_available_host_memory() * 0.9
-                               and num_layers == 0)
-            if enable_prefetch:
-                logger.info(
-                    f"Prefetching {prefetch_size / (1024**3):.2f}GB checkpoint files."
-                )
-                self.prefetch_files(weight_files)
-            # Sync all local ranks unconditionally. `enable_prefetch` depends on
-            # `psutil.virtual_memory().available`, a per-rank volatile value, so
-            # different ranks may take different branches; gating the barrier on
-            # it would deadlock between ranks that prefetched and ranks that
-            # skipped. Ranks that didn't prefetch reach the barrier immediately.
-            local_mpi_barrier()
-
-            return self._load_weights_in_parallel(
-                weight_files, self._load_safetensors_file,
-                "Loading safetensors weights in parallel")
+            return self._with_weight_cache(
+                weight_files,
+                use_consolidated,
+                barrier_on_hit=True,
+                load_fn=lambda: self._prefetch_and_load(weight_files))
 
         weight_files = glob.glob(f"{checkpoint_dir}/*.bin")
         if not weight_files:
             weight_files = glob.glob(f"{checkpoint_dir}/*.pth")
 
         if weight_files:
-            return self._load_weights_in_parallel(
-                weight_files, self._load_bin_or_path_file,
-                "Loading bin weights in parallel")
+            return self._with_weight_cache(
+                weight_files,
+                use_consolidated,
+                barrier_on_hit=False,
+                load_fn=lambda: self._load_weights_in_parallel(
+                    weight_files, self._load_bin_or_path_file,
+                    "Loading bin weights in parallel"))
 
         raise RuntimeError(f"No weight files found in {checkpoint_dir}.")
+
+    def _prefetch_and_load(self,
+                           weight_files: List[str]) -> ConsumableWeightsDict:
+        # Prefetch the weight files to CPU memory if the size is less than 90% of the available memory.
+        # This is a heuristic to avoid prefetching files that are too large and causing file cache thrashing.
+        prefetch_size = sum(os.path.getsize(file) for file in weight_files)
+        # If the layer number is overridden, it indicates that only a subset of layers are loaded.
+        # Prefetching all layers is unnecessary.
+        num_layers = int(os.environ.get("TLLM_OVERRIDE_LAYER_NUM", "0"))
+        enable_prefetch = (prefetch_size
+                           < self._get_local_available_host_memory() * 0.9
+                           and num_layers == 0)
+        if enable_prefetch:
+            logger.info(
+                f"Prefetching {prefetch_size / (1024**3):.2f}GB checkpoint files."
+            )
+            self.prefetch_files(weight_files)
+        # Sync all local ranks unconditionally. `enable_prefetch` depends on
+        # `psutil.virtual_memory().available`, a per-rank volatile value, so
+        # different ranks may take different branches; gating the barrier on
+        # it would deadlock between ranks that prefetched and ranks that
+        # skipped. Ranks that didn't prefetch reach the barrier immediately.
+        local_mpi_barrier()
+
+        return self._load_weights_in_parallel(
+            weight_files, self._load_safetensors_file,
+            "Loading safetensors weights in parallel")
 
     def _load_weights_in_parallel(self, weight_files: List[str], load_func,
                                   description: str) -> ConsumableWeightsDict:

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -100,29 +100,75 @@ class HfWeightLoader(BaseWeightLoader):
                 _WEIGHT_CACHE.popitem(last=False)
 
     @staticmethod
+    def _tensor_sig(t: torch.Tensor) -> tuple:
+        """A cheap integrity fingerprint: shape, dtype and a sampled sum.
+
+        Recomputing the same sum over the same (unmutated) memory is exactly
+        deterministic, so plain equality detects in-place mutation. Sampling
+        up to 1024 strided elements keeps this at microseconds per tensor.
+        """
+        flat = t.detach().reshape(-1)
+        stride = max(1, flat.numel() // 1024)
+        sample = flat[::stride][:1024]
+        return (tuple(t.shape), str(t.dtype),
+                float(torch.nan_to_num(sample.float()).sum()))
+
+    @staticmethod
+    def _fingerprint(weights: dict[str, Any]) -> dict[str, tuple]:
+        return {
+            key: HfWeightLoader._tensor_sig(value)
+            for key, value in weights.items() if torch.is_tensor(value)
+        }
+
+    @staticmethod
     def _cache_loaded_weights(cache_key: tuple,
                               loaded_weights: dict[str, Any]) -> None:
         max_entries = HfWeightLoader._weight_cache_max_entries()
         if max_entries <= 0:
             return
 
+        weights = dict(loaded_weights)
+        # Fingerprint outside the lock; the cache shares tensors across loads
+        # (read-only by contract), and the fingerprint turns a violation of
+        # that contract into a detected, self-healing miss instead of
+        # silently corrupted weights (see _get_cached_weights).
+        sigs = HfWeightLoader._fingerprint(weights)
         # Room was already made by the caller-side evict-before-load in
         # _with_weight_cache (the load-bearing one for the memory peak).
         with _WEIGHT_CACHE_LOCK:
-            _WEIGHT_CACHE[cache_key] = dict(loaded_weights)
+            _WEIGHT_CACHE[cache_key] = (weights, sigs)
 
     @staticmethod
     def _get_cached_weights(cache_key: tuple) -> ConsumableWeightsDict | None:
         with _WEIGHT_CACHE_LOCK:
-            weights = _WEIGHT_CACHE.get(cache_key)
-            if weights is None:
+            entry = _WEIGHT_CACHE.get(cache_key)
+            if entry is None:
                 return None
+            weights, sigs = entry
             _WEIGHT_CACHE.move_to_end(cache_key)
-            # Return a fresh dict wrapper because model loaders call
-            # mark_consumed(). Tensor values are intentionally shared: this
-            # cache targets read-only raw checkpoint tensors, not per-config
-            # materialized module weights.
-            return ConsumableWeightsDict(dict(weights))
+        # Integrity check: cached tensors are shared, so an earlier consumer
+        # mutating them in place (e.g. an in-place transform in a weight
+        # mapper) would poison every later load. Detect it, name the culprit
+        # keys, drop the entry and let the caller reload from disk.
+        mutated = [
+            key for key, sig in sigs.items()
+            if HfWeightLoader._tensor_sig(weights[key]) != sig
+        ]
+        if mutated:
+            logger.warning(
+                "HF weight cache entry was mutated in place since it was "
+                f"stored (keys: {mutated[:5]}{'...' if len(mutated) > 5 else ''}); "
+                "dropping it and reloading from disk. Weight preprocessing "
+                "must not mutate raw checkpoint tensors.")
+            with _WEIGHT_CACHE_LOCK:
+                if _WEIGHT_CACHE.get(cache_key) is entry:
+                    del _WEIGHT_CACHE[cache_key]
+            return None
+        # Return a fresh dict wrapper because model loaders call
+        # mark_consumed(). Tensor values are intentionally shared: this
+        # cache targets read-only raw checkpoint tensors, not per-config
+        # materialized module weights.
+        return ConsumableWeightsDict(dict(weights))
 
     @staticmethod
     def _get_local_available_host_memory() -> int:
@@ -143,7 +189,8 @@ class HfWeightLoader(BaseWeightLoader):
         return available_host_memory
 
     def _with_weight_cache(self, weight_files: List[str],
-                           use_consolidated: bool, barrier_on_hit: bool,
+                           use_consolidated: bool,
+                           mirror_load_collectives: bool,
                            load_fn) -> ConsumableWeightsDict:
         """Wrap ``load_fn`` with the optional raw-weight cache.
 
@@ -158,12 +205,14 @@ class HfWeightLoader(BaseWeightLoader):
             cached_weights = self._get_cached_weights(cache_key)
             if cached_weights is not None:
                 logger.info("Reusing cached HF checkpoint weights.")
-                if barrier_on_hit:
-                    # The safetensors miss path has a local barrier before
-                    # deserialization. Cache hits must participate as well:
-                    # rank-local caches can diverge after eviction, and a hit
-                    # on one rank must not skip a barrier that a miss on
-                    # another rank is about to enter.
+                if mirror_load_collectives:
+                    # Rank-local caches can diverge, so a hit on one rank must
+                    # enqueue EXACTLY the collectives a miss on another rank
+                    # enqueues, in the same order, or the job deadlocks. The
+                    # safetensors miss path performs an Allreduce (inside
+                    # _get_local_available_host_memory) and then a Barrier;
+                    # mirror both here (the allreduce result is unused).
+                    self._get_local_available_host_memory()
                     local_mpi_barrier()
                 return cached_weights
             self._evict_to_make_room()
@@ -191,7 +240,7 @@ class HfWeightLoader(BaseWeightLoader):
             return self._with_weight_cache(
                 weight_files,
                 use_consolidated,
-                barrier_on_hit=True,
+                mirror_load_collectives=True,
                 load_fn=lambda: self._prefetch_and_load(weight_files))
 
         weight_files = glob.glob(f"{checkpoint_dir}/*.bin")
@@ -202,7 +251,7 @@ class HfWeightLoader(BaseWeightLoader):
             return self._with_weight_cache(
                 weight_files,
                 use_consolidated,
-                barrier_on_hit=False,
+                mirror_load_collectives=False,
                 load_fn=lambda: self._load_weights_in_parallel(
                     weight_files, self._load_bin_or_path_file,
                     "Loading bin weights in parallel"))

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -83,8 +83,8 @@ class HfWeightLoader(BaseWeightLoader):
                 (os.path.abspath(file_name), stat.st_size, stat.st_mtime_ns))
         return (tuple(file_fingerprint), use_consolidated)
 
-    @classmethod
-    def _clear_weight_cache(cls) -> None:
+    @staticmethod
+    def _clear_weight_cache() -> None:
         with _WEIGHT_CACHE_LOCK:
             _WEIGHT_CACHE.clear()
 
@@ -106,7 +106,8 @@ class HfWeightLoader(BaseWeightLoader):
         if max_entries <= 0:
             return
 
-        HfWeightLoader._evict_to_make_room()
+        # Room was already made by the caller-side evict-before-load in
+        # _with_weight_cache (the load-bearing one for the memory peak).
         with _WEIGHT_CACHE_LOCK:
             _WEIGHT_CACHE[cache_key] = dict(loaded_weights)
 

--- a/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
@@ -201,3 +201,82 @@ def test_weight_cache_disabled_by_default(tmp_path, monkeypatch):
         loader.load_weights(str(checkpoint_dir), mapping=Mapping())
 
     assert load_weights_in_parallel.call_count == 2
+
+
+def test_weight_cache_detects_inplace_mutation_and_reloads(tmp_path, monkeypatch):
+    # The cache shares raw tensors across loads (read-only by contract). A
+    # consumer mutating one in place (e.g. an in-place transform in a weight
+    # mapper) must be detected on the next hit: the poisoned entry is dropped
+    # and the weights are reloaded from disk instead of silently corrupted.
+    import torch
+
+    monkeypatch.setenv("TRTLLM_HF_WEIGHT_CACHE", "1")
+
+    checkpoint_dir = tmp_path / "foo"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "model.safetensors").touch()
+
+    loader = HfWeightLoader()
+
+    def fresh_weights(*args, **kwargs):
+        return ConsumableWeightsDict({"a.weight": torch.ones(64)})
+
+    with (
+        mock.patch.object(
+            loader, "_load_weights_in_parallel", side_effect=fresh_weights
+        ) as load_weights_in_parallel,
+        mock.patch.object(loader, "prefetch_files"),
+    ):
+        first = loader.load_weights(str(checkpoint_dir), mapping=Mapping())
+        first["a.weight"].neg_()  # in-place mutation through the shared tensor
+
+        second = loader.load_weights(str(checkpoint_dir), mapping=Mapping())
+
+    assert load_weights_in_parallel.call_count == 2  # poisoned hit -> reload
+    assert torch.equal(second["a.weight"], torch.ones(64))  # clean weights
+
+
+def test_cache_hit_and_miss_issue_identical_collectives(tmp_path, monkeypatch):
+    # Rank-local caches can diverge, so a hit on one rank and a miss on
+    # another must enqueue the SAME collectives in the same order (Allreduce
+    # from _get_local_available_host_memory, then Barrier) or the job
+    # deadlocks. Record the sequence each path produces and compare.
+    monkeypatch.setenv("TRTLLM_HF_WEIGHT_CACHE", "1")
+
+    checkpoint_dir = tmp_path / "foo"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "model.safetensors").touch()
+
+    loader = HfWeightLoader()
+    sequences = {"miss": [], "hit": []}
+    current: list = []
+
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.models.checkpoints.hf.weight_loader.local_mpi_barrier",
+        lambda: current.append("barrier"),
+    )
+
+    def record_allreduce():
+        current.append("allreduce")
+        return 1 << 60  # plenty of host memory
+
+    with (
+        mock.patch.object(
+            loader,
+            "_load_weights_in_parallel",
+            return_value=ConsumableWeightsDict({"foo.weight": object()}),
+        ),
+        mock.patch.object(loader, "prefetch_files"),
+        mock.patch.object(
+            HfWeightLoader,
+            "_get_local_available_host_memory",
+            side_effect=record_allreduce,
+        ),
+    ):
+        current = sequences["miss"]
+        loader.load_weights(str(checkpoint_dir), mapping=Mapping())
+        current = sequences["hit"]
+        loader.load_weights(str(checkpoint_dir), mapping=Mapping())
+
+    assert sequences["miss"] == ["allreduce", "barrier"]
+    assert sequences["hit"] == sequences["miss"]  # divergence-safe ordering

--- a/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
@@ -3,11 +3,19 @@ from unittest import mock
 import pytest
 
 from tensorrt_llm._torch.models.checkpoints import HfWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import ConsumableWeightsDict
 from tensorrt_llm.mapping import Mapping
 
 
 class MyError(Exception):
     pass
+
+
+@pytest.fixture(autouse=True)
+def clean_weight_cache():
+    HfWeightLoader._clear_weight_cache()
+    yield
+    HfWeightLoader._clear_weight_cache()
 
 
 @pytest.mark.parametrize(
@@ -97,3 +105,99 @@ def test_load_weights_ignores_consolidated_ckpt_when_sharded_ckpt_exists(
     load_weights_in_parallel.assert_called_once()
     loaded_weight_files = load_weights_in_parallel.call_args[0][0]
     assert set(loaded_weight_files) == expected_safetensor_filenames
+
+
+def test_weight_cache_reuses_raw_weights_with_fresh_consumable_wrapper(tmp_path, monkeypatch):
+    monkeypatch.setenv("TRTLLM_HF_WEIGHT_CACHE", "1")
+
+    checkpoint_dir = tmp_path / "foo"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "model.safetensors").touch()
+
+    raw_weight = object()
+    loader = HfWeightLoader()
+
+    with (
+        mock.patch.object(
+            loader,
+            "_load_weights_in_parallel",
+            return_value=ConsumableWeightsDict({"foo.weight": raw_weight}),
+        ) as load_weights_in_parallel,
+        mock.patch.object(loader, "prefetch_files"),
+    ):
+        first = loader.load_weights(str(checkpoint_dir), mapping=Mapping())
+        assert first["foo.weight"] is raw_weight
+        assert first.mark_consumed("foo") == 1
+        assert len(first) == 0
+
+        second = loader.load_weights(str(checkpoint_dir), mapping=Mapping())
+
+    load_weights_in_parallel.assert_called_once()
+    assert second["foo.weight"] is raw_weight
+
+
+def test_weight_cache_evicts_before_load_on_miss(tmp_path, monkeypatch):
+    # On a cross-model miss with a full cache (max_entries=1), the old entry
+    # must be evicted BEFORE the new weights load, so CPU never holds both the
+    # old (cached) and new (loading) weights at once (no transient 2x peak).
+    from tensorrt_llm._torch.models.checkpoints.hf import weight_loader as wl
+
+    monkeypatch.setenv("TRTLLM_HF_WEIGHT_CACHE", "1")
+    monkeypatch.setenv("TRTLLM_HF_WEIGHT_CACHE_MAX_ENTRIES", "1")
+
+    dir_a = tmp_path / "a"
+    dir_a.mkdir()
+    (dir_a / "model.safetensors").touch()
+    dir_b = tmp_path / "b"
+    dir_b.mkdir()
+    (dir_b / "model.safetensors").touch()
+
+    loader = HfWeightLoader()
+    with mock.patch.object(loader, "prefetch_files"):
+        with mock.patch.object(
+            loader,
+            "_load_weights_in_parallel",
+            return_value=ConsumableWeightsDict({"foo.weight": object()}),
+        ):
+            loader.load_weights(str(dir_a), mapping=Mapping())
+        assert len(wl._WEIGHT_CACHE) == 1
+
+        def assert_room_freed_before_load(*args, **kwargs):
+            # The old (A) entry must already be gone by the time B loads.
+            assert len(wl._WEIGHT_CACHE) == 0
+            return ConsumableWeightsDict({"foo.weight": object()})
+
+        with mock.patch.object(
+            loader,
+            "_load_weights_in_parallel",
+            side_effect=assert_room_freed_before_load,
+        ):
+            loader.load_weights(str(dir_b), mapping=Mapping())
+
+    assert len(wl._WEIGHT_CACHE) == 1
+
+
+def test_weight_cache_disabled_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("TRTLLM_HF_WEIGHT_CACHE", raising=False)
+
+    checkpoint_dir = tmp_path / "foo"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "model.safetensors").touch()
+
+    loader = HfWeightLoader()
+
+    with (
+        mock.patch.object(
+            loader,
+            "_load_weights_in_parallel",
+            side_effect=[
+                ConsumableWeightsDict({"foo.weight": object()}),
+                ConsumableWeightsDict({"foo.weight": object()}),
+            ],
+        ) as load_weights_in_parallel,
+        mock.patch.object(loader, "prefetch_files"),
+    ):
+        loader.load_weights(str(checkpoint_dir), mapping=Mapping())
+        loader.load_weights(str(checkpoint_dir), mapping=Mapping())
+
+    assert load_weights_in_parallel.call_count == 2


### PR DESCRIPTION
## Summary

Independent optimization split out of #15777 per review. Workers that load the same checkpoint repeatedly (e.g. across LLM instances sharing one MPI worker pool) can keep the raw checkpoint tensors in CPU RAM instead of re-reading and re-deserializing them.

- **Off by default**; enable with `TRTLLM_HF_WEIGHT_CACHE=1`. The default path pays nothing (no fingerprinting).
- **Invalidation**: keyed by file fingerprints (abs path, size, mtime_ns) — any checkpoint change invalidates.
- **Memory**: LRU bounded by `TRTLLM_HF_WEIGHT_CACHE_MAX_ENTRIES` (default 1). Eviction happens BEFORE the new load so CPU never holds the old cached and the new loading weights at once (a ~2x transient peak otherwise).
- **Correctness**: hits return a fresh `ConsumableWeightsDict` wrapper sharing the read-only tensors; the safetensors hit path joins the same local MPI barrier the miss path is about to enter (rank-local caches can diverge after eviction). One `_with_weight_cache()` wrapper serves both the safetensors and bin/pth paths.

## Measured

Qwen3-235B-A22B nvfp4 on 4xB200: warm reload 106.6s -> 76.2s with the cache (page-cache-warm baseline); DeepSeek-V3-Lite accuracy suites show the same per-case reload saving when workers are shared.

## Companion PRs

- MPI session ownership: #16053
- Test-side automatic session reuse (enables this cache for its managed pools): #16055

## Test plan

- [x] Unit tests: hit/miss/eviction-before-load/fingerprint invalidation (8 tests)
- [x] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional cache for loaded checkpoint weights to speed up repeated loading of the same files.
  * Added environment-based controls to enable caching and limit how many checkpoints are kept.

* **Bug Fixes**
  * Improved synchronization during weight loading to reduce the risk of rank mismatches and deadlocks.
  * Ensured older cached weights are evicted before new ones load when the cache is full.

* **Tests**
  * Added coverage for cache reuse, cache eviction, and the default uncached behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->