### PR TITLE
[TRTLLM-13409][fix] make proxy shutdown non-blocking when the engine is dead

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -311,15 +311,10 @@ class GenerationExecutorProxy(GenerationExecutor):
                 result.queue.put(dead_error)
             except Exception:  # noqa: BLE001 - a full/closed queue must not stop the sweep
                 pass
-        # Release the session's exit joins NOW rather than at teardown: the
-        # dead pool's manager thread is wedged in an MPI call forever, and
-        # CPython joins non-daemon threads (threading._shutdown) BEFORE the
-        # atexit/GC teardown that runs shutdown() -- deregistering at
-        # teardown time is already too late to let the process exit. This is
-        # non-destructive bookkeeping, so it applies to external (unowned)
-        # sessions too: in the LLM API path the session is created by the
-        # LLM object and passed in, and its owner's later blocking
-        # shutdown() must also not join the dead world.
+        # Release the session's exit joins here, not at teardown: interpreter
+        # exit joins non-daemon threads before any teardown code runs, so a
+        # wedged pool manager thread must be deregistered while user code is
+        # still alive. Non-destructive, hence safe for unowned sessions.
         release = getattr(getattr(self, 'mpi_session', None),
                           'release_exit_joins', None)
         if release is not None:
@@ -656,12 +651,9 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         logger_debug('Proxy.shutdown...\n', "yellow")
 
-        # A worker world torn down abruptly (MPI_Abort by the HangDetector,
-        # SIGKILL, the OOM killer) never completes its mpi4py futures, so once
-        # the engine is known dead the blocking waits below would hang
-        # teardown until an outer timeout (e.g. pytest's) fires. Give the
-        # futures one short collective grace instead, and skip the ones still
-        # pending.
+        # An abruptly-killed worker world (MPI_Abort, SIGKILL, OOM) never
+        # completes its mpi4py futures: give them one short collective grace
+        # instead of blocking on each, and skip the ones still pending.
         if self._engine_dead:
             concurrent.futures.wait(self.mpi_futures, timeout=5.0)
 
@@ -684,10 +676,9 @@ class GenerationExecutorProxy(GenerationExecutor):
         if self.dispatch_result_thread is not None and self.dispatch_result_thread.is_alive(
         ):
             self.dispatch_result_thread.stop()
-            # With the engine dead, the worker that would send the shutdown
-            # sentinel is gone, so the dispatcher may be blocked in a ZMQ
-            # recv that never returns: bound the join and leak the daemon
-            # thread rather than hang teardown.
+            # With the engine dead, the shutdown sentinel will never arrive
+            # and the dispatcher may be blocked in a ZMQ recv forever: bound
+            # the join and leak the daemon thread.
             self.dispatch_result_thread.join(
                 timeout=5.0 if self._engine_dead else None)
 
@@ -708,9 +699,7 @@ class GenerationExecutorProxy(GenerationExecutor):
         self.workers_started = False
         if self._owns_mpi_session:
             if self._engine_dead:
-                # Joining anything owned by an abruptly-killed worker world
-                # blocks forever (the pool join, and later interpreter exit
-                # on the wedged manager thread): abandon instead of joining.
+                # Anything joining a dead worker world blocks forever.
                 self.mpi_session.abandon()
             else:
                 self.mpi_session.shutdown()

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -639,7 +639,18 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         logger_debug('Proxy.shutdown...\n', "yellow")
 
+        # A worker world torn down abruptly (MPI_Abort by the HangDetector,
+        # SIGKILL, the OOM killer) never completes its mpi4py futures, so once
+        # the engine is known dead the blocking waits below would hang
+        # teardown until an outer timeout (e.g. pytest's) fires. Give the
+        # futures one short collective grace instead, and skip the ones still
+        # pending.
+        if self._engine_dead:
+            concurrent.futures.wait(self.mpi_futures, timeout=5.0)
+
         for f in self.mpi_futures:
+            if self._engine_dead and not f.done():
+                continue
             try:
                 f.result()
             except:
