### PR TITLE
[TRTLLM-14054][perf] Reduce per-step host preparation overhead in the PyTorch executor decode path

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -1301,8 +1301,13 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         beam_width: int,
         num_contexts: int,
         num_seqs: int,
+        max_blocks: Optional[int] = None,
     ) -> None:
-        """For compatibility with AttentionOp, copy only the SWA block offsets."""
+        """For compatibility with AttentionOp, copy only the SWA block offsets.
+
+        max_blocks is accepted for signature parity with KVCacheManager; the
+        copy below is already bounded by the precomputed SWA table width.
+        """
         assert beam_width == 1, "DSV4 only supports beam width 1 now"
         assert dst_tensor.is_cuda, "copy_batch_block_offsets expects a CUDA destination"
         dst_tensor.fill_(BAD_PAGE_INDEX)

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -592,11 +592,23 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                 f"exceeds the KV cache manager's maximum supported length "
                 f"({self.kv_cache_manager.max_seq_len}).")
 
-            # Kernels only read each sequence's allocated block prefix, so cap
-            # the staged/H2D block-table width at the batch's maximum instead
-            # of max_seq_len's worth of columns.
-            max_blocks = -(-max_kv_len // self.kv_cache_manager.tokens_per_block
-                           ) if self.kv_cache_manager.tokens_per_block else None
+            # On the non-speculative path the host kv_lens snapshot bounds
+            # every block-table access, so the staged/H2D width can be capped
+            # at the batch's maximum instead of max_seq_len's worth of
+            # columns. Speculative decoding must stage the full width:
+            # draft/tree sub-steps and the overlap scheduler advance
+            # kv_lens_cuda on device past the host snapshot, and their
+            # kernels dereference block columns a host-derived cap would
+            # leave unstaged (uninitialized in this buffer).
+            spec_active = (self.draft_kv_cache_manager is not None
+                           or self.is_spec_decoding_enabled
+                           or bool(self.kv_cache_params.num_extra_kv_tokens) or
+                           (self.runtime_features is not None and
+                            self.runtime_features.has_speculative_draft_tokens))
+            max_blocks = None
+            if not spec_active and self.kv_cache_manager.tokens_per_block:
+                max_blocks = -(-max_kv_len //
+                               self.kv_cache_manager.tokens_per_block)
             self.kv_cache_manager.copy_batch_block_offsets(
                 self.kv_cache_block_offsets,
                 self.request_ids,

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -586,24 +586,35 @@ class TrtllmAttentionMetadata(AttentionMetadata):
         # kv block offsets
         assert self.request_ids is not None
         if self.kv_cache_manager is not None:
-            self.kv_cache_manager.copy_batch_block_offsets(
-                self.kv_cache_block_offsets, self.request_ids, self.beam_width,
-                self.num_contexts, self.num_seqs)
-
-            error_message = (
-                f"The max KV cache length of input sequences ({self.kv_lens[:self.num_seqs].max()}) "
+            max_kv_len = int(self.kv_lens[:self.num_seqs].max())
+            assert max_kv_len <= self.kv_cache_manager.max_seq_len, (
+                f"The max KV cache length of input sequences ({max_kv_len}) "
                 f"exceeds the KV cache manager's maximum supported length "
                 f"({self.kv_cache_manager.max_seq_len}).")
 
-            assert self.kv_lens[:self.num_seqs].max(
-            ) <= self.kv_cache_manager.max_seq_len, error_message
+            # Kernels only read each sequence's allocated block prefix, so cap
+            # the staged/H2D block-table width at the batch's maximum instead
+            # of max_seq_len's worth of columns.
+            max_blocks = -(-max_kv_len // self.kv_cache_manager.tokens_per_block
+                           ) if self.kv_cache_manager.tokens_per_block else None
+            self.kv_cache_manager.copy_batch_block_offsets(
+                self.kv_cache_block_offsets,
+                self.request_ids,
+                self.beam_width,
+                self.num_contexts,
+                self.num_seqs,
+                max_blocks=max_blocks)
 
             # Also prepare draft KV cache block offsets if draft_kv_cache_manager exists
             if self.draft_kv_cache_manager is not None:
                 # Use the wrapper method which works for both V1 and V2
                 self.draft_kv_cache_manager.copy_batch_block_offsets(
-                    self.draft_kv_cache_block_offsets, self.request_ids,
-                    self.beam_width, self.num_contexts, self.num_seqs)
+                    self.draft_kv_cache_block_offsets,
+                    self.request_ids,
+                    self.beam_width,
+                    self.num_contexts,
+                    self.num_seqs,
+                    max_blocks=max_blocks)
 
         # Don't pass self.kv_lens as kv_lens here because it includes extra
         # tokens. Use the actual KV length (without extra tokens) for

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -31,6 +31,7 @@ from tensorrt_llm._torch.attention_backend.fmha import (
 from tensorrt_llm._utils import get_sm_version, maybe_pin_memory, prefer_pinned
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
+from tensorrt_llm.math_utils import ceil_div
 from tensorrt_llm.models.modeling_utils import QuantConfig
 
 from ..utils import (compute_swizzled_sf_shape, get_global_attrs,
@@ -607,8 +608,8 @@ class TrtllmAttentionMetadata(AttentionMetadata):
                             self.runtime_features.has_speculative_draft_tokens))
             max_blocks = None
             if not spec_active and self.kv_cache_manager.tokens_per_block:
-                max_blocks = -(-max_kv_len //
-                               self.kv_cache_manager.tokens_per_block)
+                max_blocks = ceil_div(max_kv_len,
+                                      self.kv_cache_manager.tokens_per_block)
             self.kv_cache_manager.copy_batch_block_offsets(
                 self.kv_cache_block_offsets,
                 self.request_ids,

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -369,9 +369,11 @@ class Mamba2Metadata:
                     self.state_indices_cpu[:batch_size], non_blocking=True)
             else:
                 # indices is a Python sequence (e.g. List[int]); data
-                # already lives on host, CPU staging is fine.
-                for i, idx in enumerate(indices):
-                    self.state_indices_cpu[i] = idx
+                # already lives on host, CPU staging is fine. One bulk
+                # conversion instead of a per-element tensor write.
+                self.state_indices_cpu[:batch_size].copy_(
+                    torch.as_tensor(indices,
+                                    dtype=self.state_indices_cpu.dtype))
                 self.state_indices[:batch_size].copy_(
                     self.state_indices_cpu[:batch_size], non_blocking=True)
 

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -371,6 +371,9 @@ class Mamba2Metadata:
                 # indices is a Python sequence (e.g. List[int]); data
                 # already lives on host, CPU staging is fine. One bulk
                 # conversion instead of a per-element tensor write.
+                assert len(indices) == batch_size, (
+                    f"get_state_indices() returned {len(indices)} entries for "
+                    f"a batch of {batch_size} requests.")
                 self.state_indices_cpu[:batch_size].copy_(
                     torch.as_tensor(indices,
                                     dtype=self.state_indices_cpu.dtype))

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -3194,7 +3194,10 @@ class KVCacheManagerV2(BaseResourceManager):
         beam_width: int,
         num_contexts: int,
         num_seqs: int,
+        max_blocks: Optional[int] = None,
     ):
