### PR TITLE
[None][test] copy AD smoke tests to LLMC standalone

### DIFF
--- a/examples/auto_deploy/llmc/create_standalone_package.py
+++ b/examples/auto_deploy/llmc/create_standalone_package.py
@@ -201,6 +201,18 @@ EXCLUDE_TEST_FILES = {
     "test_trtllm_quant_mxfp4_trtllm_gen_moe.py",
 }
 
+# Single-GPU smoke tests. Some run with LLMC alone; others exercise the optional
+# TensorRT-LLM wheel/CLI path and are gated by TRTLLM_REDIRECT_AD_TO_LLMC.
+STANDALONE_SINGLEGPU_SMOKE_TEST_FILES = (
+    "smoke/test_ad_build_small_single.py",
+    "smoke/test_ad_guided_decoding_regex.py",
+    "smoke/test_ad_speculative_decoding.py",
+    "smoke/test_ad_trtllm_bench.py",
+    "smoke/test_ad_trtllm_sampler.py",
+    "smoke/test_ad_trtllm_serve.py",
+    "smoke/test_disagg.py",
+)
+
 # Multi-GPU tests that exercise only AutoDeploy and its standalone dependencies.
 # Keep this list explicit: the remaining multi-GPU tests depend on TensorRT-LLM
 # runtime components, kernels, or test infrastructure that LLMC does not ship.
