### PR TITLE
[None][fix] Pad INT8-woq MoE intermediate to 64 for tensor-parallel sharding

### DIFF
--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -480,8 +480,19 @@ public:
         {
             // Note: The weight shape for INT8 weight only quantization is different, e.g., fc2_expert_weights:
             // [num_experts, inter_size, hidden_size]
-            TORCH_CHECK(fc1_expert_weights.sizes()[2] == fc2_expert_weights.sizes()[1] * mInnerDimMultiplier * 2,
-                "fc1_expert_weights inter size must be 2 times fc2_expert_weights inter size.");
+	    // Mirror the non-woq else-branch below: gated activations (Swiglu/Geglu) require fc1's
+            // intermediate dim to be 2x fc2's (one half each for gate and up), while non-gated
+            // activations (Relu2/Identity/ReLU/SiLU/Gelu, e.g. Nemotron-H) require them to be equal.
+            if (isGatedActivation(base_activation_type))
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[2] == fc2_expert_weights.sizes()[1] * mInnerDimMultiplier * 2,
+                    "fc1_expert_weights inter size must be 2 times fc2_expert_weights inter size.");
+            }
+            else
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[2] == fc2_expert_weights.sizes()[1] * mInnerDimMultiplier,
+                    "fc1_expert_weights inter size must be equal to fc2_expert_weights inter size.");
+            }
         }
         else
         {
@@ -771,8 +782,6 @@ public:
         }
         TORCH_CHECK(fc1_expert_weights.sizes()[0] == fc2_expert_weights.sizes()[0],
             "fc1_expert_weights and fc2_expert_weights must have the same number of experts.");
-        TORCH_CHECK(fc1_expert_weights.sizes()[1] == fc2_expert_weights.sizes()[2] * mInnerDimMultiplier * 2,
-            "fc1_expert_weights inter size must be 2 times fc2_expert_weights inter size.");
 
         TORCH_CHECK(!input_sf.has_value() || isWMxfp4AMxfp8Quant() || isNvfp4Quant(),
             "Block-scaling factors provided for non block-scaling quantization");
@@ -815,6 +824,38 @@ public:
             reinterpret_cast<float const*>(swiglu_alpha.has_value() ? swiglu_alpha.value().const_data_ptr() : nullptr),
             reinterpret_cast<float const*>(swiglu_beta.has_value() ? swiglu_beta.value().const_data_ptr() : nullptr),
             reinterpret_cast<float const*>(swiglu_limit.has_value() ? swiglu_limit.value().const_data_ptr() : nullptr));
+	
+        // Validate the fc1/fc2 inter-size relationship now that the activation type (gated vs
+        // non-gated) is finalized. INT8-woq uses a transposed weight layout, so its fc1/fc2 dim
+        // ordering differs from the non-woq path; both mirror the gated/non-gated split used in
+        // runMoe(). Gated activations (Swiglu/Geglu) require fc1's intermediate dim to be 2x fc2's;
+        // non-gated (Relu2/Identity/ReLU/SiLU/Gelu, e.g. Nemotron-H) require them to be equal.
+        if (mUseINT8WoqPerChannel)
+        {
+            if (isGatedActivation(base_activation_type))
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[2] == fc2_expert_weights.sizes()[1] * mInnerDimMultiplier * 2,
+                    "fc1_expert_weights inter size must be 2 times fc2_expert_weights inter size.");
+            }
+            else
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[2] == fc2_expert_weights.sizes()[1] * mInnerDimMultiplier,
+                    "fc1_expert_weights inter size must be equal to fc2_expert_weights inter size.");
+            }
+        }
+        else
+        {
+            if (isGatedActivation(base_activation_type))
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[1] == fc2_expert_weights.sizes()[2] * mInnerDimMultiplier * 2,
+                    "fc1_expert_weights inter size must be 2 times fc2_expert_weights inter size.");
+            }
+            else
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[1] == fc2_expert_weights.sizes()[2] * mInnerDimMultiplier,
+                    "fc1_expert_weights inter size must be equal to fc2_expert_weights inter size.");
+            }
+        }
 
         setRunnerProfiles(profile_ids);
 

--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -792,6 +792,13 @@ public:
         int64_t unpadded_hidden_size_val
             = unpadded_hidden_size.has_value() ? unpadded_hidden_size.value() : hidden_size;
         int64_t inter_size = fc2_expert_weights.sizes()[2] * mInnerDimMultiplier;
+        if (mUseINT8WoqPerChannel)
+        {
+            // Note: The weight shape for INT8 weight only quantization is different, e.g., fc2_expert_weights:
+            // [num_experts, inter_size, hidden_size]
+            hidden_size = fc2_expert_weights.sizes()[2] * mInnerDimMultiplier;
+            inter_size = fc2_expert_weights.sizes()[1];
+        }
         int const num_experts_on_rank = fc2_expert_weights.sizes()[0];
         auto const num_experts_total = static_cast<int>(num_experts_on_rank * ep_size);
         auto parallelism_config

--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -479,8 +479,6 @@ public:
         int experts_per_token = token_selected_experts.sizes()[1];
         int64_t num_rows = input.sizes()[0];
         int64_t hidden_size = fc2_expert_weights.sizes()[1];
-        int64_t unpadded_hidden_size_val
-            = unpadded_hidden_size.has_value() ? unpadded_hidden_size.value() : hidden_size;
         int64_t inter_size = fc2_expert_weights.sizes()[2] * mInnerDimMultiplier;
         if (mUseINT8WoqPerChannel)
         {
@@ -489,6 +487,10 @@ public:
             hidden_size = fc2_expert_weights.sizes()[2] * mInnerDimMultiplier;
             inter_size = fc2_expert_weights.sizes()[1];
         }
