### PR TITLE
[TRTLLM-14010][feat] report KV cache transfer state on executor hangs

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -27,6 +27,7 @@
 #include "tensorrt_llm/executor/dataTransceiverState.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include "tensorrt_llm/runtime/utils/pgUtils.h"
+#include <atomic>
 #include <cstddef>
 #include <fstream>
 #include <future>
@@ -309,8 +310,39 @@ public:
     [[nodiscard]] std::vector<char> getSerializedDataTransceiverState() const override;
 
     [[nodiscard]] bool hasPoisonedTransferBuffer() const override;
+    /// Return a human-readable dump of transceiver state for debugging hangs.
+    std::string getStatusDump() const;
 
 private:
+    struct StatusSnapshot
+    {
+        size_t senderAsyncActive{0};
+        size_t requesterAsyncActive{0};
+        size_t timedOutSenders{0};
+        size_t timedOutRequesters{0};
+        size_t cancelingSenders{0};
+        size_t cancelingRequesters{0};
+        size_t completedSenders{0};
+        size_t completedRequesters{0};
+        size_t failedSenders{0};
+        size_t failedRequesters{0};
+        size_t sendersAwaitingConsensus{0};
+        size_t requestersAwaitingConsensus{0};
+    };
+
+    class SyncRequesterStatusGuard
+    {
+    public:
+        explicit SyncRequesterStatusGuard(CacheTransceiver& transceiver);
+        ~SyncRequesterStatusGuard() noexcept;
+
+        SyncRequesterStatusGuard(SyncRequesterStatusGuard const&) = delete;
+        SyncRequesterStatusGuard& operator=(SyncRequesterStatusGuard const&) = delete;
+
+    private:
+        CacheTransceiver& mTransceiver;
+    };
+
     void initializeCommState();
 
     void setContextState(LlmRequest* llmRequest);
@@ -318,6 +350,7 @@ private:
     // Append one row per completed request to the gen-side transfer summary CSV. Opens the file
     // lazily on first use; expects timing to already be synced across ranks by the caller.
     void writeGenTransferSummary(std::vector<LlmRequest*> const& completedRequests);
+    void publishStatusSnapshot() noexcept;
 
     std::unique_ptr<CacheSender> mCacheSender;
     std::unique_ptr<CacheReceiver> mCacheReceiver;
@@ -338,6 +371,12 @@ private:
     std::unordered_set<LlmRequest::RequestIdType> mCompletedRequesterRequestIds;
     std::unordered_set<LlmRequest::RequestIdType> mFailedRequesterRequestIds;
     std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<LlmRequest>> mRequesterRequestsAwaitingConsensus;
+    std::atomic_size_t mSyncRequesterActive{0};
+    // Live transfer containers are owned by the executor worker thread. Synchronous receive threads update only the
+    // atomic count above. The executor publishes snapshots after state transitions, while the hang-detector thread only
+    // copies the snapshot under this short lock.
+    mutable std::mutex mStatusSnapshotMutex;
+    StatusSnapshot mStatusSnapshot;
     mpi::MpiComm const* mMpiWorldComm{nullptr};
 
     std::shared_ptr<CacheTransceiverComm> mGroupComm;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -747,12 +747,20 @@ CacheTransceiver::~CacheTransceiver()
 std::string CacheTransceiver::getStatusDump() const
 {
     auto const backendType = mCacheTransceiverConfig->getBackendType().value();
+    auto const requesterSyncActive = mSyncRequesterActive.load(std::memory_order_relaxed);
     StatusSnapshot snapshot;
     {
-        std::lock_guard<std::mutex> lock(mStatusSnapshotMutex);
+        std::unique_lock<std::mutex> lock(mStatusSnapshotMutex, std::try_to_lock);
+        if (!lock.owns_lock())
+        {
+            std::ostringstream oss;
+            oss << "KV cache transceiver | backend=" << cacheTransceiverBackendName(backendType)
+                << " | snapshot=unavailable | RX(sync_active=" << requesterSyncActive
+                << ") | poisoned=" << (hasPoisonedTransferBuffer() ? "yes" : "no");
+            return oss.str();
+        }
         snapshot = mStatusSnapshot;
     }
-    auto const requesterSyncActive = mSyncRequesterActive.load(std::memory_order_relaxed);
     std::ostringstream oss;
     oss << "KV cache transceiver | backend=" << cacheTransceiverBackendName(backendType)
         << " | TX(async_active=" << snapshot.senderAsyncActive << ", timed_out=" << snapshot.timedOutSenders

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -64,6 +64,7 @@
 #include <numeric>
 #include <random>
 #include <sstream>
+#include <system_error>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -101,6 +102,20 @@ namespace
 using RequestIdType = LlmRequest::RequestIdType;
 
 constexpr int kTransferFuturePollIntervalMs = 10;
+
+char const* cacheTransceiverBackendName(executor::CacheTransceiverConfig::BackendType backendType)
+{
+    using BackendType = executor::CacheTransceiverConfig::BackendType;
+    switch (backendType)
+    {
+    case BackendType::DEFAULT: return "DEFAULT";
+    case BackendType::MPI: return "MPI";
+    case BackendType::UCX: return "UCX";
+    case BackendType::NIXL: return "NIXL";
+    case BackendType::MOONCAKE: return "MOONCAKE";
+    }
+    return "UNKNOWN";
+}
 
 // Finite status checks are scheduler polls, not terminal deadlines. Pure polls
 // use short slices; calls that ask for at least one completion keep bounded
@@ -729,6 +744,65 @@ CacheTransceiver::~CacheTransceiver()
     }
 }
 
