### PR TITLE
[None][feat] BREAKING: add per-model transceiver runtime auto selection

### DIFF
--- a/docs/source/developer-guide/telemetry.md
+++ b/docs/source/developer-guide/telemetry.md
@@ -55,7 +55,7 @@ unset or when the safety sanitizer rejects the runtime value.
 | `cache_transceiver_config.kv_transfer_sender_future_timeout_ms` | `Optional[Annotated[int, Gt(gt=0)]]` | `value` |  |  |
 | `cache_transceiver_config.kv_transfer_timeout_ms` | `Optional[Annotated[int, Gt(gt=0)]]` | `value` |  |  |
 | `cache_transceiver_config.max_tokens_in_buffer` | `Optional[int]` | `value` |  |  |
-| `cache_transceiver_config.transceiver_runtime` | `Optional[Literal['CPP', 'PYTHON']]` | `categorical` |  | `CPP`, `PYTHON` |
+| `cache_transceiver_config.transceiver_runtime` | `Optional[Literal['CPP', 'PYTHON', 'auto']]` | `categorical` |  | `CPP`, `PYTHON`, `auto` |
 | `context_parallel_size` | `<class 'int'>` | `value` |  |  |
 | `cp_config.block_size` | `Optional[int]` | `value` |  |  |
 | `cp_config.cp_anchor_size` | `Optional[int]` | `value` |  |  |
@@ -376,7 +376,7 @@ unset or when the safety sanitizer rejects the runtime value.
 | `cache_transceiver_config.kv_transfer_sender_future_timeout_ms` | `Optional[Annotated[int, Gt(gt=0)]]` | `value` |  |  |
 | `cache_transceiver_config.kv_transfer_timeout_ms` | `Optional[Annotated[int, Gt(gt=0)]]` | `value` |  |  |
 | `cache_transceiver_config.max_tokens_in_buffer` | `Optional[int]` | `value` |  |  |
-| `cache_transceiver_config.transceiver_runtime` | `Optional[Literal['CPP', 'PYTHON']]` | `categorical` |  | `CPP`, `PYTHON` |
+| `cache_transceiver_config.transceiver_runtime` | `Optional[Literal['CPP', 'PYTHON', 'auto']]` | `categorical` |  | `CPP`, `PYTHON`, `auto` |
 | `calib_config.calib_batch_size` | `<class 'int'>` | `value` |  |  |
 | `calib_config.calib_batches` | `<class 'int'>` | `value` |  |  |
 | `calib_config.calib_max_seq_length` | `<class 'int'>` | `value` |  |  |

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -1,10 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import contextlib
 import inspect
 import math
 import os
 import time
 from dataclasses import dataclass
-from typing import Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (Any, Dict, Generic, List, Literal, Optional, Tuple, Type,
+                    TypeVar, Union)
 
 import torch
 from torch import nn
