### PR TITLE
[None][feat] Integrate KVCMv2 `commit_min_snapshot` in runtime

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -19,7 +19,11 @@ from typing import Dict, List, Optional, Tuple
 import torch
 
 from tensorrt_llm._torch.pyexecutor import llm_request
-from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import GPU_LEVEL, KVCacheManagerV2
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import (
+    GPU_LEVEL,
+    BlockReusePolicy,
+    KVCacheManagerV2,
+)
 from tensorrt_llm._utils import (
     TensorWrapper,
     convert_to_torch_tensor,
@@ -937,7 +941,12 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             vocab_size=vocab_size,
             cache_tiers=cache_tiers,
             max_util_for_resume=kv_cache_config.max_util_for_resume,
+            enable_partial_reuse=kv_cache_config.enable_partial_reuse,
             swa_scratch_reuse=scratch_reuse_config,
+            commit_min_snapshot=(
+                kv_cache_config.enable_block_reuse
+                and self.block_reuse_policy != BlockReusePolicy.ALL_REUSABLE
+            ),
             layers=layers,
             typical_step=typical_step,
             constraints=constraints,

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1547,8 +1547,13 @@ class KVCacheManagerV2(BaseResourceManager):
             vocab_size=vocab_size,
             cache_tiers=cache_tiers,
             max_util_for_resume=kv_cache_config.max_util_for_resume,
+            enable_partial_reuse=kv_cache_config.enable_partial_reuse,
             enable_stats=self.enable_stats,
             swa_scratch_reuse=scratch_reuse_config,
+            commit_min_snapshot=(
+                kv_cache_config.enable_block_reuse
+                and self.block_reuse_policy != BlockReusePolicy.ALL_REUSABLE
+            ),
             initial_pool_ratio=kv_cache_config.pool_ratio,
             layers=layer_configs,
         )
@@ -2749,6 +2754,8 @@ class KVCacheManagerV2(BaseResourceManager):
                 start=kv_cache.num_committed_tokens,
                 end=request.context_current_position,
             )