@@ -220,18 +232,30 @@ STANDALONE_MULTIGPU_TEST_FILES = (
 # Pytest support files required by the allowlisted multi-GPU tests.
 STANDALONE_MULTIGPU_SUPPORT_FILES = ("transformations/library/conftest.py",)
 
+# Newer AD unit tests live under tests/unittest/_torch/auto_deploy. Copy only
+# tracked tests whose dependencies are available in LLMC plus the optional
+# TensorRT-LLM wheel.
+STANDALONE_TORCH_UNIT_TEST_FILES = ("unit/singlegpu/models/test_gpt_oss_modeling.py",)
+
 # Import path rewrite: old -> new (applied to test files only).
 _IMPORT_REWRITE = "tensorrt_llm._torch.auto_deploy"
 _IMPORT_TARGET = "llmc"
 _BUILD_AND_RUN_AD_IMPORT = "from build_and_run_ad import ExperimentConfig, main"
-_LLMC_TRTLLM_RUNNER_IMPORT = """
-if os.environ.get("TRTLLM_REDIRECT_AD_TO_LLMC") != "true":
+_TRTLLM_IMPORT_RE = re.compile(
+    r"(?m)^(?:from|import) "
+    r"(?:tensorrt_llm(?:\.|\b)|llmc\.models\.custom\.modeling_gpt_oss(?:\.|\b))"
+)
+_LLMC_OPTIONAL_TRTLLM_GUARD = """
+_trtllm_redirect_value = os.environ.get("TRTLLM_REDIRECT_AD_TO_LLMC", "").lower()
+if _trtllm_redirect_value not in {"1", "true", "yes", "on"}:
     pytest.skip(
-        "LLMC TRT-LLM redirect smoke requires TRTLLM_REDIRECT_AD_TO_LLMC=true",
+        "LLMC optional TRT-LLM tests require TRTLLM_REDIRECT_AD_TO_LLMC=true",
         allow_module_level=True,
     )
-pytest.importorskip("tensorrt_llm")
-from runners.trtllm.build_and_run_llmc_trtllm import ExperimentConfig, main"""
+pytest.importorskip("tensorrt_llm")"""
+_LLMC_TRTLLM_RUNNER_IMPORT = (
+    "from runners.trtllm.build_and_run_llmc_trtllm import ExperimentConfig, main"
+)
 
 # Paths that the script owns and regenerates on every run.
 # Everything else in the output directory (e.g., .git/, .github/) is preserved
@@ -281,7 +305,7 @@ def _copy_tree(src_dir: str, dst_dir: str) -> int:
     return count
 
 
-def _rewrite_imports_in_file(filepath: str) -> int:
+def _rewrite_imports_in_file(filepath: str, *, optional_trtllm_guards: bool = True) -> int:
     """Rewrite imports in a copied test file for standalone mode.
 
     Source files inside ``tensorrt_llm/_torch/auto_deploy`` already use
@@ -300,9 +324,57 @@ def _rewrite_imports_in_file(filepath: str) -> int:
 
     original = content
     content = content.replace(_IMPORT_REWRITE, _IMPORT_TARGET)
-    if _BUILD_AND_RUN_AD_IMPORT in content:
-        content = content.replace("import pytest\n", "import os\n\nimport pytest\n")
+
+    def ensure_imports(before_pos: int, *imports: str) -> None:
+        nonlocal content
+        prefix = content[:before_pos]
+        missing_imports = [
+            import_name for import_name in imports if f"import {import_name}\n" not in prefix
+        ]
+        if not missing_imports:
+            return
+        first_import = re.search(r"(?m)^(?:import|from) ", content)
+        if first_import is None:
+            raise ValueError(f"No import block found in {filepath}")
+        content = (
+            content[: first_import.start()]
+            + "\n".join(f"import {import_name}" for import_name in missing_imports)
+            + "\n"
+            + content[first_import.start() :]
+        )
+
+    def insert_optional_trtllm_guard() -> None:
+        nonlocal content
+        if _LLMC_OPTIONAL_TRTLLM_GUARD in content:
+            return
+        pytest_import = re.search(r"(?m)^import pytest\n", content)
+        if pytest_import is None:
+            raise ValueError(f"No pytest import found in {filepath}")
+        content = (
+            content[: pytest_import.end()]
+            + _LLMC_OPTIONAL_TRTLLM_GUARD
+            + "\n"
+            + content[pytest_import.end() :]
+        )
+
+    if optional_trtllm_guards and _BUILD_AND_RUN_AD_IMPORT in content:
+        build_import_pos = content.index(_BUILD_AND_RUN_AD_IMPORT)
+        ensure_imports(build_import_pos, "os", "pytest")
+        insert_optional_trtllm_guard()
         content = content.replace(_BUILD_AND_RUN_AD_IMPORT, _LLMC_TRTLLM_RUNNER_IMPORT)
+    elif optional_trtllm_guards:
+        trtllm_import = _TRTLLM_IMPORT_RE.search(content)
+        if trtllm_import is not None:
+            ensure_imports(trtllm_import.start(), "os", "pytest")
+            insert_optional_trtllm_guard()
+
+    if optional_trtllm_guards:
+        # The standalone package can rely on the installed trtllm-bench entrypoint,
+        # but it does not ship TensorRT-LLM's source-tree benchmarks/cpp directory.
+        content = content.replace(
+            '    script_dir = Path(root_dir, "benchmarks", "cpp")\n',
+            "    script_dir = Path(temp_dir)\n",
+        )
 
     replacements = sum(1 for a, b in zip(original, content) if a != b)  # rough count
     if content != original:
@@ -314,13 +386,16 @@ def _rewrite_imports_in_file(filepath: str) -> int:
     return replacements
 
 
-def _rewrite_imports_in_dir(directory: str) -> int:
+def _rewrite_imports_in_dir(directory: str, *, optional_trtllm_guards: bool = True) -> int:
     """Rewrite imports in all .py files in a directory tree."""
     total = 0
     for root, _, files in os.walk(directory):
         for filename in files:
             if filename.endswith(".py"):
-                total += _rewrite_imports_in_file(os.path.join(root, filename))
+                total += _rewrite_imports_in_file(
+                    os.path.join(root, filename),
+                    optional_trtllm_guards=optional_trtllm_guards,
+                )
     return total
 
 
@@ -395,6 +470,20 @@ def _copy_tests(output_dir: str) -> int:
                 shutil.copy2(src_path, dst_path)
                 count += 1
 
+    # Copy all single-GPU smoke tests. Tests that require the optional
+    # TensorRT-LLM wheel are guarded during import rewriting.
+    singlegpu_smoke_files = STANDALONE_SINGLEGPU_SMOKE_TEST_FILES
+    for rel_path in singlegpu_smoke_files:
+        src_path = os.path.join(singlegpu_src, rel_path)
+        if not os.path.isfile(src_path):
+            raise FileNotFoundError(
+                f"Allowlisted single-GPU smoke test file does not exist: {src_path}"
+            )
+        dst_path = os.path.join(tests_dst, "singlegpu", rel_path)
+        os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+        shutil.copy2(src_path, dst_path)
+        count += 1
+
     # Copy only the explicitly standalone-compatible multi-GPU tests. Unlike
     # singlegpu/, this tree contains several tests that require TensorRT-LLM.
     multigpu_src = os.path.join(AD_TESTS_DIR, "multigpu")
@@ -404,6 +493,18 @@ def _copy_tests(output_dir: str) -> int:
         if not os.path.isfile(src_path):
             raise FileNotFoundError(f"Allowlisted multi-GPU test file does not exist: {src_path}")
         dst_path = os.path.join(tests_dst, "multigpu", rel_path)
+        os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+        shutil.copy2(src_path, dst_path)
+        count += 1
+
+    # Copy standalone-compatible tests from the newer _torch/auto_deploy unit tree.
+    for rel_path in STANDALONE_TORCH_UNIT_TEST_FILES:
+        src_path = os.path.join(AD_TORCH_TESTS_DIR, rel_path)
+        if not os.path.isfile(src_path):
+            raise FileNotFoundError(
+                f"Allowlisted _torch AutoDeploy unit test does not exist: {src_path}"
+            )
+        dst_path = os.path.join(tests_dst, "_torch", "auto_deploy", rel_path)
         os.makedirs(os.path.dirname(dst_path), exist_ok=True)
         shutil.copy2(src_path, dst_path)
         count += 1
@@ -424,6 +525,7 @@ def _copy_tests(output_dir: str) -> int:
 
     # Create a stub for test_common.llm_data (used by some model tests)
     _create_test_common_stub(tests_dst)
+    _create_test_utils_stub(tests_dst)
 
     return count
 
@@ -450,23 +552,38 @@ def _create_test_conftest(tests_dir: str) -> None:
         import importlib.util
         import os
         import sys
+        from pathlib import Path
+
+        import pytest
 
         _allow_trtllm_redirect = (
-            os.environ.get("TRTLLM_REDIRECT_AD_TO_LLMC") == "true"
+            os.environ.get("TRTLLM_REDIRECT_AD_TO_LLMC", "").lower()
+            in {"1", "true", "yes", "on"}
         )
         _trtllm_spec = importlib.util.find_spec("tensorrt_llm")
         if _trtllm_spec is not None and not _allow_trtllm_redirect:
             raise RuntimeError(
                 "Standalone llmc tests must not be able to import tensorrt_llm; "
-                "set TRTLLM_REDIRECT_AD_TO_LLMC=true only for redirect smoke tests; "
+                "set TRTLLM_REDIRECT_AD_TO_LLMC=true only for optional TRT-LLM tests; "
                 f"found {getattr(_trtllm_spec, 'origin', None)!r}"
             )
 
-        # Add _utils_test to the Python path so test files can import from it
-        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "_utils_test"))
+        _tests_dir = os.path.dirname(__file__)
+        _package_root = os.path.dirname(_tests_dir)
 
-        # Add the tests directory itself to the path for cross-test imports
-        sys.path.insert(0, os.path.dirname(__file__))
+        # Add generated package/test roots to the Python path so tests can import
+        # local llmc, runners, and _utils_test even under safe-path settings.
+        sys.path.insert(0, _package_root)
+        sys.path.insert(0, _tests_dir)
+        sys.path.insert(0, os.path.join(_tests_dir, "_utils_test"))
+
+
+        @pytest.fixture(scope="module")
+        def llm_root():
+            env_root = os.environ.get("LLM_ROOT")
+            if env_root:
+                return Path(env_root)
+            return Path(_package_root)
     """)
     with open(os.path.join(tests_dir, "conftest.py"), "w") as f:
         f.write(content)
