### PR TITLE
[TRTLLM-12352][feat] add post-transform capability profiles

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -300,7 +300,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 mapping,
                 reason=(
                     "source publishes post-transform weights but this model is "
-                    "not allow-listed for staged MX receiver loading"
+                    "not qualified for staged MX receiver loading"
                 ),
                 **kwargs,
             )
@@ -554,7 +554,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
 
         Called by the integration in `model_loader.py` after
         `post_load_weights()` so targets receive the post-transform runtime
-        layout and, when allow-listed, can skip their own one-shot transforms.
+        layout and, when qualified, can skip their own one-shot transforms.
 
         Delegates to the upstream
         `modelexpress.trtllm_live_transfer.publish_model_params`

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -222,6 +222,9 @@ class MXCheckpointLoader(HfCheckpointLoader):
             mapping: Distributed mapping configuration.
             **kwargs: Additional keyword arguments. When `model` is
                 passed it is used as the target for direct P2P writes.
+                `prepare_post_transform_receiver`, when present, is called
+                after a post-transform source is qualified and before those
+                direct writes begin.
 
         Returns:
             A weights dict. Empty when MX P2P fully succeeded (weights
@@ -232,6 +235,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
         # Popped here so it never leaks into the disk-fallback signature.
         self._local_source_identity = kwargs.pop("source_identity", None)
         allow_post_transform_weights = kwargs.pop("allow_post_transform_weights", False)
+        prepare_post_transform_receiver = kwargs.pop("prepare_post_transform_receiver", None)
         self._p2p_succeeded = False
         self._post_transform_weights_preloaded = False
         self._source_identity_compatible_for_last_load = False
@@ -304,6 +308,23 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 ),
                 **kwargs,
             )
+        if self._post_transform_weights_preloaded:
+            if prepare_post_transform_receiver is None:
+                self._post_transform_weights_preloaded = False
+                self._source_identity_compatible_for_last_load = False
+                return self._fallback_to_disk(
+                    checkpoint_dir,
+                    mapping,
+                    reason=(
+                        "post-transform source requires receiver structure "
+                        "preparation before exact-name P2P transfer"
+                    ),
+                    **kwargs,
+                )
+            # Source-side setup_aliases() may change the first canonical name
+            # returned for aliased parameters. Mirror that structural state on
+            # the receiver before upstream MX matches tensors by exact name.
+            prepare_post_transform_receiver(model)
 
         timeout_override = self._resolve_query_timeout_override(
             checkpoint_dir,

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -13,7 +13,10 @@ import torch
 from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import (
     AutoCheckpointMapper, BaseCheckpointLoader)
 from tensorrt_llm._torch.weight_sharing import (
-    IdentityCheckPolicy, SourceIdentity, check_weight_sharing_compatibility)
+    IdentityCheckPolicy, PostTransformFeature, PostTransformProfile,
+    PostTransformProfileRegistry, PostTransformQualificationDecision,
+    PostTransformTransferScope, SourceIdentity,
+    check_weight_sharing_compatibility)
 from tensorrt_llm._utils import str_dtype_to_torch
 from tensorrt_llm.llmapi.llm_args import (DecodingBaseConfig,
                                           ExecutorMemoryType,
@@ -296,9 +299,16 @@ class ModelLoader:
     This class isolates model loading logic from the main execution engine.
     """
     _MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION = 1
-    _MX_STAGED_RECEIVER_ALLOWLIST = frozenset({
-        (LlamaForCausalLM, _MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION)
-    })
+    _POST_TRANSFORM_PROFILE_REGISTRY = PostTransformProfileRegistry(
+        profiles=(PostTransformProfile(
+            profile_id="llama-for-causal-lm-target-v1",
+            root_model_class=LlamaForCausalLM,
+            architecture="LlamaForCausalLM",
+            model_type="llama",
+            speculative_mode=None,
+            protocol_version=_MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
+            transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+        ), ))
 
     def __init__(self,
                  llm_args: TorchLlmArgs,
@@ -519,6 +529,7 @@ class ModelLoader:
             loads_draft_weights = (
                 self.spec_config is not None
                 and self.spec_config.spec_dec_mode.need_load_draft_weights())
+            speculative_mode = self._speculative_mode_name(self.spec_config)
             # Set when either GMS RW or GMS RO branch has already run the
             # post_load_* hooks itself, so the shared post-load block below
             # must skip them. RW handles them inside `mem_pool_scope` so the
@@ -543,9 +554,12 @@ class ModelLoader:
                     # do not accept post-transform bytes for only the target
                     # model. Enable this only after target and draft subgraphs
                     # have an explicit mixed-layout policy.
-                    load_weights_kwargs["allow_post_transform_weights"] = (
-                        self._is_mx_staged_receiver_allowlisted(model)
-                        and not loads_draft_weights)
+                    qualification = self._qualify_post_transform_profile(
+                        model,
+                        speculative_mode=speculative_mode,
+                        loads_draft_weights=loads_draft_weights)
+                    load_weights_kwargs[
+                        "allow_post_transform_weights"] = qualification.qualified
 
                 if hasattr(model, 'llm_checkpoint_dir'):
                     weights = checkpoint_loader.load_weights(
@@ -664,10 +678,12 @@ class ModelLoader:
                                 "source_identity": self._source_identity,
                             }
                             if checkpoint_loader.checkpoint_format == "MX":
+                                qualification = self._qualify_post_transform_profile(
+                                    model,
+                                    speculative_mode=speculative_mode,
+                                    loads_draft_weights=loads_draft_weights)
                                 load_weights_kwargs[
-                                    "allow_post_transform_weights"] = (
-                                        self._is_mx_staged_receiver_allowlisted(
-                                            model) and not loads_draft_weights)
+                                    "allow_post_transform_weights"] = qualification.qualified
                             weights = checkpoint_loader.load_weights(
                                 weight_source, **load_weights_kwargs)
 
@@ -731,6 +747,7 @@ class ModelLoader:
                                 checkpoint_loader,
                                 model,
                                 weights_preloaded=weights_preloaded,
+                                speculative_mode=speculative_mode,
                                 loads_draft_weights=loads_draft_weights)
                             if mx_staged_receiver_path:
                                 self._setup_aliases(model)
@@ -756,7 +773,9 @@ class ModelLoader:
                                 checkpoint_loader,
                                 model,
                                 checkpoint_dir=checkpoint_dir,
-                                weights_preloaded=weights_preloaded)
+                                weights_preloaded=weights_preloaded,
+                                speculative_mode=speculative_mode,
+                                loads_draft_weights=loads_draft_weights)
 
                         # Pool closed. Commit the post-post_load layout.
                         gms_backend.finalize_write(model)
@@ -804,10 +823,13 @@ class ModelLoader:
                         gms_backend.materialize_module(model)
                         self._walk_cache_state(model)
 
-                        self._post_load_publish(checkpoint_loader,
-                                                model,
-                                                checkpoint_dir=checkpoint_dir,
-                                                weights_preloaded=True)
+                        self._post_load_publish(
+                            checkpoint_loader,
+                            model,
+                            checkpoint_dir=checkpoint_dir,
+                            weights_preloaded=True,
+                            speculative_mode=speculative_mode,
+                            loads_draft_weights=loads_draft_weights)
                         gms_post_load_handled = True
                         logger.info("LoadFormat.GMS (RO): materialized weights")
                     else:
@@ -846,6 +868,7 @@ class ModelLoader:
                     checkpoint_loader,
                     model,
                     weights_preloaded=weights_preloaded,
+                    speculative_mode=speculative_mode,
                     loads_draft_weights=loads_draft_weights)
                 if mx_staged_receiver_path:
                     self._setup_aliases(model)
@@ -856,7 +879,9 @@ class ModelLoader:
                 self._post_load_publish(checkpoint_loader,
                                         model,
                                         checkpoint_dir=checkpoint_dir,
-                                        weights_preloaded=weights_preloaded)
+                                        weights_preloaded=weights_preloaded,
+                                        speculative_mode=speculative_mode,
+                                        loads_draft_weights=loads_draft_weights)
 
             # TODO(GMS-MOE-LB): when the (MoE, GMS) combination is enabled,
             # `register_weight_slots_after_to_cuda` and `finalize_model`
@@ -916,11 +941,12 @@ class ModelLoader:
             model: DecoderModelForCausalLM,
             *,
             weights_preloaded: bool,
+            speculative_mode: Optional[str] = None,
             loads_draft_weights: bool = False) -> bool:
         """Whether an MX receiver can skip one-shot weight transforms.
 
         MXCheckpointLoader only accepts post-transform P2P bytes when this same
-        allow-list check passes before transfer. It also refuses
+        exact-profile check passes before transfer. It also refuses
         target-plus-draft mixed layouts until there is an explicit policy for
         that combination, so this post-load branch should never see an unsafe
         post-transform receiver in normal use.
@@ -934,49 +960,93 @@ class ModelLoader:
         ):
             return False
 
