### PR TITLE
[None][fix] raise clear error on unknown delay_dist in get_list_of_delays

### DIFF
--- a/tensorrt_llm/bench/dataset/utils.py
+++ b/tensorrt_llm/bench/dataset/utils.py
@@ -54,6 +54,10 @@ def get_list_of_delays(delay_dist, mean_time_bet_reqs, num_reqs, random_seed):
         delays = [mean_time_bet_reqs] * num_reqs
     elif delay_dist == "exponential_dist":
         delays = get_exponential_dist_delays(mean_time_bet_reqs, num_reqs, random_seed)
+    else:
+        raise ValueError(
+            f"Unknown delay_dist '{delay_dist}'; expected 'constant' or 'exponential_dist'."
+        )
 
     return delays
 

--- a/tests/unittest/others/test_bench_delays.py
+++ b/tests/unittest/others/test_bench_delays.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from tensorrt_llm.bench.dataset.utils import get_list_of_delays
+
+
+def test_constant_delays() -> None:
+    assert get_list_of_delays("constant", 2.0, 3, 0) == [2.0, 2.0, 2.0]
+
+
+def test_unknown_delay_dist_raises_value_error() -> None:
+    # Previously fell through to `return delays` with delays unbound,
+    # raising a cryptic UnboundLocalError.
+    with pytest.raises(ValueError, match="Unknown delay_dist"):
+        get_list_of_delays("uniform", 1.0, 5, 0)

--- a/tests/unittest/others/test_bench_delays.py
+++ b/tests/unittest/others/test_bench_delays.py
@@ -24,5 +24,9 @@ def test_constant_delays() -> None:
 def test_unknown_delay_dist_raises_value_error() -> None:
     # Previously fell through to `return delays` with delays unbound,
     # raising a cryptic UnboundLocalError.
-    with pytest.raises(ValueError, match="Unknown delay_dist"):
+    with pytest.raises(
+        ValueError,
+        match=r"Unknown delay_dist 'uniform'; expected 'constant' or "
+        r"'exponential_dist'\.",
+    ):
         get_list_of_delays("uniform", 1.0, 5, 0)


### PR DESCRIPTION
## Description

`get_list_of_delays` (`tensorrt_llm/bench/dataset/utils.py`) assigns `delays` only in the `constant` and `exponential_dist` branches, with no `else`:

```python
if delay_dist == "constant":
    delays = ...
elif delay_dist == "exponential_dist":
    delays = ...
return delays   # UnboundLocalError for any other value
```

Any other `delay_dist` reaches `return delays` with the variable unbound, raising a cryptic `UnboundLocalError` instead of a clear message.

## Change

Add an `else` that raises `ValueError` naming the accepted values.

## Test

New CPU-only unit test in `tests/unittest/others/test_bench_delays.py`: `constant` returns the expected list; an unknown distribution raises `ValueError`. (Verified locally — module has no GPU/torch dependency.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for unsupported delay distribution settings.
  * Clear error messages are now provided when an invalid option is selected.

* **Tests**
  * Added coverage for constant delay generation.
  * Added coverage confirming invalid delay distributions return the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->