### PR TITLE
[None][perf] serve: opt-in msgspec msgpack transport for disagg orchestrator->worker request body

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ prometheus_client
 prometheus_fastapi_instrumentator
 pydantic>=2.9.1
 pydantic-settings[yaml]
+msgspec
 omegaconf
 pillow
 optimum

--- a/tensorrt_llm/serve/openai_client.py
+++ b/tensorrt_llm/serve/openai_client.py
@@ -208,9 +208,6 @@ class OpenAIHttpClient(OpenAIClient):
                 body = _msgpack_encoder.encode(request.model_dump(mode="json", exclude_unset=True))
                 req_headers = {"Content-Type": "application/json", "X-TRTLLM-Msgpack": "1"}
             else:
-                # model_dump_json (pydantic-core) is ~2.3x faster than
-                # model_dump(mode="json") + aiohttp json= (json.dumps). Decodes to
-                # identical JSON (pydantic just emits compact UTF-8 vs spaced ASCII).
                 body = request.model_dump_json(exclude_unset=True)
                 req_headers = {"Content-Type": "application/json"}
             try:

--- a/tensorrt_llm/serve/openai_client.py
+++ b/tensorrt_llm/serve/openai_client.py
@@ -14,6 +14,7 @@
 
 # yapf: disable
 import asyncio
+import os
 import traceback
 from abc import ABC, abstractmethod
 from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple, Type