@@ -656,7 +667,12 @@ class GenerationExecutorProxy(GenerationExecutor):
         if self.dispatch_result_thread is not None and self.dispatch_result_thread.is_alive(
         ):
             self.dispatch_result_thread.stop()
-            self.dispatch_result_thread.join()
+            # With the engine dead, the worker that would send the shutdown
+            # sentinel is gone, so the dispatcher may be blocked in a ZMQ
+            # recv that never returns: bound the join and leak the daemon
+            # thread rather than hang teardown.
+            self.dispatch_result_thread.join(
+                timeout=5.0 if self._engine_dead else None)
 
         # step3: finish all remaining work
 
@@ -674,7 +690,10 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         self.workers_started = False
         if self._owns_mpi_session:
-            self.mpi_session.shutdown()
+            # Joining a pool whose workers were killed abruptly blocks
+            # forever; when the engine is dead, shut the session down without
+            # waiting.
+            self.mpi_session.shutdown(wait=not self._engine_dead)
 
         # Process the errors in-case error during shutting down the threads
         self._handle_background_error()

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -690,10 +690,13 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         self.workers_started = False
         if self._owns_mpi_session:
-            # Joining a pool whose workers were killed abruptly blocks
-            # forever; when the engine is dead, shut the session down without
-            # waiting.
-            self.mpi_session.shutdown(wait=not self._engine_dead)
+            if self._engine_dead:
+                # Joining anything owned by an abruptly-killed worker world
+                # blocks forever (the pool join, and later interpreter exit
+                # on the wedged manager thread): abandon instead of joining.
+                self.mpi_session.abandon()
+            else:
+                self.mpi_session.shutdown()
 
         # Process the errors in-case error during shutting down the threads
         self._handle_background_error()

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -311,18 +311,23 @@ class GenerationExecutorProxy(GenerationExecutor):
                 result.queue.put(dead_error)
             except Exception:  # noqa: BLE001 - a full/closed queue must not stop the sweep
                 pass
-        # Abandon the owned MPI session NOW rather than at teardown: the dead
-        # pool's manager thread is wedged in an MPI call forever, and CPython
-        # joins non-daemon threads (threading._shutdown) BEFORE the
+        # Release the session's exit joins NOW rather than at teardown: the
+        # dead pool's manager thread is wedged in an MPI call forever, and
+        # CPython joins non-daemon threads (threading._shutdown) BEFORE the
         # atexit/GC teardown that runs shutdown() -- deregistering at
-        # teardown time is already too late to let the process exit.
-        if getattr(self, '_owns_mpi_session', False):
-            abandon = getattr(self.mpi_session, 'abandon', None)
-            if abandon is not None:
-                try:
-                    abandon()
-                except Exception as e:  # noqa: BLE001 - best-effort cleanup
-                    logger.debug(f"MPI session abandon failed (ignored): {e!r}")
+        # teardown time is already too late to let the process exit. This is
+        # non-destructive bookkeeping, so it applies to external (unowned)
+        # sessions too: in the LLM API path the session is created by the
+        # LLM object and passed in, and its owner's later blocking
+        # shutdown() must also not join the dead world.
+        release = getattr(getattr(self, 'mpi_session', None),
+                          'release_exit_joins', None)
+        if release is not None:
+            try:
+                release()
+            except Exception as e:  # noqa: BLE001 - best-effort cleanup
+                logger.debug(
+                    f"MPI session exit-join release failed (ignored): {e!r}")
 
     def _handle_worker_death(self, error: BaseException) -> None:
         """Event-driven worker-death handler.

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -311,6 +311,18 @@ class GenerationExecutorProxy(GenerationExecutor):
                 result.queue.put(dead_error)
             except Exception:  # noqa: BLE001 - a full/closed queue must not stop the sweep
                 pass
+        # Abandon the owned MPI session NOW rather than at teardown: the dead
+        # pool's manager thread is wedged in an MPI call forever, and CPython
+        # joins non-daemon threads (threading._shutdown) BEFORE the
+        # atexit/GC teardown that runs shutdown() -- deregistering at
+        # teardown time is already too late to let the process exit.
+        if getattr(self, '_owns_mpi_session', False):
+            abandon = getattr(self.mpi_session, 'abandon', None)
+            if abandon is not None:
+                try:
+                    abandon()
+                except Exception as e:  # noqa: BLE001 - best-effort cleanup
+                    logger.debug(f"MPI session abandon failed (ignored): {e!r}")
 
     def _handle_worker_death(self, error: BaseException) -> None:
         """Event-driven worker-death handler.

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -149,21 +149,14 @@ class MpiSession(abc.ABC):
     def release_exit_joins(self):
         """Mark the worker world dead and release anything that would join it.
 
-        Non-destructive counterpart of ``abandon()``: called the moment the
-        workers are known dead (killed by ``MPI_Abort`` from the hang
-        detector, SIGKILL, or the OOM killer), possibly by a component that
-        does not own the session. It must not tear the session down -- only
-        ensure that nothing (interpreter exit, a later blocking
-        ``shutdown()`` by the owner) will wait forever on the dead world.
-        Default: no-op.
+        Non-destructive, so it may be called by a component that does not
+        own the session. Must not tear the session down -- only ensure that
+        nothing (interpreter exit, a later blocking ``shutdown()`` by the
+        owner) waits forever on the dead world. Default: no-op.
         """
 
     def abandon(self):
