### PR TITLE
[None][fix] block space-prefixed bad-word variant for BPE tokenizers

### DIFF
--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -409,9 +409,23 @@ class SamplingParams:
                 # For tiktokenizer, the encode method does not have add_special_tokens argument
                 return tokenizer.encode(text)
 
+        def _encode_bad_word(tokenizer, word, add_special_tokens):
+            # BPE / prefix-space tokenizers (GPT-2, Qwen, ...) tokenize a word
+            # differently at the start of a sequence ("London") than in the
+            # middle (" London"). Record both variants so the word is blocked
+            # in every position. Deduplicate for tokenizers where the two forms
+            # coincide.
+            variants = [_encode(tokenizer, word, add_special_tokens)]
+            prefixed = _encode(tokenizer, f" {word}", add_special_tokens)
+            if prefixed not in variants:
+                variants.append(prefixed)
+            return variants
+
         if self.bad is not None:
             strs = [self.bad] if isinstance(self.bad, str) else self.bad
-            self._bad_word_ids = [_encode(tokenizer, s, add_special_tokens) for s in strs]
+            self._bad_word_ids = [
+                ids for s in strs for ids in _encode_bad_word(tokenizer, s, add_special_tokens)
+            ]
 
         if self.stop is not None:
             strs = [self.stop] if isinstance(self.stop, str) else self.stop

--- a/tests/unittest/llmapi/test_sampling_params_bad_words.py
+++ b/tests/unittest/llmapi/test_sampling_params_bad_words.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+
+from tensorrt_llm.sampling_params import SamplingParams
+
+
+class _PrefixSpaceTokenizer:
+    """Mimics a BPE prefix-space tokenizer (GPT-2 / Qwen).
+
+    A word tokenizes to different ids at the start of a sequence than in the
+    middle.
+    """
+
+    eos_token_id = 0
+    pad_token_id = 0
+    # "London" -> [23421], " London" -> [3995] (as reported in the issue).
+    _table = {"London": [23421], " London": [3995]}
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+        if text in self._table:
+            return list(self._table[text])
+        return [ord(c) for c in text]
+
+
+class _ConstantTokenizer:
+    """Encodes any text to the same id.
+
+    The unprefixed and space-prefixed forms of a word coincide, exercising the
+    dedup path.
+    """
+
+    eos_token_id = 0
+    pad_token_id = 0
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+        return [7]
+
+
+def test_bad_words_records_both_position_variants() -> None:
+    sp = SamplingParams(bad="London")
+    sp._setup(
+        _PrefixSpaceTokenizer(),
+        hf_model_config=None,
+        generation_config=None,
+        add_special_tokens=False,
+    )
+    bad_words = sp._get_bad_words()
+    assert [23421] in bad_words  # start-of-sequence form
+    assert [3995] in bad_words  # mid-sequence (space-prefixed) form
+
+
+def test_bad_words_deduplicates_identical_variants() -> None:
+    sp = SamplingParams(bad="hi")
+    sp._setup(
+        _ConstantTokenizer(), hf_model_config=None, generation_config=None, add_special_tokens=False
+    )
+    bad_words = sp._get_bad_words()
+    assert bad_words.count([7]) == 1
+
+
+def test_bad_words_handles_list_input() -> None:
+    sp = SamplingParams(bad=["London"])
+    sp._setup(
+        _PrefixSpaceTokenizer(),
+        hf_model_config=None,
+        generation_config=None,
+        add_special_tokens=False,
+    )
+    bad_words = sp._get_bad_words()
+    assert [23421] in bad_words
+    assert [3995] in bad_words


### PR DESCRIPTION
## Description

Fixes #15706.

BPE / prefix-space tokenizers (GPT-2, Qwen, ...) tokenize a word differently depending on position:

- start of sequence: `"London"` → `[23421]`
- mid sequence: `" London"` → `[3995]`

`SamplingParams._setup` only encoded the start-of-sequence form, so a bad word was **not** blocked when it appeared mid-generation.

## Change

- `tensorrt_llm/sampling_params.py`: encode both the unprefixed and space-prefixed variant of each `bad` word and record both in `_bad_word_ids`. Deduplicated for tokenizers where the two forms coincide (e.g. SentencePiece), so behavior there is unchanged.

## Test

New CPU-only unit tests in `tests/unittest/llmapi/test_sampling_params_bad_words.py` using stub tokenizers (no model weights / GPU): both position variants recorded, dedup when identical, and list input.

## Scope note

Limited to `bad` words per the issue. `stop` words have the same positional-tokenization characteristic; happy to follow up in a separate PR if maintainers want that too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blocked-word handling so specified words are filtered consistently at the beginning of text and after spaces.
  * Prevented duplicate token patterns from being recorded when both forms are identical.

* **Tests**
  * Added coverage for individual words, lists of words, and duplicate tokenizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->