### PR TITLE
[TRTLLM-13643][feat] Add perf sanity tests for Gemma-3-1B and verify cache transceiver V2 support

### DIFF
--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -1034,6 +1034,7 @@ def getMultiGpuFileChanged(pipeline, testFilter, globalVars)
         "tests/integration/test_lists/test-db/l0_gb200_multi_gpus.yml",
         "tests/integration/test_lists/test-db/l0_gb200_multi_gpus_perf_sanity.yml",
         "tests/integration/test_lists/test-db/l0_gb200_multi_nodes.yml",
+        "tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu1.yml",
         "tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu2.yml",
         "tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu4.yml",
         "tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node2_gpu8.yml",

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -4999,6 +4999,14 @@ def launchTestJobs(pipeline, testFilter)
     // PerfSanity post-merge disaggregated
     // 2 Nodes
     multiNodesSBSAConfigs += buildStageConfigs(
+        "GB200-8_GPUs-2_Nodes-PyTorch-Disagg-PerfSanity-CTX1-NODE1-GPU1-GEN1-NODE1-GPU1-Post-Merge",
+        "auto:gb200-flex",
+        "l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu1",
+        1,
+        8,
+        2
+    )
+    multiNodesSBSAConfigs += buildStageConfigs(
         "GB200-8_GPUs-2_Nodes-PyTorch-Disagg-PerfSanity-CTX1-NODE1-GPU1-GEN1-NODE1-GPU2-Post-Merge",
         "auto:gb200-flex",
         "l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu2",

--- a/tests/integration/defs/perf/_model_paths.py
+++ b/tests/integration/defs/perf/_model_paths.py
@@ -44,6 +44,7 @@ MODEL_PATH_DICT = {
     "gemma_3_12b_it": "gemma/gemma-3-12b-it",
     "gemma_3_12b_it_fp8": "gemma/gemma-3-12b-it-fp8",
     "gemma_3_12b_it_fp4": "gemma/gemma-3-12b-it-fp4",
+    "gemma_3_1b_it": "gemma/gemma-3-1b-it",
     "deepseek_r1_fp8": "DeepSeek-R1/DeepSeek-R1",
     "deepseek_r1_nvfp4": "DeepSeek-R1/DeepSeek-R1-FP4",
     "deepseek_r1_0528_fp8": "DeepSeek-R1/DeepSeek-R1-0528/",

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu1.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu1.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.0.1
+l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu1:
+- condition:
+    ranges:
+      # 1 ctx worker with 1 node and 1 GPU
+      # 1 gen worker with 1 node and 1 GPU
+      system_gpu_count:
+        gte: 8
+        lte: 8
+    wildcards:
+      gpu:
+      - '*gb200*'
+    terms:
+      stage: post_merge
+      backend: pytorch
+  tests:
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb200_gemma-3-1b-bf16_1k1k_con256_ctx1_tp1_gen1_tp1_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gemma-3-1b-bf16_1k1k_con256_ctx1_tp1_gen1_tp1_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gemma-3-1b-bf16_1k1k_con256_ctx1_tp1_gen1_tp1_eplb0_mtp0_ccb-NIXL.yaml
@@ -76,7 +76,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 4096
       backend: NIXL
-      transceiver_runtime: CPP
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
@@ -99,5 +99,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 4096
       backend: NIXL
-      transceiver_runtime: CPP
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gemma-3-1b-bf16_1k1k_con256_ctx1_tp1_gen1_tp1_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gemma-3-1b-bf16_1k1k_con256_ctx1_tp1_gen1_tp1_eplb0_mtp0_ccb-NIXL.yaml
@@ -76,7 +76,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 4096
       backend: NIXL
-      transceiver_runtime: PYTHON
+      transceiver_runtime: CPP
     disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
@@ -99,5 +99,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 4096
       backend: NIXL
-      transceiver_runtime: PYTHON
+      transceiver_runtime: CPP
     disable_overlap_scheduler: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gemma-3-1b-bf16_1k1k_con256_ctx1_tp1_gen1_tp1_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gemma-3-1b-bf16_1k1k_con256_ctx1_tp1_gen1_tp1_eplb0_mtp0_ccb-NIXL.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metadata:
+  model_name: gemma_3_1b_it
+  precision: bf16
+  model_dir_name: gemma-3-1b-it
+  supported_gpus:
+  - GB200
+  script_file: disaggr_torch.slurm
+  benchmark_type: 1k1k
+slurm:
+  script_file: disaggr_torch.slurm
+  partition: <partition>
+  account: <account>
+  job_time: 02:00:00
+  job_name: unified-benchmark
+  extra_args: --gres=gpu:4
+  numa_bind: true
+benchmark:
+  mode: e2e
+  use_nv_sa_benchmark: false
+  multi_round: 10
+  benchmark_ratio: 0.0
+  streaming: true
+  concurrency_list: '256'
+  input_length: 1024
+  output_length: 1024
+  dataset_file: <dataset_file>
+hardware:
+  gpus_per_node: 4
+  num_ctx_servers: 1
+  num_gen_servers: 1
+environment:
+  container_mount: <container_mount>
+  container_image: <container_image>
+  model_path: <model_path>
+  trtllm_repo: ''
+  build_wheel: false
+  work_dir: <full_path_to_work_dir>
+  worker_env_var: TLLM_LOG_LEVEL=INFO TRTLLM_SERVER_DISABLE_GC=1 TRTLLM_WORKER_DISABLE_GC=1 ENROOT_ALLOW_DEV=yes
+  server_env_var: TRTLLM_SERVER_DISABLE_GC=1
+profiling:
+  nsys_on: false
+worker_config:
+  gen:
+    print_iter_log: true
+    max_batch_size: 256
+    max_num_tokens: 512
+    tensor_parallel_size: 1
+    moe_expert_parallel_size: 1
+    pipeline_parallel_size: 1
+    context_parallel_size: 1
+    enable_attention_dp: false
+    cuda_graph_config:
+      enable_padding: true
+      max_batch_size: 256
+    kv_cache_config:
+      use_kv_cache_manager_v2: false
+      enable_block_reuse: false
+      free_gpu_memory_fraction: 0.85
+      dtype: auto
+      max_attention_window: [512, 512, 512, 512, 512, 32768]
+    cache_transceiver_config:
+      max_tokens_in_buffer: 4096
+      backend: NIXL
+      transceiver_runtime: CPP
+    disable_overlap_scheduler: false
+    num_postprocess_workers: 4
+    stream_interval: 20
+  ctx:
+    print_iter_log: true
+    max_batch_size: 32
+    max_num_tokens: 8192
+    tensor_parallel_size: 1
+    moe_expert_parallel_size: 1
+    pipeline_parallel_size: 1
+    context_parallel_size: 1
+    enable_attention_dp: false
+    cuda_graph_config: null
+    kv_cache_config:
+      use_kv_cache_manager_v2: false
+      enable_block_reuse: false
+      free_gpu_memory_fraction: 0.85
+      dtype: auto
+      max_attention_window: [512, 512, 512, 512, 512, 32768]
+    cache_transceiver_config:
+      max_tokens_in_buffer: 4096
+      backend: NIXL
+      transceiver_runtime: CPP
+    disable_overlap_scheduler: true


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new GB200 multi-node disaggregated performance sanity test for Gemma 3 1B (IT) and the associated test configuration.
  * Added Gemma 3 1B IT model path support for performance testing.
  * Extended post-merge disaggregated PerfSanity coverage with a GPU1→GPU1 configuration for the new scenario.
* **CI/Test Reliability**
  * Updated multi-GPU change-detection to treat the new GB200 multi-node sanity test list entry as multi-GPU relevant, ensuring the right validation runs on 8-GPU systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Adds new perf sanity tests for Gemma-3-1B that use the new Python KV cache transceiver V2

## Test Coverage

**Pre-Merge Perf Results**

1. First run:
- Python (v2):
```
Metric	                        Latest Value
Output Token Throughput (tok/s)	48445.12	
Total Token Throughput (tok/s)	96890.23
```
- CPP (v1):
```
Metric	                        Latest Value
Output Token Throughput (tok/s)	41990.30	
Total Token Throughput (tok/s)	83980.61
```
Python's Output Token Throughput is 15% higher than CPP's.
Python's Total Token Throughput is 15% higher than CPP's.

2. Second run:
- Python (v2):
```
Metric	                        Latest Value
Output Token Throughput (tok/s)	39551.51	
Total Token Throughput (tok/s)	79103.01
```
- CPP (v1):
```
Metric	                        Latest Value
Output Token Throughput (tok/s)	41019.11	
Total Token Throughput (tok/s)	82038.22
```
Python's Output Token Throughput is 4% lower than CPP's.
Python's Total Token Throughput is 4% lower than CPP's.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
