### PR TITLE
[https://nvbugs/6402018][fix] Defer DeepGEMM PDL init to MoE construction to preserve KV cache

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_deepgemm.py
@@ -27,7 +27,8 @@ from tensorrt_llm.models.modeling_utils import QuantAlgo
 from ...distributed import allgather
 from ...memory_buffer_utils import get_memory_buffers
 from ...model_config import ModelConfig
-from ...utils import AuxStreamType, EventType, Fp4QuantizedTensor
+from ...utils import (AuxStreamType, EventType, Fp4QuantizedTensor,
+                      configure_deep_gemm_pdl)
 from .fused_moe_cutlass import CutlassFusedMoE
 from .interface import AlltoallMethodType
 from .quantization import (DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm,
@@ -802,6 +803,8 @@ class DeepGemmFusedMoE(CutlassFusedMoE):
         init_load_balancer: bool = True,
         without_comm: bool = False,
     ):
+        configure_deep_gemm_pdl()
+
         # moe_max_num_tokens is set in ModelConfig.__post_init__ if not specified
         # The default value is max_num_tokens * dp_size
         # For DeepGemm, we need to limit moe_max_num_tokens to avoid OOM

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -34,7 +34,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.models.modeling_utils import QuantAlgo
 
 from ....model_config import ModelConfig
-from ....utils import ActivationType, AuxStreamType
+from ....utils import ActivationType, AuxStreamType, configure_deep_gemm_pdl
 from ..interface import MoE, MoESchedulerKind, MoEWeightLoadingMode
 from ..quantization import (
     W4A8MXFP4MXFP8MegaMoEDeepGemmMethod,
@@ -211,6 +211,7 @@ class MegaMoEDeepGemm(MoE):
         fast_math: bool = True,
         **kwargs,
     ) -> None:
+        configure_deep_gemm_pdl()
         super().__init__(
             routing_method=routing_method,
             num_experts=num_experts,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -226,20 +226,6 @@ def _filter_cuda_graph_seq_lens(cuda_graph_seq_lens: list[int],
     return result
 
 
-_DEEP_GEMM_PDL_CONFIGURED = False
-
-
-def _configure_deep_gemm_pdl() -> None:
-    global _DEEP_GEMM_PDL_CONFIGURED
-    if _DEEP_GEMM_PDL_CONFIGURED:
-        return
-
-    from tensorrt_llm import deep_gemm
-
-    deep_gemm.set_pdl(os.environ.get("TRTLLM_ENABLE_PDL", "1") == "1")
-    _DEEP_GEMM_PDL_CONFIGURED = True
-
-
 class PyTorchModelEngine(ModelEngine):
 
     def __init__(
@@ -259,8 +245,6 @@ class PyTorchModelEngine(ModelEngine):
         model_weights_memory_tag: Optional[str] = None,
         model_weights_restore_mode=None,
     ):
-        _configure_deep_gemm_pdl()
-
         self.forward_pass_callable = None
         self.ub_buffers = None
         if llm_args.encode_only and llm_args.mm_encoder_only:

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -643,3 +643,18 @@ def torch_multi_arange(
     seq = seq.repeat_interleave(seq_repeats, output_size=output_length_arg)
     seq = seq.cumsum(0, dtype=ends.dtype)
     return seq
+
+
+_DEEP_GEMM_PDL_CONFIGURED = False
+
+
+def configure_deep_gemm_pdl() -> None:
+    # Deferred until first DeepGEMM-backed op init: set-time reserves
+    # a workspace that would otherwise shrink KV-cache HBM on non-DG
+    # workloads.
+    global _DEEP_GEMM_PDL_CONFIGURED
+    if _DEEP_GEMM_PDL_CONFIGURED:
+        return
+    from tensorrt_llm import deep_gemm
+    deep_gemm.set_pdl(os.environ.get("TRTLLM_ENABLE_PDL", "1") == "1")
+    _DEEP_GEMM_PDL_CONFIGURED = True


### PR DESCRIPTION
## Summary
- **Root cause**: `PyTorchModelEngine.__init__` unconditionally called `_configure_deep_gemm_pdl()`, which invoked `deep_gemm.set_pdl(...)` and eagerly reserved a DeepGEMM workspace on every model load. On workloads that never use a DeepGEMM-backed MoE, that workspace still consumed HBM, shrinking the pool available to the KV-cache manager and producing the 6–15% KV cache size regression observed in 1.3.0rc20.
- **Fix**: Move the one-shot PDL configuration helper into `tensorrt_llm/_torch/utils.py` as `configure_deep_gemm_pdl()` and drop the eager call from `PyTorchModelEngine.__init__`. It is now invoked lazily from the constructors of `DeepGemmFusedMoE` and `MegaMoEDeepGemm`, so the DeepGEMM workspace is only reserved when a DeepGEMM path is actually instantiated, restoring the previous KV-cache footprint on non-DeepGEMM workloads while keeping the idempotent guard.
- **Perf metric**: kv_cache_size (higher-is-better)
- **Bad perf**: 13.17
- **Good perf**: 15.54
- **Perf after fix**: 15.85
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6402018


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DeepGEMM startup behavior so PDL settings are applied consistently during initialization.
  * Made the configuration process run only once, avoiding repeated setup work and reducing initialization overhead.
  * Updated backend setup flow so DeepGEMM-related components initialize more reliably across supported paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->