### PR TITLE
[https://nvbugs/6435113][fix] Revert the three regressions — drop the real_text_lens per-batch slicing path…

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/cosmos3/defaults.py
+++ b/tensorrt_llm/_torch/visual_gen/models/cosmos3/defaults.py
@@ -30,7 +30,7 @@ COSMOS3_720P_PARAMS = {
     "width": 1280,
     "num_inference_steps": 35,
     "guidance_scale": 6.0,
-    "max_sequence_length": 4096,
+    "max_sequence_length": 1024,
     "num_frames": 189,
     "frame_rate": 24.0,
 }

--- a/tensorrt_llm/_torch/visual_gen/models/cosmos3/pipeline_cosmos3.py
+++ b/tensorrt_llm/_torch/visual_gen/models/cosmos3/pipeline_cosmos3.py
@@ -39,7 +39,14 @@ from .guardrails import check_video_safety, download_guardrail_checkpoint
 from .sound_tokenizer import LatentAutoEncoderV2
 from .transformer_cosmos3 import Cosmos3VFMTransformer
 
-COSMOS3_DEFAULT_NEGATIVE_PROMPT = ""
+COSMOS3_DEFAULT_NEGATIVE_PROMPT = (
+    "The video captures a series of frames showing ugly scenes, static with no motion, motion blur, "
+    "over-saturation, shaky footage, low resolution, grainy texture, pixelated images, poorly lit areas, "
+    "underexposed and overexposed scenes, poor color balance, washed out colors, choppy sequences, jerky movements, "
+    "low frame rate, artifacting, color banding, unnatural transitions, outdated special effects, fake elements, "
+    "unconvincing visuals, poorly edited content, jump cuts, visual noise, and flickering. Overall, the video is of "
+    "poor quality."
+)
 COSMOS3_DEFAULT_SYSTEM_PROMPT = (
     "You are a helpful assistant who will generate videos from a given prompt."
 )

--- a/tensorrt_llm/_torch/visual_gen/models/cosmos3/transformer_cosmos3.py
+++ b/tensorrt_llm/_torch/visual_gen/models/cosmos3/transformer_cosmos3.py
@@ -351,7 +351,6 @@ class Cosmos3CrossAttention(Attention):
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
         timestep=None,
-        real_text_lens: Optional[list[int]] = None,
     ) -> torch.Tensor:
         """
         Args:
@@ -375,33 +374,16 @@ class Cosmos3CrossAttention(Attention):
         q, k = self.apply_qk_norm(q, k)
         q, k = qwen3_apply_rotary_pos_emb(q, k, freqs_cos, freqs_sin)
 
-        if real_text_lens is not None and batch_size > 1:
-            outs = []
-            for b in range(batch_size):
-                Lb = int(real_text_lens[b])
-                k_all_b = torch.cat([k_und[b : b + 1, :Lb], k[b : b + 1]], dim=1)
-                v_all_b = torch.cat([v_und[b : b + 1, :Lb], v[b : b + 1]], dim=1)
-                outs.append(
-                    self._attn_impl(
-                        q[b : b + 1],
-                        k_all_b,
-                        v_all_b,
-                        attention_mask=PredefinedAttentionMask.FULL,
-                        timestep=timestep,
-                    )
-                )
-            out = torch.cat(outs, dim=0)
-        else:
-            k_all = torch.cat([k_und, k], dim=1).contiguous()
-            v_all = torch.cat([v_und, v], dim=1).contiguous()
+        k_all = torch.cat([k_und, k], dim=1).contiguous()
+        v_all = torch.cat([v_und, v], dim=1).contiguous()
 
-            out = self._attn_impl(
-                q,
-                k_all,
-                v_all,
-                attention_mask=PredefinedAttentionMask.FULL,
-                timestep=timestep,
-            )
+        out = self._attn_impl(
+            q,
+            k_all,
+            v_all,
+            attention_mask=PredefinedAttentionMask.FULL,
+            timestep=timestep,
+        )
 
         return self.to_out[0](out)
 
@@ -521,7 +503,6 @@ class Cosmos3GenDecoderLayer(nn.Module):
         v_und: torch.Tensor,
         freqs: Tuple[torch.Tensor, torch.Tensor],
         timestep=None,
-        real_text_lens: Optional[list[int]] = None,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
@@ -534,7 +515,6 @@ class Cosmos3GenDecoderLayer(nn.Module):
             freqs_cos=cos,
             freqs_sin=sin,
             timestep=timestep,
-            real_text_lens=real_text_lens,
         )
         hidden_states = residual + hidden_states
 
@@ -1016,7 +996,6 @@ class Cosmos3VFMTransformer(BaseDiffusionModel):
         T, H, W = video_shape
         Hp, Wp, _, _ = self._pad_to_patch_size(H, W)
         max_real_len = text_mask.sum(dim=1).max().item()
-        real_text_lens = text_mask.sum(dim=1).tolist()
 
         hidden_gen = self.vae2llm(self.patchify(hidden_states, T, H, W))
 
@@ -1113,22 +1092,13 @@ class Cosmos3VFMTransformer(BaseDiffusionModel):
             if not self.sharder.is_active:
                 k_und = k_und[:, :max_real_len]
                 v_und = v_und[:, :max_real_len]
-                hidden_gen = layer(
-                    hidden_gen,
-                    k_und,
-                    v_und,
-                    freqs_gen,
-                    timestep=timestep,
-                    real_text_lens=real_text_lens,
-                )
-            else:
-                hidden_gen = layer(
-                    hidden_gen,
-                    k_und,
-                    v_und,
-                    freqs_gen,
-                    timestep=timestep,
-                )
+            hidden_gen = layer(
+                hidden_gen,
+                k_und,
+                v_und,
+                freqs_gen,
+                timestep=timestep,
+            )
 
         hidden_gen = self.sharder.gather(hidden_gen, dim=1, unpad_to=S_gen)
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -193,7 +193,6 @@ examples/test_ray.py::test_llm_inference_distributed_ray[pp2] SKIP (https://nvbu
 examples/test_ray.py::test_llm_inference_distributed_ray[tp2pp2] SKIP (https://nvbugs/6427411)
 examples/test_ray.py::test_ray_disaggregated_serving[tp2] SKIP (https://nvbugs/5612502)
 examples/test_whisper.py::test_llm_whisper_general[large-v3-disable_gemm_plugin-disable_attention_plugin-disable_weight_only-float16-nb:1-use_python_runtime] SKIP (https://nvbugs/5244570)
-examples/visual_gen/test_visual_gen.py::test_cosmos3_nano_t2i_lpips_against_golden SKIP (https://nvbugs/6418815)
 examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_multi_gpu[attn2d_2x2] SKIP (https://nvbugs/6272644)
 examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_multi_gpu[cfg2_ulysses2] SKIP (https://nvbugs/6272644)
 examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_multi_gpu[cfg2_ulysses2_attn2d_2x1] SKIP (https://nvbugs/6272644)


### PR DESCRIPTION
## Summary
- **Root cause**: Commit f50ca53dae (Cosmos3 Audio Output Support) silently changed three CFG-affecting behaviors — per-batch cross-attn slicing under CFG, empty COSMOS3_DEFAULT_NEGATIVE_PROMPT, and max_sequence_length 1024→4096 — that the T2I LPIPS golden was baked against.
- **Fix**: Revert the three regressions — drop the real_text_lens per-batch slicing path from Cosmos3CrossAttention/Cosmos3GenDecoderLayer/Cosmos3VFMTransformer, restore the descriptive COSMOS3_DEFAULT_NEGATIVE_PROMPT, and reset max_sequence_length to 1024. Also remove the stale 6418815 waiver.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6435113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Cosmos3 generation defaults for more stable outputs, including a stronger negative prompt and shorter default sequence length.
* **Bug Fixes**
  * Adjusted text-conditioning behavior in Cosmos3 generation to make attention handling more consistent across inputs.
* **Tests**
  * Updated integration test waivers, allowing a previously skipped Cosmos3 visual generation check to be re-evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->