### PR TITLE
[TRTLLM-14123][feat] add ParallelVAE_TrtllmWan for native Wan VAE

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/wan/parallel_vae.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/parallel_vae.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Literal
 
 import torch
@@ -6,6 +21,7 @@ from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKLOutput
 from diffusers.models.autoencoders.autoencoder_kl_wan import WanAttentionBlock, WanCausalConv3d
 from diffusers.models.autoencoders.vae import DecoderOutput, DiagonalGaussianDistribution
 
+from tensorrt_llm._torch.visual_gen.models.wan import wan_vae
 from tensorrt_llm._torch.visual_gen.modules.vae import (
     HaloExchangeConv,
     HaloExchangeConv2dStride2,
@@ -34,6 +50,12 @@ class WanCausalConvHalo(HaloExchangeConv):
 
 class ParallelVAE_Wan(ParallelVAEBase):
     """Parallel VAE wrapper for ``AutoencoderKLWan``."""
+
+    # Module classes replaced with parallel variants. Subclasses that wrap a
+    # different VAE implementation (e.g. the native ``WanVAE``) override these
+    # to target their own module classes; everything else is inherited.
+    _conv3d_cls: type = WanCausalConv3d
+    _attn_cls: type = WanAttentionBlock
 
     @staticmethod
     def make_spec(split_dim: Literal["height", "width"]) -> SplitSpec:
@@ -88,7 +110,7 @@ class ParallelVAE_Wan(ParallelVAEBase):
         targets = [
             (name, module)
             for name, module in model.named_modules()
-            if isinstance(module, WanCausalConv3d) and max(module.kernel_size) > 1
+            if isinstance(module, self._conv3d_cls) and max(module.kernel_size) > 1
         ]
         for name, module in targets:
             self._replace_module(
@@ -108,7 +130,7 @@ class ParallelVAE_Wan(ParallelVAEBase):
         targets = [
             (name, module)
             for name, module in model.named_modules()
-            if isinstance(module, WanAttentionBlock)
+            if isinstance(module, self._attn_cls)
         ]
         for name, module in targets:
             self._replace_module(
@@ -172,3 +194,24 @@ class ParallelVAE_Wan(ParallelVAEBase):
                     pad_before_conv=pad_module.padding,
                 ),
             )
+
+
+# Two parallel-VAE wrappers, one per VAE *class* (not a temporary transition):
+#   ParallelVAE_Wan       wraps the diffusers AutoencoderKLWan -- used by Cosmos3
+#                         (models/cosmos3) and the Wan TRTLLM_USE_DIFFUSER_VAE
+#                         debug fallback.
+#   ParallelVAE_TrtllmWan wraps the native WanVAE -- the default for Wan2.1/2.2.
+# They share all splitting logic via the base class; only the conv3d/attention
+# module classes differ. ParallelVAE_Wan stays as long as any model uses the
+# diffusers AutoencoderKLWan.
+class ParallelVAE_TrtllmWan(ParallelVAE_Wan):
+    """Parallel VAE wrapper for the native ``WanVAE``.
+
+    Identical parallelisation to ``ParallelVAE_Wan``; only the conv3d/attention
+    module classes differ (the native ``WanCausalConv3d`` / ``WanAttentionBlock``
+    in ``wan_vae.py``). Resample Conv2d replacement is inherited unchanged because
+    the native ``WanConv2d`` subclasses ``nn.Conv2d``.
+    """
+
+    _conv3d_cls = wan_vae.WanCausalConv3d
+    _attn_cls = wan_vae.WanAttentionBlock

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import time
 from typing import List, Optional, Union
@@ -251,7 +266,6 @@ class WanPipeline(BasePipeline):
             self.vae = load_wan_vae(
                 checkpoint_dir,
                 device,
-                self.pipeline_config.visual_gen_mapping,
                 dtype=self.pipeline_config.torch_dtype,
             )
 

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import os
 import time
@@ -236,7 +251,6 @@ class WanImageToVideoPipeline(BasePipeline):
             self.vae = load_wan_vae(
                 checkpoint_dir,
                 device,
-                self.pipeline_config.visual_gen_mapping,
                 dtype=self.pipeline_config.torch_dtype,
             )
 

--- a/tensorrt_llm/_torch/visual_gen/models/wan/vae_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/vae_loader.py
@@ -15,7 +15,6 @@
 
 import os
 from pathlib import Path
-from typing import Any
 
 import torch
 import torch.nn as nn
@@ -50,25 +49,14 @@ def _use_diffuser_vae_env() -> bool:
         ) from None
 
 
