### PR TITLE
[https://nvbugs/6388359][test] Unwaive Qwen3-30B-A3B test_w4a8_mxfp4 mxfp8-latency-CUTLASS

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -97,7 +97,6 @@ accuracy/test_llm_api_pytorch.py::TestQwen3NextInstruct::test_bf16_4gpu[tep4] SK
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_fp8[latency] SKIP (https://nvbugs/6177390)
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_fp8[throughput_latency] SKIP (https://nvbugs/6177390)
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_trtllm] SKIP (https://nvbugs/6402009)
-accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_w4a8_mxfp4[mxfp8-latency-CUTLASS] SKIP (https://nvbugs/6388359)
 accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention_4gpus[target_sparsity_0.9-fp8kv=False] SKIP (https://nvbugs/6388157)
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16_mtp SKIP (https://nvbugs/6206179)
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8[enable_block_reuse=True] SKIP (https://nvbugs/6210714)


### PR DESCRIPTION
## Description

The timeout reported in [NVBug 6388359](https://nvbugs/6388359) for
`accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_w4a8_mxfp4[mxfp8-latency-CUTLASS]`
could not be reproduced, so the failure is treated as resolved. This PR
re-enables the test by removing its entry from
`tests/integration/test_lists/waives.txt` (added in #15705).

## Test Coverage

- `accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_w4a8_mxfp4[mxfp8-latency-CUTLASS]`
  is re-enabled (post_merge / pytorch, DGX_B200).

Per the NVBug removal-of-waiver instructions, the corresponding post-merge
stage must run without skipping CI:

```
/bot run --stage-list "DGX_B200-PyTorch-Post-Merge-1"
```

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed one outdated test waiver from the integration test list, so that test case is now expected to run without being skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->