### PR TITLE
[None][fix] compare library versions with packaging.version, not strings

### DIFF
--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -1,4 +1,5 @@
 import transformers
+from packaging import version
 
 from .modeling_auto import AutoModelForCausalLM
 from .modeling_bert import BertForSequenceClassification
@@ -89,7 +90,7 @@ __all__ = [
     "Cohere2ForCausalLM",
 ]
 
-if transformers.__version__ >= "4.45.1":
+if version.parse(transformers.__version__) >= version.parse("4.45.1"):
     from .modeling_mllama import MllamaForConditionalGeneration  # noqa
 
     __all__.append("MllamaForConditionalGeneration")

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -7,6 +7,7 @@ from enum import IntEnum, auto
 from typing import TYPE_CHECKING, List, Optional, Type
 
 import torch
+from packaging import version
 from torch import nn
 
 from tensorrt_llm.logger import logger
@@ -517,7 +518,8 @@ class SpecWorkerBase(nn.Module, ABC):
         super().__init__()
         self.guided_decoder: Optional["CapturableGuidedDecoder"] = None
         self.force_num_accepted_tokens = get_force_num_accepted_tokens()
-        self.use_flashinfer = IS_FLASHINFER_AVAILABLE and flashinfer.__version__ >= "0.6.4"
+        self.use_flashinfer = IS_FLASHINFER_AVAILABLE and version.parse(
+            flashinfer.__version__) >= version.parse("0.6.4")
         self.seed: Optional[torch.Tensor] = None
         self.offset: Optional[torch.Tensor] = None
         self.use_separate_draft_kv_cache = use_separate_draft_kv_cache

--- a/tensorrt_llm/tools/multimodal_builder.py
+++ b/tensorrt_llm/tools/multimodal_builder.py
@@ -6,6 +6,7 @@ import tarfile
 from time import time
 
 import yaml
+from packaging import version
 
 # isort: off
 import torch
@@ -1406,7 +1407,8 @@ def build_qwen2_vl_engine(args):
 
         def __init__(self, config: Qwen2VLVisionConfig):
             # Fallback for compatibility with older transformers versions (for certain nvbugs/tests)
-            if transformers.__version__ >= '4.53.0':
+            if version.parse(
+                    transformers.__version__) >= version.parse('4.53.0'):
                 super().__init__(config)
                 self.head_dim = config.embed_dim // config.num_heads
             else:


### PR DESCRIPTION
## Description

Three version gates compared `__version__` strings with `>=`, which is **lexicographic**, not numeric:

- `tensorrt_llm/_torch/models/__init__.py` — `transformers.__version__ >= "4.45.1"` (gates `MllamaForConditionalGeneration` registration)
- `tensorrt_llm/tools/multimodal_builder.py` — `transformers.__version__ >= '4.53.0'`
- `tensorrt_llm/_torch/speculative/interface.py` — `flashinfer.__version__ >= "0.6.4"`

Lexicographic comparison is wrong at version boundaries, e.g. `"4.9.0" >= "4.45.1"` is `True` (should be False) and `"4.100.0" >= "4.53.0"` is `False` (should be True).

## Change

Use `packaging.version.parse(...)` for numeric comparison — the same pattern already used in `_torch/modules/mamba/softplus.py` and `_torch/modules/fla/utils.py`. Behavior is unchanged for currently-supported versions; this only corrects the edge cases.

## Test

No dedicated test: these are import-time gates and the change is a standard `packaging.version` substitution with no behavior change for supported versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks for Transformers and FlashInfer versions.
  * Ensured version comparisons correctly follow semantic versioning, including multi-digit releases.
  * Improved selection of multimodal attention behavior across supported Transformers versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->