-def _vae_is_parallel(visual_gen_mapping: Any | None) -> bool:
-    if visual_gen_mapping is None:
-        return False
-    return getattr(visual_gen_mapping, "parallel_vae_size", 1) > 1
-
-
-def _use_native_wan_vae(visual_gen_mapping: Any | None) -> bool:
+def _use_native_wan_vae() -> bool:
     """Select the Wan VAE backend and log the reason.
 
-    The native ``WanVAE`` is the default. Diffusers ``AutoencoderKLWan`` is used
-    only when the VAE is tensor-parallel (``parallel_vae_size > 1``), which the
-    native path does not support yet, or when forced via
-    ``TRTLLM_USE_DIFFUSER_VAE``.
+    The native ``WanVAE`` is the default; the diffusers ``AutoencoderKLWan``
+    is used only when forced via ``TRTLLM_USE_DIFFUSER_VAE``.
     """
     if _use_diffuser_vae_env():
         logger.info(f"Loading Diffusers Wan VAE because {TRTLLM_USE_DIFFUSER_VAE_ENV} is non-zero.")
-        return False
-    if _vae_is_parallel(visual_gen_mapping):
-        logger.info("Loading Diffusers Wan VAE because parallel VAE is not supported natively yet.")
         return False
     return True
 
@@ -76,10 +64,9 @@ def _use_native_wan_vae(visual_gen_mapping: Any | None) -> bool:
 def load_wan_vae(
     checkpoint_dir: str,
     device: torch.device,
-    visual_gen_mapping: Any | None = None,
     dtype: torch.dtype = torch.bfloat16,
 ) -> nn.Module:
-    if not _use_native_wan_vae(visual_gen_mapping):
+    if not _use_native_wan_vae():
         return AutoencoderKLWan.from_pretrained(
             checkpoint_dir,
             subfolder="vae",

--- a/tensorrt_llm/_torch/visual_gen/modules/vae/conv.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/vae/conv.py
@@ -1,8 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import List, Optional
 
 import torch
 import torch.distributed as dist
 import torch.nn as nn
+
+
+def _spatial_channels_last_format(x: torch.Tensor) -> Optional[torch.memory_format]:
+    """Return ``x``'s channels-last memory format (2D or 3D), or ``None``.
+
+    The halo exchange builds row-major send/recv buffers and concatenates them
+    with ``x`` along the split dimension. When ``x`` is channels-last (as the
+    native Wan VAE convs require and produce), a mixed-format ``torch.cat`` falls
+    back to row-major, so every downstream conv re-converts via a full-tensor
+    ``channels_last`` copy. Materialising the halo slices in ``x``'s format
+    before the ``cat`` lets it preserve channels-last, making the conv's
+    ``_channels_last_*_if_needed`` a no-op. Returns ``None`` when ``x`` is not
+    unambiguously channels-last, in which case the caller leaves layout untouched.
+    """
+    if x.dim() == 5 and x.is_contiguous(memory_format=torch.channels_last_3d):
+        return torch.channels_last_3d
+    if x.dim() == 4 and x.is_contiguous(memory_format=torch.channels_last):
+        return torch.channels_last
+    return None
 
 
 class HaloExchangeConv(nn.Module):
@@ -122,6 +156,13 @@ class HaloExchangeConv(nn.Module):
         if self.halo_right < exchange_size:
             recv_from_right = torch.narrow(recv_from_right, dim, 0, self.halo_right)
 
+        # Match the halo slices' layout to ``x`` so the cat preserves
+        # channels-last and downstream convs skip a full-tensor re-conversion.
+        mf = _spatial_channels_last_format(x)
+        if mf is not None:
+            recv_from_left = recv_from_left.contiguous(memory_format=mf)
+            recv_from_right = recv_from_right.contiguous(memory_format=mf)
+
         return torch.cat([recv_from_left, x, recv_from_right], dim=dim)
 
     def _strip_halo(self, x: torch.Tensor) -> torch.Tensor:
@@ -233,6 +274,11 @@ class HaloExchangeConv2dStride2(nn.Module):
             dist.send(send_left, dst=self.rank - 1)
 
         if self.rank != self.world_size - 1:
+            # Match the halo slice's layout to ``x`` so the cat preserves
+            # channels-last (see ``_spatial_channels_last_format``).
+            mf = _spatial_channels_last_format(x)
+            if mf is not None:
+                right_context = right_context.contiguous(memory_format=mf)
             x = torch.cat([x, right_context], dim=dim)
 
         if self.rank == self.world_size - 1:

--- a/tensorrt_llm/_torch/visual_gen/modules/vae/parallel_vae_interface.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/vae/parallel_vae_interface.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Tuple, Type
 
@@ -135,6 +150,10 @@ class ParallelVAEFactory:
         "diffusers.models.autoencoders.autoencoder_kl_wan.AutoencoderKLWan": (
             "tensorrt_llm._torch.visual_gen.models.wan.parallel_vae",
             "ParallelVAE_Wan",
+        ),
+        "tensorrt_llm._torch.visual_gen.models.wan.wan_vae.WanVAE": (
+            "tensorrt_llm._torch.visual_gen.models.wan.parallel_vae",
+            "ParallelVAE_TrtllmWan",
         ),
     }
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
@@ -30,6 +30,7 @@ try:
         HaloExchangeConv,
         HaloExchangeConv2dStride2,
     )
