### PR TITLE
[None][fix] Derive DSA indexer tokens-per-block from the active KV cache manager

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -770,16 +770,17 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
 
         if self.kv_cache_manager is not None and self.num_tokens > 0:
             # Refresh the effective tokens-per-block from the CURRENT cache
-            # manager: the __post_init__-cached value may have been computed
-            # against a non-DSV4 manager (e.g. during KV cache estimation),
-            # skipping the compress-ratio division and leaving the raw
-            # tokens_per_block, which makes the slot-mapping stride 4x too
-            # large.
+            # manager and compress ratios: the __post_init__-cached values
+            # are computed before sparse_attention_config/compress_ratios
+            # are known (DeepseekV4TrtllmAttentionMetadata corrects
+            # compress_ratios from sparse_metadata_params only after the
+            # base __post_init__ ran), leaving the raw tokens_per_block,
+            # which makes the slot-mapping stride 4x too large.
             if hasattr(self.kv_cache_manager, 'compressed_block_sizes'):
                 self._tokens_per_block = (
                     self.kv_cache_manager.tokens_per_block //
                     _effective_compress_ratio_divisor(
-                        self._indexer_compress_ratio))
+                        _select_indexer_compress_ratio(self.compress_ratios)))
             seq_lens = self.seq_lens_cuda[:self.num_seqs]
             # Runtime cached lengths after overlap/spec-dec correction.
             start_positions = self.kv_lens_cuda[:self.num_seqs] - seq_lens

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -769,6 +769,17 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         self.shared_topk_indices = None
 
         if self.kv_cache_manager is not None and self.num_tokens > 0:
+            # Refresh the effective tokens-per-block from the CURRENT cache
+            # manager: the __post_init__-cached value may have been computed
+            # against a non-DSV4 manager (e.g. during KV cache estimation),
+            # skipping the compress-ratio division and leaving the raw
+            # tokens_per_block, which makes the slot-mapping stride 4x too
+            # large.
+            if hasattr(self.kv_cache_manager, 'compressed_block_sizes'):
+                self._tokens_per_block = (
+                    self.kv_cache_manager.tokens_per_block //
+                    _effective_compress_ratio_divisor(
+                        self._indexer_compress_ratio))
             seq_lens = self.seq_lens_cuda[:self.num_seqs]
             # Runtime cached lengths after overlap/spec-dec correction.
             start_positions = self.kv_lens_cuda[:self.num_seqs] - seq_lens
@@ -1930,13 +1941,25 @@ class Indexer(nn.Module):
             kv_cache_manager, 'use_fp4', False) else head_dim
         compress_ratio = _effective_compress_ratio_divisor(
             _select_indexer_compress_ratio(metadata.compress_ratios))
+        # Derive the effective tokens-per-block from the CURRENT cache
+        # manager instead of metadata._tokens_per_block. The cached value is
+        # computed once in __post_init__, but the kv_cache_manager attached
+        # at that time may not be the DeepSeek-V4 manager (e.g. during KV
+        # cache estimation); the compress-ratio division is then skipped and
+        # the raw tokens_per_block (256) is cached, which makes every
+        # indexer slot mapping stride 4x too large (indexer cache blocks
+        # hold tokens_per_block // compress_ratio compressed tokens).
+        tokens_per_block = kv_cache_manager.tokens_per_block
+        if hasattr(kv_cache_manager, 'compressed_block_sizes'):
+            tokens_per_block = tokens_per_block // compress_ratio
+        metadata._tokens_per_block = tokens_per_block
         return IndexerParams(
             num_contexts=metadata.num_contexts,
             num_generations=metadata.num_generations,
             num_ctx_tokens=metadata.num_ctx_tokens,
             head_dim=head_dim,
             quant_block_size=metadata.indexer_quant_block_size,
-            tokens_per_block=metadata._tokens_per_block,
+            tokens_per_block=tokens_per_block,
             compress_ratio=compress_ratio,
             request_ids=metadata.request_ids,
             num_past_tokens=metadata.kv_cache_params.num_cached_tokens_per_seq,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2086,6 +2086,7 @@ class PyTorchModelEngine(ModelEngine):
                 enable_context_mla_with_cached_kv,
                 cache_indirection=cache_indirection,
                 num_heads_per_kv=num_heads_per_kv,
+                sparse_attention_config=self.sparse_attention_config,
                 sparse_metadata_params=sparse_metadata_params)
             self.encoder_attn_metadata.block_ids_per_seq = None
             self.encoder_attn_metadata.kv_block_ids_per_seq = None
