### PR TITLE
[None][ci] Update golden telemetry manifest

### DIFF
--- a/tensorrt_llm/usage/llm_args_golden_manifest.json
+++ b/tensorrt_llm/usage/llm_args_golden_manifest.json
@@ -151,6 +151,13 @@
     },
     {
       "allowed_values": [],
+      "annotation": "<class 'int'>",
+      "converter": "",
+      "kind": "value",
+      "path": "cache_transceiver_config.kv_cache_bounce_size_mb"
+    },
+    {
+      "allowed_values": [],
       "annotation": "Optional[Annotated[int, Gt(gt=0)]]",
       "converter": "",
       "kind": "value",
@@ -430,6 +437,13 @@
       "converter": "",
       "kind": "value",
       "path": "enable_lora"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "<class 'bool'>",
+      "converter": "",
+      "kind": "value",
+      "path": "enable_low_latency_host_dispatch"
     },
     {
       "allowed_values": [],
@@ -954,6 +968,20 @@
       "converter": "",
       "kind": "value",
       "path": "moe_tensor_parallel_size"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "<class 'int'>",
+      "converter": "",
+      "kind": "value",
+      "path": "multimodal_config.encoder_side_stream_max_ahead"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "Optional[float]",
+      "converter": "",
+      "kind": "value",
+      "path": "multimodal_config.video_pruning_rate"
     },
     {
       "allowed_values": [
@@ -1972,13 +2000,6 @@
       "converter": "",
       "kind": "value",
       "path": "use_cute_dsl_blockscaling_mm"
-    },
-    {
-      "allowed_values": [],
-      "annotation": "Optional[float]",
-      "converter": "",
-      "kind": "value",
-      "path": "video_pruning_rate"
     }
   ],
   "TrtLlmArgs": [
@@ -2636,6 +2657,13 @@
       "converter": "",
       "kind": "categorical",
       "path": "cache_transceiver_config.backend"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "<class 'int'>",
+      "converter": "",
+      "kind": "value",
+      "path": "cache_transceiver_config.kv_cache_bounce_size_mb"
     },
     {
       "allowed_values": [],
@@ -3499,6 +3527,7 @@
         "W4A8_MXFP4_MXFP8",
         "W4A16_MXFP4",
         "MXFP8",
+        "W4A16_NVFP4",
         "NVFP4_AWQ",
         "NVFP4_ARC",
         "NO_QUANT"
@@ -3555,6 +3584,7 @@
         "W4A8_MXFP4_MXFP8",
         "W4A16_MXFP4",
         "MXFP8",
+        "W4A16_NVFP4",
         "NVFP4_AWQ",
         "NVFP4_ARC",
         "NO_QUANT"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options for KV-cache transfer sizing and low-latency host dispatch.
  * Added multimodal tuning options for encoder stream scheduling and video pruning.
  * Added support for the `W4A16_NVFP4` quantization algorithm.

* **Updates**
  * Replaced the legacy top-level video pruning setting with the nested multimodal configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

#16013 Introduced a new reference file that unfortunately was merged
without changes in `main` that would have required it to be updated
(test-time conflict).

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
