### PR TITLE
[https://nvbugs/6428144][test] Unwaive GB300 DeepSeek-R1 gen-only disagg PerfSanity

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -386,7 +386,6 @@ perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_1k1k_con2048_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL] SKIP (https://nvbugs/6324123)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL] SKIP (https://nvbugs/6379406)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con64_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL] SKIP (https://nvbugs/6418834)
-perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL] SKIP (https://nvbugs/6428144)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-r1-fp4_1k1k_con3072_ctx1_dep4_gen1_dep4_eplb0_mtp1_ccb-NIXL] SKIP (https://nvbugs/6422339)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_1k1k_con1_ctx1_dep2_gen1_tep4_eplb0_mtp3_ccb-NIXL] SKIP (https://nvbugs/6418834)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_1k1k_con4096_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL] SKIP (https://nvbugs/6422339)


### PR DESCRIPTION
## Summary

Remove the waiver filed under [NVBug 6428144](https://nvbugs/6428144) and restore post-merge CI coverage for:

`perf/test_perf_sanity.py::test_e2e[disagg_upload-gen-only-gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL]`

## Rationale

[PR #15737](https://github.com/NVIDIA/TensorRT-LLM/pull/15737) normalized the gathered per-rank status before the gen-only disaggregated benchmark fill-gate reduction, addressing the list/int failure reported by [NVBug 6438586](https://nvbugs/6438586). This waived workload exercises that gate and now passes on the fixed code.

NVBug 6428144 remains the tracker attached to this test's waiver; NVBug 6438586 and PR #15737 provide the related product-fix context.

## Validation

Tested commit: `907c581354f5dc394a01fb5e8739270a281570be`

- [Targeted L0 pipeline #47307](http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=47307), launched by [PR_Github #58724](https://nv/trt-llm-cicd/job/helpers/job/PR_Github/58724/): the exact GB300 test was selected and passed (`1 passed`; 3,582.82-second call; pytest exit code 0).
- [Full L0 pipeline #47430](http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=47430), launched by [PR_Github #58888](https://nv/trt-llm-cicd/job/helpers/job/PR_Github/58888/): passed on the same commit. The pipeline reused both successful targeted stages from #47307 and separately ran the CBTS-selected coverage (15 passed, 0 failed, 0 skipped).
- `python3 scripts/check_test_list.py --validate --check-duplicate-waives` — 2,209 unique entries validated.
- `git diff --check`
