### PR TITLE
[https://nvbugs/6411873][fix] DSV4: size KV constraint with num_extra_kv_tokens

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -916,7 +916,13 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             # at max_num_tokens (the per-iteration token budget).
             if max_num_tokens is not None:
                 constraints.append(
-                    BatchDesc([KVCacheDesc(capacity=max_num_tokens, history_length=0)])
+                    BatchDesc(
+                        [
+                            KVCacheDesc(
+                                capacity=max_num_tokens + self.num_extra_kv_tokens, history_length=0
+                            )
+                        ]
+                    )
                 )
 
         scratch_reuse_config = None


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

DeepSeek-V4 (sparse attention) disaggregated **context** workers can livelock at startup during KV cache size estimation. The scheduler repeatedly logs `Scheduler could not fit any request this iteration` and never makes progress.

### Root cause

`DeepseekV4CacheManager._build_cache_config` builds a min-slot sizing constraint
for the chunked-prefill / general warmup case:

```python
# Constraint 2: fresh context request at max_num_tokens
BatchDesc([KVCacheDesc(capacity=max_num_tokens, history_length=0)])
```
It uses capacity = max_num_tokens, but at runtime a context request reserves num_tokens + num_extra_kv_tokens (see KVCacheManagerV2.resize_context). Both the sizing path and the runtime allocation path run the same slot formula (compute_scratch_range + ceil(num_scratch * frac_max)); the only difference
is this capacity input.

When max_num_tokens is an exact multiple of tokens_per_block (e.g. 8192 = 64 * 128), the extra num_extra_kv_tokens tokens spill into one more block (ceil(8194/128) = 65 vs 64). The windowed pools (SWA / lightning indexer) are therefore sized one slot short, the first prefill chunk cannot be admitted, and resize_context livelocks on suspend/retry. This is a sizing-input mismatch, not an insufficient KV cache quota.

### Fix

Include num_extra_kv_tokens in the constraint capacity so the estimation
matches the actual runtime allocation:

BatchDesc([KVCacheDesc(capacity=max_num_tokens + self.num_extra_kv_tokens, history_length=0)])

## Test Coverage

Reproduced on a DeepSeek-V4 disaggregated context worker (fp8, TP8/EP8, MTP-3, max_num_tokens=8192, max_seq_len≈39640):

- Before: windowed-pool slot supply [SWA, COMPRESS, INDEXER] = [4, 311, 4] while the first chunk demands [5, 65, 5]; could not fit spams and startup hangs.
- After: supply [5, 311, 5] — exactly the runtime demand; could not fit count is 0 and estimation completes. Unchanged estimation quota (0.3738 GiB), confirming the quota was always sufficient.

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
