### PR TITLE
[https://nvbugs/6422334][fix] In PyExecutor._prepare_draft_requests, gate the py_last_draft_tokens snapshot…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3966,7 +3966,9 @@ class PyExecutor:
                                      LlmRequestState.DISAGG_GENERATION_INIT):
                     continue
 
-                req.py_last_draft_tokens = req.py_draft_tokens
+                # Skip DISAGG_GENERATION_INIT: snapshotting the dummy py_draft_tokens leaks stale state into the first real draft.
+                if req.state == LlmRequestState.GENERATION_IN_PROGRESS:
+                    req.py_last_draft_tokens = req.py_draft_tokens
 
                 if self.max_total_draft_tokens > 0 and self.use_spec_decode and not req.py_disable_speculative_decoding:
                     req.py_draft_tokens = [0] * self.max_total_draft_tokens

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -270,8 +270,6 @@ full:H100/test_e2e.py::test_ptp_quickstart_advanced_deepseek_multi_nodes[DeepSee
 full:H100_PCIe/unittest/llmapi/test_llm_pytorch.py::test_llama_7b_multi_lora_evict_and_reload_lora_gpu_cache SKIP (https://nvbugs/5682551)
 full:H20/accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype[mtp_nextn=2-overlap_scheduler=False] SKIP (https://nvbugs/6345827)
 full:H20/accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype[mtp_nextn=2-overlap_scheduler=True] SKIP (https://nvbugs/6345827)
-full:H20/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_guided_decoding_with_eagle3[llguidance-eagle3_one_model=False] SKIP (https://nvbugs/6422334)
-full:H20/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_guided_decoding_with_eagle3[xgrammar-eagle3_one_model=False] SKIP (https://nvbugs/6422334)
 full:H20/accuracy/test_llm_api_autodeploy.py::TestModelRegistryAccuracy::test_autodeploy_from_registry[nvidia_Llama-3.1-8B-Instruct-FP8-True] SKIP (https://nvbugs/6422351)
 full:H20/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=True-enable_chunked_prefill=True-v2_kv_cache=False] SKIP (https://nvbugs/6422343)
 full:H20/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=True-enable_chunked_prefill=True-v2_kv_cache=True] SKIP (https://nvbugs/6422343)


### PR DESCRIPTION
## Summary
- **Root cause**: PyExecutor._prepare_draft_requests snapshotted py_last_draft_tokens = py_draft_tokens for DISAGG_GENERATION_INIT requests every iteration, leaving a stale dummy [0]*max_total_draft_tokens in py_last_draft_tokens by the time the request transitioned to GENERATION_IN_PROGRESS
- **Fix**: In PyExecutor._prepare_draft_requests, gate the py_last_draft_tokens snapshot on req.state == GENERATION_IN_PROGRESS so DISAGG_GENERATION_INIT dummies never leak; also remove the two H20 waivers this makes obsolete
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6422334


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling so initial draft-token state is no longer carried into the first real generation step, reducing the risk of incorrect output during early decoding.
* **Tests**
  * Removed obsolete waiver entries related to guided decoding coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->