### PR TITLE
[None][fix] Propagate NCCL_INCLUDE_DIR to common header dirs

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -493,6 +493,13 @@ endif()
 message("CMAKE_CUDA_FLAGS: ${CMAKE_CUDA_FLAGS}")
 
 set(COMMON_HEADER_DIRS ${PROJECT_SOURCE_DIR} ${CUDAToolkit_INCLUDE_DIR})
+if(ENABLE_MULTI_DEVICE AND NCCL_INCLUDE_DIR)
+  # nccl.h is included from common headers whenever multi-device is enabled,
+  # by targets that do not link NCCL::nccl; propagate the directory FindNCCL
+  # located so a build against an NCCL outside the compiler's default search
+  # path (e.g. --nccl_root) can compile.
+  list(APPEND COMMON_HEADER_DIRS ${NCCL_INCLUDE_DIR})
+endif()
 message(STATUS "COMMON_HEADER_DIRS: ${COMMON_HEADER_DIRS}")
 
 if(NOT WIN32 AND NOT DEFINED USE_CXX11_ABI)


### PR DESCRIPTION
When building against a custom NCCL via `--nccl_root` (e.g. the pip `nvidia-nccl-cu13` wheel, whose headers do not live in a compiler default path), FindNCCL resolves `NCCL_INCLUDE_DIR` correctly but the directory is never added to the compile include paths — multi-device translation units then fail with `nccl.h: No such file or directory` even though configure succeeded.

Append `NCCL_INCLUDE_DIR` to `COMMON_HEADER_DIRS` when `ENABLE_MULTI_DEVICE` is on. No behavior change for builds whose NCCL headers already sit in default include paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-device builds so components can locate the NCCL header when the NCCL include directory is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->