### PR TITLE
[https://nvbugs/6384375][fix] Keep nested pytest controllers CPU-only

### DIFF
--- a/tests/integration/defs/common.py
+++ b/tests/integration/defs/common.py
@@ -27,12 +27,6 @@ from typing import Any
 import yaml
 from packaging import version
 
-from tensorrt_llm import LLM as LLM_torch
-from tensorrt_llm._utils import get_free_port
-from tensorrt_llm.executor.request import LoRARequest
-from tensorrt_llm.lora_manager import LoraConfig
-from tensorrt_llm.sampling_params import SamplingParams
-
 from .trt_test_alternative import (check_call, check_output, exists, is_windows,
                                    print_info, print_warning)
 
@@ -948,6 +942,13 @@ def test_llm_torch_multi_lora_support(
     outputs (since zero-weight LoRAs should not alter behavior).
     """
 
+    # This module is imported by wrappers that run GPU workloads in a child.
+    # Delay TRT-LLM imports until this in-process GPU test actually runs.
+    from tensorrt_llm import LLM as LLM_torch
+    from tensorrt_llm.executor.request import LoRARequest
+    from tensorrt_llm.lora_manager import LoraConfig
+    from tensorrt_llm.sampling_params import SamplingParams
+
     assert zero_lora_weights, (
         "This test compares LoRA outputs against base model outputs, "
         "which is only valid when zero_lora_weights=True.")
@@ -1256,7 +1257,9 @@ def get_free_port_in_ci(max_attempts=100):
 
     # No port found in the range, try to get a random free port from the system
     for _ in range(max_attempts):
-        port = get_free_port()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("", 0))
+            port = sock.getsockname()[1]
         if port not in PORTS_IN_USE:
             PORTS_IN_USE.add(port)
             print_info(

--- a/tests/integration/defs/conftest.py
+++ b/tests/integration/defs/conftest.py
@@ -28,20 +28,16 @@ import tempfile
 import time
 import urllib.request
 import warnings
-from functools import wraps
+from functools import cache, wraps
 from pathlib import Path
 from typing import Iterable, Sequence
 
 import defs.ci_profiler
 import psutil
 import pytest
-import torch
 import tqdm
 import yaml
 from _pytest.mark import ParameterSet
-
-from tensorrt_llm.bindings import ipc_nvls_supported
-from tensorrt_llm.llmapi.mpi_session import get_mpi_world_size
 
 from .perf.gpu_clock_lock import GPUClockLock
 from .perf.session_data_writer import SessionDataWriter
@@ -1755,6 +1751,8 @@ def skip_by_device_count(request):
 def skip_by_mpi_world_size(request):
     "fixture for skip less mpi world size"
     if request.node.get_closest_marker("skip_less_mpi_world_size"):
+        from tensorrt_llm.llmapi.mpi_session import get_mpi_world_size
+
         mpi_world_size = get_mpi_world_size()
         device_count = get_device_count()
         if mpi_world_size == 1:
@@ -1784,15 +1782,29 @@ def skip_by_device_memory(request):
                 f"Device memory {device_memory} is less than {expected_memory}")
 
 
+@cache
 def get_sm_version():
-    "get compute capability"
-    if not torch.cuda.is_available():
-        return 0
+    """Get compute capability without retaining a CUDA context."""
+    probe = ("import torch\n"
+             "try:\n"
+             "    if torch.cuda.is_available():\n"
+             "        major, minor = torch.cuda.get_device_capability(0)\n"
+             "        print(major * 10 + minor)\n"
+             "    else:\n"
+             "        print(0)\n"
+             "except RuntimeError:\n"
+             "    print(0)\n")
     try:
-        prop = torch.cuda.get_device_properties(0)
-    except RuntimeError:
-        return 0
-    return prop.major * 10 + prop.minor
+        output = sp.check_output([sys.executable, "-c", probe],
+                                 stderr=sp.STDOUT,
+                                 text=True)
+    except sp.CalledProcessError as error:
+        raise RuntimeError(f"CUDA SM probe failed:\n{error.output}") from error
+    try:
+        return int(output.splitlines()[-1])
+    except (IndexError, ValueError) as error:
+        raise RuntimeError(
+            f"CUDA SM probe produced invalid output: {output!r}") from error
 
 
 def is_sm_100f(sm_version=None):
@@ -1817,13 +1829,36 @@ def check_device_contain(keyword_list):
     return any(keyword in device for keyword in keyword_list)
 
 
+@cache
 def is_ipc_nvls_supported():
-    if not torch.cuda.is_available():
-        return False
+    # These probes run while integration tests are collected. Keep their CUDA
+    # context in a short-lived child so wrappers that launch GPU-heavy tests do
+    # not reserve hundreds of MiB on the device for the rest of the session.
+    probe = ("import torch\n"
+             "from tensorrt_llm.bindings import ipc_nvls_supported\n"
+             "try:\n"
+             "    supported = (torch.cuda.is_available() and "
+             "ipc_nvls_supported())\n"
+             "except RuntimeError:\n"
+             "    supported = False\n"
+             "print(int(supported))\n")
     try:
-        return ipc_nvls_supported()
-    except RuntimeError:
-        return False
+        output = sp.check_output([sys.executable, "-c", probe],
+                                 stderr=sp.STDOUT,
+                                 text=True)
+    except sp.CalledProcessError as error:
+        raise RuntimeError(
+            f"CUDA IPC NVLS probe failed:\n{error.output}") from error
+    try:
+        supported = int(output.splitlines()[-1])
+    except (IndexError, ValueError) as error:
+        raise RuntimeError(
+            f"CUDA IPC NVLS probe produced invalid output: {output!r}"
+        ) from error
+    if supported not in (0, 1):
+        raise RuntimeError(
+            f"CUDA IPC NVLS probe produced invalid result: {supported}")
+    return bool(supported)
 
 
 skip_pre_ada = pytest.mark.skipif(
@@ -2644,7 +2679,8 @@ def torch_empty_cache() -> None:
     """
     Manually empty the torch CUDA cache before each test, to reduce risk of OOM errors.
     """
-    if torch.cuda.is_available():
+    torch_module = sys.modules.get("torch")
+    if torch_module is not None and torch_module.cuda.is_initialized():
         gc.collect()
-        torch.cuda.empty_cache()
+        torch_module.cuda.empty_cache()
         gc.collect()

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # # Force resource release after test
+import faulthandler
 import os
 import signal
 import sys
@@ -21,20 +22,12 @@ import warnings
 from functools import partial
 from typing import Any, Generator
 
-try:
-    import ray
-except ModuleNotFoundError:
-    from tensorrt_llm import ray_stub as ray
-
 import _pytest.outcomes
 import pytest
 import torch
 import tqdm
 from mpi4py.futures import MPIPoolExecutor
 from utils.cpp_paths import llm_root  # noqa: F401
-from utils.util import get_current_process_gpu_memory
-
-from tensorrt_llm._utils import print_all_stacks
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from integration.defs import test_list_parser
@@ -42,7 +35,7 @@ from test_common import s3_output
 
 
 def dump_threads(signum, frame):
-    print_all_stacks()
+    faulthandler.dump_traceback(all_threads=True)
 
 
 def pytest_configure(config):
@@ -108,9 +101,10 @@ def pytest_runtest_protocol(item, nextitem):
             import torch
             worker_count = int(os.environ.get('PYTEST_XDIST_WORKER_COUNT', 1))
 
-            if (torch.cuda.memory_reserved(0) + torch.cuda.memory_allocated(0)
-                ) >= (torch.cuda.get_device_properties(0).total_memory //
-                      worker_count) * 0.9:
+            if (torch.cuda.is_initialized() and
+                (torch.cuda.memory_reserved(0) + torch.cuda.memory_allocated(0))
+                    >= (torch.cuda.get_device_properties(0).total_memory //
+                        worker_count) * 0.9):
                 gc.collect()
                 print("torch.cuda.memory_allocated: %fGB" %
                       (torch.cuda.memory_allocated(0) / 1024 / 1024 / 1024))
@@ -343,7 +337,7 @@ def torch_empty_cache() -> None:
     """
     Automatically empty the torch CUDA cache before each test, to reduce risk of OOM errors.
     """
-    if torch.cuda.is_available():
+    if torch.cuda.is_initialized():
         torch.cuda.empty_cache()
 
 
@@ -440,6 +434,8 @@ def process_gpu_memory_info_available():
     torch.cuda.synchronize()
 
     # Try to get memory usage
+    from utils.util import get_current_process_gpu_memory
+
     usage = get_current_process_gpu_memory()
 
     # Clean up
@@ -457,6 +453,11 @@ def process_gpu_memory_info_available():
 @pytest.fixture(scope="function")
 def setup_ray_cluster() -> Generator[int, None, None]:
     import time
+
+    try:
+        import ray
+    except ModuleNotFoundError:
+        from tensorrt_llm import ray_stub as ray
 
     os.environ.setdefault("RAY_raylet_start_wait_time_s", "120")
     runtime_env = {

--- a/tests/unittest/llmapi/apps/_test_openai_chat_guided_decoding.py
+++ b/tests/unittest/llmapi/apps/_test_openai_chat_guided_decoding.py
@@ -9,9 +9,8 @@ import jsonschema
 import openai
 import pytest
 import yaml
-from utils.llm_data import llm_datasets_root
+from utils.llm_data import llm_datasets_root, llm_models_root
 
-from ..test_llm import get_model_path
 from .openai_server import RemoteOpenAIServer
 
 pytestmark = pytest.mark.threadleak(enabled=False)
@@ -19,6 +18,13 @@ os.environ['TIKTOKEN_RS_CACHE_DIR'] = os.path.join(llm_datasets_root(),
                                                    'tiktoken_vocab')
 os.environ['TIKTOKEN_ENCODINGS_BASE'] = os.path.join(llm_datasets_root(),
                                                      'tiktoken_vocab')
+
+
+def get_model_path(model_name):
+    engine_dir = os.environ.get('LLM_ENGINE_DIR')
+    if engine_dir:
+        return engine_dir
+    return str(llm_models_root() / model_name)
 
 
 @pytest.fixture(scope="module",

--- a/tests/unittest/llmapi/apps/openai_server.py
+++ b/tests/unittest/llmapi/apps/openai_server.py
@@ -1,18 +1,27 @@
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/baaedfdb2d3f1d70b7dbcde08b083abfe6017a92/tests/utils.py
 import os
+import socket
 import subprocess
 import sys
 import tempfile
 import time
-from typing import List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 import openai
 import requests
 import yaml
 
-from tensorrt_llm._utils import get_free_port
-from tensorrt_llm.llmapi.disagg_utils import ServerRole
+if TYPE_CHECKING:
+    from tensorrt_llm.llmapi.disagg_utils import ServerRole
+else:
+    ServerRole = Any
+
+
+def get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
 
 
 class RemoteOpenAIServer:
@@ -30,7 +39,7 @@ class RemoteOpenAIServer:
                  extra_config: Optional[dict] = None,
                  log_path: Optional[str] = None,
                  wait: bool = True,
-                 role: Optional[ServerRole] = None) -> None:
+                 role: Optional["ServerRole"] = None) -> None:
         self.host = host
         self.port = port if port is not None else get_free_port()
         self.rank = rank if rank != -1 else int(
@@ -214,8 +223,6 @@ class RemoteMMEncoderServer(RemoteOpenAIServer):
                  log_path: Optional[str] = None) -> None:
         # Reuse parent initialization but change the command
         import subprocess
-
-        from tensorrt_llm._utils import get_free_port
 
         self.host = "localhost"
         self.port = port if port is not None else get_free_port()

--- a/tests/unittest/utils/cpp_paths.py
+++ b/tests/unittest/utils/cpp_paths.py
@@ -4,9 +4,6 @@ import sys as _sys
 
 import pytest
 
-import tensorrt_llm.bindings as _tb
-from tensorrt_llm.bindings.internal.testing import ModelSpec
-
 _sys.path.append(_os.path.join(_os.path.dirname(__file__), '..', '..', '..'))
 
 
@@ -37,7 +34,10 @@ def engine_path(resource_path: _pl.Path) -> _pl.Path:
     return resource_path / "models" / "rt_engine"
 
 
-def get_base_model_spec() -> ModelSpec:
+def get_base_model_spec():
+    import tensorrt_llm.bindings as _tb
+    from tensorrt_llm.bindings.internal.testing import ModelSpec
+
     model_spec_obj = ModelSpec('input_tokens.npy', _tb.DataType.HALF)
     model_spec_obj.use_gpt_plugin().set_kv_cache_type(
         _tb.KVCacheType.PAGED).use_packed_input()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test and CI stability by loading heavy GPU-related components only when needed.
  * Made CUDA and distributed test setup safer to reduce side effects during test collection.
  * Strengthened port selection for test servers to avoid conflicts in CI.
  * Improved debugging for stuck tests by using more reliable thread-dump output.
  * Made OpenAI test server and model-path resolution more robust across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixes [NVBug 6384375](https://nvbugspro.nvidia.com/bug/6384375).

The GPT-OSS 120B guided-decoding test can OOM on an 80GB H100 while preparing MXFP4 weights. The reproduced failure requests 1.03 GiB with only 943.88 MiB free; the subsequent `ConnectionRefusedError` is a consequence of the server exiting after that OOM.

The outer integration pytest and nested unit-test pytest only control a child workload, but collection-time probes and eager TensorRT-LLM imports initialize CUDA in both processes. Each controller retains approximately 554 MiB for the lifetime of the workload, reducing available memory by about 1.08 GiB.

This change keeps those controllers CPU-only by:

- Delaying TensorRT-LLM, Ray, binding, and GPU-memory helper imports until needed.
- Running SM and IPC NVLS collection probes in cached, short-lived subprocesses.
- Avoiding CUDA cache/device operations unless CUDA is already initialized.
- Using lightweight standard-library and test-data helpers for stack dumps, model paths, free ports, and type-only annotations.

This only changes the test harness; it does not change TRT-LLM runtime or API behavior.

## Test Coverage

Exact H100 80GB validation on main `d567f924`:

```bash
python -m pytest \
  'tests/integration/defs/test_e2e.py::test_openai_chat_guided_decoding[openai/gpt-oss-120b]' \
  -s
```

- Unpatched: reproduced the MXFP4 swizzle OOM.
- Patched: outer test passed; nested suite passed all 6 selected cases.
- Patched with another process holding 998 MiB of GPU memory: passed, with neither pytest controller retaining GPU memory.
- Clean nested-module `--collect-only`: created no GPU process.

Rebased and checked on current main `7a56db9886`:

- Repository pre-commit hooks passed for all six changed files.
- `python -m py_compile` passed for all six changed files.
- `ruff check --select F401,F821` passed for all six changed files.
- Nested guided-decoding collection selected the expected 6 GPT-OSS cases.
- `git diff --check` passed.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