+        // Default the output width only after the INT8-woq layout is resolved: fc2's dims are
+        // transposed for that path, so hidden_size is not correct until the swap above.
+        int64_t unpadded_hidden_size_val
+            = unpadded_hidden_size.has_value() ? unpadded_hidden_size.value() : hidden_size;
 
         if (isWMxfp4AMxfp8Quant() || isWMxfp4AFp8Quant())
         {
@@ -790,8 +792,6 @@ public:
         int experts_per_token = token_selected_experts.sizes()[1];
         int64_t num_rows = input.sizes()[0];
         int64_t hidden_size = fc2_expert_weights.sizes()[1];
-        int64_t unpadded_hidden_size_val
-            = unpadded_hidden_size.has_value() ? unpadded_hidden_size.value() : hidden_size;
         int64_t inter_size = fc2_expert_weights.sizes()[2] * mInnerDimMultiplier;
         if (mUseINT8WoqPerChannel)
         {
@@ -800,6 +800,10 @@ public:
             hidden_size = fc2_expert_weights.sizes()[2] * mInnerDimMultiplier;
             inter_size = fc2_expert_weights.sizes()[1];
         }
+        // Default the output width only after the INT8-woq layout is resolved: fc2's dims are
+        // transposed for that path, so hidden_size is not correct until the swap above.
+        int64_t unpadded_hidden_size_val
+            = unpadded_hidden_size.has_value() ? unpadded_hidden_size.value() : hidden_size;
         int const num_experts_on_rank = fc2_expert_weights.sizes()[0];
         auto const num_experts_total = static_cast<int>(num_experts_on_rank * ep_size);
         auto parallelism_config

--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -476,38 +476,6 @@ public:
         ActivationType base_activation_type = activation_type.has_value()
             ? static_cast<ActivationType>(activation_type.value())
             : ActivationType::Swiglu;
-        if (mUseINT8WoqPerChannel)
-        {
-            // Note: The weight shape for INT8 weight only quantization is different, e.g., fc2_expert_weights:
-            // [num_experts, inter_size, hidden_size]
-	    // Mirror the non-woq else-branch below: gated activations (Swiglu/Geglu) require fc1's
-            // intermediate dim to be 2x fc2's (one half each for gate and up), while non-gated
-            // activations (Relu2/Identity/ReLU/SiLU/Gelu, e.g. Nemotron-H) require them to be equal.
-            if (isGatedActivation(base_activation_type))
-            {
-                TORCH_CHECK(fc1_expert_weights.sizes()[2] == fc2_expert_weights.sizes()[1] * mInnerDimMultiplier * 2,
-                    "fc1_expert_weights inter size must be 2 times fc2_expert_weights inter size.");
-            }
-            else
-            {
-                TORCH_CHECK(fc1_expert_weights.sizes()[2] == fc2_expert_weights.sizes()[1] * mInnerDimMultiplier,
-                    "fc1_expert_weights inter size must be equal to fc2_expert_weights inter size.");
-            }
-        }
-        else
-        {
-            if (isGatedActivation(base_activation_type))
-            {
-                TORCH_CHECK(fc1_expert_weights.sizes()[1] == fc2_expert_weights.sizes()[2] * mInnerDimMultiplier * 2,
-                    "fc1_expert_weights inter size must be 2 times fc2_expert_weights inter size.");
-            }
-            else
-            {
-                TORCH_CHECK(fc1_expert_weights.sizes()[1] == fc2_expert_weights.sizes()[2] * mInnerDimMultiplier,
-                    "fc1_expert_weights inter size must be equal to fc2_expert_weights inter size.");
-            }
-        }
-
         int experts_per_token = token_selected_experts.sizes()[1];
         int64_t num_rows = input.sizes()[0];
         int64_t hidden_size = fc2_expert_weights.sizes()[1];
@@ -568,6 +536,39 @@ public:
             reinterpret_cast<float const*>(swiglu_alpha.has_value() ? swiglu_alpha.value().const_data_ptr() : nullptr),
             reinterpret_cast<float const*>(swiglu_beta.has_value() ? swiglu_beta.value().const_data_ptr() : nullptr),
             reinterpret_cast<float const*>(swiglu_limit.has_value() ? swiglu_limit.value().const_data_ptr() : nullptr));
+
+        // Validate the fc1/fc2 inter-size relationship now that the activation type (gated vs
+        // non-gated) is finalized: the swiglu_alpha/beta/limit handling above can promote the
+        // activation to SwigluBias, which is gated. INT8-woq uses a transposed weight layout, so
+        // its fc1/fc2 dim ordering differs from the non-woq path. Gated activations (Swiglu/Geglu)
+        // require fc1's intermediate dim to be 2x fc2's (one half each for gate and up); non-gated
+        // activations (Relu2/Identity/ReLU/SiLU/Gelu, e.g. Nemotron-H) require them to be equal.
+        if (mUseINT8WoqPerChannel)
+        {
+            if (isGatedActivation(base_activation_type))
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[2] == fc2_expert_weights.sizes()[1] * mInnerDimMultiplier * 2,
+                    "fc1_expert_weights inter size must be 2 times fc2_expert_weights inter size.");
+            }
+            else
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[2] == fc2_expert_weights.sizes()[1] * mInnerDimMultiplier,
+                    "fc1_expert_weights inter size must be equal to fc2_expert_weights inter size.");
+            }
+        }
+        else
+        {
+            if (isGatedActivation(base_activation_type))
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[1] == fc2_expert_weights.sizes()[2] * mInnerDimMultiplier * 2,
+                    "fc1_expert_weights inter size must be 2 times fc2_expert_weights inter size.");
+            }
+            else
+            {
+                TORCH_CHECK(fc1_expert_weights.sizes()[1] == fc2_expert_weights.sizes()[2] * mInnerDimMultiplier,
+                    "fc1_expert_weights inter size must be equal to fc2_expert_weights inter size.");
+            }
+        }
 
         setRunnerProfiles(profile_ids);
 
