### PR TITLE
[https://nvbugs/6374873][fix] Allow fp4 KV Cache + non-FP4 Mamba State

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -687,12 +687,7 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
         // radix-tree / scheduler / disagg machinery that already iterates pools internally.
         auto const poolIt = poolByWindow.find(windowSize);
         auto const windowSizePerHead = (poolIt != poolByWindow.end()) ? poolIt->second->sizePerHead : sizePerHead;
-        // Python treats the recurrent-state pool as byte storage before viewing each state with its actual dtype.
-        // Keep its backing type independent of the attention KV-cache dtype.
-        auto const windowDtype = LinearAttentionMetadata::hasRecurrentStatesCache(windowSize)
-            ? nvinfer1::DataType::kINT8
-            : (poolIt != poolByWindow.end()) ? poolIt->second->dtype
-                                             : dtype;
+        auto const windowDtype = (poolIt != poolByWindow.end()) ? poolIt->second->dtype : dtype;
         mWindowBlockManagers.try_emplace(SizeType32(windowSize), windowDtype, windowSize, layersWithWindowSize,
             numKvHeadsPerLayer, windowSizePerHead, tokensPerBlock,
             /*isSWA=*/(windowSize < maxSequenceLength) && (windowSize >= 0), allottedPrimaryBlocks,

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -687,7 +687,12 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
         // radix-tree / scheduler / disagg machinery that already iterates pools internally.
         auto const poolIt = poolByWindow.find(windowSize);
         auto const windowSizePerHead = (poolIt != poolByWindow.end()) ? poolIt->second->sizePerHead : sizePerHead;
-        auto const windowDtype = (poolIt != poolByWindow.end()) ? poolIt->second->dtype : dtype;
+        // Python treats the recurrent-state pool as byte storage before viewing each state with its actual dtype.
+        // Keep its backing type independent of the attention KV-cache dtype.
+        auto const windowDtype = LinearAttentionMetadata::hasRecurrentStatesCache(windowSize)
+            ? nvinfer1::DataType::kINT8
+            : (poolIt != poolByWindow.end()) ? poolIt->second->dtype
+                                             : dtype;
         mWindowBlockManagers.try_emplace(SizeType32(windowSize), windowDtype, windowSize, layersWithWindowSize,
             numKvHeadsPerLayer, windowSizePerHead, tokensPerBlock,
             /*isSWA=*/(windowSize < maxSequenceLength) && (windowSize >= 0), allottedPrimaryBlocks,
@@ -3371,28 +3376,43 @@ void KVCacheManager::allocatePools(bool useUvm)
 
     // Code in the attention kernels is cleaner if we can access the KV values and block scales separately.
     mBlockPoolPointers = BufferManager::cpu(ITensor::makeShape({numKVPools, 2}), TRTDataType<void*>::value);
+    // Attention expects scale-pointer rows to align one-to-one with KV-pool rows. Pools without block scales use
+    // null pointers in those rows.
+    auto const numAlignedBlockScalePools = numBlockScalePools > 0 ? numKVPools : 0;
     mBlockScalePoolPointers
-        = BufferManager::cpu(ITensor::makeShape({numBlockScalePools, 2}), TRTDataType<void*>::value);
+        = BufferManager::cpu(ITensor::makeShape({numAlignedBlockScalePools, 2}), TRTDataType<void*>::value);
 
     auto poolPtrsRange = BufferRange<void*>(*mBlockPoolPointers);
     auto blockScalePtrsRange = BufferRange<void*>(*mBlockScalePoolPointers);
+    std::fill(blockScalePtrsRange.begin(), blockScalePtrsRange.end(), nullptr);
     SizeType32 kvPoolIdx = 0;
-    SizeType32 blockScalePoolIdx = 0;
+    std::map<SizeType32, std::vector<SizeType32>> kvPoolIndicesByWindow;
+    std::map<SizeType32, SizeType32> numBlockScalePoolsByWindow;
 
     for (SizeType32 poolIdx = 0; poolIdx < numPools; poolIdx++)
     {
         auto const& pool = mBlockManager.getPool(poolIdx);
-        auto& outIdx = pool.containsBlockScales ? blockScalePoolIdx : kvPoolIdx;
-        auto& outRange = pool.containsBlockScales ? blockScalePtrsRange : poolPtrsRange;
         if (pool.containsIndexerKCache)
         {
             mIndexerKCachePoolPointers = pool.primaryPtr;
         }
+        else if (pool.containsBlockScales)
+        {
+            auto const windowSize = mBlockManager.getPoolWindowSize(poolIdx);
+            auto const blockScalePoolIdx = numBlockScalePoolsByWindow[windowSize]++;
+            auto const& kvPoolIndices = kvPoolIndicesByWindow.at(windowSize);
+            TLLM_CHECK_WITH_INFO(blockScalePoolIdx < static_cast<SizeType32>(kvPoolIndices.size()),
+                "Block-scale pool %d for window size %d has no matching KV pool", blockScalePoolIdx, windowSize);
+            auto const outIdx = kvPoolIndices.at(blockScalePoolIdx);
+            blockScalePtrsRange[outIdx * 2] = pool.primaryPtr->data();
+            blockScalePtrsRange[outIdx * 2 + 1] = pool.secondaryPtr ? pool.secondaryPtr->data() : nullptr;
+        }
         else
         {
-            outRange[outIdx * 2] = pool.primaryPtr->data();
-            outRange[outIdx * 2 + 1] = pool.secondaryPtr ? pool.secondaryPtr->data() : nullptr;
-            outIdx++;
+            poolPtrsRange[kvPoolIdx * 2] = pool.primaryPtr->data();
+            poolPtrsRange[kvPoolIdx * 2 + 1] = pool.secondaryPtr ? pool.secondaryPtr->data() : nullptr;
+            kvPoolIndicesByWindow[mBlockManager.getPoolWindowSize(poolIdx)].push_back(kvPoolIdx);
+            ++kvPoolIdx;
         }
     }
 

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -3371,43 +3371,28 @@ void KVCacheManager::allocatePools(bool useUvm)
 
     // Code in the attention kernels is cleaner if we can access the KV values and block scales separately.
     mBlockPoolPointers = BufferManager::cpu(ITensor::makeShape({numKVPools, 2}), TRTDataType<void*>::value);
-    // Attention expects scale-pointer rows to align one-to-one with KV-pool rows. Pools without block scales use
-    // null pointers in those rows.
-    auto const numAlignedBlockScalePools = numBlockScalePools > 0 ? numKVPools : 0;
     mBlockScalePoolPointers
-        = BufferManager::cpu(ITensor::makeShape({numAlignedBlockScalePools, 2}), TRTDataType<void*>::value);
+        = BufferManager::cpu(ITensor::makeShape({numBlockScalePools, 2}), TRTDataType<void*>::value);
 
     auto poolPtrsRange = BufferRange<void*>(*mBlockPoolPointers);
     auto blockScalePtrsRange = BufferRange<void*>(*mBlockScalePoolPointers);
-    std::fill(blockScalePtrsRange.begin(), blockScalePtrsRange.end(), nullptr);
     SizeType32 kvPoolIdx = 0;
-    std::map<SizeType32, std::vector<SizeType32>> kvPoolIndicesByWindow;
-    std::map<SizeType32, SizeType32> numBlockScalePoolsByWindow;
+    SizeType32 blockScalePoolIdx = 0;
 
     for (SizeType32 poolIdx = 0; poolIdx < numPools; poolIdx++)
     {
         auto const& pool = mBlockManager.getPool(poolIdx);
+        auto& outIdx = pool.containsBlockScales ? blockScalePoolIdx : kvPoolIdx;
+        auto& outRange = pool.containsBlockScales ? blockScalePtrsRange : poolPtrsRange;
         if (pool.containsIndexerKCache)
         {
             mIndexerKCachePoolPointers = pool.primaryPtr;
         }
-        else if (pool.containsBlockScales)
-        {
-            auto const windowSize = mBlockManager.getPoolWindowSize(poolIdx);
-            auto const blockScalePoolIdx = numBlockScalePoolsByWindow[windowSize]++;
-            auto const& kvPoolIndices = kvPoolIndicesByWindow.at(windowSize);
-            TLLM_CHECK_WITH_INFO(blockScalePoolIdx < static_cast<SizeType32>(kvPoolIndices.size()),
-                "Block-scale pool %d for window size %d has no matching KV pool", blockScalePoolIdx, windowSize);
-            auto const outIdx = kvPoolIndices.at(blockScalePoolIdx);
-            blockScalePtrsRange[outIdx * 2] = pool.primaryPtr->data();
-            blockScalePtrsRange[outIdx * 2 + 1] = pool.secondaryPtr ? pool.secondaryPtr->data() : nullptr;
-        }
         else
         {
-            poolPtrsRange[kvPoolIdx * 2] = pool.primaryPtr->data();
-            poolPtrsRange[kvPoolIdx * 2 + 1] = pool.secondaryPtr ? pool.secondaryPtr->data() : nullptr;
-            kvPoolIndicesByWindow[mBlockManager.getPoolWindowSize(poolIdx)].push_back(kvPoolIdx);
-            ++kvPoolIdx;
+            outRange[outIdx * 2] = pool.primaryPtr->data();
+            outRange[outIdx * 2 + 1] = pool.secondaryPtr ? pool.secondaryPtr->data() : nullptr;
+            outIdx++;
         }
     }
 

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -800,7 +800,7 @@ TEST_F(KVCacheManagerTest, FP4BlockScaleManagementTest)
     EXPECT_EQ(blockManager.getBlockSize(0) * numFp4EltsPerContainer / vectorSize, blockManager.getBlockSize(1));
 }
 
-TEST_F(KVCacheManagerTest, FP4AttentionWithInt8RecurrentStatesPoolTest)
+TEST_F(KVCacheManagerTest, FP4AttentionWithHalfRecurrentStatesPoolTest)
 {
     auto constexpr numKvHeads = 2;
     auto constexpr sizePerHead = 16;
@@ -823,7 +823,7 @@ TEST_F(KVCacheManagerTest, FP4AttentionWithInt8RecurrentStatesPoolTest)
         {maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}},
     };
     auto const poolConfigurations = std::vector<PoolConfiguration>{
-        {recurrentStatesWindow, sizePerHead, nvinfer1::DataType::kINT8},
+        {recurrentStatesWindow, sizePerHead, nvinfer1::DataType::kHALF},
         {maxAttentionWindow, sizePerHead, nvinfer1::DataType::kFP4},
     };
     auto const stream = std::make_shared<tr::CudaStream>();
@@ -838,13 +838,14 @@ TEST_F(KVCacheManagerTest, FP4AttentionWithInt8RecurrentStatesPoolTest)
     kvCacheManager.allocatePools(/*useUvm=*/false);
     auto const& blockManager = kvCacheManager.getBlockManager();
 
-    EXPECT_EQ(blockManager.getDataTypeForWindow(recurrentStatesWindow), nvinfer1::DataType::kINT8);
+    EXPECT_EQ(blockManager.getDataTypeForWindow(recurrentStatesWindow), nvinfer1::DataType::kHALF);
     EXPECT_EQ(blockManager.getDataTypeForWindow(maxAttentionWindow), nvinfer1::DataType::kFP4);
 
     auto const& recurrentStatesPool = blockManager.getRecurrentStatesPool();
     ASSERT_NE(recurrentStatesPool.primaryPtr, nullptr);
-    EXPECT_EQ(recurrentStatesPool.primaryPtr->getDataType(), nvinfer1::DataType::kINT8);
-    EXPECT_EQ(recurrentStatesPool.blockSize, recurrentStatesBytes);
+    EXPECT_EQ(recurrentStatesPool.primaryPtr->getDataType(), nvinfer1::DataType::kHALF);
+    auto const recurrentStatesElementsPerBlock = recurrentStatesBytes / tc::getDTypeSize(nvinfer1::DataType::kHALF);
+    EXPECT_EQ(recurrentStatesPool.blockSize, recurrentStatesElementsPerBlock);
 
     SizeType32 numRecurrentScalePools = 0;
     SizeType32 numAttentionScalePools = 0;

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -799,6 +799,87 @@ TEST_F(KVCacheManagerTest, FP4BlockScaleManagementTest)
     // The expected block size of pool 1 should be the number of FP4 elements / vectorSize.
     EXPECT_EQ(blockManager.getBlockSize(0) * numFp4EltsPerContainer / vectorSize, blockManager.getBlockSize(1));
 }
