### PR TITLE
[None][perf] Prewarm DeepGEMM paged_mqa_logits_metadata JIT buckets

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1084,6 +1084,15 @@ class PyTorchModelEngine(ModelEngine):
         with self.cuda_graph_runner.allow_capture():
             self._run_cuda_graph_warmup(resource_manager)
         log_mem_snapshot("warmup/after_cuda_graph_capture")
+        # Pre-compile DeepGEMM paged_mqa_logits_metadata for every 32-aligned
+        # batch bucket up to max_batch_size. CUDA-graph warmup only exercises
+        # the batch sizes in cuda_graph_batch_sizes, which round up to a
+        # subset of buckets; any inference iter whose num_generations lands
+        # on an uncovered bucket triggers an nvcc-driven JIT compile
+        # (~3s stall inside _prepare_inputs) on first touch. Pre-touching
+        # every bucket funnels that cost into warmup. No-op on non-DSA models.
+        self._warmup_dg_paged_mqa_logits_metadata()
+        log_mem_snapshot("warmup/after_dg_paged_mqa_logits_metadata")
         if can_run_general_warmup:
             # Pre-populate the memory pool with max-shape allocations to reduce
             # fragmentation at runtime.
@@ -1091,6 +1100,66 @@ class PyTorchModelEngine(ModelEngine):
                 resource_manager)
             self._general_warmup(resource_manager, warmup_requests_configs)
             log_mem_snapshot("warmup/after_memory_pool_prepop")
