### PR TITLE
[None][fix] Fix fused mHC output reuse and extend compressor next_n

### DIFF
--- a/cpp/tensorrt_llm/kernels/compressorKernels/compressorKernels.cu
+++ b/cpp/tensorrt_llm/kernels/compressorKernels/compressorKernels.cu
@@ -64,7 +64,6 @@
 #include "tensorrt_llm/kernels/compressorKernels/compressorKernels.h"
 
 #include "tensorrt_llm/common/assert.h"
-#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cuda_bf16.h>
@@ -213,8 +212,8 @@ enum class CacheScaleType
 // ============================================================================
 // Decode Kernel: pagedKvCompressKernel
 //
-// Template: <HEAD_DIM, KV_SCORE_ELEM_BYTES, STATE_ELEM_BYTES, NEXT_N>
-//   NEXT_N: number of new tokens per sequence in this decode step (1-4)
+// Template: <HEAD_DIM, KV_SCORE_ELEM_BYTES, STATE_ELEM_BYTES, COMPRESS_RATIO, NEXT_N, NUM_RED_WARPS>
+//   NEXT_N: number of new tokens per sequence in this decode step (1-8)
 //
 // Grid:  (batch_size) — one block per batch element
 // Block: (NTHRD) where NTHRD = HEAD_DIM / VEC (>= 32 threads)