-        """Tear the session down without waiting on a dead worker world.
-
-        Called instead of ``shutdown()`` once the workers are known dead:
-        joining anything owned by such a session can block forever.
-        """
+        """Tear the session down without waiting on a dead worker world."""
         self.release_exit_joins()
         self.shutdown(wait=False)
 
@@ -171,19 +164,16 @@ class MpiSession(abc.ABC):
 def _abandon_mpi_pool_threads(mpi_pool) -> None:
     """Let interpreter exit proceed despite a wedged pool manager thread.
 
-    After the worker world dies abruptly, the ``MPIPoolExecutor``'s manager
-    thread stays blocked in an MPI call forever. Two independent mechanisms
-    then hang process exit even after a non-waiting shutdown: mpi4py's exit
-    hook joins every manager thread it registered, and CPython's
-    ``threading._shutdown`` joins every non-daemon thread. Deregister the
-    wedged thread from both so exit can proceed (the thread dies with the
-    process).
+    When the worker world dies abruptly, the ``MPIPoolExecutor`` manager
+    thread stays blocked in an MPI call forever, and process exit hangs on
+    it twice: mpi4py's exit hook joins every registered manager thread, and
+    CPython joins every non-daemon thread. Deregister the thread from both;
+    it is reaped with the process.
 
-    Best-effort by design: the names are private to mpi4py (``_lib`` in
-    3.x, ``_core`` in 4.x; both use ``THREADS_QUEUES``) and CPython
-    (``threading._shutdown_locks``, Python 3.9-3.12). Where a name is
-    absent (e.g. Python 3.13+), that mechanism is left alone and exit may
-    still block on it.
+    Best-effort: the touched names are private to mpi4py (``THREADS_QUEUES``
+    in ``_lib``/3.x and ``_core``/4.x) and CPython
+    (``threading._shutdown_locks``, 3.9-3.12). Where a name is absent, that
+    mechanism is left alone and exit may still block on it.
     """
     thread = getattr(getattr(mpi_pool, '_pool', None), 'thread', None)
     if thread is None:

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -146,6 +146,56 @@ class MpiSession(abc.ABC):
         fut.set_result(None)
         killer.join()
 