+std::string CacheTransceiver::getStatusDump() const
+{
+    auto const backendType = mCacheTransceiverConfig->getBackendType().value();
+    StatusSnapshot snapshot;
+    {
+        std::lock_guard<std::mutex> lock(mStatusSnapshotMutex);
+        snapshot = mStatusSnapshot;
+    }
+    auto const requesterSyncActive = mSyncRequesterActive.load(std::memory_order_relaxed);
+    std::ostringstream oss;
+    oss << "KV cache transceiver | backend=" << cacheTransceiverBackendName(backendType)
+        << " | TX(async_active=" << snapshot.senderAsyncActive << ", timed_out=" << snapshot.timedOutSenders
+        << ", cancel_requested=" << snapshot.cancelingSenders << ", local_completed=" << snapshot.completedSenders
+        << ", local_failed=" << snapshot.failedSenders << ", awaiting_consensus=" << snapshot.sendersAwaitingConsensus
+        << ") | RX(async_active=" << snapshot.requesterAsyncActive << ", sync_active=" << requesterSyncActive
+        << ", timed_out=" << snapshot.timedOutRequesters << ", cancel_requested=" << snapshot.cancelingRequesters
+        << ", local_completed=" << snapshot.completedRequesters << ", local_failed=" << snapshot.failedRequesters
+        << ", awaiting_consensus=" << snapshot.requestersAwaitingConsensus
+        << ") | poisoned=" << (hasPoisonedTransferBuffer() ? "yes" : "no");
+    return oss.str();
+}
+
+void CacheTransceiver::publishStatusSnapshot() noexcept
+{
+    StatusSnapshot snapshot;
+    snapshot.senderAsyncActive = mSenderFutures.size();
+    snapshot.requesterAsyncActive = mRequesterFutures.size();
+    snapshot.timedOutSenders = mTimedOutSenderIds.size();
+    snapshot.timedOutRequesters = mTimedOutRequesterIds.size();
+    snapshot.cancelingSenders = mCancelRequestedSenderIds.size();
+    snapshot.cancelingRequesters = mCancelRequestedRequesterIds.size();
+    snapshot.completedSenders = mCompletedSenderRequestIds.size();
+    snapshot.completedRequesters = mCompletedRequesterRequestIds.size();
+    snapshot.failedSenders = mFailedSenderRequestIds.size();
+    snapshot.failedRequesters = mFailedRequesterRequestIds.size();
+    snapshot.sendersAwaitingConsensus = mSenderRequestsAwaitingConsensus.size();
+    snapshot.requestersAwaitingConsensus = mRequesterRequestsAwaitingConsensus.size();
+    try
+    {
+        std::lock_guard<std::mutex> lock(mStatusSnapshotMutex);
+        mStatusSnapshot = snapshot;
+    }
+    catch (std::system_error const&)
+    {
+        // Status publication is best-effort and must never fail a transfer path.
+    }
+}
+
+CacheTransceiver::SyncRequesterStatusGuard::SyncRequesterStatusGuard(CacheTransceiver& transceiver)
+    : mTransceiver{transceiver}
+{
+    mTransceiver.mSyncRequesterActive.fetch_add(1, std::memory_order_relaxed);
+}
+
+CacheTransceiver::SyncRequesterStatusGuard::~SyncRequesterStatusGuard() noexcept
+{
+    mTransceiver.mSyncRequesterActive.fetch_sub(1, std::memory_order_relaxed);
+}
+
 void CacheTransceiver::initializeCommState()
 {
     mCommState = std::addressof(mCacheSender->getCommState());
@@ -780,6 +854,7 @@ void CacheTransceiver::respondAndSendAsync(std::shared_ptr<LlmRequest> llmReques
     setContextState(llmRequest.get());
     auto future = mCacheSender->sendAsync(llmRequest);
     mSenderFutures.emplace_back(std::move(llmRequest), std::move(future));
+    publishStatusSnapshot();
 }
 
 void CacheTransceiver::respondAndSendLayerWise(
@@ -797,6 +872,7 @@ void CacheTransceiver::respondAndSendLayerWise(
         auto future = mCacheSender->sendAsync(llmRequest);
         mSenderFutures.emplace_back(llmRequest, std::move(future));
     }
+    publishStatusSnapshot();
 }
 
 void CacheTransceiver::requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequest)
