### PR TITLE
[None][fix] Correct RocketKV KT cache byte accounting for FP8 KV cache

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/rocket.py
@@ -1098,12 +1098,12 @@ class RocketKVCacheManager(KVCacheManager):
                                  mapping: Mapping,
                                  num_layers: Optional[int] = None,
                                  **kwargs):
-        # get kv cache dtype bytes
-        mem_per_token = 2
+        # main KV cache dtype bytes (one each for K and V)
+        kv_dtype_bytes = 2
         quant_config = model_config.quant_config
         if quant_config is not None and quant_config.quant_mode.has_fp8_kv_cache(
         ):
-            mem_per_token = 1
+            kv_dtype_bytes = 1
 
         # get num key value heads
         config = model_config.pretrained_config
@@ -1122,10 +1122,10 @@ class RocketKVCacheManager(KVCacheManager):
 
         num_attention_layers = KVCacheManager._resolve_num_attention_layers(
             model_config, mapping, num_layers)
-        mem_per_token *= num_attention_layers * head_dim
 
-        # K and V
-        # 2 for K and V, 2 * kt_tokens_per_block / tokens_per_block for KT cache
+        # K and V: two tensors stored at the main KV cache dtype.
+        mem_per_token = kv_dtype_bytes * 2 * num_attention_layers * head_dim
+
         tokens_per_block = kwargs['tokens_per_block']
         sparse_attention_config = model_config.sparse_attention_config
         if sparse_attention_config is None:
@@ -1138,21 +1138,23 @@ class RocketKVCacheManager(KVCacheManager):
                 "RocketKV cache requires RocketKV sparse parameters")
         kt_tokens_per_block = next_power_of_2(
             math.ceil(tokens_per_block / sparse_params.page_size))
-        kt_factor = 2
-        if sparse_params.kt_cache_dtype == "float8_e5m2":
-            kt_factor = 1
-        kv_factor = 2 + kt_factor * kt_tokens_per_block / tokens_per_block
-        mem_per_token *= kv_factor
+        # KT (key-landmark) cache: a separate pool stored at kt_cache_dtype,
+        # NOT the main KV dtype. Per real token it holds
+        # kt_tokens_per_block / tokens_per_block landmark slots, each storing
+        # the concatenated (min, max) landmark -- a factor of 2 over head_dim.
+        # Size it at its own dtype's byte width (1 for float8_e5m2, else 2) so
+        # the estimate is independent of the main KV dtype and matches both
+        # get_cache_bytes_per_token and the physical pool allocated in
+        # RocketKVCacheManager.__init__.
+        kt_dtype_bytes = 1 if sparse_params.kt_cache_dtype == "float8_e5m2" else 2
+        mem_per_token += (kt_dtype_bytes * 2 * kt_tokens_per_block /
+                          tokens_per_block * num_attention_layers * head_dim)
         return mem_per_token
 
     def get_cache_bytes_per_token(self):
-        # 2 for K and V, 2 * kt_tokens_per_block / tokens_per_block for KT cache
-        kt_factor = 2
-        if self.kt_cache_dtype == torch.float8_e5m2:
-            kt_factor = 1
-        kv_factor = self.kv_factor + kt_factor * self.kt_tokens_per_block / self.tokens_per_block
+        # Main K/V cache: stored at the main KV cache dtype (self.dtype).
         cache_size_per_token = math.ceil(
-            kv_factor * sum(self.num_kv_heads_per_layer) * self.head_dim)
+            self.kv_factor * sum(self.num_kv_heads_per_layer) * self.head_dim)
 
         if self.dtype not in (DataType.FP8, DataType.HALF, DataType.BF16,
                               DataType.FLOAT, DataType.NVFP4):
@@ -1165,4 +1167,20 @@ class RocketKVCacheManager(KVCacheManager):
                 cache_size_per_token,
                 quant_vector_size=16,
                 scaling_factor_dtype=DataType.FP8)
+
+        # KT (key-landmark) cache: a separate pool physically allocated at
+        # kt_cache_dtype, NOT the main KV dtype -- see __init__:
+        #   torch.empty((num_blocks, kt_tokens_per_block, num_kv_heads,
+        #                head_dim * 2), dtype=kt_cache_dtype).
+        # The trailing factor of 2 is the concatenated (min, max) landmark per
+        # head_dim. Per real token the pool holds
+        # kt_tokens_per_block / tokens_per_block landmark slots. Size it at its
+        # own dtype's byte width (1 for float8_e5m2, else 2) so the estimate
+        # matches the allocation regardless of self.dtype.
+        kt_dtype_bytes = 1 if self.kt_cache_dtype == torch.float8_e5m2 else 2
+        kt_elements_per_token = math.ceil(
+            2 * self.kt_tokens_per_block / self.tokens_per_block *
+            sum(self.num_kv_heads_per_layer) * self.head_dim)
+        cache_size_bytes_per_token += kt_elements_per_token * kt_dtype_bytes
+
         return cache_size_bytes_per_token

--- a/tests/unittest/_torch/attention/sparse/rocketkv/test_rocketkv.py
+++ b/tests/unittest/_torch/attention/sparse/rocketkv/test_rocketkv.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 
 import pytest
