### PR TITLE
[https://nvbugs/6426886][fix] Forward use_host_stop_criteria alongside sample_state.host and py_result_diffs…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2600,10 +2600,15 @@ class PyExecutor:
         if not self.dist.is_last_pp_rank:
             # Receive tokens from previous pp rank (w.r.t model forward direction)
             with nvtx_range("recv_sample_state"):
-                sample_state.host, py_result_diffs = self.dist.recv_object(
-                    src=self.dist.prev_pp_rank,
-                    tag=tag,
-                )
+                sample_state.host, py_result_diffs, use_host_stop_criteria = \
+                    self.dist.recv_object(src=self.dist.prev_pp_rank, tag=tag)
+
+            # The last PP rank's fast host-stop path leaves
+            # host.finish_reasons=None; without this flag, non-last ranks would
+            # take the finish_reasons-indexing branch in update_requests and
+            # raise IndexError on the empty list.
+            if hasattr(sample_state, "use_host_stop_criteria"):
+                sample_state.use_host_stop_criteria = use_host_stop_criteria
 
             for request, py_result_diff in zip(requests, py_result_diffs):
                 request.py_result.apply_diff(py_result_diff)
@@ -2621,7 +2626,8 @@ class PyExecutor:
             self.wait_on_pp_send_handles(self.send_handles, microbatch_id)
             with nvtx_range("send_sample_state"):
                 self.send_handles[microbatch_id] = self.dist.isend_object(
-                    (sample_state.host, py_result_diffs),
+                    (sample_state.host, py_result_diffs,
+                     getattr(sample_state, "use_host_stop_criteria", False)),
                     dest=self.dist.next_pp_rank,
                     tag=tag,
                 )


### PR DESCRIPTION
## Summary
- **Root cause**: Last PP rank's use_host_stop_criteria=True (finish_reasons_host=None) is not propagated over the PP ring, so non-last ranks default to False and try to index the empty finish_reasons list.
- **Fix**: Forward use_host_stop_criteria alongside sample_state.host and py_result_diffs in _ring_broadcast_sample_state, and restore it on the receiver (guarded by hasattr/getattr for other sampler flavors).
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6426886


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in pipeline-parallel generation where stop-criteria settings were not consistently shared across ranks.
  * Improved handling of host-side stopping behavior so non-final pipeline stages no longer follow an incorrect finish path in certain fast-stop cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->