### PR TITLE
[https://nvbugs/6438586][fix] Make gen-only benchmark insufficient-KV fail-fast ADP-safe

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3476,17 +3476,34 @@ class PyExecutor:
             # scheduler could not allocate KV for any of them, the benchmark
             # will hang forever because in-progress generation requests won't
             # release their KV cache.
-            if (self.benchmark_req_queues_size > 0 and not self.is_warmup
-                    and not fitting_disagg_gen_init_requests):
+            if self.benchmark_req_queues_size > 0 and not self.is_warmup:
                 stuck_init_requests = [
                     req for req in self.active_requests
                     if req.is_disagg_generation_init_state
                 ]
                 # Only fail once all benchmark requests have been fetched
                 # so that _handle_errors covers every request and every
-                # client receives an error response.
-                if (stuck_init_requests and self.num_fetch_requests
-                        >= self.benchmark_req_queues_size):
+                # client receives an error response.  Requests deferred by
+                # the transfer admission controller
+                # (wait_for_disagg_gen_transfer_progress) are waiting on
+                # in-flight transfers, not on KV capacity, so they are
+                # not stuck.
+                local_stuck = bool(stuck_init_requests
+                                   and not fitting_disagg_gen_init_requests
+                                   and not wait_for_disagg_gen_transfer_progress
+                                   and self.num_fetch_requests
+                                   >= self.benchmark_req_queues_size)
+                # All DP ranks must agree before failing: entering
+                # _handle_errors on a subset of ranks desyncs its response
+                # gather against the fill-gate allgather running on the
+                # other ranks (https://nvbugs/6438586).  The consensus
+                # allgather runs on every iteration regardless of local
+                # state so all ranks stay collective-aligned.
+                if self.enable_attention_dp and self.dist.world_size != 1:
+                    should_fail = any(self.dist.tp_allgather(local_stuck))
+                else:
+                    should_fail = local_stuck
+                if should_fail:
                     error_msg = (
                         f"Insufficient KV cache for gen-only benchmark mode: "
                         f"{len(stuck_init_requests)} request(s) are waiting for "
@@ -5992,8 +6009,14 @@ class PyExecutor:
                                      client_id=getattr(item.request,
                                                        'client_id', None))))
 
-            if waiting_responses:
+            # Under ADP, waiting_responses is only populated on rank 0
+            # (or with gather_all_responses), but _enqueue_responses runs
+            # a collective gather — every rank must enter it, even with an
+            # empty list, to stay in lockstep.
+            if waiting_responses or (self.enable_attention_dp
+                                     and self.dist.world_size != 1):
                 self._enqueue_responses(waiting_responses)
+            if waiting_responses:
                 logger.info(f"Drained {len(waiting_responses)} queued requests "
                             "on fatal error")
 

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -1065,6 +1065,80 @@ class TestFailFastDuringBenchmarkFill:
             )
             ex._handle_errors.assert_called_once()
 
+    def test_admission_deferral_does_not_kill(self):
+        """Requests deferred by the transfer admission controller are not stuck.
+
+        When the scheduler fits INIT requests but the admission controller
+        defers all of them behind in-flight transfers
+        (wait_for_disagg_gen_transfer_progress=True), the fill is making
+        progress and the fail-fast must not fire (nvbug 6438586).
+        """
+        ex = self._make_executor(fill_phase_active=True)
+        ex._apply_disagg_transfer_admission = Mock(return_value=([], True))
+
+        result, _ = ex._prepare_and_schedule_batch()
+
+        assert result is not None, (
+            "Fail-fast should NOT fire while the admission controller is "
+            "deferring INIT requests behind active KV transfers"
+        )
+        ex._handle_errors.assert_not_called()
+
+    def _make_adp_executor(self, **kwargs):
+        """ADP variant of the executor stub (2 DP ranks)."""
+        ex = self._make_executor(**kwargs)
+        ex.enable_attention_dp = True
+        ex.dist = Mock(rank=0, tp_size=2, world_size=2)
+        ex.dist.allreduce.return_value = 0
+        ex.dist.tp_allreduce.return_value = 0
+        return ex
+
+    def test_adp_consensus_runs_allgather_even_when_healthy(self):
+        """Under ADP the stuck-consensus allgather must run every iteration.
+
+        A rank that skips the collective while a peer enters it desyncs all
+        subsequent collectives (nvbug 6438586: peers crashed with
+        `TypeError: '<' not supported between instances of 'list' and 'int'`
+        in the fill-gate allgather).
+        """
+        fitting_req = _make_active_request(in_init=True)
+        ex = self._make_adp_executor(fill_phase_active=True, fitting_init_requests=[fitting_req])
+        ex.dist.tp_allgather.return_value = [False, False]
+
+        result, _ = ex._prepare_and_schedule_batch()
+
+        assert result is not None
+        ex.dist.tp_allgather.assert_called_once_with(False)
+        ex._handle_errors.assert_not_called()
+
+    def test_adp_consensus_kills_all_ranks_when_peer_is_stuck(self):
+        """A healthy rank must fail together with a stuck peer rank."""
+        fitting_req = _make_active_request(in_init=True)
+        ex = self._make_adp_executor(fill_phase_active=True, fitting_init_requests=[fitting_req])
+        # This rank is healthy (local flag False) but a peer reports stuck.
+        ex.dist.tp_allgather.return_value = [False, True]
+
+        result, _ = ex._prepare_and_schedule_batch()
+
+        assert result is None, (
+            "All DP ranks must enter _handle_errors together when any rank "
+            "is stuck; failing on a subset desyncs the response gather "
+            "against the fill-gate allgather on the healthy ranks"
+        )
+        ex.dist.tp_allgather.assert_called_once_with(False)
+        ex._handle_errors.assert_called_once()
+
+    def test_adp_consensus_local_stuck_reported(self):
+        """A locally stuck rank contributes True to the consensus."""
+        ex = self._make_adp_executor(fill_phase_active=True)
+        ex.dist.tp_allgather.return_value = [True, False]
+
+        result, _ = ex._prepare_and_schedule_batch()
+
+        assert result is None
+        ex.dist.tp_allgather.assert_called_once_with(True)
+        ex._handle_errors.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # End-to-end fill phase reproducer
@@ -1172,10 +1246,15 @@ class TestFillPhaseEndToEnd:
         # Phase 2b: Healthy fill keeps making progress, so fail-fast must not
         # fire even though some active requests remain in INIT.
         ex._schedule = Mock(return_value=(ScheduledRequests(), [init_reqs[0]], 0))
