### PR TITLE
[None][feat] Ring-buffer reuse of out-of-window SWA pages during decode in KV cache manager v2

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1549,6 +1549,7 @@ class KVCacheManagerV2(BaseResourceManager):
             max_util_for_resume=kv_cache_config.max_util_for_resume,
             enable_stats=self.enable_stats,
             swa_scratch_reuse=scratch_reuse_config,
+            enable_swa_ring_reuse=kv_cache_config.enable_swa_ring_reuse,
             initial_pool_ratio=kv_cache_config.pool_ratio,
             layers=layer_configs,
         )

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3481,6 +3481,16 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         "The maximum utilization of the KV cache for resume. Default is 95%. Only used when using KV cache manager v2 (experimental)."
     )
 
+    enable_swa_ring_reuse: bool = Field(
+        default=False,
+        status="prototype",
+        description=
+        "Recycle a sequence's freshly out-of-window sliding-window-attention pages in "
+        "place to back the new blocks its decode allocates, instead of a free-list "
+        "round-trip. Only fully-orphaned pages (no prefix-reuse retention) are recycled, "
+        "so behavior is unchanged except for which physical slot backs the new block. "
+        "Only used when using KV cache manager v2 (experimental).")
+
     enable_kv_pool_rebalance: bool = Field(
         default=False,
         status="prototype",

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
@@ -175,6 +175,7 @@ class KVCacheManagerConfig:
     initial_pool_ratio: list[float] | None = None
     swa_scratch_reuse: SwaScratchReuseConfig | None = None
     commit_min_snapshot: bool = False
+    enable_swa_ring_reuse: bool = False
     enable_stats: bool = True
     @property
     def enable_swa_scratch_reuse(self) -> bool: ...

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -255,8 +255,9 @@ class KVCacheManagerConfig:
     Only fully-orphaned stale pages are parked: uncommitted, with committing disallowed for
     the cache (so the radix tree cannot retain them) and resident on GPU. Committed pages
     kept for prefix reuse are never touched, so behavior is identical to the default
-    allocate-then-free path except for which physical slot backs the new block. The pocket
-    is drained on suspend()/close().
+    allocate-then-free path except for which physical slot backs the new block. Parked
+    pages are pinned against inter-level eviction (migrating them would waste bandwidth
+    on dead data) until consumed or drained; the pocket is drained on suspend()/close().
     """
 
     enable_stats: bool = True

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -242,6 +242,23 @@ class KVCacheManagerConfig:
     Required when SSM layers are present.
     """
 
+    enable_swa_ring_reuse: bool = False
+    """
+    When True, a sequence's freshly out-of-window (stale) SWA pages are parked in a small
+    per-sequence pocket and recycled in place to back the new blocks allocated by upcoming
+    resize() calls -- the steady state of decode with a sliding window, where each block
+    boundary crossing retires one block and adds one. This makes the window's storage behave
+    as a ring buffer (the same few physical blocks in rotation) and skips the allocator
+    free-list round-trip; on the same CUDA stream the recycled slot is immediately safe to
+    overwrite.
+
+    Only fully-orphaned stale pages are parked: uncommitted, with committing disallowed for
+    the cache (so the radix tree cannot retain them) and resident on GPU. Committed pages
+    kept for prefix reuse are never touched, so behavior is identical to the default
+    allocate-then-free path except for which physical slot backs the new block. The pocket
+    is drained on suspend()/close().
+    """
+
     enable_stats: bool = True
     """
     Collect V2 KV cache allocation, reuse, and transfer statistics.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -197,6 +197,7 @@ class _KVCache:
         "_never_resumed",
         "_enable_swa_scratch_reuse",
         "_scratch_slots",
+        "_swa_reuse_pocket",
         "_pending_stats",
         "__rawref__",
     )
@@ -245,6 +246,9 @@ class _KVCache:
     # Managed via delta in resize(): existing slots are reused across resize calls,
     # only the additional needed slots are allocated. Freed on teardown/suspend.
     _scratch_slots: TypedIndexList[LifeCycleId, list[ScratchSlotLock]]
+    # Freshly out-of-window, fully-orphaned pages parked for in-place reuse by upcoming
+    # decode blocks (enable_swa_ring_reuse). Drained on suspend()/close().
+    _swa_reuse_pocket: TypedIndexList[LifeCycleId, list[_PageHolder]]
     _pending_stats: _PendingStats
 
     def __init__(
@@ -287,6 +291,9 @@ class _KVCache:
         self._enable_swa_scratch_reuse = manager.enable_swa_scratch_reuse
         self._scratch_slots = make_typed(
             lambda _: list[ScratchSlotLock](), manager._storage.num_life_cycles
+        )
+        self._swa_reuse_pocket = make_typed(
+            lambda _: list[_PageHolder](), manager._storage.num_life_cycles
         )
         self._pending_stats = _PendingStats()
         self.__rawref__ = rawref.NULL
@@ -519,6 +526,10 @@ class _KVCache:
             return
         self.discard_pending_stats()
         self.stop_committing()
+        if any(self._swa_reuse_pocket):
+            with self._record_event():
+                for pocket in self._swa_reuse_pocket:
+                    pocket.clear()  # release parked pages back to the allocator
         assert NDEBUG or self._check_sanity()
         manager = self.manager
         if self.capacity > 0:
@@ -752,8 +763,23 @@ class _KVCache:
                         num_new_blocks_to_add = new_num_blocks - max(stale_end, old_num_blocks)
                     num_new_slots[lc] = num_new_blocks_to_add * beam_width
 
+            # SWA ring reuse: consume pages parked in the reuse pocket by earlier
+            # resize() calls (freshly out-of-window, fully-orphaned pages -- see the refill
+            # below) to back new blocks, instead of requesting slots from the allocator.
+            # Scratch mode has its own slot machinery, so the pocket is bypassed there.
+            enable_ring_reuse = (
+                manager._init_config.enable_swa_ring_reuse and not enable_scratch
+            )
+            num_pocket_slots = filled_list(0, num_life_cycles)
+            if enable_ring_reuse:
+                for lc in typed_range(num_life_cycles):
+                    num_pocket_slots[lc] = min(
+                        len(self._swa_reuse_pocket[lc]), num_new_slots[lc]
+                    )
+
             net_alloc_counts = make_typed(
-                lambda lc: num_new_slots[lc] + delta_scratch_slots[lc], num_life_cycles
+                lambda lc: num_new_slots[lc] - num_pocket_slots[lc] + delta_scratch_slots[lc],
+                num_life_cycles,
             )
             storage = self._storage
             if any(c > 0 for c in net_alloc_counts):
@@ -778,9 +804,18 @@ class _KVCache:
             # Combine slots and distribute
             slots = make_typed(lambda _: list[Slot](), num_life_cycles)
             for lc in typed_range(num_life_cycles):
-                slots[lc] = new_slots[lc] + [
-                    lock.detach_slot() for lock in excess_scratch_slots[lc]
-                ]
+                # Pocket pages transfer their slots directly: moving the slot out
+                # invalidates the page, making its destruction a no-op. Their last use
+                # was issued on this cache's stream, so in-order execution makes them
+                # immediately safe for the new block without an event wait.
+                slots[lc] = (
+                    new_slots[lc]
+                    + [lock.detach_slot() for lock in excess_scratch_slots[lc]]
+                    + [
+                        self._swa_reuse_pocket[lc].pop().page.move_to_new_slot()
+                        for _ in range(num_pocket_slots[lc])
+                    ]
+                )
                 new_slots[lc].clear()
                 excess_scratch_slots[lc].clear()
 
@@ -851,6 +886,24 @@ class _KVCache:
                         ).lock(self, beam_index, ordinal, lc, skip_wait=True)
                 self._blocks.append(SeqBlock(block, None))
             assert all(len(slots[lc]) == 0 for lc in typed_range(num_life_cycles))
+            # Park this call's freshly staled, fully-orphaned pages for reuse by upcoming
+            # resize() calls. Qualifying pages are uncommitted with committing disallowed
+            # (the radix tree cannot retain them; backup_holders holds the sole reference)
+            # and GPU-resident. Holding the _PageHolder keeps the slot alive. Bounded per
+            # life cycle to the ring working set (one block retired per boundary crossing,
+            # +1 for straddle).
+            if enable_ring_reuse and self._commit_state != self.CommitState.ALLOWED:
+                for _, _, holder_lc, holder in backup_holders:
+                    if len(self._swa_reuse_pocket[holder_lc]) >= 2:
+                        continue
+                    page = holder.page
+                    if (
+                        page.is_committed()
+                        or not page.has_valid_slot
+                        or page.cache_level != GPU_LEVEL
+                    ):
+                        continue
+                    self._swa_reuse_pocket[holder_lc].append(holder)
         self._capacity = capacity
         self._history_length = history_length
         self._refresh_generation_alloc_ready()
@@ -1020,6 +1073,8 @@ class _KVCache:
                     self.set_base_page_index_buf(beam_idx, lc, None)
         ssm_lc_id = self.manager._life_cycles.ssm_life_cycle_id
         with self._record_event():  # used by _SharedPageLock.__del__
+            for pocket in self._swa_reuse_pocket:
+                pocket.clear()  # release parked pages back to the allocator
             for ordinal, beam_idx, lc_idx in self._active_pages():
                 beam_block = (
                     self._block(ordinal, beam_idx)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -767,15 +767,24 @@ class _KVCache:
             # resize() calls (freshly out-of-window, fully-orphaned pages -- see the refill
             # below) to back new blocks, instead of requesting slots from the allocator.
             # Scratch mode has its own slot machinery, so the pocket is bypassed there.
-            enable_ring_reuse = (
-                manager._init_config.enable_swa_ring_reuse and not enable_scratch
-            )
+            enable_ring_reuse = manager._init_config.enable_swa_ring_reuse and not enable_scratch
             num_pocket_slots = filled_list(0, num_life_cycles)
             if enable_ring_reuse:
                 for lc in typed_range(num_life_cycles):
-                    num_pocket_slots[lc] = min(
-                        len(self._swa_reuse_pocket[lc]), num_new_slots[lc]
-                    )
+                    # Re-validate parked pages before use. Parked pages are excluded from
+                    # eviction (see the refill below), so with the current eviction policy
+                    # this drops nothing; it keeps the consume path locally correct even if
+                    # a future policy migrates or invalidates held pages.
+                    pocket = self._swa_reuse_pocket[lc]
+                    if pocket:
+                        pocket[:] = [
+                            h
+                            for h in pocket
+                            if not h.page.is_committed()
+                            and h.page.has_valid_slot
+                            and h.page.cache_level == GPU_LEVEL
+                        ]
+                    num_pocket_slots[lc] = min(len(pocket), num_new_slots[lc])
 
             net_alloc_counts = make_typed(
                 lambda lc: num_new_slots[lc] - num_pocket_slots[lc] + delta_scratch_slots[lc],
@@ -903,6 +912,12 @@ class _KVCache:
                         or page.cache_level != GPU_LEVEL
                     ):
                         continue
+                    # Pin against eviction: unlocking (in _unlock_stale_blocks) scheduled
+                    # this held page for eviction when lower cache levels exist. Migrating
+                    # it would waste bandwidth on dead data and move it off GPU_LEVEL,
+                    # invalidating the park-time checks above before the page is consumed.
+                    if page.scheduled_for_eviction:
+                        storage.exclude_from_eviction(page)
                     self._swa_reuse_pocket[holder_lc].append(holder)
         self._capacity = capacity
         self._history_length = history_length

--- a/tensorrt_llm/usage/llm_args_golden_manifest.json
+++ b/tensorrt_llm/usage/llm_args_golden_manifest.json
@@ -628,6 +628,13 @@
       "annotation": "<class 'bool'>",
       "converter": "",
       "kind": "value",
+      "path": "kv_cache_config.enable_swa_ring_reuse"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "<class 'bool'>",
+      "converter": "",
+      "kind": "value",
       "path": "kv_cache_config.enable_swa_scratch_reuse"
     },
     {
@@ -3042,6 +3049,13 @@
       "converter": "",
       "kind": "value",
       "path": "kv_cache_config.enable_partial_reuse"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "<class 'bool'>",
+      "converter": "",
+      "kind": "value",
+      "path": "kv_cache_config.enable_swa_ring_reuse"
     },
     {
       "allowed_values": [],

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -697,6 +697,88 @@ class TestNoBatching(TestKVCacheManagerV2):
             profiler.dump_stats("profiler.prof")
 
 
+class TestSwaRingReuse(TestNoBatching):
+    """KVCacheManagerConfig.enable_swa_ring_reuse.
+
+    Drives a disaggregated-decode-style uncommitted generation (committing disallowed,
+    history advanced directly via resize) across many sliding-window advances and checks:
+      * data correctness via FakeEngine refcheck at every step, and
+      * allocator traffic: with the flag ON, the windowed layer's freshly staled pages are
+        parked in the reuse pocket and recycled in place, so after the pocket warms up the
+        global allocator receives no further requests for the windowed life cycle (only the
+        full-attention life cycle still allocates one block per boundary crossing); with the
+        flag OFF, every boundary crossing requests one block for each life cycle.
+    """
+
+    def _run_uncommitted_decode(self, enable: bool) -> "tuple[int, int]":
+        tokens_per_block = 32
+        window = 2 * tokens_per_block
+        self.cfg = create_config(
+            tokens_per_block,
+            32 << 20,
+            0,
+            0,
+            num_layers=2,  # layer 0: sliding window; layer 1: full attention
+            window_size=window,
+            sink_tokens=0,
+        )
+        self.cfg.enable_swa_ring_reuse = enable
+        self.engine = FakeEngine(self.cfg)
+        self.manager = KVCacheManager(self.cfg)
+
+        prompt_len = window  # no prompt block is stale at generation start
+        decode_len = 8 * tokens_per_block
+        req = self.new_request(0, None, prompt_len, decode_len)
+        kv_cache = req.kv_cache
+
+        alloc_requests: "list[int]" = []
+        orig_new_gpu_slots = StorageManager.new_gpu_slots
+
+        def spying_new_gpu_slots(mgr, counts, *args, **kwargs):
+            alloc_requests.append(sum(int(c) for c in counts))
+            return orig_new_gpu_slots(mgr, counts, *args, **kwargs)
+
+        with TemporaryCudaStream([]) as s:
+            stream = cast(CudaStream, s.handle)
+            self.assertTrue(kv_cache.resume(stream))
+            # Disaggregated decode style: KV arrives from elsewhere; nothing is committed,
+            # so freshly staled blocks are fully orphaned.
+            kv_cache.stop_committing()
+            self.assertTrue(kv_cache.resize(prompt_len, prompt_len))
+            self.engine.execute([Step(kv_cache, req.prompt, [])], stream)
+            history = list(req.prompt)
+            StorageManager.new_gpu_slots = spying_new_gpu_slots  # type: ignore[method-assign]
+            try:
+                for _ in range(decode_len):
+                    token = self.next_token()
+                    self.assertTrue(kv_cache.resize(len(history) + 1, len(history)))
+                    self.engine.execute([Step(kv_cache, [token], history)], stream)
+                    history.append(token)
+            finally:
+                StorageManager.new_gpu_slots = orig_new_gpu_slots  # type: ignore[method-assign]
+            self.engine.execute([Step(kv_cache, [], history)], stream)
+        s.take_finish_event().synchronize()
+        kv_cache.close()
+        total_requested = sum(alloc_requests)
+        num_crossings = div_up(prompt_len + decode_len, tokens_per_block) - div_up(
+            prompt_len, tokens_per_block
+        )
+        return total_requested, num_crossings
+
+    def test_disabled_baseline_traffic(self) -> None:
+        total, crossings = self._run_uncommitted_decode(enable=False)
+        # One new block per boundary crossing for the windowed AND the full-attention
+        # life cycle.
+        self.assertEqual(total, 2 * crossings)
+
+    def test_enabled_reuses_stale_window_pages(self) -> None:
+        total, crossings = self._run_uncommitted_decode(enable=True)
+        # The windowed life cycle allocates only until its first page goes stale (one
+        # block); every later boundary crossing is served from the reuse pocket. The
+        # full-attention life cycle still allocates one block per crossing.
+        self.assertEqual(total, crossings + 1)
+
+
 class TestBatching(TestKVCacheManagerV2):
     num_requests: int
     avg_length: int


### PR DESCRIPTION
## Description

During decode with a sliding-window-attention (SWA) layer, every `tokens_per_block` tokens the window slides across a block boundary: one out-of-window block is retired and one new block is allocated. Today the staled page takes a full free-list round-trip (release with a ready event, later re-allocation with cross-stream event bookkeeping) while the new block draws a different slot from the global allocator.

This PR makes the sliding window's KV storage behave as a **ring buffer** during decode: at steady state a sequence's SWA footprint is served by the **same ~3 physical blocks in rotation** (for a 131-token window), with the newest tokens overwriting the block that just left the window — instead of an allocate-new/free-old round-trip per boundary crossing.

It is implemented as an opt-in per-sequence **reuse pocket** in KV cache manager v2 (`kv_cache_config.enable_swa_ring_reuse`, default **off**): a `resize()` that orphans a freshly staled page parks it; a later `resize()` that needs a new block consumes the parked page's slot directly. On the same CUDA stream the recycled slot is immediately safe to overwrite, so e.g. for a 131-token window a sequence's SWA footprint is served by the same ~3 physical blocks in rotation instead of continuous allocate-then-free.

Safety gating (behavior is unchanged except for which physical slot backs the new block):
- only **fully-orphaned** pages are parked: uncommitted, with committing disallowed for the cache (so the block radix tree cannot retain them for prefix reuse) and GPU-resident;
- the pocket is bounded (2 pages per life cycle), consumed and refilled only on `resize()` **success** paths, so the `OutOfPagesError` revert path (`_lock_held_blocks`) is unaffected;
- the pocket is drained on `suspend()`/`close()`.

Plumbed through `KvCacheConfig.enable_swa_ring_reuse` (prototype) -> pyexecutor `KVCacheManagerV2` -> `KVCacheManagerConfig`.

## Test Coverage

- New `TestSwaRingReuse` in `tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py`: drives a disaggregated-decode-style uncommitted generation across 8 window advances with FakeEngine refcheck at every step, plus deterministic allocator-traffic assertions:
  - flag off: one slot request per boundary crossing per life cycle (`2 x crossings`);
  - flag on: the windowed life cycle allocates only until its first page is parked (`crossings + 1`).
- Existing `TestNoBatching` battery passes unchanged under the patched module (flag off is a no-op: two cheap branches).
- Perf A/B on DeepSeek-V4 disaggregated GEN (GB200, dep32/EP32, 256K ISL, per-rank batch 84, MTP3, MoE backend MEGAMOE_DEEPGEMM, 2688/2688 requests completed on both arms):

  | arm | output tok/s per GEN GPU | mean TPOT |
  |---|---|---|
  | flag off | 3481.6 | 26.932 ms |
  | flag on | 3513.2 (+0.9%) | 26.900 ms |

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental option to reuse stale sliding-window-attention cache pages during decoding.
  * Reused pages can reduce new cache-slot allocations and improve memory efficiency.
  * The option is disabled by default and only applies to eligible, fully released pages.

* **Bug Fixes**
  * Ensured the new cache-reuse setting is consistently passed through runtime configuration.

* **Tests**
  * Added coverage verifying both disabled behavior and reduced allocation activity when reuse is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->