### PR TITLE
[None][perf] Batch KV block allocation in kv_cache_manager_v2

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -60,6 +60,7 @@ from .._page import (
     _PageHolder,
     _SharedPageLock,
     batched_lock_to_gpu,
+    bulk_lock_new_pages,
 )
 from .._stats import KVCacheIterationStatsDelta, KVCacheStatsDelta
 from .._storage._core import Slot
@@ -827,28 +828,66 @@ class _KVCache:
                 excluded_ranges,
                 record_generation_alloc_stats,
             )
-            for ordinal in typed_range(old_num_blocks, new_num_blocks):
-                block = make_typed(
-                    lambda _: filled_list(cast(BlockPage, None), num_life_cycles), beam_width
+            # Range-decomposed bulk path. Instead of building the page-lock object tree
+            # block-by-block (per ordinal x beam x lc), decompose [old, new) per life
+            # cycle into contiguous allocatable segments (the complement of the
+            # stale/scratch range) and build each segment's locks in one fused loop
+            # (bulk_lock_new_pages). Semantics match the per-block path; two deliberate
+            # differences:
+            #  - slot-to-ordinal assignment order (slots of one pool are fungible here:
+            #    all ready events were waited above),
+            #  - _base_page_indices is written per segment via slice assignment instead
+            #    of per element inside _SharedPageLock.__init__.
+            num_new = int(new_num_blocks) - int(old_num_blocks)
+            new_block_range = HalfOpenRange(old_num_blocks, new_num_blocks)
+            new_grids = [
+                cast(
+                    "TypedIndexList[BeamIndex, TypedIndexList[LifeCycleId, BlockPage]]",
+                    [[None] * int(num_life_cycles) for _ in range(int(beam_width))],
                 )
+                for _ in range(num_new)
+            ]
+            for lc in typed_range(num_life_cycles):
+                if lc == ssm_lc_id:
+                    continue  # SSM pages live in _ssm_blocks, not in _blocks
+                excluded = intersect(
+                    scratch_ranges[lc] if enable_scratch else stale_ranges[lc],
+                    new_block_range,
+                )
+                if excluded:
+                    segments = [
+                        HalfOpenRange(old_num_blocks, excluded.beg),
+                        HalfOpenRange(excluded.end, new_num_blocks),
+                    ]
+                else:
+                    segments = [new_block_range]
+                lc_slots = slots[lc]
                 for beam_index in typed_range(beam_width):
-                    for lc in typed_range(num_life_cycles):
-                        if lc == ssm_lc_id:
-                            continue  # SSM pages live in _ssm_blocks, not in _blocks
-                        if enable_scratch:
-                            # Assertion guarantees no new block is stale.
-                            if ordinal in scratch_ranges[lc]:
-                                continue  # Scratch block — no per-block page allocation
-                        else:
-                            stale_beg, stale_end = stale_ranges[lc]
-                            if stale_beg <= ordinal < stale_end:
-                                continue
-                        slot = slots[lc].pop()
+                    for seg in segments:
+                        if not seg:
+                            continue
+                        n = len(seg)
                         # We have already waited for ready_event of the slots.
-                        block[beam_index][lc] = UncommittedPage(
-                            self, ordinal, lc, GPU_LEVEL, slot, beam_index
-                        ).lock(self, beam_index, ordinal, lc, skip_wait=True)
-                self._blocks.append(SeqBlock(block, None))
+                        seg_slots = lc_slots[-n:]
+                        del lc_slots[-n:]
+                        locks, page_ids = bulk_lock_new_pages(
+                            self, beam_index, lc, GPU_LEVEL, seg.beg, seg_slots
+                        )
+                        base = int(seg.beg) - int(old_num_blocks)
+                        for i, locked in enumerate(locks):
+                            new_grids[base + i][beam_index][lc] = locked
+                        indices = self._base_page_indices[beam_index][lc]
+                        assert NDEBUG or all(
+                            indices[o] == BAD_PAGE_INDEX for o in range(seg.beg, seg.end)
+                        )
+                        if type(indices) is array.array:
+                            indices[seg.beg : seg.end] = page_ids
+                        else:
+                            seg_beg_i = int(seg.beg)
+                            for i in range(n):
+                                indices[seg_beg_i + i] = page_ids[i]
+            for grid in new_grids:
+                self._blocks.append(SeqBlock(grid, None))
             assert all(len(slots[lc]) == 0 for lc in typed_range(num_life_cycles))
         self._capacity = capacity
         self._history_length = history_length

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
@@ -395,15 +395,19 @@ class _SharedPageLock:
         ordinal: BlockOrdinal,
         life_cycle: LifeCycleId,
         skip_wait: bool,
+        update_index: bool = True,
     ) -> None:
         self._uniq_lock = uniq_lock
         if not skip_wait:
             self.page.ready_event.wait_in_stream(kv_cache.cuda_stream)
         self._user = LockOwner(rawref.ref(kv_cache), beam_index, ordinal, life_cycle)
