### PR TITLE
[None][fix] validate sampling params in trtllm-serve request models

### DIFF
--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -349,15 +349,15 @@ class CompletionRequest(OpenAIBaseModel):
     stream: Optional[bool] = False
     stream_options: Optional[StreamOptions] = None
     suffix: Optional[str] = None
-    temperature: Optional[float] = None
-    top_p: Optional[float] = None
+    temperature: Optional[float] = Field(default=None, ge=0.0)
+    top_p: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     user: Optional[str] = None
     lora_request: Optional[LoRARequest] = None
     prompt_ignore_length: Optional[int] = 0
 
     # doc: begin-completion-sampling-params
     use_beam_search: bool = False
-    top_k: int = 0
+    top_k: int = Field(default=0, ge=0)
     top_p_min: float = 0.0
     min_p: float = 0.0
     repetition_penalty: float = 1.0
@@ -664,8 +664,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     stream: Optional[bool] = False
     stream_options: Optional[StreamOptions] = None
-    temperature: Optional[float] = None
-    top_p: Optional[float] = None
+    temperature: Optional[float] = Field(default=None, ge=0.0)
+    top_p: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     tools: Optional[List[ChatCompletionToolsParam]] = None
     tool_choice: Optional[Union[Literal["none", "auto"],
                                 ChatCompletionNamedToolChoiceParam]] = "none"
@@ -683,7 +683,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     # doc: begin-chat-completion-sampling-params
     best_of: Optional[int] = None
     use_beam_search: bool = False
-    top_k: int = 0
+    top_k: int = Field(default=0, ge=0)
     top_p_min: float = 0.0
     min_p: float = 0.0
     repetition_penalty: float = 1.0
@@ -897,12 +897,12 @@ class ResponsesRequest(OpenAIBaseModel):
                           "priority"] = "auto"
     store: Optional[bool] = True
     stream: Optional[bool] = False
-    temperature: Optional[float] = None
+    temperature: Optional[float] = Field(default=None, ge=0.0)
     text: Optional[ResponseTextConfig] = None
     tool_choice: ToolChoice = "auto"
     tools: list[Tool] = Field(default_factory=list)
     top_logprobs: Optional[int] = 0
-    top_p: Optional[float] = None
+    top_p: Optional[float] = Field(default=None, ge=0.0, le=1.0)
     truncation: Optional[Literal["auto", "disabled"]] = "disabled"
     user: Optional[str] = None
 

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -349,15 +349,23 @@ class CompletionRequest(OpenAIBaseModel):
     stream: Optional[bool] = False
     stream_options: Optional[StreamOptions] = None
     suffix: Optional[str] = None
-    temperature: Optional[float] = Field(default=None, ge=0.0)
-    top_p: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    temperature: Optional[float] = Field(
+        default=None, ge=0.0, description="Sampling temperature; must be >= 0.")
+    top_p: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Nucleus sampling probability; must be in [0, 1].")
     user: Optional[str] = None
     lora_request: Optional[LoRARequest] = None
     prompt_ignore_length: Optional[int] = 0
 
     # doc: begin-completion-sampling-params
     use_beam_search: bool = False
-    top_k: int = Field(default=0, ge=0)
+    top_k: int = Field(
+        default=0,
+        ge=0,
+        description="Top-k sampling; must be >= 0 (0 disables top-k).")
     top_p_min: float = 0.0
     min_p: float = 0.0
     repetition_penalty: float = 1.0
@@ -664,8 +672,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     stream: Optional[bool] = False
     stream_options: Optional[StreamOptions] = None
-    temperature: Optional[float] = Field(default=None, ge=0.0)
-    top_p: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    temperature: Optional[float] = Field(
+        default=None, ge=0.0, description="Sampling temperature; must be >= 0.")
+    top_p: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Nucleus sampling probability; must be in [0, 1].")
     tools: Optional[List[ChatCompletionToolsParam]] = None
     tool_choice: Optional[Union[Literal["none", "auto"],
                                 ChatCompletionNamedToolChoiceParam]] = "none"
@@ -683,7 +696,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
     # doc: begin-chat-completion-sampling-params
     best_of: Optional[int] = None
     use_beam_search: bool = False