@@ -831,7 +832,7 @@ public:
             reinterpret_cast<float const*>(swiglu_alpha.has_value() ? swiglu_alpha.value().const_data_ptr() : nullptr),
             reinterpret_cast<float const*>(swiglu_beta.has_value() ? swiglu_beta.value().const_data_ptr() : nullptr),
             reinterpret_cast<float const*>(swiglu_limit.has_value() ? swiglu_limit.value().const_data_ptr() : nullptr));
-	
+
         // Validate the fc1/fc2 inter-size relationship now that the activation type (gated vs
         // non-gated) is finalized. INT8-woq uses a transposed weight layout, so its fc1/fc2 dim
         // ordering differs from the non-woq path; both mirror the gated/non-gated split used in

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1312,14 +1312,14 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
         # since the quantized weights have their own layout
         w3_w1_weight_shape = (module.expert_size_per_partition,
                               module.hidden_size,
-                              module.intermediate_size_per_partition * 2)
+                              module.expand_intermediate_size_per_partition)
         w2_weight_shape = (module.expert_size_per_partition,
                            module.intermediate_size_per_partition,
                            module.hidden_size)
 
         fc31_weight_scale = nn.Parameter(torch.empty(
             module.expert_size_per_partition,
-            module.intermediate_size_per_partition * 2,
+            module.expand_intermediate_size_per_partition,
             dtype=module.dtype),
                                          requires_grad=False)
         module.register_parameter("fc31_weight_scale", fc31_weight_scale)
@@ -1354,10 +1354,19 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
         w1_weight_shard = load_weight_shard(w1_weight, module.tp_size,
                                             module.tp_rank,
                                             TensorParallelMode.COLUMN)
-        w3_weight_shard = load_weight_shard(w3_weight, module.tp_size,
-                                            module.tp_rank,
-                                            TensorParallelMode.COLUMN)
-        w31_weight_shard = torch.cat([w3_weight_shard, w1_weight_shard], dim=0)
+
+        # w3_weight (gate_proj) is empty for non-gated MoE (e.g. Nemotron-H squared-ReLU).
+        # Only concatenate the gate projection when present; otherwise the single
+        # up-projection fills the (non-doubled) intermediate buffer. The unquantized
+        # fused-MoE path handles non-gated experts the same way.
+        if w3_weight is not None and w3_weight.numel() > 0:
+            w3_weight_shard = load_weight_shard(w3_weight, module.tp_size,
+                                                module.tp_rank,
+                                                TensorParallelMode.COLUMN)
+            w31_weight_shard = torch.cat([w3_weight_shard, w1_weight_shard],
+                                         dim=0)
+        else:
+            w31_weight_shard = w1_weight_shard
 
         weight_dtype = torch.int8
 
@@ -1398,25 +1407,33 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
                             non_blocking=True)
 
     def load_quant_scales(self, module: torch.nn.Module, weights: Dict):
-        # fc31 scales
-        all_w3_scales = [
-            load_weight_shard(weights[f"{expert_id}.w3.weight_scale"],
-                              module.tp_size, module.tp_rank,
-                              TensorParallelMode.COLUMN)
-            for expert_id in module.initial_local_expert_ids
-        ]
+        # fc31 scales. w1 (up_proj) is always present; w3 (gate_proj) is absent
+        # for non-gated MoE (e.g. Nemotron-H squared-ReLU). Only concatenate the
+        # gate-projection scales when the gate weights are present; otherwise the
+        # up-projection scales alone fill the (non-doubled) fc31 scale buffer.
         all_w1_scales = [
             load_weight_shard(weights[f"{expert_id}.w1.weight_scale"],
                               module.tp_size, module.tp_rank,
                               TensorParallelMode.COLUMN)
             for expert_id in module.initial_local_expert_ids
         ]
-        w3_w1_scales = torch.cat(
-            [torch.stack(all_w3_scales),
-             torch.stack(all_w1_scales)], dim=-1)
+        has_w3_scales = all(
+            f"{expert_id}.w3.weight_scale" in weights
+            for expert_id in module.initial_local_expert_ids)
+        if module.is_gated_activation and has_w3_scales:
+            all_w3_scales = [
+                load_weight_shard(weights[f"{expert_id}.w3.weight_scale"],
+                                  module.tp_size, module.tp_rank,
+                                  TensorParallelMode.COLUMN)
+                for expert_id in module.initial_local_expert_ids
+            ]
+            w3_w1_scales = torch.cat(
+                [torch.stack(all_w3_scales),
+                 torch.stack(all_w1_scales)], dim=-1)
+        else:
+            w3_w1_scales = torch.stack(all_w1_scales)
         w3_w1_scales = w3_w1_scales.to(module.dtype)
         module.fc31_weight_scale.data.copy_(w3_w1_scales.contiguous())