@@ -806,6 +882,7 @@ void CacheTransceiver::requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequ
     auto const contextRequestId = llmRequest->getContextPhaseParams().value().getReqId();
     TLLM_LOG_DEBUG("Synchronous KV cache receive request %zu, context request %zu waiting for native completion.",
         requestId, contextRequestId);
+    SyncRequesterStatusGuard statusGuard{*this};
     try
     {
         auto future = mCacheReceiver->receiveAsync(llmRequest);
@@ -854,6 +931,7 @@ void CacheTransceiver::requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmReq
     auto* requestPtr = llmRequest.get();
     mRequesterFutures.emplace_back(std::move(llmRequest), std::move(future));
     requestPtr->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+    publishStatusSnapshot();
 }
 
 std::vector<LlmRequest::RequestIdType> gatherRequestIds(
@@ -1024,7 +1102,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
             contextCompleteRequestIds.push_back(request->mRequestId);
         }
     }
-
+    publishStatusSnapshot();
     std::unordered_map<LlmRequest::RequestIdType, int> frequencyMap;
     if ((syncComm) && syncComm->getSize() > 1)
     {
@@ -1174,6 +1252,8 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         }
     }
 
+    // Publish after local polling and before consensus, which may be the point at which a rank hangs.
+    publishStatusSnapshot();
     RequestStatuses requestsStatus{};
     TransferConsensusOutcome consensusOutcome;
     if (mContextTransferCoordinator)
@@ -1271,6 +1351,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
             requestId, mCompletedSenderRequestIds, mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
     }
 
+    publishStatusSnapshot();
     return requestsStatus;
 }
 
@@ -1313,6 +1394,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             collectReadyRequestIds();
         }
     }
+    publishStatusSnapshot();
     std::unordered_map<LlmRequest::RequestIdType, int> frequencyMap;
 
     std::vector<LlmRequest::RequestIdType> toBlockRequestIds;
@@ -1466,6 +1548,8 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
         }
     }
 
+    // Publish after local polling and before collectives, which may be the point at which a rank hangs.
+    publishStatusSnapshot();
     auto const consensusOutcome
         = reduceTransferStates(syncComm, mCompletedRequesterRequestIds, mFailedRequesterRequestIds,
             inflightCancelEnabled ? mTimedOutRequesterIds : std::unordered_set<RequestIdType>{});
@@ -1524,6 +1608,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
         eraseLocalTransferOutcome(
             requestId, mCompletedRequesterRequestIds, mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
     }
+    publishStatusSnapshot();
 
     // Batch-sync timing across ranks in one allgather (instead of per-request), then write
     // the gen-side transfer summary CSV.

