### PR TITLE
[TRTLLM-13969][feat] MiniMax M3 disagg KV transfer via per-class pool views

### DIFF
--- a/cpp/include/tensorrt_llm/executor/transferAgent.h
+++ b/cpp/include/tensorrt_llm/executor/transferAgent.h
@@ -216,12 +216,17 @@ struct VmmDescSplitter
     /// For non-VRAM or addresses not in the map, descs pass through unchanged.
     [[nodiscard]] static MemoryDescs splitDescsWithRegionMap(MemoryDescs const& descs, VramRegionMap const& regionMap);
 
-    /// @brief Split paired src/dst descs using local and remote region maps.
-    /// src is split by localRegionMap, dst is split by remoteRegionMap.
-    /// The final piece size is min(srcPiece, dstPiece, remaining).
-    [[nodiscard]] static std::pair<MemoryDescs, MemoryDescs> splitTransferDescsWithRegionMaps(
-        MemoryDescs const& srcDescs, MemoryDescs const& dstDescs, VramRegionMap const& localRegionMap,
-        VramRegionMap const& remoteRegionMap);
+    /// @brief Split paired src/dst descs at chunk boundaries, then coalesce contiguous pieces.
+    /// src is split by localRegionMap, dst is split by remoteRegionMap; each piece size is
+    /// min(srcPiece, dstPiece, remaining). Pairs are sorted by src address, and adjacent pieces
+    /// whose src AND dst are both contiguous (same deviceId) are merged — but a merged desc never
+    /// crosses a chunk boundary on either side, and never spans two distinct regions, so every
+    /// output desc stays within a single registered memory region. Non-kVRAM descs pass through
+    /// unchanged (no region info is available to bound the merge).
+    /// @param enableCoalesce When false, only split at chunk boundaries without merging pieces.
+    [[nodiscard]] static std::pair<MemoryDescs, MemoryDescs> splitAndCoalesceTransferDescs(MemoryDescs const& srcDescs,
+        MemoryDescs const& dstDescs, VramRegionMap const& localRegionMap, VramRegionMap const& remoteRegionMap,
+        bool enableCoalesce = true);
 
     /// @brief Split VRAM descs at VMM chunk boundaries detected via cuMemGetAddressRange.
     /// For cudaMalloc memory (single allocation), descs pass through unchanged.

--- a/cpp/tensorrt_llm/common/envUtils.cpp
+++ b/cpp/tensorrt_llm/common/envUtils.cpp
@@ -517,10 +517,10 @@ uint16_t getEnvNixlPort()
     return nixlPort;
 }
 
-bool getEnvNixlEnableCoalesce()
+bool getEnvNixlDisableCoalesce()
 {
-    static bool const enableCoalesce = getBoolEnv("TRTLLM_NIXL_ENABLE_COALESCE");
-    return enableCoalesce;
+    static bool const disableCoalesce = getBoolEnv("TRTLLM_NIXL_DISABLE_COALESCE");
+    return disableCoalesce;
 }
 
 bool getEnvDisaggBenchmarkGenOnly()

--- a/cpp/tensorrt_llm/common/envUtils.h
+++ b/cpp/tensorrt_llm/common/envUtils.h
@@ -151,7 +151,8 @@ bool getEnvKVCachePoolUseFabricMemory();
 
 uint16_t getEnvNixlPort();
 
-bool getEnvNixlEnableCoalesce();
+// Whether to disable coalescing of contiguous NIXL transfer descriptors (coalescing is on by default).
+bool getEnvNixlDisableCoalesce();
 
 bool getEnvDisaggBenchmarkGenOnly();
 

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
@@ -347,164 +347,6 @@ NixlTransferStatus::~NixlTransferStatus() noexcept
     }
 }
 
-[[nodiscard]] MemoryDescs NixlHelper::coalesceMemoryDescs(MemoryDescs const& descs)
-{
-    auto const& descVec = descs.getDescs();
-
-    // If empty or single element, return as-is
-    if (descVec.size() <= 1)
-    {
-        return descs;
-    }
-
-    size_t const numDescs = descVec.size();
-
-    // Create index array and sort by address
-    std::vector<size_t> sortedIndices(numDescs);
-    std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
-
-    std::sort(sortedIndices.begin(), sortedIndices.end(),
-        [&descVec](size_t lhs, size_t rhs)
-        {
-            // Sort by deviceId first, then by address
-            if (descVec[lhs].getDeviceId() != descVec[rhs].getDeviceId())
-            {
-                return descVec[lhs].getDeviceId() < descVec[rhs].getDeviceId();
-            }
-            return descVec[lhs].getAddr() < descVec[rhs].getAddr();
-        });
-
-    std::vector<MemoryDesc> coalesced;
-    coalesced.reserve(numDescs);
-
-    // Start with the first entry
-    size_t firstIdx = sortedIndices[0];
-    uintptr_t currentAddr = descVec[firstIdx].getAddr();
-    size_t currentLen = descVec[firstIdx].getLen();
-    uint32_t currentDeviceId = descVec[firstIdx].getDeviceId();
-
-    for (size_t idx = 1; idx < numDescs; ++idx)
-    {
-        size_t sortedIdx = sortedIndices[idx];
-        auto const& desc = descVec[sortedIdx];
-
-        // Check if current can be coalesced with previous
-        bool isContiguous = (currentAddr + currentLen == desc.getAddr()) && (currentDeviceId == desc.getDeviceId());
-
-        if (isContiguous)
-        {
-            // Coalesce: extend the current region
-            currentLen += desc.getLen();
-        }
-        else
-        {
-            // Cannot coalesce: save the current region and start a new one
-            coalesced.emplace_back(currentAddr, currentLen, currentDeviceId);
-
-            currentAddr = desc.getAddr();
-            currentLen = desc.getLen();
-            currentDeviceId = desc.getDeviceId();
-        }
-    }
-
-    // Add the last region
-    coalesced.emplace_back(currentAddr, currentLen, currentDeviceId);
-
-    TLLM_LOG_DEBUG("NixlHelper::coalesceMemoryDescs: coalesced %zu -> %zu entries", descVec.size(), coalesced.size());
-
-    return MemoryDescs{descs.getType(), std::move(coalesced)};
-}
-
-[[nodiscard]] std::pair<MemoryDescs, MemoryDescs> NixlHelper::coalesceTransferDescs(
-    TransferDescs const& srcDescs, TransferDescs const& dstDescs)
-{
-    auto const& srcVec = srcDescs.getDescs();
-    auto const& dstVec = dstDescs.getDescs();
-
-    // If sizes don't match or empty, return as-is
-    if (srcVec.size() != dstVec.size() || srcVec.empty())
-    {
-        return {srcDescs, dstDescs};
-    }
-
-    size_t const numDescs = srcVec.size();
-
-    // Create index array and sort by src address
-    // This allows us to find contiguous regions even if the original order is scattered
-    std::vector<size_t> sortedIndices(numDescs);
-    std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
-
-    std::sort(sortedIndices.begin(), sortedIndices.end(),
-        [&srcVec](size_t lhs, size_t rhs)
-        {
-            // Sort by deviceId first, then by address
-            if (srcVec[lhs].getDeviceId() != srcVec[rhs].getDeviceId())
-            {
-                return srcVec[lhs].getDeviceId() < srcVec[rhs].getDeviceId();
-            }
-            return srcVec[lhs].getAddr() < srcVec[rhs].getAddr();
-        });
-
-    std::vector<MemoryDesc> coalescedSrc;
-    std::vector<MemoryDesc> coalescedDst;
-    coalescedSrc.reserve(numDescs);
-    coalescedDst.reserve(numDescs);
-
-    // Start with the first entry (using sorted order)
-    size_t firstIdx = sortedIndices[0];
-    uintptr_t currentSrcAddr = srcVec[firstIdx].getAddr();
-    size_t currentSrcLen = srcVec[firstIdx].getLen();
-    uint32_t currentSrcDeviceId = srcVec[firstIdx].getDeviceId();
-
-    uintptr_t currentDstAddr = dstVec[firstIdx].getAddr();
-    size_t currentDstLen = dstVec[firstIdx].getLen();
-    uint32_t currentDstDeviceId = dstVec[firstIdx].getDeviceId();
-
-    for (size_t idx = 1; idx < numDescs; ++idx)
-    {
-        size_t sortedIdx = sortedIndices[idx];
-        auto const& src = srcVec[sortedIdx];
-        auto const& dst = dstVec[sortedIdx];
-
-        // Check if current src and dst can be coalesced with previous
-        bool srcContiguous
-            = (currentSrcAddr + currentSrcLen == src.getAddr()) && (currentSrcDeviceId == src.getDeviceId());
-        bool dstContiguous
-            = (currentDstAddr + currentDstLen == dst.getAddr()) && (currentDstDeviceId == dst.getDeviceId());
-
-        if (srcContiguous && dstContiguous)
-        {
-            // Coalesce: extend the current region
-            currentSrcLen += src.getLen();
-            currentDstLen += dst.getLen();
-        }
-        else
-        {
-            // Cannot coalesce: save the current region and start a new one
-            coalescedSrc.emplace_back(currentSrcAddr, currentSrcLen, currentSrcDeviceId);
-            coalescedDst.emplace_back(currentDstAddr, currentDstLen, currentDstDeviceId);
-
-            currentSrcAddr = src.getAddr();
-            currentSrcLen = src.getLen();
-            currentSrcDeviceId = src.getDeviceId();
-
-            currentDstAddr = dst.getAddr();
-            currentDstLen = dst.getLen();
-            currentDstDeviceId = dst.getDeviceId();
-        }
-    }
-
-    // Don't forget to add the last region
-    coalescedSrc.emplace_back(currentSrcAddr, currentSrcLen, currentSrcDeviceId);
-    coalescedDst.emplace_back(currentDstAddr, currentDstLen, currentDstDeviceId);
-
-    TLLM_LOG_DEBUG(
-        "NixlHelper::coalesceTransferDescs: coalesced %zu -> %zu transfer entries", srcVec.size(), coalescedSrc.size());
-
-    return {MemoryDescs{srcDescs.getType(), std::move(coalescedSrc)},
-        MemoryDescs{dstDescs.getType(), std::move(coalescedDst)}};
-}
-
 TransferState NixlTransferStatus::wait(int64_t timeout_ms) const
 {
     auto startTime = std::chrono::steady_clock::now();
@@ -693,12 +535,8 @@ void NixlTransferAgent::registerMemory(RegisterDescs const& descs)
     auto detectedRegionMap = VmmDescSplitter::detectVramRegionMap(descs);
     mLocalVramRegionInfo.merge(detectedRegionMap);
 
-    // Coalesce contiguous memory regions to reduce registration overhead (disabled by default)
-    // Set TRTLLM_NIXL_ENABLE_COALESCE=1 to enable this optimization
-    auto coalescedDescs = common::getEnvNixlEnableCoalesce() ? NixlHelper::coalesceMemoryDescs(splitDescs) : splitDescs;
-
     nixl_status_t status;
-    status = mRawAgent->registerMem(NixlHelper::convertRegDlist(coalescedDescs), &mExtraParams);
+    status = mRawAgent->registerMem(NixlHelper::convertRegDlist(splitDescs), &mExtraParams);
     TLLM_CHECK(status == NIXL_SUCCESS);
 
     std::string localMD;
@@ -713,12 +551,8 @@ void NixlTransferAgent::deregisterMemory(RegisterDescs const& descs)
     // Split using per-region registry info to match what was registered
     auto splitDescs = VmmDescSplitter::splitDescsWithRegionMap(descs, mLocalVramRegionInfo);
 
-    // Coalesce contiguous memory regions to match what was registered (disabled by default)
-    // Set TRTLLM_NIXL_ENABLE_COALESCE=1 to enable this optimization
-    auto coalescedDescs = common::getEnvNixlEnableCoalesce() ? NixlHelper::coalesceMemoryDescs(splitDescs) : splitDescs;
-
     nixl_status_t status;
-    status = mRawAgent->deregisterMem(NixlHelper::convertRegDlist(coalescedDescs), &mExtraParams);
+    status = mRawAgent->deregisterMem(NixlHelper::convertRegDlist(splitDescs), &mExtraParams);
     TLLM_CHECK(status == NIXL_SUCCESS);
 
     // Remove entries from registry
@@ -743,7 +577,7 @@ void NixlTransferAgent::loadRemoteAgent(std::string const& name, AgentDesc const
         name == remoteName, "loadRemoteAgent gets error agent name: %s != %s", name.c_str(), remoteName.c_str());
 
     // Store remote VMM region info for chunk boundary calculations in
-    // VmmDescSplitter::splitTransferDescsWithRegionMaps. Per-agent map because different remote agents may have
+    // VmmDescSplitter::splitAndCoalesceTransferDescs. Per-agent map because different remote agents may have
     // overlapping virtual addresses.
     auto const& regions = agentDesc.getVramRegions();
     if (!regions.empty())
@@ -764,14 +598,13 @@ AgentDesc NixlTransferAgent::getLocalAgentDesc()
     nixl_status_t status = mRawAgent->getLocalMD(nixlBlob);
     TLLM_CHECK(status == NIXL_SUCCESS);
 
-    // Pack local VMM region info so remote agents can compute chunk boundaries.
+    // Pack ALL local region info (VMM multi-chunk and single-allocation alike) so remote agents can
+    // compute chunk boundaries and never coalesce transfer descs across separately registered regions.
     std::vector<VramRegionMeta> regions;
+    regions.reserve(mLocalVramRegionInfo.size());
     for (auto const& [base, info] : mLocalVramRegionInfo)
     {
-        if (info.chunkSize > 0)
-        {
-            regions.push_back({base, info.totalLen, info.chunkSize});
-        }
+        regions.push_back({base, info.totalLen, info.chunkSize});
     }
 
     return AgentDesc{nixlBlob, std::move(regions)};
@@ -809,32 +642,22 @@ void NixlTransferAgent::invalidateRemoteAgent(std::string const& name)
     {
         reqParams.hasNotif = false;
     }
-    // Split transfer descriptors at VMM chunk boundaries to match registered memory.
-    // Both src and dst are split at chunk boundaries to ensure each descriptor
-    // falls within a single registered memory region on both local and remote sides.
-    // Find remote agent's VMM region map (empty map if not found).
+    // Split transfer descriptors at VMM chunk boundaries to match registered memory, then coalesce
+    // contiguous pieces. A coalesced descriptor never crosses a chunk boundary or a registered
+    // region boundary on either side, so every descriptor still falls within a single registered
+    // memory region on both local and remote sides. Set TRTLLM_NIXL_DISABLE_COALESCE=1 to fall back
+    // to split-only descriptors. Find remote agent's region map (empty map if not found).
     static VramRegionMap const kEmptyMap;
     auto remoteIt = mRemoteVramRegionInfo.find(request.getRemoteName());
     auto const& remoteRegionMap = (remoteIt != mRemoteVramRegionInfo.end()) ? remoteIt->second : kEmptyMap;
 
-    auto [splitSrc, splitDst] = VmmDescSplitter::splitTransferDescsWithRegionMaps(
-        request.getSrcDescs(), request.getDstDescs(), mLocalVramRegionInfo, remoteRegionMap);
+    auto [xferSrc, xferDst] = VmmDescSplitter::splitAndCoalesceTransferDescs(request.getSrcDescs(),
+        request.getDstDescs(), mLocalVramRegionInfo, remoteRegionMap, !common::getEnvNixlDisableCoalesce());
 
-    // Coalesce contiguous memory regions to reduce transfer count (disabled by default)
-    // This matches the coalescing done during registerMemory()
-    // Set TRTLLM_NIXL_ENABLE_COALESCE=1 to enable this optimization
-    if (common::getEnvNixlEnableCoalesce())
     {
-        NVTX3_SCOPED_RANGE(coalesceTransferDescs_CreateXferReq);
-        auto [coalescedSrc, coalescedDst] = NixlHelper::coalesceTransferDescs(splitSrc, splitDst);
-        status
-            = mRawAgent->createXferReq(NixlHelper::convert(request.getOp()), NixlHelper::convertXferDist(coalescedSrc),
-                NixlHelper::convertXferDist(coalescedDst), request.getRemoteName(), handle, &reqParams);
-    }
-    else
-    {
-        status = mRawAgent->createXferReq(NixlHelper::convert(request.getOp()), NixlHelper::convertXferDist(splitSrc),
-            NixlHelper::convertXferDist(splitDst), request.getRemoteName(), handle, &reqParams);
+        NVTX3_SCOPED_RANGE(createXferReq);
+        status = mRawAgent->createXferReq(NixlHelper::convert(request.getOp()), NixlHelper::convertXferDist(xferSrc),
+            NixlHelper::convertXferDist(xferDst), request.getRemoteName(), handle, &reqParams);
     }
 
     TLLM_CHECK_WITH_INFO(status == NIXL_SUCCESS,

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
@@ -39,21 +39,6 @@ struct NixlHelper
     [[nodiscard]] static nixl_xfer_dlist_t convertXferDist(FileDescs const& descs);
     static void posixGpuToFileFallback(MemoryDescs const& memoryDesc, FileDescs const& fileDescs);
     static void posixFileToGpuFallback(MemoryDescs const& memoryDesc, FileDescs const& fileDescs);
-
-    /// @brief Coalesce contiguous memory regions to reduce memory registration overhead.
-    /// Adjacent memory regions with the same deviceId will be merged into a single region.
-    /// @param descs Memory descriptors to coalesce
-    /// @return Coalesced MemoryDescs
-    [[nodiscard]] static MemoryDescs coalesceMemoryDescs(MemoryDescs const& descs);
-
-    /// @brief Coalesce contiguous memory regions in src and dst to reduce transfer count.
-    /// If src[i] and src[i+1] are contiguous, and dst[i] and dst[i+1] are also contiguous
-    /// (with same deviceId), they will be merged into a single transfer.
-    /// @param srcDescs Source memory descriptors
-    /// @param dstDescs Destination memory descriptors
-    /// @return Pair of coalesced (src, dst) MemoryDescs
-    [[nodiscard]] static std::pair<MemoryDescs, MemoryDescs> coalesceTransferDescs(
-        TransferDescs const& srcDescs, TransferDescs const& dstDescs);
 };
 
 class NixlTransferStatus final : public TransferStatus

--- a/cpp/tensorrt_llm/executor/cache_transmission/transferAgent.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/transferAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +19,10 @@
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/serializeUtils.h"
 
+#include <algorithm>
 #include <cuda.h>
 #include <dlfcn.h>
+#include <numeric>
 #include <sstream>
 
 namespace tensorrt_llm::executor::kv_cache
@@ -152,8 +154,9 @@ MemoryDescs VmmDescSplitter::splitDescsWithRegionMap(MemoryDescs const& descs, V
     return MemoryDescs{descs.getType(), std::move(result)};
 }
 
-std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitTransferDescsWithRegionMaps(MemoryDescs const& srcDescs,
-    MemoryDescs const& dstDescs, VramRegionMap const& localRegionMap, VramRegionMap const& remoteRegionMap)
+std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitAndCoalesceTransferDescs(MemoryDescs const& srcDescs,
+    MemoryDescs const& dstDescs, VramRegionMap const& localRegionMap, VramRegionMap const& remoteRegionMap,
+    bool enableCoalesce)
 {
     if (srcDescs.getType() != MemoryType::kVRAM)
         return {srcDescs, dstDescs};
@@ -161,54 +164,138 @@ std::pair<MemoryDescs, MemoryDescs> VmmDescSplitter::splitTransferDescsWithRegio
     auto const& srcVec = srcDescs.getDescs();
     auto const& dstVec = dstDescs.getDescs();
     TLLM_CHECK(srcVec.size() == dstVec.size());
+    if (srcVec.empty())
+        return {srcDescs, dstDescs};
 
-    std::vector<MemoryDesc> splitSrc, splitDst;
-    splitSrc.reserve(srcVec.size());
-    splitDst.reserve(dstVec.size());
-
-    for (size_t i = 0; i < srcVec.size(); ++i)
+    // Sort pair indices by (src deviceId, src addr) so pairs that are contiguous in memory become
+    // adjacent, maximizing coalescing regardless of input order. Pairs are independent transfers,
+    // so reordering is safe. The sort only serves coalescing; with it disabled, keep input order.
+    std::vector<size_t> order(srcVec.size());
+    std::iota(order.begin(), order.end(), 0);
+    if (enableCoalesce)
     {
-        auto [srcChunkSize, srcBase] = lookupChunkInfo(srcVec[i].getAddr(), localRegionMap);
-        auto [dstChunkSize, dstBase] = lookupChunkInfo(dstVec[i].getAddr(), remoteRegionMap);
+        std::sort(order.begin(), order.end(),
+            [&srcVec](size_t lhs, size_t rhs)
+            {
+                if (srcVec[lhs].getDeviceId() != srcVec[rhs].getDeviceId())
+                {
+                    return srcVec[lhs].getDeviceId() < srcVec[rhs].getDeviceId();
+                }
+                return srcVec[lhs].getAddr() < srcVec[rhs].getAddr();
+            });
+    }
 
-        // If neither side is multi-chunk VMM, no splitting is needed.
-        if (srcChunkSize == 0 && dstChunkSize == 0)
+    std::vector<MemoryDesc> outSrc, outDst;
+    outSrc.reserve(srcVec.size());
+    outDst.reserve(dstVec.size());
+
+    // Region info of the last emitted piece. Invariant: every emitted desc lies within a single
+    // chunk on both sides, so a merge is legal iff the new piece is contiguous, in the same region,
+    // and does not start on a chunk boundary (starting on a boundary means the merge would cross it).
+    size_t prevSrcChunkSize = 0, prevDstChunkSize = 0;
+    uintptr_t prevSrcBase = 0, prevDstBase = 0;
+
+    auto emitPiece = [&](uintptr_t srcAddr, uintptr_t dstAddr, size_t len, uint32_t srcDev, uint32_t dstDev,
+                         size_t srcChunkSize, uintptr_t srcBase, size_t dstChunkSize, uintptr_t dstBase)
+    {
+        if (enableCoalesce && !outSrc.empty())
         {
-            splitSrc.push_back(srcVec[i]);
-            splitDst.push_back(dstVec[i]);
-            continue;
+            auto const& lastSrc = outSrc.back();
+            auto const& lastDst = outDst.back();
+            bool contiguous = lastSrc.getAddr() + lastSrc.getLen() == srcAddr && lastSrc.getDeviceId() == srcDev
+                && lastDst.getAddr() + lastDst.getLen() == dstAddr && lastDst.getDeviceId() == dstDev;
+            bool sameSrcRegion = srcChunkSize == prevSrcChunkSize && srcBase == prevSrcBase;
+            bool sameDstRegion = dstChunkSize == prevDstChunkSize && dstBase == prevDstBase;
+            bool srcWithinChunk = srcChunkSize == 0 || (srcAddr - srcBase) % srcChunkSize != 0;
+            bool dstWithinChunk = dstChunkSize == 0 || (dstAddr - dstBase) % dstChunkSize != 0;
+            if (contiguous && sameSrcRegion && sameDstRegion && srcWithinChunk && dstWithinChunk)
+            {
+                outSrc.back() = MemoryDesc{lastSrc.getAddr(), lastSrc.getLen() + len, srcDev};
+                outDst.back() = MemoryDesc{lastDst.getAddr(), lastDst.getLen() + len, dstDev};
+                return;
+            }
         }
+        outSrc.emplace_back(srcAddr, len, srcDev);
+        outDst.emplace_back(dstAddr, len, dstDev);
+        prevSrcChunkSize = srcChunkSize;
+        prevSrcBase = srcBase;
+        prevDstChunkSize = dstChunkSize;
+        prevDstBase = dstBase;
+    };
 
-        uintptr_t srcAddr = srcVec[i].getAddr();
-        uintptr_t dstAddr = dstVec[i].getAddr();
-        size_t remaining = srcVec[i].getLen();
+    // One-entry region cache per side: after sorting, consecutive pairs almost always fall in the
+    // same region (typically one KV pool), so the O(log R) map lookup is skipped on cache hits.
+    struct RegionCache
+    {
+        uintptr_t base = 0;
+        size_t totalLen = 0;
+        size_t chunkSize = 0;
+        bool valid = false;
+    };
+
+    auto cachedLookup = [](uintptr_t addr, VramRegionMap const& regionMap, RegionCache& cache)
+    {
+        if (cache.valid && addr >= cache.base && addr - cache.base < cache.totalLen)
+        {
+            return std::pair<size_t, uintptr_t>{cache.chunkSize, cache.base};
+        }
+        auto it = regionMap.upper_bound(addr);
+        if (it != regionMap.begin())
+        {
+            --it;
+            if (addr >= it->first && addr - it->first < it->second.totalLen)
+            {
+                cache = {it->first, it->second.totalLen, it->second.chunkSize, true};
+                return std::pair<size_t, uintptr_t>{cache.chunkSize, cache.base};
+            }
+        }
+        return std::pair<size_t, uintptr_t>{0, 0};
+    };
+
+    RegionCache srcCache, dstCache;
+    size_t numPieces = 0;
+    for (size_t idx : order)
+    {
+        auto const& src = srcVec[idx];
+        auto const& dst = dstVec[idx];
+        auto [srcChunkSize, srcBase] = cachedLookup(src.getAddr(), localRegionMap, srcCache);
+        auto [dstChunkSize, dstBase] = cachedLookup(dst.getAddr(), remoteRegionMap, dstCache);
+
+        uintptr_t srcAddr = src.getAddr();
+        uintptr_t dstAddr = dst.getAddr();
+        size_t remaining = src.getLen();
 
         while (remaining > 0)
         {
             size_t srcPieceSize = remaining;
             if (srcChunkSize > 0)
             {
-                size_t srcOffsetInChunk = static_cast<size_t>((srcAddr - srcBase) % srcChunkSize);
-                srcPieceSize = srcChunkSize - srcOffsetInChunk;
+                srcPieceSize = srcChunkSize - static_cast<size_t>((srcAddr - srcBase) % srcChunkSize);
             }
 
             size_t dstPieceSize = remaining;
             if (dstChunkSize > 0)
             {
-                size_t dstOffsetInChunk = static_cast<size_t>((dstAddr - dstBase) % dstChunkSize);
-                dstPieceSize = dstChunkSize - dstOffsetInChunk;
+                dstPieceSize = dstChunkSize - static_cast<size_t>((dstAddr - dstBase) % dstChunkSize);
             }
 
             size_t pieceSize = std::min({remaining, srcPieceSize, dstPieceSize});
-            splitSrc.emplace_back(srcAddr, pieceSize, srcVec[i].getDeviceId());
-            splitDst.emplace_back(dstAddr, pieceSize, dstVec[i].getDeviceId());
+            emitPiece(srcAddr, dstAddr, pieceSize, src.getDeviceId(), dst.getDeviceId(), srcChunkSize, srcBase,
+                dstChunkSize, dstBase);
             srcAddr += pieceSize;
             dstAddr += pieceSize;
             remaining -= pieceSize;
+            ++numPieces;
         }
     }
 
-    return {MemoryDescs{srcDescs.getType(), std::move(splitSrc)}, MemoryDescs{dstDescs.getType(), std::move(splitDst)}};
+    if (outSrc.size() != srcVec.size())
+    {
+        TLLM_LOG_DEBUG("VmmDescSplitter::splitAndCoalesceTransferDescs: %zu pairs -> %zu pieces -> %zu transfers",
+            srcVec.size(), numPieces, outSrc.size());
+    }
+
+    return {MemoryDescs{srcDescs.getType(), std::move(outSrc)}, MemoryDescs{dstDescs.getType(), std::move(outDst)}};
 }
 
 MemoryDescs VmmDescSplitter::splitVmmDescs(MemoryDescs const& descs, size_t& detectedChunkSize)

--- a/cpp/tests/unit_tests/executor/CMakeLists.txt
+++ b/cpp/tests/unit_tests/executor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION &
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION &
 # AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -34,6 +34,7 @@ add_gtest(requestWithIdTest requestWithIdTest.cpp)
 add_gtest(loraConfigTest loraConfigTest.cpp)
 add_gtest(intervalSetTest intervalSetTest.cpp)
 add_gtest(dynamicBatchTunerTest dynamicBatchTunerTest.cpp)
+add_gtest(coalesceTest coalesceTest.cpp)
 add_gtest(genUniqueAgentNameTest genUniqueAgentNameTest.cpp)
 target_link_libraries(genUniqueAgentNameTest PRIVATE ${Python3_LIBRARIES})
 add_gtest(ucxCommTest ucxCommTest.cpp)
@@ -56,10 +57,6 @@ if(NIXL_ROOT OR (MOONCAKE_ROOT AND NOT IS_ROCKY8))
                                                 ${Python3_LIBRARIES})
     target_compile_definitions(transferAgentTest PRIVATE TEST_NIXL_BACKEND=1)
     target_compile_definitions(agentCommTest PRIVATE TEST_NIXL_BACKEND=1)
-
-    add_gtest(coalesceTest coalesceTest.cpp)
-    target_link_libraries(coalesceTest PRIVATE tensorrt_llm_nixl_wrapper
-                                               NIXL::nixl)
   endif()
 
   if(MOONCAKE_ROOT)

--- a/cpp/tests/unit_tests/executor/coalesceTest.cpp
+++ b/cpp/tests/unit_tests/executor/coalesceTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,154 +15,50 @@
  * limitations under the License.
  */
 
-#include "tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h"
+#include "tensorrt_llm/executor/transferAgent.h"
 #include <gtest/gtest.h>
 
 using namespace tensorrt_llm::executor::kv_cache;
 
-// ==================== coalesceMemoryDescs tests ====================
-
-TEST(CoalesceMemoryDescsTest, EmptyInput)
+namespace
 {
-    MemoryDescs descs{MemoryType::kVRAM, {}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    EXPECT_EQ(result.getDescs().size(), 0);
-}
+VramRegionMap const kEmptyMap;
 
-TEST(CoalesceMemoryDescsTest, SingleEntry)
+std::pair<MemoryDescs, MemoryDescs> run(TransferDescs const& src, TransferDescs const& dst,
+    VramRegionMap const& localMap = kEmptyMap, VramRegionMap const& remoteMap = kEmptyMap)
 {
-    MemoryDescs descs{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 1);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 256);
-    EXPECT_EQ(result.getDescs()[0].getDeviceId(), 0);
+    return VmmDescSplitter::splitAndCoalesceTransferDescs(src, dst, localMap, remoteMap);
 }
+} // namespace
 
-TEST(CoalesceMemoryDescsTest, TwoContiguous)
-{
-    // [0x1000, 256) then [0x1100, 256) — adjacent, should merge into one
-    MemoryDescs descs{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 1);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 512);
-    EXPECT_EQ(result.getDescs()[0].getDeviceId(), 0);
-}
+// ==================== pure coalescing (no region maps) ====================
 
-TEST(CoalesceMemoryDescsTest, TwoNonContiguous)
-{
-    // Gap between blocks — should stay as two
-    MemoryDescs descs{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x2000, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 2);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 256);
-    EXPECT_EQ(result.getDescs()[1].getAddr(), 0x2000);
-    EXPECT_EQ(result.getDescs()[1].getLen(), 256);
-}
-
-TEST(CoalesceMemoryDescsTest, ThreeContiguous)
-{
-    MemoryDescs descs{
-        MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1200, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 1);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 768);
-}
-
-TEST(CoalesceMemoryDescsTest, UnsortedInput)
-{
-    // Same three contiguous blocks but in reverse order — sorting should fix it
-    MemoryDescs descs{
-        MemoryType::kVRAM, {MemoryDesc{0x1200, 256, 0}, MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 1);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 768);
-}
-
-TEST(CoalesceMemoryDescsTest, DifferentDevices)
-{
-    // Contiguous addresses but different devices — should NOT merge
-    MemoryDescs descs{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 1}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 2);
-}
-
-TEST(CoalesceMemoryDescsTest, MixedContiguousAndGaps)
-{
-    // First two are contiguous, then a gap before the third
-    MemoryDescs descs{
-        MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x3000, 128, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 2);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 512);
-    EXPECT_EQ(result.getDescs()[1].getAddr(), 0x3000);
-    EXPECT_EQ(result.getDescs()[1].getLen(), 128);
-}
-
-TEST(CoalesceMemoryDescsTest, MultipleDevicesEachContiguous)
-{
-    // Two contiguous on device 0, two contiguous on device 1
-    MemoryDescs descs{MemoryType::kVRAM,
-        {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x2000, 128, 1},
-            MemoryDesc{0x2080, 128, 1}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 2);
-    EXPECT_EQ(result.getDescs()[0].getAddr(), 0x1000);
-    EXPECT_EQ(result.getDescs()[0].getLen(), 512);
-    EXPECT_EQ(result.getDescs()[0].getDeviceId(), 0);
-    EXPECT_EQ(result.getDescs()[1].getAddr(), 0x2000);
-    EXPECT_EQ(result.getDescs()[1].getLen(), 256);
-    EXPECT_EQ(result.getDescs()[1].getDeviceId(), 1);
-}
-
-TEST(CoalesceMemoryDescsTest, PreservesMemoryType)
-{
-    MemoryDescs descs{MemoryType::kDRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    EXPECT_EQ(result.getType(), MemoryType::kDRAM);
-}
-
-TEST(CoalesceMemoryDescsTest, AllSeparate)
-{
-    // Nothing can be merged — all have gaps
-    MemoryDescs descs{MemoryType::kVRAM,
-        {MemoryDesc{0x1000, 100, 0}, MemoryDesc{0x2000, 100, 0}, MemoryDesc{0x3000, 100, 0},
-            MemoryDesc{0x4000, 100, 0}}};
-    auto result = NixlHelper::coalesceMemoryDescs(descs);
-    ASSERT_EQ(result.getDescs().size(), 4);
-}
-
-// ==================== coalesceTransferDescs tests ====================
-
-TEST(CoalesceTransferDescsTest, EmptyInput)
+TEST(SplitAndCoalesceTest, EmptyInput)
 {
     TransferDescs src{MemoryType::kVRAM, {}};
     TransferDescs dst{MemoryType::kVRAM, {}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     EXPECT_EQ(resSrc.getDescs().size(), 0);
     EXPECT_EQ(resDst.getDescs().size(), 0);
 }
 
-TEST(CoalesceTransferDescsTest, SinglePair)
+TEST(SplitAndCoalesceTest, SinglePair)
 {
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x5000);
 }
 
-TEST(CoalesceTransferDescsTest, BothSidesContiguous)
+TEST(SplitAndCoalesceTest, BothSidesContiguous)
 {
     // src contiguous AND dst contiguous — should merge into one transfer
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
@@ -171,98 +67,79 @@ TEST(CoalesceTransferDescsTest, BothSidesContiguous)
     EXPECT_EQ(resDst.getDescs()[0].getLen(), 512);
 }
 
-TEST(CoalesceTransferDescsTest, SrcContiguousDstNot)
+TEST(SplitAndCoalesceTest, SrcContiguousDstNot)
 {
-    // src is contiguous but dst has a gap — can't merge
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x6000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
 
-TEST(CoalesceTransferDescsTest, DstContiguousSrcNot)
+TEST(SplitAndCoalesceTest, DstContiguousSrcNot)
 {
-    // dst is contiguous but src has a gap — can't merge
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x2000, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
 
-TEST(CoalesceTransferDescsTest, DifferentDevicesOnSrc)
+TEST(SplitAndCoalesceTest, DifferentDevicesOnSrc)
 {
-    // src addresses look contiguous but are on different devices — can't merge
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 1}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 0}, MemoryDesc{0x5100, 256, 0}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
 
-TEST(CoalesceTransferDescsTest, DifferentDevicesOnDst)
+TEST(SplitAndCoalesceTest, DifferentDevicesOnDst)
 {
-    // dst addresses look contiguous but are on different devices — can't merge
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 0}, MemoryDesc{0x5100, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
 }
 
-TEST(CoalesceTransferDescsTest, MismatchedSizes)
-{
-    // src has 2 entries, dst has 1 — sizes don't match, return as-is
-    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
-    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
-    ASSERT_EQ(resSrc.getDescs().size(), 2);
-    ASSERT_EQ(resDst.getDescs().size(), 1);
-}
-
-TEST(CoalesceTransferDescsTest, ThreePairsAllContiguous)
+TEST(SplitAndCoalesceTest, ThreePairsAllContiguous)
 {
     TransferDescs src{
         MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1200, 256, 0}}};
     TransferDescs dst{
         MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}, MemoryDesc{0x5200, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getLen(), 768);
     EXPECT_EQ(resDst.getDescs()[0].getLen(), 768);
 }
 
