### PR TITLE
[https://nvbugs/6435100][fix] Replace the hard assertion with a branch that accepts both shapes: length-1…

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -427,12 +427,14 @@ class ConfigurableMoE(MoE):
         if self.use_dp and self.comm is not None:
             num_rows = self._dp_padded_num_rows(all_rank_num_tokens)
         else:
-            # non-DP: no cross-rank dispatch. The scheduler fills all_rank_num_tokens
-            # from [x.shape[0]] before calling here, so it must be a single-element list.
-            assert len(all_rank_num_tokens) == 1, (
-                f"non-DP path expects a single-element list, got {len(all_rank_num_tokens)}"
-            )
-            num_rows = all_rank_num_tokens[0]
+            # non-DP: no cross-rank dispatch. Chunking is over the local rank's
+            # rows only. The scheduler either passes the length-1 fast path
+            # ``[x.shape[0]]`` (single-rank / no meta), or the TEP path passes a
+            # per-rank list of length ``world_size``; both are valid here.
+            if len(all_rank_num_tokens) == 1:
+                num_rows = all_rank_num_tokens[0]
+            else:
+                num_rows = all_rank_num_tokens[self.mapping.tp_rank]
         return (num_rows + self.moe_max_num_tokens - 1) // self.moe_max_num_tokens
 
     def split_chunk(self, split_token_num: int, split_num_chunks: int) -> List[int]:


### PR DESCRIPTION
## Summary
- **Root cause**: The non-DP branch of calculate_num_chunks asserted a single-element all_rank_num_tokens, but the TEP (attention TP + MoE-EP) path passes a per-rank list of length world_size.
- **Fix**: Replace the hard assertion with a branch that accepts both shapes: length-1 uses index [0], multi-element (TEP) uses the local rank's count via self.mapping.tp_rank; each rank chunks over its own local rows only.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6435100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expert routing handling for non-data-parallel execution when token counts are provided per rank.
  * The system now uses the token count for the current tensor-parallel rank, avoiding failures when more than one per-rank value is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->