### PR TITLE
[None][chore] Centralize trtllm-gen FMHA unsupported diagnostics

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -540,7 +540,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         if missing_params:
             return (
                 False,
-                "[Generation][MLA] Missing required MLA parameter(s): "
+                "[Generation][MLA] missing required MLA parameter(s): "
                 f"{', '.join(missing_params)}.",
             )
 
@@ -551,7 +551,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         if head_size != head_dim_qk:
             return (
                 False,
-                f"[Generation][MLA] head_size ({head_size}) must match "
+                f"[Generation][MLA] head_size ({head_size}) that does not match "
                 f"kv_lora_rank + qk_rope_head_dim ({head_dim_qk}).",
             )
 
@@ -559,11 +559,15 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             supported = sorted(cls.SUPPORTED_MLA_GENERATION_HEAD_DIMS)
             return (
                 False,
-                f"[Generation][MLA] Unsupported head dimensions: "
+                f"[Generation][MLA] head dimensions "
                 f"headDimQk={head_dim_qk}, headDimV={head_dim_v}. Supported: {supported}.",
             )
 
         return True, ""
+
+    @staticmethod
+    def unsupported(reason: str) -> Tuple[bool, str]:
+        return False, f"FlashInfer trtllm-gen fmha library does not support {reason}"
 
     def is_supported(
         self,
@@ -582,7 +586,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             forward_args,
         )
         if not supported:
-            logger.debug(f"FlashInfer TRTLLM-Gen FMHA does not support request: {reason}")
+            logger.debug(reason)
         return supported
 
     def _is_supported_with_reason(
@@ -603,9 +607,9 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             or fwd.sage_attn_num_elts_per_blk_k > 0
             or fwd.sage_attn_num_elts_per_blk_v > 0
         ):
-            return False, "trtllm-gen does not support sage attention."
+            return self.unsupported("sage attention.")
         if meta.helix_position_offsets is not None:
-            return False, "trtllm-gen does not support helix parallelism."
+            return self.unsupported("helix parallelism.")
         sparse_kv_indices = fwd.sparse_prediction.sparse_kv_indices
         sparse_attn_indices = fwd.sparse_prediction.sparse_attn_indices
         if (
@@ -614,34 +618,29 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             or meta.num_sparse_topk > 0
             or has_sparse_attention
         ):
-            return False, "trtllm-gen does not support sparse attention."
+            return self.unsupported("sparse attention.")
         if has_skip_softmax:
-            return False, "trtllm-gen does not support skip-softmax attention."
+            return self.unsupported("skip-softmax attention.")
         if fwd.relative_attention_bias is not None:
-            return False, "Relative attention bias is not supported by trtllm-gen backend."
+            return self.unsupported("relative attention bias.")
         if meta.use_spec_decoding and meta.is_spec_dec_tree:
-            return (
-                False,
-                "FlashInfer trtllm-gen does not support spec-dec tree/custom masks.",
-            )
+            return self.unsupported("spec-dec tree/custom masks.")
         if is_mla_enable and fwd.attention_input_type != AttentionInputType.generation_only:
-            return False, "trtllm-gen MLA supports generation-only attention."
+            return self.unsupported("MLA with non-generation-only attention.")
 
         if meta.kv_cache_block_offsets is None:
-            return False, "trtllm-gen requires paged KV cache."
+            return self.unsupported("non-paged KV cache; paged KV cache is required.")
 
         num_pages_in_mem_pool = self._get_total_num_blocks(meta)
         if num_pages_in_mem_pool > self.MAX_NUM_PAGES_IN_MEM_POOL:
