### PR TITLE
[https://nvbugs/6443620][fix] Reserve overlap-scheduler slack in gen KV capacity for one-model spec decode

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1811,9 +1811,18 @@ class KVCacheManagerV2(BaseResourceManager):
     def _required_gen_capacity(self, req: LlmRequest, current_capacity: int) -> int:
         """Compute generation KV cache capacity for a request.
 
-        Grows *current_capacity* by 1 + draft tokens.
+        Grows *current_capacity* by 1 + draft tokens, plus another draft_len
+        of slack for one-model speculative decoding: under the overlap
+        scheduler the device-side KV position runs one verification round
+        ahead of host bookkeeping (up to draft_len accepted-but-uncommitted
+        tokens), and the MTP draft layers then append draft KV beyond that
+        position. Without the slack, the draft KV append can address a block
+        ordinal the host has not allocated yet whenever the overrun crosses a
+        tokens_per_block boundary — an illegal memory access in the MLA rope
+        generation kernel (observed with DSV4 DEP+MTP3 at 128k, where the
+        first window-slide boundary crossing after prefill faults).
         """
-        return current_capacity + 1 + self._effective_draft_len(req)
+        return current_capacity + 1 + 2 * self._effective_draft_len(req)
 
     def try_allocate_generation(self, req: LlmRequest) -> bool:
         """Try to allocate one additional KV cache slot for a generation request.
@@ -1853,7 +1862,8 @@ class KVCacheManagerV2(BaseResourceManager):
         draft_len = self._allocated_draft_lens.pop(
             req.py_request_id, self._effective_draft_len(req)
         )
-        reverted_cap = kv_cache.capacity - 1 - draft_len
+        # Mirror the 1 + 2 * draft_len growth in _required_gen_capacity.
+        reverted_cap = kv_cache.capacity - 1 - 2 * draft_len
         if reverted_cap < 0:
             return
         if not kv_cache.resize(reverted_cap):
@@ -2059,7 +2069,9 @@ class KVCacheManagerV2(BaseResourceManager):
         if allocated is None:
             return
         current_draft_len = get_draft_token_length(request)
-        delta = current_draft_len - allocated
+        # Growth is 1 + 2 * draft_len (see _required_gen_capacity), so the
+        # padding delta scales by 2 as well.
+        delta = 2 * (current_draft_len - allocated)
         if delta <= 0:
             return
         kv_cache = self.kv_cache_map[request.py_request_id]

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -942,6 +942,16 @@ class KVCacheManagerV2(BaseResourceManager):
         # unbounded capacity growth.
         self._allocated_draft_lens: dict[int, int] = {}
 
+        # Overlap-scheduler slack (the extra draft_len in
+        # _required_gen_capacity's 1 + 2 * draft_len growth) granted to each
+        # request and not yet reclaimed.  The sampler's py_rewind_len only
+        # covers the rejected part of the recurring 1 + draft_len growth, so
+        # update_resources must additionally trim this slack — otherwise it
+        # compounds, leaking draft_len tokens of capacity per generation
+        # iteration until the request's block count overruns
+        # max_blocks_per_seq ("User-provided base page indices is too short").
+        self._pending_overlap_slack: dict[int, int] = {}
+
         # Defensive cap for get_num_available_tokens: when host cache is
         # enabled, clamp_max_seq_len_for_mem may return a value that spans
         # both GPU and host tiers.  Storing the explicit max_tokens (if set)
@@ -1821,6 +1831,11 @@ class KVCacheManagerV2(BaseResourceManager):
         tokens_per_block boundary — an illegal memory access in the MLA rope
         generation kernel (observed with DSV4 DEP+MTP3 at 128k, where the
         first window-slide boundary crossing after prefill faults).
+
+        The slack must stay a *constant* offset over the request's lifetime:
+        py_rewind_len only rewinds the rejected part of the recurring
+        1 + draft_len growth, so every call site records the extra draft_len
+        in _pending_overlap_slack and update_resources trims it back.
         """
         return current_capacity + 1 + 2 * self._effective_draft_len(req)
 
@@ -1841,7 +1856,13 @@ class KVCacheManagerV2(BaseResourceManager):
 
         draft_len = self._effective_draft_len(req)
         self._allocated_draft_lens[req.py_request_id] = draft_len
-        return kv_cache.resize(self._required_gen_capacity(req, kv_cache.capacity))
+        if not kv_cache.resize(self._required_gen_capacity(req, kv_cache.capacity)):
+            return False
+        if draft_len > 0:
+            self._pending_overlap_slack[req.py_request_id] = (
+                self._pending_overlap_slack.get(req.py_request_id, 0) + draft_len
+            )
+        return True
 
     def revert_allocate_generation(self, req: LlmRequest) -> None:
         """Undo the capacity growth from try_allocate_generation.
@@ -1866,6 +1887,15 @@ class KVCacheManagerV2(BaseResourceManager):
         reverted_cap = kv_cache.capacity - 1 - 2 * draft_len
         if reverted_cap < 0:
             return
+        # The reverted growth included draft_len of overlap slack; deduct it
+        # so update_resources does not trim slack that no longer exists.
+        if draft_len > 0:
+            req_id = req.py_request_id
+            remaining = self._pending_overlap_slack.get(req_id, 0) - draft_len
+            if remaining > 0:
+                self._pending_overlap_slack[req_id] = remaining
+            else:
+                self._pending_overlap_slack.pop(req_id, None)
         if not kv_cache.resize(reverted_cap):
             raise RuntimeError(
                 f"Failed to revert KV cache capacity for request "
@@ -2074,6 +2104,11 @@ class KVCacheManagerV2(BaseResourceManager):
         delta = 2 * (current_draft_len - allocated)
         if delta <= 0:
             return
+        # Half of the delta tops up the overlap slack; record it so
+        # update_resources reclaims the full slack for this iteration.
+        self._pending_overlap_slack[request.py_request_id] = self._pending_overlap_slack.get(
+            request.py_request_id, 0
+        ) + (current_draft_len - allocated)
         kv_cache = self.kv_cache_map[request.py_request_id]
         new_capacity = kv_cache.capacity + delta
         success = kv_cache.resize(new_capacity)
@@ -2170,6 +2205,11 @@ class KVCacheManagerV2(BaseResourceManager):
                     raise RuntimeError(
                         f"Draft KV cache generation resize failed for request "
                         f"{req.py_request_id}: could not resize to {new_cap} tokens"
+                    )
+                slack = self._effective_draft_len(req)
+                if slack > 0:
+                    self._pending_overlap_slack[req.py_request_id] = (
+                        self._pending_overlap_slack.get(req.py_request_id, 0) + slack
                     )
 
     def _augment_tokens_for_block_reuse(
@@ -2779,6 +2819,7 @@ class KVCacheManagerV2(BaseResourceManager):
 
     def free_resources(self, request: LlmRequest, pin_on_release: bool = False):
         self._allocated_draft_lens.pop(request.py_request_id, None)
+        self._pending_overlap_slack.pop(request.py_request_id, None)
         kv_cache = self.kv_cache_map.pop(request.py_request_id, None)
         if kv_cache is None:
             self.impl.clear_stats_excluded(request.py_request_id)
@@ -3068,10 +3109,18 @@ class KVCacheManagerV2(BaseResourceManager):
             # will be resumed by the scheduler on the next iteration.
             if not kv_cache.is_active:
                 continue
+            # Reclaim this iteration's overlap slack together with the
+            # rejected-draft rewind; without this the constant slack in
+            # _required_gen_capacity compounds by draft_len every iteration
+            # and eventually overruns max_blocks_per_seq.
+            overlap_slack = self._pending_overlap_slack.pop(req.py_request_id, 0)
             new_capacity = (
                 None
                 if req.state in (LlmRequestState.GENERATION_COMPLETE, LlmRequestState.CONTEXT_INIT)
-                else kv_cache.capacity - req.py_rewind_len
+                else max(
+                    kv_cache.capacity - req.py_rewind_len - overlap_slack,
+                    req.max_beam_num_tokens - 1,
+                )
             )
             success = kv_cache.resize(new_capacity, req.max_beam_num_tokens - 1)
             if not success:


### PR DESCRIPTION
## Background

With the overlap scheduler enabled and one-model speculative decoding (MTP), the KV-cache-manager V2 scheduler grows a generation request's KV capacity by `1 + draft_len` per scheduled step, computed from **host-side** bookkeeping. However, under overlap the **device-side** KV position runs one verification round ahead of the host (up to `draft_len` accepted-but-uncommitted tokens), and the MTP draft layers then append draft-token KV beyond that position. The device's write reach can therefore exceed the host-allocated capacity by up to `draft_len` tokens.

This overrun is harmless while it stays inside an already-allocated block, but whenever it crosses a `tokens_per_block` boundary, `applyMLARopeAndAssignQKVKernelGeneration` looks up a block ordinal whose block-offset entry is still the empty sentinel (`-1`). A `-1` offset computes an address below the pool base, producing:

```
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

(reported asynchronously at the next sampler-event sync; the GPU coredump shows a Warp MMU Fault on the FP8 KV-append `STG` in the MLA rope generation kernel).

**Observed** with DeepSeek-V4 attention-DP (DEP8) + MTP3 at 128k ISL on a disaggregated gen worker: with the prompt length near a block boundary, the first sliding-window boundary crossing after prefill faults ~20–30 decode iterations in, deterministically. Debug instrumentation caught the exact inconsistency: a step ran with device `kv_len = 131071` while manager capacity was `131070` (the grow to `131074` landed one scheduling round later), and the draft-KV append touched block ordinal 512 whose offsets entry was still `-1`.

Notably, TP-sharded attention (TEP) only escaped this because its measured MTP acceptance was near zero in the same setup, so the device position never outran the allocation — the bug is acceptance-rate-dependent, not attention-DP-specific.

## Summary

Grow generation KV capacity by `1 + 2 * draft_len` instead of `1 + draft_len` — one `draft_len` for the step's draft tokens, one as slack for the overlap scheduler's advance booking. `revert_allocate_generation` and `extend_capacity_for_tokens` are updated symmetrically.

## Impact

- Cost: at most `draft_len` extra reserved KV tokens per in-flight generation request (transiently one extra block near block boundaries; freed at request completion). Measured kv_cache_util impact in the repro: +0.2% over a 1024-token generation.
- No effect when speculative decoding is disabled (`draft_len == 0`) or for two-model spec decode (which reserves via dummy draft tokens in the scheduler).

## Validation

- Repro (DSV4 DEP8 + MTP3, bs1/rank, 128k ISL, disaggregated gen worker, overlap scheduler + CUDA graphs): faulted at decode iter 19–28 in five consecutive runs before the fix; with the fix, the same config runs the full benchmark to completion (775+ iters, zero IMA), verified both with and without a debug validator that checks every block-offset entry the MLA rope kernel will address.
- One-axis ablations confirmed the trigger is the overlap+MTP capacity under-reservation: MTP0 clean, CUDA-graphs-off still faults, lm-head-TP-in-ADP-off still faults, CTX-server count and benchmark client irrelevant.

## Follow-up (2nd commit): reclaim the slack each iteration

Long-decode validation under MTP3 (128k ISL / 1k OSL, disaggregated gen worker) exposed a defect in the first commit: the extra `draft_len` slack was granted on **every** scheduled iteration, but `update_resources` only rewinds the rejected drafts (`py_rewind_len = draft_len - num_accepted`), which balances just the recurring `1 + draft_len` part. Net capacity growth per iteration was `1 + accepted + draft_len` while the sequence only grows `1 + accepted` — the slack compounded, leaking `draft_len` tokens of KV capacity per generation iteration. After ~750 iterations (MTP3) the leak reached ~2.3k tokens (~9 blocks at `tokens_per_block=256`), overran the `max_blocks_per_seq`-sized `host_kv_cache_block_offsets` rows, and crashed the scheduler in `kv_cache.resize()`:

```
ValueError: User-provided base page indices is too short
```

right as requests approached the end of their 1024-token decode (reproduced 6/6 on DEP8/DEP16 × batch 1/2/4; MTP0 is unaffected since `draft_len == 0`).

The second commit keeps the slack a **constant** offset over the request lifetime: every grant site (`try_allocate_generation`, the draft-manager `prepare_resources` path, and the CUDA-graph padding top-up in `extend_capacity_for_tokens`) records the granted slack in `_pending_overlap_slack`, `revert_allocate_generation` deducts it, and `update_resources` reclaims it alongside the rewind. Capacity at forward prep still always includes the fresh `1 + 2 * draft_len` growth, so the IMA protection from the first commit is preserved, while steady-state net growth returns to `1 + accepted` per iteration.

**Validation of the follow-up**: the DSV4 DEP8 + MTP3 128k/1k gen-worker benchmark that previously crashed at iter ~757 in all six swept configs now runs to completion (1027+ iterations, all requests reaching the full 1024-token OSL, zero resize errors), on top of the original repro staying IMA-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