+
+TEST_F(KVCacheManagerTest, FP4AttentionWithInt8RecurrentStatesPoolTest)
+{
+    auto constexpr numKvHeads = 2;
+    auto constexpr sizePerHead = 16;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimaryPool = 4;
+    auto constexpr blocksInSecondaryPool = 0;
+    auto constexpr maxNumSequences = 2;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr maxAttentionWindow = 16;
+    auto constexpr recurrentStatesBytes = 64;
+    SizeType32 constexpr recurrentStatesWindow = LinearAttentionMetadata::LinearCacheType::kRecurrentStates;
+
+    LinearAttentionMetadata const linearAttentionMetadata{
+        .linearLayerIndices = {0},
+        .cacheType = recurrentStatesWindow,
+        .allRecurrentStatesBytes = recurrentStatesBytes,
+    };
+    auto const blocksPerWindow = BlocksPerWindow{
+        {recurrentStatesWindow, {blocksInPrimaryPool, blocksInSecondaryPool}},
+        {maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}},
+    };
+    auto const stream = std::make_shared<tr::CudaStream>();
+
+    KVCacheManager kvCacheManager(std::vector<SizeType32>{0, numKvHeads}, sizePerHead, tokensPerBlock, blocksPerWindow,
+        maxNumSequences, maxBeamWidth, std::vector<SizeType32>{recurrentStatesWindow, maxAttentionWindow},
+        nvinfer1::DataType::kFP4,
+        /*sinkTokenLength=*/0, stream, maxAttentionWindow, /*chunkSize=*/0, /*enableBlockReuse=*/false,
+        CacheType::kSELF, std::nullopt, nullptr, /*enablePartialReuse=*/false, /*copyOnPartialReuse=*/true, nullptr,
+        /*enableIndexerKCache=*/false, /*indexerKCacheQuantBlockSize=*/128, /*indexerKCacheIndexHeadDim=*/0,
+        /*indexerKCacheUseFp4=*/false, linearAttentionMetadata);
+    kvCacheManager.allocatePools(/*useUvm=*/false);
+    auto const& blockManager = kvCacheManager.getBlockManager();
+
+    EXPECT_EQ(blockManager.getDataTypeForWindow(recurrentStatesWindow), nvinfer1::DataType::kINT8);
+    EXPECT_EQ(blockManager.getDataTypeForWindow(maxAttentionWindow), nvinfer1::DataType::kFP4);
+
+    auto const& recurrentStatesPool = blockManager.getRecurrentStatesPool();
+    ASSERT_NE(recurrentStatesPool.primaryPtr, nullptr);
+    EXPECT_EQ(recurrentStatesPool.primaryPtr->getDataType(), nvinfer1::DataType::kINT8);
+    EXPECT_EQ(recurrentStatesPool.blockSize, recurrentStatesBytes);
+
+    SizeType32 numRecurrentScalePools = 0;
+    SizeType32 numAttentionScalePools = 0;
+    for (SizeType32 poolIdx = 0; poolIdx < blockManager.getNumPools(); ++poolIdx)
+    {
+        if (!blockManager.containsBlockScales(poolIdx))
+        {
+            continue;
+        }
+        if (blockManager.getPoolWindowSize(poolIdx) == recurrentStatesWindow)
+        {
+            ++numRecurrentScalePools;
+        }
+        else if (blockManager.getPoolWindowSize(poolIdx) == maxAttentionWindow)
+        {
+            ++numAttentionScalePools;
+        }
+    }
+    EXPECT_EQ(numRecurrentScalePools, 0);
+    EXPECT_EQ(numAttentionScalePools, 1);
+
+    auto const blockPoolPointers = kvCacheManager.getBlockPoolPointers();
+    auto const blockScalePoolPointers = kvCacheManager.getBlockScalePoolPointers();
+    ASSERT_NE(blockPoolPointers, nullptr);
+    ASSERT_NE(blockScalePoolPointers, nullptr);
+    EXPECT_EQ(blockPoolPointers->getShape().d[0], 2);
+    EXPECT_EQ(blockScalePoolPointers->getShape().d[0], 2);
+    auto const blockScalePoolPointersRange = tr::BufferRange<void*>(*blockScalePoolPointers);
+    EXPECT_EQ(blockScalePoolPointersRange[0], nullptr);
+    EXPECT_EQ(blockScalePoolPointersRange[1], nullptr);
+    EXPECT_NE(blockScalePoolPointersRange[2], nullptr);
+    EXPECT_EQ(blockScalePoolPointersRange[3], nullptr);
+
+    auto const layerToPoolMapping = kvCacheManager.getLayerToPoolMapping();
+    ASSERT_NE(layerToPoolMapping, nullptr);
+    auto const layerToPoolMappingRange = tr::BufferRange<SizeType32>(*layerToPoolMapping);
+    EXPECT_EQ(layerToPoolMappingRange[0], 0);
+    EXPECT_EQ(layerToPoolMappingRange[2], 1);
+}
 #endif
 
 TEST_F(KVCacheManagerTest, BlockManagerReuseTest)

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -822,6 +822,10 @@ TEST_F(KVCacheManagerTest, FP4AttentionWithInt8RecurrentStatesPoolTest)
         {recurrentStatesWindow, {blocksInPrimaryPool, blocksInSecondaryPool}},
         {maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}},
     };
