### PR TITLE
[https://nvbugs/6412108][fix] AutoDeploy:Shard shared Qwen3.5 experts

### DIFF
--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -36,8 +36,6 @@ transforms:
   apply_sharding_hints:
     enabled: true
     allreduce_strategy: SYMM_MEM
-    # Shared expert is excluded from sharding for performance purpose
-    shard_layers: ["moe", "delta", "mha"]
     simple_shard_filter: "lm_head"
   multi_stream_moe:
     stage: compile

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -635,25 +635,31 @@ class Qwen3_5MoeMLP(nn.Module):
         self.act_fn = ACT2FN[config.hidden_act]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # Intentionally left untagged: with no ``layer_type`` it defaults to "unknown",
-        # which the ``shard_layers`` inclusion whitelist excludes -> kept replicated.
+        # Tagged ``layer_type="mlp"`` so the shared expert is TP-sharded like the
+        # routed experts (colwise gate/up + rowwise down). Its rowwise down_proj
+        # therefore emits a per-rank partial that is summed with the routed
+        # partial and lifted to full by the single merge-point all_reduce in
+        # ``Qwen3_5MoeSparseMoeBlock.forward``.
         gate = torch.ops.auto_deploy.torch_linear_simple(
             x,
             self.gate_proj.weight,
             self.gate_proj.bias,
             tp_mode="colwise",
+            layer_type="mlp",
         )
         up = torch.ops.auto_deploy.torch_linear_simple(
             x,
             self.up_proj.weight,
             self.up_proj.bias,
             tp_mode="colwise",
+            layer_type="mlp",
         )
         return torch.ops.auto_deploy.torch_linear_simple(
             self.act_fn(gate) * up,
             self.down_proj.weight,
             self.down_proj.bias,
             tp_mode="rowwise",
+            layer_type="mlp",
         )
 
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -25,7 +25,6 @@ accuracy/test_epd_disagg_multimodal.py::TestVideoMMEEPD::test_disaggregated_vide
 accuracy/test_llm_api.py::TestLlama3_1_8BInstruct::test_guided_decoding_4gpus[xgrammar] SKIP (https://nvbugs/5346443)
 accuracy/test_llm_api_autodeploy.py::TestMiniMaxM2::test_finegrained_fp8 SKIP (https://nvbugs/6396422)
 accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_mtp[nvfp4_ws8_80gb-trtllm] SKIP (https://nvbugs/6450341)
-accuracy/test_llm_api_autodeploy.py::TestQwen3_5_397B_MoE::test_nvfp4[8] SKIP (https://nvbugs/6412108)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp] SKIP (https://nvbugs/6428101)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp_trtllm] SKIP (https://nvbugs/6426868)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload] SKIP (https://nvbugs/6384136)


### PR DESCRIPTION
## Summary
Fix the Qwen3.5-397B MoE NVFP4 accuracy regression (nvbugs/6412108) by sharding the shared expert instead of keeping it replicated.

## Root cause
The shared expert (`Qwen3_5MoeMLP`) had its `torch_linear_simple` ops left untagged, and `qwen3.5_moe_400b.yaml` set `apply_sharding_hints.shard_layers: ["moe","delta","mha"]`, which excludes untagged ("unknown") nodes. So the shared expert stayed replicated (full output on every rank) while the routed experts were sharded. The single merge-point `expert_output + shared_expert_output` followed by `all_reduce` then scaled the replicated shared output by `world_size` (8x), dropping MMLU from ~85 to ~0.05.

## Fix
Shard the shared expert like the routed experts rather than special-casing the reduction order:
- Tag the shared expert's gate/up (`colwise`) and down (`rowwise`) linears with `layer_type="mlp"` in `modeling_qwen3_5_moe.py`.
- Remove the `shard_layers` whitelist from `qwen3.5_moe_400b.yaml` so all tagged nodes shard.
- Keep the existing add-then-`all_reduce` merge point: both routed and shared branches now emit per-rank partials, so one reduction on the sum lifts both to full.

This decouples modeling-code numerical correctness from an optional YAML knob (the whitelist).

## Relation to #15922
This supersedes the alternative fix in https://github.com/NVIDIA/TensorRT-LLM/pull/15922, which instead reordered the collective (`all_reduce` the routed partial first, then add the replicated shared output). That approach keeps the shared expert replicated and leaves correctness dependent on the yaml whitelist. Local benchmarking (Qwen3.5-397B-A17B-NVFP4, 8xB200, ISL/OSL 1024, concurrency 1/16/32/64) shows replicating vs sharding the shared expert is within ~1-2% throughput (run-to-run noise, no consistent winner), so there is no perf reason to keep it replicated; sharding both paths is the simpler, self-consistent fix.

## Test plan
- [x] `TestQwen3_5_397B_MoE::test_nvfp4[8]` accuracy: MMLU ~86.8 (was ~0.05), passes threshold; unwaived here.
- [x] `test_sharding_num_correctness.py` for `modeling_qwen3_5_moe` across tp-only / ep-only / tep / attn-dp (normal pass + `SHARDING_IR_SABOTAGE=1` true-negative).
- [x] `tests/unittest/auto_deploy/multigpu/` suite.
- [x] CI green (triggered after open).

## Risk
library-visible (AutoDeploy sharding / modeling).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved deployment configuration for Qwen3.5 MoE models with enhanced sharding and multi-stream execution.
  * Optimized expert-layer parallelism to support more efficient inference.
* **Compatibility**
  * Improved coordination of model outputs during distributed execution.
* **Testing**
  * Expanded integration test coverage by removing an outdated waiver for Qwen3.5 MoE accuracy testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->