### PR TITLE
[https://nvbugs/6435097][fix] Remove the single stale `nvbugs/6427411` waiver line for…

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -1,5 +1,4 @@
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_first[noadp-mtp0] SKIP (https://nvbugs/6481375)
-accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=2] SKIP (https://nvbugs/6427411)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=4] SKIP (https://nvbugs/6428069)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=2-ctx_pp=2] SKIP (https://nvbugs/6427411)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=2-ctx_pp=4] SKIP (https://nvbugs/6428069)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -1,5 +1,4 @@
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype_with_helix[fifo_v2-cudagraph:with_padding-pp1dp2cp2] SKIP (https://nvbugs/6567057)
-accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=2] SKIP (https://nvbugs/6427411)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=4] SKIP (https://nvbugs/6428069)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=2-ctx_pp=2] SKIP (https://nvbugs/6427411)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=2-ctx_pp=4] SKIP (https://nvbugs/6428069)


### PR DESCRIPTION
## Summary
- **Root cause**: PR #15920 added a `use_host_stop_criteria` fast path that under-populated per-step/seq_slot/beam token buffers on non-last PP ranks, causing IndexError; PR #16163 (commit 9a8ec0567c) reverted PR #15920 and is present at HEAD, so the code is already fixed. The waiver line for this test was left behind by cleanup PRs #16103/#16105/#16127.
- **Fix**: Remove the single stale `nvbugs/6427411` waiver line for `test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=2]` in `waives.txt`; do not touch other test entries or other bug IDs.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6435097


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Removed the stale `nvbugs/6427411` waiver and `SKIP` marker for `TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=2]`.
- The change is limited to one `waives.txt` entry.
- The test-list format remains consistent.
- No other tests, bug references, or public entities changed.

## QA Engineer Review

- No `test-db/` or `qa/` files were modified.
- Removed one entry from `tests/integration/test_lists/waives.txt`.
- The affected test will run without the obsolete waiver.
- Verdict: needs follow-up because CBTS coverage data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->