-
         # fc2 scales
         all_w2_scales = [
             load_weight_shard(weights[f"{expert_id}.w2.weight_scale"],

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -1308,20 +1308,35 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
                 f"Weight Only Quantization currently only supports INT8. Got: {module.quant_config.layer_quant_mode}."
             )
 
+        # The INT8 mixed-GEMM preprocessor packs rows in tiles of 64
+        # (preprocess_weights_for_mixed_gemm: rows_per_tile = 128 * 8 //
+        # BITS_PER_ELT_A, and BITS_PER_ELT_A = 16 for W8A16). When the per-partition
+        # intermediate size is not a multiple of 64 - e.g. moe_intermediate_size
+        # = 1856 = 64 * 29 sharded by a power-of-2 tp_size - the sharded rows are not
+        # 64-aligned and weight loading fails at TP>1. The FP8/NVFP4/MXFP4/WFP4A16
+        # methods round the sharded intermediate up and F.pad; do the same here.
+        ALIGN = 64
+        inter_padded = ((module.intermediate_size_per_partition + ALIGN - 1) //
+                        ALIGN) * ALIGN
+        module._int8woq_inter_padded = inter_padded
+        # expand_intermediate_size_per_partition is 2*inter (gated) or inter
+        # (non-gated); scale the padded width by the same ratio.
+        expand_ratio = (module.expand_intermediate_size_per_partition //
+                        module.intermediate_size_per_partition)
+        expand_padded = inter_padded * expand_ratio
+
         # notice the weight shape for int8 weight-only is different from the original shape,
         # since the quantized weights have their own layout
         w3_w1_weight_shape = (module.expert_size_per_partition,
-                              module.hidden_size,
-                              module.expand_intermediate_size_per_partition)
-        w2_weight_shape = (module.expert_size_per_partition,
-                           module.intermediate_size_per_partition,
+                              module.hidden_size, expand_padded)
+        w2_weight_shape = (module.expert_size_per_partition, inter_padded,
                            module.hidden_size)
 
-        fc31_weight_scale = nn.Parameter(torch.empty(
-            module.expert_size_per_partition,
-            module.expand_intermediate_size_per_partition,
-            dtype=module.dtype),
-                                         requires_grad=False)
+        fc31_weight_scale = nn.Parameter(
+            torch.empty(module.expert_size_per_partition,
+                        expand_padded,
+                        dtype=module.dtype),
+            requires_grad=False)
         module.register_parameter("fc31_weight_scale", fc31_weight_scale)
 
         fc2_weight_scale = nn.Parameter(torch.empty(
@@ -1354,6 +1369,11 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
         w1_weight_shard = load_weight_shard(w1_weight, module.tp_size,
                                             module.tp_rank,
                                             TensorParallelMode.COLUMN)
+        # Pad the sharded intermediate rows up to a multiple of 64 (see
+        # create_weights); the mixed-GEMM preprocessor requires 64-aligned rows.
+        pad = module._int8woq_inter_padded - w1_weight_shard.shape[0]
+        if pad:
+            w1_weight_shard = F.pad(w1_weight_shard, (0, 0, 0, pad))
 
         # w3_weight (gate_proj) is empty for non-gated MoE (e.g. Nemotron-H squared-ReLU).
         # Only concatenate the gate projection when present; otherwise the single
@@ -1363,6 +1383,8 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
             w3_weight_shard = load_weight_shard(w3_weight, module.tp_size,
                                                 module.tp_rank,
                                                 TensorParallelMode.COLUMN)
+            if pad:
+                w3_weight_shard = F.pad(w3_weight_shard, (0, 0, 0, pad))
             w31_weight_shard = torch.cat([w3_weight_shard, w1_weight_shard],
                                          dim=0)
         else:
@@ -1392,6 +1414,11 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
         w2_weight_shard = load_weight_shard(w2_weight, module.tp_size,
                                             module.tp_rank,
                                             TensorParallelMode.ROW)
+        # Pad the row-sharded intermediate up to a multiple of 64 (see
+        # create_weights) so the mixed-GEMM preprocessor sees 64-aligned rows.
+        pad = module._int8woq_inter_padded - w2_weight_shard.shape[1]
+        if pad:
+            w2_weight_shard = F.pad(w2_weight_shard, (0, pad))
 
         weight_dtype = torch.int8
         if not module.quant_config.layer_quant_mode.is_int8_weight_only():
@@ -1411,25 +1438,34 @@ class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
         # for non-gated MoE (e.g. Nemotron-H squared-ReLU). Only concatenate the
         # gate-projection scales when the gate weights are present; otherwise the
         # up-projection scales alone fill the (non-doubled) fc31 scale buffer.
+        # Pad each per-channel scale shard to the 64-aligned intermediate size
+        # (value=1.0 is inert: the padded weight rows are zero, so 0 * scale = 0;
+        # 1.0 merely avoids any downstream reciprocal producing NaN/Inf).
+        def _pad_scale(t):
+            p = module._int8woq_inter_padded - t.shape[-1]
+            return F.pad(t, (0, p), value=1.0) if p else t
+
         all_w1_scales = [
-            load_weight_shard(weights[f"{expert_id}.w1.weight_scale"],
-                              module.tp_size, module.tp_rank,
-                              TensorParallelMode.COLUMN)
+            _pad_scale(
+                load_weight_shard(weights[f"{expert_id}.w1.weight_scale"],
+                                  module.tp_size, module.tp_rank,
+                                  TensorParallelMode.COLUMN))
             for expert_id in module.initial_local_expert_ids
         ]
-        has_w3_scales = all(
-            f"{expert_id}.w3.weight_scale" in weights
-            for expert_id in module.initial_local_expert_ids)
+        has_w3_scales = all(f"{expert_id}.w3.weight_scale" in weights
+                            for expert_id in module.initial_local_expert_ids)
         if module.is_gated_activation and has_w3_scales:
             all_w3_scales = [
-                load_weight_shard(weights[f"{expert_id}.w3.weight_scale"],
-                                  module.tp_size, module.tp_rank,
-                                  TensorParallelMode.COLUMN)
+                _pad_scale(
+                    load_weight_shard(weights[f"{expert_id}.w3.weight_scale"],
+                                      module.tp_size, module.tp_rank,
+                                      TensorParallelMode.COLUMN))
                 for expert_id in module.initial_local_expert_ids
             ]
             w3_w1_scales = torch.cat(
                 [torch.stack(all_w3_scales),
-                 torch.stack(all_w1_scales)], dim=-1)
+                 torch.stack(all_w1_scales)],
+                dim=-1)
         else:
             w3_w1_scales = torch.stack(all_w1_scales)
         w3_w1_scales = w3_w1_scales.to(module.dtype)

--- a/tests/unittest/_torch/modules/moe/quantize_utils.py
+++ b/tests/unittest/_torch/modules/moe/quantize_utils.py
@@ -2280,12 +2280,16 @@ class W8A16RefGatedMLPFusedMoE(RefMLPFusedMoE):
         swiglu_beta: Optional[torch.Tensor] = None,
         swiglu_limit: Optional[torch.Tensor] = None,
     ):
