### PR TITLE
[https://nvbugs/6437410][fix] Bound proc.join to 1800s (well under the 2400s outer harness timeout, well…

### DIFF
--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
@@ -745,8 +745,23 @@ def test_llm_update_weights_nemotron_h(mamba_deps):
     queue = ctx.Queue()
     proc = ctx.Process(target=_nemotron_h_subprocess_entry, args=(queue,))
     proc.start()
-    proc.join()
+    # Bound the child wait well below the outer pytest thread-timeout (2400s)
+    # so a silent hang doesn't leak Ray workers and swallow the traceback.
+    child_timeout_s = 1800
+    proc.join(timeout=child_timeout_s)
+    timed_out = proc.is_alive()
+    if timed_out:
+        proc.terminate()
+        proc.join(30)
+        if proc.is_alive():
+            proc.kill()
+            proc.join()
     err = queue.get() if not queue.empty() else None
+    if timed_out:
+        pytest.fail(
+            f"Subprocess did not finish within {child_timeout_s}s and was killed.\n"
+            f"Partial traceback (if any):\n{err or '<none>'}"
+        )
     if proc.exitcode != 0:
         pytest.fail(f"Subprocess exited with code {proc.exitcode}\n{err or ''}")
     if err is not None:


### PR DESCRIPTION
## Summary
- **Root cause**: proc.join() has no timeout, so any child stall (mamba build, TP=4 model load, update_weights IPC, generate) pins pytest until the outer 2400s thread-timeout kills it, producing "failure reported in unittests" with no traceback and leaked Ray workers.
- **Fix**: Bound proc.join to 1800s (well under the 2400s outer harness timeout, well over the ~225s healthy path); on timeout, terminate → kill the child, drain the queue, and pytest.fail with a diagnostic so future recurrences surface as clean bounded failures instead of silent kills.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6437410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a maximum runtime for the Nemotron-H subprocess test.
  * Tests now terminate stalled processes and report captured traceback details when a timeout occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->