### PR TITLE
[None][fix] Restore overlap headroom in seq slot pool sizing

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -2085,7 +2085,13 @@ def create_py_executor_instance(
 
     spec_config = model_engine.spec_config
 
-    max_num_sequences = max_batch_size * mapping.pp_size
+    # Slot pool needs headroom for two iterations under overlap (prev-iter
+    # finished requests still hold slots when next-iter prepare_resources runs).
+    if mapping.has_pp():
+        num_micro_batches = mapping.pp_size
+    else:
+        num_micro_batches = 1 if llm_args.disable_overlap_scheduler else 2
+    max_num_sequences = max_batch_size * num_micro_batches
 
     logger.info(
         f"max_seq_len={max_seq_len}, max_num_requests={max_num_sequences}, max_num_tokens={max_num_tokens}, max_batch_size={max_batch_size}"
@@ -2282,7 +2288,8 @@ def create_py_executor_instance(
 
     # When scheduler_capacity == 1, attention dp dummy request will prevent the scheduling of DISAGG_GENERATION_INIT.
     # Enlarge scheduler capacity to avoid DISAGG_GENERATION_INIT stuck in the scheduler.
-    scheduler_capacity = max_num_sequences
+    # V1 scheduler handles overlap via two_step_lookahead, so skip the slot-pool overlap factor here.
+    scheduler_capacity = max_batch_size * mapping.pp_size
     if scheduler_capacity == 1 and mapping.enable_attention_dp and kv_cache_manager:
         scheduler_capacity += 1
 
@@ -2440,7 +2447,12 @@ def create_torch_sampler_args(
     enable_async_worker: bool,
     enable_speculative_beam_history_d2h: bool,
 ):
-    max_num_sequences = max_batch_size * mapping.pp_size
+    # Must match create_py_executor_instance's slot-pool sizing.
+    if mapping.has_pp():
+        num_micro_batches = mapping.pp_size
+    else:
+        num_micro_batches = 1 if disable_overlap_scheduler else 2
+    max_num_sequences = max_batch_size * num_micro_batches
     max_draft_len = (0 if speculative_config is None else
                      speculative_config.max_draft_len)
     max_total_draft_tokens = (0 if speculative_config is None else

--- a/tests/unittest/_torch/executor/test_resource_manager.py
+++ b/tests/unittest/_torch/executor/test_resource_manager.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import pathlib
 import subprocess
@@ -64,6 +78,31 @@ def test_v1_kv_cache_event_hash_algo_no_warning_for_auto():
             KV_CACHE_HASH_ALGO_AUTO)
 
     warning.assert_not_called()
+
+
+def test_torch_sampler_args_overlap_doubles_slot_pool():
+    """Ensure overlap scheduling reserves slots for adjacent iterations."""
+    from tensorrt_llm._torch.pyexecutor._util import create_torch_sampler_args
+
+    mapping = Mapping(world_size=1, tp_size=1, pp_size=1)
+    common_args = dict(
+        mapping=mapping,
+        max_seq_len=64,
+        max_batch_size=2,
+        speculative_config=None,
+        max_beam_width=1,
+        disable_flashinfer_sampling=False,
+        enable_async_worker=False,
+        enable_speculative_beam_history_d2h=False,
+    )
+
+    overlap_args = create_torch_sampler_args(**common_args,
+                                             disable_overlap_scheduler=False)
+    assert overlap_args.max_num_sequences == 4
+
+    non_overlap_args = create_torch_sampler_args(**common_args,
+                                                 disable_overlap_scheduler=True)
+    assert non_overlap_args.max_num_sequences == 2
 
 
 class TestResourceManager(unittest.TestCase):


### PR DESCRIPTION
## What changed

- Restore two-iteration sequence-slot headroom when overlap scheduling is enabled with PP=1.
- Keep V1 scheduler admission capacity at the per-forward limit instead of inheriting the enlarged slot-pool capacity.
- Size TorchSampler sequence storage consistently with the executor slot pool.
- Add a regression test covering `max_batch_size=2` with overlap enabled and disabled.

## Root cause

The overlap executor prepares the next iteration before finished requests from the previous iteration release their sequence slots. With PP=1, main sized the slot pool to only `max_batch_size`, so a full previous batch could exhaust all slots while the next batch was being prepared and raise `ValueError: No free slots`.

## Impact

PP=1 overlap configurations now reserve `2 * max_batch_size` sequence slots. Non-overlap and PP configurations retain their existing capacity behavior.

## Validation

- `git diff --check`
- Full pre-commit run on the two changed files
- Python 3.12 `py_compile` on the two changed files
- Added `test_torch_sampler_args_overlap_doubles_slot_pool`

The targeted pytest could not start locally because the host Python is 3.9 and cannot install the repository-required `transformers==5.5.4`; CI will execute it in the supported Python environment.