+
+    def _warmup_dg_paged_mqa_logits_metadata(self) -> None:
+        """Pre-compile the DeepGEMM `smxx_paged_mqa_logits_metadata` kernel
+        for every 32-aligned batch bucket up to `max_batch_size`.
+
+        DSA's `Indexer.prepare_scheduler_metadata` calls
+        `deep_gemm.get_paged_mqa_logits_metadata(context_lens, block_kv,
+        num_sms)` inside `_prepare_inputs` every iteration. The kernel is
+        templated on `kAlignedBatchSize = ceil(num_generations, 32)`, and
+        deep_gemm's Python-side JIT compiles a fresh cubin (spawning
+        nvcc/cicc/ptxas, ~3s on GB300) the first time any bucket is
+        requested. CUDA-graph warmup exercises only the batch sizes in
+        `cuda_graph_batch_sizes`, which round up to a subset of the 32-
+        aligned buckets; every uncovered bucket that the inference
+        workload later touches produces a 3s stall on that iteration.
+        Pre-touching every bucket here funnels those compiles into the
+        deterministic warmup phase.
+
+        Cost: one nvcc invocation per bucket the CUDA-graph warmup didn't
+        already trigger (typically 5-6 extra compiles for max_batch_size
+        512). No-op on non-DSA models.
+        """
+        attn_meta = getattr(self, "attn_metadata", None)
+        if attn_meta is None:
+            return
+        try:
+            from tensorrt_llm._torch.attention_backend.sparse.dsa import (
+                DSAtrtllmAttentionMetadata, _DG_SCHEDULE_BLOCK_KV)
+        except ImportError:
+            return
+        if not isinstance(attn_meta, DSAtrtllmAttentionMetadata):
+            return
+        try:
+            from tensorrt_llm.deep_gemm import get_paged_mqa_logits_metadata
+        except ImportError:
+            logger.info(
+                "[DG warmup] deep_gemm.get_paged_mqa_logits_metadata not "
+                "available; skipping paged_mqa_logits_metadata prewarm.")
+            return
+
+        num_sms = attn_meta.num_sms
+        max_bs = max(1, int(self.batch_size))
+        max_aligned = ((max_bs + 31) // 32) * 32
+        buckets = list(range(32, max_aligned + 32, 32))
+        logger.info(
+            f"[DG warmup] Pre-compiling paged_mqa_logits_metadata for "
+            f"{len(buckets)} aligned batch buckets up to {max_aligned} "
+            f"(block_kv={_DG_SCHEDULE_BLOCK_KV}, num_sms={num_sms})")
+        for aligned_bs in buckets:
+            # Kernel scans `context_lens` and prefix-sums schedules; a
+            # zero-filled 2D tensor of shape (aligned_bs, 1) is enough to
+            # trigger dispatch and compile — the metadata output is
+            # discarded.
+            dummy = torch.zeros(aligned_bs,
+                                1,
+                                dtype=torch.int32,
+                                device="cuda")
+            _ = get_paged_mqa_logits_metadata(dummy, _DG_SCHEDULE_BLOCK_KV,
+                                              num_sms)
+        torch.cuda.synchronize()
 
     def _general_warmup(self, resource_manager: ResourceManager,
                         warmup_requests_configs: List[Tuple[int, int]]):

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1124,10 +1124,19 @@ class PyTorchModelEngine(ModelEngine):
 
         `context_lens.size(0)` is not always `num_generations`. For MTP
         with `use_expanded_buffers_for_mtp=True` the expanded call passes
-        `num_generations * (1 + max_draft_tokens)`, and for DSL expansion
-        it passes `num_generations * dsl_expand_factor`. Bucket range is
-        scaled by the max of these expansion factors so the expanded
-        paths are covered too. No-op on non-DSA models.
+        `num_generations * (1 + max_draft_tokens)`. For DSL expansion the
+        call passes `num_generations * dsl_expand_factor`, where
+        `dsl_expand_factor = next_n // eff` (`eff in kernel_atoms`, see
+        `_pick_dsl_expand` in `dsa.py`); its worst case is
+        `next_n = 1 + max_draft_tokens` when `eff == 1`. Reading the
+        current `dsl_expand_factor` off the metadata would under-estimate
+        the eventual max (it defaults to 1 before any prepare() has run,
+        and per-iter picks can differ across iters when CUDA graph is
+        off), so we use the static upper bound `1 + max_draft_tokens`
+        for both expansion paths. Bucket range is also scaled by
+        `max_beam_width` as a defense-in-depth ceiling for future beam
+        support (no-op today — DSA does not use beam). No-op on non-DSA
+        models.
 
         Best-effort: per-bucket JIT failures are logged and skipped so a
         single broken bucket does not abort PyExecutor startup.
@@ -1152,26 +1161,26 @@ class PyTorchModelEngine(ModelEngine):
 
         num_sms = attn_meta.num_sms
         max_bs = max(1, int(self.batch_size))
-        # Cover the two paths whose `context_lens.size(0)` exceeds
-        # `num_generations`: MTP-expanded (`num_generations * (1 +
-        # max_draft_tokens)`) and DSL-expanded (`num_generations *
-        # dsl_expand_factor`). Both fields are only meaningful on the DSA
-        # metadata; default to 1 when the attribute is missing / disabled.
-        expand_factor = 1
-        if getattr(attn_meta, "use_expanded_buffers_for_mtp", False):
-            expand_factor = max(
-                expand_factor,
-                1 + int(getattr(attn_meta, "max_draft_tokens", 0) or 0))
-        if getattr(attn_meta, "expand_for_dsl", False):
-            expand_factor = max(
-                expand_factor,
-                int(getattr(attn_meta, "dsl_expand_factor", 1) or 1))
-        max_aligned = ((max_bs * expand_factor + 31) // 32) * 32
+        beam_width = max(1, int(getattr(self, "max_beam_width", 1) or 1))
+        # Static upper bound on the row-count multiplier applied to
+        # `context_lens`. Both MTP-expanded and DSL-expanded call sites
+        # are bounded above by `(1 + max_draft_tokens)`; see the
+        # docstring for why we don't read the runtime `dsl_expand_factor`
+        # here.
+        max_draft_tokens = int(
+            getattr(attn_meta, "max_draft_tokens", 0) or 0)
+        expands_batch = (
+            getattr(attn_meta, "use_expanded_buffers_for_mtp", False)
+            or getattr(attn_meta, "expand_for_dsl", False))
+        expand_factor = 1 + max_draft_tokens if expands_batch else 1
+        max_aligned = ((max_bs * beam_width * expand_factor + 31) //
+                       32) * 32
         buckets = list(range(32, max_aligned + 32, 32))
         logger.info(f"[DG warmup] Pre-compiling paged_mqa_logits_metadata for "
                     f"{len(buckets)} aligned batch buckets up to {max_aligned} "
                     f"(block_kv={_DG_SCHEDULE_BLOCK_KV}, num_sms={num_sms}, "
-                    f"max_bs={max_bs}, expand_factor={expand_factor})")
+                    f"max_bs={max_bs}, beam_width={beam_width}, "
+                    f"expand_factor={expand_factor})")
         for aligned_bs in buckets:
             # Kernel scans `context_lens` and prefix-sums schedules; a
             # zero-filled 2D tensor of shape (aligned_bs, 1) is enough to
@@ -1181,7 +1190,10 @@ class PyTorchModelEngine(ModelEngine):
             try:
                 _ = get_paged_mqa_logits_metadata(dummy, _DG_SCHEDULE_BLOCK_KV,
                                                   num_sms)
-            except Exception as e:
+            except RuntimeError as e:
+                # Narrow to RuntimeError so signature drifts in
+                # get_paged_mqa_logits_metadata (TypeError / ValueError)
+                # surface loudly instead of silently degrading perf.
                 logger.warning(
                     f"[DG warmup] paged_mqa_logits_metadata prewarm failed "
                     f"for aligned_bs={aligned_bs} "

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1167,14 +1167,12 @@ class PyTorchModelEngine(ModelEngine):
         # are bounded above by `(1 + max_draft_tokens)`; see the
         # docstring for why we don't read the runtime `dsl_expand_factor`
         # here.
-        max_draft_tokens = int(
-            getattr(attn_meta, "max_draft_tokens", 0) or 0)
-        expands_batch = (
-            getattr(attn_meta, "use_expanded_buffers_for_mtp", False)
-            or getattr(attn_meta, "expand_for_dsl", False))
+        max_draft_tokens = int(getattr(attn_meta, "max_draft_tokens", 0) or 0)
+        expands_batch = (getattr(attn_meta, "use_expanded_buffers_for_mtp",
+                                 False)
+                         or getattr(attn_meta, "expand_for_dsl", False))
         expand_factor = 1 + max_draft_tokens if expands_batch else 1
-        max_aligned = ((max_bs * beam_width * expand_factor + 31) //
-                       32) * 32
+        max_aligned = ((max_bs * beam_width * expand_factor + 31) // 32) * 32
         buckets = list(range(32, max_aligned + 32, 32))
         logger.info(f"[DG warmup] Pre-compiling paged_mqa_logits_metadata for "
                     f"{len(buckets)} aligned batch buckets up to {max_aligned} "

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1102,21 +1102,24 @@ class PyTorchModelEngine(ModelEngine):
             log_mem_snapshot("warmup/after_memory_pool_prepop")
 
     def _warmup_dg_paged_mqa_logits_metadata(self) -> None:
-        """Pre-compile the DeepGEMM `smxx_paged_mqa_logits_metadata` kernel
-        for every 32-aligned batch bucket up to `max_batch_size`.
+        """Pre-compile DeepGEMM's `get_paged_mqa_logits_metadata` helper for
+        every 32-aligned batch bucket up to `max_batch_size`.
 
         DSA's `Indexer.prepare_scheduler_metadata` calls
         `deep_gemm.get_paged_mqa_logits_metadata(context_lens, block_kv,
-        num_sms)` inside `_prepare_inputs` every iteration. The kernel is
-        templated on `kAlignedBatchSize = ceil(num_generations, 32)`, and
-        deep_gemm's Python-side JIT compiles a fresh cubin (spawning
-        nvcc/cicc/ptxas, ~3s on GB300) the first time any bucket is
-        requested. CUDA-graph warmup exercises only the batch sizes in
+        num_sms)` inside `_prepare_inputs` every iteration. The underlying
+        kernel is templated on `kAlignedBatchSize = ceil(num_generations,
+        32)`, and deep_gemm's Python-side JIT compiles a fresh cubin
+        (spawning nvcc/cicc/ptxas, ~3s on GB300) the first time any bucket
+        is requested. CUDA-graph warmup exercises only the batch sizes in
         `cuda_graph_batch_sizes`, which round up to a subset of the 32-
         aligned buckets; every uncovered bucket that the inference
         workload later touches produces a 3s stall on that iteration.
         Pre-touching every bucket here funnels those compiles into the
         deterministic warmup phase.
+
+        Best-effort: per-bucket JIT failures are logged and skipped so a
+        single broken bucket does not abort PyExecutor startup.
 
         Cost: one nvcc invocation per bucket the CUDA-graph warmup didn't
         already trigger (typically 5-6 extra compiles for max_batch_size
@@ -1127,7 +1130,7 @@ class PyTorchModelEngine(ModelEngine):
             return
         try:
             from tensorrt_llm._torch.attention_backend.sparse.dsa import (
-                DSAtrtllmAttentionMetadata, _DG_SCHEDULE_BLOCK_KV)
+                _DG_SCHEDULE_BLOCK_KV, DSAtrtllmAttentionMetadata)
         except ImportError:
             return
         if not isinstance(attn_meta, DSAtrtllmAttentionMetadata):
@@ -1144,21 +1147,24 @@ class PyTorchModelEngine(ModelEngine):
         max_bs = max(1, int(self.batch_size))
         max_aligned = ((max_bs + 31) // 32) * 32
         buckets = list(range(32, max_aligned + 32, 32))
-        logger.info(
-            f"[DG warmup] Pre-compiling paged_mqa_logits_metadata for "
-            f"{len(buckets)} aligned batch buckets up to {max_aligned} "
-            f"(block_kv={_DG_SCHEDULE_BLOCK_KV}, num_sms={num_sms})")
+        logger.info(f"[DG warmup] Pre-compiling paged_mqa_logits_metadata for "
+                    f"{len(buckets)} aligned batch buckets up to {max_aligned} "
+                    f"(block_kv={_DG_SCHEDULE_BLOCK_KV}, num_sms={num_sms})")
         for aligned_bs in buckets:
             # Kernel scans `context_lens` and prefix-sums schedules; a
             # zero-filled 2D tensor of shape (aligned_bs, 1) is enough to
             # trigger dispatch and compile — the metadata output is
             # discarded.
-            dummy = torch.zeros(aligned_bs,
-                                1,
-                                dtype=torch.int32,
-                                device="cuda")
-            _ = get_paged_mqa_logits_metadata(dummy, _DG_SCHEDULE_BLOCK_KV,
-                                              num_sms)
+            dummy = torch.zeros(aligned_bs, 1, dtype=torch.int32, device="cuda")
+            try:
+                _ = get_paged_mqa_logits_metadata(dummy, _DG_SCHEDULE_BLOCK_KV,
+                                                  num_sms)
+            except Exception as e:
+                logger.warning(
+                    f"[DG warmup] paged_mqa_logits_metadata prewarm failed "
+                    f"for aligned_bs={aligned_bs} "
+                    f"(block_kv={_DG_SCHEDULE_BLOCK_KV}, num_sms={num_sms}); "
+                    f"skipping bucket. {type(e).__name__}: {e}")
         torch.cuda.synchronize()
 
     def _general_warmup(self, resource_manager: ResourceManager,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1085,12 +1085,14 @@ class PyTorchModelEngine(ModelEngine):
             self._run_cuda_graph_warmup(resource_manager)
         log_mem_snapshot("warmup/after_cuda_graph_capture")
         # Pre-compile DeepGEMM paged_mqa_logits_metadata for every 32-aligned
-        # batch bucket up to max_batch_size. CUDA-graph warmup only exercises
-        # the batch sizes in cuda_graph_batch_sizes, which round up to a
-        # subset of buckets; any inference iter whose num_generations lands
-        # on an uncovered bucket triggers an nvcc-driven JIT compile
-        # (~3s stall inside _prepare_inputs) on first touch. Pre-touching
-        # every bucket funnels that cost into warmup. No-op on non-DSA models.
+        # batch bucket the runtime can produce (max_batch_size scaled by the
+        # MTP / DSL expansion factor when applicable). CUDA-graph warmup only
+        # exercises the batch sizes in cuda_graph_batch_sizes, which round
+        # up to a subset of buckets; any inference iter whose
+        # context_lens.size(0) lands on an uncovered bucket triggers an
+        # nvcc-driven JIT compile (~3s stall inside _prepare_inputs) on
+        # first touch. Pre-touching every bucket funnels that cost into
+        # warmup. No-op on non-DSA models.
         self._warmup_dg_paged_mqa_logits_metadata()
         log_mem_snapshot("warmup/after_dg_paged_mqa_logits_metadata")
         if can_run_general_warmup:
@@ -1103,14 +1105,16 @@ class PyTorchModelEngine(ModelEngine):
 
     def _warmup_dg_paged_mqa_logits_metadata(self) -> None:
         """Pre-compile DeepGEMM's `get_paged_mqa_logits_metadata` helper for
-        every 32-aligned batch bucket up to `max_batch_size`.
+        every 32-aligned batch bucket the runtime can produce.
 
         DSA's `Indexer.prepare_scheduler_metadata` calls
         `deep_gemm.get_paged_mqa_logits_metadata(context_lens, block_kv,
         num_sms)` inside `_prepare_inputs` every iteration. The underlying
-        kernel is templated on `kAlignedBatchSize = ceil(num_generations,
-        32)`, and deep_gemm's Python-side JIT compiles a fresh cubin
-        (spawning nvcc/cicc/ptxas, ~3s on GB300) the first time any bucket
+        kernel is templated on `<kAlignedBatchSize, split_kv, num_sms>`
+        where `kAlignedBatchSize = align(context_lens.size(0), 32)` and
+        `split_kv` / `num_sms` are fixed for a given (block_kv, device).
+        deep_gemm's Python-side JIT compiles a fresh cubin (spawning
+        nvcc/cicc/ptxas, ~3s on GB300) the first time each `aligned_bs`
         is requested. CUDA-graph warmup exercises only the batch sizes in
         `cuda_graph_batch_sizes`, which round up to a subset of the 32-
         aligned buckets; every uncovered bucket that the inference
@@ -1118,12 +1122,15 @@ class PyTorchModelEngine(ModelEngine):
         Pre-touching every bucket here funnels those compiles into the
         deterministic warmup phase.
 
+        `context_lens.size(0)` is not always `num_generations`. For MTP
+        with `use_expanded_buffers_for_mtp=True` the expanded call passes
+        `num_generations * (1 + max_draft_tokens)`, and for DSL expansion
+        it passes `num_generations * dsl_expand_factor`. Bucket range is
+        scaled by the max of these expansion factors so the expanded
+        paths are covered too. No-op on non-DSA models.
+
         Best-effort: per-bucket JIT failures are logged and skipped so a
         single broken bucket does not abort PyExecutor startup.
-
-        Cost: one nvcc invocation per bucket the CUDA-graph warmup didn't
-        already trigger (typically 5-6 extra compiles for max_batch_size
-        512). No-op on non-DSA models.
         """
         attn_meta = getattr(self, "attn_metadata", None)
         if attn_meta is None:
@@ -1145,11 +1152,26 @@ class PyTorchModelEngine(ModelEngine):
 
         num_sms = attn_meta.num_sms
         max_bs = max(1, int(self.batch_size))
-        max_aligned = ((max_bs + 31) // 32) * 32
+        # Cover the two paths whose `context_lens.size(0)` exceeds
+        # `num_generations`: MTP-expanded (`num_generations * (1 +
+        # max_draft_tokens)`) and DSL-expanded (`num_generations *
+        # dsl_expand_factor`). Both fields are only meaningful on the DSA
+        # metadata; default to 1 when the attribute is missing / disabled.
+        expand_factor = 1
+        if getattr(attn_meta, "use_expanded_buffers_for_mtp", False):
+            expand_factor = max(
+                expand_factor,
+                1 + int(getattr(attn_meta, "max_draft_tokens", 0) or 0))
+        if getattr(attn_meta, "expand_for_dsl", False):
+            expand_factor = max(
+                expand_factor,
+                int(getattr(attn_meta, "dsl_expand_factor", 1) or 1))
+        max_aligned = ((max_bs * expand_factor + 31) // 32) * 32
         buckets = list(range(32, max_aligned + 32, 32))
         logger.info(f"[DG warmup] Pre-compiling paged_mqa_logits_metadata for "
                     f"{len(buckets)} aligned batch buckets up to {max_aligned} "
-                    f"(block_kv={_DG_SCHEDULE_BLOCK_KV}, num_sms={num_sms})")
+                    f"(block_kv={_DG_SCHEDULE_BLOCK_KV}, num_sms={num_sms}, "
+                    f"max_bs={max_bs}, expand_factor={expand_factor})")
         for aligned_bs in buckets:
             # Kernel scans `context_lens` and prefix-sums schedules; a
             # zero-filled 2D tensor of shape (aligned_bs, 1) is enough to


### PR DESCRIPTION
## Description

DSA's `Indexer.prepare_scheduler_metadata` (`tensorrt_llm/_torch/attention_backend/sparse/dsa.py`) calls `deep_gemm.get_paged_mqa_logits_metadata(context_lens, block_kv, num_sms)` on every iteration inside `_prepare_inputs`. The underlying kernel `deep_gemm::sched::smxx_paged_mqa_logits_metadata` is templated on `kAlignedBatchSize = ceil(num_generations, 32)`, and deep_gemm's Python-side JIT (`deep_gemm_cpp_tllm.so`) compiles a fresh cubin — spawning `nvcc` → `cicc` → `ptxas` — the first time each bucket is requested (~3s per bucket on Blackwell).

CUDA-graph warmup exercises only the batch sizes in `cuda_graph_batch_sizes`. On a typical `max_batch_size=512` config, those round up to only `{32, 64, 96, 128, 192, 256, 320, 384, 448, 512}` — leaving `{160, 224, 288, 352, 416, 480}` uncompiled. Any inference iter whose `num_generations` lands on an uncovered bucket eats a ~3s stall inside `_prepare_inputs` on first touch, and the stall repeats every time a fresh container process starts (the JIT cache is either process-local `LruCache` or an on-disk cache at `$DG_JIT_CACHE_DIR`, which defaults to a container-ephemeral path).

### Observed behavior (before fix)

**Case A — DeepSeek V3.2 FP4 `ep:4-gpus:4` on lyris GB300 (SM103 aarch64, num_sms=152):**

| rep | total_token_throughput (tok/s) |
|---:|---:|
| 1 (fresh container) | 6,494 |
| 2 (same container) | 10,730 |
| 3 (same container) | 10,727 |

**Case B — DeepSeek V3.2 FP4 `ep:8-gpus:8` on bia B300 (SM103 x86_64, num_sms=148):**

| rep | total_token_throughput (tok/s) |
|---:|---:|
| 1 (fresh container) | 4,233 |
| 2 (same container) | 9,761 |
| 3 (same container) | 9,749 |

nsys of Case A rep 1 iters 140-150 (`TLLM_PROFILE_START_STOP=140-150`):

| iter | `_prepare_inputs` | `_forward_step` |
|---:|---:|---:|
| 140 | **3,092 ms** | 388 ms |
| 141 | 22 ms | 501 ms |
| 142 | 21 ms | 416 ms |
| 143 | 22 ms | 430 ms |
| 144 | **3,144 ms** | 422 ms |
| 145 | 21 ms | 392 ms |
| 149 | **3,158 ms** | 416 ms |

`num_generations` at slow iters: 139 (→ aligned 160), 198 (→ 224), 268 (→ 288) — exactly the buckets warmup missed. CPU sampling during the stalls is dominated by `nvvm/bin/cicc` (14,932 samples across the 3 slow iters), `cc1plus`, `nvcc`, `ptxas` — the deep_gemm Python-side JIT firing on first touch. Warm autotuner / TorchInductor / CuTe DSL persistent caches all had no effect (verified by bisection); only `$DG_JIT_CACHE_DIR` populated the missing cubins.

### Fix

After `_run_cuda_graph_warmup`, call `get_paged_mqa_logits_metadata` for every 32-aligned batch bucket up to `max_batch_size` using a zero-filled dummy `context_lens` tensor. This funnels the missing compiles into the deterministic warmup phase.

- **Scope**: `_torch/pyexecutor/model_engine.py` — one new method (`_warmup_dg_paged_mqa_logits_metadata`) plus one call site after CUDA-graph warmup. Guarded on `isinstance(self.attn_metadata, DSAtrtllmAttentionMetadata)`, so it is a strict no-op on non-DSA models.
- **Cost**: one `nvcc` invocation per bucket the CUDA-graph warmup didn't already trigger (typically 5-6 extra compiles for `max_batch_size=512`), added to warmup wall-clock (~15-30s). No runtime cost.
- **Benefit**: eliminates the per-fresh-process 3s stalls at first-touch iters.

### Test Coverage

Validated on two DeepSeek V3.2 FP4 workloads across two different clusters and two different topologies:

**Case A — lyris GB300, `ep:4-gpus:4`** (empty `$DG_JIT_CACHE_DIR`, so rep 1 cannot cheat via disk):

| rep | total_token_throughput (tok/s) |
|---:|---:|
| 1 (patched) | **10,516** |
| 2 (patched) | 10,360 |

Rep2/Rep1: 0.99× (down from 1.65× / +62% rep-1 recovery).

**Case B — bia B300, `ep:8-gpus:8`** (fresh container, wheel reuse across baseline/patched):

| rep | total_token_throughput (tok/s) |
|---:|---:|
| 1 (patched) | **9,793** |
| 2 (patched) | 9,743 |
| 3 (patched) | 9,786 |

Rep2/Rep1: 0.99× (down from 2.31× / +131% rep-1 recovery). CV across 3 reps: 0.24% (down from ~40%).

Both runs show identical warmup evidence in bench logs:
```
[TRT-LLM] [I] [_torch][RANK 0] [DG warmup] Pre-compiling paged_mqa_logits_metadata for 16 aligned batch buckets up to 512 (block_kv=64, num_sms={148,152})
```

The existing `perf-sanity` DSA tests (e.g. `deepseek_v3.2_fp4-...ep:{4,8}-gpus:{4,8}`) exercise this code path; the fix should show up as improved / more stable first-rep throughput on any DSA benchmark that reports rep-1 numbers.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of my knowledge.
- [x] No API changes.
- [x] No new dependencies.
