### PR TITLE
[https://nvbugs/6428113][fix] Fix TEP token-count handling in MoE Test

### DIFF
--- a/tests/unittest/_torch/modules/test_moe_routing.py
+++ b/tests/unittest/_torch/modules/test_moe_routing.py
@@ -794,15 +794,17 @@ def _perfect_router_worker(parallel_mode, routing_name, num_tokens, dtype,
 
         # Simulate per-rank token-count skew so each rank exercises a
         # different cache key (num_tokens, routing_method, dtype, ep_size).
-        # DEP processes its own share of tokens per rank; TEP replicates
-        # input across ranks so keep a uniform list there.
-        if parallel_mode == "DEP":
+        # When attention uses DP (parallel_mode starts with "D"), each rank
+        # processes its own token share; otherwise all ranks see the same
+        # token count so pass a single-element list.
+        if parallel_mode[0] == "D":
             all_rank_num_tokens = [
                 num_tokens + i for i in range(mapping.world_size)
             ]
+            my_num_tokens = all_rank_num_tokens[mapping.rank]
         else:
-            all_rank_num_tokens = [num_tokens] * mapping.world_size
-        my_num_tokens = all_rank_num_tokens[mapping.rank]
+            all_rank_num_tokens = [num_tokens]
+            my_num_tokens = num_tokens
 
         model_config = ModelConfig(pretrained_config=pretrained_config,
                                    mapping=mapping,


### PR DESCRIPTION
## Description

test_perfect_router_load_balanced_multi_gpu built all_rank_num_tokens as a per-rank replicated list ([num_tokens] * world_size) for the non-attention-DP(TEP) case and indexed it by mapping.rank. Non-DP MoE forward expects a single
global token count, so the replicated list produced a wrong cache key / dispatch and broke the flat-router hotspot/load-balance assertion for the Renormalize router (e.g. [dtype0-32-Renormalize-TEP-4]). 

Use a single-element all_rank_num_tokens for non-DP modes; keep the per-rank list for attention-DP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved multi-GPU routing test coverage for different parallel execution modes.
  * Added validation for varying token distributions across ranks, helping ensure consistent routing behavior in distributed scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->