### PR TITLE
[https://nvbugs/6400533][fix] Cache per-request greedy flag to fast-exit spec-dec sampling scan

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -723,6 +723,22 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_orig_prompt_len = self.orig_prompt_len
         self.py_max_new_tokens = self.max_new_tokens
         self.py_min_length = self.sampling_config.min_length
+        # Cached per-request greedy flag. Sampling params are immutable
+        # after admission, so this classification is invariant across all
+        # generation steps for the request; caching it here lets the
+        # one-model spec-dec sampler take an O(1) batch reduce every step
+        # (see `_scan_one_model_sampling`) instead of a per-step Python
+        # loop over the batch.
+        _sc = self.sampling_config
+        _temp = _sc.temperature[0] if _sc.temperature is not None and len(
+            _sc.temperature) > 0 else None
+        _top_k = _sc.top_k[0] if _sc.top_k is not None and len(
+            _sc.top_k) > 0 else None
+        _top_p = _sc.top_p[0] if _sc.top_p is not None and len(
+            _sc.top_p) > 0 else None
+        self.py_is_greedy_sample: bool = ((_temp is None and _top_p is None
+                                           and _top_k is None) or _top_k == 1
+                                          or _top_p == 0.0 or _temp == 0)
         # `seqlen_this_rank_cp`, `total_input_len_cp`, and `py_helix_is_inactive_rank` are relevant to helix parallelism.
         self.seqlen_this_rank_cp = self.prompt_len
         self.total_input_len_cp = self.prompt_len

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -681,6 +681,41 @@ class SpecMetadata:
                 is_greedy,
             )
 
+        # Hot-path fast-exit for the all-greedy batch. `py_is_greedy_sample`
+        # is cached on LlmRequest at admission (sampling params are
+        # immutable), so this is an O(batch_size) `all(...)` over cached
+        # bools instead of a per-request Python-level normalization of
+        # temperature / top_k / top_p. `populate_sampling_params_for_one_model`
+        # returns early when `is_all_greedy_sample` is True (skipping the
+        # H2D copies of the per-token buffers), so producing the normalized
+        # tuples here is wasted work in the common case.
+        #
+        # Skipped when `_force_non_greedy_for_capture` is set (CUDA-graph
+        # warmup capture of the advanced-sampling variant): the caller
+        # needs a populated `per_request_normalized` with synthetic
+        # non-greedy scalars for Phase 2 to fill the GPU buffers.
+        if (requests
+                and not getattr(self, '_force_non_greedy_for_capture', False)
+                and all(r.py_is_greedy_sample for r in requests)):
+            self.skip_temperature = True
+            self.skip_top_k = True
+            self.skip_top_p = True
+            self.has_greedy_requests = True
+            self.is_all_greedy_sample = True
+            # Slot ids are only consumed downstream when
+            # `use_rejection_sampling` is enabled (see the
+            # `batch_slot_ids` copy in `populate_sampling_params_for_one_model`).
+            # For default MTP / Eagle3 one-model configs
+            # (`use_rejection_sampling=False`), skip that list too.
+            if self.use_rejection_sampling:
+                per_request_slot_ids = [
+                    r.py_seq_slot if r.py_seq_slot is not None else 0
+                    for r in requests
+                ]
+            else:
+                per_request_slot_ids = []
+            return [], per_request_slot_ids
+
         # Phase 1: collect per-request flags and normalized values.
         per_request_normalized: list[tuple[float, int, float, int]] = []
         temperature_enabled = False


### PR DESCRIPTION
## Summary
- **Root cause**: The one-model speculative-decoding sampler ran a per-step Python-level normalization of temperature/top_k/top_p across the entire batch inside `_scan_one_model_sampling`, even when every request was greedy. On gen-only workloads (e.g., DeepSeek-R1 FP4 with MTP3, con=1024), this per-step per-request work became a measurable host overhead and regressed generation throughput because the downstream `populate_sampling_params_for_one_model` fast-exits on all-greedy anyway, making the normalization wasted work.
- **Fix**: Cache an immutable `py_is_greedy_sample` bool on `LlmRequest` at admission time (sampling params don't change afterward), then add a hot-path fast-exit in `SpecMetadata` that does an O(batch_size) `all(...)` over cached bools and short-circuits with the greedy flags set, skipping the normalized-tuple construction and per-token H2D copies. The capture-time `_force_non_greedy_for_capture` path and the rejection-sampling slot-id list are preserved so CUDA-graph warmup and rejection-sampling configs remain correct.
- **Perf metric**: mean_gen_worker_per_iter_device_step_time (lower-is-better)
- **Bad perf**: 32.56
- **Good perf**: 31.33
- **Perf after fix**: 31.85
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6400533


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved generation efficiency for requests using greedy sampling.
  * Added faster handling for batches where all requests use greedy sampling, reducing unnecessary sampling-parameter processing.
  * Preserved compatibility with rejection sampling and capture configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->