### PR TITLE
[https://nvbugs/6445322][fix] Restore the pre-#16108 baseline `- accuracy: 56.667` alongside the existing…

### DIFF
--- a/tests/integration/defs/accuracy/references/mmmu.yaml
+++ b/tests/integration/defs/accuracy/references/mmmu.yaml
@@ -14,6 +14,7 @@ google/gemma-3-27b-it:
     kv_cache_quant_algo: FP8
     accuracy: 48.0
 google/gemma-4-26B-A4B-it:
+  - accuracy: 56.667
   # B200 PyTorch backend baseline for nvidia/Gemma-4-26B-A4B-NVFP4.
   - quant_algo: NVFP4
     kv_cache_quant_algo: FP8

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -23,7 +23,6 @@ accuracy/test_disaggregated_serving.py::TestQwen3_30B_A3B::test_mixed_ctx_gen_mo
 accuracy/test_epd_disagg_multimodal.py::TestVideoMMEEPD::test_disaggregated_videomme[nemotron_nano_v3_omni_nvfp4] SKIP (https://nvbugs/6336747)
 accuracy/test_epd_disagg_multimodal.py::TestVideoMMEEPD::test_disaggregated_videomme[qwen3vl_2b_instruct] SKIP (https://nvbugs/6422294)
 accuracy/test_llm_api.py::TestLlama3_1_8BInstruct::test_guided_decoding_4gpus[xgrammar] SKIP (https://nvbugs/5346443)
-accuracy/test_llm_api_autodeploy.py::TestGemma4MoE::test_bf16 SKIP (https://nvbugs/6445322)
 accuracy/test_llm_api_autodeploy.py::TestMiniMaxM2::test_finegrained_fp8 SKIP (https://nvbugs/6396422)
 accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[bf16-4-attn_dp_off-trtllm] SKIP (https://nvbugs/6367792)
 accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[fp8-4-attn_dp_off-trtllm] SKIP (https://nvbugs/6367792)


### PR DESCRIPTION
## Summary
- **Root cause**: PR #16108 replaced the plain bf16 entry for `google/gemma-4-26B-A4B-it` in `tests/integration/defs/accuracy/references/mmmu.yaml` with only an NVFP4 entry, so the autodeploy bf16 test's default acc_specs matched no row and raised `ValueError: Not registered specs`.
- **Fix**: Restore the pre-#16108 baseline `- accuracy: 56.667` alongside the existing NVFP4 entry (same coexistence pattern used for gemma-3-27b-it / gemma-3-12b-it in the same file).
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6445322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated MMMU integration reference data with an accuracy benchmark for the Gemma 4 26B A4B IT model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->