-        old_base_index = kv_cache._update_base_page_index(
-            beam_index, ordinal, life_cycle, PageIndex(self.page.slot_id)
-        )
-        assert old_base_index == BAD_PAGE_INDEX
+        if update_index:
+            old_base_index = kv_cache._update_base_page_index(
+                beam_index, ordinal, life_cycle, PageIndex(self.page.slot_id)
+            )
+            assert old_base_index == BAD_PAGE_INDEX
+        # When update_index is False (bulk allocation), the caller writes the base
+        # page indices for the whole range at once instead of per element.
 
     def __del__(self) -> None:
         if self._uniq_lock is not None:
@@ -443,63 +447,40 @@ def bulk_lock_new_pages(
     slots: Sequence[Slot],
 ) -> "tuple[list[_SharedPageLock], array.array[int]]":
     """
-    Fused equivalent of, for each slot at consecutive ordinals starting from first_ordinal:
+    Batched equivalent of, for each slot at consecutive ordinals starting from first_ordinal:
         UncommittedPage(kv_cache, ordinal, life_cycle, cache_level, slot, beam_index)
             .lock(kv_cache, beam_index, ordinal, life_cycle, skip_wait=True)
-    Builds the identical object graph (UncommittedPage <- _PageHolder <- _UniqPageLock
-    <- _SharedPageLock) in one tight loop, skipping work that is statically dead for
-    brand-new pages: hold()/lock() existence checks, scheduled_for_eviction handling
-    (fresh pages have node_ref None), and the ready-event wait (skip_wait contract).
+    All objects are built with their regular constructors; only the hold()/lock()
+    wrapper wiring is inlined, because for brand-new pages the checks in those
+    wrappers are statically false (a fresh page has no holder, no lock, and is
+    never scheduled for eviction).
 
     Caller responsibilities (differences from the layered path):
-      - All slots' ready_event must already be waited on in kv_cache.cuda_stream.
-      - _base_page_indices is NOT updated per element here; the returned slot-id
-        array must be written by the caller (bulk slice assignment).
+      - All slots' ready_event must already be waited on in kv_cache.cuda_stream
+        (skip_wait contract).
+      - _base_page_indices is NOT updated per element (update_index=False); the
+        returned slot-id array must be written by the caller (bulk slice assignment).
     """
     if cache_level != GPU_LEVEL:
         raise ValueError("bulk_lock_new_pages supports GPU pages only")
-    manager = kv_cache.manager
-    # rawref.ref is a per-target singleton: these are the same objects the per-page
-    # constructors would create, hoisted out of the loop.
-    storage_ref = rawref.ref(manager._storage)
-    kv_ref = rawref.ref(kv_cache)
-    get_priority = kv_cache._get_priority
-    lc_obj = manager._life_cycles.get_life_cycle(life_cycle)
     locks: list[_SharedPageLock] = []
     ids = array.array("i")
     ordinal = int(first_ordinal)
     for slot in slots:
-        slot_id = slot.slot_id
-        ids.append(slot_id)
+        ids.append(slot.slot_id)  # read before set_slot() transfers ownership
         bo = BlockOrdinal(ordinal)
