### PR TITLE
[None][perf] Memoize multimodal run metadata and drop identity block-offset gather

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -280,9 +280,19 @@ def _ensure_int64_cpu_tensor(values: Sequence[int] | torch.Tensor) -> torch.Tens
     return torch.as_tensor(values, dtype=torch.int64)
 
 
+_MM_RUN_METADATA_UNSET = object()
+
+
 def _resolve_multimodal_run_metadata(req: LlmRequest) -> Optional[_MmRunMetadata]:
-    # TODO(perf): cache per request; block-reuse invokes this once per block,
-    # repeatedly rebuilding identical tensors for the same request metadata.
+    # Memoize on the request. Block reuse resolves this on the first context
+    # chunk, again on every commit during chunked prefill, and on prefetch, yet
+    # the result is a pure function of the request's immutable multimodal run
+    # layout. Caching on the request bounds the cache to the request lifetime,
+    # so no separate teardown is needed.
+    cached = getattr(req, "py_mm_run_metadata", _MM_RUN_METADATA_UNSET)
+    if cached is not _MM_RUN_METADATA_UNSET:
+        return cached
+
     # Worked example for one logical multimodal item split by text:
     #
     #   prompt index: 0    1      2      3    4      5
@@ -315,6 +325,7 @@ def _resolve_multimodal_run_metadata(req: LlmRequest) -> Optional[_MmRunMetadata
     run_lengths = req.multimodal_run_lengths
 
     if all(field is None for field in (item_run_cu_offsets, run_positions, run_lengths)):
+        req.py_mm_run_metadata = None
         return None
 
     if item_run_cu_offsets is None or run_positions is None or run_lengths is None:
@@ -349,12 +360,14 @@ def _resolve_multimodal_run_metadata(req: LlmRequest) -> Optional[_MmRunMetadata
     # Shape [num_runs]; one-past-last full-prompt index for each flat run.
     run_ends = run_positions + run_lengths
 
-    return _MmRunMetadata(
+    metadata = _MmRunMetadata(
         run_positions=run_positions,
         run_ends=run_ends,
         run_item_indices=run_item_indices,
         run_item_offsets=run_item_offsets,
     )
+    req.py_mm_run_metadata = metadata
+    return metadata
 
 
 def _augment_tokens_with_mm_run_metadata(

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2261,10 +2261,6 @@ class BlockManager:
         self.tokens_per_block = tokens_per_block
         self.max_blocks_per_seq = self.num_blocks
 
-        self.base_block_offsets = torch.arange(self.num_blocks,
-                                               device="cpu",
-                                               dtype=torch.int32)
-
         self.block_ids = dict()
         self.num_sequences = dict()
         self.free_blocks = deque(range(self.num_blocks))
@@ -2288,10 +2284,9 @@ class BlockManager:
         for i in range(len(request_ids)):
             block_ids = self.block_ids[request_ids[i]]
             block_num = len(block_ids)
+            # Block ids are the page offsets directly; no lookup table needed.
             block_offsets[i, 0:block_num].copy_(
-                self.base_block_offsets[torch.tensor(block_ids,
-                                                     dtype=torch.int32,
-                                                     device="cpu")])
+                torch.tensor(block_ids, dtype=torch.int32, device="cpu"))
 
     def compute_block_count(self, token_count: int,
                             tokens_per_page: int) -> int:


### PR DESCRIPTION
## Description

Two host-side overhead reductions in the KV cache managers. Both are performance-only with **no external behavior change**.

1. **Memoize per-request multimodal run metadata** (`kv_cache_manager_v2.py`). `_resolve_multimodal_run_metadata` is resolved on the first context chunk, again on every commit during chunked prefill, and on prefetch. Its result is a pure function of the request's immutable multimodal run layout (`multimodal_item_run_cu_offsets` / `multimodal_run_positions` / `multimodal_run_lengths`), so the CPU tensors it builds (`arange` / `repeat_interleave` / `cumsum` / `cat` / int64 casts) were being rebuilt identically on every call. The result is now cached on the request, whose lifetime bounds the cache, so no separate teardown is needed. This resolves the existing `TODO(perf)`. The non-`None` path is exercised by the VLMs that populate run metadata (Qwen2VL, Qwen3VL, LLaVA-Next, Kimi-K2.5, Nemotron-Nano).

2. **Remove an identity gather** (`resource_manager.py`, `BlockManager.copy_block_offsets`). `base_block_offsets` was a `torch.arange`, so `base_block_offsets[block_ids]` returns `block_ids` unchanged. The block ids are now converted directly and the unused `base_block_offsets` buffer is removed (also dropping its per-manager allocation). This `BlockManager` backs the RocketKV KT cache.

## Test Coverage

No new tests are added: both changes are performance-only with no external behavior change. Existing coverage exercises the touched paths:

- `tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py` — calls `_augment_tokens_for_block_reuse` multiple times on the same request, exercising the memoized `_resolve_multimodal_run_metadata` on both the cache-miss (build) and cache-hit (return) paths, as well as the contiguous `None` path.
- `tests/unittest/_torch/executor/test_kv_cache_manager_v2.py` — KV cache manager v2 behavior.
- `tests/unittest/_torch/attention/sparse/rocketkv/test_rocketkv.py` — RocketKV path that calls `BlockManager.copy_block_offsets`.

## PR Checklist

- No API changes; no new dependencies; no CODEOWNERS or documentation changes required.

- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved multimodal request processing by reusing computed metadata during repeated operations.
  * Streamlined block offset preparation to reduce unnecessary intermediate data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->