### PR TITLE
[None][fix] validate trtllm-serve --port with ValueError not assert

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -397,7 +397,10 @@ def launch_server(
         [info[0] == socket.AF_INET6 for info in addr_info]) else socket.AF_INET
     with socket.socket(address_family, socket.SOCK_STREAM) as s:
         # If disagg cluster config is provided and port is not specified, try to find a free port, otherwise try to bind to the specified port
-        assert port > 0 or disagg_cluster_config is not None, "Port must be specified if disagg cluster config is not provided"
+        if not (port > 0 or disagg_cluster_config is not None):
+            raise ValueError(
+                "Port must be specified (--port > 0) if disagg cluster config is not provided"
+            )
         try:
             s.bind((host, port))
             if port == 0:

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -626,9 +626,8 @@ def launch_server(
     # port == 0 lets the kernel pick the port; the caller then needs a way
     # to learn it, either by service discovery or by report_addr. Validate
     # before getaddrinfo, which rejects negative ports with its own error.
-    if not (port > 0 or
-            (port == 0 and
-             (disagg_cluster_config is not None or report_addr))):
+    if not (port > 0 or (port == 0 and
+                         (disagg_cluster_config is not None or report_addr))):
         raise ValueError(
             "Port must be a positive integer, or 0 to let the kernel pick "
             "one when disagg cluster config or --report_addr is provided")

--- a/tests/unittest/llmapi/apps/test_serve_port_validation.py
+++ b/tests/unittest/llmapi/apps/test_serve_port_validation.py
@@ -12,19 +12,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import socket
+from unittest import mock
+
 import pytest
 
+import tensorrt_llm.commands.serve as serve_mod
 from tensorrt_llm.commands.serve import launch_server
 
 
-def test_launch_server_rejects_nonpositive_port_without_disagg() -> None:
+@pytest.mark.parametrize("port", [0, -1])
+def test_launch_server_rejects_nonpositive_port_without_disagg(port: int) -> None:
     # --port is user input; a non-positive port without a disagg cluster
     # config must raise a clear ValueError (survives `python -O`) rather than
-    # an AssertionError, before any bind/model load.
-    with pytest.raises(ValueError, match="Port must be specified"):
-        launch_server(
-            host="localhost",
-            port=0,
-            llm_args={"backend": "pytorch", "model": "dummy-model"},
-            disagg_cluster_config=None,
-        )
+    # an AssertionError, and must never bind a socket. socket is mocked so the
+    # negative-port case does not fail earlier in getaddrinfo.
+    with mock.patch.object(serve_mod, "socket") as mock_socket:
+        mock_socket.AF_UNSPEC = socket.AF_UNSPEC
+        mock_socket.AF_INET = socket.AF_INET
+        mock_socket.AF_INET6 = socket.AF_INET6
+        mock_socket.SOCK_STREAM = socket.SOCK_STREAM
+        mock_socket.getaddrinfo.return_value = [
+            (socket.AF_INET, None, None, None, ("127.0.0.1", port))
+        ]
+        sock = mock_socket.socket.return_value.__enter__.return_value
+
+        with pytest.raises(ValueError, match="Port must be specified"):
+            launch_server(
+                host="localhost",
+                port=port,
+                llm_args={"backend": "pytorch", "model": "dummy-model"},
+                disagg_cluster_config=None,
+            )
+
+        sock.bind.assert_not_called()

--- a/tests/unittest/llmapi/apps/test_serve_port_validation.py
+++ b/tests/unittest/llmapi/apps/test_serve_port_validation.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from tensorrt_llm.commands.serve import launch_server
+
+
+def test_launch_server_rejects_nonpositive_port_without_disagg() -> None:
+    # --port is user input; a non-positive port without a disagg cluster
+    # config must raise a clear ValueError (survives `python -O`) rather than
+    # an AssertionError, before any bind/model load.
+    with pytest.raises(ValueError, match="Port must be specified"):
+        launch_server(
+            host="localhost",
+            port=0,
+            llm_args={"backend": "pytorch", "model": "dummy-model"},
+            disagg_cluster_config=None,
+        )


### PR DESCRIPTION
## Description

`launch_server` (`tensorrt_llm/commands/serve.py`) guarded the `trtllm-serve --port` CLI argument with:

```python
assert port > 0 or disagg_cluster_config is not None, "Port must be specified ..."
```

Using `assert` on user input means an `AssertionError` (not a clear error), and under `python -O` the check is stripped entirely — so `--port 0` without a disagg config silently binds an ephemeral port instead of erroring. Behavior should not depend on the `-O` flag.

## Change

Replace the `assert` with an explicit `raise ValueError`.

## Test

New CPU-only unit test in `tests/unittest/llmapi/apps/test_serve_port_validation.py`: `launch_server` with `port=0` and no disagg config raises `ValueError` (the check runs before any bind/model load).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- `launch_server` now uses explicit `ValueError` validation instead of `assert`.
- Port `0` is allowed with disaggregated configuration or `report_addr`.
- Negative ports remain invalid.
- Validation occurs before address resolution and socket binding.
- The CPU test-list entry uses the correct path and scope.

## QA Engineer Review

- Added `test_launch_server_rejects_nonpositive_port_without_disagg`.
- The test covers ports `0` and `-1`.
- The test verifies that `ValueError` occurs before address resolution and that `bind()` is not called.
- The test is registered in `tests/integration/test_lists/test-db/l0_cpu.yml`.
- Verdict: sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->