+            # TODO: On a disaggregated prefill server, pass is_end=True for
+            # the last context chunk to improve performance.
             kv_cache.commit(tokens)
         if request.context_remaining_length == 0:
             kv_cache.stop_committing()

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -35,13 +35,18 @@ from tensorrt_llm._torch.disaggregation.resource.kv_extractor import (
 from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.pyexecutor._util import CacheCost
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestState
+from tensorrt_llm._torch.pyexecutor.resource_manager import BlockReusePolicy
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm._utils import binding_to_torch_dtype
 from tensorrt_llm.bindings import DataType, SamplingConfig
 from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
 from tensorrt_llm.llmapi.llm_args import DeepSeekV4SparseAttentionConfig, KvCacheConfig
 from tensorrt_llm.mapping import Mapping
-from tensorrt_llm.runtime.kv_cache_manager_v2 import GpuCacheTierConfig, PageIndexMode
+from tensorrt_llm.runtime.kv_cache_manager_v2 import (
+    GpuCacheTierConfig,
+    KVCacheManagerConfig,
+    PageIndexMode,
+)
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX
 
 _RequestCache = Dict[
@@ -189,7 +194,8 @@ def _build_deepseek_v4_cache_config_for_test(
     max_seq_len: int = 1024,
     max_num_tokens: int | None = 2048,
     max_draft_len: int = 0,
-):
+    is_draft: bool = False,
+) -> KVCacheManagerConfig:
     cache_manager = object.__new__(DeepseekV4CacheManager)
     cache_manager.pp_layers = [0, 1, 2]
     cache_manager._compress_ratios = [1, 4, 128]
@@ -207,6 +213,8 @@ def _build_deepseek_v4_cache_config_for_test(
     cache_manager.enable_stats = False
     cache_manager.enable_swa_scratch_reuse = False
     cache_manager.num_extra_kv_tokens = 0
+    cache_manager.block_reuse_policy = BlockReusePolicy(kv_cache_config.block_reuse_policy)
+    cache_manager.is_draft = is_draft
 
     return cache_manager._build_cache_config(
         kv_cache_config,
@@ -251,6 +259,43 @@ def test_deepseek_v4_avg_seq_len_must_not_exceed_max_seq_len():
             KvCacheConfig(avg_seq_len=2048),
             max_seq_len=1024,
         )
+
+
+@pytest.mark.parametrize(
+    ("enable_block_reuse", "block_reuse_policy", "is_draft", "commit_min_snapshot"),
+    [
+        (True, "all_reusable", False, False),
+        (True, "per_request", False, True),
+        (False, "per_request", False, False),
+        (True, "per_request", True, True),
+    ],
+)
+def test_deepseek_v4_commit_min_snapshot_follows_block_reuse_policy(
+    enable_block_reuse: bool,
+    block_reuse_policy: str,
+    is_draft: bool,
+    commit_min_snapshot: bool,
+) -> None:
+    config = _build_deepseek_v4_cache_config_for_test(
+        KvCacheConfig(
+            enable_block_reuse=enable_block_reuse,
+            block_reuse_policy=block_reuse_policy,
+            enable_partial_reuse=True,
+        ),
+        is_draft=is_draft,
+    )
+
+    assert config.commit_min_snapshot is commit_min_snapshot
+    assert config.enable_partial_reuse
+
+
+@pytest.mark.parametrize("enable_partial_reuse", [False, True])
+def test_deepseek_v4_propagates_partial_reuse_config(enable_partial_reuse: bool) -> None:
+    config = _build_deepseek_v4_cache_config_for_test(
+        KvCacheConfig(enable_partial_reuse=enable_partial_reuse)
+    )
+
+    assert config.enable_partial_reuse is enable_partial_reuse
 
 
 @pytest.fixture(params=[False, True], ids=["scratch_reuse_disabled", "scratch_reuse_enabled"])

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -34,8 +34,8 @@ from tensorrt_llm._torch.disaggregation.resource.kv_extractor import (
 )
 from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.pyexecutor._util import CacheCost
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import BlockReusePolicy
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestState
-from tensorrt_llm._torch.pyexecutor.resource_manager import BlockReusePolicy
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm._utils import binding_to_torch_dtype
 from tensorrt_llm.bindings import DataType, SamplingConfig

--- a/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
@@ -1,27 +1,94 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from types import SimpleNamespace
 
-from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
+import pytest
+
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import BlockReusePolicy, KVCacheManagerV2
+from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+from tensorrt_llm.runtime.kv_cache_manager_v2 import GpuCacheTierConfig, KVCacheManagerConfig
 
 
 class _FakeKVCache:
-    def __init__(self, num_committed_tokens: int):
+    def __init__(self, num_committed_tokens: int) -> None:
         self.num_committed_tokens = num_committed_tokens
-        self.committed_tokens = None
+        self.committed_tokens: list[int] | None = None
         self.stopped_committing = False
 
-    def commit(self, tokens):
+    def commit(self, tokens: list[int]) -> None:
         self.committed_tokens = tokens
         self.num_committed_tokens += len(tokens)
 
-    def stop_committing(self):
+    def stop_committing(self) -> None:
         self.stopped_committing = True
 
 
-def test_try_commit_blocks_commits_uncommitted_tokens_and_stops_at_context_end():
+def _build_cache_config_for_test(
+    kv_cache_config: KvCacheConfig, *, is_draft: bool = False
+) -> KVCacheManagerConfig:
+    cache_manager = object.__new__(KVCacheManagerV2)
+    cache_manager.kv_cache_type = CacheTypeCpp.SELFKONLY
+    cache_manager.head_dim_per_layer = [128]
+    cache_manager.enable_swa_scratch_reuse = False
+    cache_manager.num_extra_kv_tokens = 0
+    cache_manager.enable_stats = False
+    cache_manager.block_reuse_policy = BlockReusePolicy(kv_cache_config.block_reuse_policy)
+    cache_manager.is_draft = is_draft
+    cache_manager.num_local_layers = 1
+    cache_manager.pp_layers = [0]
+    cache_manager.max_attention_window_vec = [None]
+    cache_manager.get_layer_bytes_per_token = lambda **_: 128
+
+    return cache_manager._build_cache_config(
+        kv_cache_config,
+        tokens_per_block=128,
+        vocab_size=129280,
+        cache_tiers=[GpuCacheTierConfig(quota=1 << 30)],
+    )
+
+
+@pytest.mark.parametrize(
+    ("enable_block_reuse", "block_reuse_policy", "is_draft", "commit_min_snapshot"),
+    [
+        (True, "all_reusable", False, False),
+        (True, "per_request", False, True),
+        (False, "per_request", False, False),
+        (True, "per_request", True, True),
+    ],
+)
+def test_commit_min_snapshot_follows_block_reuse_policy(
+    enable_block_reuse: bool,
+    block_reuse_policy: str,
+    is_draft: bool,
+    commit_min_snapshot: bool,
+) -> None:
+    config = _build_cache_config_for_test(
+        KvCacheConfig(
+            enable_block_reuse=enable_block_reuse,
+            block_reuse_policy=block_reuse_policy,
+            enable_partial_reuse=True,
+        ),
+        is_draft=is_draft,
+    )
+
+    assert config.commit_min_snapshot is commit_min_snapshot
+    assert config.enable_partial_reuse
+
+
+@pytest.mark.parametrize("enable_partial_reuse", [False, True])
+def test_propagates_partial_reuse_config(enable_partial_reuse: bool) -> None:
+    config = _build_cache_config_for_test(KvCacheConfig(enable_partial_reuse=enable_partial_reuse))
+
+    assert config.enable_partial_reuse is enable_partial_reuse
+
+
+def test_try_commit_blocks_commits_partial_block_at_context_end() -> None:
     request = SimpleNamespace(
         py_request_id=1,
         is_dummy_request=False,
-        context_current_position=8,
+        context_current_position=10,
         context_remaining_length=0,
         get_tokens=lambda beam_id: list(range(10)),
     )
@@ -34,6 +101,6 @@ def test_try_commit_blocks_commits_uncommitted_tokens_and_stops_at_context_end()
 
     manager.try_commit_blocks(request)
 
-    assert kv_cache.committed_tokens == [4, 5, 6, 7]
-    assert kv_cache.num_committed_tokens == 8
+    assert kv_cache.committed_tokens == [4, 5, 6, 7, 8, 9]
+    assert kv_cache.num_committed_tokens == 10
     assert kv_cache.stopped_committing

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -325,7 +325,7 @@ class TestKVCacheManagerV2(unittest.TestCase):
         tokens_per_block: int = 32,
         kv_buf_size: int = 8192,
         block_quant_buf_size: int | None = None,
-    ):
+    ) -> None:
         self.cfg = create_config(
             tokens_per_block,
             gpu_quota,
@@ -1905,6 +1905,10 @@ class TestSSMSupport(unittest.TestCase):
         kv4.commit(prompt[:48])
         self.assertEqual(kv4.num_committed_tokens, 48)
         kv4.close()
+
+    def test_ssm_reuse_config_allows_partial_reuse(self) -> None:
+        config = self._make_ssm_config(enable_partial_reuse=True)
+        self.assertTrue(config.enable_partial_reuse)
 
     def test_ssm_reuse_config_validation(self) -> None:
         """SSM reuse requires commit_min_snapshot."""

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_stats_behavior.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_stats_behavior.py
@@ -114,13 +114,14 @@ def _create_manager(
     num_layers: int = 1,
     max_attention_window: list[int] | None = None,
     enable_block_reuse: bool = True,
+    enable_partial_reuse: bool = True,
     block_reuse_policy: str = "all_reusable",
     enable_stats: bool = True,
 ) -> KVCacheManagerV2:
     return KVCacheManagerV2(
         KvCacheConfig(
             enable_block_reuse=enable_block_reuse,
-            enable_partial_reuse=True,
+            enable_partial_reuse=enable_partial_reuse,
             max_gpu_total_bytes=gpu_bytes,
             max_util_for_resume=1.0,
             max_attention_window=max_attention_window,
@@ -515,6 +516,7 @@ def test_all_reusable_policy_commits_each_context_chunk(resource_guard) -> None:
     manager = resource_guard(
         _create_manager(gpu_bytes=8 << 20, block_reuse_policy="all_reusable"), request
     )
+    assert not manager.kv_cache_manager_py_config.commit_min_snapshot
 
     assert manager.prepare_context(request)
     assert manager.resize_context(request, num_tokens=4)
@@ -530,8 +532,13 @@ def test_all_reusable_policy_commits_each_context_chunk(resource_guard) -> None:
 def test_per_request_policy_delays_commit_until_last_context_chunk(resource_guard) -> None:
     request = _StatsRequest(1, list(range(8)), context_remaining_length=8)
     manager = resource_guard(
-        _create_manager(gpu_bytes=8 << 20, block_reuse_policy="per_request"), request
+        _create_manager(
+            gpu_bytes=8 << 20,
+            block_reuse_policy="per_request",
+        ),
+        request,
     )
+    assert manager.kv_cache_manager_py_config.commit_min_snapshot
 
     assert manager.prepare_context(request)
     assert manager.resize_context(request, num_tokens=4)
@@ -552,6 +559,52 @@ def test_per_request_policy_delays_commit_until_last_context_chunk(resource_guar
 
     assert kv_cache.num_committed_tokens == 8
     assert kv_cache.history_length == 8
+
+
+def test_per_request_policy_commits_partial_final_context_chunk(resource_guard) -> None:
+    request = _StatsRequest(1, list(range(6)), context_remaining_length=6)
+    manager = resource_guard(
+        _create_manager(
+            gpu_bytes=8 << 20,
+            block_reuse_policy="per_request",
+        ),
+        request,
+    )
+
+    assert manager.prepare_context(request)
+    assert manager.resize_context(request, num_tokens=6)
+    _finish_context(manager, request)
+
+    kv_cache = manager.kv_cache_map[request.py_request_id]
+    assert kv_cache.num_committed_tokens == request.prompt_len
+    assert kv_cache.history_length == request.prompt_len
+
+
+@pytest.mark.parametrize(
+    ("enable_partial_reuse", "expected_reused_tokens"), [(False, 8), (True, 9)]
+)
+def test_v2_propagates_partial_reuse_config(
+    resource_guard, enable_partial_reuse: bool, expected_reused_tokens: int
+) -> None:
+    warmup_request = _StatsRequest(1, list(range(12)), context_remaining_length=12)
+    reuse_request = _StatsRequest(2, list(range(10)), context_remaining_length=10)
+    manager = resource_guard(
+        _create_manager(
+            gpu_bytes=8 << 20,
+            enable_partial_reuse=enable_partial_reuse,
+        ),
+        warmup_request,
+        reuse_request,
+    )
+    assert manager.kv_cache_manager_py_config.enable_partial_reuse is enable_partial_reuse
+
+    assert manager.prepare_context(warmup_request)
+    assert manager.resize_context(warmup_request, num_tokens=12)
+    _finish_context(manager, warmup_request)
+    manager.free_resources(warmup_request)
+
+    assert manager.prepare_context(reuse_request)
+    assert reuse_request.prepopulated_prompt == (expected_reused_tokens, TOKENS_PER_BLOCK)
 
 
 def test_v2_generation_alloc_updates_request_metrics_unlike_v1(resource_guard) -> None:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring partial KV-cache reuse.
  * Improved block-reuse behavior so eligible partial context blocks can be committed.
  * Added policy-aware snapshot commit handling for cache reuse configurations.
* **Bug Fixes**
  * Corrected propagation of cache reuse settings across supported cache managers.
* **Tests**
  * Expanded coverage for partial reuse, block-reuse policies, snapshot commits, and SSM configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Integrate `commit_min_snapshot` support for SSM reuse from #15752 and connect it to the KV cache manager V2 block-reuse policies.

The cache manager now commits a minimal SSM snapshot when block reuse is enabled for policies other than `all_reusable`, propagates partial-reuse configuration, and handles the final context commit path. The change includes coverage for SSM/SWA reuse, partial-page commits, cache statistics, DeepSeek V4 sparse cache configuration, and V2 reuse-policy selection.

## Test Coverage

- Pre-commit hooks passed for both commits.
- `python3 -m py_compile` passed for the directly modified Python implementation and test files.
- Targeted pytest files were not run locally because the current environment does not have `pytest` installed.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
