### PR TITLE
[None][perf] fuse gdn post-conv split, QK norm and gating and  RMSNorm with FP8 quantization

### DIFF
--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -610,6 +610,11 @@ class FP8QDQLinearMethod(UnquantizedLinearMethod):
 
     supports_nccl_symmetric_memory_window_output: ClassVar[bool] = True
 
+    def get_static_input_scale(self, module: Linear) -> Optional[torch.Tensor]:
+        if module.input_scale is not None and not module.force_dynamic_quantization:
+            return module.input_scale
+        return None
+
     def create_weights(self, module: Linear, in_features: int,
                        out_features: int, bias: bool, dtype: torch.dtype):
         weight_shape = (out_features, in_features)
@@ -643,12 +648,13 @@ class FP8QDQLinearMethod(UnquantizedLinearMethod):
         if input.dim() > 2:
             input = input.reshape(-1, input.shape[-1])
 
+        static_input_scale = self.get_static_input_scale(module)
         cur_input_scale = module.input_scale
         if input.dtype != torch.float8_e4m3fn:
-            if module.input_scale is not None and not module.force_dynamic_quantization:
+            if static_input_scale is not None:
                 # Static quantization
                 qinput, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(
-                    input, module.input_scale)
+                    input, static_input_scale)
             else:
                 # Dynamic quantization
                 qinput, cur_input_scale = torch.ops.tensorrt_llm.quantize_e4m3_per_tensor(

--- a/tensorrt_llm/_torch/modules/mamba/fuse_elementwise_ops.py
+++ b/tensorrt_llm/_torch/modules/mamba/fuse_elementwise_ops.py
@@ -203,235 +203,368 @@ def fused_split_rearrange_after_conv1d(
 
 
 @triton.jit
-def _transpose_and_split_qkv_kernel(
-    prefill_t_ptr,
+def _fused_gdn_post_conv_kernel(
+    prefill_ptr,
     decode_ptr,
+    a_ptr,
+    b_ptr,
+    A_log_ptr,
+    dt_bias_ptr,
     q_ptr,
     k_ptr,
     v_ptr,
-    num_prefill,
-    num_decode,
-    decode_stride_seq,
-    q_dim: tl.constexpr,
-    k_dim: tl.constexpr,
-    v_dim: tl.constexpr,
-    BLOCK_SEQ: tl.constexpr,
-    BLOCK_DIM: tl.constexpr,
+    g_ptr,
+    beta_ptr,
+    num_prefill_tokens,
+    num_decode_tokens,
+    prefill_stride_token,
+    prefill_stride_dim,
+    decode_stride_token,
+    decode_stride_dim,
+    a_stride_token,
+    a_stride_head,
+    b_stride_token,
+    b_stride_head,
+    l2_norm_eps,
+    softplus_threshold,
+    NUM_K_HEADS: tl.constexpr,
+    NUM_V_HEADS: tl.constexpr,
+    HEAD_K_DIM: tl.constexpr,
+    HEAD_V_DIM: tl.constexpr,
+    HAS_DECODE: tl.constexpr,
+    BLOCK_TOKENS: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_V: tl.constexpr,
 ):
-    """Fused transpose-prefill + split-decode into contiguous q, k, v.
+    """Prepare contiguous Q/K/V and GDN gates from causal-conv output."""
+    token_block = tl.program_id(0)
+    head_idx = tl.program_id(1)
 
-    Reads prefill from transposed layout [D, T_p] and decode from row-major
-    layout [T_d, D] with contiguous rows of arbitrary stride, writes both
-    into contiguous q/k/v outputs.
-    Grid: (num_seq_blocks_total, num_dim_blocks, 3)
-    program_id(2): 0=Q, 1=K, 2=V
-    """
-    pid_seq = tl.program_id(0)
-    pid_dim = tl.program_id(1)
-    pid_out = tl.program_id(2)
+    token_offsets = token_block * BLOCK_TOKENS + tl.arange(0, BLOCK_TOKENS)
+    total_tokens = num_prefill_tokens + num_decode_tokens
+    token_mask = token_offsets < total_tokens
+    is_prefill = token_offsets < num_prefill_tokens
+    if HAS_DECODE:
+        is_decode = ~is_prefill & token_mask
 
-    total_seq = num_prefill + num_decode
-    out_dim = tl.where(pid_out == 2, v_dim, tl.where(pid_out == 1, k_dim, q_dim))
-    src_col_offset = tl.where(pid_out == 0, 0, tl.where(pid_out == 1, q_dim, q_dim + k_dim))
+    if head_idx < NUM_K_HEADS:
+        dim_offsets = tl.arange(0, BLOCK_K)
+        dim_mask = dim_offsets < HEAD_K_DIM
+        load_mask_prefill = is_prefill[:, None] & dim_mask[None, :]
+        store_mask = token_mask[:, None] & dim_mask[None, :]
 
-    seq_offsets = pid_seq * BLOCK_SEQ + tl.arange(0, BLOCK_SEQ)
-    dim_offsets = pid_dim * BLOCK_DIM + tl.arange(0, BLOCK_DIM)
+        q_feature_offsets = head_idx * HEAD_K_DIM + dim_offsets
 
-    seq_mask = seq_offsets < total_seq
-    dim_mask = dim_offsets < out_dim
-    mask = seq_mask[:, None] & dim_mask[None, :]
+        prefill_q_offsets = (
+            token_offsets[:, None].to(tl.int64) * prefill_stride_token
+            + q_feature_offsets[None, :].to(tl.int64) * prefill_stride_dim
+        )
+        prefill_k_offsets = prefill_q_offsets + NUM_K_HEADS * HEAD_K_DIM * prefill_stride_dim
+        q_prefill = tl.load(prefill_ptr + prefill_q_offsets, mask=load_mask_prefill, other=0.0)
+        k_prefill = tl.load(prefill_ptr + prefill_k_offsets, mask=load_mask_prefill, other=0.0)
 
-    # Determine if each row is prefill or decode
-    is_prefill = seq_offsets < num_prefill
-    is_decode = ~is_prefill & (seq_offsets < total_seq)
+        if HAS_DECODE:
+            load_mask_decode = is_decode[:, None] & dim_mask[None, :]
+            decode_rows = token_offsets - num_prefill_tokens
+            decode_q_offsets = (
+                decode_rows[:, None].to(tl.int64) * decode_stride_token
+                + q_feature_offsets[None, :].to(tl.int64) * decode_stride_dim
+            )
+            decode_k_offsets = decode_q_offsets + NUM_K_HEADS * HEAD_K_DIM * decode_stride_dim
+            q_decode = tl.load(decode_ptr + decode_q_offsets, mask=load_mask_decode, other=0.0)
+            k_decode = tl.load(decode_ptr + decode_k_offsets, mask=load_mask_decode, other=0.0)
+            q_values = tl.where(is_prefill[:, None], q_prefill, q_decode).to(tl.float32)
+            k_values = tl.where(is_prefill[:, None], k_prefill, k_decode).to(tl.float32)
+        else:
+            q_values = q_prefill.to(tl.float32)
+            k_values = k_prefill.to(tl.float32)
 
-    # Prefill: read from prefill_t[D, T_p] transposed — index [col, row]
-    prefill_src_col = src_col_offset + dim_offsets
-    prefill_indices = prefill_src_col[None, :].to(tl.int64) * num_prefill + seq_offsets[:, None].to(
-        tl.int64
-    )
-    prefill_data = tl.load(
-        prefill_t_ptr + prefill_indices, mask=is_prefill[:, None] & dim_mask[None, :], other=0.0
-    )
+        q_inv_norm = 1.0 / tl.sqrt(tl.sum(q_values * q_values, axis=1) + l2_norm_eps)
+        k_inv_norm = 1.0 / tl.sqrt(tl.sum(k_values * k_values, axis=1) + l2_norm_eps)
+        q_values *= q_inv_norm[:, None]
+        k_values *= k_inv_norm[:, None]
 
-    # Decode: read from decode_ptr[T_d, D] row-major
-    decode_row = seq_offsets - num_prefill
-    decode_indices = decode_row[:, None].to(tl.int64) * decode_stride_seq + (
-        src_col_offset + dim_offsets[None, :]
-    ).to(tl.int64)
-    decode_data = tl.load(
-        decode_ptr + decode_indices, mask=is_decode[:, None] & dim_mask[None, :], other=0.0
-    )
+        output_offsets = (
+            token_offsets[:, None].to(tl.int64) * (NUM_K_HEADS * HEAD_K_DIM)
+            + q_feature_offsets[None, :]
+        )
+        tl.store(q_ptr + output_offsets, q_values, mask=store_mask)
+        tl.store(k_ptr + output_offsets, k_values, mask=store_mask)
+    else:
+        value_head_idx = head_idx - NUM_K_HEADS
+        dim_offsets = tl.arange(0, BLOCK_V)
+        dim_mask = dim_offsets < HEAD_V_DIM
+        load_mask_prefill = is_prefill[:, None] & dim_mask[None, :]
+        store_mask = token_mask[:, None] & dim_mask[None, :]
 
-    # Merge
-    data = tl.where(is_prefill[:, None], prefill_data, decode_data)
+        value_feature_offsets = (
+            2 * NUM_K_HEADS * HEAD_K_DIM + value_head_idx * HEAD_V_DIM + dim_offsets
+        )
+        prefill_v_offsets = (
+            token_offsets[:, None].to(tl.int64) * prefill_stride_token
+            + value_feature_offsets[None, :].to(tl.int64) * prefill_stride_dim
+        )
+        v_prefill = tl.load(prefill_ptr + prefill_v_offsets, mask=load_mask_prefill, other=0.0)
+        if HAS_DECODE:
+            load_mask_decode = is_decode[:, None] & dim_mask[None, :]
+            decode_rows = token_offsets - num_prefill_tokens
+            decode_v_offsets = (
+                decode_rows[:, None].to(tl.int64) * decode_stride_token
+                + value_feature_offsets[None, :].to(tl.int64) * decode_stride_dim
+            )
+            v_decode = tl.load(decode_ptr + decode_v_offsets, mask=load_mask_decode, other=0.0)
+            v_values = tl.where(is_prefill[:, None], v_prefill, v_decode)
+        else:
+            v_values = v_prefill
 
-    # Write to output [total_seq, out_dim]
-    out_ptr = tl.where(pid_out == 0, q_ptr, tl.where(pid_out == 1, k_ptr, v_ptr))
-    dst_indices = seq_offsets[:, None].to(tl.int64) * out_dim + dim_offsets[None, :]
-    tl.store(out_ptr + dst_indices, data, mask=mask)
+        output_offsets = (
+            token_offsets[:, None].to(tl.int64) * (NUM_V_HEADS * HEAD_V_DIM)
+            + value_head_idx * HEAD_V_DIM
+            + dim_offsets[None, :]
+        )
+        tl.store(v_ptr + output_offsets, v_values, mask=store_mask)
+
+        a_offsets = token_offsets.to(tl.int64) * a_stride_token + value_head_idx * a_stride_head
+        b_offsets = token_offsets.to(tl.int64) * b_stride_token + value_head_idx * b_stride_head
+        a_values = tl.load(a_ptr + a_offsets, mask=token_mask, other=0.0).to(tl.float32)
+        b_values = tl.load(b_ptr + b_offsets, mask=token_mask, other=0.0).to(tl.float32)
+        A_log = tl.load(A_log_ptr + value_head_idx).to(tl.float32)
+        dt_bias = tl.load(dt_bias_ptr + value_head_idx).to(tl.float32)
+
+        gate_input = a_values + dt_bias
+        softplus = tl.where(
+            gate_input <= softplus_threshold,
+            tl.log(1.0 + tl.exp(gate_input)),
+            gate_input,
+        )
+        g_values = -tl.exp(A_log) * softplus
+        beta_values = tl.sigmoid(b_values)
+        gate_offsets = token_offsets.to(tl.int64) * NUM_V_HEADS + value_head_idx
+        tl.store(g_ptr + gate_offsets, g_values, mask=token_mask)
+        tl.store(beta_ptr + gate_offsets, beta_values, mask=token_mask)
 
 
-def transpose_and_split_qkv(
-    prefill_t: torch.Tensor,
-    decode: torch.Tensor,
-    q_dim: int,
-    k_dim: int,
-    v_dim: int,
-    num_q_heads: int,
+def fused_gdn_post_conv(
+    prefill: torch.Tensor,
+    decode: torch.Tensor | None,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    num_k_heads: int,
     head_k_dim: int,
     num_v_heads: int,
     head_v_dim: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    l2_norm_eps: float = 1e-6,
+    softplus_threshold: float = 20.0,
+    beta_dtype: torch.dtype = torch.float32,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fuse GDN post-conv split, Q/K normalization, and gate preparation.
+
+    Args:
+        prefill: Prefill causal-conv output with shape ``[qkv_dim, num_prefill_tokens]``.
+        decode: Optional decode causal-conv output with shape ``[num_decode_tokens, qkv_dim]``.
+        a: Gate input with shape ``[num_tokens, num_v_heads]``.
+        b: Beta input with shape ``[num_tokens, num_v_heads]``.
+        A_log: Log decay with shape ``[num_v_heads]``.
+        dt_bias: Time-step bias with shape ``[num_v_heads]``.
+        num_k_heads: Number of local query/key heads.
+        head_k_dim: Query/key dimension per head.
+        num_v_heads: Number of local value heads.
+        head_v_dim: Value dimension per head.
+        l2_norm_eps: Epsilon added to the Q/K squared norm.
+        softplus_threshold: Linear fallback threshold for the decay gate softplus.
+        beta_dtype: Output dtype for beta. Target verification uses the input dtype for parity.
+    Returns:
+        Contiguous Q, K, V, log-space G, and beta tensors with shapes
+        ``[1, num_tokens, num_k_heads, head_k_dim]``,
+        ``[1, num_tokens, num_k_heads, head_k_dim]``,
+        ``[1, num_tokens, num_v_heads, head_v_dim]``, and twice
+        ``[1, num_tokens, num_v_heads]``.
     """
-    Fused transpose prefill [D, T_p] + split decode [T_d, D] into contiguous q, k, v.
+    num_prefill_tokens = prefill.shape[1]
+    num_decode_tokens = 0 if decode is None else decode.shape[0]
+    num_tokens = num_prefill_tokens + num_decode_tokens
 
-    The decode tensor may be a column-slice view of a wider tensor (contiguous
-    rows, arbitrary row stride).
-
-    Replaces separate transpose_copy_back + split_qkv_contiguous for mixed batches.
-    """
-    assert decode.stride(-1) == 1
-    num_prefill = prefill_t.shape[1]
-    num_decode = decode.shape[0]
-    total_seq = num_prefill + num_decode
-
-    q_flat = torch.empty(total_seq, q_dim, dtype=prefill_t.dtype, device=prefill_t.device)
-    k_flat = torch.empty(total_seq, k_dim, dtype=prefill_t.dtype, device=prefill_t.device)
-    v_flat = torch.empty(total_seq, v_dim, dtype=prefill_t.dtype, device=prefill_t.device)
-
-    BLOCK_SEQ, BLOCK_DIM = 32, 128
-    max_dim = max(q_dim, k_dim, v_dim)
-    grid = (triton.cdiv(total_seq, BLOCK_SEQ), triton.cdiv(max_dim, BLOCK_DIM), 3)
-
-    _transpose_and_split_qkv_kernel[grid](
-        prefill_t,
-        decode,
-        q_flat,
-        k_flat,
-        v_flat,
-        num_prefill,
-        num_decode,
-        decode.stride(0),
-        q_dim,
-        k_dim,
-        v_dim,
-        BLOCK_SEQ,
-        BLOCK_DIM,
+    q = torch.empty(
+        (1, num_tokens, num_k_heads, head_k_dim), dtype=prefill.dtype, device=prefill.device
     )
-
-    return (
-        q_flat.view(1, total_seq, num_q_heads, head_k_dim),
-        k_flat.view(1, total_seq, num_q_heads, head_k_dim),
-        v_flat.view(1, total_seq, num_v_heads, head_v_dim),
+    k = torch.empty_like(q)
+    v = torch.empty(
+        (1, num_tokens, num_v_heads, head_v_dim), dtype=prefill.dtype, device=prefill.device
     )
+    g = torch.empty((1, num_tokens, num_v_heads), dtype=torch.float32, device=prefill.device)
+    beta = torch.empty((1, num_tokens, num_v_heads), dtype=beta_dtype, device=prefill.device)
+    if num_tokens == 0:
+        return q, k, v, g, beta
+
+    has_decode = decode is not None
+    # Triton requires a tensor for every pointer argument. HAS_DECODE=False
+    # compile-time eliminates all decode address arithmetic and loads, so this
+    # pointer and its strides are never interpreted as a decode tensor.
+    decode_input = prefill if decode is None else decode
+    block_tokens = 16
+    block_k = triton.next_power_of_2(head_k_dim)
+    block_v = triton.next_power_of_2(head_v_dim)
+    grid = (triton.cdiv(num_tokens, block_tokens), num_k_heads + num_v_heads)
+    _fused_gdn_post_conv_kernel[grid](
+        prefill,
+        decode_input,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        q,
+        k,
+        v,
+        g,
+        beta,
+        num_prefill_tokens,
+        num_decode_tokens,
+        prefill.stride(1),
+        prefill.stride(0),
+        decode_input.stride(0),
+        decode_input.stride(1),
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        l2_norm_eps,
+        softplus_threshold,
+        num_k_heads,
+        num_v_heads,
+        head_k_dim,
+        head_v_dim,
+        has_decode,
+        block_tokens,
+        block_k,
+        block_v,
+        num_warps=4,
+        num_stages=2,
+    )
+    return q, k, v, g, beta
 
 
 @triton.jit
-def _split_qkv_contiguous_kernel(
-    src_ptr,
+def _pack_gdn_decode_qkv_kernel(
+    mixed_qkv_ptr,
     q_ptr,
     k_ptr,
     v_ptr,
-    seq_len,
-    src_stride_seq,
-    src_stride_dim,
-    q_dim: tl.constexpr,
-    k_dim: tl.constexpr,
-    v_dim: tl.constexpr,
-    BLOCK_SEQ: tl.constexpr,
-    BLOCK_DIM: tl.constexpr,
+    num_tokens,
+    stride_token,
+    stride_dim,
+    NUM_K_HEADS: tl.constexpr,
+    NUM_V_HEADS: tl.constexpr,
+    HEAD_K_DIM: tl.constexpr,
+    HEAD_V_DIM: tl.constexpr,
+    BLOCK_TOKENS: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_V: tl.constexpr,
 ):
-    """Split mixed_qkv [T, qkv_dim] into 3 contiguous output tensors.
+    """Pack target-verification decode Q/K/V without normalization or gates."""
+    token_offsets = tl.program_id(0) * BLOCK_TOKENS + tl.arange(0, BLOCK_TOKENS)
+    head_idx = tl.program_id(1)
+    token_mask = token_offsets < num_tokens
 
-    Supports arbitrary source strides to handle both contiguous and
-    transposed inputs (e.g. from causal_conv1d_fn(...).transpose(0, 1)).
+    if head_idx < NUM_K_HEADS:
+        dim_offsets = tl.arange(0, BLOCK_K)
+        dim_mask = dim_offsets < HEAD_K_DIM
+        mask = token_mask[:, None] & dim_mask[None, :]
+        q_feature_offsets = head_idx * HEAD_K_DIM + dim_offsets
+        q_offsets = (
+            token_offsets[:, None].to(tl.int64) * stride_token
+            + q_feature_offsets[None, :].to(tl.int64) * stride_dim
+        )
+        k_offsets = q_offsets + NUM_K_HEADS * HEAD_K_DIM * stride_dim
+        output_offsets = (
+            token_offsets[:, None].to(tl.int64) * (NUM_K_HEADS * HEAD_K_DIM)
+            + q_feature_offsets[None, :]
+        )
+        tl.store(q_ptr + output_offsets, tl.load(mixed_qkv_ptr + q_offsets, mask=mask), mask=mask)
+        tl.store(k_ptr + output_offsets, tl.load(mixed_qkv_ptr + k_offsets, mask=mask), mask=mask)
+    else:
+        value_head_idx = head_idx - NUM_K_HEADS
+        dim_offsets = tl.arange(0, BLOCK_V)
+        dim_mask = dim_offsets < HEAD_V_DIM
+        mask = token_mask[:, None] & dim_mask[None, :]
+        value_feature_offsets = (
+            2 * NUM_K_HEADS * HEAD_K_DIM + value_head_idx * HEAD_V_DIM + dim_offsets
+        )
+        value_offsets = (
+            token_offsets[:, None].to(tl.int64) * stride_token
+            + value_feature_offsets[None, :].to(tl.int64) * stride_dim
+        )
+        output_offsets = (
+            token_offsets[:, None].to(tl.int64) * (NUM_V_HEADS * HEAD_V_DIM)
+            + value_head_idx * HEAD_V_DIM
+            + dim_offsets[None, :]
+        )
+        tl.store(
+            v_ptr + output_offsets, tl.load(mixed_qkv_ptr + value_offsets, mask=mask), mask=mask
+        )
 
-    Grid: (num_seq_blocks, num_dim_blocks_for_max_dim, 3)
-    program_id(2): 0=Q, 1=K, 2=V
-    """
-    pid_seq = tl.program_id(0)
-    pid_dim = tl.program_id(1)
-    pid_out = tl.program_id(2)
 
-    # Determine output dim and source column offset for this output
-    out_dim = tl.where(pid_out == 2, v_dim, tl.where(pid_out == 1, k_dim, q_dim))
-    src_col_offset = tl.where(pid_out == 0, 0, tl.where(pid_out == 1, q_dim, q_dim + k_dim))
-
-    seq_offsets = pid_seq * BLOCK_SEQ + tl.arange(0, BLOCK_SEQ)
-    dim_offsets = pid_dim * BLOCK_DIM + tl.arange(0, BLOCK_DIM)
-
-    seq_mask = seq_offsets < seq_len
-    dim_mask = dim_offsets < out_dim
-    mask = seq_mask[:, None] & dim_mask[None, :]
-
-    # Read from src [T, qkv_dim] using actual strides
-    src_indices = (
-        seq_offsets[:, None].to(tl.int64) * src_stride_seq
-        + (src_col_offset + dim_offsets[None, :]).to(tl.int64) * src_stride_dim
-    )
-    data = tl.load(src_ptr + src_indices, mask=mask, other=0.0)
-
-    # Write to output [T, out_dim] — contiguous, stride = (out_dim, 1)
-    out_ptr = tl.where(pid_out == 0, q_ptr, tl.where(pid_out == 1, k_ptr, v_ptr))
-    dst_indices = seq_offsets[:, None].to(tl.int64) * out_dim + dim_offsets[None, :]
-    tl.store(out_ptr + dst_indices, data, mask=mask)
-
-
-def split_qkv_contiguous(
+def pack_gdn_decode_qkv(
     mixed_qkv: torch.Tensor,
-    q_dim: int,
-    k_dim: int,
-    v_dim: int,
-    num_q_heads: int,
+    num_k_heads: int,
     head_k_dim: int,
     num_v_heads: int,
     head_v_dim: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """
-    Split mixed_qkv [T, qkv_dim] into 3 contiguous tensors and reshape.
+    """Pack target-verification decode Q/K/V while keeping them unnormalized.
+
+    Args:
+        mixed_qkv: Decode causal-conv output with shape ``[num_tokens, qkv_dim]``.
+        num_k_heads: Number of local query/key heads.
+        head_k_dim: Query/key dimension per head.
+        num_v_heads: Number of local value heads.
+        head_v_dim: Value dimension per head.
 
     Returns:
-        q_out [1, T, num_q_heads, head_k_dim]  — contiguous
-        k_out [1, T, num_q_heads, head_k_dim]  — contiguous
-        v_out [1, T, num_v_heads, head_v_dim]  — contiguous
+        Contiguous Q, K, and V tensors with shapes
+        ``[1, num_tokens, num_k_heads, head_k_dim]``,
+        ``[1, num_tokens, num_k_heads, head_k_dim]``, and
+        ``[1, num_tokens, num_v_heads, head_v_dim]``.
     """
-    seq_len = mixed_qkv.shape[0]
-    src_stride_seq, src_stride_dim = mixed_qkv.stride()
-
-    q_flat = torch.empty(seq_len, q_dim, dtype=mixed_qkv.dtype, device=mixed_qkv.device)
-    k_flat = torch.empty(seq_len, k_dim, dtype=mixed_qkv.dtype, device=mixed_qkv.device)
-    v_flat = torch.empty(seq_len, v_dim, dtype=mixed_qkv.dtype, device=mixed_qkv.device)
-
-    BLOCK_SEQ = 32
-    BLOCK_DIM = 128
-    max_dim = max(q_dim, k_dim, v_dim)
-    grid = (
-        triton.cdiv(seq_len, BLOCK_SEQ),
-        triton.cdiv(max_dim, BLOCK_DIM),
-        3,
+    num_tokens = mixed_qkv.shape[0]
+    q = torch.empty(
+        (1, num_tokens, num_k_heads, head_k_dim),
+        dtype=mixed_qkv.dtype,
+        device=mixed_qkv.device,
     )
+    k = torch.empty_like(q)
+    v = torch.empty(
+        (1, num_tokens, num_v_heads, head_v_dim),
+        dtype=mixed_qkv.dtype,
+        device=mixed_qkv.device,
+    )
+    if num_tokens == 0:
+        return q, k, v
 
-    _split_qkv_contiguous_kernel[grid](
+    block_tokens = 16
+    block_k = triton.next_power_of_2(head_k_dim)
+    block_v = triton.next_power_of_2(head_v_dim)
+    grid = (triton.cdiv(num_tokens, block_tokens), num_k_heads + num_v_heads)
+    _pack_gdn_decode_qkv_kernel[grid](
         mixed_qkv,
-        q_flat,
-        k_flat,
-        v_flat,
-        seq_len,
-        src_stride_seq,
-        src_stride_dim,
-        q_dim,
-        k_dim,
-        v_dim,
-        BLOCK_SEQ,
-        BLOCK_DIM,
+        q,
+        k,
+        v,
+        num_tokens,
+        mixed_qkv.stride(0),
+        mixed_qkv.stride(1),
+        num_k_heads,
+        num_v_heads,
+        head_k_dim,
+        head_v_dim,
+        block_tokens,
+        block_k,
+        block_v,
+        num_warps=4,
+        num_stages=2,
     )
-
-    return (
-        q_flat.view(1, seq_len, num_q_heads, head_k_dim),
-        k_flat.view(1, seq_len, num_q_heads, head_k_dim),
-        v_flat.view(1, seq_len, num_v_heads, head_v_dim),
-    )
+    return q, k, v
 
 
 @triton.jit

--- a/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
@@ -28,7 +28,7 @@ from ...distributed import AllReduceParams
 from ...model_config import ModelConfig
 from ...speculative import SpecMetadata
 from ...utils import EventType, get_model_extra_attrs, is_torch_compiling
-from ..linear import Linear, TensorParallelMode
+from ..linear import FP8QDQLinearMethod, Linear, TensorParallelMode
 from ..multi_stream_utils import maybe_execute_in_parallel
 from .causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 from .causal_conv1d_triton import causal_conv1d_update as causal_conv1d_update_triton
@@ -316,6 +316,19 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         self.event_dict = {key: torch.cuda.Event() for key in [EventType.Main, EventType.Attention]}
         self.aux_stream = aux_stream
 
+    def cache_derived_state(self) -> None:
+        """Attach downstream static quantization state after loading weights."""
+        self.norm.fp8_scale = None
+        if isinstance(self.out_proj.quant_method, FP8QDQLinearMethod):
+            scale = self.out_proj.quant_method.get_static_input_scale(self.out_proj)
+            # detach() strips the Parameter wrapper so nn.Module.__setattr__
+            # does not register the derived scale into norm's state_dict; the
+            # detached view still shares storage with out_proj.input_scale.
+            self.norm.fp8_scale = scale.detach() if scale is not None else None
+
+    def post_load_weights(self) -> None:
+        self.cache_derived_state()
+
     def _compute_tokenwise_inputs(self, hidden_states: torch.Tensor):
         def _compute_projected_states_qkvz():
             return self.in_proj_qkvz(hidden_states)
@@ -359,7 +372,11 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         # gated norm reads it through its token stride instead of packing a
         # copy.
         attn_out = rms_norm_gated_token_major(
-            attn_out.reshape(-1, self.head_v_dim), z, self.norm.weight, self.norm.eps
+            attn_out.reshape(-1, self.head_v_dim),
+            z,
+            self.norm.weight,
+            self.norm.eps,
+            fp8_scale=self.norm.fp8_scale,
         )
         attn_out = attn_out.view(-1, self.value_dim_per_tp)
         return self.out_proj(attn_out, all_reduce_params=all_reduce_params)

--- a/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
@@ -34,8 +34,8 @@ from .causal_conv1d import causal_conv1d_fn, causal_conv1d_update
 from .causal_conv1d_triton import causal_conv1d_update as causal_conv1d_update_triton
 from .fuse_elementwise_ops import (
     extract_transpose_prefill_slice,
-    split_qkv_contiguous,
-    transpose_and_split_qkv,
+    fused_gdn_post_conv,
+    pack_gdn_decode_qkv,
 )
 from .layernorm_gated import RMSNorm as RMSNormGated
 from .layernorm_gated import rms_norm_gated_token_major
@@ -160,80 +160,6 @@ def fused_gdn_gating(
         g, A_log, a, dt_bias, a.stride(0), num_heads, beta, threshold, 8, num_warps=1
     )
     return g
-
-
-@triton.jit
-def fused_gdn_gating_with_sigmoid_kernel(
-    g,
-    beta_out,
-    A_log,
-    a,
-    dt_bias,
-    b,
-    stride_a_row,
-    stride_b_row,
-    NUM_HEADS: tl.constexpr,
-    sp_beta: tl.constexpr,
-    threshold: tl.constexpr,
-    BLK_HEADS: tl.constexpr,
-):
-    """Fuse gdn_gating + sigmoid(b) into one kernel."""
-    i_b, i_d = tl.program_id(0), tl.program_id(1)
-    head_off = i_d * BLK_HEADS + tl.arange(0, BLK_HEADS)
-    # a/b may be row-strided views sliced out of the packed ba projection;
-    # g/beta_out are always allocated packed.
-    off_a = i_b * stride_a_row + head_off
-    off_b = i_b * stride_b_row + head_off
-    off_out = i_b * NUM_HEADS + head_off
-    mask = head_off < NUM_HEADS
-    blk_A_log = tl.load(A_log + head_off, mask=mask)
-    blk_a = tl.load(a + off_a, mask=mask)
-    blk_bias = tl.load(dt_bias + head_off, mask=mask)
-    x = blk_a.to(tl.float32) + blk_bias.to(tl.float32)
-    softplus_x = tl.where(
-        sp_beta * x <= threshold, (1 / sp_beta) * tl.log(1 + tl.exp(sp_beta * x)), x
-    )
-    blk_g = -tl.exp(blk_A_log.to(tl.float32)) * softplus_x
-    tl.store(g + off_out, blk_g.to(g.dtype.element_ty), mask=mask)
-    # sigmoid(b)
-    blk_b = tl.load(b + off_b, mask=mask)
-    blk_beta = tl.sigmoid(blk_b.to(tl.float32))
-    tl.store(beta_out + off_out, blk_beta.to(beta_out.dtype.element_ty), mask=mask)
-
-
-def fused_gdn_gating_with_sigmoid(
-    A_log: torch.Tensor,
-    a: torch.Tensor,
-    dt_bias: torch.Tensor,
-    b: torch.Tensor,
-    sp_beta: float = 1.0,
-    threshold: float = 20.0,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Fused GDN gating + sigmoid: compute g and beta in one kernel launch."""
-    batch, num_heads = a.shape
-    grid = (batch, triton.cdiv(num_heads, 8))
-    g = torch.empty(batch, num_heads, dtype=torch.float32, device=a.device)
-    # Allocate beta in fp32 since (1) the kernel already computes sigmoid in fp32
-    # and was previously casting back to b.dtype only to be re-cast to fp32 by the
-    # FlashInfer GDN prefill wrapper, and (2) the Triton chunk_gated_delta_rule
-    # path also accepts fp32 beta. Eliminates a redundant cast in the FI hot path.
-    beta_out = torch.empty(batch, num_heads, dtype=torch.float32, device=b.device)
-    fused_gdn_gating_with_sigmoid_kernel[grid](
-        g,
-        beta_out,
-        A_log,
-        a,
-        dt_bias,
-        b,
-        a.stride(0),
-        b.stride(0),
-        num_heads,
-        sp_beta,
-        threshold,
-        8,
-        num_warps=1,
-    )
-    return g, beta_out
 
 
 class Qwen3NextGatedDeltaNet(nn.Module):
@@ -660,8 +586,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         seqlen_split_size = [num_prefill_tokens, num_decode_tokens]
         if num_decode_tokens > 0:
             mixed_qkv_p, mixed_qkv_d = torch.split(mixed_qkv, seqlen_split_size, dim=0)
-            a_p, a_d = torch.split(a, seqlen_split_size, dim=0)
-            b_p, b_d = torch.split(b, seqlen_split_size, dim=0)
             query_start_loc_p = query_start_loc[: num_prefill + 1]
             has_initial_states_p = has_initial_states[:num_prefill]
 
@@ -683,6 +607,8 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             )
 
             if is_target_verify:
+                a_d = a[num_prefill_tokens:]
+                b_d = b[num_prefill_tokens:]
                 draft_token_num = spec_metadata.runtime_draft_len + 1
                 assert num_decodes > 0
                 assert mixed_qkv_d.shape[0] == num_decodes * draft_token_num
@@ -715,20 +641,41 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                     activation=self.activation,
                     conv_state_indices=state_indices_d,
                 )
-            key_split_dim = self.key_dim // self.attn_tp_size
-            value_split_dim = self.value_dim // self.attn_tp_size
-            # Fused transpose + split for mixed prefill+decode batch
-            query, key, value = transpose_and_split_qkv(
-                mixed_qkv_p_t,
-                mixed_qkv_d,
-                key_split_dim,
-                key_split_dim,
-                value_split_dim,
-                self.num_k_heads_per_tp,
-                self.head_k_dim,
-                self.num_v_heads_per_tp,
-                self.head_v_dim,
-            )
+            if is_target_verify:
+                if num_prefill_tokens > 0:
+                    query_p, key_p, value_p, g_p, beta_p = fused_gdn_post_conv(
+                        mixed_qkv_p_t,
+                        None,
+                        a[:num_prefill_tokens],
+                        b[:num_prefill_tokens],
+                        self.A_log,
+                        self.dt_bias,
+                        self.num_k_heads_per_tp,
+                        self.head_k_dim,
+                        self.num_v_heads_per_tp,
+                        self.head_v_dim,
+                        beta_dtype=b.dtype,
+                    )
+                query_d, key_d, value_d = pack_gdn_decode_qkv(
+                    mixed_qkv_d,
+                    self.num_k_heads_per_tp,
+                    self.head_k_dim,
+                    self.num_v_heads_per_tp,
+                    self.head_v_dim,
+                )
+            else:
+                query, key, value, g, beta = fused_gdn_post_conv(
+                    mixed_qkv_p_t,
+                    mixed_qkv_d,
+                    a,
+                    b,
+                    self.A_log,
+                    self.dt_bias,
+                    self.num_k_heads_per_tp,
+                    self.head_k_dim,
+                    self.num_v_heads_per_tp,
+                    self.head_v_dim,
+                )
         else:
             mixed_qkv_t = extract_transpose_prefill_slice(
                 mixed_qkv,
@@ -746,14 +693,13 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 cache_indices=cache_indices,
                 query_start_loc=query_start_loc,
             )
-            key_split_dim = self.key_dim // self.attn_tp_size
-            value_split_dim = self.value_dim // self.attn_tp_size
-            # Fused split for pure prefill (data in [D,T] layout from conv1d)
-            query, key, value = split_qkv_contiguous(
-                mixed_qkv_t.transpose(0, 1),
-                key_split_dim,
-                key_split_dim,
-                value_split_dim,
+            query, key, value, g, beta = fused_gdn_post_conv(
+                mixed_qkv_t,
+                None,
+                a,
+                b,
+                self.A_log,
+                self.dt_bias,
                 self.num_k_heads_per_tp,
                 self.head_k_dim,
                 self.num_v_heads_per_tp,
@@ -763,11 +709,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         if is_target_verify and num_decode_tokens > 0:
             attn_out_prefill = None
             if num_prefill_tokens > 0:
-                query_p = query[:, :num_prefill_tokens, :, :]
-                key_p = key[:, :num_prefill_tokens, :, :]
-                value_p = value[:, :num_prefill_tokens, :, :]
-                beta_p = b_p.sigmoid().unsqueeze(0)
-                g_p = fused_gdn_gating(self.A_log, a_p, self.dt_bias).unsqueeze(0)
                 recurrent_state_p = ssm_states[state_indices_p]
                 output_p = output[:, :num_prefill_tokens, :, :] if output is not None else None
                 attn_out_prefill, last_recurrent_state = chunk_gated_delta_rule(
@@ -780,20 +721,20 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                     output_final_state=True,
                     cu_seqlens=query_start_loc_long[: num_prefill + 1],
                     head_first=False,
-                    use_qk_l2norm_in_kernel=True,
+                    use_qk_l2norm_in_kernel=False,
                     output=output_p,
                 )
                 last_recurrent_state = last_recurrent_state.to(ssm_states.dtype, copy=False)
                 ssm_states[state_indices_p] = last_recurrent_state
 
             draft_token_num = spec_metadata.runtime_draft_len + 1
-            query_d = query[:, num_prefill_tokens:, :, :].reshape(
+            query_d = query_d.reshape(
                 num_decodes, draft_token_num, self.num_k_heads // self.attn_tp_size, self.head_k_dim
             )
-            key_d = key[:, num_prefill_tokens:, :, :].reshape(
+            key_d = key_d.reshape(
                 num_decodes, draft_token_num, self.num_k_heads // self.attn_tp_size, self.head_k_dim
             )
-            value_d = value[:, num_prefill_tokens:, :, :].reshape(
+            value_d = value_d.reshape(
                 num_decodes, draft_token_num, self.num_v_heads // self.attn_tp_size, self.head_v_dim
             )
 
@@ -867,11 +808,6 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 return attn_out_decode
             return torch.cat((attn_out_prefill, attn_out_decode), dim=1)
 
-        g, beta = fused_gdn_gating_with_sigmoid(self.A_log, a, self.dt_bias, b)
-
-        g = g.unsqueeze(0)
-        beta = beta.unsqueeze(0)
-
         core_attn_out, _ = chunk_gated_delta_rule(
             q=query,
             k=key,
@@ -886,7 +822,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             output_final_state=False,
             cu_seqlens=query_start_loc_long,
             head_first=False,
-            use_qk_l2norm_in_kernel=True,
+            use_qk_l2norm_in_kernel=False,
             output=output,
         )
 

--- a/tensorrt_llm/_torch/modules/mamba/layernorm_gated.py
+++ b/tensorrt_llm/_torch/modules/mamba/layernorm_gated.py
@@ -19,6 +19,7 @@
 import torch
 import triton
 import triton.language as tl
+import triton.language.extra.libdevice as tldevice
 
 from ...._utils import get_sm_version
 from ...utils import Fp4QuantizedTensor
@@ -43,6 +44,7 @@ def fused_gated_rmsnorm_quant_shape_ok(hidden_size: int,
 
 @triton.heuristics({"HAS_BIAS": lambda args: args["B"] is not None})
 @triton.heuristics({"HAS_Z": lambda args: args["Z"] is not None})
+@triton.heuristics({"OUTPUT_FP8": lambda args: args["FP8_SCALE"] is not None})
 @triton.jit
 def _layer_norm_fwd_1pass_kernel(
     X,  # pointer to the input
@@ -52,6 +54,7 @@ def _layer_norm_fwd_1pass_kernel(
     Z,  # pointer to the other branch
     Mean,  # pointer to the mean
     Rstd,  # pointer to the 1/std
+    FP8_SCALE,  # static scale for an optional FP8 output
     stride_x_row,  # how much to increase the pointer when moving by 1 row
     stride_y_row,
     stride_z_row,
@@ -63,6 +66,7 @@ def _layer_norm_fwd_1pass_kernel(
     HAS_Z: tl.constexpr,
     NORM_BEFORE_GATE: tl.constexpr,
     IS_RMS_NORM: tl.constexpr,
+    OUTPUT_FP8: tl.constexpr,
 ):
     # Map the program id to the row of X and Y it should compute.
     row = tl.program_id(0)
@@ -105,8 +109,14 @@ def _layer_norm_fwd_1pass_kernel(
     if HAS_Z and NORM_BEFORE_GATE:
         z = tl.load(Z + cols, mask=mask).to(tl.float32)
         y *= z * tl.sigmoid(z)
+    if OUTPUT_FP8:
+        # Match the existing two-kernel path: RMSNorm first stores to the
+        # input dtype, then static quantization reloads and multiplies by the
+        # rounded reciprocal of its input scale.
+        y = y.to(X.dtype.element_ty).to(tl.float32)
+        y *= tldevice.rcp_rn(tl.load(FP8_SCALE).to(tl.float32))
     # Write output
-    tl.store(Y + cols, y, mask=mask)
+    tl.store(Y + cols, y.to(Y.dtype.element_ty), mask=mask)
 
 
 # Rows per program of the multi-row gated-RMSNorm kernel. At the GDN decode
@@ -118,6 +128,7 @@ _MULTIROW_NUM_WARPS = 4
 _MULTIROW_MAX_N = 256
 
 
+@triton.heuristics({"OUTPUT_FP8": lambda args: args["FP8_SCALE"] is not None})
 @triton.jit
 def _rms_norm_gated_fwd_multirow_kernel(
     X,  # pointer to the input
@@ -125,6 +136,7 @@ def _rms_norm_gated_fwd_multirow_kernel(
     W,  # pointer to the weights
     Z,  # pointer to the gate branch
     Rstd,  # pointer to the 1/std
+    FP8_SCALE,  # static scale for an optional FP8 output
     stride_x_row,
     stride_y_row,
     stride_z_tok,
@@ -133,6 +145,7 @@ def _rms_norm_gated_fwd_multirow_kernel(
     N: tl.constexpr,  # row length; power of two, whole row per program
     ROWS: tl.constexpr,  # rows per program
     HEADS_PER_TOK: tl.constexpr,
+    OUTPUT_FP8: tl.constexpr,
 ):
     """rmsnorm(x) * silu(z), several short rows per program.
 
@@ -160,6 +173,12 @@ def _rms_norm_gated_fwd_multirow_kernel(
              cols[None, :])
     z = tl.load(Z + z_off, mask=mask2d, other=0.0).to(tl.float32)
     y *= z * tl.sigmoid(z)
+    if OUTPUT_FP8:
+        # Match the existing two-kernel path: RMSNorm first stores to the
+        # input dtype, then static quantization reloads and multiplies by the
+        # rounded reciprocal of its input scale.
+        y = y.to(X.dtype.element_ty).to(tl.float32)
+        y *= tldevice.rcp_rn(tl.load(FP8_SCALE).to(tl.float32))
     y_off = rows[:, None].to(tl.int64) * stride_y_row + cols[None, :]
     tl.store(Y + y_off, y.to(Y.dtype.element_ty), mask=mask2d)
 
@@ -170,7 +189,7 @@ def _multirow_gated_rmsnorm_eligible(N, ngroups, bias, z, norm_before_gate,
             and ngroups == 1 and N <= _MULTIROW_MAX_N and (N & (N - 1)) == 0)
 
 
-def rms_norm_gated_token_major(x, z, weight, eps, out=None):
+def rms_norm_gated_token_major(x, z, weight, eps, out=None, fp8_scale=None):
     """rmsnorm(x) * silu(z) with z read in place from a 3D token-major view.
 
     x: [num_tokens * heads, N] with contiguous rows. z: [num_tokens, heads, N]
@@ -178,6 +197,10 @@ def rms_norm_gated_token_major(x, z, weight, eps, out=None):
     arbitrary (e.g. a column slice of a wider per-token projection). Falls
     back to the generic kernel on a packed copy of z when the shape is not
     eligible for the multi-row kernel.
+
+    When fp8_scale (a scalar fp32 tensor holding the downstream static input
+    scale) is given, the output is quantized to float8_e4m3fn in the same
+    kernel.
     """
     M, N = x.shape
     num_tokens, heads, n_z = z.shape
@@ -196,10 +219,12 @@ def rms_norm_gated_token_major(x, z, weight, eps, out=None):
             out=out,
             norm_before_gate=True,
             is_rms_norm=True,
+            fp8_scale=fp8_scale,
         )
         return y
     if out is None:
-        out = torch.empty_like(x)
+        out_dtype = torch.float8_e4m3fn if fp8_scale is not None else x.dtype
+        out = torch.empty_like(x, dtype=out_dtype)
     rstd = torch.empty((M, ), dtype=torch.float32, device=x.device)
     grid = (triton.cdiv(M, _MULTIROW_ROWS), )
     with torch.cuda.device(x.device.index):
@@ -209,6 +234,7 @@ def rms_norm_gated_token_major(x, z, weight, eps, out=None):
             weight,
             z,
             rstd,
+            fp8_scale,
             x.stride(0),
             out.stride(0),
             z.stride(0),
@@ -232,6 +258,7 @@ def _layer_norm_fwd(
     group_size=None,
     norm_before_gate=True,
     is_rms_norm=False,
+    fp8_scale=None,
 ):
     M, N = x.shape
     if group_size is None:
@@ -251,8 +278,13 @@ def _layer_norm_fwd(
     if out is not None:
         assert out.shape == x.shape
     else:
-        out = torch.empty_like(x)
+        out_dtype = torch.float8_e4m3fn if fp8_scale is not None else x.dtype
+        out = torch.empty_like(x, dtype=out_dtype)
     assert out.stride(-1) == 1
+    if fp8_scale is not None:
+        assert fp8_scale.dtype == torch.float32
+        assert fp8_scale.numel() == 1
+        assert out.dtype == torch.float8_e4m3fn
     mean = (torch.empty((ngroups * M, ), dtype=torch.float32, device=x.device)
             if not is_rms_norm else None)
     rstd = torch.empty((ngroups * M, ), dtype=torch.float32, device=x.device)
@@ -266,6 +298,7 @@ def _layer_norm_fwd(
                 weight,
                 z,
                 rstd,
+                fp8_scale,
                 x.stride(0),
                 out.stride(0),
                 z.stride(0),
@@ -295,6 +328,7 @@ def _layer_norm_fwd(
             z,
             mean,
             rstd,
+            fp8_scale,
             x.stride(0),
             out.stride(0),
             z.stride(0) if z is not None else 0,
@@ -337,11 +371,14 @@ class RMSNorm(torch.nn.Module):
         self.is_nvfp4 = is_nvfp4
         # nvfp4_scale will be set externally if is_nvfp4 is True
         self.nvfp4_scale: torch.Tensor | None = None
+        # fp8_scale will be attached from the downstream static FP8 linear.
+        self.fp8_scale: torch.Tensor | None = None
 
     def forward(
-            self,
-            x: torch.Tensor,
-            z: torch.Tensor | None = None) -> torch.Tensor | Fp4QuantizedTensor:
+        self,
+        x: torch.Tensor,
+        z: torch.Tensor | None = None,
+    ) -> torch.Tensor | Fp4QuantizedTensor:
         """If z is not None, we do norm(x) * silu(z) if norm_before_gate, else norm(x * silu(z))"""
         x_shape_og = x.shape
         # reshape input data into 2D tensor
@@ -357,6 +394,12 @@ class RMSNorm(torch.nn.Module):
         bias = None
         if self.bias is not None:
             bias = self.bias.contiguous()
+
+        fp8_scale = self.fp8_scale
+        if fp8_scale is not None:
+            if self.is_nvfp4:
+                raise ValueError(
+                    "FP8 and NVFP4 RMSNorm outputs are mutually exclusive")
 
         # NVFP4 quantized path - uses optimized fused CUDA kernel
         # Fuses: SiLU gating + Group RMSNorm + FP4 quantization
@@ -391,5 +434,6 @@ class RMSNorm(torch.nn.Module):
             group_size=self.group_size,
             norm_before_gate=self.norm_before_gate,
             is_rms_norm=True,
+            fp8_scale=fp8_scale,
         )
         return y.reshape(x_shape_og)

--- a/tests/unittest/_torch/modules/mamba/test_gdn_kernel_optimizations.py
+++ b/tests/unittest/_torch/modules/mamba/test_gdn_kernel_optimizations.py
@@ -16,6 +16,8 @@
 decode QKV packing, the dense in_proj row permutation, and the multi-row
 gated RMSNorm."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -459,3 +461,77 @@ def test_pack_gdn_decode_qkv(
     torch.testing.assert_close(actual_q.view(num_tokens, -1), expected_q, rtol=0, atol=0)
     torch.testing.assert_close(actual_k.view(num_tokens, -1), expected_k, rtol=0, atol=0)
     torch.testing.assert_close(actual_v.view(num_tokens, -1), expected_v, rtol=0, atol=0)
+
+
+# ---- Tests for the GDN compile boundary and derived state ----
+
+
+def test_gdn_custom_op_forwards_split_inputs(monkeypatch):
+    """The compile boundary consumes split inputs and mutates its output."""
+    import tensorrt_llm._torch.modules.mamba.gdn_mixer as gdn_mixer
+
+    class FakeMetadata:
+        num_tokens = 2
+        mamba_metadata = object()
+
+    class FakeLayer:
+        def forward_core(
+            self,
+            mixed_qkv,
+            a,
+            b,
+            attn_metadata,
+            mamba_metadata,
+            spec_metadata,
+            output,
+        ):
+            assert mixed_qkv.shape[0] == 2
+            assert a.shape[0] == 2
+            assert b.shape[0] == 2
+            assert attn_metadata is metadata
+            assert mamba_metadata is metadata.mamba_metadata
+            assert spec_metadata is None
+            output.fill_(5)
+
+    metadata = FakeMetadata()
+    monkeypatch.setattr(
+        gdn_mixer,
+        "_extract_gdn_extra_attrs",
+        lambda layer_idx: (metadata, FakeLayer(), None),
+    )
+    mixed_qkv = torch.zeros(3, 8)
+    a = torch.zeros(3, 2)
+    b = torch.zeros(3, 2)
+    output = torch.zeros(1, 3, 2, 2)
+
+    gdn_mixer.gdn_custom_op_inplace(mixed_qkv, a, b, "0", output)
+
+    torch.testing.assert_close(output[:, :2], torch.full_like(output[:, :2], 5))
+    torch.testing.assert_close(output[:, 2:], torch.zeros_like(output[:, 2:]))
+
+
+def test_gdn_attaches_only_static_fp8_scale():
+    from tensorrt_llm._torch.modules.linear import FP8QDQLinearMethod
+    from tensorrt_llm._torch.modules.mamba.gdn_mixer import Qwen3NextGatedDeltaNet
+    from tensorrt_llm._torch.modules.mamba.layernorm_gated import RMSNorm
+
+    layer = Qwen3NextGatedDeltaNet.__new__(Qwen3NextGatedDeltaNet)
+    torch.nn.Module.__init__(layer)
+    layer.norm = RMSNorm(8)
+    scale = torch.nn.Parameter(torch.tensor(0.13), requires_grad=False)
+    layer.out_proj = SimpleNamespace(
+        quant_method=FP8QDQLinearMethod(),
+        input_scale=scale,
+        force_dynamic_quantization=False,
+    )
+
+    layer.cache_derived_state()
+    assert not isinstance(layer.norm.fp8_scale, torch.nn.Parameter)
+    assert "fp8_scale" not in layer.norm.state_dict()
+    assert "fp8_scale" not in dict(layer.norm.named_parameters())
+    assert torch.equal(layer.norm.fp8_scale, scale)
+    assert layer.norm.fp8_scale.data_ptr() == scale.data_ptr()
+
+    layer.out_proj.force_dynamic_quantization = True
+    layer.cache_derived_state()
+    assert layer.norm.fp8_scale is None

--- a/tests/unittest/_torch/modules/mamba/test_gdn_kernel_optimizations.py
+++ b/tests/unittest/_torch/modules/mamba/test_gdn_kernel_optimizations.py
@@ -12,8 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for GDN kernel optimizations: fused gating+sigmoid, split_qkv,
-transpose_and_split, the dense in_proj row permutation, and the multi-row
+"""Unit tests for GDN kernel optimizations: fused post-conv split/norm/gating,
+decode QKV packing, the dense in_proj row permutation, and the multi-row
 gated RMSNorm."""
 
 import pytest
@@ -27,13 +27,6 @@ skip_no_cuda = pytest.mark.skipif(
 
 
 # ---- Reference implementations ----
-
-
-def _ref_gdn_gating_with_sigmoid(A_log, a, dt_bias, b, beta=1.0, threshold=20.0):
-    """Reference: g = -exp(A_log) * softplus(a + dt_bias), beta_out = sigmoid(b)."""
-    g = -torch.exp(A_log.float()) * F.softplus(a.float() + dt_bias.float(), beta, threshold)
-    beta_out = torch.sigmoid(b.float()).to(b.dtype)
-    return g, beta_out
 
 
 def _ref_split_grouped_qkvz(y, num_groups, head_k_dim, head_v_dim, heads_ratio):
@@ -190,160 +183,165 @@ def test_rms_norm_gated_token_major(num_tokens, heads, N):
     assert torch.equal(y, y_dense)
 
 
-def _ref_split_qkv_contiguous(mixed_qkv, q_dim, k_dim, v_dim):
-    """Reference: torch.split + contiguous."""
-    q, k, v = torch.split(mixed_qkv, [q_dim, k_dim, v_dim], dim=-1)
-    return q.contiguous(), k.contiguous(), v.contiguous()
-
-
-def _ref_transpose_and_split_qkv(prefill_t, decode, q_dim, k_dim, v_dim):
-    """Reference: transpose prefill [D,T] -> [T,D], cat with decode, then split."""
-    prefill = prefill_t.transpose(0, 1).contiguous()
-    mixed = torch.cat([prefill, decode], dim=0)
-    q, k, v = torch.split(mixed, [q_dim, k_dim, v_dim], dim=-1)
-    return q.contiguous(), k.contiguous(), v.contiguous()
-
-
-# ---- Tests for fused_gdn_gating_with_sigmoid ----
-
-
-@skip_no_cuda
-@pytest.mark.parametrize("batch_size", [1, 16, 128, 512])
-@pytest.mark.parametrize("num_heads", [16, 30])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_fused_gdn_gating_with_sigmoid(batch_size, num_heads, dtype):
-    """Test fused gating+sigmoid matches separate sigmoid + gating."""
-    from tensorrt_llm._torch.modules.mamba.gdn_mixer import fused_gdn_gating_with_sigmoid
-
-    torch.manual_seed(42)
-    device = torch.device("cuda")
-
-    A_log = torch.randn(num_heads, dtype=dtype, device=device)
-    a = torch.randn(batch_size, num_heads, dtype=dtype, device=device)
-    dt_bias = torch.randn(num_heads, dtype=dtype, device=device)
-    b = torch.randn(batch_size, num_heads, dtype=dtype, device=device)
-
-    g_ref, beta_ref = _ref_gdn_gating_with_sigmoid(A_log, a, dt_bias, b)
-    g_fused, beta_fused = fused_gdn_gating_with_sigmoid(A_log, a, dt_bias, b)
-
-    assert g_fused.shape == g_ref.shape
-    assert beta_fused.shape == beta_ref.shape
-    torch.testing.assert_close(g_fused, g_ref, rtol=1e-2, atol=1e-2)
-    torch.testing.assert_close(beta_fused.float(), beta_ref.float(), rtol=1e-2, atol=1e-2)
-
-
-# ---- Tests for split_qkv_contiguous ----
-
-
-@skip_no_cuda
-@pytest.mark.parametrize("seq_len", [1, 32, 128, 1024])
-@pytest.mark.parametrize(
-    "q_dim,k_dim,v_dim,num_q_heads,head_k_dim,num_v_heads,head_v_dim",
-    [
-        (256, 256, 16, 16, 16, 16, 1),  # Qwen3.5-35B like
-        (512, 512, 64, 16, 32, 16, 4),
-    ],
-)
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-def test_split_qkv_contiguous(
-    seq_len, q_dim, k_dim, v_dim, num_q_heads, head_k_dim, num_v_heads, head_v_dim, dtype
-):
-    """Test split_qkv_contiguous matches torch.split + contiguous."""
-    from tensorrt_llm._torch.modules.mamba.fuse_elementwise_ops import split_qkv_contiguous
-
-    torch.manual_seed(42)
-    device = torch.device("cuda")
-
-    total_dim = q_dim + k_dim + v_dim
-    mixed_qkv = torch.randn(seq_len, total_dim, dtype=dtype, device=device)
-
-    q_ref, k_ref, v_ref = _ref_split_qkv_contiguous(mixed_qkv, q_dim, k_dim, v_dim)
-    q_out, k_out, v_out = split_qkv_contiguous(
-        mixed_qkv,
-        q_dim,
-        k_dim,
-        v_dim,
-        num_q_heads,
-        head_k_dim,
-        num_v_heads,
-        head_v_dim,
-    )
-
-    # Output is 4D [1, T, heads, head_dim], ref is 2D [T, dim]
-    assert q_out.shape == (1, seq_len, num_q_heads, head_k_dim)
-    assert k_out.shape == (1, seq_len, num_q_heads, head_k_dim)
-    assert v_out.shape == (1, seq_len, num_v_heads, head_v_dim)
-
-    torch.testing.assert_close(q_out.view(seq_len, -1), q_ref, rtol=0, atol=0)
-    torch.testing.assert_close(k_out.view(seq_len, -1), k_ref, rtol=0, atol=0)
-    torch.testing.assert_close(v_out.view(seq_len, -1), v_ref, rtol=0, atol=0)
-
-
-# ---- Tests for transpose_and_split_qkv ----
-
-
-@skip_no_cuda
-@pytest.mark.parametrize("num_prefill,num_decode", [(32, 8), (128, 16), (1, 1), (256, 0)])
-@pytest.mark.parametrize(
-    "q_dim,k_dim,v_dim,num_q_heads,head_k_dim,num_v_heads,head_v_dim",
-    [
-        (256, 256, 16, 16, 16, 16, 1),
-        (512, 512, 64, 16, 32, 16, 4),
-    ],
-)
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-def test_transpose_and_split_qkv(
-    num_prefill,
-    num_decode,
-    q_dim,
-    k_dim,
-    v_dim,
-    num_q_heads,
+def _ref_gdn_post_conv(
+    prefill,
+    decode,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    num_k_heads,
     head_k_dim,
     num_v_heads,
     head_v_dim,
-    dtype,
+    beta_dtype,
 ):
-    """Test transpose_and_split_qkv matches transpose + cat + split."""
-    from tensorrt_llm._torch.modules.mamba.fuse_elementwise_ops import transpose_and_split_qkv
+    """Reference GDN post-conv preparation."""
+    mixed_qkv = prefill.transpose(0, 1)
+    if decode is not None:
+        mixed_qkv = torch.cat((mixed_qkv, decode), dim=0)
 
-    if num_decode == 0:
-        pytest.skip("transpose_and_split_qkv requires decode tokens")
+    q_dim = num_k_heads * head_k_dim
+    v_dim = num_v_heads * head_v_dim
+    q, k, v = torch.split(mixed_qkv, (q_dim, q_dim, v_dim), dim=-1)
+    q = q.view(-1, num_k_heads, head_k_dim).contiguous()
+    k = k.view(-1, num_k_heads, head_k_dim).contiguous()
+    v = v.view(-1, num_v_heads, head_v_dim).contiguous()
+
+    q_normalized = q.float() / torch.sqrt(
+        torch.sum(q.float() * q.float(), dim=-1, keepdim=True) + 1e-6
+    )
+    k_normalized = k.float() / torch.sqrt(
+        torch.sum(k.float() * k.float(), dim=-1, keepdim=True) + 1e-6
+    )
+    q = q_normalized.to(q.dtype)
+    k = k_normalized.to(k.dtype)
+
+    gate_input = a.float() + dt_bias.float()
+    g = -torch.exp(A_log.float()) * F.softplus(gate_input, beta=1.0, threshold=20.0)
+    beta = torch.sigmoid(b.float()).to(beta_dtype)
+    return q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0), g.unsqueeze(0), beta.unsqueeze(0)
+
+
+# ---- Tests for fused_gdn_post_conv ----
+
+
+@skip_no_cuda
+@pytest.mark.parametrize(
+    "num_k_heads,num_v_heads,head_k_dim,head_v_dim",
+    [
+        (16, 32, 128, 128),  # Qwen3.6-35B
+        (16, 64, 128, 128),  # Qwen3.5-397B
+        (4, 8, 64, 64),
+    ],
+)
+@pytest.mark.parametrize(
+    "num_prefill_tokens,num_decode_tokens,beta_dtype",
+    [
+        (1, 0, torch.float32),
+        (127, 0, torch.bfloat16),
+        (128, 16, torch.float32),
+    ],
+)
+def test_fused_gdn_post_conv(
+    num_k_heads,
+    num_v_heads,
+    head_k_dim,
+    head_v_dim,
+    num_prefill_tokens,
+    num_decode_tokens,
+    beta_dtype,
+):
+    """Test fused post-conv preparation for pure and mixed prefill."""
+    from tensorrt_llm._torch.modules.mamba.fuse_elementwise_ops import fused_gdn_post_conv
 
     torch.manual_seed(42)
     device = torch.device("cuda")
+    dtype = torch.bfloat16
+    qkv_dim = 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim
+    num_tokens = num_prefill_tokens + num_decode_tokens
 
-    total_dim = q_dim + k_dim + v_dim
-    prefill_t = torch.randn(total_dim, num_prefill, dtype=dtype, device=device)  # [D, T_p]
-    decode = torch.randn(num_decode, total_dim, dtype=dtype, device=device)  # [T_d, D]
-
-    q_ref, k_ref, v_ref = _ref_transpose_and_split_qkv(
-        prefill_t,
-        decode,
-        q_dim,
-        k_dim,
-        v_dim,
+    prefill = torch.randn(qkv_dim, num_prefill_tokens, dtype=dtype, device=device)
+    decode = (
+        torch.randn(num_decode_tokens, qkv_dim, dtype=dtype, device=device)
+        if num_decode_tokens
+        else None
     )
-    q_out, k_out, v_out = transpose_and_split_qkv(
-        prefill_t,
+    a = torch.randn(num_tokens, num_v_heads, dtype=dtype, device=device)
+    b = torch.randn(num_tokens, num_v_heads, dtype=dtype, device=device)
+    A_log = torch.randn(num_v_heads, dtype=torch.float32, device=device) - 2.0
+    dt_bias = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+
+    expected = _ref_gdn_post_conv(
+        prefill,
         decode,
-        q_dim,
-        k_dim,
-        v_dim,
-        num_q_heads,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+        beta_dtype,
+    )
+    actual = fused_gdn_post_conv(
+        prefill,
+        decode,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+        beta_dtype=beta_dtype,
+    )
+
+    for output in actual:
+        assert output.is_contiguous()
+    for actual_output, expected_output in zip(actual[:3], expected[:3]):
+        torch.testing.assert_close(actual_output, expected_output, rtol=1e-2, atol=1e-2)
+    for actual_output, expected_output in zip(actual[3:], expected[3:]):
+        torch.testing.assert_close(actual_output, expected_output, rtol=1e-4, atol=1e-4)
+    assert actual[4].dtype == beta_dtype
+    torch.testing.assert_close(actual[4].to(b.dtype), b.sigmoid().unsqueeze(0), rtol=0, atol=0)
+
+
+@skip_no_cuda
+def test_fused_gdn_post_conv_empty():
+    """Test the empty-input fast path."""
+    from tensorrt_llm._torch.modules.mamba.fuse_elementwise_ops import fused_gdn_post_conv
+
+    device = torch.device("cuda")
+    num_k_heads, num_v_heads = 4, 8
+    head_k_dim = head_v_dim = 64
+    qkv_dim = 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim
+    prefill = torch.empty(qkv_dim, 0, dtype=torch.bfloat16, device=device)
+    a = torch.empty(0, num_v_heads, dtype=torch.bfloat16, device=device)
+    b = torch.empty_like(a)
+    A_log = torch.empty(num_v_heads, dtype=torch.float32, device=device)
+    dt_bias = torch.empty_like(A_log)
+
+    q, k, v, g, beta = fused_gdn_post_conv(
+        prefill,
+        None,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        num_k_heads,
         head_k_dim,
         num_v_heads,
         head_v_dim,
     )
 
-    total_seq = num_prefill + num_decode
-    assert q_out.shape == (1, total_seq, num_q_heads, head_k_dim)
-    assert k_out.shape == (1, total_seq, num_q_heads, head_k_dim)
-    assert v_out.shape == (1, total_seq, num_v_heads, head_v_dim)
-
-    torch.testing.assert_close(q_out.view(total_seq, -1), q_ref, rtol=0, atol=0)
-    torch.testing.assert_close(k_out.view(total_seq, -1), k_ref, rtol=0, atol=0)
-    torch.testing.assert_close(v_out.view(total_seq, -1), v_ref, rtol=0, atol=0)
+    assert q.shape == (1, 0, num_k_heads, head_k_dim)
+    assert k.shape == q.shape
+    assert v.shape == (1, 0, num_v_heads, head_v_dim)
+    assert g.shape == (1, 0, num_v_heads)
+    assert beta.shape == g.shape
 
 
 # ---- Strided (column-slice view) inputs, as produced by the dense in_proj ----
@@ -351,28 +349,16 @@ def test_transpose_and_split_qkv(
 
 @skip_no_cuda
 def test_gdn_gating_strided_views():
-    """a/b sliced out of the packed ba projection must match packed inputs."""
-    from tensorrt_llm._torch.modules.mamba.gdn_mixer import (
-        fused_gdn_gating,
-        fused_gdn_gating_with_sigmoid,
-    )
+    """a sliced out of the packed ba projection must match packed inputs."""
+    from tensorrt_llm._torch.modules.mamba.gdn_mixer import fused_gdn_gating
 
     torch.manual_seed(42)
     device = torch.device("cuda")
     ba = torch.randn(300, 64, dtype=torch.bfloat16, device=device)
-    b_view, a_view = ba[:, :32], ba[:, 32:]
+    a_view = ba[:, 32:]
 
     A_log = torch.randn(32, dtype=torch.float32, device=device)
     dt_bias = torch.randn(32, dtype=torch.float32, device=device)
-
-    g_v, beta_v = fused_gdn_gating_with_sigmoid(A_log, a_view, dt_bias, b_view)
-    g_c, beta_c = fused_gdn_gating_with_sigmoid(
-        A_log, a_view.contiguous(), dt_bias, b_view.contiguous()
-    )
-    assert torch.equal(g_v, g_c) and torch.equal(beta_v, beta_c)
-    g_ref, beta_ref = _ref_gdn_gating_with_sigmoid(A_log, a_view, dt_bias, b_view)
-    torch.testing.assert_close(g_v, g_ref, rtol=1e-2, atol=1e-2)
-    torch.testing.assert_close(beta_v, beta_ref.float(), rtol=1e-2, atol=1e-2)
 
     assert torch.equal(
         fused_gdn_gating(A_log, a_view, dt_bias),
@@ -382,10 +368,9 @@ def test_gdn_gating_strided_views():
 
 @skip_no_cuda
 def test_transpose_helpers_strided_views():
-    """The prefill transpose/split helpers must read column-slice views in place."""
+    """The prefill transpose helper must read column-slice views in place."""
     from tensorrt_llm._torch.modules.mamba.fuse_elementwise_ops import (
         extract_transpose_prefill_slice,
-        transpose_and_split_qkv,
     )
 
     torch.manual_seed(42)
@@ -396,11 +381,81 @@ def test_transpose_helpers_strided_views():
     out = extract_transpose_prefill_slice(view, 100, 0, 1024)
     assert torch.equal(out, view.T.contiguous())
 
-    prefill_t = torch.randn(1024, 40, dtype=torch.bfloat16, device=device)
-    decode_view = wide[40:80, :1024]
-    outs_view = transpose_and_split_qkv(prefill_t, decode_view, 256, 256, 512, 16, 16, 16, 32)
-    outs_packed = transpose_and_split_qkv(
-        prefill_t, decode_view.contiguous(), 256, 256, 512, 16, 16, 16, 32
+
+@skip_no_cuda
+def test_fused_gdn_post_conv_strided_views():
+    """a/b and decode sliced out of wider projections must match packed inputs."""
+    from tensorrt_llm._torch.modules.mamba.fuse_elementwise_ops import fused_gdn_post_conv
+
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_k_heads, num_v_heads, head_k_dim, head_v_dim = 4, 8, 64, 64
+    qkv_dim = 2 * num_k_heads * head_k_dim + num_v_heads * head_v_dim
+    num_prefill_tokens, num_decode_tokens = 33, 7
+    num_tokens = num_prefill_tokens + num_decode_tokens
+
+    prefill = torch.randn(qkv_dim, num_prefill_tokens, dtype=dtype, device=device)
+    wide_qkvz = torch.randn(num_decode_tokens, qkv_dim + 256, dtype=dtype, device=device)
+    decode_view = wide_qkvz[:, :qkv_dim]  # rows contiguous, wider row stride
+    ba = torch.randn(num_tokens, 2 * num_v_heads, dtype=dtype, device=device)
+    b_view, a_view = ba[:, :num_v_heads], ba[:, num_v_heads:]
+    A_log = torch.randn(num_v_heads, dtype=torch.float32, device=device) - 2.0
+    dt_bias = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+
+    args = (A_log, dt_bias, num_k_heads, head_k_dim, num_v_heads, head_v_dim)
+    outs_view = fused_gdn_post_conv(prefill, decode_view, a_view, b_view, *args)
+    outs_packed = fused_gdn_post_conv(
+        prefill, decode_view.contiguous(), a_view.contiguous(), b_view.contiguous(), *args
     )
     for got, ref in zip(outs_view, outs_packed):
         assert torch.equal(got, ref)
+
+
+@skip_no_cuda
+@pytest.mark.parametrize(
+    "num_k_heads,num_v_heads,head_k_dim,head_v_dim",
+    [
+        (16, 32, 128, 128),  # Qwen3.6-35B
+        (16, 64, 128, 128),  # Qwen3.5-397B
+        (4, 8, 64, 64),
+    ],
+)
+@pytest.mark.parametrize("num_tokens", [1, 16, 127])
+@pytest.mark.parametrize("strided_input", [False, True])
+def test_pack_gdn_decode_qkv(
+    num_k_heads,
+    num_v_heads,
+    head_k_dim,
+    head_v_dim,
+    num_tokens,
+    strided_input,
+):
+    """Test target-verification decode packing without normalization."""
+    from tensorrt_llm._torch.modules.mamba.fuse_elementwise_ops import pack_gdn_decode_qkv
+
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    q_dim = num_k_heads * head_k_dim
+    v_dim = num_v_heads * head_v_dim
+    qkv_dim = 2 * q_dim + v_dim
+    if strided_input:
+        mixed_qkv = torch.randn(num_tokens, qkv_dim * 2, dtype=dtype, device=device)[:, ::2]
+    else:
+        mixed_qkv = torch.randn(num_tokens, qkv_dim, dtype=dtype, device=device)
+
+    expected_q, expected_k, expected_v = torch.split(mixed_qkv, (q_dim, q_dim, v_dim), dim=-1)
+    actual_q, actual_k, actual_v = pack_gdn_decode_qkv(
+        mixed_qkv,
+        num_k_heads,
+        head_k_dim,
+        num_v_heads,
+        head_v_dim,
+    )
+
+    for output in (actual_q, actual_k, actual_v):
+        assert output.is_contiguous()
+    torch.testing.assert_close(actual_q.view(num_tokens, -1), expected_q, rtol=0, atol=0)
+    torch.testing.assert_close(actual_k.view(num_tokens, -1), expected_k, rtol=0, atol=0)
+    torch.testing.assert_close(actual_v.view(num_tokens, -1), expected_v, rtol=0, atol=0)

--- a/tests/unittest/_torch/modules/mamba/test_layernorm_gated.py
+++ b/tests/unittest/_torch/modules/mamba/test_layernorm_gated.py
@@ -153,6 +153,56 @@ class TestRMSNormBasic:
 
         torch.testing.assert_close(output_triton, output_ref, rtol=1e-2, atol=1e-2)
 
+    @pytest.mark.parametrize("scale", [32.0, 0.13])
+    def test_fp8_matches_separate_static_quantization(self, scale):
+        hidden_size = 128
+        batch_size = 32
+        device = "cuda"
+        dtype = torch.bfloat16
+
+        torch.manual_seed(3)
+        norm = RMSNorm(hidden_size, eps=1e-6, norm_before_gate=True).to(device).to(dtype)
+        torch.nn.init.normal_(norm.weight, mean=1.0, std=0.1)
+        x = torch.randn(batch_size, hidden_size, device=device, dtype=dtype)
+        z = torch.randn(batch_size, hidden_size, device=device, dtype=dtype)
+        fp8_scale = torch.tensor(scale, device=device, dtype=torch.float32)
+
+        bf16_output = norm(x, z=z)
+        expected, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(bf16_output, fp8_scale)
+        norm.fp8_scale = fp8_scale
+        actual = norm(x, z=z)
+
+        assert actual.dtype == torch.float8_e4m3fn
+        assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+
+    @pytest.mark.parametrize("scale", [32.0, 0.13])
+    @pytest.mark.parametrize("num_tokens,heads,N", [(64, 8, 128), (33, 4, 512)])
+    def test_token_major_fp8_matches_separate_static_quantization(
+        self, scale, num_tokens, heads, N
+    ):
+        """Both the multi-row (N<=256) and generic-fallback (N>256) paths of
+        rms_norm_gated_token_major must quantize identically to norm-then-
+        static-quantize."""
+        from tensorrt_llm._torch.modules.mamba.layernorm_gated import rms_norm_gated_token_major
+
+        device = "cuda"
+        dtype = torch.bfloat16
+
+        torch.manual_seed(3)
+        M = num_tokens * heads
+        x = torch.randn(M, N, device=device, dtype=dtype)
+        weight = torch.randn(N, device=device, dtype=dtype) * 0.1 + 1.0
+        wide = torch.randn(num_tokens, heads * N + 256, device=device, dtype=dtype)
+        z = wide[:, 256:].view(num_tokens, heads, N)
+        fp8_scale = torch.tensor(scale, device=device, dtype=torch.float32)
+
+        bf16_output = rms_norm_gated_token_major(x, z, weight, 1e-6)
+        expected, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(bf16_output, fp8_scale)
+        actual = rms_norm_gated_token_major(x, z, weight, 1e-6, fp8_scale=fp8_scale)
+
+        assert actual.dtype == torch.float8_e4m3fn
+        assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+
 
 @skip_no_cuda
 class TestRMSNormNVFP4:


### PR DESCRIPTION
Got 4.9%(bs1)/2.3%(bs8)/2.7%(bs16) e2e speed up on qwen3.6 35b nvfp4 ckpt with B200

<img width="1454" height="912" alt="image" src="https://github.com/user-attachments/assets/05f26ca1-654e-485e-8458-ca4b4f4b20de" />

<img width="1454" height="732" alt="image" src="https://github.com/user-attachments/assets/dccbca0a-dbe3-469a-abf5-1b6419fb13ad" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Mamba/GDN processing for mixed prefill and decode workloads with more efficient fused operations.
  * Added optimized Q/K/V preparation and decode packing paths.

* **FP8 Support**
  * Added optional FP8-scaled outputs for RMSNorm.
  * Improved selection between static and dynamic FP8 quantization.

* **Reliability**
  * Expanded CUDA coverage for fused GDN operations, FP8 outputs, caching, and decode workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->