### PR TITLE
[None][fix] Pass max_num_tokens to MLA KV manager and keep warmup-feasibility floors

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -253,6 +253,10 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         # _build_cache_config() needs them to build constraints
         self._max_input_len = max_input_len
         self._max_num_tokens = max_num_tokens
+        # Size of the largest CUDA-graph warmup batch the engine will run:
+        # 0 when graphs are disabled, None when unknown (falls back to
+        # max_batch_size so the warmup floor stays conservative).
+        self._max_cuda_graph_batch_size = kwargs.pop("max_cuda_graph_batch_size", None)
 
         # General initialization
         super().__init__(
@@ -903,27 +907,53 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
                 * (max_batch_size - 1),
             )
 
-            # Constraint 1: cuda graph generation warmup — one decode request that has
-            # accumulated to the tail of max_seq_len. Using history_length=max_seq_len-1
-            # (instead of 0) lets SWA / SSM pools collapse to their windowed working set,
-            # while full-cache pools still need max_seq_len/tokens_per_block blocks
-            # because they don't age.
+        # The constraints below are feasibility floors (min slots per pool
+        # group) for the warmup workloads every executor runs, so they are
+        # built even when an explicit pool_ratio is provided — the ratio only
+        # decides how quota beyond these floors is split. Without the floors,
+        # a tight quota (e.g. the KV-estimation temporary pool) sized by a
+        # pure ratio split can starve one pool group and make warmup silently
+        # skip batch sizes, which under-measures the profiling peak and
+        # inflates the final KV cache estimate.
+
+        # Constraint 1: cuda graph generation warmup batch — one decode request
+        # that has accumulated to the tail of max_seq_len, plus enough fresh
+        # minimal decode requests to match the largest CUDA-graph warmup batch
+        # the engine will actually run (_create_cuda_graph_warmup_request's
+        # dummy batch). Skipped entirely when graphs are disabled: no other
+        # warmup creates a max_seq_len-long request, so keeping even the
+        # single long request would floor (and possibly bump) the quota for a
+        # warmup that will not happen. Using history_length=max_seq_len-1
+        # (instead of 0) lets SWA / SSM pools collapse to their windowed
+        # working set, while full-cache pools still need
+        # max_seq_len/tokens_per_block blocks because they don't age.
+        warmup_batch_size = (
+            max_batch_size
+            if self._max_cuda_graph_batch_size is None
+            else min(max_batch_size, self._max_cuda_graph_batch_size)
+        )
+        if warmup_batch_size > 0:
+            min_decode_capacity = 1 + max_draft_len + self.num_extra_kv_tokens
             constraints.append(
-                BatchDesc([KVCacheDesc(capacity=max_seq_len, history_length=max_seq_len - 1)])
+                BatchDesc(
+                    [KVCacheDesc(capacity=max_seq_len, history_length=max_seq_len - 1)]
+                    + [KVCacheDesc(capacity=min_decode_capacity, history_length=0)]
+                    * (warmup_batch_size - 1)
+                )
             )
 