+    def abandon(self):
+        """Tear the session down without waiting on a dead worker world.
+
+        Called instead of ``shutdown()`` once the workers are known dead
+        (e.g. killed by ``MPI_Abort`` from the hang detector, SIGKILL, or
+        the OOM killer): joining anything owned by such a session can block
+        forever. The default is a non-waiting shutdown; subclasses extend
+        it where extra unblocking is needed.
+        """
+        self.shutdown(wait=False)
+
+
+def _abandon_mpi_pool_threads(mpi_pool) -> None:
+    """Let interpreter exit proceed despite a wedged pool manager thread.
+
+    After the worker world dies abruptly, the ``MPIPoolExecutor``'s manager
+    thread stays blocked in an MPI call forever. Two independent mechanisms
+    then hang process exit even after a non-waiting shutdown: mpi4py's exit
+    hook joins every manager thread it registered, and CPython's
+    ``threading._shutdown`` joins every non-daemon thread. Deregister the
+    wedged thread from both so exit can proceed (the thread dies with the
+    process).
+
+    Best-effort by design: the names are private to mpi4py (``_lib`` in
+    3.x, ``_core`` in 4.x; both use ``THREADS_QUEUES``) and CPython
+    (``threading._shutdown_locks``, Python 3.9-3.12). Where a name is
+    absent (e.g. Python 3.13+), that mechanism is left alone and exit may
+    still block on it.
+    """
+    thread = getattr(getattr(mpi_pool, '_pool', None), 'thread', None)
+    if thread is None:
+        return
+    # mpi4py's own exit hook (joins all registered manager threads).
+    for mod_name in ('mpi4py.futures._lib', 'mpi4py.futures._core'):
+        mod = sys.modules.get(mod_name)
+        registry = getattr(mod, 'THREADS_QUEUES', None) if mod else None
+        if registry is not None:
+            try:
+                registry.pop(thread, None)
+            except Exception as e:  # noqa: BLE001 - best-effort cleanup
+                logger.debug(f"THREADS_QUEUES cleanup failed (ignored): {e!r}")
+    # CPython's non-daemon thread join at interpreter shutdown.
+    tstate_lock = getattr(thread, '_tstate_lock', None)
+    shutdown_locks = getattr(threading, '_shutdown_locks', None)
+    if tstate_lock is not None and shutdown_locks is not None:
+        try:
+            shutdown_locks.discard(tstate_lock)
+        except Exception as e:  # noqa: BLE001 - best-effort cleanup
+            logger.debug(f"_shutdown_locks cleanup failed (ignored): {e!r}")
+
 
 class MpiPoolSession(MpiSession):
 
@@ -177,6 +227,11 @@ class MpiPoolSession(MpiSession):
         if self.mpi_pool is not None:
             self.mpi_pool.shutdown(wait=wait)
             self.mpi_pool = None
+
+    def abandon(self):
+        if self.mpi_pool is not None:
+            _abandon_mpi_pool_threads(self.mpi_pool)
+        self.shutdown(wait=False)
 
     def abort(self):
         self.get_comm().Abort(1)

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -146,15 +146,25 @@ class MpiSession(abc.ABC):
         fut.set_result(None)
         killer.join()
 
+    def release_exit_joins(self):
+        """Mark the worker world dead and release anything that would join it.
+
+        Non-destructive counterpart of ``abandon()``: called the moment the
+        workers are known dead (killed by ``MPI_Abort`` from the hang
+        detector, SIGKILL, or the OOM killer), possibly by a component that
+        does not own the session. It must not tear the session down -- only
+        ensure that nothing (interpreter exit, a later blocking
+        ``shutdown()`` by the owner) will wait forever on the dead world.
+        Default: no-op.
+        """
+
     def abandon(self):
         """Tear the session down without waiting on a dead worker world.
 
-        Called instead of ``shutdown()`` once the workers are known dead
-        (e.g. killed by ``MPI_Abort`` from the hang detector, SIGKILL, or
-        the OOM killer): joining anything owned by such a session can block
-        forever. The default is a non-waiting shutdown; subclasses extend
-        it where extra unblocking is needed.
+        Called instead of ``shutdown()`` once the workers are known dead:
+        joining anything owned by such a session can block forever.
         """
+        self.release_exit_joins()
         self.shutdown(wait=False)
 
 
@@ -224,14 +234,18 @@ class MpiPoolSession(MpiSession):
         return [future.result() for future in futures]
 
     def shutdown(self, wait=True):