+    from tensorrt_llm._torch.visual_gen.modules.vae.conv import _spatial_channels_last_format
 
     # Spawn distributed workers via a helper that retries with a fresh master
     # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
@@ -206,6 +207,36 @@ class TestHaloExchangeConv:
 class TestHaloExchangeConv2dStride2:
     def test_conv2d_stride2_2gpu(self):
         _run(2, _logic_halo_conv2d_stride2)
+
+
+@pytest.mark.skipif(not MODULES_AVAILABLE, reason="Required modules not available")
+class TestSpatialChannelsLastFormat:
+    """CPU unit tests for the halo channels-last layout helper.
+
+    ``_spatial_channels_last_format`` is what lets the halo ``cat`` preserve
+    channels-last (so downstream convs skip a full-tensor re-conversion). It runs
+    on CPU tensors, so no GPU/distributed setup is needed here.
+    """
+
+    def test_channels_last_3d_detected(self):
+        x = torch.randn(1, 4, 3, 8, 8).contiguous(memory_format=torch.channels_last_3d)
+        assert _spatial_channels_last_format(x) is torch.channels_last_3d
+
+    def test_channels_last_2d_detected(self):
+        x = torch.randn(2, 4, 8, 8).contiguous(memory_format=torch.channels_last)
+        assert _spatial_channels_last_format(x) is torch.channels_last
+
+    def test_row_major_returns_none(self):
+        assert _spatial_channels_last_format(torch.randn(1, 4, 3, 8, 8)) is None
+        assert _spatial_channels_last_format(torch.randn(2, 4, 8, 8)) is None
+
+    def test_cat_preserves_channels_last_when_halos_match(self):
+        # The core invariant: cat of same-format channels-last slices stays
+        # channels-last (a mixed-format cat would fall back to row-major).
+        x = torch.randn(1, 4, 3, 8, 8).contiguous(memory_format=torch.channels_last_3d)
+        halo = torch.zeros(1, 4, 3, 1, 8).contiguous(memory_format=torch.channels_last_3d)
+        out = torch.cat([halo, x, halo], dim=3)
+        assert out.is_contiguous(memory_format=torch.channels_last_3d)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
@@ -1,9 +1,10 @@
-"""Multi-GPU tests for parallel VAE (ParallelVAE_Wan).
+"""Multi-GPU tests for parallel VAE (ParallelVAE_Wan and ParallelVAE_TrtllmWan).
 
-Validates that the parallel VAE adapter produces numerically equivalent
-decode/encode output compared to the original single-GPU AutoencoderKLWan.
+Validates that both parallel VAE adapters produce numerically equivalent
+decode/encode output compared to their single-GPU counterparts
+(diffusers ``AutoencoderKLWan`` and the native ``WanVAE``).
 
-Uses a small randomly-initialised model (no pretrained weights required).
+Uses small randomly-initialised models (no pretrained weights required).
 
 Run with:
     pytest tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py -v
