### PR TITLE
[TRTLLM-13614][fix] Enhance the dis-agg bounce buffer workflow

### DIFF
--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/agentBindings.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/agentBindings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -261,28 +261,35 @@ NB_MODULE(tensorrt_llm_transfer_agent_binding, m)
     nb::class_<kvc::NixlTransferAgent, kvc::BaseTransferAgent>(m, "NixlTransferAgent")
         .def(nb::init<kvc::BaseAgentConfig const&>(), nb::arg("config"), nb::call_guard<nb::gil_scoped_release>())
         .def("shutdown", &kvc::NixlTransferAgent::shutdown, nb::call_guard<nb::gil_scoped_release>())
-        .def("register_memory", &kvc::NixlTransferAgent::registerMemory, nb::arg("descs"))
-        .def("deregister_memory", &kvc::NixlTransferAgent::deregisterMemory, nb::arg("descs"))
+        .def("register_memory", &kvc::NixlTransferAgent::registerMemory, nb::arg("descs"),
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("deregister_memory", &kvc::NixlTransferAgent::deregisterMemory, nb::arg("descs"),
+            nb::call_guard<nb::gil_scoped_release>())
         .def("load_remote_agent",
             nb::overload_cast<std::string const&, kvc::AgentDesc const&>(&kvc::NixlTransferAgent::loadRemoteAgent),
-            nb::arg("name"), nb::arg("agent_desc"))
+            nb::arg("name"), nb::arg("agent_desc"), nb::call_guard<nb::gil_scoped_release>())
         .def("load_remote_agent_by_connection",
             nb::overload_cast<std::string const&, kvc::ConnectionInfoType const&>(
                 &kvc::NixlTransferAgent::loadRemoteAgent),
-            nb::arg("name"), nb::arg("connection_info"))
-        .def("get_local_agent_desc", &kvc::NixlTransferAgent::getLocalAgentDesc)
-        .def("get_local_connection_info", &kvc::NixlTransferAgent::getLocalConnectionInfo)
-        .def("invalidate_remote_agent", &kvc::NixlTransferAgent::invalidateRemoteAgent, nb::arg("name"))
+            nb::arg("name"), nb::arg("connection_info"), nb::call_guard<nb::gil_scoped_release>())
+        .def("get_local_agent_desc", &kvc::NixlTransferAgent::getLocalAgentDesc,
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("get_local_connection_info", &kvc::NixlTransferAgent::getLocalConnectionInfo,
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("invalidate_remote_agent", &kvc::NixlTransferAgent::invalidateRemoteAgent, nb::arg("name"),
+            nb::call_guard<nb::gil_scoped_release>())
         .def(
             "submit_transfer_requests",
             [](kvc::NixlTransferAgent& self, kvc::TransferRequest const& request)
             { return self.submitTransferRequests(request).release(); },
             nb::arg("request"), nb::rv_policy::take_ownership, nb::call_guard<nb::gil_scoped_release>(),
             nb::keep_alive<0, 1>())
-        .def(
-            "notify_sync_message", &kvc::NixlTransferAgent::notifySyncMessage, nb::arg("name"), nb::arg("sync_message"))
-        .def("get_notified_sync_messages", &kvc::NixlTransferAgent::getNotifiedSyncMessages)
-        .def("check_remote_descs", &kvc::NixlTransferAgent::checkRemoteDescs, nb::arg("name"), nb::arg("memory_descs"));
+        .def("notify_sync_message", &kvc::NixlTransferAgent::notifySyncMessage, nb::arg("name"),
+            nb::arg("sync_message"), nb::call_guard<nb::gil_scoped_release>())
+        .def("get_notified_sync_messages", &kvc::NixlTransferAgent::getNotifiedSyncMessages,
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("check_remote_descs", &kvc::NixlTransferAgent::checkRemoteDescs, nb::arg("name"), nb::arg("memory_descs"),
+            nb::call_guard<nb::gil_scoped_release>());
 #endif
 
     // NOTE: MooncakeTransferAgent/MooncakeTransferStatus class bindings are intentionally

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/config.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/config.py
@@ -15,10 +15,36 @@
 """Bounce configuration and pluggable sizing policy. A config enables bounce; leaving it unset keeps
 the per-block path. The size knob doubles as the on and off switch."""
 
+import os
 from dataclasses import dataclass, field
 from typing import Optional
 
+from tensorrt_llm import logger
+
 _MIB = 1024 * 1024
+
+# Test/advanced override for the block-count gate below (users only tune the bounce size). Read on
+# the generation side, so set it there; unset uses the default.
+_MIN_BLOCKS_ENV = "TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS"
+
+
+def _env_min_blocks(default: int) -> int:
+    """Read the gate from the env, defensively: unset or malformed falls back to the default (never
+    crashing), and the value is clamped to at least 1."""
+    raw = os.environ.get(_MIN_BLOCKS_ENV)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(f"{_MIN_BLOCKS_ENV}={raw!r} is not an integer; using default {default}")
+        return default
+    if value < 1:
+        logger.warning(
+            f"{_MIN_BLOCKS_ENV}={value} < 1; clamping to 1 (bounce always clears the gate)"
+        )
+        return 1
+    return value
 
 
 def _round_up(a: int, b: int) -> int:
@@ -85,9 +111,12 @@ class Config:
     min_blocks: int = 96
 
 
-def config_from_size(size_mb: int) -> Optional[Config]:
-    """Build a bounce config from a per-region size in MiB, or None to leave bounce off when the size
-    is not positive. The size is both the capacity and the on and off switch."""
+def config_from_size(size_mb: int, min_blocks: Optional[int] = None) -> Optional[Config]:
+    """Build a bounce config from a per-region size in MiB, or None to leave bounce off (size <= 0).
+    Size is both the capacity and the on/off switch. min_blocks is the gate below which a transfer
+    stays on the per-block path; when unset it comes from the env, else the default."""
     if size_mb is None or size_mb <= 0:
         return None
-    return Config(sizing=FixedSizing(capacity_mb=size_mb))
+    if min_blocks is None:
+        min_blocks = _env_min_blocks(Config.min_blocks)
+    return Config(sizing=FixedSizing(capacity_mb=size_mb), min_blocks=min_blocks)

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/core.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/core.py
@@ -208,6 +208,10 @@ class BounceTransport(ABC):
         """Immediately free a reservation cancelled before any address went out."""
 
     @abstractmethod
+    def orphan_reservation(self, rid_slice) -> None:
+        """Give up on an in-flight reservation (cancel/timeout/lost result); quarantine, don't leak."""
+
+    @abstractmethod
     def record_result(
         self, rid_slice, peer_rank, dst_ptrs=None, sizes=None, src_base=None, on_done=None
     ) -> None:

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/impl.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/impl.py
@@ -146,22 +146,21 @@ class VmmBounceTransport(BounceTransport):
     def _new_stream(self):
         return CUASSERT(cudart.cudaStreamCreate())[0]
 
-    def _launch_gather(self, src_addr: int, write_meta, total: int):
-        """Launch the gather of the scattered fragments into the send region and return an event to
-        wait on."""
+    def _gather_blocking(self, src_addr: int, write_meta, total: int) -> None:
+        """Gather the scattered fragments into the send region and block until done. The whole gather
+        runs under the stream lock so a second sender thread can't overwrite the shared staging buffer
+        mid-copy and corrupt this region; only the fast gather serializes, the writes stay parallel."""
         plan = Plan(write_meta.src_ptrs, write_meta.dst_ptrs, write_meta.sizes, total)
         with self._send_stream_lock:
             gather_contiguous(
                 src_addr, plan.src_ptrs, plan.sizes, plan.offsets, stream=self._send_stream
             )
             event = CUASSERT(cudart.cudaEventCreate())[0]
-            CUASSERT(cudart.cudaEventRecord(event, self._send_stream))
-        return event
-
-    def _wait_gather(self, event) -> None:
-        if event is not None:
-            CUASSERT(cudart.cudaEventSynchronize(event))
-            CUASSERT(cudart.cudaEventDestroy(event))
+            try:
+                CUASSERT(cudart.cudaEventRecord(event, self._send_stream))
+                CUASSERT(cudart.cudaEventSynchronize(event))
+            finally:
+                CUASSERT(cudart.cudaEventDestroy(event))
 
     def _make_write(self, src_addr: int, write_meta, total: int):
         # one coalesced descriptor spanning the whole region
@@ -189,20 +188,20 @@ class VmmBounceTransport(BounceTransport):
             )
             return None
         slot_id, src_addr = res
-        return slot_id, src_addr, total, self._launch_gather(src_addr, write_meta, total)
+        try:
+            self._gather_blocking(src_addr, write_meta, total)
+        except Exception:
+            self._send_alloc.release(slot_id)  # free the slot if the gather raises
+            raise
+        return slot_id, src_addr, total
 
     def build_request(self, write_meta):
-        """Gather into a send slot and build the coalesced write, or None on backpressure. Frees the
-        slot if the gather raises."""
+        """Gather into a send slot and build the coalesced write, or None on backpressure. The gather
+        blocks (and frees the slot on failure) inside _reserve_and_gather."""
         gathered = self._reserve_and_gather(write_meta, timeout=_RESERVE_TIMEOUT_S)
         if gathered is None:  # backpressure: fall back
             return None
-        slot_id, src_addr, total, event = gathered
-        try:
-            self._wait_gather(event)
-        except Exception:
-            self._send_alloc.release(slot_id)
-            raise
+        slot_id, src_addr, total = gathered
         return self._make_write(src_addr, write_meta, total), slot_id
 
     def release_send(self, slot_id) -> None:
@@ -239,6 +238,21 @@ class VmmBounceTransport(BounceTransport):
                 f"({total % num_writers}B remainder); head-mismatch explosion NOT mitigated",
                 warn_key="kv-bounce-uneven-fanin",
             )
+        if num_writers > 1:
+            # Fan-in gives each writer an equal share of the region, which only matches where it
+            # writes when all writers send the same bytes. Equal layer count guarantees that only
+            # when the per-block sizes match, so require that here, else fall back.
+            present_slot_bytes = {
+                self._block_bytes_per_group[g]
+                for g, block_ids in enumerate(recv_req.block_ids_per_layer_groups)
+                if int(block_ids.size) > 0
+            }
+            if len(present_slot_bytes) > 1:
+                return self._skip_bounce(
+                    f"fan-in across {num_writers} senders with non-uniform layer-group slot bytes "
+                    f"{sorted(present_slot_bytes)}; the equal split would overrun a sub-region",
+                    warn_key="kv-bounce-heterogeneous-fanin",
+                )
         if total > self._recv_alloc.capacity:  # too big to ever fit, unlike transient backpressure
             return self._skip_bounce(
                 f"transfer {total // _MIB}MiB exceeds the {self._recv_alloc.capacity // _MIB}MiB bounce "
@@ -261,6 +275,14 @@ class VmmBounceTransport(BounceTransport):
                 num_writers=num_writers,
             )
             self._reserved_map[ctx.rid_slice] = ctx  # inactive until the first writer reports
+        # Positive marker: all fall-back guards above passed, so this transfer provably takes the
+        # coalesced-bounce WRITE path. Logged once (per process) so an e2e test can assert that
+        # bounce actually engaged instead of silently falling back to the per-fragment path.
+        logger.info_once(
+            f"[kv-bounce] coalesced {nblocks} blocks / {total // _MIB}MiB into one region "
+            f"across {num_writers} writer(s)",
+            key="kv-bounce-coalesced",
+        )
         return True
 
     def writer_base(self, rid_slice: RidSlice, writer_index: int) -> Optional[int]:
@@ -280,6 +302,12 @@ class VmmBounceTransport(BounceTransport):
             ctx = self._reserved_map.pop(rid_slice, None)
         if ctx is not None:
             self._recv_alloc.release(ctx.slot_id)
+
+    def orphan_reservation(self, rid_slice: RidSlice) -> None:
+        """Give up on a reservation whose write may still be in flight (cancel/timeout/lost result).
+        The write can't be aborted, so quarantine the region (reclaimed later) rather than releasing
+        or leaking it. Idempotent; a no-op once the transfer has settled."""
+        self._apply(rid_slice, lambda ctx: ctx.mark_orphaned())
 
     def _apply(self, rid_slice: RidSlice, mutate: Callable[[TransferContext], None]) -> None:
         """Mutate the state under the lock, then do what it asks (scatter or settle) with the lock
@@ -419,6 +447,9 @@ class NoBounceTransport(BounceTransport):
         return False
 
     def release_idle_reservation(self, rid_slice) -> None:
+        pass
+
+    def orphan_reservation(self, rid_slice) -> None:
         pass
 
     def record_result(

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -550,11 +550,30 @@ class Sender(SenderBase):
         agent_result = AgentResult.SUCCESS
         send_slot_id = None
         if write_meta.src_ptrs.size > 0:
-            request, send_slot_id = build_send_request(
-                self._bounce,
-                write_meta,
-                lambda: Sender._make_agent_request(write_meta, device_id=self._device_id),
-            )
+            try:
+                request, send_slot_id = build_send_request(
+                    self._bounce,
+                    write_meta,
+                    lambda: Sender._make_agent_request(write_meta, device_id=self._device_id),
+                )
+            except Exception as e:
+                # Don't let a gather fault escape: without a result the receiver would hang and its
+                # region leak. Tell the receiver it failed and fail the local task instead.
+                logger.error(
+                    f"_deliver_kv_to_agent: failed to build the KV send request for "
+                    f"{write_meta.unique_rid} slice={write_meta.slice_id}: {e}"
+                )
+                task.fail(RuntimeError(f"build_send_request failed: {e}"))
+                self._get_or_connect_dealer(write_meta.peer_endpoint).send(
+                    _make_kv_result_msg(
+                        self._instance_rank,
+                        write_meta.unique_rid,
+                        write_meta.slice_id,
+                        True,  # is_last_slice — ensures receiver resolves its task future
+                        AgentResult.FAILED,
+                    )
+                )
+                return
             if timer:
                 timer.record_transfer_start(write_meta.peer_rank)
             try:
@@ -1503,9 +1522,8 @@ class Receiver(ReceiverBase):
             (peer_ri.layer_num_per_pp all-equal) or per-writer sizes differ. If that full per-stage
             list isn't available (shorter than the fan-in degree), be conservative and fall back.
         Otherwise fall back to the per-fragment path (correct, just not coalesced).
-        NOTE: equal layer COUNT == equal BYTES only when per-layer KV is uniform; for mixed layer
-        groups (e.g. differing slot_bytes) reserve()'s `total % num_writers` divisibility guard is the
-        backstop, and a fully size-aware split (per-writer offsets) would be the general fix."""
+        Equal layer count means equal bytes only when the per-block sizes match; reserve() rejects
+        the mismatched case, so this only needs the count to split evenly."""
         if overlap.duplicate_head_factor != 1:
             return False
         if overlap.overlap_pp_size > 1:
@@ -1990,13 +2008,16 @@ class RxSession(RxSessionBase):
             self._terminal_status = SessionStatus.CANCELLED
             exc = RuntimeError(f"RxSession {self.disagg_request_id} cancelled")
             for task in self._kv_tasks:
+                rid_slice = (self.disagg_request_id, task.slice_id)
                 if task.status == TaskStatus.INIT:
                     # INIT = reserved but no write in flight, so freeing its bounce reservation here
-                    # is safe (TRANSFERRING tasks keep running and self-release on SUCCESS/FAILED).
-                    self._receiver._bounce.release_idle_reservation(
-                        (self.disagg_request_id, task.slice_id)
-                    )
+                    # is safe.
+                    self._receiver._bounce.release_idle_reservation(rid_slice)
                     task.fail(exc)
+                elif task.status == TaskStatus.TRANSFERRING:
+                    # A write may still be mid-flight, so quarantine the region rather than freeing
+                    # it; this keeps a cancelled transfer from leaking. No-op when bounce is off.
+                    self._receiver._bounce.orphan_reservation(rid_slice)
         # Send outside the lock to avoid holding it during I/O.
         self._receiver.send_cancel_to_senders(self.disagg_request_id, self._sender_endpoints)
 
@@ -2054,6 +2075,10 @@ class RxSession(RxSessionBase):
             self.aux_slot = None
         # Unregister from Receiver; keep fields alive for in-flight listener messages.
         if self._receiver is not None:
+            # Reclaim any bounce region still live at teardown (closed mid-transfer) so it isn't
+            # leaked; a no-op for finished or non-bounce transfers.
+            for task in self._kv_tasks:
+                self._receiver._bounce.orphan_reservation((self.disagg_request_id, task.slice_id))
             self._receiver.clear_session(self.disagg_request_id)
 
     def __enter__(self):

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -86,7 +86,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 max_concurrent_sessions=max(1, int(kv_cache_manager.max_batch_size)) * 20000,
                 tx_timeout_s=self._sender_future_timeout_ms / 1000.0,
                 rx_timeout_s=self.kv_transfer_timeout_ms / 1000.0,
-                # On/off switch via config (size 0 => None => per-block path).
+                # Size 0 turns bounce off; the block-count gate is internal (tuned via env).
                 bounce=bounce_config_from_size(cache_transceiver_config.kv_cache_bounce_size_mb),
             )
         )
@@ -345,14 +345,6 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         return _find_consensus_request_ids(all_ranks, sync_size)
 
     @staticmethod
-    def _allgather_or_passthrough(
-        local_ids, allgather: Callable, need_sync: bool
-    ) -> List[List[int]]:
-        if not need_sync:
-            return [list(local_ids)]
-        return list(allgather(list(local_ids)))
-
-    @staticmethod
     def _union(all_lists: List[List[int]]) -> set:
         merged: set = set()
         for ids in all_lists:
@@ -373,9 +365,14 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self, to_process, cancelled, failed, completed, allgather: Callable, need_sync: bool
     ):
         # CANCELLED/FAILED on any rank → global; COMPLETED only when ALL ranks agree.
-        all_c = self._allgather_or_passthrough(cancelled, allgather, need_sync)
-        all_f = self._allgather_or_passthrough(failed, allgather, need_sync)
-        all_done = self._allgather_or_passthrough(completed, allgather, need_sync)
+        # Batch the three id lists into one allgather to cut the per-step collective count.
+        if not need_sync:
+            all_c, all_f, all_done = [list(cancelled)], [list(failed)], [list(completed)]
+        else:
+            packed = list(allgather([list(cancelled), list(failed), list(completed)]))
+            all_c = [p[0] for p in packed]
+            all_f = [p[1] for p in packed]
+            all_done = [p[2] for p in packed]
         n = len(all_c)
         global_cancelled = self._union(all_c)
         global_failed = self._union(all_f)
@@ -546,9 +543,13 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
     def check_context_transfer_status(
         self, at_least_request_num: Optional[int], mark_complete: bool = False
     ):
-        if not self._ever_had_send_session and not (
-            self._ctx_need_tp_sync or self._ctx_need_pp_sync
-        ):
+        # A worker that never sends KV has nothing to reconcile here, so skip the consensus. Safe
+        # because the flag flips together on every rank and never resets, so they all skip in step;
+        # gating on the live session dict instead would not be, since a cancel clears it per-rank.
+        # Keep the original sweep (only when tp/pp sync is on) so nothing is leaked.
+        if not self._ever_had_send_session:
+            if self._ctx_need_tp_sync or self._ctx_need_pp_sync:
+                self._transfer_worker.sweep_stale_req_infos()
             return [], []
         block_all = at_least_request_num is None
         wait_num = at_least_request_num if not block_all else 0
@@ -783,6 +784,11 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             if rid not in self._send_sessions:
                 self._wait_reqs[rid] = req
                 req.state = LlmRequestState.DISAGG_CONTEXT_WAIT_SCHEDULER
+
+        # Nothing waiting on any rank, so skip the consensus. The waiting set is the same on every
+        # rank, so they all skip together.
+        if not self._wait_reqs:
+            return
 
         # Check which waiting requests have peer info locally, then allgather
         # consensus so all TP/PP ranks agree before promoting.

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap_transceiver_runtime_python_bounce.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap_transceiver_runtime_python_bounce.yaml
@@ -1,3 +1,12 @@
+# Disaggregated config that exercises the KV-cache bounce buffer.
+#
+# Same as disagg_config_overlap_transceiver_runtime_python.yaml, plus the bounce switch on both the
+# context (sender) and generation (receiver) cache_transceiver_config:
+#   kv_cache_bounce_size_mb: >0 turns bounce on and sizes the per-region fabric-VMM arena.
+# The block-count gate below which a transfer keeps the per-block path is lowered to 1 via the
+# TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS env (set by the test) so the ordinary short test prompts still
+# take the coalesced-bounce WRITE path (the production default of 96 would need a ~2k-token prompt).
+# GB200/GB300 only, since the bounce arena is fabric (MNNVL) VMM memory.
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 hostname: localhost
 port: 8000
@@ -18,7 +27,7 @@ context_servers:
   cache_transceiver_config:
     backend: NIXL
     transceiver_runtime: PYTHON
-    kv_cache_bounce_size_mb: 64
+    kv_cache_bounce_size_mb: 128
   urls:
       - "localhost:8001"
 generation_servers:
@@ -35,6 +44,6 @@ generation_servers:
   cache_transceiver_config:
     backend: NIXL
     transceiver_runtime: PYTHON
-    kv_cache_bounce_size_mb: 64
+    kv_cache_bounce_size_mb: 128
   urls:
       - "localhost:8002"

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -422,7 +422,7 @@ def run_client_tests(example_dir,
             '--server-start-timeout',
             str(server_start_timeout)
         ]
-        if prompt_file == "long_prompts.json":
+        if prompt_file.startswith("long_"):
             # Use max_tokens 4 for long prompts to reduce test time
             client_cmd.extend(['--max-tokens', '4'])
 
@@ -467,7 +467,8 @@ def run_client_tests(example_dir,
                        poll_procs=poll_procs)
 
         # Skip output verification for long prompts or tool call tests
-        if prompt_file == "long_prompts.json" or prompt_file == "tool_call_prompts.json":
+        if prompt_file.startswith(
+                "long_") or prompt_file == "tool_call_prompts.json":
             continue
 
         if extra_endpoints_test is not None:
@@ -783,8 +784,14 @@ def run_disaggregated_test(example_dir,
                            model_path=None,
                            cwd=None,
                            disagg_schedule_style=None,
-                           post_client_test=None):
-    """Run disaggregated test using service discovery instead of MPI."""
+                           post_client_test=None,
+                           assert_gen_log_contains=None):
+    """Run disaggregated test using service discovery instead of MPI.
+
+    If assert_gen_log_contains is set, the generation-worker logs are captured and, after the
+    client tests, at least one of them must contain that substring (used to prove the KV-cache
+    bounce path actually engaged instead of silently falling back to the per-fragment path).
+    """
     if mpi_disabled():
         pytest.skip(
             "https://nvbugs/5584607 Ray orchestrator is not supported with NIXL(DEFAULT) cache transceiver backend."
@@ -797,7 +804,8 @@ def run_disaggregated_test(example_dir,
                                   os.path.dirname(__file__))
     config, ctx_workers, gen_workers, disagg_server, server_port, work_dir = \
         setup_disagg_cluster(config_file, model_name=model_path, env=run_env, cwd=cwd,
-                             schedule_style=disagg_schedule_style)
+                             schedule_style=disagg_schedule_style,
+                             save_log=assert_gen_log_contains is not None)
 
     server_host = config.get("hostname", "localhost")
 
@@ -833,6 +841,18 @@ def run_disaggregated_test(example_dir,
             use_ray=True)
         if post_client_test is not None:
             post_client_test(server_url)
+        if assert_gen_log_contains is not None:
+            # Fail loudly if the marker is absent: the transfer silently fell back to the
+            # per-fragment path, so the bounce path we meant to exercise never ran.
+            logs = []
+            for w in gen_workers:
+                if w.log_path and os.path.exists(w.log_path):
+                    with open(w.log_path, 'r', errors='replace') as f:
+                        logs.append(f.read())
+            assert any(assert_gen_log_contains in log for log in logs), (
+                f"expected marker {assert_gen_log_contains!r} in a generation-worker log, "
+                f"but none of {len(logs)} log(s) contained it (bounce did not engage)"
+            )
     finally:
         terminate(*ctx_workers, *gen_workers, disagg_server)
         shutil.rmtree(work_dir, ignore_errors=True)
@@ -1138,6 +1158,14 @@ def test_disaggregated_overlap_transceiver_runtime_python_fabric_memory(
 # KV-cache bounce optimization (cache_transceiver_config.kv_cache_bounce_size_mb > 0): scattered
 # per-block WRITEs are gathered into one coalesced fabric-VMM buffer before a single NIXL WRITE.
 # Restricted to GB200/GB300 since the bounce arena is fabric (MNNVL) VMM memory.
+#
+# The bounce transport coalesces a transfer only when it clears the receiver's min_blocks gate.
+# The test lowers that gate via the TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS env so the ordinary short
+# prompts still take the coalesced-bounce WRITE path -- no special long prompt is needed. The test
+# runs the normal disagg output verification (the coalesced KV must still decode to the right
+# answer, e.g. "Berlin"; a corrupt transfer would garble it) AND asserts the generation worker
+# logged the coalesced-bounce marker, so a silent fall-back to the per-fragment path fails the
+# test instead of passing quietly.
 @pytest.mark.skip_device_not_contain(["GB200", "GB300"])
 @pytest.mark.parametrize("llama_model_root", ['TinyLlama-1.1B-Chat-v1.0'],
                          indirect=True)
@@ -1149,12 +1177,15 @@ def test_disaggregated_overlap_transceiver_runtime_python_bounce(
 
     env = llm_venv._new_env.copy()
     env["UCX_TLS"] = get_ucx_tls()
-    env["TRTLLM_KVCACHE_POOL_USE_FABRIC_MEMORY"] = "1"
+    # min_blocks=1 forces bounce on even for the short test prompt (the gate is internal, tuned via
+    # env). No fabric-pool env is needed: the bounce arena is its own fabric memory.
+    env["TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS"] = "1"
     run_disaggregated_test(disaggregated_example_root,
                            "overlap_transceiver_runtime_python_bounce",
                            env=env,
                            model_path=llama_model_root,
-                           cwd=llm_venv.get_working_directory())
+                           cwd=llm_venv.get_working_directory(),
+                           assert_gen_log_contains="[kv-bounce] coalesced")
 
 
 def _verify_python_transceiver_under_host_offload(server_url: str, model: str):

--- a/tests/unittest/bindings/test_transfer_agent_bindings.py
+++ b/tests/unittest/bindings/test_transfer_agent_bindings.py
@@ -802,8 +802,9 @@ class TestMooncakeFunctionalTransfer:
         )
         status = agent_a.submit_transfer_requests(request)
 
+        # Zero-timeout poll must not block; a fast device may already be done, so accept either.
         result = status.wait(timeout_ms=0)
-        assert result == tab.TransferState.IN_PROGRESS
+        assert result in (tab.TransferState.IN_PROGRESS, tab.TransferState.SUCCESS)
 
         final_result = status.wait(timeout_ms=5000)
         assert final_result == tab.TransferState.SUCCESS

--- a/tests/unittest/disaggregated/test_bounce.py
+++ b/tests/unittest/disaggregated/test_bounce.py
@@ -106,6 +106,25 @@ class TestConfigFromSize:
         assert isinstance(cfg, bcfg.Config)
         assert cfg.sizing.capacity_mb == 2048
 
+    def test_min_blocks_defaults_and_overrides(self, monkeypatch):
+        monkeypatch.delenv("TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS", raising=False)
+        assert bcfg.config_from_size(2048).min_blocks == 96  # keeps the Config default
+        assert bcfg.config_from_size(2048, 1).min_blocks == 1  # explicit arg still overrides
+        assert bcfg.config_from_size(2048, 250).min_blocks == 250
+        # The gate is lowered for tests via the env override (no user-facing config field).
+        monkeypatch.setenv("TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS", "1")
+        assert bcfg.config_from_size(2048).min_blocks == 1  # env override
+        assert bcfg.config_from_size(2048, 250).min_blocks == 250  # explicit arg beats env
+
+    def test_min_blocks_env_is_parsed_defensively(self, monkeypatch):
+        # A bad value must not crash setup (falls back to the default); a non-positive value clamps to 1.
+        for bad in ("", "auto", "1.5"):
+            monkeypatch.setenv("TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS", bad)
+            assert bcfg.config_from_size(2048).min_blocks == 96
+        for nonpos in ("0", "-5"):
+            monkeypatch.setenv("TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS", nonpos)
+            assert bcfg.config_from_size(2048).min_blocks == 1
+
 
 # --------------------------------------------------------------------------- #
 # wire format — KV_AGENT_RESULT struct prefix + bounce result tail
@@ -313,6 +332,24 @@ class TestFanInReserve:
         assert t.reserve(req, num_writers=2) is False
         assert req.bounce_dst_base is None
 
+    def test_reserve_heterogeneous_fanin_falls_back(self, monkeypatch):
+        # Two groups with different per-block sizes: the equal split would overrun a sub-region, so
+        # fall back (even though the total is divisible).
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100, 200])
+        req = _recv_req([2, 2])  # total = 2*100 + 2*200 = 600
+        assert t.reserve(req, num_writers=2) is False
+        assert req.bounce_dst_base is None
+
+    def test_reserve_uniform_multigroup_fanin_ok(self, monkeypatch):
+        # Uniform slot bytes across present groups -> even byte split -> bounce allowed.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100, 100])
+        assert t.reserve(_recv_req([2, 2]), num_writers=2) is True
+
+    def test_reserve_heterogeneous_single_writer_ok(self, monkeypatch):
+        # num_writers==1 has no split, so heterogeneous slot bytes are fine.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100, 200])
+        assert t.reserve(_recv_req([2, 2]), num_writers=1) is True
+
     def test_reserve_single_writer_ok(self, monkeypatch):
         t = _make_transport(monkeypatch, block_bytes_per_group=[3])
         req = _recv_req([1])  # total = 3, num_writers=1 -> no even-split requirement
@@ -481,6 +518,20 @@ class TestFanInReserve:
         assert t.is_bounced(rid_slice) is False
         assert t._recv_alloc.released  # slot freed
         t.release_idle_reservation(rid_slice)  # already gone -> no-op, must not raise
+
+    def test_orphan_reservation_quarantines_and_is_idempotent(self, monkeypatch):
+        # Giving up on an in-flight reservation must quarantine the region (a write may still land),
+        # not release or leak it; a second give-up is a no-op.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=1) is True
+        rid_slice = (req.unique_rid, req.slice_id)
+        t.orphan_reservation(rid_slice)
+        assert t._recv_alloc.quarantined == [0]  # quarantined, not released
+        assert t._recv_alloc.released == []
+        assert t.is_bounced(rid_slice) is False  # settled and removed from the live map
+        t.orphan_reservation(rid_slice)  # already gone -> no-op, must not raise
+        assert t._recv_alloc.quarantined == [0]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
+++ b/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
@@ -235,9 +235,13 @@ class ThreadSafeDistributed:
             if key not in self._s:
                 self._s[key] = [None] * self._pp_size
             self._s[key][self._pp_rank] = obj
-        self._s["barrier"].wait()
+        # Sync only the PP group that shares this tp_rank. With attention data parallelism
+        # each tp_rank is an independent instance that may run a different number of
+        # collectives, so a single global barrier would deadlock; a per-group one does not.
+        pp_barrier = self._s["pp_barriers"][self._tp_rank]
+        pp_barrier.wait()
         result = list(self._s[key])
-        self._s["barrier"].wait()
+        pp_barrier.wait()
         return result
 
     def tp_allgather(self, obj):
@@ -248,9 +252,11 @@ class ThreadSafeDistributed:
             if key not in self._s:
                 self._s[key] = [None] * self._tp_size
             self._s[key][self._tp_rank] = obj
-        self._s["barrier"].wait()
+        # Sync only the TP group that shares this pp_rank (see pp_allgather).
+        tp_barrier = self._s["tp_barriers"][self._pp_rank]
+        tp_barrier.wait()
         result = list(self._s[key])
-        self._s["barrier"].wait()
+        tp_barrier.wait()
         return result
 
 
@@ -551,7 +557,15 @@ def create_instance_transceivers(
 ) -> List[KvCacheTransceiverV2]:
     """Create KvCacheTransceiverV2 for all ranks via threaded init."""
     world_size = tp * pp
-    shared = {"barrier": threading.Barrier(world_size), "lock": threading.Lock()}
+    shared = {
+        "barrier": threading.Barrier(world_size),
+        # Per-group barriers for the grouped collectives, so attention-DP instances can
+        # diverge in how many collectives they issue: pp_allgather syncs the PP ranks that
+        # share a tp_rank, tp_allgather the TP ranks that share a pp_rank.
+        "pp_barriers": [threading.Barrier(pp) for _ in range(tp)],
+        "tp_barriers": [threading.Barrier(tp) for _ in range(pp)],
+        "lock": threading.Lock(),
+    }
     results = [None] * world_size
     errors = [None] * world_size
     threads = []

--- a/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
+++ b/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
@@ -189,7 +189,9 @@ def test_context_transfer_status_zero_budget_processes_task_level_failure() -> N
     assert 13 not in transceiver._send_reqs
 
 
-def test_context_transfer_status_enters_consensus_when_tp_sync_required() -> None:
+def test_context_transfer_status_skips_consensus_when_never_sent() -> None:
+    # A worker that never sends skips the ctx consensus even when TP sync would need it, but still
+    # sweeps so nothing leaks.
     transceiver = object.__new__(KvCacheTransceiverV2)
     transceiver._ever_had_send_session = False
     transceiver._ctx_need_tp_sync = True
@@ -197,17 +199,31 @@ def test_context_transfer_status_enters_consensus_when_tp_sync_required() -> Non
     transceiver._send_sessions = {}
     transceiver._send_reqs = {}
     transceiver._transfer_worker = _FakeTransferWorker()
-    transceiver._ctx_consensus = Mock(return_value=[])
-    transceiver._build_to_process = Mock(return_value=[])
-    transceiver._ctx_consensus_outcome = Mock(return_value=([], [], [], []))
-    transceiver._close_failed_sessions = Mock()
+    transceiver._ctx_consensus = Mock(side_effect=AssertionError("consensus must be skipped"))
 
     completed, failed = transceiver.check_context_transfer_status(at_least_request_num=0)
 
     assert completed == []
     assert failed == []
-    transceiver._ctx_consensus.assert_called_once_with([])
+    transceiver._ctx_consensus.assert_not_called()
     assert transceiver._transfer_worker.sweep_count == 1
+
+
+def test_context_transfer_status_never_sent_no_sync_is_a_noop() -> None:
+    # With no tp/pp sync (e.g. attention_dp), a never-sent worker skips the consensus and the sweep,
+    # unchanged from before -- a true no-op, so the fix can't slow attention_dp workers.
+    transceiver = object.__new__(KvCacheTransceiverV2)
+    transceiver._ever_had_send_session = False
+    transceiver._ctx_need_tp_sync = False
+    transceiver._ctx_need_pp_sync = False
+    transceiver._send_sessions = {}
+    transceiver._send_reqs = {}
+    transceiver._transfer_worker = _FakeTransferWorker()
+    transceiver._ctx_consensus = Mock(side_effect=AssertionError("consensus must be skipped"))
+
+    assert transceiver.check_context_transfer_status(at_least_request_num=0) == ([], [])
+    transceiver._ctx_consensus.assert_not_called()
+    assert transceiver._transfer_worker.sweep_count == 0  # matches the original early-out exactly
 
 
 def test_gen_transfer_status_enters_consensus_when_sync_required() -> None:
@@ -253,39 +269,6 @@ def test_consensus_outcome_uses_single_batched_allgather() -> None:
     assert new_completed == [7]  # intersection only (8 is completed on the peer only)
 
 
-def test_ctx_consensus_fastpath_skips_when_idle(monkeypatch) -> None:
-    # With the fast-path enabled, an all-zero terminal count (one fixed-size
-    # allreduce) makes every rank skip the variable-length consensus; a non-zero
-    # count falls through to the normal consensus path.
-    monkeypatch.setattr(
-        "tensorrt_llm._torch.disaggregation.transceiver._CTX_CONSENSUS_FASTPATH", True
-    )
-    transceiver = object.__new__(KvCacheTransceiverV2)
-    transceiver._ever_had_send_session = True
-    transceiver._ctx_need_tp_sync = True
-    transceiver._ctx_need_pp_sync = False
-    transceiver._send_sessions = {}
-    transceiver._send_reqs = {}
-    transceiver._dist = Mock()
-    transceiver._dist.allreduce = Mock(return_value=0)
-    transceiver._ctx_consensus = Mock(return_value=[])
-    transceiver._build_to_process = Mock(return_value=[])
-    transceiver._ctx_consensus_outcome = Mock(return_value=([], [], [], []))
-    transceiver._transfer_worker = _FakeTransferWorker()
-    transceiver._close_failed_sessions = Mock()
-
-    completed, failed = transceiver.check_context_transfer_status(at_least_request_num=0)
-
-    assert completed == [] and failed == []
-    transceiver._dist.allreduce.assert_called_once()
-    transceiver._ctx_consensus.assert_not_called()  # idle fast-path skipped the consensus
-
-    # Non-zero global terminal count => fast-path does not skip; consensus runs.
-    transceiver._dist.allreduce = Mock(return_value=2)
-    transceiver.check_context_transfer_status(at_least_request_num=0)
-    transceiver._ctx_consensus.assert_called_once()
-
-
 def test_tx_session_wait_complete_defaults_to_blocking() -> None:
     task = _FakeTask(TaskStatus.INIT, wait_result=False)
     session = _make_tx_session([task])
@@ -317,3 +300,26 @@ def test_tx_session_has_failed_reports_task_error() -> None:
     session = _make_tx_session([task])
 
     assert session.has_failed()
+
+
+def test_check_context_runs_consensus_after_a_send() -> None:
+    # Once the worker has sent, the ctx consensus runs as usual.
+    transceiver = _make_transceiver({})
+    transceiver._ever_had_send_session = True
+    transceiver._ctx_need_tp_sync = True
+    transceiver._ctx_consensus = Mock(return_value=[])
+    transceiver._ctx_consensus_outcome = Mock(return_value=([], [], [], []))
+
+    transceiver.check_context_transfer_status(0)
+    transceiver._ctx_consensus.assert_called_once()
+
+
+def test_prepare_context_requests_skips_consensus_when_nothing_waiting() -> None:
+    # With nothing waiting on any rank, prepare_context_requests returns before the consensus; the
+    # waiting set is the same on every rank.
+    transceiver = _make_transceiver({})
+    transceiver._wait_reqs = {}
+    transceiver._ctx_consensus = Mock(side_effect=AssertionError("consensus must be skipped"))
+
+    transceiver.prepare_context_requests([])
+    transceiver._ctx_consensus.assert_not_called()


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This pull request introduces several improvements and bug fixes to the bounce (coalesced transfer) path in the disaggregated KV cache implementation. The main themes are enhanced robustness (especially around error handling and resource cleanup), improved configurability via environment variables, and stricter correctness checks for coalesced transfers. Additionally, some refactoring and logging enhancements are included to aid debugging and testing.

**Bounce Path Robustness & Error Handling:**

* Added an `orphan_reservation` method to the bounce allocator interface and implementations, ensuring that partially completed or cancelled transfers properly quarantine (rather than leak or prematurely release) bounce regions. This is called on cancellation, teardown, or failed transfer initiation. [[1]](diffhunk://#diff-cf03151ea02e8744577d78b5f8de6b34e2da70f2025a021edcd20904a8a0aad4R210-R213) [[2]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433R306-R311) [[3]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433R452-R454) [[4]](diffhunk://#diff-337dabe32d190384907e8c1330d67ed73ff63f41fbf0c1a347ff9f2ad18d4590R2016-R2025) [[5]](diffhunk://#diff-337dabe32d190384907e8c1330d67ed73ff63f41fbf0c1a347ff9f2ad18d4590R2083-R2086)
* Improved error handling in `_deliver_kv_to_agent` so that if building a coalesced send request fails, the receiver is notified and the region is not leaked.

**Configurability & Tuning:**

* Introduced an environment variable (`TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS`) to override the minimum block count required for the bounce path, allowing advanced/test tuning without code changes. The config logic now reads and clamps this value safely. [[1]](diffhunk://#diff-ba40c1c0fad5a3f5d11f7645b69557b07d088ac9db4097b0475f6a9f1355185eR18-R48) [[2]](diffhunk://#diff-ba40c1c0fad5a3f5d11f7645b69557b07d088ac9db4097b0475f6a9f1355185eL88-R122) [[3]](diffhunk://#diff-3cab8f284e64d42a9c7004535a761cabcdc7323d787ddbecdbd467b7e4f935b9L92-R92)

**Correctness & Safety of Coalesced Transfers:**

* Added stricter checks to ensure that fan-in (multi-writer) coalesced transfers only proceed when all writers have uniform per-block sizes, preventing region overruns. [[1]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433R241-R255) [[2]](diffhunk://#diff-337dabe32d190384907e8c1330d67ed73ff63f41fbf0c1a347ff9f2ad18d4590L1511-R1531)
* Added a positive log marker when a transfer successfully engages the bounce path, aiding end-to-end testing and debugging.

**Refactoring & Minor Improvements:**

* Simplified gather logic: gather is now blocking and runs under a lock, with resource cleanup on error, reducing concurrency bugs. [[1]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L149-R162) [[2]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L192-R204)
* Batched allgather calls for consensus outcomes to reduce collective communication overhead. [[1]](diffhunk://#diff-3cab8f284e64d42a9c7004535a761cabcdc7323d787ddbecdbd467b7e4f935b9L355-L362) [[2]](diffhunk://#diff-3cab8f284e64d42a9c7004535a761cabcdc7323d787ddbecdbd467b7e4f935b9L384-R383)
* Updated copyright years in `agentBindings.cpp`.
* Added `gil_scoped_release` call guards to all pybind11 bindings for `NixlTransferAgent` to avoid deadlocks and improve concurrency.

These changes collectively make the bounce path more robust, configurable, and correct, while improving observability and testability.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a faster idle path during disaggregated KV-cache coordination, reducing unnecessary work when no transfers are needed.
  * Added a new long-bounce prompt example for exercising cache transfer behavior.

* **Bug Fixes**
  * Improved handling of long prompts in disaggregated runs.
  * Increased test coverage for bounce-buffer transfers to better match real runtime conditions.

* **Tests**
  * Updated integration tests to use the new long-bounce prompt and validate the bounce transfer path more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->