### PR TITLE
[https://nvbugs/6422299][fix] Setup dependency for Cosmos3 nano t2v LPIPS test

### DIFF
--- a/tests/integration/defs/examples/visual_gen/test_visual_gen.py
+++ b/tests/integration/defs/examples/visual_gen/test_visual_gen.py
@@ -985,7 +985,7 @@ def test_qwenimage_lpips_against_golden(tmp_path):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_cosmos3_nano_t2v_lpips_against_golden(tmp_path):
+def test_cosmos3_nano_t2v_lpips_against_golden(_visual_gen_deps, tmp_path):
     generated_path = tmp_path / "cosmos3_nano_t2v_generated.mp4"
     golden_path = _golden_media_path(
         tmp_path,

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -148,7 +148,6 @@ examples/test_qwen2audio.py::test_llm_qwen2audio_single_gpu[qwen2_audio_7b_instr
 examples/test_ray.py::test_ray_disaggregated_serving[tp2] SKIP (https://nvbugs/5612502)
 examples/test_whisper.py::test_llm_whisper_general[large-v3-disable_gemm_plugin-disable_attention_plugin-disable_weight_only-float16-nb:1-use_python_runtime] SKIP (https://nvbugs/5244570)
 examples/visual_gen/test_visual_gen.py::test_cosmos3_nano_t2i_lpips_against_golden SKIP (https://nvbugs/6418815)
-examples/visual_gen/test_visual_gen.py::test_cosmos3_nano_t2v_lpips_against_golden SKIP (https://nvbugs/6422299)
 examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_multi_gpu[attn2d_2x2] SKIP (https://nvbugs/6272644)
 examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_multi_gpu[cfg2_ulysses2] SKIP (https://nvbugs/6272644)
 examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_multi_gpu[cfg2_ulysses2_attn2d_2x1] SKIP (https://nvbugs/6272644)


### PR DESCRIPTION
## Description
Fix the Cosmos3-Nano T2V LPIPS test dependency wiring so the `_visual_gen_deps` fixture runs before the test writes an MP4 file.

The test uses `_save_lpips_video_mp4()`, which intentionally fails when ffmpeg is unavailable to avoid comparing codec artifacts against the golden video. Without this fixture, isolated or sharded runs can skip the ffmpeg install path and fail before LPIPS is evaluated.

## Testing
- `git diff --check`
- `python3 -m py_compile tests/integration/defs/examples/visual_gen/test_visual_gen.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a visual generation integration test to use the shared VisualGen setup fixture.
  * Adjusted a waived test entry to match the current visual generation variant under test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->