@@ -623,9 +622,10 @@ __global__ void pagedKvCompressKernel(void const* __restrict__ kv_score_raw, flo
 //   KV_EB    — kv_score element bytes in {2 (bf16), 4 (fp32)}
 //   STATE_EB — paged state element bytes in {2 (bf16), 4 (fp32)}
 //   CR       — COMPRESS_RATIO in {4, 128}
-//   NN       — NEXT_N (new tokens / decode step) in {1..4}
-//   NRW      — NUM_RED_WARPS — 4 only when CR=128 (multi-warp Phase 3 reduce
-//              hides DRAM latency for the heavier R=128 chunk); 1 otherwise.
+//   NN       — NEXT_N (new tokens / decode step) in {1..8}
+//   NRW      — NUM_RED_WARPS — 4 when CR=128 and NN<=4 (multi-warp Phase 3
+//              reduction hides DRAM latency for the heavier R=128 chunk);
+//              1 when CR=4 or when CR=128 and NN>=5.
 //
 // Multi-warp SMEM budget (per block): 3 * NRW * ELEM_PER_BLOCK * sizeof(float).
 //   HD=128:        ELEM_PER_BLOCK=128 → 6 KB
@@ -634,22 +634,30 @@ __global__ void pagedKvCompressKernel(void const* __restrict__ kv_score_raw, flo
 // ============================================================================
 
 // Per-axis fan-outs (used to keep the master list compact).
-#define FOREACH_DECODE_NN(F, HD, KV, ST, CR, NRW)                                                                      \
+#define FOREACH_DECODE_NN_1_4(F, HD, KV, ST, CR, NRW)                                                                  \
     F(HD, KV, ST, CR, 1, NRW) F(HD, KV, ST, CR, 2, NRW) F(HD, KV, ST, CR, 3, NRW) F(HD, KV, ST, CR, 4, NRW)
-#define FOREACH_DECODE_DTYPE(F, HD, CR, NRW)                                                                           \
-    FOREACH_DECODE_NN(F, HD, 2, 2, CR, NRW)                                                                            \
-    FOREACH_DECODE_NN(F, HD, 2, 4, CR, NRW)                                                                            \
-    FOREACH_DECODE_NN(F, HD, 4, 2, CR, NRW) FOREACH_DECODE_NN(F, HD, 4, 4, CR, NRW)
+#define FOREACH_DECODE_NN_5_8(F, HD, KV, ST, CR, NRW)                                                                  \
+    F(HD, KV, ST, CR, 5, NRW) F(HD, KV, ST, CR, 6, NRW) F(HD, KV, ST, CR, 7, NRW) F(HD, KV, ST, CR, 8, NRW)
+#define FOREACH_DECODE_DTYPE_1_4(F, HD, CR, NRW)                                                                       \
+    FOREACH_DECODE_NN_1_4(F, HD, 2, 2, CR, NRW)                                                                        \
+    FOREACH_DECODE_NN_1_4(F, HD, 2, 4, CR, NRW)                                                                        \
+    FOREACH_DECODE_NN_1_4(F, HD, 4, 2, CR, NRW) FOREACH_DECODE_NN_1_4(F, HD, 4, 4, CR, NRW)
+#define FOREACH_DECODE_DTYPE_5_8(F, HD, CR, NRW)                                                                       \
+    FOREACH_DECODE_NN_5_8(F, HD, 2, 2, CR, NRW)                                                                        \
+    FOREACH_DECODE_NN_5_8(F, HD, 2, 4, CR, NRW)                                                                        \
+    FOREACH_DECODE_NN_5_8(F, HD, 4, 2, CR, NRW) FOREACH_DECODE_NN_5_8(F, HD, 4, 4, CR, NRW)
+#define FOREACH_DECODE_DTYPE_1_8(F, HD, CR, NRW)                                                                       \
+    FOREACH_DECODE_DTYPE_1_4(F, HD, CR, NRW) FOREACH_DECODE_DTYPE_5_8(F, HD, CR, NRW)
 
 // Master list. Order does not matter; the dispatcher walks linearly.
 // clang-format off
 #define FOREACH_DECODE_CONFIG(F)                                                                                       \
-    /* CR=4: single-warp only (small reduction; multi-warp would over-subscribe). */                                   \
-    FOREACH_DECODE_DTYPE(F, 128, 4, 1) FOREACH_DECODE_DTYPE(F, 512, 4, 1)                                              \
-    /* CR=128: single-warp fallback (covers next_n>4 path which currently isn't reached). */                           \
-    FOREACH_DECODE_DTYPE(F, 128, 128, 1) FOREACH_DECODE_DTYPE(F, 512, 128, 1)                                          \
-    /* CR=128: multi-warp fast path. Used whenever next_n <= 4 (i.e. MTP-3 and below). */                              \
-    FOREACH_DECODE_DTYPE(F, 128, 128, 4) FOREACH_DECODE_DTYPE(F, 512, 128, 4)
+    /* CR=4: single-warp for next_n 1..8 (small reduction; multi-warp would over-subscribe). */                         \
+    FOREACH_DECODE_DTYPE_1_8(F, 128, 4, 1) FOREACH_DECODE_DTYPE_1_8(F, 512, 4, 1)                                      \
+    /* CR=128: single-warp fallback for next_n 5..8. */                                                                \
+    FOREACH_DECODE_DTYPE_5_8(F, 128, 128, 1) FOREACH_DECODE_DTYPE_5_8(F, 512, 128, 1)                                  \
+    /* CR=128: multi-warp fast path for next_n 1..4. */                                                                \
+    FOREACH_DECODE_DTYPE_1_4(F, 128, 128, 4) FOREACH_DECODE_DTYPE_1_4(F, 512, 128, 4)
 // clang-format on
 
 // Generate explicit template instantiations.
@@ -663,7 +671,7 @@ FOREACH_DECODE_CONFIG(INST_DECODE)
 // Decode Launch Wrapper
 //
 // Dispatches to the correct template instantiation based on head_dim, elem_bytes,
-// and next_n (number of new tokens per decode step, capped at 4).
+// and next_n (number of new tokens per decode step, in the range 1..8).
 // Grid is 2D: (batch_size, head_blocks) where head_blocks = NTHRD_BASE / 32.
 // For HD=512 bf16: head_blocks=2; for HD=128 bf16: head_blocks=1.
 // ============================================================================
@@ -679,6 +687,10 @@ void pagedKvCompressLaunch(void const* kv_score, float const* ape, void* paged_k
     TLLM_CHECK_WITH_INFO(
         (kv_score_elem_bytes == 2 || kv_score_elem_bytes == 4) && (state_elem_bytes == 2 || state_elem_bytes == 4),
         "pagedKvCompressLaunch only supports bf16/fp32 kv_score and paged state");
+    constexpr int kMinNextN = 1;
+    constexpr int kMaxNextN = 8;
+    TLLM_CHECK_WITH_INFO(next_n >= kMinNextN && next_n <= kMaxNextN,
+        "pagedKvCompressLaunch only supports next_n in [1, 8], got %d", next_n);
 
     // Compute HEAD_BLOCKS: mirrors the compile-time constant in the kernel.
     // VEC = max_vec if HEAD_DIM/max_vec >= 32, else HEAD_DIM/32.
@@ -693,10 +705,9 @@ void pagedKvCompressLaunch(void const* kv_score, float const* ape, void* paged_k
 
     // For large compress_ratio, use 4-warp parallel reduction to cut the serial
     // softmax loop from COMPRESS_RATIO iterations to COMPRESS_RATIO/4 per warp.
-    // Supported configs: CR=128, (HD=128 or HD=512), NEXT_N in 1..4.  NEXT_N>2
-    // is required for MTP-3 decode (each step accepts up to 4 tokens per request);
-    // without multi-warp the slow path is a single warp doing 128 serial paged
-    // loads, which is DRAM-latency-bound (no other warps to hide it).
+    // The multi-warp path supports CR=128, (HD=128 or HD=512), and NEXT_N in
+    // 1..4. Larger NEXT_N values use a single reduction warp to limit block
+    // size while still processing every new token exactly.
     //
     // smem per block = 3 * MULTI_WARP * ELEM_PER_BLOCK * sizeof(float)
     //   where ELEM_PER_BLOCK = nthreads_inner * vec = HEAD_DIM / HEAD_BLOCKS.
@@ -712,15 +723,11 @@ void pagedKvCompressLaunch(void const* kv_score, float const* ape, void* paged_k
 
     dim3 grid(batch_size, head_blocks);
 
-    // Clamp the runtime next_n into the supported range; configs above 4 fall
-    // back to the NN=4 instantiation (matches the prior `default:` arm).
-    int const next_n_dispatch = std::min(next_n, 4);
-
     // Walk FOREACH_DECODE_CONFIG until we find a matching (HD, KV, ST, CR, NN, NRW)
     // tuple, then launch that instantiation. Any unsupported tuple bails via TLLM_THROW.
 #define TRY_LAUNCH(HD, KV_EB, STATE_EB, CR, NN, NRW)                                                                   \
     if (head_dim == HD && kv_score_elem_bytes == KV_EB && state_elem_bytes == STATE_EB && compress_ratio == CR         \
-        && next_n_dispatch == NN && num_red_warps == NRW)                                                              \
+        && next_n == NN && num_red_warps == NRW)                                                                       \
     {                                                                                                                  \
         pagedKvCompressKernel<HD, KV_EB, STATE_EB, CR, NN, NRW><<<grid, nthreads, smem_bytes, stream>>>(kv_score, ape, \
             paged_kv, paged_score, block_table_kv, block_table_score, output, kv_lens, cu_seq_lens, cu_kv_comp,        \
@@ -732,12 +739,15 @@ void pagedKvCompressLaunch(void const* kv_score, float const* ape, void* paged_k
 
     TLLM_THROW(
         "pagedKvCompressLaunch: no matching instantiation for HD=%d, kv_eb=%d, state_eb=%d, CR=%d, NN=%d, NRW=%d",
-        head_dim, kv_score_elem_bytes, state_elem_bytes, compress_ratio, next_n_dispatch, num_red_warps);
+        head_dim, kv_score_elem_bytes, state_elem_bytes, compress_ratio, next_n, num_red_warps);
 }
 
 #undef FOREACH_DECODE_CONFIG
-#undef FOREACH_DECODE_DTYPE
-#undef FOREACH_DECODE_NN
+#undef FOREACH_DECODE_DTYPE_1_8
+#undef FOREACH_DECODE_DTYPE_5_8
+#undef FOREACH_DECODE_DTYPE_1_4
+#undef FOREACH_DECODE_NN_5_8
+#undef FOREACH_DECODE_NN_1_4
 
 // ============================================================================
 // Prefill Kernel: prefillReductionKernel

--- a/cpp/tensorrt_llm/kernels/mhcKernels/mhcFusedHcKernel.cu
+++ b/cpp/tensorrt_llm/kernels/mhcKernels/mhcFusedHcKernel.cu
@@ -187,13 +187,13 @@ static CUtensorMap makeTma2D(void* base, CUtensorMapDataType dtype, uint64_t gme
 // CUDA-graph capture: cuTensorMapEncodeTiled is a pure host function that does
 // not record any stream operation, so cache miss inside capture is safe. The
 // descriptor is passed by value as __grid_constant__; the recorded graph node
-// holds those bytes and replays correctly under workspace-stable replay
-// (already enforced by _FusedHcWorkspaceCache in mhc_cuda.py).
+// holds those bytes and replays correctly while captured tensor addresses
+// remain stable for the lifetime of the graph.
 //
 // Eviction: LRU bounded to kTmaDescCacheCap entries per thread. Eager mode
 // without CUDA-graph capture sees the PyTorch caching allocator hand out
-// fresh `base` pointers when the workspace cache misses, so the unbounded
-// version would grow on every shape transition. 128 entries × ~256 B = ~32 KB
+// fresh `base` pointers as public outputs are allocated, so the unbounded
+// version would grow across shape transitions. 128 entries × ~256 B = ~32 KB
 // per host thread — fits in L1, sized to cover the working set of any single
 // model (~4-8 distinct shapes × 4 descriptors each = O(20) live, with
 // headroom for shape transitions).

--- a/cpp/tensorrt_llm/thop/compressorOp.cpp
+++ b/cpp/tensorrt_llm/thop/compressorOp.cpp
@@ -38,6 +38,10 @@ void compressorPagedKvCompressOp(torch::Tensor kv_score, // [m, 2*state_dim] bf1
     torch::Tensor cu_kv_comp,                            // [bsz+1] int32
     int64_t batch_size, int64_t page_size, int64_t head_dim, int64_t compress_ratio, int64_t next_n)
 {
+    constexpr int64_t kMinNextN = 1;
+    constexpr int64_t kMaxNextN = 8;
+    TORCH_CHECK(next_n >= kMinNextN && next_n <= kMaxNextN, "next_n must be in [1, 8], got ", next_n);
+
     auto stream = at::cuda::getCurrentCUDAStream();
     int kv_score_eb = static_cast<int>(kv_score.element_size());
     int state_eb = static_cast<int>(paged_kv.element_size());

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -821,6 +821,7 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
             }
             self._compute_gen_compressed_position_ids(
                 self.past_kv_lens_cuda,
+                self.cu_new_comp_kv_cuda,
                 self.compressed_position_ids_cuda,
                 num_contexts,
                 num_generations,
@@ -927,6 +928,7 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
     @maybe_compile(dynamic=True, options={"max-autotune": True})
     def _compute_gen_compressed_position_ids(
         past_kv_lens_bufs: Dict[int, torch.Tensor],
+        cu_new_comp_kv_bufs: Dict[int, torch.Tensor],
         compressed_position_ids_bufs: Dict[int, torch.Tensor],
         num_contexts: int,
         num_generations: int,
@@ -934,7 +936,12 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
         compress_ratios: list,
         gen_output_offsets: Dict[int, int],
     ):
-        """Generation compressed position IDs.
+        """Generation position IDs in exact compact compressor output order.
+
+        The decode kernel packs valid outputs according to ``cu_new_comp_kv``.
+        The corresponding request and local offset are recovered for every
+        compact output index. Reserved slots after the compact prefix are masked
+        during postprocess, so their position IDs are irrelevant.
 
         gen_output_offsets: dict mapping compress_ratio -> Python int offset,
         pre-extracted by the caller to avoid tensor-scalar .item() inside
@@ -942,13 +949,17 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
         device = past_kv_lens_bufs[compress_ratios[0]].device
         batch_size = num_contexts + num_generations
         for compress_ratio in compress_ratios:
-            gen_past = past_kv_lens_bufs[compress_ratio][num_contexts:batch_size]
             new_gen_comp = (num_gen_tokens_per_seq + compress_ratio - 1) // compress_ratio
-            gen_offsets = torch.arange(new_gen_comp, dtype=torch.int32, device=device)
-            gen_pos = gen_past.unsqueeze(1) + gen_offsets.unsqueeze(0)
             gen_comp = num_generations * new_gen_comp
-            result = (gen_pos.reshape(-1) * compress_ratio).to(torch.int)
             output_offset = gen_output_offsets[compress_ratio]
+            cu_new_comp = cu_new_comp_kv_bufs[compress_ratio]
+            output_idx = torch.arange(gen_comp, dtype=torch.int32, device=device) + output_offset
+            # Search the zero-offset prefix: Inductor miscompiles searchsorted on cu_new_comp[1:].
+            req_idx = torch.searchsorted(cu_new_comp[: batch_size + 1], output_idx, right=True) - 1
+            req_idx = req_idx.clamp(min=num_contexts, max=batch_size - 1)
+            offset_in_req = output_idx - cu_new_comp[req_idx]
+            past_kv_lens = past_kv_lens_bufs[compress_ratio]
+            result = ((past_kv_lens[req_idx] + offset_in_req) * compress_ratio).to(torch.int)
             compressed_position_ids_bufs[compress_ratio][
                 output_offset : output_offset + gen_comp
             ] = result

--- a/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
+++ b/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
@@ -525,6 +525,7 @@ _FUSED_HC_BACKEND_CODE = {
     "fused_all_mma": 2,  # 1-kernel tf32 tcgen05 all-in-one (Path D)
     "fused_all_fma": 3,  # 1-kernel fp32 FMA all-in-one    (Path F)
 }
+_FUSED_HC_MMA_BLOCK_M = 64
 
 # The SM100/tcgen05 MMA fused-HC C++ kernels are statically instantiated.
 # FMA fused-HC paths use runtime hidden_size, but MMA paths must be explicitly
@@ -697,76 +698,34 @@ def _fused_hc_call(
     )
 
 
-class _FusedHcScratchCache:
-    """Size- and stream-keyed bounded LRU for fused-HC scratch tensors.
+def _alloc_fused_hc_scratch(
+    backend: str,
+    B: int,
+    n: int,
+    num_k_splits: int,
+    tile_m: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Allocate backend-specific scratch for one fused-HC invocation."""
+    shape_n = n * (2 + n)
 
-    Public outputs are deliberately not cached: target layers feed one
-    fused-HC call's outputs into the next call, so reusing an output tensor
-    for the same shape would make the next kernel read and write the same
-    storage. The FMA backends are not in-place safe.
+    if backend == "fused_half_fma" and num_k_splits > 1:
+        y_acc_ws = torch.empty((num_k_splits, B, shape_n), dtype=torch.float32, device=device)
+        r_acc_ws = torch.empty((num_k_splits, B), dtype=torch.float32, device=device)
+    else:
+        y_acc_ws = torch.empty((B, shape_n), dtype=torch.float32, device=device)
+        r_acc_ws = torch.empty((B,), dtype=torch.float32, device=device)
 
-    Eager scratch reuse is scoped to a CUDA stream because the kernels mutate
-    every workspace. During CUDA graph capture scratch allocation bypasses
-    this cache and is owned by the graph-private memory pool instead.
-
-    Two bounds keep this from ballooning:
-
-    1. ``_CACHE_MAX_B``: a per-call threshold. Prefill shapes flow straight
-       through to ``torch.empty``, which the torch caching allocator already
-       keeps cheap on repeated calls.
-    2. ``_maxsize``: LRU cap on the number of cached entries. Covers the
-       discrete eager decode batch sizes plus a few stragglers; decode is the
-       only regime that actually benefits from the cache.
-
-    These bounds prevent a long sequence of distinct eager prefill shapes
-    from retaining one scratch allocation per shape.
-    """
-
-    __slots__ = ("n", "_cache", "_maxsize")
-
-    # Up to 48 distinct entries covers the eager decode buckets plus headroom.
-    DEFAULT_MAXSIZE = 48
-    # Skip the cache above this B; prefill rides the torch allocator.
-    _CACHE_MAX_B = 256
-
-    def __init__(self, n: int, maxsize: int = DEFAULT_MAXSIZE):
-        self.n = n
-        self._maxsize = maxsize
-        from collections import OrderedDict
-
-        self._cache: "OrderedDict" = OrderedDict()
-
-    def get(self, B: int, num_k_splits: int, tile_m: int, device):
-        n = self.n
-        ws_ks = max(1, num_k_splits)
-        tm = max(1, tile_m)
-        m_batches = (B + tm - 1) // tm
-        shape_n = n * (2 + n)
-
-        def _alloc():
-            if ws_ks == 1:
-                y_acc_ws = torch.empty((B, shape_n), dtype=torch.float32, device=device)
-                r_acc_ws = torch.empty((B,), dtype=torch.float32, device=device)
-            else:
-                y_acc_ws = torch.empty((ws_ks, B, shape_n), dtype=torch.float32, device=device)
-                r_acc_ws = torch.empty((ws_ks, B), dtype=torch.float32, device=device)
-            done_counter_ws = torch.empty((m_batches,), dtype=torch.int32, device=device)
-            return y_acc_ws, r_acc_ws, done_counter_ws
-
-        if B > self._CACHE_MAX_B or torch.cuda.is_current_stream_capturing():
-            return _alloc()
-
-        stream = torch.cuda.current_stream(device)
-        key = (B, ws_ks, m_batches, device, stream.cuda_stream)
-        hit = self._cache.get(key)
-        if hit is not None:
-            self._cache.move_to_end(key)
-            return hit
-        entry = _alloc()
-        self._cache[key] = entry
-        if len(self._cache) > self._maxsize:
-            self._cache.popitem(last=False)
-        return entry
+    if backend == "fused_all_mma":
+        num_done_counters = (B + _FUSED_HC_MMA_BLOCK_M - 1) // _FUSED_HC_MMA_BLOCK_M
+    elif backend == "fused_all_fma":
+        tokens_per_cta = max(1, tile_m)
+        num_done_counters = (B + tokens_per_cta - 1) // tokens_per_cta
+    else:
+        # The half-fused backends do not consume this argument.
+        num_done_counters = 1
+    done_counter_ws = torch.empty((num_done_counters,), dtype=torch.int32, device=device)
+    return y_acc_ws, r_acc_ws, done_counter_ws
 
 
 # Fallback tactic: backend, tile_n, num_k_splits, bigfuse_bs, tile_m.
@@ -826,8 +785,6 @@ class MhcFusedHcRunner(TunableRunner):
             # comb_mix_prev (input[3]) dim 0 = M
             ConstraintSpec(input_idx=3, dim_idx=0, infer_shape=lambda shapes: shapes[0][0]),
         ),
-        # TODO: re-enable distributed_tuning_strategy=PARALLEL once
-        # _FusedHcScratchCache no longer keys on chosen-tactic fields.
     )
 
     def __init__(
@@ -847,7 +804,6 @@ class MhcFusedHcRunner(TunableRunner):
         self.hc_sinkhorn_eps = hc_sinkhorn_eps
         self.hc_post_mult_value = hc_post_mult_value
         self.sinkhorn_repeat = sinkhorn_repeat
-        self._scratch_cache = _FusedHcScratchCache(n=n)
 
     def unique_id(self):
         return (self.n, self.hidden_size)
@@ -942,8 +898,13 @@ class MhcFusedHcRunner(TunableRunner):
         post_mix_cur = torch.empty((B, self.n), dtype=torch.float32, device=x_prev.device)
         comb_mix_cur = torch.empty((B, self.n * self.n), dtype=torch.float32, device=x_prev.device)
         layer_input_cur = torch.empty_like(x_prev)
-        y_acc_ws, r_acc_ws, done_counter_ws = self._scratch_cache.get(
-            B, num_k_splits, tile_m, x_prev.device
+        y_acc_ws, r_acc_ws, done_counter_ws = _alloc_fused_hc_scratch(
+            backend=backend,
+            B=B,
+            n=self.n,
+            num_k_splits=num_k_splits,
+            tile_m=tile_m,
+            device=x_prev.device,
         )
 
         _fused_hc_call(
@@ -981,8 +942,7 @@ class MhcFusedHcRunner(TunableRunner):
 
 
 # Process-wide runner cache keyed on the mHC configuration. Avoids recreating
-# a MhcFusedHcRunner (and its scratch cache) on every call, which would also
-# defeat scratch reuse inside the runner.
+# a MhcFusedHcRunner on every call.
 _fused_hc_runner_cache: dict = {}
 
 

--- a/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
+++ b/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
@@ -787,13 +787,6 @@ class _FusedHcWorkspaceCache:
         return entry
 
 
-def _alloc_fused_hc_outputs(
-    B: int, n: int, hidden_size: int, num_k_splits: int, tile_m: int, device
-):
-    """Uncached fallback (kept for API compatibility)."""
-    return _FusedHcWorkspaceCache(n=n, hidden_size=hidden_size).get(B, num_k_splits, tile_m, device)
-
-
 # Fallback tactic: backend, tile_n, num_k_splits, bigfuse_bs, tile_m.
 #
 # The MMA (tcgen05) default delegates ks/bs to the C++ heuristic (pickKSplits

--- a/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
+++ b/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
@@ -697,45 +697,40 @@ def _fused_hc_call(
     )
 
 
-class _FusedHcWorkspaceCache:
-    """Size-keyed bounded LRU for the 4 outputs + 3 workspaces of mhc_fused_hc.
+class _FusedHcScratchCache:
+    """Size- and stream-keyed bounded LRU for fused-HC scratch tensors.
 
-    The 4 outputs are consumed by the caller (so they can't alias across
-    calls at different B), but repeatedly calling ``torch.empty`` for each
-    call inside a CUDA-graph-captured inference loop is wasteful. Keyed on
-    ``(B, ws_ks, tile_m, device)``: same-shape calls reuse the previously
-    allocated buffers; tensors are stable across graph captures (same ptr
-    under the torch allocator's retained block).
+    Public outputs are deliberately not cached: target layers feed one
+    fused-HC call's outputs into the next call, so reusing an output tensor
+    for the same shape would make the next kernel read and write the same
+    storage. The FMA backends are not in-place safe.
+
+    Eager scratch reuse is scoped to a CUDA stream because the kernels mutate
+    every workspace. During CUDA graph capture scratch allocation bypasses
+    this cache and is owned by the graph-private memory pool instead.
 
     Two bounds keep this from ballooning:
 
-    1. ``_CACHE_MAX_B``: a per-call threshold. Only cache when the request's
-       residual_cur footprint is modest (B * n * hidden * 2 bytes; e.g. at
-       n=4 hidden=4096 that's 32 KB/token, so a 256-token cap = 8 MB/entry).
-       Prefill shapes (B in the tens of thousands) flow straight through to
-       ``torch.empty``, which the torch caching allocator already keeps
-       cheap on repeated calls.
+    1. ``_CACHE_MAX_B``: a per-call threshold. Prefill shapes flow straight
+       through to ``torch.empty``, which the torch caching allocator already
+       keeps cheap on repeated calls.
     2. ``_maxsize``: LRU cap on the number of cached entries. Covers the
-       discrete CUDA-graph decode batch sizes plus a few stragglers; decode
-       is the only regime that actually benefits from the cache.
+       discrete eager decode batch sizes plus a few stragglers; decode is the
+       only regime that actually benefits from the cache.
 
-    Without these bounds every distinct prefill B leaks ~B * n * hidden * 2
-    bytes (≈1.3 GB at B=32768, n=4, hidden=4096). Under a prefill ramp-up
-    admitting one new ctx request per iter, the leak reaches tens of GB per
-    rank within a dozen iters and blows past HBM.
+    These bounds prevent a long sequence of distinct eager prefill shapes
+    from retaining one scratch allocation per shape.
     """
 
-    __slots__ = ("n", "hidden_size", "_cache", "_maxsize")
+    __slots__ = ("n", "_cache", "_maxsize")
 
-    # Up to 48 distinct entries — covers the 35 CUDA-graph decode buckets
-    # plus headroom. Each entry at B<=256 is under ~10 MB.
+    # Up to 48 distinct entries covers the eager decode buckets plus headroom.
     DEFAULT_MAXSIZE = 48
     # Skip the cache above this B; prefill rides the torch allocator.
     _CACHE_MAX_B = 256
 
-    def __init__(self, n: int, hidden_size: int, maxsize: int = DEFAULT_MAXSIZE):
+    def __init__(self, n: int, maxsize: int = DEFAULT_MAXSIZE):
         self.n = n
-        self.hidden_size = hidden_size
         self._maxsize = maxsize
         from collections import OrderedDict
 
@@ -743,18 +738,12 @@ class _FusedHcWorkspaceCache:
 
     def get(self, B: int, num_k_splits: int, tile_m: int, device):
         n = self.n
-        hidden_size = self.hidden_size
         ws_ks = max(1, num_k_splits)
         tm = max(1, tile_m)
         m_batches = (B + tm - 1) // tm
-        n2 = n * n
         shape_n = n * (2 + n)
 
         def _alloc():
-            residual_cur = torch.empty((B, n, hidden_size), dtype=torch.bfloat16, device=device)
-            post_mix_cur = torch.empty((B, n), dtype=torch.float32, device=device)
-            comb_mix_cur = torch.empty((B, n2), dtype=torch.float32, device=device)
-            layer_input_cur = torch.empty((B, hidden_size), dtype=torch.bfloat16, device=device)
             if ws_ks == 1:
                 y_acc_ws = torch.empty((B, shape_n), dtype=torch.float32, device=device)
                 r_acc_ws = torch.empty((B,), dtype=torch.float32, device=device)
@@ -762,20 +751,13 @@ class _FusedHcWorkspaceCache:
                 y_acc_ws = torch.empty((ws_ks, B, shape_n), dtype=torch.float32, device=device)
                 r_acc_ws = torch.empty((ws_ks, B), dtype=torch.float32, device=device)
             done_counter_ws = torch.empty((m_batches,), dtype=torch.int32, device=device)
-            return (
-                residual_cur,
-                post_mix_cur,
-                comb_mix_cur,
-                layer_input_cur,
-                y_acc_ws,
-                r_acc_ws,
-                done_counter_ws,
-            )
+            return y_acc_ws, r_acc_ws, done_counter_ws
 
-        if B > self._CACHE_MAX_B:
+        if B > self._CACHE_MAX_B or torch.cuda.is_current_stream_capturing():
             return _alloc()
 
-        key = (B, ws_ks, m_batches, device)
+        stream = torch.cuda.current_stream(device)
+        key = (B, ws_ks, m_batches, device, stream.cuda_stream)
         hit = self._cache.get(key)
         if hit is not None:
             self._cache.move_to_end(key)
@@ -845,7 +827,7 @@ class MhcFusedHcRunner(TunableRunner):
             ConstraintSpec(input_idx=3, dim_idx=0, infer_shape=lambda shapes: shapes[0][0]),
         ),
         # TODO: re-enable distributed_tuning_strategy=PARALLEL once
-        # _FusedHcWorkspaceCache no longer keys on chosen-tactic fields.
+        # _FusedHcScratchCache no longer keys on chosen-tactic fields.
     )
 
     def __init__(
@@ -865,7 +847,7 @@ class MhcFusedHcRunner(TunableRunner):
         self.hc_sinkhorn_eps = hc_sinkhorn_eps
         self.hc_post_mult_value = hc_post_mult_value
         self.sinkhorn_repeat = sinkhorn_repeat
-        self._ws_cache = _FusedHcWorkspaceCache(n=n, hidden_size=hidden_size)
+        self._scratch_cache = _FusedHcScratchCache(n=n)
 
     def unique_id(self):
         return (self.n, self.hidden_size)
@@ -956,15 +938,13 @@ class MhcFusedHcRunner(TunableRunner):
             norm_weight = norm_weight.contiguous()
 
         B = residual_prev.shape[0]
-        (
-            residual_cur,
-            post_mix_cur,
-            comb_mix_cur,
-            layer_input_cur,
-            y_acc_ws,
-            r_acc_ws,
-            done_counter_ws,
-        ) = self._ws_cache.get(B, num_k_splits, tile_m, x_prev.device)
+        residual_cur = torch.empty_like(residual_prev)
+        post_mix_cur = torch.empty((B, self.n), dtype=torch.float32, device=x_prev.device)
+        comb_mix_cur = torch.empty((B, self.n * self.n), dtype=torch.float32, device=x_prev.device)
+        layer_input_cur = torch.empty_like(x_prev)
+        y_acc_ws, r_acc_ws, done_counter_ws = self._scratch_cache.get(
+            B, num_k_splits, tile_m, x_prev.device
+        )
 
         _fused_hc_call(
             backend_code,
@@ -1001,8 +981,8 @@ class MhcFusedHcRunner(TunableRunner):
 
 
 # Process-wide runner cache keyed on the mHC configuration. Avoids recreating
-# a MhcFusedHcRunner (and its workspace cache) on every call, which would also
-# defeat the workspace cache inside the runner.
+# a MhcFusedHcRunner (and its scratch cache) on every call, which would also
+# defeat scratch reuse inside the runner.
 _fused_hc_runner_cache: dict = {}
 
 

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_kernel.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_kernel.py
@@ -1407,8 +1407,13 @@ def test_prefill_then_decode(
 MTP_CONFIGS = [
     pytest.param(1, 4, 128, True, 4, id="overlap_hd128_next4"),
     pytest.param(1, 4, 512, True, 3, id="overlap_hd512_next3"),
+    pytest.param(1, 4, 512, True, 8, id="overlap_hd512_next8"),
     pytest.param(2, 128, 128, False, 4, id="basic_hd128_multi_batch_next4"),
     pytest.param(1, 128, 512, False, 4, id="basic_hd512_next4"),
+    pytest.param(1, 128, 512, False, 5, id="basic_hd512_next5"),
+    pytest.param(1, 128, 512, False, 6, id="basic_hd512_next6"),
+    pytest.param(1, 128, 512, False, 7, id="basic_hd512_next7"),
+    pytest.param(1, 128, 512, False, 8, id="basic_hd512_next8"),
 ]
 
 
@@ -1524,6 +1529,54 @@ def test_decode_mtp(batch_size, compress_ratio, head_dim, overlap, next_n):
                     ), f"Token {token_idx}, Batch {b}: mismatch diff={(diff).abs().max():.6f}"
 
         step += actual_n
+
+
+@pytest.mark.parametrize(
+    "next_n,storage_next_n",
+    [
+        pytest.param(0, 1, id="zero"),
+        pytest.param(9, 9, id="above_max"),
+        pytest.param((1 << 32) + 1, 1, id="large_int64"),
+    ],
+)
+def test_decode_rejects_unsupported_next_n(next_n, storage_next_n):
+    """Decode rejects next_n outside the supported range before narrowing."""
+    batch_size, compress_ratio, head_dim = 1, 4, 128
+    state_dim = 2 * head_dim
+    page_size = 8
+    max_blocks = (storage_next_n + page_size - 1) // page_size
+    num_outputs = max(1, (storage_next_n + compress_ratio - 1) // compress_ratio)
+
+    kv_score = torch.zeros(storage_next_n, 2 * state_dim, device="cuda")
+    ape = torch.zeros(compress_ratio, state_dim, device="cuda")
+    paged_kv = torch.zeros(max_blocks, page_size, state_dim, device="cuda")
+    paged_score = torch.zeros_like(paged_kv)
+    block_table = torch.arange(max_blocks, device="cuda", dtype=torch.int32).unsqueeze(0)
+    output = torch.empty(num_outputs, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv_lens = torch.tensor([storage_next_n], device="cuda", dtype=torch.int32)
+    start_pos = torch.zeros(batch_size, device="cuda", dtype=torch.int32)
+    cu_seq_lens = torch.tensor([0, storage_next_n], device="cuda", dtype=torch.int32)
+    cu_outputs = torch.tensor([0, num_outputs], device="cuda", dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match=r"next_n.*\[1, 8\]"):
+        decode_kernel(
+            kv_score,
+            ape,
+            kv_lens,
+            start_pos,
+            cu_seq_lens,
+            cu_outputs,
+            output,
+            paged_kv,
+            paged_score,
+            block_table,
+            block_table,
+            compress_ratio,
+            head_dim,
+            page_size,
+            next_n=next_n,
+        )
+        torch.cuda.synchronize()
 
 
 CHUNKED_PREFILL_CONFIGS = [

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py
@@ -39,6 +39,7 @@ from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4.deepseek_v4 import
     DEEPSEEK_V4_SLIDING_ATTENTION,
     DeepseekV4AttentionType,
     DeepseekV4Indexer,
+    DeepseekV4TrtllmAttentionMetadata,
 )
 from tensorrt_llm._torch.modules.rotary_embedding import RopeParams
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestState
@@ -359,6 +360,93 @@ INDEX_HEAD_DIM = 128  # Fixed head_dim for indexer (INDEXER_COMPRESS)
 MAX_BATCH, MAX_SEQ, PAGE_SIZE = 16, 4096, 128
 ORI_SEQ_LEN = 65536
 ROPE_THETA, ROPE_FACTOR, BETA_FAST, BETA_SLOW = 40000.0, 4, 32, 1
+
+
+def _active_compressed_position_ids(
+    compress_ratio, num_contexts, num_gen_tokens_per_seq, cached_tokens, kv_lens
+):
+    """Run the real metadata helpers and return IDs consumed by postprocess."""
+    batch_size = len(cached_tokens)
+    num_generations = batch_size - num_contexts
+    cached_tokens = torch.tensor(cached_tokens, dtype=torch.int32, device=DEVICE)
+    kv_lens = torch.tensor(kv_lens, dtype=torch.int32, device=DEVICE)
+
+    metadata = object.__new__(DeepseekV4TrtllmAttentionMetadata)
+    metadata.num_contexts = num_contexts
+    metadata.num_generations = num_generations
+    metadata.num_gen_tokens_per_seq = num_gen_tokens_per_seq
+    metadata._compress_ratios_sorted = [compress_ratio]
+    metadata.compressed_kv_lens_cuda = {
+        compress_ratio: torch.empty(batch_size, dtype=torch.int32, device=DEVICE)
+    }
+    metadata.past_kv_lens_cuda = {
+        compress_ratio: torch.empty(batch_size, dtype=torch.int32, device=DEVICE)
+    }
+    metadata.new_comp_kv_lens_cuda = {
+        compress_ratio: torch.empty(batch_size, dtype=torch.int32, device=DEVICE)
+    }
+    metadata.cu_new_comp_kv_cuda = {
+        compress_ratio: torch.empty(batch_size + 1, dtype=torch.int32, device=DEVICE)
+    }
+
+    ctx_comp = (
+        (kv_lens[:num_contexts] // compress_ratio)
+        - (cached_tokens[:num_contexts] // compress_ratio)
+    ).sum()
+    gen_slots = num_generations * ((num_gen_tokens_per_seq + compress_ratio - 1) // compress_ratio)
+    total_slots = int(ctx_comp.item()) + gen_slots
+    metadata.compressed_position_ids_cuda = {
+        compress_ratio: torch.full((total_slots,), -1, dtype=torch.int32, device=DEVICE)
+    }
+    compressed_mask = {compress_ratio: torch.empty(total_slots, dtype=torch.bool, device=DEVICE)}
+
+    metadata.prepare_compressed_kv_metadata(kv_lens, cached_tokens)
+    metadata._compute_compressed_mask(
+        metadata.new_comp_kv_lens_cuda,
+        metadata.cu_new_comp_kv_cuda,
+        compressed_mask,
+        batch_size,
+        {compress_ratio: total_slots},
+        [compress_ratio],
+    )
+
+    position_ids = metadata.compressed_position_ids_cuda[compress_ratio]
+    return position_ids[compressed_mask[compress_ratio]].cpu().tolist()
+
+
+@pytest.mark.parametrize(
+    "compress_ratio,next_n,cached_tokens,expected_position_ids",
+    [
+        pytest.param(4, 5, [4, 4], [4, 4], id="cr4_next5"),
+        pytest.param(4, 6, [4, 7], [4, 4, 8], id="cr4_next6_mixed"),
+        pytest.param(4, 7, [4, 6, 7], [4, 4, 8, 4, 8], id="cr4_next7_mixed"),
+        pytest.param(128, 8, [120, 128, 383], [0, 256], id="cr128_boundary_mixed"),
+    ],
+)
+def test_generation_position_ids_follow_compact_compressor_output(
+    compress_ratio, next_n, cached_tokens, expected_position_ids
+):
+    """Active postprocess rows use IDs in exact cu_new_comp ownership order."""
+    kv_lens = [cached + next_n for cached in cached_tokens]
+
+    actual_position_ids = _active_compressed_position_ids(
+        compress_ratio, 0, next_n, cached_tokens, kv_lens
+    )
+
+    assert actual_position_ids == expected_position_ids
+
+
+def test_mixed_context_generation_position_ids_follow_compact_output():
+    """Generation IDs remain compact after an exact context output prefix."""
+    actual_position_ids = _active_compressed_position_ids(
+        compress_ratio=4,
+        num_contexts=1,
+        num_gen_tokens_per_seq=5,
+        cached_tokens=[0, 4, 4],
+        kv_lens=[8, 9, 9],
+    )
+
+    assert actual_position_ids == [0, 4, 4, 4]
 
 
 def precompute_freqs_cis(

--- a/tests/unittest/_torch/modules/test_mhc.py
+++ b/tests/unittest/_torch/modules/test_mhc.py
@@ -954,10 +954,8 @@ def test_mhc_fused_hc_cuda_graph(n: int, hidden_size: int, hc_mult: int):
             cur_module.base,
         ]
 
-    # Eager reference — runner's workspace cache reuses output tensors across
-    # calls with matching shape, so eager_out and graph_out alias the same
-    # storage. Clone eager_out so we can compare after the graph replay
-    # overwrites the workspace.
+    # Clone the eager result into an immutable golden before warmup and graph
+    # capture exercise additional allocations.
     eager_raw = runner(inputs=_inputs(), tactic=tactic)
     eager_out = tuple(t.clone() for t in eager_raw)
 
@@ -1053,6 +1051,150 @@ def _make_fused_hc_runner_case(n: int, hidden_size: int, hc_mult: int, seed: int
         cur_module.base,
     ]
     return runner, inputs
+
+
+def test_mhc_fused_hc_chained_outputs_do_not_alias_inputs():
+    """A fused-HC call must not overwrite state returned by the previous call."""
+    runner, inputs = _make_fused_hc_runner_case(n=6, hidden_size=7168, hc_mult=4, seed=61)
+    tactic = ("fused_half_fma", 2, 4, 512, 1)
+
+    first_outputs = runner(inputs=inputs, tactic=tactic)
+    chained_inputs = [
+        inputs[0],
+        first_outputs[0],
+        first_outputs[1],
+        first_outputs[2],
+        *inputs[4:],
+    ]
+    saved_inputs = tuple(tensor.clone() for tensor in chained_inputs[1:4])
+
+    second_outputs = runner(inputs=chained_inputs, tactic=tactic)
+
+    for output, input_tensor, name in zip(
+        second_outputs[:3],
+        chained_inputs[1:4],
+        ("residual", "post_mix", "comb_mix"),
+    ):
+        assert output.data_ptr() != input_tensor.data_ptr(), (
+            f"fused_hc {name} output aliases its input"
+        )
+
+    for actual, expected, name in zip(
+        chained_inputs[1:4],
+        saved_inputs,
+        ("residual", "post_mix", "comb_mix"),
+    ):
+        torch.testing.assert_close(
+            actual,
+            expected,
+            rtol=0,
+            atol=0,
+            msg=f"fused_hc mutated its {name} input",
+        )
+
+    reference_inputs = [inputs[0].clone(), *saved_inputs, *inputs[4:]]
+    reference_outputs = runner(inputs=reference_inputs, tactic=tactic)
+    for actual, expected, name, tolerance in zip(
+        second_outputs,
+        reference_outputs,
+        ("residual", "post_mix", "comb_mix", "layer_input"),
+        (1e-2, 5e-3, 5e-3, 1e-2),
+    ):
+        torch.testing.assert_close(
+            actual,
+            expected,
+            rtol=tolerance,
+            atol=tolerance,
+            msg=f"chained fused_hc produced an incorrect {name}",
+        )
+
+
+def test_mhc_fused_hc_three_call_cuda_graph_replay():
+    """An odd-length fused-HC chain must remain stable across graph replays."""
+    runner, inputs = _make_fused_hc_runner_case(n=6, hidden_size=4096, hc_mult=4, seed=73)
+    tactic = ("fused_half_fma", 2, 1, 512, 1)
+
+    def run_chain():
+        first = runner(inputs=inputs, tactic=tactic)
+        second = runner(
+            inputs=[inputs[0], first[0], first[1], first[2], *inputs[4:]],
+            tactic=tactic,
+        )
+        return runner(
+            inputs=[inputs[0], second[0], second[1], second[2], *inputs[4:]],
+            tactic=tactic,
+        )
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            run_chain()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_outputs = run_chain()
+
+    for scale in (1.0003, 1.0005, 1.0007):
+        for tensor in inputs[:4]:
+            tensor.mul_(scale)
+        expected = tuple(tensor.clone() for tensor in run_chain())
+        graph.replay()
+        torch.cuda.synchronize()
+        for actual, reference, name in zip(
+            graph_outputs,
+            expected,
+            ("residual", "post_mix", "comb_mix", "layer_input"),
+        ):
+            torch.testing.assert_close(
+                actual,
+                reference,
+                rtol=0,
+                atol=0,
+                msg=f"three-call CUDA graph replay mismatch in {name}",
+            )
+
+
+def test_mhc_fused_hc_scratch_isolated_between_streams():
+    """Concurrent fused-HC calls must not mutate another stream's scratch."""
+    runner, first_inputs = _make_fused_hc_runner_case(n=6, hidden_size=4096, hc_mult=4, seed=79)
+    second_inputs = [tensor.clone() for tensor in first_inputs]
+    for tensor in second_inputs[:4]:
+        tensor.mul_(1.01)
+    tactic = ("fused_half_fma", 2, 1, 512, 1)
+
+    current_stream = torch.cuda.current_stream()
+    first_stream = torch.cuda.Stream()
+    second_stream = torch.cuda.Stream()
+    first_stream.wait_stream(current_stream)
+    second_stream.wait_stream(current_stream)
+
+    with torch.cuda.stream(first_stream):
+        first_scratch = runner._scratch_cache.get(6, 1, 1, first_inputs[0].device)
+        first_outputs = runner(inputs=first_inputs, tactic=tactic)
+    with torch.cuda.stream(second_stream):
+        second_scratch = runner._scratch_cache.get(6, 1, 1, second_inputs[0].device)
+        second_outputs = runner(inputs=second_inputs, tactic=tactic)
+
+    current_stream.wait_stream(first_stream)
+    current_stream.wait_stream(second_stream)
+    torch.cuda.synchronize()
+
+    for first_workspace, second_workspace in zip(first_scratch, second_scratch):
+        assert first_workspace.data_ptr() != second_workspace.data_ptr()
+
+    first_reference = tuple(tensor.clone() for tensor in runner(inputs=first_inputs, tactic=tactic))
+    second_reference = tuple(
+        tensor.clone() for tensor in runner(inputs=second_inputs, tactic=tactic)
+    )
+    for actual_outputs, reference_outputs in (
+        (first_outputs, first_reference),
+        (second_outputs, second_reference),
+    ):
+        for actual, reference in zip(actual_outputs, reference_outputs):
+            torch.testing.assert_close(actual, reference, rtol=0, atol=0)
 
 
 def _assert_graph_replay_matches_eager(runner, inputs, tactic):

--- a/tests/unittest/_torch/modules/test_mhc.py
+++ b/tests/unittest/_torch/modules/test_mhc.py
@@ -1053,7 +1053,38 @@ def _make_fused_hc_runner_case(n: int, hidden_size: int, hc_mult: int, seed: int
     return runner, inputs
 
 
-def test_mhc_fused_hc_chained_outputs_do_not_alias_inputs():
+@pytest.mark.parametrize(
+    "backend,num_k_splits,tile_m,expected_shapes",
+    [
+        ("fused_half_mma", 56, 1, ((129, 24), (129,), (1,))),
+        ("fused_half_fma", 4, 1, ((4, 129, 24), (4, 129), (1,))),
+        ("fused_all_mma", 56, 1, ((129, 24), (129,), (3,))),
+        ("fused_all_fma", 2, 4, ((129, 24), (129,), (33,))),
+    ],
+)
+def test_mhc_fused_hc_allocates_minimal_scratch(
+    backend: str,
+    num_k_splits: int,
+    tile_m: int,
+    expected_shapes: tuple[tuple[int, ...], ...],
+) -> None:
+    from tensorrt_llm._torch.modules.mhc import mhc_cuda
+
+    alloc_scratch = mhc_cuda._alloc_fused_hc_scratch
+
+    scratch = alloc_scratch(
+        backend=backend,
+        B=129,
+        n=4,
+        num_k_splits=num_k_splits,
+        tile_m=tile_m,
+        device=torch.device("cpu"),
+    )
+
+    assert tuple(tuple(tensor.shape) for tensor in scratch) == expected_shapes
+
+
+def test_mhc_fused_hc_preserves_chained_inputs():
     """A fused-HC call must not overwrite state returned by the previous call."""
     runner, inputs = _make_fused_hc_runner_case(n=6, hidden_size=7168, hc_mult=4, seed=61)
     tactic = ("fused_half_fma", 2, 4, 512, 1)
@@ -1069,15 +1100,6 @@ def test_mhc_fused_hc_chained_outputs_do_not_alias_inputs():
     saved_inputs = tuple(tensor.clone() for tensor in chained_inputs[1:4])
 
     second_outputs = runner(inputs=chained_inputs, tactic=tactic)
-
-    for output, input_tensor, name in zip(
-        second_outputs[:3],
-        chained_inputs[1:4],
-        ("residual", "post_mix", "comb_mix"),
-    ):
-        assert output.data_ptr() != input_tensor.data_ptr(), (
-            f"fused_hc {name} output aliases its input"
-        )
 
     for actual, expected, name in zip(
         chained_inputs[1:4],
@@ -1157,8 +1179,8 @@ def test_mhc_fused_hc_three_call_cuda_graph_replay():
             )
 
 
-def test_mhc_fused_hc_scratch_isolated_between_streams():
-    """Concurrent fused-HC calls must not mutate another stream's scratch."""
+def test_mhc_fused_hc_concurrent_streams() -> None:
+    """Concurrent fused-HC calls on separate streams must remain independent."""
     runner, first_inputs = _make_fused_hc_runner_case(n=6, hidden_size=4096, hc_mult=4, seed=79)
     second_inputs = [tensor.clone() for tensor in first_inputs]
     for tensor in second_inputs[:4]:
@@ -1172,18 +1194,13 @@ def test_mhc_fused_hc_scratch_isolated_between_streams():
     second_stream.wait_stream(current_stream)
 
     with torch.cuda.stream(first_stream):
-        first_scratch = runner._scratch_cache.get(6, 1, 1, first_inputs[0].device)
         first_outputs = runner(inputs=first_inputs, tactic=tactic)
     with torch.cuda.stream(second_stream):
-        second_scratch = runner._scratch_cache.get(6, 1, 1, second_inputs[0].device)
         second_outputs = runner(inputs=second_inputs, tactic=tactic)
 
     current_stream.wait_stream(first_stream)
     current_stream.wait_stream(second_stream)
     torch.cuda.synchronize()
-
-    for first_workspace, second_workspace in zip(first_scratch, second_scratch):
-        assert first_workspace.data_ptr() != second_workspace.data_ptr()
 
     first_reference = tuple(tensor.clone() for tensor in runner(inputs=first_inputs, tactic=tactic))
     second_reference = tuple(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended compressed KV-cache decoding to support up to 8 new tokens per batch element.
  * Improved generation position IDs to follow compact compressed-output ordering.
  * Strengthened fused-HC scratch-buffer handling across CUDA graphs and streams.

* **Bug Fixes**
  * Added validation and clearer errors for unsupported token counts.
  * Prevented fused-HC output aliasing and improved correctness across chained operations.

* **Tests**
  * Added coverage for token counts 5–8, position-ID ordering, CUDA graph replay, and multi-stream execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR fixes two common correctness issues that affect speculative decoding workloads:

- Extend the DeepSeek-V4 compressor decode path from `next_n <= 4` to `next_n <= 8`, including explicit THOP/launcher validation and the required CUDA template instantiations.
- Generate compressed-token position IDs in the same compact `cu_new_comp_kv` order used by the compressor kernel. This prevents multi-request batches from assigning RoPE positions from the wrong request when requests produce different numbers of compressed tokens.
- Stop caching fused mHC public outputs across calls. Public outputs are now freshly allocated while only bounded, stream-scoped scratch tensors are reused; CUDA graph capture uses graph-private allocations.
- Remove the unused fused-HC output allocator helper.

The branch contains common fixes only and does not modify DSpark-specific code.

## Test Coverage

Regression coverage added or retained for:

- Compressor `next_n=5..8`, including `next_n=8` and invalid-range rejection.
- Compact compressed position IDs for mixed requests and mixed context/generation batches.
- Chained fused-HC calls, ensuring outputs do not alias or mutate the previous call's live inputs.
- Three-call CUDA graph replay and cross-stream scratch isolation.

Validation performed on the final main-based branch:

- Pre-commit and commit-message hooks passed.
- `git diff --check origin/main..HEAD` passed.
- Independent static scope and code-quality reviews passed.
- Runtime unit tests, build, and GSM8K were not rerun on the final branch per the requested validation scope.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] PR follows the TRT-LLM coding guidelines to the best of my knowledge.
- [x] Test cases are provided for the new code paths.
- [x] No public API changes are introduced.
- [x] No new dependencies are introduced.
- [x] No CODEOWNERS, documentation, or architecture diagram updates are required.