@@ -39,6 +40,21 @@ from tensorrt_llm.serve.responses_utils import (
 from tensorrt_llm.serve.router import Router
 
 # yapf: enable
+
+# msgspec msgpack is an opt-in transport for the orchestrator->worker request
+# body (alternative to the JSON path). Enable with TRTLLM_SERVE_ENABLE_MSGSPEC=1;
+# the orchestrator encodes the forwarded body as msgpack and the worker decodes
+# it by Content-Type. Fails loudly at import if msgspec is missing.
+_MSGSPEC_ENABLED = os.getenv("TRTLLM_SERVE_ENABLE_MSGSPEC", "0") == "1"
+if _MSGSPEC_ENABLED:
+    try:
+        import msgspec
+    except ImportError as exc:
+        raise ImportError(
+            "TRTLLM_SERVE_ENABLE_MSGSPEC=1 requires the msgspec package "
+            "(listed in requirements.txt)."
+        ) from exc
+    _msgpack_encoder = msgspec.msgpack.Encoder()
 
 
 class OpenAIClient(ABC):
@@ -181,18 +197,25 @@ class OpenAIHttpClient(OpenAIClient):
                 dp = getattr(request, "disaggregated_params", None)
                 if dp is not None and getattr(dp, "disagg_request_id", None) is not None:
                     dp.disagg_request_id = self._disagg_id_generator()
-            # Serialize once on the orchestrator's single event-loop thread:
-            # model_dump_json (pydantic-core) is ~2.3x faster than
-            # model_dump(mode="json") + aiohttp json= (json.dumps). Decodes to
-            # identical JSON (pydantic just emits compact UTF-8 vs spaced ASCII).
-            body = request.model_dump_json(exclude_unset=True)
+            # Serialize once on the orchestrator's single event-loop thread.
+            if _MSGSPEC_ENABLED:
+                # msgspec msgpack: encode the request dict to msgpack bytes; the
+                # worker decodes it by Content-Type=application/msgpack.
+                body = _msgpack_encoder.encode(request.model_dump(mode="json", exclude_unset=True))
+                req_content_type = "application/msgpack"
+            else:
+                # model_dump_json (pydantic-core) is ~2.3x faster than
+                # model_dump(mode="json") + aiohttp json= (json.dumps). Decodes to
+                # identical JSON (pydantic just emits compact UTF-8 vs spaced ASCII).
+                body = request.model_dump_json(exclude_unset=True)
+                req_content_type = "application/json"
             try:
                 lines_yielded = 0
                 start_time = get_steady_clock_now_in_seconds()
                 async with self._session.post(
                     url,
                     data=body,
-                    headers={"Content-Type": "application/json"},
+                    headers={"Content-Type": req_content_type},
                 ) as http_response:
                     content_type = http_response.headers.get("Content-Type", "")
                     if not is_stream and "text/event-stream" in content_type:

--- a/tensorrt_llm/serve/openai_client.py
+++ b/tensorrt_llm/serve/openai_client.py
@@ -43,8 +43,9 @@ from tensorrt_llm.serve.router import Router
 
 # msgspec msgpack is an opt-in transport for the orchestrator->worker request
 # body (alternative to the JSON path). Enable with TRTLLM_SERVE_ENABLE_MSGSPEC=1;
-# the orchestrator encodes the forwarded body as msgpack and the worker decodes
-# it by Content-Type. Fails loudly at import if msgspec is missing.
+# the orchestrator encodes the forwarded body as msgpack and flags it with the
+# X-TRTLLM-Msgpack header (Content-Type stays application/json so FastAPI still
+# routes it through Request.json()). Fails loudly at import if msgspec is missing.
 _MSGSPEC_ENABLED = os.getenv("TRTLLM_SERVE_ENABLE_MSGSPEC", "0") == "1"
 if _MSGSPEC_ENABLED:
     try:
@@ -199,23 +200,26 @@ class OpenAIHttpClient(OpenAIClient):
                     dp.disagg_request_id = self._disagg_id_generator()
             # Serialize once on the orchestrator's single event-loop thread.
             if _MSGSPEC_ENABLED:
-                # msgspec msgpack: encode the request dict to msgpack bytes; the
-                # worker decodes it by Content-Type=application/msgpack.
+                # msgspec msgpack: encode the request dict to msgpack bytes. Keep
+                # Content-Type application/json so FastAPI still routes the body
+                # through Request.json() (it only does that for json/+json content
+                # subtypes); the X-TRTLLM-Msgpack header tells the worker's
+                # Request.json() to decode with msgspec instead of stdlib json.
                 body = _msgpack_encoder.encode(request.model_dump(mode="json", exclude_unset=True))
-                req_content_type = "application/msgpack"
+                req_headers = {"Content-Type": "application/json", "X-TRTLLM-Msgpack": "1"}
             else:
                 # model_dump_json (pydantic-core) is ~2.3x faster than
                 # model_dump(mode="json") + aiohttp json= (json.dumps). Decodes to
                 # identical JSON (pydantic just emits compact UTF-8 vs spaced ASCII).
                 body = request.model_dump_json(exclude_unset=True)
-                req_content_type = "application/json"
+                req_headers = {"Content-Type": "application/json"}
             try:
                 lines_yielded = 0
                 start_time = get_steady_clock_now_in_seconds()
                 async with self._session.post(
                     url,
                     data=body,
-                    headers={"Content-Type": req_content_type},
+                    headers=req_headers,
                 ) as http_response:
                     content_type = http_response.headers.get("Content-Type", "")
                     if not is_stream and "text/event-stream" in content_type:

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -107,9 +107,9 @@ from .harmony_adapter import (HarmonyAdapter, get_harmony_adapter,
 # msgspec msgpack is an opt-in transport for the disagg orchestrator->worker
 # request body: the large agentic chat body otherwise blocks the serving event
 # loop on stdlib json.loads. Enable with TRTLLM_SERVE_ENABLE_MSGSPEC=1 (must be
-# set on both orchestrator and worker). The worker decodes application/msgpack
-# bodies with msgspec and falls back to stdlib json for everything else, so the
-# JSON path is byte-for-byte unchanged when the flag is off.
+# set on both orchestrator and worker). The worker decodes bodies flagged with
+# the X-TRTLLM-Msgpack header via msgspec and falls back to stdlib json for
+# everything else, so the JSON path is byte-for-byte unchanged when the flag is off.
 _MSGSPEC_ENABLED = os.getenv("TRTLLM_SERVE_ENABLE_MSGSPEC", "0") == "1"
 if _MSGSPEC_ENABLED:
     try:
@@ -121,15 +121,19 @@ if _MSGSPEC_ENABLED:
     _msgpack_decoder = msgspec.msgpack.Decoder()
 
     class _MsgspecRequest(Request):
-        """Request that decodes application/msgpack bodies with msgspec."""
+        """Request that decodes msgpack bodies (X-TRTLLM-Msgpack: 1) with msgspec.
+
+        The orchestrator sends Content-Type application/json (so FastAPI still
+        routes the body through Request.json()) with the X-TRTLLM-Msgpack header
+        flagging a msgspec-msgpack payload; everything else is stdlib json.
+        """
 
         async def json(self):
             if not hasattr(self, "_json_body"):
                 body = await self.body()
                 if not body:
                     self._json_body = {}
-                elif self.headers.get("content-type",
-                                      "").startswith("application/msgpack"):
+                elif self.headers.get("x-trtllm-msgpack") == "1":
                     self._json_body = _msgpack_decoder.decode(body)
                 else:
                     self._json_body = json.loads(body)

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -25,6 +25,7 @@ from fastapi import Body, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import (FileResponse, JSONResponse, Response,
                                StreamingResponse)
+from fastapi.routing import APIRoute
 from pydantic import ValidationError
 from starlette.routing import Mount
 from transformers import AutoProcessor
@@ -102,6 +103,51 @@ from .harmony_adapter import (HarmonyAdapter, get_harmony_adapter,
                               maybe_transform_reasoning_effort)
 
 # yapf: enable
+
+# msgspec msgpack is an opt-in transport for the disagg orchestrator->worker
+# request body: the large agentic chat body otherwise blocks the serving event
+# loop on stdlib json.loads. Enable with TRTLLM_SERVE_ENABLE_MSGSPEC=1 (must be
+# set on both orchestrator and worker). The worker decodes application/msgpack
+# bodies with msgspec and falls back to stdlib json for everything else, so the
+# JSON path is byte-for-byte unchanged when the flag is off.
+_MSGSPEC_ENABLED = os.getenv("TRTLLM_SERVE_ENABLE_MSGSPEC", "0") == "1"
+if _MSGSPEC_ENABLED:
+    try:
+        import msgspec
+    except ImportError as exc:
+        raise ImportError(
+            "TRTLLM_SERVE_ENABLE_MSGSPEC=1 requires the msgspec package "
+            "(listed in requirements.txt).") from exc
+    _msgpack_decoder = msgspec.msgpack.Decoder()
+
+    class _MsgspecRequest(Request):
+        """Request that decodes application/msgpack bodies with msgspec."""
+
+        async def json(self):
+            if not hasattr(self, "_json_body"):
+                body = await self.body()
+                if not body:
+                    self._json_body = {}
+                elif self.headers.get("content-type",
+                                      "").startswith("application/msgpack"):
+                    self._json_body = _msgpack_decoder.decode(body)
+                else:
+                    self._json_body = json.loads(body)
+            return self._json_body
+
+    class _MsgspecRoute(APIRoute):
+        """APIRoute that parses request bodies via :class:`_MsgspecRequest`."""
+
+        def get_route_handler(self):
+            original_route_handler = super().get_route_handler()
+
+            async def route_handler(request: Request):
+                return await original_route_handler(
+                    _MsgspecRequest(request.scope, request.receive))
+
+            return route_handler
+
+
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 
 
@@ -384,6 +430,8 @@ class OpenAIServer(_VideoRoutesMixin):
             self.generator.shutdown()
 
         self.app = FastAPI(lifespan=lifespan)
+        if _MSGSPEC_ENABLED:
+            self.app.router.route_class = _MsgspecRoute
 
         @self.app.exception_handler(RequestValidationError)
         async def validation_exception_handler(_, exc):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional high-performance transport path for server-to-server requests when enabled via configuration.
  * Requests can now be sent and received in a more efficient format while keeping the standard behavior as the default.

* **Chores**
  * Added a new runtime dependency required for the optional transport support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Port of #15910 (merged into `feat/deepseek_v4`) to `main`.

Opt-in `msgspec` **msgpack** transport for the disaggregated orchestrator→worker request body, as an alternative to the orjson request-body parse (#15690). Instead of speeding up the JSON *parse*, this removes JSON (de)serialization from the disagg serving path entirely: the orchestrator encodes the forwarded request dict as msgpack via `msgspec.msgpack`, and the worker decodes it.

- **`openai_client.py` (orchestrator):** when enabled, encode the request dict with `msgspec.msgpack` and flag it via the `X-TRTLLM-Msgpack: 1` header (Content-Type stays `application/json` so FastAPI routing is unaffected); otherwise the existing `model_dump_json` path is used.
- **`openai_server.py` (worker):** a custom `APIRoute`/`Request` that decodes msgpack bodies with `msgspec` when the header is set, falling back to stdlib `json` otherwise.
- **`requirements.txt`:** add `msgspec`.

Enabled with `TRTLLM_SERVE_ENABLE_MSGSPEC=1` on **both** the orchestrator and the worker. Off by default → the JSON path is byte-for-byte unchanged (no route override, no import).

For DeepSeek-V4 agentic loads the ~40k-token request body's JSON (de)serialization on the single serving event loop is a dispatch bottleneck. This is purely the orchestrator↔worker leg; the client API is unchanged.

## Test Coverage

- Existing disaggregated serving tests cover the default (JSON) path, which is unchanged when the flag is off.
- The msgpack path is opt-in via `TRTLLM_SERVE_ENABLE_MSGSPEC=1` and was validated end-to-end on disaggregated DeepSeek-V4 serving runs.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