-        if loads_draft_weights:
-            raise RuntimeError(
-                "MX receiver accepted post-transform weights while a separate "
-                "draft-model load is required. This is unsafe because the "
-                "target and draft subgraphs may need different post-load "
-                "transform handling. Disable post-transform MX for this load "
-                "or add an explicit mixed target/draft policy.")
-
-        if cls._is_mx_staged_receiver_allowlisted(model):
+        qualification = cls._qualify_post_transform_profile(
+            model,
+            speculative_mode=speculative_mode,
+            loads_draft_weights=loads_draft_weights)
+        profile = qualification.profile
+        if qualification.qualified and profile is not None:
             logger.info(
-                "MX receiver using staged post-load path for %s "
+                "MX receiver using staged post-load profile %s for %s "
                 "(transform protocol v%d).",
+                profile.profile_id,
                 type(model).__name__,
                 cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
             )
             return True
 
+        unsupported_features = ",".join(
+            sorted(feature.value
+                   for feature in qualification.unsupported_features))
+        feature_detail = (f"; unsupported_features={unsupported_features}"
+                          if unsupported_features else "")
         raise RuntimeError(
             f"MX receiver got post-transform weights for {type(model).__name__}, "
-            "but the model is not allow-listed for staged post-load transform "
-            f"protocol v{cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION}. "
+            "but the load does not match a qualified staged post-load profile "
+            f"for protocol v{cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION}: "
+            f"reason={qualification.reason.value}{feature_detail}. "
             "Refusing to run the full post-load path on already-transformed "
             "weights.")
 
+    @staticmethod
+    def _speculative_mode_name(
+            spec_config: Optional[DecodingBaseConfig]) -> Optional[str]:
+        if spec_config is None:
+            return None
+        spec_dec_mode = getattr(spec_config, "spec_dec_mode", None)
+        mode_name = getattr(spec_dec_mode, "name", None)
+        return mode_name.lower() if isinstance(mode_name, str) else "unknown"
+
     @classmethod
-    def _is_mx_staged_receiver_allowlisted(
-            cls, model: DecoderModelForCausalLM) -> bool:
-        for model_type, protocol_version in cls._MX_STAGED_RECEIVER_ALLOWLIST:
-            if (protocol_version
-                    == cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION
-                    and isinstance(model, model_type)):
-                return True
-        return False
+    def _qualify_post_transform_profile(
+            cls, model: DecoderModelForCausalLM, *,
+            speculative_mode: Optional[str],
+            loads_draft_weights: bool) -> PostTransformQualificationDecision:
+        pretrained_config = model.model_config.pretrained_config
+        architectures = getattr(pretrained_config, "architectures", None)
+        architecture = (architectures[0]
+                        if isinstance(architectures,
+                                      (list, tuple)) and architectures
+                        and isinstance(architectures[0], str) else None)
+        configured_model_type = getattr(pretrained_config, "model_type", None)
+        model_type = (configured_model_type if isinstance(
+            configured_model_type, str) else None)
+        enabled_features = set()
+        if loads_draft_weights:
+            enabled_features.add(PostTransformFeature.SEPARATE_DRAFT_MODEL)
+        return cls._POST_TRANSFORM_PROFILE_REGISTRY.qualify(
+            root_model_class=type(model),
+            architecture=architecture,
+            model_type=model_type,
+            speculative_mode=speculative_mode,
+            protocol_version=cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
+            transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+            enabled_features=frozenset(enabled_features),
+        )
 
     def _post_load_publish(self, checkpoint_loader: BaseCheckpointLoader,
                            model: DecoderModelForCausalLM, *,
-                           checkpoint_dir: str,
-                           weights_preloaded: bool) -> None:
+                           checkpoint_dir: str, weights_preloaded: bool,
+                           speculative_mode: Optional[str],
+                           loads_draft_weights: bool) -> None:
         kwargs = {
             "checkpoint_dir": checkpoint_dir,
             "weights_preloaded": weights_preloaded,
         }
         if checkpoint_loader.checkpoint_format == "MX":
+            qualification = self._qualify_post_transform_profile(
+                model,
+                speculative_mode=speculative_mode,
+                loads_draft_weights=loads_draft_weights)
+            if not qualification.qualified:
+                if not weights_preloaded:
+                    logger.info(
+                        "Skipping MX post-transform publish for %s: "
+                        "qualification reason=%s.",
+                        type(model).__name__,
+                        qualification.reason.value,
+                    )
+                return
             kwargs["source_identity"] = self._source_identity
         checkpoint_loader.post_load_publish(model, **kwargs)
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -560,6 +560,9 @@ class ModelLoader:
                         loads_draft_weights=loads_draft_weights)
                     load_weights_kwargs[
                         "allow_post_transform_weights"] = qualification.qualified
+                    if qualification.qualified:
+                        load_weights_kwargs[
+                            "prepare_post_transform_receiver"] = self._setup_aliases
 
                 if hasattr(model, 'llm_checkpoint_dir'):
                     weights = checkpoint_loader.load_weights(
@@ -684,6 +687,9 @@ class ModelLoader:
                                     loads_draft_weights=loads_draft_weights)
                                 load_weights_kwargs[
                                     "allow_post_transform_weights"] = qualification.qualified
+                                if qualification.qualified:
+                                    load_weights_kwargs[
+                                        "prepare_post_transform_receiver"] = self._setup_aliases
                             weights = checkpoint_loader.load_weights(
                                 weight_source, **load_weights_kwargs)
 

--- a/tensorrt_llm/_torch/weight_sharing/__init__.py
+++ b/tensorrt_llm/_torch/weight_sharing/__init__.py
@@ -14,6 +14,14 @@
 # limitations under the License.
 """Backend-agnostic weight-sharing utilities (MX, GMS, ...)."""
 