-            # Constraint 2: general / chunked-prefill warmup — one fresh context request
-            # at max_num_tokens (the per-iteration token budget).
-            if max_num_tokens is not None:
-                constraints.append(
-                    BatchDesc(
-                        [
-                            KVCacheDesc(
-                                capacity=max_num_tokens + self.num_extra_kv_tokens, history_length=0
-                            )
-                        ]
-                    )
+        # Constraint 2: general / chunked-prefill warmup — one fresh context request
+        # at max_num_tokens (the per-iteration token budget).
+        if max_num_tokens is not None:
+            constraints.append(
+                BatchDesc(
+                    [
+                        KVCacheDesc(
+                            capacity=max_num_tokens + self.num_extra_kv_tokens, history_length=0
+                        )
+                    ]
                 )
+            )
 
         scratch_reuse_config = None
         if self.enable_swa_scratch_reuse:

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1799,6 +1799,12 @@ def _create_kv_cache_manager(
     manager_extra_kwargs = {}
     if issubclass(kv_cache_manager_cls, KVCacheManagerV2):
         manager_extra_kwargs["enable_stats"] = enable_kv_cache_stats
+        # Lets the manager size its warmup-batch feasibility floor by the
+        # CUDA-graph warmup the engine will actually run (0 = graphs
+        # disabled, None = unknown).
+        manager_extra_kwargs["max_cuda_graph_batch_size"] = (
+            model_engine._max_cuda_graph_batch_size
+            if model_engine is not None else None)
 
     if is_mla(config):
         kv_cache_manager = kv_cache_manager_cls(
@@ -1814,6 +1820,7 @@ def _create_kv_cache_manager(
             dtype=kv_cache_dtype,
             spec_config=spec_config,
             vocab_size=config.vocab_size,
+            max_num_tokens=max_num_tokens,
             max_beam_width=max_beam_width,
             is_draft=is_draft,
             kv_connector_manager=kv_connector_manager

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1142,11 +1142,22 @@ class PyTorchModelEngine(ModelEngine):
                                                     num_tokens, num_gen_tokens),
                         resource_manager) as batch:
                     if batch is None and self.mapping.tp_size <= 1:
-                        continue  # Not enough KV cache space (single rank, safe to skip)
+                        # Safe to skip, but never silently: a skip during KV
+                        # cache estimation makes the profiling peak
+                        # unrepresentative of this shape.
+                        logger.warning(
+                            f"Skipping general warmup with {num_tokens} tokens "
+                            f"({num_gen_tokens} generation): not enough KV "
+                            f"cache space.")
+                        continue
                     self._assert_all_tp_ranks_have_warmup_batch(
                         batch, num_tokens)
                     if batch is None:
-                        continue  # All ranks agree: not enough space
+                        logger.warning(
+                            f"Skipping general warmup with {num_tokens} tokens "
+                            f"({num_gen_tokens} generation): not enough KV "
+                            f"cache space on any TP rank.")
+                        continue
                     logger.info(
                         f"Run warmup with {num_tokens} tokens, include {num_gen_tokens} generation tokens"
                     )
@@ -1539,7 +1550,14 @@ class PyTorchModelEngine(ModelEngine):
                         with self._release_batch_context(
                                 warmup_request, resource_manager) as batch:
                             if batch is None:
-                                # No KV cache space, cannot continue capturing graphs
+                                # No KV cache space for this batch size. During KV
+                                # cache estimation this makes the profiling peak
+                                # unrepresentative (the final executor still
+                                # captures this graph), so don't skip silently.
+                                logger.warning(
+                                    f"Skipping CUDA graph warmup ({label}) for "
+                                    f"batch size={bs}, draft_len={draft_len}: "
+                                    f"not enough KV cache space.")
                                 continue
                             logger.info(
                                 f"Run generation-only CUDA graph warmup ({label}) "

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -204,7 +204,11 @@ class KVCacheManagerConfig:
 
     constraints: list[BatchDesc] = field(default_factory=list)
     """
-    A list of step configurations that must always be supported.
+    A list of step configurations that must always be supported. They act as
+    feasibility floors: every pool group is guaranteed at least the slots these
+    batches need, scaled by 1/max_util_for_resume so the last request of a
+    constraint batch still passes resume's utilization gate. The floors apply
+    even when initial_pool_ratio is set.
     """
 
     typical_step: BatchDesc | None = None
@@ -216,7 +220,9 @@ class KVCacheManagerConfig:
     initial_pool_ratio: list[float] | None = None
     """
     User-provided initial memory partitioning between pool groups. When set, this
-    takes precedence over typical_step and constraints for initial sizing.
+    replaces the typical_step-derived ratio and decides how quota beyond the
+    constraint floors is split; constraints still clamp each pool group up to its
+    minimum feasible size.
     """
 
     swa_scratch_reuse: SwaScratchReuseConfig | None = None

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -264,6 +264,7 @@ class KVCacheManager:
             constraints=config.constraints,
             initial_pool_ratio=config.initial_pool_ratio,
             event_manager=event_manager,
+            max_util_for_resume=config.max_util_for_resume,
         )
         self._living_kv_caches = set[rawref.ref[_KVCache]]()
         decay = 0.9999

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -219,6 +219,7 @@ class StorageManager:
         constraints: list[BatchDesc] | None = None,
         initial_pool_ratio: list[float] | None = None,
         event_manager: "KVCacheEventManager | None" = None,
+        max_util_for_resume: float = 1.0,
     ) -> None:
         self.__rawref__ = rawref.NULL
         self._event_manager = event_manager
@@ -243,9 +244,17 @@ class StorageManager:
         gpu_quota = config.cache_tiers[GPU_LEVEL].quota
         gpu_granularity = CacheLevelManager.cache_tier_granularity(CacheTier.GPU_MEM, gpu_quota)
 
-        constraints_for_min_slots = [] if initial_pool_ratio is not None else constraints or []
+        # Constraints are feasibility floors and apply even when an explicit
+        # initial_pool_ratio is provided: the ratio drives how excess quota is
+        # split, but must not shrink a pool group below what the declared
+        # batches (e.g. the CUDA-graph warmup batch) need — with a tight quota
+        # (such as the KV-estimation temporary pool) a pure ratio split can
+        # starve one pool group while others hold unused excess. The floors
+        # are scaled by 1/max_util_for_resume because _KVCache.resume rejects
+        # any pool group above that utilization, so a constraint batch only
+        # runs if its slots stay below the utilization gate.
         self._min_slots = self._compute_min_slots_from_constraints(
-            constraints_for_min_slots, tokens_per_block, swa_scratch_reuse
+            constraints or [], tokens_per_block, swa_scratch_reuse, max_util_for_resume
         )
 
         # Compute init_ratio from explicit config, typical_batch, constraints, or fallback.
@@ -901,11 +910,23 @@ class StorageManager:
         constraints: list[BatchDesc],
         tokens_per_block: int,
         swa_scratch_reuse: SwaScratchReuseConfig | None,
+        max_util_for_resume: float = 1.0,
     ) -> TypedIndexList[PoolGroupIndex, int]:
         """Compute the minimum slots per pool group across all constraints (element-wise max).
 
-        All returned elements are positive.
+        All returned elements are positive. Constraint-derived counts are
+        scaled by 1/max_util_for_resume so the last request of a constraint
+        batch still passes _KVCache.resume's utilization gate when the batch
+        fully occupies its floor.
         """