--- a/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
@@ -27,6 +27,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/trampoline.h>
@@ -133,7 +134,8 @@ void tb::CacheTransceiverBindings::initBindings(nb::module_& m)
             nb::arg("cache_manager"), nb::arg("num_kv_heads_per_layer"), nb::arg("size_per_head"),
             nb::arg("tokens_per_block"), nb::arg("world_config"), nb::arg("attention_layer_num_per_pp"),
             nb::arg("dtype"), nb::arg("attention_type"), nb::arg("cache_transceiver_config") = std::nullopt,
-            nb::arg("rnn_layer_num_per_pp") = std::vector<SizeType32>{});
+            nb::arg("rnn_layer_num_per_pp") = std::vector<SizeType32>{})
+        .def("get_status_dump", &tb::CacheTransceiver::getStatusDump);
 
     nb::class_<tb::CacheTransceiverComm>(m, "CacheTransceiverComm")
         .def(

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -171,25 +171,18 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             sessions: Dict[int, Any],
             include_receiver_ready: bool,
         ) -> str:
-            session_items = list(sessions.items())
+            session_items = list(sessions.copy().items())
             status_counts = Counter()
             receiver_ready = 0
             for _, session in session_items:
-                try:
-                    status = session.status
-                except Exception:
-                    status_counts["unknown"] += 1
+                status = session.status
+                if isinstance(status, SessionStatus):
+                    status_counts[status] += 1
                 else:
-                    if isinstance(status, SessionStatus):
-                        status_counts[status] += 1
-                    else:
-                        status_counts["unknown"] += 1
+                    status_counts["unknown"] += 1
 
                 if include_receiver_ready:
-                    try:
-                        receiver_ready += int(bool(session.receiver_ready))
-                    except Exception:
-                        pass
+                    receiver_ready += int(bool(session.receiver_ready))
 
             fields = [
                 f"sessions={len(session_items)}",

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -1,7 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 import time
 import uuid
-from collections import defaultdict
+from collections import Counter, defaultdict
 from itertools import chain
 from typing import Any, Callable, Dict, List, Optional, cast
 
@@ -149,6 +163,55 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         logger.info(f"transfer worker ctx_server_endpoints: {endpoints}")
         logger.info(f"layer_num_per_pp: {layer_num_per_pp}")
         logger.info(f"self._context_info_endpoint: {self._context_info_endpoint}")
+
+    def get_status_dump(self) -> str:
+        """Return a one-line summary of transceiver state for debugging hangs."""
+
+        def summarize(
+            sessions: Dict[int, Any],
+            include_receiver_ready: bool,
+        ) -> str:
+            session_items = list(sessions.items())
+            status_counts = Counter()
+            receiver_ready = 0
+            for _, session in session_items:
+                try:
+                    status = session.status
+                except Exception:
+                    status_counts["unknown"] += 1
+                else:
+                    if isinstance(status, SessionStatus):
+                        status_counts[status] += 1
+                    else:
+                        status_counts["unknown"] += 1
+
+                if include_receiver_ready:
+                    try:
+                        receiver_ready += int(bool(session.receiver_ready))
+                    except Exception:
+                        pass
+
+            fields = [
+                f"sessions={len(session_items)}",
+                f"init={status_counts[SessionStatus.INIT]}",
+                f"ready_to_transfer={status_counts[SessionStatus.READY]}",
+                f"transferring={status_counts[SessionStatus.TRANSFERRING]}",
+                f"kv_transferred={status_counts[SessionStatus.KV_TRANSFERRED]}",
+                f"fully_transferred={status_counts[SessionStatus.FULLY_TRANSFERRED]}",
+                f"error={status_counts[SessionStatus.ERROR]}",
+                f"cancelled={status_counts[SessionStatus.CANCELLED]}",
+                f"unknown={status_counts['unknown']}",
+            ]
+            if include_receiver_ready:
+                fields.append(f"peer_ready={receiver_ready}/{len(session_items)}")
+            return ", ".join(fields)
+
+        tx_status = summarize(self._send_sessions, include_receiver_ready=True)
+        rx_status = summarize(self._recv_sessions, include_receiver_ready=False)
+        return (
+            f"KV cache transceiver | backend=NIXL | TX({tx_status}) | RX({rx_status}) | "
+            f"waiting_for_peer_info={len(self._wait_reqs)}"
+        )
 
     def shutdown(self):
         if getattr(self, "_shutdown", False):

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -171,10 +171,10 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             sessions: Dict[int, Any],
             include_receiver_ready: bool,
         ) -> str:
-            session_items = list(sessions.copy().items())
+            sessions_snapshot = list(sessions.values())
             status_counts = Counter()
             receiver_ready = 0
-            for _, session in session_items:
+            for session in sessions_snapshot:
                 status = session.status
                 if isinstance(status, SessionStatus):
                     status_counts[status] += 1
@@ -185,7 +185,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                     receiver_ready += int(bool(session.receiver_ready))
 
             fields = [
-                f"sessions={len(session_items)}",
+                f"sessions={len(sessions_snapshot)}",
                 f"init={status_counts[SessionStatus.INIT]}",
                 f"ready_to_transfer={status_counts[SessionStatus.READY]}",
                 f"transferring={status_counts[SessionStatus.TRANSFERRING]}",
@@ -196,7 +196,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 f"unknown={status_counts['unknown']}",
             ]
             if include_receiver_ready:
-                fields.append(f"peer_ready={receiver_ready}/{len(session_items)}")
+                fields.append(f"peer_ready={receiver_ready}/{len(sessions_snapshot)}")
             return ", ".join(fields)
 
         tx_status = summarize(self._send_sessions, include_receiver_ready=True)

--- a/tensorrt_llm/_torch/pyexecutor/hang_detector.py
+++ b/tensorrt_llm/_torch/pyexecutor/hang_detector.py
@@ -100,6 +100,7 @@ class HangDetector:
         self.lock = threading.Lock()
         self.active = False
         self._detected = False
+        self._status_providers: list[Callable[[], str]] = []
 
     def start(self):
         """Enable hang detection."""
@@ -113,11 +114,22 @@ class HangDetector:
         self.loop_thread = threading.Thread(target=run_loop, daemon=True, name="hang_detector_loop")
         self.loop_thread.start()
 
+    def register_status_provider(self, provider: Callable[[], str]):
+        """Register a callable that returns a status string to dump on hang detection."""
+        self._status_providers.append(provider)
+
     async def _detect_hang(self):
         await asyncio.sleep(self.timeout)
         with self.lock:
             self._detected = True
             logger.error(f"Hang detected after {self.timeout} seconds.")
+            for provider in self._status_providers:
+                try:
+                    status = provider()
+                    if status:
+                        logger.error(status)
+                except Exception:
+                    pass
             print_all_stacks()
             self.on_detected()
 

--- a/tensorrt_llm/_torch/pyexecutor/hang_detector.py
+++ b/tensorrt_llm/_torch/pyexecutor/hang_detector.py
@@ -114,23 +114,30 @@ class HangDetector:
         self.loop_thread = threading.Thread(target=run_loop, daemon=True, name="hang_detector_loop")
         self.loop_thread.start()
 
-    def register_status_provider(self, provider: Callable[[], str]):
-        """Register a callable that returns a status string to dump on hang detection."""
-        self._status_providers.append(provider)
+    def register_status_provider(self, provider: Callable[[], str]) -> None:
+        """Register a nonblocking callable that returns status to dump on hang detection."""
+        with self.lock:
+            self._status_providers.append(provider)
 
-    async def _detect_hang(self):
+    async def _detect_hang(self) -> None:
         await asyncio.sleep(self.timeout)
         with self.lock:
             self._detected = True
-            logger.error(f"Hang detected after {self.timeout} seconds.")
-            for provider in self._status_providers:
+            status_providers = tuple(self._status_providers)
+
+        _best_effort_log_error(f"Hang detected after {self.timeout} seconds.")
+        try:
+            for provider in status_providers:
                 try:
                     status = provider()
                     if status:
-                        logger.error(status)
-                except Exception:
-                    pass
+                        _best_effort_log_error(status)
+                except Exception as error:  # noqa: BLE001 - isolate diagnostic providers
+                    _best_effort_log_error(
+                        f"HangDetector: status provider failed with {type(error).__name__}: {error}"
+                    )
             print_all_stacks()
+        finally:
             self.on_detected()
 
     def detected(self):

--- a/tensorrt_llm/_torch/pyexecutor/hang_detector.py
+++ b/tensorrt_llm/_torch/pyexecutor/hang_detector.py
@@ -122,23 +122,22 @@ class HangDetector:
     async def _detect_hang(self) -> None:
         await asyncio.sleep(self.timeout)
         with self.lock:
-            self._detected = True
             status_providers = tuple(self._status_providers)
 
         _best_effort_log_error(f"Hang detected after {self.timeout} seconds.")
-        try:
-            for provider in status_providers:
-                try:
-                    status = provider()
-                    if status:
-                        _best_effort_log_error(status)
-                except Exception as error:  # noqa: BLE001 - isolate diagnostic providers
-                    _best_effort_log_error(
-                        f"HangDetector: status provider failed with {type(error).__name__}: {error}"
-                    )
-            print_all_stacks()
-        finally:
-            self.on_detected()
+        for provider in status_providers:
+            try:
+                status = provider()
+                if status:
+                    _best_effort_log_error(status)
+            except Exception as error:  # noqa: BLE001 - isolate diagnostic providers
+                _best_effort_log_error(
+                    f"HangDetector: status provider failed with {type(error).__name__}: {error}"
+                )
+        print_all_stacks()
+        with self.lock:
+            self._detected = True
+        self.on_detected()
 
     def detected(self):
         """Return True if hang is detected."""

--- a/tensorrt_llm/_torch/pyexecutor/hang_detector.py
+++ b/tensorrt_llm/_torch/pyexecutor/hang_detector.py
@@ -124,6 +124,8 @@ class HangDetector:
         with self.lock:
             status_providers = tuple(self._status_providers)
 
+        # All diagnostics are best-effort: nothing may prevent on_detected()
+        # (hard-kill propagation) from firing.
         _best_effort_log_error(f"Hang detected after {self.timeout} seconds.")
         for provider in status_providers:
             try:
@@ -134,7 +136,13 @@ class HangDetector:
                 _best_effort_log_error(
                     f"HangDetector: status provider failed with {type(error).__name__}: {error}"
                 )
-        print_all_stacks()
+        try:
+            print_all_stacks()
+        except Exception:  # noqa: BLE001 - stack dump must not block hard kill
+            pass
+
+        # Set _detected last so observers (and tests) see it only once
+        # diagnostics are done and on_detected is about to fire.
         with self.lock:
             self._detected = True
         self.on_detected()

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -241,6 +241,10 @@ class KvCacheTransceiver(ABC):
         """Get the serialized DataTransceiverState (CacheState + CommState)."""
         return b""
 
+    def get_status_dump(self) -> str:
+        """Return a human-readable dump of transceiver state for debugging hangs."""
+        return ""
+
     def shutdown(self):
         """Shut down the transceiver and release registered resources."""
 
@@ -334,6 +338,9 @@ class BindKvCacheTransceiver(KvCacheTransceiver):
         if not is_disagg_inflight_cancel_enabled():
             return False
         return self.impl.has_poisoned_transfer_buffer()
+
+    def get_status_dump(self) -> str:
+        return self.impl.get_status_dump()
 
     def prepare_context_requests(self, requests: List[LlmRequest]):
         # not implemented, an empty placeholder to allow being invoked unconditionally

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -918,6 +918,9 @@ class PyExecutor:
         self.gather_all_responses = False
 
         self.kv_cache_transceiver = kv_cache_transceiver
