### PR TITLE
[None][feat] LTX-2: run v2a cross-attention under distributed Attention2D

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -133,8 +133,11 @@ class LTX2Attention(Attention):
         # the plain backend + all-gather in the AV cross-attn forward path.
         ulysses_size = vgm.ulysses_size if vgm is not None else 1
         cp_size = vgm.cp_size if vgm is not None else 1
+        attn2d_active = vgm is not None and vgm.attn2d_row_size * vgm.attn2d_col_size > 1
         if self._is_cross_attn:
-            enable_sp = enable_sequence_parallel and cp_size == 1
+            # v2a (the only SP-enabled cross-attn) runs distributed Attention2D+Ulysses
+            # under attn2d instead of all-gathering the full video K/V; a2v/text keep SP off.
+            enable_sp = enable_sequence_parallel and (cp_size == 1 or attn2d_active)
         else:
             enable_sp = enable_sequence_parallel
 
@@ -186,7 +189,7 @@ class LTX2Attention(Attention):
         # UlyssesAttention(inner_backend=sharded_backend).
         if (
             enable_sequence_parallel
-            and (cp_size == 1 or not self._is_cross_attn)
+            and (cp_size == 1 or not self._is_cross_attn or attn2d_active)
             and ulysses_size > 1
         ):
             self._ulysses_attn = self.attn

--- a/tensorrt_llm/_torch/visual_gen/modules/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/attention.py
@@ -198,10 +198,16 @@ class Attention(nn.Module):
         # V/Q/K projections AND still needs the head-sharding wrap — opt in
         # via async_ulysses=True.
         cp_size = vgm.cp_size if vgm else 1
+        attn2d_active = vgm is not None and vgm.attn2d_row_size * vgm.attn2d_col_size > 1
         use_ulysses = (
             ulysses_size > 1
             and enable_sequence_parallel
-            and (self.qkv_mode != QKVMode.SEPARATE_QKV or async_ulysses or cp_size == 1)
+            and (
+                self.qkv_mode != QKVMode.SEPARATE_QKV
+                or async_ulysses
+                or cp_size == 1
+                or attn2d_active
+            )
         )
         if ulysses_size > 1 and enable_sequence_parallel and not use_ulysses:
             # Ulysses was requested (ulysses_size > 1, SP on) but disabled: this is a

--- a/tensorrt_llm/_torch/visual_gen/modules/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/attention.py
@@ -4,7 +4,6 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 
-from tensorrt_llm.logger import logger
 from tensorrt_llm.visual_gen.sparse_attention import SkipSoftmaxAttentionConfig
 
 from ...modules.linear import Linear, TensorParallelMode, WeightMode, WeightsLoadingConfig
@@ -193,32 +192,11 @@ class Attention(nn.Module):
             ]
         )
 
-        # Ulysses auto-wrap normally skips SEPARATE_QKV (cross-attention).
-        # The async-ulysses path uses SEPARATE_QKV for stream-pipelined
-        # V/Q/K projections AND still needs the head-sharding wrap — opt in
-        # via async_ulysses=True.
-        cp_size = vgm.cp_size if vgm else 1
-        attn2d_active = vgm is not None and vgm.attn2d_row_size * vgm.attn2d_col_size > 1
-        use_ulysses = (
-            ulysses_size > 1
-            and enable_sequence_parallel
-            and (
-                self.qkv_mode != QKVMode.SEPARATE_QKV
-                or async_ulysses
-                or cp_size == 1
-                or attn2d_active
-            )
-        )
-        if ulysses_size > 1 and enable_sequence_parallel and not use_ulysses:
-            # Ulysses was requested (ulysses_size > 1, SP on) but disabled: this is a
-            # SEPARATE_QKV cross-attention that is neither async nor pure-Ulysses
-            # (cp_size > 1), so it falls back to the all-gather K/V path.
-            logger.debug(
-                f"Attention(layer={layer_idx}): Ulysses disabled despite ulysses_size="
-                f"{ulysses_size} — qkv_mode={self.qkv_mode.value}, "
-                f"async_ulysses={async_ulysses}, cp_size={cp_size} "
-                f"(SEPARATE_QKV cross-attn needs async_ulysses or cp_size==1)."
-            )
+        # Ulysses (head-sharding) is orthogonal to CP (sequence-sharding), so it
+        # composes with pure-Ulysses, Attention2D and async alike, including for
+        # SEPARATE_QKV cross-attn. Ring + SEPARATE_QKV is the only unsupported
+        # combination and is rejected below.
+        use_ulysses = ulysses_size > 1 and enable_sequence_parallel
 
         # Compute head counts for the backend
         # Ulysses shards heads across workers; inner backend sees sharded count


### PR DESCRIPTION
## Description

When Attention2D (`attn2d`) is active, let the **v2a cross-attention** — the only sequence-parallel-enabled cross-attn direction — run under **distributed Attention2D + Ulysses** instead of all-gathering the full video K/V. An `attn2d_active` flag opens three gates in `LTX2Attention` / `Attention`: `enable_sp` for cross-attn, the Ulysses dual-attn wiring, and `use_ulysses`. `a2v` and text cross-attn keep sequence parallelism off (unchanged). Extends the v2a-Ulysses path (#15303) to the Attention2D mesh.

## Test Coverage

Structurally exercised on 16-GPU LTX-2 (cfg2 × attn2d). **End-to-end numerical validation is still pending — opening as draft.**

## Notes

Orthogonal to `async_ulysses` (a separate flag, off here). The config validator only forbids `async_ulysses` + `ring_size>1`, not `attn2d`; whether the async fast-path composes correctly with the Attention2D wrapper is a separate question and not exercised by this change.