+        if getattr(self, '_pool_dead', False):
+            # A dead pool can never be joined; never block on it, no matter
+            # what the caller asked for.
+            wait = False
         if self.mpi_pool is not None:
             self.mpi_pool.shutdown(wait=wait)
             self.mpi_pool = None
 
-    def abandon(self):
+    def release_exit_joins(self):
         if self.mpi_pool is not None:
             _abandon_mpi_pool_threads(self.mpi_pool)
-        self.shutdown(wait=False)
+        self._pool_dead = True
 
     def abort(self):
         self.get_comm().Abort(1)

--- a/tests/unittest/executor/test_proxy_fast_death.py
+++ b/tests/unittest/executor/test_proxy_fast_death.py
@@ -392,8 +392,9 @@ def test_shutdown_does_not_block_on_dead_engine():
     # The dispatcher join is bounded (daemon thread is leaked, not awaited).
     dispatcher.stop.assert_called_once()
     dispatcher.join.assert_called_once_with(timeout=5.0)
-    # The dead pool is not joined.
-    proxy.mpi_session.shutdown.assert_called_once_with(wait=False)
+    # The dead pool is not joined; the session is abandoned instead.
+    proxy.mpi_session.abandon.assert_called_once_with()
+    proxy.mpi_session.shutdown.assert_not_called()
     assert proxy.workers_started is False
 
 
@@ -411,7 +412,8 @@ def test_shutdown_keeps_blocking_semantics_when_engine_alive():
     proxy.shutdown()
 
     dispatcher.join.assert_called_once_with(timeout=None)
-    proxy.mpi_session.shutdown.assert_called_once_with(wait=True)
+    proxy.mpi_session.shutdown.assert_called_once_with()
+    proxy.mpi_session.abandon.assert_not_called()
     assert proxy.workers_started is False
 
 
@@ -424,3 +426,53 @@ def test_shutdown_does_not_shut_down_external_session():
     proxy.shutdown()
 
     proxy.mpi_session.shutdown.assert_not_called()
+    proxy.mpi_session.abandon.assert_not_called()
+
+
+def test_abandon_mpi_pool_threads_unblocks_interpreter_exit():
+    """Both exit-join mechanisms release a wedged pool manager thread.
+
+    The thread is deregistered from mpi4py's THREADS_QUEUES and CPython's
+    _shutdown_locks, so process exit can proceed without joining it.
+    """
+    import sys as _sys
+    import threading as _threading
+    import types as _types
+
+    from tensorrt_llm.llmapi.mpi_session import _abandon_mpi_pool_threads
+
+    release = _threading.Event()
+    wedged = _threading.Thread(target=release.wait, name="fake_manager")
+    wedged.daemon = False
+    wedged.start()
+    try:
+        # Fake mpi4py registry module, as mpi4py would have registered it.
+        fake_mod = _types.ModuleType("mpi4py.futures._lib")
+        fake_mod.THREADS_QUEUES = {wedged: object()}
+        prev = _sys.modules.get("mpi4py.futures._lib")
+        _sys.modules["mpi4py.futures._lib"] = fake_mod
+        try:
+            fake_pool = _Mock()
+            fake_pool._pool.thread = wedged
+
+            _abandon_mpi_pool_threads(fake_pool)
+
+            assert wedged not in fake_mod.THREADS_QUEUES
+            shutdown_locks = getattr(_threading, "_shutdown_locks", None)
+            if shutdown_locks is not None:  # CPython 3.9-3.12
+                assert wedged._tstate_lock not in shutdown_locks
+        finally:
+            if prev is None:
+                del _sys.modules["mpi4py.futures._lib"]
+            else:
+                _sys.modules["mpi4py.futures._lib"] = prev
+    finally:
+        release.set()
+        wedged.join(timeout=5)
+
+
+def test_abandon_mpi_pool_threads_tolerates_missing_pool():
+    from tensorrt_llm.llmapi.mpi_session import _abandon_mpi_pool_threads
+
+    _abandon_mpi_pool_threads(None)
+    _abandon_mpi_pool_threads(object())  # no _pool attribute

