### PR TITLE
[https://nvbugs/6379636][fix] Fix Gemma4 MoE weight loading

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/gemma4_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/gemma4_weight_mapper.py
@@ -205,12 +205,19 @@ class Gemma4HfWeightMapper(HfWeightMapper):
         HF stores MoE as 3D tensors:
           experts.gate_up_proj [E, 2*I, H] → per-expert {id}.w1.weight + {id}.w3.weight
           experts.down_proj    [E, H, I]   → per-expert {id}.w2.weight
+        ModelOpt NVFP4 checkpoints store already-split per-expert tensors:
+          experts.{id}.{gate,up,down}_proj.{field} → moe.experts.{id}.{w1,w3,w2}.{field}
           router.per_expert_scale          → moe.per_expert_scale
           router.*                         → moe.router.*
 
         Paths are also adjusted: layers.N.{experts,router} → layers.N.moe.{...}
         """
         _layer_re = r"((?:model\.|language_model\.model\.)?layers\.\d+)\."
+        expert_projection_map = {
+            "gate_proj": "w1",
+            "up_proj": "w3",
+            "down_proj": "w2",
+        }
         remapped = {}
         for key, val in weights.items():
             # per_expert_scale: HF router.per_expert_scale → TRT moe.per_expert_scale
@@ -218,6 +225,18 @@ class Gemma4HfWeightMapper(HfWeightMapper):
             if m_pes:
                 prefix = m_pes.group(1)
                 remapped[f"{prefix}.moe.per_expert_scale"] = val
+                continue
+
+            # ModelOpt NVFP4 per-expert layout. Preserve the field suffix so
+            # weight, weight_scale, input_scale, and weight_scale_2 all map.
+            m_expert = re.match(
+                _layer_re + r"experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.(.+)$", key
+            )
+            if m_expert:
+                prefix, expert_id, projection, field = m_expert.groups()
+                remapped[
+                    f"{prefix}.moe.experts.{expert_id}.{expert_projection_map[projection]}.{field}"
+                ] = val
                 continue
 
             # experts.gate_up_proj [E, 2*I, H] → per-expert w1 + w3
@@ -244,6 +263,9 @@ class Gemma4HfWeightMapper(HfWeightMapper):
                 new_key = re.sub(_layer_re + r"router\.", r"\1.moe.router.", key)
                 remapped[new_key] = val
                 continue
+
+            if re.match(_layer_re + r"experts\.", key):
+                raise ValueError(f"Unsupported Gemma4 expert checkpoint tensor: {key}")
 
             # Non-MoE key: pass through
             remapped[key] = val

--- a/tests/integration/defs/accuracy/references/mmmu.yaml
+++ b/tests/integration/defs/accuracy/references/mmmu.yaml
@@ -14,7 +14,10 @@ google/gemma-3-27b-it:
     kv_cache_quant_algo: FP8
     accuracy: 48.0
 google/gemma-4-26B-A4B-it:
-  - accuracy: 56.667
+  # B200 PyTorch backend baseline for nvidia/Gemma-4-26B-A4B-NVFP4.
+  - quant_algo: NVFP4
+    kv_cache_quant_algo: FP8
+    accuracy: 54.0
 google/gemma-3-12b-it:
   - accuracy: 50.44
   - quant_algo: FP8

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
@@ -397,6 +397,44 @@ class TestGemma3_12BInstruct(LlmapiAccuracyTestHarness):
             task.evaluate(llm, sampling_params=self.sampling_params)
 
 
+@pytest.mark.skip_device_not_contain(["B200"])
+class TestGemma4_26B_A4B(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "google/gemma-4-26B-A4B-it"
+    MODEL_PATH = f"{llm_models_root()}/gemma/nvidia-Gemma-4-26B-A4B-NVFP4"
+    EXTRA_EVALUATOR_KWARGS = {
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+    # NOTE: MMMU adds <|endoftext|> to the stop token.
+    sampling_params = SamplingParams(
+        max_tokens=MMMU.MAX_OUTPUT_LEN,
+        truncate_prompt_tokens=MMMU.MAX_INPUT_LEN,
+        stop="<|endoftext|>",
+    )
+
+    kv_cache_config = KvCacheConfig(
+        enable_block_reuse=False,
+        enable_partial_reuse=False,
+        free_gpu_memory_fraction=0.6,
+        dtype="fp8",
+    )
+
+    def test_nvfp4(self):
+        with LLM(
+            self.MODEL_PATH,
+            max_batch_size=16,
+            kv_cache_config=self.kv_cache_config,
+            enable_chunked_prefill=True,
+        ) as llm:
+            assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4
+            task = MMMU(self.MODEL_NAME)
+            task.evaluate(
+                llm,
+                sampling_params=self.sampling_params,
+                extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS,
+            )
+
+
 class TestQwen3VL_MOE(LlmapiAccuracyTestHarness):
     MODEL_NAME = "Qwen/Qwen3-VL-30B-A3B-Instruct"
     MODEL_PATH = f"{llm_models_root()}/Qwen3/Qwen3-VL-30B-A3B-Instruct"

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -340,6 +340,7 @@ l0_b200:
   - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8B_Instruct_RocketKV::test_auto_dtype
   - accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_1gpu[v1_kv_cache-True-True-trtllm-auto]
   - accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_1gpu[v2_kv_cache-True-True-trtllm-auto]
+  - accuracy/test_llm_api_pytorch_multimodal.py::TestGemma4_26B_A4B::test_nvfp4
   - accuracy/test_llm_api_pytorch_multimodal.py::TestNanoV3Omni::test_auto_dtype[bf16]
   - accuracy/test_llm_api_pytorch_multimodal.py::TestNanoV3Omni::test_auto_dtype[nvfp4]
   # ------------- VisualGen single-GPU tests ---------------

--- a/tests/unittest/_torch/modeling/test_modeling_gemma4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma4.py
@@ -23,38 +23,21 @@ import unittest
 import unittest.mock
 from copy import deepcopy
 
-import pytest
 import torch
-import transformers
-from packaging.version import Version
+from transformers import Gemma4Config, Gemma4TextConfig
 
-# Gemma4 requires transformers>=5.5.0 (native Gemma4 config/model classes).
-# Use a module-level pytestmark.skipif (not pytest.importorskip) so collection
-# still picks up the test cases when the version gate fires. importorskip
-# causes pytest to report "collected 0 items / 1 skipped" with exit code 5
-# ("no tests collected"), which the CI test_unittests_v2 wrapper rejects.
-# With pytestmark.skipif, pytest reports "N collected, N skipped, exit 0".
-_HAS_GEMMA4 = Version(transformers.__version__) >= Version("5.5.0")
-
-pytestmark = pytest.mark.skipif(
-    not _HAS_GEMMA4,
-    reason=(f"Gemma4 requires transformers>=5.5.0 (installed: {transformers.__version__})"),
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.hf.gemma4_weight_mapper import Gemma4HfWeightMapper
+from tensorrt_llm._torch.models.modeling_gemma4 import (
+    Gemma4Attention,
+    Gemma4DecoderLayer,
+    Gemma4ForCausalLM,
+    Gemma4MoE,
+    Gemma4MoeRoutingMethod,
+    Gemma4TextModel,
+    Gemma4TextScaledWordEmbedding,
 )
-
-if _HAS_GEMMA4:
-    from transformers import Gemma4Config, Gemma4TextConfig  # noqa: E402
-
-    from tensorrt_llm._torch.model_config import ModelConfig  # noqa: E402
-    from tensorrt_llm._torch.models.modeling_gemma4 import (  # noqa: E402
-        Gemma4Attention,
-        Gemma4DecoderLayer,
-        Gemma4ForCausalLM,
-        Gemma4MoE,
-        Gemma4MoeRoutingMethod,
-        Gemma4TextModel,
-        Gemma4TextScaledWordEmbedding,
-    )
-    from tensorrt_llm.mapping import Mapping  # noqa: E402
+from tensorrt_llm.mapping import Mapping
 
 # ---------------------------------------------------------------------------
 # Small test configs
@@ -373,6 +356,84 @@ class TestGemma4ModelInstantiation(unittest.TestCase):
             self.assertEqual(
                 attn.num_key_value_heads, expected_kv_heads, f"Layer {i} kv_heads mismatch"
             )
+
+
+class TestGemma4HfWeightMapper(unittest.TestCase):
+    """Tests for Gemma4-specific checkpoint key transformations."""
+
+    def test_remap_modelopt_nvfp4_per_expert_weights(self):
+        """ModelOpt's split expert tensors should map to the VANILLA MoE layout."""
+        mapper = Gemma4HfWeightMapper()
+        projection_map = {
+            "gate_proj": "w1",
+            "up_proj": "w3",
+            "down_proj": "w2",
+        }
+        fields = ("weight", "weight_scale", "input_scale", "weight_scale_2")
+        weights = {}
+        expected = {}
+        for projection, trt_projection in projection_map.items():
+            for field in fields:
+                marker = object()
+                weights[f"model.layers.7.experts.13.{projection}.{field}"] = marker
+                expected[f"model.layers.7.moe.experts.13.{trt_projection}.{field}"] = marker
+
+        remapped = mapper._remap_moe_keys(weights)
+
+        self.assertEqual(set(remapped), set(expected))
+        for key, marker in expected.items():
+            self.assertIs(remapped[key], marker)
+
+    def test_remap_modelopt_nvfp4_vlm_prefix(self):
+        """The VLM preprocessing prefix should use the same expert translation."""
+        marker = object()
+        weights = {
+            "language_model.model.layers.2.experts.5.down_proj.weight": marker,
+        }
+
+        remapped = Gemma4HfWeightMapper()._remap_moe_keys(weights)
+
+        self.assertEqual(
+            remapped,
+            {"language_model.model.layers.2.moe.experts.5.w2.weight": marker},
+        )
+
+    def test_remap_fused_bf16_experts(self):
+        """The existing fused Hugging Face expert layout should remain supported."""
+        gate_up = torch.arange(24).reshape(2, 6, 2)
+        down = torch.arange(16).reshape(2, 4, 2)
+        weights = {
+            "model.layers.1.experts.gate_up_proj": gate_up,
+            "model.layers.1.experts.down_proj": down,
+        }
+
+        remapped = Gemma4HfWeightMapper()._remap_moe_keys(weights)
+
+        for expert_id in range(2):
+            gate, up = gate_up[expert_id].chunk(2, dim=0)
+            self.assertTrue(
+                torch.equal(remapped[f"model.layers.1.moe.experts.{expert_id}.w1.weight"], gate)
+            )
+            self.assertTrue(
+                torch.equal(remapped[f"model.layers.1.moe.experts.{expert_id}.w3.weight"], up)
+            )
+            self.assertTrue(
+                torch.equal(
+                    remapped[f"model.layers.1.moe.experts.{expert_id}.w2.weight"],
+                    down[expert_id],
+                )
+            )
+
+    def test_reject_unrecognized_expert_weights(self):
+        """Unknown expert layouts should fail instead of leaving MoE weights uninitialized."""
+        weights = {"model.layers.0.experts.0.unknown_proj.weight": object()}
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Unsupported Gemma4 expert checkpoint tensor: "
+            r"model\.layers\.0\.experts\.0\.unknown_proj\.weight",
+        ):
+            Gemma4HfWeightMapper()._remap_moe_keys(weights)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Gemma 4 NVFP4 checkpoint formats in expert weight mapping, improving compatibility with newer model exports.
  * Expanded multimodal accuracy coverage for Gemma 4 on supported hardware.

* **Bug Fixes**
  * Improved handling of unsupported expert tensor layouts by raising an error instead of silently accepting them.
  * Updated accuracy baselines for the Gemma 4 NVFP4 multimodal configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This commit fixes some issues in MoE weight loading for Gemma4, and adds an E2E accuracy test for it.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
