### PR TITLE
[None][fix] handle preloaded HF model in MambaForCausalLM.from_hugging_face

### DIFF
--- a/tensorrt_llm/models/mamba/model.py
+++ b/tensorrt_llm/models/mamba/model.py
@@ -458,8 +458,10 @@ class MambaForCausalLM(PretrainedModel):
 
         if use_preloading:
             # hf_model_dir is unset on the preload path; use the already
-            # provided model directly.
-            weights = convert_hf_mamba(hf_model, dtype)
+            # provided model directly. Use the config's resolved dtype since
+            # convert_hf_mamba expects a concrete torch dtype name (the
+            # incoming dtype may still be 'auto').
+            weights = convert_hf_mamba(hf_model, config.dtype)
         elif not os.path.exists(hf_model_dir):
             hf_model = AutoModelForCausalLM.from_pretrained(
                 hf_model_dir, dtype="auto", trust_remote_code=True)

--- a/tensorrt_llm/models/mamba/model.py
+++ b/tensorrt_llm/models/mamba/model.py
@@ -456,7 +456,11 @@ class MambaForCausalLM(PretrainedModel):
                                                quant_config=quant_config,
                                                **kwargs)
 
-        if not os.path.exists(hf_model_dir):
+        if use_preloading:
+            # hf_model_dir is unset on the preload path; use the already
+            # provided model directly.
+            weights = convert_hf_mamba(hf_model, dtype)
+        elif not os.path.exists(hf_model_dir):
             hf_model = AutoModelForCausalLM.from_pretrained(
                 hf_model_dir, dtype="auto", trust_remote_code=True)
 

--- a/tests/unittest/others/test_mamba_preload.py
+++ b/tests/unittest/others/test_mamba_preload.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+
+import transformers
+
+import tensorrt_llm.models.mamba.model as mamba_model
+from tensorrt_llm.models.mamba.model import MambaForCausalLM
+
+
+def test_from_hugging_face_preloaded_model_does_not_unbound_error() -> None:
+    # Passing a preloaded transformers model previously raised
+    # UnboundLocalError because hf_model_dir was only assigned on the
+    # string-path branch but referenced unconditionally (issue #15501).
+    preloaded = mock.MagicMock(spec=transformers.PreTrainedModel)
+
+    with (
+        mock.patch.object(
+            mamba_model.MambaConfig, "from_hugging_face", return_value=mock.MagicMock()
+        ),
+        mock.patch.object(mamba_model, "convert_hf_mamba", return_value={}) as convert_hf,
+        mock.patch.object(mamba_model, "convert_from_hf_checkpoint") as convert_ckpt,
+        mock.patch.object(MambaForCausalLM, "__init__", return_value=None),
+        mock.patch.object(MambaForCausalLM, "load", return_value=None),
+    ):
+        MambaForCausalLM.from_hugging_face(preloaded)
+
+    # The preloaded model is converted directly; the checkpoint path is not used.
+    convert_hf.assert_called_once()
+    assert convert_hf.call_args.args[0] is preloaded
+    convert_ckpt.assert_not_called()


### PR DESCRIPTION
## Description

Revives the stale, closed-unmerged PR #15501.

`MambaForCausalLM.from_hugging_face` accepts either a path/string or a preloaded `transformers.PreTrainedModel`. On the preload branch, `hf_model_dir` is never assigned (it is only set in the string-path `else`), but the code then unconditionally runs:

```python
if not os.path.exists(hf_model_dir):   # UnboundLocalError when preloading
```

So passing a preloaded model raised `UnboundLocalError: local variable 'hf_model_dir' referenced before assignment` before any conversion.

## Change

Handle `use_preloading` first and convert the already-provided model directly via `convert_hf_mamba`; the string-path branches are unchanged.

## Test

New CPU-only unit test in `tests/unittest/others/test_mamba_preload.py`: passing a preloaded model no longer raises, routes to `convert_hf_mamba` with that model, and does not touch the checkpoint path (downstream TRT construction is mocked).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading of preloaded Mamba models to avoid initialization errors.
  * Ensured preloaded models are converted directly without attempting unnecessary checkpoint loading.

* **Tests**
  * Added coverage confirming preloaded model loading completes without errors and uses the correct conversion path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->