### PR TITLE
[#16151][feat] Expose SmoothQuant alpha via --smoothquant_alpha in quantize.py

### DIFF
--- a/examples/quantization/README.md
+++ b/examples/quantization/README.md
@@ -31,6 +31,11 @@ python quantize.py --model_dir $MODEL_PATH --qformat int4_awq --awq_block_size 6
 # INT8 SQ with INT8 kv cache.
 python quantize.py --model_dir $MODEL_PATH --qformat int8_sq --kv_cache_dtype int8 --output_dir $OUTPUT_PATH
 
+# INT8 SQ with a custom SmoothQuant migration strength (alpha). The default alpha=1.0 migrates
+# all quantization difficulty to the weights and can regress accuracy on some models; values
+# around 0.5-0.85 often work better (see the SmoothQuant paper).
+python quantize.py --model_dir $MODEL_PATH --qformat int8_sq --kv_cache_dtype int8 --smoothquant_alpha 0.85 --output_dir $OUTPUT_PATH
+
 # Auto quantization(e.g. fp8 + int4_awq + w4a8_awq) using average weights bits 5
 python quantize.py --model_dir $MODEL_PATH  --autoq_format fp8,int4_awq,w4a8_awq  --output_dir $OUTPUT_PATH --auto_quantize_bits 5 --tp_size 2
 

--- a/examples/quantization/quantize.py
+++ b/examples/quantization/quantize.py
@@ -107,6 +107,14 @@ if __name__ == "__main__":
     parser.add_argument("--pp_size", type=int, default=1)
     parser.add_argument("--cp_size", type=int, default=1)
     parser.add_argument("--awq_block_size", type=int, default=128)
+    parser.add_argument(
+        "--smoothquant_alpha",
+        type=float,
+        default=None,
+        help=
+        "SmoothQuant migration strength (alpha) in [0, 1]; effective for int8_sq qformat only. "
+        "When unset, keeps the ModelOpt built-in behavior (alpha=1.0, or 0.5 for Gemma)."
+    )
     parser.add_argument("--kv_cache_dtype",
                         help="KV Cache dtype.",
                         default=None,
@@ -156,6 +164,17 @@ if __name__ == "__main__":
             )
             args.auto_quantize_bits = lower_bound
 
+    # smoothquant_alpha check
+    if args.smoothquant_alpha is not None:
+        if not 0.0 <= args.smoothquant_alpha <= 1.0:
+            parser.error(
+                f"--smoothquant_alpha must be in [0, 1], got {args.smoothquant_alpha}"
+            )
+        if args.qformat != "int8_sq" or args.auto_quantize_bits is not None:
+            print(
+                "Warning: --smoothquant_alpha only takes effect for the int8_sq "
+                "qformat without auto quantization; it will be ignored.")
+
     if args.model_dir is not None:
         quantize_and_export(
             model_dir=args.model_dir,
@@ -169,6 +188,7 @@ if __name__ == "__main__":
             batch_size=args.batch_size,
             calib_max_seq_length=args.calib_max_seq_length,
             awq_block_size=args.awq_block_size,
+            smoothquant_alpha=args.smoothquant_alpha,
             output_dir=args.output_dir,
             tp_size=args.tp_size,
             pp_size=args.pp_size,

--- a/tensorrt_llm/quantization/quantize_by_modelopt.py
+++ b/tensorrt_llm/quantization/quantize_by_modelopt.py
@@ -789,6 +789,35 @@ def combine_medusa_weight(tp_size, pp_size, base_model_output_dir,
     logger.info("Combine medusa heads' weight, done.")
 
 
+def override_smoothquant_alpha(quant_cfg: dict, qformat: str,
+                               smoothquant_alpha: float | None) -> dict:
+    """Override the SmoothQuant migration strength (alpha) in ``quant_cfg`` when requested.
+
+    A user-specified ``smoothquant_alpha`` (from ``--smoothquant_alpha``) replaces ModelOpt's
+    default (alpha=1.0) and the Gemma special case, for the ``int8_sq`` qformat only. The dict is
+    deep-copied first so the input (e.g. a shared ModelOpt preset) is never mutated. No-op that
+    returns ``quant_cfg`` unchanged when ``smoothquant_alpha`` is None or the qformat is not
+    int8_sq. Range validation is intentionally left to the CLI (``--smoothquant_alpha``); this
+    helper applies whatever value it is given.
+
+    Args:
+        quant_cfg: The ModelOpt quantization config dict to potentially override.
+        qformat: The quantization format string (e.g. ``"int8_sq"``).
+        smoothquant_alpha: User-specified alpha, or ``None`` to keep the defaults.
+
+    Returns:
+        The input ``quant_cfg`` unchanged (no-op case), or a deep-copied dict with
+        ``algorithm`` set to the requested SmoothQuant alpha.
+    """
+    if smoothquant_alpha is not None and "int8_sq" in qformat:
+        quant_cfg = copy.deepcopy(quant_cfg)
+        quant_cfg["algorithm"] = {
+            "method": "smoothquant",
+            "alpha": smoothquant_alpha
+        }
+    return quant_cfg
+
+
 def quantize_and_export(*,
                         model_dir,
                         device,
@@ -814,7 +843,8 @@ def quantize_and_export(*,
                         quant_medusa_head=None,
                         auto_quantize_bits=None,
                         device_map="auto",
-                        quantize_lm_head=False):
+                        quantize_lm_head=False,
+                        smoothquant_alpha=None):
     '''
         Load model from the model_dir, call Modelopt to quantize the model, and then export
         the quantized model as TRT-LLM checkpoint
@@ -882,12 +912,15 @@ def quantize_and_export(*,
         quant_cfg = None
         if not auto_quantize_bits:
             if qformat in quant_cfg_choices():
-                quant_cfg = quant_cfg_choices()[qformat]
+                # Deep-copy the selected preset: the values in quant_cfg_choices() are
+                # ModelOpt's shared module-level config dicts, and the in-place updates
+                # below (kv-cache, Gemma alpha, lm_head) must not leak into later
+                # quantize calls in the same process.
+                quant_cfg = copy.deepcopy(quant_cfg_choices()[qformat])
             else:
                 raise ValueError(f"Unsupported quantization format: {qformat}")
 
             if "awq" in qformat:
-                quant_cfg = copy.deepcopy(quant_cfg_choices()[qformat])
                 weight_quantizer = quant_cfg["quant_cfg"]["*weight_quantizer"]
                 if isinstance(weight_quantizer, list):
                     weight_quantizer = weight_quantizer[0]
@@ -912,6 +945,11 @@ def quantize_and_export(*,
             # Gemma 7B has accuracy regression using alpha 1. We set 0.5 instead.
             if model_type == "gemma" and "int8_sq" in qformat:
                 quant_cfg["algorithm"] = {"method": "smoothquant", "alpha": 0.5}
+
+            # A user-specified SmoothQuant alpha (--smoothquant_alpha) overrides the defaults
+            # above (ModelOpt's alpha=1.0, or the Gemma special case).
+            quant_cfg = override_smoothquant_alpha(quant_cfg, qformat,
+                                                   smoothquant_alpha)
 
             if qformat == 'fp8' and quantize_lm_head:
                 print_rank_0("Quantizing lm_head layer")

--- a/tests/unittest/trt/quantization/test_smoothquant_alpha.py
+++ b/tests/unittest/trt/quantization/test_smoothquant_alpha.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the --smoothquant_alpha override (quantize_by_modelopt)."""
+
+import copy
+
+import pytest
+
+# quantize_by_modelopt imports modelopt/torch at module load; skip cleanly where absent.
+pytest.importorskip("modelopt")
+from tensorrt_llm.quantization.quantize_by_modelopt import override_smoothquant_alpha
+
+
+def _int8_sq_cfg():
+    """Minimal stand-in for an INT8_SMOOTHQUANT preset.
+
+    Carries an ``algorithm`` with the ModelOpt default alpha=1.0, plus a nested
+    ``quant_cfg`` to catch accidental mutation.
+    """
+    return {
+        "quant_cfg": {"*weight_quantizer": {"num_bits": 8, "axis": 0}},
+        "algorithm": {"method": "smoothquant", "alpha": 1.0},
+    }
+
+
+def test_none_is_noop():
+    # Unset flag -> ModelOpt default is preserved and the same object is returned.
+    cfg = _int8_sq_cfg()
+    out = override_smoothquant_alpha(cfg, "int8_sq", None)
+    assert out is cfg
+    assert out["algorithm"]["alpha"] == 1.0
+
+
+@pytest.mark.parametrize("alpha", [0.0, 0.5, 0.85, 1.0])
+def test_override_applied_for_int8_sq(alpha):
+    # int8_sq + a value -> algorithm rewritten to that alpha.
+    out = override_smoothquant_alpha(_int8_sq_cfg(), "int8_sq", alpha)
+    assert out["algorithm"] == {"method": "smoothquant", "alpha": alpha}
+
+
+@pytest.mark.parametrize("qformat", ["fp8", "int4_awq", "w4a8_awq"])
+def test_noop_for_non_int8_sq(qformat):
+    # The flag only affects int8_sq; other formats are untouched.
+    cfg = _int8_sq_cfg()
+    out = override_smoothquant_alpha(cfg, qformat, 0.5)
+    assert out is cfg
+    assert out["algorithm"]["alpha"] == 1.0
+
+
+def test_does_not_mutate_input():
+    # The shared ModelOpt preset dict must not be mutated by the override (deep-copy).
+    cfg = _int8_sq_cfg()
+    snapshot = copy.deepcopy(cfg)
+    override_smoothquant_alpha(cfg, "int8_sq", 0.5)
+    assert cfg == snapshot
+
+
+def test_out_of_range_alpha_not_validated_here():
+    # Range validation is intentionally CLI-only (--smoothquant_alpha rejects values
+    # outside [0, 1] via parser.error); the helper applies whatever it is given.
+    # Locks in that design decision so validation is never duplicated in this layer.
+    out = override_smoothquant_alpha(_int8_sq_cfg(), "int8_sq", 2.0)
+    assert out["algorithm"] == {"method": "smoothquant", "alpha": 2.0}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--smoothquant_alpha` option to customize SmoothQuant alpha during INT8 SQ quantization.
  * Updated the quantization example to show how to use `--smoothquant_alpha 0.85`.
* **Bug Fixes**
  * Applied the custom alpha only to the relevant INT8 SQ workflow, with warnings when it’s not applicable.
  * Ensured preset/config handling doesn’t unintentionally share or change settings across runs.
* **Tests**
  * Added unit coverage for alpha overrides, no-op behavior for other formats, and non-mutation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #16151

## Description

`examples/quantization/quantize.py` currently offers no way to set the SmoothQuant migration
strength (alpha) for the `int8_sq` qformat. ModelOpt's `SmoothQuantCalibConfig` defaults to
**alpha = 1.0** (migrate *all* quantization difficulty into the weights), and the only override in
the codebase is a hardcoded special case:

```python
# tensorrt_llm/quantization/quantize_by_modelopt.py
# Gemma 7B has accuracy regression using alpha 1. We set 0.5 instead.
if model_type == "gemma" and "int8_sq" in qformat:
    quant_cfg["algorithm"] = {"method": "smoothquant", "alpha": 0.5}
```

This PR generalizes that existing mechanism into a user-facing knob:

- `--smoothquant_alpha` (float, default `None`) on `examples/quantization/quantize.py`;
- a matching keyword-only `smoothquant_alpha=None` parameter on `quantize_and_export`;
- when set (and qformat is `int8_sq`), the quant config gets
  `quant_cfg["algorithm"] = {"method": "smoothquant", "alpha": <value>}` — the exact dict form
  ModelOpt already validates via pydantic (`SmoothQuantCalibConfig`, bounds `[0, 1]`) and the same
  form the Gemma special case uses today.

**No behavior change when the flag is unset** (default `None` preserves ModelOpt's default and the
Gemma special case). The override `copy.deepcopy`s the shared ModelOpt preset dict before mutating,
so the setting cannot leak into later `quantize` calls in the same process. The CLI validates the
range (`[0, 1]`) and warns if the flag is passed with a non-`int8_sq` qformat. The NeMo path is
untouched.

### Motivation / evidence

The SmoothQuant paper recommends alpha in 0.5–0.9 depending on the model; the hardcoded 1.0 is
frequently far from optimal. We swept 11 alphas × 2 calibration sets × 2 Qwen3 model sizes
(real TRT engines, full GSM8K-1319 + WikiText-2 PPL, TRT-LLM 1.0 + ModelOpt 0.33.1):

| Model | Calib | alpha=1.0 (current default) | best alpha | GSM8K cost of the default |
|---|---|---|---|---|
| Qwen3-1.7B | wikitext | 39.80% (525/1319) | **57.09%** @ α=0.75 | **−17.3 pts** |
| Qwen3-1.7B | gsm8k-train | 61.87% (816/1319) | **63.76%** @ α=0.85 | −1.9 pts |
| Qwen3-0.6B | wikitext | 21.76% (287/1319) | **31.54%** @ α=0.75 | −9.8 pts |
| Qwen3-0.6B | gsm8k-train | 15.39% (203/1319) | **35.41%** @ α=0.85 | **−20.0 pts** |

alpha=1.0 was never the optimum in any of the 4 conditions (PPL agrees: 0.7–2.7 PPL worse than the
per-condition best). The best alpha consistently sits in 0.70–0.85 — unreachable today without
editing library code.

## Test Coverage

- **Unit test** (GPU-free): `tests/unittest/trt/quantization/test_smoothquant_alpha.py`. The
  override is factored into a pure helper `override_smoothquant_alpha(quant_cfg, qformat, alpha)`
  so it is testable without loading a model; the test covers — default preserved when the flag is
  unset, alpha applied for `int8_sq` (parametrized over several values), no-op for other qformats
  (`fp8` / `int4_awq` / `w4a8_awq`), and the shared ModelOpt preset dict is never mutated (deep-copy).
- `python examples/quantization/quantize.py --help` shows the new flag; range/format validation
  covered by CLI checks (out-of-range values are rejected with `parser.error`).
- Default path (flag unset): quant_cfg is bitwise-identical to before the change (verified by
  diffing the exported checkpoint scaling factors on Qwen3-0.6B).
- Flag path: `--smoothquant_alpha 0.85` on Qwen3-0.6B reproduces the checkpoint produced by
  directly setting `{"method": "smoothquant", "alpha": 0.85}` in the quant config (same exported
  scaling factors, same GSM8K score within run-to-run noise).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.