@@ -531,6 +648,56 @@ def _create_test_common_stub(tests_dir: str) -> None:
             return func  # No-op in standalone mode
     """)
     with open(os.path.join(stub_dir, "llm_data.py"), "w") as f:
+        f.write(content)
+
+
+def _create_test_utils_stub(tests_dir: str) -> None:
+    """Create minimal TensorRT-LLM unittest utility shims used by copied tests."""
+    utils_dir = os.path.join(tests_dir, "utils")
+    os.makedirs(utils_dir, exist_ok=True)
+
+    with open(os.path.join(utils_dir, "__init__.py"), "w") as f:
+        f.write(
+            "# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION"
+            " & AFFILIATES. All rights reserved.\n"
+            "# SPDX-License-Identifier: Apache-2.0\n"
+        )
+
+    content = textwrap.dedent("""\
+        # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+        # SPDX-License-Identifier: Apache-2.0
+        #
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        # http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+
+        \"\"\"Minimal unittest utility shims for standalone LLMC tests.\"\"\"
+
+        import pytest
+        import torch
+
+
+        def _sm_version() -> int:
+            if not torch.cuda.is_available():
+                return 0
+            major, minor = torch.cuda.get_device_capability(0)
+            return major * 10 + minor
+
+
+        skip_pre_hopper = pytest.mark.skipif(
+            _sm_version() < 90,
+            reason="This test is not supported in pre-Hopper architecture",
+        )
+    """)
+    with open(os.path.join(utils_dir, "util.py"), "w") as f:
         f.write(content)
 
 
@@ -647,7 +814,10 @@ def create_standalone_package(output_dir: str) -> None:
     #     + model_registry) and rewrite its imports auto_deploy -> llmc. YAML is
     #     left untouched.
     runner_count = _copy_runners(output_dir)
-    runner_rewrites = _rewrite_imports_in_dir(os.path.join(output_dir, "runners"))
+    runner_rewrites = _rewrite_imports_in_dir(
+        os.path.join(output_dir, "runners"),
+        optional_trtllm_guards=False,
+    )
     print(
         f"  Copied {runner_count} runner files to runners/trtllm/ ({runner_rewrites} import rewrites)"
     )

--- a/tests/unittest/auto_deploy/standalone/test_standalone_test_export.py
+++ b/tests/unittest/auto_deploy/standalone/test_standalone_test_export.py
@@ -15,6 +15,7 @@
 
 """Tests for exporting standalone-compatible AutoDeploy tests to LLMC."""
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -23,13 +24,30 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 CREATE_SCRIPT = REPO_ROOT / "examples" / "auto_deploy" / "llmc" / "create_standalone_package.py"
+AD_SINGLEGPU_TESTS = REPO_ROOT / "tests" / "unittest" / "auto_deploy" / "singlegpu"
 AD_MULTIGPU_TESTS = REPO_ROOT / "tests" / "unittest" / "auto_deploy" / "multigpu"
-LLMC_TRTLLM_SMOKE_TEST = Path("smoke/test_ad_build_small_multi.py")
+AD_TORCH_TESTS = REPO_ROOT / "tests" / "unittest" / "_torch" / "auto_deploy"
+LLMC_TRTLLM_SINGLEGPU_SMOKE_TEST = Path("smoke/test_ad_build_small_single.py")
+LLMC_TRTLLM_MULTIGPU_SMOKE_TEST = Path("smoke/test_ad_build_small_multi.py")
+LLMC_TRTLLM_RUNNER_TESTS = {
+    LLMC_TRTLLM_SINGLEGPU_SMOKE_TEST,
+    Path("smoke/test_ad_guided_decoding_regex.py"),
+    Path("smoke/test_ad_speculative_decoding.py"),
+    Path("smoke/test_ad_trtllm_sampler.py"),
+    LLMC_TRTLLM_MULTIGPU_SMOKE_TEST,
+}
 
+EXPECTED_SINGLEGPU_SMOKE_FILES = {
+    path for path in LLMC_TRTLLM_RUNNER_TESTS if path != LLMC_TRTLLM_MULTIGPU_SMOKE_TEST
+} | {
+    Path("smoke/test_ad_trtllm_bench.py"),
+    Path("smoke/test_ad_trtllm_serve.py"),
+    Path("smoke/test_disagg.py"),
+}
 EXPECTED_MULTIGPU_FILES = {
     Path("custom_ops/test_dist.py"),
     Path("custom_ops/test_sharded_rmsnorm.py"),
-    LLMC_TRTLLM_SMOKE_TEST,
+    LLMC_TRTLLM_MULTIGPU_SMOKE_TEST,
     Path("transformations/library/conftest.py"),
     Path("transformations/library/test_apply_sharding_hints.py"),
     Path("transformations/library/test_bmm_sharding.py"),
@@ -39,30 +57,80 @@ EXPECTED_MULTIGPU_FILES = {
     Path("transformations/library/test_step3p7_sharding_ir.py"),
     Path("transformations/library/test_tp_sharding.py"),
 }
+EXPECTED_TORCH_UNIT_FILES = {
+    Path("unit/singlegpu/models/test_gpt_oss_modeling.py"),
+}
 CANONICAL_IMPORT = "tensorrt_llm._torch.auto_deploy"
 STANDALONE_IMPORT = "llmc"
 BUILD_AND_RUN_AD_IMPORT = "from build_and_run_ad import ExperimentConfig, main"
-LLMC_TRTLLM_RUNNER_IMPORT = """
-if os.environ.get("TRTLLM_REDIRECT_AD_TO_LLMC") != "true":
+TRTLLM_IMPORT_RE = re.compile(
+    r"(?m)^(?:from|import) "
+    r"(?:tensorrt_llm(?:\.|\b)|llmc\.models\.custom\.modeling_gpt_oss(?:\.|\b))"
+)
+LLMC_OPTIONAL_TRTLLM_GUARD = """
+_trtllm_redirect_value = os.environ.get("TRTLLM_REDIRECT_AD_TO_LLMC", "").lower()
+if _trtllm_redirect_value not in {"1", "true", "yes", "on"}:
     pytest.skip(
-        "LLMC TRT-LLM redirect smoke requires TRTLLM_REDIRECT_AD_TO_LLMC=true",
+        "LLMC optional TRT-LLM tests require TRTLLM_REDIRECT_AD_TO_LLMC=true",
         allow_module_level=True,
     )
-pytest.importorskip("tensorrt_llm")
-from runners.trtllm.build_and_run_llmc_trtllm import ExperimentConfig, main"""
+pytest.importorskip("tensorrt_llm")"""
+LLMC_TRTLLM_RUNNER_IMPORT = (
+    "from runners.trtllm.build_and_run_llmc_trtllm import ExperimentConfig, main"
+)
 
 
 def _expected_exported_test(source: str, relative_path: Path) -> str:
     expected = source.replace(CANONICAL_IMPORT, STANDALONE_IMPORT)
-    if relative_path == LLMC_TRTLLM_SMOKE_TEST:
-        expected = expected.replace("import pytest\n", "import os\n\nimport pytest\n")
+
+    def ensure_imports(before_pos: int, *imports: str) -> None:
+        nonlocal expected
+        prefix = expected[:before_pos]
+        missing_imports = [
+            import_name for import_name in imports if f"import {import_name}\n" not in prefix
+        ]
+        if not missing_imports:
+            return
+        first_import = re.search(r"(?m)^(?:import|from) ", expected)
+        assert first_import is not None
+        expected = (
+            expected[: first_import.start()]
+            + "\n".join(f"import {import_name}" for import_name in missing_imports)
+            + "\n"
+            + expected[first_import.start() :]
+        )
+
+    def insert_optional_trtllm_guard() -> None:
+        nonlocal expected
+        pytest_import = re.search(r"(?m)^import pytest\n", expected)
+        assert pytest_import is not None
+        expected = (
+            expected[: pytest_import.end()]
+            + LLMC_OPTIONAL_TRTLLM_GUARD
+            + "\n"
+            + expected[pytest_import.end() :]
+        )
+
+    if relative_path in LLMC_TRTLLM_RUNNER_TESTS:
+        build_import_pos = expected.index(BUILD_AND_RUN_AD_IMPORT)
+        ensure_imports(build_import_pos, "os", "pytest")
+        insert_optional_trtllm_guard()
         expected = expected.replace(BUILD_AND_RUN_AD_IMPORT, LLMC_TRTLLM_RUNNER_IMPORT)
+    else:
+        trtllm_import = TRTLLM_IMPORT_RE.search(expected)
+        if trtllm_import is not None:
+            ensure_imports(trtllm_import.start(), "os", "pytest")
+            insert_optional_trtllm_guard()
+    expected = expected.replace(
+        '    script_dir = Path(root_dir, "benchmarks", "cpp")\n',
+        "    script_dir = Path(temp_dir)\n",
+    )
     return expected
 
 
 @pytest.fixture(scope="module")
-def generated_multigpu_tests(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Generate the package once and return its multi-GPU test directory."""
+def generated_package(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Generate the package once and return the package directory."""
     output_dir = tmp_path_factory.mktemp("llmc_test_export")
     subprocess.run(
         [sys.executable, str(CREATE_SCRIPT), "--output-dir", str(output_dir)],
@@ -71,7 +139,25 @@ def generated_multigpu_tests(tmp_path_factory: pytest.TempPathFactory) -> Path:
         text=True,
         timeout=60,
     )
-    return output_dir / "tests" / "multigpu"
+    return output_dir
+
+
+@pytest.fixture(scope="module")
+def generated_singlegpu_tests(generated_package: Path) -> Path:
+    """Return the generated single-GPU test directory."""
+    return generated_package / "tests" / "singlegpu"
+
+
+@pytest.fixture(scope="module")
+def generated_multigpu_tests(generated_package: Path) -> Path:
+    """Return the generated multi-GPU test directory."""
+    return generated_package / "tests" / "multigpu"
+
+
+@pytest.fixture(scope="module")
+def generated_torch_unit_tests(generated_package: Path) -> Path:
+    """Return the generated _torch/auto_deploy unit test directory."""
+    return generated_package / "tests" / "_torch" / "auto_deploy"
 
 
 def test_exports_exact_multigpu_allowlist(generated_multigpu_tests: Path) -> None:
@@ -80,6 +166,22 @@ def test_exports_exact_multigpu_allowlist(generated_multigpu_tests: Path) -> Non
         for path in generated_multigpu_tests.rglob("*.py")
     }
     assert exported_files == EXPECTED_MULTIGPU_FILES
+
+
+def test_exports_exact_singlegpu_smoke_allowlist(generated_singlegpu_tests: Path) -> None:
+    exported_smoke_files = {
+        path.relative_to(generated_singlegpu_tests)
+        for path in (generated_singlegpu_tests / "smoke").rglob("*.py")
+    }
+    assert exported_smoke_files == EXPECTED_SINGLEGPU_SMOKE_FILES
+
+
+def test_exports_exact_torch_unit_allowlist(generated_torch_unit_tests: Path) -> None:
+    exported_files = {
+        path.relative_to(generated_torch_unit_tests)
+        for path in generated_torch_unit_tests.rglob("test*.py")
+    }
+    assert exported_files == EXPECTED_TORCH_UNIT_FILES
 
 
 def test_registers_inert_threadleak_marker(generated_multigpu_tests: Path) -> None:
@@ -91,7 +193,41 @@ def test_conftest_allows_explicit_redirect_mode(generated_multigpu_tests: Path) 
     conftest = generated_multigpu_tests.parent / "conftest.py"
     content = conftest.read_text()
     assert "TRTLLM_REDIRECT_AD_TO_LLMC" in content
-    assert "set TRTLLM_REDIRECT_AD_TO_LLMC=true only for redirect smoke tests" in content
+    assert "set TRTLLM_REDIRECT_AD_TO_LLMC=true only for optional TRT-LLM tests" in content
+    assert "_package_root = os.path.dirname(_tests_dir)" in content
+    assert "sys.path.insert(0, _package_root)" in content
+    assert "def llm_root()" in content
+
+
+def test_creates_minimal_utils_util_stub(generated_package: Path) -> None:
+    util_stub = generated_package / "tests" / "utils" / "util.py"
+    content = util_stub.read_text()
+    assert "skip_pre_hopper" in content
+    assert "torch.cuda.get_device_capability" in content
+
+
+def test_does_not_add_test_guards_to_runners(generated_package: Path) -> None:
+    runner = generated_package / "runners" / "trtllm" / "build_and_run_llmc_trtllm.py"
+    content = runner.read_text()
+    assert "pytest.skip" not in content
+    assert "pytest.importorskip" not in content
+
+
+@pytest.mark.parametrize("relative_path", sorted(EXPECTED_SINGLEGPU_SMOKE_FILES, key=str), ids=str)
+def test_rewrites_singlegpu_smoke_auto_deploy_imports(
+    generated_singlegpu_tests: Path, relative_path: Path
+) -> None:
+    source = (AD_SINGLEGPU_TESTS / relative_path).read_text()
+    exported = (generated_singlegpu_tests / relative_path).read_text()
+
+    assert exported == _expected_exported_test(source, relative_path)
+    assert CANONICAL_IMPORT not in exported
+    if relative_path in LLMC_TRTLLM_RUNNER_TESTS:
+        assert BUILD_AND_RUN_AD_IMPORT not in exported
+        assert "build_and_run_llmc_trtllm" in exported
+    else:
+        assert "LLMC optional TRT-LLM tests require TRTLLM_REDIRECT_AD_TO_LLMC=true" in exported
+    assert "TRTLLM_REDIRECT_AD_TO_LLMC" in exported
 
 
 @pytest.mark.parametrize("relative_path", sorted(EXPECTED_MULTIGPU_FILES, key=str), ids=str)
@@ -103,7 +239,19 @@ def test_rewrites_multigpu_auto_deploy_imports(
 
     assert exported == _expected_exported_test(source, relative_path)
     assert CANONICAL_IMPORT not in exported
-    if relative_path == LLMC_TRTLLM_SMOKE_TEST:
+    if relative_path == LLMC_TRTLLM_MULTIGPU_SMOKE_TEST:
         assert BUILD_AND_RUN_AD_IMPORT not in exported
         assert "build_and_run_llmc_trtllm" in exported
         assert "TRTLLM_REDIRECT_AD_TO_LLMC" in exported
+
+
+@pytest.mark.parametrize("relative_path", sorted(EXPECTED_TORCH_UNIT_FILES, key=str), ids=str)
+def test_rewrites_torch_unit_auto_deploy_imports(
+    generated_torch_unit_tests: Path, relative_path: Path
+) -> None:
+    source = (AD_TORCH_TESTS / relative_path).read_text()
+    exported = (generated_torch_unit_tests / relative_path).read_text()
+
+    assert exported == _expected_exported_test(source, relative_path)
+    assert CANONICAL_IMPORT not in exported
+    assert "LLMC optional TRT-LLM tests require TRTLLM_REDIRECT_AD_TO_LLMC=true" in exported


### PR DESCRIPTION
## Summary
- copy all AutoDeploy single-GPU smoke tests into the standalone LLMC package
- gate optional TRT-LLM wheel/CLI smoke coverage behind TRTLLM_REDIRECT_AD_TO_LLMC
- add the tracked GPT-OSS _torch AutoDeploy unit test plus minimal standalone test shims

## Tests
- python3 -m py_compile examples/auto_deploy/llmc/create_standalone_package.py tests/unittest/auto_deploy/standalone/test_standalone_test_export.py
- pytest -q tests/unittest/auto_deploy/standalone/test_standalone_test_export.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded standalone test packaging to include additional single-GPU smoke tests and newer unit tests.
  * Added support for optional TRT-LLM import handling during test rewriting, with environment-aware behavior.
  * Generated packages now include a minimal `tests/utils` shim so copied tests can run correctly.

* **Bug Fixes**
  * Improved generated test setup and path handling to make packaged tests more reliable.
  * Tightened redirect checks so incompatible TRT-LLM imports are handled more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->