--- a/tests/unittest/executor/test_proxy_fast_death.py
+++ b/tests/unittest/executor/test_proxy_fast_death.py
@@ -476,3 +476,31 @@ def test_abandon_mpi_pool_threads_tolerates_missing_pool():
 
     _abandon_mpi_pool_threads(None)
     _abandon_mpi_pool_threads(object())  # no _pool attribute
+
+
+def test_mark_engine_dead_abandons_owned_session_immediately():
+    """Abandon must happen at detection time, not at teardown.
+
+    CPython's exit sequence joins non-daemon threads before atexit/GC can
+    run shutdown(), so a wedged pool manager thread must be deregistered
+    the moment the engine is marked dead.
+    """
+    proxy = _bare_proxy()
+    proxy._owns_mpi_session = True
+    proxy.mpi_session = _Mock()
+
+    proxy._mark_engine_dead(RuntimeError("worker died"))
+    proxy.mpi_session.abandon.assert_called_once_with()
+
+    # Sticky: a second death report must not re-abandon.
+    proxy._mark_engine_dead(RuntimeError("again"))
+    proxy.mpi_session.abandon.assert_called_once_with()
+
+
+def test_mark_engine_dead_leaves_external_session_alone():
+    proxy = _bare_proxy()
+    proxy._owns_mpi_session = False
+    proxy.mpi_session = _Mock()
+
+    proxy._mark_engine_dead(RuntimeError("worker died"))
+    proxy.mpi_session.abandon.assert_not_called()

--- a/tests/unittest/executor/test_proxy_fast_death.py
+++ b/tests/unittest/executor/test_proxy_fast_death.py
@@ -344,12 +344,10 @@ def test_proxy_check_remote_worker_death_marks_engine_dead():
 
 
 # --- Non-blocking teardown on a dead engine ---
-# A worker world torn down abruptly (MPI_Abort by the HangDetector, SIGKILL,
-# the OOM killer) never completes its mpi4py futures and never sends the
-# result-queue shutdown sentinel. Without bounds, shutdown() blocks forever on
-# f.result(), the dispatcher join, and the dead pool join -- so detection
-# (PR #16338 / #15816) alone only moves the client hang from generate() into
-# teardown. These tests pin the bounded-teardown behavior.
+# An abruptly-killed worker world never completes its mpi4py futures and
+# never sends the result-queue shutdown sentinel, so an unbounded shutdown()
+# blocks forever on f.result(), the dispatcher join, and the pool join.
+# These tests pin the bounded-teardown behavior.
 
 
 def _teardown_proxy(engine_dead):
@@ -373,7 +371,7 @@ def _teardown_proxy(engine_dead):
 def test_shutdown_does_not_block_on_dead_engine():
     """With the engine dead, never-completing futures must not hang teardown."""
     proxy = _teardown_proxy(engine_dead=True)
-    pending = _Future()  # never completes -- the MPI_Abort premise
+    pending = _Future()  # never completes: abrupt worker death
     done = _Future()
     done.set_exception(RuntimeError("captured by mpi_done_callback already"))
     proxy.mpi_futures = [pending, done]
@@ -499,10 +497,9 @@ def test_mark_engine_dead_releases_exit_joins_immediately():
 def test_mark_engine_dead_releases_external_sessions_too():
     """Ownership must not gate the exit-join release.
 
-    In the LLM API path the session is created by the LLM object and
-    passed in (proxy does not own it), yet its exit joins must still be
-    released -- this exact gap kept the process hanging in the GB200
-    hardware validation. The release is non-destructive bookkeeping.
+    The LLM API creates the session and passes it in, so the proxy does
+    not own it; the release is non-destructive bookkeeping and must still
+    happen.
     """
     proxy = _bare_proxy()
     proxy._owns_mpi_session = False

--- a/tests/unittest/executor/test_proxy_fast_death.py
+++ b/tests/unittest/executor/test_proxy_fast_death.py
@@ -16,7 +16,10 @@
 
 import asyncio
 import queue as _queue