@@ -17,6 +18,8 @@ from tensorrt_llm._torch.attention_backend.sparse.rocket import (
     RocketVanillaAttentionMetadata,
 )
 from tensorrt_llm._torch.metadata import KVCacheParams
+from tensorrt_llm._utils import get_size_in_bytes
+from tensorrt_llm.bindings import DataType
 from tensorrt_llm.llmapi import CudaGraphConfig, KvCacheConfig, RocketSparseAttentionConfig
 from tensorrt_llm.mapping import Mapping
 
@@ -702,6 +705,48 @@ def test_sparse_attn_predict(batch_size, num_contexts):
         assert len(vanilla_sparse_attn_indices_list) == 0, (
             "Both should return None when no sparse attention is needed"
         )
+
+
+@pytest.mark.skipif(getSMVersion() < 100, reason="RocketKV requires SM100 (Blackwell)")
+def test_rocketkv_kt_cache_sized_by_kt_dtype_not_kv_dtype():
+    """get_cache_bytes_per_token() must size the KT (key-landmark) cache from the KT
+    pool's own dtype, matching the pool physically allocated in __init__ -- not the
+    main KV cache dtype. The old code scaled the KT term by the main KV dtype byte
+    width, under-counting the KT pool by 2x when the main KV cache was FP8. Using
+    FP8 main KV + bfloat16 KT makes the two dtypes differ, so this fails without the
+    fix and passes with it.
+    """
+    sparse_attn_config = RocketSparseAttentionConfig(
+        prompt_budget=2048, page_size=4, kt_cache_dtype="bfloat16"
+    )
+    kv_cache_manager = create_rocket_kv_cache_manager(
+        num_layers=4,
+        num_kv_heads=8,
+        head_dim=128,
+        tokens_per_block=64,
+        max_seq_len=4096,
+        max_batch_size=8,
+        dtype=DataType.FP8,
+        sparse_attn_config=sparse_attn_config,
+    )
+    try:
+        # KT contribution: ground truth from the physically allocated KT pool.
+        kt_pool_bytes = sum(
+            t.numel() * t.element_size() for t in kv_cache_manager.kt_cache_pool_per_layer
+        )
+        tokens = kv_cache_manager.num_blocks * kv_cache_manager.tokens_per_block
+        # Main K/V contribution is unchanged (sized at the main KV dtype).
+        main_bytes = get_size_in_bytes(
+            math.ceil(
+                kv_cache_manager.kv_factor
+                * sum(kv_cache_manager.num_kv_heads_per_layer)
+                * kv_cache_manager.head_dim
+            ),
+            kv_cache_manager.dtype,
+        )
+        assert kv_cache_manager.get_cache_bytes_per_token() == main_bytes + kt_pool_bytes // tokens
+    finally:
+        kv_cache_manager.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

The RocketKV KT (key-landmark) cache is a separate pool physically allocated at
`kt_cache_dtype` (see `RocketKVCacheManager.__init__`:
`torch.empty((num_blocks, kt_tokens_per_block, num_kv_heads, head_dim * 2), dtype=kt_cache_dtype)`),
independent of the main KV cache dtype. Two accounting methods sized the KT term by the
**main** KV dtype byte width and folded the `(min, max)` factor-of-2 into a dtype-dependent
`kt_factor`:

- `RocketKVCacheManager.get_cache_size_per_token` — the pre-allocation memory estimate
  (KV-cache budget path in `_util.py`).
- `RocketKVCacheManager.get_cache_bytes_per_token` — used by `calculate_max_num_blocks`
  (`max_tokens = free_mem_fraction * free_mem / bytes_per_token`).

This was numerically correct **only when the main KV cache is bf16**. With an **FP8 KV cache**
the KT pool was under-counted by 2×, which over-estimates the block count and over-subscribes
GPU memory (OOM risk), since the KT pool is allocated with the same block count as the primary
pool.

This PR sizes the KT contribution at its own dtype's byte width with an explicit factor of 2,
matching the physically allocated pool regardless of the main KV dtype. The bf16 main-KV path
(the RocketKV default) is numerically unchanged.

## Test Coverage

`tests/unittest/_torch/attention/sparse/rocketkv/test_rocketkv.py::test_rocketkv_kt_cache_sized_by_kt_dtype_not_kv_dtype`

Constructs a `RocketKVCacheManager` with an **FP8 main KV cache + bfloat16 KT cache** (so the two
dtypes differ) and asserts `get_cache_bytes_per_token()` matches the physically allocated
`kt_cache_pool_per_layer` bytes. It fails on the old code (KT sized at the 1-byte main dtype) and
passes with the fix. The test runs in the L0 pre-merge B200 stage via the existing
`unittest/_torch/attention` test-db entry (SM100-gated; `getSMVersion() < 100` is skipped).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. (N/A — internal cache-accounting only, no public API change.)
- Any new dependencies have been scanned for license and vulnerabilities (N/A — no new dependencies).
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes (N/A).
- Documentation updated as needed (N/A — no behavior change to documented interfaces).
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR (N/A).
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RocketKV cache memory estimation for FP8 and other KV-cache data types.
  * Corrected key-landmark cache sizing to use its configured data type independently from the main KV cache.
  * Ensured reported cache bytes per token more accurately reflect allocated memory.

* **Tests**
  * Added coverage validating key-landmark cache sizing across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->