### PR TITLE
[None][test] Add coverage for Eagle3ForCausalLM.apply_eagle3_fc

### DIFF
--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -14,6 +14,7 @@ l0_a30:
       backend: pytorch
   tests:
   # ------------- PyTorch tests ---------------
+  - unittest/_torch/modeling/test_modeling_speculative.py::test_apply_eagle3_fc_with_fc_norm
   - unittest/_torch/modeling -k "modeling_nemotron_nas"
   - unittest/_torch/modeling -k "modeling_phi3"
   - unittest/_torch/modeling -k "modeling_qwen"

--- a/tests/unittest/_torch/modeling/test_modeling_speculative.py
+++ b/tests/unittest/_torch/modeling/test_modeling_speculative.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.modules.rms_norm import RMSNorm
+
+
+def _make_eagle3_for_causal_lm(hidden_size, num_capture_layers, dtype):
+    """Build a minimal mock of Eagle3ForCausalLM with fc_norm enabled."""
+    from types import SimpleNamespace
+
+    model = SimpleNamespace()
+    model.dtype = dtype
+    model.hidden_size = hidden_size
+
+    fc_norm_layers = nn.ModuleList(
+        [RMSNorm(hidden_size=hidden_size, eps=1e-5, dtype=dtype) for _ in range(num_capture_layers)]
+    ).cuda()
+    model.fc_norm = fc_norm_layers
+
+    model._norm_before_fc = True
+    model.input_norm = RMSNorm(
+        hidden_size=hidden_size * num_capture_layers, eps=1e-5, dtype=dtype
+    ).cuda()
+
+    fc_linear = nn.Linear(
+        hidden_size * num_capture_layers, hidden_size, bias=False, dtype=dtype
+    ).cuda()
+    model.fc = fc_linear
+
+    obj = SimpleNamespace()
+    obj.model = model
+
+    from tensorrt_llm._torch.models.modeling_speculative import Eagle3ForCausalLM
+
+    obj.apply_eagle3_fc = Eagle3ForCausalLM.apply_eagle3_fc.__get__(obj)
+
+    return obj
+
+
+def test_apply_eagle3_fc_with_fc_norm():
+    hidden_size = 16
+    num_capture_layers = 3
+    dtype = torch.bfloat16
+    batch_size = 2
+
+    obj = _make_eagle3_for_causal_lm(hidden_size, num_capture_layers, dtype)
+
+    hidden_states = torch.randn(
+        batch_size, hidden_size * num_capture_layers, device="cuda", dtype=dtype
+    )
+
+    # Track calls to each fc_norm layer
+    norm_call_inputs = []
+    original_norms = [n for n in obj.model.fc_norm]
+    for i, norm in enumerate(original_norms):
+        orig_forward = norm.forward
+
+        def make_hook(idx, orig_fn):
+            def hooked(x):
+                norm_call_inputs.append((idx, x.clone()))
+                return orig_fn(x)
+
+            return hooked
+
+        norm.forward = make_hook(i, orig_forward)
+
+    # Patch input_norm to detect if it gets called (it should NOT)
+    input_norm_called = []
+    orig_input_norm_forward = obj.model.input_norm.forward
+
+    def input_norm_spy(x):
+        input_norm_called.append(True)
+        return orig_input_norm_forward(x)
+
+    obj.model.input_norm.forward = input_norm_spy
+
+    result = obj.apply_eagle3_fc(hidden_states)
+
+    # fc_norm chunks and normalizes each chunk
+    assert len(norm_call_inputs) == num_capture_layers
+    chunks = hidden_states.chunk(num_capture_layers, dim=-1)
+    for idx, (call_idx, call_input) in enumerate(norm_call_inputs):
+        assert call_idx == idx
+        assert call_input.shape == (batch_size, hidden_size)
+        assert torch.allclose(call_input, chunks[idx], atol=1e-5)
+
+    # input_norm must NOT be called (fc_norm takes precedence over _norm_before_fc)
+    assert len(input_norm_called) == 0
+
+    # Result has correct shape from fc projection
+    assert result.shape == (batch_size, hidden_size)


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Adds regression coverage for behavior introduced in [`1047091fcbd3`](https://github.com/NVIDIA/TensorRT-LLM/commit/1047091fcbd37fcc24800a013e8b257a5596aa98).

`tests/unittest/_torch/modeling/test_modeling_speculative.py::test_apply_eagle3_fc_with_fc_norm` verifies: When config.fc_norm is True, a new ModuleList of per-capture-layer RMSNorm modules is created and applied in apply_eagle3_fc: hidden states are chunked by num_capture_layers, each chunk is independently normalized by its corresponding fc_norm layer, then concatenated before the fc linear projection. This takes priority over the existing _norm_before_fc path.

## Test Coverage

- Test case: `unittest/_torch/modeling/test_modeling_speculative.py::test_apply_eagle3_fc_with_fc_norm`
- Jenkins log: [Jenkins #16](https://prod.blsm.nvidia.com/swqa-tensorrt-qa-test/job/LLM_PATCH_CHECKER/16/) — `SUCCESS`

## Gap Fixer Validation

- Patch review: The patch correctly tests the fc_norm chunking/normalization logic and precedence over _norm_before_fc, with verified API usage and proper CI registration.
- Gap Fixer run: [Job #33](http://nvllm-qa.nvidia.com:9998/jobs/33)

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
