### PR TITLE
[None][fix] read chat_format from generation_config dict with .get()

### DIFF
--- a/tensorrt_llm/models/qwen/convert.py
+++ b/tensorrt_llm/models/qwen/convert.py
@@ -1011,7 +1011,9 @@ def quantize(hf_model_dir: str,
     gen_config_path = os.path.join(hf_model_dir, 'generation_config.json')
     with open(gen_config_path, 'r') as f:
         gen_config = json.load(f)
-    chat_format = getattr(gen_config, 'chat_format', 'chatml')
+    # gen_config is a dict from json.load; getattr never finds the key and
+    # always returned the 'chatml' default, ignoring the checkpoint's value.
+    chat_format = gen_config.get('chat_format', 'chatml')
     act_range = capture_activation_range(hf_model, config.qwen_type, tokenizer,
                                          dataset, system_prompt, chat_format)
     qkv_para = {}


### PR DESCRIPTION
## Description

In the Qwen SmoothQuant calibration path (`tensorrt_llm/models/qwen/convert.py`):

```python
with open(gen_config_path, 'r') as f:
    gen_config = json.load(f)          # a dict
chat_format = getattr(gen_config, 'chat_format', 'chatml')   # always 'chatml'
```

`gen_config` is a `dict`, which has no `chat_format` attribute, so `getattr(..., 'chatml')` **always** returned the default and silently ignored the checkpoint's `generation_config.json`. `chat_format` then drives prompt formatting in `capture_activation_range`, so a model configured with a non-default chat format is calibrated incorrectly.

## Change

Use `gen_config.get('chat_format', 'chatml')`.

## Test

No unit test: the fix is a one-line dict-access correction, and the only caller is a GPU calibration routine that requires a model + weights to exercise. The change is self-evidently correct (`dict.get` vs `getattr` on a dict).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected chat format detection during model quantization.
  * Checkpoints now honor the configured chat format when specified, while retaining ChatML as the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->