-    top_k: int = Field(default=0, ge=0)
+    top_k: int = Field(
+        default=0,
+        ge=0,
+        description="Top-k sampling; must be >= 0 (0 disables top-k).")
     top_p_min: float = 0.0
     min_p: float = 0.0
     repetition_penalty: float = 1.0

--- a/tests/unittest/llmapi/apps/test_openai_protocol_validation.py
+++ b/tests/unittest/llmapi/apps/test_openai_protocol_validation.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Boundary validation for trtllm-serve request models (issue #6329).
+
+Invalid sampling parameters must be rejected at the API boundary with a
+pydantic ValidationError (surfaced to clients as HTTP 422) instead of crashing
+the server downstream.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from tensorrt_llm.serve.openai_protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    ResponsesRequest,
+)
+
+
+def _completion(**kw):
+    return CompletionRequest(model="m", prompt="hi", **kw)
+
+
+def _chat(**kw):
+    return ChatCompletionRequest(model="m", messages=[{"role": "user", "content": "hi"}], **kw)
+
+
+def _responses(**kw):
+    return ResponsesRequest(model="m", input="hi", **kw)
+
+
+# top_k only exists on completion / chat requests.
+BUILDERS_WITH_TOP_K = [_completion, _chat]
+ALL_BUILDERS = [_completion, _chat, _responses]
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_valid_sampling_params_accepted(build):
+    # Boundary-valid values must pass unchanged.
+    req = build(temperature=0.0, top_p=1.0)
+    assert req.temperature == 0.0
+    assert req.top_p == 1.0
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+def test_negative_temperature_rejected(build):
+    with pytest.raises(ValidationError):
+        build(temperature=-0.1)
+
+
+@pytest.mark.parametrize("build", ALL_BUILDERS)
+@pytest.mark.parametrize("bad_top_p", [-0.1, 1.1, 2.0])
+def test_out_of_range_top_p_rejected(build, bad_top_p):
+    with pytest.raises(ValidationError):
+        build(top_p=bad_top_p)
+
+
+@pytest.mark.parametrize("build", BUILDERS_WITH_TOP_K)
+def test_negative_top_k_rejected(build):
+    # top_k = -1 is vLLM's default; TRT-LLM's backend requires top_k >= 0, so
+    # reject it cleanly at the boundary rather than crashing.
+    with pytest.raises(ValidationError):
+        build(top_k=-1)
+
+
+@pytest.mark.parametrize("build", BUILDERS_WITH_TOP_K)
+def test_top_k_zero_accepted(build):
+    assert build(top_k=0).top_k == 0


### PR DESCRIPTION
## Description

Fixes #6329.

`trtllm-serve` did not validate client sampling parameters at the API boundary. Values like `top_k=-1` (vLLM's default), `top_p=2.0`, or a negative `temperature` were forwarded downstream where `SamplingParams._validate` raises — surfacing as an unhandled error / server crash rather than a clean client-side error. A single malformed request could disrupt service.

## Change

Add pydantic `Field` bounds to the sampling params on `CompletionRequest`, `ChatCompletionRequest`, and `ResponsesRequest` in `tensorrt_llm/serve/openai_protocol.py`:

- `top_k >= 0`
- `0 <= top_p <= 1`
- `temperature >= 0`

These mirror `SamplingParams`' own constraints, so **no currently-valid request is newly rejected** — invalid input now fails fast with HTTP 422 + field detail instead of crashing the server.

## Scope

Limited to the static sampling-param bounds (the crash class in the issue's first example). The issue's second example — input length exceeding `max_seq_len` — needs runtime model config and is left as a follow-up.

## Test

New CPU-only unit tests in `tests/unittest/llmapi/apps/test_openai_protocol_validation.py`: valid boundary values accepted; negative temperature, out-of-range `top_p`, and negative `top_k` rejected with `ValidationError`; across all three request models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for sampling parameters in completion, chat completion, and responses requests.
  * Rejects negative temperatures, out-of-range `top_p` values, and negative `top_k` values.
  * Accepts valid boundary values such as `top_p` of 0 or 1 and `top_k` of 0.

* **Tests**
  * Added coverage for valid and invalid sampling-parameter combinations across supported request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->