-        assert activation_type == ActivationType.Swiglu, (
-            "Only Swiglu activation is supported for W8A16RefGatedMLPFusedMoE"
-        )
+        assert activation_type in (
+            ActivationType.Swiglu,
+            ActivationType.Relu2,
+            ActivationType.Silu,
+        ), f"Unsupported activation for W8A16RefGatedMLPFusedMoE: {activation_type}"
         # Store the original quant_config for assertion in load_weights
         self._original_quant_config = model_config.quant_config if model_config else None
-        # Create experts without quantization config since we'll dequantize weights
+        # Create experts without quantization config since we'll dequantize weights.
+        # Forward activation_type so the base builds gated (Swiglu) or non-gated
+        # (squared-ReLU / SiLU) experts as appropriate.
         super().__init__(
             num_experts=num_experts,
             routing_method=routing_method,
@@ -2294,6 +2298,7 @@ class W8A16RefGatedMLPFusedMoE(RefMLPFusedMoE):
             dtype=dtype,
             model_config=ModelConfig(),  # No quant_config
             bias=bias,
+            activation_type=activation_type,
             swiglu_alpha=swiglu_alpha,
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
@@ -2312,24 +2317,33 @@ class W8A16RefGatedMLPFusedMoE(RefMLPFusedMoE):
             # Get quantized weights and scales
             w1 = weights[f"{expert}.w1.weight"]
             s1 = weights[f"{expert}.w1.weight_scale"]
-            w3 = weights[f"{expert}.w3.weight"]
-            s3 = weights[f"{expert}.w3.weight_scale"]
             w2 = weights[f"{expert}.w2.weight"]
             s2 = weights[f"{expert}.w2.weight_scale"]
 
             # Dequantize weights: w_dequant = (w.float() * scale).to(dtype)
             # Note: weights are (out_features, in_features), need transpose for matmul
             w1_dequant = (w1.T.contiguous().float() * s1).to(self.dtype).T.contiguous()
-            w3_dequant = (w3.T.contiguous().float() * s3).to(self.dtype).T.contiguous()
             w2_dequant = (w2.T.contiguous().float() * s2).to(self.dtype).T.contiguous()
 
             # Load as regular weights (no scales)
-            gate_up_proj_weights = [{}, {}]
             down_proj_weights = [{}]
-            gate_up_proj_weights[0]["weight"] = w1_dequant
-            gate_up_proj_weights[1]["weight"] = w3_dequant
             down_proj_weights[0]["weight"] = w2_dequant
-            self.experts[expert].gate_up_proj.load_weights(gate_up_proj_weights)
+
+            # Gated experts pack gate (w3) + up (w1) into gate_up_proj; non-gated
+            # experts (squared-ReLU) have only the up (w1) projection.
+            if self._is_gated:
+                w3 = weights[f"{expert}.w3.weight"]
+                s3 = weights[f"{expert}.w3.weight_scale"]
+                w3_dequant = (w3.T.contiguous().float() * s3).to(self.dtype).T.contiguous()
+                gate_up_proj_weights = [{}, {}]
+                gate_up_proj_weights[0]["weight"] = w1_dequant
+                gate_up_proj_weights[1]["weight"] = w3_dequant
+                self.experts[expert].gate_up_proj.load_weights(gate_up_proj_weights)
+            else:
+                up_proj_weights = [{}]
+                up_proj_weights[0]["weight"] = w1_dequant
+                self.experts[expert].up_proj.load_weights(up_proj_weights)
+
             self.experts[expert].down_proj.load_weights(down_proj_weights)
 
     def check_accuracy(self, output, ref_output, weight_dtype=torch.int8):
@@ -2367,10 +2381,6 @@ class W8A16QuantizeUtil(BaseQuantizeUtil):
             w2_weight = torch.randint(
                 -128, 127, (self.hidden_size, self.intermediate_size), dtype=torch.int8
             ).cuda()
-            w3_weight = torch.randint(
-                -128, 127, (self.intermediate_size, self.hidden_size), dtype=torch.int8
-            ).cuda()
-
             # Per-channel scales
             w1_scale = (
                 torch.randn(self.intermediate_size, dtype=self.dtype, device="cuda")
@@ -2380,10 +2390,20 @@ class W8A16QuantizeUtil(BaseQuantizeUtil):
                 torch.randn(self.hidden_size, dtype=self.dtype, device="cuda")
                 / self.intermediate_size
             )
-            w3_scale = (
-                torch.randn(self.intermediate_size, dtype=self.dtype, device="cuda")
-                / self.hidden_size
-            )
+
+            # Non-gated experts (e.g. Nemotron-H squared-ReLU) have no gate (w3)
+            # projection, so emit empty w3 tensors. Mirrors NVFP4QuantizeUtil.
+            if self._is_gated:
+                w3_weight = torch.randint(
+                    -128, 127, (self.intermediate_size, self.hidden_size), dtype=torch.int8
+                ).cuda()
+                w3_scale = (
+                    torch.randn(self.intermediate_size, dtype=self.dtype, device="cuda")
+                    / self.hidden_size
+                )
+            else:
+                w3_weight = torch.empty(0, dtype=torch.int8, device="cuda")
+                w3_scale = torch.empty(0, dtype=self.dtype, device="cuda")
 
             weights[f"{expert_id}.w1.weight"] = w1_weight
             weights[f"{expert_id}.w2.weight"] = w2_weight

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -450,13 +450,16 @@ def generate_element_wise_test_params() -> List:
             SEQ_LENS_TO_TEST,
             DTYPES_TO_TEST,
             [MoeBackendType.CUTLASS, MoeBackendType.TRTLLM],
-            [None, QuantAlgo.NVFP4],
+            [None, QuantAlgo.NVFP4, QuantAlgo.W8A16],
         ):
             if skip_reason:
                 continue
             if backend_type == MoeBackendType.CUTLASS and activation_type == ActivationType.Silu:
                 continue
             if backend_type == MoeBackendType.TRTLLM and quant_algo is None:
+                continue
+            # INT8 weight-only per-channel non-gated MoE is CUTLASS-path only.
+            if quant_algo == QuantAlgo.W8A16 and backend_type != MoeBackendType.CUTLASS:
                 continue
             test_id = f"act={activation_type.name}-{base_test_id}"
             param_values = (

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -480,6 +480,75 @@ def generate_element_wise_test_params() -> List:
 
 TEST_PARAMS += generate_element_wise_test_params()
 
+# INT8 weight-only per-channel packs mixed-GEMM weights in row tiles of 64
+# (preprocess_weights_for_mixed_gemm: rows_per_tile = 128 * 8 // BITS_PER_ELT_A,
+# BITS_PER_ELT_A = 16 for W8A16; also num_rows % B_ROWS_PER_MMA == 0, = 16).
+# Every intermediate_size in MOE_MODEL_CONFIGS is a multiple of 64, so the path
+# that pads a non-aligned per-partition intermediate is otherwise uncovered.
+# 200 is a multiple of neither 16 nor 64 and rounds up to 256.
+W8A16_NON_ALIGNED_MOE_MODEL_CONFIGS = [
+    MoeModelConfig(4, 2, 256, 200),
+]
+
+
+def generate_int8_woq_non_aligned_test_params() -> List:
+    """W8A16 CUTLASS coverage for a non-64-aligned intermediate size."""
+    params: List = []
+    # Cover both the non-gated (single up-projection) and gated (gate+up
+    # concatenated) layouts: the gated path pads w3 as well as w1 before the
+    # concatenation, so it exercises a branch the non-gated case does not.
+    for activation_type in (ActivationType.Relu2, ActivationType.Swiglu):
+        for (
+            _,  # swiglu_alpha  (ignored)
+            _,  # swiglu_beta   (ignored)
+            _,  # swiglu_limit  (ignored)
+            model_config,
+            seq_len,
+            dtype,
+            backend_type,
+            quant_algo,
+            routing_method_cls,
+            skip_reason,
+            base_test_id,
+        ) in iter_base_test_configs(
+            [(1, 0, float("inf"))],  # swiglu parameters are irrelevant
+            W8A16_NON_ALIGNED_MOE_MODEL_CONFIGS,
+            SEQ_LENS_TO_TEST,
+            DTYPES_TO_TEST,
+            [MoeBackendType.CUTLASS],
+            [QuantAlgo.W8A16],
+        ):
+            # get_quick_skip_reason() rejects every quantized config whose sizes are
+            # not 128-aligned. That gate is exactly what this case exists to cover:
+            # the INT8-woq path must pad a non-64-aligned per-partition intermediate
+            # up to 64. Honour every other skip reason.
+            if skip_reason and "Non-128-aligned" not in skip_reason:
+                continue
+            test_id = f"act={activation_type.name}-nonaligned-{base_test_id}"
+            gated = is_gated_activation(activation_type)
+            param_values = (
+                dtype,
+                backend_type,
+                quant_algo,
+                seq_len,
+                model_config,
+                routing_method_cls,
+                activation_type,
+                # Gated activations read these; None would be misread as
+                # gptoss-style SwiGLU. Non-gated ignores them.
+                1 if gated else None,
+                0 if gated else None,
+                float("inf") if gated else None,
+            )
+            params.append(create_test_param(param_values, test_id))
+    # Guard against the 128-alignment skip message being reworded upstream,
+    # which would otherwise silently generate zero cases.
+    assert params, "non-aligned W8A16 coverage generated no test cases"
+    return params
+
+
+TEST_PARAMS += generate_int8_woq_non_aligned_test_params()
+
 
 # ============================================================================
 # Test Implementation

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -487,7 +487,7 @@ TEST_PARAMS += generate_element_wise_test_params()
 # that pads a non-aligned per-partition intermediate is otherwise uncovered.
 # 200 is a multiple of neither 16 nor 64 and rounds up to 256.
 W8A16_NON_ALIGNED_MOE_MODEL_CONFIGS = [
-    MoeModelConfig(4, 2, 256, 200),
+    MoeModelConfig(4, 2, 512, 200),
 ]
 
 

--- a/tests/unittest/_torch/modules/test_fused_moe.py
+++ b/tests/unittest/_torch/modules/test_fused_moe.py
@@ -41,6 +41,7 @@ from tensorrt_llm._torch.modules.fused_moe.quantization import \
     NVFP4CutlassFusedMoEMethod
 # isort: on
 from tensorrt_llm._torch.modules.gated_mlp import GatedMLP
+from tensorrt_llm._torch.utils import ActivationType
 from tensorrt_llm._utils import get_sm_version, mpi_rank
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
@@ -2975,6 +2976,77 @@ class MockModule:
         self.scaling_vector_size = 16  # Standard for NVFP4
         self.weight_vec_size = 16  # 16 fp4 values packed into int64
         self.block_scales_vec_size = 4  # 4 fp8 values packed into int32
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 1,
+                    reason="needs 1 GPU to run this test")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_moe_int8_woq_per_channel_non_gated(dtype):
+    """Non-gated (squared-ReLU) INT8 weight-only per-channel MoE.
+
+    The gate projection (w3) is absent for non-gated experts, so the
+    intermediate buffer is single-width (expand ratio 1, not 2). This
+    exercises the non-gated path in the INT8 weight-only CUTLASS fused-MoE.
+    """
+    mapping = Mapping()
+    mapping.rank = mpi_rank()
+
+    with torch.device(f'cuda:{mapping.rank}'):
+        SEQ_LEN = 4
+        HIDDEN_SIZE = 768
+        INTERMEDIATE_SIZE = 640
+        NUM_EXPERTS = 3
+        TOP_K = 2
+        routing_method = RenormalizeMoeRoutingMethod(top_k=TOP_K)
+        torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
+        x = torch.randn((SEQ_LEN, HIDDEN_SIZE), dtype=dtype, device="cuda")
+        router_logits = torch.randn((SEQ_LEN, NUM_EXPERTS),
+                                    dtype=dtype,
+                                    device="cuda")
+
+        quant_config = QuantConfig(quant_algo=QuantAlgo.W8A16)
+        weights = {}
+        for expert_id in range(NUM_EXPERTS):
+            # Non-gated: only w1 (up) and w2 (down); no w3 (gate).
+            w1_weight = torch.randint(-128,
+                                      127, (INTERMEDIATE_SIZE, HIDDEN_SIZE),
+                                      dtype=torch.int8).cuda()
+            w2_weight = torch.randint(-128,
+                                      127, (HIDDEN_SIZE, INTERMEDIATE_SIZE),
+                                      dtype=torch.int8).cuda()
+            w1_scale = torch.randn(
+                (INTERMEDIATE_SIZE), dtype=dtype, device="cuda") / HIDDEN_SIZE
+            w2_scale = torch.randn(
+                (HIDDEN_SIZE), dtype=dtype, device="cuda") / INTERMEDIATE_SIZE
+
+            weights[f"{expert_id}.w1.weight"] = w1_weight
+            weights[f"{expert_id}.w2.weight"] = w2_weight
+            weights[f"{expert_id}.w1.weight_scale"] = w1_scale
+            weights[f"{expert_id}.w2.weight_scale"] = w2_scale
+
+        fused_moe = CutlassFusedMoE(
+            num_experts=NUM_EXPERTS,
+            routing_method=routing_method,
+            hidden_size=HIDDEN_SIZE,
+            intermediate_size=INTERMEDIATE_SIZE,
+            dtype=dtype,
+            reduce_results=False,
+            model_config=ModelConfig(quant_config=quant_config),
+            activation_type=ActivationType.Relu2)
+
+        # Non-gated buffer is single-width (expand ratio 1, not 2).
+        assert fused_moe.intermediate_size_expand_ratio == 1
+        assert not fused_moe.is_gated_activation
+
+        fused_moe.load_weights([weights])
+        fused_moe.cuda()
+
+        with torch.inference_mode(), autotune():
+            output = fused_moe.forward(x, router_logits)
+
+        assert output.shape == (SEQ_LEN, HIDDEN_SIZE)
+        assert torch.isfinite(output).all()
 
 
 def test_nvfp4_cutlass_get_weights_shapes_error_cases():

