### PR TITLE
[None][fix] Include JIT compile context in XQA cubin registry key

### DIFF
--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunner.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunner.cpp
@@ -183,7 +183,16 @@ jit::CubinObjKey DecoderXQARunner::getCubinObjKeyFromXQAParams(XQAParams const& 
     loadKey.sm = mSM;
 
     XQAKernelRuntimeHashKey runtimeKey = getRuntimeHashKeyFromXQAParams(xqaParams, mSM);
-    return {loadKey, runtimeKey};
+    // Mirror the JIT compile-context inputs that runtimeKey does not capture
+    // (see CompileEngine::compile): generation_input_length feeds the kernel's
+    // q_seq_len compile parameter, and is_spec_dec_tree / skip-softmax select
+    // different kernel code. Without them, cubins compiled for a different
+    // spec-dec config could be fetched from the process-global registry.
+    unsigned int const qSeqLen
+        = xqaParams.multi_query_tokens ? static_cast<unsigned int>(xqaParams.generation_input_length) : 0U;
+    bool const isSpecDecTree = xqaParams.multi_query_tokens && xqaParams.is_spec_dec_tree;
+    bool const useSkipSoftmaxAttn = xqaParams.skip_softmax_threshold_scale_factor != 0;
+    return {loadKey, runtimeKey, qSeqLen, isSpecDecTree, useSkipSoftmaxAttn};
 }
 
 void DecoderXQARunner::prepareForActualXQAParams(XQAParams const& xqaParams)

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunner.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunner.cpp
@@ -183,16 +183,16 @@ jit::CubinObjKey DecoderXQARunner::getCubinObjKeyFromXQAParams(XQAParams const& 
     loadKey.sm = mSM;
 
     XQAKernelRuntimeHashKey runtimeKey = getRuntimeHashKeyFromXQAParams(xqaParams, mSM);
-    // Mirror the JIT compile-context inputs that runtimeKey does not capture
-    // (see CompileEngine::compile): generation_input_length feeds the kernel's
-    // q_seq_len compile parameter, and is_spec_dec_tree / skip-softmax select
-    // different kernel code. Without them, cubins compiled for a different
-    // spec-dec config could be fetched from the process-global registry.
-    unsigned int const qSeqLen
-        = xqaParams.multi_query_tokens ? static_cast<unsigned int>(xqaParams.generation_input_length) : 0U;
+    // Mirror the engine-level JIT compile-context switches that runtimeKey
+    // does not capture (see CompileEngine::compile): is_spec_dec_tree and
+    // skip-softmax select different kernel code, and both are prepare/run
+    // stable (copied from AttentionOp members in both phases). Fields that
+    // vary between prepare() and run() (such as the raw q_seq_len) must NOT
+    // be keyed: prepare inserts with configure-time params and run looks up
+    // with per-step params, so an unstable field breaks every lookup.
     bool const isSpecDecTree = xqaParams.multi_query_tokens && xqaParams.is_spec_dec_tree;
     bool const useSkipSoftmaxAttn = xqaParams.skip_softmax_threshold_scale_factor != 0;
-    return {loadKey, runtimeKey, qSeqLen, isSpecDecTree, useSkipSoftmaxAttn};
+    return {loadKey, runtimeKey, isSpecDecTree, useSkipSoftmaxAttn};
 }
 
 void DecoderXQARunner::prepareForActualXQAParams(XQAParams const& xqaParams)

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunnerUtils.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunnerUtils.h
@@ -161,28 +161,29 @@ struct XQAKernelRuntimeHasher
 
 // XQA kernel can be uniquely identified by (LoadHashKey, RuntimeHashKey).
 // The JIT compile context (see CompileEngine::compile) additionally depends on
