### PR TITLE
[None][fix] namespace cnn_dailymail calibration dataset id

### DIFF
--- a/tensorrt_llm/models/convert_utils.py
+++ b/tensorrt_llm/models/convert_utils.py
@@ -317,6 +317,11 @@ def load_calib_dataset(dataset_name_or_dir: str,
                     key = meta[2]
                 break
 
+    # The bare "cnn_dailymail" repo id was relocated to "abisee/cnn_dailymail";
+    # newer huggingface_hub rejects un-namespaced ids.
+    if dataset_name_or_dir == "cnn_dailymail":
+        dataset_name_or_dir = "abisee/cnn_dailymail"
+
     dataset = load_dataset(dataset_name_or_dir,
                            name=config_name,
                            split=split,

--- a/tests/unittest/others/test_calib_dataset_namespace.py
+++ b/tests/unittest/others/test_calib_dataset_namespace.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 from unittest import mock
 
+import pytest
+
 import tensorrt_llm.models.convert_utils as convert_utils
 from tensorrt_llm.models.convert_utils import load_calib_dataset
 
@@ -29,10 +31,13 @@ def test_bare_cnn_dailymail_is_namespaced() -> None:
     assert load_dataset.call_args.args[0] == "abisee/cnn_dailymail"
 
 
-def test_other_dataset_ids_are_passed_through() -> None:
+# ccdv/cnn_dailymail is the important boundary: the already-qualified id must
+# NOT be rewritten — only the bare "cnn_dailymail" maps to abisee/cnn_dailymail.
+@pytest.mark.parametrize("dataset_name", ["lambada", "ccdv/cnn_dailymail"])
+def test_other_dataset_ids_are_passed_through(dataset_name: str) -> None:
     with mock.patch.object(
-        convert_utils, "load_dataset", return_value={"text": ["x"]}
+        convert_utils, "load_dataset", return_value={"text": ["x"], "article": ["x"]}
     ) as load_dataset:
-        load_calib_dataset("lambada")
+        load_calib_dataset(dataset_name)
 
-    assert load_dataset.call_args.args[0] == "lambada"
+    assert load_dataset.call_args.args[0] == dataset_name

--- a/tests/unittest/others/test_calib_dataset_namespace.py
+++ b/tests/unittest/others/test_calib_dataset_namespace.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+
+import tensorrt_llm.models.convert_utils as convert_utils
+from tensorrt_llm.models.convert_utils import load_calib_dataset
+
+
+def test_bare_cnn_dailymail_is_namespaced() -> None:
+    # Newer huggingface_hub rejects the bare "cnn_dailymail" repo id; it must
+    # be rewritten to the relocated "abisee/cnn_dailymail" (issue #15802/#16124).
+    with mock.patch.object(
+        convert_utils, "load_dataset", return_value={"article": ["x"]}
+    ) as load_dataset:
+        load_calib_dataset("cnn_dailymail")
+
+    assert load_dataset.call_args.args[0] == "abisee/cnn_dailymail"
+
+
+def test_other_dataset_ids_are_passed_through() -> None:
+    with mock.patch.object(
+        convert_utils, "load_dataset", return_value={"text": ["x"]}
+    ) as load_dataset:
+        load_calib_dataset("lambada")
+
+    assert load_dataset.call_args.args[0] == "lambada"


### PR DESCRIPTION
## Description

Revives the stale, closed-unmerged PR #16124 (issue #15802).

`load_calib_dataset("cnn_dailymail")` passes the bare repo id to `datasets.load_dataset`. Newer `huggingface_hub` requires a `namespace/name` id and rejects the bare `cnn_dailymail` with `HfUriError: Repository id must be ...`, breaking INT8/SmoothQuant calibration.

## Change

Rewrite the bare `cnn_dailymail` id to the relocated canonical `abisee/cnn_dailymail` before calling `load_dataset` (in `tensorrt_llm/models/convert_utils.py`). Other dataset ids are untouched.

## Test

New CPU-only unit test in `tests/unittest/others/test_calib_dataset_namespace.py` (mocks `load_dataset`, no network): the bare id becomes `abisee/cnn_dailymail`; other ids (e.g. `lambada`) pass through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calibration dataset loading by using the correct namespaced identifier for CNN/DailyMail.
  * Preserved existing behavior for other dataset names.

* **Tests**
  * Added coverage to verify CNN/DailyMail name conversion and unchanged handling of other datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->