@@ -605,8 +609,40 @@ class DecoderModelForCausalLM(nn.Module,
 
         The returned dict is deep-merged with the user's llm_args, with
         user-set values taking priority over these defaults.
+
+        Note: ``cache_transceiver_config`` is rejected here (enforced at
+        load time) — the deep-merge could materialize or silently enable a
+        transceiver config the user did not turn on. Use
+        :meth:`get_preferred_transceiver_runtime` instead.
         """
         return {}
+
+    @classmethod
+    def get_preferred_transceiver_runtime(
+            cls,
+            pretrained_config: Any = None
+    ) -> Optional[Literal["CPP", "PYTHON"]]:
+        """Return the model's preferred KV-cache transceiver runtime.
+
+        Subclasses can override this to opt into a specific transceiver
+        implementation ('CPP' or 'PYTHON') that is adopted when the user
+        leaves ``cache_transceiver_config.transceiver_runtime`` at its
+        default 'auto'. Return None to defer to the global default (C++).
+
+        Args:
+            pretrained_config: the loaded HF pretrained config (may be None
+                on paths where no config was loaded). Implementation classes
+                shared by several architectures can inspect e.g.
+                ``pretrained_config.architectures`` to differentiate per
+                checkpoint.
+
+        This preference is intentionally kept out of the generic
+        :meth:`get_model_defaults` deep-merge: it must not materialize a
+        ``cache_transceiver_config`` when disaggregated serving is disabled,
+        and it is only honored when the effective backend supports it (the
+        Python transceiver requires NIXL).
+        """
+        return None
 
     @property
     def config(self):
@@ -876,7 +912,7 @@ def get_model_architecture(
             model_config.architectures) > 0:
         cls = MODEL_CLASS_MAPPING.get(model_config.architectures[0])
     else:
-        raise RuntimeError(f"Model architecture is not provided.")
+        raise RuntimeError("Model architecture is not provided.")
 
     if cls is None:
         arch = model_config.architectures[0]

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from os import getenv
 from typing import Any, Dict, List, Optional
@@ -6,7 +9,8 @@ import tensorrt_llm
 from tensorrt_llm import logger
 from tensorrt_llm._torch.distributed.communicator import Distributed
 from tensorrt_llm.bindings import WorldConfig
-from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig
+from tensorrt_llm.llmapi.llm_args import (_CACHE_TRANSCEIVER_BACKEND_ENV_VARS,
+                                          CacheTransceiverConfig)
 from tensorrt_llm.mapping import Mapping
 
 from .llm_request import LlmRequest
@@ -25,12 +29,6 @@ _DISABLE_KV_CACHE_TRANSFER_OVERLAP_ENV = "TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERL
 _DISAGG_LAYERWISE_ENV = "TRTLLM_DISAGG_LAYERWISE"
 _TRY_ZCOPY_FOR_KV_CACHE_TRANSFER_ENV = "TRTLLM_TRY_ZCOPY_FOR_KVCACHE_TRANSFER"
 _SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND = "UCX"
-_CACHE_TRANSCEIVER_BACKEND_ENV_VARS = (
-    ("TRTLLM_USE_NIXL_KVCACHE", "NIXL"),
-    ("TRTLLM_USE_UCX_KVCACHE", "UCX"),
-    ("TRTLLM_USE_MOONCAKE_KVCACHE", "MOONCAKE"),
-    ("TRTLLM_USE_MPI_KVCACHE", "MPI"),
-)
 _disagg_inflight_cancel_enabled_cache: Optional[bool] = None
 
 
@@ -122,29 +120,35 @@ def create_kv_cache_transceiver(
         logger.info("cache_transceiver is disabled")
         return None
 
+    # "auto" is normally resolved against the model's preference at config
+    # load time (ModelLoader.load_config_and_apply_defaults); paths that skip
+    # that step (e.g. AutoDeploy) fall back to the C++ transceiver here. This
+    # must run before any consumer of transceiver_runtime below (e.g. the
+    # inflight-cancel validation, which treats non-CPP runtimes as
+    # unsupported).
+    if cache_transceiver_config.transceiver_runtime == "auto":
+        cache_transceiver_config.transceiver_runtime = None
+
     _validate_disagg_inflight_cancel_config(cache_transceiver_config)
 
     if cache_transceiver_config.backend == "DEFAULT":
         # When cache_transceiver_config.backend is not set, fallback to env_vars settings
         # NIXL is the default backend for non hybrid models
-        cache_transceiver_config.backend = "NIXL"
-        # Ordered by priority
-        for env_var, be_type in _CACHE_TRANSCEIVER_BACKEND_ENV_VARS:
-            if getenv(env_var) == "1":
-                logger.warning(
-                    f"{env_var}=1 is set, but it's recommended to set cache_transceiver_config.backend in yaml config"
-                )
-                cache_transceiver_config.backend = be_type
-                break
+        backend, env_var = cache_transceiver_config._resolve_default_backend()
+        if env_var is not None:
+            logger.warning(
+                f"{env_var}=1 is set, but it's recommended to set cache_transceiver_config.backend in yaml config"
+            )
+        cache_transceiver_config.backend = backend
 
     if cache_transceiver_config.backend == "MPI":
         logger.warning(
             "MPI CacheTransceiver is deprecated, UCX or NIXL is recommended")
     elif cache_transceiver_config.backend == "UCX":
         logger.info(
-            f"Using UCX kv-cache transceiver. If your devices are not in the same domain, please consider setting "
-            f"UCX_CUDA_IPC_ENABLE_MNNVL=n, UCX_RNDV_SCHEME=put_zcopy and/or unset UCX_NET_DEVICES upon server "
-            f"hangs or lower-than-expected performance.")
+            "Using UCX kv-cache transceiver. If your devices are not in the same domain, please consider setting "
+            "UCX_CUDA_IPC_ENABLE_MNNVL=n, UCX_RNDV_SCHEME=put_zcopy and/or unset UCX_NET_DEVICES upon server "
+            "hangs or lower-than-expected performance.")
 
     # Select transceiver implementation based on transceiver_runtime
     # transceiver_runtime == None or "CPP" -> use C++ transceiver (default)

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -20,6 +20,7 @@ from tensorrt_llm.llmapi.llm_args import (DecodingBaseConfig,
                                           ModelExpressConfig,
                                           SparseAttentionConfig, TorchLlmArgs)
 from tensorrt_llm.llmapi.llm_utils import (_resolve_kv_cache_manager_v2_auto,
+                                           _resolve_transceiver_runtime_auto,
                                            apply_model_defaults_to_llm_args)
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_helper import LoraConfig
@@ -31,7 +32,8 @@ from ...llmapi.llm_args import LoadFormat
 from ..model_config import ModelConfig
 from ..models import AutoModelForCausalLM, LlamaForCausalLM
 from ..models.checkpoints.base_checkpoint_loader import BaseCheckpointLoader
-from ..models.modeling_utils import (DecoderModelForCausalLM, MetaInitMode,
+from ..models.modeling_utils import (MODEL_CLASS_MAPPING,
+                                     DecoderModelForCausalLM, MetaInitMode,
                                      timing)
 from ..modules.fused_moe.moe_load_balancer import (
     MoeLoadBalancer, maybe_create_moe_load_balancer)
@@ -346,6 +348,9 @@ class ModelLoader:
             checkpoint_loader: BaseCheckpointLoader) -> TorchLlmArgs:
         """Load model config and apply model-specific defaults to llm_args."""
         if checkpoint_loader is None:
+            # No config to resolve a model class from; still resolve the
+            # "auto" sentinel so it never leaks past config loading.
+            _resolve_transceiver_runtime_auto(llm_args)
             return llm_args
 
         config_kwargs = {
@@ -389,6 +394,20 @@ class ModelLoader:
                 llm_args.kv_cache_config.use_kv_cache_manager_v2,
                 model_cls.__name__
                 if model_cls is not None else "unknown model")
+
+        # The transceiver preference follows the checkpoint's original
+        # architecture: _resolve_class may rewrite it to an execution class
+        # (e.g. MTPDraftModelForCausalLM), which must not drop the target
+        # model's preference.
+        preference_cls = model_cls
+        architectures = getattr(config.pretrained_config, 'architectures', None)
+        if architectures:
+            preference_cls = MODEL_CLASS_MAPPING.get(architectures[0],
+                                                     model_cls)
+
+        # Resolve "auto" sentinel values after model defaults are applied.
+        _resolve_transceiver_runtime_auto(llm_args, preference_cls,
+                                          config.pretrained_config)
 
         return llm_args
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -412,8 +412,7 @@ class EncodeCudaGraphConfig(BaseCudaGraphConfig):
     @staticmethod
     def _generate_cuda_graph_seq_lens(max_seq_len: int,
                                       enable_padding: bool) -> List[int]:
-        """
-        Generate a list of max per-request sequence lengths for encoder CUDA graphs.
+        """Generate a list of max per-request sequence lengths for encoder CUDA graphs.
 
         Args:
             max_seq_len: Maximum per-request sequence length to generate up to.
@@ -3668,6 +3667,17 @@ class ExtendedRuntimePerfKnobConfig(StrictBaseModel, PybindMirror):
         return res
 
 
+# Legacy env-var selectors for the "DEFAULT" cache-transceiver backend,
+# ordered by priority. Single source of truth shared with
+# _torch/pyexecutor/kv_cache_transceiver.py.
+_CACHE_TRANSCEIVER_BACKEND_ENV_VARS = (
+    ("TRTLLM_USE_NIXL_KVCACHE", "NIXL"),
+    ("TRTLLM_USE_UCX_KVCACHE", "UCX"),
+    ("TRTLLM_USE_MOONCAKE_KVCACHE", "MOONCAKE"),
+    ("TRTLLM_USE_MPI_KVCACHE", "MPI"),
+)
+
+
 @PybindMirror.mirror_pybind_fields(_CacheTransceiverConfig)
 class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
     """Configuration for the cache transceiver."""
@@ -3678,11 +3688,16 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
             description=
             "The communication backend type to use for the cache transceiver.")
 
-    transceiver_runtime: Optional[Literal["CPP", "PYTHON"]] = Field(
-        default=None,
+    transceiver_runtime: Optional[Literal["CPP", "PYTHON", "auto"]] = Field(
+        default="auto",
         description=
-        "The runtime implementation. 'CPP' for C++ transceiver (default when not set), 'PYTHON' for Python transceiver."
-    )
+        "The runtime implementation. 'auto' (default) adopts the model's "
+        "preferred runtime when the effective backend supports it, and falls "
+        "back to the C++ transceiver otherwise. 'CPP' selects the C++ "
+        "transceiver, 'PYTHON' the Python transceiver. None is equivalent to "
+        "'CPP'. The model preference is only consulted on the PyTorch "
+        "backend's standard model-loading path; other paths (e.g. AutoDeploy) "
+        "fall back to the C++ transceiver under 'auto'.")
 
     max_tokens_in_buffer: Optional[int] = Field(
         default=None,
@@ -3712,6 +3727,20 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         description=
         "Per-region size in MiB of the native-disagg KV-cache bounce buffer (one for send, one for recv). Bounce coalesces a request's scattered per-block KV into one contiguous fabric-VMM buffer and issues a single multi-rail NIXL write. The size doubles as the on/off switch: 0 (default) keeps the per-block path, >0 enables bounce at that capacity. Only used by the Python (v2) transceiver."
     )
+
+    def _resolve_default_backend(self) -> Tuple[Optional[str], Optional[str]]:
+        """Effective backend after resolving "DEFAULT" against legacy env vars.
+
+        Returns (effective_backend, env_var) where env_var is the legacy
+        environment variable that determined the choice, or None when the
+        backend was explicit or no env var was set (NIXL fallback).
+        """
+        if self.backend != "DEFAULT":
+            return self.backend, None
+        for env_var, backend in _CACHE_TRANSCEIVER_BACKEND_ENV_VARS:
+            if os.getenv(env_var) == "1":
+                return backend, env_var
+        return "NIXL", None
 
     def _to_pybind(self):
         return _CacheTransceiverConfig(

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import os
 import tempfile
@@ -513,6 +516,16 @@ def apply_model_defaults_to_llm_args(
     if not model_defaults_dict:
         return {}
 
+    # Key-presence check: any value form (dict, pydantic object, None) is
+    # rejected — the deep-merge could materialize a transceiver config in
+    # aggregated mode or silently enable a disabled one.
+    if "cache_transceiver_config" in model_defaults_dict:
+        raise ValueError(
+            "Model defaults must not contain 'cache_transceiver_config': the "
+            "deep-merge could materialize or silently enable a transceiver "
+            "config the user did not turn on. Declare a runtime preference "
+            "via get_preferred_transceiver_runtime() instead.")
+
     user_overrides = llm_args.model_dump(exclude_unset=True)
     base_state = llm_args.model_dump()
     merged_state = _deep_merge(base_state, model_defaults_dict, user_overrides)
@@ -563,3 +576,51 @@ def _resolve_kv_cache_manager_v2_auto(
 
     llm_args.kv_cache_config.use_kv_cache_manager_v2 = model_default
     return model_default
+
+
+def _resolve_transceiver_runtime_auto(llm_args: 'TorchLlmArgs',
+                                      model_cls: Optional[type] = None,
+                                      pretrained_config: Any = None) -> None:
+    """Resolve the 'auto' sentinel in cache_transceiver_config.transceiver_runtime.
+
+    Semantics:
+    - Disagg disabled (config is None or backend is None): no-op. The model
+      preference must never materialize or alter a transceiver config that the
+      user did not enable.
+    - Explicit user value ('CPP'/'PYTHON'/None): left untouched.
+    - 'auto': adopt ``model_cls.get_preferred_transceiver_runtime()`` when the
+      effective backend supports it (the Python transceiver requires NIXL);
+      otherwise fall back to None (C++ transceiver).
+
+    ``pretrained_config`` is forwarded to the hook so implementation classes
+    shared by several architectures can differentiate per checkpoint.
+    """
+    cfg = llm_args.cache_transceiver_config
+    if cfg is None or cfg.backend is None:
+        return
+    if cfg.transceiver_runtime != "auto":
+        return
+
+    preferred = None
+    if model_cls is not None:
+        get_preferred = getattr(model_cls, 'get_preferred_transceiver_runtime',
+                                None)
+        if get_preferred is not None:
+            preferred = get_preferred(pretrained_config)
+    if preferred not in (None, "CPP", "PYTHON"):
+        raise ValueError(
+            f"{model_cls.__name__}.get_preferred_transceiver_runtime() must "
+            f"return 'CPP', 'PYTHON', or None, got {preferred!r}.")
+
+    effective_backend, _ = cfg._resolve_default_backend()
+    if preferred == "PYTHON" and effective_backend != "NIXL":
+        logger.info(
+            f"Model prefers the Python transceiver, but backend "
+            f"{effective_backend} does not support it; falling back to the "
+            f"C++ transceiver.")
+        preferred = None
+
+    cfg.transceiver_runtime = preferred
+    logger.info(
+        f"Resolved transceiver_runtime='auto' to {preferred!r} for "
+        f"{model_cls.__name__ if model_cls is not None else 'unknown model'}.")

--- a/tensorrt_llm/usage/llm_args_golden_manifest.json
+++ b/tensorrt_llm/usage/llm_args_golden_manifest.json
@@ -187,9 +187,10 @@
     {
       "allowed_values": [
         "CPP",
-        "PYTHON"
+        "PYTHON",
+        "auto"
       ],
-      "annotation": "Optional[Literal['CPP', 'PYTHON']]",
+      "annotation": "Optional[Literal['CPP', 'PYTHON', 'auto']]",
       "converter": "",
       "kind": "categorical",
       "path": "cache_transceiver_config.transceiver_runtime"

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import tempfile
 from collections import defaultdict
@@ -51,6 +54,7 @@ from tensorrt_llm.llmapi.llm_args import (BaseLlmArgs, CacheTransceiverConfig,
                                           update_llm_args_with_extra_dict)
 # fmt: on
 from tensorrt_llm.llmapi.llm_utils import (_resolve_kv_cache_manager_v2_auto,
+                                           _resolve_transceiver_runtime_auto,
                                            apply_model_defaults_to_llm_args)
 from tensorrt_llm.llmapi.mm_encoder import MultimodalEncoder
 from tensorrt_llm.llmapi.utils import print_traceback_on_error
@@ -2814,3 +2818,296 @@ class TestEnableLowLatencyHostDispatch:
         with pytest.raises(ValidationError):
             TorchLlmArgs(model="gpt2",
                          enable_low_latency_host_dispatch={"val": 1})
+
+
+class _PreferPythonTransceiverModel:
+    """Fake model class opting into the Python transceiver."""
+
+    @classmethod
+    def get_model_defaults(cls, llm_args):
+        return {}
+
+    @classmethod
+    def get_preferred_transceiver_runtime(cls, pretrained_config=None):
+        return "PYTHON"
+
+
+class _ArchSensitiveTransceiverModel:
+    """Fake shared implementation class with a per-checkpoint preference."""
+
+    @classmethod
+    def get_model_defaults(cls, llm_args):
+        return {}
+
+    @classmethod
+    def get_preferred_transceiver_runtime(cls, pretrained_config=None):
+        architectures = getattr(pretrained_config, "architectures", None) or []
+        if architectures and architectures[0] == "ModelAForCausalLM":
+            return "PYTHON"
+        return None
+
+
+class TestTransceiverRuntimeAutoResolution:
+    """Tests for the transceiver_runtime 'auto' selection mechanism."""
+
+    def _disagg_args(self, backend="NIXL", **cfg_kwargs):
+        return TorchLlmArgs(
+            model="/tmp/dummy_model",
+            cache_transceiver_config=CacheTransceiverConfig(backend=backend,
+                                                            **cfg_kwargs),
+        )
+
+    def test_default_is_auto(self):
+        cfg = CacheTransceiverConfig(backend="NIXL")
+        assert cfg.transceiver_runtime == "auto"
+
+    def test_auto_no_model_preference_falls_back_to_none(self):
+        """'auto' with no model preference resolves to None (C++ transceiver)."""
+        args = self._disagg_args()
+        _resolve_transceiver_runtime_auto(args)
+        assert args.cache_transceiver_config.transceiver_runtime is None
+
+    @pytest.mark.parametrize("explicit_auto", [False, True])
+    def test_model_preference_adopted(self, explicit_auto):
+        """Model preference applies whether 'auto' is implicit or explicit."""
+        cfg_kwargs = {"transceiver_runtime": "auto"} if explicit_auto else {}
+        args = self._disagg_args(**cfg_kwargs)
+        _resolve_transceiver_runtime_auto(args, _PreferPythonTransceiverModel)
+        assert args.cache_transceiver_config.transceiver_runtime == "PYTHON"
+
+    @pytest.mark.parametrize("explicit_runtime", ["CPP", "PYTHON", None])
+    def test_explicit_value_not_overridden_by_model_preference(
+            self, explicit_runtime):
+        """User's explicit transceiver_runtime wins over the model preference."""
+        args = self._disagg_args(transceiver_runtime=explicit_runtime)
+        _resolve_transceiver_runtime_auto(args, _PreferPythonTransceiverModel)
+        assert args.cache_transceiver_config.transceiver_runtime == explicit_runtime
+
+    @pytest.mark.parametrize("backend", ["UCX", "MPI", "MOONCAKE"])
+    def test_python_preference_incompatible_backend_falls_back_to_cpp(
+            self, backend):
+        """Python transceiver requires NIXL; other backends fall back to C++."""
+        args = self._disagg_args(backend=backend)
+        _resolve_transceiver_runtime_auto(args, _PreferPythonTransceiverModel)
+        assert args.cache_transceiver_config.transceiver_runtime is None
+
+    def test_default_backend_resolves_to_nixl_and_adopts_preference(
+            self, monkeypatch):
+        for env_var in ("TRTLLM_USE_NIXL_KVCACHE", "TRTLLM_USE_UCX_KVCACHE",
+                        "TRTLLM_USE_MOONCAKE_KVCACHE",
+                        "TRTLLM_USE_MPI_KVCACHE"):
+            monkeypatch.delenv(env_var, raising=False)
+        args = self._disagg_args(backend="DEFAULT")
+        _resolve_transceiver_runtime_auto(args, _PreferPythonTransceiverModel)
+        assert args.cache_transceiver_config.transceiver_runtime == "PYTHON"
+        # The resolver only peeks at the effective backend; the "DEFAULT"
+        # sentinel is still resolved (with its warning) at transceiver
+        # creation time.
+        assert args.cache_transceiver_config.backend == "DEFAULT"
+
+    def test_default_backend_env_override_falls_back_to_cpp(self, monkeypatch):
+        """DEFAULT + TRTLLM_USE_UCX_KVCACHE=1 means effective UCX -> C++."""
+        monkeypatch.delenv("TRTLLM_USE_NIXL_KVCACHE", raising=False)
+        monkeypatch.setenv("TRTLLM_USE_UCX_KVCACHE", "1")
+        args = self._disagg_args(backend="DEFAULT")
+        _resolve_transceiver_runtime_auto(args, _PreferPythonTransceiverModel)
+        assert args.cache_transceiver_config.transceiver_runtime is None
+
+    def test_disagg_disabled_is_noop(self):
+        """Resolver never creates a config when cache_transceiver_config is None."""
+        args = TorchLlmArgs(model="/tmp/dummy_model")
+        assert args.cache_transceiver_config is None
+        _resolve_transceiver_runtime_auto(args, _PreferPythonTransceiverModel)
+        assert args.cache_transceiver_config is None
+
+    def test_backend_none_is_noop(self):
+        """A config without a backend (disagg off) is left untouched."""
+        args = TorchLlmArgs(
+            model="/tmp/dummy_model",
+            cache_transceiver_config=CacheTransceiverConfig(),
+        )
+        _resolve_transceiver_runtime_auto(args, _PreferPythonTransceiverModel)
+        assert args.cache_transceiver_config.backend is None
+        assert args.cache_transceiver_config.transceiver_runtime == "auto"
+
+    def test_invalid_model_preference_raises(self):
+
+        class _BadModel:
+
+            @classmethod
+            def get_preferred_transceiver_runtime(cls, pretrained_config=None):
+                return "JAVA"
+
+        args = self._disagg_args()
+        with pytest.raises(ValueError, match="JAVA"):
+            _resolve_transceiver_runtime_auto(args, _BadModel)
+
+    @pytest.mark.parametrize("disagg_enabled", [False, True])
+    @pytest.mark.parametrize("transceiver_defaults", [
+        {
+            "transceiver_runtime": "PYTHON"
+        },
+        {
+            "max_tokens_in_buffer": 4096
+        },
+        {
+            "backend": "NIXL"
+        },
+    ])
+    def test_model_defaults_reject_cache_transceiver_config(
+            self, disagg_enabled, transceiver_defaults):
+        """get_model_defaults must never carry cache_transceiver_config.
+
+        The deep-merge could materialize a config in aggregated mode or
+        silently enable a disabled one; the runtime preference belongs to
+        get_preferred_transceiver_runtime().
+        """
+        args = (self._disagg_args() if disagg_enabled else TorchLlmArgs(
+            model="/tmp/dummy_model"))
+        with pytest.raises(ValueError, match="cache_transceiver_config"):
+            apply_model_defaults_to_llm_args(
+                args, {"cache_transceiver_config": transceiver_defaults})
+        if not disagg_enabled:
+            assert args.cache_transceiver_config is None
+
+    def test_model_defaults_reject_transceiver_config_object_form(self):
+        """A Pydantic object value must not bypass the guard either."""
+        args = TorchLlmArgs(model="/tmp/dummy_model")
+        with pytest.raises(ValueError, match="cache_transceiver_config"):
+            apply_model_defaults_to_llm_args(
+                args, {
+                    "cache_transceiver_config":
+                    CacheTransceiverConfig(backend="NIXL",
+                                           transceiver_runtime="PYTHON")
+                })
+        assert args.cache_transceiver_config is None
+
+    def test_model_loader_resolves_auto_without_checkpoint_loader(self):
+        """The checkpoint_loader=None early return must still resolve 'auto'."""
+        from tensorrt_llm._torch.pyexecutor.model_loader import ModelLoader
+        args = self._disagg_args()
+        ModelLoader.load_config_and_apply_defaults("/tmp/dummy_model", args,
+                                                   None)
+        assert args.cache_transceiver_config.transceiver_runtime is None
+
+    @staticmethod
+    def _fake_checkpoint_loader(architectures):
+        from unittest.mock import MagicMock
+        fake_loader = MagicMock()
+        fake_config = MagicMock()
+        fake_config.pretrained_config.architectures = architectures
+        fake_loader.load_config.return_value = fake_config
+        return fake_loader
+
+    def test_model_loader_full_chain_adopts_model_preference(self, monkeypatch):
+        """End-to-end: load config -> resolve model class -> adopt preference."""
+        from tensorrt_llm._torch.pyexecutor import \
+            model_loader as model_loader_mod
+
+        monkeypatch.setattr(
+            model_loader_mod.AutoModelForCausalLM, "_resolve_class",
+            staticmethod(lambda config: _PreferPythonTransceiverModel))
+        fake_loader = self._fake_checkpoint_loader(["NotInMappingForCausalLM"])
+
+        args = self._disagg_args()
+        model_loader_mod.ModelLoader.load_config_and_apply_defaults(
+            "/tmp/dummy_model", args, fake_loader)
+        assert args.cache_transceiver_config.transceiver_runtime == "PYTHON"
+
+    @pytest.mark.parametrize("arch,expected", [
+        ("ModelAForCausalLM", "PYTHON"),
+        ("ModelBForCausalLM", None),
+    ])
+    def test_shared_class_differentiates_per_architecture(
+            self, monkeypatch, arch, expected):
+        """Shared implementation classes differentiate per checkpoint.
+
+        The preference hook receives pretrained_config so one implementation
+        class can vary its answer by architecture.
+        """
+        from tensorrt_llm._torch.pyexecutor import \
+            model_loader as model_loader_mod
+
+        monkeypatch.setattr(
+            model_loader_mod.AutoModelForCausalLM, "_resolve_class",
+            staticmethod(lambda config: _ArchSensitiveTransceiverModel))
+        fake_loader = self._fake_checkpoint_loader([arch])
+
+        args = self._disagg_args()
+        model_loader_mod.ModelLoader.load_config_and_apply_defaults(
+            "/tmp/dummy_model", args, fake_loader)
+        assert args.cache_transceiver_config.transceiver_runtime == expected
+
+    def test_mtp_execution_class_rewrite_keeps_target_preference(
+            self, monkeypatch):
+        """The MTP execution-class rewrite keeps the target's preference.
+
+        _resolve_class may return an execution class (MTP draft); the
+        preference must still follow the checkpoint's original architecture
+        via MODEL_CLASS_MAPPING.
+        """
+        from tensorrt_llm._torch.models.modeling_utils import \
+            MODEL_CLASS_MAPPING
+        from tensorrt_llm._torch.pyexecutor import \
+            model_loader as model_loader_mod
+
+        class _MtpDraftExecutionModel:
+
+            @classmethod
+            def get_model_defaults(cls, llm_args):
+                return {}
+
+            @classmethod
+            def get_preferred_transceiver_runtime(cls, pretrained_config=None):
+                return None
+
+        monkeypatch.setitem(MODEL_CLASS_MAPPING, "FakeTargetForCausalLM",
+                            _PreferPythonTransceiverModel)
+        monkeypatch.setattr(
+            model_loader_mod.AutoModelForCausalLM, "_resolve_class",
+            staticmethod(lambda config: _MtpDraftExecutionModel))
+        fake_loader = self._fake_checkpoint_loader(["FakeTargetForCausalLM"])
+
+        args = self._disagg_args()
+        model_loader_mod.ModelLoader.load_config_and_apply_defaults(
+            "/tmp/dummy_model", args, fake_loader)
+        assert args.cache_transceiver_config.transceiver_runtime == "PYTHON"
+
+    def test_model_loader_full_chain_aggregated_stays_none(self, monkeypatch):
+        """Full chain in aggregated mode: no transceiver config appears."""
+        from tensorrt_llm._torch.pyexecutor import \
+            model_loader as model_loader_mod
+
+        monkeypatch.setattr(
+            model_loader_mod.AutoModelForCausalLM, "_resolve_class",
+            staticmethod(lambda config: _PreferPythonTransceiverModel))
+        fake_loader = self._fake_checkpoint_loader(["NotInMappingForCausalLM"])
+
+        args = TorchLlmArgs(model="/tmp/dummy_model")
+        model_loader_mod.ModelLoader.load_config_and_apply_defaults(
+            "/tmp/dummy_model", args, fake_loader)
+        assert args.cache_transceiver_config is None
+
+    def test_resolve_default_backend_env_priority(self, monkeypatch):
+        env_vars = ("TRTLLM_USE_NIXL_KVCACHE", "TRTLLM_USE_UCX_KVCACHE",
+                    "TRTLLM_USE_MOONCAKE_KVCACHE", "TRTLLM_USE_MPI_KVCACHE")
+        for env_var in env_vars:
+            monkeypatch.delenv(env_var, raising=False)
+        cfg = CacheTransceiverConfig(backend="DEFAULT")
+
+        # No env var set: NIXL fallback.
+        assert cfg._resolve_default_backend() == ("NIXL", None)
+        # Each env var alone, then stacked in reverse priority order: the
+        # higher-priority variable must win.
+        monkeypatch.setenv("TRTLLM_USE_MPI_KVCACHE", "1")
+        assert cfg._resolve_default_backend() == ("MPI",
+                                                  "TRTLLM_USE_MPI_KVCACHE")
+        monkeypatch.setenv("TRTLLM_USE_MOONCAKE_KVCACHE", "1")
+        assert cfg._resolve_default_backend()[0] == "MOONCAKE"
+        monkeypatch.setenv("TRTLLM_USE_UCX_KVCACHE", "1")
+        assert cfg._resolve_default_backend()[0] == "UCX"
+        monkeypatch.setenv("TRTLLM_USE_NIXL_KVCACHE", "1")
+        assert cfg._resolve_default_backend()[0] == "NIXL"
+        # An explicit backend bypasses the env vars entirely.
+        assert CacheTransceiverConfig(
+            backend="UCX")._resolve_default_backend() == ("UCX", None)

--- a/tests/unittest/usage/test_llmapi_config_capture.py
+++ b/tests/unittest/usage/test_llmapi_config_capture.py
@@ -654,6 +654,31 @@ def test_collect_llm_api_config_captures_sampler_type_categorical():
     assert meta["capture_succeeded"] is True
 
 
+def test_collect_llm_api_config_captures_transceiver_runtime_categorical():
+    """transceiver_runtime is a single Optional[Literal] categorical.
+
+    Regression: a two-branch Literal union (Optional[Literal['CPP','PYTHON']]
+    | Literal['auto']) would not unwrap to a top-level Literal, degrading the
+    manifest kind to 'value' and making the sanitizer reject all three
+    strings. Every allowed value plus None must be captured, not excluded.
+    """
+    from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig
+
+    for runtime in ("CPP", "PYTHON", "auto", None):
+        args = TorchLlmArgs(
+            model="/customer/private/Llama",
+            skip_tokenizer_init=True,
+            cache_transceiver_config=CacheTransceiverConfig(
+                backend="NIXL", transceiver_runtime=runtime
+            ),
+        )
+
+        config, meta = _loads_payloads(args)
+
+        assert config["cache_transceiver_config.transceiver_runtime"] == runtime
+        assert meta["capture_succeeded"] is True
+
+
 def test_collect_llm_api_config_redacts_out_of_allowlist_categorical_str():
     """An out-of-allowlist value on a categorical bare-str field is dropped.
 


### PR DESCRIPTION
## Description

Add per-model auto selection for the KV-cache transceiver runtime on the standard PyTorch model-loading path.

- Add `auto` as the default value of `CacheTransceiverConfig.transceiver_runtime`.
- Add `get_preferred_transceiver_runtime()` for models to declare their preferred runtime.
- Preserve explicit user settings (`CPP`, `PYTHON`, or `None`).
- Apply the Python runtime preference only when the effective backend is NIXL.
- Fall back to the C++ transceiver when the model does not provide a preference, the effective backend is incompatible, model resolution is unavailable, or the loading path does not use the standard PyTorch model loader.
- Preserve the original model preference when the resolved execution class is redirected, such as the MTP draft-model path.
- Prevent `get_model_defaults()` from implicitly creating or enabling `cache_transceiver_config`.
- Share DEFAULT backend resolution between runtime selection and transceiver creation.
- Update the telemetry manifest, generated documentation, and related tests.

No model opts into the Python transceiver in this PR, so the effective default remains the C++ transceiver until model-specific migrations are added.

## Model Opt-in

To provide an automatic preference for a model, override `get_preferred_transceiver_runtime()` in its `ForCausalLM` implementation:

```python
@classmethod
def get_preferred_transceiver_runtime(cls, pretrained_config=None):
    return "PYTHON"
```

Valid return values are `"PYTHON"`, `"CPP"`, or `None` (defer to the global default, i.e. the C++ transceiver). Shared implementation classes can inspect `pretrained_config.architectures` to return different preferences for different model architectures.

The user can always override the model preference explicitly:

```yaml
cache_transceiver_config:
  backend: NIXL
  transceiver_runtime: CPP  # CPP, PYTHON, or auto
```

Resolution outcomes:

| User setting      | Model preference | Effective backend | Result                             |
|-------------------|------------------|-------------------|------------------------------------|
| unset / `auto`    | `PYTHON`         | NIXL              | Python transceiver                 |
| unset / `auto`    | `PYTHON`         | UCX/MPI/MOONCAKE  | C++ transceiver (fallback, logged) |
| unset / `auto`    | `None`           | any               | C++ transceiver                    |
| `CPP` / `None`    | any              | any               | C++ transceiver (user wins)        |
| `PYTHON`          | any              | NIXL              | Python transceiver (user wins)     |
| `PYTHON`          | any              | non-NIXL          | Error (unchanged behavior)         |

`auto` only selects the runtime after the user enables `cache_transceiver_config`; it does not enable disaggregated serving by itself. On paths that skip the standard PyTorch model loader (e.g. AutoDeploy), `auto` falls back to the C++ transceiver — in mixed deployments, set `transceiver_runtime` explicitly on both sides to keep them aligned.

The preference must not be declared through `get_model_defaults()`, because model defaults must not create or enable a transceiver configuration (rejected at load time).

With `TLLM_LOG_LEVEL=INFO`, adoption is visible at startup: `Resolved transceiver_runtime='auto' to 'PYTHON' for GptOssForCausalLM.` followed by `Using KvCacheTransceiverV2`.

## Breaking Change

The default value of `CacheTransceiverConfig.transceiver_runtime` changes from `None` (C++ runtime) to `auto`. Existing explicit values (`CPP`, `PYTHON`, and `None`) remain supported. No model opts into the Python runtime in this PR, so the effective runtime still falls back to C++ unless a model-specific preference is added later.

## Test Coverage

```bash
LLM_MODELS_ROOT=/tmp python -m pytest -q tests/unittest/llmapi/test_llm_args.py::TestTransceiverRuntimeAutoResolution

python -m pytest -q tests/unittest/usage/test_llmapi_config_capture.py::test_collect_llm_api_config_captures_transceiver_runtime_categorical

LLM_MODELS_ROOT=<model-root> python -m pytest -q tests/unittest/llmapi/test_llm_args.py tests/unittest/usage/
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatic option for transceiver runtime selection, letting the system choose the best runtime when not set explicitly.
  * Expanded support for an additional runtime value in configuration capture and validation.

* **Bug Fixes**
  * Improved configuration loading so automatic runtime settings are resolved consistently across model setups and checkpoint-based workflows.
  * Prevented model defaults from overriding transceiver configuration in unsupported ways.

* **Documentation**
  * Updated telemetry/configuration docs to reflect the new runtime option and updated field counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->