+    auto const poolConfigurations = std::vector<PoolConfiguration>{
+        {recurrentStatesWindow, sizePerHead, nvinfer1::DataType::kINT8},
+        {maxAttentionWindow, sizePerHead, nvinfer1::DataType::kFP4},
+    };
     auto const stream = std::make_shared<tr::CudaStream>();
 
     KVCacheManager kvCacheManager(std::vector<SizeType32>{0, numKvHeads}, sizePerHead, tokensPerBlock, blocksPerWindow,
@@ -830,7 +834,7 @@ TEST_F(KVCacheManagerTest, FP4AttentionWithInt8RecurrentStatesPoolTest)
         /*sinkTokenLength=*/0, stream, maxAttentionWindow, /*chunkSize=*/0, /*enableBlockReuse=*/false,
         CacheType::kSELF, std::nullopt, nullptr, /*enablePartialReuse=*/false, /*copyOnPartialReuse=*/true, nullptr,
         /*enableIndexerKCache=*/false, /*indexerKCacheQuantBlockSize=*/128, /*indexerKCacheIndexHeadDim=*/0,
-        /*indexerKCacheUseFp4=*/false, linearAttentionMetadata);
+        /*indexerKCacheUseFp4=*/false, linearAttentionMetadata, poolConfigurations);
     kvCacheManager.allocatePools(/*useUvm=*/false);
     auto const& blockManager = kvCacheManager.getBlockManager();
 

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -871,12 +871,10 @@ TEST_F(KVCacheManagerTest, FP4AttentionWithInt8RecurrentStatesPoolTest)
     ASSERT_NE(blockPoolPointers, nullptr);
     ASSERT_NE(blockScalePoolPointers, nullptr);
     EXPECT_EQ(blockPoolPointers->getShape().d[0], 2);
-    EXPECT_EQ(blockScalePoolPointers->getShape().d[0], 2);
+    EXPECT_EQ(blockScalePoolPointers->getShape().d[0], 1);
     auto const blockScalePoolPointersRange = tr::BufferRange<void*>(*blockScalePoolPointers);
-    EXPECT_EQ(blockScalePoolPointersRange[0], nullptr);
+    EXPECT_NE(blockScalePoolPointersRange[0], nullptr);
     EXPECT_EQ(blockScalePoolPointersRange[1], nullptr);
-    EXPECT_NE(blockScalePoolPointersRange[2], nullptr);
-    EXPECT_EQ(blockScalePoolPointersRange[3], nullptr);
 
     auto const layerToPoolMapping = kvCacheManager.getLayerToPoolMapping();
     ASSERT_NE(layerToPoolMapping, nullptr);

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -1466,6 +1466,7 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
         use_replay_state_update: bool = False,
         mamba_ssm_stochastic_rounding: bool = False,
         model_type: str = "nemotron_hybrid",
+        pool_configurations: Optional[List[PoolConfiguration]] = None,
         **kwargs,
     ) -> None:
         # 3 kinds of layers:
@@ -1539,6 +1540,7 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
                 layer_mask=full_attention_layer_mask,
                 is_estimating_kv_cache=is_estimating_kv_cache,
                 is_draft=is_draft,
+                pool_configurations=pool_configurations,
             )
             return
 
@@ -1626,6 +1628,65 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
                     LinearCacheType.RECURRENT_STATES.
                     value if mamba_layer_mask[i] else max_seq_len)
 