+from tensorrt_llm._torch.weight_sharing.post_transform_profiles import (
+    PostTransformFeature,
+    PostTransformProfile,
+    PostTransformProfileRegistry,
+    PostTransformQualificationDecision,
+    PostTransformQualificationReason,
+    PostTransformTransferScope,
+)
 from tensorrt_llm._torch.weight_sharing.source_identity import (
     SOURCE_IDENTITY_FORMAT_VERSION,
     IdentityCheckDecision,
@@ -26,6 +34,12 @@ from tensorrt_llm._torch.weight_sharing.source_identity import (
 
 __all__ = [
     "SOURCE_IDENTITY_FORMAT_VERSION",
+    "PostTransformFeature",
+    "PostTransformProfile",
+    "PostTransformProfileRegistry",
+    "PostTransformQualificationDecision",
+    "PostTransformQualificationReason",
+    "PostTransformTransferScope",
     "SourceIdentity",
     "IdentityMatchResult",
     "IdentityCheckPolicy",

--- a/tensorrt_llm/_torch/weight_sharing/post_transform_profiles.py
+++ b/tensorrt_llm/_torch/weight_sharing/post_transform_profiles.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Qualified model profiles for sharing post-transform weights.
+
+Staged post-load hooks make it possible to receive weights that already use
+their final runtime layout. They do not prove that every root model and feature
+combination is safe to skip one-shot transforms. This module records the exact
+profiles that have completed that qualification.
+
+The registry deliberately matches root classes by identity rather than
+``isinstance``. A subclass must have its own profile unless it was explicitly
+qualified under the same architecture and lifecycle contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torch import nn
+
+
+class PostTransformTransferScope(str, Enum):
+    """The model component represented by a post-transform transfer."""
+
+    TARGET_MODEL = "target_model"
+    LANGUAGE_MODEL = "language_model"
+    COMPLETE_MODEL = "complete_model"
+
+
+class PostTransformFeature(str, Enum):
+    """Optional lifecycle features that require explicit qualification."""
+
+    SEPARATE_DRAFT_MODEL = "separate_draft_model"
+
+
+class PostTransformQualificationReason(str, Enum):
+    """Structured outcome of matching a request to a qualified profile."""
+
+    QUALIFIED = "qualified"
+    ROOT_MODEL_CLASS_NOT_REGISTERED = "root_model_class_not_registered"
+    ARCHITECTURE_NOT_REGISTERED = "architecture_not_registered"
+    MODEL_TYPE_NOT_REGISTERED = "model_type_not_registered"
+    SPECULATIVE_MODE_NOT_REGISTERED = "speculative_mode_not_registered"
+    PROTOCOL_NOT_REGISTERED = "protocol_not_registered"
+    TRANSFER_SCOPE_NOT_REGISTERED = "transfer_scope_not_registered"
+    FEATURE_NOT_SUPPORTED = "feature_not_supported"
+
+
+@dataclass(frozen=True)
+class PostTransformProfile:
+    """One exact root-model profile qualified for post-transform sharing."""
+
+    profile_id: str
+    root_model_class: type[nn.Module]
+    architecture: str
+    model_type: str
+    speculative_mode: str | None
+    protocol_version: int
+    transfer_scope: PostTransformTransferScope
+    supported_features: frozenset[PostTransformFeature] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        if not self.profile_id:
+            raise ValueError("Post-transform profile_id must not be empty")
+        if not self.architecture:
+            raise ValueError("Post-transform architecture must not be empty")
+        if not self.model_type:
+            raise ValueError("Post-transform model_type must not be empty")
+        if self.speculative_mode == "":
+            raise ValueError("Post-transform speculative_mode must not be empty")
+        if self.protocol_version < 1:
+            raise ValueError("Post-transform protocol_version must be positive")
+        object.__setattr__(self, "supported_features", frozenset(self.supported_features))
+
+
+@dataclass(frozen=True)
+class PostTransformQualificationDecision:
+    """Result of looking up a requested post-transform receiver profile."""
+
+    reason: PostTransformQualificationReason
+    profile: PostTransformProfile | None = None
+    unsupported_features: frozenset[PostTransformFeature] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "unsupported_features", frozenset(self.unsupported_features))
+        if self.reason is PostTransformQualificationReason.QUALIFIED:
+            if self.profile is None:
+                raise ValueError("A qualified decision must include its profile")
+            if self.unsupported_features:
+                raise ValueError("A qualified decision cannot include unsupported features")
+        elif self.unsupported_features and (
+            self.reason is not PostTransformQualificationReason.FEATURE_NOT_SUPPORTED
+        ):
+            raise ValueError("Unsupported features require a feature_not_supported decision")
+
+    @property
+    def qualified(self) -> bool:
+        """Whether the request exactly matched a qualified profile."""
+
+        return (
+            self.reason is PostTransformQualificationReason.QUALIFIED and self.profile is not None
+        )
+
+
+@dataclass(frozen=True)
+class PostTransformProfileRegistry:
+    """Immutable collection of audited post-transform profiles."""
+
+    profiles: tuple[PostTransformProfile, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "profiles", tuple(self.profiles))
+
+        profile_ids: set[str] = set()
+        profile_keys: set[
+            tuple[type[nn.Module], str, str, str | None, int, PostTransformTransferScope]
+        ] = set()
+        for profile in self.profiles:
+            if profile.profile_id in profile_ids:
+                raise ValueError(f"Duplicate post-transform profile_id: {profile.profile_id!r}")
+            profile_ids.add(profile.profile_id)
+
+            key = (
+                profile.root_model_class,
+                profile.architecture,
+                profile.model_type,
+                profile.speculative_mode,
+                profile.protocol_version,
+                profile.transfer_scope,
+            )
+            if key in profile_keys:
+                raise ValueError(
+                    "Duplicate post-transform profile for "
+                    f"{profile.root_model_class.__name__}/{profile.architecture}/"
+                    f"{profile.model_type}/{profile.speculative_mode or 'target-only'}/"
+                    f"v{profile.protocol_version}/{profile.transfer_scope.value}"
+                )
+            profile_keys.add(key)
+
+    def qualify(
+        self,
+        *,
+        root_model_class: type[nn.Module],
+        architecture: str | None,
+        model_type: str | None,
+        speculative_mode: str | None,
+        protocol_version: int,
+        transfer_scope: PostTransformTransferScope,
+        enabled_features: frozenset[PostTransformFeature] = frozenset(),
+    ) -> PostTransformQualificationDecision:
+        """Match a receiver request against the exact qualified profile set.
+
+        Args:
+            root_model_class: Exact constructed root model class.
+            architecture: Canonical architecture from the resolved model config.
+            model_type: Canonical Hugging Face model type.
+            speculative_mode: Canonical speculative decoding mode, or `None`
+                for target-only loading.
+            protocol_version: Post-transform transfer protocol version.
+            transfer_scope: Component represented by the transfer.
+            enabled_features: Optional lifecycle features active for this load.
+
+        Returns:
+            A structured qualification decision and the matching profile, when
+            one exists.
+        """
+
+        model_profiles = tuple(
+            profile for profile in self.profiles if profile.root_model_class is root_model_class
+        )
+        if not model_profiles:
+            return PostTransformQualificationDecision(
+                PostTransformQualificationReason.ROOT_MODEL_CLASS_NOT_REGISTERED
+            )
+
+        architecture_profiles = tuple(
+            profile for profile in model_profiles if profile.architecture == architecture
+        )
+        if not architecture_profiles:
+            return PostTransformQualificationDecision(
+                PostTransformQualificationReason.ARCHITECTURE_NOT_REGISTERED
+            )
+
+        model_type_profiles = tuple(
+            profile for profile in architecture_profiles if profile.model_type == model_type
+        )
+        if not model_type_profiles:
+            return PostTransformQualificationDecision(
+                PostTransformQualificationReason.MODEL_TYPE_NOT_REGISTERED
+            )
+
+        speculative_mode_profiles = tuple(
+            profile
+            for profile in model_type_profiles
+            if profile.speculative_mode == speculative_mode
+        )
+        if not speculative_mode_profiles:
+            return PostTransformQualificationDecision(
+                PostTransformQualificationReason.SPECULATIVE_MODE_NOT_REGISTERED
+            )
+
+        protocol_profiles = tuple(
+            profile
+            for profile in speculative_mode_profiles
+            if profile.protocol_version == protocol_version
+        )
+        if not protocol_profiles:
+            return PostTransformQualificationDecision(
+                PostTransformQualificationReason.PROTOCOL_NOT_REGISTERED
+            )
+
+        scope_profiles = tuple(
+            profile for profile in protocol_profiles if profile.transfer_scope is transfer_scope
+        )
+        if not scope_profiles:
+            return PostTransformQualificationDecision(
+                PostTransformQualificationReason.TRANSFER_SCOPE_NOT_REGISTERED
+            )
+
+        profile = scope_profiles[0]
+        unsupported_features = frozenset(enabled_features) - profile.supported_features
+        if unsupported_features:
+            return PostTransformQualificationDecision(
+                PostTransformQualificationReason.FEATURE_NOT_SUPPORTED,
+                profile=profile,
+                unsupported_features=unsupported_features,
+            )
+
+        return PostTransformQualificationDecision(
+            PostTransformQualificationReason.QUALIFIED, profile=profile
+        )

--- a/tests/unittest/_torch/executor/test_model_loader_gms.py
+++ b/tests/unittest/_torch/executor/test_model_loader_gms.py
@@ -144,10 +144,15 @@ class _PostTransformMxLoader:
     checkpoint_format = "MX"
 
     def __init__(self) -> None:
-        self.load_weights = MagicMock(return_value={})
+        self.load_weights = MagicMock(side_effect=self._load_weights)
         self.is_weights_preloaded = MagicMock(return_value=True)
         self.post_load_apply = MagicMock()
         self.post_load_publish = MagicMock()
+
+    @staticmethod
+    def _load_weights(*_args, **kwargs):
+        kwargs["prepare_post_transform_receiver"](kwargs["model"])
+        return {}
 
     def is_post_transform_weights_preloaded(self) -> bool:
         return True
@@ -415,6 +420,7 @@ def test_gms_rw_mx_post_transform_preload_uses_staged_path(monkeypatch):
         "pool_enter",
         "_apply",
         "to",
+        "setup_aliases",
         "post_load_apply",
         "setup_aliases",
         "cache_derived_state",
@@ -427,6 +433,7 @@ def test_gms_rw_mx_post_transform_preload_uses_staged_path(monkeypatch):
     assert model._weights_transformed is True
     _args, kwargs = checkpoint_loader.load_weights.call_args
     assert kwargs["allow_post_transform_weights"] is True
+    assert callable(kwargs["prepare_post_transform_receiver"])
     loader._call_load_weights.assert_not_called()
     checkpoint_loader.post_load_publish.assert_called_once_with(
         model,

--- a/tests/unittest/_torch/executor/test_model_loader_gms.py
+++ b/tests/unittest/_torch/executor/test_model_loader_gms.py
@@ -13,6 +13,11 @@ from torch import nn
 from tensorrt_llm._torch import memory as memory_mod
 from tensorrt_llm._torch.pyexecutor import model_loader as model_loader_mod
 from tensorrt_llm._torch.pyexecutor.model_loader import ModelLoader
+from tensorrt_llm._torch.weight_sharing import (
+    PostTransformProfile,
+    PostTransformProfileRegistry,
+    PostTransformTransferScope,
+)
 from tensorrt_llm.llmapi.llm_args import LoadFormat
 
 _SOURCE_IDENTITY = model_loader_mod.SourceIdentity(
@@ -29,6 +34,9 @@ _SOURCE_IDENTITY = model_loader_mod.SourceIdentity(
 class _TinyModel(nn.Module):
     def __init__(self, events, *, include_draft=False):
         super().__init__()
+        self.model_config = SimpleNamespace(
+            pretrained_config=SimpleNamespace(architectures=["TinyForCausalLM"], model_type="tiny")
+        )
         self._weights_transformed = False
         self._events = events
         if include_draft:
@@ -149,6 +157,22 @@ def _spec_config_needing_draft_weights():
     return SimpleNamespace(
         spec_dec_mode=SimpleNamespace(need_load_draft_weights=lambda: True),
         speculative_model="/draft",
+    )
+
+
+def _tiny_profile_registry() -> PostTransformProfileRegistry:
+    return PostTransformProfileRegistry(
+        profiles=(
+            PostTransformProfile(
+                profile_id="tiny-for-causal-lm-target-v1",
+                root_model_class=_TinyModel,
+                architecture="TinyForCausalLM",
+                model_type="tiny",
+                speculative_mode=None,
+                protocol_version=(ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION),
+                transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+            ),
+        )
     )
 
 
@@ -367,8 +391,8 @@ def test_gms_rw_mx_post_transform_preload_uses_staged_path(monkeypatch):
     loader = _make_loader(monkeypatch, events=events)
     monkeypatch.setattr(
         ModelLoader,
-        "_MX_STAGED_RECEIVER_ALLOWLIST",
-        frozenset({(_TinyModel, ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION)}),
+        "_POST_TRANSFORM_PROFILE_REGISTRY",
+        _tiny_profile_registry(),
     )
     backend = _build_gms_backend(is_rw=True, events=events)
     backend.move_untracked_params.side_effect = lambda _model: events.append(

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -6,9 +6,14 @@ from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 import torch
 from torch import nn
 from transformers import LlamaConfig
+from utils.post_transform_qualification import (
+    PostTransformQualificationCase,
+    assert_post_transform_lifecycle_equivalent,
+)
 
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models import modeling_llama as modeling_llama_mod
@@ -17,6 +22,13 @@ from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.modules.mla import MLA
 from tensorrt_llm._torch.pyexecutor import model_loader as model_loader_mod
 from tensorrt_llm._torch.pyexecutor.model_loader import ModelLoader
+from tensorrt_llm._torch.weight_sharing import (
+    PostTransformFeature,
+    PostTransformProfile,
+    PostTransformProfileRegistry,
+    PostTransformQualificationReason,
+    PostTransformTransferScope,
+)
 from tensorrt_llm.llmapi.llm_args import LoadFormat
 
 _SOURCE_IDENTITY = model_loader_mod.SourceIdentity(
@@ -61,6 +73,9 @@ class _DraftModel(nn.Module):
 class _TinyModel(nn.Module):
     def __init__(self, events):
         super().__init__()
+        self.model_config = SimpleNamespace(
+            pretrained_config=SimpleNamespace(architectures=["TinyForCausalLM"], model_type="tiny")
+        )
         self._weights_transformed = False
         self.linear = _LinearStub()
         self.draft_config = _make_draft_model_config()
@@ -134,13 +149,20 @@ def _llama_alias_state(model):
     }
 
 
-def _transform_guard_state(model):
-    return {
-        name: module._weights_transformed
-        for name, module in model.named_modules()
-        if hasattr(module, "_weights_transformed")
-        and not getattr(module, "_weights_removed", False)
-    }
+def _tiny_profile_registry(*, speculative_mode: str | None = None) -> PostTransformProfileRegistry:
+    return PostTransformProfileRegistry(
+        profiles=(
+            PostTransformProfile(
+                profile_id="tiny-for-causal-lm-target-v1",
+                root_model_class=_TinyModel,
+                architecture="TinyForCausalLM",
+                model_type="tiny",
+                speculative_mode=speculative_mode,
+                protocol_version=(ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION),
+                transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+            ),
+        )
+    )
 
 
 def _make_loader(monkeypatch, *, events, spec_config=None):
@@ -203,12 +225,7 @@ def test_mx_success_initializes_mapper_skips_weight_mapping_and_reload_works(mon
     assert loader._call_load_weights.call_count == 0
     checkpoint_loader.get_initialized_weight_mapper.assert_called_once()
     assert loader.weight_mapper is checkpoint_loader.get_initialized_weight_mapper.return_value
-    checkpoint_loader.post_load_publish.assert_called_once_with(
-        model,
-        checkpoint_dir="/ckpt",
-        weights_preloaded=True,
-        source_identity=loader._source_identity,
-    )
+    checkpoint_loader.post_load_publish.assert_not_called()
 
     # reload() uses self.weight_mapper unconditionally; MX success must
     # initialize it even though the initial load skipped _call_load_weights.
@@ -254,12 +271,7 @@ def test_mx_partial_fallback_merges_returned_weights(monkeypatch):
     assert load_fn == model.load_weights
     assert weights is fallback_weights
     assert mapper is loader.weight_mapper
-    checkpoint_loader.post_load_publish.assert_called_once_with(
-        model,
-        checkpoint_dir="/ckpt",
-        weights_preloaded=True,
-        source_identity=loader._source_identity,
-    )
+    checkpoint_loader.post_load_publish.assert_not_called()
 
 
 class _PostTransformMxLoader:
@@ -286,13 +298,18 @@ class _PostTransformMxLoader:
         return self._post_transform
 
 
-def test_mx_post_transform_receiver_uses_staged_path_when_allowlisted(monkeypatch):
+class _UnsafePostTransformMxLoader(_PostTransformMxLoader):
+    def _load_weights(self, *_args, **_kwargs):
+        return {}
+
+
+def test_mx_post_transform_receiver_uses_staged_path_when_qualified(monkeypatch):
     events = []
     loader = _make_loader(monkeypatch, events=events)
     monkeypatch.setattr(
         ModelLoader,
-        "_MX_STAGED_RECEIVER_ALLOWLIST",
-        frozenset({(_TinyModel, ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION)}),
+        "_POST_TRANSFORM_PROFILE_REGISTRY",
+        _tiny_profile_registry(),
     )
     checkpoint_loader = _PostTransformMxLoader(post_transform=True)
 
@@ -316,42 +333,72 @@ def test_mx_post_transform_receiver_uses_staged_path_when_allowlisted(monkeypatc
     assert events == ["setup_aliases", "cache_derived_state"]
 
 
-def test_default_mx_staged_receiver_allowlist_matches_real_tiny_llama(monkeypatch):
-    full_model = _tiny_llama_model(monkeypatch)
-    staged_model = _tiny_llama_model(monkeypatch)
-    checkpoint_loader = _PostTransformMxLoader(post_transform=True)
-
-    ModelLoader._walk_full_post_load(full_model)
-    assert (
-        ModelLoader._should_run_mx_staged_receiver_path(
-            checkpoint_loader,
-            staged_model,
-            weights_preloaded=True,
-        )
-        is True
+def test_default_profile_qualifies_real_tiny_llama_lifecycle(monkeypatch):
+    case = PostTransformQualificationCase(
+        profile_id="llama-for-causal-lm-target-v1",
+        model_factory=lambda: _tiny_llama_model(monkeypatch),
+        qualify_model=lambda model: ModelLoader._qualify_post_transform_profile(
+            model,
+            speculative_mode=None,
+            loads_draft_weights=False,
+        ),
+        state_probes=(("aliases", _llama_alias_state),),
     )
 
-    transform_weights_calls = []
-    for module in staged_model.modules():
-        transform_weights = getattr(module, "transform_weights", None)
-        if transform_weights is None:
-            continue
-
-        def _record_transform_weights(*_args, module=module, **_kwargs):
-            transform_weights_calls.append(type(module).__name__)
-
-        module.transform_weights = _record_transform_weights
-
-    ModelLoader._setup_aliases(staged_model)
-    ModelLoader._mark_weights_transformed(staged_model)
-    ModelLoader._walk_cache_state(staged_model)
-
-    assert transform_weights_calls == []
-    assert _llama_alias_state(staged_model) == _llama_alias_state(full_model)
-    assert _transform_guard_state(staged_model) == _transform_guard_state(full_model)
+    assert_post_transform_lifecycle_equivalent(case)
 
 
-def test_mx_post_transform_receiver_falls_back_for_non_allowlisted_model(monkeypatch):
+def test_separate_draft_model_is_not_qualified_by_target_only_profile(monkeypatch):
+    monkeypatch.setattr(
+        ModelLoader,
+        "_POST_TRANSFORM_PROFILE_REGISTRY",
+        _tiny_profile_registry(speculative_mode="eagle3_one_model"),
+    )
+
+    decision = ModelLoader._qualify_post_transform_profile(
+        _TinyModel([]),
+        speculative_mode="eagle3_one_model",
+        loads_draft_weights=True,
+    )
+
+    assert not decision.qualified
+    assert decision.reason is PostTransformQualificationReason.FEATURE_NOT_SUPPORTED
+    assert decision.unsupported_features == frozenset({PostTransformFeature.SEPARATE_DRAFT_MODEL})
+
+
+def test_one_engine_speculative_mode_is_not_qualified_by_target_only_profile(monkeypatch):
+    monkeypatch.setattr(
+        ModelLoader,
+        "_POST_TRANSFORM_PROFILE_REGISTRY",
+        _tiny_profile_registry(),
+    )
+
+    decision = ModelLoader._qualify_post_transform_profile(
+        _TinyModel([]),
+        speculative_mode="mtp",
+        loads_draft_weights=False,
+    )
+
+    assert not decision.qualified
+    assert decision.reason is PostTransformQualificationReason.SPECULATIVE_MODE_NOT_REGISTERED
+    assert decision.unsupported_features == frozenset()
+
+
+def test_speculative_mode_name_is_canonical_and_fails_closed() -> None:
+    assert ModelLoader._speculative_mode_name(None) is None
+    assert (
+        ModelLoader._speculative_mode_name(
+            SimpleNamespace(spec_dec_mode=SimpleNamespace(name="MTP"))
+        )
+        == "mtp"
+    )
+    assert (
+        ModelLoader._speculative_mode_name(SimpleNamespace(spec_dec_mode=SimpleNamespace()))
+        == "unknown"
+    )
+
+
+def test_mx_post_transform_receiver_falls_back_for_unqualified_model(monkeypatch):
     events = []
     loader = _make_loader(monkeypatch, events=events)
     checkpoint_loader = _PostTransformMxLoader(post_transform=True)
@@ -367,11 +414,32 @@ def test_mx_post_transform_receiver_falls_back_for_non_allowlisted_model(monkeyp
     assert weights == {"disk.weight": checkpoint_loader._disk_weight}
     assert mapper is loader.weight_mapper
     assert events == ["load_weights", "post_load_weights"]
+    checkpoint_loader.post_load_publish.assert_not_called()
+
+
+def test_mx_rejects_post_transform_preload_after_failed_qualification(monkeypatch):
+    loader = _make_loader(monkeypatch, events=[])
+    checkpoint_loader = _UnsafePostTransformMxLoader(post_transform=True)
+
+    with pytest.raises(
+        RuntimeError,
+        match="reason=root_model_class_not_registered",
+    ):
+        loader.load("/ckpt", checkpoint_loader)
+
+    _args, kwargs = checkpoint_loader.load_weights.call_args
+    assert kwargs["allow_post_transform_weights"] is False
+    checkpoint_loader.post_load_publish.assert_not_called()
 
 
 def test_mx_fallback_runs_standard_weight_mapping(monkeypatch):
     events = []
     loader = _make_loader(monkeypatch, events=events)
+    monkeypatch.setattr(
+        ModelLoader,
+        "_POST_TRANSFORM_PROFILE_REGISTRY",
+        _tiny_profile_registry(),
+    )
     checkpoint_loader = MagicMock(name="checkpoint_loader")
     checkpoint_loader.checkpoint_format = "MX"
     checkpoint_loader.is_weights_preloaded.return_value = False

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -292,6 +292,8 @@ class _PostTransformMxLoader:
             self._post_transform = False
             self._weights_preloaded = False
             return {"disk.weight": self._disk_weight}
+        if self._post_transform:
+            kwargs["prepare_post_transform_receiver"](kwargs["model"])
         return {}
 
     def is_post_transform_weights_preloaded(self) -> bool:
@@ -318,6 +320,7 @@ def test_mx_post_transform_receiver_uses_staged_path_when_qualified(monkeypatch)
     loader._call_load_weights.assert_not_called()
     _args, kwargs = checkpoint_loader.load_weights.call_args
     assert kwargs["allow_post_transform_weights"] is True
+    assert callable(kwargs["prepare_post_transform_receiver"])
     checkpoint_loader.post_load_publish.assert_called_once_with(
         model,
         checkpoint_dir="/ckpt",
@@ -330,7 +333,7 @@ def test_mx_post_transform_receiver_uses_staged_path_when_qualified(monkeypatch)
     assert model._weights_transformed is True
     assert model.linear._weights_transformed is True
     assert model.draft_model.linear._weights_transformed is True
-    assert events == ["setup_aliases", "cache_derived_state"]
+    assert events == ["setup_aliases", "setup_aliases", "cache_derived_state"]
 
 
 def test_default_profile_qualifies_real_tiny_llama_lifecycle(monkeypatch):
@@ -407,6 +410,7 @@ def test_mx_post_transform_receiver_falls_back_for_unqualified_model(monkeypatch
 
     _args, kwargs = checkpoint_loader.load_weights.call_args
     assert kwargs["allow_post_transform_weights"] is False
+    assert "prepare_post_transform_receiver" not in kwargs
     assert checkpoint_loader.is_weights_preloaded() is False
     assert loader._call_load_weights.call_count == 1
     load_fn, weights, mapper = loader._call_load_weights.call_args.args

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -243,6 +243,7 @@ class TestLoadWeightsMxPath:
         )
         mapping = MagicMock(name="mapping")
         model = MagicMock(name="model")
+        prepare_receiver = MagicMock()
 
         with _install_fake_modelexpress(fake_mx):
             result = loader.load_weights(
@@ -250,11 +251,14 @@ class TestLoadWeightsMxPath:
                 mapping=mapping,
                 model=model,
                 source_identity=identity,
+                allow_post_transform_weights=True,
+                prepare_post_transform_receiver=prepare_receiver,
             )
 
         assert result == {}
         assert loader.is_weights_preloaded() is True
         assert loader.is_post_transform_weights_preloaded() is False
+        prepare_receiver.assert_not_called()
 
         # Verify the integration contract with the upstream library:
         # 1. Constructed MxLiveWeightLoader with our mx_server_url.
@@ -298,11 +302,14 @@ class TestLoadWeightsMxPath:
         assert result is fallback
         mock_super_load.assert_not_called()
 
-    def test_post_transform_full_success_sets_skip_signal_when_allowlisted(self):
+    def test_post_transform_full_success_prepares_receiver_before_p2p(self):
         identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        model = MagicMock(name="model")
+        events = []
+        prepare_receiver = MagicMock(side_effect=lambda _model: events.append("prepare_receiver"))
         fake_mx = _build_fake_modelexpress(
-            load_weights_return={},
+            load_weights_side_effect=lambda *_args, **_kwargs: events.append("p2p") or {},
             source_instances=[_source_instance(identity)],
         )
 
@@ -310,16 +317,19 @@ class TestLoadWeightsMxPath:
             result = loader.load_weights(
                 "/nonexistent",
                 mapping=MagicMock(),
-                model=MagicMock(),
+                model=model,
                 source_identity=identity,
                 allow_post_transform_weights=True,
+                prepare_post_transform_receiver=prepare_receiver,
             )
 
         assert result == {}
         assert loader.is_weights_preloaded() is True
         assert loader.is_post_transform_weights_preloaded() is True
+        prepare_receiver.assert_called_once_with(model)
+        assert events == ["prepare_receiver", "p2p"]
 
-    def test_post_transform_source_falls_back_before_p2p_when_not_allowlisted(self):
+    def test_post_transform_source_without_receiver_preparer_falls_back_before_p2p(self):
         identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         disk_weights = {"disk.weight": MagicMock()}
@@ -339,7 +349,7 @@ class TestLoadWeightsMxPath:
                 mapping=MagicMock(),
                 model=MagicMock(),
                 source_identity=identity,
-                allow_post_transform_weights=False,
+                allow_post_transform_weights=True,
             )
 
         assert result is disk_weights
@@ -347,6 +357,39 @@ class TestLoadWeightsMxPath:
         assert loader.is_post_transform_weights_preloaded() is False
         mx_loader = fake_mx.trtllm_live_transfer.MxLiveWeightLoader.return_value
         mx_loader.load_weights.assert_not_called()
+        mock_super_load.assert_called_once()
+
+    def test_post_transform_source_falls_back_before_p2p_when_not_allowlisted(self):
+        identity = _identity()
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        disk_weights = {"disk.weight": MagicMock()}
+        prepare_receiver = MagicMock()
+        fake_mx = _build_fake_modelexpress(
+            load_weights_return={},
+            source_instances=[_source_instance(identity)],
+        )
+
+        with (
+            _install_fake_modelexpress(fake_mx),
+            patch.object(
+                HfCheckpointLoader, "load_weights", return_value=disk_weights
+            ) as mock_super_load,
+        ):
+            result = loader.load_weights(
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
+                allow_post_transform_weights=False,
+                prepare_post_transform_receiver=prepare_receiver,
+            )
+
+        assert result is disk_weights
+        assert loader.is_weights_preloaded() is False
+        assert loader.is_post_transform_weights_preloaded() is False
+        mx_loader = fake_mx.trtllm_live_transfer.MxLiveWeightLoader.return_value
+        mx_loader.load_weights.assert_not_called()
+        prepare_receiver.assert_not_called()
         mock_super_load.assert_called_once()
 
     @pytest.mark.parametrize(
@@ -360,6 +403,7 @@ class TestLoadWeightsMxPath:
         identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         disk_weights = {"disk.weight": MagicMock()}
+        prepare_receiver = MagicMock()
         source_instance = _source_instance(identity)
         if protocol_value is _MISSING:
             source_instance.metadata.pop(_MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY)
@@ -382,6 +426,7 @@ class TestLoadWeightsMxPath:
                 model=MagicMock(),
                 source_identity=identity,
                 allow_post_transform_weights=True,
+                prepare_post_transform_receiver=prepare_receiver,
             )
 
         assert result is disk_weights
@@ -389,12 +434,15 @@ class TestLoadWeightsMxPath:
         assert loader.is_post_transform_weights_preloaded() is False
         mx_loader = fake_mx.trtllm_live_transfer.MxLiveWeightLoader.return_value
         mx_loader.load_weights.assert_not_called()
+        prepare_receiver.assert_not_called()
         mock_super_load.assert_called_once()
 
     def test_selects_matching_source_metadata_from_multiple_instances(self):
         rank0_identity = _identity(rank=0)
         rank1_identity = _identity(rank=1)
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        model = MagicMock(name="model")
+        prepare_receiver = MagicMock()
         fake_mx = _build_fake_modelexpress(
             load_weights_return={},
             source_instances=[
@@ -410,14 +458,16 @@ class TestLoadWeightsMxPath:
             result = loader.load_weights(
                 "/nonexistent",
                 mapping=MagicMock(),
-                model=MagicMock(),
+                model=model,
                 source_identity=rank1_identity,
                 allow_post_transform_weights=True,
+                prepare_post_transform_receiver=prepare_receiver,
             )
 
         assert result == {}
         assert loader.is_weights_preloaded() is True
         assert loader.is_post_transform_weights_preloaded() is True
+        prepare_receiver.assert_called_once_with(model)
         mock_super_load.assert_not_called()
 
     def test_post_transform_mixed_success_falls_back_to_full_disk_load(self):
@@ -428,6 +478,8 @@ class TestLoadWeightsMxPath:
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         fallback = {"some.weight": MagicMock(numel=lambda: 1, element_size=lambda: 4)}
         disk_weights = {"disk.weight": MagicMock()}
+        model = MagicMock(name="model")
+        prepare_receiver = MagicMock()
         fake_mx = _build_fake_modelexpress(
             load_weights_return=fallback,
             source_instances=[_source_instance(identity)],
@@ -442,14 +494,16 @@ class TestLoadWeightsMxPath:
             result = loader.load_weights(
                 "/nonexistent",
                 mapping=MagicMock(),
-                model=MagicMock(),
+                model=model,
                 source_identity=identity,
                 allow_post_transform_weights=True,
+                prepare_post_transform_receiver=prepare_receiver,
             )
 
         assert result is disk_weights
         assert loader.is_weights_preloaded() is False
         assert loader.is_post_transform_weights_preloaded() is False
+        prepare_receiver.assert_called_once_with(model)
         mock_super_load.assert_called_once()
 
     def test_post_transform_source_can_be_disallowed_before_p2p(self):
@@ -460,6 +514,7 @@ class TestLoadWeightsMxPath:
         identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         disk_weights = {"disk.weight": MagicMock()}
+        prepare_receiver = MagicMock()
         fake_mx = _build_fake_modelexpress(
             load_weights_return={},
             source_instances=[_source_instance(identity)],
@@ -477,12 +532,14 @@ class TestLoadWeightsMxPath:
                 model=MagicMock(),
                 source_identity=identity,
                 allow_post_transform_weights=False,
+                prepare_post_transform_receiver=prepare_receiver,
             )
 
         assert result is disk_weights
         assert loader.is_weights_preloaded() is False
         assert loader.is_post_transform_weights_preloaded() is False
         fake_mx.trtllm_live_transfer.MxLiveWeightLoader.assert_not_called()
+        prepare_receiver.assert_not_called()
         mock_super_load.assert_called_once()
 
 

--- a/tests/unittest/_torch/weight_sharing/test_post_transform_profiles.py
+++ b/tests/unittest/_torch/weight_sharing/test_post_transform_profiles.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from torch import nn
+
+from tensorrt_llm._torch.weight_sharing import (
+    PostTransformFeature,
+    PostTransformProfile,
+    PostTransformProfileRegistry,
+    PostTransformQualificationReason,
+    PostTransformTransferScope,
+)
+
+
+class _Model(nn.Module):
+    pass
+
+
+class _ModelSubclass(_Model):
+    pass
+
+
+def _profile(
+    *,
+    profile_id: str = "model-target-v1",
+    root_model_class: type[nn.Module] = _Model,
+    architecture: str = "ModelForCausalLM",
+    model_type: str = "model",
+    speculative_mode: str | None = None,
+    protocol_version: int = 1,
+    transfer_scope: PostTransformTransferScope = PostTransformTransferScope.TARGET_MODEL,
+    supported_features: frozenset[PostTransformFeature] = frozenset(),
+) -> PostTransformProfile:
+    return PostTransformProfile(
+        profile_id=profile_id,
+        root_model_class=root_model_class,
+        architecture=architecture,
+        model_type=model_type,
+        speculative_mode=speculative_mode,
+        protocol_version=protocol_version,
+        transfer_scope=transfer_scope,
+        supported_features=supported_features,
+    )
+
+
+def test_exact_profile_is_qualified() -> None:
+    profile = _profile()
+    registry = PostTransformProfileRegistry((profile,))
+
+    decision = registry.qualify(
+        root_model_class=_Model,
+        architecture="ModelForCausalLM",
+        model_type="model",
+        speculative_mode=None,
+        protocol_version=1,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+    )
+
+    assert decision.qualified
+    assert decision.reason is PostTransformQualificationReason.QUALIFIED
+    assert decision.profile is profile
+    assert decision.unsupported_features == frozenset()
+
+
+def test_subclass_does_not_inherit_qualification() -> None:
+    registry = PostTransformProfileRegistry((_profile(),))
+
+    decision = registry.qualify(
+        root_model_class=_ModelSubclass,
+        architecture="ModelForCausalLM",
+        model_type="model",
+        speculative_mode=None,
+        protocol_version=1,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+    )
+
+    assert not decision.qualified
+    assert decision.reason is PostTransformQualificationReason.ROOT_MODEL_CLASS_NOT_REGISTERED
+    assert decision.profile is None
+
+
+@pytest.mark.parametrize(
+    "overrides, expected_reason",
+    [
+        pytest.param(
+            {"architecture": "OtherForCausalLM"},
+            PostTransformQualificationReason.ARCHITECTURE_NOT_REGISTERED,
+            id="architecture",
+        ),
+        pytest.param(
+            {"model_type": "other"},
+            PostTransformQualificationReason.MODEL_TYPE_NOT_REGISTERED,
+            id="model-type",
+        ),
+        pytest.param(
+            {"speculative_mode": "mtp"},
+            PostTransformQualificationReason.SPECULATIVE_MODE_NOT_REGISTERED,
+            id="speculative-mode",
+        ),
+        pytest.param(
+            {"protocol_version": 2},
+            PostTransformQualificationReason.PROTOCOL_NOT_REGISTERED,
+            id="protocol",
+        ),
+        pytest.param(
+            {"transfer_scope": PostTransformTransferScope.COMPLETE_MODEL},
+            PostTransformQualificationReason.TRANSFER_SCOPE_NOT_REGISTERED,
+            id="transfer-scope",
+        ),
+    ],
+)
+def test_profile_dimensions_must_match_exactly(
+    overrides: dict[str, object],
+    expected_reason: PostTransformQualificationReason,
+) -> None:
+    registry = PostTransformProfileRegistry((_profile(),))
+    request = {
+        "root_model_class": _Model,
+        "architecture": "ModelForCausalLM",
+        "model_type": "model",
+        "speculative_mode": None,
+        "protocol_version": 1,
+        "transfer_scope": PostTransformTransferScope.TARGET_MODEL,
+    }
+    request.update(overrides)
+
+    decision = registry.qualify(**request)
+
+    assert not decision.qualified
+    assert decision.reason is expected_reason
+
+
+def test_registry_selects_exact_speculative_mode_profile() -> None:
+    target_profile = _profile()
+    mtp_profile = _profile(
+        profile_id="model-mtp-v1",
+        speculative_mode="mtp",
+    )
+    registry = PostTransformProfileRegistry((target_profile, mtp_profile))
+
+    decision = registry.qualify(
+        root_model_class=_Model,
+        architecture="ModelForCausalLM",
+        model_type="model",
+        speculative_mode="mtp",
+        protocol_version=1,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+    )
+
+    assert decision.qualified
+    assert decision.profile is mtp_profile
+
+
+def test_optional_feature_requires_explicit_profile_support() -> None:
+    profile = _profile()
+    registry = PostTransformProfileRegistry((profile,))
+
+    decision = registry.qualify(
+        root_model_class=_Model,
+        architecture="ModelForCausalLM",
+        model_type="model",
+        speculative_mode=None,
+        protocol_version=1,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+        enabled_features=frozenset({PostTransformFeature.SEPARATE_DRAFT_MODEL}),
+    )
+
+    assert not decision.qualified
+    assert decision.reason is PostTransformQualificationReason.FEATURE_NOT_SUPPORTED
+    assert decision.profile is profile
+    assert decision.unsupported_features == frozenset({PostTransformFeature.SEPARATE_DRAFT_MODEL})
+
+
+def test_explicitly_supported_optional_feature_is_qualified() -> None:
+    profile = _profile(supported_features=frozenset({PostTransformFeature.SEPARATE_DRAFT_MODEL}))
+    registry = PostTransformProfileRegistry((profile,))
+
+    decision = registry.qualify(
+        root_model_class=_Model,
+        architecture="ModelForCausalLM",
+        model_type="model",
+        speculative_mode=None,
+        protocol_version=1,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+        enabled_features=frozenset({PostTransformFeature.SEPARATE_DRAFT_MODEL}),
+    )
+
+    assert decision.qualified
+    assert decision.profile is profile
+
+
+def test_registry_rejects_duplicate_profile_id() -> None:
+    with pytest.raises(ValueError, match="Duplicate post-transform profile_id"):
+        PostTransformProfileRegistry(
+            (
+                _profile(),
+                _profile(
+                    root_model_class=_ModelSubclass,
+                    architecture="ModelSubclassForCausalLM",
+                ),
+            )
+        )
+
+
+def test_registry_rejects_duplicate_match_key() -> None:
+    with pytest.raises(ValueError, match="Duplicate post-transform profile for"):
+        PostTransformProfileRegistry((_profile(), _profile(profile_id="other-profile-id")))
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_message",
+    [
+        pytest.param({"profile_id": ""}, "profile_id", id="profile-id"),
+        pytest.param({"architecture": ""}, "architecture", id="architecture"),
+        pytest.param({"model_type": ""}, "model_type", id="model-type"),
+        pytest.param(
+            {"speculative_mode": ""},
+            "speculative_mode",
+            id="speculative-mode",
+        ),
+        pytest.param({"protocol_version": 0}, "protocol_version", id="protocol"),
+    ],
+)
+def test_profile_rejects_invalid_required_fields(
+    kwargs: dict[str, object], expected_message: str
+) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        _profile(**kwargs)

--- a/tests/unittest/utils/post_transform_qualification.py
+++ b/tests/unittest/utils/post_transform_qualification.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reusable unit harness for post-transform receiver qualification."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.pyexecutor.model_loader import ModelLoader
+from tensorrt_llm._torch.weight_sharing import PostTransformQualificationDecision
+
+ModelFactory = Callable[[], nn.Module]
+ModelQualifier = Callable[[nn.Module], PostTransformQualificationDecision]
+ReceiverPreparer = Callable[[nn.Module, nn.Module], None]
+StateProbe = Callable[[nn.Module], object]
+
+
+def copy_post_transform_parameters(producer: nn.Module, receiver: nn.Module) -> None:
+    """Simulate an exact-name post-transform parameter transfer."""
+    producer_parameters = dict(producer.named_parameters())
+    receiver_parameters = dict(receiver.named_parameters())
+    assert receiver_parameters.keys() == producer_parameters.keys(), (
+        "Producer and receiver parameter names differ before staged finalization"
+    )
+
+    with torch.no_grad():
+        for name, producer_parameter in producer_parameters.items():
+            receiver_parameter = receiver_parameters[name]
+            assert receiver_parameter.shape == producer_parameter.shape, (
+                f"Parameter {name!r} shape differs: receiver "
+                f"{tuple(receiver_parameter.shape)} != producer "
+                f"{tuple(producer_parameter.shape)}"
+            )
+            assert receiver_parameter.dtype == producer_parameter.dtype, (
+                f"Parameter {name!r} dtype differs: receiver "
+                f"{receiver_parameter.dtype} != producer {producer_parameter.dtype}"
+            )
+            assert receiver_parameter.layout == producer_parameter.layout, (
+                f"Parameter {name!r} layout differs: receiver "
+                f"{receiver_parameter.layout} != producer {producer_parameter.layout}"
+            )
+            if producer_parameter.layout is torch.strided:
+                assert receiver_parameter.stride() == producer_parameter.stride(), (
+                    f"Parameter {name!r} stride differs: receiver "
+                    f"{receiver_parameter.stride()} != producer "
+                    f"{producer_parameter.stride()}"
+                )
+                assert receiver_parameter.storage_offset() == producer_parameter.storage_offset(), (
+                    f"Parameter {name!r} storage offset differs: receiver "
+                    f"{receiver_parameter.storage_offset()} != producer "
+                    f"{producer_parameter.storage_offset()}"
+                )
+            receiver_parameter.copy_(producer_parameter)
+
+
+@dataclass(frozen=True)
+class PostTransformQualificationCase:
+    """Inputs needed to prove full and staged post-load lifecycle equivalence.
+
+    `prepare_receiver` simulates installation of a producer's post-transform
+    tensors when a family needs value-level coverage. A real MX donor/receiver
+    test is still required before enabling a production profile.
+    """
+
+    profile_id: str
+    model_factory: ModelFactory
+    qualify_model: ModelQualifier
+    state_probes: tuple[tuple[str, StateProbe], ...]
+    prepare_receiver: ReceiverPreparer = copy_post_transform_parameters
+
+    def __post_init__(self) -> None:
+        if not self.profile_id:
+            raise ValueError("Qualification case profile_id must not be empty")
+        if not self.state_probes:
+            raise ValueError("Qualification case must define at least one state probe")
+        probe_names = tuple(name for name, _probe in self.state_probes)
+        if len(probe_names) != len(set(probe_names)):
+            raise ValueError("Qualification case state probe names must be unique")
+
+
+def _transform_guard_state(model: nn.Module) -> dict[str, bool]:
+    return {
+        name: module._weights_transformed
+        for name, module in model.named_modules()
+        if hasattr(module, "_weights_transformed")
+        and not getattr(module, "_weights_removed", False)
+    }
+
+
+def _assert_named_tensors_equal(
+    producer_tensors: dict[str, torch.Tensor],
+    receiver_tensors: dict[str, torch.Tensor],
+    *,
+    tensor_kind: str,
+) -> None:
+    assert receiver_tensors.keys() == producer_tensors.keys(), (
+        f"Producer and receiver {tensor_kind} names differ after staged finalization"
+    )
+    for name, producer_tensor in producer_tensors.items():
+        receiver_tensor = receiver_tensors[name]
+        assert receiver_tensor.shape == producer_tensor.shape, (
+            f"Post-transform {tensor_kind} {name!r} shape differs: receiver "
+            f"{tuple(receiver_tensor.shape)} != producer {tuple(producer_tensor.shape)}"
+        )
+        assert receiver_tensor.dtype == producer_tensor.dtype, (
+            f"Post-transform {tensor_kind} {name!r} dtype differs: receiver "
+            f"{receiver_tensor.dtype} != producer {producer_tensor.dtype}"
+        )
+        assert receiver_tensor.layout == producer_tensor.layout, (
+            f"Post-transform {tensor_kind} {name!r} layout differs: receiver "
+            f"{receiver_tensor.layout} != producer {producer_tensor.layout}"
+        )
+        if producer_tensor.layout is torch.strided:
+            assert receiver_tensor.stride() == producer_tensor.stride(), (
+                f"Post-transform {tensor_kind} {name!r} stride differs: receiver "
+                f"{receiver_tensor.stride()} != producer {producer_tensor.stride()}"
+            )
+            assert receiver_tensor.storage_offset() == producer_tensor.storage_offset(), (
+                f"Post-transform {tensor_kind} {name!r} storage offset differs: "
+                f"receiver {receiver_tensor.storage_offset()} != producer "
+                f"{producer_tensor.storage_offset()}"
+            )
+        try:
+            torch.testing.assert_close(
+                receiver_tensor,
+                producer_tensor,
+                rtol=0,
+                atol=0,
+                equal_nan=True,
+            )
+        except AssertionError as error:
+            raise AssertionError(f"Post-transform {tensor_kind} {name!r} values differ") from error
+
+
+def _install_transform_call_recorders(model: nn.Module) -> list[str]:
+    calls: list[str] = []
+    for name, module in model.named_modules():
+        if getattr(module, "transform_weights", None) is None:
+            continue
+
+        def _record_transform_weights(
+            *_args: object,
+            module_name: str = name,
+            module_type_name: str = type(module).__name__,
+            **_kwargs: object,
+        ) -> None:
+            calls.append(module_name or module_type_name)
+
+        module.transform_weights = _record_transform_weights
+    return calls
+
+
+def assert_post_transform_lifecycle_equivalent(
+    case: PostTransformQualificationCase,
+) -> tuple[nn.Module, nn.Module]:
+    """Assert one exact profile's full and staged lifecycle states agree.
+
+    Args:
+        case: Model construction, registry lookup, transfer simulator, and
+            family-specific comparable state probes.
+
+    Returns:
+        The fully post-loaded producer and staged receiver for optional
+        additional assertions by the caller.
+    """
+    producer = case.model_factory()
+    receiver = case.model_factory()
+    assert producer is not receiver, "model_factory must return a fresh model"
+
+    decision = case.qualify_model(receiver)
+    assert decision.qualified, (
+        f"Profile {case.profile_id!r} is not registered: {decision.reason.value}"
+    )
+    assert decision.profile is not None
+    assert decision.profile.profile_id == case.profile_id
+
+    ModelLoader._walk_full_post_load(producer)
+    case.prepare_receiver(producer, receiver)
+
+    transform_calls = _install_transform_call_recorders(receiver)
+    ModelLoader._setup_aliases(receiver)
+    ModelLoader._mark_weights_transformed(receiver)
+    ModelLoader._walk_cache_state(receiver)
+
+    assert transform_calls == [], f"Staged receiver invoked transform_weights(): {transform_calls}"
+    assert _transform_guard_state(receiver) == _transform_guard_state(producer)
+
+    _assert_named_tensors_equal(
+        dict(producer.named_parameters()),
+        dict(receiver.named_parameters()),
+        tensor_kind="parameter",
+    )
+    _assert_named_tensors_equal(
+        dict(producer.named_buffers()),
+        dict(receiver.named_buffers()),
+        tensor_kind="buffer",
+    )
+
+    for probe_name, probe in case.state_probes:
+        assert probe(receiver) == probe(producer), (
+            f"Post-transform qualification probe {probe_name!r} differs "
+            f"for profile {case.profile_id!r}"
+        )
+
+    return producer, receiver

--- a/tests/unittest/utils/post_transform_qualification.py
+++ b/tests/unittest/utils/post_transform_qualification.py
@@ -190,10 +190,13 @@ def assert_post_transform_lifecycle_equivalent(
     assert decision.profile is not None
     assert decision.profile.profile_id == case.profile_id
 
+    transform_calls = _install_transform_call_recorders(receiver)
     ModelLoader._walk_full_post_load(producer)
+    ModelLoader._setup_aliases(receiver)
     case.prepare_receiver(producer, receiver)
 
-    transform_calls = _install_transform_call_recorders(receiver)
+    # Runtime finalization repeats setup_aliases(), whose contract is
+    # idempotent, after the checkpoint loader's pre-transfer preparation.
     ModelLoader._setup_aliases(receiver)
     ModelLoader._mark_weights_transformed(receiver)
     ModelLoader._walk_cache_state(receiver)


### PR DESCRIPTION
## Description

Replace the MX staged-receiver `isinstance` allowlist with an immutable, backend-neutral post-transform capability registry.

The registry matches an exact qualified profile across:

- root model class
- Hugging Face architecture and `model_type`
- speculative decoding mode
- transfer protocol and component scope
- explicitly supported lifecycle features

The same decision now gates MX reception before P2P, validates the staged path after preload, and gates post-transform source publication. Unqualified models fall back to disk and are not republished.

For qualified post-transform sources, the receiver now establishes structural aliases after source metadata is validated and before exact-name P2P matching begins. This mirrors the producer's post-load module graph without running tensor transforms; runtime finalization repeats the idempotent alias step and refreshes derived state.

This PR retains exactly one profile: target-only `LlamaForCausalLM` using transform protocol v1. It does not enable another model family or add the separate transform-layout ABI follow-up.

A reusable unit qualification harness now:

- simulates exact-name transfer of fully transformed parameters
- rejects name, shape, dtype, layout, stride, or storage-offset differences
- compares exact parameter and registered-buffer values after staged finalization
- verifies `transform_weights()` is never invoked on the receiver
- compares transform guards and family-specific alias/derived-state probes

Design context: https://github.com/chienchunhung/TensorRT-LLM/blob/docs-and-plans/docs/design/mx-gms-integration/21-mx-readiness-gaps-and-model-family-plan.md

## Test Plan

- [x] Changed-file pre-commit suite
- [x] Python syntax compilation for all changed Python files
- [x] Standalone registry smoke tests for exact profile selection, subclass rejection, and speculative-mode selection
- [x] Iterative `trtllm-review` self-review; all findings addressed and final pass found no new issues
- [x] Initial full CI isolated an exact-name alias-ordering failure in the new tiny-Llama lifecycle test; fixed in `598967b4c9`
- [x] Linux CI focused lifecycle coverage passed on B200 package sanity, A10, A100X, DGX H100, and B300
- [x] Full CI rerun on `598967b4c9` succeeded ([PR_Github #58686](https://nv/trt-llm-cicd/job/helpers/job/PR_Github/58686/), [merge pipeline #47272](https://nv/trt-llm-cicd/job/main/job/L0_MergeRequest_PR/47272/)): x86 50,406 passed / 15,839 skipped / 0 failed; SBSA 54 passed / 3 skipped / 0 failed

Local pytest collection is unavailable in the macOS control environment because it does not have `torch`, `transformers`, or the built TRT-LLM runtime. The completed Linux full-CI gate is the authoritative executable verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile-based qualification for staged post-transform weight loading.
  * Improved support for speculative decoding and draft-model weight scenarios.
  * Added receiver preparation during eligible staged loading to ensure correct weight sharing.
  * Exposed post-transform qualification types for broader integration.

* **Bug Fixes**
  * Improved fallback behavior for unsupported or unqualified configurations.
  * Prevented post-load publishing when staged loading is not eligible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->