### PR TITLE
[https://nvbugs/6426852][fix] Add explicit `gc.collect()` between `del weights` and…

### DIFF
--- a/tensorrt_llm/llmapi/rlhf_utils.py
+++ b/tensorrt_llm/llmapi/rlhf_utils.py
@@ -124,6 +124,11 @@ class WorkerExtension:
                     self.engine.model_engine.model, weights, allow_partial_loading=True
                 )
                 del weights
+                # ipc_collect only reclaims mappings whose Python refs are
+                # already gone; force GC so cudaIpcOpenMemHandle storages are
+                # released before the sweep, or the IPC handle table saturates
+                # across repeated RPCs.
+                gc.collect()
                 torch.cuda.ipc_collect()
             else:
                 logger.info("Finalize update weights")


### PR DESCRIPTION
## Summary
- **Root cause**: Per-RPC ipc_collect() couldn't reclaim IPC mappings because `del weights` alone left the mapped storages in unreachable cycles; many partial-update RPCs on MoE model exhausted CUDA driver's IPC handle table.
- **Fix**: Add explicit `gc.collect()` between `del weights` and `torch.cuda.ipc_collect()` in the per-RPC branch so IPC-mapped storages are released in the same iteration, complementing the prior producer-side lazy-replica fix.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6426852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weight update reliability during repeated requests by ensuring GPU memory handles are released more consistently.
  * Reduced the chance of failures when updating model weights across multiple GPU operations.

* **Tests**
  * Updated integration waivers and related GPU test behavior to reflect the new weight-handling flow.
  * Adjusted test helpers to create GPU weight copies more lazily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->