+        # The stuck-consensus allgather (nvbug 6438586) shares
+        # dist.tp_allgather with the fill gate; during a healthy fill no
+        # rank reports stuck.
+        ex.dist.tp_allgather = Mock(return_value=[False, False])
         result, _ = ex._prepare_and_schedule_batch()
         assert result is not None, (
             "Fail-fast must not kill requests while the scheduler can still fit INIT requests"
         )
+        ex.dist.tp_allgather.assert_called_once_with(False)
 
         # Phase 3: All transfers complete, gate opens
         for req in init_reqs:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark fill-phase failure detection to avoid premature failures while transfer activity is still progressing.
  * Synchronized failure handling across distributed attention-processing ranks.
  * Ensured all ranks remain coordinated during fatal error handling, including when no responses are queued.

* **Tests**
  * Added coverage for healthy and stuck distributed fill scenarios.
  * Strengthened assertions for cross-rank health checks and synchronized shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixes https://nvbugs/6438586 (and the crash mode of https://nvbugs/6438658).

In gen-only benchmark mode, the "Insufficient KV cache" fail-fast in `_prepare_and_schedule_batch` fired on **rank-local** conditions (`fitting_disagg_gen_init_requests` / stuck INIT requests). Under attention DP, a subset of ranks could enter `_handle_errors` (which runs a collective response gather) while the remaining ranks sat in the fill gate's `tp_allgather`. The mismatched collectives desync the TP group: peer ranks crash with `TypeError: '<' not supported between instances of 'list' and 'int'` in `_is_benchmark_disagg_fill_complete` (nvbug 6438586), or hang until the HangDetector hard-kills all ranks via `MPI_Abort`.

The check also mistook requests deferred by the disagg transfer admission controller (#15356) for stuck requests: deferred requests are waiting on in-flight KV transfers, not on KV capacity, so the fail-fast could kill benchmarks whose fill was still making progress (nvbug 6438658).

Changes:
- Skip the fail-fast when the admission controller is deferring requests behind active transfers (`wait_for_disagg_gen_transfer_progress`).
- Reach an ADP consensus (`any` over a `tp_allgather`, run on every iteration regardless of local state) before failing, so all ranks enter `_handle_errors` together and stay collective-aligned.
- In `_handle_errors`' fatal path, enter the waiting-queue response gather on every ADP rank (it was rank-0 only — same desync class).

Note: `feat/deepseek_v4` fixed the same desync in 95245c90e0 ("[TRTLLM-12403][fix] Fix deepseekv4 stall") but the fix was never ported to main, which is why 1.3.0rc15.post1 (dsv4) is unaffected while rc21 (main) regressed.

Verified on Lyris (4x GB200, DeepSeek-V4-Flash ctx tp8 / gen dep8 ADP, gen-only benchmark, concurrency 512, TensorRT-LLM 1.3.0rc21 container):
- Unfixed + per-rank divergence: ranks 1-7 fire the fail-fast alone, rank 0 blocks in the fill-gate collective, HangDetector `MPI_Abort`s all GEN ranks at benchmark start.
- Fixed + same divergence: all 8 ranks fail together at the same timestamp with the real error message; no TypeError, no hang.
- Fixed + healthy KV config: benchmark runs to completion with zero error signatures.

## Test Coverage

- `tests/unittest/_torch/executor/test_benchmark_disagg.py`:
  - New `test_admission_deferral_does_not_kill` — deferral by the admission controller must not trigger the fail-fast.
  - New `test_adp_consensus_runs_allgather_even_when_healthy` — the consensus collective runs every iteration to keep ranks aligned.
  - New `test_adp_consensus_kills_all_ranks_when_peer_is_stuck` / `test_adp_consensus_local_stuck_reported` — consensus semantics.
  - Updated `TestFillPhaseEndToEnd::test_full_lifecycle` for the new consensus collective.
  - Full file passes (59 passed) against the fixed executor in the rc21 SBSA container.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