+        # Recurrent states are stored as bytes and cast to their actual SSM /
+        # convolution dtypes by this manager. They therefore need an INT8
+        # backing pool even when the attention KV cache uses NVFP4. Pass both
+        # window configurations so BlockManager::poolByWindow does not fall
+        # back to the manager-level attention dtype for recurrent states.
+        recurrent_states_window = LinearCacheType.RECURRENT_STATES.value
+        normalized_pool_configurations = [
+            PoolConfiguration(
+                window_size=min(config.window_size, max_seq_len),
+                head_dim=config.head_dim,
+                dtype=config.dtype,
+            ) for config in (pool_configurations or [])
+        ]
+        pool_by_window = {
+            pc.window_size: pc
+            for pc in normalized_pool_configurations
+        }
+        if len(pool_by_window) != len(normalized_pool_configurations):
+            raise ValueError(
+                "Multiple pool configurations share the same window size")
+        unexpected_windows = set(pool_by_window) - {
+            recurrent_states_window, max_seq_len
+        }
+        if unexpected_windows:
+            raise ValueError(
+                "CppMambaHybridCacheManager received pool configurations for "
+                f"unexpected window sizes: {sorted(unexpected_windows)}")
+        recurrent_pool = pool_by_window.get(recurrent_states_window)
+        if recurrent_pool is not None and recurrent_pool.dtype != DataType.INT8:
+            raise ValueError(
+                "Recurrent states require an INT8 backing pool, got "
+                f"{recurrent_pool.dtype}")
+        local_windows = {
+            recurrent_states_window
+            if mamba_layer_mask[layer_idx] else max_seq_len
+            for layer_idx in self.pp_layers
+        }
+        if recurrent_states_window in local_windows:
+            pool_by_window.setdefault(
+                recurrent_states_window,
+                PoolConfiguration(
+                    window_size=recurrent_states_window,
+                    head_dim=head_dim,
+                    dtype=DataType.INT8,
+                ),
+            )
+        if max_seq_len in local_windows:
+            pool_by_window.setdefault(
+                max_seq_len,
+                PoolConfiguration(
+                    window_size=max_seq_len,
+                    head_dim=head_dim,
+                    dtype=dtype,
+                ),
+            )
+        pool_configurations = [
+            pool_by_window[window_size] for window_size in sorted(local_windows)
+        ]
+
         # Normalize num_kv_heads to a per-layer list and zero out mamba
         # layer positions: those layers carry SSM/conv state instead of KV
         # heads, so the parent KV cache should not allocate KV head storage
@@ -1661,6 +1722,7 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
             is_estimating_kv_cache=is_estimating_kv_cache,
             is_draft=is_draft,
             linear_attention_metadata=self.linear_attention_metadata,
+            pool_configurations=pool_configurations,
             **kwargs,
         )
 

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -1466,7 +1466,6 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
         use_replay_state_update: bool = False,
         mamba_ssm_stochastic_rounding: bool = False,
         model_type: str = "nemotron_hybrid",
-        pool_configurations: Optional[List[PoolConfiguration]] = None,
         **kwargs,
     ) -> None:
         # 3 kinds of layers:
@@ -1540,7 +1539,6 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
                 layer_mask=full_attention_layer_mask,
                 is_estimating_kv_cache=is_estimating_kv_cache,
                 is_draft=is_draft,
-                pool_configurations=pool_configurations,
             )
             return
 
@@ -1628,63 +1626,19 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
                     LinearCacheType.RECURRENT_STATES.
                     value if mamba_layer_mask[i] else max_seq_len)
 
-        # Recurrent states are stored as bytes and cast to their actual SSM /
-        # convolution dtypes by this manager. They therefore need an INT8
-        # backing pool even when the attention KV cache uses NVFP4. Pass both
-        # window configurations so BlockManager::poolByWindow does not fall
-        # back to the manager-level attention dtype for recurrent states.
         recurrent_states_window = LinearCacheType.RECURRENT_STATES.value
-        normalized_pool_configurations = [
-            PoolConfiguration(
-                window_size=min(config.window_size, max_seq_len),
-                head_dim=config.head_dim,
-                dtype=config.dtype,
-            ) for config in (pool_configurations or [])
-        ]
-        pool_by_window = {
-            pc.window_size: pc
-            for pc in normalized_pool_configurations
-        }
-        if len(pool_by_window) != len(normalized_pool_configurations):
-            raise ValueError(
-                "Multiple pool configurations share the same window size")
-        unexpected_windows = set(pool_by_window) - {
-            recurrent_states_window, max_seq_len
-        }
-        if unexpected_windows:
-            raise ValueError(
-                "CppMambaHybridCacheManager received pool configurations for "
-                f"unexpected window sizes: {sorted(unexpected_windows)}")
-        recurrent_pool = pool_by_window.get(recurrent_states_window)
-        if recurrent_pool is not None and recurrent_pool.dtype != DataType.INT8:
-            raise ValueError(
-                "Recurrent states require an INT8 backing pool, got "
-                f"{recurrent_pool.dtype}")
         local_windows = {
             recurrent_states_window
             if mamba_layer_mask[layer_idx] else max_seq_len
             for layer_idx in self.pp_layers
         }
-        if recurrent_states_window in local_windows:
-            pool_by_window.setdefault(
-                recurrent_states_window,
-                PoolConfiguration(
-                    window_size=recurrent_states_window,
-                    head_dim=head_dim,
-                    dtype=DataType.INT8,
-                ),
-            )
-        if max_seq_len in local_windows:
-            pool_by_window.setdefault(
-                max_seq_len,
-                PoolConfiguration(
-                    window_size=max_seq_len,
-                    head_dim=head_dim,
-                    dtype=dtype,
-                ),
-            )
-        pool_configurations = [
-            pool_by_window[window_size] for window_size in sorted(local_windows)
+        kwargs["pool_configurations"] = [
+            PoolConfiguration(
+                window_size=window_size,
+                head_dim=head_dim,
+                dtype=torch_dtype_to_binding(self.ssm_state_dtype)
+                if window_size == recurrent_states_window else dtype,
+            ) for window_size in sorted(local_windows)
         ]
 
         # Normalize num_kv_heads to a per-layer list and zero out mamba
@@ -1722,7 +1676,6 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
             is_estimating_kv_cache=is_estimating_kv_cache,
             is_draft=is_draft,
             linear_attention_metadata=self.linear_attention_metadata,
-            pool_configurations=pool_configurations,
             **kwargs,
         )
 

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -114,6 +114,55 @@ def _warn_if_unsupported_v1_kv_cache_event_hash_algo(hash_algo: str) -> None:
         "event hashes.")
 
 
+def _merge_kv_cache_pool_pointers(
+    kv_cache_pool_pointers: torch.Tensor,
+    block_scale_pool_pointers: torch.Tensor,
+    layer_to_pool_mapping: torch.Tensor,
+    layer_pool_dtypes: Sequence["DataType"],
+) -> torch.Tensor:
+    """Align compact block-scale pointers with compact KV-pool pointers."""
+    if block_scale_pool_pointers.numel() == 0:
+        return kv_cache_pool_pointers
+
+    if (kv_cache_pool_pointers.ndim != 2 or block_scale_pool_pointers.ndim != 2
+            or kv_cache_pool_pointers.shape[1:]
+            != block_scale_pool_pointers.shape[1:]
+            or kv_cache_pool_pointers.dtype != block_scale_pool_pointers.dtype
+            or kv_cache_pool_pointers.device
+            != block_scale_pool_pointers.device):
+        raise RuntimeError(
+            "KV-cache data and block-scale pointer tables are incompatible")
+    if layer_to_pool_mapping.shape[0] != len(layer_pool_dtypes):
+        raise RuntimeError(
+            "KV-cache layer mapping and layer dtype counts do not match")
+
+    dtype_by_pool: Dict[int, "DataType"] = {}
+    for pool_idx, pool_dtype in zip(layer_to_pool_mapping[:, 0].tolist(),
+                                    layer_pool_dtypes):
+        previous_dtype = dtype_by_pool.setdefault(pool_idx, pool_dtype)
+        if previous_dtype != pool_dtype:
+            raise RuntimeError(
+                f"KV-cache pool {pool_idx} is mapped to multiple dtypes")
+
+    num_data_pools = kv_cache_pool_pointers.shape[0]
+    if sorted(dtype_by_pool) != list(range(num_data_pools)):
+        raise RuntimeError(
+            "KV-cache layer mapping is not aligned with compact data-pool rows")
+
+    fp4_pool_indices = [
+        pool_idx for pool_idx in range(num_data_pools)
+        if dtype_by_pool[pool_idx] == DataType.NVFP4
+    ]
+    if len(fp4_pool_indices) != block_scale_pool_pointers.shape[0]:
+        raise RuntimeError(
+            "NVFP4 KV-cache pool and block-scale pointer counts do not match")
+
+    aligned_scale_pool_pointers = torch.zeros_like(kv_cache_pool_pointers)
+    aligned_scale_pool_pointers[fp4_pool_indices] = block_scale_pool_pointers
+    return torch.stack([kv_cache_pool_pointers, aligned_scale_pool_pointers],
+                       dim=-1)
+
+
 class BaseResourceManager(ABC):
 
     @abstractmethod