-        # -- UncommittedPage.__init__ + Page.__init__ + set_slot, flattened.
-        #    (tokens is intentionally left unset: the layered __init__ never sets it.)
-        page = UncommittedPage.__new__(UncommittedPage)
-        page._slot_id = slot_id  # set_slot: take ownership from `slot`
-        page.ready_event = slot.ready_event
-        slot._slot_id = None
-        slot.ready_event = CachedCudaEvent.NULL
-        page._manager = storage_ref
-        page.life_cycle = life_cycle
-        page.cache_level = cache_level
-        page._priority = get_priority(bo, lc_obj)  # user callback; may depend on ordinal
-        page._holder = None
-        page.node_ref = None
-        page.kv_cache = kv_ref
-        page.ordinal = bo
-        page.beam_index = beam_index
-        # -- Page.hold(): fresh page has no holder and is not scheduled for eviction.
+        page = UncommittedPage(kv_cache, bo, life_cycle, cache_level, slot, beam_index)
+        # Page.hold(): a fresh page has no holder and is not scheduled for eviction.
         holder = _PageHolder(page)
         page._holder = rawref.ref(holder)
-        # -- _PageHolder.lock(): fresh holder has no lock.
+        # _PageHolder.lock(): a fresh holder has no lock.
         lock = _UniqPageLock(holder)
         holder._lock = rawref.ref(lock)
-        # -- _UniqPageLock.share() / _SharedPageLock.__init__ with skip_wait=True,
-        #    minus the per-element _update_base_page_index (caller bulk-writes).
-        shared = _SharedPageLock.__new__(_SharedPageLock)
-        shared._uniq_lock = lock
-        shared._user = LockOwner(kv_ref, beam_index, bo, life_cycle)
-        locks.append(shared)
+        locks.append(
+            _SharedPageLock(
+                lock, kv_cache, beam_index, bo, life_cycle, skip_wait=True, update_index=False
+            )
+        )
         ordinal += 1
     return locks, ids
 

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import array
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, NamedTuple, cast
@@ -431,6 +432,76 @@ class _SharedPageLock:
 
 
 BlockPage = _SharedPageLock | _PageHolder | None
+
+
+def bulk_lock_new_pages(
+    kv_cache: "_KVCache",
+    beam_index: BeamIndex,
+    life_cycle: LifeCycleId,
+    cache_level: CacheLevel,
+    first_ordinal: BlockOrdinal,
+    slots: Sequence[Slot],
+) -> "tuple[list[_SharedPageLock], array.array[int]]":
+    """
+    Fused equivalent of, for each slot at consecutive ordinals starting from first_ordinal:
+        UncommittedPage(kv_cache, ordinal, life_cycle, cache_level, slot, beam_index)
+            .lock(kv_cache, beam_index, ordinal, life_cycle, skip_wait=True)
+    Builds the identical object graph (UncommittedPage <- _PageHolder <- _UniqPageLock
+    <- _SharedPageLock) in one tight loop, skipping work that is statically dead for
+    brand-new pages: hold()/lock() existence checks, scheduled_for_eviction handling
+    (fresh pages have node_ref None), and the ready-event wait (skip_wait contract).
+
+    Caller responsibilities (differences from the layered path):
+      - All slots' ready_event must already be waited on in kv_cache.cuda_stream.
+      - _base_page_indices is NOT updated per element here; the returned slot-id
+        array must be written by the caller (bulk slice assignment).
+    """
+    if cache_level != GPU_LEVEL:
+        raise ValueError("bulk_lock_new_pages supports GPU pages only")
+    manager = kv_cache.manager
+    # rawref.ref is a per-target singleton: these are the same objects the per-page
+    # constructors would create, hoisted out of the loop.
+    storage_ref = rawref.ref(manager._storage)
+    kv_ref = rawref.ref(kv_cache)
+    get_priority = kv_cache._get_priority
+    lc_obj = manager._life_cycles.get_life_cycle(life_cycle)
+    locks: list[_SharedPageLock] = []
+    ids = array.array("i")
+    ordinal = int(first_ordinal)
+    for slot in slots:
+        slot_id = slot.slot_id
+        ids.append(slot_id)
+        bo = BlockOrdinal(ordinal)
+        # -- UncommittedPage.__init__ + Page.__init__ + set_slot, flattened.
+        #    (tokens is intentionally left unset: the layered __init__ never sets it.)
+        page = UncommittedPage.__new__(UncommittedPage)
+        page._slot_id = slot_id  # set_slot: take ownership from `slot`
+        page.ready_event = slot.ready_event
+        slot._slot_id = None
+        slot.ready_event = CachedCudaEvent.NULL
+        page._manager = storage_ref
+        page.life_cycle = life_cycle
+        page.cache_level = cache_level
+        page._priority = get_priority(bo, lc_obj)  # user callback; may depend on ordinal
+        page._holder = None
+        page.node_ref = None
+        page.kv_cache = kv_ref
+        page.ordinal = bo
+        page.beam_index = beam_index
+        # -- Page.hold(): fresh page has no holder and is not scheduled for eviction.
+        holder = _PageHolder(page)
+        page._holder = rawref.ref(holder)
+        # -- _PageHolder.lock(): fresh holder has no lock.
+        lock = _UniqPageLock(holder)
+        holder._lock = rawref.ref(lock)
+        # -- _UniqPageLock.share() / _SharedPageLock.__init__ with skip_wait=True,
+        #    minus the per-element _update_base_page_index (caller bulk-writes).
+        shared = _SharedPageLock.__new__(_SharedPageLock)
+        shared._uniq_lock = lock
+        shared._user = LockOwner(kv_ref, beam_index, bo, life_cycle)
+        locks.append(shared)
+        ordinal += 1
+    return locks, ids
 
 
 class BatchedLockTarget(NamedTuple):

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -22,6 +22,7 @@ import warnings
 from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
