### PR TITLE
[https://nvbugs/6428085][fix] Include use_host_stop_criteria in the isend/recv tuple in…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2597,13 +2597,23 @@ class PyExecutor:
         sample_state = executed_batch.sample_state
         requests = sample_state.requests
 
+        # SampleStateTorch.use_host_stop_criteria is set on the last PP rank
+        # (and skips writing finish_reasons when True), so it must ride the
+        # PP ring along with .host or non-last ranks will IndexError on the
+        # empty finish_reasons_list in process_draft_tokens.
+        use_host_stop_criteria = getattr(sample_state, "use_host_stop_criteria",
+                                         False)
+
         if not self.dist.is_last_pp_rank:
             # Receive tokens from previous pp rank (w.r.t model forward direction)
             with nvtx_range("recv_sample_state"):
-                sample_state.host, py_result_diffs = self.dist.recv_object(
-                    src=self.dist.prev_pp_rank,
-                    tag=tag,
-                )
+                (sample_state.host, py_result_diffs,
+                 use_host_stop_criteria) = self.dist.recv_object(
+                     src=self.dist.prev_pp_rank,
+                     tag=tag,
+                 )
+            if hasattr(sample_state, "use_host_stop_criteria"):
+                sample_state.use_host_stop_criteria = use_host_stop_criteria
 
             for request, py_result_diff in zip(requests, py_result_diffs):
                 request.py_result.apply_diff(py_result_diff)
@@ -2621,7 +2631,8 @@ class PyExecutor:
             self.wait_on_pp_send_handles(self.send_handles, microbatch_id)
             with nvtx_range("send_sample_state"):
                 self.send_handles[microbatch_id] = self.dist.isend_object(
-                    (sample_state.host, py_result_diffs),
+                    (sample_state.host, py_result_diffs,
+                     use_host_stop_criteria),
                     dest=self.dist.next_pp_rank,
                     tag=tag,
                 )


### PR DESCRIPTION
## Summary
- **Root cause**: _ring_broadcast_sample_state does not ship SampleStateTorch.use_host_stop_criteria across PP ranks, so non-last PP ranks default it to False and take the process_draft_tokens branch which indexes the empty finish_reasons_list() the sender skipped populating.
- **Fix**: Include use_host_stop_criteria in the isend/recv tuple in _ring_broadcast_sample_state and assign it back onto SampleStateTorch after receive (getattr/hasattr-guarded so non-Torch samplers remain unaffected). waives.txt is intentionally left untouched.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6428085


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of generation stop handling across distributed pipeline stages.
  * Fixed state syncing so stopping rules are preserved correctly when passing control between stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->