### PR TITLE
[None][fix] Bump DeepGEMM to nv_dev HEAD for SM120 attention support

### DIFF
--- a/3rdparty/fetch_content.json
+++ b/3rdparty/fetch_content.json
@@ -32,7 +32,7 @@
     {
       "name": "deepgemm",
       "git_repository": "https://github.com/deepseek-ai/DeepGEMM",
-      "git_tag": "245dc5d6a5fe344c61505fe71011d203141d4479",
+      "git_tag": "a6b593d2826719dcf4892609af7b84ee23aaf32a",
       "git_submodules_recurse": true,
       "source_subdir": "dont-add-this-project-with-add-subdirectory"
     },


### PR DESCRIPTION
The pinned DeepGEMM commit predates the SM120 implementations of the DSA/DSv4 indexer attention kernels (`sm120_fp8_mqa_logits` / `sm120_fp8_paged_mqa_logits`), so on SM120/SM121 the sparse-attention indexer fails with an unsupported-architecture error even though current DeepGEMM `nv_dev` supports the arch.

Bump the 3rdparty fetch pin to nv_dev `a6b593d2826719dcf4892609af7b84ee23aaf32a`, which carries the SM120 kernels. Validated as part of DeepSeek-V4 bring-up on RTX PRO 6000 Blackwell (the indexer dispatches and the model passes gsm8k gating at tp2/tp4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying third-party component to a newer revision.
  * No changes to exported functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->