### PR TITLE
[None][fix] Generate CUTLASS kernel instantiations without installing cutlass_library

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/CMakeLists.txt
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/CMakeLists.txt
@@ -28,17 +28,6 @@ if(NOT Python3_EXECUTABLE)
 endif()
 
 set(cutlass_source_dir ${CMAKE_BINARY_DIR}/_deps/cutlass-src)
-execute_process(
-  WORKING_DIRECTORY ${cutlass_source_dir}/python/
-  COMMAND ${Python3_EXECUTABLE} setup_library.py develop --user
-  RESULT_VARIABLE _CUTLASS_LIBRARY_SUCCESS)
-
-if(NOT _CUTLASS_LIBRARY_SUCCESS EQUAL 0)
-  message(
-    FATAL_ERROR
-      "Failed to set up the CUTLASS library in ${cutlass_source_dir} due to"
-      " ${_CUTLASS_LIBRARY_SUCCESS}.")
-endif()
 
 set(GENERATE_KERNELS_SCRIPT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/python)
 set_directory_properties(
@@ -48,10 +37,15 @@ set_directory_properties(
 set(INSTANTIATION_GENERATION_DIR
     ${CMAKE_CURRENT_BINARY_DIR}/cutlass_instantiations)
 
+# cutlass_library is a pure-python package usable straight from the CUTLASS
+# source tree: import it from there instead of installing it into whichever
+# site-packages the invoking interpreter happens to resolve.
 execute_process(
   WORKING_DIRECTORY ${GENERATE_KERNELS_SCRIPT_DIR}
-  COMMAND ${Python3_EXECUTABLE} generate_kernels.py -a
-          "${CMAKE_CUDA_ARCHITECTURES_ORIG}" -o ${INSTANTIATION_GENERATION_DIR}
+  COMMAND
+    ${CMAKE_COMMAND} -E env "PYTHONPATH=${cutlass_source_dir}/python"
+    ${Python3_EXECUTABLE} generate_kernels.py -a
+    "${CMAKE_CUDA_ARCHITECTURES_ORIG}" -o ${INSTANTIATION_GENERATION_DIR}
   RESULT_VARIABLE _KERNEL_GEN_SUCCESS)
 
 if(NOT _KERNEL_GEN_SUCCESS EQUAL 0)


### PR DESCRIPTION
The cutlass_kernels CMake step made `cutlass_library` importable for the kernel-instantiation generator by running `setup_library.py develop --user` at configure time. Under externally managed Python environments (conda/pixi/uv, which commonly set `PYTHONNOUSERSITE=1`) this is self-defeating — the install writes to the user site that the interpreter then refuses to read, and the generator fails with `ModuleNotFoundError: cutlass_library`. It also mutates the user's home site-packages (`~/.local` easy-install path entries) as a side effect of building one checkout, leaking state into every other Python environment of that user.

This change drops the develop-install entirely and runs the generator with `PYTHONPATH` pointing at the vendored CUTLASS python directory. Same generation output, no installation, no mutation outside the build tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Tooling**
  * Improved CUTLASS kernel generation setup by loading Python tooling directly from the source tree.
  * Removed the requirement to install CUTLASS Python components into the local environment during configuration.
  * Kernel generation now uses an explicitly configured Python import path for more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->