### PR TITLE
[https://nvbugs/6384375][fix] Cap MXFP4 Hopper swizzle transient GPU memory during MoE weight load

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
@@ -27,7 +27,10 @@ from triton_kernels.matmul_ogs import (FlexCtx, FnSpecs, FusedActivation,
                                        PrecisionConfig, matmul_ogs)
 from triton_kernels.numerics import InFlexData
 from triton_kernels.numerics_details.mxfp import downcast_to_mxfp_torch
-from triton_kernels.tensor import FP4, convert_layout, wrap_torch_tensor
+from triton_kernels.tensor import FP4
+from triton_kernels.tensor import Storage as TritonStorage
+from triton_kernels.tensor import Tensor as TritonTensor
+from triton_kernels.tensor import convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 
 from ...model_config import ModelConfig
@@ -710,6 +713,56 @@ def is_swizzling_supported() -> bool:
     return not is_h20_family
 
 
+# Swizzling a full MoE weight tensor in one shot materializes several int32
+# temporaries of the full tensor size inside HopperMXValueLayout.swizzle_data
+# (~8x the packed weight bytes; the padded/permuted copies come on top). For
+# gpt-oss-120b that is a >8 GiB transient per MoE layer on top of the nearly
+# fully resident model, which OOMs 80GB GPUs during weight loading
+# (nvbugs/6384375). The expert dim is a pure batch dim for these layouts, so
+# swizzling expert chunks of at most this many source bytes is bit-identical
+# while capping the transient.
+MXFP4_SWIZZLE_CHUNK_BYTES = 64 * 1024 * 1024
+
+
+def convert_layout_expert_chunked(t: torch.Tensor,
+                                  dtype,
+                                  layout_cls,
+                                  layout_opts: dict,
+                                  max_chunk_bytes=MXFP4_SWIZZLE_CHUNK_BYTES):
+    """Memory-frugal equivalent of
+    ``convert_layout(wrap_torch_tensor(t, dtype=dtype), layout_cls, **layout_opts)``
+    for 3D ``(num_experts, K, N)`` tensors and layouts that treat the leading
+    dim as a batch dim (Hopper MXFP4 value/scale layouts).
+    """
+    assert t.dim() == 3
+    wrapped = wrap_torch_tensor(t, dtype=dtype) if dtype is not None \
+        else wrap_torch_tensor(t)
+    new_layout = layout_cls(t.shape, **layout_opts)
+    num_experts = t.shape[0]
+    bytes_per_expert = t[:1].numel() * t.element_size()
+    chunk = min(num_experts,
+                max(1,
+                    int(max_chunk_bytes) // max(bytes_per_expert, 1)))
+    new_data = None
+    for i in range(0, num_experts, chunk):
+        piece = new_layout.swizzle_data(t[i:i + chunk])
+        # Expert blocks must be dense and independent in storage for the
+        # chunked reassembly to be equivalent to the one-shot swizzle.
+        assert piece.stride(0) == piece[0].numel()
+        if new_data is None:
+            new_data = torch.empty_strided(
+                (num_experts, ) + tuple(piece.shape[1:]),
+                (piece.stride(0), ) + tuple(piece.stride()[1:]),
+                dtype=piece.dtype,
+                device=piece.device)
+        new_data[i:i + piece.shape[0]].copy_(piece)
+        del piece
+    return TritonTensor(TritonStorage(new_data, new_layout),
+                        dtype=wrapped.dtype,
+                        shape=wrapped.shape,
+                        shape_max=wrapped.shape_max)
+
+
 def swizzle_weight_and_scale(w: torch.Tensor, w_scale: torch.Tensor):
     # (num_experts, in_dim//2, out_dim)
     w_shape = w.shape
@@ -749,10 +802,23 @@ def swizzle_weight_and_scale(w: torch.Tensor, w_scale: torch.Tensor):
             "scale_layout": scale_layout, "scale_layout_opts": scale_layout_opts}
 
     # w, w_scale = downcast_to_mxfp(tensor.to(torch.bfloat16), torch.uint8, axis=1)
-    w = convert_layout(wrap_torch_tensor(w, dtype=FP4), opt["value_layout"],
-                       **opt["value_layout_opts"])
-    w_scale = convert_layout(wrap_torch_tensor(w_scale), opt["scale_layout"],
-                             **opt["scale_layout_opts"])
+    # The Hopper layouts are the ones whose one-shot swizzle needs several
+    # times the tensor size in temporaries; other layouts (Strided alias,
+    # Blackwell pad-only) are kept on the one-shot path to preserve their
+    # storage-aliasing behavior.
+    if value_layout is layout.HopperMXValueLayout:
+        w = convert_layout_expert_chunked(w, FP4, value_layout,
+                                          value_layout_opts)
+    else:
+        w = convert_layout(wrap_torch_tensor(w, dtype=FP4), opt["value_layout"],
+                           **opt["value_layout_opts"])
+    if scale_layout is layout.HopperMXScaleLayout:
+        w_scale = convert_layout_expert_chunked(w_scale, None, scale_layout,
+                                                scale_layout_opts)
+    else:
+        w_scale = convert_layout(wrap_torch_tensor(w_scale),
+                                 opt["scale_layout"],
+                                 **opt["scale_layout_opts"])
     return w, w_scale
 
 

--- a/tests/unittest/_torch/modules/fused_moe/test_triton_mxfp4_swizzle.py
+++ b/tests/unittest/_torch/modules/fused_moe/test_triton_mxfp4_swizzle.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from triton_kernels.tensor import FP4, convert_layout, wrap_torch_tensor
+from triton_kernels.tensor_details.layout import HopperMXScaleLayout, HopperMXValueLayout
+
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_triton import (
+    convert_layout_expert_chunked,
+    update_weight_stride,
+)
+
+
+def _assert_tensors_identical(chunked, reference):
+    assert chunked.storage.data.shape == reference.storage.data.shape
+    assert chunked.storage.data.stride() == reference.storage.data.stride()
+    assert chunked.storage.data.dtype == reference.storage.data.dtype
+    assert torch.equal(chunked.storage.data, reference.storage.data)
+    assert type(chunked.storage.layout) is type(reference.storage.layout)
+    assert chunked.dtype == reference.dtype
+    assert list(chunked.shape) == list(reference.shape)
+    assert list(chunked.shape_max) == list(reference.shape_max)
+
+
+# Shapes: (num_experts, in_dim // 2, out_dim). The last two trigger the
+# 64-alignment padding inside HopperMXValueLayout.swizzle_data.
+@pytest.mark.parametrize("shape", [(8, 64, 128), (5, 128, 64), (3, 72, 96), (8, 40, 200)])
+@pytest.mark.parametrize("max_chunk_bytes", [1, 16 * 1024])
+def test_chunked_value_swizzle_matches_one_shot(shape, max_chunk_bytes):
+    torch.manual_seed(1234)
+    w = torch.randint(0, 256, shape, dtype=torch.uint8)
+    # Match the (num_experts, K, N) stride layout used at the real call site.
+    w = update_weight_stride(w)
+
+    reference = convert_layout(wrap_torch_tensor(w, dtype=FP4), HopperMXValueLayout, mx_axis=1)
+    chunked = convert_layout_expert_chunked(
+        w, FP4, HopperMXValueLayout, {"mx_axis": 1}, max_chunk_bytes=max_chunk_bytes
+    )
+    _assert_tensors_identical(chunked, reference)
+
+
+@pytest.mark.parametrize("shape", [(8, 4, 128), (5, 6, 64), (3, 5, 96)])
+@pytest.mark.parametrize("num_warps", [4, 8])
+@pytest.mark.parametrize("max_chunk_bytes", [1, 4 * 1024])
+def test_chunked_scale_swizzle_matches_one_shot(shape, num_warps, max_chunk_bytes):
+    torch.manual_seed(1234)
+    w_scale = torch.randint(0, 256, shape, dtype=torch.uint8)
+
+    reference = convert_layout(
+        wrap_torch_tensor(w_scale), HopperMXScaleLayout, mx_axis=1, num_warps=num_warps
+    )
+    chunked = convert_layout_expert_chunked(
+        w_scale,
+        None,
+        HopperMXScaleLayout,
+        {"mx_axis": 1, "num_warps": num_warps},
+        max_chunk_bytes=max_chunk_bytes,
+    )
+    _assert_tensors_identical(chunked, reference)


### PR DESCRIPTION
## Description

Fixes https://nvbugs/6384375 (`test_e2e.py::test_openai_chat_guided_decoding[openai/gpt-oss-120b]` OOM on H100 80GB during server startup).

**Root cause.** During gpt-oss-120b weight loading, `swizzle_weight_and_scale` converts each MoE weight tensor to the Hopper MXFP4 swizzled layout in one shot. Inside `HopperMXValueLayout.swizzle_data`, `_pack_bits` holds **eight concurrent full-size int32 temporaries** (1.0332 GiB each for the padded `(128, 1472, 5888)` w3_w1 tensor — the exact "Tried to allocate 1.03 GiB" from the bug), plus padded/permuted copies: a **~9.3 GiB transient** on top of the almost fully resident model. Measured on an empty H100-80GB at main TOT, the load-phase spike reaches 79,787 of 81,559 MiB — only ~1.7 GiB of headroom. The QA harness keeps ~1.7 GiB of additional co-resident GPU memory (pytest controller CUDA contexts + server), which is why QA reproduces the OOM while dev runs on clean GPUs pass.

**Fix.** The expert dim is a pure batch dim for the Hopper value/scale layouts, so swizzle bounded expert-dim chunks (64 MiB of source bytes each) into a preallocated output instead. The result is bit-identical to the one-shot conversion — same values, shape, strides, layout metadata, and TMA compliance — while the transient is capped at the chunk size. The `StridedLayout` (H20) and Blackwell layouts keep the one-shot path to preserve their storage-aliasing behavior.

**Measured effect** (H100-80GB, main TOT, 100 ms `nvidia-smi` sampling):

| Configuration | Load-phase peak | Result |
|---|---|---|
| unpatched, clean GPU | 79,787 MiB (spike) | pass, ~1.7 GiB margin |
| unpatched + 2.5 GiB co-resident ballast (QA-magnitude) | — | **OOM, exact bug signature** (1.03 GiB at `hopper_value.py::_compress_fourth`, worker 74.20 GiB PyTorch-allocated, matching QA build 1667) |
| patched + same ballast | 73,708 MiB | pass |
| patched, clean GPU | 71,193 MiB | pass (**~8.6 GiB headroom recovered**) |

Model load also gets faster (nested guided-decoding suite: 148 s vs 227 s unpatched).

## Test Coverage

- New unit test `tests/unittest/_torch/modules/fused_moe/test_triton_mxfp4_swizzle.py`: chunked-vs-one-shot bit-exactness (values, strides, dtype, layout, `shape`/`shape_max`) for `HopperMXValueLayout` and `HopperMXScaleLayout`, across padding-triggering shapes, `num_warps` 4/8, and non-dividing chunk sizes (20 cases; passes on H100).
- End-to-end: `test_e2e.py::test_openai_chat_guided_decoding[openai/gpt-oss-120b]` verified red → green on the same H100-80GB node (see table above), including a final pass on the exact committed tree.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for large MXFP4 weight and scale conversions by processing them in smaller chunks for better handling of Hopper-specific layouts.
  * Preserved existing conversion behavior for other layouts.

* **Tests**
  * Added coverage to verify chunked conversions match the previous full-conversion results exactly for both value and scale data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->