+import time as _time
+from concurrent.futures import Future as _Future
 from unittest.mock import Mock
+from unittest.mock import Mock as _Mock
 
 import pytest
 
@@ -338,3 +341,86 @@ def test_proxy_check_remote_worker_death_marks_engine_dead():
     proxy2 = _bare_proxy()
     proxy2.mpi_session = object()
     assert proxy2._check_remote_worker_death() is False
+
+
+# --- Non-blocking teardown on a dead engine ---
+# A worker world torn down abruptly (MPI_Abort by the HangDetector, SIGKILL,
+# the OOM killer) never completes its mpi4py futures and never sends the
+# result-queue shutdown sentinel. Without bounds, shutdown() blocks forever on
+# f.result(), the dispatcher join, and the dead pool join -- so detection
+# (PR #16338 / #15816) alone only moves the client hang from generate() into
+# teardown. These tests pin the bounded-teardown behavior.
+
+
+def _teardown_proxy(engine_dead):
+    proxy = _bare_proxy()
+    proxy.workers_started = True
+    proxy.doing_shutdown = True  # skip pre_shutdown(); teardown path only
+    proxy._engine_dead = engine_dead
+    proxy._fatal_error = RuntimeError("worker died") if engine_dead else None
+    proxy.dispatch_result_thread = None
+    proxy.rpc_client = None
+    proxy.request_queue = _Mock()
+    proxy.worker_init_status_queue = _Mock()
+    proxy.result_queue = _Mock()
+    proxy._resource_governor_queue = None
+    proxy._owns_mpi_session = True
+    proxy.mpi_session = _Mock()
+    proxy._handle_background_error = lambda *a, **k: None
+    return proxy
+
+
+def test_shutdown_does_not_block_on_dead_engine():
+    """With the engine dead, never-completing futures must not hang teardown."""
+    proxy = _teardown_proxy(engine_dead=True)
+    pending = _Future()  # never completes -- the MPI_Abort premise
+    done = _Future()
+    done.set_exception(RuntimeError("captured by mpi_done_callback already"))
+    proxy.mpi_futures = [pending, done]
+
+    dispatcher = _Mock()
+    dispatcher.is_alive.return_value = True
+    proxy.dispatch_result_thread = dispatcher
+
+    start = _time.monotonic()
+    proxy.shutdown()
+    elapsed = _time.monotonic() - start
+
+    # One collective 5 s grace, not an unbounded f.result() per future.
+    assert elapsed < 30
+    assert not pending.done()
+    # The dispatcher join is bounded (daemon thread is leaked, not awaited).
+    dispatcher.stop.assert_called_once()
+    dispatcher.join.assert_called_once_with(timeout=5.0)
+    # The dead pool is not joined.
+    proxy.mpi_session.shutdown.assert_called_once_with(wait=False)
+    assert proxy.workers_started is False
+
+
+def test_shutdown_keeps_blocking_semantics_when_engine_alive():
+    """Orderly shutdown is unchanged: futures reaped, session joined."""
+    proxy = _teardown_proxy(engine_dead=False)
+    done = _Future()
+    done.set_result(None)
+    proxy.mpi_futures = [done]
+
+    dispatcher = _Mock()
+    dispatcher.is_alive.return_value = True
+    proxy.dispatch_result_thread = dispatcher
+
+    proxy.shutdown()
+
+    dispatcher.join.assert_called_once_with(timeout=None)
+    proxy.mpi_session.shutdown.assert_called_once_with(wait=True)
+    assert proxy.workers_started is False
+
+
+def test_shutdown_does_not_shut_down_external_session():
+    """An externally owned session must stay alive even on a dead engine."""
+    proxy = _teardown_proxy(engine_dead=True)
+    proxy._owns_mpi_session = False
+    proxy.mpi_futures = []
+
+    proxy.shutdown()
+
+    proxy.mpi_session.shutdown.assert_not_called()