@@ -26,7 +27,12 @@ try:
 
     from diffusers.models.autoencoders.autoencoder_kl_wan import AutoencoderKLWan
 
-    from tensorrt_llm._torch.visual_gen.models.wan.parallel_vae import ParallelVAE_Wan
+    from tensorrt_llm._torch.visual_gen.models.wan.parallel_vae import (
+        ParallelVAE_TrtllmWan,
+        ParallelVAE_Wan,
+    )
+    from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import WanVAE, WanVAEConfig
+    from tensorrt_llm._torch.visual_gen.modules.vae.parallel_vae_interface import ParallelVAEFactory
 
     # Spawn distributed workers via a helper that retries with a fresh master
     # port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
@@ -130,6 +136,46 @@ def _create_parallel_vae(vae, world_size, split_dim):
         for i in range(world_size - 1)
     ]
     return ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec(split_dim), adj_groups)
+
+
+def _create_small_trtllm_vae(device):
+    """Create a small native ``WanVAE`` with random weights for testing.
+
+    Config mirrors ``_create_small_vae``: base_dim=32, z_dim=4, 2 resolution
+    levels, 1 res block, ``attn_scales=[]``, no temporal downsampling. Note
+    ``attn_scales=[]`` only disables the optional down-block attention; the
+    encoder and decoder mid-blocks each still contain a ``WanAttentionBlock``,
+    so the parallel attention replacement IS exercised by these tests. The
+    native WanVAE always runs in channels-last (no layout knob).
+    """
+    vae = (
+        WanVAE(
+            WanVAEConfig(
+                base_dim=32,
+                z_dim=4,
+                dim_mult=[1, 2],
+                num_res_blocks=1,
+                attn_scales=[],
+                temperal_downsample=[False],
+            )
+        )
+        .to(device)
+        .float()
+    )
+    vae.eval()
+    return vae
+
+
+def _create_parallel_trtllm_vae(vae, world_size, split_dim):
+    # Route through ParallelVAEFactory so the registry mapping
+    # (WanVAE -> ParallelVAE_TrtllmWan) is exercised, not just direct construction.
+    ranks = list(range(world_size))
+    pg = dist.new_group(ranks, use_local_synchronization=False)
+    adj_groups = [
+        dist.new_group([ranks[i], ranks[i + 1]], use_local_synchronization=False)
+        for i in range(world_size - 1)
+    ]
+    return ParallelVAEFactory.from_vae(vae, split_dim, pg, adj_groups)
 
 
 # ===========================================================================
@@ -330,6 +376,117 @@ class TestParallelVAEEncode:
 
     def test_encode_height_2gpu(self):
         _run(2, _logic_encode_height)