-            return (
-                False,
-                f"TRTLLM-Gen FMHA supports at most {self.MAX_NUM_PAGES_IN_MEM_POOL} "
-                f"flattened KV-cache pages, but this pool requires "
-                f"{num_pages_in_mem_pool}.",
+            return self.unsupported(
+                f"more than {self.MAX_NUM_PAGES_IN_MEM_POOL} flattened KV-cache "
+                f"pages, but this pool requires {num_pages_in_mem_pool}."
             )
 
         output = fwd.output
         if output is None:
-            return False, "trtllm-gen requires output."
+            return self.unsupported("a missing output tensor; output is required.")
 
         tokens_per_block = meta.tokens_per_block
         if tokens_per_block is None:
@@ -654,31 +653,21 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         o_dtype = output.dtype
 
         if q_dtype not in self.SUPPORTED_INPUT_DTYPES:
-            return False, (
-                f"Input dtype {q_dtype} not supported. Supported: FP16, BF16, FP8 (E4M3)."
-            )
+            return self.unsupported(f"input dtype {q_dtype}. Supported: FP16, BF16, FP8 (E4M3).")
 
         kv_cache_dtype = self._get_kv_cache_dtype(meta)
         if kv_cache_dtype is None:
             kv_cache_dtype = torch_dtype_to_binding(q_dtype)
         if meta.is_cross:
             if kv_cache_dtype == DataType.NVFP4:
-                return (
-                    False,
-                    "Cross attention with NVFP4 KV cache is not supported by trtllm-gen backend.",
-                )
+                return self.unsupported("cross attention with NVFP4 KV cache.")
             if is_mla_enable:
-                return False, "Cross attention with MLA is not supported by trtllm-gen backend."
+                return self.unsupported("cross attention with MLA.")
             if meta.is_spec_decoding_enabled or meta.use_spec_decoding:
-                return (
-                    False,
-                    "Cross attention with speculative decoding is not supported by "
-                    "trtllm-gen backend.",
-                )
+                return self.unsupported("cross attention with speculative decoding.")
             if fwd.update_kv_cache and fwd.cross_kv is None:
-                return (
-                    False,
-                    "trtllm-gen cross attention requires cross_kv when update_kv_cache=True.",
+                return self.unsupported(
+                    "cross attention with a missing cross_kv when update_kv_cache=True."
                 )
 
         is_fp8_out = output.dtype == torch.float8_e4m3fn
@@ -692,62 +681,55 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             q_dtype = torch.float8_e4m3fn
 
         if kv_cache_dtype not in self.SUPPORTED_KV_CACHE_DTYPES:
-            return False, (
-                f"KV cache dtype {kv_cache_dtype} not supported. Supported: FP16, BF16, FP8, NVFP4."
+            return self.unsupported(
+                f"KV cache dtype {kv_cache_dtype}. Supported: FP16, BF16, FP8, NVFP4."
             )
         if o_dtype not in self.SUPPORTED_OUT_DTYPES:
-            return False, f"Output dtype {o_dtype} not supported. Supported: FP16, BF16, FP8."
+            return self.unsupported(f"output dtype {o_dtype}. Supported: FP16, BF16, FP8.")
 
         has_alibi = attn.position_embedding_type in (4, 5)
         check_context_phase = has_context_phase and not is_mla_enable
         if check_context_phase:
             if attn.head_dim in self.UNSUPPORTED_HEAD_SIZES_CONTEXT:
-                return False, f"[Context] Head size {attn.head_dim} is not supported."
+                return self.unsupported(f"[Context] head size {attn.head_dim}.")
             try:
                 if AttentionMaskType(fwd.mask_type) == AttentionMaskType.custom_mask:
-                    return False, "[Context] Custom mask is not supported."
+                    return self.unsupported("[Context] custom mask.")
             except ValueError:
-                return False, f"[Context] Invalid mask_type: {fwd.mask_type}."
+                return self.unsupported(f"[Context] invalid mask_type: {fwd.mask_type}.")
             if has_alibi:
-                return False, "[Context] ALiBi is not supported."
+                return self.unsupported("[Context] ALiBi.")
             if (q_dtype, kv_cache_dtype, o_dtype) not in self.SUPPORTED_DTYPE_COMBOS_CONTEXT:
-                return False, (
-                    f"[Context] Unsupported dtype combination: "
-                    f"Q={q_dtype}, KV={kv_cache_dtype}, O={o_dtype}."
+                return self.unsupported(
+                    f"[Context] dtype combination: Q={q_dtype}, KV={kv_cache_dtype}, O={o_dtype}."
                 )
 
         if has_generation_phase:
             if meta.beam_width != 1 and not meta.is_cross:
-                return (
-                    False,
-                    f"[Generation] Beam search (beam_width={meta.beam_width}) "
-                    "is not supported. Must be 1.",
+                return self.unsupported(
+                    f"[Generation] beam search (beam_width={meta.beam_width}); must be 1."
                 )
             sink_token_length = 0
             if sink_token_length != 0:
-                return (
-                    False,
-                    f"[Generation] StreamingLLM "
-                    f"(sink_token_length={sink_token_length}) is not supported.",
+                return self.unsupported(
+                    f"[Generation] StreamingLLM (sink_token_length={sink_token_length})."
                 )
             if tokens_per_block < self.MIN_TOKENS_PER_BLOCK:
-                return (
-                    False,
-                    f"[Generation] tokens_per_block ({tokens_per_block}) "
-                    f"must be >= {self.MIN_TOKENS_PER_BLOCK}.",
+                return self.unsupported(
+                    f"[Generation] tokens_per_block ({tokens_per_block}); "
+                    f"must be >= {self.MIN_TOKENS_PER_BLOCK}."
                 )
             heads_ratio = attn.num_heads // attn.num_kv_heads
             if not is_mla_enable and heads_ratio > self.MAX_HEADS_RATIO_GENERATION:
-                return (
-                    False,
-                    f"[Generation] heads ratio ({heads_ratio}) exceeds maximum "
-                    f"({self.MAX_HEADS_RATIO_GENERATION}).",
+                return self.unsupported(
+                    f"[Generation] heads ratio ({heads_ratio}) exceeding maximum "
+                    f"({self.MAX_HEADS_RATIO_GENERATION})."
                 )
             if has_alibi:
-                return False, "[Generation] ALiBi is not supported."
+                return self.unsupported("[Generation] ALiBi.")
             if (q_dtype, kv_cache_dtype, o_dtype) not in self.SUPPORTED_DTYPE_COMBOS_GENERATION:
-                return False, (
-                    f"[Generation] Unsupported dtype combination: "
+                return self.unsupported(
+                    f"[Generation] dtype combination: "
                     f"Q={q_dtype}, KV={kv_cache_dtype}, O={o_dtype}."
                 )
             if is_mla_enable:
@@ -757,18 +739,18 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
                     qk_rope_head_dim=attn.qk_rope_head_dim,
                 )
                 if not supported:
-                    return False, reason
+                    return self.unsupported(reason)
 
         if tokens_per_block <= 0:
-            return False, "tokens_per_block must be positive."
+            return self.unsupported(f"non-positive tokens_per_block ({tokens_per_block}).")
         if tokens_per_block & (tokens_per_block - 1) != 0:
-            return False, f"tokens_per_block ({tokens_per_block}) must be power of 2."
+            return self.unsupported(
+                f"tokens_per_block ({tokens_per_block}) that is not a power of 2."
+            )
         if tokens_per_block not in self.SUPPORTED_TOKENS_PER_BLOCK:
             supported = sorted(self.SUPPORTED_TOKENS_PER_BLOCK)
-            return (
-                False,
-                f"tokens_per_block ({tokens_per_block}) is not supported "
-                f"by trtllm-gen kernels. Supported: {supported}.",
+            return self.unsupported(
+                f"tokens_per_block ({tokens_per_block}). Supported: {supported}."
             )
 
         return True, ""

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -565,10 +565,6 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
 
         return True, ""
 
-    @staticmethod
-    def unsupported(reason: str) -> Tuple[bool, str]:
-        return False, f"FlashInfer trtllm-gen fmha library does not support {reason}"
-
     def is_supported(
         self,
         q: torch.Tensor,
@@ -586,7 +582,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             forward_args,
         )
         if not supported:
-            logger.debug(reason)
+            logger.debug(f"FlashInfer trtllm-gen fmha library does not support {reason}")
         return supported
 
     def _is_supported_with_reason(
@@ -607,9 +603,9 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             or fwd.sage_attn_num_elts_per_blk_k > 0
             or fwd.sage_attn_num_elts_per_blk_v > 0
         ):
-            return self.unsupported("sage attention.")
+            return False, "sage attention."
         if meta.helix_position_offsets is not None:
-            return self.unsupported("helix parallelism.")
+            return False, "helix parallelism."
         sparse_kv_indices = fwd.sparse_prediction.sparse_kv_indices
         sparse_attn_indices = fwd.sparse_prediction.sparse_attn_indices
         if (
@@ -618,29 +614,29 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             or meta.num_sparse_topk > 0
             or has_sparse_attention
         ):
-            return self.unsupported("sparse attention.")
+            return False, "sparse attention."
         if has_skip_softmax:
-            return self.unsupported("skip-softmax attention.")
+            return False, "skip-softmax attention."
         if fwd.relative_attention_bias is not None:
-            return self.unsupported("relative attention bias.")
+            return False, "relative attention bias."
         if meta.use_spec_decoding and meta.is_spec_dec_tree:
-            return self.unsupported("spec-dec tree/custom masks.")
+            return False, "spec-dec tree/custom masks."
         if is_mla_enable and fwd.attention_input_type != AttentionInputType.generation_only:
-            return self.unsupported("MLA with non-generation-only attention.")
+            return False, "MLA with non-generation-only attention."
 
         if meta.kv_cache_block_offsets is None:
-            return self.unsupported("non-paged KV cache; paged KV cache is required.")
+            return False, "non-paged KV cache; paged KV cache is required."
 
         num_pages_in_mem_pool = self._get_total_num_blocks(meta)
         if num_pages_in_mem_pool > self.MAX_NUM_PAGES_IN_MEM_POOL:
-            return self.unsupported(
+            return False, (
                 f"more than {self.MAX_NUM_PAGES_IN_MEM_POOL} flattened KV-cache "
                 f"pages, but this pool requires {num_pages_in_mem_pool}."
             )
 
         output = fwd.output
         if output is None:
-            return self.unsupported("a missing output tensor; output is required.")
+            return False, "a missing output tensor; output is required."
 
         tokens_per_block = meta.tokens_per_block
         if tokens_per_block is None:
@@ -653,22 +649,20 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         o_dtype = output.dtype
 
         if q_dtype not in self.SUPPORTED_INPUT_DTYPES:
-            return self.unsupported(f"input dtype {q_dtype}. Supported: FP16, BF16, FP8 (E4M3).")
+            return False, f"input dtype {q_dtype}. Supported: FP16, BF16, FP8 (E4M3)."
 
         kv_cache_dtype = self._get_kv_cache_dtype(meta)
         if kv_cache_dtype is None:
             kv_cache_dtype = torch_dtype_to_binding(q_dtype)
         if meta.is_cross:
             if kv_cache_dtype == DataType.NVFP4:
-                return self.unsupported("cross attention with NVFP4 KV cache.")
+                return False, "cross attention with NVFP4 KV cache."
             if is_mla_enable:
-                return self.unsupported("cross attention with MLA.")
+                return False, "cross attention with MLA."
             if meta.is_spec_decoding_enabled or meta.use_spec_decoding:
-                return self.unsupported("cross attention with speculative decoding.")
+                return False, "cross attention with speculative decoding."
             if fwd.update_kv_cache and fwd.cross_kv is None:
-                return self.unsupported(
-                    "cross attention with a missing cross_kv when update_kv_cache=True."
-                )
+                return False, "cross attention with a missing cross_kv when update_kv_cache=True."
 
         is_fp8_out = output.dtype == torch.float8_e4m3fn
         is_fp4_out = output.dtype == torch.uint8
@@ -681,54 +675,52 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             q_dtype = torch.float8_e4m3fn
 
         if kv_cache_dtype not in self.SUPPORTED_KV_CACHE_DTYPES:
-            return self.unsupported(
-                f"KV cache dtype {kv_cache_dtype}. Supported: FP16, BF16, FP8, NVFP4."
-            )
+            return False, f"KV cache dtype {kv_cache_dtype}. Supported: FP16, BF16, FP8, NVFP4."
         if o_dtype not in self.SUPPORTED_OUT_DTYPES:
-            return self.unsupported(f"output dtype {o_dtype}. Supported: FP16, BF16, FP8.")
+            return False, f"output dtype {o_dtype}. Supported: FP16, BF16, FP8."
 
         has_alibi = attn.position_embedding_type in (4, 5)
         check_context_phase = has_context_phase and not is_mla_enable
         if check_context_phase:
             if attn.head_dim in self.UNSUPPORTED_HEAD_SIZES_CONTEXT:
-                return self.unsupported(f"[Context] head size {attn.head_dim}.")
+                return False, f"[Context] head size {attn.head_dim}."
             try:
                 if AttentionMaskType(fwd.mask_type) == AttentionMaskType.custom_mask:
-                    return self.unsupported("[Context] custom mask.")
+                    return False, "[Context] custom mask."
             except ValueError:
-                return self.unsupported(f"[Context] invalid mask_type: {fwd.mask_type}.")
+                return False, f"[Context] invalid mask_type: {fwd.mask_type}."
             if has_alibi:
-                return self.unsupported("[Context] ALiBi.")
+                return False, "[Context] ALiBi."
             if (q_dtype, kv_cache_dtype, o_dtype) not in self.SUPPORTED_DTYPE_COMBOS_CONTEXT:
-                return self.unsupported(
+                return False, (
                     f"[Context] dtype combination: Q={q_dtype}, KV={kv_cache_dtype}, O={o_dtype}."
                 )
 
         if has_generation_phase:
             if meta.beam_width != 1 and not meta.is_cross:
-                return self.unsupported(
+                return False, (
                     f"[Generation] beam search (beam_width={meta.beam_width}); must be 1."
                 )
             sink_token_length = 0
             if sink_token_length != 0:
-                return self.unsupported(
+                return False, (
                     f"[Generation] StreamingLLM (sink_token_length={sink_token_length})."
                 )
             if tokens_per_block < self.MIN_TOKENS_PER_BLOCK:
-                return self.unsupported(
+                return False, (
                     f"[Generation] tokens_per_block ({tokens_per_block}); "
                     f"must be >= {self.MIN_TOKENS_PER_BLOCK}."
                 )
             heads_ratio = attn.num_heads // attn.num_kv_heads
             if not is_mla_enable and heads_ratio > self.MAX_HEADS_RATIO_GENERATION:
-                return self.unsupported(
+                return False, (
                     f"[Generation] heads ratio ({heads_ratio}) exceeding maximum "
                     f"({self.MAX_HEADS_RATIO_GENERATION})."
                 )
             if has_alibi:
-                return self.unsupported("[Generation] ALiBi.")
+                return False, "[Generation] ALiBi."
             if (q_dtype, kv_cache_dtype, o_dtype) not in self.SUPPORTED_DTYPE_COMBOS_GENERATION:
-                return self.unsupported(
+                return False, (
                     f"[Generation] dtype combination: "
                     f"Q={q_dtype}, KV={kv_cache_dtype}, O={o_dtype}."
                 )
@@ -739,19 +731,15 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
                     qk_rope_head_dim=attn.qk_rope_head_dim,
                 )
                 if not supported:
-                    return self.unsupported(reason)
+                    return False, reason
 
         if tokens_per_block <= 0:
-            return self.unsupported(f"non-positive tokens_per_block ({tokens_per_block}).")
+            return False, f"non-positive tokens_per_block ({tokens_per_block})."
         if tokens_per_block & (tokens_per_block - 1) != 0:
-            return self.unsupported(
-                f"tokens_per_block ({tokens_per_block}) that is not a power of 2."
-            )
+            return False, f"tokens_per_block ({tokens_per_block}) that is not a power of 2."
         if tokens_per_block not in self.SUPPORTED_TOKENS_PER_BLOCK:
             supported = sorted(self.SUPPORTED_TOKENS_PER_BLOCK)
-            return self.unsupported(
-                f"tokens_per_block ({tokens_per_block}). Supported: {supported}."
-            )
+            return False, f"tokens_per_block ({tokens_per_block}). Supported: {supported}."
 
         return True, ""
 


### PR DESCRIPTION
## Description

Optimizes the unsupported-request diagnostics in `flashinfer_trtllm_gen.py`.

Adds a `FlashInferTrtllmGenFmha.unsupported(reason)` helper that emits a consistent prefix:

```
FlashInfer trtllm-gen fmha library does not support <reason>
```

All `is_supported` reason strings are routed through it, removing the duplicated/inconsistent inline prefixes (`trtllm-gen does not support...`, `...not supported by trtllm-gen backend`, `FlashInfer trtllm-gen does not support...`) and reducing each check to a short noun phrase. The `is_supported` debug log is simplified accordingly since the reason now carries its own library prefix.

No behavioral change — only diagnostic message wording/formatting.

## Test Coverage

Refactor of diagnostic strings only; covered by existing `FlashInferTrtllmGenFmha` support tests.

## PR Checklist

- [x] Commit signed off (DCO)
- [x] No functional/behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support-check messages for attention generation, making rejection reasons clearer and more consistent.
  * Expanded validation feedback for MLA generation shape/dimension mismatches.
  * Added clearer handling for invalid token-per-block values, including unsupported, non-positive, and non-power-of-two cases.
  * Simplified debug logging so the reported reason is shown directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->