### PR TITLE
[None][fix] Remove redundant residual bound check in EAGLE3 hidden-state capture

### DIFF
--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -559,11 +559,10 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
                         f"hidden_states={hidden_states.shape[0]}")
                 to_save = hidden_states[:num_tokens]
                 if residual is not None:
-                    if num_tokens > residual.shape[0]:
-                        raise RuntimeError(
-                            "EAGLE3 hidden-state capture token count exceeds "
-                            f"available residual states: num_tokens={num_tokens}, "
-                            f"residual={residual.shape[0]}")
+                    # residual shares its leading (token) dim with hidden_states
+                    # (both come from the same decoder layer), so the bound
+                    # check above already guarantees num_tokens <=
+                    # residual.shape[0]; no separate check is needed.
                     to_save = to_save + residual[:num_tokens]
                 inplace_slice_copy(self.hidden_states, to_save,
                                    i * self.hidden_size,


### PR DESCRIPTION
## Description

Follow-up to review feedback on #15708. During review, @lancelly noted that the `residual` bound check in `Eagle3OneModelSpecMetadata.maybe_capture_hidden_states` is redundant with the preceding `hidden_states` check. This PR removes it.

In every caller, `residual` and `hidden_states` are produced by the **same decoder layer** and therefore share their leading (token) dimension, so once the `num_tokens > hidden_states.shape[0]` check passes, `num_tokens <= residual.shape[0]` is already guaranteed — the residual branch was unreachable dead code. It is replaced with a short comment explaining why no separate check is needed, so it is not re-added.

The two remaining checks are intentionally kept because they guard **different** tensors:
- the buffer-capacity check (`self.hidden_states.shape[0]`) protects the preallocated capture buffer that `inplace_slice_copy` writes into (the overrun the original fix addresses);
- the available-hidden-states check (`hidden_states.shape[0]`) protects the input read.

No behavior change.

## Test Coverage

No new tests. The existing GPU-gated `test_eagle3_one_model_capture_uses_real_token_count` in `tests/unittest/_torch/speculative/test_eagle3.py` exercises the retained residual path (`hidden_states[:4] + residual[:4]`); the removed branch was never reachable, so no test regresses. This is a pure dead-code removal on the CUDA-only `maybe_capture_hidden_states` → `inplace_slice_copy` path, covered by the same CI stages that passed on #15708.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when capturing hidden states during speculative decoding by simplifying internal bounds handling.
  * Reduced the chance of unnecessary runtime checks while preserving safe token-limited copying behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->