@@ -2109,6 +2110,7 @@ class PyTorchModelEngine(ModelEngine):
             enable_context_mla_with_cached_kv=enable_context_mla_with_cached_kv,
             cache_indirection=cache_indirection,
             num_heads_per_kv=num_heads_per_kv,
+            sparse_attention_config=self.sparse_attention_config,
             sparse_metadata_params=sparse_metadata_params,
         )
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved attention cache handling when cache managers change during runtime.
  - Ensured token block sizing and index mapping use the active cache configuration.
  - Fixed potential inaccuracies caused by stale cache sizing information during cache estimation and subsequent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

`DSAtrtllmAttentionMetadata.__post_init__` caches `_tokens_per_block`, dividing `kv_cache_manager.tokens_per_block` by the indexer compress ratio **only when the attached manager exposes `compressed_block_sizes`**. When the metadata object is created while a non-DeepSeek-V4 manager is attached (e.g. during the KV-cache estimation phase), the division is skipped and the raw `tokens_per_block` (256) is cached. The manager is later swapped for the DeepSeek-V4 manager (model_engine re-attaches the resource-manager's KV cache manager on each forward), but the cached value is never refreshed.

As a result every indexer K-cache slot mapping is built with a 4x too large block stride (256×68 = 17408 bytes instead of 64×68 = 4352):

- gather/scatter offsets are **silently wrong** for every chunked-prefill / KV-reuse context request (in-bounds but pointing at the wrong cache blocks), and
- once a KV page index exceeds `pool_pages / 4`, the mapping goes out of bounds and the CTX worker crashes with an illegal memory access in `indexerKCacheGather.cu:159`.

On the DeepSeek-V4-Pro disaggregated AgentX benchmark (GB300, ctx dep8/b128/mnt8192 + gen dep8/b64/mnt256, MTP3, conc160) this crashed the CTX worker deterministically at iter≈317 — the first iteration where allocated page ids cross the pool_pages/4 threshold. The failure was insensitive to `record_stream`, blocking H2D copies, CUDA ready-events, host-cache on/off, and stream-overlap settings, because it is an arithmetic bug rather than a lifetime race. Instrumented runs confirmed the poisoned values are produced on the CPU at mapping-build time and equal `table_entry × 17408` exactly, while the block-offset table itself is valid.

**Fix**: derive the effective tokens-per-block from the *currently attached* cache manager at use time — in `Indexer.build_indexer_params` (also refreshing `metadata._tokens_per_block` for consistency) and in `on_update_kv_lens` — instead of trusting the `__post_init__`-time snapshot. Plain DSA (no `compressed_block_sizes`) is unaffected: the raw value is kept, matching the previous behavior.

## Test Coverage

- E2E reproducer: DeepSeek-V4-Pro disaggregated AgentX benchmark on GB300 (ctx1_dep8_b128_mnt8192 + gen1_dep8_b64_mnt256, eplb0, mtp3, conc160). Without the fix the CTX worker hits the indexer K-cache gather OOB/IMA deterministically at iter≈317; validation job with this fix (plus env-gated tripwire assertions on the computed mapping bounds) is running through the full benchmark.
- Existing DSA/DeepSeek-V4 unit and integration tests cover the unchanged plain-DSA path.

## PR Checklist
- [x] PR title follows the template
- [x] PR description explains the issue and the solution
- [x] Test coverage listed