### PR TITLE
[https://nvbugs/6428113][fix] Replace the assertion + `[0]` indexing with `max(all_rank_num_tokens)`…

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -427,12 +427,11 @@ class ConfigurableMoE(MoE):
         if self.use_dp and self.comm is not None:
             num_rows = self._dp_padded_num_rows(all_rank_num_tokens)
         else:
-            # non-DP: no cross-rank dispatch. The scheduler fills all_rank_num_tokens
-            # from [x.shape[0]] before calling here, so it must be a single-element list.
-            assert len(all_rank_num_tokens) == 1, (
-                f"non-DP path expects a single-element list, got {len(all_rank_num_tokens)}"
-            )
-            num_rows = all_rank_num_tokens[0]
+            # non-DP: no cross-rank dispatch. The list is either a single
+            # element (scheduler default / bench-moe) or per-rank (TEP: TP
+            # attention + EP MoE); ``max`` handles both and keeps chunk
+            # counts in lockstep across ranks.
+            num_rows = max(all_rank_num_tokens)
         return (num_rows + self.moe_max_num_tokens - 1) // self.moe_max_num_tokens
 
     def split_chunk(self, split_token_num: int, split_num_chunks: int) -> List[int]:


### PR DESCRIPTION
## Summary
- **Root cause**: PR #15397 added `assert len(all_rank_num_tokens) == 1` on the non-DP branch, but TEP callers legitimately pass a length-world_size list (one entry per rank).
- **Fix**: Replace the assertion + `[0]` indexing with `max(all_rank_num_tokens)`; collapses to the same scalar for single-element lists (bench-moe callsite unaffected) and gives every rank a consistent worst-case chunk count for TEP.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6428113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MoE chunk calculation so it now handles both single-value and per-rank token counts without failing.
  * Kept chunk sizing consistent across ranks, which helps avoid mismatches in mixed execution setups.
  * No change to data-parallel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->