+
+
+# ===========================================================================
+# Trtllm WanVAE parallel test-logic functions
+# ===========================================================================
+
+
+def _logic_trtllm_decode_width(rank, world_size):
+    """ParallelVAE_TrtllmWan decode (width split) matches single-GPU WanVAE."""
+    device = f"cuda:{rank}"
+
+    vae = _create_small_trtllm_vae(device)
+    _broadcast_params(vae)
+
+    latent = torch.randn(1, 4, 3, 16, 16, dtype=torch.float32, device=device)
+    dist.broadcast(latent, src=0)
+
+    with torch.no_grad():
+        ref = vae.decode(latent, return_dict=False)[0].detach().clone()
+
+    parallel = _create_parallel_trtllm_vae(vae, world_size, "width")
+    # The factory must resolve the native WanVAE to the trtllm parallel wrapper.
+    assert isinstance(parallel, ParallelVAE_TrtllmWan)
+
+    with torch.no_grad():
+        par = parallel.decode(latent, return_dict=False)[0]
+
+    max_diff = torch.max(torch.abs(par - ref)).item()
+    assert max_diff < 0.01, f"Rank {rank}: trtllm decode width max_diff={max_diff:.6f}"
+
+
+def _logic_trtllm_decode_height(rank, world_size):
+    """ParallelVAE_TrtllmWan decode (height split) matches single-GPU WanVAE."""
+    device = f"cuda:{rank}"
+
+    vae = _create_small_trtllm_vae(device)
+    _broadcast_params(vae)
+
+    latent = torch.randn(1, 4, 3, 16, 16, dtype=torch.float32, device=device)
+    dist.broadcast(latent, src=0)
+
+    with torch.no_grad():
+        ref = vae.decode(latent, return_dict=False)[0].detach().clone()
+
+    parallel = _create_parallel_trtllm_vae(vae, world_size, "height")
+
+    with torch.no_grad():
+        par = parallel.decode(latent, return_dict=False)[0]
+
+    max_diff = torch.max(torch.abs(par - ref)).item()
+    assert max_diff < 0.01, f"Rank {rank}: trtllm decode height max_diff={max_diff:.6f}"
+
+
+def _logic_trtllm_encode_width(rank, world_size):
+    """ParallelVAE_TrtllmWan encode (width split) matches single-GPU WanVAE."""
+    device = f"cuda:{rank}"
+
+    vae = _create_small_trtllm_vae(device)
+    _broadcast_params(vae)
+
+    video = torch.randn(1, 3, 3, 32, 32, dtype=torch.float32, device=device)
+    dist.broadcast(video, src=0)
+
+    with torch.no_grad():
+        ref = vae.encode(video).latent_dist.mode().detach().clone()
+
+    parallel = _create_parallel_trtllm_vae(vae, world_size, "width")
+
+    with torch.no_grad():
+        par = parallel.encode(video).latent_dist.mode()
+
+    max_diff = torch.max(torch.abs(par - ref)).item()
+    assert max_diff < 0.01, f"Rank {rank}: trtllm encode width max_diff={max_diff:.6f}"
+
+
+def _logic_trtllm_encode_height(rank, world_size):
+    """ParallelVAE_TrtllmWan encode (height split) matches single-GPU WanVAE."""
+    device = f"cuda:{rank}"
+
+    vae = _create_small_trtllm_vae(device)
+    _broadcast_params(vae)
+
+    video = torch.randn(1, 3, 3, 32, 32, dtype=torch.float32, device=device)
+    dist.broadcast(video, src=0)
+
+    with torch.no_grad():
+        ref = vae.encode(video).latent_dist.mode().detach().clone()
+
+    parallel = _create_parallel_trtllm_vae(vae, world_size, "height")
+
+    with torch.no_grad():
+        par = parallel.encode(video).latent_dist.mode()
+
+    max_diff = torch.max(torch.abs(par - ref)).item()
+    assert max_diff < 0.01, f"Rank {rank}: trtllm encode height max_diff={max_diff:.6f}"
+
+
+class TestParallelVAETrtllmDecode:
+    def test_decode_width_2gpu(self):
+        _run(2, _logic_trtllm_decode_width)
+
+    def test_decode_height_2gpu(self):
+        _run(2, _logic_trtllm_decode_height)
+
+
+class TestParallelVAETrtllmEncode:
+    def test_encode_width_2gpu(self):
+        _run(2, _logic_trtllm_encode_width)
+
+    def test_encode_height_2gpu(self):
+        _run(2, _logic_trtllm_encode_height)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/visual_gen/test_wan_vae.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_vae.py
@@ -5,7 +5,6 @@
 
 import os
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -98,31 +97,21 @@ def test_load_wan_vae_defaults_to_native(monkeypatch):
     assert isinstance(wan_vae, WanVAE)
 
 
-def test_use_native_wan_vae_selects_native_unless_parallel(monkeypatch):
-    single_gpu_mapping = MagicMock(world_size=1, parallel_vae_size=1)
-    multi_gpu_mapping = MagicMock(world_size=2, parallel_vae_size=1)
-    parallel_vae_mapping = MagicMock(world_size=2, parallel_vae_size=2)
-
+def test_use_native_wan_vae_default(monkeypatch):
+    """Native VAE is the default when the diffusers-fallback env is unset."""
     monkeypatch.delenv(TRTLLM_USE_DIFFUSER_VAE_ENV, raising=False)
-    # Selection depends only on parallel_vae_size, not world_size.
-    assert _use_native_wan_vae(single_gpu_mapping)
-    assert _use_native_wan_vae(multi_gpu_mapping)
-    assert not _use_native_wan_vae(parallel_vae_mapping)
+    assert _use_native_wan_vae()
 
 
 @pytest.mark.parametrize("fallback_value", ["1", "2", "-1"])
 def test_use_diffuser_vae_env_forces_diffusers(monkeypatch, fallback_value):
