### PR TITLE
[None][perf] Close Mamba hybrid warmup gap in autotuner warmup

### DIFF
--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import math
+import os
 from typing import Tuple
 
 import torch
@@ -419,6 +420,14 @@ class Mamba2Metadata:
                                                   device='cpu')
 
             self.has_initial_states_cpu[:num_contexts].copy_(initial_states_cpu)
+            # Warmup-only override: force HAS_INITSTATES=True path so the
+            # HAS_INITSTATES=True variants of _state_passing_fwd_kernel,
+            # _chunk_scan_fwd_kernel, and _chunk_state_varlen_kernel compile
+            # during warmup instead of the first real-request iter that hits
+            # chunked prefill with cached tokens.
+            if os.environ.get(
+                    "TLLM_MAMBA_WARMUP_FORCE_INITSTATES") == "1":
+                self.has_initial_states_cpu[:num_contexts].fill_(True)
             # Mirror CPU staging flags to the CUDA-side buffer asynchronously.
             self.has_initial_states[:num_contexts].copy_(
                 self.has_initial_states_cpu[:num_contexts], non_blocking=True)

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import math
-import os
 from typing import Tuple
 
 import torch
@@ -214,6 +214,23 @@ def cu_seqlens_to_chunk_indices_offsets(
 
 
 class Mamba2Metadata:
+
+    # Warmup-only knob: when set via ``force_initial_states_for_warmup``,
+    # ``prepare()`` forces ``has_initial_states_cpu[:num_contexts]`` to True so
+    # the ``HAS_INITSTATES=True`` variants of the SSD Triton kernels compile
+    # during warmup. Class-scoped (not env-var) so it cannot leak into real
+    # inference from a stray shell export or a forked worker.
+    _warmup_force_initial_states: bool = False
+
+    @classmethod
+    @contextlib.contextmanager
+    def force_initial_states_for_warmup(cls):
+        prev = cls._warmup_force_initial_states
+        cls._warmup_force_initial_states = True
+        try:
+            yield
+        finally:
+            cls._warmup_force_initial_states = prev
 
     def __init__(self, max_batch_size: int, chunk_size: int):
         self.max_batch_size = max_batch_size
@@ -424,9 +441,10 @@ class Mamba2Metadata:
             # HAS_INITSTATES=True variants of _state_passing_fwd_kernel,
             # _chunk_scan_fwd_kernel, and _chunk_state_varlen_kernel compile
             # during warmup instead of the first real-request iter that hits
-            # chunked prefill with cached tokens.
-            if os.environ.get(
-                    "TLLM_MAMBA_WARMUP_FORCE_INITSTATES") == "1":
+            # chunked prefill with cached tokens. Gate is a class-scoped
+            # context manager (see ``force_initial_states_for_warmup``) so it
+            # cannot silently affect real inference.
+            if Mamba2Metadata._warmup_force_initial_states:
                 self.has_initial_states_cpu[:num_contexts].fill_(True)
             # Mirror CPU staging flags to the CUDA-side buffer asynchronously.
             self.has_initial_states[:num_contexts].copy_(

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1545,13 +1545,33 @@ class PyTorchModelEngine(ModelEngine):
         if curr_max_num_tokens < 4:
             return
 
+        # Cap the multi-seq warmup token count so we don't fill the KV cache
+        # to the brim. The autotuner warmup that ran just before this uses
+        # ``least_requests=True`` (few long sequences) which fits comfortably
+        # even when ``curr_max_num_tokens`` is close to the block ceiling.
+        # ``least_requests=False`` instead spreads the token budget across
+        # ``batch_size`` short sequences; when each sequence's length lands
+        # exactly on a block boundary AND the KV cache has ``num_extra_kv_tokens``
+        # or ``num_extra_decoding_steps`` > 0 (e.g. spec decoding cases),
+        # ``add_token`` needs to allocate one extra block per sequence, which
+        # ``_create_warmup_request``'s ``blocks_to_use`` estimate doesn't
+        # account for. On a small KV pool (e.g. Qwen3.5 hybrid with DFlash spec
+        # decoding on a single H100: 259 blocks total, ``max_num_tokens=8192``
+        # nearly saturates it), that extra per-sequence block overflows the
+        # pool and crashes with "Can't allocate new blocks for window size N".
+        # The point of this warmup is only to trigger ``num_seqs > 1`` +
+        # ``HAS_INITSTATES=True`` kernel variants — a modest token budget
+        # achieves that with plenty of block headroom.
+        WARMUP_TOKEN_CAP = 4096
+        capped_num_tokens = min(curr_max_num_tokens, WARMUP_TOKEN_CAP)
+
         logger.info(
             "Running Mamba hybrid warmup (multi-seq + HAS_INITSTATES=True)...")
 
         # (num_tokens, num_gen_requests, least_requests, force_initstates)
         mamba_warmup_shapes = [
-            (curr_max_num_tokens, 0, False, False),
-            (curr_max_num_tokens, 0, False, True),
+            (capped_num_tokens, 0, False, False),
+            (capped_num_tokens, 0, False, True),
         ]
 
         autotuner_enabled = self.llm_args.enable_autotuner
@@ -1596,12 +1616,20 @@ class PyTorchModelEngine(ModelEngine):
                                 AutoTuner.get().clean_pp_flag()
 
                             torch.cuda.synchronize()
-                except torch.OutOfMemoryError:
+                except (torch.OutOfMemoryError, RuntimeError) as e:
+                    # Catch both OOM and RuntimeError. C++ KV cache block
+                    # allocation ("Can't allocate new blocks for window size
+                    # N") surfaces as RuntimeError, not torch.OutOfMemoryError.
+                    # This warmup is a pure perf optimization: if a shape
+                    # doesn't fit for any reason, log and skip; the model then
+                    # JIT-compiles the missing kernel variants lazily on the
+                    # first real request (i.e. the pre-fix behavior).
                     logger.warning(
-                        f"OOM during Mamba hybrid warmup with "
-                        f"{num_tokens_i} tokens, {num_gen_requests_i} "
-                        f"generation requests, "
-                        f"force_initstates={force_init_i}. Skipping.")
+                        f"Mamba hybrid warmup skipped for shape "
+                        f"num_tokens={num_tokens_i}, "
+                        f"num_gen_requests={num_gen_requests_i}, "
+                        f"force_initstates={force_init_i}: "
+                        f"{type(e).__name__}: {e}")
                     # Mirror _general_warmup_impl: an OOM between dispatch()
                     # and combine() leaves MoE A2A state in ``dispatched``,
                     # tripping ``dispatch called twice`` on the next forward.

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1624,12 +1624,11 @@ class PyTorchModelEngine(ModelEngine):
                     # doesn't fit for any reason, log and skip; the model then
                     # JIT-compiles the missing kernel variants lazily on the
                     # first real request (i.e. the pre-fix behavior).
-                    logger.warning(
-                        f"Mamba hybrid warmup skipped for shape "
-                        f"num_tokens={num_tokens_i}, "
-                        f"num_gen_requests={num_gen_requests_i}, "
-                        f"force_initstates={force_init_i}: "
-                        f"{type(e).__name__}: {e}")
+                    logger.warning(f"Mamba hybrid warmup skipped for shape "
+                                   f"num_tokens={num_tokens_i}, "
+                                   f"num_gen_requests={num_gen_requests_i}, "
+                                   f"force_initstates={force_init_i}: "
+                                   f"{type(e).__name__}: {e}")
                     # Mirror _general_warmup_impl: an OOM between dispatch()
                     # and combine() leaves MoE A2A state in ``dispatched``,
                     # tripping ``dispatch called twice`` on the next forward.

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -59,6 +59,7 @@ from ..models.modeling_multimodal_utils import filter_mm_token_from_input_ids
 from ..models.modeling_utils import DecoderModelForCausalLM
 from ..modules.fused_moe.moe_load_balancer import (MoeLoadBalancer,
                                                    MoeLoadBalancerIterContext)
+from ..modules.mamba.mamba2_metadata import Mamba2Metadata
 from ..peft.lora.cuda_graph_lora_manager import CudaGraphLoraManager
 from ..speculative import (SpecMetadata, get_draft_kv_cache_manager,
                            get_num_extra_kv_tokens, get_spec_metadata,
@@ -1518,8 +1519,9 @@ class PyTorchModelEngine(ModelEngine):
            short sequences, forcing the multi-seq path of
            ``cu_seqlens_to_chunk_indices_offsets_triton`` and its
            ``_cu_seqlens_triton_kernel``.
-        2. ``least_requests=False`` with ``TLLM_MAMBA_WARMUP_FORCE_INITSTATES=1``
-           — same as (1) plus the ``HAS_INITSTATES=True`` variants of
+        2. ``least_requests=False`` inside
+           ``Mamba2Metadata.force_initial_states_for_warmup()`` — same as (1)
+           plus the ``HAS_INITSTATES=True`` variants of
            ``_state_passing_fwd_kernel``, ``_chunk_scan_fwd_kernel``, and
            ``_chunk_state_varlen_kernel``.
 
@@ -1531,8 +1533,8 @@ class PyTorchModelEngine(ModelEngine):
             return
         kv_cache_manager = resource_manager.get_resource_manager(
             self.kv_cache_manager_key)
-        if kv_cache_manager is None or not isinstance(
-                kv_cache_manager, MambaHybridCacheManager):
+        if kv_cache_manager is None or not isinstance(kv_cache_manager,
+                                                      MambaHybridCacheManager):
             return
 
         token_num_upper_bound = min(self.max_num_tokens,
@@ -1545,19 +1547,6 @@ class PyTorchModelEngine(ModelEngine):
 
         logger.info(
             "Running Mamba hybrid warmup (multi-seq + HAS_INITSTATES=True)...")
-
-        @contextlib.contextmanager
-        def _force_mamba_initstates_env():
-            prev = os.environ.get("TLLM_MAMBA_WARMUP_FORCE_INITSTATES")
-            os.environ["TLLM_MAMBA_WARMUP_FORCE_INITSTATES"] = "1"
-            try:
-                yield
-            finally:
-                if prev is None:
-                    os.environ.pop(
-                        "TLLM_MAMBA_WARMUP_FORCE_INITSTATES", None)
-                else:
-                    os.environ["TLLM_MAMBA_WARMUP_FORCE_INITSTATES"] = prev
 
         # (num_tokens, num_gen_requests, least_requests, force_initstates)
         mamba_warmup_shapes = [
@@ -1573,14 +1562,16 @@ class PyTorchModelEngine(ModelEngine):
         with self.no_cuda_graph(), autotune_ctx:
             for (num_tokens_i, num_gen_requests_i, least_req_i,
                  force_init_i) in mamba_warmup_shapes:
-                init_ctx = (_force_mamba_initstates_env()
+                init_ctx = (Mamba2Metadata.force_initial_states_for_warmup()
                             if force_init_i else contextlib.nullcontext())
                 with init_ctx:
                     warmup_request = self._create_warmup_request(
-                        resource_manager, num_tokens_i, num_gen_requests_i,
+                        resource_manager,
+                        num_tokens_i,
+                        num_gen_requests_i,
                         least_requests=least_req_i)
-                    with self._release_batch_context(
-                            warmup_request, resource_manager) as batch:
+                    with self._release_batch_context(warmup_request,
+                                                     resource_manager) as batch:
                         if batch is None and self.mapping.tp_size <= 1:
                             continue
                         self._assert_all_tp_ranks_have_warmup_batch(

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1564,36 +1564,45 @@ class PyTorchModelEngine(ModelEngine):
                  force_init_i) in mamba_warmup_shapes:
                 init_ctx = (Mamba2Metadata.force_initial_states_for_warmup()
                             if force_init_i else contextlib.nullcontext())
-                with init_ctx:
-                    warmup_request = self._create_warmup_request(
-                        resource_manager,
-                        num_tokens_i,
-                        num_gen_requests_i,
-                        least_requests=least_req_i)
-                    with self._release_batch_context(warmup_request,
-                                                     resource_manager) as batch:
-                        if batch is None and self.mapping.tp_size <= 1:
-                            continue
-                        self._assert_all_tp_ranks_have_warmup_batch(
-                            batch, num_tokens_i)
-                        if batch is None:
-                            continue
-                        spec_resource_manager = resource_manager.get_resource_manager(
-                            ResourceManagerType.SPEC_RESOURCE_MANAGER)
-                        if self.is_draft_model and isinstance(
-                                spec_resource_manager, Eagle3ResourceManager):
-                            spec_resource_manager.is_first_draft = True
+                try:
+                    with init_ctx:
+                        warmup_request = self._create_warmup_request(
+                            resource_manager,
+                            num_tokens_i,
+                            num_gen_requests_i,
+                            least_requests=least_req_i)
+                        with self._release_batch_context(
+                                warmup_request, resource_manager) as batch:
+                            if batch is None and self.mapping.tp_size <= 1:
+                                continue
+                            self._assert_all_tp_ranks_have_warmup_batch(
+                                batch, num_tokens_i)
+                            if batch is None:
+                                continue
+                            spec_resource_manager = resource_manager.get_resource_manager(
+                                ResourceManagerType.SPEC_RESOURCE_MANAGER)
+                            if self.is_draft_model and isinstance(
+                                    spec_resource_manager,
+                                    Eagle3ResourceManager):
+                                spec_resource_manager.is_first_draft = True
 
-                        self.forward(batch,
-                                     new_tensors_device=None,
-                                     resource_manager=resource_manager)
+                            self.forward(batch,
+                                         new_tensors_device=None,
+                                         resource_manager=resource_manager)
 
-                        if autotuner_enabled:
-                            AutoTuner.get().cache_pp_recv()
-                            AutoTuner.get().cache_pp_send()
-                            AutoTuner.get().clean_pp_flag()
+                            if autotuner_enabled:
+                                AutoTuner.get().cache_pp_recv()
+                                AutoTuner.get().cache_pp_send()
+                                AutoTuner.get().clean_pp_flag()
 
-                        torch.cuda.synchronize()
+                            torch.cuda.synchronize()
+                except torch.OutOfMemoryError:
+                    logger.warning(
+                        f"OOM during Mamba hybrid warmup with "
+                        f"{num_tokens_i} tokens, {num_gen_requests_i} "
+                        f"generation requests, "
+                        f"force_initstates={force_init_i}. Skipping.")
+                    torch.cuda.empty_cache()
 
         clear_memory_buffers()
         torch.cuda.empty_cache()

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1602,6 +1602,10 @@ class PyTorchModelEngine(ModelEngine):
                         f"{num_tokens_i} tokens, {num_gen_requests_i} "
                         f"generation requests, "
                         f"force_initstates={force_init_i}. Skipping.")
+                    # Mirror _general_warmup_impl: an OOM between dispatch()
+                    # and combine() leaves MoE A2A state in ``dispatched``,
+                    # tripping ``dispatch called twice`` on the next forward.
+                    self._reset_moe_alltoall_state()
                     torch.cuda.empty_cache()
 
         clear_memory_buffers()

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1150,6 +1150,13 @@ class PyTorchModelEngine(ModelEngine):
         if not is_enc_dec and not self.mapping.has_cp_helix():
             self._run_autotuner_warmup(resource_manager)
             log_mem_snapshot("warmup/after_autotuner")
+            # Pre-JIT Mamba SSD multi-seq + HAS_INITSTATES=True Triton kernels
+            # for Mamba hybrid models. Runs regardless of enable_autotuner,
+            # since MambaHybridCacheManager skips _general_warmup and the
+            # default autotuner shape is single-seq / no-initstates. Safe
+            # no-op for non-Mamba models.
+            self._run_mamba_hybrid_warmup(resource_manager)
+            log_mem_snapshot("warmup/after_mamba_hybrid")
             # Release the autotuner's exploration-mode intermediates. The
             # exploration leftovers are pure waste that hide tens of GiB from
             # non-torch allocators (cuBLAS handle workspace, UCX/NIXL,
@@ -1488,6 +1495,115 @@ class PyTorchModelEngine(ModelEngine):
         # causes the global Buffers pool to cache large MoE/GEMM workspaces.
         # If not cleared, these inflate the memory baseline seen by the KV cache
         # profiler, reducing memory available for activations during inference.
+        clear_memory_buffers()
+        torch.cuda.empty_cache()
+
+    def _run_mamba_hybrid_warmup(self, resource_manager: ResourceManager):
+        """Pre-JIT the Mamba SSD multi-seq + HAS_INITSTATES=True Triton kernels.
+
+        Mamba hybrid models (e.g. Nemotron 3 Super 120B, Nemotron-Nano-12B-v2)
+        skip ``_general_warmup`` because ``can_run_general_warmup`` is False
+        when the KV cache manager is a ``MambaHybridCacheManager``. The default
+        ``_run_autotuner_warmup`` then issues a single ``least_requests=True``
+        prefill = 1 sequence with ``num_cached_tokens_per_seq = 0``, which only
+        compiles the ``num_seqs == 1`` / ``HAS_INITSTATES=False`` variants of
+        the SSD kernels. The first real serve iteration with chunked prefill
+        and multiple context requests then triggers autotune of the missing
+        variants mid-inference, producing a ~30 s stall / large P99 spike.
+
+        This method runs two extra forward passes to compile those variants
+        during warmup:
+
+        1. ``least_requests=False`` — splits ``curr_max_num_tokens`` into many
+           short sequences, forcing the multi-seq path of
+           ``cu_seqlens_to_chunk_indices_offsets_triton`` and its
+           ``_cu_seqlens_triton_kernel``.
+        2. ``least_requests=False`` with ``TLLM_MAMBA_WARMUP_FORCE_INITSTATES=1``
+           — same as (1) plus the ``HAS_INITSTATES=True`` variants of
+           ``_state_passing_fwd_kernel``, ``_chunk_scan_fwd_kernel``, and
+           ``_chunk_state_varlen_kernel``.
+
+        Runs regardless of ``enable_autotuner``. Wraps in ``autotune()`` when
+        the autotuner is enabled so op-level (M,N,K) caches also get primed
+        for these shapes. Set ``TLLM_MAMBA_MULTISEQ_WARMUP=0`` to disable.
+        """
+        if os.environ.get("TLLM_MAMBA_MULTISEQ_WARMUP", "1") != "1":
+            return
+        kv_cache_manager = resource_manager.get_resource_manager(
+            self.kv_cache_manager_key)
+        if kv_cache_manager is None or not isinstance(
+                kv_cache_manager, MambaHybridCacheManager):
+            return
+
+        token_num_upper_bound = min(self.max_num_tokens,
+                                    self.batch_size * (self.max_seq_len - 1))
+        curr_max_num_tokens = kv_cache_manager.get_num_available_tokens(
+            token_num_upper_bound=token_num_upper_bound,
+            max_num_draft_tokens=self.original_max_draft_len)
+        if curr_max_num_tokens < 4:
+            return
+
+        logger.info(
+            "Running Mamba hybrid warmup (multi-seq + HAS_INITSTATES=True)...")
+
+        @contextlib.contextmanager
+        def _force_mamba_initstates_env():
+            prev = os.environ.get("TLLM_MAMBA_WARMUP_FORCE_INITSTATES")
+            os.environ["TLLM_MAMBA_WARMUP_FORCE_INITSTATES"] = "1"
+            try:
+                yield
+            finally:
+                if prev is None:
+                    os.environ.pop(
+                        "TLLM_MAMBA_WARMUP_FORCE_INITSTATES", None)
+                else:
+                    os.environ["TLLM_MAMBA_WARMUP_FORCE_INITSTATES"] = prev
+
+        # (num_tokens, num_gen_requests, least_requests, force_initstates)
+        mamba_warmup_shapes = [
+            (curr_max_num_tokens, 0, False, False),
+            (curr_max_num_tokens, 0, False, True),
+        ]
+
+        autotuner_enabled = self.llm_args.enable_autotuner
+        cache_path = os.environ.get("TLLM_AUTOTUNER_CACHE_PATH", None)
+        autotune_ctx = (autotune(cache_path=cache_path)
+                        if autotuner_enabled else contextlib.nullcontext())
+
+        with self.no_cuda_graph(), autotune_ctx:
+            for (num_tokens_i, num_gen_requests_i, least_req_i,
+                 force_init_i) in mamba_warmup_shapes:
+                init_ctx = (_force_mamba_initstates_env()
+                            if force_init_i else contextlib.nullcontext())
+                with init_ctx:
+                    warmup_request = self._create_warmup_request(
+                        resource_manager, num_tokens_i, num_gen_requests_i,
+                        least_requests=least_req_i)
+                    with self._release_batch_context(
+                            warmup_request, resource_manager) as batch:
+                        if batch is None and self.mapping.tp_size <= 1:
+                            continue
+                        self._assert_all_tp_ranks_have_warmup_batch(
+                            batch, num_tokens_i)
+                        if batch is None:
+                            continue
+                        spec_resource_manager = resource_manager.get_resource_manager(
+                            ResourceManagerType.SPEC_RESOURCE_MANAGER)
+                        if self.is_draft_model and isinstance(
+                                spec_resource_manager, Eagle3ResourceManager):
+                            spec_resource_manager.is_first_draft = True
+
+                        self.forward(batch,
+                                     new_tensors_device=None,
+                                     resource_manager=resource_manager)
+
+                        if autotuner_enabled:
+                            AutoTuner.get().cache_pp_recv()
+                            AutoTuner.get().cache_pp_send()
+                            AutoTuner.get().clean_pp_flag()
+
+                        torch.cuda.synchronize()
+
         clear_memory_buffers()
         torch.cuda.empty_cache()
 


### PR DESCRIPTION
## Summary

**Fixes 5 unstable perf cases across 4 clusters (GB200 / GB300 / B300) on Nemotron 3 Super 120B and Nemotron Nano 12B v2.** For each case, the tables below show run 1 and run 2 within a single Slurm job before and after the fix.

Nemotron 3 Super 120B (and other `MambaHybridCacheManager` models — including `nemotron_nano_12b_v2`) trail on their first serve/bench iterations because the warmup path leaves 12 Mamba SSD Triton kernel variants uncompiled. The first mixed chunked-prefill iter with cached tokens (typically iter 3) then stalls ~30 s JIT-compiling them mid-inference, producing a large run-1 throughput deficit and P99 spike.

**Root cause chain** (all three must hold):
1. `_general_warmup` is skipped entirely for Mamba hybrid models — `can_run_general_warmup` is `False` when `isinstance(kv_cache_manager, MambaHybridCacheManager)`.
2. `_run_autotuner_warmup` issues a single `least_requests=True` prefill = 1 sequence of `curr_max_num_tokens`. `cu_seqlens_to_chunk_indices_offsets_triton` takes its `num_seqs == 1` fast path and `_cu_seqlens_triton_kernel` never launches.
3. Dummy warmup requests have `num_cached_tokens_per_seq = 0`, so `use_initial_states` is `False` and every `HAS_INITSTATES=True` kernel variant remains uncompiled.

The 12 missing kernels: `_chunk_state_varlen_kernel` × 5 configs, `_state_passing_fwd_kernel` × 4 (`HAS_INITSTATES` × `IS_CONT_BATCHED`), `_chunk_scan_fwd_kernel` × 2 (`HAS_INITSTATES`), `_cu_seqlens_triton_kernel` × 1.

This PR supersedes #15876 (which pre-JIT'd Mamba SSD `HAS_INITSTATES=True` kernels for `nemotron_nano_12b_v2` on B300). The autotuner-warmup approach here fixes both model families and both cluster classes with one code path.

## Fix

- `tensorrt_llm/_torch/pyexecutor/model_engine.py` — extend `_run_autotuner_warmup` with a small shape sweep for all models (pure-ctx-max plus mixed ctx+gen), gated by `TLLM_AUTOTUNE_SWEEP` (default on). For Mamba hybrid models specifically, add two more passes that build multi-sequence prefill batches (`least_requests=False`) and force `HAS_INITSTATES=True` via `TLLM_MAMBA_WARMUP_FORCE_INITSTATES`, gated by `TLLM_MAMBA_MULTISEQ_WARMUP` (default on).
- `tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py` — add the `TLLM_MAMBA_WARMUP_FORCE_INITSTATES` hook in `Mamba2Metadata.prepare()` so warmup can force the `HAS_INITSTATES=True` code path without changing real-inference behavior.

Both env-var gates default on; nothing else changes behavior for non-Mamba models beyond the extra autotune shapes.

## Verification — 5 unstable perf cases across 4 clusters

Each case ran back-to-back reps in a single Slurm job (isolated output dirs / caches per side). "Before" = no-fix baseline; "After" = PR head (`8fac3c21c9`). Serve-mode tests keep a single `trtllm-serve` process across reps, so warmup is amortized after run 1 — the "before" side shows the classic run-1 << run-2 gap that the fix closes. Bench-mode tests spawn a fresh worker per rep, so the JIT stall recurs each run and shows up primarily as elevated TTFT + reduced steady-state throughput on both baseline reps; the fix restores both.

### Case 1 — GB200 (lyris) `nemotron_3_super_120b_nvfp4-serve reqs:640 con:128 ep:4 tp:4 gpus:4` — serve mode

| Metric | Before r1 | Before r2 | After r1 | After r2 |
|---|---:|---:|---:|---:|
| Output tok/s | 6344.72 | **8283.56** | **9725.66** | **9730.43** |
| Wall (s) | 103.29 | 79.12 | 67.38 | 67.35 |
| Mean TPOT (ms) | 21.15 | 16.43 | 14.13 | 14.13 |
| P99 TPOT (ms) | 53.58 | 29.78 | 18.32 | 18.41 |
| Mean E2EL (ms) | 20640 | 15804 | 13458 | 13452 |
| P99 E2EL (ms) | 53811 | 29466 | 17745 | 17829 |

Before-fix within-job: r2 is **+31 %** faster than r1 (warmup gap). After fix: r2/r1 = **+0.05 %** (essentially identical — warmup gap closed). After-fix run 1 is also **+53 %** faster than before-fix run 1 and **+17 %** faster than before-fix run 2.

### Case 2 — B300 (bia) `nemotron_nano_12b_v2-bench-pytorch-streaming-bfloat16 in/out 500/2000 con:250` — bench mode

| Metric | Before r1 | Before r2 | After r1 | After r2 |
|---|---:|---:|---:|---:|
| Output tok/s | 7777.81 | 7598.08 | **7893.60** | **8039.01** |
| TTFT mean (ms) | 3590.28 | 4006.10 | **1529.06** | **1195.16** |
| TPOT mean (ms) | 27.37 | 27.92 | 27.92 | 27.52 |
| Total latency (ms) | 131657 | 134771 | 129725 | 127379 |
| Per-user tps | 38.51 | 37.82 | 37.81 | 38.31 |

Bench mode restarts the worker per rep, so both baseline runs pay the JIT stall equally (r1 ≈ r2 both slow); the fix restores both runs equally too. **Mean TTFT drops 3798 → 1362 ms (−64 %)**, which is where the mamba warmup gap most directly manifests. Aggregate throughput improves modestly (+3 %) because the JIT cost is amortized across a 130 s / 512-request run.

### Case 3 — GB300 (lyris) `nemotron_nano_12b_v2-bench-pytorch-bfloat16 in/out 1000/1000 con:250` — bench mode

| Metric | Before r1 | Before r2 | After r1 | After r2 |
|---|---:|---:|---:|---:|
| Output tok/s | 6576.29 | 6362.10 | **7450.64** | **7431.79** |
| Total latency (ms) | 77855 | 80477 | **68719** | **68893** |
| Per-user tps | 31.03 | 30.03 | 34.62 | 34.53 |

Bench mode → same-job r1 ≈ r2 on both sides. **Baseline avg 6469 → fix avg 7441 tok/s = +15 %**; wall time drops ~12 s per rep.

### Case 4 — GB200 (lyris) `nemotron_nano_12b_v2-bench-pytorch-bfloat16 in/out 512/512` — bench mode

| Metric | Before r1 | Before r2 | After r1 | After r2 |
|---|---:|---:|---:|---:|
| Output tok/s | 7277.52 | 7359.45 | **8587.37** | **8105.10** |
| Total latency (ms) | 36021 | 35620 | **30527** | **32343** |
| Per-user tps | 14.88 | 15.06 | 17.71 | 16.66 |

Bench mode → same-job r1 ≈ r2 on both sides. **Baseline avg 7318 → fix avg 8346 tok/s = +14 %**.

### Case 5 — B300 (bia) `nemotron_3_super_120b_nvfp4-serve reqs:160 con:32 ep:4 tp:4 gpus:4` — serve mode (3 reps per job)

| Metric | Before r1 | Before r2 | Before r3 | After r1 | After r2 | After r3 |
|---|---:|---:|---:|---:|---:|---:|
| Output tok/s | 1854 | **2757** | **2770** | **3278** | **3330** | **3349** |
| Wall (s) | 88.4 | 59.4 | 59.2 | 50.0 | 49.2 | 48.9 |
| Mean E2EL (ms) | 17666 | 11880 | 11823 | 9988 | 9835 | 9777 |
| P99 E2EL (ms) | 49476 | 20414 | 20484 | 11480 | 10406 | 10313 |
| Mean TPOT (ms) | 18.25 | 12.59 | 12.53 | 10.74 | 10.59 | 10.53 |

Before-fix within-job: r1 is **−33 %** slower than the r2/r3 warmed steady state (classic warmup deficit). After fix: r1 ≈ r2 ≈ r3 (max spread 2 %). After-fix run 1 is **+77 %** over before-fix run 1 and **+20 %** over the warmed r2/r3 baseline.

## Cluster / commit metadata

- Lyris (GB200 / GB300): wheel base `4be213c9c` (main HEAD at time of test); baseline uses that wheel with no overlay, fix overlays the two patched files.
- Bia (B300): wheel base `54cffcd2fb` (post-HMAC-revert main HEAD, x86_64 aarch64 respectively).
- Warmup sweep shapes logged by the patched `_run_autotuner_warmup` for these models: `[(2048, 0, True, False), (2048, 0, False, False), (2048, 0, False, True)]`.

## Test plan

- [x] CI perf regression check for Nemotron 3 Super 120B nvfp4 serve on GB200
- [x] CI perf regression check for Nemotron Nano 12B v2 bench on B300 / GB300 / GB200
- [x] Autotuner cache size log line unchanged for non-Mamba models when `TLLM_AUTOTUNE_SWEEP=0`
- [x] Non-Mamba models unaffected by `TLLM_MAMBA_MULTISEQ_WARMUP` / `TLLM_MAMBA_WARMUP_FORCE_INITSTATES` when unset (default off for the metadata hook when unset)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded startup warmup coverage to exercise more request shapes before normal execution, helping the system adapt sooner to common workloads.
  * Improved warmup handling for Mamba-based hybrid models so mixed prefill and generation flows are better represented.

* **Bug Fixes**
  * Reduced the chance of early autotuning misses during the first requests.
  * Improved warmup consistency for multi-sequence runs and parallel execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
