### PR TITLE
[None][fix] Fix VSWA gate in KVCacheManager window-size resolution

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1252,14 +1252,20 @@ class KVCacheManager(BaseResourceManager):
         assert max_atten_window_upper_bound > 0, "Impossible to fit in any sequence in kvCache"
         return max_atten_window_upper_bound
 
+    def _resolve_window_size(
+            self,
+            window_size: Optional[int],
+            error_msg: str = "window_size must be provided for VSWA") -> int:
+        if window_size is not None:
+            return window_size
+        if self.is_vswa:
+            raise ValueError(error_msg)
+        return self.max_attention_window_vec[0]
+
     def get_cache_indices(self,
                           request: LlmRequest,
                           window_size: Optional[int] = None) -> List[int]:
-        if window_size is None:
-            if len(self.max_attention_window_vec) > 1:
-                raise ValueError("window_size must be provided for VSWA")
-            window_size = self.max_attention_window_vec[0]
-
+        window_size = self._resolve_window_size(window_size)
         result = self.impl.get_cache_block_ids(request.py_request_id,
                                                window_size)
         assert len(result) == 1
@@ -1296,16 +1302,7 @@ class KVCacheManager(BaseResourceManager):
         hash matches what ``storeBlocks`` would later compute. Beam-width-1
         only; the connector enforces this at startup.
         """
-        if window_size is None:
-            # ``is_vswa`` (distinct window sizes) is the real VSWA signal; a
-            # uniform per-layer vector such as ``[4096, 4096, ...]`` has
-            # ``len > 1`` yet a single effective window, so keying off the
-            # length would spuriously reject it for connector callers that omit
-            # ``window_size``.
-            if self.is_vswa:
-                raise ValueError("window_size must be provided for VSWA")
-            window_size = self.max_attention_window_vec[0]
-
+        window_size = self._resolve_window_size(window_size)
         return list(
             self.impl.commit_and_get_block_hashes_for_request(
                 request, window_size))
@@ -1329,10 +1326,7 @@ class KVCacheManager(BaseResourceManager):
         Returns:
             The retention priority of the block (0-100), or default priority (35) if not found.
         """
-        if window_size is None:
-            if len(self.max_attention_window_vec) > 1:
-                raise ValueError("window_size must be provided for VSWA")
-            window_size = self.max_attention_window_vec[0]
+        window_size = self._resolve_window_size(window_size)
         return self.impl.get_priority_by_block_id(block_id, window_size)
 
     def get_batch_cache_indices(
@@ -1346,10 +1340,9 @@ class KVCacheManager(BaseResourceManager):
         beam_width = beam_width or 1
         if window_size is None:
             if layer_idx is None:
-                if len(self.max_attention_window_vec) > 1:
-                    raise ValueError(
-                        "layer_idx or window_size must be provided for VSWA")
-                window_size = self.max_attention_window_vec[0]
+                window_size = self._resolve_window_size(
+                    window_size,
+                    "layer_idx or window_size must be provided for VSWA")
             else:
                 layer_offset = self.layer_offsets[layer_idx]
                 # Explicit layer_offset -> window_size mapping (no modulo

--- a/tests/unittest/_torch/executor/test_resource_manager.py
+++ b/tests/unittest/_torch/executor/test_resource_manager.py
@@ -994,5 +994,25 @@ class TestKVCacheManagerConfigForwarding(unittest.TestCase):
             kv_cache_manager.shutdown()
 
 
+class TestResolveWindowSize(unittest.TestCase):
+
+    @staticmethod
+    def _make_manager(max_attention_window_vec, is_vswa):
+        mgr = KVCacheManager.__new__(KVCacheManager)
+        mgr.max_attention_window_vec = max_attention_window_vec
+        mgr.is_vswa = is_vswa
+        return mgr
+
+    def test_uniform_multi_layer_vector_does_not_raise(self):
+        mgr = self._make_manager([4096, 4096, 4096], is_vswa=False)
+        self.assertEqual(mgr._resolve_window_size(None), 4096)
+
+    def test_genuine_vswa_requires_window_size(self):
+        mgr = self._make_manager([4096, 8192], is_vswa=True)
+        with self.assertRaises(ValueError):
+            mgr._resolve_window_size(None)
+        self.assertEqual(mgr._resolve_window_size(8192), 8192)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
@coderabbitai summary

## Description

`KVCacheManager.get_cache_indices`, `get_priority_by_block_id`, and
`get_batch_cache_indices` gated the "window_size required" check on
`len(max_attention_window_vec) > 1`. That spuriously rejects a *uniform*
per-layer window vector such as `[4096, 4096, ...]`, which has `len > 1` but a
single effective window (`is_vswa` is False). `commit_and_get_block_hashes`
already used the correct `is_vswa` signal (distinct *positive* windows); the
others did not — so callers that legitimately omit `window_size` (e.g. the KV
cache connector) broke on any model with a uniform per-layer window vector.

This extracts a single `_resolve_window_size` helper keyed on `is_vswa` and
routes all four per-window accessors through it, removing the copy-pasted guard
and its divergence. Behavior for genuine VSWA (raise when `window_size` is
omitted) and for an explicitly-provided `window_size` is unchanged.

## Test Coverage

`tests/unittest/_torch/executor/test_resource_manager.py::TestResolveWindowSize`
- `test_uniform_multi_layer_vector_does_not_raise` — the regression: a uniform
  `[4096, 4096, 4096]` vector resolves to `4096` instead of raising.
- `test_genuine_vswa_requires_window_size` — genuine VSWA still raises when
  `window_size` is omitted, and an explicit `window_size` passes through.

## PR Checklist
- [x] Please check this after reviewing the above items as appropriate for this PR.