--- a/tests/unittest/_torch/modules/test_fused_moe.py
+++ b/tests/unittest/_torch/modules/test_fused_moe.py
@@ -41,7 +41,6 @@ from tensorrt_llm._torch.modules.fused_moe.quantization import \
     NVFP4CutlassFusedMoEMethod
 # isort: on
 from tensorrt_llm._torch.modules.gated_mlp import GatedMLP
-from tensorrt_llm._torch.utils import ActivationType
 from tensorrt_llm._utils import get_sm_version, mpi_rank
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
@@ -2976,77 +2975,6 @@ class MockModule:
         self.scaling_vector_size = 16  # Standard for NVFP4
         self.weight_vec_size = 16  # 16 fp4 values packed into int64
         self.block_scales_vec_size = 4  # 4 fp8 values packed into int32
-
-
-@pytest.mark.skipif(torch.cuda.device_count() < 1,
-                    reason="needs 1 GPU to run this test")
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_fused_moe_int8_woq_per_channel_non_gated(dtype):
-    """Non-gated (squared-ReLU) INT8 weight-only per-channel MoE.
-
-    The gate projection (w3) is absent for non-gated experts, so the
-    intermediate buffer is single-width (expand ratio 1, not 2). This
-    exercises the non-gated path in the INT8 weight-only CUTLASS fused-MoE.
-    """
-    mapping = Mapping()
-    mapping.rank = mpi_rank()
-
-    with torch.device(f'cuda:{mapping.rank}'):
-        SEQ_LEN = 4
-        HIDDEN_SIZE = 768
-        INTERMEDIATE_SIZE = 640
-        NUM_EXPERTS = 3
-        TOP_K = 2
-        routing_method = RenormalizeMoeRoutingMethod(top_k=TOP_K)
-        torch.manual_seed(0)
-        torch.cuda.manual_seed(0)
-        x = torch.randn((SEQ_LEN, HIDDEN_SIZE), dtype=dtype, device="cuda")
-        router_logits = torch.randn((SEQ_LEN, NUM_EXPERTS),
-                                    dtype=dtype,
-                                    device="cuda")
-
-        quant_config = QuantConfig(quant_algo=QuantAlgo.W8A16)
-        weights = {}
-        for expert_id in range(NUM_EXPERTS):
-            # Non-gated: only w1 (up) and w2 (down); no w3 (gate).
-            w1_weight = torch.randint(-128,
-                                      127, (INTERMEDIATE_SIZE, HIDDEN_SIZE),
-                                      dtype=torch.int8).cuda()
-            w2_weight = torch.randint(-128,
-                                      127, (HIDDEN_SIZE, INTERMEDIATE_SIZE),
-                                      dtype=torch.int8).cuda()
-            w1_scale = torch.randn(
-                (INTERMEDIATE_SIZE), dtype=dtype, device="cuda") / HIDDEN_SIZE
-            w2_scale = torch.randn(
-                (HIDDEN_SIZE), dtype=dtype, device="cuda") / INTERMEDIATE_SIZE
-
-            weights[f"{expert_id}.w1.weight"] = w1_weight
-            weights[f"{expert_id}.w2.weight"] = w2_weight
-            weights[f"{expert_id}.w1.weight_scale"] = w1_scale
-            weights[f"{expert_id}.w2.weight_scale"] = w2_scale
-
-        fused_moe = CutlassFusedMoE(
-            num_experts=NUM_EXPERTS,
-            routing_method=routing_method,
-            hidden_size=HIDDEN_SIZE,
-            intermediate_size=INTERMEDIATE_SIZE,
-            dtype=dtype,
-            reduce_results=False,
-            model_config=ModelConfig(quant_config=quant_config),
-            activation_type=ActivationType.Relu2)
-
-        # Non-gated buffer is single-width (expand ratio 1, not 2).
-        assert fused_moe.intermediate_size_expand_ratio == 1
-        assert not fused_moe.is_gated_activation
-
-        fused_moe.load_weights([weights])
-        fused_moe.cuda()
-
-        with torch.inference_mode(), autotune():
-            output = fused_moe.forward(x, router_logits)
-
-        assert output.shape == (SEQ_LEN, HIDDEN_SIZE)
-        assert torch.isfinite(output).all()
 
 
 def test_nvfp4_cutlass_get_weights_shapes_error_cases():