-    single_gpu_mapping = MagicMock(world_size=1, parallel_vae_size=1)
-
     monkeypatch.setenv(TRTLLM_USE_DIFFUSER_VAE_ENV, fallback_value)
-    assert not _use_native_wan_vae(single_gpu_mapping)
+    assert not _use_native_wan_vae()
 
 
 def test_use_diffuser_vae_env_zero_keeps_native(monkeypatch):
-    single_gpu_mapping = MagicMock(world_size=1, parallel_vae_size=1)
-
     monkeypatch.setenv(TRTLLM_USE_DIFFUSER_VAE_ENV, "0")
-    assert _use_native_wan_vae(single_gpu_mapping)
+    assert _use_native_wan_vae()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native TensorRT-LLM Wan VAE support for parallel encoding and decoding.
  - Added automatic registration and selection of the native Wan VAE implementation.
  - Diffusers VAE usage can now be enabled explicitly through the `TRTLLM_USE_DIFFUSER_VAE` environment setting.

- **Bug Fixes**
  - Improved VAE loading behavior by removing unnecessary configuration-based restrictions.

- **Tests**
  - Added multi-GPU validation for native Wan VAE encoding and decoding across width and height splits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Adds `ParallelVAE_TrtllmWan`, a tensor-parallel (`parallel_vae_size > 1`) wrapper for the native `WanVAE` (added in #15555), so multi-GPU Wan VAE decode/encode uses the native VAE instead of falling back to the diffusers `AutoencoderKLWan`. It mirrors the existing `ParallelVAE_Wan` by parameterizing the replaced conv3d / attention module classes (`_conv3d_cls` / `_attn_cls`) and overriding only those in a small subclass; `vae_loader` no longer forces diffusers under `parallel_vae_size > 1`; `ParallelVAEFactory` registers `WanVAE -> ParallelVAE_TrtllmWan`. `ParallelVAE_Wan` is kept because it wraps the diffusers `AutoencoderKLWan` still used by Cosmos3 and the `TRTLLM_USE_DIFFUSER_VAE` fallback.

This PR also includes a channels-last (NHWC) fix in `HaloExchangeConv` / `HaloExchangeConv2dStride2` (`conv.py`): the halo exchange built row-major send/recv buffers, so the boundary `torch.cat` fell back to row-major and forced every halo'd conv to re-convert the full tensor. A shared `_spatial_channels_last_format` helper now materialises the halo slices in `x`'s memory format before the cat, keeping it channels-last so the native VAE convs (which run in channels-last) skip the re-conversion. Output is **bit-identical**.

### Performance & accuracy (4×GB200, BF16, Wan2.2-TI2V-5B, 720p / 81 frames)

| Comparison | Result | Accuracy |
|---|---|---|
| channels-last halo fix (parallel_vae_size=4 decode, with vs without) | **1.31×** (1.243 → 0.951 s) | bit-identical |
| parallel VAE on vs off (parallel_vae_size 4 vs 1, VAE-only decode) | **2.88×** (2.735 → 0.951 s) | 54.3 dB PSNR (near-lossless) |
| end-to-end, true 4-GPU (cfg×ulysses DiT + parallel VAE) vs parallel_vae_size=1 | **1.65× @10 steps / 1.18× @50 steps** | 50.4 / 57.1 dB PSNR |

## Test Coverage

- `tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py` — `TestParallelVAETrtllmDecode` / `TestParallelVAETrtllmEncode`: native `WanVAE` parallel decode/encode match single-GPU (width + height split, 2-GPU). The wrapper is built via `ParallelVAEFactory.from_vae`, so the `WanVAE -> ParallelVAE_TrtllmWan` registry mapping is exercised (with an explicit `isinstance` assert). The small test VAE keeps a mid-block `WanAttentionBlock`, so `_replace_attention` on native attention is covered.
- `tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py` — `TestSpatialChannelsLastFormat`: CPU unit tests for the channels-last halo helper (memory-format detection + `cat` preservation).
- `tests/unittest/_torch/visual_gen/test_wan_vae.py` — updated `_use_native_wan_vae` / `load_wan_vae` tests for the removed `visual_gen_mapping` parameter (backend selection is now env-only via `TRTLLM_USE_DIFFUSER_VAE`).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
