### PR TITLE
[None][perf] Skip redundant Qwen Image attention masks

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
@@ -251,12 +251,12 @@ class QwenImagePipeline(BasePipeline):
         prompt: List[str],
         device: torch.device,
         max_sequence_length: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Encode a list of prompts via Qwen2.5-VL + chat template.
 
         Returns:
             prompt_embeds: ``(B, S, 3584)`` in transformer dtype.
-            prompt_embeds_mask: ``(B, S)`` bool mask.
+            prompt_embeds_mask: Optional ``(B, S)`` mask. ``None`` means all tokens are valid.
         """
         drop_idx = _PROMPT_TEMPLATE_START_IDX
         txt = [_PROMPT_TEMPLATE.format(e) for e in prompt]
@@ -292,6 +292,8 @@ class QwenImagePipeline(BasePipeline):
         prompt_embeds = prompt_embeds[:, :max_sequence_length]
         prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
         prompt_embeds = prompt_embeds.to(dtype=self.dtype, device=device)
+        if prompt_embeds_mask.bool().all():
+            return prompt_embeds, None
         return prompt_embeds, prompt_embeds_mask
 
     # ------------------------------------------------------------------

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -1045,13 +1045,14 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
         if encoder_hidden_states_mask is not None:
             if encoder_hidden_states_mask.dtype != torch.bool:
                 encoder_hidden_states_mask = encoder_hidden_states_mask.to(torch.bool)
-            batch_size, image_seq_len = hidden_states.shape[:2]
-            image_mask = torch.ones(
-                (batch_size, image_seq_len),
-                dtype=torch.bool,
-                device=hidden_states.device,
-            )
-            block_attention_mask = torch.cat([encoder_hidden_states_mask, image_mask], dim=1)
+            if not encoder_hidden_states_mask.all():
+                batch_size, image_seq_len = hidden_states.shape[:2]
+                image_mask = torch.ones(
+                    (batch_size, image_seq_len),
+                    dtype=torch.bool,
+                    device=hidden_states.device,
+                )
+                block_attention_mask = torch.cat([encoder_hidden_states_mask, image_mask], dim=1)
 
         for block in self.transformer_blocks:
             encoder_hidden_states, hidden_states = block(

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -483,6 +483,9 @@ class QwenJointAttention(Attention):
         )
         self.heads = num_attention_heads
         self.head_dim = attention_head_dim
+        self._supports_key_padding_mask = _supports_qwen_key_padding_mask(
+            self.attn_backend, self.attn
+        )
 
         # Text-stream QKV (diffusers names).
         self.add_q_proj = Linear(
@@ -583,28 +586,25 @@ class QwenJointAttention(Attention):
         joint_k = torch.cat([txt_k, img_k], dim=1)
         joint_v = torch.cat([txt_v, img_v], dim=1)
 
-        # SDPA expects (B, H, S, D); diffusers dispatch_attention_fn
-        # accepts (B, S, H, D) and transposes internally. Do the same.
-        joint_q = joint_q.transpose(1, 2)
-        joint_k = joint_k.transpose(1, 2)
-        joint_v = joint_v.transpose(1, 2)
-
-        attn_mask = None
-        if attention_mask is not None:
-            # attention_mask is (B, Sjoint) bool or float. Expand to
-            # (B, 1, 1, Sjoint) so SDPA broadcasts over (H, Sq).
-            # Qwen pads text embeddings before concatenating [text | image],
-            # so masked SDPA is required to ignore padded text tokens.
-            attn_mask = attention_mask[:, None, None, :]
-
-        if attn_mask is None:
+        if attention_mask is None or self._supports_key_padding_mask:
+            attn_kwargs = {}
+            if attention_mask is not None:
+                attn_kwargs["key_padding_mask"] = attention_mask
             out = self._attn_impl(
-                joint_q.transpose(1, 2).flatten(2),
-                joint_k.transpose(1, 2).flatten(2),
-                joint_v.transpose(1, 2).flatten(2),
+                joint_q.flatten(2),
+                joint_k.flatten(2),
+                joint_v.flatten(2),
                 timestep=timestep,
+                **attn_kwargs,
             )
         else:
+            # Fallback for backends that do not accept arbitrary key padding masks.
+            # SDPA expects (B, H, S, D); diffusers dispatch_attention_fn accepts
+            # (B, S, H, D) and transposes internally. Do the same.
+            joint_q = joint_q.transpose(1, 2)
+            joint_k = joint_k.transpose(1, 2)
+            joint_v = joint_v.transpose(1, 2)
+            attn_mask = attention_mask[:, None, None, :]
             out = F.scaled_dot_product_attention(
                 joint_q, joint_k, joint_v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False
             )
@@ -756,6 +756,31 @@ class QwenImageTransformerBlock(nn.Module):
 # ===========================================================================
 # Top-level transformer.
 # ===========================================================================
+
+
+def _supports_qwen_key_padding_mask(attn_backend: str, attn: Any) -> bool:
+    return attn_backend in ("VANILLA", "FA4") and type(attn).__name__ not in (
+        "Attention2DAttention",
+        "RingAttention",
+        "UlyssesAttention",
+    )
+
+
+def _build_joint_attention_mask(
+    encoder_hidden_states_mask: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+) -> Optional[torch.Tensor]:
+    if encoder_hidden_states_mask is None:
+        return None
+    if encoder_hidden_states_mask.dtype != torch.bool:
+        encoder_hidden_states_mask = encoder_hidden_states_mask.to(torch.bool)
+    batch_size, image_seq_len = hidden_states.shape[:2]
+    image_mask = torch.ones(
+        (batch_size, image_seq_len),
+        dtype=torch.bool,
+        device=hidden_states.device,
+    )
+    return torch.cat([encoder_hidden_states_mask, image_mask], dim=1)
 
 
 class QwenImageTransformer2DModel(BaseDiffusionModel):
@@ -1041,18 +1066,9 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
         )
 
         # Build joint attention mask [text_mask | all-ones image_mask] once.
-        block_attention_mask = None
-        if encoder_hidden_states_mask is not None:
-            if encoder_hidden_states_mask.dtype != torch.bool:
-                encoder_hidden_states_mask = encoder_hidden_states_mask.to(torch.bool)
-            if not encoder_hidden_states_mask.all():
-                batch_size, image_seq_len = hidden_states.shape[:2]
-                image_mask = torch.ones(
-                    (batch_size, image_seq_len),
-                    dtype=torch.bool,
-                    device=hidden_states.device,
-                )
-                block_attention_mask = torch.cat([encoder_hidden_states_mask, image_mask], dim=1)
+        block_attention_mask = _build_joint_attention_mask(
+            encoder_hidden_states_mask, hidden_states
+        )
 
         for block in self.transformer_blocks:
             encoder_hidden_states, hidden_states = block(

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py
@@ -12,9 +12,10 @@ import torch
 # Importing the models package applies the Qwen-Image registration side effect.
 from tensorrt_llm._torch.visual_gen import models  # noqa: F401
 from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig, DiffusionPipelineConfig
-from tensorrt_llm._torch.visual_gen.models.qwen_image import (
-    QwenImageTransformer2DModel,
-    QwenJointAttention,
+from tensorrt_llm._torch.visual_gen.models.qwen_image import QwenImagePipeline, QwenJointAttention
+from tensorrt_llm._torch.visual_gen.models.qwen_image.transformer_qwen_image import (
+    _build_joint_attention_mask,
+    _supports_qwen_key_padding_mask,
 )
 from tensorrt_llm._torch.visual_gen.modules.attention import QKVMode
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
@@ -232,40 +233,130 @@ def test_qwen_joint_attention_keeps_separate_qkv_path_unwrapped(visual_gen_mappi
     assert attention.attn.__class__.__name__ != not_wrapped_as
 
 
-def test_qwen_transformer_treats_all_true_text_mask_as_unmasked():
-    torch.manual_seed(0)
-    model = QwenImageTransformer2DModel(
-        patch_size=2,
-        in_channels=4,
-        out_channels=4,
-        num_layers=1,
-        attention_head_dim=8,
+class _FakeTokenBatch:
+    def __init__(self, attention_mask):
+        self.attention_mask = attention_mask
+        self.input_ids = torch.arange(attention_mask.numel()).view_as(attention_mask)
+
+    def to(self, device):
+        self.attention_mask = self.attention_mask.to(device)
+        self.input_ids = self.input_ids.to(device)
+        return self
+
+
+class _FakeTokenizer:
+    def __init__(self, attention_mask):
+        self.attention_mask = attention_mask
+
+    def __call__(self, *args, **kwargs):
+        return _FakeTokenBatch(self.attention_mask.clone())
+
+
+class _FakeTextEncoder:
+    def __call__(self, input_ids, **kwargs):
+        hidden = torch.arange(
+            input_ids.numel() * 4,
+            dtype=torch.float32,
+            device=input_ids.device,
+        ).view(*input_ids.shape, 4)
+        return SimpleNamespace(hidden_states=[hidden])
+
+
+@pytest.mark.parametrize(
+    ("attention_mask", "expect_none"),
+    [
+        pytest.param(torch.ones(2, 36, dtype=torch.long), True, id="all-valid"),
+        pytest.param(
+            torch.tensor([[1] * 36, [1] * 35 + [0]], dtype=torch.long),
+            False,
+            id="has-padding",
+        ),
+    ],
+)
+def test_qwen_encode_prompt_returns_none_for_all_valid_masks(attention_mask, expect_none):
+    pipeline = QwenImagePipeline(SimpleNamespace(torch_dtype=torch.float32))
+    pipeline.tokenizer = _FakeTokenizer(attention_mask)
+    pipeline.text_encoder = _FakeTextEncoder()
+
+    prompt_embeds, prompt_embeds_mask = pipeline._encode_prompt(
+        ["one", "two"],
+        torch.device("cpu"),
+        max_sequence_length=8,
+    )
+
+    assert prompt_embeds.shape == (2, 2, 4)
+    if expect_none:
+        assert prompt_embeds_mask is None
+    else:
+        assert prompt_embeds_mask is not None
+        assert prompt_embeds_mask.shape == (2, 2)
+        assert not prompt_embeds_mask.bool().all()
+
+
+def test_qwen_joint_attention_passes_padding_mask_to_backend(monkeypatch):
+    attention = QwenJointAttention(
+        dim=16,
         num_attention_heads=2,
-        joint_attention_dim=16,
-        axes_dims_rope=(2, 2, 4),
-    ).eval()
+        attention_head_dim=8,
+        config=DiffusionModelConfig(attention=AttentionConfig(backend="VANILLA")),
+    )
+    captured = {}
 
-    hidden_states = torch.randn(1, 4, 4)
+    def fake_attn_impl(q, k, v, **kwargs):
+        captured["key_padding_mask"] = kwargs.get("key_padding_mask")
+        return q.new_zeros(q.shape)
+
+    monkeypatch.setattr(attention, "_attn_impl", fake_attn_impl)
+
+    hidden_states = torch.randn(1, 4, 16)
     encoder_hidden_states = torch.randn(1, 3, 16)
-    timestep = torch.tensor([0.5])
-    img_shapes = [(1, 2, 2)]
+    attention_mask = torch.tensor([[True, False, True, True, True, True, True]])
 
-    with torch.inference_mode():
-        unmasked = model(
-            hidden_states=hidden_states,
-            encoder_hidden_states=encoder_hidden_states,
-            encoder_hidden_states_mask=None,
-            timestep=timestep,
-            img_shapes=img_shapes,
-            return_dict=False,
-        )[0]
-        all_true_masked = model(
-            hidden_states=hidden_states,
-            encoder_hidden_states=encoder_hidden_states,
-            encoder_hidden_states_mask=torch.ones(1, 3, dtype=torch.bool),
-            timestep=timestep,
-            img_shapes=img_shapes,
-            return_dict=False,
-        )[0]
+    attention(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        attention_mask=attention_mask,
+    )
 
-    torch.testing.assert_close(all_true_masked, unmasked)
+    assert captured["key_padding_mask"] is attention_mask
+
+
+def test_qwen_key_padding_mask_support_excludes_sequence_parallel_wrappers():
+    class VanillaAttention:
+        pass
+
+    class Attention2DAttention:
+        pass
+
+    class RingAttention:
+        pass
+
+    class UlyssesAttention:
+        pass
+
+    assert _supports_qwen_key_padding_mask("VANILLA", VanillaAttention())
+    assert _supports_qwen_key_padding_mask("FA4", VanillaAttention())
+    assert not _supports_qwen_key_padding_mask("TRTLLM", VanillaAttention())
+    assert not _supports_qwen_key_padding_mask("VANILLA", Attention2DAttention())
+    assert not _supports_qwen_key_padding_mask("VANILLA", RingAttention())
+    assert not _supports_qwen_key_padding_mask("VANILLA", UlyssesAttention())
+
+
+def test_qwen_build_joint_attention_mask_appends_valid_image_tokens():
+    hidden_states = torch.empty(2, 4, 8)
+    text_mask = torch.tensor([[1, 0, 1], [1, 1, 0]], dtype=torch.int64)
+
+    joint_mask = _build_joint_attention_mask(text_mask, hidden_states)
+
+    expected = torch.tensor(
+        [
+            [True, False, True, True, True, True, True],
+            [True, True, False, True, True, True, True],
+        ],
+        dtype=torch.bool,
+    )
+    torch.testing.assert_close(joint_mask, expected)
+
+
+def test_qwen_build_joint_attention_mask_none_stays_none():
+    assert _build_joint_attention_mask(None, torch.empty(2, 4, 8)) is None

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py
@@ -7,11 +7,15 @@ import json
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 # Importing the models package applies the Qwen-Image registration side effect.
 from tensorrt_llm._torch.visual_gen import models  # noqa: F401
 from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig, DiffusionPipelineConfig
-from tensorrt_llm._torch.visual_gen.models.qwen_image import QwenJointAttention
+from tensorrt_llm._torch.visual_gen.models.qwen_image import (
+    QwenImageTransformer2DModel,
+    QwenJointAttention,
+)
 from tensorrt_llm._torch.visual_gen.modules.attention import QKVMode
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
 from tensorrt_llm.quantization.mode import QuantAlgo
@@ -226,3 +230,42 @@ def test_qwen_joint_attention_keeps_separate_qkv_path_unwrapped(visual_gen_mappi
 
     assert attention.qkv_mode == QKVMode.SEPARATE_QKV
     assert attention.attn.__class__.__name__ != not_wrapped_as
+
+
+def test_qwen_transformer_treats_all_true_text_mask_as_unmasked():
+    torch.manual_seed(0)
+    model = QwenImageTransformer2DModel(
+        patch_size=2,
+        in_channels=4,
+        out_channels=4,
+        num_layers=1,
+        attention_head_dim=8,
+        num_attention_heads=2,
+        joint_attention_dim=16,
+        axes_dims_rope=(2, 2, 4),
+    ).eval()
+
+    hidden_states = torch.randn(1, 4, 4)
+    encoder_hidden_states = torch.randn(1, 3, 16)
+    timestep = torch.tensor([0.5])
+    img_shapes = [(1, 2, 2)]
+
+    with torch.inference_mode():
+        unmasked = model(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_hidden_states_mask=None,
+            timestep=timestep,
+            img_shapes=img_shapes,
+            return_dict=False,
+        )[0]
+        all_true_masked = model(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_hidden_states_mask=torch.ones(1, 3, dtype=torch.bool),
+            timestep=timestep,
+            img_shapes=img_shapes,
+            return_dict=False,
+        )[0]
+
+    torch.testing.assert_close(all_true_masked, unmasked)


### PR DESCRIPTION
## Description\nSkip Qwen-Image joint attention mask construction when the text mask is all valid. This keeps all-valid prompt batches on the normal VisualGen attention backend path instead of falling into the masked SDPA fallback.\n\n## Changes\n- Return `None` from Qwen prompt encoding when all prompt tokens are valid.\n- Treat all-true `encoder_hidden_states_mask` as unmasked in the transformer direct-call path.\n- Add a unit test covering all-true mask output equivalence with the unmasked path.\n\n## Testing\n- `git diff --check`\n- `python3 -m py_compile tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py`\n- Targeted pytest blocked locally: `ModuleNotFoundError: No module named 'mpi4py'` from `tests/unittest/conftest.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-generation handling so fully valid prompt masks are treated as unmasked, reducing unnecessary masking during inference.
  * Updated attention behavior to skip mask construction when it isn’t needed, helping results stay consistent with unmasked runs.

* **Tests**
  * Added coverage confirming that an all-true text mask produces the same output as no mask.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->