+        if kv_cache_transceiver is not None:
+            self.hang_detector.register_status_provider(
+                kv_cache_transceiver.get_status_dump)
         cache_transceiver_config = getattr(self.llm_args,
                                            "cache_transceiver_config", None)
         max_tokens_in_buffer = getattr(cache_transceiver_config,

--- a/tests/unittest/_torch/executor/test_hang_detector_kill.py
+++ b/tests/unittest/_torch/executor/test_hang_detector_kill.py
@@ -14,12 +14,14 @@
 # limitations under the License.
 """HangDetector timer behavior and the hard-kill propagation mechanism (no GPU)."""
 
+import asyncio
 import os
 import signal
 import subprocess
 import sys
 import time
 
+from tensorrt_llm._torch.pyexecutor import hang_detector as hang_detector_module
 from tensorrt_llm._torch.pyexecutor.hang_detector import HangDetector
 
 
@@ -62,6 +64,39 @@ def test_pause_suppresses_detection():
             time.sleep(2.0)  # would have fired if not paused
         assert fired == []
         assert hd.detected() is False
+
+
+def test_status_provider_errors_are_logged(monkeypatch):
+    events = []
+
+    async def no_sleep(_timeout):
+        pass
+
+    def failing_provider():
+        raise RuntimeError("provider failed")
+
+    monkeypatch.setattr(hang_detector_module.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(
+        hang_detector_module,
+        "_best_effort_log_error",
+        lambda message: events.append(("log", message)),
+    )
+    monkeypatch.setattr(
+        hang_detector_module,
+        "print_all_stacks",
+        lambda: events.append(("stacks", None)),
+    )
+
+    detector = HangDetector(timeout=1, on_detected=lambda: events.append(("detected", None)))
+    detector.register_status_provider(failing_provider)
+    detector.register_status_provider(lambda: "transceiver status")
+
+    asyncio.run(detector._detect_hang())
+
+    messages = "\n".join(message for kind, message in events if kind == "log")
+    assert "provider failed" in messages
+    assert "transceiver status" in messages
+    assert events[-2:] == [("stacks", None), ("detected", None)]
 
 
 def test_propagate_hard_kill_self_sigkills_without_mpi():


### PR DESCRIPTION
## Summary

  - Adds KV-cache transceiver status reporting to HangDetector, logged before stack traces and termination.
  - Uses synchronized snapshots for the C++ V1 transceiver to avoid reading live transfer containers concurrently.
  - Reports Python V2 session states, peer readiness, and requests waiting for peer information.
  - Keeps snapshots current around consensus and terminal cleanup.
  
  ## Status output

  V1 / C++ transceiver:
```
  TX(async_active=2, timed_out=1, cancel_requested=1, local_completed=0, local_failed=1, awaiting_consensus=1) |
  RX(async_active=1, sync_active=0, timed_out=0, cancel_requested=0, local_completed=1, local_failed=0, awaiting_consensus=1) |
  poisoned=no
```

  V2 / Python NIXL transceiver:

```
  KV cache transceiver | backend=NIXL |
  TX(sessions=2, init=0, ready_to_transfer=1, transferring=1, kv_transferred=0, fully_transferred=0, error=0, cancelled=0, unknown=0, peer_ready=1/2) |
  RX(sessions=1, init=0, ready_to_transfer=0, transferring=0, kv_transferred=0, fully_transferred=1, error=0, cancelled=0, unknown=0) |
  waiting_for_peer_info=0
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Dev Engineer Review**

- Added thread-safe KV cache transceiver hang/debug instrumentation:
  - `CacheTransceiver` now maintains a synchronized `StatusSnapshot` (mutex-guarded, with an atomic “sync requester active” counter) and exposes `getStatusDump()` for a consistent TX/RX/transfer-buffer status view.
  - Introduced RAII `SyncRequesterStatusGuard` plus `publishStatusSnapshot() noexcept` to refresh snapshot data at key transfer checkpoints and around consensus/terminal cleanup.
- Improved diagnostics safety:
  - Snapshot publication is best-effort (`noexcept`, swallows `std::system_error`) to avoid disrupting transfer flows.
  - Python-side status dumping aggregates per-session state and includes “waiting for peer info” via `_wait_reqs` size.
- HangDetector diagnostics wiring:
  - `HangDetector` now supports registration of caller-provided status providers; failures in individual providers are caught and logged so hang handling/stack reporting and `on_detected` still proceed.
- Consistency/API notes:
  - C++ `getStatusDump()` is surfaced to Python via `KvCacheTransceiver.get_status_dump()` / `BindKvCacheTransceiver.get_status_dump()`, and then registered with `HangDetector` from `PyExecutor` when a transceiver is present.
- Other changes:
  - Nanobind binding update only adds `<nanobind/stl/string.h>` and reformats a constructor default.
- Test-list/config scan:
  - Confirmed `tests/unittest/_torch/executor/test_hang_detector_kill.py` is listed in `tests/integration/test_lists/test-db/l0_sanity_check.yml` (entry at line ~41).

**QA Engineer Review**

- Test functions added:
  - `tests/unittest/_torch/executor/test_hang_detector_kill.py::test_status_provider_errors_are_logged`
- Coverage:
  - Covered in CI via `tests/integration/test_lists/test-db/l0_sanity_check.yml` entry for `unittest/_torch/executor/test_hang_detector_kill.py`.
- Verdict: sufficient
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