+        # The gate only binds for values in (0, 1): with 0 (permitted by the
+        # llmapi field) only the first resume of an empty pool passes and
+        # every later one is rejected, so no finite floor helps; values >= 1
+        # never trigger since utilization cannot exceed 1. Scale floors only
+        # in the binding range so 0 doesn't divide by zero and >1 doesn't
+        # shrink floors.
+        if not 0 < max_util_for_resume < 1:
+            max_util_for_resume = 1.0
         max_slots = filled_list(0, self.num_pool_groups)
 
         def swa_floor_blocks(lc: AttnLifeCycle) -> int:
@@ -931,7 +952,8 @@ class StorageManager:
         for batch in constraints:
             slots = self._compute_slots_for_batch(batch, tokens_per_block, swa_scratch_reuse)
             for pg_idx in typed_range(self.num_pool_groups):
-                max_slots[pg_idx] = max(max_slots[pg_idx], slots[pg_idx])
+                scaled = math.ceil(slots[pg_idx] / max_util_for_resume)
+                max_slots[pg_idx] = max(max_slots[pg_idx], scaled)
         return max_slots
 
     def _compute_slots_for_batch(

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -189,6 +189,7 @@ def _build_deepseek_v4_cache_config_for_test(
     max_seq_len: int = 1024,
     max_num_tokens: int | None = 2048,
     max_draft_len: int = 0,
+    max_cuda_graph_batch_size: int | None = None,
 ):
     cache_manager = object.__new__(DeepseekV4CacheManager)
     cache_manager.pp_layers = [0, 1, 2]
@@ -196,6 +197,7 @@ def _build_deepseek_v4_cache_config_for_test(
     cache_manager._swa_window_size = 128
     cache_manager._max_draft_len = max_draft_len
     cache_manager._max_num_tokens = max_num_tokens
+    cache_manager._max_cuda_graph_batch_size = max_cuda_graph_batch_size
     cache_manager.compressed_block_sizes = [128, 32, 1]
     cache_manager.index_head_dim = 128
     cache_manager.head_dim = 512
@@ -216,13 +218,95 @@ def _build_deepseek_v4_cache_config_for_test(
     )
 
 
-def test_deepseek_v4_pool_ratio_overrides_typical_step_and_constraints():
+def test_deepseek_v4_pool_ratio_overrides_typical_step_but_keeps_constraints():
+    """pool_ratio replaces the typical_step-derived ratio, but the warmup
+    constraints must still be built: they are feasibility floors, and dropping
+    them lets a tight quota (the KV-estimation temporary pool) starve a pool
+    group so CUDA-graph warmup silently skips batch sizes (DSV4-Pro OOM)."""
     config = _build_deepseek_v4_cache_config_for_test(
         KvCacheConfig(pool_ratio=[0.2, 0.3, 0.5], avg_seq_len=256)
     )
 
     assert config.initial_pool_ratio == [0.2, 0.3, 0.5]
     assert config.typical_step is None
+    assert len(config.constraints) == 2
+    assert config.constraints[0].kv_caches[0].capacity == 1024
+    assert config.constraints[0].kv_caches[0].history_length == 1023
+
+
+def test_deepseek_v4_constraints_cover_cuda_graph_warmup_batch():
+    """Constraint 1 must describe the whole CUDA-graph warmup batch: one
+    decode request at max_seq_len plus minimal decode requests matching
+    _create_cuda_graph_warmup_request's dummy batch. When the real graph
+    batch size is unknown, it falls back to max_batch_size."""
+    max_batch_size = 4
+    max_draft_len = 2
+    config = _build_deepseek_v4_cache_config_for_test(
+        KvCacheConfig(),
+        max_batch_size=max_batch_size,
+        max_seq_len=1024,
+        max_num_tokens=2048,
+        max_draft_len=max_draft_len,
+    )
+
+    warmup = config.constraints[0].kv_caches
+    assert len(warmup) == max_batch_size
+    assert warmup[0].capacity == 1024
+    assert warmup[0].history_length == 1023
+    # num_extra_kv_tokens is 0 in this fixture.
+    assert all(kv.capacity == 1 + max_draft_len for kv in warmup[1:])
+    assert all(kv.history_length == 0 for kv in warmup[1:])
+
+
+def test_deepseek_v4_warmup_floor_shrinks_to_actual_graph_batch():
+    """With max(cuda_graph_batch_sizes) far below max_batch_size, the warmup
+    floor must size to the real graph batch — an unconditional
+    max_batch_size floor would force pool allocations (and quota bumps) for
+    a warmup that never runs."""
+    config = _build_deepseek_v4_cache_config_for_test(
+        KvCacheConfig(),
+        max_batch_size=128,
+        max_seq_len=1024,
+        max_num_tokens=2048,
+        max_cuda_graph_batch_size=4,
+    )
+
+    warmup = config.constraints[0].kv_caches
+    assert len(warmup) == 4
+    assert warmup[0].capacity == 1024
+
+
+def test_deepseek_v4_no_warmup_floor_when_graphs_disabled():
+    """CUDA graphs disabled (max_cuda_graph_batch_size=0): the generation
+    graph warmup never runs, and no other warmup creates a max_seq_len-long
+    request, so the constraint must be dropped entirely — keeping even the
+    single full-length request would floor (and possibly bump) the quota for
+    a warmup that will not happen. Only the chunked-prefill constraint
+    remains."""
+    max_num_tokens = 2048
+    config = _build_deepseek_v4_cache_config_for_test(
+        KvCacheConfig(),
+        max_batch_size=128,
+        max_seq_len=1024,
+        max_num_tokens=max_num_tokens,
+        max_cuda_graph_batch_size=0,
+    )
+
+    assert len(config.constraints) == 1
+    prefill = config.constraints[0].kv_caches
+    assert len(prefill) == 1
+    # num_extra_kv_tokens is 0 in this fixture.
+    assert prefill[0].capacity == max_num_tokens
+    assert prefill[0].history_length == 0
+
+    # Without a chunked-prefill budget either, no constraints remain at all.
+    config = _build_deepseek_v4_cache_config_for_test(
+        KvCacheConfig(),
+        max_batch_size=128,
+        max_seq_len=1024,
+        max_num_tokens=None,
+        max_cuda_graph_batch_size=0,
+    )
     assert config.constraints == []
 
 

--- a/tests/unittest/_torch/executor/test_kv_cache_estimation.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_estimation.py
@@ -477,3 +477,69 @@ def test_kv_manager_int_max_seq_len_stays_int_through_util_expression():
         "Sanity check: the pre-fix float path must still be demonstrable "
         "in the test, otherwise this regression guard is hollow."
     )
+
+
+# ---------------------------------------------------------------------------
+# _create_kv_cache_manager: MLA branch must forward max_num_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_mla_branch_forwards_max_num_tokens_to_manager() -> None:
+    """The is_mla branch of ``_create_kv_cache_manager`` must pass
+    ``max_num_tokens`` to the manager, like the generic branch does.
+
+    Regression guard: when the argument is dropped,
+    ``DeepseekV4CacheManager._max_num_tokens`` stays ``None`` and the
+    profiling-phase context extra quota is sized by the full ``max_tokens``
+    estimate instead of the runtime chunk size (observed as a 27.59 GiB vs
+    11.92 GiB temp-quota inflation on DeepSeek-V4-Pro, raising peak memory
+    and OOM risk during KV cache estimation).
+    """
+    import torch
+
+    from tensorrt_llm._torch.pyexecutor._util import _create_kv_cache_manager
+
+    captured_kwargs = {}
+
+    class _RecordingManager:
+        def __init__(self, *args, **kwargs) -> None:
+            captured_kwargs.update(kwargs)
+
+    # Minimal MLA pretrained config: is_mla() keys on kv_lora_rank and
+    # qk_rope_head_dim being set.
+    pretrained = SimpleNamespace(
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        hidden_size=1024,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+        num_hidden_layers=2,
+        vocab_size=32000,
+    )
+    model_config = Mock()
+    model_config.pretrained_config = pretrained
+    model_config.quant_config = None
+
+    _create_kv_cache_manager(
+        model_engine=None,
+        kv_cache_manager_cls=_RecordingManager,
+        mapping=Mock(),
+        kv_cache_config=KvCacheConfig(),
+        tokens_per_block=32,
+        max_seq_len=2048,
+        max_batch_size=8,
+        spec_config=None,
+        sparse_attention_config=None,
+        max_num_tokens=333,
+        max_beam_width=1,
+        kv_connector_manager=None,
+        model_config=model_config,
+        dtype=torch.bfloat16,
+        is_draft=False,
+    )
+
+    assert captured_kwargs.get("max_num_tokens") == 333, (
+        "is_mla branch dropped max_num_tokens: DeepseekV4CacheManager then "
+        "falls back to _max_num_tokens=None and over-sizes the estimation "
+        "temp quota."
+    )

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -17,6 +17,7 @@ import functools
 import gc
 import hashlib
 import itertools
+import math
 import os
 import random
 import time
@@ -2040,10 +2041,14 @@ class TestInitRatioConfig(unittest.TestCase):
         mgr_unconstrained.shutdown()
         mgr_constrained.shutdown()
 
-    def test_initial_pool_ratio_overrides_typical_step_and_constraints(self):
-        """Explicit initial_pool_ratio takes precedence over inferred sizing inputs."""
+    def test_initial_pool_ratio_overrides_typical_step(self):
+        """Explicit initial_pool_ratio takes precedence over typical_step.
+
+        A constraint whose floors are far below the ratio shares does not
+        disturb the requested split.
+        """
         typical = BatchDesc(kv_caches=[KVCacheDesc(capacity=4096, history_length=4000)] * 32)
-        constraint = BatchDesc(kv_caches=[KVCacheDesc(capacity=256, history_length=128)] * 256)
+        constraint = BatchDesc(kv_caches=[KVCacheDesc(capacity=64, history_length=32)])
         cfg = self._make_config(
             typical_step=typical,
             constraints=[constraint],
@@ -2054,6 +2059,115 @@ class TestInitRatioConfig(unittest.TestCase):
 
         self.assertGreater(ratio[0], ratio[1])
         self.assertAlmostEqual(sum(ratio), 1.0, places=6)
+        manager.shutdown()
+
+    def test_initial_pool_ratio_respects_constraint_floors(self):
+        """Constraints stay feasibility floors under explicit initial_pool_ratio.
+
+        A ratio share below what a declared batch needs in some pool group is
+        clamped up to the constraint minimum.
+
+        Regression guard for the DSV4-Pro KV-estimation warmup starvation:
+        pool_ratio used to disable constraint floors entirely, so a tight
+        estimation quota starved the ageless pool group and CUDA-graph warmup
+        silently skipped batch sizes.
+
+        The floors must additionally be scaled by 1/max_util_for_resume:
+        _KVCache.resume rejects any pool group above that utilization, so a
+        batch that exactly fills an unscaled floor fails its last resume
+        (observed as a 32-request warmup batch failing at request 32 with a
+        32-slot pool group at 31/32 = 97% utilization).
+        """
+        granularity = 2 << 20
+        num_requests = 8
+        capacity = 512
+        tpb = self.TOKENS_PER_BLOCK
+        total_blocks = div_up(capacity, tpb)
+        # history_length=0: no stale blocks in either pool group.
+        slots_pg0 = num_requests * total_blocks
+        slots_pg1 = num_requests * total_blocks
+        constraint = BatchDesc(
+            kv_caches=[KVCacheDesc(capacity=capacity, history_length=0)] * num_requests
+        )
+
+        # Quota exactly covers the unscaled floors; the skewed ratio alone
+        # would give PG1 a small fraction of its floor, and the utilization
+        # scaling must push both pool groups above the raw batch need.
+        pg0_bytes = round_up(slots_pg0 * self.PG0_SLOT_SIZE, granularity)
+        pg1_bytes = round_up(slots_pg1 * self.PG1_SLOT_SIZE, granularity)
+        cfg = self._make_config(
+            gpu_quota=pg0_bytes + pg1_bytes,
+            constraints=[constraint],
+            initial_pool_ratio=[0.9, 0.1],
+        )
+        floor_pg0 = math.ceil(slots_pg0 / cfg.max_util_for_resume)
+        floor_pg1 = math.ceil(slots_pg1 / cfg.max_util_for_resume)
+        assert floor_pg1 > slots_pg1, "utilization scaling must be observable"
+        manager = KVCacheManager(cfg)
+        stats = manager._storage.get_statistics()
+        self.assertGreaterEqual(
+            stats[0].total,
+            floor_pg0,
+            f"Pool group 0 must have >= {floor_pg0} slots so the constraint "
+            f"batch passes resume's utilization gate",
+        )
+        self.assertGreaterEqual(
+            stats[1].total,
+            floor_pg1,
+            f"Pool group 1 must have >= {floor_pg1} slots so the constraint "
+            f"batch passes resume's utilization gate",
+        )
+        manager.shutdown()
+
+    def test_small_constraint_floors_do_not_inflate_quota(self):
+        """Floors below the ratio shares must leave the tier quota untouched.
+
+        Guards the graphs-disabled path: when the generation-graph warmup
+        constraint is dropped, the remaining small constraints must not bump
+        the requested quota or disturb the explicit ratio split.
+        """
+        gpu_quota = 128 << 20
+        tiny = BatchDesc(kv_caches=[KVCacheDesc(capacity=64, history_length=0)])
+        cfg = self._make_config(
+            gpu_quota=gpu_quota,
+            constraints=[tiny],
+            initial_pool_ratio=[0.5, 0.5],
+        )
+        manager = KVCacheManager(cfg)
+        stats = manager._storage.get_statistics()
+        total_bytes = stats[0].total * self.PG0_SLOT_SIZE + stats[1].total * self.PG1_SLOT_SIZE
+        self.assertLessEqual(
+            total_bytes,
+            gpu_quota,
+            "non-binding constraint floors must not inflate the allocation "
+            "beyond the requested quota",
+        )
+        manager.shutdown()
+
+    def test_constraint_floors_tolerate_degenerate_max_util_for_resume(self):
+        """max_util_for_resume=0 is permitted by the llmapi field (ge=0).
+
+        The gate then rejects every resume of a non-empty pool (only the
+        first resume, at utilization 0, passes), so no finite floor helps and
+        no scaling applies — construction must not divide by zero, and the
+        floors must fall back to the unscaled constraint counts.
+        """
+        num_requests = 8
+        capacity = 512
+        total_blocks = div_up(capacity, self.TOKENS_PER_BLOCK)
+        raw_slots = num_requests * total_blocks
+        constraint = BatchDesc(
+            kv_caches=[KVCacheDesc(capacity=capacity, history_length=0)] * num_requests
+        )
+        cfg = self._make_config(
+            constraints=[constraint],
+            initial_pool_ratio=[0.9, 0.1],
+        )
+        cfg.max_util_for_resume = 0.0
+        manager = KVCacheManager(cfg)
+        stats = manager._storage.get_statistics()
+        self.assertGreaterEqual(stats[0].total, raw_slots)
+        self.assertGreaterEqual(stats[1].total, raw_slots)
         manager.shutdown()
 
     def test_initial_pool_ratio_length_must_match_pool_groups(self):


### PR DESCRIPTION
## Description

`_create_kv_cache_manager`'s `is_mla` branch omits `max_num_tokens` from the manager constructor call, while the generic (non-MLA) branch passes it. As a result `DeepseekV4CacheManager` falls back to `_max_num_tokens=None` and `_build_cache_config` sizes the context extra quota by the full `max_tokens` estimate instead of the runtime chunk size, inflating the KV-estimation temporary quota (23.69 GiB instead of 8.14 GiB per rank on DeepSeek-V4-Pro, ISL≈990K, MTP3, dep4/ADP) — and with it the profiling peak and its OOM risk.

Forwarding `max_num_tokens` (one line in `_util.py`) fixes that, **but on its own it trades the profiling-peak risk for a deterministic post-estimation OOM**: every DSV4-Pro agentx disagg GEN config failed with it applied. The tight quota exposed two latent sizing bugs:

1. **`pool_ratio` disabled the sizing constraints entirely** (two independent sites: `_build_cache_config` only built constraints when `pool_ratio is None`, and `StorageManager` dropped constraints from `min_slots` when `initial_pool_ratio` was provided). The estimation quota was then split purely by ratio: the ageless COMPRESS pool group got 3,084 blocks < the 3,872 blocks one full-length request needs, the estimation manager clamped `max_seq_len` 991048→789502, and CUDA-graph warmup **silently skipped every batch size ≥ 2**. The profiling peak missed ~5 GiB of capture working set, the KV estimate rose from the calibrated 36.09 GiB to 40.70 GiB, and the final executor OOM'd during the advanced-sampling bs=32 graph capture with only 5.75 GiB free after KV-pool creation.
2. **`_KVCache.resume`'s utilization gate** rejects any pool group above `max_util_for_resume`, so a warmup batch that exactly fills its floor fails its last resume (observed: a 32-request warmup batch failing at request 32 with a 32-slot pool group at 31/32 = 97% utilization).

## Fix

Treat constraints as feasibility floors everywhere:

- `DeepseekV4CacheManager._build_cache_config` always builds its constraints (`pool_ratio` only replaces the `typical_step`-derived ratio), and Constraint 1 now describes the **CUDA-graph warmup batch the engine will actually run**: one `max_seq_len` decode plus minimal decodes up to the engine's largest configured graph batch (`model_engine._max_cuda_graph_batch_size`, plumbed through `_create_kv_cache_manager`). With `max(cuda_graph_batch_sizes) ≪ max_batch_size` the floor sizes to the real graph batch, and with CUDA graphs disabled (`0`) the constraint is **dropped entirely** — no other warmup creates a `max_seq_len`-long request, so even the single long request would floor (and, on tight quotas, bump) the allocation for a warmup that will not happen. The floor never forces pool allocation for a warmup that won't run.
- `StorageManager` derives `min_slots` from constraints even when `initial_pool_ratio` is provided, and scales the floors by `1/max_util_for_resume` so the last request of a constraint batch still passes resume's utilization gate. The scaling only applies in the binding range `(0, 1)`: the llmapi field permits `max_util_for_resume=0`, where only the first resume of an empty pool (utilization 0) passes and every later one is rejected — no finite floor helps and construction must not divide by zero; values `>= 1` never trigger the gate (utilization cannot exceed 1). Neither degenerate value scales the floors.
- `model_engine` warns instead of silently skipping CUDA-graph warmup batch sizes and general warmup shapes, since a skip during estimation makes the profiling peak unrepresentative.

### Behavior change note (V2 cache manager owners)

`initial_pool_ratio` no longer overrides constraints completely: the explicit ratio still decides how quota **beyond the floors** is split, but pool groups are clamped up to the (utilization-scaled) constraint minimums. A ratio split that cannot hold the declared warmup batches produced a manager that could not run them — that behavior was the bug. The existing test `test_initial_pool_ratio_overrides_typical_step_and_constraints` encoded the old semantics and is split into `test_initial_pool_ratio_overrides_typical_step` + `test_initial_pool_ratio_respects_constraint_floors` accordingly. When a tier quota is below the floor bytes, construction rounds the quota up (pre-existing `_compute_slot_count_for_level` behavior); the estimation accounting stays correct because it adds back the actually-allocated pool bytes.

## Verification

A/B on the previously always-failing config (DeepSeek-V4-Pro agentx disagg gen-only, GB300, dep4/ADP, MTP3, c32, `max_batch_size=32`, `max_num_tokens=128`, `pool_ratio=[0.3,0.4,0.3]`), GEN rank 0:

| | main (no fix) | `max_num_tokens` only | this PR |
|---|---|---|---|
| estimation temp quota | 23.69 GiB | 8.14 GiB | 8.14 GiB (8.22 allocated with floors) |
| estimation-phase graph-warmup coverage | bs=32→1, greedy+advanced | **bs=1 only** | bs=32→1, greedy+advanced |
| profiling peak | 260.21 GiB | 239.54 GiB (unrepresentative) | 244.74 GiB |
| estimated max KV memory | 36.09 GiB | **40.70 GiB** | **36.09 GiB** |
| result | done | **OOM in bs=32 advanced-sampling capture** | done (benchmark runs to completion) |

The same arithmetic was verified for the tep8 shape (`max_batch_size=128`, mtp0): estimation warmup previously capped at bs=64, now fits bs=128 at the reduced 19.46 GiB quota.

A second end-to-end run with the final code reproduced the result (estimate 35.94 GiB, run-to-run peak jitter ~0.2 GiB) and exercised the graphs-disabled path on the CTX worker (`cuda_graph_config: null`): its generation-graph constraint is dropped, and the (pre-existing) capacity-limited skip of the CTX 128-request general-warmup shape is now visible via the new warning instead of silent.

Unit red/green inside the container:
- `test_initial_pool_ratio_respects_constraint_floors` fails on the old storage manager (pool group pinned at 20 slots vs the required scaled floor of 132) and passes with the fix; the full `kv_cache_manager_v2` suite (75 tests) passes unchanged.
- `test_deepseek_v4_pool_ratio_overrides_typical_step_but_keeps_constraints` and `test_deepseek_v4_constraints_cover_cuda_graph_warmup_batch` fail on stock code and pass with the fix.

Note on non-DSV4 MLA models (e.g. DeepSeek-V3/R1 with the V1 manager): they now receive the real `max_num_tokens` instead of the constructor default `8192`, which only affects the C++ manager's `chunk_size = min(max_num_tokens, max_seq_len)` — the same value every non-MLA model already gets.

Related: #16236 (sibling stale-`_indexer_compress_ratio` fix from the same DSV4 port; independent of this change).

## Test Coverage

- `tests/unittest/_torch/executor/test_kv_cache_estimation.py::test_mla_branch_forwards_max_num_tokens_to_manager`
- `tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py::test_deepseek_v4_pool_ratio_overrides_typical_step_but_keeps_constraints`
- `tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py::test_deepseek_v4_constraints_cover_cuda_graph_warmup_batch`
- `tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py::test_deepseek_v4_warmup_floor_shrinks_to_actual_graph_batch`
- `tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py::test_deepseek_v4_no_warmup_floor_when_graphs_disabled`
- `tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py::TestInitRatioConfig::test_small_constraint_floors_do_not_inflate_quota`
- `tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py::TestInitRatioConfig::test_initial_pool_ratio_respects_constraint_floors` (red/green against the old storage manager)
- `tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py::TestInitRatioConfig::test_initial_pool_ratio_overrides_typical_step`
- `tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py::TestInitRatioConfig::test_constraint_floors_tolerate_degenerate_max_util_for_resume`

## PR Checklist

- [x] PR title follows the `[None][fix]` format
- [x] Commit is signed off (DCO)
- [x] Pre-commit hooks pass on the changed files
- [x] Regression tests added and red/green verified
- [x] End-to-end verified on the previously failing GB300 benchmark config