-TEST(CoalesceTransferDescsTest, PartialMerge)
+TEST(SplitAndCoalesceTest, PartialMerge)
 {
-    // First two pairs: both sides contiguous — merge
-    // Third pair: src contiguous but dst has gap — stays separate
+    // First two pairs merge; third pair's dst has a gap — stays separate
     TransferDescs src{
         MemoryType::kVRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1200, 256, 0}}};
     TransferDescs dst{
         MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 1}, MemoryDesc{0x5100, 256, 1}, MemoryDesc{0x9000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 2);
     ASSERT_EQ(resDst.getDescs().size(), 2);
-    // Merged pair
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
     EXPECT_EQ(resSrc.getDescs()[0].getLen(), 512);
     EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x5000);
     EXPECT_EQ(resDst.getDescs()[0].getLen(), 512);
-    // Separate pair
     EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x1200);
-    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 256);
     EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0x9000);
-    EXPECT_EQ(resDst.getDescs()[1].getLen(), 256);
 }
 
-TEST(CoalesceTransferDescsTest, UnsortedInput)
+TEST(SplitAndCoalesceTest, UnsortedInput)
 {
-    // Same as BothSidesContiguous but in reverse order — sorting should fix it
+    // Same as BothSidesContiguous but in reverse order — sorting by src addr should fix it
     TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1100, 256, 0}, MemoryDesc{0x1000, 256, 0}}};
     TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5100, 256, 1}, MemoryDesc{0x5000, 256, 1}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    auto [resSrc, resDst] = run(src, dst);
     ASSERT_EQ(resSrc.getDescs().size(), 1);
     ASSERT_EQ(resDst.getDescs().size(), 1);
     EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x1000);
@@ -271,11 +148,224 @@ TEST(CoalesceTransferDescsTest, UnsortedInput)
     EXPECT_EQ(resDst.getDescs()[0].getLen(), 512);
 }
 
-TEST(CoalesceTransferDescsTest, PreservesMemoryType)
+TEST(SplitAndCoalesceTest, NonVramPassthrough)
 {
-    TransferDescs src{MemoryType::kDRAM, {MemoryDesc{0x1000, 256, 0}}};
-    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x5000, 256, 0}}};
-    auto [resSrc, resDst] = NixlHelper::coalesceTransferDescs(src, dst);
+    // Non-kVRAM descs pass through unchanged: no region info exists to bound a merge
+    TransferDescs src{MemoryType::kDRAM, {MemoryDesc{0x1000, 256, 0}, MemoryDesc{0x1100, 256, 0}}};
+    TransferDescs dst{MemoryType::kDRAM, {MemoryDesc{0x5000, 256, 0}, MemoryDesc{0x5100, 256, 0}}};
+    auto [resSrc, resDst] = run(src, dst);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
     EXPECT_EQ(resSrc.getType(), MemoryType::kDRAM);
