### PR TITLE
[DeepSeek-V4][fix] Detect MTP routed-expert layout separately

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -676,14 +676,46 @@ class ModelConfig(Generic[TConfig]):
         else:
             layer_quant_config = dict(layer_quant_config)
 
-        num_moe_layers = pretrained_config.num_hidden_layers
-        if (spec_config is not None
-                and spec_config.spec_dec_mode.is_mtp_one_model()):
-            num_moe_layers += spec_config.num_nextn_predict_layers
-
-        for layer_idx in range(num_moe_layers):
+        num_hidden = pretrained_config.num_hidden_layers
+        for layer_idx in range(num_hidden):
             layer_quant_config[
                 f"model.layers.{layer_idx}.mlp.experts"] = experts_quant_config
+
+        # The MTP layers' routed experts can carry a DIFFERENT layout than the
+        # dense layers: the ModelOpt experts-only repack (e.g.
+        # nvidia/DeepSeek-V4-Pro-NVFP4) re-quantizes only the dense experts to
+        # NVFP4 (U8) and leaves the MTP routed experts at the base model's MXFP4
+        # (I8). Detect the MTP expert layout separately so the MTP layers do not
+        # inherit the dense NVFP4 config and crash in fused_moe load_quant_scales.
+        num_mtp = 0
+        if (spec_config is not None
+                and spec_config.spec_dec_mode.is_mtp_one_model()):
+            num_mtp = spec_config.num_nextn_predict_layers or 0
+        if num_mtp:
+            mtp_info = ModelConfig._get_safetensors_header_for_tensor(
+                checkpoint_dir, "mtp.0.ffn.experts.0.w1.weight")
+            mtp_dtype = mtp_info.get("dtype") if mtp_info else None
+            mtp_layout = {"I8": "mxfp4", "U8": "nvfp4"}.get(mtp_dtype)
+            if mtp_layout is not None and mtp_layout != layout:
+                mtp_experts_quant_config = QuantConfig()
+                if mtp_layout == "mxfp4":
+                    mtp_experts_quant_config.quant_algo = (
+                        ModelConfig.get_mxfp4_quant_algo(moe_backend))
+                    mtp_experts_quant_config.group_size = 32
+                else:
+                    mtp_experts_quant_config.quant_algo = QuantAlgo.NVFP4
+                    mtp_experts_quant_config.group_size = 16
+                mtp_experts_quant_config.exclude_modules = (
+                    experts_quant_config.exclude_modules)
+                logger.info(
+                    "DeepSeek-V4 MTP routed experts use a different layout (%s) "
+                    "than the dense experts (%s).", mtp_layout, layout)
+            else:
+                mtp_experts_quant_config = experts_quant_config
+            for i in range(num_mtp):
+                layer_quant_config[
+                    f"model.layers.{num_hidden + i}.mlp.experts"] = (
+                        mtp_experts_quant_config)
 
         logger.info(
             "Detected DeepSeek-V4 routed MoE %s checkpoint layout; using "

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -716,18 +716,18 @@ class ModelConfig(Generic[TConfig]):
                 # fused_moe load_quant_scales.
                 logger.warning(
                     "DeepSeek-V4 MTP routed-expert layout could not be detected "
-                    "from %s; assuming the dense layout (%s). If this checkpoint "
+                    f"from {_DEEPSEEK_V4_MTP_ROUTED_EXPERT_WEIGHT}; assuming the "
+                    f"dense layout ({layout}). If this checkpoint "
                     "stores its MTP routed experts in a different format, "
-                    "loading will fail in fused_moe load_quant_scales.",
-                    _DEEPSEEK_V4_MTP_ROUTED_EXPERT_WEIGHT, layout)
+                    "loading will fail in fused_moe load_quant_scales.")
                 mtp_experts_quant_config = experts_quant_config
             elif mtp_layout != layout:
                 mtp_experts_quant_config = (
                     ModelConfig._make_routed_experts_quant_config(
                         mtp_layout, moe_backend))
                 logger.info(
-                    "DeepSeek-V4 MTP routed experts use a different layout (%s) "
-                    "than the dense experts (%s).", mtp_layout, layout)
+                    f"DeepSeek-V4 MTP routed experts use a different layout "
+                    f"({mtp_layout}) than the dense experts ({layout}).")
             else:
                 mtp_experts_quant_config = experts_quant_config
             for i in range(num_mtp):

--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
@@ -640,7 +640,7 @@ def test_deepseek_v4_mtp_routed_experts_warn_when_probe_missing(tmp_path, monkey
     warnings = []
     monkeypatch.setattr(
         "tensorrt_llm._torch.model_config.logger.warning",
-        lambda msg, *args: warnings.append(msg % args if args else msg),
+        warnings.append,
     )
 
     num_hidden_layers = 2


### PR DESCRIPTION
## Description

#16433 merged the base mixed-precision construction and loading fix for `nvidia/DeepSeek-V4-Pro-NVFP4`, superseding the earlier construction commits in this PR. This PR now contains only the remaining MTP-specific fix, authored by @d3nb.

The checkpoint stores dense routed experts as NVFP4 (`U8`) but leaves MTP routed experts at the base model's MXFP4 layout (`I8`). `_set_deepseek_v4_routed_moe_quant_config()` previously detected one layout from `layers.0` and assigned it to every MoE layer, so MTP speculative decoding received NVFP4 configuration and crashed in `fused_moe` scale loading.

The loader now probes the MTP expert header separately and assigns MXFP4 or NVFP4 configuration to the MTP layer range only when its layout differs from the dense experts. Matching or absent MTP headers retain the existing dense configuration.

Related: #16196, #16433.

## Test Coverage

- @d3nb validated the equivalent change on the actual 851 GB `nvidia/DeepSeek-V4-Pro-NVFP4` checkpoint using 4x B300, TP4, and the TRT-LLM MoE backend.
- Weights loaded completely, the server generated successfully with MTP=1 and MTP=3, and observed MTP acceptance length was approximately 2.86.
- The original commit and authorship are preserved after rebasing onto current `main`.

## PR Checklist

- [x] Scope reflects the remaining non-superseded fix
- [x] Commit is signed off
- [x] Validated on real weights and hardware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- The loader detects dense and MTP routed-expert layouts independently.
- MTP layers use their detected MXFP4 or NVFP4 configuration when it differs from the dense layout.
- Missing MTP metadata triggers a warning and uses the dense configuration.
- QuantConfig construction and layout detection are centralized.
- No public API, configuration-file, or test-list changes were identified.
- Full unit-test execution remains unverified because the local TensorRT-LLM installation is incompatible with current `main`.

## QA Engineer Review

- Added tests for dense NVFP4 with MTP MXFP4.
- Added tests for dense MXFP4 with MTP NVFP4.
- Added tests for missing MTP metadata, warning verification, and dense-layout fallback.
- No matching `test-db/` or `qa/` coverage entry was identified for these tests.
- Verdict: **insufficient**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->