### PR TITLE
[None][chore] Remove unused token_range and is_last_slice parameters from _create_kv_slice

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -176,7 +176,6 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
     def _create_kv_slice(
         self,
         req: LlmRequest,
-        token_range: Optional[TokenRange] = None,
         is_last_slice: bool = True,
     ) -> KVSlice:
         adapter = self._reuse_adapter
@@ -191,7 +190,8 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             else [0] * len(layer_groups)
         )
 
-        if token_range is None and req.prompt_len > 0:
+        token_range = None
+        if req.prompt_len > 0:
             # Align with KV cache allocation (prepare_disagg_gen_init /
             # _get_context_bytes), which reserves prompt_len +
             # num_extra_kv_tokens slots for speculative decoding methods

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -173,11 +173,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
     def __exit__(self, _exc_type, _exc_val, _exc_tb):
         self.shutdown()
 
-    def _create_kv_slice(
-        self,
-        req: LlmRequest,
-        is_last_slice: bool = True,
-    ) -> KVSlice:
+    def _create_kv_slice(self, req: LlmRequest) -> KVSlice:
         adapter = self._reuse_adapter
         tpb = adapter.tokens_per_block
         assert self._page_table is not None
@@ -242,7 +238,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             mamba_state_index = self._kv_cache_manager.mamba_cache_index[req.py_request_id]
 
         return KVSlice(
-            is_last_slice=is_last_slice,
+            is_last_slice=True,
             block_ids_per_layer_groups=groups,
             mamba_state_index=mamba_state_index,
             token_range=token_range,

--- a/tests/unittest/disaggregated/test_cache_reuse_adapter.py
+++ b/tests/unittest/disaggregated/test_cache_reuse_adapter.py
@@ -342,17 +342,6 @@ class TestCreateKvSliceTokenRange:
         assert kv_slice.token_range is not None
         assert (kv_slice.token_range.start, kv_slice.token_range.end) == (0, prompt_len)
 
-    def test_respects_explicit_token_range(self):
-        prompt_len = 17
-        transceiver, req = _build_transceiver_for_kv_slice(
-            num_extra_kv_tokens=7, prompt_len=prompt_len
-        )
-        explicit = TokenRange(start=0, end=8)
-
-        kv_slice = transceiver._create_kv_slice(req, token_range=explicit)
-
-        assert kv_slice.token_range is explicit
-
 
 # ---------------------------------------------------------------------------
 # CacheReuseAdapter.get_cached_token_count_per_layer_group: SWA clamp.


### PR DESCRIPTION
@coderabbitai summary

## Description

Part of the Python CacheTransceiver refactoring/cleanup.

The `token_range` and `is_last_slice` parameters of `KvCacheTransceiverV2._create_kv_slice` are dead code: no caller ever passes them — all call sites invoke `_create_kv_slice(req)` and rely on the defaults (computed range `TokenRange(0, prompt_len + num_extra_kv_tokens)` and `is_last_slice=True`). This PR removes both parameters, inlines the default range computation, and hardcodes `is_last_slice=True` in the constructed `KVSlice`.

Notes:
- The `KVSlice.token_range` and `KVSlice.is_last_slice` **fields** are unchanged; only the never-used function parameters are removed. Downstream consumers (e.g. the native transfer protocol in `native/transfer.py`) are unaffected.
- The chunked/pipelined prefill transfer work (#15727) does not use these parameters either — it constructs chunked `KVSlice` objects directly via the dataclass constructor.
- The unit test `test_respects_explicit_token_range`, which existed solely to exercise the removed passthrough, is deleted. The tests covering the default range computation are kept.

## Test Coverage

- `tests/unittest/disaggregated/test_cache_reuse_adapter.py::TestCreateKvSliceTokenRange` (default-range tests retained)
- `tests/unittest/disaggregated/test_cache_transceiver_single_process.py`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
