### PR TITLE
[None][fix] avoid UnboundLocalError in CnnDailymail.compute_score

### DIFF
--- a/tensorrt_llm/evaluate/cnn_dailymail.py
+++ b/tensorrt_llm/evaluate/cnn_dailymail.py
@@ -65,6 +65,7 @@ class CnnDailymail(Evaluator):
 
     def compute_score(self, outputs: List[RequestOutput],
                       references: List[str]) -> float:
+        rouge1 = 0.0
         for beam_idx in range(len(outputs[0].outputs)):
             metrics = self.rouge.compute(
                 predictions=[output.outputs[0].text for output in outputs],

--- a/tests/unittest/others/test_cnn_dailymail_score.py
+++ b/tests/unittest/others/test_cnn_dailymail_score.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from types import SimpleNamespace
+
+from tensorrt_llm.evaluate.cnn_dailymail import CnnDailymail
+
+
+def test_compute_score_with_no_beams_returns_zero() -> None:
+    # When outputs[0].outputs is empty the beam loop never runs; rouge1 was
+    # then returned while unbound, raising UnboundLocalError. It should now
+    # return the 0.0 default.
+    evaluator = CnnDailymail.__new__(CnnDailymail)  # skip heavy __init__
+    empty_request = SimpleNamespace(outputs=[])
+    assert evaluator.compute_score([empty_request], references=[]) == 0.0


### PR DESCRIPTION
## Description

`CnnDailymail.compute_score` (`tensorrt_llm/evaluate/cnn_dailymail.py`) assigns `rouge1` only inside the beam loop:

```python
for beam_idx in range(len(outputs[0].outputs)):
    ...
    if beam_idx == 0:
        rouge1 = metrics["rouge1"] * 100
return rouge1   # UnboundLocalError if outputs[0].outputs is empty
```

If `outputs[0].outputs` is empty the loop never runs and `return rouge1` raises `UnboundLocalError` instead of yielding a score.

## Change

Initialize `rouge1 = 0.0` before the loop.

## Test

New CPU-only unit test in `tests/unittest/others/test_cnn_dailymail_score.py`: `compute_score` with an empty beam list returns `0.0` (constructed via `__new__` to skip the heavy metric-loading `__init__`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CNN/DailyMail evaluation when no beam outputs are available.
  * The evaluator now returns a score of `0.0` instead of failing in this scenario.

* **Tests**
  * Added coverage for scoring requests with empty outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->