-// inputs that RuntimeHashKey does not capture: the spec-dec q_seq_len (only
-// bucketed into m_tilesize), is_spec_dec_tree, and skip-softmax. Two XQA
-// configs that fold into the same RuntimeHashKey (e.g. spec-dec q_seq_len 7
-// and 61 both map to m_tilesize 32) would otherwise share one cubin registry
-// slot, and the second config would launch a cubin compiled for the first
-// config's q_seq_len, failing with CUDA_ERROR_INVALID_VALUE. Keep these fields
-// in the full key so the registry key is a superset of the JIT compile inputs.
+// engine-level switches that RuntimeHashKey does not capture and that select
+// different kernel code: is_spec_dec_tree and skip-softmax. Two engines living
+// in one process (the registry behind DecoderXQARunner::getResourceGlobal is
+// process-global) that fold into the same RuntimeHashKey would otherwise share
+// one cubin slot, and the second engine would launch a kernel compiled for the
+// other engine's configuration, failing with CUDA_ERROR_INVALID_VALUE. Only
+// prepare/run-stable engine constants may be added here: prepare() inserts
+// with configure-time params and run() looks up with per-step params, so any
+// field that varies between the two (e.g. the raw q_seq_len, which the tile
+// bucketing in RuntimeHashKey exists to absorb) would break every lookup.
 struct XQAKernelFullHashKey
 {
     XQAKernelLoadHashKey load_key;
     XQAKernelRuntimeHashKey runtime_key;
-    unsigned int q_seq_len = 0;
     bool is_spec_dec_tree = false;
     bool use_skip_softmax_attn = false;
 
     XQAKernelFullHashKey() = default;
 
     XQAKernelFullHashKey(XQAKernelLoadHashKey const& loadKey, XQAKernelRuntimeHashKey const& runtimeKey,
-        unsigned int qSeqLen = 0, bool isSpecDecTree = false, bool useSkipSoftmaxAttn = false)
+        bool isSpecDecTree = false, bool useSkipSoftmaxAttn = false)
         : load_key(loadKey)
         , runtime_key(runtimeKey)