-    EXPECT_EQ(resDst.getType(), MemoryType::kVRAM);
+}
+
+// ==================== chunk-boundary-constrained coalescing ====================
+
+TEST(SplitAndCoalesceTest, MergeStopsAtSrcChunkBoundary)
+{
+    // Local VMM region: base=0x100000, 4MB total, 2MB chunks → boundary at 0x300000.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x400000, 0x200000};
+
+    // Four contiguous 1MB pairs covering 4MB on both sides; dst has no region info.
+    std::vector<MemoryDesc> srcVec, dstVec;
+    for (size_t i = 0; i < 4; ++i)
+    {
+        srcVec.emplace_back(0x100000 + i * 0x100000, 0x100000, 0);
+        dstVec.emplace_back(0x900000 + i * 0x100000, 0x100000, 1);
+    }
+    TransferDescs src{MemoryType::kVRAM, srcVec};
+    TransferDescs dst{MemoryType::kVRAM, dstVec};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    // Merged per src chunk: two 2MB transfers, split exactly at the chunk boundary.
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x200000);
+    EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x300000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x200000);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x900000);
+    EXPECT_EQ(resDst.getDescs()[0].getLen(), 0x200000);
+    EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0xB00000);
+    EXPECT_EQ(resDst.getDescs()[1].getLen(), 0x200000);
+}
+
+TEST(SplitAndCoalesceTest, MergeStopsAtDstChunkBoundary)
+{
+    // Remote VMM region: base=0x800000, 1MB chunks → boundary at 0x900000.
+    VramRegionMap remoteMap;
+    remoteMap[0x800000] = {0x400000, 0x100000};
+
+    // Two contiguous pairs whose dst junction sits exactly on the remote chunk boundary.
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x1000, 0x80000, 0}, MemoryDesc{0x81000, 0x80000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x880000, 0x80000, 1}, MemoryDesc{0x900000, 0x80000, 1}}};
+
+    // Without the remote map they would merge into one transfer...
+    {
+        auto [resSrc, resDst] = run(src, dst);
+        ASSERT_EQ(resSrc.getDescs().size(), 1);
+        ASSERT_EQ(resDst.getDescs().size(), 1);
+    }
+    // ...but the dst chunk boundary must block the merge.
+    auto [resSrc, resDst] = run(src, dst, kEmptyMap, remoteMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x880000);
+    EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0x900000);
+}
+
+TEST(SplitAndCoalesceTest, SplitPiecesAreNotRemerged)
+{
+    // A single pair spanning two src chunks stays split even though the pieces are contiguous.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x400000, 0x100000};
+
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x200000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x200000, 1}}};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x100000);
+}
+
+TEST(SplitAndCoalesceTest, UnalignedRegionBaseBoundary)
+{
+    // Chunk boundaries are relative to the region base, not absolute alignment.
+    // base=0x180000, 1MB chunks → boundaries at 0x280000, 0x380000, ...
+    VramRegionMap localMap;
+    localMap[0x180000] = {0x300000, 0x100000};
+
+    // Three contiguous 512KB pairs: first two share the first chunk, third starts a new chunk.
+    std::vector<MemoryDesc> srcVec, dstVec;
+    for (size_t i = 0; i < 3; ++i)
+    {
+        srcVec.emplace_back(0x180000 + i * 0x80000, 0x80000, 0);
+        dstVec.emplace_back(0x900000 + i * 0x80000, 0x80000, 1);
+    }
+    TransferDescs src{MemoryType::kVRAM, srcVec};
+    TransferDescs dst{MemoryType::kVRAM, dstVec};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x180000);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x280000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x80000);
+}
+
+TEST(SplitAndCoalesceTest, NoMergeAcrossRegions)
+{
+    // Two VA-adjacent but distinct local regions (cudaMalloc-style, chunkSize=0):
+    // contiguous descs must not merge across the region boundary.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x100000, 0};
+    localMap[0x200000] = {0x100000, 0};
+
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x100000, 0}, MemoryDesc{0x200000, 0x100000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x100000, 1}, MemoryDesc{0xA00000, 0x100000, 1}}};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+}
+
+TEST(SplitAndCoalesceTest, MergeWithinSingleRegion)
+{
+    // Control for NoMergeAcrossRegions: same layout as one region (chunkSize=0) merges freely.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x200000, 0};
+
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x100000, 0}, MemoryDesc{0x200000, 0x100000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x100000, 1}, MemoryDesc{0xA00000, 0x100000, 1}}};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 1);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x200000);
+    EXPECT_EQ(resDst.getDescs()[0].getLen(), 0x200000);
+}
+
+TEST(SplitAndCoalesceTest, NoMergeAcrossRemoteRegions)
+{
+    // The remote side registered two discrete but VA-adjacent buffers (chunkSize=0 each):
+    // contiguous dst descs must not merge across the remote registration boundary.
+    VramRegionMap remoteMap;
+    remoteMap[0x900000] = {0x100000, 0};
+    remoteMap[0xA00000] = {0x100000, 0};
+
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x100000, 0x100000, 0}, MemoryDesc{0x200000, 0x100000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x900000, 0x100000, 1}, MemoryDesc{0xA00000, 0x100000, 1}}};
+
+    auto [resSrc, resDst] = run(src, dst, kEmptyMap, remoteMap);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    ASSERT_EQ(resDst.getDescs().size(), 2);
+}
+
+TEST(SplitAndCoalesceTest, CoalesceDisabledSplitsOnly)
+{
+    // With coalescing disabled, contiguous pairs stay separate and chunk splitting still applies.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x400000, 0x100000};
+
+    // Two contiguous 512KB pairs within one chunk plus one pair spanning a chunk boundary.
+    TransferDescs src{MemoryType::kVRAM,
+        {MemoryDesc{0x100000, 0x80000, 0}, MemoryDesc{0x180000, 0x80000, 0}, MemoryDesc{0x200000, 0x200000, 0}}};
+    TransferDescs dst{MemoryType::kVRAM,
+        {MemoryDesc{0x900000, 0x80000, 1}, MemoryDesc{0x980000, 0x80000, 1}, MemoryDesc{0xA00000, 0x200000, 1}}};
+
+    auto [resSrc, resDst]
+        = VmmDescSplitter::splitAndCoalesceTransferDescs(src, dst, localMap, kEmptyMap, /*enableCoalesce=*/false);
+    // No merging: pair 1, pair 2, and pair 3 split into two chunk pieces → 4 descs.
+    ASSERT_EQ(resSrc.getDescs().size(), 4);
+    ASSERT_EQ(resDst.getDescs().size(), 4);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x80000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x80000);
+    EXPECT_EQ(resSrc.getDescs()[2].getLen(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[3].getLen(), 0x100000);
+}
+
+TEST(SplitAndCoalesceTest, CoalesceDisabledPreservesInputOrder)
+{
+    // With coalescing disabled there is no sorting either: descs come out in input order,
+    // matching the historical split-only behavior.
+    TransferDescs src{MemoryType::kVRAM, {MemoryDesc{0x2000, 256, 0}, MemoryDesc{0x1000, 256, 0}}};
+    TransferDescs dst{MemoryType::kVRAM, {MemoryDesc{0x6000, 256, 1}, MemoryDesc{0x5000, 256, 1}}};
+
+    auto [resSrc, resDst]
+        = VmmDescSplitter::splitAndCoalesceTransferDescs(src, dst, kEmptyMap, kEmptyMap, /*enableCoalesce=*/false);
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x2000);
+    EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x1000);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x6000);
+    EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0x5000);
+}
+
+TEST(SplitAndCoalesceTest, SplitAndMergeScatteredBlocks)
+{
+    // Scattered input order + chunked src region: blocks are sorted, merged per chunk.
+    // base=0x100000, 1MB chunks; four 512KB blocks given out of order.
+    VramRegionMap localMap;
+    localMap[0x100000] = {0x400000, 0x100000};
+
+    std::vector<size_t> perm{2, 0, 3, 1};
+    std::vector<MemoryDesc> srcVec, dstVec;
+    for (size_t i : perm)
+    {
+        srcVec.emplace_back(0x100000 + i * 0x80000, 0x80000, 0);
+        dstVec.emplace_back(0x900000 + i * 0x80000, 0x80000, 1);
+    }
+    TransferDescs src{MemoryType::kVRAM, srcVec};
+    TransferDescs dst{MemoryType::kVRAM, dstVec};
+
+    auto [resSrc, resDst] = run(src, dst, localMap);
+    // 2MB of contiguous data over two 1MB chunks → one transfer per chunk.
+    ASSERT_EQ(resSrc.getDescs().size(), 2);
+    EXPECT_EQ(resSrc.getDescs()[0].getAddr(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[0].getLen(), 0x100000);
+    EXPECT_EQ(resSrc.getDescs()[1].getAddr(), 0x200000);
+    EXPECT_EQ(resSrc.getDescs()[1].getLen(), 0x100000);
+    EXPECT_EQ(resDst.getDescs()[0].getAddr(), 0x900000);
+    EXPECT_EQ(resDst.getDescs()[1].getAddr(), 0xA00000);
 }

--- a/cpp/tests/unit_tests/executor/transferAgentTest.cpp
+++ b/cpp/tests/unit_tests/executor/transferAgentTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -702,8 +702,7 @@ TEST(VmmDescSplitterTest, SplitTransferDescsDifferentChunkSizes)
     MemoryDescs srcInput{MemoryType::kVRAM, srcDescs};
     MemoryDescs dstInput{MemoryType::kVRAM, dstDescs};
 
-    auto [splitSrc, splitDst]
-        = VmmDescSplitter::splitTransferDescsWithRegionMaps(srcInput, dstInput, localMap, remoteMap);
+    auto [splitSrc, splitDst] = VmmDescSplitter::splitAndCoalesceTransferDescs(srcInput, dstInput, localMap, remoteMap);
 
     // dst has smaller chunks (512KB), so we get 4 pieces: 512K, 512K, 512K, 512K
     ASSERT_EQ(splitSrc.getDescs().size(), 4);
@@ -735,8 +734,7 @@ TEST(VmmDescSplitterTest, SplitTransferDescsUnalignedBothSides)
     MemoryDescs srcInput{MemoryType::kVRAM, srcDescs};
     MemoryDescs dstInput{MemoryType::kVRAM, dstDescs};
 
-    auto [splitSrc, splitDst]
-        = VmmDescSplitter::splitTransferDescsWithRegionMaps(srcInput, dstInput, localMap, remoteMap);
+    auto [splitSrc, splitDst] = VmmDescSplitter::splitAndCoalesceTransferDescs(srcInput, dstInput, localMap, remoteMap);
 
     // src has 4MB chunks starting at srcBase → 1 piece from src side
     // dst has 2MB chunks starting at dstBase → 2 pieces from dst side
@@ -760,7 +758,7 @@ TEST(VmmDescSplitterTest, SplitTransferDescsNoDstRegion)
     MemoryDescs dstInput{MemoryType::kVRAM, dstDescs};
 
     auto [splitSrc, splitDst]
-        = VmmDescSplitter::splitTransferDescsWithRegionMaps(srcInput, dstInput, localMap, emptyRemoteMap);
+        = VmmDescSplitter::splitAndCoalesceTransferDescs(srcInput, dstInput, localMap, emptyRemoteMap);
 
     // Only src boundaries: 2 pieces of 1MB each
     ASSERT_EQ(splitSrc.getDescs().size(), 2);

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """KV cache management for MiniMax-M3 sparse attention.
 
 Provides:
@@ -13,21 +25,17 @@ Provides:
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import torch
 
-from tensorrt_llm._utils import (
-    TensorWrapper,
-    binding_to_torch_dtype,
-    convert_to_torch_tensor,
-    prefer_pinned,
-)
+from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
+from tensorrt_llm._utils import TensorWrapper, binding_to_torch_dtype, convert_to_torch_tensor
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
-from tensorrt_llm.runtime.kv_cache_manager_v2 import BufferConfig, LayerId
+from tensorrt_llm.runtime.kv_cache_manager_v2 import BufferConfig
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX
-from tensorrt_llm.runtime.kv_cache_manager_v2._utils import typed_range
+from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
 
 from ....pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2, Role
 
@@ -176,6 +184,15 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
 
         super().__init__(*args, **kwargs)
 
+        index_v_layer_ids = set(self.sparse_layer_ids) - self.disable_index_value_layer_ids
+        if self.is_disagg and index_v_layer_ids:
+            raise ValueError(
+                "MiniMax M3 disaggregated serving requires disable_index_value=True "
+                "for every sparse layer because the optional test-only index-V cache "
+                "is not managed or transferred by KVCacheManagerV2; enabled layers="
+                f"{sorted(index_v_layer_ids)}"
+            )
+
         # Optional plain-tensor index-V cache for non-disabled sparse
         # layers (test-only; production has disable_index_value=True
         # on every sparse layer).
@@ -210,6 +227,13 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
             self.layer_offsets[layer_id]: [BufferConfig(role=Role.INDEX_KEY, size=size_per_block)]
             for layer_id in self.sparse_layer_ids
             if layer_id in self.layer_offsets
+        }
+
+    def get_disagg_role_mapper_kinds(self) -> dict[DataRole, MapperKind]:
+        """Declare MiniMax M3's token-major K/V and replicated index-K."""
+        return {
+            Role.ALL: MapperKind.NHD,
+            Role.INDEX_KEY: MapperKind.REPLICATED,
         }
 
     def _compute_num_total_slots(self) -> int:
@@ -260,12 +284,12 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
 
         The base :meth:`KVCacheManagerV2.get_buffers` produces a
         ``[num_pages, kv_factor, ...]`` view with contiguous strides
-        that assume each slot contains exactly K+V. With INDEX_KEY
-        registered, sparse layers may have ``scale > 2`` per-slot
-        buffers (e.g. M3 TP=8 coalesces K, V, INDEX_K into one pool
-        where ``scale == 3 * num_sparse + 2 * num_dense``), and the
-        base view's dim-0 stride no longer reaches the next slot's K
-        for this layer.
+        that assume the slot holds exactly one layer's K+V. In M3's
+        pool the slot packs K+V for *all* layers of the group
+        (``scale >= 2 * num_layers_in_group``), so the base view's
+        dim-0 stride does not reach the next slot's K for this layer.
+        (When INDEX_KEY's per-block size coincides with K/V's, it is
+        coalesced into the same pool and contributes to ``scale`` too.)
 
         The override builds a ``[num_slots, scale, ...]`` view rooted
         at K's base, then slices ``[:, :2]`` to extract K+V. The slice
@@ -341,75 +365,20 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         full_view = convert_to_torch_tensor(TensorWrapper(addr_key, torch_dtype, full_slot_shape))
         return full_view[:, :2]
 
-    def _build_pool_mapping_tensors(self):
-        """Compute pool-mapping offsets from layer position in the pool group.
+    def _kv_pool_mapping_offset(self, layer_id, layer_group_id, key_base_addr) -> int:
+        """Pool-mapping offset from layer position in the pool group.
 
-        The base method does ``exact_div(addr_offset, key_bytes *
-        kv_factor * tokens_per_block)``, which assumes each layer
-        contributes exactly K+V. When INDEX_KEY coincidentally shares
-        the same per-block size as K/V (M3 production at TP=8: all
-        three are 256 B/token), V2 coalesces all three into one pool
-        and the per-layer stride becomes ``3 * single_buffer_size`` —
-        the base ``exact_div`` then asserts.
-
-        Compute ``offset`` directly from
-        ``self.impl.layer_grouping[group_id]`` so the formula stays
-        correct regardless of how many extra buffers coalesce with
-        K/V. The M3 forward path uses :meth:`get_buffers` /
+        The base formula ``exact_div(addr_offset, key_bytes * kv_factor *
+        tokens_per_block)`` assumes each layer contributes exactly K+V to
+        its pool slot. When index-K coalesces into the K/V pool the layer
+        stride is non-uniform (sparse layers add an INDEX_KEY sub-page),
+        so derive ``offset`` from ``self.impl.layer_grouping`` instead.
+        The M3 forward path uses :meth:`get_buffers` /
         :meth:`get_index_k_buffer` rather than this mapping, so the
         offset just needs to be consistent (layer position in group).
         """
-        kv_cache_pool_pointers = torch.tensor(
-            [
-                [
-                    self.impl.get_mem_pool_base_address(
-                        self.impl.layer_grouping[pool_id][0], Role.KEY
-                    ),
-                    0,
-                ]
-                for pool_id in range(self.num_pools)
-            ],
-            dtype=torch.int64,
-            device="cpu",
-            pin_memory=prefer_pinned(),
-        )
-
-        if self.dtype == DataType.NVFP4:
-            kv_cache_pool_pointers = torch.stack(
-                [
-                    kv_cache_pool_pointers,
-                    torch.tensor(
-                        [
-                            [
-                                self.impl.get_mem_pool_base_address(
-                                    self.impl.layer_grouping[pool_id][0], Role.KEY_BLOCK_SCALE
-                                ),
-                                0,
-                            ]
-                            for pool_id in range(self.num_pools)
-                        ],
-                        dtype=torch.int64,
-                        device="cpu",
-                        pin_memory=prefer_pinned(),
-                    ),
-                ],
-                dim=-1,
-            )
-
-        kv_cache_pool_mapping_list = []
-        for layer_id in typed_range(LayerId(self.num_local_layers)):
-            layer_group_id = self.impl.get_layer_group_id(layer_id)
-            layers_in_group = list(self.impl.layer_grouping[int(layer_group_id)])
-            offset = layers_in_group.index(int(layer_id))
-            kv_cache_pool_mapping_list.append([int(layer_group_id), offset])
-
-        kv_cache_pool_mapping = torch.tensor(
-            kv_cache_pool_mapping_list,
-            dtype=torch.int32,
-            device="cpu",
-            pin_memory=prefer_pinned(),
-        )
-        return kv_cache_pool_pointers, kv_cache_pool_mapping
+        layers_in_group = list(self.impl.layer_grouping[int(layer_group_id)])
+        return layers_in_group.index(int(layer_id))
 
     def _get_batch_cache_indices_by_pool_id(
         self,
@@ -417,34 +386,41 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         *,
         pool_id: int = 0,
         is_kv_aggregate: bool = True,
+        num_blocks_per_seq: Optional[Sequence[int]] = None,
     ):
-        """Return per-request slot ids in ``[0, num_slots)`` directly.
+        """Return page indices; padded entries remain ``BAD_PAGE_INDEX`` (-1).
 
         The base method converts slot ids to V1-style block ids via
         ``base_idx * index_scales[pool_id] // kv_factor``, which is
-        only correct when each layer contributes exactly K+V. With
-        INDEX_KEY-coalesced sparse pools (M3 production), the scale
-        breaks the V1 conversion and produces out-of-bounds block ids
-        during V2 warmup.
+        only correct when each layer contributes exactly K+V. M3's slot
+        packs K+V for all layers of the group, so the scale breaks the
+        V1 conversion and produces out-of-bounds block ids during V2
+        warmup.
 
         Bypass the conversion: the M3 forward path indexes paged
         views (built by :meth:`get_buffers` /
         :meth:`get_index_k_buffer`) directly by slot id.
-        ``BAD_PAGE_INDEX`` slots stay as 0 to match the legacy
-        padding contract.
+        ``BAD_PAGE_INDEX`` slots remain ``-1`` here because disaggregation's
+        :class:`KVRegionExtractorV1` filters ``region_ids >= 0``.
+        :meth:`get_block_ids_per_seq` maps them to zero for the attention
+        metadata's padded tensor.
+
+        Args:
+            request_ids: Request IDs whose page-index rows are returned.
+            pool_id: V2 pool whose page indices are requested.
+            is_kv_aggregate: Kept for compatibility with the base virtual method.
+            num_blocks_per_seq: Optional per-request truncation limits. When
+                omitted, preserve the full padded width required by MiniMax
+                CUDA-graph metadata initialization.
         """
         res = []
-        for req_id in request_ids:
-            idx_tensor = torch.as_tensor(self.kv_cache_map[req_id].get_base_page_indices(pool_id))
-            res.append(
-                (
-                    torch.where(
-                        idx_tensor != BAD_PAGE_INDEX,
-                        idx_tensor,
-                        torch.full_like(idx_tensor, BAD_PAGE_INDEX),
-                    )
-                ).tolist()
-            )
+        for req_idx, req_id in enumerate(request_ids):
+            kv_cache = self.kv_cache_map[req_id]
+            base_page_indices = kv_cache.get_base_page_indices(pool_id)
+            if num_blocks_per_seq is not None:
+                num_blocks = min(kv_cache.num_blocks, num_blocks_per_seq[req_idx])
+                base_page_indices = base_page_indices[:num_blocks]
+            res.append(list(base_page_indices))
         return res
 
     def get_block_ids_per_seq(self, request_ids):

--- a/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
@@ -1,3 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Sequence
+
 import numpy as np
 
 from tensorrt_llm import logger
@@ -12,107 +29,124 @@ from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._utils import nvtx_range
 
 
-class IdentityMapper(RegionMapperBase):
+class IntactMapper(RegionMapperBase):
     """
-    ---- mapper_identity ----
+    ---- mapper_intact ----
 
-    Pass-through mapping. Do not change pointers or sizes.
+    Copy the selected layers' class regions between slots. Consumes slot-base
+    pointers from the extractor and expands them with slot-relative per-layer
+    byte offsets taken from the logical view's buffer entries, so it handles
+    non-uniform layer strides (a slot may interleave other role classes
+    between this class's layers).
 
-    src_ptrs: [ S0 ] [ S1 ] [ S2 ] ...
-                |      |      |
-                v      v      v
-    dst_ptrs: [ D0 ] [ D1 ] [ D2 ] ...
-    """
+    src slot: [ base ]--+off(L2)--> [L2 region] --+off(L3)--> [L3 region] ...
+    dst slot: [ base ]--+off'(L2)-> [L2 region] --+off'(L3)-> [L3 region] ...
 
-    @nvtx_range("IdentityMapper.map")
-    def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
-        src_group = src_regions.memory
-        dst_group = dst_regions.memory
-        assert src_group.ptrs.size == dst_group.ptrs.size, (
-            f"Number of regions of src({src_group.ptrs.size}) and dst({dst_group.ptrs.size}) must match"
-        )
-        return SpecRegionPair(
-            src=SpecRegion(memory=src_group, spec=src_regions.spec),
-            dst=SpecRegion(memory=dst_group, spec=dst_regions.spec),
-        )
-
-
-class HeadMatchMapper(RegionMapperBase):
-    """
-    ---- mapper_head_match ----
-
-    Move/copy entire contiguous block(s) (multi-layer fragment) as a single chunk.
-    Align by whole fragment size (frag_size) and apply a constant source/destination block offset.
-
-    src_ptrs:  [ S0 ]         [ S1 ]          ...
-                 |              |
-              + src_off      + src_off
-                 |              |
-          [ S0 + src_off ] [ S1 + src_off ]   ->  (each points to a frag of size frag_size)
-                   copy whole frag
-                 |              |
-                 v              v
-          [ D0 + dst_off ] [ D1 + dst_off ]   ->  (destination frags)
-
-    Contiguous-layer assumption:
-        This mapper assumes that ``transfer_layers`` consecutive layers
-        starting at ``src_layer_off`` (and ``dst_layer_off``) are laid out
-        contiguously within each slot.  This holds because
-        ``buffer_attributes()`` in the storage config assigns buffer
-        offsets sequentially from 0 for each layer_group (life cycle),
-        and each PoolDescriptor only contains layers belonging to a single
-        layer_group.  Even when multiple layer_groups share the same
-        physical storage pool_group, each layer_group independently
-        occupies the full slot (offsets start from 0), so the contiguous
-        layout is preserved.
+    Layers whose regions are contiguous on BOTH sides are merged into one
+    fragment, so a fully contiguous class (e.g. K/V in a dedicated pool)
+    degrades to a single whole-region copy per block.
     """
 
     def __init__(
         self,
-        transfer_layers: int,
-        src_layer_off: int,
-        dst_layer_off: int,
-        self_ri: RankInfo,
-        peer_ri: RankInfo,
-        slot_size_per_layer: int,
-    ):
-        if not isinstance(slot_size_per_layer, int):
-            raise TypeError(
-                f"slot_size_per_layer must be int, got {type(slot_size_per_layer).__name__} "
-                f"(value={slot_size_per_layer}). Use // instead of / for integer division."
+        src_layer_offsets: Sequence[int] | np.ndarray,
+        dst_layer_offsets: Sequence[int] | np.ndarray,
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
+        *,
+        mapper_name: str = "Intact",
+    ) -> None:
+        if self_bytes_per_layer != peer_bytes_per_layer:
+            raise ValueError(
+                f"{mapper_name} cache region size mismatch: "
+                f"local={self_bytes_per_layer}, peer={peer_bytes_per_layer}"
             )
-        self._kv_factor = self_ri.attention.kv_factor
-        self._frag_size = self._block_size(transfer_layers, slot_size_per_layer=slot_size_per_layer)
-        self._src_block_off = self._block_size(
-            src_layer_off, slot_size_per_layer=slot_size_per_layer
-        )
-        self._dst_block_off = self._block_size(
-            dst_layer_off, slot_size_per_layer=slot_size_per_layer
-        )
+        src = np.asarray(src_layer_offsets, dtype=np.int64)
+        dst = np.asarray(dst_layer_offsets, dtype=np.int64)
+        if src.size == 0 or src.size != dst.size:
+            raise ValueError(
+                f"{mapper_name} layer offsets must be non-empty and equal-length: "
+                f"src={src.size}, dst={dst.size}"
+            )
+        self._runs = self._merge_contiguous(src, dst, self_bytes_per_layer)
 
-    @nvtx_range("HeadMatchMapper.map")
-    def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
+    @staticmethod
+    def _merge_contiguous(
+        src: np.ndarray, dst: np.ndarray, bytes_per_layer: int
+    ) -> list[tuple[int, int, int]]:
+        runs: list[tuple[int, int, int]] = []
+        run_start = 0
+        for i in range(1, src.size + 1):
+            if (
+                i == src.size
+                or src[i] != src[i - 1] + bytes_per_layer
+                or dst[i] != dst[i - 1] + bytes_per_layer
+            ):
+                run_layers = i - run_start
+                runs.append(
+                    (int(src[run_start]), int(dst[run_start]), run_layers * bytes_per_layer)
+                )
+                run_start = i
+        return runs
+
+    @nvtx_range("IntactMapper.map")
+    def map(self, src_regions: SpecRegion, dst_regions: SpecRegion):
         src_group = src_regions.memory
         dst_group = dst_regions.memory
-        assert src_group.ptrs.size == dst_group.ptrs.size, (
-            f"Number of regions of src({src_group.ptrs.size}) and dst({dst_group.ptrs.size}) must match"
-        )
-        new_src_ptrs = src_group.ptrs + self._src_block_off
-        new_dst_ptrs = dst_group.ptrs + self._dst_block_off
-        new_src = MemRegionGroup(ptrs=new_src_ptrs, bytes_per_region=self._frag_size)
-        new_dst = MemRegionGroup(ptrs=new_dst_ptrs, bytes_per_region=self._frag_size)
-        return SpecRegionPair(
-            src=SpecRegion(memory=new_src, spec=src_regions.spec),
-            dst=SpecRegion(memory=new_dst, spec=dst_regions.spec),
-        )
+        if src_group.ptrs.size != dst_group.ptrs.size:
+            raise ValueError(
+                f"Number of regions of src({src_group.ptrs.size}) and "
+                f"dst({dst_group.ptrs.size}) must match"
+            )
+        pairs = [
+            SpecRegionPair(
+                src=SpecRegion(
+                    memory=MemRegionGroup(
+                        ptrs=src_group.ptrs + src_off, bytes_per_region=run_bytes
+                    ),
+                    spec=src_regions.spec,
+                ),
+                dst=SpecRegion(
+                    memory=MemRegionGroup(
+                        ptrs=dst_group.ptrs + dst_off, bytes_per_region=run_bytes
+                    ),
+                    spec=dst_regions.spec,
+                ),
+            )
+            for src_off, dst_off, run_bytes in self._runs
+        ]
+        return pairs[0] if len(pairs) == 1 else pairs
 
-    def _block_size(self, layer_num: int, slot_size_per_layer: int) -> int:
-        return layer_num * slot_size_per_layer
 
+class ReplicatedMapper(IntactMapper):
+    """Copy TP-replicated per-layer regions without KV-head remapping.
 
-class HeadMismatchMapper(RegionMapperBase):
+    Every TP rank holds identical bytes per layer (MiniMax M3 index-key, DSA
+    indexer K), so no head slicing applies. Layer selection under partial PP
+    overlap happens through the per-layer offsets, and fan-in routing (one
+    owning sender per destination) is decided upstream by
+    ``PeerRegistrar.should_send_pool``.
     """
-    ---- mapper_head_mismatch ----
+
+    def __init__(
+        self,
+        src_layer_offsets: Sequence[int] | np.ndarray,
+        dst_layer_offsets: Sequence[int] | np.ndarray,
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
+    ) -> None:
+        super().__init__(
+            src_layer_offsets,
+            dst_layer_offsets,
+            self_bytes_per_layer,
+            peer_bytes_per_layer,
+            mapper_name="Replicated",
+        )
+
+
+class HNDHeadMismatchMapper(RegionMapperBase):
+    """
+    ---- mapper_hnd_head_mismatch ----
 
     Fine-grained mapping when head counts or TP/DP partitioning differ.
     Split layers into per-head (or contiguous-heads) fragments and map them individually.
@@ -134,26 +168,60 @@ class HeadMismatchMapper(RegionMapperBase):
 
     def __init__(
         self,
-        transfer_layers: int,
-        src_layer_off: int,
-        peer_layer_off: int,
+        *,
+        src_layer_offsets: "Sequence[int] | np.ndarray",
+        dst_layer_offsets: "Sequence[int] | np.ndarray",
         self_ri: RankInfo,
         peer_ri: RankInfo,
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
+        self_buffers_per_layer: int,
+        peer_buffers_per_layer: int,
     ):
         self._ri = self_ri
         self._peer_ri = peer_ri
 
-        kv_factor = self_ri.attention.kv_factor
         self_tp_per_dp = self_ri.tp_size_per_dp_group
         peer_tp_per_dp = peer_ri.tp_size_per_dp_group
         self_tp_rank = self_ri.tp_rank
         peer_tp_rank = peer_ri.tp_rank
 
-        bytes_per_head = (
-            self._ri.attention.tokens_per_block
-            * self._ri.attention.dims_per_head
-            * self._ri.attention.element_bytes
+        if self_buffers_per_layer != peer_buffers_per_layer:
+            raise ValueError(
+                "HND buffer count per layer mismatch: "
+                f"local={self_buffers_per_layer}, peer={peer_buffers_per_layer}"
+            )
+        src_offsets = np.asarray(src_layer_offsets, dtype=np.int64)
+        dst_offsets = np.asarray(dst_layer_offsets, dtype=np.int64)
+        if src_offsets.size == 0 or src_offsets.size != dst_offsets.size:
+            raise ValueError(
+                "HND layer offsets must be non-empty and equal-length: "
+                f"src={src_offsets.size}, dst={dst_offsets.size}"
+            )
+
+        # Byte geometry is derived from the per-layer region size registered
+        # by storage (always whole bytes) rather than element_bytes x dims
+        # arithmetic, so sub-byte dtypes (e.g. NVFP4) stay exact-integer.
+        src_buffer_bytes = self._bytes_per_buffer(
+            bytes_per_layer=self_bytes_per_layer,
+            buffers_per_layer=self_buffers_per_layer,
+            side="local",
         )
+        dst_buffer_bytes = self._bytes_per_buffer(
+            bytes_per_layer=peer_bytes_per_layer,
+            buffers_per_layer=peer_buffers_per_layer,
+            side="peer",
+        )
+        bytes_per_head = self._bytes_per_head(
+            src_buffer_bytes, self._ri.attention.kv_heads_per_rank, side="local"
+        )
+        peer_bytes_per_head = self._bytes_per_head(
+            dst_buffer_bytes, peer_ri.attention.kv_heads_per_rank, side="peer"
+        )
+        if bytes_per_head != peer_bytes_per_head:
+            raise ValueError(
+                f"HND bytes per head mismatch: local={bytes_per_head}, peer={peer_bytes_per_head}"
+            )
         self._bytes_cont_heads = (
             min(self._ri.attention.kv_heads_per_rank, peer_ri.attention.kv_heads_per_rank)
             * bytes_per_head
@@ -168,55 +236,41 @@ class HeadMismatchMapper(RegionMapperBase):
             peer_kv_heads=peer_ri.attention.kv_heads_per_rank,
             bytes_per_head=bytes_per_head,
         )
-        self._peer_layer_off = peer_layer_off
 
-        # --- Pre-compute flat 1D offset arrays ---
-        #
-        # Each KV cache block (slot) is laid out as:
-        #
-        #   block_base ──► [layer_0 kv_0] [layer_0 kv_1] [layer_1 kv_0] [layer_1 kv_1] ...
-        #                   ◄─ layer_kv ─► ◄─ layer_kv ─►
-        #                   ◄────── layer_num (= layer_kv * kv_factor) ──────►
-        #
-        # To address fragment (layer=j, kv=k) within a block at base_ptr:
-        #
-        #   frag_ptr = base_ptr
-        #            + layer_num * (layer_off + j)    # skip to the right layer
-        #            + layer_kv  * k                  # skip to key or value
-        #            + head_off                       # head offset for TP mismatch
-        #
-        # The original code computed this as a 3D broadcast in map():
-        #   bases[:, None, None] + layer_offsets[None, :, None]
-        #                        + kv_offsets[None, None, :] + head_off
-        # producing shape (n_blocks, transfer_layers, kv_factor) then .ravel().
-        #
-        # Optimization: since the (layer, kv) offsets are independent of the
-        # per-call block base pointers, we pre-compute them here as a flat 1D
-        # array of length (transfer_layers * kv_factor).  At map() time we only
-        # need np.add.outer(bases, flat_offsets).ravel(), which produces the
-        # same result in the same C-order traversal (blocks outer, offsets inner)
-        # but with fewer intermediate allocations.
-        layer_indices = np.arange(transfer_layers, dtype=np.int64)
-        kv_indices = np.arange(kv_factor, dtype=np.int64)
+        # Pre-compute flat 1D offset arrays: one fragment per (layer, buffer)
+        # where buffers are the layer's K/V (or scale) buffers laid out
+        # back-to-back within the layer's region. Layer starts come from the
+        # view's buffer entries, so interleaved role classes (non-uniform
+        # layer strides) are handled the same way as everywhere else. At
+        # map() time a single np.add.outer(bases, flat_offsets) expands the
+        # per-block base pointers.
+        self._src_flat_offsets = self._build_flat_offsets(
+            layer_offsets=src_offsets,
+            buffers_per_layer=self_buffers_per_layer,
+            buffer_bytes=src_buffer_bytes,
+            head_offset=self._src_head_off,
+        )
+        self._dst_flat_offsets = self._build_flat_offsets(
+            layer_offsets=dst_offsets,
+            buffers_per_layer=peer_buffers_per_layer,
+            buffer_bytes=dst_buffer_bytes,
+            head_offset=self._dst_head_off,
+        )
 
-        src_layer_kv_num = self._get_layer_kv_num(self._ri)
-        src_layer_num = src_layer_kv_num * kv_factor
-        # Shape (transfer_layers, kv_factor) → ravel to 1D
-        self._src_flat_offsets = (
-            src_layer_num * (src_layer_off + layer_indices)[:, None]
-            + src_layer_kv_num * kv_indices[None, :]
-            + self._src_head_off
+    @staticmethod
+    def _build_flat_offsets(
+        *,
+        layer_offsets: np.ndarray,
+        buffers_per_layer: int,
+        buffer_bytes: int,
+        head_offset: int,
+    ) -> np.ndarray:
+        buffer_indices = np.arange(buffers_per_layer, dtype=np.int64)
+        return (
+            layer_offsets[:, None] + buffer_bytes * buffer_indices[None, :] + head_offset
         ).ravel()
 
-        dst_layer_kv_num = self._get_layer_kv_num(self._peer_ri)
-        dst_layer_num = dst_layer_kv_num * kv_factor
-        self._dst_flat_offsets = (
-            dst_layer_num * (peer_layer_off + layer_indices)[:, None]
-            + dst_layer_kv_num * kv_indices[None, :]
-            + self._dst_head_off
-        ).ravel()
-
-    @nvtx_range("HeadMismatchMapper.map")
+    @nvtx_range("HNDHeadMismatchMapper.map")
     def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
         src_group = src_regions.memory
         dst_group = dst_regions.memory
@@ -261,56 +315,166 @@ class HeadMismatchMapper(RegionMapperBase):
             return 0, dst_head_idx * bytes_per_head
 
     @staticmethod
-    def _get_layer_kv_num(ri: RankInfo) -> int:
-        return (
-            ri.attention.kv_heads_per_rank
-            * ri.attention.tokens_per_block
-            * ri.attention.dims_per_head
-            * ri.attention.element_bytes
-        )
+    def _bytes_per_buffer(*, bytes_per_layer: int, buffers_per_layer: int, side: str) -> int:
+        """Bytes of one buffer (K or V) within a layer's region."""
+        if buffers_per_layer <= 0 or bytes_per_layer % buffers_per_layer != 0:
+            raise ValueError(
+                f"HND layer geometry is not evenly divisible ({side}): "
+                f"bytes_per_layer={bytes_per_layer}, buffers_per_layer={buffers_per_layer}"
+            )
+        return bytes_per_layer // buffers_per_layer
+
+    @staticmethod
+    def _bytes_per_head(layer_kv_bytes: int, heads: int, *, side: str) -> int:
+        """Bytes of one head's rows within a K/V buffer.
+
+        Byte-granular head slicing is only valid when a head lands on a byte
+        boundary; sub-byte dtypes (e.g. NVFP4) satisfy this whenever the
+        per-head element count covers whole bytes, which this divisibility
+        check enforces without any fractional arithmetic.
+        """
+        if heads <= 0 or layer_kv_bytes % heads != 0:
+            raise ValueError(
+                f"HND head slicing is not byte-aligned ({side}): "
+                f"layer_kv_bytes={layer_kv_bytes}, kv_heads={heads}"
+            )
+        return layer_kv_bytes // heads
 
 
-class IndexerKCacheHeadMatchMapper(RegionMapperBase):
-    """
-    Mapper for indexer K cache when head counts match.
+class NHDHeadMismatchMapper(HNDHeadMismatchMapper):
+    """Map heterogeneous KV heads stored token-major as ``[N, H, D]``.
 
-    Moves contiguous block(s) as a single chunk, aligned by block_size_per_layer,
-    with constant source/destination block offsets.
+    ``HNDHeadMismatchMapper`` selects one contiguous head range per K/V buffer,
+    which is correct for HND storage. In NHD storage, the selected head range
+    is contiguous only within one token, so this mapper emits one fragment per
+    ``(layer, K/V, token)``. Only offset precomputation differs from the
+    parent; the inherited :meth:`map` consumes ``_src_flat_offsets``,
+    ``_dst_flat_offsets``, and ``_bytes_cont_heads``.
     """
 
     def __init__(
         self,
-        transfer_layers: int,
-        src_layer_off: int,
-        dst_layer_off: int,
+        *,
+        src_layer_offsets: Sequence[int] | np.ndarray,
+        dst_layer_offsets: Sequence[int] | np.ndarray,
         self_ri: RankInfo,
         peer_ri: RankInfo,
-        block_size_per_layer: int,
-    ):
-        if not isinstance(block_size_per_layer, int):
-            raise TypeError(
-                f"block_size_per_layer must be int, got {type(block_size_per_layer).__name__} "
-                f"(value={block_size_per_layer}). Use // instead of / for integer division."
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
+        self_buffers_per_layer: int,
+        peer_buffers_per_layer: int,
+    ) -> None:
+        # Deliberately do not call HNDHeadMismatchMapper.__init__: its offsets
+        # assume HND-contiguous heads. Initialize the three attributes consumed
+        # by the inherited map() with NHD token-granular geometry instead.
+        self_tpb = self_ri.attention.tokens_per_block
+        peer_tpb = peer_ri.attention.tokens_per_block
+        if self_tpb != peer_tpb:
+            raise ValueError(
+                "NHDHeadMismatchMapper requires equal tokens_per_block; "
+                f"local={self_tpb}, peer={peer_tpb}"
             )
-        self._frag_size = block_size_per_layer * transfer_layers
-        self._src_block_off = block_size_per_layer * src_layer_off
-        self._dst_block_off = block_size_per_layer * dst_layer_off
 
-    @nvtx_range("IndexerKCacheHeadMatchMapper.map")
-    def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
-        src_group = src_regions.memory
-        dst_group = dst_regions.memory
-        assert src_group.ptrs.size == dst_group.ptrs.size, (
-            f"Number of regions of src({src_group.ptrs.size}) and dst({dst_group.ptrs.size}) must match"
+        self_heads = self_ri.attention.kv_heads_per_rank
+        peer_heads = peer_ri.attention.kv_heads_per_rank
+        if self_buffers_per_layer != peer_buffers_per_layer:
+            raise ValueError(
+                "NHD buffer count per layer mismatch: "
+                f"local={self_buffers_per_layer}, peer={peer_buffers_per_layer}"
+            )
+        src_offsets = np.asarray(src_layer_offsets, dtype=np.int64)
+        dst_offsets = np.asarray(dst_layer_offsets, dtype=np.int64)
+        if src_offsets.size == 0 or src_offsets.size != dst_offsets.size:
+            raise ValueError(
+                "NHD layer offsets must be non-empty and equal-length: "
+                f"src={src_offsets.size}, dst={dst_offsets.size}"
+            )
+
+        self_bytes_per_token_head = self._bytes_per_token_head(
+            bytes_per_layer=self_bytes_per_layer,
+            buffers_per_layer=self_buffers_per_layer,
+            tokens_per_block=self_tpb,
+            heads=self_heads,
         )
-        new_src_ptrs = src_group.ptrs + self._src_block_off
-        new_dst_ptrs = dst_group.ptrs + self._dst_block_off
-        new_src = MemRegionGroup(ptrs=new_src_ptrs, bytes_per_region=self._frag_size)
-        new_dst = MemRegionGroup(ptrs=new_dst_ptrs, bytes_per_region=self._frag_size)
-        return SpecRegionPair(
-            src=SpecRegion(memory=new_src, spec=src_regions.spec),
-            dst=SpecRegion(memory=new_dst, spec=dst_regions.spec),
+        peer_bytes_per_token_head = self._bytes_per_token_head(
+            bytes_per_layer=peer_bytes_per_layer,
+            buffers_per_layer=peer_buffers_per_layer,
+            tokens_per_block=peer_tpb,
+            heads=peer_heads,
         )
+        if self_bytes_per_token_head != peer_bytes_per_token_head:
+            raise ValueError(
+                "NHD bytes per token/head mismatch: "
+                f"local={self_bytes_per_token_head}, peer={peer_bytes_per_token_head}"
+            )
+        self._bytes_cont_heads = min(self_heads, peer_heads) * self_bytes_per_token_head
+
+        src_head_off, dst_head_off = HNDHeadMismatchMapper._compute_head_offsets(
+            self_ri.tp_size_per_dp_group,
+            peer_ri.tp_size_per_dp_group,
+            self_ri.tp_rank,
+            peer_ri.tp_rank,
+            self_kv_heads=self_heads,
+            peer_kv_heads=peer_heads,
+            bytes_per_head=self_bytes_per_token_head,
+        )
+
+        self._src_flat_offsets = self._build_flat_offsets(
+            layer_offsets=src_offsets,
+            buffers_per_layer=self_buffers_per_layer,
+            tokens_per_block=self_tpb,
+            heads=self_heads,
+            bytes_per_token_head=self_bytes_per_token_head,
+            head_offset=src_head_off,
+        )
+        self._dst_flat_offsets = self._build_flat_offsets(
+            layer_offsets=dst_offsets,
+            buffers_per_layer=peer_buffers_per_layer,
+            tokens_per_block=peer_tpb,
+            heads=peer_heads,
+            bytes_per_token_head=peer_bytes_per_token_head,
+            head_offset=dst_head_off,
+        )
+
+    @staticmethod
+    def _bytes_per_token_head(
+        *,
+        bytes_per_layer: int,
+        buffers_per_layer: int,
+        tokens_per_block: int,
+        heads: int,
+    ) -> int:
+        denominator = buffers_per_layer * tokens_per_block * heads
+        if denominator <= 0 or bytes_per_layer % denominator != 0:
+            raise ValueError(
+                "NHD region geometry is not evenly divisible: "
+                f"bytes_per_layer={bytes_per_layer}, "
+                f"buffers_per_layer={buffers_per_layer}, "
+                f"tokens_per_block={tokens_per_block}, kv_heads={heads}, "
+                f"denominator={denominator}"
+            )
+        return bytes_per_layer // denominator
+
+    @staticmethod
+    def _build_flat_offsets(
+        *,
+        layer_offsets: np.ndarray,
+        buffers_per_layer: int,
+        tokens_per_block: int,
+        heads: int,
+        bytes_per_token_head: int,
+        head_offset: int,
+    ) -> np.ndarray:
+        buffer_indices = np.arange(buffers_per_layer, dtype=np.int64)
+        token_indices = np.arange(tokens_per_block, dtype=np.int64)
+        token_bytes = heads * bytes_per_token_head
+        buffer_bytes = tokens_per_block * token_bytes
+        return (
+            layer_offsets[:, None, None]
+            + buffer_bytes * buffer_indices[None, :, None]
+            + token_bytes * token_indices[None, None, :]
+            + head_offset
+        ).ravel()
 
 
 class AttentionPolicy:
@@ -335,9 +499,29 @@ class AttentionPolicy:
             local != peer, f"{field} mismatch", field=field, local=local, peer=peer
         )
 
-    def _tpb_check(self, local: int, peer: int) -> bool:
+    @staticmethod
+    def _uses_exact_tpb_mapper(ri: RankInfo) -> bool:
+        """NHD / replicated pools address bytes inside a block, so their
+        geometry only lines up when both sides use the same tokens_per_block."""
+        if ri.page_table is None:
+            return False
+        return any(
+            pool_view.mapper_kind in (MapperKind.NHD, MapperKind.REPLICATED)
+            for layer_group in ri.page_table.layer_groups
+            for pool_view in getattr(layer_group, "pool_views", ())
+        )
+
+    def _tpb_check(self, local: int, peer: int, peer_ri: RankInfo) -> bool:
         if local == peer:
             return False
+        if self._uses_exact_tpb_mapper(self._ri) or self._uses_exact_tpb_mapper(peer_ri):
+            logger.warning(
+                "AttentionPolicy: incompatible: tokens_per_block mismatch for "
+                "NHD/replicated pools; local=%d peer=%d",
+                local,
+                peer,
+            )
+            return True
         larger, smaller = max(local, peer), min(local, peer)
         if larger % smaller != 0:
             logger.warning(
@@ -367,7 +551,15 @@ class AttentionPolicy:
                 peer=peer_ri.cp_size,
             )
             or self._mismatch("element_bytes", a.element_bytes, b.element_bytes)
-            or self._tpb_check(a.tokens_per_block, b.tokens_per_block)
+            or self._fail_if(
+                not self.head_match(peer_ri)[0]
+                and not float(a.tokens_per_block * a.dims_per_head * a.element_bytes).is_integer(),
+                "sub-byte head slicing is not byte-aligned",
+                tokens_per_block=a.tokens_per_block,
+                dims_per_head=a.dims_per_head,
+                element_bytes=a.element_bytes,
+            )
+            or self._tpb_check(a.tokens_per_block, b.tokens_per_block, peer_ri)
             or self._mismatch("dims_per_head", a.dims_per_head, b.dims_per_head)
             or self._fail_if(
                 a.is_mla and (a.kv_heads_per_rank != 1 or b.kv_heads_per_rank != 1),
@@ -405,53 +597,66 @@ class AttentionPolicy:
         *,
         peer_ri: RankInfo,
         mapper_kind: MapperKind,
-        transfer_layers: int,
-        self_layer_offset: int,
-        peer_layer_offset: int,
-        self_pool_num_layers: int,
-        peer_pool_num_layers: int,
-        self_pool_slot_bytes: int,
-        peer_pool_slot_bytes: int,
+        self_layer_offsets: "Sequence[int] | np.ndarray",
+        peer_layer_offsets: "Sequence[int] | np.ndarray",
+        self_bytes_per_layer: int,
+        peer_bytes_per_layer: int,
+        self_buffers_per_layer: int = 1,
+        peer_buffers_per_layer: int = 1,
     ) -> RegionMapperBase:
-        head_match, _ = self.head_match(peer_ri)
+        """Pick the mapper for one view pair.
 
-        if head_match and transfer_layers == self_pool_num_layers == peer_pool_num_layers:
-            return IdentityMapper()
+        Every view is entries-driven: layer selection always uses explicit
+        slot-relative per-layer byte offsets, never positional arithmetic
+        (other role classes may interleave between this class's layers).
+        The kind only decides the two irreducible semantic differences:
 
-        if head_match:
-            if mapper_kind == MapperKind.FLAT:
-                block_size_per_layer = self_pool_slot_bytes // self_pool_num_layers
-                return IndexerKCacheHeadMatchMapper(
-                    transfer_layers=transfer_layers,
-                    src_layer_off=self_layer_offset,
-                    dst_layer_off=peer_layer_offset,
-                    self_ri=self._ri,
-                    peer_ri=peer_ri,
-                    block_size_per_layer=block_size_per_layer,
-                )
+        - REPLICATED skips head matching entirely (bytes are identical on
+          every TP rank; fan-in ownership is decided upstream).
+        - Under head mismatch, HND (INDEXED) slices one contiguous head
+          range per K/V buffer, while NHD must slice inside every token.
 
-            slot_size_per_layer = self_pool_slot_bytes // self_pool_num_layers
-            peer_size_per_layer = peer_pool_slot_bytes // peer_pool_num_layers
-            assert slot_size_per_layer == peer_size_per_layer, (
-                f"slot_size_per_layer mismatch between self ({slot_size_per_layer}) "
-                f"and peer ({peer_size_per_layer}) for HeadMatchMapper"
+        Head-matched views of any kind collapse into IntactMapper,
+        whose run merging degrades to a single whole-region copy per block
+        when the selected layers are contiguous on both sides.
+        """
+        if mapper_kind == MapperKind.REPLICATED:
+            return ReplicatedMapper(
+                self_layer_offsets,
+                peer_layer_offsets,
+                self_bytes_per_layer,
+                peer_bytes_per_layer,
             )
-            return HeadMatchMapper(
-                transfer_layers=transfer_layers,
-                src_layer_off=self_layer_offset,
-                dst_layer_off=peer_layer_offset,
+
+        head_match, _ = self.head_match(peer_ri)
+        if head_match:
+            return IntactMapper(
+                self_layer_offsets,
+                peer_layer_offsets,
+                self_bytes_per_layer,
+                peer_bytes_per_layer,
+                mapper_name=mapper_kind.name,
+            )
+
+        if mapper_kind == MapperKind.NHD:
+            return NHDHeadMismatchMapper(
+                src_layer_offsets=self_layer_offsets,
+                dst_layer_offsets=peer_layer_offsets,
                 self_ri=self._ri,
                 peer_ri=peer_ri,
-                slot_size_per_layer=slot_size_per_layer,
+                self_bytes_per_layer=self_bytes_per_layer,
+                peer_bytes_per_layer=peer_bytes_per_layer,
+                self_buffers_per_layer=self_buffers_per_layer,
+                peer_buffers_per_layer=peer_buffers_per_layer,
             )
 
-        if mapper_kind == MapperKind.FLAT:
-            raise ValueError("IndexerKCacheHeadMatchMapper is not supported for head mismatch case")
-
-        return HeadMismatchMapper(
-            transfer_layers=transfer_layers,
-            src_layer_off=self_layer_offset,
-            peer_layer_off=peer_layer_offset,
+        return HNDHeadMismatchMapper(
+            src_layer_offsets=self_layer_offsets,
+            dst_layer_offsets=peer_layer_offsets,
             self_ri=self._ri,
             peer_ri=peer_ri,
+            self_bytes_per_layer=self_bytes_per_layer,
+            peer_bytes_per_layer=peer_bytes_per_layer,
+            self_buffers_per_layer=self_buffers_per_layer,
+            peer_buffers_per_layer=peer_buffers_per_layer,
         )

--- a/tensorrt_llm/_torch/disaggregation/native/mixers/attention/spec.py
+++ b/tensorrt_llm/_torch/disaggregation/native/mixers/attention/spec.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import asdict, dataclass
 
 
@@ -7,7 +22,7 @@ class AttentionInfo:
     kv_heads_per_rank: int
     tokens_per_block: int
     dims_per_head: int
-    element_bytes: int
+    element_bytes: int | float
     enable_attention_dp: bool
     is_mla: bool
 

--- a/tensorrt_llm/_torch/disaggregation/native/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/peer.py
@@ -1,17 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
+
+import numpy as np
 
 from tensorrt_llm import logger
 from tensorrt_llm._torch.disaggregation.base.region import RegionMapperBase
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import AttentionPolicy
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
-from tensorrt_llm._torch.disaggregation.resource.page import AttentionLayerGroup, MapperKind
+from tensorrt_llm._torch.disaggregation.resource.page import (
+    AttentionLayerGroup,
+    MapperKind,
+    PoolView,
+)
 from tensorrt_llm._torch.disaggregation.resource.utils import (
-    get_global_layer_ids,
-    get_layer_group_num_layers,
+    get_layer_byte_ranges,
     get_layer_to_layer_group,
-    get_physical_pool,
+    get_num_buffer_entries,
     get_pool_view_global_layer_ids,
     get_pool_view_num_layers,
 )
@@ -56,6 +76,33 @@ class PeerRegistrar:
         peer_ri = self.get_peer_rank_info(peer_name, peer_rank)
         extractor = KVRegionExtractorV1(peer_ri.page_table)
         self._peer_ext_cache[key] = extractor
+
+        head_match, _ = self._attention_policy.head_match(peer_ri)
+        if not head_match:
+            self_page_table = self._self_ext_cache.page_table
+            nhd_fragments_per_token = sum(
+                len(
+                    self_page_table.layer_groups[layer_group_id].pool_views[pool_idx].buffer_entries
+                )
+                for layer_group_id, pool_idx in self.get_pool_mapping(peer_ri)
+                if self_page_table.layer_groups[layer_group_id].pool_views[pool_idx].mapper_kind
+                == MapperKind.NHD
+            )
+            if nhd_fragments_per_token:
+                local_heads = self._ri.attention.kv_heads_per_rank
+                peer_heads = peer_ri.attention.kv_heads_per_rank
+                logger.warning_once(
+                    "NHD head-mismatched disaggregated KV transfer has no "
+                    "contiguous staging path and will emit approximately "
+                    f"{nhd_fragments_per_token} NIXL descriptors per transferred "
+                    "token per peer, excluding block-level replicated pools "
+                    f"(local_kv_heads={local_heads}, peer_kv_heads={peer_heads}). "
+                    "Long-context TEP/DEP transfers may have high latency.",
+                    key=(
+                        "native-nhd-head-mismatch-"
+                        f"{local_heads}-{peer_heads}-{nhd_fragments_per_token}"
+                    ),
+                )
 
     def peer_extractor(self, peer_name: str, peer_rank: int) -> KVRegionExtractorV1:
         return self._peer_ext_cache[self._unique_key(peer_name, peer_rank)]
@@ -140,17 +187,12 @@ class PeerRegistrar:
             if not isinstance(self_lg, AttentionLayerGroup):
                 continue
             for self_pi, self_pv in enumerate(self_lg.pool_views):
-                # The only place mapper_kind affects pool matching:
-                #   INDEXED → pool may cover a subset of the LG; read
-                #             buffer_entries to find the exact layer set.
-                #   FLAT    → pool covers the entire LG by convention;
-                #             use the LG's layer ids directly.
-                self_is_flat = self_pv.mapper_kind == MapperKind.FLAT
-                pv_global_ids = (
-                    get_global_layer_ids(self_lg)
-                    if self_is_flat
-                    else get_pool_view_global_layer_ids(self_pv, self_lg)
-                )
+                # Every view carries buffer_entries, so a view's exact layer
+                # set always comes from its entries (a view may cover a
+                # subset of the LG when V2 splits an LG into multiple pools
+                # by buffer-size class, or when a role class exists only on
+                # some layers, e.g. sparse-layer index-K).
+                pv_global_ids = get_pool_view_global_layer_ids(self_pv, self_lg)
                 if not pv_global_ids:
                     continue
 
@@ -181,11 +223,7 @@ class PeerRegistrar:
                 for peer_pi, peer_pv in enumerate(peer_lg.pool_views):
                     if peer_pv.pool_role != self_pv.pool_role:
                         continue
-                    peer_global_ids = (
-                        get_global_layer_ids(peer_lg)
-                        if peer_pv.mapper_kind == MapperKind.FLAT
-                        else get_pool_view_global_layer_ids(peer_pv, peer_lg)
-                    )
+                    peer_global_ids = get_pool_view_global_layer_ids(peer_pv, peer_lg)
                     if not set(peer_global_ids) & self_layer_set:
                         continue
                     if peer_pv.mapper_kind != self_pv.mapper_kind:
@@ -240,52 +278,74 @@ class PeerRegistrar:
                 f"(local={self_pv.mapper_kind.name}, peer={peer_pv.mapper_kind.name})"
             )
 
-        # FLAT pools carry no per-buffer layer info, so layer ids and
-        # layer count come from the layer_group itself.
-        #
-        # Sort by global_layer_id so that ``.index(first_overlap_layer)``
-        # below returns the layer's slot position. This relies on the
-        # convention that managers (V1 / V2 / DSv4) assign global_layer_id
-        # monotonically with the layer's byte offset in the slot.
-        if self_pv.mapper_kind == MapperKind.FLAT:
-            self_global_ids = sorted(get_global_layer_ids(self_lg))
-            peer_global_ids = sorted(get_global_layer_ids(peer_lg))
-            self_num_layers = get_layer_group_num_layers(self_lg)
-            peer_num_layers = get_layer_group_num_layers(peer_lg)
-        else:
-            self_global_ids = sorted(get_pool_view_global_layer_ids(self_pv, self_lg))
-            peer_global_ids = sorted(get_pool_view_global_layer_ids(peer_pv, peer_lg))
-            self_num_layers = get_pool_view_num_layers(self_pv)
-            peer_num_layers = get_pool_view_num_layers(peer_pv)
-
+        # Every view is entries-driven: resolve the overlap layers to
+        # slot-relative byte offsets on each side from the views' buffer
+        # entries. Layer selection is explicit, so mappers never assume a
+        # uniform layer stride (other role classes may interleave), and no
+        # convention about global-id/byte-offset ordering is needed.
+        self_num_layers = get_pool_view_num_layers(self_pv)
+        peer_num_layers = get_pool_view_num_layers(peer_pv)
+        self_global_ids = get_pool_view_global_layer_ids(self_pv, self_lg)
+        peer_global_ids = get_pool_view_global_layer_ids(peer_pv, peer_lg)
         overlapping_layers = sorted(set(self_global_ids) & set(peer_global_ids))
-        transfer_layers = len(overlapping_layers)
 
-        if transfer_layers > 0:
-            first_overlap_layer = overlapping_layers[0]
-            self_layer_offset = self_global_ids.index(first_overlap_layer)
-            peer_layer_offset = peer_global_ids.index(first_overlap_layer)
-        else:
-            self_layer_offset = 0
-            peer_layer_offset = 0
-
-        self_phys = get_physical_pool(self_pt, self_lg_idx, self_pv.pool_idx)
-        peer_phys = get_physical_pool(peer_pt, peer_lg_idx, peer_pv.pool_idx)
+        self_starts, self_bytes_per_layer = get_layer_byte_ranges(self_pv)
+        peer_starts, peer_bytes_per_layer = get_layer_byte_ranges(peer_pv)
+        self_g2l = {ll.global_layer_id: ll.local_layer_id for ll in self_lg.local_layers}
+        peer_g2l = {ll.global_layer_id: ll.local_layer_id for ll in peer_lg.local_layers}
+        self_layer_offsets = np.array(
+            [self_starts[self_g2l[gid]] for gid in overlapping_layers], dtype=np.int64
+        )
+        peer_layer_offsets = np.array(
+            [peer_starts[peer_g2l[gid]] for gid in overlapping_layers], dtype=np.int64
+        )
+        # Per-layer buffer count (K and V are separate buffers within a
+        # layer's region); head-mismatch mappers slice heads inside each.
+        self_buffers_per_layer = self._get_buffers_per_layer(
+            self_pv,
+            self_num_layers,
+            layer_group_id=self_lg_idx,
+            pool_idx=self_pi,
+        )
+        peer_buffers_per_layer = self._get_buffers_per_layer(
+            peer_pv,
+            peer_num_layers,
+            layer_group_id=peer_lg_idx,
+            pool_idx=peer_pi,
+        )
 
         mapper = self._attention_policy.build_kv_mapper(
             peer_ri=peer_ri,
             mapper_kind=self_pv.mapper_kind,
-            transfer_layers=transfer_layers,
-            self_layer_offset=self_layer_offset,
-            peer_layer_offset=peer_layer_offset,
-            self_pool_num_layers=self_num_layers,
-            peer_pool_num_layers=peer_num_layers,
-            self_pool_slot_bytes=self_phys.slot_bytes,
-            peer_pool_slot_bytes=peer_phys.slot_bytes,
+            self_layer_offsets=self_layer_offsets,
+            peer_layer_offsets=peer_layer_offsets,
+            self_bytes_per_layer=self_bytes_per_layer,
+            peer_bytes_per_layer=peer_bytes_per_layer,
+            self_buffers_per_layer=self_buffers_per_layer,
+            peer_buffers_per_layer=peer_buffers_per_layer,
         )
 
         self._kv_map_cache[cache_key] = mapper
         return mapper
+
+    @staticmethod
+    def _get_buffers_per_layer(
+        pool_view: PoolView,
+        num_layers: int,
+        *,
+        layer_group_id: int,
+        pool_idx: int,
+    ) -> int:
+        num_entries = get_num_buffer_entries(pool_view)
+        if num_entries == 0:
+            return 1
+        if num_layers <= 0 or num_entries % num_layers != 0:
+            raise ValueError(
+                "PoolView buffer entries are not evenly distributed across layers: "
+                f"layer_group={layer_group_id}, pool={pool_idx}, "
+                f"entries={num_entries}, layers={num_layers}"
+            )
+        return num_entries // num_layers
 
     @staticmethod
     def _find_overlap(self_val, peer_val, self_rank, peer_rank=None):
@@ -367,6 +427,44 @@ class PeerRegistrar:
         return (peer_rank_info.dp_rank % dup_head_factor) == (
             self_tp_rank_in_dp_group % dup_head_factor
         )
+
+    def _owns_tp_fan_in(self, peer_rank_info: RankInfo) -> bool:
+        """Elect one owner when replicated bytes fan in across TP ranks.
+
+        A peer with fewer TP shards receives identical replicated data from
+        several local ranks. Rotate the elected owner by the destination's
+        DP rank (mirroring ``should_send_kv``'s head-duplication pairing) so
+        that with a multi-DP-group generation side the extra replicated
+        traffic spreads across local ranks instead of always landing on the
+        first rank of each fan-in group.
+        """
+        ratio = max(
+            1,
+            self._ri.tp_size_per_dp_group // peer_rank_info.tp_size_per_dp_group,
+        )
+        self_tp_rank = self._ri.tp_rank % self._ri.tp_size_per_dp_group
+        return self_tp_rank % ratio == peer_rank_info.dp_rank % ratio
+
+    def should_send_pool(
+        self,
+        peer_overlap: PeerOverlap,
+        peer_rank_info: RankInfo,
+        layer_group_id: int,
+        pool_idx: int,
+    ) -> bool:
+        """Return whether this rank owns the transfer of one view pair.
+
+        ``pool_idx`` indexes the layer group's ``pool_views`` list (one view
+        per role class; several views may share a physical pool). Each view
+        is kind-homogeneous, so ownership is a single per-view decision:
+        replicated views use one sender per fan-in group, sharded views
+        retain head-duplication routing.
+        """
+        layer_group = self._self_ext_cache.page_table.layer_groups[layer_group_id]
+        pool_view = layer_group.pool_views[pool_idx]
+        if pool_view.mapper_kind == MapperKind.REPLICATED:
+            return self._owns_tp_fan_in(peer_rank_info)
+        return self.should_send_kv(peer_overlap, peer_rank_info)
 
     def should_send_aux(self, peer_rank_info: RankInfo) -> bool:
         # to ensure the transfer aux is not duplicated

--- a/tensorrt_llm/_torch/disaggregation/native/rank_info.py
+++ b/tensorrt_llm/_torch/disaggregation/native/rank_info.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import asdict, dataclass
 from typing import List, Optional
 
@@ -59,6 +74,14 @@ class RankInfo:
         m = kv_cache_manager.mapping
         kvm = kv_cache_manager
         enable_attention_dp = m.enable_attention_dp
+        # Eight is the smallest element count guaranteed to occupy whole bytes
+        # for every supported sub-byte cache dtype (including NVFP4).
+        bytes_for_eight_elements = get_size_in_bytes(8, kvm.dtype)
+        element_bytes = (
+            bytes_for_eight_elements // 8
+            if bytes_for_eight_elements % 8 == 0
+            else bytes_for_eight_elements / 8
+        )
         return cls(
             instance_name=instance_name,
             instance_rank=m.rank,
@@ -80,7 +103,7 @@ class RankInfo:
                 kv_heads_per_rank=kvm.num_kv_heads_per_layer[0],
                 tokens_per_block=kvm.tokens_per_block,
                 dims_per_head=kvm.head_dim,
-                element_bytes=get_size_in_bytes(1, kvm.dtype),
+                element_bytes=element_bytes,
                 enable_attention_dp=enable_attention_dp,
                 is_mla=kvm.kv_factor == 1,
             ),

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import os
@@ -48,6 +63,7 @@ from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
 from tensorrt_llm._torch.disaggregation.native.utils import get_local_ip
 from tensorrt_llm._torch.disaggregation.nixl.agent import NixlTransferAgent
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
+from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.disaggregation.resource.utils import get_unique_pool_memory_descs
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
@@ -747,89 +763,90 @@ class Sender(SenderBase):
         peer_extractor = self._registrar.peer_extractor(
             peer_ri.instance_name, peer_ri.instance_rank
         )
-        if self._registrar.should_send_kv(targets, peer_ri):
-            pool_mapping = self._registrar.get_pool_mapping(peer_ri)
-            dst_block_ids_per_groups = req_info.block_ids_per_layer_groups
-            src_block_ids_per_groups = task._slice.block_ids_per_layer_groups
+        pool_mapping = self._registrar.get_pool_mapping(peer_ri)
+        dst_block_ids_per_groups = req_info.block_ids_per_layer_groups
+        src_block_ids_per_groups = task._slice.block_ids_per_layer_groups
 
-            # Aggregate fragments from all matching pools using numpy concatenation
-            for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
-                src_block_ids = src_block_ids_per_groups[self_lg]
-                dst_block_ids = dst_block_ids_per_groups[peer_lg]
+        # Aggregate fragments from all matching pools using numpy concatenation.
+        # Send ownership is per pool: replicated pools elect one fan-in
+        # owner, sharded pools keep head-duplication routing.
+        for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
+            if not self._registrar.should_send_pool(targets, peer_ri, self_lg, self_pi):
+                continue
+            src_block_ids = src_block_ids_per_groups[self_lg]
+            dst_block_ids = dst_block_ids_per_groups[peer_lg]
 
-                # Speculative decoding: generation may have one extra draft-token block.
-                block_diff = dst_block_ids.size - src_block_ids.size
-                if block_diff == 1:
-                    logger.debug(
-                        f"Trimming 1 extra dst block for draft tokens: "
-                        f"src={src_block_ids.size}, dst={dst_block_ids.size}"
-                    )
-                    dst_block_ids = dst_block_ids[:-1]
-                elif block_diff > 1:
-                    raise ValueError(
-                        f"src/dst block count mismatch: {src_block_ids.size} vs "
-                        f"{dst_block_ids.size} (expected diff <= 1)"
-                    )
-                tpb = extractor.page_table.tokens_per_block
-                token_range = task._slice.token_range
-                lg_info = extractor.page_table.layer_groups[self_lg]
-                window_size = getattr(lg_info, "sliding_window_size", None)
+            # Speculative decoding: generation may have one extra draft-token block.
+            block_diff = dst_block_ids.size - src_block_ids.size
+            if block_diff == 1:
+                logger.debug(
+                    f"Trimming 1 extra dst block for draft tokens: "
+                    f"src={src_block_ids.size}, dst={dst_block_ids.size}"
+                )
+                dst_block_ids = dst_block_ids[:-1]
+            elif block_diff > 1:
+                raise ValueError(
+                    f"src/dst block count mismatch: {src_block_ids.size} vs "
+                    f"{dst_block_ids.size} (expected diff <= 1)"
+                )
+            tpb = extractor.page_table.tokens_per_block
+            token_range = task._slice.token_range
+            lg_info = extractor.page_table.layer_groups[self_lg]
+            window_size = getattr(lg_info, "sliding_window_size", None)
 
-                # Block lists are the suffix of [..., slice_end); cached prefix
-                # is implicit in their size. token_start = (total_blocks - n) * tpb.
-                slice_end = token_range.end if token_range is not None else 0
-                total_blocks = (slice_end + tpb - 1) // tpb
-                src_beam0_blocks = Sender._beam0_block_count(
-                    src_block_ids, total_blocks, task._beam_width
+            # Block lists are the suffix of [..., slice_end); cached prefix
+            # is implicit in their size. token_start = (total_blocks - n) * tpb.
+            slice_end = token_range.end if token_range is not None else 0
+            total_blocks = (slice_end + tpb - 1) // tpb
+            src_beam0_blocks = Sender._beam0_block_count(
+                src_block_ids, total_blocks, task._beam_width
+            )
+            dst_beam0_blocks = Sender._beam0_block_count(
+                dst_block_ids, total_blocks, task._beam_width
+            )
+            assert src_beam0_blocks <= total_blocks, (
+                f"src beam-0 block list ({src_beam0_blocks}) exceeds total slice "
+                f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
+            )
+            assert dst_beam0_blocks <= total_blocks, (
+                f"dst beam-0 block list ({dst_beam0_blocks}) exceeds total slice "
+                f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
+            )
+            src_start = (total_blocks - src_beam0_blocks) * tpb
+            dst_start = (total_blocks - dst_beam0_blocks) * tpb
+            if req_info.dst_start_token is not None:
+                dst_start = max(dst_start, req_info.dst_start_token)
+            if window_size is not None:
+                # SWA stale_end uses the request prompt_len (not slice_end —
+                # they differ for non-final slices). prompt_len must be plumbed
+                # via the session; falling back to slice_end is wrong on
+                # non-final slices.
+                assert task._prompt_len is not None, (
+                    "SWA layer requires session.prompt_len; "
+                    "set TxSession(prompt_len=request.prompt_len)."
                 )
-                dst_beam0_blocks = Sender._beam0_block_count(
-                    dst_block_ids, total_blocks, task._beam_width
-                )
-                assert src_beam0_blocks <= total_blocks, (
-                    f"src beam-0 block list ({src_beam0_blocks}) exceeds total slice "
-                    f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
-                )
-                assert dst_beam0_blocks <= total_blocks, (
-                    f"dst beam-0 block list ({dst_beam0_blocks}) exceeds total slice "
-                    f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
-                )
-                src_start = (total_blocks - src_beam0_blocks) * tpb
-                dst_start = (total_blocks - dst_beam0_blocks) * tpb
-                if req_info.dst_start_token is not None:
-                    dst_start = max(dst_start, req_info.dst_start_token)
-                if window_size is not None:
-                    # SWA stale_end uses the request prompt_len (not slice_end —
-                    # they differ for non-final slices). prompt_len must be plumbed
-                    # via the session; falling back to slice_end is wrong on
-                    # non-final slices.
-                    assert task._prompt_len is not None, (
-                        "SWA layer requires session.prompt_len; "
-                        "set TxSession(prompt_len=request.prompt_len)."
-                    )
-                    stale_end = max(0, (task._prompt_len + 1 - window_size) // tpb)
-                    src_start = max(stale_end * tpb, src_start)
-                    dst_start = max(stale_end * tpb, dst_start)
-                src_block_ids, dst_block_ids = Sender._align_kv_blocks(
-                    src_block_ids,
-                    dst_block_ids,
-                    src_token_start=src_start,
-                    dst_token_start=dst_start,
-                    tokens_per_block=tpb,
-                )
+                stale_end = max(0, (task._prompt_len + 1 - window_size) // tpb)
+                src_start = max(stale_end * tpb, src_start)
+                dst_start = max(stale_end * tpb, dst_start)
+            src_block_ids, dst_block_ids = Sender._align_kv_blocks(
+                src_block_ids,
+                dst_block_ids,
+                src_token_start=src_start,
+                dst_token_start=dst_start,
+                tokens_per_block=tpb,
+            )
 
-                src_region = extractor.extract(
-                    src_block_ids, layer_group_id=self_lg, pool_idx=self_pi
-                )
-                dst_region = peer_extractor.extract(
-                    dst_block_ids, layer_group_id=peer_lg, pool_idx=peer_pi
-                )
-                mapper = self._registrar.get_kv_map(peer_ri, (self_lg, self_pi), (peer_lg, peer_pi))
-                region_pair = mapper.map(src_region, dst_region)
-                region_pairs = region_pair if isinstance(region_pair, list) else [region_pair]
-                for rp in region_pairs:
-                    src_frag_parts.append(rp.src.memory.ptrs)
-                    dst_frag_parts.append(rp.dst.memory.ptrs)
-                    size_specs.append((rp.src.memory.ptrs.size, rp.src.memory.bytes_per_region))
+            src_region = extractor.extract(src_block_ids, layer_group_id=self_lg, pool_idx=self_pi)
+            dst_region = peer_extractor.extract(
+                dst_block_ids, layer_group_id=peer_lg, pool_idx=peer_pi
+            )
+            mapper = self._registrar.get_kv_map(peer_ri, (self_lg, self_pi), (peer_lg, peer_pi))
+            region_pair = mapper.map(src_region, dst_region)
+            region_pairs = region_pair if isinstance(region_pair, list) else [region_pair]
+            for rp in region_pairs:
+                src_frag_parts.append(rp.src.memory.ptrs)
+                dst_frag_parts.append(rp.dst.memory.ptrs)
+                size_specs.append((rp.src.memory.ptrs.size, rp.src.memory.bytes_per_region))
 
         if src_frag_parts:
             src_frags = np.concatenate(src_frag_parts)
@@ -1516,6 +1533,14 @@ class Receiver(ReceiverBase):
             lpp = getattr(peer_ri, "layer_num_per_pp", None)
             if not lpp or len(lpp) < overlap.overlap_pp_size or len(set(lpp)) != 1:
                 return False
+        # Replicated pools (e.g. MiniMax M3 index-key) are sent by one elected
+        # fan-in owner only, so with multiple writers their contributions
+        # differ in size and the equal split is invalid.
+        if len(overlap.ranks) > 1 and peer_ri.page_table is not None:
+            for layer_group in peer_ri.page_table.layer_groups:
+                for pool_view in getattr(layer_group, "pool_views", ()):
+                    if pool_view.mapper_kind == MapperKind.REPLICATED:
+                        return False
         return True
 
     def dispatch_task(self, task: KVRecvTask):

--- a/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/kv_extractor.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Dict, List
 
 import numpy as np
@@ -20,11 +35,27 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     PhysicalPoolGroup,
     PoolView,
 )
-from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool
+from tensorrt_llm._torch.disaggregation.resource.utils import (
+    compute_layer_byte_ranges,
+    get_physical_pool,
+)
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import Role
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import MambaHybridCacheManager
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._utils import get_size_in_bytes, nvtx_range
 from tensorrt_llm.bindings import DataType
+
+# Mapper kinds a V2 manager may declare via get_disagg_role_mapper_kinds().
+# A physical pool may mix kinds (V2 storage coalesces buffers purely by
+# size within a life cycle); the page-table builder emits one PoolView per
+# (pool, kind) so each view stays kind-homogeneous.
+_V2_ROLE_MAPPER_KINDS = frozenset(
+    {
+        MapperKind.INDEXED,
+        MapperKind.REPLICATED,
+        MapperKind.NHD,
+    }
+)
 
 
 class KVRegionExtractorV1(RegionExtractorBase):
@@ -60,8 +91,9 @@ class KVRegionExtractorV1(RegionExtractorBase):
         described by region_ids.
 
         For KV cache: each ptr = base_address + slot_id * slot_bytes, pointing
-        to the start of a full slot.  The slot contains buffer entries for all
-        layers in this layer_group laid out contiguously from offset 0.
+        to the start of a full slot. Sub-slot selection (layers, role classes,
+        heads) is the mappers' responsibility; logical views carry that
+        geometry in their buffer entries.
 
         Args:
             layer_group_id: The layer group index (= life cycle index).
@@ -193,11 +225,15 @@ def build_page_table(kv_cache_manager: KVCacheManager) -> KVCachePageTable:
             buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE),
             pool_role=frozenset(kv_role_names),
             mapper_kind=MapperKind.INDEXED,
+            bytes_per_layer=stride,
         )
         physical_pools = [kv_physical]
         pool_views = [kv_view]
 
-        # Indexer K cache support
+        # Indexer K cache support. The DSA indexer K cache is identical on
+        # every TP rank (single index head), so its view is REPLICATED with
+        # one synthesized buffer entry per local layer: the slot packs the
+        # layers equal-sized in local-layer order.
         if getattr(kv_cache_manager, "enable_indexer_k_cache", False):
             indexer_pool = kv_cache_manager.impl.get_indexer_k_cache_pool()
             # indexer_pool shape: (numBlocks, numLayers, kvFactor, blockSize), dtype=UINT8
@@ -211,11 +247,19 @@ def build_page_table(kv_cache_manager: KVCacheManager) -> KVCachePageTable:
                 slot_bytes=indexer_slot_bytes,
                 num_slots=num_blocks,
             )
+            indexer_bytes_per_layer = indexer_slot_bytes // len(local_layer_ids)
             indexer_view = PoolView(
                 pool_idx=1,
-                buffer_entries=np.array([], dtype=BUFFER_ENTRY_DTYPE),
+                buffer_entries=np.array(
+                    [
+                        (lid, i * indexer_bytes_per_layer, indexer_bytes_per_layer)
+                        for i, lid in enumerate(local_layer_ids)
+                    ],
+                    dtype=BUFFER_ENTRY_DTYPE,
+                ),
                 pool_role=frozenset({"indexer_k"}),
-                mapper_kind=MapperKind.FLAT,
+                mapper_kind=MapperKind.REPLICATED,
+                bytes_per_layer=indexer_bytes_per_layer,
             )
             physical_pools.append(indexer_physical)
             pool_views.append(indexer_view)
@@ -313,20 +357,51 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
             gpu_level = level_idx
             break
 
-    # Collect buffer entries keyed by (life_cycle_id, pool_idx).
-    # Also collect the set of native role-name strings per pool — used as
-    # ``PoolView.pool_role``, the manager-supplied equivalence label that
-    # disagg uses to match pools across peers without enumerating roles.
-    buffer_by_lc_pool: Dict[tuple, list] = defaultdict(list)
-    native_roles_by_pool: Dict[tuple, set] = defaultdict(set)
+    # Every V2 manager declares how native roles map to the closed set of
+    # disaggregation mapper kinds; Role.ALL is the required fallback.
+    role_mapper_kinds = manager.get_disagg_role_mapper_kinds()
+    if Role.ALL not in role_mapper_kinds:
+        raise ValueError("Disaggregation role mapping must define Role.ALL")
+    for role, mapper_kind in role_mapper_kinds.items():
+        if not isinstance(mapper_kind, MapperKind):
+            raise ValueError(
+                f"Invalid disaggregation mapper kind {mapper_kind!r} for role {role!s}"
+            )
+        if mapper_kind not in _V2_ROLE_MAPPER_KINDS:
+            supported = ", ".join(kind.name for kind in sorted(_V2_ROLE_MAPPER_KINDS))
+            raise ValueError(
+                f"Unsupported V2 disaggregation mapper kind {mapper_kind.name} "
+                f"for role {role!s}; supported kinds: {supported}"
+            )
+        # INDEXED is the whole-manager legacy default, not a per-role
+        # choice: it may only appear as the Role.ALL fallback. Side-cache
+        # roles (e.g. INDEX_KEY) may declare their own non-INDEXED kind
+        # alongside it.
+        if mapper_kind is MapperKind.INDEXED and role != Role.ALL:
+            raise ValueError(
+                f"MapperKind.INDEXED is only valid as the Role.ALL mapping; "
+                f"got it for role {role!s}"
+            )
+    default_mapper_kind = role_mapper_kinds[Role.ALL]
 
+    # Bucket buffer entries by (life_cycle, pool, mapper kind). One PoolView
+    # is emitted per bucket and spans every layer of that role class, so the
+    # view count per layer group is bounded by the number of role classes —
+    # never by the layer count. A physical pool may hold several classes
+    # (V2 storage coalesces buffers purely by size within a life cycle, so
+    # e.g. MiniMax M3's index-K shares the K/V pool when their per-block
+    # sizes coincide); each class still gets its own view, which keeps peer
+    # matching independent of that physical coalescing decision.
+    # ``pool_role`` stays the manager-supplied equivalence label used for
+    # peer matching without enumerating role names.
+    bucket_entries: Dict[tuple, list] = defaultdict(list)
+    bucket_roles: Dict[tuple, set] = defaultdict(set)
     for buffer_id, attr in storage._buffer_attr.items():
         layer_id, role = buffer_id
-        lc_id = attr.life_cycle_id
-        pool_idx = attr.pool_index
-        pool_key = (int(lc_id), pool_idx)
-        buffer_by_lc_pool[pool_key].append((layer_id, attr.offset, attr.size))
-        native_roles_by_pool[pool_key].add(str(role))
+        kind = role_mapper_kinds.get(role, default_mapper_kind)
+        bucket_key = (int(attr.life_cycle_id), int(attr.pool_index), kind)
+        bucket_entries[bucket_key].append((int(layer_id), int(attr.offset), int(attr.size)))
+        bucket_roles[bucket_key].add(str(role))
 
     # Iterate over life cycles (layer groups), not storage pool groups.
     # Multiple layer_groups can share the same storage pool_group when their
@@ -377,23 +452,49 @@ def _build_page_table_v2(manager) -> KVCachePageTable:
             for iid, gid in zip(all_internal_layer_ids, all_global_layer_ids)
         ]
 
+        # Emit this life cycle's views: one per bucket, i.e. per
+        # (life_cycle, pool, mapper kind) — the life-cycle component is
+        # fixed by the enclosing loop, so within this group it reads as
+        # one view per (pool, mapper-kind class of roles). Roles sharing a
+        # kind share a view (KEY+VALUE); roles with different kinds in the
+        # same physical pool get separate views (M3 coalesced index-K).
+        # The life-cycle filter also handles pool-group sharing: multiple
+        # life cycles may draw slots from the same storage pool group, and
+        # each group only picks up buckets holding its own buffers.
+        # All ordering below is canonicalization — the page table is
+        # serialized and matched against peers, so view order (pool, then
+        # lowest slot offset), entry order (slot offset), and role text
+        # must not depend on dict/set iteration order.
         pool_views = []
-        for pool_idx in range(num_pools):
-            pool_key = (lc_idx, pool_idx)
-            buffers_info = buffer_by_lc_pool.get(pool_key, [])
-
-            # Skip pools that have no buffers for this layer group.
-            # Multiple life cycles may share the same storage pool group;
-            # only include pools that actually belong to this life cycle.
-            if not buffers_info:
-                continue
-
+        lc_bucket_keys = sorted(
+            (key for key in bucket_entries if key[0] == lc_idx),
+            key=lambda key: (key[1], min(entry[1] for entry in bucket_entries[key])),
+        )
+        for bucket_key in lc_bucket_keys:
+            _, pool_idx, mapper_kind = bucket_key
+            roles = frozenset(bucket_roles[bucket_key])
+            entries = np.array(
+                sorted(bucket_entries[bucket_key], key=lambda entry: entry[1]),
+                dtype=BUFFER_ENTRY_DTYPE,
+            )
+            # Fail fast on invalid geometry and record the uniform per-layer
+            # region size on the wire. Every kind is entries-driven, so the
+            # contiguous-layer-region / uniform-size invariants apply to all
+            # views uniformly.
+            _, bytes_per_layer = compute_layer_byte_ranges(
+                entries,
+                context=(
+                    f"View(life_cycle={lc_idx}, pool={pool_idx}, "
+                    f"kind={mapper_kind.name}, role={sorted(roles)})"
+                ),
+            )
             pool_views.append(
                 PoolView(
                     pool_idx=pool_idx,
-                    buffer_entries=np.array(buffers_info, dtype=BUFFER_ENTRY_DTYPE),
-                    pool_role=frozenset(native_roles_by_pool[pool_key]),
-                    mapper_kind=MapperKind.INDEXED,
+                    buffer_entries=entries,
+                    pool_role=roles,
+                    mapper_kind=mapper_kind,
+                    bytes_per_layer=bytes_per_layer,
                 )
             )
 

--- a/tensorrt_llm/_torch/disaggregation/resource/page.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/page.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -16,23 +31,38 @@ BUFFER_ENTRY_DTYPE = np.dtype(
 
 
 class MapperKind(IntEnum):
-    """Slot metadata shape — selects how disagg derives the pool's layer set.
+    """Transfer semantics of one physical pool's bytes.
 
-    INDEXED: PoolView.buffer_entries lists ``(local_layer_id, offset, size)``
-        per buffer. Disagg reads ``local_layer_id`` to know *which* layers
-        from the LG live in this pool (a pool may cover a subset when V2
-        splits an LG into multiple pools by buffer-size class). The
-        ``offset`` / ``size`` columns are carried for future use but are not
-        currently consumed at byte-transfer time.
-    FLAT:    PoolView.buffer_entries is empty. Disagg assumes the pool
-        covers *all* layers of the LG, packed equal-sized in
-        ``local_layers`` order. Used today by the DSA (DeepSeek Sparse
-        Attention, v3.2) indexer K cache pool, whose slot layout is a dense
-        ``(numLayers, kvFactor, blockSize)`` array.
+    Every PoolView carries ``buffer_entries`` listing
+    ``(local_layer_id, offset, size)`` per buffer; the view's exact layer
+    set always comes from those entries (a view may cover a subset of the
+    LG when V2 splits an LG into multiple pools by buffer-size class, or
+    when a role class exists only on some layers). The kind selects how
+    bytes move between heterogeneous topologies:
 
-    Byte arithmetic is the same for both kinds: per-layer stride is
-    ``slot_bytes // num_layers``. The kind only affects how disagg discovers
-    the pool's layer set during pool matching.
+    INDEXED: Head-major (HND) K/V — the layout written by the TRTLLM
+        attention kernels and the default for V1 and standard V2 managers.
+        Heterogeneous-head transfer selects one contiguous head-major range
+        per K/V buffer.
+    REPLICATED: The pool holds bytes that are identical on every TP rank
+        (MiniMax M3 index-key, DSA indexer K). Copied without KV-head
+        remapping using per-layer strides; fan-in routing elects one owning
+        sender per destination so each peer receives exactly one copy.
+    NHD: Ordinary K/V whose per-buffer storage is token-major
+        ``[token, head, dim]``. Heterogeneous-head transfer must select the
+        corresponding head slice inside every token rather than a single
+        contiguous head-major range.
+
+    A physical pool may hold roles of different kinds: V2 storage coalesces
+    buffers purely by ``(life_cycle, buffer size)``, so e.g. MiniMax M3's
+    replicated index-K shares the K/V pool at TP degrees where their
+    per-block sizes coincide. The page-table builder therefore emits one
+    PoolView per ``(physical pool, mapper kind)`` — a view covers exactly
+    the bytes of one role class, and its per-layer byte ranges come from
+    ``buffer_entries`` (offsets are per layer because another class may
+    interleave between layers; only the per-layer size is uniform, recorded
+    in ``bytes_per_layer``). View count per layer group is bounded by the
+    number of role classes, never by layer count.
 
     Mamba state pools do not use this enum: Mamba's transfer is dispatched
     through :class:`MambaPolicy` which hard-codes the ``is_conv`` switch and
@@ -40,7 +70,8 @@ class MapperKind(IntEnum):
     """
 
     INDEXED = 0
-    FLAT = 1
+    REPLICATED = 1
+    NHD = 2
 
 
 @dataclass
@@ -107,7 +138,7 @@ class PoolView:
         pool_idx: Index of the physical pool within its pool group.
         buffer_entries: Structured array using ``BUFFER_ENTRY_DTYPE``. Each
             entry records a buffer's ``local_layer_id`` and its byte ``offset``
-            and ``size`` within the pool slot. FLAT pools have no entries.
+            and ``size`` within the pool slot.
         pool_role: Set of native role-name strings (whatever the cache manager
             uses, e.g. ``"key"`` / ``"value"`` / ``"deepseek_v4_swa"``) that
             live in this pool. Used as the *equivalence label* for peer-to-peer
@@ -115,12 +146,19 @@ class PoolView:
             are equal. Disagg never enumerates the role-name vocabulary —
             adding a new role on the manager side requires no disagg change.
         mapper_kind: Closed-set discriminator for picking the Mapper family.
+        bytes_per_layer: Uniform byte size of one layer's region within the
+            slot. The per-layer *offsets* live in ``buffer_entries``; only
+            the size is uniform, because a slot may interleave other role
+            classes between layers, making the layer stride non-uniform.
+            Set for every kind; ``None`` only in tables serialized by older
+            builders, where consumers re-derive it from the entries.
     """
 
     pool_idx: int
     buffer_entries: np.ndarray  # dtype=BUFFER_ENTRY_DTYPE
     pool_role: FrozenSet[str] = field(default_factory=frozenset)
     mapper_kind: MapperKind = MapperKind.INDEXED
+    bytes_per_layer: Optional[int] = None
 
     def to_dict(self) -> dict:
         return {
@@ -128,6 +166,9 @@ class PoolView:
             "buffer_entries": self.buffer_entries.tolist(),
             "pool_role": sorted(self.pool_role),
             "mapper_kind": int(self.mapper_kind),
+            "bytes_per_layer": (
+                int(self.bytes_per_layer) if self.bytes_per_layer is not None else None
+            ),
         }
 
     @staticmethod
@@ -143,6 +184,9 @@ class PoolView:
             ),
             pool_role=frozenset(data["pool_role"]),
             mapper_kind=MapperKind(int(data["mapper_kind"])),
+            bytes_per_layer=(
+                int(data["bytes_per_layer"]) if data.get("bytes_per_layer") is not None else None
+            ),
         )
 
 

--- a/tensorrt_llm/_torch/disaggregation/resource/utils.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/utils.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 from typing import Dict, List, Set
@@ -24,6 +39,64 @@ def get_slot_address(pool: PhysicalPool, slot_id: int) -> int:
 # -------------------------------------------------------------------------
 # PoolView helpers
 # -------------------------------------------------------------------------
+
+
+def compute_layer_byte_ranges(
+    buffer_entries,
+    *,
+    declared_bytes_per_layer: "int | None" = None,
+    context: str = "PoolView",
+) -> tuple[Dict[int, int], int]:
+    """Per-layer slot-relative byte offsets from raw buffer entries.
+
+    Returns ``({local_layer_id: start_offset}, bytes_per_layer)``. A layer's
+    region is the concatenation of its buffer entries, which must be
+    contiguous within the slot; the region size must be uniform across
+    layers (the slot may interleave other role classes between layers, so
+    only the *size* is uniform — offsets are per layer). ``context`` labels
+    error messages; ``declared_bytes_per_layer`` cross-checks a size that
+    was recorded elsewhere.
+    """
+    starts: Dict[int, int] = {}
+    totals: Dict[int, int] = {}
+    entries_by_layer: Dict[int, list] = {}
+    for entry in buffer_entries:
+        entries_by_layer.setdefault(int(entry["local_layer_id"]), []).append(
+            (int(entry["offset"]), int(entry["size"]))
+        )
+    if not entries_by_layer:
+        raise ValueError(f"{context} has no buffer entries; per-layer byte ranges are undefined")
+    for layer_id, spans in entries_by_layer.items():
+        spans.sort()
+        for (off, size), (next_off, _) in zip(spans, spans[1:]):
+            if off + size != next_off:
+                raise ValueError(
+                    f"{context} layer {layer_id} buffers are "
+                    f"not contiguous: [{off}, {off + size}) is followed by offset {next_off}"
+                )
+        starts[layer_id] = spans[0][0]
+        totals[layer_id] = sum(size for _, size in spans)
+    distinct_totals = set(totals.values())
+    if len(distinct_totals) != 1:
+        raise ValueError(
+            f"{context} per-layer region sizes are not uniform: {sorted(totals.items())}"
+        )
+    bytes_per_layer = distinct_totals.pop()
+    if declared_bytes_per_layer is not None and declared_bytes_per_layer != bytes_per_layer:
+        raise ValueError(
+            f"{context} declares bytes_per_layer={declared_bytes_per_layer} but buffer "
+            f"entries sum to {bytes_per_layer} per layer"
+        )
+    return starts, bytes_per_layer
+
+
+def get_layer_byte_ranges(pool_view: PoolView) -> tuple[Dict[int, int], int]:
+    """Per-layer byte ranges of a view; see :func:`compute_layer_byte_ranges`."""
+    return compute_layer_byte_ranges(
+        pool_view.buffer_entries,
+        declared_bytes_per_layer=pool_view.bytes_per_layer,
+        context=f"PoolView(pool_idx={pool_view.pool_idx}, role={sorted(pool_view.pool_role)})",
+    )
 
 
 def get_unique_layers(pool_view: PoolView) -> Set[int]:

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import time
 import uuid
 from collections import defaultdict
@@ -254,8 +269,11 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             n = int((block_ids >= 0).sum())
             if n == 0:
                 continue
-            for pv in lg.pool_views:
-                pool = get_physical_pool(pt, lg_id, pv.pool_idx)
+            # Logical views can share one physical pool (e.g. K/V and a
+            # replicated side cache split out of the same slot); count each
+            # physical pool once.
+            for pool_idx in sorted({pv.pool_idx for pv in lg.pool_views}):
+                pool = get_physical_pool(pt, lg_id, pool_idx)
                 total += n * pool.slot_bytes
         return total
 
@@ -370,10 +388,15 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
     def _consensus_outcome(
         self, to_process, cancelled, failed, completed, allgather: Callable, need_sync: bool
     ):
-        # CANCELLED/FAILED on any rank → global; COMPLETED only when ALL ranks agree.
-        all_c = self._allgather_or_passthrough(cancelled, allgather, need_sync)
-        all_f = self._allgather_or_passthrough(failed, allgather, need_sync)
-        all_done = self._allgather_or_passthrough(completed, allgather, need_sync)
+        # CANCELLED/FAILED on any rank → global; COMPLETED only when ALL ranks
+        # agree. The three id lists travel in ONE allgather (packed as a
+        # list-of-lists) instead of three collectives.
+        per_rank = self._allgather_or_passthrough(
+            [list(cancelled), list(failed), list(completed)], allgather, need_sync
+        )
+        all_c = [rank_lists[0] for rank_lists in per_rank]
+        all_f = [rank_lists[1] for rank_lists in per_rank]
+        all_done = [rank_lists[2] for rank_lists in per_rank]
         n = len(all_c)
         global_cancelled = self._union(all_c)
         global_failed = self._union(all_f)
@@ -552,6 +575,17 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         wait_num = at_least_request_num if not block_all else 0
 
         local_completed, local_failed = self._collect_done(self._send_sessions, self._send_reqs)
+
+        # TODO: support a ctx consensus fast-path in a follow-up PR: gate the
+        # variable-length consensus allgathers below with a fixed-size integer
+        # reduction of the local terminal-session count, so idle executor
+        # polls (wait_num == 0, nothing finished anywhere) return early. The
+        # reduction must mirror _ctx_consensus()'s communicator scope (TP
+        # group, then PP group; TP skipped under attention DP) — a
+        # WORLD-scoped collective would mismatch ordering or hang under
+        # ADP+PP, where independent attention-DP lanes poll on their own
+        # schedules. See the skipped test
+        # test_ctx_consensus_fastpath_skips_when_idle.
         to_process = self._build_to_process(
             self._send_sessions,
             self._ctx_consensus(local_completed + local_failed),

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 from strenum import StrEnum
 
+from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.distributed.communicator import Distributed, ReduceOp
 from tensorrt_llm._utils import (
     TensorWrapper,
@@ -1061,23 +1062,11 @@ class KVCacheManagerV2(BaseResourceManager):
 
             for layer_id in typed_range(LayerId(self.num_local_layers)):
                 layer_group_id = self.impl.get_layer_group_id(layer_id)
-                if self.dtype != DataType.NVFP4:
-                    key_base_addr = kv_cache_pool_pointers_list[layer_group_id][0]
-                    addr_offset = (
-                        self.impl.get_mem_pool_base_address(
-                            layer_id, Role.KEY, PageIndexMode.SHARED
-                        )
-                        - key_base_addr
-                    )
-                else:
-                    key_base_addr = kv_cache_pool_pointers_list[layer_group_id][0]
+                key_base_addr = kv_cache_pool_pointers_list[layer_group_id][0]
+                offset = self._kv_pool_mapping_offset(layer_id, layer_group_id, key_base_addr)
+
+                if self.dtype == DataType.NVFP4:
                     block_scale_base_addr = block_scale_pool_pointers_list[layer_group_id][0]
-                    addr_offset = (
-                        self.impl.get_mem_pool_base_address(
-                            layer_id, Role.KEY, PageIndexMode.SHARED
-                        )
-                        - key_base_addr
-                    )
                     block_scale_addr_offset = (
                         self.impl.get_mem_pool_base_address(
                             layer_id, Role.KEY_BLOCK_SCALE, PageIndexMode.SHARED
@@ -1090,14 +1079,6 @@ class KVCacheManagerV2(BaseResourceManager):
                         * self.kv_factor
                         * self.tokens_per_block,
                     )
-                offset = exact_div(
-                    addr_offset,
-                    self.get_layer_bytes_per_token(layer_id, Role.KEY)
-                    * self.kv_factor
-                    * self.tokens_per_block,
-                )
-
-                if self.dtype == DataType.NVFP4:
                     assert block_scale_offset == offset, (
                         "Block scale offset and offset should be the same"
                     )
@@ -1157,6 +1138,29 @@ class KVCacheManagerV2(BaseResourceManager):
         )
         if self.enable_swa_scratch_reuse:
             self._prepare_swa_scratch_copy_tensors(index_mapper_capacity)
+
+    def _kv_pool_mapping_offset(
+        self, layer_id: LayerId, layer_group_id: int, key_base_addr: int
+    ) -> int:
+        """Per-layer offset recorded in ``kv_cache_pool_mapping``.
+
+        The default derives the layer's position within its pool from the K
+        base address, assuming every layer contributes exactly K(+V) to the
+        pool slot so the layer stride is uniform. Managers whose pool slots
+        may interleave extra per-layer buffers between layers (non-uniform
+        layer strides — e.g. MiniMax M3 when the index-K buffer coalesces
+        into the K/V pool) must override this with a positional formula.
+        """
+        addr_offset = (
+            self.impl.get_mem_pool_base_address(layer_id, Role.KEY, PageIndexMode.SHARED)
+            - key_base_addr
+        )
+        return exact_div(
+            addr_offset,
+            self.get_layer_bytes_per_token(layer_id, Role.KEY)
+            * self.kv_factor
+            * self.tokens_per_block,
+        )
 
     def _get_runtime_cache_size_layer_components(self) -> tuple[List[int], List[Optional[int]]]:
         layer_sizes = []
@@ -1587,6 +1591,38 @@ class KVCacheManagerV2(BaseResourceManager):
         new roles do not require C++ changes.
         """
         return None
+
+    def get_disagg_role_mapper_kinds(self) -> dict[DataRole, MapperKind]:
+        """Map native cache roles to disaggregation mapper kinds.
+
+        ``Role.ALL`` is the required fallback for roles without an explicit
+        entry. The default is the head-major (HND) ``INDEXED`` layout written
+        by the TRTLLM attention kernels — correct for V1 and standard V2
+        managers. ``Role.INDEX_KEY`` defaults to ``REPLICATED``: every
+        index-key side cache shipped so far (DSA indexer-K on V1, MiniMax M3
+        on V2) computes its projection replicated across TP ranks, so the
+        cache bytes are identical per rank; the entry is inert unless a
+        subclass actually registers ``INDEX_KEY`` buffers via
+        ``_extra_buffers_per_layer``. Model-specific managers may declare
+        logical layouts without requiring the shared extractor to inspect
+        private attributes or role names. MiniMax M3, for example, maps
+        ordinary K/V to ``NHD`` and keeps index-key ``REPLICATED``.
+
+        This declaration does not influence storage pooling: V2 storage
+        coalesces buffers purely by ``(life_cycle, buffer size)``, so roles
+        with different transfer semantics may share a pool slot when their
+        per-block sizes coincide (e.g. MiniMax M3 at TP degrees where
+        K == V == INDEX_KEY bytes per block). The disagg page-table builder
+        splits each physical pool into one logical view per mapper kind, so
+        transfer correctness never depends on the coalescing outcome.
+
+        Pool memory is layout-agnostic; this declaration describes what the
+        manager's paired attention backend actually writes. A static mapping
+        is valid only for a fixed manager/backend pair. A manager whose backend
+        selects the layout at runtime must derive the mapping from that
+        backend's configuration.
+        """
+        return {Role.ALL: MapperKind.INDEXED, Role.INDEX_KEY: MapperKind.REPLICATED}
 
     @property
     def blocks_in_primary_pool(self) -> int:

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -286,6 +286,9 @@ class KVCacheManager(BaseResourceManager):
         self.mapping = mapping
         self.dtype = dtype
         self.kv_cache_type = kv_cache_type
+        # Consumed by the disaggregation page-table builder to expose the DSA
+        # indexer K cache pool as a REPLICATED pool view.
+        self.enable_indexer_k_cache = enable_indexer_k_cache
         self.spec_config = spec_config
         self.pp_layers, self.num_layers = get_pp_layers(
             num_layers,

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -85,6 +85,10 @@ l0_h100:
   - unittest/disaggregated/test_request_id.py
   - unittest/disaggregated/test_kv_transfer.py
   - unittest/disaggregated/test_kv_transfer_mp.py
+  - unittest/disaggregated/test_transceiver_bounded_polling.py
+  - unittest/disaggregated/test_pool_matching.py
+  - unittest/disaggregated/test_deepseek_v4_kv_transfer.py
+  - unittest/disaggregated/test_minimax_m3_kv_transfer.py
   # Split the large cache transceiver parametrization into readable chunks.
   # Main transfer matrix.
   - unittest/disaggregated/test_cache_transceiver_single_process.py::test_cache_transceiver -k "v1 and no_window"
@@ -99,6 +103,8 @@ l0_h100:
   # Boundary request lengths.
   - unittest/disaggregated/test_cache_transceiver_single_process.py::test_cache_transceiver_boundary_lengths -k "v1"
   - unittest/disaggregated/test_cache_transceiver_single_process.py::test_cache_transceiver_boundary_lengths -k "v2"
+  # DSA indexer-K side cache (V1, REPLICATED).
+  - unittest/disaggregated/test_cache_transceiver_single_process.py::test_cache_transceiver_v1_dsa_indexer
   - unittest/disaggregated/test_cache_transceiver_harness_report.py
   - unittest/disaggregated/test_cache_transceiver_harness.py
   - unittest/others/test_kv_cache_transceiver.py::test_kv_cache_transceiver_single_process[PYTHON-mha-ctx_fp16_gen_fp16]

--- a/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
@@ -1,5 +1,17 @@
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from types import SimpleNamespace
 
@@ -104,3 +116,19 @@ def test_try_commit_blocks_commits_partial_block_at_context_end() -> None:
     assert kv_cache.committed_tokens == [4, 5, 6, 7, 8, 9]
     assert kv_cache.num_committed_tokens == 10
     assert kv_cache.stopped_committing
+
+
+def test_disagg_role_mapper_kinds_default_to_indexed():
+    from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
+    from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import Role
+
+    manager = object.__new__(KVCacheManagerV2)
+
+    # K/V default to the TRTLLM head-major layout; the index-key side cache
+    # defaults to REPLICATED (every shipped index-K — DSA V1, MiniMax M3 —
+    # is TP-replicated). The INDEX_KEY entry is inert unless a subclass
+    # registers such buffers.
+    assert manager.get_disagg_role_mapper_kinds() == {
+        Role.ALL: MapperKind.INDEXED,
+        Role.INDEX_KEY: MapperKind.REPLICATED,
+    }

--- a/tests/unittest/disaggregated/kv_transfer_harness.py
+++ b/tests/unittest/disaggregated/kv_transfer_harness.py
@@ -1,0 +1,514 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Threaded single-process NIXL harness for V2 disaggregated KV transfer tests.
+
+Creates one ``KvCacheTransceiverV2`` per rank inside a single process using
+threads plus a Barrier-based ``Distributed`` mock, then drives a full
+ctx-send / gen-receive transfer and hands verification back to the caller.
+Model specifics (cache-manager construction, pool initialization, post-transfer
+verification) are injected as hooks; see ``test_deepseek_v4_kv_transfer.py``
+and ``test_minimax_m3_kv_transfer.py`` for the two current users.
+"""
+
+import os
+import threading
+import uuid
+from typing import Dict, List, Optional, Protocol, Sequence, TypeVar
+
+import tensorrt_llm
+import tensorrt_llm.bindings
+import tensorrt_llm.tensorrt_llm_transfer_agent_binding  # noqa: F401
+from tensorrt_llm import DisaggregatedParams, Mapping, SamplingParams
+from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestType
+from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
+from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig
+
+# Reduce NIXL threads for unit test: default 8 threads per agent causes heavy
+# contention when creating multiple agents on a single GPU in the same process.
+os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
+
+
+# ---------------------------------------------------------------------------
+# Harness-scale constants shared by all model-specific manager factories
+# ---------------------------------------------------------------------------
+TOKENS_PER_BLOCK = 128
+MAX_SEQ_LEN = 512
+MAX_BATCH_SIZE = 16
+VOCAB_SIZE = 129280
+
+_CacheManagerT = TypeVar("_CacheManagerT", bound=KVCacheManagerV2)
+_CacheManagerT_co = TypeVar("_CacheManagerT_co", bound=KVCacheManagerV2, covariant=True)
+_CacheManagerT_contra = TypeVar("_CacheManagerT_contra", bound=KVCacheManagerV2, contravariant=True)
+
+
+class ManagerFactory(Protocol[_CacheManagerT_co]):
+    """Build one cache manager per rank of a (tp x pp) instance.
+
+    Model-specific knobs (dtype, compress ratios, sparse layers, ...) are
+    closed over by the caller rather than threaded through the harness.
+    """
+
+    def __call__(
+        self,
+        tp: int,
+        pp: int,
+        enable_dp: bool,
+        /,
+    ) -> Sequence[_CacheManagerT_co]: ...
+
+
+class CacheInitializer(Protocol[_CacheManagerT_contra]):
+    def __call__(
+        self,
+        managers: Sequence[_CacheManagerT_contra],
+        tp: int,
+        /,
+        *,
+        seed_base: int = 0,
+        fill_random: bool = True,
+    ) -> None: ...
+
+
+class CacheVerifier(Protocol[_CacheManagerT_contra]):
+    def __call__(
+        self,
+        *,
+        request_lengths: List[int],
+        ctx_managers: Sequence[_CacheManagerT_contra],
+        gen_managers: Sequence[_CacheManagerT_contra],
+        ctx_tp: int,
+        ctx_pp: int,
+        gen_tp: int,
+        gen_pp: int,
+        ctx_enable_dp: bool,
+        gen_enable_dp: bool,
+        ctx_request_ids: List[int],
+        gen_request_ids: List[int],
+    ) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# ThreadSafeDistributed: threading.Barrier-based Distributed mock
+# ---------------------------------------------------------------------------
+class ThreadSafeDistributed:
+    """Distributed mock using threading.Barrier for single-process multi-rank testing.
+
+    Provides the same interface as TorchDistributedWrapper from test_py_cache_transceiver_mp.py
+    but uses Barrier + Lock + shared dict instead of torch.distributed.
+    """
+
+    def __init__(
+        self,
+        local_rank: int,
+        world_size: int,
+        tp_size: int,
+        pp_size: int,
+        tp_rank: int,
+        pp_rank: int,
+        shared: dict,
+    ):
+        self.rank = local_rank
+        self._world_size = world_size
+        self._tp_size = tp_size
+        self._pp_size = pp_size
+        self._tp_rank = tp_rank
+        self._pp_rank = pp_rank
+        self._s = shared
+        self._bcast_idx = 0
+        self._ag_idx = 0
+        self._pp_ag_idx = 0
+        self._tp_ag_idx = 0
+
+    @property
+    def tp_size(self):
+        return self._tp_size
+
+    @property
+    def pp_size(self):
+        return self._pp_size
+
+    @property
+    def world_size(self):
+        return self._world_size
+
+    def broadcast(self, obj, root=0):
+        idx = self._bcast_idx
+        self._bcast_idx += 1
+        key = f"bcast_{idx}"
+        if self.rank == root:
+            self._s[key] = obj
+        self._s["barrier"].wait()
+        result = self._s[key]
+        self._s["barrier"].wait()
+        return result
+
+    def allgather(self, obj):
+        idx = self._ag_idx
+        self._ag_idx += 1
+        key = f"ag_{idx}"
+        with self._s["lock"]:
+            if key not in self._s:
+                self._s[key] = [None] * self._world_size
+            self._s[key][self.rank] = obj
+        self._s["barrier"].wait()
+        result = list(self._s[key])
+        self._s["barrier"].wait()
+        return result
+
+    def pp_allgather(self, obj):
+        idx = self._pp_ag_idx
+        self._pp_ag_idx += 1
+        key = f"pp_ag_{idx}_tp{self._tp_rank}"
+        with self._s["lock"]:
+            if key not in self._s:
+                self._s[key] = [None] * self._pp_size
+            self._s[key][self._pp_rank] = obj
+        self._s["barrier"].wait()
+        result = list(self._s[key])
+        self._s["barrier"].wait()
+        return result
+
+    def tp_allgather(self, obj):
+        idx = self._tp_ag_idx
+        self._tp_ag_idx += 1
+        key = f"tp_ag_{idx}_pp{self._pp_rank}"
+        with self._s["lock"]:
+            if key not in self._s:
+                self._s[key] = [None] * self._tp_size
+            self._s[key][self._tp_rank] = obj
+        self._s["barrier"].wait()
+        result = list(self._s[key])
+        self._s["barrier"].wait()
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Threading helpers
+# ---------------------------------------------------------------------------
+def run_concurrent(items, fn):
+    """Run fn(item) for each item concurrently in threads and propagate errors."""
+    errors = [None] * len(items)
+    results = [None] * len(items)
+
+    def _worker(idx, item):
+        try:
+            results[idx] = fn(item)
+        except Exception as e:
+            errors[idx] = e
+
+    threads = [threading.Thread(target=_worker, args=(i, item)) for i, item in enumerate(items)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    for i, err in enumerate(errors):
+        if err is not None:
+            raise err
+    return results
+
+
+def _create_transceiver_in_thread(rank, mapping, cache_manager, dist_mock, config, results, errors):
+    """Thread target: create one KvCacheTransceiverV2."""
+    try:
+        tc = KvCacheTransceiverV2(
+            mapping=mapping,
+            dist=dist_mock,
+            kv_cache_manager=cache_manager,
+            cache_transceiver_config=config,
+        )
+        results[rank] = tc
+    except Exception as e:
+        errors[rank] = e
+
+
+def create_instance_transceivers(
+    tp: int,
+    pp: int,
+    enable_dp: bool,
+    cache_managers: Sequence[KVCacheManagerV2],
+    config: CacheTransceiverConfig,
+) -> List[KvCacheTransceiverV2]:
+    """Create KvCacheTransceiverV2 for all ranks via threaded init."""
+    world_size = tp * pp
+    shared = {"barrier": threading.Barrier(world_size), "lock": threading.Lock()}
+    results = [None] * world_size
+    errors = [None] * world_size
+    threads = []
+
+    for rank in range(world_size):
+        pp_rank = rank // tp
+        tp_rank = rank % tp
+        mapping = Mapping(
+            world_size=world_size,
+            rank=rank,
+            tp_size=tp,
+            pp_size=pp,
+            enable_attention_dp=enable_dp,
+        )
+        dist_mock = ThreadSafeDistributed(rank, world_size, tp, pp, tp_rank, pp_rank, shared)
+        t = threading.Thread(
+            target=_create_transceiver_in_thread,
+            args=(
+                rank,
+                mapping,
+                cache_managers[rank],
+                dist_mock,
+                config,
+                results,
+                errors,
+            ),
+        )
+        threads.append(t)
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for rank, err in enumerate(errors):
+        if err is not None:
+            raise err
+
+    return results
+
+
+def get_ctx_info_endpoint(tc: KvCacheTransceiverV2) -> Optional[str]:
+    """Extract the context_info_endpoint from a transceiver's disaggregated params."""
+    endpoints = tc.get_disaggregated_params().get("ctx_info_endpoint") or []
+    return endpoints[0] if endpoints else None
+
+
+def get_layers_per_pp(num_layers: int, pp_size: int) -> List[int]:
+    """Return a list of layer counts per PP rank (mirrors C++ getLayerNumPPRank).
+
+    When num_layers is not evenly divisible by pp_size, the first
+    (num_layers % pp_size) ranks get one extra layer.
+    Matches Mapping.pp_layers / torch.tensor_split behaviour.
+    """
+    base = num_layers // pp_size
+    extra = num_layers % pp_size
+    return [base + (1 if r < extra else 0) for r in range(pp_size)]
+
+
+def run_kv_transfer_test(
+    ctx_tp: int,
+    ctx_pp: int,
+    gen_tp: int,
+    gen_pp: int,
+    ctx_enable_dp: bool,
+    gen_enable_dp: bool,
+    update_before_transfer: bool = True,
+    *,
+    manager_factory: ManagerFactory[_CacheManagerT],
+    init_fn: CacheInitializer[_CacheManagerT],
+    verify_fn: CacheVerifier[_CacheManagerT],
+) -> None:
+    """Run one ctx->gen KV transfer with injectable model-specific cache hooks."""
+    ctx_world = ctx_tp * ctx_pp
+    gen_world = gen_tp * gen_pp
+
+    # Mix of block-aligned and non-aligned lengths for boundary testing.
+    # TOKENS_PER_BLOCK=128: 65=half+1, 256=2x exact, 129=1x+1, 383=3x-1
+    request_lengths = [65, 256, 129, 383]
+
+    # ===== 1. Create cache managers =====
+    ctx_managers = list(manager_factory(ctx_tp, ctx_pp, ctx_enable_dp))
+    gen_managers = list(manager_factory(gen_tp, gen_pp, gen_enable_dp))
+
+    # ===== 2. Initialize data =====
+    # ctx: random data, seed=pp_rank (same across TP, different across PP)
+    init_fn(ctx_managers, ctx_tp, seed_base=1000, fill_random=True)
+    # gen: zeros
+    init_fn(gen_managers, gen_tp, fill_random=False)
+
+    # ===== 3. Create KvCacheTransceiverV2 instances (threaded init) =====
+    config = CacheTransceiverConfig(
+        backend="NIXL",
+        transceiver_runtime="PYTHON",
+        max_tokens_in_buffer=512,
+    )
+    ctx_tcs = create_instance_transceivers(ctx_tp, ctx_pp, ctx_enable_dp, ctx_managers, config)
+    gen_tcs = create_instance_transceivers(gen_tp, gen_pp, gen_enable_dp, gen_managers, config)
+
+    try:
+        ctx_info_endpoint = get_ctx_info_endpoint(ctx_tcs[0])
+
+        # ===== 4. Create requests and determine handle map =====
+        # handle_map: rank -> [(req_idx, ctx_request, gen_request)]
+        ctx_handle_map: Dict[int, List] = {r: [] for r in range(ctx_world)}
+        gen_handle_map: Dict[int, List] = {r: [] for r in range(gen_world)}
+        ctx_request_ids: List[int] = []
+        gen_request_ids: List[int] = []
+
+        sampling_params = SamplingParams()
+
+        for req_idx, req_len in enumerate(request_lengths):
+            unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
+            ctx_rid = req_idx * 2
+            gen_rid = req_idx * 2 + 1
+            ctx_request_ids.append(ctx_rid)
+            gen_request_ids.append(gen_rid)
+
+            ctx_dp_rank = req_idx % ctx_tp if ctx_enable_dp else 0
+
+            ctx_request = LlmRequest(
+                request_id=ctx_rid,
+                max_new_tokens=1,
+                input_tokens=list(range(req_len)),
+                sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                    sampling_params._get_sampling_config()
+                ),
+                is_streaming=False,
+                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
+            )
+            ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
+
+            gen_request = LlmRequest(
+                request_id=gen_rid,
+                max_new_tokens=1,
+                input_tokens=list(range(req_len)),
+                sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                    sampling_params._get_sampling_config()
+                ),
+                is_streaming=False,
+                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+            )
+            gen_request.py_disaggregated_params = DisaggregatedParams(
+                ctx_request_id=ctx_rid,
+                ctx_dp_rank=ctx_dp_rank,
+                ctx_info_endpoint=ctx_info_endpoint,
+                disagg_request_id=unique_rid,
+            )
+
+            for rank in range(ctx_world):
+                tp_rank = rank % ctx_tp
+                should_handle = (not ctx_enable_dp) or (req_idx % ctx_tp == tp_rank)
+                if should_handle:
+                    ctx_handle_map[rank].append((req_idx, ctx_request))
+
+            for rank in range(gen_world):
+                tp_rank = rank % gen_tp
+                should_handle = (not gen_enable_dp) or (req_idx % gen_tp == tp_rank)
+                if should_handle:
+                    gen_handle_map[rank].append((req_idx, gen_request))
+
+        # ===== 5. Allocate KV cache for all ranks =====
+        # prepare_resources is a no-op for non-draft KVCacheManagerV2.
+        # All ranks must allocate BEFORE mutating shared request objects
+        # (add_new_token changes is_first_context_chunk).
+        #
+        # Gen ranks take the disagg-gen-init path: prepare_disagg_gen_init
+        # sizes the cache for the full prompt and pre-declares
+        # history_length=prompt_len, matching what the V2 scheduler's
+        # _try_schedule_disagg_gen_init does in production so the
+        # transceiver's TRANS_COMPLETE contract check is satisfied.
+        # Ctx ranks take the regular prefill path (prepare_context +
+        # resize_context).
+        gen_batches: Dict[int, ScheduledRequests] = {}
+        for rank in range(gen_world):
+            reqs = [req for _, req in gen_handle_map[rank]]
+            if reqs:
+                batch = ScheduledRequests()
+                batch.context_requests_last_chunk = reqs
+                for req in reqs:
+                    gen_managers[rank].prepare_disagg_gen_init(req)
+                gen_batches[rank] = batch
+
+        ctx_batches: Dict[int, ScheduledRequests] = {}
+        for rank in range(ctx_world):
+            reqs = [req for _, req in ctx_handle_map[rank]]
+            if reqs:
+                batch = ScheduledRequests()
+                batch.context_requests_last_chunk = reqs
+                for req in reqs:
+                    ctx_managers[rank].prepare_context(req)
+                    ctx_managers[rank].resize_context(req, req.context_chunk_size)
+                ctx_batches[rank] = batch
+
+        # ===== 5.5. context_current_position + add_new_token =====
+        # Set position on each unique request once (needed for transfer metadata).
+        seen: set = set()
+        for rank in range(ctx_world):
+            for _, req in ctx_handle_map[rank]:
+                if req.py_request_id not in seen:
+                    req.context_current_position = req.prompt_len
+                    req.add_new_token(req.prompt_len, 0)
+                    seen.add(req.py_request_id)
+
+        seen = set()
+        for rank in range(gen_world):
+            for _, req in gen_handle_map[rank]:
+                if req.py_request_id not in seen:
+                    req.context_current_position = req.prompt_len
+                    req.add_new_token(req.prompt_len, 0)
+                    seen.add(req.py_request_id)
+
+        # ===== 5.6. update_resources BEFORE transfer (mode: update_before) =====
+        if update_before_transfer:
+            for rank, batch in ctx_batches.items():
+                ctx_managers[rank].update_resources(batch)
+            for rank, batch in gen_batches.items():
+                gen_managers[rank].update_resources(batch)
+
+        # ===== 6. gen receive + ctx send =====
+        for rank in range(gen_world):
+            for _, req in gen_handle_map[rank]:
+                gen_tcs[rank].request_and_receive_async(req)
+        for rank in range(ctx_world):
+            for _, req in ctx_handle_map[rank]:
+                ctx_tcs[rank].respond_and_send_async(req)
+
+        # ===== 7. Wait for completion (threaded, dist calls inside) =====
+        run_concurrent(
+            ctx_tcs, lambda tc: tc.check_context_transfer_status(None, mark_complete=True)
+        )
+        run_concurrent(gen_tcs, lambda tc: tc.check_gen_transfer_status(None))
+
+        # ===== 7.5. update_resources AFTER transfer (mode: update_after) =====
+        if not update_before_transfer:
+            for rank, batch in ctx_batches.items():
+                ctx_managers[rank].update_resources(batch)
+            for rank, batch in gen_batches.items():
+                gen_managers[rank].update_resources(batch)
+
+        # ===== 8. Verify =====
+        verify_fn(
+            request_lengths=request_lengths,
+            ctx_managers=ctx_managers,
+            gen_managers=gen_managers,
+            ctx_tp=ctx_tp,
+            ctx_pp=ctx_pp,
+            gen_tp=gen_tp,
+            gen_pp=gen_pp,
+            ctx_enable_dp=ctx_enable_dp,
+            gen_enable_dp=gen_enable_dp,
+            ctx_request_ids=ctx_request_ids,
+            gen_request_ids=gen_request_ids,
+        )
+
+    finally:
+        for tc in ctx_tcs + gen_tcs:
+            try:
+                tc.shutdown()
+            except Exception:
+                pass
+        for mgr in ctx_managers + gen_managers:
+            try:
+                mgr.shutdown()
+            except Exception:
+                pass

--- a/tests/unittest/disaggregated/region/test_block.py
+++ b/tests/unittest/disaggregated/region/test_block.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 
 from tensorrt_llm._torch.disaggregation.base.region import (
@@ -6,9 +21,8 @@ from tensorrt_llm._torch.disaggregation.base.region import (
     SpecRegionPair,
 )
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import (
-    HeadMatchMapper,
-    HeadMismatchMapper,
-    IdentityMapper,
+    HNDHeadMismatchMapper,
+    IntactMapper,
 )
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.spec import AttentionInfo
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
@@ -81,12 +95,13 @@ def test_spec_region_and_spec_region_pair():
     assert pair.dst.spec == "spec_dst"
 
 
-def test_identity_mapper():
+def test_intact_mapper_identity_degenerate():
+    """Full contiguous overlap degrades to a whole-region pass-through copy."""
     src_group = MemRegionGroup(ptrs=np.array([100, 200], dtype=np.int64), bytes_per_region=32)
     dst_group = MemRegionGroup(ptrs=np.array([300, 400], dtype=np.int64), bytes_per_region=32)
     src_spec = SpecRegion(memory=src_group, spec="a")
     dst_spec = SpecRegion(memory=dst_group, spec="b")
-    mapper = IdentityMapper()
+    mapper = IntactMapper([0, 16], [0, 16], 16, 16)
     result = mapper.map(src_spec, dst_spec)
     assert isinstance(result, SpecRegionPair)
     np.testing.assert_array_equal(result.src.memory.ptrs, [100, 200])
@@ -95,14 +110,11 @@ def test_identity_mapper():
     assert result.dst.memory.bytes_per_region == 32
 
 
-def test_head_match_mapper():
+def test_intact_mapper_partial_layers():
+    """Selecting a contiguous layer subset yields one shifted fragment."""
     self_ri = make_rankinfo(kv_heads_per_rank=2)
-    peer_ri = make_rankinfo(kv_heads_per_rank=2)
-    transfer_layers = 2
-    src_layer_off = 1
-    dst_layer_off = 1
-    # slot_size_per_layer = kv_factor * kv_heads * tokens_per_block * dims_per_head * element_bytes
-    slot_size_per_layer = (
+    # bytes_per_layer = kv_factor * kv_heads * tokens_per_block * dims_per_head * element_bytes
+    bytes_per_layer = (
         self_ri.attention.kv_factor
         * self_ri.attention.kv_heads_per_rank
         * self_ri.attention.tokens_per_block
@@ -113,39 +125,43 @@ def test_head_match_mapper():
     dst_group = MemRegionGroup(ptrs=np.array([30, 40], dtype=np.int64), bytes_per_region=1)
     src_spec = SpecRegion(memory=src_group, spec="srcspec")
     dst_spec = SpecRegion(memory=dst_group, spec="dstspec")
-    mapper = HeadMatchMapper(
-        transfer_layers,
-        src_layer_off,
-        dst_layer_off,
-        self_ri,
-        peer_ri,
-        slot_size_per_layer=slot_size_per_layer,
-    )
+    # Layers 1..2 of a 3-layer slot on both sides.
+    offsets = [bytes_per_layer, 2 * bytes_per_layer]
+    mapper = IntactMapper(offsets, offsets, bytes_per_layer, bytes_per_layer)
     result = mapper.map(src_spec, dst_spec)
-    expected_off = transfer_layers * slot_size_per_layer
+    expected_bytes = 2 * bytes_per_layer
     np.testing.assert_array_equal(
-        result.src.memory.ptrs, [10 + mapper._src_block_off, 20 + mapper._src_block_off]
+        result.src.memory.ptrs, [10 + bytes_per_layer, 20 + bytes_per_layer]
     )
     np.testing.assert_array_equal(
-        result.dst.memory.ptrs, [30 + mapper._dst_block_off, 40 + mapper._dst_block_off]
+        result.dst.memory.ptrs, [30 + bytes_per_layer, 40 + bytes_per_layer]
     )
-    assert result.src.memory.bytes_per_region == expected_off
-    assert result.dst.memory.bytes_per_region == expected_off
+    assert result.src.memory.bytes_per_region == expected_bytes
+    assert result.dst.memory.bytes_per_region == expected_bytes
 
 
 def test_head_mismatch_mapper():
     self_ri = make_rankinfo(kv_heads_per_rank=2, tp_size=2, tp_rank=1)
     peer_ri = make_rankinfo(kv_heads_per_rank=4, tp_size=4, tp_rank=2)
-    transfer_layers = 1
-    src_layer_off = 0
-    peer_layer_off = 1
+    # buffer bytes = heads * tokens_per_block * dims_per_head * element_bytes
+    self_bytes_per_layer = 2 * (2 * 4 * 2 * 1)  # kv_factor x K-buffer bytes
+    peer_bytes_per_layer = 2 * (4 * 4 * 2 * 1)
     src_group = MemRegionGroup(ptrs=np.array([111], dtype=np.int64), bytes_per_region=32)
     dst_group = MemRegionGroup(ptrs=np.array([222], dtype=np.int64), bytes_per_region=32)
     src_spec = SpecRegion(memory=src_group, spec="srcspec")
     dst_spec = SpecRegion(memory=dst_group, spec="dstspec")
-    mapper = HeadMismatchMapper(transfer_layers, src_layer_off, peer_layer_off, self_ri, peer_ri)
+    mapper = HNDHeadMismatchMapper(
+        src_layer_offsets=[0],
+        dst_layer_offsets=[peer_bytes_per_layer],  # layer 1 on the peer side
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_bytes_per_layer=self_bytes_per_layer,
+        peer_bytes_per_layer=peer_bytes_per_layer,
+        self_buffers_per_layer=2,
+        peer_buffers_per_layer=2,
+    )
     result = mapper.map(src_spec, dst_spec)
-    expected_frag_count = self_ri.attention.kv_factor * transfer_layers
+    expected_frag_count = 2  # one fragment per (layer, K/V buffer)
     assert isinstance(result, SpecRegionPair)
     assert len(result.src.memory.ptrs) == expected_frag_count
     assert len(result.dst.memory.ptrs) == expected_frag_count

--- a/tests/unittest/disaggregated/region/test_page.py
+++ b/tests/unittest/disaggregated/region/test_page.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 
 from tensorrt_llm._torch.disaggregation.resource.page import (
@@ -6,6 +21,7 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     KVCachePageTable,
     LayerGroup,
     LocalLayer,
+    MapperKind,
     PhysicalPool,
     PhysicalPoolGroup,
     PoolView,
@@ -47,6 +63,24 @@ def test_pool_view_roundtrip():
     assert len(restored.buffer_entries) == 2
     assert restored.buffer_entries[0]["offset"] == 0
     assert restored.buffer_entries[1]["offset"] == 128
+
+
+def test_pool_view_kind_roundtrip():
+    """REPLICATED / NHD kinds survive serialization; default stays INDEXED."""
+    entries = _make_buffer_entries()
+    for kind in (MapperKind.REPLICATED, MapperKind.NHD):
+        view = PoolView(
+            pool_idx=2,
+            buffer_entries=entries,
+            pool_role=frozenset({"index_key"}),
+            mapper_kind=kind,
+        )
+        restored = PoolView.from_dict(view.to_dict())
+        assert restored.mapper_kind == kind
+        assert restored.pool_role == frozenset({"index_key"})
+
+    legacy = PoolView(pool_idx=0, buffer_entries=entries).to_dict()
+    assert PoolView.from_dict(legacy).mapper_kind == MapperKind.INDEXED
 
 
 def test_local_layer_roundtrip():
@@ -100,3 +134,94 @@ def test_kv_cache_page_table_roundtrip():
     assert len(restored.layer_groups) == 1
     assert len(restored.pool_groups) == 1
     assert restored.pool_groups[0].pools[0].base_address == 0x10000
+
+
+# ---------------------------------------------------------------------------
+# bytes_per_layer serialization and get_layer_byte_ranges geometry
+# ---------------------------------------------------------------------------
+
+
+def test_pool_view_bytes_per_layer_roundtrip():
+    entries = _make_buffer_entries()
+    view = PoolView(
+        pool_idx=1,
+        buffer_entries=entries,
+        pool_role=frozenset({"key", "value"}),
+        mapper_kind=MapperKind.NHD,
+        bytes_per_layer=256,
+    )
+    restored = PoolView.from_dict(view.to_dict())
+    assert restored.bytes_per_layer == 256
+
+    # None (INDEXED views) survives the roundtrip too.
+    legacyless = PoolView(pool_idx=0, buffer_entries=entries)
+    assert PoolView.from_dict(legacyless.to_dict()).bytes_per_layer is None
+
+
+def _view(entries, bytes_per_layer=None):
+    return PoolView(
+        pool_idx=0,
+        buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE),
+        pool_role=frozenset({"key", "value"}),
+        mapper_kind=MapperKind.NHD,
+        bytes_per_layer=bytes_per_layer,
+    )
+
+
+def test_layer_byte_ranges_uniform_stride():
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    # Dedicated K/V pool: dense layers, uniform stride.
+    starts, bytes_per_layer = get_layer_byte_ranges(
+        _view([(0, 0, 128), (0, 128, 128), (1, 256, 128), (1, 384, 128)])
+    )
+    assert starts == {0: 0, 1: 256}
+    assert bytes_per_layer == 256
+
+
+def test_layer_byte_ranges_non_uniform_stride():
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    # Coalesced slot: another role class interleaves 64B after layer 0,
+    # so the layer stride is non-uniform while sizes stay uniform.
+    starts, bytes_per_layer = get_layer_byte_ranges(
+        _view([(0, 0, 128), (0, 128, 128), (1, 320, 128), (1, 448, 128)])
+    )
+    assert starts == {0: 0, 1: 320}
+    assert bytes_per_layer == 256
+
+
+def test_layer_byte_ranges_noncontiguous_layer_raises():
+    import pytest
+
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    with pytest.raises(ValueError, match="not contiguous"):
+        get_layer_byte_ranges(_view([(0, 0, 128), (0, 192, 128)]))
+
+
+def test_layer_byte_ranges_nonuniform_size_raises():
+    import pytest
+
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    with pytest.raises(ValueError, match="not uniform"):
+        get_layer_byte_ranges(_view([(0, 0, 128), (1, 128, 64)]))
+
+
+def test_layer_byte_ranges_declared_size_mismatch_raises():
+    import pytest
+
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    with pytest.raises(ValueError, match="declares bytes_per_layer"):
+        get_layer_byte_ranges(_view([(0, 0, 128)], bytes_per_layer=256))
+
+
+def test_layer_byte_ranges_empty_view_raises():
+    import pytest
+
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    with pytest.raises(ValueError, match="no buffer entries"):
+        get_layer_byte_ranges(_view([]))

--- a/tests/unittest/disaggregated/test_bounce.py
+++ b/tests/unittest/disaggregated/test_bounce.py
@@ -177,13 +177,19 @@ def test_fanin_bounce_safe_gate():
     expected_transfers) must fall back to the per-fragment path.
     """
     tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
+    from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
+
     safe = tfr.Receiver._fanin_bounce_safe
 
-    def ov(dup, pp):
-        return SimpleNamespace(duplicate_head_factor=dup, overlap_pp_size=pp)
+    def ov(dup, pp, ranks=(0,)):
+        return SimpleNamespace(duplicate_head_factor=dup, overlap_pp_size=pp, ranks=list(ranks))
 
-    def ri(lpp):
-        return SimpleNamespace(layer_num_per_pp=lpp)
+    def ri(lpp, page_table=None):
+        return SimpleNamespace(layer_num_per_pp=lpp, page_table=page_table)
+
+    def pt(mapper_kind):
+        view = SimpleNamespace(mapper_kind=mapper_kind)
+        return SimpleNamespace(layer_groups=[SimpleNamespace(pool_views=[view])])
 
     # single PP stage (overlap_pp_size <= 1): only duplicate_head_factor matters
     assert safe(ov(1, 1), ri([24])) is True
@@ -197,6 +203,12 @@ def test_fanin_bounce_safe_gate():
     assert safe(ov(1, 4), ri([20])) is False
     # duplicate heads blocks even an otherwise-even PP split
     assert safe(ov(2, 4), ri([20, 20, 20, 20])) is False
+    # replicated views (one elected sender per destination) make multi-writer
+    # contributions unequal -> fall back; single-writer overlap stays safe,
+    # and sharded-only view schemes are unaffected
+    assert safe(ov(1, 1, ranks=(0, 1)), ri([24], pt(MapperKind.REPLICATED))) is False
+    assert safe(ov(1, 1, ranks=(0,)), ri([24], pt(MapperKind.REPLICATED))) is True
+    assert safe(ov(1, 1, ranks=(0, 1)), ri([24], pt(MapperKind.NHD))) is True
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
+++ b/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Single-process test for KVCacheManager (V1/V2) + KvCacheTransceiverV2.
 
 Uses threading + ThreadSafeDistributed to create KvCacheTransceiverV2 instances
@@ -47,6 +62,7 @@ os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
 # Constants
 # ---------------------------------------------------------------------------
 NUM_LAYERS = 4
+INDEXER_HEAD_DIM = 128
 NUM_KV_HEADS = 4  # 1 for MLA
 HEAD_DIM = 128
 TOKENS_PER_BLOCK = 8
@@ -303,8 +319,10 @@ def _create_cache_manager(
     max_attention_window_vec: Optional[List[int]] = None,
     num_layers: int = NUM_LAYERS,
     max_batch_size: int = MAX_BATCH_SIZE,
+    enable_indexer_k_cache: bool = False,
 ) -> "KVCacheManager | KVCacheManagerV2":
     """Create a KVCacheManager (V1) or KVCacheManagerV2 for the given mapping."""
+    assert not (enable_indexer_k_cache and use_v2), "DSA indexer K cache is V1-only"
     num_kv_heads = 1 if is_mla else NUM_KV_HEADS
     cache_type = CacheTypeCpp.SELFKONLY if is_mla else CacheTypeCpp.SELF
 
@@ -371,6 +389,9 @@ def _create_cache_manager(
             mapping=mapping,
             dtype=DataType.FLOAT,
             model_config=model_config,
+            enable_indexer_k_cache=enable_indexer_k_cache,
+            indexer_k_cache_quant_block_size=128,
+            indexer_k_cache_index_head_dim=INDEXER_HEAD_DIM if enable_indexer_k_cache else 0,
         )
 
 
@@ -383,6 +404,7 @@ def _create_managers_for_instance(
     max_attention_window_vec: Optional[List[int]] = None,
     num_layers: int = NUM_LAYERS,
     max_batch_size: int = MAX_BATCH_SIZE,
+    enable_indexer_k_cache: bool = False,
 ) -> List:
     """Create cache managers for all ranks in an instance."""
     managers = []
@@ -398,7 +420,13 @@ def _create_managers_for_instance(
             )
             managers.append(
                 _create_cache_manager(
-                    mapping, is_mla, use_v2, max_attention_window_vec, num_layers, max_batch_size
+                    mapping,
+                    is_mla,
+                    use_v2,
+                    max_attention_window_vec,
+                    num_layers,
+                    max_batch_size,
+                    enable_indexer_k_cache,
                 )
             )
     return managers
@@ -432,6 +460,27 @@ def _init_pool_data_v1(
             pool_tensor.copy_(random_values)
         else:
             pool_tensor.zero_()
+
+        if getattr(mgr, "enable_indexer_k_cache", False):
+            # DSA indexer K is TP-replicated: seed by PP stage only so every
+            # TP rank of a stage holds identical bytes.
+            indexer_pool = mgr.impl.get_indexer_k_cache_pool().view(torch.uint8)
+            if fill_random:
+                generator = torch.Generator(device=indexer_pool.device).manual_seed(
+                    seed_base + 7000 + pp_rank
+                )
+                indexer_pool.copy_(
+                    torch.randint(
+                        0,
+                        256,
+                        indexer_pool.shape,
+                        dtype=torch.uint8,
+                        device=indexer_pool.device,
+                        generator=generator,
+                    )
+                )
+            else:
+                indexer_pool.zero_()
 
 
 def _init_pool_data_v2(
@@ -802,6 +851,77 @@ def verify_all_requests(
             )
 
 
+def _get_indexer_block_data(mgr, request_id, layer_idx, num_layers, pp, tp, enable_dp, req_idx):
+    """Per-request indexer-K bytes for one global layer on the owning rank.
+
+    Indexer K is TP-replicated, so any TP rank of the layer's PP stage works;
+    with attention DP only the request's DP group holds the request.
+    """
+    pp_rank = _pp_rank_of_layer(layer_idx, num_layers, pp)
+    tp_rank = req_idx % tp if enable_dp else 0
+    owner = mgr[pp_rank * tp + tp_rank]
+    block_indices = owner.get_batch_cache_indices([request_id], layer_idx)[0]
+    valid = [idx for idx in block_indices if idx >= 0]
+    if not valid:
+        return None
+    local_layer = layer_idx - _pp_layer_start(pp_rank, num_layers, pp)
+    # Pool shape: (numBlocks, numLayers, kvFactor, blockSize), dtype uint8.
+    pool = owner.impl.get_indexer_k_cache_pool().view(torch.uint8)
+    return pool[valid, local_layer]
+
+
+def _verify_indexer_k_all_requests(
+    request_lengths: List[int],
+    ctx_managers: List,
+    gen_managers: List,
+    ctx_tp: int,
+    ctx_pp: int,
+    gen_tp: int,
+    gen_pp: int,
+    ctx_enable_dp: bool,
+    gen_enable_dp: bool,
+    ctx_request_ids: List[int],
+    gen_request_ids: List[int],
+    num_layers: int,
+):
+    """Compare the transferred DSA indexer K bytes for every request/layer."""
+    for req_idx, _req_len in enumerate(request_lengths):
+        for layer_idx in range(num_layers):
+            ctx_data = _get_indexer_block_data(
+                ctx_managers,
+                ctx_request_ids[req_idx],
+                layer_idx,
+                num_layers,
+                ctx_pp,
+                ctx_tp,
+                ctx_enable_dp,
+                req_idx,
+            )
+            gen_data = _get_indexer_block_data(
+                gen_managers,
+                gen_request_ids[req_idx],
+                layer_idx,
+                num_layers,
+                gen_pp,
+                gen_tp,
+                gen_enable_dp,
+                req_idx,
+            )
+            if ctx_data is None or gen_data is None:
+                continue
+            assert ctx_data.shape == gen_data.shape, (
+                f"Indexer shape mismatch at req={req_idx} layer={layer_idx}: "
+                f"ctx={ctx_data.shape} gen={gen_data.shape}"
+            )
+            torch.testing.assert_close(
+                gen_data,
+                ctx_data,
+                rtol=0,
+                atol=0,
+                msg=lambda m: (f"Indexer data mismatch at req={req_idx} layer={layer_idx}: {m}"),
+            )
+
+
 # ---------------------------------------------------------------------------
 # Main test orchestrator
 # ---------------------------------------------------------------------------
@@ -817,6 +937,7 @@ def run_transfer_test(
     max_attention_window_vec: Optional[List[int]] = None,
     num_layers: int = NUM_LAYERS,
     request_lengths: Optional[List[int]] = None,
+    enable_indexer_k_cache: bool = False,
 ):
     """Run a full KV transfer test using KvCacheTransceiverV2."""
     if request_lengths is None:
@@ -835,6 +956,7 @@ def run_transfer_test(
         max_attention_window_vec,
         num_layers,
         max_batch_size,
+        enable_indexer_k_cache,
     )
     gen_managers = _create_managers_for_instance(
         gen_tp,
@@ -845,6 +967,7 @@ def run_transfer_test(
         max_attention_window_vec,
         num_layers,
         max_batch_size,
+        enable_indexer_k_cache,
     )
 
     # 2. Initialize data: random for ctx, zeros for gen
@@ -973,6 +1096,21 @@ def run_transfer_test(
             max_attention_window_vec=max_attention_window_vec,
             num_layers=num_layers,
         )
+        if enable_indexer_k_cache:
+            _verify_indexer_k_all_requests(
+                request_lengths=request_lengths,
+                ctx_managers=ctx_managers,
+                gen_managers=gen_managers,
+                ctx_tp=ctx_tp,
+                ctx_pp=ctx_pp,
+                gen_tp=gen_tp,
+                gen_pp=gen_pp,
+                ctx_enable_dp=ctx_enable_dp,
+                gen_enable_dp=gen_enable_dp,
+                ctx_request_ids=ctx_request_ids,
+                gen_request_ids=gen_request_ids,
+                num_layers=num_layers,
+            )
 
         # 9. Cleanup
         if use_v2:
@@ -1295,6 +1433,50 @@ def test_cache_transceiver_boundary_lengths(
     )
 
     print("PASSED")
+
+
+# DSA (DeepSeek V3.2) indexer K cache: V1-only, MLA, TP-replicated single
+# index head. Covers the REPLICATED pool view end to end through the real
+# python transceiver: fan-in owner election, fan-out, and PP layer subsets
+# (layer-strided ReplicatedMapper offsets).
+DSA_INDEXER_CONFIGS = [
+    # (ctx_tp, ctx_pp, gen_tp, gen_pp, ctx_dp, gen_dp, test_id)
+    (1, 1, 1, 1, False, False, "tp1_to_tp1"),
+    (2, 1, 1, 1, False, False, "tp2_to_tp1_fanin"),
+    (1, 1, 2, 1, False, False, "tp1_to_tp2_fanout"),
+    (1, 2, 1, 1, False, False, "pp2_to_pp1"),
+    (1, 1, 1, 2, False, False, "pp1_to_pp2"),
+    (2, 2, 1, 1, False, False, "tp2pp2_to_tp1"),
+    (2, 1, 2, 1, False, True, "tp2_to_dep2"),
+]
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,gen_tp,gen_pp,ctx_enable_dp,gen_enable_dp",
+    [c[:6] for c in DSA_INDEXER_CONFIGS],
+    ids=[c[6] for c in DSA_INDEXER_CONFIGS],
+)
+def test_cache_transceiver_v1_dsa_indexer(
+    ctx_tp,
+    ctx_pp,
+    gen_tp,
+    gen_pp,
+    ctx_enable_dp,
+    gen_enable_dp,
+):
+    """V1 KVCacheManager + DSA indexer K cache through KvCacheTransceiverV2."""
+    run_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        is_mla=True,
+        use_v2=False,
+        enable_indexer_k_cache=True,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
@@ -1,22 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Test KV Transfer for DeepseekV4CacheManager with KvCacheTransceiverV2.
 
-Uses threading + ThreadSafeDistributed to create KvCacheTransceiverV2 instances
-in a single process. Validates all DeepseekV4AttentionType cache transfers across
-different TP/PP/DP configurations.
+Drives the shared threaded single-process harness (``kv_transfer_harness``)
+with DeepSeek-V4 cache managers. Validates all DeepseekV4AttentionType cache
+transfers across different TP/PP/DP configurations.
 """
 
-import os
-import threading
-import uuid
-from typing import Dict, List, Optional, Tuple
+import functools
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import pytest
 import torch
+from kv_transfer_harness import (
+    MAX_BATCH_SIZE,
+    MAX_SEQ_LEN,
+    TOKENS_PER_BLOCK,
+    VOCAB_SIZE,
+    get_layers_per_pp,
+    run_kv_transfer_test,
+)
 
-import tensorrt_llm
-import tensorrt_llm.bindings
-import tensorrt_llm.tensorrt_llm_transfer_agent_binding  # noqa: F401
-from tensorrt_llm import DisaggregatedParams, Mapping, SamplingParams
+from tensorrt_llm import Mapping
 from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4 import DeepseekV4CacheManager
 from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4.deepseek_v4 import (
     DEEPSEEK_V4_OVERLAP_COMPRESSOR_RATIO,
@@ -25,22 +43,10 @@ from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4.deepseek_v4 import
 )
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
 from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool, get_pool_bytes
-from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
-from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestType
-from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
-from tensorrt_llm.llmapi.llm_args import (
-    CacheTransceiverConfig,
-    DeepSeekV4SparseAttentionConfig,
-    KvCacheConfig,
-)
-
-# Reduce NIXL threads for unit test: default 8 threads per agent causes heavy
-# contention when creating multiple agents on a single GPU in the same process.
-os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
-
+from tensorrt_llm.llmapi.llm_args import DeepSeekV4SparseAttentionConfig, KvCacheConfig
 
 # ---------------------------------------------------------------------------
 # Constants matching DeepseekV4CacheManager defaults
@@ -48,198 +54,12 @@ os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
 HEAD_DIM = 256  # Reduced from 512: test validates transfer, not attention correctness
 INDEX_HEAD_DIM = 128
 WINDOW_SIZE = 128
-TOKENS_PER_BLOCK = 128
-MAX_SEQ_LEN = 512
-MAX_BATCH_SIZE = 16
-VOCAB_SIZE = 129280
 NUM_KV_HEADS = 1
 INDEXER_QUANT_BLOCK_SIZE = 128
-
 
 # DeepSeek-V4 specific ratios (mirrors module constants)
 SPARSE_RATIO = DEEPSEEK_V4_SPARSE_RATIO
 OVERLAP_COMPRESSOR_RATIO = DEEPSEEK_V4_OVERLAP_COMPRESSOR_RATIO
-
-
-# ---------------------------------------------------------------------------
-# ThreadSafeDistributed: threading.Barrier-based Distributed mock
-# ---------------------------------------------------------------------------
-class ThreadSafeDistributed:
-    """Distributed mock using threading.Barrier for single-process multi-rank testing.
-
-    Provides the same interface as TorchDistributedWrapper from test_py_cache_transceiver_mp.py
-    but uses Barrier + Lock + shared dict instead of torch.distributed.
-    """
-
-    def __init__(
-        self,
-        local_rank: int,
-        world_size: int,
-        tp_size: int,
-        pp_size: int,
-        tp_rank: int,
-        pp_rank: int,
-        shared: dict,
-    ):
-        self.rank = local_rank
-        self._world_size = world_size
-        self._tp_size = tp_size
-        self._pp_size = pp_size
-        self._tp_rank = tp_rank
-        self._pp_rank = pp_rank
-        self._s = shared
-        self._bcast_idx = 0
-        self._ag_idx = 0
-        self._pp_ag_idx = 0
-        self._tp_ag_idx = 0
-
-    @property
-    def tp_size(self):
-        return self._tp_size
-
-    @property
-    def pp_size(self):
-        return self._pp_size
-
-    @property
-    def world_size(self):
-        return self._world_size
-
-    def broadcast(self, obj, root=0):
-        idx = self._bcast_idx
-        self._bcast_idx += 1
-        key = f"bcast_{idx}"
-        if self.rank == root:
-            self._s[key] = obj
-        self._s["barrier"].wait()
-        result = self._s[key]
-        self._s["barrier"].wait()
-        return result
-
-    def allgather(self, obj):
-        idx = self._ag_idx
-        self._ag_idx += 1
-        key = f"ag_{idx}"
-        with self._s["lock"]:
-            if key not in self._s:
-                self._s[key] = [None] * self._world_size
-            self._s[key][self.rank] = obj
-        self._s["barrier"].wait()
-        result = list(self._s[key])
-        self._s["barrier"].wait()
-        return result
-
-    def pp_allgather(self, obj):
-        idx = self._pp_ag_idx
-        self._pp_ag_idx += 1
-        key = f"pp_ag_{idx}_tp{self._tp_rank}"
-        with self._s["lock"]:
-            if key not in self._s:
-                self._s[key] = [None] * self._pp_size
-            self._s[key][self._pp_rank] = obj
-        self._s["barrier"].wait()
-        result = list(self._s[key])
-        self._s["barrier"].wait()
-        return result
-
-    def tp_allgather(self, obj):
-        idx = self._tp_ag_idx
-        self._tp_ag_idx += 1
-        key = f"tp_ag_{idx}_pp{self._pp_rank}"
-        with self._s["lock"]:
-            if key not in self._s:
-                self._s[key] = [None] * self._tp_size
-            self._s[key][self._tp_rank] = obj
-        self._s["barrier"].wait()
-        result = list(self._s[key])
-        self._s["barrier"].wait()
-        return result
-
-
-# ---------------------------------------------------------------------------
-# Threading helpers
-# ---------------------------------------------------------------------------
-def run_concurrent(items, fn):
-    """Run fn(item) for each item concurrently in threads and propagate errors."""
-    errors = [None] * len(items)
-    results = [None] * len(items)
-
-    def _worker(idx, item):
-        try:
-            results[idx] = fn(item)
-        except Exception as e:
-            errors[idx] = e
-
-    threads = [threading.Thread(target=_worker, args=(i, item)) for i, item in enumerate(items)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-    for i, err in enumerate(errors):
-        if err is not None:
-            raise err
-    return results
-
-
-def _create_transceiver_in_thread(rank, mapping, cache_manager, dist_mock, config, results, errors):
-    """Thread target: create one KvCacheTransceiverV2."""
-    try:
-        tc = KvCacheTransceiverV2(
-            mapping=mapping,
-            dist=dist_mock,
-            kv_cache_manager=cache_manager,
-            cache_transceiver_config=config,
-        )
-        results[rank] = tc
-    except Exception as e:
-        errors[rank] = e
-
-
-def create_instance_transceivers(
-    tp: int, pp: int, enable_dp: bool, cache_managers: List, config: CacheTransceiverConfig
-) -> List[KvCacheTransceiverV2]:
-    """Create KvCacheTransceiverV2 for all ranks via threaded init."""
-    world_size = tp * pp
-    shared = {"barrier": threading.Barrier(world_size), "lock": threading.Lock()}
-    results = [None] * world_size
-    errors = [None] * world_size
-    threads = []
-
-    for rank in range(world_size):
-        pp_rank = rank // tp
-        tp_rank = rank % tp
-        mapping = Mapping(
-            world_size=world_size,
-            rank=rank,
-            tp_size=tp,
-            pp_size=pp,
-            enable_attention_dp=enable_dp,
-        )
-        dist_mock = ThreadSafeDistributed(rank, world_size, tp, pp, tp_rank, pp_rank, shared)
-        t = threading.Thread(
-            target=_create_transceiver_in_thread,
-            args=(
-                rank,
-                mapping,
-                cache_managers[rank],
-                dist_mock,
-                config,
-                results,
-                errors,
-            ),
-        )
-        threads.append(t)
-
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
-    for rank, err in enumerate(errors):
-        if err is not None:
-            raise err
-
-    return results
 
 
 # ---------------------------------------------------------------------------
@@ -302,7 +122,12 @@ def _create_managers_for_instance(
     return managers
 
 
-def _init_pool_data(managers: List, tp: int, seed_base: int = 0, fill_random: bool = True):
+def _init_pool_data(
+    managers: Sequence[DeepseekV4CacheManager],
+    tp: int,
+    seed_base: int = 0,
+    fill_random: bool = True,
+) -> None:
     """Initialize pool data for all managers.
 
     Uses half-precision view of pool memory for initialization.
@@ -466,7 +291,7 @@ def _read_cache_data(
 
 def _find_ctx_rank_for_layer(
     layer_idx: int,
-    ctx_managers: List[DeepseekV4CacheManager],
+    ctx_managers: Sequence[DeepseekV4CacheManager],
     ctx_tp: int,
     ctx_enable_dp: bool,
     req_idx: int,
@@ -491,8 +316,8 @@ def _find_ctx_rank_for_layer(
 def verify_all_requests(
     request_lengths: List[int],
     compress_ratios: List[int],
-    ctx_managers: List[DeepseekV4CacheManager],
-    gen_managers: List[DeepseekV4CacheManager],
+    ctx_managers: Sequence[DeepseekV4CacheManager],
+    gen_managers: Sequence[DeepseekV4CacheManager],
     ctx_tp: int,
     ctx_pp: int,
     gen_tp: int,
@@ -581,12 +406,6 @@ def verify_all_requests(
 # ---------------------------------------------------------------------------
 # Main test function
 # ---------------------------------------------------------------------------
-def _get_ctx_info_endpoint(tc: KvCacheTransceiverV2) -> Optional[str]:
-    """Extract the context_info_endpoint from a transceiver's disaggregated params."""
-    endpoints = tc.get_disaggregated_params().get("ctx_info_endpoint") or []
-    return endpoints[0] if endpoints else None
-
-
 def run_deepseek_v4_transfer_test(
     ctx_tp: int,
     ctx_pp: int,
@@ -596,202 +415,22 @@ def run_deepseek_v4_transfer_test(
     gen_enable_dp: bool,
     compress_ratios: List[int],
     update_before_transfer: bool = True,
-):
-    """Run a full DeepSeek-V4 KV transfer test."""
-    ctx_world = ctx_tp * ctx_pp
-    gen_world = gen_tp * gen_pp
-
-    # Mix of block-aligned and non-aligned lengths for boundary testing.
-    # TOKENS_PER_BLOCK=128: 65=half+1, 256=2x exact, 129=1x+1, 383=3x-1
-    request_lengths = [65, 256, 129, 383]
-
-    # ===== 1. Create DeepseekV4CacheManagers =====
-    ctx_managers = _create_managers_for_instance(ctx_tp, ctx_pp, ctx_enable_dp, compress_ratios)
-    gen_managers = _create_managers_for_instance(gen_tp, gen_pp, gen_enable_dp, compress_ratios)
-
-    # ===== 2. Initialize data =====
-    # ctx: random data, seed=pp_rank (same across TP, different across PP)
-    _init_pool_data(ctx_managers, ctx_tp, seed_base=1000, fill_random=True)
-    # gen: zeros
-    _init_pool_data(gen_managers, gen_tp, fill_random=False)
-
-    # ===== 3. Create KvCacheTransceiverV2 instances (threaded init) =====
-    config = CacheTransceiverConfig(
-        backend="NIXL",
-        transceiver_runtime="PYTHON",
-        max_tokens_in_buffer=512,
+) -> None:
+    """Run the shared transfer harness with DeepSeek-V4 cache hooks."""
+    run_kv_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        update_before_transfer=update_before_transfer,
+        manager_factory=lambda tp, pp, enable_dp: _create_managers_for_instance(
+            tp, pp, enable_dp, compress_ratios
+        ),
+        init_fn=_init_pool_data,
+        verify_fn=functools.partial(verify_all_requests, compress_ratios=compress_ratios),
     )
-    ctx_tcs = create_instance_transceivers(ctx_tp, ctx_pp, ctx_enable_dp, ctx_managers, config)
-    gen_tcs = create_instance_transceivers(gen_tp, gen_pp, gen_enable_dp, gen_managers, config)
-
-    try:
-        ctx_info_endpoint = _get_ctx_info_endpoint(ctx_tcs[0])
-
-        # ===== 4. Create requests and determine handle map =====
-        # handle_map: rank -> [(req_idx, ctx_request, gen_request)]
-        ctx_handle_map: Dict[int, List] = {r: [] for r in range(ctx_world)}
-        gen_handle_map: Dict[int, List] = {r: [] for r in range(gen_world)}
-        ctx_request_ids: List[int] = []
-        gen_request_ids: List[int] = []
-
-        sampling_params = SamplingParams()
-
-        for req_idx, req_len in enumerate(request_lengths):
-            unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
-            ctx_rid = req_idx * 2
-            gen_rid = req_idx * 2 + 1
-            ctx_request_ids.append(ctx_rid)
-            gen_request_ids.append(gen_rid)
-
-            ctx_dp_rank = req_idx % ctx_tp if ctx_enable_dp else 0
-
-            ctx_request = LlmRequest(
-                request_id=ctx_rid,
-                max_new_tokens=1,
-                input_tokens=list(range(req_len)),
-                sampling_config=tensorrt_llm.bindings.SamplingConfig(
-                    sampling_params._get_sampling_config()
-                ),
-                is_streaming=False,
-                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
-            )
-            ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
-
-            gen_request = LlmRequest(
-                request_id=gen_rid,
-                max_new_tokens=1,
-                input_tokens=list(range(req_len)),
-                sampling_config=tensorrt_llm.bindings.SamplingConfig(
-                    sampling_params._get_sampling_config()
-                ),
-                is_streaming=False,
-                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
-            )
-            gen_request.py_disaggregated_params = DisaggregatedParams(
-                ctx_request_id=ctx_rid,
-                ctx_dp_rank=ctx_dp_rank,
-                ctx_info_endpoint=ctx_info_endpoint,
-                disagg_request_id=unique_rid,
-            )
-
-            for rank in range(ctx_world):
-                tp_rank = rank % ctx_tp
-                should_handle = (not ctx_enable_dp) or (req_idx % ctx_tp == tp_rank)
-                if should_handle:
-                    ctx_handle_map[rank].append((req_idx, ctx_request))
-
-            for rank in range(gen_world):
-                tp_rank = rank % gen_tp
-                should_handle = (not gen_enable_dp) or (req_idx % gen_tp == tp_rank)
-                if should_handle:
-                    gen_handle_map[rank].append((req_idx, gen_request))
-
-        # ===== 5. Allocate KV cache for all ranks =====
-        # prepare_resources is a no-op for non-draft KVCacheManagerV2.
-        # All ranks must allocate BEFORE mutating shared request objects
-        # (add_new_token changes is_first_context_chunk).
-        #
-        # Gen ranks take the disagg-gen-init path: prepare_disagg_gen_init
-        # sizes the cache for the full prompt and pre-declares
-        # history_length=prompt_len, matching what the V2 scheduler's
-        # _try_schedule_disagg_gen_init does in production so the
-        # transceiver's TRANS_COMPLETE contract check is satisfied.
-        # Ctx ranks take the regular prefill path (prepare_context +
-        # resize_context).
-        gen_batches: Dict[int, ScheduledRequests] = {}
-        for rank in range(gen_world):
-            reqs = [req for _, req in gen_handle_map[rank]]
-            if reqs:
-                batch = ScheduledRequests()
-                batch.context_requests_last_chunk = reqs
-                for req in reqs:
-                    gen_managers[rank].prepare_disagg_gen_init(req)
-                gen_batches[rank] = batch
-
-        ctx_batches: Dict[int, ScheduledRequests] = {}
-        for rank in range(ctx_world):
-            reqs = [req for _, req in ctx_handle_map[rank]]
-            if reqs:
-                batch = ScheduledRequests()
-                batch.context_requests_last_chunk = reqs
-                for req in reqs:
-                    ctx_managers[rank].prepare_context(req)
-                    ctx_managers[rank].resize_context(req, req.context_chunk_size)
-                ctx_batches[rank] = batch
-
-        # ===== 5.5. context_current_position + add_new_token =====
-        # Set position on each unique request once (needed for transfer metadata).
-        seen: set = set()
-        for rank in range(ctx_world):
-            for _, req in ctx_handle_map[rank]:
-                if req.py_request_id not in seen:
-                    req.context_current_position = req.prompt_len
-                    req.add_new_token(req.prompt_len, 0)
-                    seen.add(req.py_request_id)
-
-        seen = set()
-        for rank in range(gen_world):
-            for _, req in gen_handle_map[rank]:
-                if req.py_request_id not in seen:
-                    req.context_current_position = req.prompt_len
-                    req.add_new_token(req.prompt_len, 0)
-                    seen.add(req.py_request_id)
-
-        # ===== 5.6. update_resources BEFORE transfer (mode: update_before) =====
-        if update_before_transfer:
-            for rank, batch in ctx_batches.items():
-                ctx_managers[rank].update_resources(batch)
-            for rank, batch in gen_batches.items():
-                gen_managers[rank].update_resources(batch)
-
-        # ===== 6. gen receive + ctx send =====
-        for rank in range(gen_world):
-            for _, req in gen_handle_map[rank]:
-                gen_tcs[rank].request_and_receive_async(req)
-        for rank in range(ctx_world):
-            for _, req in ctx_handle_map[rank]:
-                ctx_tcs[rank].respond_and_send_async(req)
-
-        # ===== 7. Wait for completion (threaded, dist calls inside) =====
-        run_concurrent(
-            ctx_tcs, lambda tc: tc.check_context_transfer_status(None, mark_complete=True)
-        )
-        run_concurrent(gen_tcs, lambda tc: tc.check_gen_transfer_status(None))
-
-        # ===== 7.5. update_resources AFTER transfer (mode: update_after) =====
-        if not update_before_transfer:
-            for rank, batch in ctx_batches.items():
-                ctx_managers[rank].update_resources(batch)
-            for rank, batch in gen_batches.items():
-                gen_managers[rank].update_resources(batch)
-
-        # ===== 8. Verify =====
-        verify_all_requests(
-            request_lengths=request_lengths,
-            compress_ratios=compress_ratios,
-            ctx_managers=ctx_managers,
-            gen_managers=gen_managers,
-            ctx_tp=ctx_tp,
-            ctx_pp=ctx_pp,
-            gen_tp=gen_tp,
-            gen_pp=gen_pp,
-            ctx_enable_dp=ctx_enable_dp,
-            gen_enable_dp=gen_enable_dp,
-            ctx_request_ids=ctx_request_ids,
-            gen_request_ids=gen_request_ids,
-        )
-
-    finally:
-        for tc in ctx_tcs + gen_tcs:
-            try:
-                tc.shutdown()
-            except Exception:
-                pass
-        for mgr in ctx_managers + gen_managers:
-            try:
-                mgr.shutdown()
-            except Exception:
-                pass
 
 
 # ---------------------------------------------------------------------------
@@ -863,21 +502,6 @@ def test_deepseek_v4_kv_transfer(
 
 
 # ---------------------------------------------------------------------------
-# PP layer distribution helpers (mirrors C++ getLayerNumPPRank)
-# ---------------------------------------------------------------------------
-def _get_layers_per_pp(num_layers: int, pp_size: int) -> List[int]:
-    """Return a list of layer counts per PP rank.
-
-    When num_layers is not evenly divisible by pp_size, the first
-    (num_layers % pp_size) ranks get one extra layer.
-    Matches Mapping.pp_layers / torch.tensor_split behaviour.
-    """
-    base = num_layers // pp_size
-    extra = num_layers % pp_size
-    return [base + (1 if r < extra else 0) for r in range(pp_size)]
-
-
-# ---------------------------------------------------------------------------
 # Uneven PP layer test configurations
 # ---------------------------------------------------------------------------
 # compress_ratios templates for different num_layers (covering ratios 1, 4, 128)
@@ -945,8 +569,8 @@ def test_deepseek_v4_kv_transfer_uneven_pp(
         f"ctx_tp={ctx_tp} ctx_pp={ctx_pp} gen_tp={gen_tp} gen_pp={gen_pp} "
         f"ctx_dp={ctx_enable_dp} gen_dp={gen_enable_dp} "
         f"num_layers={num_layers} compress_ratios={compress_ratios} "
-        f"layers_per_pp(ctx)={_get_layers_per_pp(num_layers, ctx_pp)} "
-        f"layers_per_pp(gen)={_get_layers_per_pp(num_layers, gen_pp)}"
+        f"layers_per_pp(ctx)={get_layers_per_pp(num_layers, ctx_pp)} "
+        f"layers_per_pp(gen)={get_layers_per_pp(num_layers, gen_pp)}"
     )
 
     run_deepseek_v4_transfer_test(

--- a/tests/unittest/disaggregated/test_extractor.py
+++ b/tests/unittest/disaggregated/test_extractor.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import pytest
 
@@ -5,16 +20,19 @@ from tensorrt_llm._torch.disaggregation.base.region import MemRegionGroup, SpecR
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import (
     KVRegionExtractorV1,
     build_page_table,
+    build_page_table_from_manager,
 )
 from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
 from tensorrt_llm._torch.disaggregation.resource.utils import (
     get_global_layer_ids,
+    get_layer_byte_ranges,
     get_layer_to_layer_group,
     get_num_layer_groups,
     get_num_layers,
     get_physical_pool,
     get_unique_layers,
 )
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import Role
 from tensorrt_llm._torch.pyexecutor.resource_manager import (
     CacheTypeCpp,
     DataType,
@@ -187,6 +205,142 @@ def test_build_page_table():
     manager.shutdown()
 
 
+def _make_v1_dsa_manager(pp_size: int = 1, pp_rank: int = 0) -> KVCacheManager:
+    """V1 KVCacheManager with the DSA indexer K cache enabled (MLA-style)."""
+    return KVCacheManager(
+        kv_cache_config=KvCacheConfig(
+            max_tokens=512,
+            enable_block_reuse=False,
+            event_buffer_max_size=0,
+        ),
+        kv_cache_type=CacheTypeCpp.SELFKONLY,
+        num_layers=4,
+        num_kv_heads=1,
+        head_dim=64,
+        tokens_per_block=32,
+        max_seq_len=256,
+        max_batch_size=2,
+        mapping=Mapping(world_size=pp_size, rank=pp_rank, tp_size=1, pp_size=pp_size),
+        dtype=DataType.HALF,
+        enable_indexer_k_cache=True,
+        indexer_k_cache_quant_block_size=128,
+        indexer_k_cache_index_head_dim=128,
+    )
+
+
+def _byte_view(ptr: int, nbytes: int):
+    from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
+
+    return convert_to_torch_tensor(TensorWrapper(int(ptr), DataType.INT8, [int(nbytes)]))
+
+
+@pytest.mark.cuda
+def test_v1_dsa_indexer_page_table_is_replicated_with_per_layer_entries():
+    manager = _make_v1_dsa_manager()
+    try:
+        page_table = build_page_table(manager)
+        lg = page_table.layer_groups[0]
+        assert len(lg.pool_views) == 2
+
+        kv_view, idx_view = lg.pool_views
+        assert kv_view.mapper_kind == MapperKind.INDEXED
+        assert idx_view.mapper_kind == MapperKind.REPLICATED
+        assert idx_view.pool_role == frozenset({"indexer_k"})
+
+        # One synthesized entry per LG layer, equal-sized, contiguous from 0.
+        assert get_unique_layers(idx_view) == get_unique_layers(kv_view)
+        idx_pool = get_physical_pool(page_table, 0, idx_view.pool_idx)
+        sizes = {int(entry["size"]) for entry in idx_view.buffer_entries}
+        assert len(sizes) == 1
+        per_layer = sizes.pop()
+        assert per_layer * len(idx_view.buffer_entries) == idx_pool.slot_bytes
+        offsets = sorted(int(entry["offset"]) for entry in idx_view.buffer_entries)
+        assert offsets == [i * per_layer for i in range(len(offsets))]
+    finally:
+        manager.shutdown()
+
+
+@pytest.mark.cuda
+def test_v1_dsa_indexer_replicated_transfer_across_pp():
+    """PP1 ctx sends the DSA indexer K cache into two PP2 gen ranks.
+
+    Exercises the full python path on real V1 managers: page-table build,
+    role-set matching, ReplicatedMapper layer-strided offsets, and a
+    byte-level copy that must land each gen rank's layer subset at the
+    right offsets.
+    """
+    import torch
+
+    from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import ReplicatedMapper
+    from tensorrt_llm._torch.disaggregation.native.peer import PeerRegistrar
+    from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
+
+    ctx = _make_v1_dsa_manager()
+    gens = [_make_v1_dsa_manager(pp_size=2, pp_rank=r) for r in range(2)]
+    try:
+        ctx_extractor = KVRegionExtractorV1(ctx)
+        ctx_ri = RankInfo.from_kv_cache_manager("ctx", ctx, device_id=0)
+        registrar = PeerRegistrar(ctx_ri, ctx_extractor)
+
+        # Fill ctx indexer pool with position-dependent bytes; zero gen pools.
+        ctx_pool_tensor = ctx.impl.get_indexer_k_cache_pool()
+        flat = ctx_pool_tensor.view(torch.uint8).flatten()
+        flat.copy_(torch.arange(flat.numel(), dtype=torch.int64, device=flat.device) % 251)
+        for gen in gens:
+            gen.impl.get_indexer_k_cache_pool().view(torch.uint8).zero_()
+
+        block_ids = np.array([0, 2, 3], dtype=np.int64)
+        ctx_pt = ctx_extractor.page_table
+        idx_pool = get_physical_pool(ctx_pt, 0, 1)
+        layers_per_gen = 2
+        per_layer = idx_pool.slot_bytes // 4
+
+        for gen_pp_rank, gen in enumerate(gens):
+            gen_ri = RankInfo.from_kv_cache_manager("gen", gen, device_id=0)
+            registrar.register("gen", gen_ri.instance_rank, gen_ri)
+            mapping = registrar.get_pool_mapping(gen_ri)
+            # KV pool and indexer pool each match 1:1.
+            assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
+
+            mapper = registrar.get_kv_map(gen_ri, (0, 1), (0, 1))
+            assert isinstance(mapper, ReplicatedMapper)
+
+            gen_extractor = registrar.peer_extractor("gen", gen_ri.instance_rank)
+            pair = mapper.map(
+                ctx_extractor.extract(block_ids, layer_group_id=0, pool_idx=1),
+                gen_extractor.extract(block_ids, layer_group_id=0, pool_idx=1),
+            )
+            # This gen rank holds 2 of the 4 layers; the fragment is the
+            # contiguous 2-layer range at this PP stage's offset within
+            # the ctx slot.
+            assert pair.src.memory.bytes_per_region == layers_per_gen * per_layer
+            expected_src_off = gen_pp_rank * layers_per_gen * per_layer
+            base_ptrs = idx_pool.base_address + block_ids * idx_pool.slot_bytes
+            np.testing.assert_array_equal(pair.src.memory.ptrs, base_ptrs + expected_src_off)
+
+            # Emulate the transfer with raw byte copies, then verify content.
+            for src_ptr, dst_ptr in zip(pair.src.memory.ptrs, pair.dst.memory.ptrs):
+                _byte_view(dst_ptr, pair.dst.memory.bytes_per_region).copy_(
+                    _byte_view(src_ptr, pair.src.memory.bytes_per_region)
+                )
+
+            gen_pool_tensor = gen.impl.get_indexer_k_cache_pool()
+            gen_bytes = gen_pool_tensor.view(torch.uint8).reshape(gen_pool_tensor.shape[0], -1)
+            ctx_bytes = ctx_pool_tensor.view(torch.uint8).reshape(ctx_pool_tensor.shape[0], -1)
+            src_lo = gen_pp_rank * layers_per_gen * per_layer
+            src_hi = src_lo + layers_per_gen * per_layer
+            torch.testing.assert_close(
+                gen_bytes[block_ids],
+                ctx_bytes[block_ids, src_lo:src_hi],
+                rtol=0,
+                atol=0,
+            )
+    finally:
+        ctx.shutdown()
+        for gen in gens:
+            gen.shutdown()
+
+
 def test_layer_group_meta_serialization():
     import numpy as np
 
@@ -230,6 +384,183 @@ def test_layer_group_meta_serialization():
     assert restored_lg.kv_head_num_per_rank == 4
     assert len(restored_lg.local_layers) == 2
     assert len(restored_lg.pool_views[0].buffer_entries) == 2
+
+
+def _make_fake_v2_manager(attrs, role_mapper_kinds, *, num_pools=1, slot_bytes_list=(640,)):
+    """Build a minimal duck-typed KVCacheManagerV2 for _build_page_table_v2."""
+    from types import SimpleNamespace
+
+    from tensorrt_llm.runtime.kv_cache_manager_v2 import CacheTier
+
+    base = 0x1000
+
+    def _make_pool(slot_bytes):
+        return SimpleNamespace(
+            slot_size=slot_bytes,
+            num_slots=4,
+            slot_address=lambda slot, _sb=slot_bytes: base + slot * _sb,
+        )
+
+    impl = SimpleNamespace(
+        layer_grouping=((0, 1),),
+        _life_cycles=[SimpleNamespace(window_size=None)],
+        _init_config=SimpleNamespace(
+            cache_tiers=[SimpleNamespace(tier=CacheTier.GPU_MEM)], tokens_per_block=16
+        ),
+        _storage=SimpleNamespace(
+            _buffer_attr=attrs,
+            num_life_cycles=1,
+            get_pool_group_index=lambda _lc: 0,
+            _levels=[
+                SimpleNamespace(
+                    storage=SimpleNamespace(
+                        _pool_groups=[
+                            SimpleNamespace(
+                                num_pools=num_pools,
+                                _pools=[_make_pool(sb) for sb in slot_bytes_list],
+                            )
+                        ]
+                    )
+                )
+            ],
+        ),
+    )
+    return SimpleNamespace(
+        impl=impl,
+        pp_layers=[0, 1],
+        num_kv_heads_per_layer=[1, 1],
+        get_disagg_role_mapper_kinds=lambda: role_mapper_kinds,
+    )
+
+
+def test_v2_builder_stamps_homogeneous_pool_kinds():
+    """Split KV / INDEX_KEY pools get NHD and REPLICATED views respectively."""
+    from types import SimpleNamespace
+
+    attrs = {
+        (0, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=0, size=128),
+        (0, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=128, size=128),
+        (1, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=256, size=128),
+        (1, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=384, size=128),
+        (1, Role.INDEX_KEY): SimpleNamespace(life_cycle_id=0, pool_index=1, offset=0, size=128),
+    }
+    manager = _make_fake_v2_manager(
+        attrs,
+        {Role.ALL: MapperKind.NHD, Role.INDEX_KEY: MapperKind.REPLICATED},
+        num_pools=2,
+        slot_bytes_list=(512, 128),
+    )
+
+    views = build_page_table_from_manager(manager).layer_groups[0].pool_views
+    assert len(views) == 2
+    assert views[0].pool_role == frozenset({"key", "value"})
+    assert views[0].mapper_kind == MapperKind.NHD
+    assert get_unique_layers(views[0]) == {0, 1}
+    assert views[1].pool_role == frozenset({"index_key"})
+    assert views[1].mapper_kind == MapperKind.REPLICATED
+    assert get_unique_layers(views[1]) == {1}
+
+
+def test_v2_builder_splits_mixed_kind_pool_into_per_class_views():
+    """A pool coalescing several role classes yields one view per class.
+
+    Miniature of the MiniMax M3 layout at TP degrees where
+    K == V == INDEX_KEY bytes per block: V2 storage coalesces all three
+    into one pool and the slot interleaves the sparse layer's INDEX_KEY
+    between the layers' K/V regions. The builder must split the pool into
+    a NHD K/V view (non-uniform layer offsets, uniform per-layer size)
+    and a REPLICATED INDEX_KEY view covering only the sparse layer.
+    """
+    from types import SimpleNamespace
+
+    attrs = {
+        (0, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=0, size=128),
+        (0, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=128, size=128),
+        (0, Role.INDEX_KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=256, size=128),
+        (1, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=384, size=128),
+        (1, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=512, size=128),
+    }
+    manager = _make_fake_v2_manager(
+        attrs,
+        {Role.ALL: MapperKind.NHD, Role.INDEX_KEY: MapperKind.REPLICATED},
+    )
+
+    views = build_page_table_from_manager(manager).layer_groups[0].pool_views
+    assert len(views) == 2
+    kv_view, idx_view = views
+    # Both views address the same physical pool.
+    assert kv_view.pool_idx == idx_view.pool_idx == 0
+
+    assert kv_view.pool_role == frozenset({"key", "value"})
+    assert kv_view.mapper_kind == MapperKind.NHD
+    assert get_unique_layers(kv_view) == {0, 1}
+    assert kv_view.bytes_per_layer == 256
+    kv_starts, kv_bytes_per_layer = get_layer_byte_ranges(kv_view)
+    # Layer stride is non-uniform: INDEX_KEY interleaves after layer 0.
+    assert kv_starts == {0: 0, 1: 384}
+    assert kv_bytes_per_layer == 256
+
+    assert idx_view.pool_role == frozenset({"index_key"})
+    assert idx_view.mapper_kind == MapperKind.REPLICATED
+    assert get_unique_layers(idx_view) == {0}
+    assert idx_view.bytes_per_layer == 128
+    idx_starts, _ = get_layer_byte_ranges(idx_view)
+    assert idx_starts == {0: 256}
+
+
+def test_v2_builder_validates_role_mapper_declaration():
+    from types import SimpleNamespace
+
+    attrs = {
+        (0, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=0, size=128),
+        (0, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=128, size=128),
+        (1, Role.KEY): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=256, size=128),
+        (1, Role.VALUE): SimpleNamespace(life_cycle_id=0, pool_index=0, offset=384, size=128),
+    }
+
+    # Default INDEXED declaration keeps the whole-slot HND view.
+    views = (
+        build_page_table_from_manager(_make_fake_v2_manager(attrs, {Role.ALL: MapperKind.INDEXED}))
+        .layer_groups[0]
+        .pool_views
+    )
+    assert len(views) == 1
+    assert views[0].mapper_kind == MapperKind.INDEXED
+
+    # V2 managers must expose the capability method explicitly.
+    missing_capability = _make_fake_v2_manager(attrs, {Role.ALL: MapperKind.INDEXED})
+    del missing_capability.get_disagg_role_mapper_kinds
+    with pytest.raises(AttributeError, match="get_disagg_role_mapper_kinds"):
+        build_page_table_from_manager(missing_capability)
+
+    with pytest.raises(ValueError, match="must define Role.ALL"):
+        build_page_table_from_manager(
+            _make_fake_v2_manager(attrs, {Role.INDEX_KEY: MapperKind.REPLICATED})
+        )
+
+    with pytest.raises(ValueError, match="Invalid disaggregation mapper kind 'HND'"):
+        build_page_table_from_manager(_make_fake_v2_manager(attrs, {Role.ALL: "HND"}))
+
+    with pytest.raises(ValueError, match="INDEXED is only valid as the Role.ALL mapping"):
+        build_page_table_from_manager(
+            _make_fake_v2_manager(attrs, {Role.ALL: MapperKind.NHD, Role.KEY: MapperKind.INDEXED})
+        )
+
+    # INDEXED as the Role.ALL fallback coexists with side-cache roles that
+    # declare their own kind (the base-manager default for INDEX_KEY); with
+    # no INDEX_KEY buffers registered the declaration is inert.
+    views = (
+        build_page_table_from_manager(
+            _make_fake_v2_manager(
+                attrs,
+                {Role.ALL: MapperKind.INDEXED, Role.INDEX_KEY: MapperKind.REPLICATED},
+            )
+        )
+        .layer_groups[0]
+        .pool_views
+    )
+    assert len(views) == 1
+    assert views[0].mapper_kind == MapperKind.INDEXED
 
 
 def test_mamba_layer_group_serialization():

--- a/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_minimax_m3_kv_transfer.py
@@ -1,0 +1,617 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MiniMax M3 heterogeneous-topology KV transfer tests.
+
+This drives the shared threaded NIXL harness (``kv_transfer_harness``) with
+MiniMax M3 cache managers and validates both ordinary K/V and the
+replicated INDEX_KEY cache. V2 storage coalesces buffers purely by (life
+cycle, size), so at TP degrees where K == V == INDEX_KEY bytes per block the
+index-K cache shares the K/V pool and the slot interleaves per layer; at
+other degrees it gets its own pool. The disagg page-table builder splits each
+pool into per-mapper-kind views, so both layouts (and transfers between them)
+are exercised by the topology matrix below.
+"""
+
+from collections.abc import Sequence
+
+import kv_transfer_harness as transfer_harness
+import pytest
+import torch
+
+from tensorrt_llm import Mapping
+from tensorrt_llm._torch.attention_backend.sparse.minimax_m3 import MiniMaxM3KVCacheManagerV2
+from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
+from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
+from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool, get_pool_bytes
+from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2, Role
+from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
+from tensorrt_llm.bindings import DataType
+from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+NUM_LAYERS = 4
+NUM_KV_HEADS = 2
+HEAD_DIM = 128
+INDEX_DIM = 128
+TOKENS_PER_BLOCK = transfer_harness.TOKENS_PER_BLOCK
+SPARSE_LAYERS = [3]
+
+
+class _FakeKVCache:
+    num_blocks = 3
+
+    @staticmethod
+    def get_base_page_indices(_pool_id):
+        return [4, 5, 6, -1]
+
+
+class _ShortFakeKVCache:
+    num_blocks = 2
+
+    @staticmethod
+    def get_base_page_indices(_pool_id):
+        return [7, 8, -1, -1]
+
+
+def test_minimax_cache_indices_support_block_count_limit() -> None:
+    manager = object.__new__(MiniMaxM3KVCacheManagerV2)
+    manager.kv_cache_map = {7: _FakeKVCache(), 8: _ShortFakeKVCache()}
+
+    assert manager._get_batch_cache_indices_by_pool_id([7]) == [[4, 5, 6, -1]]
+    assert manager._get_batch_cache_indices_by_pool_id([7], num_blocks_per_seq=[2]) == [[4, 5]]
+    assert manager._get_batch_cache_indices_by_pool_id([7], num_blocks_per_seq=[99]) == [[4, 5, 6]]
+    assert manager._get_batch_cache_indices_by_pool_id([7, 8]) == [
+        [4, 5, 6, -1],
+        [7, 8, -1, -1],
+    ]
+    assert manager.get_block_ids_per_seq([7]).tolist() == [[4, 5, 6, 0]]
+    assert manager.get_block_ids_per_seq([7, 8]).tolist() == [
+        [4, 5, 6, 0],
+        [7, 8, 0, 0],
+    ]
+
+
+def test_v2_disagg_role_mapper_kind_defaults() -> None:
+    manager = object.__new__(KVCacheManagerV2)
+
+    assert manager.get_disagg_role_mapper_kinds() == {
+        Role.ALL: MapperKind.INDEXED,
+        Role.INDEX_KEY: MapperKind.REPLICATED,
+    }
+
+
+def test_minimax_disagg_role_mapper_kinds() -> None:
+    manager = object.__new__(MiniMaxM3KVCacheManagerV2)
+
+    role_mapper_kinds = manager.get_disagg_role_mapper_kinds()
+
+    assert role_mapper_kinds == {
+        Role.ALL: MapperKind.NHD,
+        Role.INDEX_KEY: MapperKind.REPLICATED,
+    }
+
+
+def test_minimax_disagg_rejects_unmanaged_index_value(monkeypatch) -> None:
+    def fake_base_init(self, *args, **kwargs):
+        self.is_disagg = kwargs.get("is_disagg", False)
+        self.layer_offsets = {layer_id: layer_id for layer_id in range(kwargs["num_layers"])}
+
+    monkeypatch.setattr(KVCacheManagerV2, "__init__", fake_base_init)
+
+    with pytest.raises(ValueError, match="requires disable_index_value=True"):
+        MiniMaxM3KVCacheManagerV2(
+            num_layers=4,
+            sparse_layer_ids=[3],
+            disable_index_value_layer_ids=[],
+            sparse_index_dim=INDEX_DIM,
+            is_disagg=True,
+        )
+
+
+def _create_manager(
+    mapping: Mapping, dtype: DataType, sparse_layers: list[int] | None = None
+) -> MiniMaxM3KVCacheManagerV2:
+    max_num_tokens = 2048
+    kv_cache_dtype = {
+        DataType.FP8: "fp8",
+        DataType.NVFP4: "nvfp4",
+    }.get(dtype, "auto")
+    return MiniMaxM3KVCacheManagerV2(
+        kv_cache_config=KvCacheConfig(
+            enable_block_reuse=False,
+            max_tokens=max_num_tokens,
+            event_buffer_max_size=0,
+            dtype=kv_cache_dtype,
+        ),
+        kv_cache_type=CacheTypeCpp.SELF,
+        num_layers=NUM_LAYERS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        tokens_per_block=TOKENS_PER_BLOCK,
+        max_seq_len=transfer_harness.MAX_SEQ_LEN,
+        max_batch_size=transfer_harness.MAX_BATCH_SIZE,
+        mapping=mapping,
+        dtype=dtype,
+        vocab_size=transfer_harness.VOCAB_SIZE,
+        max_num_tokens=max_num_tokens,
+        sparse_layer_ids=sparse_layers if sparse_layers is not None else SPARSE_LAYERS,
+        disable_index_value_layer_ids=sparse_layers if sparse_layers is not None else SPARSE_LAYERS,
+        sparse_index_dim=INDEX_DIM,
+    )
+
+
+def test_minimax_m3_pool_view_scheme_coalesced_vs_separate() -> None:
+    """Pool composition varies with TP; the view scheme must not.
+
+    TP=2 makes kv_heads_per_rank == 1, so K == V == INDEX_KEY bytes per
+    block and V2 coalesces all three into one pool whose slot interleaves
+    the sparse layer's index-K between K/V regions (non-uniform layer
+    stride). TP=1 doubles K/V, so index-K gets its own pool and strides are
+    uniform. Both layouts must yield the same two per-class views.
+    """
+    from tensorrt_llm._torch.disaggregation.resource.kv_extractor import (
+        build_page_table_from_manager,
+    )
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_layer_byte_ranges
+
+    # --- TP=2: coalesced, interleaved slot ---
+    manager = _create_manager(
+        Mapping(world_size=2, rank=0, tp_size=2, pp_size=1), DataType.BF16, sparse_layers=[1]
+    )
+    try:
+        lg = build_page_table_from_manager(manager).layer_groups[0]
+        assert len(lg.pool_views) == 2
+        kv_view = next(pv for pv in lg.pool_views if pv.mapper_kind == MapperKind.NHD)
+        idx_view = next(pv for pv in lg.pool_views if pv.mapper_kind == MapperKind.REPLICATED)
+        assert kv_view.pool_role == frozenset({str(Role.KEY), str(Role.VALUE)})
+        assert idx_view.pool_role == frozenset({str(Role.INDEX_KEY)})
+        # Coalesced: both views address the same physical pool.
+        assert kv_view.pool_idx == idx_view.pool_idx
+        starts, bytes_per_layer = get_layer_byte_ranges(kv_view)
+        unit = bytes_per_layer // 2  # one K or V buffer per block
+        # Slot: L0K L0V L1K L1V L1IDX L2K L2V L3K L3V — the sparse layer's
+        # index-K makes the K/V layer stride non-uniform.
+        assert starts == {0: 0, 1: 2 * unit, 2: 5 * unit, 3: 7 * unit}
+        idx_starts, idx_bytes_per_layer = get_layer_byte_ranges(idx_view)
+        assert idx_starts == {1: 4 * unit}
+        assert idx_bytes_per_layer == unit
+    finally:
+        manager.shutdown()
+
+    # --- TP=1: separate pools, uniform strides ---
+    manager = _create_manager(
+        Mapping(world_size=1, rank=0, tp_size=1, pp_size=1), DataType.BF16, sparse_layers=[1]
+    )
+    try:
+        lg = build_page_table_from_manager(manager).layer_groups[0]
+        assert len(lg.pool_views) == 2
+        kv_view = next(pv for pv in lg.pool_views if pv.mapper_kind == MapperKind.NHD)
+        idx_view = next(pv for pv in lg.pool_views if pv.mapper_kind == MapperKind.REPLICATED)
+        assert kv_view.pool_idx != idx_view.pool_idx
+        starts, bytes_per_layer = get_layer_byte_ranges(kv_view)
+        assert starts == {i: i * bytes_per_layer for i in range(NUM_LAYERS)}
+    finally:
+        manager.shutdown()
+
+
+def _create_managers(
+    tp: int,
+    pp: int,
+    enable_dp: bool,
+    dtype: DataType = DataType.BF16,
+    sparse_layers: list[int] | None = None,
+) -> list[MiniMaxM3KVCacheManagerV2]:
+    return [
+        _create_manager(
+            Mapping(
+                world_size=tp * pp,
+                rank=rank,
+                tp_size=tp,
+                pp_size=pp,
+                enable_attention_dp=enable_dp,
+            ),
+            dtype,
+            sparse_layers,
+        )
+        for rank in range(tp * pp)
+    ]
+
+
+def _zero_physical_pools(manager: MiniMaxM3KVCacheManagerV2) -> None:
+    page_table = KVRegionExtractorV1(manager).page_table
+    unique_pools = {}
+    for pool_group in page_table.pool_groups:
+        for pool in pool_group.pools:
+            unique_pools[pool.base_address] = max(
+                unique_pools.get(pool.base_address, 0), get_pool_bytes(pool)
+            )
+    for base_address, size in unique_pools.items():
+        tensor = convert_to_torch_tensor(TensorWrapper(base_address, DataType.INT8, [size]))
+        tensor.zero_()
+
+
+def _get_nvfp4_scale_view(
+    manager: MiniMaxM3KVCacheManagerV2, layer_idx: int
+) -> torch.Tensor | None:
+    if manager.dtype != DataType.NVFP4:
+        return None
+    page_table = KVRegionExtractorV1(manager).page_table
+    local_layer_id = manager.layer_offsets[layer_idx]
+    scale_roles = frozenset({"key_block_scale", "value_block_scale"})
+    for layer_group_id, layer_group in enumerate(page_table.layer_groups):
+        for pool_view in getattr(layer_group, "pool_views", ()):
+            # Scale buffers land in their own pool (smaller size class), so
+            # selecting the pool by role set suffices; every entry for the
+            # layer inside that pool is a scale buffer.
+            if not (pool_view.pool_role & scale_roles):
+                continue
+            matching_entries = [
+                entry
+                for entry in pool_view.buffer_entries
+                if int(entry["local_layer_id"]) == local_layer_id
+            ]
+            if not matching_entries:
+                continue
+            pool = get_physical_pool(page_table, layer_group_id, pool_view.pool_idx)
+            raw_slots = convert_to_torch_tensor(
+                TensorWrapper(
+                    pool.base_address,
+                    DataType.INT8,
+                    [pool.num_slots, pool.slot_bytes],
+                )
+            )
+            start = min(int(entry["offset"]) for entry in matching_entries)
+            end = max(int(entry["offset"] + entry["size"]) for entry in matching_entries)
+            return raw_slots[:, start:end]
+    raise AssertionError(f"missing NVFP4 scale view for layer {layer_idx}")
+
+
+def _fill_position_dependent(
+    tensor: torch.Tensor,
+    *,
+    layer_idx: int,
+    first_global_head: int,
+) -> None:
+    """Fill ``[block, role, token, head, dim]`` with exact small integers."""
+    block = torch.arange(tensor.shape[0], device=tensor.device)[:, None, None, None, None]
+    role = torch.arange(tensor.shape[1], device=tensor.device)[None, :, None, None, None]
+    token = torch.arange(tensor.shape[2], device=tensor.device)[None, None, :, None, None]
+    head = (first_global_head + torch.arange(tensor.shape[3], device=tensor.device))[
+        None, None, None, :, None
+    ]
+    dim = torch.arange(tensor.shape[4], device=tensor.device)[None, None, None, None, :]
+    values = (layer_idx * 17 + block * 11 + role * 13 + token * 3 + head * 19 + dim) % 97
+    tensor.copy_(values.to(tensor.dtype))
+
+
+def _as_nvfp4_scale_tensor(
+    manager: MiniMaxM3KVCacheManagerV2,
+    layer_idx: int,
+) -> torch.Tensor | None:
+    scale_view = _get_nvfp4_scale_view(manager, layer_idx)
+    if scale_view is None:
+        return None
+    local_layer_id = manager.layer_offsets[layer_idx]
+    local_heads = manager.num_kv_heads_per_layer[local_layer_id]
+    bytes_per_token_head = HEAD_DIM // 16
+    return scale_view.view(
+        scale_view.shape[0],
+        2,
+        TOKENS_PER_BLOCK,
+        local_heads,
+        bytes_per_token_head,
+    )
+
+
+def _valid_indices(
+    manager: MiniMaxM3KVCacheManagerV2,
+    request_id: int,
+    layer_idx: int,
+) -> list[int]:
+    return [
+        index for index in manager.get_batch_cache_indices([request_id], layer_idx)[0] if index >= 0
+    ]
+
+
+def _first_global_head(manager: MiniMaxM3KVCacheManagerV2) -> int:
+    """Map a TP rank to its first logical head, including duplicated heads."""
+    if manager.mapping.enable_attention_dp:
+        return 0
+    return manager.mapping.tp_rank * NUM_KV_HEADS // manager.mapping.tp_size
+
+
+def _find_ctx_source(
+    ctx_managers: list[MiniMaxM3KVCacheManagerV2],
+    *,
+    ctx_tp: int,
+    ctx_enable_dp: bool,
+    request_idx: int,
+    layer_idx: int,
+    global_head: int,
+) -> tuple[MiniMaxM3KVCacheManagerV2, int]:
+    """Return the context manager/local head that owns one logical KV head."""
+    for manager in ctx_managers:
+        if layer_idx not in manager.pp_layers:
+            continue
+        tp_rank = manager.mapping.tp_rank
+        local_layer_id = manager.layer_offsets[layer_idx]
+        local_heads = manager.num_kv_heads_per_layer[local_layer_id]
+        if ctx_enable_dp:
+            if tp_rank == request_idx % ctx_tp:
+                return manager, global_head
+            continue
+        first_global_head = _first_global_head(manager)
+        if first_global_head <= global_head < first_global_head + local_heads:
+            return manager, global_head - first_global_head
+    raise AssertionError(
+        f"missing context source for request={request_idx}, layer={layer_idx}, "
+        f"global_head={global_head}"
+    )
+
+
+def _initialize_cache(
+    managers: Sequence[MiniMaxM3KVCacheManagerV2],
+    _tp: int,
+    seed_base: int = 0,
+    fill_random: bool = True,
+) -> None:
+    del seed_base
+    for manager in managers:
+        _zero_physical_pools(manager)
+        if not fill_random:
+            continue
+
+        for layer_idx in manager.pp_layers:
+            kv = manager.get_buffers(layer_idx, kv_layout="NHD")
+            first_global_head = _first_global_head(manager)
+            _fill_position_dependent(
+                kv,
+                layer_idx=layer_idx,
+                first_global_head=first_global_head,
+            )
+
+            index_key = manager.get_index_k_buffer(layer_idx)
+            if index_key is not None:
+                index_tensor = index_key.unsqueeze(1)
+                _fill_position_dependent(
+                    index_tensor,
+                    layer_idx=layer_idx,
+                    first_global_head=0,
+                )
+
+            scale_tensor = _as_nvfp4_scale_tensor(manager, layer_idx)
+            if scale_tensor is not None:
+                _fill_position_dependent(
+                    scale_tensor,
+                    layer_idx=layer_idx,
+                    first_global_head=first_global_head,
+                )
+
+
+def _verify_cache(
+    request_lengths: list[int],
+    ctx_managers: Sequence[MiniMaxM3KVCacheManagerV2],
+    gen_managers: Sequence[MiniMaxM3KVCacheManagerV2],
+    ctx_tp: int,
+    ctx_pp: int,
+    gen_tp: int,
+    gen_pp: int,
+    ctx_enable_dp: bool,
+    gen_enable_dp: bool,
+    ctx_request_ids: list[int],
+    gen_request_ids: list[int],
+) -> None:
+    del ctx_pp
+
+    for req_idx, _request_length in enumerate(request_lengths):
+        gen_request_id = gen_request_ids[req_idx]
+        for gen_rank, manager in enumerate(gen_managers):
+            tp_rank = gen_rank % gen_tp
+            if gen_enable_dp and req_idx % gen_tp != tp_rank:
+                continue
+
+            for layer_idx in manager.pp_layers:
+                gen_indices = _valid_indices(manager, gen_request_id, layer_idx)
+                assert gen_indices
+
+                gen_kv = manager.get_buffers(layer_idx, kv_layout="NHD")[gen_indices]
+                local_heads = gen_kv.shape[3]
+                first_global_head = _first_global_head(manager)
+                for kv_idx in range(2):
+                    for local_head in range(local_heads):
+                        global_head = first_global_head + local_head
+                        ctx_manager, ctx_local_head = _find_ctx_source(
+                            ctx_managers,
+                            ctx_tp=ctx_tp,
+                            ctx_enable_dp=ctx_enable_dp,
+                            request_idx=req_idx,
+                            layer_idx=layer_idx,
+                            global_head=global_head,
+                        )
+                        ctx_indices = _valid_indices(
+                            ctx_manager, ctx_request_ids[req_idx], layer_idx
+                        )
+                        ctx_kv = ctx_manager.get_buffers(layer_idx, kv_layout="NHD")
+                        torch.testing.assert_close(
+                            gen_kv[:, kv_idx, :, local_head, :],
+                            ctx_kv[ctx_indices, kv_idx, :, ctx_local_head, :],
+                            rtol=0,
+                            atol=0,
+                        )
+
+                index_key = manager.get_index_k_buffer(layer_idx)
+                if index_key is not None:
+                    ctx_manager, _ = _find_ctx_source(
+                        ctx_managers,
+                        ctx_tp=ctx_tp,
+                        ctx_enable_dp=ctx_enable_dp,
+                        request_idx=req_idx,
+                        layer_idx=layer_idx,
+                        global_head=0,
+                    )
+                    ctx_indices = _valid_indices(ctx_manager, ctx_request_ids[req_idx], layer_idx)
+                    ctx_index_key = ctx_manager.get_index_k_buffer(layer_idx)
+                    assert ctx_index_key is not None
+                    torch.testing.assert_close(
+                        index_key[gen_indices],
+                        ctx_index_key[ctx_indices],
+                        rtol=0,
+                        atol=0,
+                    )
+
+                gen_scales = _as_nvfp4_scale_tensor(manager, layer_idx)
+                if gen_scales is not None:
+                    for local_head in range(local_heads):
+                        global_head = first_global_head + local_head
+                        ctx_manager, ctx_local_head = _find_ctx_source(
+                            ctx_managers,
+                            ctx_tp=ctx_tp,
+                            ctx_enable_dp=ctx_enable_dp,
+                            request_idx=req_idx,
+                            layer_idx=layer_idx,
+                            global_head=global_head,
+                        )
+                        ctx_indices = _valid_indices(
+                            ctx_manager, ctx_request_ids[req_idx], layer_idx
+                        )
+                        ctx_scales = _as_nvfp4_scale_tensor(ctx_manager, layer_idx)
+                        assert ctx_scales is not None
+                        torch.testing.assert_close(
+                            gen_scales[gen_indices, :, :, local_head, :],
+                            ctx_scales[ctx_indices, :, :, ctx_local_head, :],
+                            rtol=0,
+                            atol=0,
+                        )
+
+
+# Production is expected to use TEP/DEP context and DEP generation. Bias the
+# committed matrix toward head-matched layouts while retaining representative
+# head-mismatch, degree-8 duplication, fan-in/fan-out, and PP2 coverage.
+HEAD_MATCHED_BF16_TOPOLOGIES = [
+    (1, 1, True, 1, 1, True, "dep1_to_dep1"),
+    (2, 1, True, 2, 1, True, "dep2_to_dep2"),
+    (4, 1, True, 4, 1, True, "dep4_to_dep4"),
+    (8, 1, True, 8, 1, True, "dep8_to_dep8"),
+    (1, 1, True, 8, 1, True, "dep1_to_dep8"),
+    (8, 1, True, 1, 1, True, "dep8_to_dep1"),
+    (1, 1, False, 4, 1, True, "tep1_to_dep4"),
+    (1, 1, False, 8, 1, True, "tep1_to_dep8"),
+    (1, 2, False, 2, 1, True, "tp1pp2_to_dep2"),
+]
+
+HEAD_MISMATCHED_BF16_TOPOLOGIES = [
+    (2, 1, False, 2, 1, True, "tep2_to_dep2"),
+    (4, 1, False, 4, 1, True, "tep4_to_dep4"),
+    (8, 1, False, 8, 1, True, "tep8_to_dep8"),
+    (8, 1, False, 1, 1, True, "tep8_to_dep1"),
+]
+
+BF16_TOPOLOGIES = HEAD_MATCHED_BF16_TOPOLOGIES + HEAD_MISMATCHED_BF16_TOPOLOGIES
+
+# Smaller quantized-cache sets cover packed K/V geometry across the same
+# production directions without repeating the BF16 topology matrix. NVFP4
+# additionally exercises its block-scale pools.
+QUANTIZED_TOPOLOGIES = [
+    (4, 1, True, 4, 1, True, "dep4_to_dep4"),
+    (8, 1, True, 1, 1, True, "dep8_to_dep1"),
+    (1, 1, False, 8, 1, True, "tep1_to_dep8"),
+    (4, 1, False, 4, 1, True, "tep4_to_dep4"),
+    (8, 1, False, 1, 1, True, "tep8_to_dep1"),
+]
+
+CACHE_CASES = [(*topology[:6], DataType.BF16, topology[6]) for topology in BF16_TOPOLOGIES] + [
+    (*topology[:6], dtype, f"{prefix}_{topology[6]}")
+    for dtype, prefix in ((DataType.FP8, "fp8"), (DataType.NVFP4, "nvfp4"))
+    for topology in QUANTIZED_TOPOLOGIES
+]
+
+
+@pytest.mark.cuda
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,ctx_enable_dp,gen_tp,gen_pp,gen_enable_dp,cache_dtype",
+    [case[:7] for case in CACHE_CASES],
+    ids=[case[7] for case in CACHE_CASES],
+)
+@pytest.mark.parametrize(
+    "update_before_transfer",
+    [True, False],
+    ids=["update_before", "update_after"],
+)
+def test_minimax_m3_kv_transfer(
+    ctx_tp,
+    ctx_pp,
+    ctx_enable_dp,
+    gen_tp,
+    gen_pp,
+    gen_enable_dp,
+    cache_dtype,
+    update_before_transfer,
+) -> None:
+    transfer_harness.run_kv_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        update_before_transfer=update_before_transfer,
+        manager_factory=lambda tp, pp, enable_dp: _create_managers(tp, pp, enable_dp, cache_dtype),
+        init_fn=_initialize_cache,
+        verify_fn=_verify_cache,
+    )
+
+
+# Multiple sparse layers spread across PP stages: the replicated index-key
+# pool overlaps only partially between peers, exercising the layer-strided
+# ReplicatedMapper offsets (a single-sparse-layer model always fully
+# overlaps and would degenerate to a whole-slot copy).
+MULTI_SPARSE_LAYERS = [1, 2, 3]
+
+
+@pytest.mark.cuda
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,ctx_enable_dp,gen_tp,gen_pp,gen_enable_dp",
+    [
+        (1, 1, True, 1, 2, False),  # ctx full index pool -> per-PP-stage subsets
+        (1, 2, False, 1, 1, True),  # per-PP-stage subsets -> full index pool
+        (2, 1, False, 1, 2, False),  # TEP fan-in + PP subset on the same transfer
+    ],
+    ids=["dep1_to_tp1pp2", "tp1pp2_to_dep1", "tep2_to_tp1pp2"],
+)
+def test_minimax_m3_multi_sparse_layer_pp_transfer(
+    ctx_tp,
+    ctx_pp,
+    ctx_enable_dp,
+    gen_tp,
+    gen_pp,
+    gen_enable_dp,
+) -> None:
+    transfer_harness.run_kv_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        update_before_transfer=True,
+        manager_factory=lambda tp, pp, enable_dp: _create_managers(
+            tp, pp, enable_dp, DataType.BF16, sparse_layers=MULTI_SPARSE_LAYERS
+        ),
+        init_fn=_initialize_cache,
+        verify_fn=_verify_cache,
+    )

--- a/tests/unittest/disaggregated/test_peer.py
+++ b/tests/unittest/disaggregated/test_peer.py
@@ -1,10 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import pytest
 
+import tensorrt_llm._torch.disaggregation.native.peer as peer_module
+from tensorrt_llm._torch.disaggregation.base.region import MemRegionGroup, SpecRegion
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.peer import (
-    HeadMatchMapper,
-    HeadMismatchMapper,
-    IdentityMapper,
+    HNDHeadMismatchMapper,
+    IntactMapper,
+    NHDHeadMismatchMapper,
+    ReplicatedMapper,
 )
 from tensorrt_llm._torch.disaggregation.native.mixers.attention.spec import AttentionInfo
 from tensorrt_llm._torch.disaggregation.native.peer import PeerOverlap, PeerRegistrar
@@ -16,6 +34,7 @@ from tensorrt_llm._torch.disaggregation.resource.page import (
     KVCachePageTable,
     LocalLayer,
     MambaLayerGroup,
+    MapperKind,
     PhysicalPool,
     PhysicalPoolGroup,
     PoolView,
@@ -31,21 +50,22 @@ def make_page_table(pool_ptrs=None, block_bytes=None, global_layer_ids=None):
     if global_layer_ids is None:
         global_layer_ids = [0, 1]
 
-    # Build buffer entries: K + V per local layer
-    buffer_size = 256  # bytes per buffer entry (arbitrary for tests)
-    entries = []
-    for i in range(len(global_layer_ids)):
-        base_offset = i * buffer_size * 2
-        entries.append((i, base_offset, buffer_size))
-        entries.append((i, base_offset + buffer_size, buffer_size))
-    buffer_entries = np.array(entries, dtype=BUFFER_ENTRY_DTYPE)
-
     local_layers = [
         LocalLayer(local_layer_id=i, global_layer_id=gid) for i, gid in enumerate(global_layer_ids)
     ]
-    pool_views = [
-        PoolView(pool_idx=pi, buffer_entries=buffer_entries) for pi in range(len(pool_ptrs))
-    ]
+    # Build buffer entries: K + V per local layer, sized so the layers fill
+    # the pool slot (keeps entry geometry consistent with slot_bytes).
+    pool_views = []
+    for pi, bs in enumerate(block_bytes):
+        buffer_size = bs // (len(global_layer_ids) * 2)
+        entries = []
+        for i in range(len(global_layer_ids)):
+            base_offset = i * buffer_size * 2
+            entries.append((i, base_offset, buffer_size))
+            entries.append((i, base_offset + buffer_size, buffer_size))
+        pool_views.append(
+            PoolView(pool_idx=pi, buffer_entries=np.array(entries, dtype=BUFFER_ENTRY_DTYPE))
+        )
     physical_pools = [
         PhysicalPool(base_address=ptr, slot_bytes=bs, num_slots=128)
         for ptr, bs in zip(pool_ptrs, block_bytes)
@@ -359,7 +379,15 @@ def test_peer_registrar_get_kv_map_identity():
     )
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
     mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
-    assert isinstance(mapper, IdentityMapper)
+    # Full contiguous overlap: one whole-region fragment per block.
+    assert isinstance(mapper, IntactMapper)
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=1024)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=1024)),
+    )
+    assert not isinstance(pair, list)
+    assert pair.src.memory.ptrs.tolist() == [1000]
+    assert pair.src.memory.bytes_per_region == 1024
 
 
 def test_peer_registrar_get_kv_map_head_match():
@@ -380,12 +408,23 @@ def test_peer_registrar_get_kv_map_head_match():
     )
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
     mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
-    assert isinstance(mapper, HeadMatchMapper)
+    # Partial layer overlap with matching heads: a single shifted fragment.
+    assert isinstance(mapper, IntactMapper)
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=1024)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=512)),
+    )
+    # Overlap is global layer 1: self slot holds layers [0, 1] (512B each),
+    # peer slot holds only layer 1.
+    assert pair.src.memory.ptrs.tolist() == [1512]
+    assert pair.dst.memory.ptrs.tolist() == [2000]
+    assert pair.src.memory.bytes_per_region == 512
 
 
 def test_peer_registrar_get_kv_map_head_mismatch():
     self_rankinfo = make_rankinfo(instance_name="local", page_table=make_page_table())
     reg = _make_peer_registrar(self_rankinfo)
+    # Twice the KV heads per rank -> twice the slot bytes on the peer side.
     peer_ri = make_rankinfo(
         instance_name="peer",
         instance_rank=3,
@@ -397,11 +436,156 @@ def test_peer_registrar_get_kv_map_head_mismatch():
         tokens_per_block=16,
         dims_per_head=8,
         layer_num_per_pp=[2],
-        page_table=make_page_table(),
+        page_table=make_page_table(block_bytes=[2048]),
     )
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
     mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
-    assert isinstance(mapper, HeadMismatchMapper)
+    assert isinstance(mapper, HNDHeadMismatchMapper)
+
+
+def test_nhd_head_mismatch_mapper_slices_each_token():
+    self_ri = make_rankinfo(
+        instance_name="local",
+        tp_size=2,
+        tp_rank=0,
+        dp_size=2,
+        dp_rank=0,
+        kv_heads_per_rank=2,
+        tokens_per_block=2,
+        dims_per_head=2,
+        element_bytes=2,
+        enable_attention_dp=True,
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=2,
+        tp_rank=0,
+        kv_heads_per_rank=1,
+        tokens_per_block=2,
+        dims_per_head=2,
+        element_bytes=2,
+    )
+    mapper = NHDHeadMismatchMapper(
+        src_layer_offsets=[0],
+        dst_layer_offsets=[0],
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_bytes_per_layer=32,
+        peer_bytes_per_layer=16,
+        self_buffers_per_layer=2,
+        peer_buffers_per_layer=2,
+    )
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=32)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=16)),
+    )
+
+    # Source NHD has two heads per token: select head 0 at offsets 0 and 8
+    # for K, then 16 and 24 for V. Destination has one head per token.
+    assert pair.src.memory.ptrs.tolist() == [1000, 1008, 1016, 1024]
+    assert pair.dst.memory.ptrs.tolist() == [2000, 2004, 2008, 2012]
+    assert pair.src.memory.bytes_per_region == 4
+    assert pair.dst.memory.bytes_per_region == 4
+
+
+def test_nhd_head_mismatch_mapper_uses_scale_pool_geometry():
+    self_ri = make_rankinfo(
+        tp_size=2,
+        kv_heads_per_rank=2,
+        tokens_per_block=2,
+        dims_per_head=128,
+        element_bytes=0.5,
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=1,
+        kv_heads_per_rank=1,
+        tokens_per_block=2,
+        dims_per_head=128,
+        element_bytes=0.5,
+    )
+    mapper = NHDHeadMismatchMapper(
+        src_layer_offsets=[0],
+        dst_layer_offsets=[0],
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_bytes_per_layer=8,
+        peer_bytes_per_layer=4,
+        self_buffers_per_layer=2,
+        peer_buffers_per_layer=2,
+    )
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=8)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=4)),
+    )
+
+    assert pair.src.memory.ptrs.tolist() == [1000, 1002, 1004, 1006]
+    assert pair.dst.memory.ptrs.tolist() == [2000, 2001, 2002, 2003]
+    assert pair.src.memory.bytes_per_region == 1
+    assert pair.dst.memory.bytes_per_region == 1
+
+
+def test_replicated_mapper_ignores_kv_head_mismatch():
+    self_pt = make_page_table(global_layer_ids=[0])
+    peer_pt = make_page_table(global_layer_ids=[0])
+    for page_table in (self_pt, peer_pt):
+        view = page_table.layer_groups[0].pool_views[0]
+        view.pool_role = frozenset({"index_key"})
+        view.mapper_kind = MapperKind.REPLICATED
+
+    self_rankinfo = make_rankinfo(instance_name="local", kv_heads_per_rank=1, page_table=self_pt)
+    reg = _make_peer_registrar(self_rankinfo)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        instance_rank=3,
+        tp_size=1,
+        kv_heads_per_rank=8,
+        layer_num_per_pp=[1],
+        page_table=peer_pt,
+    )
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+    assert isinstance(mapper, ReplicatedMapper)
+
+
+@pytest.mark.parametrize("peer_dp_rank", [0, 1, 3, 7])
+def test_replicated_pool_owner_rotates_by_destination_dp_rank(peer_dp_rank):
+    """Exactly one owner per fan-in group, rotated by destination DP rank.
+
+    Mirrors the C++ MLACacheFormatter::needSendCache pairing so the
+    replicated traffic spreads across local ranks for multi-DP generation.
+    """
+    page_table = make_page_table(global_layer_ids=[0])
+    view = page_table.layer_groups[0].pool_views[0]
+    view.mapper_kind = MapperKind.REPLICATED
+
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=8,
+        dp_size=8,
+        dp_rank=peer_dp_rank,
+        enable_attention_dp=True,
+        page_table=page_table,
+        layer_num_per_pp=[1],
+    )
+    overlap = PeerOverlap()
+    ownership = []
+    for tp_rank in range(8):
+        self_ri = make_rankinfo(
+            instance_name="local",
+            tp_size=8,
+            tp_rank=tp_rank,
+            page_table=page_table,
+            layer_num_per_pp=[1],
+        )
+        reg = _make_peer_registrar(self_ri)
+        ownership.append(reg.should_send_pool(overlap, peer_ri, 0, 0))
+
+    # ratio = self_tp(8) / peer_tp_per_dp(1) = 8: exactly one owner, at the
+    # slot selected by the destination dp rank.
+    assert sum(ownership) == 1
+    assert ownership.index(True) == peer_dp_rank % 8
 
 
 def test_peer_registrar_tpb_divisible_warns_but_compatible():
@@ -432,3 +616,380 @@ def test_peer_registrar_tpb_not_divisible_raises():
     )
     with pytest.raises(ValueError):
         reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+
+@pytest.mark.parametrize("mapper_kind", [MapperKind.NHD, MapperKind.REPLICATED])
+def test_peer_registrar_exact_tpb_mapper_rejects_divisible_mismatch(mapper_kind):
+    self_pt = make_page_table()
+    peer_pt = make_page_table()
+    self_pt.layer_groups[0].pool_views[0].mapper_kind = mapper_kind
+    peer_pt.layer_groups[0].pool_views[0].mapper_kind = mapper_kind
+    self_ri = make_rankinfo(page_table=self_pt, tokens_per_block=16)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        instance_rank=7,
+        page_table=peer_pt,
+        tokens_per_block=32,
+    )
+    reg = _make_peer_registrar(self_ri)
+
+    with pytest.raises(ValueError):
+        reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+
+def test_intact_mapper_region_size_mismatch_raises():
+    with pytest.raises(ValueError, match="cache region size mismatch"):
+        IntactMapper([0], [0], 256, 128)
+
+
+def test_replicated_mapper_per_layer_size_mismatch_raises():
+    with pytest.raises(ValueError, match="Replicated cache region size mismatch"):
+        ReplicatedMapper(
+            src_layer_offsets=[0, 128],
+            dst_layer_offsets=[0, 64],
+            self_bytes_per_layer=128,
+            peer_bytes_per_layer=64,
+        )
+
+
+def test_replicated_mapper_selects_partial_layer_range():
+    """PP mismatch selects the overlap layers via explicit offsets.
+
+    The peer slot holds a superset of layers; only the overlap moves, and
+    contiguous layers on both sides merge into one fragment.
+    """
+    mapper = ReplicatedMapper(
+        src_layer_offsets=[0, 128],  # self slot: 2 layers x 128B
+        dst_layer_offsets=[128, 256],  # peer slot: 3 layers x 128B, overlap at 1..2
+        self_bytes_per_layer=128,
+        peer_bytes_per_layer=128,
+    )
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=256)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=384)),
+    )
+
+    assert pair.src.memory.ptrs.tolist() == [1000]
+    assert pair.dst.memory.ptrs.tolist() == [2128]
+    assert pair.src.memory.bytes_per_region == 256
+    assert pair.dst.memory.bytes_per_region == 256
+
+
+def test_intact_mapper_splits_non_contiguous_runs():
+    """Interleaved slots (another role class between layers) split runs.
+
+    Source layers sit at non-uniform strides (something interleaves after
+    layer 0); destination is densely packed. Runs must break where either
+    side is discontiguous, and each fragment must carry the run's bytes.
+    """
+    mapper = IntactMapper(
+        src_layer_offsets=[0, 192, 320],  # gap after layer 0 (64B interleaved)
+        dst_layer_offsets=[0, 128, 256],  # dense
+        self_bytes_per_layer=128,
+        peer_bytes_per_layer=128,
+    )
+
+    pairs = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=448)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=384)),
+    )
+
+    assert isinstance(pairs, list) and len(pairs) == 2
+    # Run 1: layer 0 alone (src gap breaks the run).
+    assert pairs[0].src.memory.ptrs.tolist() == [1000]
+    assert pairs[0].dst.memory.ptrs.tolist() == [2000]
+    assert pairs[0].src.memory.bytes_per_region == 128
+    # Run 2: layers 1-2 contiguous on both sides -> merged.
+    assert pairs[1].src.memory.ptrs.tolist() == [1192]
+    assert pairs[1].dst.memory.ptrs.tolist() == [2128]
+    assert pairs[1].src.memory.bytes_per_region == 256
+
+
+def test_nhd_mapper_rejects_non_divisible_region_geometry():
+    self_ri = make_rankinfo(kv_heads_per_rank=2, tokens_per_block=2)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=1,
+        kv_heads_per_rank=4,
+        tokens_per_block=2,
+    )
+
+    with pytest.raises(ValueError, match="not evenly divisible"):
+        NHDHeadMismatchMapper(
+            src_layer_offsets=[0],
+            dst_layer_offsets=[0],
+            self_ri=self_ri,
+            peer_ri=peer_ri,
+            self_bytes_per_layer=17,
+            peer_bytes_per_layer=32,
+            self_buffers_per_layer=2,
+            peer_buffers_per_layer=2,
+        )
+
+
+def test_nhd_mapper_rejects_tokens_per_block_mismatch():
+    self_ri = make_rankinfo(tokens_per_block=2)
+    peer_ri = make_rankinfo(instance_name="peer", tokens_per_block=4)
+
+    with pytest.raises(ValueError, match="requires equal tokens_per_block"):
+        NHDHeadMismatchMapper(
+            src_layer_offsets=[0],
+            dst_layer_offsets=[0],
+            self_ri=self_ri,
+            peer_ri=peer_ri,
+            self_bytes_per_layer=32,
+            peer_bytes_per_layer=64,
+            self_buffers_per_layer=2,
+            peer_buffers_per_layer=2,
+        )
+
+
+def test_get_buffers_per_layer_rejects_non_uniform_nhd_entries():
+    pool_view = PoolView(
+        pool_idx=0,
+        buffer_entries=np.array(
+            [(0, 0, 16), (0, 16, 16), (1, 32, 16)],
+            dtype=BUFFER_ENTRY_DTYPE,
+        ),
+        mapper_kind=MapperKind.NHD,
+    )
+
+    with pytest.raises(ValueError, match="layer_group=3, pool=4"):
+        PeerRegistrar._get_buffers_per_layer(
+            pool_view,
+            2,
+            layer_group_id=3,
+            pool_idx=4,
+        )
+
+
+def test_non_uniform_view_geometry_rejected_for_all_kinds():
+    """Entries-driven views require uniform per-layer regions for every kind.
+
+    Under the unified contract INDEXED views are no longer exempt: a view
+    whose layers have different region sizes cannot be addressed per layer
+    and must fail loudly instead of transferring garbage.
+    """
+    entries = np.array(
+        [(0, 0, 16), (0, 16, 16), (1, 32, 16)],
+        dtype=BUFFER_ENTRY_DTYPE,
+    )
+    self_pt = make_page_table()
+    peer_pt = make_page_table()
+    self_pt.layer_groups[0].pool_views[0].buffer_entries = entries
+    peer_pt.layer_groups[0].pool_views[0].buffer_entries = entries.copy()
+    self_ri = make_rankinfo(page_table=self_pt)
+    peer_ri = make_rankinfo(instance_name="peer", page_table=peer_pt)
+    reg = _make_peer_registrar(self_ri)
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+    with pytest.raises(ValueError, match="not uniform"):
+        reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+
+
+def test_peer_registrar_allows_byte_aligned_subbyte_head_mismatch():
+    """Byte-aligned sub-byte head slicing is allowed on the HND path.
+
+    Per-head bytes are integral here: tpb=16 x dims=8 x 0.5B = 64B.
+    """
+    self_ri = make_rankinfo(
+        element_bytes=0.5,
+        kv_heads_per_rank=2,
+        tp_size=2,
+        page_table=make_page_table(),
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        element_bytes=0.5,
+        kv_heads_per_rank=4,
+        tp_size=1,
+        page_table=make_page_table(block_bytes=[2048]),
+    )
+    reg = _make_peer_registrar(self_ri)
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+
+    assert isinstance(mapper, HNDHeadMismatchMapper)
+
+
+def test_peer_registrar_rejects_misaligned_subbyte_head_mismatch():
+    """Head slicing that lands mid-byte must fail at registration.
+
+    tpb=1 x dims=1 x 0.5B = 0.5B per head is not byte-aligned.
+    """
+    self_ri = make_rankinfo(
+        element_bytes=0.5,
+        kv_heads_per_rank=2,
+        tokens_per_block=1,
+        dims_per_head=1,
+        tp_size=2,
+        page_table=make_page_table(),
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        element_bytes=0.5,
+        kv_heads_per_rank=4,
+        tokens_per_block=1,
+        dims_per_head=1,
+        tp_size=1,
+        page_table=make_page_table(block_bytes=[2048]),
+    )
+    reg = _make_peer_registrar(self_ri)
+
+    with pytest.raises(ValueError):
+        reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+
+def test_peer_registrar_dispatches_nhd_mapper():
+    self_pt = make_page_table()
+    peer_pt = make_page_table(block_bytes=[2048])
+    self_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    peer_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    self_ri = make_rankinfo(
+        kv_heads_per_rank=2,
+        tp_size=2,
+        page_table=self_pt,
+    )
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        kv_heads_per_rank=4,
+        tp_size=1,
+        page_table=peer_pt,
+    )
+    reg = _make_peer_registrar(self_ri)
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+
+    assert isinstance(mapper, NHDHeadMismatchMapper)
+
+
+def test_peer_registrar_warns_for_nhd_head_mismatch(monkeypatch):
+    self_pt = make_page_table()
+    peer_pt = make_page_table(block_bytes=[2048])
+    self_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    peer_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    self_ri = make_rankinfo(kv_heads_per_rank=2, tp_size=2, page_table=self_pt)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        kv_heads_per_rank=4,
+        tp_size=1,
+        page_table=peer_pt,
+    )
+    warnings = []
+    monkeypatch.setattr(
+        peer_module.logger,
+        "warning_once",
+        lambda *message, key: warnings.append((" ".join(map(str, message)), key)),
+    )
+
+    _make_peer_registrar(self_ri).register(
+        peer_ri.instance_name,
+        peer_ri.instance_rank,
+        peer_ri,
+    )
+
+    assert len(warnings) == 1
+    message, key = warnings[0]
+    assert "4 NIXL descriptors per transferred token per peer" in message
+    assert "local_kv_heads=2, peer_kv_heads=4" in message
+    assert key == "native-nhd-head-mismatch-2-4-4"
+
+
+def test_peer_registrar_nhd_head_match_uses_intact_mapper():
+    """NHD + equal heads takes the merged-run fast path, not per-token slicing.
+
+    With a dedicated (non-interleaved) K/V pool the run merge collapses the
+    whole class region into a single fragment per block — the fragment-count
+    budget for separate layouts.
+    """
+    self_pt = make_page_table()
+    peer_pt = make_page_table()
+    self_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    peer_pt.layer_groups[0].pool_views[0].mapper_kind = MapperKind.NHD
+    self_ri = make_rankinfo(page_table=self_pt)
+    peer_ri = make_rankinfo(instance_name="peer", instance_rank=9, page_table=peer_pt)
+    reg = _make_peer_registrar(self_ri)
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+
+    mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
+    assert isinstance(mapper, IntactMapper)
+    assert not isinstance(mapper, NHDHeadMismatchMapper)
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000, 5000]), bytes_per_region=1024)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000, 6000]), bytes_per_region=1024)),
+    )
+    # Fully contiguous on both sides -> exactly one fragment per block.
+    assert not isinstance(pair, list)
+    assert pair.src.memory.ptrs.tolist() == [1000, 5000]
+    assert pair.dst.memory.ptrs.tolist() == [2000, 6000]
+    assert pair.src.memory.bytes_per_region == 1024
+
+
+def test_indexed_head_mismatch_subbyte_geometry_is_entries_derived():
+    """HND head-mismatch byte math comes from slot bytes, never element_bytes.
+
+    Emulates an NVFP4-like cache: element_bytes is fractional (0.5), but the
+    slot size registered by storage is whole bytes, so every derived offset
+    and fragment size must be an exact integer.
+    """
+    # self: 2 kv heads/rank, per-head bytes = 16 tokens x 8 dims x 0.5B = 64.
+    self_ri = make_rankinfo(
+        tp_size=1,
+        tp_rank=0,
+        kv_heads_per_rank=2,
+        tokens_per_block=16,
+        dims_per_head=8,
+        element_bytes=0.5,
+    )
+    # peer: twice the TP -> 1 kv head/rank, half the slot bytes.
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        tp_size=2,
+        tp_rank=1,
+        kv_heads_per_rank=1,
+        tokens_per_block=16,
+        dims_per_head=8,
+        element_bytes=0.5,
+    )
+    mapper = HNDHeadMismatchMapper(
+        src_layer_offsets=[0, 256],  # 2 layers x 256B/layer (kv_factor 2 x 128B)
+        dst_layer_offsets=[0, 128],  # 2 layers x 128B/layer (kv_factor 2 x 64B)
+        self_ri=self_ri,
+        peer_ri=peer_ri,
+        self_bytes_per_layer=256,
+        peer_bytes_per_layer=128,
+        self_buffers_per_layer=2,
+        peer_buffers_per_layer=2,
+    )
+
+    pair = mapper.map(
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([1000]), bytes_per_region=512)),
+        SpecRegion(memory=MemRegionGroup(ptrs=np.array([2000]), bytes_per_region=256)),
+    )
+    # peer tp_rank=1 selects head 1 inside self's per-rank pair of heads:
+    # src_head_off = 1 x 64B; fragments = (layer, k/v) x 2 layers.
+    assert pair.src.memory.ptrs.tolist() == [1064, 1192, 1320, 1448]
+    assert pair.dst.memory.ptrs.tolist() == [2000, 2064, 2128, 2192]
+    assert pair.src.memory.bytes_per_region == 64
+    assert pair.src.memory.ptrs.dtype == np.int64
+    assert pair.dst.memory.ptrs.dtype == np.int64
+
+
+def test_indexed_head_mismatch_inconsistent_slot_geometry_raises():
+    self_ri = make_rankinfo(tp_size=1, kv_heads_per_rank=2)
+    peer_ri = make_rankinfo(instance_name="peer", tp_size=2, kv_heads_per_rank=1)
+    with pytest.raises(ValueError, match="HND bytes per head mismatch"):
+        HNDHeadMismatchMapper(
+            src_layer_offsets=[0, 256],
+            dst_layer_offsets=[0, 256],
+            self_ri=self_ri,
+            peer_ri=peer_ri,
+            self_bytes_per_layer=256,
+            peer_bytes_per_layer=256,  # should be 128 for half the heads
+            self_buffers_per_layer=2,
+            peer_buffers_per_layer=2,
+        )

--- a/tests/unittest/disaggregated/test_pool_matching.py
+++ b/tests/unittest/disaggregated/test_pool_matching.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Golden tests for ``PeerRegistrar.get_pool_mapping``.
 
 Locks the current (pre-refactor) behavior of disagg pool matching across the
@@ -6,7 +21,7 @@ representative scenarios that the refactor must keep working:
   * single KV pool, full layer overlap (basic MHA)
   * MLA (kv_factor=1, KEY-only pool)
   * KV + block-scale pools coexisting in one LG
-  * KV + FLAT pools coexisting in one LG (FLAT has empty buffer_entries)
+  * KV + REPLICATED indexer pools coexisting in one LG
   * PP partial layer overlap (Step-1 LG match by global_layer_id)
   * Two pools with same role but different layer sets within a peer LG
     (DSv4 virtual-layer scenario, exercises ``best_overlap``)
@@ -70,13 +85,13 @@ def _pool_view(pool_idx, layer_role_pairs, *, pool_role=None, mapper_kind=Mapper
     )
 
 
-def _empty_pool_view(pool_idx, *, pool_role=frozenset({"indexer_k"})):
-    """Pool view with no buffer entries — FLAT pool convention."""
-    return PoolView(
-        pool_idx=pool_idx,
-        buffer_entries=np.array([], dtype=BUFFER_ENTRY_DTYPE),
+def _indexer_pool_view(pool_idx, local_layer_ids, *, pool_role=frozenset({"indexer_k"})):
+    """Replicated indexer pool view: one synthesized entry per local layer."""
+    return _pool_view(
+        pool_idx,
+        [(lid, "indexer_k") for lid in local_layer_ids],
         pool_role=pool_role,
-        mapper_kind=MapperKind.FLAT,
+        mapper_kind=MapperKind.REPLICATED,
     )
 
 
@@ -229,16 +244,16 @@ def test_kv_and_block_scale_in_same_lg():
 
 
 def test_kv_and_indexer_in_same_lg():
-    """KV pool + FLAT pool. FLAT has empty buffer_entries; matches by role."""
+    """KV pool + replicated indexer pool match independently by role."""
     self_lg = _attn_lg(
         0,
         [(0, 0), (1, 1)],
-        [_kv_pool_view(0, [0, 1]), _empty_pool_view(1)],
+        [_kv_pool_view(0, [0, 1]), _indexer_pool_view(1, [0, 1])],
     )
     peer_lg = _attn_lg(
         0,
         [(0, 0), (1, 1)],
-        [_kv_pool_view(0, [0, 1]), _empty_pool_view(1)],
+        [_kv_pool_view(0, [0, 1]), _indexer_pool_view(1, [0, 1])],
     )
 
     self_pt = _page_table([self_lg], pool_specs={0: [(1024, 64, 0x1000), (512, 64, 0x2000)]})
@@ -249,6 +264,58 @@ def test_kv_and_indexer_in_same_lg():
 
     mapping = reg.get_pool_mapping(peer_ri)
     assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
+
+
+def test_minimax_split_kv_and_replicated_index_pools_match():
+    """MiniMax M3 shape: NHD KV pool + REPLICATED index-key pool.
+
+    coalescing_group derivation keeps INDEX_KEY in its own pool on every
+    topology, so both sides always present the same two role sets and
+    role-set matching pairs them 1:1 with kinds intact.
+    """
+
+    def _lg():
+        return _attn_lg(
+            0,
+            [(0, 0), (1, 1)],
+            [
+                _pool_view(
+                    0,
+                    [(lid, role) for lid in (0, 1) for role in ("key", "value")],
+                    mapper_kind=MapperKind.NHD,
+                ),
+                _pool_view(
+                    1, [(0, "index_key"), (1, "index_key")], mapper_kind=MapperKind.REPLICATED
+                ),
+            ],
+        )
+
+    self_pt = _page_table([_lg()], pool_specs={0: [(512, 64, 0x1000), (256, 64, 0x2000)]})
+    peer_pt = _page_table([_lg()], pool_specs={0: [(512, 64, 0x3000), (256, 64, 0x4000)]})
+
+    reg = _registrar(self_pt)
+    peer_ri = _rank_info(name="peer", rank=1, page_table=peer_pt)
+
+    mapping = reg.get_pool_mapping(peer_ri)
+    assert mapping == {(0, 0): (0, 0), (0, 1): (0, 1)}
+
+
+def test_mismatched_view_kinds_raise():
+    """Kind disagreement on one role set must fail loudly.
+
+    Same role set but different kinds on the two sides is a version or
+    configuration inconsistency.
+    """
+    self_lg = _attn_lg(
+        0, [(0, 0)], [_pool_view(0, [(0, "index_key")], mapper_kind=MapperKind.REPLICATED)]
+    )
+    peer_lg = _attn_lg(0, [(0, 0)], [_pool_view(0, [(0, "index_key")], mapper_kind=MapperKind.NHD)])
+
+    reg = _registrar(_page_table([self_lg]))
+    peer_ri = _rank_info(name="peer", rank=1, page_table=_page_table([peer_lg]))
+
+    with pytest.raises(ValueError, match="incompatible mapper"):
+        reg.get_pool_mapping(peer_ri)
 
 
 def test_pp_partial_layer_overlap():
@@ -274,11 +341,11 @@ def test_two_pools_distinct_roles_in_same_lg():
     pool with the same pool_role.
     """
     self_kv = _kv_pool_view(0, [0, 1])
-    self_indexer = _empty_pool_view(1)
+    self_indexer = _indexer_pool_view(1, [0, 1])
     self_lg = _attn_lg(0, [(0, 10), (1, 11)], [self_kv, self_indexer])
 
     peer_kv = _kv_pool_view(0, [0, 1])
-    peer_indexer = _empty_pool_view(1)
+    peer_indexer = _indexer_pool_view(1, [0, 1])
     peer_lg = _attn_lg(0, [(0, 10), (1, 11)], [peer_kv, peer_indexer])
 
     self_pt = _page_table([self_lg], pool_specs={0: [(1024, 64, 0x1000), (512, 64, 0x2000)]})
@@ -323,20 +390,19 @@ def test_same_role_pools_disambiguated_by_layer_overlap():
 @pytest.mark.parametrize(
     ("self_mapper_kind", "peer_mapper_kind"),
     [
-        (MapperKind.FLAT, MapperKind.INDEXED),
-        (MapperKind.INDEXED, MapperKind.FLAT),
+        (MapperKind.REPLICATED, MapperKind.INDEXED),
+        (MapperKind.INDEXED, MapperKind.REPLICATED),
     ],
 )
 def test_mixed_mapper_kinds_are_rejected(self_mapper_kind, peer_mapper_kind):
     """Pool layouts must use the same mapper kind on both peers."""
 
     def _indexer_view(mapper_kind):
-        if mapper_kind == MapperKind.FLAT:
-            return _empty_pool_view(0)
         return _pool_view(
             0,
             [(0, "indexer_k"), (1, "indexer_k")],
             pool_role=frozenset({"indexer_k"}),
+            mapper_kind=mapper_kind,
         )
 
     self_lg = _attn_lg(0, [(0, 10), (1, 11)], [_indexer_view(self_mapper_kind)])

--- a/tests/unittest/disaggregated/test_rank_info.py
+++ b/tests/unittest/disaggregated/test_rank_info.py
@@ -1,7 +1,27 @@
-import numpy as np
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tensorrt_llm._torch.disaggregation.native import rank_info as rank_info_module
 from tensorrt_llm._torch.disaggregation.native.auxiliary import AuxBufferMeta
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
+from tensorrt_llm.bindings import DataType
 
 
 def test_rank_info_construction():
@@ -75,3 +95,41 @@ def test_rank_info_roundtrip_with_aux_meta():
     np.testing.assert_array_equal(restored.aux_meta.size, [1024, 2048])
     np.testing.assert_array_equal(restored.aux_meta.item_sizes, [64, 128])
     assert restored.aux_meta.device == "cpu"
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_element_bytes", "expected_type"),
+    [(DataType.NVFP4, 0.5, float), (DataType.HALF, 2, int)],
+)
+def test_rank_info_represents_cache_element_bytes(
+    monkeypatch, dtype, expected_element_bytes, expected_type
+):
+    monkeypatch.setattr(rank_info_module, "build_page_table_from_manager", lambda _manager: None)
+    manager = SimpleNamespace(
+        mapping=SimpleNamespace(
+            rank=0,
+            tp_size=2,
+            tp_rank=0,
+            pp_size=1,
+            pp_rank=0,
+            dp_size=1,
+            cp_size=1,
+            cp_rank=0,
+            enable_attention_dp=False,
+        ),
+        pp_layers=[0],
+        num_kv_heads_per_layer=[4],
+        tokens_per_block=64,
+        head_dim=128,
+        dtype=dtype,
+        kv_factor=2,
+    )
+
+    rank_info = RankInfo.from_kv_cache_manager("ctx", manager, device_id=0)
+
+    assert rank_info.attention.element_bytes == expected_element_bytes
+    assert isinstance(rank_info.attention.element_bytes, expected_type)
+
+    restored = RankInfo.from_bytes(rank_info.to_bytes())
+    assert restored.attention.element_bytes == expected_element_bytes
+    assert isinstance(restored.attention.element_bytes, expected_type)

--- a/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
+++ b/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from typing import Optional
 from unittest.mock import Mock
 
+import pytest
+
 from tensorrt_llm._torch.disaggregation.base.transfer import SessionStatus, WaitResult
 from tensorrt_llm._torch.disaggregation.native.transfer import TaskStatus, TxSession
 from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
@@ -253,6 +255,15 @@ def test_consensus_outcome_uses_single_batched_allgather() -> None:
     assert new_completed == [7]  # intersection only (8 is completed on the peer only)
 
 
+@pytest.mark.skip(
+    reason="ctx idle fast-path was dropped from this branch. TODO: when the "
+    "fast-path is reintroduced, its terminal-count reduction must mirror "
+    "_ctx_consensus()'s communicator scope (TP group, then PP group; TP "
+    "skipped under attention DP) — a WORLD-scoped allreduce hangs under "
+    "ADP+PP because independent attention-DP lanes poll on their own "
+    "schedules. Re-enable this test and add scoped mock coverage for the "
+    "TP+PP and ADP+PP configurations plus real-collective MP tests."
+)
 def test_ctx_consensus_fastpath_skips_when_idle(monkeypatch) -> None:
     # With the fast-path enabled, an all-zero terminal count (one fixed-size
     # allreduce) makes every rank skip the variable-length consensus; a non-zero


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved KV-cache transfer mapping across layer, head, replicated, and token-major layouts.
  * Added support for replicated indexer-K cache transfers and MiniMax M3 disaggregated KV-cache workflows.
  * Added configurable transfer descriptor coalescing, enabled by default, with an option to disable it.
  * Added stronger validation for cache geometry, alignment, and mapper compatibility.
  * Added an optional faster idle path for disaggregation polling.

* **Bug Fixes**
  * Corrected cache page indexing, layer offsets, pool matching, and replicated-transfer ownership.
  * Improved handling of shared physical pools and sub-byte cache formats.

* **Tests**
  * Expanded unit and integration coverage for transfer mapping, page tables, replicated caches, and MiniMax M3 scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Enable **disaggregated KV-cache transfer for MiniMax M3** on the KV cache manager V2 path **without modifying the V2 storage layer**.

### Problem

V2 storage coalesces buffers purely by `(life cycle, buffer size)`. For M3 this means pool composition varies with topology: at TP degrees where K == V == INDEX_KEY bytes per block, all three share one pool and the slot interleaves K/V/index-K per layer; at other degrees index-K gets its own pool. Disagg transfer must therefore never depend on the physical coalescing outcome, and the previous mapper machinery (uniform per-layer strides, global-id/byte-offset monotonicity, `element_bytes` float arithmetic) could not express M3's interleaved, non-uniform slot layouts.

### Solution

**Per-class pool views.** The disagg page-table builder buckets buffer entries by `(life cycle, physical pool, mapper kind)` and emits one kind-homogeneous `PoolView` per role class. A physical pool may hold several classes; each still gets its own view, so peer matching is independent of coalescing. View count is bounded by role-class count, never layer count.

**Entries-driven layer addressing.** Every view carries `buffer_entries` (`local_layer_id, offset, size`) plus a validated uniform `bytes_per_layer`; all mappers resolve overlap layers to slot-relative byte offsets from entries. `IntactMapper` copies selected layers via explicit per-layer offsets and merges runs contiguous on both sides (dedicated pools degrade to one fragment per block); `ReplicatedMapper` builds on it; `NHDHeadMismatchMapper` handles non-uniform layer strides in coalesced slots.

**Declarative role → mapper-kind mapping.** Managers declare transfer semantics via `get_disagg_role_mapper_kinds()`; the base default is `{ALL: INDEXED, INDEX_KEY: REPLICATED}` (every shipped index-K — DSA on V1, MiniMax M3 on V2 — is TP-replicated; the entry is inert unless INDEX_KEY buffers are registered). M3 declares `{ALL: NHD, INDEX_KEY: REPLICATED}`. Fan-in election operates per view: replicated views elect one sender per destination group (TP-only dedup — index-K is not replicated across PP, so PP routing stays layer-overlap-driven).

**Sub-byte exactness.** Head-mismatch byte geometry (HND and NHD) is derived from storage-registered slot/entry sizes with integer divisibility checks instead of `element_bytes` arithmetic, so NVFP4 stays exact; `element_bytes` remains for peer-compat validation only.

**M3 manager adjustments (no storage changes).** Pool-mapping ol_mapping_offset()` template hook (base keeps the `exact_div`formula; M3 overrides positionally since interleaved slots break the uniform-stride assumption), replacing a stale wholesale override. `get_buffers()` builds `[num_slots, scale, ...]` views spanning coalesced slots.

**NIXL transfer-desc coalescing.** The shared `cache_transmission` transfer agent now coalesces contiguous src/dst descriptor spans within chunk and registered-region bounds before submission (pairs sorted by `(deviceId, addr)` so contiguous spans merge regardless of input order). On by default; opt out via `TRTLLM_NIXL_DISABLE_COALESCE=1`.

**Transceiver fixes.** `_consensus_outcome` exchanges cancelled one packed allgather instead of three collectives. A ctx idlefast-path that would skip the variable-length consensus allgathers on idle polls is deliberately **not** part of this PR: it is left as a `TODO` in
`check_context_transfer_status` (plus a skipped unit test) for t mirror `_ctx_consensus()`'s communicator scope (TP group thenPP group, TP skipped under attention DP), since a WORLD-scoped collective can mismatch ordering or hang under ADP+PP.

### Notes for reviewers

*   `MapperKind` was renumbered contiguously (`INDEXED=0, REPLICATED=1, NHD=2`) after removing `FLAT`; this intentionally drops handshake compatibility with pre-release builds emitting the old numbering.
*   The V1-era `IdentityMapper`/`HeadMatchMapper` classes are rized as `IntactMapper` (formerly `LayerRegionMapper`) /`ReplicatedMapper` and the `HND`/`NHD` head-mismatch mappers. Head-matched views go through `IntactMapper`, byte-identical output asserted by test.
*   No changes to V2 storage, block lifecycle, or the aggregate serving path; TRTLLM-attention (INDEXED) managers keep byte-identical behavior.

## Test Coverage

*   `test_minimax_m3_kv_transfer.py` (new): full M3 topology matrix — coalesced vs separate index-K pools, TEP/DEP fan-in/fan-out up to degree 8, PP2 and
multi-sparse-layer per-PP-stage subsets, BF16/FP8/NVFP4, update
*   DSA indexer-K (V1, REPLICATED) coverage in the single-process transceiver harness; DSv4/V1/V2 transfer matrices unchanged and green.
*   Unit coverage for per-class view splitting, non-uniform layent budgets, sub-byte HND/NHD geometry, replicated fan-inelection, packed consensus allgather.
*   C++: `coalesceTest` covers the split-and-coalesce desc pipeline (21/21 locally); `transferAgentTest` updated for the renamed splitter API.
*   Extracted the shared threaded NIXL harness into `kv_transfests inject model hooks.
*   Wired previously unlisted suites into `l0_h100.yml` (`test_minimax_m3_kv_transfer`, `test_deepseek_v4_kv_transfer`, `test_pool_matching`, `test_transceiver_bounded_polling`, DSA indexer node).
*   Local run: full `tests/unittest/disaggregated/` — **995 passed, 67 skipped** (env-gated, plus the intentionally skipped ctx-fast-path TODO test).
## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