@@ -621,15 +670,29 @@ class KVCacheManager(BaseResourceManager):
 
         self.impl.allocate_pools(False)
         self.kv_cache_pool_pointers = self.impl.get_block_pool_pointers()
+        self.kv_cache_pool_mapping = self.impl.get_layer_to_pool_mapping()
         kv_cache_block_scale_pool_pointers = self.impl.get_block_scale_pool_pointers(
         )
         if kv_cache_block_scale_pool_pointers.numel() > 0:
-            self.kv_cache_pool_pointers = torch.stack([
-                self.kv_cache_pool_pointers, kv_cache_block_scale_pool_pointers
-            ],
-                                                      dim=-1)
+            dtype_by_window = {
+                config.window_size: config.dtype
+                for config in self.impl.pool_configurations
+            }
+            # Match the local layer order used by C++ to build the pointer
+            # mapping. The Python window helpers additionally account for
+            # global PP layer IDs and therefore do not describe these rows.
+            layer_pool_dtypes = [
+                dtype_by_window[self.max_attention_window_vec[
+                    layer_offset % len(self.max_attention_window_vec)]]
+                for layer_offset in range(self.num_local_layers)
+            ]
+            self.kv_cache_pool_pointers = _merge_kv_cache_pool_pointers(
+                self.kv_cache_pool_pointers,
+                kv_cache_block_scale_pool_pointers,
+                self.kv_cache_pool_mapping,
+                layer_pool_dtypes,
+            )
 
-        self.kv_cache_pool_mapping = self.impl.get_layer_to_pool_mapping()
         self.num_pools = self.impl.num_pools
         self.max_blocks_per_seq = self.impl.max_blocks_per_seq
         self.enable_block_reuse = kv_cache_config.enable_block_reuse

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -120,42 +120,14 @@ def _merge_kv_cache_pool_pointers(
     layer_to_pool_mapping: torch.Tensor,
     layer_pool_dtypes: Sequence["DataType"],
 ) -> torch.Tensor:
-    """Align compact block-scale pointers with compact KV-pool pointers."""
-    if block_scale_pool_pointers.numel() == 0:
-        return kv_cache_pool_pointers
-
-    if (kv_cache_pool_pointers.ndim != 2 or block_scale_pool_pointers.ndim != 2
-            or kv_cache_pool_pointers.shape[1:]
-            != block_scale_pool_pointers.shape[1:]
-            or kv_cache_pool_pointers.dtype != block_scale_pool_pointers.dtype
-            or kv_cache_pool_pointers.device
-            != block_scale_pool_pointers.device):
-        raise RuntimeError(
-            "KV-cache data and block-scale pointer tables are incompatible")
-    if layer_to_pool_mapping.shape[0] != len(layer_pool_dtypes):
-        raise RuntimeError(
-            "KV-cache layer mapping and layer dtype counts do not match")
-
-    dtype_by_pool: Dict[int, "DataType"] = {}
-    for pool_idx, pool_dtype in zip(layer_to_pool_mapping[:, 0].tolist(),
-                                    layer_pool_dtypes):
-        previous_dtype = dtype_by_pool.setdefault(pool_idx, pool_dtype)
-        if previous_dtype != pool_dtype:
-            raise RuntimeError(
-                f"KV-cache pool {pool_idx} is mapped to multiple dtypes")
-
-    num_data_pools = kv_cache_pool_pointers.shape[0]
-    if sorted(dtype_by_pool) != list(range(num_data_pools)):
-        raise RuntimeError(
-            "KV-cache layer mapping is not aligned with compact data-pool rows")
-
+    """Align compact scale rows with data rows in C++ physical-pool order."""
+    dtype_by_physical_pool = dict(
+        zip(layer_to_pool_mapping[:, 0].tolist(), layer_pool_dtypes))
     fp4_pool_indices = [
-        pool_idx for pool_idx in range(num_data_pools)
-        if dtype_by_pool[pool_idx] == DataType.NVFP4
+        compact_pool_idx for compact_pool_idx, physical_pool_idx in enumerate(
+            sorted(dtype_by_physical_pool))
+        if dtype_by_physical_pool[physical_pool_idx] == DataType.NVFP4
     ]
-    if len(fp4_pool_indices) != block_scale_pool_pointers.shape[0]:
-        raise RuntimeError(
-            "NVFP4 KV-cache pool and block-scale pointer counts do not match")
 
     aligned_scale_pool_pointers = torch.zeros_like(kv_cache_pool_pointers)
     aligned_scale_pool_pointers[fp4_pool_indices] = block_scale_pool_pointers

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -646,6 +646,8 @@ class KVCacheManager(BaseResourceManager):
         kv_cache_block_scale_pool_pointers = self.impl.get_block_scale_pool_pointers(
         )
         if kv_cache_block_scale_pool_pointers.numel() > 0:
+            # C++ reports one effective configuration per actual window,
+            # including manager-level defaults when none were supplied.
             dtype_by_window = {
                 config.window_size: config.dtype
                 for config in self.impl.pool_configurations

--- a/tests/unittest/_torch/executor/test_mamba_cache_manager.py
+++ b/tests/unittest/_torch/executor/test_mamba_cache_manager.py
@@ -19,7 +19,11 @@ from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import (
     PythonMambaCacheManager,
     _get_mamba_hybrid_pool_size,
 )
-from tensorrt_llm._torch.pyexecutor.resource_manager import CacheTypeCpp
+from tensorrt_llm._torch.pyexecutor.resource_manager import (
+    CacheTypeCpp,
+    DataType,
+    PoolConfiguration,
+)
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm.bindings.internal.batch_manager import LinearCacheType
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig, MTPDecodingConfig
@@ -401,6 +405,8 @@ def _build_hybrid_with_mamba_layer(
     enable_block_reuse=False,
     mamba_state_cache_interval=256,
     is_estimating_kv_cache=False,
+    dtype=DataType.HALF,
+    pool_configurations=None,
 ):
     """Construct a real CppMambaHybridCacheManager with one mamba layer +
     one full-attention layer so the parent KVCacheManager goes through the
@@ -437,7 +443,41 @@ def _build_hybrid_with_mamba_layer(
         spec_config=spec_config,
         layer_mask=attn_mask,
         is_estimating_kv_cache=is_estimating_kv_cache,
+        dtype=dtype,
+        pool_configurations=pool_configurations,
     )
+
+
+@skip_no_cuda
+def test_cpp_hybrid_passes_per_window_pool_dtypes_for_nvfp4_kv_cache():
+    mgr = _build_hybrid_with_mamba_layer(dtype=DataType.NVFP4)
+
+    expected_dtypes = [
+        (LinearCacheType.RECURRENT_STATES.value, DataType.INT8),
+        (128, DataType.NVFP4),
+    ]
+    assert [
+        (config.window_size, config.dtype) for config in mgr.pool_configurations
+    ] == expected_dtypes
+    assert [
+        (config.window_size, config.dtype) for config in mgr.impl.pool_configurations
+    ] == expected_dtypes
+    assert mgr._layer_to_pool_idx == {0: 0, 1: 1}
+    assert mgr.recurrent_states_pool_index == 0
+    assert mgr.impl.get_recurrent_states_pool().dtype == torch.int8
+
+
+def test_cpp_hybrid_rejects_nvfp4_recurrent_states_pool():
+    with pytest.raises(ValueError, match="Recurrent states require an INT8 backing pool"):
+        _build_hybrid_with_mamba_layer(
+            pool_configurations=[
+                PoolConfiguration(
+                    window_size=LinearCacheType.RECURRENT_STATES.value,
+                    head_dim=64,
+                    dtype=DataType.NVFP4,
+                )
+            ]
+        )
 
 
 @skip_no_cuda
@@ -687,6 +727,14 @@ def test_cpp_hybrid_zero_local_mamba_layers():
     # On the early-exit branch, num_layers is forwarded as-is.
     assert mgr.num_layers == 4
     assert mgr.num_local_layers == 2
+    assert all(
+        config.window_size != LinearCacheType.RECURRENT_STATES.value
+        for config in mgr.pool_configurations
+    )
+    assert all(
+        config.window_size != LinearCacheType.RECURRENT_STATES.value
+        for config in mgr.impl.pool_configurations
+    )
 
     # No mamba-only state was allocated.
     for attr in (

--- a/tests/unittest/_torch/executor/test_mamba_cache_manager.py
+++ b/tests/unittest/_torch/executor/test_mamba_cache_manager.py
@@ -407,13 +407,15 @@ def _build_hybrid_with_mamba_layer(
     is_estimating_kv_cache=False,
     dtype=DataType.HALF,
     pool_configurations=None,
+    mamba_layer_mask=None,
+    attention_layer_mask=None,
 ):
     """Construct a real CppMambaHybridCacheManager with one mamba layer +
     one full-attention layer so the parent KVCacheManager goes through the
     linear-attention pool sizing path."""
     # Layer 0: mamba; Layer 1: full attention. Single rank, no MPI.
-    mamba_mask = [True, False]
-    attn_mask = [False, True]
+    mamba_mask = mamba_layer_mask or [True, False]
+    attn_mask = attention_layer_mask or [False, True]
     mapping = Mapping(world_size=1, rank=0, tp_size=1, pp_size=1)
     # Cap max_tokens to keep the real C++ pool allocation tiny.
     kv_cache_config = KvCacheConfig(
@@ -427,13 +429,13 @@ def _build_hybrid_with_mamba_layer(
         mamba_num_heads=4,
         mamba_n_groups=1,
         mamba_head_dim=8,
-        mamba_num_layers=1,
+        mamba_num_layers=sum(mamba_mask),
         mamba_layer_mask=mamba_mask,
         mamba_cache_dtype=torch.float16,
         mamba_ssm_cache_dtype=torch.float16,
         kv_cache_config=kv_cache_config,
         kv_cache_type=CacheTypeCpp.SELF,
-        num_layers=1,
+        num_layers=sum(attn_mask),
         num_kv_heads=4,
         head_dim=64,
         tokens_per_block=32,
@@ -465,6 +467,30 @@ def test_cpp_hybrid_passes_per_window_pool_dtypes_for_nvfp4_kv_cache():
     assert mgr._layer_to_pool_idx == {0: 0, 1: 1}
     assert mgr.recurrent_states_pool_index == 0
     assert mgr.impl.get_recurrent_states_pool().dtype == torch.int8
+
+    compact_scale_pointers = mgr.impl.get_block_scale_pool_pointers()
+    assert mgr.impl.get_block_pool_pointers().shape == (2, 2)
+    assert compact_scale_pointers.shape == (1, 2)
+    assert mgr.kv_cache_pool_pointers.shape == (2, 2, 2)
+    assert torch.count_nonzero(mgr.kv_cache_pool_pointers[0, :, 1]) == 0
+    assert torch.equal(mgr.kv_cache_pool_pointers[1, :, 1], compact_scale_pointers[0])
+
+
+@skip_no_cuda
+def test_cpp_hybrid_merges_compact_scale_rows_with_unmanaged_layers():
+    mgr = _build_hybrid_with_mamba_layer(
+        dtype=DataType.NVFP4,
+        mamba_layer_mask=[True, False, True, False],
+        attention_layer_mask=[False, False, False, True],
+    )
+
+    assert mgr.pp_layers == [0, 2, 3]
+    assert mgr.kv_cache_pool_mapping[:, 0].tolist() == [0, 0, 1]
+    compact_scale_pointers = mgr.impl.get_block_scale_pool_pointers()
+    assert compact_scale_pointers.shape == (1, 2)
+    assert mgr.kv_cache_pool_pointers.shape == (2, 2, 2)
+    assert torch.count_nonzero(mgr.kv_cache_pool_pointers[0, :, 1]) == 0
+    assert torch.equal(mgr.kv_cache_pool_pointers[1, :, 1], compact_scale_pointers[0])
 
 
 def test_cpp_hybrid_rejects_nvfp4_recurrent_states_pool():

--- a/tests/unittest/_torch/executor/test_mamba_cache_manager.py
+++ b/tests/unittest/_torch/executor/test_mamba_cache_manager.py
@@ -19,12 +19,9 @@ from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import (
     PythonMambaCacheManager,
     _get_mamba_hybrid_pool_size,
 )
-from tensorrt_llm._torch.pyexecutor.resource_manager import (
-    CacheTypeCpp,
-    DataType,
-    PoolConfiguration,
-)
+from tensorrt_llm._torch.pyexecutor.resource_manager import CacheTypeCpp, DataType
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
+from tensorrt_llm._utils import torch_dtype_to_binding
 from tensorrt_llm.bindings.internal.batch_manager import LinearCacheType
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig, MTPDecodingConfig
 from tensorrt_llm.mapping import Mapping
@@ -406,9 +403,9 @@ def _build_hybrid_with_mamba_layer(
     mamba_state_cache_interval=256,
     is_estimating_kv_cache=False,
     dtype=DataType.HALF,
-    pool_configurations=None,
     mamba_layer_mask=None,
     attention_layer_mask=None,
+    mamba_ssm_cache_dtype=torch.float16,
 ):
     """Construct a real CppMambaHybridCacheManager with one mamba layer +
     one full-attention layer so the parent KVCacheManager goes through the
@@ -432,7 +429,7 @@ def _build_hybrid_with_mamba_layer(
         mamba_num_layers=sum(mamba_mask),
         mamba_layer_mask=mamba_mask,
         mamba_cache_dtype=torch.float16,
-        mamba_ssm_cache_dtype=torch.float16,
+        mamba_ssm_cache_dtype=mamba_ssm_cache_dtype,
         kv_cache_config=kv_cache_config,
         kv_cache_type=CacheTypeCpp.SELF,
         num_layers=sum(attn_mask),
@@ -446,16 +443,25 @@ def _build_hybrid_with_mamba_layer(
         layer_mask=attn_mask,
         is_estimating_kv_cache=is_estimating_kv_cache,
         dtype=dtype,
-        pool_configurations=pool_configurations,
     )
 
 
 @skip_no_cuda
-def test_cpp_hybrid_passes_per_window_pool_dtypes_for_nvfp4_kv_cache():
-    mgr = _build_hybrid_with_mamba_layer(dtype=DataType.NVFP4)
+@pytest.mark.parametrize(
+    "mamba_ssm_cache_dtype",
+    [torch.float16, torch.float32, torch.bfloat16],
+)
+def test_cpp_hybrid_passes_per_window_pool_dtypes_for_nvfp4_kv_cache(
+    mamba_ssm_cache_dtype,
+):
+    mgr = _build_hybrid_with_mamba_layer(
+        dtype=DataType.NVFP4,
+        mamba_ssm_cache_dtype=mamba_ssm_cache_dtype,
+    )
+    recurrent_pool_dtype = torch_dtype_to_binding(mamba_ssm_cache_dtype)
 
     expected_dtypes = [
-        (LinearCacheType.RECURRENT_STATES.value, DataType.INT8),
+        (LinearCacheType.RECURRENT_STATES.value, recurrent_pool_dtype),
         (128, DataType.NVFP4),
     ]
     assert [
@@ -466,7 +472,7 @@ def test_cpp_hybrid_passes_per_window_pool_dtypes_for_nvfp4_kv_cache():
     ] == expected_dtypes
     assert mgr._layer_to_pool_idx == {0: 0, 1: 1}
     assert mgr.recurrent_states_pool_index == 0
-    assert mgr.impl.get_recurrent_states_pool().dtype == torch.int8
+    assert mgr.impl.get_recurrent_states_pool().dtype == mamba_ssm_cache_dtype
 
     compact_scale_pointers = mgr.impl.get_block_scale_pool_pointers()
     assert mgr.impl.get_block_pool_pointers().shape == (2, 2)
@@ -491,19 +497,6 @@ def test_cpp_hybrid_merges_compact_scale_rows_with_unmanaged_layers():
     assert mgr.kv_cache_pool_pointers.shape == (2, 2, 2)
     assert torch.count_nonzero(mgr.kv_cache_pool_pointers[0, :, 1]) == 0
     assert torch.equal(mgr.kv_cache_pool_pointers[1, :, 1], compact_scale_pointers[0])
-
-
-def test_cpp_hybrid_rejects_nvfp4_recurrent_states_pool():
-    with pytest.raises(ValueError, match="Recurrent states require an INT8 backing pool"):
-        _build_hybrid_with_mamba_layer(
-            pool_configurations=[
-                PoolConfiguration(
-                    window_size=LinearCacheType.RECURRENT_STATES.value,
-                    head_dim=64,
-                    dtype=DataType.NVFP4,
-                )
-            ]
-        )
 
 
 @skip_no_cuda

--- a/tests/unittest/_torch/executor/test_resource_manager.py
+++ b/tests/unittest/_torch/executor/test_resource_manager.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import pathlib
 import subprocess
@@ -13,7 +16,7 @@ import tensorrt_llm
 import tensorrt_llm.bindings
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 from tensorrt_llm._torch.pyexecutor.resource_manager import (
-    KVCacheManager, PeftCacheManager,
+    KVCacheManager, PeftCacheManager, _merge_kv_cache_pool_pointers,
     _warn_if_unsupported_v1_kv_cache_event_hash_algo)
 from tensorrt_llm.bindings import LayerType
 from tensorrt_llm.bindings import ModelConfig as ModelConfigCpp
@@ -64,6 +67,72 @@ def test_v1_kv_cache_event_hash_algo_no_warning_for_auto():
             KV_CACHE_HASH_ALGO_AUTO)
 
     warning.assert_not_called()
+
+
+class TestMergeKVCachePoolPointers(unittest.TestCase):
+
+    def test_no_scale_pointers_preserve_data_table(self):
+        data_pointers = torch.tensor([[11, 12], [21, 22]])
+
+        merged = _merge_kv_cache_pool_pointers(
+            data_pointers,
+            torch.empty(0, dtype=data_pointers.dtype),
+            torch.tensor([[0, 0], [1, 0]]),
+            [DataType.INT8, DataType.INT8],
+        )
+
+        self.assertIs(merged, data_pointers)
+        self.assertEqual(merged.ndim, 2)
+
+    def test_mixed_int8_nvfp4_pools_align_scale_rows(self):
+        data_pointers = torch.tensor([[11, 12], [21, 22]])
+        scale_pointers = torch.tensor([[31, 32]])
+        layer_to_pool_mapping = torch.tensor([[0, 0], [1, 0]])
+
+        merged = _merge_kv_cache_pool_pointers(
+            data_pointers,
+            scale_pointers,
+            layer_to_pool_mapping,
+            [DataType.INT8, DataType.NVFP4],
+        )
+
+        expected = torch.tensor([
+            [[11, 0], [12, 0]],
+            [[21, 31], [22, 32]],
+        ])
+        self.assertEqual(merged.shape, (2, 2, 2))
+        self.assertTrue(torch.equal(merged, expected))
+
+    def test_shared_nvfp4_pool_consumes_one_scale_row(self):
+        data_pointers = torch.tensor([[11, 12], [21, 22]])
+        scale_pointers = torch.tensor([[31, 32]])
+        layer_to_pool_mapping = torch.tensor([[0, 0], [0, 0], [1, 0]])
+
+        merged = _merge_kv_cache_pool_pointers(
+            data_pointers,
+            scale_pointers,
+            layer_to_pool_mapping,
+            [DataType.NVFP4, DataType.NVFP4, DataType.INT8],
+        )
+
+        expected = torch.tensor([
+            [[11, 31], [12, 32]],
+            [[21, 0], [22, 0]],
+        ])
+        self.assertTrue(torch.equal(merged, expected))
+
+    def test_non_compact_data_pool_ids_raise(self):
+        data_pointers = torch.tensor([[11, 12], [21, 22]])
+        scale_pointers = torch.tensor([[31, 32]])
+        layer_to_pool_mapping = torch.tensor([[0, 0], [2, 0]])
+
+        with self.assertRaises(RuntimeError):
+            _merge_kv_cache_pool_pointers(
+                data_pointers,
+                scale_pointers,
+                layer_to_pool_mapping,
+                [DataType.INT8, DataType.NVFP4],
+            )
 
 
 class TestResourceManager(unittest.TestCase):

--- a/tests/unittest/_torch/executor/test_resource_manager.py
+++ b/tests/unittest/_torch/executor/test_resource_manager.py
@@ -71,20 +71,7 @@ def test_v1_kv_cache_event_hash_algo_no_warning_for_auto():
 
 class TestMergeKVCachePoolPointers(unittest.TestCase):
 
-    def test_no_scale_pointers_preserve_data_table(self):
-        data_pointers = torch.tensor([[11, 12], [21, 22]])
-
-        merged = _merge_kv_cache_pool_pointers(
-            data_pointers,
-            torch.empty(0, dtype=data_pointers.dtype),
-            torch.tensor([[0, 0], [1, 0]]),
-            [DataType.INT8, DataType.INT8],
-        )
-
-        self.assertIs(merged, data_pointers)
-        self.assertEqual(merged.ndim, 2)
-
-    def test_mixed_int8_nvfp4_pools_align_scale_rows(self):
+    def test_mixed_half_nvfp4_pools_align_scale_rows(self):
         data_pointers = torch.tensor([[11, 12], [21, 22]])
         scale_pointers = torch.tensor([[31, 32]])
         layer_to_pool_mapping = torch.tensor([[0, 0], [1, 0]])
@@ -93,7 +80,7 @@ class TestMergeKVCachePoolPointers(unittest.TestCase):
             data_pointers,
             scale_pointers,
             layer_to_pool_mapping,
-            [DataType.INT8, DataType.NVFP4],
+            [DataType.HALF, DataType.NVFP4],
         )
 
         expected = torch.tensor([
@@ -112,7 +99,7 @@ class TestMergeKVCachePoolPointers(unittest.TestCase):
             data_pointers,
             scale_pointers,
             layer_to_pool_mapping,
-            [DataType.NVFP4, DataType.NVFP4, DataType.INT8],
+            [DataType.NVFP4, DataType.NVFP4, DataType.HALF],
         )
 
         expected = torch.tensor([
@@ -121,18 +108,23 @@ class TestMergeKVCachePoolPointers(unittest.TestCase):
         ])
         self.assertTrue(torch.equal(merged, expected))
 
-    def test_non_compact_data_pool_ids_raise(self):
+    def test_physical_pool_ids_map_to_compact_data_rows(self):
         data_pointers = torch.tensor([[11, 12], [21, 22]])
         scale_pointers = torch.tensor([[31, 32]])
         layer_to_pool_mapping = torch.tensor([[0, 0], [2, 0]])
 
-        with self.assertRaises(RuntimeError):
-            _merge_kv_cache_pool_pointers(
-                data_pointers,
-                scale_pointers,
-                layer_to_pool_mapping,
-                [DataType.INT8, DataType.NVFP4],
-            )
+        merged = _merge_kv_cache_pool_pointers(
+            data_pointers,
+            scale_pointers,
+            layer_to_pool_mapping,
+            [DataType.NVFP4, DataType.HALF],
+        )
+
+        expected = torch.tensor([
+            [[11, 31], [12, 32]],
+            [[21, 0], [22, 0]],
+        ])
+        self.assertTrue(torch.equal(merged, expected))
 
 
 class TestResourceManager(unittest.TestCase):

--- a/tests/unittest/_torch/executor/test_resource_manager.py
+++ b/tests/unittest/_torch/executor/test_resource_manager.py
@@ -127,6 +127,43 @@ class TestMergeKVCachePoolPointers(unittest.TestCase):
         self.assertTrue(torch.equal(merged, expected))
 
 
+class TestKVCacheManagerPoolPointers(unittest.TestCase):
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_default_nvfp4_pool_configuration_merges_scale_pointers(self):
+        manager = KVCacheManager(
+            kv_cache_config=KvCacheConfig(max_tokens=64),
+            kv_cache_type=tensorrt_llm.bindings.internal.batch_manager.
+            CacheType.SELF,
+            num_layers=1,
+            num_kv_heads=1,
+            head_dim=128,
+            tokens_per_block=32,
+            max_seq_len=64,
+            max_batch_size=1,
+            mapping=Mapping(),
+            dtype=DataType.NVFP4,
+        )
+        try:
+            data_pointers = manager.impl.get_block_pool_pointers()
+            scale_pointers = manager.impl.get_block_scale_pool_pointers()
+
+            self.assertEqual(manager.pool_configurations, [])
+            self.assertEqual(
+                [(config.window_size, config.dtype)
+                 for config in manager.impl.pool_configurations],
+                [(64, DataType.NVFP4)],
+            )
+            self.assertTrue(
+                torch.equal(manager.kv_cache_pool_pointers[..., 0],
+                            data_pointers))
+            self.assertTrue(
+                torch.equal(manager.kv_cache_pool_pointers[..., 1],
+                            scale_pointers))
+        finally:
+            manager.shutdown()
+
+
 class TestResourceManager(unittest.TestCase):
     CPP_RESOURCES_DIR = os.path.join(str(root_dir), "cpp", "tests", "resources")
     CPP_DATA_DIR = os.path.join(CPP_RESOURCES_DIR, "data")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mixed-precision KV-cache handling for hybrid Mamba and attention workloads.
  - Correctly supports FP4 attention caches alongside HALF-precision recurrent-state caches.
  - Fixed cache scale metadata alignment when layers use different cache pools or mappings.
  - Improved behavior for configurations with no locally managed Mamba layers.

- **Tests**
  - Added coverage for mixed cache data types, pool allocation, scale handling, and layer routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fix NVFP4 KV-cache initialization for hybrid attention/Mamba models by forwarding per-window pool configurations and merging compact pointer tables in Python.

### Root Cause

`CppMambaHybridCacheManager` created recurrent-state and attention windows but did not supply their `pool_configurations` to `KVCacheManager`. Consequently, C++ constructed an empty `BlockManager::poolByWindow` and fell back to the manager-level NVFP4 attention dtype for the recurrent-state window.

Recurrent-state structures do not support FP4. Their backing pool must use the model's actual SSM-state dtype, while the attention pool keeps the requested KV-cache dtype. The Python manager views the backing allocation as bytes when splitting SSM and convolution state sections.

With mixed recurrent-state and NVFP4 attention pools, C++ returns separate compact data-pointer and block-scale-pointer tables. Directly stacking those tensors fails when only some data pools have scales. Python aligns each compact scale row with its NVFP4 data row before stacking, so the final `kv_cache_pool_pointers` remains `[num_data_pools, 2, 2]` without changing the C++ pointer ABI.

### Changes

- Derive the local recurrent-state and attention pool configurations directly in `CppMambaHybridCacheManager`.
- Use `torch_dtype_to_binding(self.ssm_state_dtype)` for the recurrent-state pool and the requested KV-cache dtype for attention.
- Forward those configurations so C++ `poolByWindow` selects each pool's actual dtype.
- Rank physical pool IDs into compact data rows, then place compact NVFP4 scale rows before `torch.stack`.
- Rely on the C++ `KVCacheManager` producer contract for pointer shapes, dtypes, devices, mapping consistency, and scale cardinality instead of duplicating defensive checks in Python.
- Preserve the prior two-dimensional pointer table when no block-scale pools exist.
- Document and test that C++ exposes effective per-window pool configurations even when Python supplies none.
- Add Python and C++ regression coverage for mixed SSM-state/NVFP4 pools, shared pools, unmanaged-layer gaps, and physical pool-ID gaps.

## Test Coverage

- Incremental build completed with `scripts/build_wheel.py` using SM100/SM103, ccache, benchmarks, and NIXL; no `--clean` rebuild was used.
- `tests/unittest/_torch/executor/test_mamba_cache_manager.py`: 26 passed, including FP16, FP32, and BF16 recurrent pools.
- `tests/unittest/_torch/executor/test_resource_manager.py`: 20 passed, 7 subtests passed.
- `KVCacheManagerTest.FP4*`: 2 passed.
- ModelOpt checkpoint metadata verified as `quant_algo=NVFP4` and `kv_cache_quant_algo=NVFP4` for Nemotron-Nano-3-30B-A3.5B-dev-1024.
- End-to-end generation completed on B300 after the pointer-merge simplification; the checkpoint resolved `kv_cache_quant_algo=NVFP4` and generated 8 tokens successfully.
- Target-file pre-commit checks and `git diff --check` passed.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.