### PR TITLE
[https://nvbugs/6428092][fix] Forward use_host_stop_criteria alongside host and py_result_diffs in the PP…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3086,10 +3086,14 @@ class PyExecutor:
         if not self.dist.is_last_pp_rank:
             # Receive tokens from previous pp rank (w.r.t model forward direction)
             with nvtx_range("recv_sample_state"):
-                sample_state.host, py_result_diffs = self.dist.recv_object(
-                    src=self.dist.prev_pp_rank,
-                    tag=tag,
-                )
+                sample_state.host, py_result_diffs, use_host_stop_criteria = \
+                    self.dist.recv_object(src=self.dist.prev_pp_rank, tag=tag)
+
+            # Propagate use_host_stop_criteria: the last rank's fast host-stop
+            # path leaves host.finish_reasons=None, so non-last ranks must
+            # know to skip the finish_reasons indexing in update_requests.
+            if hasattr(sample_state, "use_host_stop_criteria"):
+                sample_state.use_host_stop_criteria = use_host_stop_criteria
 
             for request, py_result_diff in zip(requests, py_result_diffs):
                 request.py_result.apply_diff(py_result_diff)
@@ -3107,7 +3111,8 @@ class PyExecutor:
             self.wait_on_pp_send_handles(self.send_handles, microbatch_id)
             with nvtx_range("send_sample_state"):
                 self.send_handles[microbatch_id] = self.dist.isend_object(
-                    (sample_state.host, py_result_diffs),
+                    (sample_state.host, py_result_diffs,
+                     getattr(sample_state, "use_host_stop_criteria", False)),
                     dest=self.dist.next_pp_rank,
                     tag=tag,
                 )

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -380,7 +380,6 @@ unittest/llmapi/test_llm.py::test_llm_with_customized_tokenizer SKIP (https://nv
 unittest/llmapi/test_llm.py::test_openai_completion_list_prompt_stream_reuses_stream_metadata SKIP (https://nvbugs/6507081)
 unittest/llmapi/test_llm.py::test_tokenizer_decode_incrementally[/scratch.trt_llm_data/llm-models/falcon-7b-instruct-False-0.95-HF] SKIP (https://nvbugs/6507082)
 unittest/llmapi/test_llm.py::test_tokenizer_decode_incrementally[/scratch.trt_llm_data/llm-models/falcon-7b-instruct-False-0.95-TRTLLM] SKIP (https://nvbugs/6507082)
-unittest/llmapi/test_llm_multi_gpu_pytorch.py -m "gpu2" SKIP (https://nvbugs/6428092)
 unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_llm_get_stats_pp2[False-False-True] SKIP (https://nvbugs/6432826)
 unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_llm_get_stats_pp4[False-False-True] SKIP (https://nvbugs/6427411)
 unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_llm_get_stats_pp4[False-True-True] SKIP (https://nvbugs/6427411)


### PR DESCRIPTION
## Summary
- **Root cause**: In PP mode, non-last ranks defaulted use_host_stop_criteria=False and re-indexed the empty finish_reasons_list produced when the last rank took the fast host stop-criteria path.
- **Fix**: Forward use_host_stop_criteria alongside host and py_result_diffs in the PP ring send/recv, using getattr/hasattr to stay safe against sampler flavors without the field.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6428092


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

* The PP sample-state payload now carries `use_host_stop_criteria` with `host` and `py_result_diffs`.
* Receiving ranks restore the flag when supported. Sending ranks default it to `False` when absent.
* The change preserves compatibility with sampler variants without this field.
* The scope is limited to pipeline state handling and one waiver removal.

## QA Engineer Review

* `tests/integration/test_lists/waives.txt` removes the waiver for `unittest/llmapi/test_llm_multi_gpu_pytorch.py -m "gpu2"`.
* No test implementation changed.
* No `test-db/` or `qa/` entries changed.
* The waiver removal enables GPU2 multi-GPU PyTorch coverage.
* Coverage verdict: sufficient.

## Per-File QA Perspective

* `tensorrt_llm/_torch/pyexecutor/py_executor.py`: Verify that all pipeline ranks receive the same `use_host_stop_criteria` value. Verify that sampler variants without the field retain the `False` default.
* `tests/integration/test_lists/waives.txt`: Verify that the GPU2 multi-GPU PyTorch test runs without the removed waiver and passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->