### PR TITLE
[None][feat] Support custom masks in TRTLLM attention

### DIFF
--- a/cpp/tensorrt_llm/kernels/unfusedAttentionKernels/unfusedAttentionKernels_2_template.h
+++ b/cpp/tensorrt_llm/kernels/unfusedAttentionKernels/unfusedAttentionKernels_2_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.  All rights reserved.
  * Copyright (c) 2021, NAVER Corp.  Authored by CLOVA.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1644,6 +1644,7 @@ void invokeApplyBiasRopeUpdateKVCacheDispatch(QKVPreprocessingParams<T, KVCacheB
     case 192: kernelV2DispatchHeadSize<192, 192, T, TCache, KVCacheBuffer>(params, stream); break;
     case 224: kernelV2DispatchHeadSize<224, 224, T, TCache, KVCacheBuffer>(params, stream); break;
     case 256: kernelV2DispatchHeadSize<256, 256, T, TCache, KVCacheBuffer>(params, stream); break;
+    case 512: kernelV2DispatchHeadSize<512, 512, T, TCache, KVCacheBuffer>(params, stream); break;
     case 576: kernelV2DispatchHeadSize<576, 576, T, TCache, KVCacheBuffer>(params, stream); break;
     default:
         // Fall back to v1 kernel.

--- a/cpp/tensorrt_llm/kernels/unfusedAttentionKernels/unfusedAttentionKernels_2_template.h
+++ b/cpp/tensorrt_llm/kernels/unfusedAttentionKernels/unfusedAttentionKernels_2_template.h
@@ -463,9 +463,9 @@ __global__ void applyBiasRopeUpdateKVCache(QKVPreprocessingParams<T, KVCacheBuff
                 = static_cast<size_t>(global_token_idx) * input_hidden_size + src_v_offset + hidden_idx_kv;
 
             VecType q, q_pair;
-            VecType k{}, v{}, k_pair{};
+            VecType k, v, k_pair;
             // key without position embedding
-            VecType k_wo_pos{};
+            VecType k_wo_pos;
 
             // load q,k,v and add bias
             if (valid_head_dim_idx)
@@ -477,6 +477,12 @@ __global__ void applyBiasRopeUpdateKVCache(QKVPreprocessingParams<T, KVCacheBuff
                     k = *reinterpret_cast<VecType const*>(&params.qkv_input[src_k_idx]);
                     v = *reinterpret_cast<VecType const*>(&params.qkv_input[src_v_idx]);
                     k_pair = *reinterpret_cast<VecType const*>(&params.qkv_input[src_k_idx + rotated_head_dim_offset]);
+                }
+                else
+                {
+                    // The rotary helpers update Q and K together. Reuse Q as the ignored K input.
+                    k = q;
+                    k_pair = q_pair;
                 }
 
                 if constexpr (ADD_BIAS)
@@ -888,16 +894,22 @@ __global__ void applyBiasRopeUpdateKVCacheV2(QKVPreprocessingParams<T, KVCacheBu
             = static_cast<size_t>(bounded_global_token_idx) * input_hidden_size + src_v_offset + hidden_idx_kv;
 
         auto q = *reinterpret_cast<VecT const*>(&params.qkv_input[src_q_idx]);
-        VecT k{};
-        VecT v{};
+        VecT k;
+        VecT v;
         [[maybe_unused]] auto q_pair
             = *reinterpret_cast<VecT const*>(&params.qkv_input[src_q_idx + rotated_head_dim_offset]);
-        [[maybe_unused]] VecT k_pair{};
+        [[maybe_unused]] VecT k_pair;
         if (!params.q_only_input)
         {
             k = *reinterpret_cast<VecT const*>(&params.qkv_input[src_k_idx]);
             v = *reinterpret_cast<VecT const*>(&params.qkv_input[src_v_idx]);
             k_pair = *reinterpret_cast<VecT const*>(&params.qkv_input[src_k_idx + rotated_head_dim_offset]);
+        }
+        else
+        {
+            // The rotary helpers update Q and K together. Reuse Q as the ignored K input.
+            k = q;
+            k_pair = q_pair;
         }
 
         // Bias should have been fused with QKV projection, but we keep the logic here for unit tests.

--- a/tensorrt_llm/_torch/attention_backend/fmha/__init__.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/__init__.py
@@ -18,6 +18,7 @@ from .flashinfer_trtllm_gen import FlashInferTrtllmGenFmha
 from .interface import Fmha
 from .phased import FmhaParams, PhasedFmha
 from .registry import DEFAULT_FMHA_LIBS, FMHA_LIBS, FmhaCls, get_enabled_fmha_lib_classes
+from .triton_custom_mask import TritonCustomMaskFmha
 
 __all__ = [
     "DEFAULT_FMHA_LIBS",
@@ -28,5 +29,6 @@ __all__ = [
     "FmhaCls",
     "FmhaParams",
     "PhasedFmha",
+    "TritonCustomMaskFmha",
     "get_enabled_fmha_lib_classes",
 ]

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -54,11 +54,11 @@ from tensorrt_llm._torch.attention_backend.sparse.skip_softmax import SkipSoftma
 from tensorrt_llm._utils import get_sm_version, is_sm_100f, torch_dtype_to_binding
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal import thop
-from tensorrt_llm.functional import AttentionMaskType
+from tensorrt_llm.functional import AttentionMaskType, PositionEmbeddingType
 from tensorrt_llm.logger import logger
 from tensorrt_llm.quantization.mode import QuantMode
 
-from .phased import FmhaParams, PhasedFmha
+from .phased import FmhaParams, PhasedFmha, get_trtllm_gen_context_workspace_size
 
 if TYPE_CHECKING:
     from tensorrt_llm._torch.attention_backend.trtllm import (
@@ -228,52 +228,6 @@ def _trtllm_gen_batch_context_with_kv_cache(
 
 
 @lru_cache(maxsize=128)
-def _get_context_workspace_layout(
-    dtype: torch.dtype,
-    batch_size: int,
-    num_tokens: int,
-    num_heads: int,
-    head_size: int,
-    rotary_embedding_dim: int,
-    fp8_context_fmha: bool,
-) -> dict[str, int]:
-    return thop.get_trtllm_gen_context_workspace_layout(
-        dtype,
-        batch_size,
-        num_tokens,
-        num_heads,
-        head_size,
-        rotary_embedding_dim,
-        True,
-        fp8_context_fmha,
-    )
-
-
-@lru_cache(maxsize=128)
-def _get_context_workspace_size(
-    dtype: torch.dtype,
-    max_num_seq: int,
-    max_num_tokens: int,
-    num_heads: int,
-    head_size: int,
-    rotary_embedding_dim: int,
-    fp8_context_fmha: bool,
-) -> int:
-    if max_num_tokens == 0:
-        return 0
-    layout = _get_context_workspace_layout(
-        dtype,
-        max_num_seq,
-        max_num_tokens,
-        num_heads,
-        head_size,
-        rotary_embedding_dim,
-        fp8_context_fmha,
-    )
-    return int(layout["total_size"])
-
-
-@lru_cache(maxsize=128)
 def _get_generation_workspace_layout(
     dtype: torch.dtype,
     batch_beam: int,
@@ -332,7 +286,7 @@ def _get_workspace_size(
     rotary_embedding_dim: int,
     fp8_context_fmha: bool,
 ) -> int:
-    context_size = _get_context_workspace_size(
+    context_size = get_trtllm_gen_context_workspace_size(
         dtype,
         max_num_requests,
         num_tokens,
@@ -417,18 +371,6 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
 
         # Lazily set on the first forward() call from the query device.
         self._multi_processor_count: Optional[int] = None
-
-    def _get_total_num_blocks(self, meta: "TrtllmAttentionMetadata") -> int:
-        kv_cache_manager = meta.kv_cache_manager
-        if kv_cache_manager is not None:
-            get_page_index_upper_bound = getattr(
-                getattr(kv_cache_manager, "impl", None), "get_page_index_upper_bound", None
-            )
-            # KVCacheManagerV2 exposes this implementation-only API and reports an
-            # already-flattened page-index bound, unlike the legacy logical block count.
-            if get_page_index_upper_bound is not None:
-                return int(kv_cache_manager.blocks_in_primary_pool)
-        return super()._get_total_num_blocks(meta)
 
     @classmethod
     def is_available(cls, attn: "TrtllmAttention") -> bool:
@@ -565,13 +507,14 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
 
         return True, ""
 
-    def is_supported(
+    def _is_phase_supported(
         self,
         q: torch.Tensor,
         k: Optional[torch.Tensor],
         v: Optional[torch.Tensor],
         metadata: "TrtllmAttentionMetadata",
         forward_args: AttentionForwardArgs,
+        phase: str,
     ) -> bool:
         supported, reason = self._is_supported_with_reason(
             q,
@@ -582,8 +525,38 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             forward_args,
         )
         if not supported:
-            logger.debug(f"FlashInfer trtllm-gen fmha library does not support {reason}")
+            logger.debug(f"FlashInfer trtllm-gen fmha library does not support {phase}: {reason}")
         return supported
+
+    def is_context_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        return self._is_phase_supported(q, k, v, metadata, forward_args, "context")
+
+    def is_generation_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        return self._is_phase_supported(q, k, v, metadata, forward_args, "generation")
+
+    def is_mla_generation_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        return self._is_phase_supported(q, k, v, metadata, forward_args, "MLA generation")
 
     def _is_supported_with_reason(
         self,
@@ -647,8 +620,35 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         attn_input_type = fwd.attention_input_type
         has_context_phase = attn_input_type != AttentionInputType.generation_only
         has_generation_phase = attn_input_type != AttentionInputType.context_only
+        has_separate_qkv = not fwd.is_fused_qkv and k is not None and v is not None
+        has_q_only = k is None and v is None and q.size(-1) == attn.num_heads * attn.head_dim
+        needs_preprocessed_generation = (
+            has_generation_phase
+            and not is_mla_enable
+            and attn.head_dim > 256
+            and not fwd.is_fused_qkv
+        )
+        has_preprocessed_generation = needs_preprocessed_generation and (
+            has_separate_qkv or has_q_only
+        )
         q_dtype = q.dtype
         o_dtype = output.dtype
+
+        if needs_preprocessed_generation and not has_preprocessed_generation:
+            return (
+                False,
+                "[Generation] Head dimensions above 256 require module-side Q/K/V preprocessing.",
+            )
+        if has_preprocessed_generation:
+            supported, reason = self._check_preprocessed_generation_with_reason(
+                q,
+                k,
+                v,
+                meta,
+                fwd,
+            )
+            if not supported:
+                return False, reason
 
         if q_dtype not in self.SUPPORTED_INPUT_DTYPES:
             return False, f"input dtype {q_dtype}. Supported: FP16, BF16, FP8 (E4M3)."
@@ -687,10 +687,11 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             if attn.head_dim in self.UNSUPPORTED_HEAD_SIZES_CONTEXT:
                 return False, f"[Context] head size {attn.head_dim}."
             try:
-                if AttentionMaskType(fwd.mask_type) == AttentionMaskType.custom_mask:
-                    return False, "[Context] custom mask."
+                mask_type = AttentionMaskType(fwd.mask_type)
             except ValueError:
                 return False, f"[Context] invalid mask_type: {fwd.mask_type}."
+            if mask_type == AttentionMaskType.custom_mask:
+                return False, "[Context] custom mask."
             if has_alibi:
                 return False, "[Context] ALiBi."
             if (q_dtype, kv_cache_dtype, o_dtype) not in self.SUPPORTED_DTYPE_COMBOS_CONTEXT:
@@ -743,6 +744,39 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             supported = sorted(self.SUPPORTED_TOKENS_PER_BLOCK)
             return False, f"tokens_per_block ({tokens_per_block}). Supported: {supported}."
 
+        return True, ""
+
+    def _check_preprocessed_generation_with_reason(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> tuple[bool, str]:
+        if metadata.is_cross:
+            return False, "Preprocessed generation does not support cross attention."
+        if metadata.kv_cache_block_offsets is None:
+            return False, "Preprocessed generation requires paged KV cache."
+        has_separate_qkv = not forward_args.is_fused_qkv and k is not None and v is not None
+        has_q_only = (
+            k is None and v is None and q.size(-1) == self.attn.num_heads * self.attn.head_dim
+        )
+        if not has_separate_qkv and not has_q_only:
+            return False, "Preprocessed generation requires separate Q/K/V or Q-only input."
+        if q.dtype not in self.SUPPORTED_INPUT_DTYPES:
+            return False, f"Input dtype {q.dtype} is not supported."
+        output = forward_args.output
+        if output is None or output.dtype != q.dtype:
+            return False, "Preprocessed generation requires output to match the input dtype."
+        if forward_args.output_sf is not None:
+            return False, "Preprocessed generation does not support NVFP4 output."
+        if QuantMode(self.attn.quant_mode).has_kv_cache_quant():
+            return False, "Preprocessed generation does not support quantized KV cache."
+        if forward_args.attention_sinks is not None:
+            return False, "Preprocessed generation does not support attention sinks."
+        if PositionEmbeddingType(self.attn.position_embedding_type).is_rope():
+            return False, "Preprocessed generation requires RoPE before the backend."
         return True, ""
 
     @staticmethod
@@ -1009,10 +1043,299 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             self._multi_processor_count,  # multi_processor_count
         )
 
+    @staticmethod
+    def _split_preprocessed_qkv(
+        params: FmhaParams,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        attn = params.attn
+        if params.qkv_input is None:
+            raise RuntimeError("Preprocessed attention requires Q input.")
+        if params.key_input is None or params.value_input is None:
+            raise RuntimeError("Preprocessed attention requires separate K and V input.")
+        q = params.qkv_input.view(
+            params.num_tokens,
+            attn.num_heads,
+            attn.head_dim,
+        )
+        k = params.key_input.view(
+            params.num_tokens,
+            attn.num_kv_heads,
+            attn.head_dim,
+        )
+        v = params.value_input.view(
+            params.num_tokens,
+            attn.num_kv_heads,
+            attn.head_dim,
+        )
+        return q, k, v
+
+    @staticmethod
+    def _append_preprocessed_kv(
+        params: FmhaParams,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        prefix_lens: torch.Tensor,
+        seq_offset: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, list[int]]:
+        attn = params.attn
+        meta = params.meta
+        if meta.kv_cache_manager is None:
+            raise RuntimeError("Preprocessed attention requires a KV cache manager.")
+
+        num_sequences = qo_indptr.numel() - 1
+        extend_lens = meta.seq_lens[seq_offset : seq_offset + num_sequences].tolist()
+        cached_lens = meta.kv_cache_params.num_cached_tokens_per_seq[
+            seq_offset : seq_offset + num_sequences
+        ]
+        total_lens = [cached + extend for cached, extend in zip(cached_lens, extend_lens)]
+        page_counts = [
+            (total_len + params.tokens_per_block - 1) // params.tokens_per_block
+            for total_len in total_lens
+        ]
+
+        layer_idx = attn.local_layer_idx
+        cache_key = (
+            layer_idx,
+            seq_offset,
+            tuple(total_lens),
+            params.tokens_per_block,
+        )
+        page_metadata_cache = getattr(meta, "_preprocessed_page_metadata", None)
+        if page_metadata_cache is None:
+            page_metadata_cache = {}
+            meta._preprocessed_page_metadata = page_metadata_cache
+        page_metadata = page_metadata_cache.get(cache_key)
+        if page_metadata is None:
+            block_ids_per_seq = meta.kv_cache_manager.get_batch_cache_indices(
+                meta.request_ids[seq_offset : seq_offset + num_sequences],
+                layer_idx=layer_idx,
+            )
+            page_indices = [
+                page_id
+                for block_ids, page_count in zip(block_ids_per_seq, page_counts)
+                for page_id in block_ids[:page_count]
+            ]
+            page_table_indices = torch.tensor(
+                page_indices,
+                dtype=torch.int32,
+                device=q.device,
+            )
+            page_table_indptr = torch.zeros(
+                num_sequences + 1,
+                dtype=torch.int32,
+                device=q.device,
+            )
+            page_table_indptr[1:] = torch.cumsum(
+                torch.tensor(page_counts, dtype=torch.int32, device=q.device),
+                dim=0,
+            )
+            last_page_lens = torch.tensor(
+                [
+                    total_len - (page_count - 1) * params.tokens_per_block
+                    for total_len, page_count in zip(total_lens, page_counts)
+                ],
+                dtype=torch.int32,
+                device=q.device,
+            )
+            batch_indices = torch.repeat_interleave(
+                torch.arange(num_sequences, dtype=torch.int32, device=q.device),
+                qo_indptr[1:] - qo_indptr[:-1],
+            )
+            positions = (
+                torch.arange(params.num_tokens, dtype=torch.int32, device=q.device)
+                - qo_indptr[:-1][batch_indices]
+                + prefix_lens[batch_indices]
+            )
+            page_metadata = (
+                page_table_indptr,
+                page_table_indices,
+                last_page_lens,
+                batch_indices,
+                positions,
+            )
+            page_metadata_cache[cache_key] = page_metadata
+        (
+            page_table_indptr,
+            page_table_indices,
+            last_page_lens,
+            batch_indices,
+            positions,
+        ) = page_metadata
+        kv_cache = meta.kv_cache_manager.get_buffers(layer_idx, kv_layout=meta.kv_layout)
+        flashinfer.page.append_paged_kv_cache(
+            append_key=k,
+            append_value=v,
+            batch_indices=batch_indices,
+            positions=positions,
+            paged_kv_cache=kv_cache,
+            kv_indices=page_table_indices,
+            kv_indptr=page_table_indptr,
+            kv_last_page_len=last_page_lens,
+            kv_layout=meta.kv_layout,
+        )
+        return (
+            kv_cache,
+            page_table_indptr,
+            page_table_indices,
+            last_page_lens,
+            total_lens,
+        )
+
+    @staticmethod
+    def _pad_generation_block_tables(
+        block_tables: torch.Tensor,
+        tokens_per_block: int,
+    ) -> torch.Tensor:
+        pages_per_superblock = 128 // tokens_per_block
+        if pages_per_superblock <= 1:
+            return block_tables
+        remainder = block_tables.size(-1) % pages_per_superblock
+        if remainder == 0:
+            return block_tables
+        return torch.nn.functional.pad(
+            block_tables,
+            (0, pages_per_superblock - remainder),
+            value=0,
+        )
+
+    def _run_preprocessed_generation(self, params: FmhaParams) -> None:
+        attn = params.attn
+        meta = params.meta
+        fwd = params.fwd
+        if params.context_buf is None or params.sequence_lengths is None:
+            raise RuntimeError("Preprocessed generation requires output and sequence lengths.")
+        if meta.kv_cache_manager is None:
+            raise RuntimeError("Preprocessed generation requires a KV cache manager.")
+        if QuantMode(attn.quant_mode).has_kv_cache_quant():
+            raise RuntimeError("Preprocessed generation does not support quantized KV cache.")
+
+        if params.qkv_input is None:
+            raise RuntimeError("Preprocessed generation requires Q input.")
+        q = params.qkv_input.view(
+            params.num_tokens,
+            attn.num_heads,
+            attn.head_dim,
+        )
+        num_sequences = meta.num_generations
+        extend_lens = meta.seq_lens[params.seq_offset : params.seq_offset + num_sequences].tolist()
+        cached_lens = meta.kv_cache_params.num_cached_tokens_per_seq[
+            params.seq_offset : params.seq_offset + num_sequences
+        ]
+        lengths_key = (params.seq_offset, tuple(extend_lens), tuple(cached_lens))
+        lengths_cache = getattr(meta, "_preprocessed_generation_lengths", None)
+        if lengths_cache is None:
+            lengths_cache = {}
+            meta._preprocessed_generation_lengths = lengths_cache
+        length_tensors = lengths_cache.get(lengths_key)
+        if length_tensors is None:
+            qo_indptr = torch.zeros(
+                num_sequences + 1,
+                dtype=torch.int32,
+                device=q.device,
+            )
+            qo_indptr[1:] = torch.cumsum(
+                torch.tensor(extend_lens, dtype=torch.int32, device=q.device),
+                dim=0,
+            )
+            prefix_lens = torch.tensor(
+                cached_lens,
+                dtype=torch.int32,
+                device=q.device,
+            )
+            length_tensors = (qo_indptr, prefix_lens)
+            lengths_cache[lengths_key] = length_tensors
+        qo_indptr, prefix_lens = length_tensors
+        if params.key_input is not None and params.value_input is not None:
+            _, k, v = self._split_preprocessed_qkv(params)
+            self._append_preprocessed_kv(
+                params,
+                q,
+                k,
+                v,
+                qo_indptr,
+                prefix_lens,
+                seq_offset=params.seq_offset,
+            )
+
+        batch_beam = params.num_requests * meta.beam_width
+        kv_metadata = thop.build_trtllm_gen_kv_cache_metadata(
+            meta.host_kv_cache_pool_pointers,
+            meta.host_kv_cache_pool_mapping,
+            meta.kv_cache_block_offsets,
+            attn.local_layer_idx,
+            attn.num_kv_heads,
+            params.tokens_per_block,
+            attn.head_dim,
+            params.kv_factor,
+            params.total_num_blocks,
+            attn.quant_mode,
+            params.seq_offset,
+            batch_beam,
+            q.dtype,
+        )
+        kv_pool = kv_metadata[0]
+        block_tables = self._pad_generation_block_tables(
+            kv_metadata[1],
+            params.tokens_per_block,
+        )
+        kv_scale_pool = kv_metadata[2] if len(kv_metadata) > 2 else None
+
+        fmha_workspace = params.workspace
+        _clear_multi_ctas_kv_counter_workspace(
+            fmha_workspace,
+            attn.num_heads,
+            meta.max_num_requests,
+            self._multi_processor_count,
+        )
+        is_multi_token_gen = any(extend_len != 1 for extend_len in extend_lens)
+        q_len_per_req = None if is_multi_token_gen else params.input_seq_length
+        decode_max_q_len = max(extend_lens) if is_multi_token_gen else None
+        decode_cu_seqlens = qo_indptr if is_multi_token_gen else None
+        window_left = self._compute_window_left(
+            params.cyclic_attention_window_size,
+            params.max_past_kv_length,
+            self._get_attention_chunk_size(attn),
+        )
+
+        _trtllm_gen_batch_decode_with_kv_cache(
+            q,
+            kv_pool,
+            fmha_workspace,
+            block_tables,
+            params.sequence_lengths,
+            params.max_past_kv_length,
+            self._get_bmm1_scale(attn),
+            1.0,
+            window_left,
+            params.context_buf,
+            fwd.attention_sinks,
+            self._enable_pdl,
+            q_len_per_req,
+            decode_max_q_len,
+            decode_cu_seqlens,
+            kv_scale_pool,
+            self.USE_SHARED_PAGED_KV_IDX,
+        )
+
     def run_generation(
         self,
         params: FmhaParams,
     ) -> None:
+        q_only_hidden_size = params.attn.num_heads * params.attn.head_dim
+        uses_preprocessed_qkv = (
+            params.attn.head_dim > 256
+            and params.qkv_input is not None
+            and (
+                (params.key_input is not None and params.value_input is not None)
+                or params.qkv_input.size(-1) == q_only_hidden_size
+            )
+        )
+        if uses_preprocessed_qkv:
+            self._run_preprocessed_generation(params)
+            return
+
         attn = params.attn
         meta = params.meta
         fwd = params.fwd
@@ -1167,14 +1490,10 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             batch_beam,  # batch_size
             params.attention_input.dtype,  # dtype
         )
-
-        pages_per_superblock = 128 // params.tokens_per_block
-        if pages_per_superblock > 1:
-            num_blocks = block_tables.size(-1)
-            remainder = num_blocks % pages_per_superblock
-            if remainder != 0:
-                pad = pages_per_superblock - remainder
-                block_tables = torch.nn.functional.pad(block_tables, (0, pad), value=0)
+        block_tables = self._pad_generation_block_tables(
+            block_tables,
+            params.tokens_per_block,
+        )
 
         kv_lora_rank = attn.kv_lora_rank or 0
         qk_nope_head_dim = attn.qk_nope_head_dim or 0

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -771,8 +771,9 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             return False, "Preprocessed generation requires output to match the input dtype."
         if forward_args.output_sf is not None:
             return False, "Preprocessed generation does not support NVFP4 output."
-        if QuantMode(self.attn.quant_mode).has_kv_cache_quant():
-            return False, "Preprocessed generation does not support quantized KV cache."
+        kv_cache_quant_mode = QuantMode(self.attn.quant_mode)
+        if kv_cache_quant_mode.has_kv_cache_quant() and not kv_cache_quant_mode.has_fp8_kv_cache():
+            return False, "Preprocessed generation supports only unquantized or FP8 KV cache."
         if forward_args.attention_sinks is not None:
             return False, "Preprocessed generation does not support attention sinks."
         if PositionEmbeddingType(self.attn.position_embedding_type).is_rope():
@@ -806,7 +807,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             output.dtype == torch.float8_e4m3fn
             or output.dtype == torch.uint8
             or kv_cache_quant_mode.has_fp4_kv_cache()
-            or (kv_cache_quant_mode.has_fp8_kv_cache() and not is_gen_only)
+            or kv_cache_quant_mode.has_fp8_kv_cache()
         )
 
     def prepare_workspace(
@@ -1208,8 +1209,9 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             raise RuntimeError("Preprocessed generation requires output and sequence lengths.")
         if meta.kv_cache_manager is None:
             raise RuntimeError("Preprocessed generation requires a KV cache manager.")
-        if QuantMode(attn.quant_mode).has_kv_cache_quant():
-            raise RuntimeError("Preprocessed generation does not support quantized KV cache.")
+        kv_cache_quant_mode = QuantMode(attn.quant_mode)
+        if kv_cache_quant_mode.has_kv_cache_quant() and not kv_cache_quant_mode.has_fp8_kv_cache():
+            raise RuntimeError("Preprocessed generation supports only unquantized or FP8 KV cache.")
 
         if params.qkv_input is None:
             raise RuntimeError("Preprocessed generation requires Q input.")
@@ -1218,6 +1220,8 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             attn.num_heads,
             attn.head_dim,
         )
+        if kv_cache_quant_mode.has_fp8_kv_cache():
+            q = q.to(torch.float8_e4m3fn)
         num_sequences = meta.num_generations
         extend_lens = meta.seq_lens[params.seq_offset : params.seq_offset + num_sequences].tolist()
         cached_lens = meta.kv_cache_params.num_cached_tokens_per_seq[
@@ -1249,6 +1253,9 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         qo_indptr, prefix_lens = length_tensors
         if params.key_input is not None and params.value_input is not None:
             _, k, v = self._split_preprocessed_qkv(params)
+            if kv_cache_quant_mode.has_fp8_kv_cache():
+                k = k.to(torch.float8_e4m3fn)
+                v = v.to(torch.float8_e4m3fn)
             self._append_preprocessed_kv(
                 params,
                 q,

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -60,7 +60,12 @@ from tensorrt_llm.quantization.mode import QuantMode
 
 from .interface import FmhaPhase, _CuteDslMlaStagingKey
 from .phased import FmhaParams, PhasedFmha
-from .trtllm_gen_utils import get_trtllm_gen_context_workspace_size
+from .utils import (
+    get_attention_chunk_size,
+    get_bmm1_scale,
+    get_multi_processor_count_for_device,
+    get_trtllm_gen_context_workspace_size,
+)
 
 if TYPE_CHECKING:
     from tensorrt_llm._torch.attention_backend.trtllm import (
@@ -569,14 +574,6 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             return kv_cache_manager.dtype
         return None
 
-    @staticmethod
-    def _get_bmm1_scale(attn: "TrtllmAttention") -> float:
-        return 1.0 / (math.sqrt(attn.head_dim) * attn.q_scaling)
-
-    @staticmethod
-    def _get_attention_chunk_size(attn: "TrtllmAttention") -> int:
-        return attn.attention_chunk_size if attn.attention_chunk_size is not None else 0
-
     @classmethod
     def _check_mla_generation_support(
         cls,
@@ -856,11 +853,6 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
 
         return True, ""
 
-    @staticmethod
-    @lru_cache(maxsize=None)
-    def _get_multi_processor_count_for_device(device_index: int) -> int:
-        return torch.cuda.get_device_properties(device_index).multi_processor_count
-
     def _get_multi_processor_count(self, device: torch.device) -> int:
         device = torch.device(device)
         if device.type != "cuda":
@@ -868,7 +860,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         device_index = device.index
         if device_index is None:
             device_index = torch.cuda.current_device()
-        return self._get_multi_processor_count_for_device(device_index)
+        return get_multi_processor_count_for_device(device_index)
 
     def _use_fp8_context_fmha(
         self,
@@ -1051,8 +1043,8 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         meta = params.meta
         fwd = params.fwd
         rope_params = attn.rope_params
-        bmm1_scale_static = self._get_bmm1_scale(attn)
-        attention_chunk_size = self._get_attention_chunk_size(attn)
+        bmm1_scale_static = get_bmm1_scale(attn)
+        attention_chunk_size = get_attention_chunk_size(attn)
         output = fwd.output
         fp8_context_fmha = self._use_fp8_context_fmha(output, fwd.attention_input_type)
         (
@@ -1209,8 +1201,8 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         meta = params.meta
         fwd = params.fwd
         rope_params = attn.rope_params
-        bmm1_scale_static = self._get_bmm1_scale(attn)
-        attention_chunk_size = self._get_attention_chunk_size(attn)
+        bmm1_scale_static = get_bmm1_scale(attn)
+        attention_chunk_size = get_attention_chunk_size(attn)
         output = fwd.output
         fp8_context_fmha = self._use_fp8_context_fmha(output, fwd.attention_input_type)
         batch_beam = params.num_requests * meta.beam_width
@@ -1335,7 +1327,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             raise NotImplementedError(
                 "Sliding-window attention is not supported by MLA decode path."
             )
-        if self._get_attention_chunk_size(attn) != 0:
+        if get_attention_chunk_size(attn) != 0:
             raise NotImplementedError("Chunked-attention is not supported by MLA decode path.")
 
         batch_beam = params.num_requests * meta.beam_width

--- a/tensorrt_llm/_torch/attention_backend/fmha/phased.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/phased.py
@@ -415,9 +415,11 @@ class PhasedFmha(Fmha):
                 f"num_ctx_tokens={num_ctx_tokens}, attention_input_type={attention_input_type}."
             )
 
+        fp8_fmha = context_fmha if context_fmha is not None else generation_fmha
+        fp8_args = context_args if context_fmha is not None else generation_args
         fp8_context_fmha = (
-            context_fmha.get_fp8_context_fmha(q, output, metadata, context_args, is_gen_only)
-            if context_fmha is not None
+            fp8_fmha.get_fp8_context_fmha(q, output, metadata, fp8_args, is_gen_only)
+            if fp8_fmha is not None
             else False
         )
         prepared_fmhas: set[PhasedFmha] = set()

--- a/tensorrt_llm/_torch/attention_backend/fmha/phased.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/phased.py
@@ -13,12 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from functools import lru_cache
 from typing import TYPE_CHECKING, Optional, cast
 
 import torch
 
-from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs, AttentionInputType
+from tensorrt_llm._torch.attention_backend.interface import (
+    AttentionForwardArgs,
+    AttentionInputType,
+    CustomAttentionMask,
+    PredefinedAttentionMask,
+)
+from tensorrt_llm.bindings.internal import thop
 
 from .interface import Fmha
 
@@ -29,6 +36,32 @@ if TYPE_CHECKING:
     )
 
 
+@lru_cache(maxsize=128)
+def get_trtllm_gen_context_workspace_size(
+    dtype: torch.dtype,
+    max_num_seq: int,
+    max_num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    rotary_embedding_dim: int,
+    fp8_context_fmha: bool,
+) -> int:
+    """Return the fused context-preprocessing workspace size in bytes."""
+    if max_num_tokens == 0:
+        return 0
+    layout = thop.get_trtllm_gen_context_workspace_layout(
+        dtype,
+        max_num_seq,
+        max_num_tokens,
+        num_heads,
+        head_size,
+        rotary_embedding_dim,
+        True,
+        fp8_context_fmha,
+    )
+    return int(layout["total_size"])
+
+
 @dataclass(slots=True)
 class FmhaParams:
     attn: "TrtllmAttention"
@@ -37,6 +70,8 @@ class FmhaParams:
     workspace: torch.Tensor
     attention_input: Optional[torch.Tensor] = None
     qkv_input: Optional[torch.Tensor] = None
+    key_input: Optional[torch.Tensor] = None
+    value_input: Optional[torch.Tensor] = None
     context_buf: Optional[torch.Tensor] = None
     sequence_lengths: Optional[torch.Tensor] = None
     context_lengths: Optional[torch.Tensor] = None
@@ -66,6 +101,7 @@ class PhasedFmha(Fmha):
 
     def __init__(self, attn: "TrtllmAttention"):
         super().__init__(attn)
+        self._followup_fmhas: tuple[PhasedFmha, ...] = ()
         self.kv_factor = 1 if attn.is_mla_enable else 2
         kv_lora_rank = attn.kv_lora_rank or 0
         self.generation_out_head_size = (
@@ -83,6 +119,16 @@ class PhasedFmha(Fmha):
         if kv_cache_manager is None:
             return 0
 
+        get_page_index_upper_bound = getattr(
+            getattr(kv_cache_manager, "impl", None),
+            "get_page_index_upper_bound",
+            None,
+        )
+        if get_page_index_upper_bound is not None:
+            # KVCacheManagerV2 exposes an already-flattened page-index bound,
+            # unlike the legacy logical block count.
+            return int(kv_cache_manager.blocks_in_primary_pool)
+
         blocks_in_primary_pool = getattr(kv_cache_manager, "blocks_in_primary_pool", None)
         if blocks_in_primary_pool is None:
             blocks_per_window = getattr(kv_cache_manager, "blocks_per_window", None)
@@ -93,6 +139,200 @@ class PhasedFmha(Fmha):
         if blocks_in_primary_pool is None:
             return 0
         return int(blocks_in_primary_pool) * kv_cache_manager.num_local_layers * self.kv_factor
+
+    def set_followup_fmhas(self, followup_fmhas: tuple["PhasedFmha", ...]) -> None:
+        """Set later phased libraries that may provide an unsupported phase."""
+        self._followup_fmhas = followup_fmhas
+
+    @staticmethod
+    def _phase_forward_args(
+        forward_args: AttentionForwardArgs,
+        input_type: AttentionInputType,
+        is_cross: bool,
+    ) -> AttentionForwardArgs:
+        updates: dict[str, object] = {"attention_input_type": input_type}
+        if (
+            input_type == AttentionInputType.generation_only
+            and not is_cross
+            and forward_args.attention_mask == CustomAttentionMask.CUSTOM
+        ):
+            # Custom multimodal masks describe context tokens only. Generation
+            # uses the regular causal decode semantics.
+            updates.update(
+                attention_mask=PredefinedAttentionMask.CAUSAL,
+                attention_mask_data=None,
+            )
+        return replace(forward_args, **updates)
+
+    def is_context_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        return False
+
+    def is_generation_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        return False
+
+    def is_mla_context_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        return False
+
+    def is_mla_generation_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        return False
+
+    def _select_phase_fmha(
+        self,
+        phase: str,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> Optional["PhasedFmha"]:
+        is_mla = self.attn.is_mla_enable
+        support_method_name = f"is_{'mla_' if is_mla else ''}{phase}_supported"
+        for fmha in (self, *self._followup_fmhas):
+            support_method = getattr(fmha, support_method_name)
+            if support_method(q, k, v, metadata, forward_args):
+                return fmha
+        return None
+
+    def _select_phase_fmhas(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> tuple[
+        Optional["PhasedFmha"],
+        Optional["PhasedFmha"],
+        AttentionForwardArgs,
+        AttentionForwardArgs,
+    ]:
+        context_args = self._phase_forward_args(
+            forward_args,
+            AttentionInputType.context_only,
+            metadata.is_cross,
+        )
+        generation_args = self._phase_forward_args(
+            forward_args,
+            AttentionInputType.generation_only,
+            metadata.is_cross,
+        )
+        has_context = (
+            metadata.num_contexts > 0
+            and forward_args.attention_input_type != AttentionInputType.generation_only
+        )
+        has_generation = (
+            metadata.num_generations > 0
+            and forward_args.attention_input_type != AttentionInputType.context_only
+        )
+        context_fmha = (
+            self._select_phase_fmha("context", q, k, v, metadata, context_args)
+            if has_context
+            else None
+        )
+        generation_fmha = (
+            self._select_phase_fmha("generation", q, k, v, metadata, generation_args)
+            if has_generation
+            else None
+        )
+        return context_fmha, generation_fmha, context_args, generation_args
+
+    def is_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        context_fmha, generation_fmha, _, _ = self._select_phase_fmhas(
+            q,
+            k,
+            v,
+            metadata,
+            forward_args,
+        )
+        return self._selected_phases_support_request(
+            context_fmha,
+            generation_fmha,
+            metadata,
+            forward_args,
+        )
+
+    @staticmethod
+    def _selected_phases_support_request(
+        context_fmha: Optional["PhasedFmha"],
+        generation_fmha: Optional["PhasedFmha"],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        has_context = (
+            metadata.num_contexts > 0
+            and forward_args.attention_input_type != AttentionInputType.generation_only
+        )
+        has_generation = (
+            metadata.num_generations > 0
+            and forward_args.attention_input_type != AttentionInputType.context_only
+        )
+        return (
+            (has_context or has_generation)
+            and (not has_context or context_fmha is not None)
+            and (not has_generation or generation_fmha is not None)
+        )
+
+    def try_forward(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        """Run a supported phased request after selecting each provider once."""
+        phase_selection = self._select_phase_fmhas(q, k, v, metadata, forward_args)
+        if not self._selected_phases_support_request(
+            phase_selection[0],
+            phase_selection[1],
+            metadata,
+            forward_args,
+        ):
+            return False
+        self._forward_with_selected_phases(
+            q,
+            k,
+            v,
+            metadata,
+            forward_args,
+            *phase_selection,
+        )
+        return True
 
     def get_fp8_context_fmha(
         self,
@@ -123,6 +363,35 @@ class PhasedFmha(Fmha):
         metadata: "TrtllmAttentionMetadata",
         forward_args: AttentionForwardArgs,
     ) -> None:
+        phase_selection = self._select_phase_fmhas(q, k, v, metadata, forward_args)
+        if not self._selected_phases_support_request(
+            phase_selection[0],
+            phase_selection[1],
+            metadata,
+            forward_args,
+        ):
+            raise RuntimeError(f"{type(self).__name__} does not support this phased request.")
+        self._forward_with_selected_phases(
+            q,
+            k,
+            v,
+            metadata,
+            forward_args,
+            *phase_selection,
+        )
+
+    def _forward_with_selected_phases(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+        context_fmha: Optional["PhasedFmha"],
+        generation_fmha: Optional["PhasedFmha"],
+        context_args: AttentionForwardArgs,
+        generation_args: AttentionForwardArgs,
+    ) -> None:
         attn = self.attn
         output = forward_args.output
         if output is None:
@@ -146,15 +415,19 @@ class PhasedFmha(Fmha):
                 f"num_ctx_tokens={num_ctx_tokens}, attention_input_type={attention_input_type}."
             )
 
-        fp8_context_fmha = self.get_fp8_context_fmha(q, output, metadata, forward_args, is_gen_only)
-        self.prepare_workspace(
-            q,
-            k,
-            v,
-            metadata,
-            forward_args,
-            workspace,
+        fp8_context_fmha = (
+            context_fmha.get_fp8_context_fmha(q, output, metadata, context_args, is_gen_only)
+            if context_fmha is not None
+            else False
         )
+        prepared_fmhas: set[PhasedFmha] = set()
+        for fmha, phase_args in (
+            (context_fmha, context_args),
+            (generation_fmha, generation_args),
+        ):
+            if fmha is not None and fmha not in prepared_fmhas:
+                fmha.prepare_workspace(q, k, v, metadata, phase_args, workspace)
+                prepared_fmhas.add(fmha)
 
         out_head_size = self.generation_out_head_size if is_gen_only else self.context_out_head_size
         out_tensor = output.view(num_tokens, attn.num_heads, out_head_size)
@@ -205,6 +478,12 @@ class PhasedFmha(Fmha):
 
             params.attention_input = q[token_offset : token_offset + num_ctx_tokens]
             params.qkv_input = params.attention_input
+            params.key_input = (
+                k[token_offset : token_offset + num_ctx_tokens] if k is not None else None
+            )
+            params.value_input = (
+                v[token_offset : token_offset + num_ctx_tokens] if v is not None else None
+            )
             params.context_buf = out_tensor[token_offset : token_offset + num_ctx_tokens]
             params.sequence_lengths = sequence_length[seq_offset:]
             params.context_lengths = context_lengths[seq_offset:]
@@ -214,9 +493,13 @@ class PhasedFmha(Fmha):
             params.input_seq_length = max_context_q_len
             params.batch_size = num_seqs
             if attn.is_mla_enable:
-                self.run_mla_context(params)
+                if context_fmha is None:
+                    raise RuntimeError("No phased FMHA library supports MLA context attention.")
+                context_fmha.run_mla_context(replace(params, fwd=context_args))
             else:
-                self.run_context(params)
+                if context_fmha is None:
+                    raise RuntimeError("No phased FMHA library supports context attention.")
+                context_fmha.run_context(replace(params, fwd=context_args))
 
         if num_generations > 0 and attention_input_type != AttentionInputType.context_only:
             seq_offset = num_contexts
@@ -242,6 +525,12 @@ class PhasedFmha(Fmha):
 
             params.attention_input = q[token_offset : token_offset + num_gen_tokens]
             params.qkv_input = params.attention_input
+            params.key_input = (
+                k[token_offset : token_offset + num_gen_tokens] if k is not None else None
+            )
+            params.value_input = (
+                v[token_offset : token_offset + num_gen_tokens] if v is not None else None
+            )
             params.context_buf = out_tensor[token_offset : token_offset + num_gen_tokens]
             params.sequence_lengths = sequence_length[seq_offset:]
             params.max_past_kv_length = max_past_kv_len
@@ -252,9 +541,13 @@ class PhasedFmha(Fmha):
             params.spec_decoding_generation_lengths = spec_gen_lengths
             params.spec_decoding_position_offsets = spec_pos_offsets
             if attn.is_mla_enable:
-                self.run_mla_generation(params)
+                if generation_fmha is None:
+                    raise RuntimeError("No phased FMHA library supports MLA generation attention.")
+                generation_fmha.run_mla_generation(replace(params, fwd=generation_args))
             else:
-                self.run_generation(params)
+                if generation_fmha is None:
+                    raise RuntimeError("No phased FMHA library supports generation attention.")
+                generation_fmha.run_generation(replace(params, fwd=generation_args))
 
     def run_context(self, params: FmhaParams) -> None:
         raise NotImplementedError(f"{type(self).__name__} does not support context attention.")

--- a/tensorrt_llm/_torch/attention_backend/fmha/registry.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/registry.py
@@ -19,10 +19,12 @@ from typing import TypeAlias
 from .fallback import FallbackFmha
 from .flashinfer_trtllm_gen import FlashInferTrtllmGenFmha
 from .interface import Fmha
+from .triton_custom_mask import TritonCustomMaskFmha
 
 FmhaCls: TypeAlias = type[Fmha]
 
 FMHA_LIBS: dict[str, FmhaCls] = {
+    "triton_custom_mask": TritonCustomMaskFmha,
     "flashinfer_trtllm_gen": FlashInferTrtllmGenFmha,
     "fallback": FallbackFmha,
 }

--- a/tensorrt_llm/_torch/attention_backend/fmha/triton_custom_mask.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/triton_custom_mask.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton custom-mask context attention for the TRT-LLM backend."""
+
+import math
+from functools import lru_cache
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from tensorrt_llm._torch.attention_backend.interface import (
+    AttentionForwardArgs,
+    CustomAttentionMask,
+)
+from tensorrt_llm.bindings.internal import thop
+from tensorrt_llm.functional import AttentionMaskType, PositionEmbeddingType
+from tensorrt_llm.logger import logger
+from tensorrt_llm.quantization.mode import QuantMode
+
+from .phased import FmhaParams, PhasedFmha, get_trtllm_gen_context_workspace_size
+
+if TYPE_CHECKING:
+    from tensorrt_llm._torch.attention_backend.trtllm import (
+        TrtllmAttention,
+        TrtllmAttentionMetadata,
+    )
+
+
+class TritonCustomMaskFmha(PhasedFmha):
+    """Run custom-mask context attention with Triton."""
+
+    SUPPORTED_DTYPES = {torch.float16, torch.bfloat16}
+
+    def __init__(self, attn: "TrtllmAttention"):
+        super().__init__(attn)
+        self._multi_processor_count: Optional[int] = None
+
+    @classmethod
+    def is_available(cls, attn: "TrtllmAttention") -> bool:
+        required_ops = (
+            "get_trtllm_gen_context_workspace_layout",
+            "trtllm_gen_context_preprocess",
+        )
+        missing_ops = [op for op in required_ops if not hasattr(thop, op)]
+        if missing_ops:
+            logger.debug(
+                "Triton custom-mask FMHA is unavailable: missing fused "
+                f"nanobind ops: {', '.join(missing_ops)}."
+            )
+            return False
+        if attn.num_heads <= 0 or attn.num_kv_heads <= 0:
+            return False
+        if attn.num_heads % attn.num_kv_heads != 0:
+            return False
+        return True
+
+    def is_context_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        supported, reason = self._check_support_with_reason(
+            q,
+            k,
+            v,
+            metadata,
+            forward_args,
+        )
+        if not supported:
+            logger.debug(f"Triton custom-mask FMHA does not support request: {reason}")
+        return supported
+
+    def _check_support_with_reason(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> tuple[bool, str]:
+        if forward_args.attention_mask != CustomAttentionMask.CUSTOM:
+            return False, "Request does not use a custom attention mask."
+        if forward_args.attention_mask_data is None:
+            return False, "Custom attention requires attention_mask_data."
+        if metadata.num_contexts <= 0:
+            return False, "Custom attention requires at least one context request."
+        if metadata.is_cross:
+            return False, "Custom-mask cross attention is not supported."
+        if metadata.kv_cache_block_offsets is None:
+            return False, "Custom-mask TRT-LLM attention requires paged KV cache."
+        if self.attn.is_mla_enable:
+            return False, "Custom-mask MLA is not supported."
+        if not forward_args.is_fused_qkv or k is not None or v is not None:
+            return False, "Custom-mask TRT-LLM attention requires fused QKV input."
+        if q.dtype not in self.SUPPORTED_DTYPES:
+            return False, f"Input dtype {q.dtype} is not supported."
+        output = forward_args.output
+        if output is None or output.dtype != q.dtype:
+            return False, "Custom-mask Triton attention requires output to match the input dtype."
+        if forward_args.output_sf is not None:
+            return False, "Custom-mask Triton attention does not support NVFP4 output."
+        if QuantMode(self.attn.quant_mode).has_kv_cache_quant():
+            return False, "Custom-mask TRT-LLM attention does not support quantized KV cache."
+        if forward_args.attention_sinks is not None:
+            return False, "Custom-mask Triton attention does not support attention sinks."
+        if (
+            getattr(self.attn, "head_dim", 0) > 256
+            and PositionEmbeddingType(self.attn.position_embedding_type).is_rope()
+        ):
+            return (
+                False,
+                "Custom-mask head dimensions above 256 require RoPE to be applied before the backend.",
+            )
+
+        return True, ""
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _get_multi_processor_count_for_device(device_index: int) -> int:
+        return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+    @classmethod
+    def _get_multi_processor_count(cls, device: torch.device) -> int:
+        device = torch.device(device)
+        if device.type != "cuda":
+            raise RuntimeError("Triton custom-mask FMHA requires CUDA tensors.")
+        device_index = device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+        return cls._get_multi_processor_count_for_device(device_index)
+
+    @staticmethod
+    def _get_bmm1_scale(attn: "TrtllmAttention") -> float:
+        return 1.0 / (math.sqrt(attn.head_dim) * attn.q_scaling)
+
+    @staticmethod
+    def _get_attention_chunk_size(attn: "TrtllmAttention") -> int:
+        return attn.attention_chunk_size if attn.attention_chunk_size is not None else 0
+
+    def prepare_workspace(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+        workspace: torch.Tensor,
+    ) -> None:
+        if self._multi_processor_count is None:
+            self._multi_processor_count = self._get_multi_processor_count(q.device)
+
+        attn = self.attn
+        required_workspace_size = get_trtllm_gen_context_workspace_size(
+            dtype=q.dtype,
+            max_num_seq=metadata.max_num_requests,
+            max_num_tokens=max(q.size(0), metadata.max_context_length),
+            num_heads=attn.num_heads,
+            head_size=attn.head_dim,
+            rotary_embedding_dim=attn.rope_dim,
+            fp8_context_fmha=False,
+        )
+        current_workspace_size = workspace.numel() * workspace.element_size()
+        if current_workspace_size < required_workspace_size:
+            if metadata.is_cuda_graph and torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "Attention CUDA graph workspace is smaller than the required size "
+                    "for Triton custom-mask FMHA."
+                )
+            required_workspace_numel = math.ceil(required_workspace_size / workspace.element_size())
+            workspace.resize_((required_workspace_numel,))
+
+    def run_context(self, params: FmhaParams) -> None:
+        """Preprocess fused QKV, then run the Triton custom-mask context kernel."""
+        attn = params.attn
+        meta = params.meta
+        fwd = params.fwd
+        rope_params = attn.rope_params
+        bmm1_scale = self._get_bmm1_scale(attn)
+        attention_chunk_size = self._get_attention_chunk_size(attn)
+
+        (
+            q_processed,
+            kv_pool,
+            block_tables,
+            _,
+            _,
+            _,
+            _,
+            cu_q_seqlens,
+            _,
+            _,
+            _,
+            window_left,
+        ) = thop.trtllm_gen_context_preprocess(
+            params.qkv_input,
+            params.workspace,
+            params.sequence_lengths,
+            params.context_lengths,
+            meta.kv_cache_block_offsets,
+            meta.host_kv_cache_pool_pointers,
+            meta.host_kv_cache_pool_mapping,
+            fwd.kv_scale_orig_quant,
+            fwd.kv_scale_quant_orig,
+            fwd.out_scale,
+            attn.rotary_inv_freq,
+            attn.rotary_cos_sin,
+            fwd.mrope_rotary_cos_sin,
+            attn.local_layer_idx,
+            attn.num_heads,
+            attn.num_kv_heads,
+            attn.head_dim,
+            params.tokens_per_block,
+            int(AttentionMaskType.causal),
+            attn.quant_mode,
+            params.max_attention_window_size,
+            params.cyclic_attention_window_size,
+            params.num_tokens,
+            params.batch_size,
+            params.input_seq_length,
+            params.max_past_kv_length,
+            rope_params.dim,
+            rope_params.theta,
+            int(rope_params.scale_type),
+            rope_params.scale,
+            rope_params.max_positions,
+            attn.position_embedding_type,
+            bmm1_scale,
+            1.0,
+            attention_chunk_size,
+            False,  # fp8_context_fmha
+            False,  # paged_context_fmha; keep processed QKV packed in-place
+            False,  # is_mla_enable
+            self._multi_processor_count,
+            params.total_num_blocks,
+            params.kv_factor,
+            True,  # need_build_kv_cache_metadata
+            None,  # cross_kv
+            False,  # cross_attention
+        )
+
+        if kv_pool is None or block_tables is None:
+            raise RuntimeError("Custom-mask TRT-LLM attention requires paged KV metadata.")
+        if params.qkv_input is None or params.context_buf is None:
+            raise RuntimeError(
+                "Custom-mask TRT-LLM attention requires context QKV and output buffers."
+            )
+        if params.sequence_lengths is None or params.context_lengths is None:
+            raise RuntimeError("Custom-mask TRT-LLM attention requires context sequence lengths.")
+
+        q_size = attn.num_heads * attn.head_dim
+        kv_size = attn.num_kv_heads * attn.head_dim
+        k_processed = params.qkv_input.narrow(1, q_size, kv_size).view(
+            params.num_tokens,
+            attn.num_kv_heads,
+            attn.head_dim,
+        )
+        v_processed = params.qkv_input.narrow(1, q_size + kv_size, kv_size).view(
+            params.num_tokens,
+            attn.num_kv_heads,
+            attn.head_dim,
+        )
+
+        block_tables = block_tables[: params.batch_size]
+        blocks_per_sequence = block_tables.size(-1)
+        page_table_indptr = (
+            torch.arange(
+                params.batch_size + 1,
+                dtype=torch.int32,
+                device=block_tables.device,
+            )
+            * blocks_per_sequence
+        )
+        prefix_lens = (
+            params.sequence_lengths[: params.batch_size]
+            - params.context_lengths[: params.batch_size]
+        )
+
+        from ..triton_prefill import triton_prefill_with_custom_mask
+
+        triton_prefill_with_custom_mask(
+            q=q_processed,
+            k=k_processed,
+            v=v_processed,
+            output=params.context_buf,
+            qo_indptr=cu_q_seqlens,
+            kv_cache=None,
+            prefix_lens=prefix_lens,
+            page_table_indptr=page_table_indptr,
+            page_table_indices=block_tables[:, 0, :].reshape(-1),
+            page_size=params.tokens_per_block,
+            custom_mask=fwd.attention_mask_data.flatten().contiguous(),
+            sm_scale=bmm1_scale,
+            window_left=window_left,
+            k_cache=kv_pool,
+            v_cache=kv_pool,
+            v_page_table_indices=block_tables[:, 1, :].reshape(-1),
+        )

--- a/tensorrt_llm/_torch/attention_backend/fmha/triton_custom_mask.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/triton_custom_mask.py
@@ -16,7 +16,6 @@
 """Triton custom-mask context attention for the TRT-LLM backend."""
 
 import math
-from functools import lru_cache
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -32,7 +31,12 @@ from tensorrt_llm.quantization.mode import QuantMode
 
 from .interface import FmhaPhase
 from .phased import FmhaParams, PhasedFmha
-from .trtllm_gen_utils import get_trtllm_gen_context_workspace_size
+from .utils import (
+    get_attention_chunk_size,
+    get_bmm1_scale,
+    get_multi_processor_count_for_device,
+    get_trtllm_gen_context_workspace_size,
+)
 
 if TYPE_CHECKING:
     from tensorrt_llm._torch.attention_backend.trtllm import (
@@ -113,6 +117,10 @@ class TritonCustomMaskFmha(PhasedFmha):
             return False, "Custom-mask cross attention is not supported."
         if metadata.kv_cache_block_offsets is None:
             return False, "Custom-mask TRT-LLM attention requires paged KV cache."
+        if metadata.kv_layout != "HND":
+            return False, "Custom-mask TRT-LLM attention requires HND KV-cache layout."
+        if getattr(metadata.kv_cache_manager, "enable_swa_scratch_reuse", False):
+            return False, "Custom-mask TRT-LLM attention does not support SWA scratch reuse."
         if self.attn.is_mla_enable:
             return False, "Custom-mask MLA is not supported."
         if not forward_args.is_fused_qkv or k is not None or v is not None:
@@ -139,11 +147,6 @@ class TritonCustomMaskFmha(PhasedFmha):
 
         return True, ""
 
-    @staticmethod
-    @lru_cache(maxsize=None)
-    def _get_multi_processor_count_for_device(device_index: int) -> int:
-        return torch.cuda.get_device_properties(device_index).multi_processor_count
-
     @classmethod
     def _get_multi_processor_count(cls, device: torch.device) -> int:
         device = torch.device(device)
@@ -152,15 +155,7 @@ class TritonCustomMaskFmha(PhasedFmha):
         device_index = device.index
         if device_index is None:
             device_index = torch.cuda.current_device()
-        return cls._get_multi_processor_count_for_device(device_index)
-
-    @staticmethod
-    def _get_bmm1_scale(attn: "TrtllmAttention") -> float:
-        return 1.0 / (math.sqrt(attn.head_dim) * attn.q_scaling)
-
-    @staticmethod
-    def _get_attention_chunk_size(attn: "TrtllmAttention") -> int:
-        return attn.attention_chunk_size if attn.attention_chunk_size is not None else 0
+        return get_multi_processor_count_for_device(device_index)
 
     def prepare_workspace(
         self,
@@ -200,12 +195,12 @@ class TritonCustomMaskFmha(PhasedFmha):
         meta = params.meta
         fwd = params.fwd
         rope_params = attn.rope_params
-        bmm1_scale = self._get_bmm1_scale(attn)
-        attention_chunk_size = self._get_attention_chunk_size(attn)
+        bmm1_scale = get_bmm1_scale(attn)
+        attention_chunk_size = get_attention_chunk_size(attn)
 
         (
             q_processed,
-            kv_pool,
+            _,
             block_tables,
             _,
             _,
@@ -263,7 +258,7 @@ class TritonCustomMaskFmha(PhasedFmha):
             False,  # cross_attention
         )
 
-        if kv_pool is None or block_tables is None:
+        if block_tables is None:
             raise RuntimeError("Custom-mask TRT-LLM attention requires paged KV metadata.")
         if params.qkv_input is None or params.context_buf is None:
             raise RuntimeError(
@@ -300,6 +295,25 @@ class TritonCustomMaskFmha(PhasedFmha):
             - params.context_lengths[: params.batch_size]
         )
 
+        if meta.kv_cache_manager is None:
+            raise RuntimeError("Custom-mask TRT-LLM attention requires a KV cache manager.")
+        kv_cache = meta.kv_cache_manager.get_buffers(
+            attn.layer_idx,
+            kv_layout=meta.kv_layout,
+        )
+        if kv_cache is None:
+            raise RuntimeError("Custom-mask TRT-LLM attention requires a KV cache buffer.")
+
+        # TRTLLM block tables index a flat physical-page pool, while get_buffers()
+        # groups K and V into each logical page. Convert the physical K-page IDs
+        # to indices in that packed view using its actual storage strides.
+        physical_pages_per_logical_page = kv_cache.stride(0) // kv_cache.stride(1)
+        page_table_indices = torch.div(
+            block_tables[:, 0, :],
+            physical_pages_per_logical_page,
+            rounding_mode="floor",
+        ).reshape(-1)
+
         from ..triton_prefill import triton_prefill_with_custom_mask
 
         triton_prefill_with_custom_mask(
@@ -308,15 +322,12 @@ class TritonCustomMaskFmha(PhasedFmha):
             v=v_processed,
             output=params.context_buf,
             qo_indptr=cu_q_seqlens,
-            kv_cache=None,
+            kv_cache=kv_cache,
             prefix_lens=prefix_lens,
             page_table_indptr=page_table_indptr,
-            page_table_indices=block_tables[:, 0, :].reshape(-1),
+            page_table_indices=page_table_indices,
             page_size=params.tokens_per_block,
             custom_mask=fwd.attention_mask_data.flatten().contiguous(),
             sm_scale=bmm1_scale,
             window_left=window_left,
-            k_cache=kv_pool,
-            v_cache=kv_pool,
-            v_page_table_indices=block_tables[:, 1, :].reshape(-1),
         )

--- a/tensorrt_llm/_torch/attention_backend/fmha/utils.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/utils.py
@@ -13,11 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
 import torch
 
 from tensorrt_llm.bindings.internal import thop
+
+if TYPE_CHECKING:
+    from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttention
 
 
 @lru_cache(maxsize=128)
@@ -44,3 +49,16 @@ def get_trtllm_gen_context_workspace_size(
         fp8_context_fmha,
     )
     return int(layout["total_size"])
+
+
+@lru_cache(maxsize=None)
+def get_multi_processor_count_for_device(device_index: int) -> int:
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+def get_bmm1_scale(attn: "TrtllmAttention") -> float:
+    return 1.0 / (math.sqrt(attn.head_dim) * attn.q_scaling)
+
+
+def get_attention_chunk_size(attn: "TrtllmAttention") -> int:
+    return attn.attention_chunk_size if attn.attention_chunk_size is not None else 0

--- a/tensorrt_llm/_torch/attention_backend/triton_prefill.py
+++ b/tensorrt_llm/_torch/attention_backend/triton_prefill.py
@@ -112,8 +112,9 @@ def _fwd_kernel(
     # Sequence boundaries
     qo_indptr,  # [batch+1] cumulative extend token counts
     prefix_indptr,  # [batch+1] cumulative prefix TOKEN counts
-    # Page table for prefix
-    page_table,  # [total_pages] physical page IDs
+    # Page tables for prefix
+    k_page_table,  # [total_pages] physical K page IDs
+    v_page_table,  # [total_pages] physical V page IDs
     page_table_indptr,  # [batch+1] cumulative page counts per seq
     # Mask
     mask_ptr,
@@ -240,8 +241,13 @@ def _fwd_kernel(
             token_positions = start_n + offs_n
             page_local_idx = token_positions // PAGE_SIZE
             token_in_page = token_positions % PAGE_SIZE
-            page_ids = tl.load(
-                page_table + cur_seq_page_start + page_local_idx,
+            k_page_ids = tl.load(
+                k_page_table + cur_seq_page_start + page_local_idx,
+                mask=mask_n,
+                other=-1,
+            )
+            v_page_ids = tl.load(
+                v_page_table + cur_seq_page_start + page_local_idx,
                 mask=mask_n,
                 other=-1,
             )
@@ -250,19 +256,21 @@ def _fwd_kernel(
             # with mask=True still issues the memory access, so a -1 page_id
             # would OOB into K_Buffer/V_Buffer (NaN propagation or illegal
             # address fault). Filter at load and at qk merge.
-            valid_page = page_ids >= 0
-            safe_page_ids = tl.where(valid_page, page_ids, 0)
+            valid_page = (k_page_ids >= 0) & (v_page_ids >= 0)
+            safe_k_page_ids = tl.where(valid_page, k_page_ids, 0)
+            safe_v_page_ids = tl.where(valid_page, v_page_ids, 0)
             # Promote to int64 before multiplying by stride: with KV pools at
             # production scale (e.g. shape [N, 2, 8, 32, 256] => stride 131072
             # elements/page), page_id * stride overflows int32 once page_id
             # exceeds ~16K and silently wraps to a negative offset, IMA-ing
             # K_Buffer/V_Buffer.
-            safe_page_ids = safe_page_ids.to(tl.int64)
+            safe_k_page_ids = safe_k_page_ids.to(tl.int64)
+            safe_v_page_ids = safe_v_page_ids.to(tl.int64)
             final_mask &= valid_page[None, :]
 
             # Load K from paged buffer (transposed for dot product)
             offs_buf_k = (
-                safe_page_ids[None, :] * stride_buf_kpage
+                safe_k_page_ids[None, :] * stride_buf_kpage
                 + cur_kv_head * stride_buf_kh
                 + token_in_page[None, :] * stride_buf_ktoken
                 + offs_d[:, None] * stride_buf_kdim
@@ -291,7 +299,7 @@ def _fwd_kernel(
 
             # Load V from paged buffer
             offs_buf_v = (
-                safe_page_ids[:, None] * stride_buf_vpage
+                safe_v_page_ids[:, None] * stride_buf_vpage
                 + cur_kv_head * stride_buf_vh
                 + token_in_page[:, None] * stride_buf_vtoken
                 + offs_dv[None, :] * stride_buf_vdim
@@ -411,7 +419,8 @@ def _extend_attention_fwd(
     v_buffer: torch.Tensor,
     qo_indptr: torch.Tensor,
     prefix_indptr: torch.Tensor,
-    page_table: torch.Tensor,
+    k_page_table: torch.Tensor,
+    v_page_table: torch.Tensor,
     page_table_indptr: torch.Tensor,
     custom_mask: Optional[torch.Tensor],
     mask_indptr: Optional[torch.Tensor],
@@ -434,7 +443,8 @@ def _extend_attention_fwd(
         v_buffer: V view of paged cache [num_pages, num_kv_heads, page_size, head_dim]
         qo_indptr: [batch+1] extend token boundaries
         prefix_indptr: [batch+1] cumulative prefix token counts
-        page_table: [total_pages] physical page IDs
+        k_page_table: [total_pages] physical K page IDs
+        v_page_table: [total_pages] physical V page IDs
         page_table_indptr: [batch+1] cumulative page counts per seq
         custom_mask: Flattened bool mask or None
         mask_indptr: [batch+1] cumulative mask element counts, or None
@@ -467,7 +477,8 @@ def _extend_attention_fwd(
         v_buffer,
         qo_indptr,
         prefix_indptr,
-        page_table,
+        k_page_table,
+        v_page_table,
         page_table_indptr,
         custom_mask,
         mask_indptr,
@@ -526,6 +537,9 @@ def triton_prefill_with_custom_mask(
     custom_mask: Optional[torch.Tensor],
     sm_scale: float,
     window_left: int = -1,
+    k_cache: Optional[torch.Tensor] = None,
+    v_cache: Optional[torch.Tensor] = None,
+    v_page_table_indices: Optional[torch.Tensor] = None,
 ) -> None:
     """Triton prefill attention with optional custom mask and paged KV cache.
 
@@ -558,32 +572,27 @@ def triton_prefill_with_custom_mask(
             A query at position p attends to keys in [p - window_left, p].
             Use (attention_window_size - 1) since TRTLLM window size is
             exclusive while flashinfer/triton convention is inclusive.
+        k_cache: Optional K-only paged cache
+            [num_pages, num_kv_heads, page_size, head_dim]. Use with
+            ``v_cache`` for backends that store K and V in separate pages.
+        v_cache: Optional V-only paged cache with the same shape as
+            ``k_cache``.
+        v_page_table_indices: Optional physical V page IDs. Defaults to
+            ``page_table_indices`` for caches whose K and V share page IDs.
     """
     device = q.device
     num_contexts = qo_indptr.shape[0] - 1
     extend_lens = qo_indptr[1:] - qo_indptr[:-1]
 
-    # Build causal mask when custom_mask is not provided
     total_kv_lens = prefix_lens + extend_lens
+    is_causal = custom_mask is None
     if custom_mask is None:
-        # Generate causal mask: each query at position i attends to
-        # positions [0..prefix_len+i] (all prefix + causal extend)
-        mask_parts = []
-        for seq_idx in range(num_contexts):
-            ext = int(extend_lens[seq_idx].item())
-            pre = int(prefix_lens[seq_idx].item())
-            total = pre + ext
-            # Row i of extend can see columns [0..pre+i]
-            rows = torch.arange(ext, device=device).unsqueeze(1)
-            cols = torch.arange(total, device=device).unsqueeze(0)
-            seq_mask = cols <= (rows + pre)
-            mask_parts.append(seq_mask.reshape(-1))
-        custom_mask = torch.cat(mask_parts)
-
-    # Compute mask_indptr: each seq's mask is [extend_len, prefix_len + extend_len]
-    mask_sizes = extend_lens * total_kv_lens
-    mask_indptr = torch.zeros(num_contexts + 1, dtype=torch.int32, device=device)
-    mask_indptr[1:] = torch.cumsum(mask_sizes, dim=0)
+        mask_indptr = torch.empty(1, dtype=torch.int32, device=device)
+    else:
+        # Each sequence's custom mask is [extend_len, prefix_len + extend_len].
+        mask_sizes = extend_lens * total_kv_lens
+        mask_indptr = torch.zeros(num_contexts + 1, dtype=torch.int32, device=device)
+        mask_indptr[1:] = torch.cumsum(mask_sizes, dim=0)
 
     # Compute prefix_indptr: cumulative prefix token counts
     prefix_indptr = torch.zeros(num_contexts + 1, dtype=torch.int32, device=device)
@@ -595,8 +604,20 @@ def triton_prefill_with_custom_mask(
     # can run tl.dot in BF16.  Only the accessed pages are copied.
     compute_dtype = q.dtype
     if kv_cache is not None:
+        if k_cache is not None or v_cache is not None:
+            raise ValueError("Specify either kv_cache or k_cache/v_cache, not both.")
         k_buffer = kv_cache.select(1, 0)  # [num_pages, num_kv_heads, page_size, head_dim]
         v_buffer = kv_cache.select(1, 1)
+    elif k_cache is not None and v_cache is not None:
+        k_buffer = k_cache
+        v_buffer = v_cache
+    elif k_cache is not None or v_cache is not None:
+        raise ValueError("k_cache and v_cache must be specified together.")
+    else:
+        k_buffer = None
+        v_buffer = None
+
+    if k_buffer is not None and v_buffer is not None:
         if k_buffer.dtype != compute_dtype:
             num_prefix_pages = int(page_table_indptr[-1].item())
             if num_prefix_pages > 0:
@@ -611,6 +632,8 @@ def triton_prefill_with_custom_mask(
         v_buffer = torch.empty(1, num_kv_heads, 1, head_dim, dtype=v.dtype, device=device)
 
     max_len_extend = int(extend_lens.max().item()) if num_contexts > 0 else 0
+    if v_page_table_indices is None:
+        v_page_table_indices = page_table_indices
 
     _extend_attention_fwd(
         q_extend=q,
@@ -621,14 +644,15 @@ def triton_prefill_with_custom_mask(
         v_buffer=v_buffer,
         qo_indptr=qo_indptr,
         prefix_indptr=prefix_indptr,
-        page_table=page_table_indices,
+        k_page_table=page_table_indices,
+        v_page_table=v_page_table_indices,
         page_table_indptr=page_table_indptr,
         custom_mask=custom_mask,
         mask_indptr=mask_indptr,
         max_len_extend=max_len_extend,
         sm_scale=sm_scale,
         page_size=page_size,
-        is_causal=False,
+        is_causal=is_causal,
         logit_cap=0.0,
         skip_prefix_custom_mask=False,
         window_left=window_left,

--- a/tensorrt_llm/_torch/attention_backend/triton_prefill.py
+++ b/tensorrt_llm/_torch/attention_backend/triton_prefill.py
@@ -112,9 +112,8 @@ def _fwd_kernel(
     # Sequence boundaries
     qo_indptr,  # [batch+1] cumulative extend token counts
     prefix_indptr,  # [batch+1] cumulative prefix TOKEN counts
-    # Page tables for prefix
-    k_page_table,  # [total_pages] physical K page IDs
-    v_page_table,  # [total_pages] physical V page IDs
+    # Page table for prefix
+    page_table,  # [total_pages] physical page IDs
     page_table_indptr,  # [batch+1] cumulative page counts per seq
     # Mask
     mask_ptr,
@@ -241,13 +240,8 @@ def _fwd_kernel(
             token_positions = start_n + offs_n
             page_local_idx = token_positions // PAGE_SIZE
             token_in_page = token_positions % PAGE_SIZE
-            k_page_ids = tl.load(
-                k_page_table + cur_seq_page_start + page_local_idx,
-                mask=mask_n,
-                other=-1,
-            )
-            v_page_ids = tl.load(
-                v_page_table + cur_seq_page_start + page_local_idx,
+            page_ids = tl.load(
+                page_table + cur_seq_page_start + page_local_idx,
                 mask=mask_n,
                 other=-1,
             )
@@ -256,21 +250,19 @@ def _fwd_kernel(
             # with mask=True still issues the memory access, so a -1 page_id
             # would OOB into K_Buffer/V_Buffer (NaN propagation or illegal
             # address fault). Filter at load and at qk merge.
-            valid_page = (k_page_ids >= 0) & (v_page_ids >= 0)
-            safe_k_page_ids = tl.where(valid_page, k_page_ids, 0)
-            safe_v_page_ids = tl.where(valid_page, v_page_ids, 0)
+            valid_page = page_ids >= 0
+            safe_page_ids = tl.where(valid_page, page_ids, 0)
             # Promote to int64 before multiplying by stride: with KV pools at
             # production scale (e.g. shape [N, 2, 8, 32, 256] => stride 131072
             # elements/page), page_id * stride overflows int32 once page_id
             # exceeds ~16K and silently wraps to a negative offset, IMA-ing
             # K_Buffer/V_Buffer.
-            safe_k_page_ids = safe_k_page_ids.to(tl.int64)
-            safe_v_page_ids = safe_v_page_ids.to(tl.int64)
+            safe_page_ids = safe_page_ids.to(tl.int64)
             final_mask &= valid_page[None, :]
 
             # Load K from paged buffer (transposed for dot product)
             offs_buf_k = (
-                safe_k_page_ids[None, :] * stride_buf_kpage
+                safe_page_ids[None, :] * stride_buf_kpage
                 + cur_kv_head * stride_buf_kh
                 + token_in_page[None, :] * stride_buf_ktoken
                 + offs_d[:, None] * stride_buf_kdim
@@ -299,7 +291,7 @@ def _fwd_kernel(
 
             # Load V from paged buffer
             offs_buf_v = (
-                safe_v_page_ids[:, None] * stride_buf_vpage
+                safe_page_ids[:, None] * stride_buf_vpage
                 + cur_kv_head * stride_buf_vh
                 + token_in_page[:, None] * stride_buf_vtoken
                 + offs_dv[None, :] * stride_buf_vdim
@@ -419,8 +411,7 @@ def _extend_attention_fwd(
     v_buffer: torch.Tensor,
     qo_indptr: torch.Tensor,
     prefix_indptr: torch.Tensor,
-    k_page_table: torch.Tensor,
-    v_page_table: torch.Tensor,
+    page_table: torch.Tensor,
     page_table_indptr: torch.Tensor,
     custom_mask: Optional[torch.Tensor],
     mask_indptr: Optional[torch.Tensor],
@@ -443,8 +434,7 @@ def _extend_attention_fwd(
         v_buffer: V view of paged cache [num_pages, num_kv_heads, page_size, head_dim]
         qo_indptr: [batch+1] extend token boundaries
         prefix_indptr: [batch+1] cumulative prefix token counts
-        k_page_table: [total_pages] physical K page IDs
-        v_page_table: [total_pages] physical V page IDs
+        page_table: [total_pages] physical page IDs
         page_table_indptr: [batch+1] cumulative page counts per seq
         custom_mask: Flattened bool mask or None
         mask_indptr: [batch+1] cumulative mask element counts, or None
@@ -477,8 +467,7 @@ def _extend_attention_fwd(
         v_buffer,
         qo_indptr,
         prefix_indptr,
-        k_page_table,
-        v_page_table,
+        page_table,
         page_table_indptr,
         custom_mask,
         mask_indptr,
@@ -537,9 +526,6 @@ def triton_prefill_with_custom_mask(
     custom_mask: Optional[torch.Tensor],
     sm_scale: float,
     window_left: int = -1,
-    k_cache: Optional[torch.Tensor] = None,
-    v_cache: Optional[torch.Tensor] = None,
-    v_page_table_indices: Optional[torch.Tensor] = None,
 ) -> None:
     """Triton prefill attention with optional custom mask and paged KV cache.
 
@@ -572,27 +558,32 @@ def triton_prefill_with_custom_mask(
             A query at position p attends to keys in [p - window_left, p].
             Use (attention_window_size - 1) since TRTLLM window size is
             exclusive while flashinfer/triton convention is inclusive.
-        k_cache: Optional K-only paged cache
-            [num_pages, num_kv_heads, page_size, head_dim]. Use with
-            ``v_cache`` for backends that store K and V in separate pages.
-        v_cache: Optional V-only paged cache with the same shape as
-            ``k_cache``.
-        v_page_table_indices: Optional physical V page IDs. Defaults to
-            ``page_table_indices`` for caches whose K and V share page IDs.
     """
     device = q.device
     num_contexts = qo_indptr.shape[0] - 1
     extend_lens = qo_indptr[1:] - qo_indptr[:-1]
 
+    # Build causal mask when custom_mask is not provided
     total_kv_lens = prefix_lens + extend_lens
-    is_causal = custom_mask is None
     if custom_mask is None:
-        mask_indptr = torch.empty(1, dtype=torch.int32, device=device)
-    else:
-        # Each sequence's custom mask is [extend_len, prefix_len + extend_len].
-        mask_sizes = extend_lens * total_kv_lens
-        mask_indptr = torch.zeros(num_contexts + 1, dtype=torch.int32, device=device)
-        mask_indptr[1:] = torch.cumsum(mask_sizes, dim=0)
+        # Generate causal mask: each query at position i attends to
+        # positions [0..prefix_len+i] (all prefix + causal extend)
+        mask_parts = []
+        for seq_idx in range(num_contexts):
+            ext = int(extend_lens[seq_idx].item())
+            pre = int(prefix_lens[seq_idx].item())
+            total = pre + ext
+            # Row i of extend can see columns [0..pre+i]
+            rows = torch.arange(ext, device=device).unsqueeze(1)
+            cols = torch.arange(total, device=device).unsqueeze(0)
+            seq_mask = cols <= (rows + pre)
+            mask_parts.append(seq_mask.reshape(-1))
+        custom_mask = torch.cat(mask_parts)
+
+    # Compute mask_indptr: each seq's mask is [extend_len, prefix_len + extend_len]
+    mask_sizes = extend_lens * total_kv_lens
+    mask_indptr = torch.zeros(num_contexts + 1, dtype=torch.int32, device=device)
+    mask_indptr[1:] = torch.cumsum(mask_sizes, dim=0)
 
     # Compute prefix_indptr: cumulative prefix token counts
     prefix_indptr = torch.zeros(num_contexts + 1, dtype=torch.int32, device=device)
@@ -604,20 +595,8 @@ def triton_prefill_with_custom_mask(
     # can run tl.dot in BF16.  Only the accessed pages are copied.
     compute_dtype = q.dtype
     if kv_cache is not None:
-        if k_cache is not None or v_cache is not None:
-            raise ValueError("Specify either kv_cache or k_cache/v_cache, not both.")
         k_buffer = kv_cache.select(1, 0)  # [num_pages, num_kv_heads, page_size, head_dim]
         v_buffer = kv_cache.select(1, 1)
-    elif k_cache is not None and v_cache is not None:
-        k_buffer = k_cache
-        v_buffer = v_cache
-    elif k_cache is not None or v_cache is not None:
-        raise ValueError("k_cache and v_cache must be specified together.")
-    else:
-        k_buffer = None
-        v_buffer = None
-
-    if k_buffer is not None and v_buffer is not None:
         if k_buffer.dtype != compute_dtype:
             num_prefix_pages = int(page_table_indptr[-1].item())
             if num_prefix_pages > 0:
@@ -632,8 +611,6 @@ def triton_prefill_with_custom_mask(
         v_buffer = torch.empty(1, num_kv_heads, 1, head_dim, dtype=v.dtype, device=device)
 
     max_len_extend = int(extend_lens.max().item()) if num_contexts > 0 else 0
-    if v_page_table_indices is None:
-        v_page_table_indices = page_table_indices
 
     _extend_attention_fwd(
         q_extend=q,
@@ -644,15 +621,14 @@ def triton_prefill_with_custom_mask(
         v_buffer=v_buffer,
         qo_indptr=qo_indptr,
         prefix_indptr=prefix_indptr,
-        k_page_table=page_table_indices,
-        v_page_table=v_page_table_indices,
+        page_table=page_table_indices,
         page_table_indptr=page_table_indptr,
         custom_mask=custom_mask,
         mask_indptr=mask_indptr,
         max_len_extend=max_len_extend,
         sm_scale=sm_scale,
         page_size=page_size,
-        is_causal=is_causal,
+        is_causal=False,
         logit_cap=0.0,
         skip_prefix_custom_mask=False,
         window_left=window_left,

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from ..speculative.spec_tree_manager import SpecTreeManager
 
 from tensorrt_llm._torch.attention_backend.fmha import (
-    Fmha, get_enabled_fmha_lib_classes)
+    Fmha, PhasedFmha, get_enabled_fmha_lib_classes)
 from tensorrt_llm._utils import get_sm_version, maybe_pin_memory, prefer_pinned
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
@@ -300,7 +300,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                                         pin_memory=prefer_pinned())
         self.host_total_kv_lens = torch.empty(2, device='cpu', dtype=torch.int)
         self.host_request_types = torch.empty_like(self.prompt_lens_cpu)
-
         if self.workspace is None:
             self.workspace = torch.empty(
                 (0, ),
@@ -1464,6 +1463,12 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             if fmha_cls.is_available(self):
                 self.fmha_libs.append(fmha_cls(self))
 
+        phased_fmhas = [
+            fmha for fmha in self.fmha_libs if isinstance(fmha, PhasedFmha)
+        ]
+        for index, fmha in enumerate(phased_fmhas):
+            fmha.set_followup_fmhas(tuple(phased_fmhas[index + 1:]))
+
     def forward(
         self,
         q: torch.Tensor,
@@ -1741,7 +1746,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             self.create_fmha_libs()
 
         for fmha in self.fmha_libs:
-            if fmha.is_supported(q, k, v, metadata, forward_args):
+            if isinstance(fmha, PhasedFmha):
+                if fmha.try_forward(q, k, v, metadata, forward_args):
+                    break
+            elif fmha.is_supported(q, k, v, metadata, forward_args):
                 fmha.forward(q, k, v, metadata, forward_args)
                 break
         else:

--- a/tensorrt_llm/_torch/models/modeling_cohere2.py
+++ b/tensorrt_llm/_torch/models/modeling_cohere2.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Optional
 
 import torch
@@ -6,7 +21,11 @@ from tqdm import tqdm
 from transformers import Cohere2Config
 from transformers.activations import ACT2FN
 
-from tensorrt_llm._torch.attention_backend import AttentionMetadata, FlashInferAttentionMetadata
+from tensorrt_llm._torch.attention_backend import (
+    AttentionMetadata,
+    FlashInferAttentionMetadata,
+    TrtllmAttentionMetadata,
+)
 from tensorrt_llm._torch.attention_backend.interface import (
     AttentionMask,
     CustomAttentionMask,
@@ -114,9 +133,10 @@ class Cohere2Attention(Attention):
         **kwargs,
     ):
         if attention_mask_data is not None:
-            assert isinstance(attn_metadata, FlashInferAttentionMetadata), (
-                "Only FlashInfer backend supports custom attention mask currently."
-            )
+            assert isinstance(
+                attn_metadata,
+                (FlashInferAttentionMetadata, TrtllmAttentionMetadata),
+            ), "Only FlashInfer and TRTLLM backends support custom attention masks."
             assert attention_mask == CustomAttentionMask.CUSTOM
         return super().forward(
             position_ids=position_ids,

--- a/tensorrt_llm/_torch/models/modeling_gemma3.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import math
 from typing import Dict, Optional, Tuple
 
@@ -11,7 +26,8 @@ from tensorrt_llm._torch.modules.qk_norm_attention import QKNormRoPEAttention
 from tensorrt_llm.functional import PositionEmbeddingType, RotaryScalingType
 from tensorrt_llm.mapping import Mapping
 
-from ..attention_backend import AttentionMetadata, FlashInferAttentionMetadata
+from ..attention_backend import (AttentionMetadata, FlashInferAttentionMetadata,
+                                 TrtllmAttentionMetadata)
 from ..attention_backend.interface import (AttentionMask, CustomAttentionMask,
                                            PositionalEmbeddingParams,
                                            PredefinedAttentionMask, RopeParams)
@@ -117,8 +133,9 @@ class Gemma3Attention(QKNormRoPEAttention):
 
         if attention_mask_data is not None:
             assert isinstance(
-                attn_metadata, FlashInferAttentionMetadata
-            ), "Only FlashInfer backend supports custom attention mask currently."
+                attn_metadata,
+                (FlashInferAttentionMetadata, TrtllmAttentionMetadata),
+            ), "Only FlashInfer and TRTLLM backends support custom attention masks."
             assert attention_mask == CustomAttentionMask.CUSTOM
         return super().forward(position_ids=position_ids,
                                hidden_states=hidden_states,
@@ -384,26 +401,31 @@ class Gemma3ForCausalLM(DecoderModelForCausalLM[Gemma3TextModel,
             A flattened boolean mask of shape (sum(q_len[i] * k_len[i] for i in range(batch_size)).
         """
 
-        assert isinstance(
-            attn_metadata, FlashInferAttentionMetadata
-        ), "Only FlashInfer backend supports custom mask currently."
         num_contexts = attn_metadata.num_contexts
         assert num_contexts > 0, "There should be at least one context request in the batch for custom mask."
 
-        qo_indptr = attn_metadata.qo_indptr[:num_contexts + 1]
-        cached_token_lens = attn_metadata.cached_token_lens[:num_contexts]
-        assert (cached_token_lens == 0).all(
-        ), "cached_token_lens should be 0 for context requests since chunked prefill and kv cache reuse must be disabled."
+        context_lens = attn_metadata.seq_lens[:num_contexts].tolist()
+        cached_token_lens = (
+            attn_metadata.kv_cache_params.
+            num_cached_tokens_per_seq[:num_contexts]
+            if attn_metadata.kv_cache_params is not None and
+            attn_metadata.kv_cache_params.num_cached_tokens_per_seq is not None
+            else [0] * num_contexts)
+        assert not any(cached_token_lens), (
+            "cached_token_lens should be 0 for context requests since chunked prefill "
+            "and kv cache reuse must be disabled.")
 
         # Create masks for context requests.
         context_mask_list = []
-        for i in range(num_contexts):
+        token_offset = 0
+        for context_len in context_lens:
             mask_i = self.get_context_mask(
-                image_token_mask=image_token_mask[qo_indptr[i]:qo_indptr[i +
-                                                                         1]],
+                image_token_mask=image_token_mask[token_offset:token_offset +
+                                                  context_len],
                 effective_sliding_window=effective_sliding_window,
             )
             context_mask_list.append(mask_i.flatten())
+            token_offset += context_len
         return torch.cat(context_mask_list, dim=0).contiguous()
 
     @inference_mode_unless_compiling

--- a/tensorrt_llm/_torch/models/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4.py
@@ -31,7 +31,11 @@ from tensorrt_llm._torch.modules.qk_norm_attention import QKNormRoPEAttention
 from tensorrt_llm.functional import PositionEmbeddingType, RotaryScalingType
 from tensorrt_llm.mapping import Mapping
 
-from ..attention_backend import AttentionMetadata, FlashInferAttentionMetadata
+from ..attention_backend import (
+    AttentionMetadata,
+    FlashInferAttentionMetadata,
+    TrtllmAttentionMetadata,
+)
 from ..attention_backend.interface import (
     AttentionMask,
     CustomAttentionMask,
@@ -212,6 +216,9 @@ class Gemma4Attention(QKNormRoPEAttention):
             dense_bias=False,
             config=model_config,
             q_scaling=q_scaling,
+            # Gemma4's H512 proportional RoPE pairs dimensions across the
+            # full head, so rotate Q/K at the module layer before fusing QKV.
+            rope_fusion=layer_head_dim <= 256,
         )
 
         # Restore original config head_dim
@@ -260,14 +267,11 @@ class Gemma4Attention(QKNormRoPEAttention):
             # the rotate split, matching HF's rotate_half(head_dim//2) pairing.
             self.rotary_emb.head_dim = layer_head_dim
 
-        # Use trtllm-gen for ALL layers.  trtllm-gen has pre-compiled cubins
-        # for both H256+SWA and H512 across all supported dtypes.
-        # For FP8 KV cache (NVFP4), Q is also cast to FP8 in the FlashInfer
-        # backend so that QkvE4m3OBfloat16 context cubins can be used
-        # (context cubins require same Q/KV dtype; decode cubins support
-        # mixed dtypes natively).  Uniform backend avoids workspace
-        # corruption between different wrapper types under CUDA graphs.
-        self.attn.flashinfer_backend = "trtllm-gen"
+        # When FlashInfer is explicitly selected, keep its trtllm-gen path for
+        # both H256+SWA and H512. The default TRTLLM backend selects phased
+        # trtllm-gen FMHA directly and does not expose this FlashInfer option.
+        if hasattr(self.attn, "flashinfer_backend"):
+            self.attn.flashinfer_backend = "trtllm-gen"
 
         # KV shared layers: use target layer's index for KV cache access
         # so the attention backend reads from the target layer's cache slot.
@@ -370,9 +374,10 @@ class Gemma4Attention(QKNormRoPEAttention):
         **kwargs,
     ) -> torch.Tensor:
         if attention_mask_data is not None:
-            assert isinstance(attn_metadata, FlashInferAttentionMetadata), (
-                "Only FlashInfer backend supports custom attention mask currently."
-            )
+            assert isinstance(
+                attn_metadata,
+                (FlashInferAttentionMetadata, TrtllmAttentionMetadata),
+            ), "Only FlashInfer and TRTLLM backends support custom attention masks."
             assert attention_mask == CustomAttentionMask.CUSTOM
         return super().forward(
             position_ids=position_ids,
@@ -939,12 +944,11 @@ class Gemma4ForCausalLM(DecoderModelForCausalLM[Gemma4TextModel, Gemma4TextConfi
     def get_model_defaults(cls, llm_args) -> dict:
         """Gemma4-specific defaults.
 
-        FlashInfer backend is required for hybrid attention (per-layer
-        head_dim 256/512 with VSWA), trtllm-gen cubin dispatch, and
-        bidirectional attention masks for multimodal tokens.
+        The TRTLLM attention backend uses trtllm-gen for the regular attention
+        phases and a Triton context phase for bidirectional multimodal masks.
         """
         return {
-            "attn_backend": "FLASHINFER",
+            "attn_backend": "TRTLLM",
         }
 
     def _get_token_type_mask(self, mm_token_type_ids: torch.Tensor):
@@ -1026,9 +1030,6 @@ class Gemma4ForCausalLM(DecoderModelForCausalLM[Gemma4TextModel, Gemma4TextConfi
         effective_sliding_window: Optional[int] = None,
     ) -> torch.Tensor:
         """Build FlashInfer custom mask for context requests."""
-        assert isinstance(attn_metadata, FlashInferAttentionMetadata), (
-            "Only FlashInfer backend supports custom mask currently."
-        )
         num_contexts = attn_metadata.num_contexts
         assert num_contexts > 0
 

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -592,7 +592,7 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
     def get_model_defaults(cls, llm_args) -> dict:
         """Gemma4-specific defaults — see Gemma4ForCausalLM.get_model_defaults."""
         return {
-            "attn_backend": "FLASHINFER",
+            "attn_backend": "TRTLLM",
         }
 
     def _check_and_adjust_experts_implementation(self, *args, **kwargs):
@@ -726,11 +726,10 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         )
         pretrained_config = getattr(model_config.pretrained_config, name)
         quant_config = model_config.quant_config if name == "text_config" else None
-        preferred_backend = "FLASHINFER" if name == "text_config" else "TRTLLM"
         sub_config: ModelConfig = dataclasses.replace(
             model_config,
             pretrained_config=pretrained_config,
-            attn_backend=preferred_backend,
+            attn_backend="TRTLLM",
             quant_config=quant_config,
         )
         if (

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -726,10 +726,11 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         )
         pretrained_config = getattr(model_config.pretrained_config, name)
         quant_config = model_config.quant_config if name == "text_config" else None
+        attn_backend = model_config.attn_backend if name == "text_config" else "TRTLLM"
         sub_config: ModelConfig = dataclasses.replace(
             model_config,
             pretrained_config=pretrained_config,
-            attn_backend="TRTLLM",
+            attn_backend=attn_backend,
             quant_config=quant_config,
         )
         if (

--- a/tensorrt_llm/_torch/modules/ATTENTION_DEVELOPER_GUIDE.md
+++ b/tensorrt_llm/_torch/modules/ATTENTION_DEVELOPER_GUIDE.md
@@ -252,7 +252,7 @@ FlashInfer into the `TRTLLM` backend, and `FallbackFmha` calls the regular
 `thop.attention` runtime path. These are not separate attention backends.
 
 `TLLM_FMHA_LIBS` controls the ordered list. Unset means
-`flashinfer_trtllm_gen,fallback`; use `TLLM_FMHA_LIBS=fallback` or
+`triton_custom_mask,flashinfer_trtllm_gen,fallback`; use `TLLM_FMHA_LIBS=fallback` or
 `TLLM_FMHA_LIBS=-flashinfer_trtllm_gen` to force the fallback path. Each FMHA
 library exposes `is_available()` for module/static environment checks and
 `is_supported()` for per-forward request checks.
@@ -261,9 +261,16 @@ The FMHA package is split by role:
 
 - `fmha/interface.py` defines the `Fmha` runtime contract.
 - `fmha/phased.py` defines `PhasedFmha`, which handles mixed context/generation
-  requests and dispatches them to phase-specific hooks.
+  requests and can dispatch each phase to a different ordered FMHA provider.
 - `fmha/flashinfer_trtllm_gen.py` implements the FlashInfer trtllm-gen FMHA
   library.
+- `fmha/triton_custom_mask.py` implements only the Triton custom-mask context
+  phase. In mixed batches, `PhasedFmha` delegates generation to the next
+  supporting provider, normally `FlashInferTrtllmGenFmha`. The mask data covers
+  context requests only; generation uses causal semantics. H512 context uses
+  the same fused C++ QKV preprocessing and paged-KV append as smaller heads.
+  Q-only KV-shared generation still uses the explicit paged-KV path and launches
+  the trtllm-gen decode kernel directly without a FlashInfer decode wrapper.
 - `fmha/fallback.py` implements the regular `thop.attention` fallback library.
 - `fmha/registry.py` owns `TLLM_FMHA_LIBS` parsing and library ordering.
 

--- a/tests/unittest/_torch/attention/test_triton_custom_mask_fmha.py
+++ b/tests/unittest/_torch/attention/test_triton_custom_mask_fmha.py
@@ -32,6 +32,7 @@ from tensorrt_llm._torch.attention_backend.interface import (
 from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttentionMetadata
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import PositionEmbeddingType
+from tensorrt_llm.quantization.mode import QuantMode
 
 
 def test_triton_custom_mask_precedes_general_fmha_libraries() -> None:
@@ -201,11 +202,20 @@ def test_mixed_batch_runs_context_and_generation_on_different_fmhas(monkeypatch)
     assert called_phases[1][2].attention_mask_data is None
 
 
-def test_large_head_generation_support_is_owned_by_trtllm_gen() -> None:
+@pytest.mark.parametrize(
+    "quant_mode",
+    [
+        QuantMode(0),
+        QuantMode.from_description(use_fp8_kv_cache=True),
+    ],
+)
+def test_large_head_generation_support_is_owned_by_trtllm_gen(
+    quant_mode: QuantMode,
+) -> None:
     attn = SimpleNamespace(
         head_dim=512,
         is_mla_enable=False,
-        quant_mode=0,
+        quant_mode=int(quant_mode),
         position_embedding_type=int(PositionEmbeddingType.learned_absolute),
     )
     fmha = object.__new__(FlashInferTrtllmGenFmha)
@@ -238,12 +248,88 @@ def test_large_head_generation_support_is_owned_by_trtllm_gen() -> None:
     assert supported, reason
 
 
+def test_fp8_kv_generation_uses_fp8_query() -> None:
+    attn = SimpleNamespace(
+        quant_mode=int(QuantMode.from_description(use_fp8_kv_cache=True)),
+    )
+    fmha = object.__new__(FlashInferTrtllmGenFmha)
+    fmha._attn_ref = lambda: attn
+
+    assert fmha.get_fp8_context_fmha(
+        torch.empty(1, dtype=torch.bfloat16),
+        torch.empty(1, dtype=torch.bfloat16),
+        SimpleNamespace(),
+        AttentionForwardArgs(),
+        is_gen_only=True,
+    )
+
+
+def test_generation_only_uses_generation_provider_fp8_mode(monkeypatch) -> None:
+    attn = SimpleNamespace(
+        is_mla_enable=False,
+        num_heads=1,
+        num_kv_heads=1,
+        head_dim=4,
+        v_head_dim=None,
+        kv_lora_rank=None,
+        predicted_tokens_per_seq=1,
+    )
+    fmha = object.__new__(FlashInferTrtllmGenFmha)
+    fmha._attn_ref = lambda: attn
+    fmha._followup_fmhas = ()
+    fmha.kv_factor = 2
+    fmha.context_out_head_size = 4
+    fmha.generation_out_head_size = 4
+
+    monkeypatch.setattr(FlashInferTrtllmGenFmha, "is_generation_supported", lambda *args: True)
+    monkeypatch.setattr(FlashInferTrtllmGenFmha, "prepare_workspace", lambda *args: None)
+    monkeypatch.setattr(
+        FlashInferTrtllmGenFmha,
+        "get_fp8_context_fmha",
+        lambda *args: True,
+    )
+    fp8_mode = None
+
+    def _run_generation(self, params):
+        nonlocal fp8_mode
+        fp8_mode = params.fp8_context_fmha
+
+    monkeypatch.setattr(FlashInferTrtllmGenFmha, "run_generation", _run_generation)
+
+    metadata = SimpleNamespace(
+        kv_cache_block_offsets=object(),
+        effective_workspace=torch.empty(0, dtype=torch.int8),
+        num_contexts=0,
+        num_ctx_tokens=0,
+        num_generations=1,
+        kv_lens_cuda_runtime=torch.tensor([5], dtype=torch.int32),
+        kv_lens_runtime=torch.tensor([5], dtype=torch.int32),
+        beam_width=1,
+        cache_indirection=None,
+        tokens_per_block=32,
+        kv_cache_manager=None,
+        is_cross=False,
+        is_spec_decoding_enabled=False,
+    )
+    q = torch.empty((1, 4), dtype=torch.bfloat16)
+    forward_args = AttentionForwardArgs(
+        output=torch.empty_like(q),
+        attention_mask=PredefinedAttentionMask.CAUSAL,
+        attention_input_type=AttentionInputType.generation_only,
+        attention_window_size=8,
+    )
+
+    assert fmha.try_forward(q, None, None, metadata, forward_args)
+    assert fp8_mode is True
+
+
 def test_preprocessed_generation_launches_trtllm_gen_directly(monkeypatch) -> None:
+    fp8_kv_quant_mode = QuantMode.from_description(use_fp8_kv_cache=True)
     attn = SimpleNamespace(
         num_heads=2,
         num_kv_heads=1,
         head_dim=512,
-        quant_mode=0,
+        quant_mode=int(fp8_kv_quant_mode),
         local_layer_idx=0,
         q_scaling=1.0,
         attention_chunk_size=None,
@@ -284,17 +370,31 @@ def test_preprocessed_generation_launches_trtllm_gen_directly(monkeypatch) -> No
     fmha._enable_pdl = False
     fmha._multi_processor_count = 1
 
+    appended_kv_dtypes = None
+
+    def _capture_append(params, q, k, v, *args, **kwargs):
+        nonlocal appended_kv_dtypes
+        appended_kv_dtypes = (q.dtype, k.dtype, v.dtype)
+        return object(), object(), object(), object(), [5]
+
     monkeypatch.setattr(
         FlashInferTrtllmGenFmha,
         "_append_preprocessed_kv",
-        staticmethod(lambda *args, **kwargs: (object(), object(), object(), object(), [5])),
+        staticmethod(_capture_append),
     )
     kv_pool = torch.empty(1)
     block_tables = torch.zeros(1, 2, 4, dtype=torch.int32)
+    metadata_dtype = None
+
+    def _build_metadata(*args, **kwargs):
+        nonlocal metadata_dtype
+        metadata_dtype = args[-1]
+        return kv_pool, block_tables
+
     monkeypatch.setattr(
         thop,
         "build_trtllm_gen_kv_cache_metadata",
-        lambda *args, **kwargs: (kv_pool, block_tables),
+        _build_metadata,
     )
     monkeypatch.setattr(
         trtllm_gen_module,
@@ -317,6 +417,9 @@ def test_preprocessed_generation_launches_trtllm_gen_directly(monkeypatch) -> No
 
     assert decode_args is not None
     assert decode_args[0].shape == (1, 2, 512)
+    assert decode_args[0].dtype == torch.float8_e4m3fn
+    assert appended_kv_dtypes == (torch.float8_e4m3fn,) * 3
+    assert metadata_dtype == torch.float8_e4m3fn
     assert decode_args[1] is kv_pool
     assert decode_args[3] is block_tables
     assert decode_args[5] == 5

--- a/tests/unittest/_torch/attention/test_triton_custom_mask_fmha.py
+++ b/tests/unittest/_torch/attention/test_triton_custom_mask_fmha.py
@@ -1,0 +1,617 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.attention_backend.fmha import flashinfer_trtllm_gen as trtllm_gen_module
+from tensorrt_llm._torch.attention_backend.fmha.flashinfer_trtllm_gen import FlashInferTrtllmGenFmha
+from tensorrt_llm._torch.attention_backend.fmha.phased import PhasedFmha
+from tensorrt_llm._torch.attention_backend.fmha.registry import DEFAULT_FMHA_LIBS
+from tensorrt_llm._torch.attention_backend.fmha.triton_custom_mask import TritonCustomMaskFmha
+from tensorrt_llm._torch.attention_backend.interface import (
+    AttentionForwardArgs,
+    AttentionInputType,
+    CustomAttentionMask,
+    PredefinedAttentionMask,
+)
+from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttentionMetadata
+from tensorrt_llm.bindings.internal import thop
+from tensorrt_llm.functional import PositionEmbeddingType
+
+
+def test_triton_custom_mask_precedes_general_fmha_libraries() -> None:
+    assert DEFAULT_FMHA_LIBS == (
+        "triton_custom_mask",
+        "flashinfer_trtllm_gen",
+        "fallback",
+    )
+
+
+def test_triton_custom_mask_implements_only_context_phase() -> None:
+    assert TritonCustomMaskFmha.__bases__ == (PhasedFmha,)
+    assert "run_generation" not in TritonCustomMaskFmha.__dict__
+    assert "_run_preprocessed_context" not in TritonCustomMaskFmha.__dict__
+
+
+def test_trtllm_metadata_does_not_add_custom_mask_buffers() -> None:
+    fields = TrtllmAttentionMetadata.__dataclass_fields__
+    assert "custom_mask_qo_indptr" not in fields
+    assert "custom_mask_cached_token_lens" not in fields
+
+
+def test_custom_mask_context_skips_trtllm_gen_context_checks() -> None:
+    attn = SimpleNamespace(is_mla_enable=False, quant_mode=0)
+    fmha = object.__new__(TritonCustomMaskFmha)
+    fmha._attn_ref = lambda: attn
+    metadata = SimpleNamespace(
+        num_contexts=1,
+        num_generations=0,
+        is_cross=False,
+        kv_cache_block_offsets=object(),
+    )
+    q = torch.empty((2, 12), dtype=torch.float16)
+    output = torch.empty((2, 4), dtype=torch.float16)
+    forward_args = AttentionForwardArgs(
+        output=output,
+        attention_mask=CustomAttentionMask.CUSTOM,
+        attention_mask_data=torch.ones((4,), dtype=torch.bool),
+        is_fused_qkv=True,
+    )
+
+    assert fmha.is_context_supported(q, None, None, metadata, forward_args)
+
+
+def test_custom_mask_mixed_batch_reuses_generation_checks(monkeypatch) -> None:
+    attn = SimpleNamespace(is_mla_enable=False, quant_mode=0)
+    fmha = object.__new__(TritonCustomMaskFmha)
+    fmha._attn_ref = lambda: attn
+    fmha._followup_fmhas = ()
+    generation_fmha = object.__new__(FlashInferTrtllmGenFmha)
+    generation_fmha._attn_ref = lambda: attn
+    generation_fmha._followup_fmhas = ()
+    fmha.set_followup_fmhas((generation_fmha,))
+    metadata = SimpleNamespace(
+        num_contexts=1,
+        num_generations=1,
+        is_cross=False,
+        kv_cache_block_offsets=object(),
+    )
+    q = torch.empty((3, 12), dtype=torch.float16)
+    output = torch.empty((3, 4), dtype=torch.float16)
+    forward_args = AttentionForwardArgs(
+        output=output,
+        attention_mask=CustomAttentionMask.CUSTOM,
+        attention_mask_data=torch.ones((4,), dtype=torch.bool),
+        attention_input_type=AttentionInputType.mixed,
+        is_fused_qkv=True,
+    )
+    checked_args = None
+
+    def _accept_generation_request(self, q, k, v, attn, metadata, forward_args):
+        nonlocal checked_args
+        checked_args = forward_args
+        return True, ""
+
+    monkeypatch.setattr(
+        FlashInferTrtllmGenFmha,
+        "_is_supported_with_reason",
+        _accept_generation_request,
+    )
+    assert fmha.is_supported(q, None, None, metadata, forward_args)
+    assert checked_args.attention_mask == PredefinedAttentionMask.CAUSAL
+    assert checked_args.attention_mask_data is None
+    assert checked_args.attention_input_type == AttentionInputType.generation_only
+    assert forward_args.attention_mask == CustomAttentionMask.CUSTOM
+
+
+def test_mixed_batch_runs_context_and_generation_on_different_fmhas(monkeypatch) -> None:
+    attn = SimpleNamespace(
+        is_mla_enable=False,
+        num_heads=1,
+        num_kv_heads=1,
+        head_dim=4,
+        v_head_dim=None,
+        kv_lora_rank=None,
+        predicted_tokens_per_seq=1,
+    )
+    context_fmha = object.__new__(TritonCustomMaskFmha)
+    context_fmha._attn_ref = lambda: attn
+    context_fmha.kv_factor = 2
+    context_fmha.context_out_head_size = 4
+    context_fmha.generation_out_head_size = 4
+    generation_fmha = object.__new__(FlashInferTrtllmGenFmha)
+    generation_fmha._attn_ref = lambda: attn
+    generation_fmha._followup_fmhas = ()
+    context_fmha.set_followup_fmhas((generation_fmha,))
+
+    monkeypatch.setattr(
+        TritonCustomMaskFmha,
+        "is_context_supported",
+        lambda *args: True,
+    )
+    monkeypatch.setattr(
+        FlashInferTrtllmGenFmha,
+        "is_generation_supported",
+        lambda *args: True,
+    )
+    monkeypatch.setattr(TritonCustomMaskFmha, "prepare_workspace", lambda *args: None)
+    monkeypatch.setattr(FlashInferTrtllmGenFmha, "prepare_workspace", lambda *args: None)
+
+    called_phases = []
+
+    def _run_context(self, params):
+        called_phases.append(("context", self, params.fwd))
+
+    def _run_generation(self, params):
+        called_phases.append(("generation", self, params.fwd))
+
+    monkeypatch.setattr(TritonCustomMaskFmha, "run_context", _run_context)
+    monkeypatch.setattr(FlashInferTrtllmGenFmha, "run_generation", _run_generation)
+
+    metadata = SimpleNamespace(
+        kv_cache_block_offsets=object(),
+        effective_workspace=torch.empty(0, dtype=torch.int8),
+        num_contexts=1,
+        num_ctx_tokens=2,
+        num_generations=1,
+        kv_lens_cuda_runtime=torch.tensor([2, 5], dtype=torch.int32),
+        kv_lens_runtime=torch.tensor([2, 5], dtype=torch.int32),
+        prompt_lens_cuda_runtime=torch.tensor([2, 4], dtype=torch.int32),
+        prompt_lens_cpu_runtime=torch.tensor([2, 4], dtype=torch.int32),
+        beam_width=1,
+        cache_indirection=None,
+        tokens_per_block=32,
+        kv_cache_manager=None,
+        is_cross=False,
+        is_spec_decoding_enabled=False,
+    )
+    q = torch.empty((3, 12), dtype=torch.float16)
+    forward_args = AttentionForwardArgs(
+        output=torch.empty((3, 4), dtype=torch.float16),
+        attention_mask=CustomAttentionMask.CUSTOM,
+        attention_mask_data=torch.ones(4, dtype=torch.bool),
+        attention_input_type=AttentionInputType.mixed,
+        attention_window_size=8,
+        is_fused_qkv=True,
+    )
+
+    assert context_fmha.try_forward(q, None, None, metadata, forward_args)
+
+    assert [(phase, fmha) for phase, fmha, _ in called_phases] == [
+        ("context", context_fmha),
+        ("generation", generation_fmha),
+    ]
+    assert called_phases[0][2].attention_mask == CustomAttentionMask.CUSTOM
+    assert called_phases[1][2].attention_mask == PredefinedAttentionMask.CAUSAL
+    assert called_phases[1][2].attention_mask_data is None
+
+
+def test_large_head_generation_support_is_owned_by_trtllm_gen() -> None:
+    attn = SimpleNamespace(
+        head_dim=512,
+        is_mla_enable=False,
+        quant_mode=0,
+        position_embedding_type=int(PositionEmbeddingType.learned_absolute),
+    )
+    fmha = object.__new__(FlashInferTrtllmGenFmha)
+    fmha._attn_ref = lambda: attn
+    metadata = SimpleNamespace(
+        num_contexts=0,
+        num_generations=1,
+        is_cross=False,
+        kv_cache_block_offsets=object(),
+    )
+    q = torch.empty((1, 8), dtype=torch.bfloat16)
+    k = torch.empty((1, 4), dtype=torch.bfloat16)
+    v = torch.empty((1, 4), dtype=torch.bfloat16)
+    output = torch.empty_like(q)
+    forward_args = AttentionForwardArgs(
+        output=output,
+        attention_mask=PredefinedAttentionMask.CAUSAL,
+        attention_input_type=AttentionInputType.generation_only,
+        is_fused_qkv=False,
+    )
+
+    supported, reason = fmha._check_preprocessed_generation_with_reason(
+        q,
+        k,
+        v,
+        metadata,
+        forward_args,
+    )
+
+    assert supported, reason
+
+
+def test_preprocessed_generation_launches_trtllm_gen_directly(monkeypatch) -> None:
+    attn = SimpleNamespace(
+        num_heads=2,
+        num_kv_heads=1,
+        head_dim=512,
+        quant_mode=0,
+        local_layer_idx=0,
+        q_scaling=1.0,
+        attention_chunk_size=None,
+    )
+    metadata = SimpleNamespace(
+        kv_cache_manager=object(),
+        num_generations=1,
+        seq_lens=torch.tensor([1], dtype=torch.int32),
+        kv_cache_params=SimpleNamespace(num_cached_tokens_per_seq=[4]),
+        beam_width=1,
+        max_num_requests=1,
+        host_kv_cache_pool_pointers=torch.empty(0),
+        host_kv_cache_pool_mapping=torch.empty(0),
+        kv_cache_block_offsets=torch.empty(0),
+    )
+    params = SimpleNamespace(
+        attn=attn,
+        meta=metadata,
+        fwd=AttentionForwardArgs(),
+        qkv_input=torch.randn(1, 2 * 512, dtype=torch.bfloat16),
+        key_input=torch.randn(1, 512, dtype=torch.bfloat16),
+        value_input=torch.randn(1, 512, dtype=torch.bfloat16),
+        context_buf=torch.empty(1, 2, 512, dtype=torch.bfloat16),
+        sequence_lengths=torch.tensor([5], dtype=torch.int32),
+        workspace=torch.empty(1024, dtype=torch.int8),
+        num_tokens=1,
+        seq_offset=0,
+        num_requests=1,
+        tokens_per_block=32,
+        kv_factor=2,
+        total_num_blocks=4,
+        input_seq_length=1,
+        max_past_kv_length=5,
+        cyclic_attention_window_size=5,
+    )
+    fmha = object.__new__(FlashInferTrtllmGenFmha)
+    fmha._attn_ref = lambda: attn
+    fmha._enable_pdl = False
+    fmha._multi_processor_count = 1
+
+    monkeypatch.setattr(
+        FlashInferTrtllmGenFmha,
+        "_append_preprocessed_kv",
+        staticmethod(lambda *args, **kwargs: (object(), object(), object(), object(), [5])),
+    )
+    kv_pool = torch.empty(1)
+    block_tables = torch.zeros(1, 2, 4, dtype=torch.int32)
+    monkeypatch.setattr(
+        thop,
+        "build_trtllm_gen_kv_cache_metadata",
+        lambda *args, **kwargs: (kv_pool, block_tables),
+    )
+    monkeypatch.setattr(
+        trtllm_gen_module,
+        "_clear_multi_ctas_kv_counter_workspace",
+        lambda *args, **kwargs: None,
+    )
+    decode_args = None
+
+    def _capture_decode(*args):
+        nonlocal decode_args
+        decode_args = args
+
+    monkeypatch.setattr(
+        trtllm_gen_module,
+        "_trtllm_gen_batch_decode_with_kv_cache",
+        _capture_decode,
+    )
+
+    fmha._run_preprocessed_generation(params)
+
+    assert decode_args is not None
+    assert decode_args[0].shape == (1, 2, 512)
+    assert decode_args[1] is kv_pool
+    assert decode_args[3] is block_tables
+    assert decode_args[5] == 5
+
+
+def test_large_head_context_requires_module_side_rope() -> None:
+    attn = SimpleNamespace(
+        head_dim=512,
+        is_mla_enable=False,
+        quant_mode=0,
+        position_embedding_type=int(PositionEmbeddingType.rope_gpt_neox),
+    )
+    fmha = object.__new__(TritonCustomMaskFmha)
+    fmha._attn_ref = lambda: attn
+    metadata = SimpleNamespace(
+        num_contexts=1,
+        num_generations=0,
+        is_cross=False,
+        kv_cache_block_offsets=object(),
+    )
+    q = torch.empty((2, 8), dtype=torch.bfloat16)
+    output = torch.empty_like(q)
+    forward_args = AttentionForwardArgs(
+        output=output,
+        attention_mask=CustomAttentionMask.CUSTOM,
+        attention_mask_data=torch.ones((4,), dtype=torch.bool),
+        attention_input_type=AttentionInputType.context_only,
+        is_fused_qkv=True,
+    )
+
+    assert not fmha.is_context_supported(q, None, None, metadata, forward_args)
+
+
+def test_triton_prefill_accepts_separate_kv_page_tables() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the Triton kernel test.")
+
+    from tensorrt_llm._torch.attention_backend.triton_prefill import triton_prefill_with_custom_mask
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    dtype = torch.float16
+    q_len = 2
+    prefix_len = 2
+    head_dim = 64
+    page_size = 2
+    q = torch.randn(q_len, 1, head_dim, device=device, dtype=dtype)
+    k = torch.randn(q_len, 1, head_dim, device=device, dtype=dtype)
+    v = torch.randn(q_len, 1, head_dim, device=device, dtype=dtype)
+    k_prefix = torch.randn(prefix_len, 1, head_dim, device=device, dtype=dtype)
+    v_prefix = torch.randn(prefix_len, 1, head_dim, device=device, dtype=dtype)
+
+    pool = torch.zeros(2, 1, page_size, head_dim, device=device, dtype=dtype)
+    pool[0].copy_(k_prefix.transpose(0, 1))
+    pool[1].copy_(v_prefix.transpose(0, 1))
+    output = torch.empty_like(q)
+    custom_mask = torch.tensor(
+        [
+            [True, False, True, False],
+            [False, True, True, True],
+        ],
+        device=device,
+        dtype=torch.bool,
+    )
+
+    triton_prefill_with_custom_mask(
+        q=q,
+        k=k,
+        v=v,
+        output=output,
+        qo_indptr=torch.tensor([0, q_len], device=device, dtype=torch.int32),
+        kv_cache=None,
+        prefix_lens=torch.tensor([prefix_len], device=device, dtype=torch.int32),
+        page_table_indptr=torch.tensor([0, 1], device=device, dtype=torch.int32),
+        page_table_indices=torch.tensor([0], device=device, dtype=torch.int32),
+        page_size=page_size,
+        custom_mask=custom_mask.flatten(),
+        sm_scale=head_dim**-0.5,
+        k_cache=pool,
+        v_cache=pool,
+        v_page_table_indices=torch.tensor([1], device=device, dtype=torch.int32),
+    )
+
+    keys = torch.cat([k_prefix, k], dim=0).squeeze(1).float()
+    values = torch.cat([v_prefix, v], dim=0).squeeze(1).float()
+    scores = q.squeeze(1).float() @ keys.T * head_dim**-0.5
+    scores.masked_fill_(~custom_mask, float("-inf"))
+    reference = (scores.softmax(dim=-1) @ values).to(dtype).unsqueeze(1)
+    torch.testing.assert_close(output, reference, atol=2e-2, rtol=2e-2)
+
+
+def test_triton_prefill_causal_generation_with_large_head() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the Triton kernel test.")
+
+    from tensorrt_llm._torch.attention_backend.triton_prefill import triton_prefill_with_custom_mask
+
+    torch.manual_seed(1)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    head_dim = 512
+    prefix_len = 3
+    page_size = 4
+    q = torch.randn(1, 1, head_dim, device=device, dtype=dtype)
+    k = torch.randn(1, 1, head_dim, device=device, dtype=dtype)
+    v = torch.randn(1, 1, head_dim, device=device, dtype=dtype)
+    k_prefix = torch.randn(prefix_len, 1, head_dim, device=device, dtype=dtype)
+    v_prefix = torch.randn(prefix_len, 1, head_dim, device=device, dtype=dtype)
+    kv_cache = torch.zeros(
+        1,
+        2,
+        1,
+        page_size,
+        head_dim,
+        device=device,
+        dtype=dtype,
+    )
+    kv_cache[0, 0, 0, :prefix_len].copy_(k_prefix.squeeze(1))
+    kv_cache[0, 1, 0, :prefix_len].copy_(v_prefix.squeeze(1))
+    output = torch.empty_like(q)
+
+    triton_prefill_with_custom_mask(
+        q=q,
+        k=k,
+        v=v,
+        output=output,
+        qo_indptr=torch.tensor([0, 1], device=device, dtype=torch.int32),
+        kv_cache=kv_cache,
+        prefix_lens=torch.tensor([prefix_len], device=device, dtype=torch.int32),
+        page_table_indptr=torch.tensor([0, 1], device=device, dtype=torch.int32),
+        page_table_indices=torch.tensor([0], device=device, dtype=torch.int32),
+        page_size=page_size,
+        custom_mask=None,
+        sm_scale=head_dim**-0.5,
+    )
+
+    keys = torch.cat([k_prefix, k], dim=0).squeeze(1).float()
+    values = torch.cat([v_prefix, v], dim=0).squeeze(1).float()
+    reference = ((q.squeeze(1).float() @ keys.T * head_dim**-0.5).softmax(dim=-1) @ values).to(
+        dtype
+    )
+    torch.testing.assert_close(output.squeeze(1), reference, atol=3e-2, rtol=3e-2)
+
+
+def test_gemma4_large_head_context_and_generation_match_flashinfer() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the Gemma4 attention test.")
+
+    transformers = pytest.importorskip("transformers")
+    if not hasattr(transformers, "Gemma4TextConfig"):
+        pytest.skip("The installed transformers version does not support Gemma4.")
+
+    import tensorrt_llm
+    from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
+    from tensorrt_llm._torch.metadata import KVCacheParams
+    from tensorrt_llm._torch.model_config import ModelConfig
+    from tensorrt_llm._torch.models.modeling_gemma4 import Gemma4Attention
+    from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
+    from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+    from tensorrt_llm.mapping import Mapping
+
+    config = transformers.Gemma4TextConfig(
+        model_type="gemma4_text",
+        vocab_size=128,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=256,
+        global_head_dim=512,
+        num_global_key_value_heads=1,
+        hidden_activation="gelu_pytorch_tanh",
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        sliding_window=64,
+        attention_k_eq_v=True,
+        use_bidirectional_attention="vision",
+        rope_parameters={
+            "sliding_attention": {
+                "rope_type": "default",
+                "rope_theta": 10000.0,
+            },
+            "full_attention": {
+                "rope_type": "proportional",
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1000000.0,
+            },
+        },
+        torch_dtype="bfloat16",
+        tie_word_embeddings=True,
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    mapping = Mapping(world_size=1, tp_size=1, rank=0)
+    seq_len = 4
+    hidden = torch.randn(seq_len, config.hidden_size, dtype=torch.bfloat16, device="cuda")
+    generation_hidden = torch.randn(
+        1,
+        config.hidden_size,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    position_ids = torch.arange(seq_len, dtype=torch.int32, device="cuda").unsqueeze(0)
+    generation_position_ids = torch.tensor([[seq_len]], dtype=torch.int32, device="cuda")
+    custom_mask = torch.ones(seq_len * seq_len, dtype=torch.bool, device="cuda")
+
+    mixed_hidden = torch.cat([hidden, generation_hidden], dim=0)
+    mixed_position_ids = torch.cat([position_ids, generation_position_ids], dim=1)
+
+    def run_backend(backend: str) -> tuple[torch.Tensor, torch.Tensor]:
+        model_config = ModelConfig(
+            pretrained_config=config,
+            mapping=mapping,
+            attn_backend=backend,
+        )
+        attention = (
+            Gemma4Attention(
+                model_config,
+                layer_idx=0,
+                is_sliding=False,
+            )
+            .cuda()
+            .eval()
+        )
+        torch.manual_seed(7)
+        with torch.no_grad():
+            for parameter in attention.parameters():
+                if parameter.is_floating_point():
+                    parameter.normal_(mean=0.0, std=0.02)
+
+        manager = KVCacheManagerV2(
+            KvCacheConfig(max_tokens=64, enable_block_reuse=False),
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            num_layers=1,
+            num_kv_heads=1,
+            head_dim=512,
+            tokens_per_block=32,
+            max_seq_len=64,
+            max_batch_size=2,
+            mapping=mapping,
+            dtype=tensorrt_llm.bindings.DataType.BF16,
+        )
+        assert manager.add_dummy_requests([1, 2], [seq_len + 1, seq_len]) is not None
+        metadata_cls = get_attention_backend(backend).Metadata
+        context_metadata = metadata_cls(
+            seq_lens=torch.tensor([seq_len], dtype=torch.int32),
+            num_contexts=1,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=[0],
+            ),
+            max_num_requests=2,
+            max_num_tokens=64,
+            kv_cache_manager=manager,
+            request_ids=[1],
+            prompt_lens=[seq_len],
+        )
+        context_metadata.prepare()
+        with torch.inference_mode():
+            context_output = attention(
+                position_ids,
+                hidden,
+                context_metadata,
+                attention_mask=CustomAttentionMask.CUSTOM,
+                attention_mask_data=custom_mask,
+            ).clone()
+
+        mixed_metadata = metadata_cls(
+            seq_lens=torch.tensor([seq_len, 1], dtype=torch.int32),
+            num_contexts=1,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=[0, seq_len],
+            ),
+            max_num_requests=2,
+            max_num_tokens=64,
+            kv_cache_manager=manager,
+            request_ids=[2, 1],
+            prompt_lens=[seq_len, seq_len],
+        )
+        mixed_metadata.prepare()
+        with torch.inference_mode():
+            mixed_output = attention(
+                mixed_position_ids,
+                mixed_hidden,
+                mixed_metadata,
+                attention_mask=CustomAttentionMask.CUSTOM,
+                attention_mask_data=custom_mask,
+            ).clone()
+        manager.shutdown()
+        return context_output, mixed_output
+
+    flashinfer_context, flashinfer_mixed = run_backend("FLASHINFER")
+    trtllm_context, trtllm_mixed = run_backend("TRTLLM")
+
+    torch.testing.assert_close(trtllm_context, flashinfer_context, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(trtllm_mixed, flashinfer_mixed, atol=2e-2, rtol=2e-2)

--- a/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
+++ b/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
@@ -25,7 +25,7 @@ Tier 0/1 (no LLM_MODELS_ROOT needed, GPU only):
 
 Tier 2 (LLM_MODELS_ROOT gated, real tokenizer/processor):
   - ``TestGemma4InputProcessor`` — image/audio/video pre-processing.
-  - ``TestGemma4MultimodalE2E`` — full LLM+vision generate parity via the
+  - ``TestGemma4MultimodalE2E`` — full LLM+vision context/decode execution via the
     shared ``TestModelingMultimodal`` skeleton (image / multi-image modalities).
 
 Audio-side tests (``TestGemma4InputProcessor.test_audio_*``) are intentionally
@@ -689,7 +689,7 @@ class TestGemma4ForConditionalGeneration(unittest.TestCase):
         mc = ModelConfig(
             pretrained_config=config,
             mapping=Mapping(world_size=1, tp_size=1, rank=0),
-            attn_backend="FLASHINFER",
+            attn_backend="TRTLLM",
         )
         model = Gemma4ForConditionalGeneration(mc)
 
@@ -831,7 +831,7 @@ class TestGemma4ForConditionalGeneration(unittest.TestCase):
         mc = ModelConfig(
             pretrained_config=config,
             mapping=Mapping(world_size=1, tp_size=1, rank=0),
-            attn_backend="FLASHINFER",
+            attn_backend="TRTLLM",
         )
         model = Gemma4ForConditionalGeneration(mc)
 
@@ -847,9 +847,18 @@ class TestGemma4ForConditionalGeneration(unittest.TestCase):
 
 def _get_model_path():
     llm_models_root = os.environ.get("LLM_MODELS_ROOT")
-    if llm_models_root:
-        return os.path.join(llm_models_root, "gemma4/gemma-4-26B-A4B-it")
-    return None
+    if not llm_models_root:
+        return None
+
+    model_subdirs = (
+        "gemma/gemma-4-26B-A4B-it",
+        "gemma4/gemma-4-26B-A4B-it",
+    )
+    for model_subdir in model_subdirs:
+        model_path = os.path.join(llm_models_root, model_subdir)
+        if os.path.isfile(os.path.join(model_path, "config.json")):
+            return model_path
+    return os.path.join(llm_models_root, model_subdirs[0])
 
 
 MODEL_26B_PATH = _get_model_path()
@@ -1230,11 +1239,7 @@ class TestGemma4InputProcessor(unittest.TestCase):
 # follow-up work.
 
 
-_GEMMA4_E2E_PATH = (
-    os.path.join(os.environ["LLM_MODELS_ROOT"], "gemma4/gemma-4-26B-A4B-it")
-    if os.environ.get("LLM_MODELS_ROOT")
-    else None
-)
+_GEMMA4_E2E_PATH = _get_model_path()
 
 
 def _gemma4_e2e_model_available() -> bool:
@@ -1258,7 +1263,7 @@ def _gemma4_e2e_model_available() -> bool:
 # Reduced-layer text+vision config for E2E. Real ``_name_or_path`` so the
 # input processor + tokenizer pick up the genuine Gemma4 processor files;
 # attention head_dim follows the existing dummy-config recipe in
-# ``test_gemma4_e2e_dummy.py`` (128 / 256 for FlashInfer compatibility).
+# ``test_gemma4_e2e_dummy.py`` (128 / 256 for TRTLLM FMHA compatibility).
 GEMMA4_E2E_CONFIG = {
     "architectures": ["Gemma4ForConditionalGeneration"],
     "model_type": "gemma4",
@@ -1267,17 +1272,17 @@ GEMMA4_E2E_CONFIG = {
     # HF Gemma4 (transformers 5.5.3) does not advertise SDPA support; pin
     # to eager so PreTrainedModel.__init__ does not raise on dispatch check.
     "_attn_implementation": "eager",
-    "image_token_id": 262145,
-    "audio_token_id": 262273,
-    "video_token_id": 262146,
-    "boi_token_index": 255999,
-    "eoi_token_index": 256000,
-    "boa_token_index": 256001,
-    "eoa_token_index": 256002,
+    "image_token_id": 258880,
+    "audio_token_id": 258881,
+    "video_token_id": 258884,
+    "boi_token_id": 255999,
+    "eoi_token_id": 258882,
+    "boa_token_id": 256000,
+    "eoa_token_index": 258883,
     "_name_or_path": _GEMMA4_E2E_PATH or "",
     "text_config": {
         "model_type": "gemma4_text",
-        "vocab_size": 262400,
+        "vocab_size": 262144,
         "hidden_size": 1024,
         "intermediate_size": 2048,
         "num_hidden_layers": 2,
@@ -1296,13 +1301,18 @@ GEMMA4_E2E_CONFIG = {
         "hidden_size_per_layer_input": 0,
         "use_double_wide_mlp": False,
         "final_logit_softcapping": None,
+        "use_bidirectional_attention": "vision",
         "torch_dtype": "bfloat16",
         "tie_word_embeddings": True,
         "attention_bias": False,
         "attention_dropout": 0.0,
         "rope_parameters": {
             "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0},
-            "full_attention": {"rope_type": "default", "rope_theta": 10000.0},
+            "full_attention": {
+                "rope_type": "proportional",
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1000000.0,
+            },
         },
     },
     "vision_config": {
@@ -1329,15 +1339,17 @@ GEMMA4_E2E_CONFIG = {
     not _gemma4_e2e_model_available(),
     reason=(
         "LLM_MODELS_ROOT not set or Gemma4 model not available — "
-        "E2E generate parity requires real tokenizer/processor files."
+        "E2E generation requires real tokenizer/processor files."
     ),
 )
 class TestGemma4MultimodalE2E(unittest.TestCase):
-    """Full LLM + vision parity via the shared multimodal skeleton.
+    """Full LLM + vision execution via the shared multimodal skeleton.
 
     Implemented as a thin wrapper around ``TestModelingMultimodal`` so we
-    reuse the standardized context+generation phase, KV cache manager
-    setup, HF input loading, and tolerance/compare helpers.
+    reuse the standardized context+generation phases and KV cache setup.
+    Component tests above cover HF numerical parity; this test targets the
+    fused TRTLLM runtime path because full-vocabulary random-weight BF16
+    parity is numerically unstable across the fused and eager implementations.
     """
 
     # The actual abstract base + skeleton live in
@@ -1370,6 +1382,29 @@ class TestGemma4MultimodalE2E(unittest.TestCase):
 
             def get_model_config_class(self) -> Type:
                 return Gemma4Config
+
+            @property
+            def skip_hf_inference(self) -> bool:
+                return True
+
+            def get_kv_cache_manager(
+                self,
+                dtype,
+                config,
+                tokens_per_block,
+                max_seq_len,
+                batch_size,
+                num_blocks,
+            ):
+                del dtype, max_seq_len
+                from test_modeling_gemma4 import _build_gemma4_kv_cache_manager
+
+                return _build_gemma4_kv_cache_manager(
+                    config.text_config,
+                    num_blocks=num_blocks,
+                    tokens_per_block=tokens_per_block,
+                    batch_size=batch_size,
+                )
 
             def get_scenarios(self) -> List[MultimodalScenario]:
                 # Single sanity-image scenario for the in-PR test list.

--- a/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
+++ b/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
@@ -702,6 +702,32 @@ class TestGemma4ForConditionalGeneration(unittest.TestCase):
         # TRT-LLM class, not ``transformers.AutoModel`` output.
         self.assertIsInstance(model.vision_tower, Gemma4VisionModel)
 
+    def test_text_submodel_preserves_explicit_attention_backend(self):
+        """The text submodel honors explicit backend overrides."""
+        text_config = Gemma4TextConfig(**SMALL_TEXT_CONFIG)
+        vision_config = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
+        config = Gemma4Config(
+            text_config=text_config,
+            vision_config=vision_config,
+            audio_config=None,
+        )
+
+        for backend in ("FLASHINFER", "TRTLLM"):
+            model_config = ModelConfig(
+                pretrained_config=config,
+                mapping=Mapping(world_size=1, tp_size=1, rank=0),
+                attn_backend=backend,
+            )
+            text_model_config = Gemma4ForConditionalGeneration.get_sub_model_config(
+                model_config, "text_config"
+            )
+            vision_model_config = Gemma4ForConditionalGeneration.get_sub_model_config(
+                model_config, "vision_config"
+            )
+
+            self.assertEqual(text_model_config.attn_backend, backend)
+            self.assertEqual(vision_model_config.attn_backend, "TRTLLM")
+
     def test_chunked_prefill_reuses_cached_vision_embeddings(self):
         """Later active chunks slice cached features without rerunning vision."""
         model = self._make_model()

--- a/tests/unittest/_torch/modeling/test_modeling_gemma4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma4.py
@@ -698,7 +698,7 @@ class TestGemma4HFComparison(unittest.TestCase):
             f"{failed * 100:.2f}% of elements differ (max {max_failed_frac * 100}%)",
         )
 
-    def _make_hf_and_trt_models(self, config_dict=None):
+    def _make_hf_and_trt_models(self, config_dict=None, attn_backend="FLASHINFER"):
         """Create paired HF and TRT-LLM models with shared weights."""
         from transformers import Gemma4ForCausalLM as HFGemma4
 
@@ -712,7 +712,7 @@ class TestGemma4HFComparison(unittest.TestCase):
         device = torch.device("cuda")
 
         hf_model = HFGemma4(config).to(dtype).to(device).eval()
-        model_config = ModelConfig(pretrained_config=config, attn_backend="FLASHINFER")
+        model_config = ModelConfig(pretrained_config=config, attn_backend=attn_backend)
         trt_model = Gemma4ForCausalLM(model_config).to(dtype).to(device)
 
         wm = Gemma4HfWeightMapper()
@@ -821,6 +821,7 @@ class TestGemma4HFComparison(unittest.TestCase):
         atol=0.5,
         rtol=0.5,
         max_failed_frac=0.01,
+        attn_backend="FLASHINFER",
     ):
         """Run context + generation comparison for a given config."""
         from transformers.cache_utils import DynamicCache
@@ -829,13 +830,15 @@ class TestGemma4HFComparison(unittest.TestCase):
         from tensorrt_llm._torch.metadata import KVCacheParams
 
         torch.random.manual_seed(42)
-        hf, trt, gemma4_config = self._make_hf_and_trt_models(config_dict)
+        hf, trt, gemma4_config = self._make_hf_and_trt_models(
+            config_dict, attn_backend=attn_backend
+        )
         if gemma4_config.enable_moe_block:
             self._stabilize_moe_routing(hf, trt, gemma4_config)
         hf_cache = DynamicCache()
 
         device = torch.device("cuda")
-        backend = "FLASHINFER"
+        backend = attn_backend
 
         # Set up KV cache
         kv_cache_manager = self._get_kv_cache_manager(gemma4_config)
@@ -935,6 +938,14 @@ class TestGemma4HFComparison(unittest.TestCase):
     def test_hybrid_headdim_config(self):
         """Hybrid head_dim: sliding=64, full=128 (per-layer KV cache)."""
         self._run_full_model_comparison(deepcopy(GEMMA4_HYBRID_HEADDIM_CONFIG))
+
+    @torch.no_grad()
+    def test_hybrid_headdim_config_trtllm(self):
+        """TRTLLM backend parity for hybrid sliding/full head dimensions."""
+        self._run_full_model_comparison(
+            deepcopy(GEMMA4_HYBRID_HEADDIM_CONFIG),
+            attn_backend="TRTLLM",
+        )
 
     @torch.no_grad()
     def test_diff_kv_heads_config(self):
@@ -2082,20 +2093,12 @@ class TestGemma4HFComparison(unittest.TestCase):
 class TestGemma4ModelDefaults(unittest.TestCase):
     """Tests for Gemma4 model defaults (get_model_defaults)."""
 
-    def test_causal_lm_requires_flashinfer_backend(self):
-        """Gemma4ForCausalLM must default to FLASHINFER attention backend.
-
-        The TRTLLM backend does not support:
-        - FlashInfer VSWA per-pool page management for hybrid head_dim
-        - trtllm-gen cubin dispatch for head_dim=512 layers
-        - Custom attention masks for bidirectional multimodal tokens
-        Without this default, models crash with:
-            'TrtllmAttentionMetadata' object has no attribute 'kv_layout'
-        """
+    def test_causal_lm_requires_trtllm_backend(self):
+        """Gemma4ForCausalLM must default to the TRTLLM attention backend."""
         defaults = Gemma4ForCausalLM.get_model_defaults(None)
         self.assertIn("attn_backend", defaults, "get_model_defaults must set attn_backend")
         self.assertEqual(
-            defaults["attn_backend"], "FLASHINFER", "Gemma4 requires FLASHINFER (exact uppercase)"
+            defaults["attn_backend"], "TRTLLM", "Gemma4 requires TRTLLM (exact uppercase)"
         )
 
     def test_causal_lm_does_not_disable_cuda_graphs(self):
@@ -2103,13 +2106,13 @@ class TestGemma4ModelDefaults(unittest.TestCase):
         defaults = Gemma4ForCausalLM.get_model_defaults(None)
         self.assertNotIn("cuda_graph_config", defaults)
 
-    def test_conditional_gen_requires_flashinfer_backend(self):
-        """Gemma4ForConditionalGeneration must also default to FLASHINFER."""
+    def test_conditional_gen_requires_trtllm_backend(self):
+        """Gemma4ForConditionalGeneration must also default to TRTLLM."""
         from tensorrt_llm._torch.models.modeling_gemma4mm import Gemma4ForConditionalGeneration
 
         defaults = Gemma4ForConditionalGeneration.get_model_defaults(None)
         self.assertIn("attn_backend", defaults)
-        self.assertEqual(defaults["attn_backend"], "FLASHINFER")
+        self.assertEqual(defaults["attn_backend"], "TRTLLM")
 
     def test_conditional_gen_does_not_disable_cuda_graphs(self):
         """Gemma4ForConditionalGeneration must not disable CUDA graphs."""
@@ -2118,34 +2121,21 @@ class TestGemma4ModelDefaults(unittest.TestCase):
         defaults = Gemma4ForConditionalGeneration.get_model_defaults(None)
         self.assertNotIn("cuda_graph_config", defaults)
 
-    def test_attn_backend_dispatches_to_flashinfer(self):
-        """Verify the exact string 'FLASHINFER' dispatches correctly.
-
-        get_attention_backend uses exact case-sensitive match. 'FlashInfer'
-        or 'flashinfer' would silently fall back to TrtllmAttention, which
-        causes 'TrtllmAttentionMetadata has no attribute kv_layout' crashes.
-        """
+    def test_attn_backend_dispatches_to_trtllm(self):
+        """Verify the Gemma4 default dispatches to TrtllmAttention."""
         from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 
         defaults = Gemma4ForCausalLM.get_model_defaults(None)
         backend_cls = get_attention_backend(defaults["attn_backend"])
 
-        # Must be FlashInferAttention, not TrtllmAttention
         self.assertEqual(
             backend_cls.__name__,
-            "FlashInferAttention",
-            "FLASHINFER must dispatch to FlashInferAttention",
+            "TrtllmAttention",
+            "TRTLLM must dispatch to TrtllmAttention",
         )
 
-    def test_all_layers_use_trtllm_gen(self):
-        """All Gemma4 layers use trtllm-gen backend uniformly.
-
-        trtllm-gen has pre-compiled cubins for H256+H512, both BF16 and
-        FP8 dtypes.  For FP8 KV cache (NVFP4), the FlashInfer backend
-        casts Q to FP8 to match KV, enabling QkvE4m3OBfloat16 context
-        cubins.  Uniform backend is required for CUDA graph workspace
-        sharing safety.
-        """
+    def test_all_layers_use_trtllm_backend(self):
+        """All Gemma4 layers use the default TRTLLM attention backend."""
         config_dict = deepcopy(GEMMA4_SMALL_CONFIG)
         config = Gemma4TextConfig(**config_dict)
         model_config = ModelConfig(pretrained_config=config)
@@ -2153,9 +2143,9 @@ class TestGemma4ModelDefaults(unittest.TestCase):
         for i in range(config.num_hidden_layers):
             attn = Gemma4Attention(model_config, i)
             self.assertEqual(
-                attn.attn.flashinfer_backend,
-                "trtllm-gen",
-                f"Layer {i} should use trtllm-gen",
+                attn.attn.__class__.__name__,
+                "TrtllmAttention",
+                f"Layer {i} should use the TRTLLM backend",
             )
 
 


### PR DESCRIPTION
## Related changes

- #18026 (`CombinedFmha`) has merged and is included in this branch’s `main` base.
- External shared-KV MTP support remains split into #18051.

## Description

Add custom-mask support to the PyTorch TRTLLM attention backend while keeping causal generation on TRTLLM-gen kernels.

- add a Triton custom-mask context FMHA to the phased TRTLLM backend
- pair that context implementation with a later causal-generation provider for mixed non-MLA batches
- support Gemma4 H512 context preprocessing and direct TRTLLM-gen generation
- reuse existing attention metadata instead of adding custom-mask-only metadata fields
- preserve explicit Gemma4 attention-backend overrides
- use FP8 queries for FP8-KV TRTLLM-gen decode, selecting the faster QkvE4m3 specialization
- reuse fused Gemma4 QKV normalization and RoPE for native TRTLLM on SM100 FP8-KV, emitting packed BF16 QKV directly to remove separate norm, RoPE, and concatenation work before TRTLLM-gen

## Performance

Latest paired measurements on B200 with TP/PP=1, NVFP4 weights, FP8 KV cache, ISL/OSL=1000/1000, max batch 256, max tokens 8192, KV-cache-manager V2, and CUDA graphs:

| Model | BS | FlashInfer latency (ms) | TRTLLM latency (ms) | FlashInfer tok/s | TRTLLM tok/s | TRTLLM latency advantage | TRTLLM throughput advantage |
|---|---:|---:|---:|---:|---:|---:|---:|
| Gemma-4-31B-IT-NVFP4 | 1 | 8,556.706 | 8,201.866 | 116.867 | 121.923 | 4.147% | 4.326% |
| Gemma-4-31B-IT-NVFP4 | 64 | 15,601.922 | 15,267.310 | 4,091.177 | 4,180.967 | 2.145% | 2.195% |
| Gemma-4-31B-IT-NVFP4 | 128 | 22,406.342 | 22,240.129 | 5,686.472 | 5,729.523 | 0.742% | 0.757% |
| Gemma-4-31B-IT-NVFP4 | 256 | 36,882.568 | 36,703.783 | 5,559.682 | 5,621.486 | 0.485% | 1.112% |
| Gemma-4-26B-A4B-NVFP4† | 64 | 8,987.069 | 8,717.389 | 7,099.641 | 7,318.827 | 3.001% | 3.087% |

For 31B, the optimized TRTLLM path improves throughput by 3.59%–7.10% relative to the pre-fix native TRTLLM results and is faster than the latest FlashInfer baseline at every remeasured batch size. The 26B BS64 point (†) was measured after fused preprocessing and before the final packed-output step, so it is a conservative intermediate result rather than a final packed-output measurement.

Nsight Systems confirmed that FMHA itself is not the regression: H256/H512 TRTLLM-gen kernel time was equal within noise. Native TRTLLM had skipped Gemma4 fused QKV preparation, leaving separate Q/K/V RMSNorm, H512 RoPE, and concatenation work. Fused preparation removed 9,000 RMSNorm calls and 500 RoPE calls over 50 decode steps; packed BF16 output then removed 3,000 remaining concat calls totaling 5.881 ms.

## Test Coverage

- Clean Release build on B200 passed.
- Full fused Gemma4 QKV suite plus focused routing tests: 28 passed and 3 subtests passed.
- Real H256/H512 TRTLLM + FP8-KV context and decode parity against Hugging Face passed.
- Packed-BF16 H256/H512 parity, strided-input, zero-token, and packed-FP8 rejection coverage passed.
- tests/unittest/_torch/attention/test_triton_prefill.py: 11 passed.
- Focused Gemma4 modeling tests: 12 passed, 84 deselected.
- Gemma4 multimodal image scenario: 1 passed.
- B200 ISL/OSL=1000/1000 CUDA-graph benchmarks passed at BS1/64/128/256 for 31B and BS64 for 26B.
- Pre-commit hooks, Ruff, formatting, py_compile, and git diff --check passed.

## PR Checklist

- [x] PR description clearly explains what and why
- [x] Follows TensorRT-LLM coding guidelines
- [x] Test cases are provided for new code paths
- [x] No new dependencies
- [x] Documentation updated for phased attention dispatch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added Triton custom-mask FMHA support and registered it as the default FMHA library.
- Preserved TRTLLM-Gen kernels for causal generation.
- Added phased context and generation handling for mixed non-MLA batches.
- Added Q-only preprocessing and prevented unintended KV-cache updates.
- Added separate K/V cache page-table support and FP8-query decode support.
- Updated Gemma3, Gemma4, Cohere2, and Gemma4 multimodal backend selection and custom-mask handling.
- Preserved Gemma4 backend overrides for external shared-KV MTP.
- Added Gemma4 H512 support and related preprocessing changes.
- Updated public exports, developer documentation, and attention-mask APIs consistently.
- No test-list or configuration-file changes were identified.
- Reported release, unit, focused Gemma4, multimodal, pre-commit, and diff checks passed.
- No correctness or API consistency blocker is evident from the reviewed changes.

## QA Engineer Review

Modified test files:

- `tests/unittest/_torch/modeling/test_gemma4_multimodal.py`
  - Updated multimodal backend setup and E2E execution.
  - Added coverage for explicit text-backend preservation.
- `tests/unittest/_torch/modeling/test_modeling_gemma3.py`
  - Renamed and updated the attention-mask test.
- `tests/unittest/_torch/modeling/test_modeling_gemma4.py`
  - Updated configurable-backend helpers.
  - Added TRTLLM parity tests for hybrid head dimensions and KV-sharing configurations.
  - Updated backend dispatch and per-layer backend tests.
- `tests/unittest/_torch/modules/test_gemma4_fused_qkv_prep.py`
  - Added packed BF16 output coverage.
  - Added empty-input, strided-input, output-equivalence, and FP8 rejection coverage.

The modified test functions are not listed in `tests/integration/test_lists/`, `test-db/`, or `qa/` based on the available change summary. CI coverage mapping is unavailable.

**Verdict: needs follow-up.**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->