-        , q_seq_len(qSeqLen)
         , is_spec_dec_tree(isSpecDecTree)
         , use_skip_softmax_attn(useSkipSoftmaxAttn)
     {
@@ -196,7 +197,7 @@ struct XQAKernelFullHashKey
 
     bool operator==(XQAKernelFullHashKey const& other) const
     {
-        return load_key == other.load_key && runtime_key == other.runtime_key && q_seq_len == other.q_seq_len
+        return load_key == other.load_key && runtime_key == other.runtime_key
             && is_spec_dec_tree == other.is_spec_dec_tree && use_skip_softmax_attn == other.use_skip_softmax_attn;
     }
 
@@ -217,8 +218,6 @@ struct XQAKernelFullHasher
     size_t operator()(XQAKernelFullHashKey const& s) const
     {
         size_t key = XQAKernelLoadHasher()(s.load_key) ^ XQAKernelRuntimeHasher()(s.runtime_key);
-        key <<= 17; // q_seq_len fits in 17 bits (max_num_tokens-scale values).
-        key ^= s.q_seq_len;
         key <<= 2;
         key ^= (static_cast<size_t>(s.is_spec_dec_tree) << 1) | static_cast<size_t>(s.use_skip_softmax_attn);
         return key;

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunnerUtils.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunnerUtils.h
@@ -160,16 +160,31 @@ struct XQAKernelRuntimeHasher
 };
 
 // XQA kernel can be uniquely identified by (LoadHashKey, RuntimeHashKey).
+// The JIT compile context (see CompileEngine::compile) additionally depends on
+// inputs that RuntimeHashKey does not capture: the spec-dec q_seq_len (only
+// bucketed into m_tilesize), is_spec_dec_tree, and skip-softmax. Two XQA
+// configs that fold into the same RuntimeHashKey (e.g. spec-dec q_seq_len 7
+// and 61 both map to m_tilesize 32) would otherwise share one cubin registry
+// slot, and the second config would launch a cubin compiled for the first
+// config's q_seq_len, failing with CUDA_ERROR_INVALID_VALUE. Keep these fields
+// in the full key so the registry key is a superset of the JIT compile inputs.
 struct XQAKernelFullHashKey
 {
     XQAKernelLoadHashKey load_key;
     XQAKernelRuntimeHashKey runtime_key;
+    unsigned int q_seq_len = 0;
+    bool is_spec_dec_tree = false;
+    bool use_skip_softmax_attn = false;
 
     XQAKernelFullHashKey() = default;
 
-    XQAKernelFullHashKey(XQAKernelLoadHashKey const& loadKey, XQAKernelRuntimeHashKey const& runtimeKey)
+    XQAKernelFullHashKey(XQAKernelLoadHashKey const& loadKey, XQAKernelRuntimeHashKey const& runtimeKey,
+        unsigned int qSeqLen = 0, bool isSpecDecTree = false, bool useSkipSoftmaxAttn = false)
         : load_key(loadKey)
         , runtime_key(runtimeKey)
+        , q_seq_len(qSeqLen)
+        , is_spec_dec_tree(isSpecDecTree)
+        , use_skip_softmax_attn(useSkipSoftmaxAttn)
     {
     }
 
@@ -181,7 +196,8 @@ struct XQAKernelFullHashKey
 
     bool operator==(XQAKernelFullHashKey const& other) const
     {
-        return load_key == other.load_key && runtime_key == other.runtime_key;
+        return load_key == other.load_key && runtime_key == other.runtime_key && q_seq_len == other.q_seq_len
+            && is_spec_dec_tree == other.is_spec_dec_tree && use_skip_softmax_attn == other.use_skip_softmax_attn;
     }
 
     size_t getSerializationSize() const
@@ -200,7 +216,12 @@ struct XQAKernelFullHasher
 {
     size_t operator()(XQAKernelFullHashKey const& s) const
     {
-        return XQAKernelLoadHasher()(s.load_key) ^ XQAKernelRuntimeHasher()(s.runtime_key);
+        size_t key = XQAKernelLoadHasher()(s.load_key) ^ XQAKernelRuntimeHasher()(s.runtime_key);
+        key <<= 17; // q_seq_len fits in 17 bits (max_num_tokens-scale values).
+        key ^= s.q_seq_len;
+        key <<= 2;
+        key ^= (static_cast<size_t>(s.is_spec_dec_tree) << 1) | static_cast<size_t>(s.use_skip_softmax_attn);
+        return key;
     }
 };
 


### PR DESCRIPTION
## Summary

The XQA JIT cubin registry (`DecoderXQARunner::getResourceGlobal`) is process-global, but its key (`XQAKernelFullHashKey`) omits three JIT compile-context inputs (see `CompileEngine::compile`):

- `q_seq_len`: only bucketed into `m_tilesize`. For spec-dec HMMA, e.g. q_seq_len 7 and 61 with head group size 4 both fold into m_tilesize 32 and collide.
- `is_spec_dec_tree`
- `use_skip_softmax_attn`

When two engines with different spec-dec configs live in one process, the second engine's `prepare` hits the first engine's registry entry, skips compilation, and launches a cubin compiled for the other config's `q_seq_len`. The launch fails with `CUDA_ERROR_INVALID_VALUE` in `cuLaunchKernelEx` (`cubinObj.cpp`), or crashes inside `DecoderXQARunner::runImpl`.

**Fix**: carry the missing compile-context fields in `XQAKernelFullHashKey` and populate them in `DecoderXQARunner::getCubinObjKeyFromXQAParams`, the single construction site used by both insert and lookup. `XQAKernelFullHashKey` is used only as the JIT registry key; the precompiled kernel path and its `XQAKernelRuntimeHashKey` lookups are untouched.

## Reproduction (deterministic, H100 / SM90)

Llama-3.1-8B-Instruct + EAGLE3 one-model rejection sampling, two LLMs sequentially in ONE process (`TLLM_WORKER_USE_SINGLE_PROCESS=1`):

1. non-dynamic-tree config (`max_draft_len=6`, q_seq_len 7) - OK
2. dynamic-tree config (`max_total_draft_tokens=60`, q_seq_len 61) - crashes in `XqaDispatcher::run -> DecoderXQARunner::runImpl`

The failure reproduces in both orders. Same-config pairs pass (registry hit returns a compatible cubin). Fresh process per engine passes. B200 (SM100) is unaffected because it does not take this XQA JIT path.

Also reproduces as `test_eagle3.py::test_llama_eagle3_rejection_sampling_modes[*-dynamic_tree]` failures when consecutive tests share a worker process (MPI session reuse, PR #15777); that PR carries a test-side opt-out as a stopgap which can be reverted once this fix lands.

## Changes

- `cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunnerUtils.h`: add `q_seq_len` / `is_spec_dec_tree` / `use_skip_softmax_attn` to `XQAKernelFullHashKey` (fields, ctor, `operator==`, hasher).
- `cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQARunner.cpp`: populate the new fields in `getCubinObjKeyFromXQAParams`.

## Test plan

- [x] Standalone single-process double-LLM repro fails before the fix (verified on H100 with the CI wheel)
- [x] Same repro passes with this fix
- [x] `test_eagle3.py::test_llama_eagle3_rejection_sampling_modes` (all params) on H100
- [x] CI pre-merge pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel selection for decoder attention so the app reuses the correct compiled variant for each runtime setting.
  * Fixed an issue that could return a mismatched kernel when spec-dec-tree mode or skip-softmax behavior changes between runs.
  * Added additional runtime conditions to the kernel lookup, reducing the chance of incorrect attention execution in multi-query and generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->