+        # max_blocks is accepted for signature parity with KVCacheManager; the
+        # device-side copy op here already scales with allocated blocks only.
         assert beam_width == 1, "beam_width must be 1 for KVCacheManagerV2"
 
         copy_idx = self.index_mapper.get_copy_index(request_ids, num_contexts, beam_width)

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -1984,15 +1984,18 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
 
         self.cuda_state_indices.copy_(self._host_state_indices,
                                       non_blocking=True)
+        is_dummy = [req.is_dummy for req in requests]
         self._refresh_dummy_request_mask(
-            [req.is_dummy for req in self.requests])
+            is_dummy if requests is
+            self.requests else [req.is_dummy for req in self.requests])
 
         # Build request_id → pool block offset mapping so that
         # get_state_indices can return indices in arbitrary request order.
-        for i, req in enumerate(requests):
-            self._request_id_to_state_index[
-                req.py_request_id] = self._host_state_indices[i].item()
-            self._request_id_to_is_dummy[req.py_request_id] = req.is_dummy
+        # Bulk tolist avoids a per-request tensor-index + .item() round-trip.
+        state_values = self._host_state_indices[:n].tolist()
+        for req, value, dummy in zip(requests, state_values, is_dummy):
+            self._request_id_to_state_index[req.py_request_id] = value
+            self._request_id_to_is_dummy[req.py_request_id] = dummy
 
     def get_state_indices(self,
                           request_ids: Optional[List[int]] = None,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -675,6 +675,16 @@ class PyTorchModelEngine(ModelEngine):
         self.position_ids_cuda = torch.empty((self.max_num_tokens, ),
                                              dtype=torch.int,
                                              device='cuda')
+        # Steady-state generation-only prepare cache (non-speculative overlap
+        # decode). Holds the per-request lists that are invariant while the
+        # scheduled generation batch keeps the same composition, plus a pinned
+        # position/cached-token buffer advanced by one per step. Invalidated
+        # (set to None) by every full _prepare_tp_inputs pass.
+        self._steady_gen_cache: Optional[Dict[str, Any]] = None
+        self._steady_gen_positions_pinned = torch.empty(
+            (self.max_num_tokens, ),
+            dtype=torch.int,
+            pin_memory=prefer_pinned())
         if self.use_mrope:
             self.mrope_position_ids_cuda = torch.empty(
                 (3, 1, self.max_num_tokens), dtype=torch.int, device='cuda')
@@ -3269,6 +3279,113 @@ class PyTorchModelEngine(ModelEngine):
 
         return inputs, self.gather_ids_cuda[:num_generation_tokens]
 
+    def _can_use_steady_gen_fast_prepare(
+            self, scheduled_requests: ScheduledRequests,
+            new_tokens_device: Optional[torch.Tensor],
+            next_draft_tokens_device: Optional[torch.Tensor],
+            spec_metadata: Optional[SpecMetadata]) -> bool:
+        """Check whether the cached steady-state generation prepare applies.
+
+        The cache is only recorded by a full _prepare_tp_inputs pass whose
+        batch consisted purely of non-dummy generation requests that all had
+        a previous overlap-scheduler tensor (see the recording site), so the
+        per-step check only needs to confirm the dynamic conditions: still a
+        generation-only batch with the exact same requests in the same order.
+        """
+        cache = self._steady_gen_cache
+        if cache is None or self.is_warmup:
+            return False
+        if new_tokens_device is None or next_draft_tokens_device is not None \
+                or spec_metadata is not None:
+            return False
+        if scheduled_requests.num_context_requests > 0:
+            return False
+        generation_requests = scheduled_requests.generation_requests
+        if len(generation_requests) != cache['num_requests']:
+            return False
+        return cache['request_ids'] == [
+            request.py_request_id for request in generation_requests
+        ]
+
+    @nvtx_range("_apply_steady_gen_fast_prepare")
+    def _apply_steady_gen_fast_prepare(
+            self, kv_cache_manager: Union[KVCacheManager, KVCacheManagerV2],
+            attn_metadata: AttentionMetadata,
+            new_tensors_device: SampleStateTensors,
+            resource_manager: Optional[ResourceManager]):
+        """Prepare inputs for an unchanged generation-only batch.
+
+        Every request advanced by exactly one committed token since the last
+        prepare, so instead of re-walking the batch in Python this advances
+        the cached positions with one vectorized op, reuses the seq-slot
+        buffer already on device, and refreshes only the per-step metadata.
+        """
+        cache = self._steady_gen_cache
+        num_requests = cache['num_requests']
+
+        # Positions and cached-token counts are the same values in this
+        # regime; advance both with a single in-place increment.
+        positions = self._steady_gen_positions_pinned[:num_requests]
+        positions.add_(1)
+        self.position_ids_cuda[:num_requests].copy_(positions,
+                                                    non_blocking=True)
+        num_cached_tokens_per_seq = positions.tolist()
+
+        # Gather this step's input tokens from the previous iteration's device
+        # sample buffer; the seq-slot indices in previous_batch_indices_cuda
+        # are unchanged since the last full pass.
+        previous_slots = self.previous_batch_indices_cuda[:num_requests]
+        new_tokens = new_tensors_device.new_tokens[:1, previous_slots, :self.
+                                                   max_beam_width]
+        self.input_ids_cuda[:num_requests * self.max_beam_width].copy_(
+            new_tokens.flatten(), non_blocking=True)
+
+        if not attn_metadata.is_cuda_graph:
+            attn_metadata.seq_lens = cache['seq_lens_ones']
+        attn_metadata.beam_width = 1
+        attn_metadata.request_ids = cache['request_ids']
+        attn_metadata.prompt_lens = cache['prompt_lens']
+        attn_metadata.num_contexts = 0
+        attn_metadata.num_chunked_ctx_requests = 0
+        attn_metadata.kv_cache_params = KVCacheParams(
+            use_cache=True,
+            num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+            num_extra_kv_tokens=get_num_extra_kv_tokens(None))
+        attn_metadata.kv_cache_manager = kv_cache_manager
+        if hasattr(self.model.model_config.pretrained_config, 'chunk_size'):
+            attn_metadata.mamba_chunk_size = \
+                self.model.model_config.pretrained_config.chunk_size
+        with nvtx_range("steady_gen_metadata_prepare"):
+            attn_metadata.prepare()
+
+        attn_all_rank_num_tokens = self._get_all_rank_num_tokens(attn_metadata)
+        padded_num_tokens, can_run_piecewise_cuda_graph, attn_all_rank_num_tokens = \
+            self._get_padding_params(num_requests, 0, attn_all_rank_num_tokens)
+        set_per_request_piecewise_cuda_graph_flag(can_run_piecewise_cuda_graph)
+        attn_metadata.padded_num_tokens = (
+            padded_num_tokens if padded_num_tokens != num_requests else None)
+        virtual_num_tokens = num_requests
+        if attn_metadata.padded_num_tokens is not None:
+            self.input_ids_cuda[num_requests:padded_num_tokens].fill_(0)
+            self.position_ids_cuda[num_requests:padded_num_tokens].fill_(0)
+            virtual_num_tokens = padded_num_tokens
+
+        self.iter_states['num_ctx_requests'] = 0
+        self.iter_states['num_ctx_tokens'] = 0
+        self.iter_states['num_generation_tokens'] = num_requests
+        self.iter_states['cached_kv_tokens'] = sum(num_cached_tokens_per_seq)
+
+        inputs = {
+            'attn_metadata': attn_metadata,
+            'input_ids': self.input_ids_cuda[:virtual_num_tokens],
+            'position_ids':
+            self.position_ids_cuda[:virtual_num_tokens].unsqueeze(0),
+            'inputs_embeds': None,
+            'multimodal_params': [],
+            'resource_manager': resource_manager,
+        }
+        return inputs, None
+
     def _prepare_tp_inputs(
             self,
             scheduled_requests: ScheduledRequests,
@@ -3310,6 +3427,18 @@ class PyTorchModelEngine(ModelEngine):
                 spec_metadata, new_tensors_device, cache_indirection_buffer,
                 num_accepted_tokens_device, req_id_to_old_request,
                 resource_manager)
+
+        if self._can_use_steady_gen_fast_prepare(scheduled_requests,
+                                                 new_tokens_device,
+                                                 next_draft_tokens_device,
+                                                 spec_metadata):
+            return self._apply_steady_gen_fast_prepare(kv_cache_manager,
+                                                       attn_metadata,
+                                                       new_tensors_device,
+                                                       resource_manager)
+        # Any full pass invalidates the steady-state cache; it is re-recorded
+        # at the end of this pass when the batch qualifies.
+        self._steady_gen_cache = None
 
         # Hoist self.use_mrope to a function-scope local so the per-request /
         # per-context-request mrope branches use LOAD_FAST instead of LOAD_ATTR.
@@ -4353,6 +4482,44 @@ class PyTorchModelEngine(ModelEngine):
         if not self.is_warmup:
             self.previous_request_ids = all_gen_request_ids
             self.has_previous_device_draft = next_draft_tokens_device is not None
+
+            # Record the steady-state generation cache when this pass handled
+            # purely non-dummy generation requests that all carried a previous
+            # overlap-scheduler tensor (previous_batch_len == _n_gen implies
+            # every request took that branch and none appended input_ids).
+            # While the batch composition holds, the next passes only need to
+            # advance positions by one and refresh per-step metadata.
+            # An mrope-capable model still takes the plain position path when
+            # the batch carried no actual mrope work (text-only requests), so
+            # gate on the pass's mrope outputs being empty rather than on
+            # use_mrope itself.
+            if (self.spec_config is None and not self.is_draft_model
+                    and spec_metadata is None and new_tokens_device is not None
+                    and self.guided_decoder is None
+                    and not self.enable_attention_dp and not mrope_position_ids
+                    and not mrope_delta_write_seq_slots
+                    and not mrope_delta_read_seq_slots
+                    and not self.use_beam_search and self.max_beam_width == 1
+                    and not is_enc_dec and not _has_cp_helix
+                    and num_ctx_requests == 0 and not extend_requests
+                    and not first_draft_requests and _n_gen > 0
+                    and previous_batch_len == _n_gen and num_tokens == 0
+                    and not _has_any_multimodal_request
+                    and not multimodal_params_list and not lora_params
+                    and attn_metadata.padded_num_tokens is None
+                    and self._get_position_id_offset() == 0):
+                self._steady_gen_positions_pinned[:_n_gen].copy_(
+                    torch.as_tensor(num_cached_tokens_per_seq, dtype=torch.int))
+                self._steady_gen_cache = {
+                    'num_requests':
+                    _n_gen,
+                    'request_ids':
+                    all_gen_request_ids,
+                    'prompt_lens':
+                    prompt_lengths,
+                    'seq_lens_ones':
+                    maybe_pin_memory(torch.ones(_n_gen, dtype=torch.int)),
+                }
 
         return inputs, self.gather_ids_cuda[:len(
             gather_ids)] if self.enable_spec_decode else None

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -678,8 +678,10 @@ class PyTorchModelEngine(ModelEngine):
         # Steady-state generation-only prepare cache (non-speculative overlap
         # decode). Holds the per-request lists that are invariant while the
         # scheduled generation batch keeps the same composition, plus a pinned
-        # position/cached-token buffer advanced by one per step. Invalidated
-        # (set to None) by every full _prepare_tp_inputs pass.
+        # cached-token counter advanced by one per step (host-side bookkeeping
+        # only; the device position buffer is advanced in place and this
+        # buffer is never the source of an async H2D). Invalidated (set to
+        # None) by every full _prepare_tp_inputs pass.
         self._steady_gen_cache: Optional[Dict[str, Any]] = None
         self._steady_gen_positions_pinned = torch.empty(
             (self.max_num_tokens, ),
@@ -3317,18 +3319,37 @@ class PyTorchModelEngine(ModelEngine):
 
         Every request advanced by exactly one committed token since the last
         prepare, so instead of re-walking the batch in Python this advances
-        the cached positions with one vectorized op, reuses the seq-slot
-        buffer already on device, and refreshes only the per-step metadata.
+        the cached positions in place (device position buffer plus a pinned
+        host counter), reuses the seq-slot buffer already on device, and
+        refreshes only the per-step metadata. For mrope models (recorded only
+        for batches with no actual mrope work) the (3,1,N) broadcast buffer
+        the model reads is the one advanced.
         """
         cache = self._steady_gen_cache
         num_requests = cache['num_requests']
 
         # Positions and cached-token counts are the same values in this
-        # regime; advance both with a single in-place increment.
+        # regime; advance both by one. The device-side position buffer is
+        # advanced in place: it still holds the previous step's positions
+        # because only _prepare_tp_inputs writes it and the cache validity
+        # invariant guarantees the previous pass wrote these same rows. This
+        # avoids reusing a mutated pinned buffer as the source of an async
+        # H2D whose previous-step copy may still be pending under the overlap
+        # scheduler (the nvbug 6293536 hazard class; see
+        # KVCacheManager._stage_block_offsets_for_copy). The pinned buffer is
+        # host-side bookkeeping only.
+        use_mrope = cache['use_mrope']
         positions = self._steady_gen_positions_pinned[:num_requests]
         positions.add_(1)
-        self.position_ids_cuda[:num_requests].copy_(positions,
-                                                    non_blocking=True)
+        if use_mrope:
+            # Text-only batch on an mrope model: the recording pass broadcast
+            # the scalar positions onto all three axes of the (3,1,N) buffer,
+            # which is what the model (and any captured CUDA graph) reads, so
+            # advance it in place. position_ids_cuda is reseeded by the next
+            # full pass.
+            self.mrope_position_ids_cuda[:, :, :num_requests].add_(1)
+        else:
+            self.position_ids_cuda[:num_requests].add_(1)
         num_cached_tokens_per_seq = positions.tolist()
 
         # Gather this step's input tokens from the previous iteration's device
@@ -3367,7 +3388,13 @@ class PyTorchModelEngine(ModelEngine):
         virtual_num_tokens = num_requests
         if attn_metadata.padded_num_tokens is not None:
             self.input_ids_cuda[num_requests:padded_num_tokens].fill_(0)
-            self.position_ids_cuda[num_requests:padded_num_tokens].fill_(0)
+            # Zero-fill the padding tail of whichever position layout the
+            # model consumes, matching the full pass.
+            if use_mrope:
+                self.mrope_position_ids_cuda[:, :, num_requests:
+                                             padded_num_tokens].fill_(0)
+            else:
+                self.position_ids_cuda[num_requests:padded_num_tokens].fill_(0)
             virtual_num_tokens = padded_num_tokens
 
         self.iter_states['num_ctx_requests'] = 0
@@ -3375,11 +3402,16 @@ class PyTorchModelEngine(ModelEngine):
         self.iter_states['num_generation_tokens'] = num_requests
         self.iter_states['cached_kv_tokens'] = sum(num_cached_tokens_per_seq)
 
+        if use_mrope:
+            final_position_ids = \
+                self.mrope_position_ids_cuda[:, :, :virtual_num_tokens]
+        else:
+            final_position_ids = \
+                self.position_ids_cuda[:virtual_num_tokens].unsqueeze(0)
         inputs = {
             'attn_metadata': attn_metadata,
             'input_ids': self.input_ids_cuda[:virtual_num_tokens],
-            'position_ids':
-            self.position_ids_cuda[:virtual_num_tokens].unsqueeze(0),
+            'position_ids': final_position_ids,
             'inputs_embeds': None,
             'multimodal_params': [],
             'resource_manager': resource_manager,
@@ -3422,6 +3454,10 @@ class PyTorchModelEngine(ModelEngine):
         if self._can_use_incremental_update(scheduled_requests,
                                             new_tokens_device,
                                             next_draft_tokens_device):
+            # Spec engines never record the steady-gen cache, but invalidate
+            # defensively so the two fast paths can never interleave if the
+            # gates ever evolve.
+            self._steady_gen_cache = None
             return self._apply_incremental_update(
                 scheduled_requests, kv_cache_manager, attn_metadata,
                 spec_metadata, new_tensors_device, cache_indirection_buffer,
@@ -4355,6 +4391,12 @@ class PyTorchModelEngine(ModelEngine):
 
         if hasattr(self.model.model_config.pretrained_config, 'chunk_size'):
             attn_metadata.mamba_chunk_size = self.model.model_config.pretrained_config.chunk_size
+        # Some sparse backends (RocketKV) clamp
+        # kv_cache_params.num_cached_tokens_per_seq in place during prepare(),
+        # and KVCacheParams holds the list by reference. Snapshot the true
+        # pre-prepare counts so the steady-gen recording below stores values
+        # that the per-step prepare() can re-clamp from scratch.
+        num_cached_tokens_snapshot = list(num_cached_tokens_per_seq)
         attn_metadata.prepare()
         cross_attention_inputs = (self._prepare_enc_dec_cross_attn_inputs(
             cross_encoder_hidden_states,
@@ -4489,10 +4531,13 @@ class PyTorchModelEngine(ModelEngine):
             # every request took that branch and none appended input_ids).
             # While the batch composition holds, the next passes only need to
             # advance positions by one and refresh per-step metadata.
-            # An mrope-capable model still takes the plain position path when
-            # the batch carried no actual mrope work (text-only requests), so
-            # gate on the pass's mrope outputs being empty rather than on
-            # use_mrope itself.
+            # MRoPE models are supported only for batches with no actual mrope
+            # work (text-only requests, empty mrope lists below): the full
+            # pass routes use_mrope models through the (3,1,N)
+            # mrope_position_ids_cuda layout even then (to keep torch.compile
+            # guards stable), with all three axes equal to the scalar
+            # positions, so the fast path advances that buffer in place and
+            # returns the same layout (see _apply_steady_gen_fast_prepare).
             if (self.spec_config is None and not self.is_draft_model
                     and spec_metadata is None and new_tokens_device is not None
                     and self.guided_decoder is None
@@ -4509,7 +4554,8 @@ class PyTorchModelEngine(ModelEngine):
                     and attn_metadata.padded_num_tokens is None
                     and self._get_position_id_offset() == 0):
                 self._steady_gen_positions_pinned[:_n_gen].copy_(
-                    torch.as_tensor(num_cached_tokens_per_seq, dtype=torch.int))
+                    torch.as_tensor(num_cached_tokens_snapshot,
+                                    dtype=torch.int))
                 self._steady_gen_cache = {
                     'num_requests':
                     _n_gen,
@@ -4519,6 +4565,8 @@ class PyTorchModelEngine(ModelEngine):
                     prompt_lengths,
                     'seq_lens_ones':
                     maybe_pin_memory(torch.ones(_n_gen, dtype=torch.int)),
+                    'use_mrope':
+                    _use_mrope,
                 }
 
         return inputs, self.gather_ids_cuda[:len(

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2173,9 +2173,13 @@ class KVCacheManager(BaseResourceManager):
     def pin_blocks(self, request_id: int):
         self.impl.pin_blocks(request_id)
 
-    def copy_batch_block_offsets(self, dst_tensor: torch.Tensor,
-                                 request_ids: List[int], beam_width: int,
-                                 num_context: int, num_seqs: int):
+    def copy_batch_block_offsets(self,
+                                 dst_tensor: torch.Tensor,
+                                 request_ids: List[int],
+                                 beam_width: int,
+                                 num_context: int,
+                                 num_seqs: int,
+                                 max_blocks: Optional[int] = None):
         # Fill the persistent host buffer in place, exactly as before. CPU-side
         # consumers read self.host_kv_cache_block_offsets directly and depend on
         # its persistent, max_batch-sized layout: DSA sparse attention, the
@@ -2241,23 +2245,39 @@ class KVCacheManager(BaseResourceManager):
         # matching the already-safe kv_lens / block_ids_per_seq staging. The
         # persistent buffer above is untouched by this and stays valid for the
         # synchronous CPU readers.
-        host_block_offsets = self._stage_block_offsets_for_copy(num_seqs)
+        host_block_offsets = self._stage_block_offsets_for_copy(
+            num_seqs, max_blocks)
+        width = host_block_offsets.shape[-1]
         for pool_idx in range(self.num_pools):
-            dst_tensor[pool_idx, :num_seqs].copy_(host_block_offsets[pool_idx],
-                                                  non_blocking=True)
+            dst_tensor[pool_idx, :num_seqs, :, :width].copy_(
+                host_block_offsets[pool_idx], non_blocking=True)
 
-    def _stage_block_offsets_for_copy(self, num_rows: int) -> torch.Tensor:
+    def _stage_block_offsets_for_copy(
+            self,
+            num_rows: int,
+            max_blocks: Optional[int] = None) -> torch.Tensor:
         """Snapshot the first ``num_rows`` rows of the persistent host block
         offset buffer into a fresh pinned buffer, to serve as the private source
-        of an asynchronous H2D copy (nvbug 6293536)."""
+        of an asynchronous H2D copy (nvbug 6293536).
+
+        ``max_blocks`` bounds the copied block width. The buffer is laid out
+        for max_seq_len (max_blocks_per_seq columns) but consumers only read
+        each sequence's allocated block prefix, so a caller that knows the
+        batch's maximum KV length can skip the unused tail — with a large
+        max_seq_len the tail dominates the copy cost."""
+        if max_blocks is None:
+            width = self.max_blocks_per_seq
+        else:
+            width = min(max(max_blocks, 1), self.max_blocks_per_seq)
         host_block_offsets = torch.empty(self.num_pools,
                                          num_rows,
                                          2,
-                                         self.max_blocks_per_seq,
+                                         width,
                                          dtype=torch.int32,
                                          pin_memory=prefer_pinned(),
                                          device='cpu')
-        host_block_offsets.copy_(self.host_kv_cache_block_offsets[:, :num_rows])
+        host_block_offsets.copy_(
+            self.host_kv_cache_block_offsets[:, :num_rows, :, :width])
         return host_block_offsets
 
     def truncate_blocks(self, target_tokens: List[int],

--- a/tests/unittest/_torch/executor/test_kv_block_offset_overlap_race.py
+++ b/tests/unittest/_torch/executor/test_kv_block_offset_overlap_race.py
@@ -103,6 +103,53 @@ def _reference_offsets(mgr, ids):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device")
+def test_copy_batch_block_offsets_max_blocks_staging_width():
+    """``max_blocks`` bounds the staged H2D width; ``None`` stages the full
+    allocated width.
+
+    The bounded copy must leave destination columns beyond the cap untouched
+    (callers only pass a cap when nothing reads past it), and the unbounded
+    copy must ship every allocated block: speculative decoding allocates
+    blocks past the host kv_lens snapshot and its kernels dereference those
+    columns, so capping by a host-derived block count corrupted the device
+    block table (EAGLE3 warmup illegal memory access).
+    """
+    mgr = _build_manager()
+
+    ids = list(range(1, 1 + _BATCH))
+    toks = [_TOKENS_PER_SEQ] * _BATCH  # 5 allocated blocks per sequence
+    mgr.add_dummy_requests(request_ids=ids, token_nums=toks, prepare_resource=True)
+    allocated_blocks = _TOKENS_PER_SEQ // _TOKENS_PER_BLOCK
+
+    ref = _reference_offsets(mgr, ids)
+
+    sentinel = -12345
+    capped_width = 2
+    assert capped_width < allocated_blocks <= mgr.max_blocks_per_seq
+
+    dst = torch.full(
+        (mgr.num_pools, 2 * _BATCH, 2, mgr.max_blocks_per_seq),
+        sentinel,
+        dtype=torch.int32,
+        device="cuda",
+    )
+    mgr.copy_batch_block_offsets(dst, ids, 1, _BATCH, _BATCH, max_blocks=capped_width)
+    torch.cuda.synchronize()
+    assert torch.equal(dst[:, :_BATCH, :, :capped_width], ref[..., :capped_width])
+    assert (dst[:, :_BATCH, :, capped_width:] == sentinel).all(), (
+        "bounded staging must not write past the requested block width"
+    )
+
+    dst.fill_(sentinel)
+    mgr.copy_batch_block_offsets(dst, ids, 1, _BATCH, _BATCH, max_blocks=None)
+    torch.cuda.synchronize()
+    assert torch.equal(dst[:, :_BATCH, :, :allocated_blocks], ref[..., :allocated_blocks]), (
+        "max_blocks=None must stage every allocated block, including blocks "
+        "past the batch's current kv length (speculative decoding reads them)"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device")
 def test_copy_batch_block_offsets_survives_overlap_overwrite():
     mgr = _build_manager()
 

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -207,6 +207,81 @@ def test_kv_lens_runtime_with_eagle3_one_model():
         f"kv_lens should be {expected_kv_lens_with_extra.tolist()}, but got {kv_lens_internal.tolist()}"
 
 
+def _make_mock_kv_cache_manager(num_seqs: int) -> MagicMock:
+    mock_kv_cache_manager = MagicMock()
+    mock_kv_cache_manager.tokens_per_block = 32
+    mock_kv_cache_manager.num_pools = 1
+    mock_kv_cache_manager.num_attention_op_pools = 1
+    mock_kv_cache_manager.max_blocks_per_seq = 16
+    mock_kv_cache_manager.max_batch_size = num_seqs
+    mock_kv_cache_manager.max_seq_len = 512
+    mock_kv_cache_manager.copy_batch_block_offsets = MagicMock()
+    return mock_kv_cache_manager
+
+
+@pytest.mark.parametrize("spec_signal", [
+    None, "num_extra_kv_tokens", "is_spec_decoding_enabled",
+    "has_speculative_draft_tokens", "draft_kv_cache_manager"
+])
+def test_block_offsets_staging_width_spec_gate(spec_signal):
+    """prepare() caps the staged block-table width by the batch's max KV
+    length only on the non-speculative path.
+
+    Any speculative-decoding signal must disable the cap (max_blocks=None):
+    spec kernels address block columns past the host kv_lens snapshot
+    (device-side kv_lens advances in draft/tree sub-steps, draft-token blocks
+    are allocated ahead), so a host-derived cap leaves columns they
+    dereference unstaged. Regression test for the EAGLE3 warmup illegal
+    memory access.
+    """
+    num_seqs = 3
+    prompt_lens = [50, 100, 75]
+    seq_lens_q = [1, 1, 1]
+    num_cached_tokens_per_seq = [
+        prompt_lens[i] - seq_lens_q[i] for i in range(num_seqs)
+    ]
+
+    mock_kv_cache_manager = _make_mock_kv_cache_manager(num_seqs)
+    metadata_kwargs = dict(
+        max_num_requests=num_seqs,
+        max_num_tokens=sum(seq_lens_q),
+        kv_cache_manager=mock_kv_cache_manager,
+    )
+    mock_draft_manager = None
+    if spec_signal == "draft_kv_cache_manager":
+        mock_draft_manager = _make_mock_kv_cache_manager(num_seqs)
+        metadata_kwargs["draft_kv_cache_manager"] = mock_draft_manager
+
+    attn_metadata = TrtllmAttentionMetadata(**metadata_kwargs)
+    if spec_signal == "is_spec_decoding_enabled":
+        attn_metadata.is_spec_decoding_enabled = True
+    elif spec_signal == "has_speculative_draft_tokens":
+        attn_metadata.runtime_features.has_speculative_draft_tokens = True
+
+    attn_metadata.request_ids = list(range(1, num_seqs + 1))
+    attn_metadata.prompt_lens = prompt_lens
+    attn_metadata._seq_lens = torch.tensor(seq_lens_q, dtype=torch.int32)
+    attn_metadata._seq_lens_kv = torch.tensor(seq_lens_q, dtype=torch.int32)
+    attn_metadata.kv_cache_params = KVCacheParams(
+        use_cache=True,
+        num_cached_tokens_per_seq=num_cached_tokens_per_seq,
+        num_extra_kv_tokens=(7 if spec_signal == "num_extra_kv_tokens" else 0))
+
+    attn_metadata.prepare()
+
+    if spec_signal is None:
+        # Non-speculative: capped at ceil(max kv len / tokens_per_block).
+        expected_max_blocks = -(-max(prompt_lens) //
+                                mock_kv_cache_manager.tokens_per_block)
+    else:
+        expected_max_blocks = None
+    call_kwargs = mock_kv_cache_manager.copy_batch_block_offsets.call_args.kwargs
+    assert call_kwargs["max_blocks"] == expected_max_blocks
+    if mock_draft_manager is not None:
+        draft_kwargs = mock_draft_manager.copy_batch_block_offsets.call_args.kwargs
+        assert draft_kwargs["max_blocks"] is None
+
+
 @pytest.mark.parametrize(
     "use_cuda_graph,attn_backend,disable_overlap_scheduler,enable_block_reuse,use_one_model,enable_chunked_prefill,use_chain_drafter,multi_batch,attention_dp,use_hf_speculative_model",
     [


### PR DESCRIPTION
## Description

At high concurrency, the per-step host preparation work in the PyTorch executor's overlap decode loop is exposed on the critical path: on Qwen3.6-35B-A3B-NVFP4 (hybrid gated-delta-net + MoE) at concurrency 256, nsys shows a recurring GPU-idle gap between decode steps dominated by `_prepare_inputs`. This PR removes three sources of that overhead:

- **Bound the KV-cache block-table staging to the batch's real width.** `KVCacheManager.copy_batch_block_offsets` staged block offsets through a freshly allocated pinned buffer sized for `max_seq_len` worth of block columns — ~33.5 MB of pinned allocation + host memcpy + H2D copy per step at batch 256 with `max_seq_len=262144`, of which only ~0.9 MB was live. A new optional `max_blocks` argument bounds the staged/H2D width by the batch's maximum KV length; kernels only read each sequence's allocated block prefix, and the persistent host buffer (used by synchronous CPU readers) is untouched. Default behavior is unchanged, and `KVCacheManagerV2` accepts the argument for signature parity (its copy already scales with allocated blocks only).

- **Stop re-walking unchanged generation batches in `_prepare_tp_inputs`.** In non-speculative overlap decode, when the scheduled batch is exactly the same set of generation requests as the previous step, every request advanced by exactly one committed token. A full prepare pass now records the batch-invariant state (request ids, prompt lens, seq-lens, pinned position buffer) when the batch qualifies — generation-only, non-dummy, all requests carrying a previous-step device tensor, no spec decode / beam search / LoRA / multimodal / mrope work / attention-DP — and subsequent steps advance positions with one vectorized increment, gather input tokens from the previous step's device sample buffer, and refresh only per-step metadata. Any full pass invalidates and re-records the cache.

- **Vectorize mamba cache-manager bookkeeping.** Replace per-request `.item()` reads and per-element pinned-buffer stores with one bulk `tolist()` / `copy_()` per step.

nsys at concurrency 256: `_prepare_inputs` drops from 2.999 ms to 0.646 ms per decode step, and per-step GPU idle from 8.6% to 2.5%.

## Test Coverage

- The touched prepare / block-offset staging paths are exercised by the existing `_torch` executor and attention-backend suites; the steady-state fast path engages for any non-speculative overlap-scheduler decode workload and is invalidated by any batch-composition change.
- Perf: `trtllm-serve` + `benchmark_serving` on Qwen3.6-35B-A3B-NVFP4, 1x B200, ISL 1024 / OSL 6144, random dataset with `--ignore-eos`, one point per concurrency (paired num_prompts 8...1024), measured at base `8ef7190ebf`:

| concurrency | baseline (tok/s) | this PR (tok/s) | delta |
|---|---|---|---|
| 1 | 329.09 | 345.15 | +4.88% |
| 2 | 615.93 | 638.76 | +3.71% |
| 4 | 1134.41 | 1166.02 | +2.79% |
| 8 | 2048.03 | 2080.29 | +1.58% |
| 16 | 3601.60 | 3711.45 | +3.05% |
| 32 | 6095.07 | 6256.17 | +2.64% |
| 64 | 9826.85 | 10079.27 | +2.57% |
| 128 | 14745.82 | 15270.86 | +3.56% |
| 256 | 19940.84 | 20685.34 | +3.73% |

Output throughput improves **+3.17%** on average across the 9-point curve, positive at every point. Independent of #16314; on the same harness the two compose to about +5.6%.

## Update (2026-07-13): hardening fixes + steady-state nsys A/B

The branch now carries a follow-up commit (`12ceb00216`) hardening the fast prepare path from review findings:

- `DeepseekV4CacheManager.copy_batch_block_offsets` accepts `max_blocks` for signature parity (the base `prepare()` now always passes it).
- Fast steps advance the device position buffer in place instead of staging a mutated pinned buffer through an async H2D whose previous-step copy may still be pending under the overlap scheduler (the nvbug 6293536 hazard class); this also removes one transfer per step.
- MRoPE models keep the `(3,1,N)` position layout on the fast path: text-only batches advance `mrope_position_ids_cuda` in place and return the mrope view, matching the full pass in eager, piecewise, and CUDA-graph modes (Qwen3.5/3.6 normalize `rope_parameters` with `mrope_section` into `rope_scaling.type='mrope'`, so they take this path even for pure-text serving).
- Steady-state recording snapshots `num_cached_tokens_per_seq` before `attn_metadata.prepare()`, so backends that clamp the aliased list in place (RocketKV) re-clamp from true values every step instead of compounding into the recorded state.
- The incremental-update early return also invalidates the steady-state cache, so the two fast paths can never interleave.

Fresh nsys A/B at the head of this branch vs its merge base `53d2bde62f` — same GPU, same prebuilt binaries (python-only diff), Qwen3.6-35B-A3B-NVFP4 on 1x B200, `trtllm-serve` (CUDA graphs `max_batch_size: 256` + padding, TRTLLM MoE backend) + `benchmark_serving` random ISL 1024 / OSL 6144 with `--ignore-eos`, c=256 / num_prompts=1024, capture window `TLLM_PROFILE_START_STOP=100-150` (`-t cuda,nvtx,python-gil -c cudaProfilerApi --cuda-graph-trace node`). Both captures contain exactly 50 forward steps, every one `0 ctx reqs, 0 ctx tokens, 256 gen reqs` — pure steady-state decode at the full batch:

| metric (50-step window) | baseline | this PR | delta |
|---|---|---|---|
| wall-clock per decode step | 11.98 ms | 10.20 ms | **-14.8%** |
| GPU idle in window | 11.49 % | 2.23 % | -80.5% |
| `_prepare_inputs` host time / step | 4.018 ms | 0.655 ms | -83.7% |
| steady-state fast-path engagements | 0 | 50 / 50 | — |
| H2D traffic in window | 1.68 GB | 8.46 MB | **-99.5%** |

The H2D reduction is the bounded block-table staging; the prepare-time and idle reduction is the steady-state fast prepare, which engaged on all 50 steps — on an mrope-normalized model, so the window also exercises the mrope in-place advance under CUDA-graph replay. Correctness probe: a fixed greedy completion (temperature 0, 64 new tokens, fresh server per side) is byte-identical between the two sides.

## Update (2026-07-14): CI fix — full-width block-table staging for speculative decoding

Pre-merge CI caught an illegal memory access during EAGLE3 warmup (`test_llama_eagle3_dynamic_tree[True-False]` on B200, `test_eagle3_cdl_sampling[True]` on H100, plus follow-on thread-leak failures in `test_eagle3_cuda_graph_padding`). Root cause: the batch-max cap on the staged block-table width assumed the host `kv_lens` snapshot bounds every block-table access. That holds only for the non-speculative path — speculative decoding advances `kv_lens_cuda` on device past the host snapshot (one-model draft/tree sub-steps, overlap-scheduler kv-len offsets), and draft-token blocks are allocated ahead of the host kv_lens, so spec kernels dereferenced block columns the cap left unstaged (uninitialized memory in the device buffer).

The new commit keeps the cap only when no speculative-decoding state is attached to the metadata (no draft KV cache manager, spec-dec attention mode off, no extra KV tokens, no draft engine or drafter in the runtime); speculative setups stage the full pre-allocated width exactly as before this PR. The non-speculative serving path that motivated the optimization keeps the bounded staging and its measured wins.

Verified on 1x B200 against `LLM_MODELS_ROOT` checkpoints: `test_llama_eagle3_dynamic_tree[True-False]` fails at the parent commit and passes with the fix; `test_eagle3_cdl_sampling`, `test_eagle3_cuda_graph_padding`, `test_llama_eagle3[True-TRTLLM-False-True-True-False-True-False-False-False]` (spec-vs-ref equality with the overlap-scheduler ref exercising the steady-state fast prepare), and `test_kv_block_offset_overlap_race.py` all pass. New unit tests pin the staging-width gate (`test_block_offsets_staging_width_spec_gate`) and the `max_blocks` copy semantics (`test_copy_batch_block_offsets_max_blocks_staging_width`).

## PR Checklist

- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved generation-step preparation for eligible workloads, reducing repeated input-processing overhead.
  * Reduced KV-cache block-table staging to only the portion required by each batch.
  * Optimized state-index transfers for faster cache preparation.

* **Bug Fixes**
  * Improved validation and handling of KV-cache sequence lengths and state mappings.
  * Ensured cache metadata remains accurate when processing changing request batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

