### PR TITLE
[https://nvbugs/6430674][fix] Surgical revert of PR #15838's dispatch guard removal: re-add…

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -408,7 +408,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         (320, 256),
         (576, 512),
     }
-    MISSING_MLA_GENERATION_KERNELS = {
+    SLOWER_MLA_GENERATION_KERNELS = {
         (576, 512, 32),
     }
 
@@ -567,10 +567,10 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
                 f"headDimQk={head_dim_qk}, headDimV={head_dim_v}. Supported: {supported}.",
             )
 
-        if (head_dim_qk, head_dim_v, tokens_per_block) in cls.MISSING_MLA_GENERATION_KERNELS:
+        if (head_dim_qk, head_dim_v, tokens_per_block) in cls.SLOWER_MLA_GENERATION_KERNELS:
             return (
                 False,
-                f"[Generation][MLA] Missing TRTLLM-GEN decode kernel for "
+                f"[Generation][MLA] slower TRTLLM-GEN decode kernel for "
                 f"headDimQk={head_dim_qk}, headDimV={head_dim_v}, "
                 f"tokens_per_block={tokens_per_block}.",
             )

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -408,6 +408,9 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         (320, 256),
         (576, 512),
     }
+    MISSING_MLA_GENERATION_KERNELS = {
+        (576, 512, 32),
+    }
 
     def __init__(self, attn: "TrtllmAttention"):
         super().__init__(attn)
@@ -526,6 +529,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
     def _check_mla_generation_support(
         cls,
         head_size: int,
+        tokens_per_block: int,
         kv_lora_rank: Optional[int],
         qk_rope_head_dim: Optional[int],
     ) -> Tuple[bool, str]:
@@ -561,6 +565,14 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
                 False,
                 f"[Generation][MLA] Unsupported head dimensions: "
                 f"headDimQk={head_dim_qk}, headDimV={head_dim_v}. Supported: {supported}.",
+            )
+
+        if (head_dim_qk, head_dim_v, tokens_per_block) in cls.MISSING_MLA_GENERATION_KERNELS:
+            return (
+                False,
+                f"[Generation][MLA] Missing TRTLLM-GEN decode kernel for "
+                f"headDimQk={head_dim_qk}, headDimV={head_dim_v}, "
+                f"tokens_per_block={tokens_per_block}.",
             )
 
         return True, ""
@@ -755,6 +767,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             if is_mla_enable:
                 supported, reason = self._check_mla_generation_support(
                     head_size=attn.head_dim,
+                    tokens_per_block=tokens_per_block,
                     kv_lora_rank=attn.kv_lora_rank,
                     qk_rope_head_dim=attn.qk_rope_head_dim,
                 )


### PR DESCRIPTION
## Summary
- **Root cause**: PR #15838 removed the MISSING_MLA_GENERATION_KERNELS guard in flashinfer_trtllm_gen.py; R1 MLA at tokens_per_block=32 on Blackwell/FP8-KV now dispatches to a slower kernel path (~6.7% regression).
- **Fix**: Surgical revert of PR #15838's dispatch guard removal: re-add MISSING_MLA_GENERATION_KERNELS={(576,512,32)} and restore tokens_per_block parameter on _check_mla_generation_support and its caller. Other PR #15838 runtime changes are intentionally left intact.
- **Perf metric**: output_token_throughput (higher-is-better)
- **Bad perf**: 5184
- **Good perf**: 5642
- **Perf after fix**: 5624
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6430674


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support checking for MLA generation so unsupported decode-kernel combinations are rejected earlier with a clearer error message.
  * Added coverage for an additional blocked configuration, helping prevent runtime failures for certain model shape and block-size combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->