### PR TITLE
[https://nvbugs/6423991][fix] Qwen3.5-VL MoE DFlash compatibility

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -1306,6 +1306,19 @@ class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
     def vocab_size_padded(self) -> int:
         return self.llm.vocab_size_padded
 
+    # Forward spec-dec attrs to the inner causal LM (``self.llm``): this wrapper
+    # is not a spec-dec model but is the outer model those paths look them up on.
+    @property
+    def draft_config(self):
+        return getattr(self.llm, "draft_config", None)
+
+    @property
+    def draft_model(self):
+        return getattr(self.llm, "draft_model", None)
+
+    def load_draft_weights(self, *args, **kwargs):
+        return self.llm.load_draft_weights(*args, **kwargs)
+
     def infer_max_seq_len(self) -> int:
         return self.llm.infer_max_seq_len()
 


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

DFlash failed to load on Qwen3.5-35B-A3B with `AttributeError: 'Qwen3_5MoeVLModel' object has no attribute 'draft_config'`.

model loader looks up `draft_config/draft_model/load_draft_weights` on the top-level VLM wrapper while they live on the inner `SpecDecOneEngineForCausalLM`. This PR forwards those three attributes from Qwen3VLModelBase wrapper to self.llm. Qwen3.5-VL MoE was added in https://github.com/NVIDIA/TensorRT-LLM/pull/14599.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
TestQwen3_5_35B_A3B::test_fp8_moe_dflash

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
