### PR TITLE
[None][test] Waive TestGemma4MoE::test_bf16 (missing bf16 MMMU reference)

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -225,6 +225,7 @@ full:DGX_B200/unittest/auto_deploy/multigpu/custom_ops/test_ad_dist_strategies.p
 full:DGX_B200/unittest/auto_deploy/multigpu/custom_ops/test_ad_dist_strategies.py::test_allreduce_strategies[ONESHOT] SKIP (https://nvbugs/6403920)
 full:DGX_B200/unittest/auto_deploy/multigpu/custom_ops/test_ad_dist_strategies.py::test_allreduce_strategies[TWOSHOT] SKIP (https://nvbugs/6403920)
 full:DGX_B300/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_4gpus[ep4-mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=False] SKIP (https://nvbugs/6432831)
+full:DGX_H100/accuracy/test_llm_api_autodeploy.py::TestGemma4MoE::test_bf16 SKIP (temporary ToT main waive; bf16 MMMU reference missing since PR 16108, accuracy harness raises Not-registered-specs before scoring)
 full:DGX_H100/unittest/_torch/attention/test_attention_backends.py::test_attention_backend[qwen2_0_5b_gqa_hd64-ctx-bf16-HND-p32-v1] SKIP (https://nvbugs/6403909)
 full:GB200/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_eagle3[eagle3_one_model=False-overlap_scheduler=False] SKIP (https://nvbugs/6402500)
 full:GB200/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_guided_decoding_with_eagle3[llguidance-eagle3_one_model=False] SKIP (https://nvbugs/6402500)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a temporary waiver for a multi-GPU accuracy test that cannot run until the required reference specifications are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

`accuracy/test_llm_api_autodeploy.py::TestGemma4MoE::test_bf16` evaluates MMMU with the plain bf16 spec, but `references/mmmu.yaml` only registers a `quant_algo: NVFP4 / kv_cache_quant_algo: FP8` entry for `google/gemma-4-26B-A4B-it` (added in #16108). The accuracy harness therefore raises before scoring:

```
FAILED accuracy/test_llm_api_autodeploy.py::TestGemma4MoE::test_bf16 - ValueError: Not registered specs: {'dtype': 'auto', 'quant_algo': None, 'kv_cache_quant_algo': None, 'spec_dec_algo': None, 'extra_acc_spec': None}
```

The failure is deterministic and PR-independent: it failed identically in every recent `LLM/main/L0_Test-x86_64-Multi-GPU` run (builds 2327–2336), currently blocking pre-merge CI for any PR that triggers the multi-GPU stage (see also the report on #16108).

This PR waives the test until the bf16 MMMU reference is added (or the test is routed to a registered spec). cc @2ez4bz

## Test Coverage

Waive-list-only change; no runtime code affected. `mergeWaiveList` picks this up for all in-flight PRs once merged.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
