### PR TITLE
[https://nvbugs/6434535][fix] Replace boolean-mask indexed writes with a static-shape keep-mask…

### DIFF
--- a/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
@@ -1118,14 +1118,16 @@ class Qwen3NextGatedDeltaNet(nn.Module):
 
         state_indices_p, state_indices_d = torch.split(state_indices, batch_split_size)
         if num_prefills > 0:
-            # PyExecutor guarantees prefill requests are placed before decode requests
+            # PyExecutor guarantees prefill requests are placed before decode requests.
+            # Zero slots whose request has no cached initial state. Use a keep-mask
+            # scaled read-modify-write instead of `state_indices_p[~mask]` boolean-mask
+            # indexed assignment: the latter lowers to torch.nonzero() with a
+            # shape-dependent D2H sync, which under piecewise CUDA-graph capture
+            # produces per-rank divergence and stalls (HangDetector fires after 300s).
             has_initial_states_p = has_initial_states[:num_prefills]
-            ssm_states[state_indices_p[~has_initial_states_p]] = torch.zeros(
-                (), dtype=ssm_states.dtype, device=ssm_states.device
-            )
-            conv_states[state_indices_p[~has_initial_states_p]] = torch.zeros(
-                (), dtype=conv_states.dtype, device=conv_states.device
-            )
+            for cache in (ssm_states, conv_states):
+                keep = has_initial_states_p.view(-1, *([1] * (cache.ndim - 1))).to(cache.dtype)
+                cache[state_indices_p] = cache[state_indices_p] * keep
 
         is_target_verify = (
             num_decodes > 0


### PR DESCRIPTION
## Summary
- **Root cause**: Boolean-mask indexed write `state_indices_p[~has_initial_states_p]` on CUDA tensors lowers to torch.nonzero() with a shape-dependent D2H sync; under piecewise CUDA-graph capture this stalls per-rank divergently and HangDetector fires after 300s.
- **Fix**: Replace boolean-mask indexed writes with a static-shape keep-mask multiplication: gather rows via integer index `state_indices_p`, multiply by `has_initial_states_p` broadcast-shaped to the row dims. Rows with `has_initial_states=True` multiply by 1 (unchanged); False rows multiply by 0 (zeroed). Semantically identical, no dynamic-shape sync.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6434535


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state handling for prefill requests without cached initial state.
  * Helps ensure cached sequence and convolution states are reset consistently during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->