### PR TITLE
[None][test] Restrict gen-worker per-iter mean to steady-state iterations

### DIFF
--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -139,14 +139,20 @@ GEN_ONLY_PERF_METRIC_LOG_QUERIES = {
 
 # Per-iter prev_device_step_time logged by each gen worker. Example line:
 #   [TRT-LLM] [I] [_torch][RANK 0] iter = 5, global_rank = 0, ...,
-#   host_step_time = 6.79ms, prev_device_step_time = 6.94ms, ...
+#   host_step_time = 6.79ms, prev_device_step_time = 6.94ms, ...,
+#   states = {..., 'num_generation_tokens': 512, ...}
 # Only the gen worker (decode) emits this. The device value reported at iter N
 # is the device step time of iter N-1 (device runs async). Iters 0-4 are
 # skipped: iter 0/1 include KV-cache transfer wait time, and iters 2-4 are
 # warmup that has not yet reached steady state. prev_device_step_time may be
 # 'N/A' (e.g. iter 1); the regex requires a numeric value so those lines do
-# not match.
-_DEVICE_STEP_TIME_RE = re.compile(r"iter\s*=\s*(\d+),.*?prev_device_step_time\s*=\s*([\d.]+)\s*ms")
+# not match. num_generation_tokens is captured so the scanner can restrict
+# the mean to steady-state iters (see _scan_gen_worker_device_step_time).
+_DEVICE_STEP_TIME_RE = re.compile(
+    r"iter\s*=\s*(\d+),.*?"
+    r"prev_device_step_time\s*=\s*([\d.]+)\s*ms.*?"
+    r"'num_generation_tokens':\s*(\d+)"
+)
 
 
 def gen_worker_log_sizes(output_dir: str, num_gen_servers: int) -> List[int]:
@@ -168,12 +174,21 @@ def _scan_gen_worker_device_step_time(
     num_gen_servers: int,
     start_offsets: Optional[List[int]] = None,
 ) -> Tuple[List[float], int]:
-    """Single pass over the gen logs. Returns (per_file_means, total_count).
+    """Two-pass scan of the gen logs. Returns (per_file_means, total_count).
 
     per_file_means holds one mean per file that had >=1 usable line;
-    total_count is the number of usable (iter >= 5, numeric) lines across all
-    files, used by the caller to detect when the cross-node log flush has
-    settled. errors="replace" guards against invalid UTF-8: tqdm progress bars
+    total_count is the number of usable lines (iter >= 5, numeric device
+    time, and num_generation_tokens == that file's max) across all files,
+    used by the caller to detect when the cross-node log flush has settled.
+
+    Within each file the mean is restricted to iterations at the maximum
+    observed num_generation_tokens (over iter >= 5). The tail of a run has
+    a shrinking num_generation_tokens as sequences finish, which would
+    otherwise pull the mean away from the steady-state cost we want to
+    track. A two-pass approach — first pass finds the file's max, second
+    pass runs a Welford mean over matching rows — keeps memory O(1).
+
+    errors="replace" guards against invalid UTF-8: tqdm progress bars
     (model load) write partial multibyte sequences that would otherwise raise
     UnicodeDecodeError mid-scan.
     """
@@ -183,19 +198,41 @@ def _scan_gen_worker_device_step_time(
         log_path = os.path.join(output_dir, f"gen_server_{i}.log")
         if not os.path.isfile(log_path):
             continue
-        # Welford streaming mean: O(1) memory and numerically stable for
-        # large iteration counts.
-        count = 0
-        mean = 0.0
+
+        seek_to = (
+            start_offsets[i]
+            if start_offsets is not None and i < len(start_offsets) and start_offsets[i]
+            else 0
+        )
+
+        max_ngen = -1
         with open(log_path, errors="replace") as f:
-            if start_offsets is not None and i < len(start_offsets) and start_offsets[i]:
-                f.seek(start_offsets[i])
+            if seek_to:
+                f.seek(seek_to)
             for line in f:
                 m = _DEVICE_STEP_TIME_RE.search(line)
                 if m is None:
                     continue
-                iter_idx = int(m.group(1))
-                if iter_idx < 5:
+                if int(m.group(1)) < 5:
+                    continue
+                ngen = int(m.group(3))
+                if ngen > max_ngen:
+                    max_ngen = ngen
+        if max_ngen < 0:
+            continue
+
+        count = 0
+        mean = 0.0
+        with open(log_path, errors="replace") as f:
+            if seek_to:
+                f.seek(seek_to)
+            for line in f:
+                m = _DEVICE_STEP_TIME_RE.search(line)
+                if m is None:
+                    continue
+                if int(m.group(1)) < 5:
+                    continue
+                if int(m.group(3)) != max_ngen:
                     continue
                 count += 1
                 mean += (float(m.group(2)) - mean) / count
@@ -214,8 +251,12 @@ def parse_gen_worker_device_step_time(
 ) -> Optional[float]:
     """Mean per-iter prev_device_step_time (ms) across all gen workers.
 
-    For each gen_server_{i}.log, average prev_device_step_time over iters >= 5,
-    then average those per-file means across the num_gen_servers workers.
+    For each gen_server_{i}.log, average prev_device_step_time over iters
+    >= 5 restricted to the maximum observed num_generation_tokens in that
+    file (steady-state batch), then average those per-file means across the
+    num_gen_servers workers. Iterations near the end of a run have a
+    shrinking num_generation_tokens as sequences finish and are excluded
+    so they don't drag the mean below the steady-state cost.
     Returns None if no usable line is found in any file.
 
     When start_offsets is provided, only the bytes from start_offsets[i] to

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -151,9 +151,7 @@ GEN_ONLY_PERF_METRIC_LOG_QUERIES = {
 # is not) so the scanner can bucket rows by ngen without silently dropping
 # any line whose states dict is printed before prev_device_step_time. See
 # _scan_gen_worker_device_step_time.
-_DEVICE_STEP_TIME_RE = re.compile(
-    r"iter\s*=\s*(\d+),.*?prev_device_step_time\s*=\s*([\d.]+)\s*ms"
-)
+_DEVICE_STEP_TIME_RE = re.compile(r"iter\s*=\s*(\d+),.*?prev_device_step_time\s*=\s*([\d.]+)\s*ms")
 _NUM_GEN_TOKENS_RE = re.compile(r"'num_generation_tokens':\s*(\d+)")
 
 
@@ -252,9 +250,7 @@ def _mean_at_mode_ngen(
     for by_ngen in per_file_by_ngen:
         if not by_ngen:
             continue
-        _mode_ngen, (_count, mean) = max(
-            by_ngen.items(), key=lambda kv: (kv[1][0], kv[0])
-        )
+        _mode_ngen, (_count, mean) = max(by_ngen.items(), key=lambda kv: (kv[1][0], kv[0]))
         means.append(mean)
     if not means:
         return None

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -146,13 +146,15 @@ GEN_ONLY_PERF_METRIC_LOG_QUERIES = {
 # skipped: iter 0/1 include KV-cache transfer wait time, and iters 2-4 are
 # warmup that has not yet reached steady state. prev_device_step_time may be
 # 'N/A' (e.g. iter 1); the regex requires a numeric value so those lines do
-# not match. num_generation_tokens is captured so the scanner can restrict
-# the mean to steady-state iters (see _scan_gen_worker_device_step_time).
+# not match. num_generation_tokens is captured by a separate regex applied
+# to the same line (name is stable, order relative to prev_device_step_time
+# is not) so the scanner can bucket rows by ngen without silently dropping
+# any line whose states dict is printed before prev_device_step_time. See
+# _scan_gen_worker_device_step_time.
 _DEVICE_STEP_TIME_RE = re.compile(
-    r"iter\s*=\s*(\d+),.*?"
-    r"prev_device_step_time\s*=\s*([\d.]+)\s*ms.*?"
-    r"'num_generation_tokens':\s*(\d+)"
+    r"iter\s*=\s*(\d+),.*?prev_device_step_time\s*=\s*([\d.]+)\s*ms"
 )
+_NUM_GEN_TOKENS_RE = re.compile(r"'num_generation_tokens':\s*(\d+)")
 
 
 def gen_worker_log_sizes(output_dir: str, num_gen_servers: int) -> List[int]:
@@ -173,26 +175,29 @@ def _scan_gen_worker_device_step_time(
     output_dir: str,
     num_gen_servers: int,
     start_offsets: Optional[List[int]] = None,
-) -> Tuple[List[float], int]:
-    """Two-pass scan of the gen logs. Returns (per_file_means, total_count).
+) -> Tuple[List[Dict[int, Tuple[int, float]]], int]:
+    """Single-pass scan of the gen logs.
 
-    per_file_means holds one mean per file that had >=1 usable line;
-    total_count is the number of usable lines (iter >= 5, numeric device
-    time, and num_generation_tokens == that file's max) across all files,
-    used by the caller to detect when the cross-node log flush has settled.
+    Returns (per_file_by_ngen, total_count):
+      - per_file_by_ngen: one dict per file that produced >=1 usable line,
+        mapping num_generation_tokens -> (count, Welford mean of
+        prev_device_step_time) over rows with iter >= 5 and a numeric
+        prev_device_step_time. Rows lacking num_generation_tokens on the same
+        line are skipped for the mean but still counted for settle detection.
+      - total_count: the number of iter >= 5 rows with a numeric
+        prev_device_step_time across all files. This is monotonic as new
+        lines flush across NFS (rows only get appended) so the caller can use
+        it as the settle signal without worrying that changes to a per-ngen
+        filter can make it drop.
 
-    Within each file the mean is restricted to iterations at the maximum
-    observed num_generation_tokens (over iter >= 5). The tail of a run has
-    a shrinking num_generation_tokens as sequences finish, which would
-    otherwise pull the mean away from the steady-state cost we want to
-    track. A two-pass approach — first pass finds the file's max, second
-    pass runs a Welford mean over matching rows — keeps memory O(1).
+    Memory is O(distinct num_generation_tokens per file), a small constant
+    in practice (steady-state plus a shrinking tail).
 
     errors="replace" guards against invalid UTF-8: tqdm progress bars
     (model load) write partial multibyte sequences that would otherwise raise
     UnicodeDecodeError mid-scan.
     """
-    per_file_means: List[float] = []
+    per_file_by_ngen: List[Dict[int, Tuple[int, float]]] = []
     total_count = 0
     for i in range(num_gen_servers):
         log_path = os.path.join(output_dir, f"gen_server_{i}.log")
@@ -205,7 +210,7 @@ def _scan_gen_worker_device_step_time(
             else 0
         )
 
-        max_ngen = -1
+        by_ngen: Dict[int, Tuple[int, float]] = {}
         with open(log_path, errors="replace") as f:
             if seek_to:
                 f.seek(seek_to)
@@ -215,31 +220,45 @@ def _scan_gen_worker_device_step_time(
                     continue
                 if int(m.group(1)) < 5:
                     continue
-                ngen = int(m.group(3))
-                if ngen > max_ngen:
-                    max_ngen = ngen
-        if max_ngen < 0:
-            continue
-
-        count = 0
-        mean = 0.0
-        with open(log_path, errors="replace") as f:
-            if seek_to:
-                f.seek(seek_to)
-            for line in f:
-                m = _DEVICE_STEP_TIME_RE.search(line)
-                if m is None:
+                total_count += 1
+                ngen_m = _NUM_GEN_TOKENS_RE.search(line)
+                if ngen_m is None:
                     continue
-                if int(m.group(1)) < 5:
-                    continue
-                if int(m.group(3)) != max_ngen:
-                    continue
+                ngen = int(ngen_m.group(1))
+                dt = float(m.group(2))
+                count, mean = by_ngen.get(ngen, (0, 0.0))
                 count += 1
-                mean += (float(m.group(2)) - mean) / count
-        if count:
-            per_file_means.append(mean)
-            total_count += count
-    return per_file_means, total_count
+                mean += (dt - mean) / count
+                by_ngen[ngen] = (count, mean)
+        if by_ngen:
+            per_file_by_ngen.append(by_ngen)
+    return per_file_by_ngen, total_count
+
+
+def _mean_at_mode_ngen(
+    per_file_by_ngen: List[Dict[int, Tuple[int, float]]],
+) -> Optional[float]:
+    """Aggregate per-file per-ngen buckets into a single mean.
+
+    Within each file pick the num_generation_tokens value with the most
+    iterations (the mode) and take its Welford mean; ties break to the
+    largest ngen because the steady-state plateau is the upper of any tied
+    clusters. Mode is more robust than strict == max — a one-off spike where
+    a single iter's ngen briefly exceeds the sustained batch would otherwise
+    collapse the mean to 1-2 samples. Then average the per-file means across
+    workers. Returns None if no file had a usable row.
+    """
+    means: List[float] = []
+    for by_ngen in per_file_by_ngen:
+        if not by_ngen:
+            continue
+        _mode_ngen, (_count, mean) = max(
+            by_ngen.items(), key=lambda kv: (kv[1][0], kv[0])
+        )
+        means.append(mean)
+    if not means:
+        return None
+    return sum(means) / len(means)
 
 
 def parse_gen_worker_device_step_time(
@@ -251,12 +270,15 @@ def parse_gen_worker_device_step_time(
 ) -> Optional[float]:
     """Mean per-iter prev_device_step_time (ms) across all gen workers.
 
-    For each gen_server_{i}.log, average prev_device_step_time over iters
-    >= 5 restricted to the maximum observed num_generation_tokens in that
-    file (steady-state batch), then average those per-file means across the
-    num_gen_servers workers. Iterations near the end of a run have a
-    shrinking num_generation_tokens as sequences finish and are excluded
-    so they don't drag the mean below the steady-state cost.
+    For each gen_server_{i}.log, bucket iter >= 5 rows by
+    num_generation_tokens, pick the bucket with the most rows (the mode; ties
+    break to the largest ngen), and take that bucket's mean. Then average
+    those per-file means across the num_gen_servers workers. Iterations near
+    the end of a run have a shrinking num_generation_tokens as sequences
+    finish and land in smaller-ngen buckets, so they don't drag the mean
+    below the steady-state cost. Using the mode (rather than strict == max)
+    is robust against a single iter whose ngen briefly spikes above the
+    sustained batch, which would otherwise collapse the mean to 1-2 samples.
     Returns None if no usable line is found in any file.
 
     When start_offsets is provided, only the bytes from start_offsets[i] to
@@ -268,26 +290,30 @@ def parse_gen_worker_device_step_time(
     benchmark_status file) when this runs — so when the client returns, the
     decode iterations are done but their log lines may still be flushing across
     NFS. Reading once immediately can see zero iter>=5 lines and wrongly return
-    None. So poll the slice until the usable-line count is non-zero AND stable
-    across two consecutive reads (flush drained), bounded by settle_timeout.
+    None. So poll the slice until the iter>=5 row count is non-zero AND
+    stable across two consecutive reads (flush drained), bounded by
+    settle_timeout. The settle signal is the raw iter>=5 row count (not the
+    mode-bucket count) because raw rows are monotonic across polls, whereas
+    the mode ngen — and therefore its bucket size — can shift while the tail
+    is still flushing.
     """
     deadline = time.time() + settle_timeout
     prev_count = -1
     while True:
-        per_file_means, total_count = _scan_gen_worker_device_step_time(
+        per_file_by_ngen, total_count = _scan_gen_worker_device_step_time(
             output_dir, num_gen_servers, start_offsets
         )
         # Non-empty and unchanged since the last poll → the flush has settled.
         if total_count > 0 and total_count == prev_count:
-            return sum(per_file_means) / len(per_file_means)
+            return _mean_at_mode_ngen(per_file_by_ngen)
         if time.time() >= deadline:
-            if per_file_means:
+            if per_file_by_ngen:
                 print_info(
                     f"parse_gen_worker_device_step_time: settle_timeout "
                     f"({settle_timeout}s) reached with {total_count} line(s); "
                     "returning current mean."
                 )
-                return sum(per_file_means) / len(per_file_means)
+                return _mean_at_mode_ngen(per_file_by_ngen)
             return None
         prev_count = total_count
         time.sleep(poll_interval)


### PR DESCRIPTION
## Summary

The disagg `gen_only` **Mean Gen Worker Per-Iter Device Step Time** metric in
`tests/integration/defs/perf/test_perf_sanity.py` currently averages
`prev_device_step_time` over every log line whose `iter` field is `>= 5`.
Near the end of a run, `num_generation_tokens` shrinks as sequences finish,
so those tail iterations have systematically shorter device step times and
drag the mean below the steady-state cost we actually want to track.

This PR restricts the mean, per `gen_server_{i}.log`, to iterations at the
**mode** (most-frequent) `num_generation_tokens` value observed for
`iter >= 5` rows in that file, with ties broken toward the larger ngen:

1. Single pass over each `gen_server_{i}.log` builds a
   `Dict[num_generation_tokens, (count, Welford mean of prev_device_step_time)]`
   over `iter >= 5` rows with a numeric `prev_device_step_time`, and
   independently counts every such row into `total_count`.
2. After the settle poll drains (see below), the per-file bucket with the
   most rows is selected (ties → largest ngen) and its mean is taken as
   that file's contribution. The per-file means are then averaged.

`num_generation_tokens` is captured by a **separate regex** applied to the
same line — the name is stable, but its position within the line relative
to `prev_device_step_time` is not, so chaining the two into one pattern
would silently drop any row whose `states` dict was printed first.

`total_count` is the number of `iter >= 5` rows with a numeric
`prev_device_step_time` across all files — **not** the size of the mode
bucket. This keeps the settle signal monotonic across polls (rows only ever
get appended as NFS flushes), so an in-flight ngen shift while the tail is
still flushing cannot hold the count flat for two consecutive polls and
trigger a premature return on a non-steady-state sample.

Note on `iter >= 5`: `iter` here is the literal value of the `iter` field
in the log line, not a running line count. Gen-worker logs emit many
`iter = 0` prefill/scheduling lines and a warmup `iter = 1` line before
generation begins, and `< 5` drops all of them before we ever look at
`num_generation_tokens`.

## Method comparison

| Aspect | Old method | New method |
|---|---|---|
| Row filter for the per-file mean | `iter >= 5` | `iter >= 5` **and** `num_generation_tokens == mode(ngen)` (ties → largest ngen) |
| Regex-captured fields | `(iter, prev_device_step_time)` | `(iter, prev_device_step_time)` from `_DEVICE_STEP_TIME_RE` plus `num_generation_tokens` from an independent `_NUM_GEN_TOKENS_RE` applied to the same line (position-independent) |
| Passes over each `gen_server_{i}.log` | 1 | 1 (per-ngen Welford dict built in the same pass; halves I/O on 10k+ line logs) |
| Rows included from a typical genonly run | Steady-state gen iters **plus** the shrinking-batch tail | Steady-state gen iters **only** |
| Robustness to a one-off `ngen` spike | N/A (no filter) | Mode ignores it (`== max` would have collapsed the file mean to 1–2 samples) |
| Memory per file | O(1) Welford | O(distinct ngen), a small constant — steady-state + a shrinking tail |
| Steady-state bias | Tail pulls the mean **downward** (fewer gen tokens → shorter step time) | Removed — only mode-ngen iters contribute |
| Settle signal for `parse_gen_worker_device_step_time` | Row count of the filtered set | Row count of **all** `iter >= 5` rows — monotonic across polls, so a mid-flush ngen shift cannot spoof "stable" |
| Aggregation across gen workers | Per-file mean, then average across files | Same |

## Impact on real logs

Sanity-checked on two real gen worker logs:

| Log | old mean (all iter>=5) | new mean (mode ngen only) | ngen filter |
|---|---:|---:|---:|
| ds-r1 disagg genonly rep3 | 53.98 ms (253 iters) | 53.30 ms (252 iters) | 512 |
| gpt_oss-120b postqwen r1  | 39.41 ms (11013 iters) | 41.37 ms (9684 iters) | 1024 |

The gpt_oss case shows the failure mode this fix addresses: the tail
included 1329 iterations with `num_generation_tokens` ranging 1–960, all
with shorter device step times, pulling the mean ~5% below the real
steady-state cost. The new metric reports the correct steady-state value.

## Review defects addressed

Three defects were flagged on the earlier revision of this PR; the current
code addresses each:

- **Non-monotonic settle counter.** In the earlier revision `total_count`
  was the size of the filtered (mode/`== max`) bucket, so a mid-run
  `max_ngen` jump could hold the count flat for two consecutive polls and
  return a mean computed on a non-steady-state sample. Fixed by making
  `total_count` count every `iter >= 5` row with a numeric device time
  (monotonic across polls) and moving the ngen bucket selection *after*
  the settle poll drains.
- **Strict `== max` with no sample-size protection.** Replaced by mode
  ngen (ties → largest ngen). A single-iter spike above the sustained
  batch used to lock `max_ngen` onto that spike and collapse the mean to
  1–2 samples; the mode is unaffected.
- **Regex order-coupling.** The previous single regex required
  `num_generation_tokens` to appear **after** `prev_device_step_time` on
  the line. `num_generation_tokens` is now captured by a separate regex
  applied to the same line, so ordering does not matter.

## Test plan

- [x] Run existing disagg gen_only perf-sanity cases end-to-end and verify
      the reported `d_mean_gen_worker_per_iter_device_step_time` matches
      the manual computation on the collected gen_server logs.
- [x] Confirm regression baseline shifts (if any) are within noise for
      workloads whose tail is small, and produce a higher, more accurate
      value for workloads with long tails.
- [x] Synthetic unit-level checks for scanner behavior: order-flipped
      `states` dict captured, iter<5 dropped, `N/A` device-time dropped,
      settle counter monotonic across a mid-flush `max_ngen` jump, mode
      wins over a one-off ngen spike, tie-break resolves to the larger
      ngen, and rows missing `num_generation_tokens` are still counted
      toward the settle signal.
