### PR TITLE
[https://nvbugs/6215107][fix] Namespace cnn_dailymail repo id in load_calib_dataset

### DIFF
--- a/tensorrt_llm/models/convert_utils.py
+++ b/tensorrt_llm/models/convert_utils.py
@@ -317,6 +317,11 @@ def load_calib_dataset(dataset_name_or_dir: str,
                     key = meta[2]
                 break
 
+    # Bare "cnn_dailymail" id is rejected by newer huggingface_hub, which
+    # requires a "namespace/name" repo id; use the namespaced repo instead.
+    if dataset_name_or_dir == "cnn_dailymail":
+        dataset_name_or_dir = "abisee/cnn_dailymail"
+
     dataset = load_dataset(dataset_name_or_dir,
                            name=config_name,
                            split=split,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset loading for CNN/DailyMail by handling the dataset name format expected by the latest Hugging Face Hub rules.
  * Prevents failures when loading the dataset using the short `"cnn_dailymail"` identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Newer `huggingface_hub` rejects the legacy bare `cnn_dailymail` dataset id and raises `HfUriError` ("Repository id must be 'namespace/name'") while resolving the dataset. `load_calib_dataset()` in `tensorrt_llm/models/convert_utils.py` still forwarded the bare id to `datasets.load_dataset()`, breaking the default calibration path of the TensorRT convert scripts.

This is the same root cause already fixed for the ModelOpt path in `quantize_by_modelopt.py`. This PR mirrors that fix by rewriting the bare id to the namespaced `abisee/cnn_dailymail` repo before loading.

## Test Coverage

Existing quantization integration tests that exercise the default calibration path (e.g. SmoothQuant / INT8 KV-cache convert flows in `tests/integration/defs`) cover `load_calib_dataset()` with the default `cnn_dailymail` dataset.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.