### PR TITLE
[https://nvbugs/6432948][fix] Exclude TRTLLM-Gen small tileN (8/16) for all FP8 block-scale MoE tactic selection

### DIFF
--- a/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
+++ b/cpp/tensorrt_llm/thop/fp8BlockScaleMoe.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/runner.h"
 #include "tensorrt_llm/thop/thUtils.h"
 
@@ -24,9 +25,10 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <cstdlib>
+#include <iterator>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 TRTLLM_NAMESPACE_BEGIN
 
@@ -37,6 +39,38 @@ namespace btg = batchedGemm::trtllm::gen;
 using tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::Routing::RoutingMethodType;
 using MoeRunnerType = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::Runner;
 using tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::computeSelectedTileN;
+
+namespace
+{
+
+// WAR: the small-tile (tileN 8/16) dynB TRTLLM-Gen batched-GEMM cubins flakily hit an illegal
+// memory access (garbage TMA-descriptor pointer, MMU fault in the gemm2 K-loop); tileN >= 32 is
+// unaffected (10/10 clean vs minutes-to-crash baseline on B300 TP=4). The exclusion was originally
+// scoped to the fused shared-expert path, but the defect is in the shared small-tile cubins and is
+// not caused by expert fusion: DeepSeek-R1 FP8 TP=8 (unfused) faults identically during warmup,
+// where the 1/2/8-token shapes are the only ones that can select tileN 8/16 (12288 tokens gets
+// tileN 64/128 and always passes). The tiles stay in mSupportedTileN: the ctor builds one runner
+// per tile and each asserts a non-empty passing-config list, so the exclusion has to happen at
+// tactic-selection time.
+//
+// TLLM_MOE_MIN_TILEN overrides the threshold (0 disables the WAR) for A/B experiments.
+// TLLM_MOE_FUSED_MIN_TILEN is the deprecated original name, still honoured as an alias because the
+// exclusion used to apply only to the fused shared-expert path.
+int32_t moeMinTileN()
+{
+    static int32_t const minTileN = []
+    {
+        auto value = tensorrt_llm::common::getIntEnv("TLLM_MOE_MIN_TILEN");
+        if (!value.has_value())
+        {
+            value = tensorrt_llm::common::getIntEnv("TLLM_MOE_FUSED_MIN_TILEN");
+        }
+        return value.value_or(32);
+    }();
+    return minTileN;
+}
+
+} // namespace
 
 at::Tensor run_fp8_block_scale_moe(at::optional<at::Tensor> const& routing_logits,
     std::optional<at::Tensor> const& routing_bias, at::Tensor const& hidden_states,
@@ -403,6 +437,13 @@ public:
         {
             mRunners.emplace(tileN, std::make_unique<RunnerType>(mDtypeElt, mUseDeepSeekFp8, tileN));
         }
+        // Tiles the small-tile WAR (see moeMinTileN) allows tactic selection to pick from. Kept as
+        // a separate sorted list so the tileN heuristic only ever proposes an eligible tile.
+        std::copy_if(mSupportedTileN.begin(), mSupportedTileN.end(), std::back_inserter(mEligibleTileN),
+            [](int32_t tileN) { return tileN >= moeMinTileN(); });
+        TORCH_CHECK(!mEligibleTileN.empty(), "The minimum tileN in force (", moeMinTileN(),
+            ") excludes every supported tileN (max ", mSupportedTileN.back(),
+            "). Lower TLLM_MOE_MIN_TILEN or set it to 0 to disable the small-tile WAR.");
     }
 
     [[nodiscard]] std::vector<std::vector<int64_t>> getValidConfigs(int64_t topK,
@@ -412,33 +453,22 @@ public:
         TORCH_CHECK(numFusedSharedExpert.value_or(0) >= 0, "num_fused_shared_experts must be non-negative.");
         int64_t const totalExpertsPerToken = topK + numFusedSharedExpert.value_or(0);
         int64_t const numTotalLocalExperts = numLocalExperts + numFusedSharedExpert.value_or(0);
-        // WAR: the small-tile (tileN 8/16) dynB TRTLLM-Gen batched-GEMM cubins flakily hit an
-        // illegal memory access (garbage TMA-descriptor pointer, MMU fault in the gemm2 K-loop)
-        // when shared experts are fused into the grouped GEMM (num_fused_shared_experts > 0);
-        // tileN >= 32 is unaffected (10/10 clean vs minutes-to-crash baseline on B300 TP=4).
-        // Restrict the fused path to tileN >= 32 until the kernel-side fix lands (nvbug TBD).
-        // TLLM_MOE_FUSED_MIN_TILEN overrides the threshold (0 disables) for A/B experiments.
-        static int const fusedMinTileN = []()
-        {
-            char const* env = std::getenv("TLLM_MOE_FUSED_MIN_TILEN");
-            return env != nullptr ? std::atoi(env) : 32;
-        }();
+        // Only offer tiles the small-tile WAR allows (see moeMinTileN). The heuristic runs on the
+        // eligible list rather than on mSupportedTileN so that excluded tiles do not consume the
+        // neighbourhood computeSelectedTileN returns -- otherwise a small shape whose heuristic
+        // tile is 8 would be left with tileN 32 as its only candidate instead of {32, 64, 128}.
+        auto const chosen = computeSelectedTileN(mEligibleTileN, numTokens, totalExpertsPerToken, numTotalLocalExperts);
         // returns (tileN, config)
         std::vector<std::vector<int64_t>> tactics;
-        for (auto& [tileN, runner] : mRunners)
+        for (auto const tileN : mEligibleTileN)
         {
-            if (numFusedSharedExpert.value_or(0) > 0 && tileN < fusedMinTileN)
-            {
-                continue;
-            }
-            auto chosen = computeSelectedTileN(mSupportedTileN, numTokens, totalExpertsPerToken, numTotalLocalExperts);
             if (chosen.find(tileN) == chosen.end())
             {
                 continue;
             }
-            auto config_indices_per_runner = runner->getValidConfigIndices(
+            auto const config_indices_per_runner = mRunners.at(tileN)->getValidConfigIndices(
                 totalExpertsPerToken, hiddenSize, intermediateSize, numTotalLocalExperts, numTokens);
-            for (auto cfg : config_indices_per_runner)
+            for (auto const cfg : config_indices_per_runner)
             {
                 tactics.push_back({tileN, cfg});
             }
@@ -472,35 +502,29 @@ public:
 
             float const avg_tokens_per_expert
                 = static_cast<float>(num_tokens * total_experts_per_token) / num_total_local_experts;
-            tileN = std::clamp(nextPowerOfTwo(avg_tokens_per_expert), mSupportedTileN.front(), mSupportedTileN.back());
+            // Snap the heuristic tile up to the smallest eligible one: small warmup batches would
+            // otherwise land on tileN 8/16, which is exactly the path that reaches the defective
+            // small-tile cubins (see moeMinTileN).
+            auto const heuristicTileN
+                = std::lower_bound(mEligibleTileN.begin(), mEligibleTileN.end(), nextPowerOfTwo(avg_tokens_per_expert));
+            tileN = heuristicTileN == mEligibleTileN.end() ? mEligibleTileN.back() : *heuristicTileN;
 
             if (num_fused_shared_experts.value_or(0) > 0)
             {
-                // getDefaultValidConfigIndex only pairs the per-GEMM "default" indices without
-                // re-validating them against the actual problem size. For the inflated fused
-                // expert/topK counts that can return a config whose kernel is absent (illegal
-                // memory access at launch). Pick an explicitly-validated config instead -- the
-                // same set the autotuner draws from -- searching the heuristic tileN first.
+                // The inflated fused expert/topK counts can leave the heuristic tile without a
+                // valid config, so walk the remaining eligible tiles instead of failing outright.
                 config = -1;
                 std::vector<int32_t> tileN_candidates{static_cast<int32_t>(tileN)};
-                for (auto t : mSupportedTileN)
+                for (auto const t : mEligibleTileN)
                 {
                     if (t != tileN)
-                        tileN_candidates.push_back(t);
-                }
-                // Same small-tile exclusion as getValidConfigs (see the WAR comment there).
-                static int const fusedMinTileNFallback = []()
-                {
-                    char const* env = std::getenv("TLLM_MOE_FUSED_MIN_TILEN");
-                    return env != nullptr ? std::atoi(env) : 32;
-                }();
-                for (auto t : tileN_candidates)
-                {
-                    if (t < fusedMinTileNFallback)
                     {
-                        continue;
+                        tileN_candidates.push_back(t);
                     }
-                    auto valid = mRunners.at(t)->getValidConfigIndices(
+                }
+                for (auto const t : tileN_candidates)
+                {
+                    auto const valid = mRunners.at(t)->getValidConfigIndices(
                         total_experts_per_token, hidden_size, intermediate_size, num_total_local_experts, num_tokens);
                     if (!valid.empty())
                     {
@@ -509,8 +533,12 @@ public:
                         break;
                     }
                 }
-                TLLM_CHECK_WITH_INFO(
-                    config != -1, "No valid TRTLLM-Gen config found for fused shared-expert FP8 block-scale MoE.");
+                TLLM_CHECK_WITH_INFO(config != -1,
+                    "No valid TRTLLM-Gen config found for fused shared-expert FP8 block-scale MoE with num_tokens=%ld, "
+                    "hidden_size=%ld, intermediate_size=%ld, experts_per_token=%ld, local_experts=%ld, min_tileN=%d.",
+                    static_cast<int64_t>(num_tokens), static_cast<int64_t>(hidden_size),
+                    static_cast<int64_t>(intermediate_size), total_experts_per_token, num_total_local_experts,
+                    moeMinTileN());
             }
             else
             {
@@ -529,6 +557,7 @@ private:
     using RunnerType = tensorrt_llm::kernels::trtllmGenFp8BlockScaleMoe::MoE::Runner;
 
     std::vector<int32_t> const mSupportedTileN;
+    std::vector<int32_t> mEligibleTileN;
     std::unordered_map<int32_t, std::unique_ptr<RunnerType>> mRunners;
 
     btg::Dtype mDtypeElt{btg::Dtype::E4m3}; // FP8 runner so hard-coded

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -742,6 +742,10 @@ class PyTorchModelEngine(ModelEngine):
         self.kv_cache_manager_key = ResourceManagerType.DRAFT_KV_CACHE_MANAGER if is_draft_model else ResourceManagerType.KV_CACHE_MANAGER
         self.lora_model_config: Optional[LoraModelConfig] = None
         self._trtllm_gen_jit_warmup = False
+        # KV-cache estimation re-instantiates PyExecutor and re-runs warmup on
+        # the same engine; the TRTLLM-Gen FMHA JIT cache is process-global, so
+        # skip subsequent passes. See nvbugs/6432948.
+        self._trtllm_gen_jit_warmup_done = False
 
         # Create config and runner
         cuda_graph_runner_config = CUDAGraphRunnerConfig(
@@ -1387,6 +1391,12 @@ class PyTorchModelEngine(ModelEngine):
         if not issubclass(self.attn_backend.Metadata, TrtllmAttentionMetadata):
             return
 
+        if self._trtllm_gen_jit_warmup_done:
+            logger.info(
+                "Skipping TRTLLM-Gen FMHA JIT warmup: already populated by a prior warmup pass."
+            )
+            return
+
         @contextlib.contextmanager
         def trtllm_gen_fmha_jit_warmup():
             previous = self._trtllm_gen_jit_warmup
@@ -1429,6 +1439,8 @@ class PyTorchModelEngine(ModelEngine):
                                  new_tensors_device=None,
                                  resource_manager=resource_manager)
                 torch.cuda.synchronize()
+
+        self._trtllm_gen_jit_warmup_done = True
 
     def _run_autotuner_warmup(self, resource_manager: ResourceManager):
         """Runs a forward pass to populate the autotuner cache."""

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -385,7 +385,6 @@ perf/test_perf.py::test_perf[t5-bench-float16-maxbs:1-input_output_len:128,20-gp
 perf/test_perf.py::test_perf[t5_base-plugin-float16-bs:8-input_output_len:60,20] SKIP # (https://nvidia.slack.com/archives/C059LSY62BT/p1704525727177449)
 perf/test_perf.py::test_perf[whisper_large_v3-bench-float16-input_output_len:128,20] SKIP
 perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp4_v2_grace_blackwell-r1_fp4_v2_dep4_mtp1_1k8k] SKIP (https://nvbugs/6422339)
-perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_blackwell-r1_fp8_tp8_mtp3_8k1k] SKIP (https://nvbugs/6432948)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-dynamo_gpt_oss_120b_fp4_blackwell-gpt_oss_fp4_tep4_adp_cutlass_8k1k] SKIP (https://nvbugs/6374910)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-glm5_fp4_blackwell-glm5_fp4_tep8_mtp3_8k1k] SKIP (https://nvbugs/6329155)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-k25_thinking_fp4_2_nodes_grace_blackwell-k25_thinking_fp4_tep8_32k8k] SKIP (https://nvbugs/6422339)


### PR DESCRIPTION
## Description

The small-tile (tileN 8/16) dynB TRTLLM-Gen batched-GEMM cubins flakily hit an illegal memory access
(garbage TMA-descriptor pointer, MMU fault in the gemm2 K-loop). tileN >= 32 is unaffected
(10/10 clean vs. minutes-to-crash baseline on B300 TP=4).

The existing workaround excluded those tiles only when shared experts were fused into the grouped GEMM
(`num_fused_shared_experts > 0`). That scoping was wrong: the defect is in the shared small-tile cubins
and is not caused by expert fusion. DeepSeek-R1 FP8 TP=8 (unfused) faults identically during warmup,
where the 1/2/8-token shapes are the only ones that can select tileN 8/16 (12288 tokens gets tileN
64/128 and always passes). The same was already observed in #15297, where the IMA reproduced with
`num_fused_shared_experts=0` and cuda-gdb pointed at a tileN-8 `dynB_sm100f` cubin faulting on
`UTMALDG.4D`.

Changes:

- Hoist the threshold into a single `moeMinTileN()` accessor built on `common::getIntEnv`, replacing two
  independently parsed function-local statics that both used unchecked `std::atoi` (an unparseable value
  silently disabled the WAR). The knob is renamed to `TLLM_MOE_MIN_TILEN`, with
  `TLLM_MOE_FUSED_MIN_TILEN` kept as a deprecated alias since the exclusion is no longer scoped to the
  fused path.
- Precompute `mEligibleTileN` in the ctor and drive both tactic selection and the tileN heuristic from
  it. Running `computeSelectedTileN` on the eligible list rather than on `mSupportedTileN` keeps the
  excluded tiles from consuming the returned neighbourhood: a shape whose heuristic tile is 8 now gets
  `{32, 64, 128}` instead of being left with 32 as its only candidate.
- Reject a threshold that excludes every supported tile at construction time instead of silently
  returning an empty tactic list.
- Include the problem dimensions in the fused fallback's no-valid-config error so a report from an
  unchecked model is actionable without a repro.

The unfused fallback keeps `getDefaultValidConfigIndex`. An earlier revision of this PR routed it
through `getValidConfigIndices(...).front()` as well; that was reverted because the two differ in
ordering, not in validation -- `getDefaultValidConfigIndex` returns the first entry of the list sorted
by the perf heuristic in `KernelRunner.cpp:540-598`, whereas `getValidConfigIndices(...).front()` takes
the first valid pair in raw cartesian order. Switching it would have changed the selected kernel config
for all default-path traffic, which is unrelated to this fix. This PR is now scoped to widening the
tileN exclusion only.

This is a runtime-side workaround; it can be reverted once the kernel-side fix lands.

## Test Coverage

No new tests -- this changes tactic selection only and is covered by the existing FP8 block-scale MoE
tests (`test_trtllm_fp8_block_scales*` in `tests/unittest/_torch/modules/moe/test_moe_backend.py`, on
`l0_b200` / `l0_b300`).

Crash-freedom:
- DeepSeek-R1 FP8 TP=8 (unfused): previously faulted during warmup, now passes.
- B300 TP=4 with fused shared experts: 10/10 clean runs (unchanged from the previous WAR).

Cost of the exclusion, measured op-level on B200 with DeepSeek-R1 FP8 EP=8 shapes
(hidden=7168, intermediate=2048, num_experts=256, local_experts=32, top_k=8). Each (num_tokens, tileN)
combination runs in its own process; the number reported is the best config for that tile, i.e. what the
autotuner would converge to.

| num_tokens | best {8,16} | best {32,64,128} | delta |
| ---: | ---: | ---: | ---: |
| 1 | 34.8 us | 34.7 us | -0.18% |
| 2 | 34.3 us | 34.8 us | +1.56% |
| 4 | 35.4 us | 36.4 us | +2.93% |
| 8 | 38.1 us | 39.1 us | +2.62% |
| 16 | 47.7 us | 50.2 us | +5.29% |
| 32 | 50.5 us | 50.7 us | +0.34% |
| 64 | 54.9 us | 54.5 us | -0.77% |

Worst case is +5.3% at 16 tokens, with every other point within +/-3% and two points slightly faster.
Note that the small tiles did not fault during this sweep -- the IMA is flaky and reproduces with
cascaded runs over real captured `token_ids` -- so these numbers bound the cost of the WAR but say
nothing about its necessity.

`TLLM_MOE_MIN_TILEN=0` restores the previous behaviour for A/B experiments.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## Links
- Bug: https://nvbugs/6432948

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