--- a/tests/unittest/executor/test_proxy_fast_death.py
+++ b/tests/unittest/executor/test_proxy_fast_death.py
@@ -478,29 +478,57 @@ def test_abandon_mpi_pool_threads_tolerates_missing_pool():
     _abandon_mpi_pool_threads(object())  # no _pool attribute
 
 
-def test_mark_engine_dead_abandons_owned_session_immediately():
-    """Abandon must happen at detection time, not at teardown.
+def test_mark_engine_dead_releases_exit_joins_immediately():
+    """Exit-join release must happen at detection time, not at teardown.
 
     CPython's exit sequence joins non-daemon threads before atexit/GC can
     run shutdown(), so a wedged pool manager thread must be deregistered
     the moment the engine is marked dead.
     """
     proxy = _bare_proxy()
-    proxy._owns_mpi_session = True
     proxy.mpi_session = _Mock()
 
     proxy._mark_engine_dead(RuntimeError("worker died"))
-    proxy.mpi_session.abandon.assert_called_once_with()
+    proxy.mpi_session.release_exit_joins.assert_called_once_with()
 
-    # Sticky: a second death report must not re-abandon.
+    # Sticky: a second death report must not re-release.
     proxy._mark_engine_dead(RuntimeError("again"))
-    proxy.mpi_session.abandon.assert_called_once_with()
+    proxy.mpi_session.release_exit_joins.assert_called_once_with()
 
 
-def test_mark_engine_dead_leaves_external_session_alone():
+def test_mark_engine_dead_releases_external_sessions_too():
+    """Ownership must not gate the exit-join release.
+
+    In the LLM API path the session is created by the LLM object and
+    passed in (proxy does not own it), yet its exit joins must still be
+    released -- this exact gap kept the process hanging in the GB200
+    hardware validation. The release is non-destructive bookkeeping.
+    """
     proxy = _bare_proxy()
     proxy._owns_mpi_session = False
     proxy.mpi_session = _Mock()
 
     proxy._mark_engine_dead(RuntimeError("worker died"))
+    proxy.mpi_session.release_exit_joins.assert_called_once_with()
+    # But destructive teardown is still reserved for the owner.
     proxy.mpi_session.abandon.assert_not_called()
+    proxy.mpi_session.shutdown.assert_not_called()
+
+
+def test_pool_session_shutdown_never_blocks_after_release():
+    """A released session never blocks, even on an explicit shutdown().
+
+    After release_exit_joins(), a blocking shutdown() from the session
+    owner must not join the dead pool.
+    """
+    from tensorrt_llm.llmapi.mpi_session import MpiPoolSession
+
+    session = MpiPoolSession.__new__(MpiPoolSession)
+    pool = _Mock()
+    pool._pool.thread = None  # no real manager thread to deregister
+    session.mpi_pool = pool
+
+    session.release_exit_joins()
+    session.shutdown()  # owner asks for the default blocking shutdown
+
+    pool.shutdown.assert_called_once_with(wait=False)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of abruptly terminated worker processes, including crashes and forced kills.
  * Pending requests now receive engine-dead errors more promptly when a worker fails.
  * Prevented executor shutdown from hanging after an engine failure.
  * Improved startup error reporting when worker initialization fails.
  * Added safeguards to distinguish restarted processes from stale worker identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Bound every teardown wait in GenerationExecutorProxy.shutdown() when the engine is known dead (_engine_dead, set by all worker-death detection paths):

Give the mpi4py worker futures one short collective 5 s grace (concurrent.futures.wait) instead of unbounded per-future result() calls, and skip futures still pending.
Bound the result-dispatcher join (5 s): the worker that would send the shutdown sentinel is dead, so the dispatcher may be blocked in a ZMQ recv that never returns. It is a daemon thread — leak it rather than hang teardown.
Shut the owned MPI session down without waiting on the dead pool (shutdown(wait=False)).

Orderly shutdown (engine alive) is byte-for-byte unchanged: futures are reaped blocking, the dispatcher join is unbounded, the session join waits.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
