### PR TITLE
[None][perf] Fuse Qwen Image QK norm RoPE prep

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -553,6 +553,7 @@ class QwenJointAttention(Attention):
         return (
             self.fuse_qk_norm_rope
             and image_rotary_emb is not None
+            and self.qk_norm
             and hidden_states.is_cuda
             and hidden_states.dtype == torch.bfloat16
             and self.head_dim in (64, 128, 256)
@@ -576,8 +577,11 @@ class QwenJointAttention(Attention):
         img_freqs, txt_freqs = image_rotary_emb
         txt_cos, txt_sin = qwen_complex_freqs_to_cos_sin(txt_freqs)
         img_cos, img_sin = qwen_complex_freqs_to_cos_sin(img_freqs)
-        freqs_cos = torch.cat([txt_cos, img_cos], dim=0)
-        freqs_sin = torch.cat([txt_sin, img_sin], dim=0)
+        freqs_cos = torch.cat([txt_cos, img_cos], dim=0).squeeze(1)
+        freqs_sin = torch.cat([txt_sin, img_sin], dim=0).squeeze(1)
+        if qkv.shape[0] > 1:
+            freqs_cos = freqs_cos.repeat(qkv.shape[0], 1)
+            freqs_sin = freqs_sin.repeat(qkv.shape[0], 1)
 
         self.apply_packed_qk_norm_rope(
             qkv,

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -309,6 +309,14 @@ def apply_rotary_emb_qwen(
     return x_out.type_as(x)
 
 
+def qwen_complex_freqs_to_cos_sin(freqs_cis: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Convert Qwen's complex RoPE cache to shared interleaved real cos/sin tensors."""
+    freqs_cis = torch.view_as_real(freqs_cis)
+    freqs_cos = freqs_cis[..., 0].repeat_interleave(2, dim=-1).unsqueeze(1).float().contiguous()
+    freqs_sin = freqs_cis[..., 1].repeat_interleave(2, dim=-1).unsqueeze(1).float().contiguous()
+    return freqs_cos, freqs_sin
+
+
 class QwenEmbedRope(nn.Module):
     """3D rotary position embedding over (frame, height, width) axes.
 
@@ -474,9 +482,7 @@ class QwenJointAttention(Attention):
             qk_norm_mode="per_head",
             eps=eps,
             bias=True,
-            # TODO: enable fused qk-norm+RoPE after adapting Qwen's
-            # complex frequency cache to the shared real cos/sin format.
-            fuse_qk_norm_rope=False,
+            fuse_qk_norm_rope=(config.mapping.tp_size == 1),
             config=config,
             layer_idx=layer_idx,
             module_name=module_name,
@@ -539,16 +545,56 @@ class QwenJointAttention(Attention):
     def _apply_rms_norm(x: torch.Tensor, norm: RMSNorm) -> torch.Tensor:
         return F.rms_norm(x, (x.shape[-1],), norm.weight, norm.variance_epsilon)
 
-    def forward(
+    def _use_fused_qk_norm_rope(
+        self,
+        hidden_states: torch.Tensor,
+        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]],
+    ) -> bool:
+        return (
+            self.fuse_qk_norm_rope
+            and image_rotary_emb is not None
+            and hidden_states.is_cuda
+            and hidden_states.dtype == torch.bfloat16
+            and self.head_dim in (64, 128, 256)
+        )
+
+    def _prepare_qkv_fused(
         self,
         hidden_states: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
-        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        timestep: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        seq_txt = encoder_hidden_states.shape[1]
+        image_rotary_emb: Tuple[torch.Tensor, torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        img_q, img_k, img_v = self.get_qkv(hidden_states)
+        txt_q = self.add_q_proj(encoder_hidden_states)
+        txt_k = self.add_k_proj(encoder_hidden_states)
+        txt_v = self.add_v_proj(encoder_hidden_states)
 
+        txt_qkv = torch.cat([txt_q, txt_k, txt_v], dim=-1)
+        img_qkv = torch.cat([img_q, img_k, img_v], dim=-1)
+        qkv = torch.cat([txt_qkv, img_qkv], dim=1)
+
+        img_freqs, txt_freqs = image_rotary_emb
+        txt_cos, txt_sin = qwen_complex_freqs_to_cos_sin(txt_freqs)
+        img_cos, img_sin = qwen_complex_freqs_to_cos_sin(img_freqs)
+        freqs_cos = torch.cat([txt_cos, img_cos], dim=0)
+        freqs_sin = torch.cat([txt_sin, img_sin], dim=0)
+
+        self.apply_packed_qk_norm_rope(
+            qkv,
+            freqs_cos,
+            freqs_sin,
+            num_txt_tokens=encoder_hidden_states.shape[1],
+            q_add_weight=self.norm_added_q.weight,
+            k_add_weight=self.norm_added_k.weight,
+        )
+        return qkv.split([self.local_q_dim, self.local_kv_dim, self.local_kv_dim], dim=-1)
+
+    def _prepare_qkv_unfused(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         # Image QKV.
         img_q, img_k, img_v = self.get_qkv(hidden_states)
         # Text QKV.
@@ -579,15 +625,34 @@ class QwenJointAttention(Attention):
             txt_k = apply_rotary_emb_qwen(txt_k, txt_freqs, use_real=False)
 
         # Joint attention: [txt | img] order.
-        joint_q = torch.cat([txt_q, img_q], dim=1)
-        joint_k = torch.cat([txt_k, img_k], dim=1)
-        joint_v = torch.cat([txt_v, img_v], dim=1)
+        joint_q = torch.cat([txt_q, img_q], dim=1).flatten(2)
+        joint_k = torch.cat([txt_k, img_k], dim=1).flatten(2)
+        joint_v = torch.cat([txt_v, img_v], dim=1).flatten(2)
+        return joint_q, joint_k, joint_v
 
-        # SDPA expects (B, H, S, D); diffusers dispatch_attention_fn
-        # accepts (B, S, H, D) and transposes internally. Do the same.
-        joint_q = joint_q.transpose(1, 2)
-        joint_k = joint_k.transpose(1, 2)
-        joint_v = joint_v.transpose(1, 2)
+    def _prepare_qkv(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self._use_fused_qk_norm_rope(hidden_states, image_rotary_emb):
+            return self._prepare_qkv_fused(hidden_states, encoder_hidden_states, image_rotary_emb)
+        return self._prepare_qkv_unfused(hidden_states, encoder_hidden_states, image_rotary_emb)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        timestep: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        seq_txt = encoder_hidden_states.shape[1]
+
+        joint_q, joint_k, joint_v = self._prepare_qkv(
+            hidden_states, encoder_hidden_states, image_rotary_emb
+        )
 
         attn_mask = None
         if attention_mask is not None:
@@ -598,13 +663,13 @@ class QwenJointAttention(Attention):
             attn_mask = attention_mask[:, None, None, :]
 
         if attn_mask is None:
-            out = self._attn_impl(
-                joint_q.transpose(1, 2).flatten(2),
-                joint_k.transpose(1, 2).flatten(2),
-                joint_v.transpose(1, 2).flatten(2),
-                timestep=timestep,
-            )
+            out = self._attn_impl(joint_q, joint_k, joint_v, timestep=timestep)
         else:
+            # SDPA expects (B, H, S, D); diffusers dispatch_attention_fn
+            # accepts (B, S, H, D) and transposes internally. Do the same.
+            joint_q = joint_q.unflatten(-1, (self.heads, -1)).transpose(1, 2)
+            joint_k = joint_k.unflatten(-1, (self.heads, -1)).transpose(1, 2)
+            joint_v = joint_v.unflatten(-1, (self.heads, -1)).transpose(1, 2)
             out = F.scaled_dot_product_attention(
                 joint_q, joint_k, joint_v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False
             )

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py
@@ -251,6 +251,59 @@ def test_qwen_complex_freqs_convert_to_shared_rope_format():
     torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
 
 
+def test_qwen_joint_attention_fused_rope_passes_2d_freqs_to_kernel(monkeypatch):
+    torch.manual_seed(0)
+    txt_seq = 5
+    img_seq = 7
+    batch_size = 2
+    head_dim = 8
+    attention = QwenJointAttention(
+        dim=16,
+        num_attention_heads=2,
+        attention_head_dim=head_dim,
+        config=DiffusionModelConfig(),
+    )
+    captured = {}
+
+    def fake_apply_packed_qk_norm_rope(qkv, freqs_cos, freqs_sin, **kwargs):
+        captured["cos_shape"] = tuple(freqs_cos.shape)
+        captured["sin_shape"] = tuple(freqs_sin.shape)
+
+    monkeypatch.setattr(attention, "apply_packed_qk_norm_rope", fake_apply_packed_qk_norm_rope)
+
+    hidden_states = torch.randn(batch_size, img_seq, 16)
+    encoder_hidden_states = torch.randn(batch_size, txt_seq, 16)
+    img_phases = torch.randn(img_seq, head_dim // 2)
+    txt_phases = torch.randn(txt_seq, head_dim // 2)
+    image_rotary_emb = (
+        torch.polar(torch.ones_like(img_phases), img_phases),
+        torch.polar(torch.ones_like(txt_phases), txt_phases),
+    )
+
+    attention._prepare_qkv_fused(hidden_states, encoder_hidden_states, image_rotary_emb)
+
+    assert captured == {
+        "cos_shape": (batch_size * (txt_seq + img_seq), head_dim),
+        "sin_shape": (batch_size * (txt_seq + img_seq), head_dim),
+    }
+
+
+def test_qwen_joint_attention_fused_rope_requires_qk_norm():
+    attention = QwenJointAttention(
+        dim=16,
+        num_attention_heads=2,
+        attention_head_dim=8,
+        config=DiffusionModelConfig(),
+    )
+    hidden_states = SimpleNamespace(is_cuda=True, dtype=torch.bfloat16)
+    image_rotary_emb = (object(), object())
+
+    assert attention._use_fused_qk_norm_rope(hidden_states, image_rotary_emb)
+
+    attention.qk_norm = False
+    assert not attention._use_fused_qk_norm_rope(hidden_states, image_rotary_emb)
+
+
 def test_qwen_transformer_cpu_fallback_uses_unfused_qk_norm_rope():
     torch.manual_seed(0)
     model = QwenImageTransformer2DModel(

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py
@@ -7,12 +7,20 @@ import json
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 # Importing the models package applies the Qwen-Image registration side effect.
 from tensorrt_llm._torch.visual_gen import models  # noqa: F401
 from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig, DiffusionPipelineConfig
-from tensorrt_llm._torch.visual_gen.models.qwen_image import QwenJointAttention
-from tensorrt_llm._torch.visual_gen.modules.attention import QKVMode
+from tensorrt_llm._torch.visual_gen.models.qwen_image import (
+    QwenImageTransformer2DModel,
+    QwenJointAttention,
+    apply_rotary_emb_qwen,
+)
+from tensorrt_llm._torch.visual_gen.models.qwen_image.transformer_qwen_image import (
+    qwen_complex_freqs_to_cos_sin,
+)
+from tensorrt_llm._torch.visual_gen.modules.attention import QKVMode, apply_rotary_emb
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
 from tensorrt_llm.quantization.mode import QuantAlgo
 from tensorrt_llm.visual_gen.args import (
@@ -226,3 +234,49 @@ def test_qwen_joint_attention_keeps_separate_qkv_path_unwrapped(visual_gen_mappi
 
     assert attention.qkv_mode == QKVMode.SEPARATE_QKV
     assert attention.attn.__class__.__name__ != not_wrapped_as
+
+
+def test_qwen_complex_freqs_convert_to_shared_rope_format():
+    torch.manual_seed(0)
+    seq_len = 8
+    head_dim = 16
+    x = torch.randn(2, seq_len, 3, head_dim)
+    phases = torch.randn(seq_len, head_dim // 2)
+    freqs_cis = torch.polar(torch.ones_like(phases), phases)
+
+    freqs_cos, freqs_sin = qwen_complex_freqs_to_cos_sin(freqs_cis)
+
+    ref = apply_rotary_emb_qwen(x, freqs_cis)
+    out = apply_rotary_emb(x, freqs_cos, freqs_sin)
+    torch.testing.assert_close(out, ref, rtol=1e-6, atol=1e-6)
+
+
+def test_qwen_transformer_cpu_fallback_uses_unfused_qk_norm_rope():
+    torch.manual_seed(0)
+    model = QwenImageTransformer2DModel(
+        model_config=DiffusionModelConfig(),
+        patch_size=1,
+        in_channels=4,
+        out_channels=4,
+        num_layers=1,
+        attention_head_dim=8,
+        num_attention_heads=2,
+        joint_attention_dim=16,
+        caption_channels=16,
+        axes_dims_rope=(4, 6, 6),
+    ).eval()
+
+    hidden_states = torch.randn(1, 4, 4)
+    encoder_hidden_states = torch.randn(1, 5, 16)
+    timestep = torch.tensor([1.0])
+
+    assert model.transformer_blocks[0].attn.fuse_qk_norm_rope
+    out = model(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        timestep=timestep,
+        img_shapes=[(1, 2, 2)],
+        txt_seq_lens=torch.tensor([5]),
+    )
+
+    assert out[0].shape == hidden_states.shape


### PR DESCRIPTION
## Summary
- convert Qwen-Image complex RoPE frequencies into the real cos/sin layout used by VisualGen fused DiT kernels
- enable the existing packed fused QK-norm + RoPE op for supported Qwen-Image bf16 CUDA runs
- keep the existing complex RoPE fallback for unsupported/local paths and add focused tests for conversion/fallback behavior

## Tests
- python3 -m py_compile tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py
- git diff --check
- python3 -m pytest tests/unittest/_torch/visual_gen/test_qwen_image_pipeline_config.py -k 'qwen_complex_freqs_convert or cpu_fallback' (blocked locally: missing mpi4py from tests/unittest/conftest.py)

## Notes
- GPU/container validation is still needed for the fused CUDA path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a shared rotary embedding format, improving compatibility across attention paths.
  * Enabled a fused attention path in more single-device configurations.

* **Bug Fixes**
  * Improved attention handling when masks are present for more consistent tensor shaping.
  * Added fallback coverage to keep image transformer outputs aligned with input shapes.

* **Tests**
  * Added coverage for rotary embedding equivalence.
  * Added a CPU fallback test for the Qwen image transformer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->