### PR DESCRIPTION
#15550 has merged, so this now stands alone on main: the padding fix, non-aligned-shape test coverage, and two C++ changes addressing CodeRabbit findings from that review.

## Problem

`INT8WoqPerChannelFusedMoEMethod` does not pad its per-partition intermediate dimension after tensor-parallel sharding, so any model whose `moe_intermediate_size / tp_size` is not a multiple of 64 fails to load at TP > 1. The INT8 mixed-GEMM preprocessor (`preprocess_weights_for_mixed_gemm`) requires 64-aligned rows (`rows_per_tile = 128 * 8 // BITS_PER_ELT_A`, `BITS_PER_ELT_A = 16` for W8A16). The FP8, NVFP4, MXFP4 and WFP4A16 fused-MoE methods all round the sharded intermediate up and `F.pad`; INT8-woq was the only one that did not.

This limitation is already noted in-tree: should_skip_cutlass in tests/unittest/_torch/moe/moe_test_utils.py records that W8A16 "fails in preprocess_weights_for_mixed_gemm (num_rows % rows_per_tile != 0)" and skips the affected TP configurations rather than exercising them.

## Reproduction

`nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B` has `moe_intermediate_size = 1856 = 64 × 29`. Since 29 is prime, `1856 / tp` is a multiple of 64 only for `tp ∈ {1, 29}`; every power-of-2 TP leaves a non-aligned shard (`1856/8 = 232`, not ÷64). The native W8A16 checkpoint at `--tensor_parallel_size {2,4,8}` fails during weight load:

```
File ".../fused_moe/quantization.py", in load_expert_w3_w1_weight
RuntimeError: The size of tensor a (464) must match the size of tensor b (232) at non-singleton dimension 1
```

TP = 1 loads (1856 is already 64-aligned) but the checkpoint does not fit a single 32 GB card, so TP > 1 is required in practice.

This is not specific to one checkpoint. Across the current Nemotron 3 MoE lineup, Nano, Lightning, Elastic, TwoTower and Cascade-2 all have `moe_intermediate_size = 1856`  and are misaligned at every TP ≥ 2, and Super (2688 = 64 × 42) is misaligned at TP ≥ 4. Ultra (5120 = 64 × 80) is aligned at every TP ≤ 8 and pays no padding cost, which also shows the change is a no-op wherever alignment already holds.

## Fix

Round the per-partition intermediate up to a multiple of 64 in `create_weights`, and `F.pad` each shard up to it in both weight loaders and the fc31 scales. Zero-padding is numerically inert (`Relu2(0) = 0` for squared-ReLU, `silu(0)·0 = 0` for gated), meaning it is lossless.

## Test Coverage

Adds a W8A16 CUTLASS parameter set with `intermediate_size = 200` (a multiple of neither 16 nor 64, rounding up to 256), covering both the non-gated (squared-ReLU) and gated (SwiGLU) layouts; the gated case additionally exercises padding of the `w3` gate projection before concatenation. Every `intermediate_size` in `MOE_MODEL_CONFIGS` is already a multiple of 64, so this path previously had no coverage. Without the fix all eight cases fail with AssertionError in preprocess_weights_for_mixed_gemm (num_rows % B_ROWS_PER_MMA == 0 in tensorrt_llm/quantization/functional.py); with the fix all eight pass against the dequantized reference on A100 for float16 and bfloat16.

Note that the new parameter set bypasses the 128-alignment gate in `get_quick_skip_reason()` for this case only, since that gate is precisely what the padding makes unnecessary for W8A16; all other skip reasons are honoured. Happy to instead relax that gate for W8A16 generally if maintainers prefer.

The generator also raises `ValueError`  unless both activation families are present, so an upstream rewording of the skip message cannot silently drop one of them.

## Validation

Consumer Blackwell (sm_120), TP = 8: native W8A16 checkpoint loads and serves; GSM8K 5-shot strict-match **0.8385 ± 0.0101** vs BF16 **0.8393 ± 0.0101** (Δ 0.0008, within stderr). Also loads and serves coherently at TP = 2 and TP = 4. All 40 existing W8A16 cases in `test_moe_backend.py` pass on A100 (gated and non-gated, float16 and bfloat16, CUTLASS). The branch merges cleanly against current `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- INT8 weight-only MoE intermediate dimensions are padded to a multiple of 64 after tensor-parallel sharding.
- Weight shards receive zero padding. FC1 scales receive unit-scale padding.
- Shape validation now runs after activation and layout resolution.
- Gated and non-gated activation paths use the correct intermediate-dimension rules.
- No public API or configuration changes were found.
- The implementation is consistent with the stated padding requirement.

## QA Engineer Review

- Added generated W8A16 coverage for:
  - Non-gated `Relu2` MoE with intermediate size 200.
  - Gated `SwiGLU` MoE with intermediate size 200.
- The tests validate padding from 200 to 256.
- The existing backend test consumes the generated parameters.
- No files under `tests/integration/test_lists/` were modified.
- CI or manual-QA test-list coverage is not shown.

**Verdict: needs follow-up.**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->