### PR TITLE
[None][fix] Make auto host tier sizing rank-aware in KVCacheManagerV2

### DIFF
--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -17,10 +17,10 @@ except Exception:
     MPI = None  # deferred; functions will error if used when ENABLE_MULTI_DEVICE is True
 
 from tensorrt_llm._mnnvl_utils import init_helix_cp_comm
-from tensorrt_llm._utils import (mpi_allgather, mpi_barrier, mpi_comm,
-                                 mpi_disabled, mpi_isend, mpi_isend_object,
-                                 mpi_recv, mpi_recv_object, mpi_send,
-                                 mpi_send_object, mpi_world_size,
+from tensorrt_llm._utils import (local_mpi_size, mpi_allgather, mpi_barrier,
+                                 mpi_comm, mpi_disabled, mpi_isend,
+                                 mpi_isend_object, mpi_recv, mpi_recv_object,
+                                 mpi_send, mpi_send_object, mpi_world_size,
                                  torch_pybind11_abi)
 from tensorrt_llm.bindings.BuildInfo import ENABLE_MULTI_DEVICE
 from tensorrt_llm.bindings.internal.process_group import init_pg
@@ -157,6 +157,11 @@ class Distributed(ABC):
     @property
     def cp_config(self):
         return self.mapping.cp_config
+
+    @property
+    @abstractmethod
+    def local_world_size(self):
+        """Number of ranks co-located on this physical node."""
 
     @abstractmethod
     def barrier(self):
@@ -668,6 +673,10 @@ class MPIDist(Distributed):
     def allgather(self, obj):
         return mpi_allgather(obj)
 
+    @property
+    def local_world_size(self):
+        return local_mpi_size()
+
     def barrier(self):
         mpi_barrier()
 
@@ -791,6 +800,10 @@ class TorchDist(Distributed):
     @property
     def rank(self):
         return torch.distributed.get_rank()
+
+    @property
+    def local_world_size(self):
+        return dist.get_world_size(group=self.local_comm)
 
     def __init__(self, mapping: Mapping):
         super().__init__(mapping)

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -841,6 +841,27 @@ class KVCacheManagerV2(BaseResourceManager):
             # suspend/resume works out of the box.  Cap at available host
             # memory and pinnable memory limit to avoid allocation failures.
             import resource
+            import socket
+
+            # Rank-aware host tier sizing: count how many ranks share this
+            # physical node so their host tiers don't collectively exceed
+            # node RAM.  Each rank independently provisions a host tier;
+            # without dividing the per-node budget by the local rank count,
+            # N co-located ranks each reserving a device-quota-sized block
+            # can OOM the host (observed on GB300 NVL72 with 4 ranks/node
+            # and ~170GiB device quota each on a 975GiB node).
+            local_ranks = 1
+            try:
+                if mapping.world_size > 1:
+                    hostnames = Distributed.get(mapping).allgather(socket.gethostname())
+                    if hostnames:
+                        self_hostname = socket.gethostname()
+                        local_ranks = max(1, sum(1 for h in hostnames if h == self_hostname))
+            except Exception:
+                try:
+                    local_ranks = max(1, mapping.gpus_per_node)
+                except Exception:
+                    local_ranks = 1
 
             try:
                 mem_available = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_AVPHYS_PAGES")
@@ -853,12 +874,17 @@ class KVCacheManagerV2(BaseResourceManager):
                 memlock_limit = float("inf")
             candidates = [quota]
             if mem_available != float("inf"):
-                candidates.append(int(mem_available * 0.5))
+                candidates.append(int(mem_available / local_ranks * 0.5))
             if memlock_limit != float("inf"):
                 candidates.append(int(memlock_limit * 0.8))
             host_quota = min(candidates)
             if host_quota <= 0:
                 host_quota = quota
+            logger.info(
+                f"KV cache manager v2 auto host tier sizing: "
+                f"{local_ranks} co-located rank(s) on this node, "
+                f"available host memory {mem_available / (1 << 30):.2f}GiB"
+            )
         if host_quota > 0:
             cache_tiers.append(HostCacheTierConfig(quota=host_quota))
             logger.info(

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -27,6 +27,7 @@ from tensorrt_llm._utils import (
     TensorWrapper,
     convert_to_torch_tensor,
     get_size_in_bytes,
+    local_mpi_size,
     prefer_pinned,
 )
 from tensorrt_llm.bindings.internal.batch_manager import KvCacheIterationStats, KvCacheStats
@@ -143,6 +144,46 @@ def _estimate_full_attn_size_per_token(
         for layer_size, window_size in zip(layer_sizes, attention_windows)
         if window_size is None or window_size <= 0
     )
+
+
+def _compute_auto_host_tier_quota(
+    quota: int,
+    local_ranks: int,
+    mem_available: float,
+    memlock_limit: float,
+) -> int:
+    """Compute the auto-provisioned host cache tier quota for a single rank.
+
+    The host tier backs the MAX_UTILIZATION scheduler's suspend/resume path,
+    so it must be positive. It defaults to the device quota, capped by the
+    per-node available-memory budget shared with co-located ranks and by the
+    pinnable-memory (RLIMIT_MEMLOCK) limit.
+
+    Args:
+        quota: Device (GPU) KV cache quota in bytes; must be positive.
+        local_ranks: Number of ranks co-located on this physical node.
+        mem_available: Available host memory in bytes, or ``float("inf")``
+            if unknown.
+        memlock_limit: RLIMIT_MEMLOCK soft limit in bytes, or
+            ``float("inf")`` if unlimited or unknown.
+
+    Returns:
+        Host cache tier quota in bytes (always positive).
+    """
+    candidates = [quota]
+    if mem_available != float("inf"):
+        candidates.append(int(mem_available / local_ranks * 0.5))
+    if memlock_limit != float("inf"):
+        candidates.append(int(memlock_limit * 0.8))
+    host_quota = min(candidates)
+    if host_quota <= 0:
+        logger.warning(
+            f"KV cache manager v2 auto host tier sizing computed a "
+            f"non-positive quota ({host_quota}); falling back to the "
+            f"device quota {quota / (1 << 30):.2f}GiB"
+        )
+        host_quota = quota
+    return host_quota
 
 
 def _estimate_swa_cache_size(
@@ -841,20 +882,14 @@ class KVCacheManagerV2(BaseResourceManager):
             # suspend/resume works out of the box.  Cap at available host
             # memory and pinnable memory limit to avoid allocation failures.
             import resource
-            import socket
 
-            # Rank-aware host tier sizing: count how many ranks share this
-            # physical node so their host tiers don't collectively exceed
-            # node RAM.  Each rank independently provisions a host tier;
-            # without dividing the per-node budget by the local rank count,
-            # N co-located ranks each reserving a device-quota-sized block
-            # can OOM the host (observed on GB300 NVL72 with 4 ranks/node
-            # and ~170GiB device quota each on a 975GiB node).
-            local_ranks = 1
-            if mapping.world_size > 1:
-                self_hostname = socket.gethostname()
-                hostnames = Distributed.get(mapping).allgather(self_hostname)
-                local_ranks = max(1, sum(1 for h in hostnames if h == self_hostname))
+            # Rank-aware host tier sizing: divide the per-node memory budget
+            # by the number of ranks sharing this physical node.  Each rank
+            # independently provisions a host tier; without this, N
+            # co-located ranks each reserving a device-quota-sized block can
+            # OOM the host (observed on GB300 NVL72 with 4 ranks/node and
+            # ~170GiB device quota each on a 975GiB node).
+            local_ranks = max(1, local_mpi_size())
 
             try:
                 mem_available = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_AVPHYS_PAGES")
@@ -865,14 +900,9 @@ class KVCacheManagerV2(BaseResourceManager):
                 memlock_limit = _soft if _soft != resource.RLIM_INFINITY else float("inf")
             except (ValueError, OSError):
                 memlock_limit = float("inf")
-            candidates = [quota]
-            if mem_available != float("inf"):
-                candidates.append(int(mem_available / local_ranks * 0.5))
-            if memlock_limit != float("inf"):
-                candidates.append(int(memlock_limit * 0.8))
-            host_quota = min(candidates)
-            if host_quota <= 0:
-                host_quota = quota
+            host_quota = _compute_auto_host_tier_quota(
+                quota, local_ranks, mem_available, memlock_limit
+            )
             logger.info(
                 f"KV cache manager v2 auto host tier sizing: "
                 f"{local_ranks} co-located rank(s) on this node, "

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -27,7 +27,6 @@ from tensorrt_llm._utils import (
     TensorWrapper,
     convert_to_torch_tensor,
     get_size_in_bytes,
-    local_mpi_size,
     prefer_pinned,
 )
 from tensorrt_llm.bindings.internal.batch_manager import KvCacheIterationStats, KvCacheStats
@@ -889,7 +888,7 @@ class KVCacheManagerV2(BaseResourceManager):
             # co-located ranks each reserving a device-quota-sized block can
             # OOM the host (observed on GB300 NVL72 with 4 ranks/node and
             # ~170GiB device quota each on a 975GiB node).
-            local_ranks = max(1, local_mpi_size())
+            local_ranks = max(1, Distributed.get(mapping).local_world_size)
 
             try:
                 mem_available = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_AVPHYS_PAGES")

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -851,17 +851,10 @@ class KVCacheManagerV2(BaseResourceManager):
             # can OOM the host (observed on GB300 NVL72 with 4 ranks/node
             # and ~170GiB device quota each on a 975GiB node).
             local_ranks = 1
-            try:
-                if mapping.world_size > 1:
-                    hostnames = Distributed.get(mapping).allgather(socket.gethostname())
-                    if hostnames:
-                        self_hostname = socket.gethostname()
-                        local_ranks = max(1, sum(1 for h in hostnames if h == self_hostname))
-            except Exception:
-                try:
-                    local_ranks = max(1, mapping.gpus_per_node)
-                except Exception:
-                    local_ranks = 1
+            if mapping.world_size > 1:
+                self_hostname = socket.gethostname()
+                hostnames = Distributed.get(mapping).allgather(self_hostname)
+                local_ranks = max(1, sum(1 for h in hostnames if h == self_hostname))
 
             try:
                 mem_available = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_AVPHYS_PAGES")

--- a/tests/unittest/_torch/executor/test_kvv2_host_tier_sizing.py
+++ b/tests/unittest/_torch/executor/test_kvv2_host_tier_sizing.py
@@ -1,0 +1,93 @@
+"""Tests for KVCacheManagerV2 rank-aware auto host tier sizing.
+
+The auto-provisioned host tier is computed per rank but drawn from a
+node-level memory budget, so it must be divided by the number of ranks
+co-located on the same physical node to avoid host OOM.
+"""
+
+import pytest
+
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import _compute_auto_host_tier_quota
+
+GiB = 1 << 30
+
+
+class TestComputeAutoHostTierQuota:
+    def test_single_rank_uses_device_quota_when_memory_is_ample(self):
+        # 1 rank, 440 GiB available: cap = 220 GiB > quota -> quota wins.
+        assert (
+            _compute_auto_host_tier_quota(
+                quota=173 * GiB,
+                local_ranks=1,
+                mem_available=float(440 * GiB),
+                memlock_limit=float("inf"),
+            )
+            == 173 * GiB
+        )
+
+    def test_colocated_ranks_divide_node_memory_budget(self):
+        # 4 co-located ranks, 440 GiB available: each gets 440/4*0.5 = 55 GiB
+        # instead of the full device quota (4 x 173 GiB would exceed node RAM).
+        assert _compute_auto_host_tier_quota(
+            quota=173 * GiB,
+            local_ranks=4,
+            mem_available=float(440 * GiB),
+            memlock_limit=float("inf"),
+        ) == int(440 * GiB / 4 * 0.5)
+
+    def test_aggregate_across_ranks_stays_within_available_memory(self):
+        local_ranks = 4
+        mem_available = float(440 * GiB)
+        per_rank = _compute_auto_host_tier_quota(
+            quota=173 * GiB,
+            local_ranks=local_ranks,
+            mem_available=mem_available,
+            memlock_limit=float("inf"),
+        )
+        assert per_rank * local_ranks <= mem_available
+
+    def test_memlock_limit_caps_quota(self):
+        assert _compute_auto_host_tier_quota(
+            quota=173 * GiB,
+            local_ranks=1,
+            mem_available=float("inf"),
+            memlock_limit=float(10 * GiB),
+        ) == int(10 * GiB * 0.8)
+
+    def test_unknown_limits_fall_back_to_device_quota(self):
+        assert (
+            _compute_auto_host_tier_quota(
+                quota=173 * GiB,
+                local_ranks=8,
+                mem_available=float("inf"),
+                memlock_limit=float("inf"),
+            )
+            == 173 * GiB
+        )
+
+    @pytest.mark.parametrize("memlock_limit", [0.0, float(1)])
+    def test_non_positive_result_falls_back_to_device_quota(self, memlock_limit):
+        # RLIMIT_MEMLOCK of 0 (common in restricted containers) would yield a
+        # zero quota; a zero host tier would deadlock the MAX_UTILIZATION
+        # scheduler's suspend/resume path, so fall back to the device quota.
+        assert (
+            _compute_auto_host_tier_quota(
+                quota=173 * GiB,
+                local_ranks=4,
+                mem_available=float(440 * GiB),
+                memlock_limit=memlock_limit,
+            )
+            == 173 * GiB
+        )
+
+    def test_result_is_always_positive(self):
+        # Exhausted node memory reading must not produce a non-positive tier.
+        assert (
+            _compute_auto_host_tier_quota(
+                quota=173 * GiB,
+                local_ranks=4,
+                mem_available=0.0,
+                memlock_limit=float("inf"),
+            )
+            > 0
+        )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic host cache sizing so it better accounts for machines with multiple colocated ranks.
  * Made host memory allocation more reliable by preventing invalid or non-positive quota results.
  * Enhanced runtime logs to show the rank count and memory values used in sizing decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

When `kv_cache_config.host_cache_size` is not set, `KVCacheManagerV2`
auto-provisions a host cache tier per rank, capped at 50% of the node's
available memory. The cap is computed by each rank independently from the
same node-level reading, so N co-located ranks can collectively reserve up
to N x 50% of node memory.

Observed on GB300 NVL72 (DSR1 FP4 disagg, decode TP16 = 4 nodes x 4 GPUs,
~173 GiB device quota, 975 GiB node RAM): the 4 ranks on each node each
provisioned a 161-173 GiB host tier (~650 GiB total vs ~440 GiB available),
and decode workers were reliably OOM-killed during engine init (6/6
reproductions). The same config with the v1 manager runs fine.

Fix: count ranks sharing the physical node (hostname allgather via the
existing `Distributed` helper, falling back to `mapping.gpus_per_node`) and
divide the available-memory cap by that count. Explicitly-set
`host_cache_size` is unaffected.

## Test Coverage

Manually validated on GB300 NVL72 with the previously-failing config:

- `local_ranks=4` detected correctly; host tier reduced to ~55 GiB per
  rank; 4/4 runs completed 43010/43010 requests with zero oom_kill events
  (previously 6/6 OOM).


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