+from itertools import chain
 from typing import ClassVar, NewType, final
 
 if sys.version_info[:2] >= (3, 12):
@@ -372,7 +373,45 @@ class SlotAllocator:
     def allocate_multiple(self, num_slots: int) -> list[Slot]:
         if self.num_free_slots < num_slots:
             raise OutOfPagesError("Not enough free slots")
-        return [self.allocate() for _ in range(num_slots)]
+        if num_slots == 0:
+            return []
+        # Batched equivalent of calling allocate() num_slots times, with the same
+        # preference order (ready recycled > new > not-ready recycled) and the same
+        # return order, but the batch structure is decided once instead of being
+        # re-evaluated per slot. One deliberate difference: events are scrubbed once
+        # up front, so a recycled slot whose event completes mid-batch may be handed
+        # out as not-ready; callers must wait on ready_event either way.
+        self._scrub_events()
+        recycled = self._recycled_slots
+        num_ready = self._num_ready_recycled_slots
+        num_from_ready = min(num_ready, num_slots)
+        mint_headroom = min(self.num_slots, self._target_capacity) - self._num_active_slots
+        num_minted = min(max(mint_headroom, 0), num_slots - num_from_ready)
+        num_from_pending = num_slots - num_from_ready - num_minted
+        assert num_from_pending <= len(recycled) - num_from_ready
+        out: list[Slot] = []
+        for _ in range(num_from_ready):
+            out.append(recycled.popleft())
+        self._num_ready_recycled_slots = num_ready - num_from_ready
+        assert NDEBUG or all(
+            s.has_valid_slot and s.ready_event is CachedCudaEvent.NULL for s in out
+        )
+        if num_minted:
+            base = self._num_active_slots
+            null_event = CachedCudaEvent.NULL
+            out.extend(Slot(SlotId(base + i), null_event) for i in range(num_minted))
+            self._num_active_slots = base + num_minted
+            self._occupied_mask.set_range(base, base + num_minted)
+        for _ in range(num_from_pending):
+            slot = recycled.popleft()
+            assert slot.has_valid_slot
+            out.append(slot)
+        if num_from_ready or num_from_pending:
+            self._occupied_mask.set_many(
+                s.slot_id for s in chain(out[:num_from_ready], out[num_from_ready + num_minted :])
+            )
+        assert NDEBUG or self._check()
+        return out
 
     def release(self, slot: Slot) -> None:
         assert slot.has_valid_slot

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_utils.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_utils.py
@@ -660,6 +660,38 @@ class DynamicBitset:
             self._bits[index // 64] &= ~(1 << (index % 64))
             self._num_set_bits -= 1
 
+    def set_many(self, indices: "Iterable[int]") -> None:
+        "Batched set(). Equivalent to calling set() for each index."
+        bits = self._bits
+        num_new = 0
+        for index in indices:
+            word = index >> 6
+            mask = 1 << (index & 63)
+            if not bits[word] & mask:
+                bits[word] |= mask
+                num_new += 1
+        self._num_set_bits += num_new
+
+    def set_range(self, beg: int, end: int) -> None:
+        "Batched set() for a contiguous [beg, end) range; sets whole 64-bit words at a time."
+        if beg >= end:
+            return
+        bits = self._bits
+        num_new = 0
+        word_beg, word_end = beg >> 6, (end - 1) >> 6
+        for word in range(word_beg, word_end + 1):
+            mask = self.ALL_SET_MASK
+            if word == word_beg:
+                mask &= self.ALL_SET_MASK << (beg & 63) & self.ALL_SET_MASK
+            if word == word_end:
+                mask &= self.ALL_SET_MASK >> (63 - ((end - 1) & 63))
+            old = bits[word]
+            new = old | mask
+            if new != old:
+                num_new += (new ^ old).bit_count()
+                bits[word] = new
+        self._num_set_bits += num_new
+
     @property
     def num_set_bits(self) -> int:
         return self._num_set_bits


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cache growth and allocation paths to handle multiple items at once, reducing overhead during larger requests.
  * Added more efficient batch updates for internal tracking, which can make allocation-heavy workloads faster and smoother.
  * Optimized bitset updates to support setting multiple positions or ranges more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

When a decode worker admits a new request, `kv_cache_manager_v2` allocates all
KV blocks for the full ISL at once (e.g. 8K ISL = 257 blocks) inside
`_KVCache.resize()`, on the executor loop thread. Blocks and slots were
processed one at a time, repeating per-item fixed overhead 257 times
(~1.9 ms per request). Under high request churn, wide attention-DP setups
(e.g. dep32) amplify this stall to every rank on every iteration, causing a
measurable TPOT regression vs the v1 manager (DeepSeek-R1 / Kimi-K2.5,
FP4 8K/1K, high concurrency).

This PR batches the allocation. Object graph and semantics are unchanged;
no model- or config-specific gating:

- `resize()`: decompose the new block range into contiguous allocatable
  segments (stale/scratch/beam become segment boundaries instead of per-block
  branches) and build each segment's page locks in one fused loop
  (`bulk_lock_new_pages`, which goes through the regular
  `Page`/`_PageHolder`/lock constructors); write base page indices per
  segment via slice assignment instead of per element.
- `SlotAllocator.allocate_multiple()`: decide the batch structure once
  (ready-recycled / newly-minted / pending) instead of re-evaluating per slot;
  scrub events once per batch.
- `DynamicBitset`: add `set_range()` / `set_many()` for bulk occupancy updates.

Measured on GB300 (DSR1 FP4 8K/1K, concurrency 666, 7 prefill + 1 dep32
decode): resize cost 1.92 → 0.80 ms per request (-58%). In same-rack, same-day
A/B runs (n=3 per variant), TPOT improves ~0.3–0.5 ms vs the unoptimized v2
manager. Correctness: 6660/6660 requests successful on every run.


## Test Coverage

- `tests/unittest/kv_cache_manager_v2_tests/` — existing manager test suite
  exercises `resize()` (grow/shrink), block reuse, and stats behavior on the
  modified paths.
- The batched paths are unconditional (no new branches to gate), so any test
  that allocates KV blocks through `resize()` / `allocate_multiple()` covers
  the new code.
- Equivalence of the range decomposition and batched slot allocation vs the
  original per-item logic was additionally verified with randomized
  property tests during development (coverage sets, allocation order, and
  allocator state across ~13k random cases).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
