### PR TITLE
[None][perf] Fuse Qwen3.5 gated QKV preprocessing for qwen3.5 v2 ckpt

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -2127,6 +2127,9 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         TLLM_CHECK_WITH_INFO(params.attention_input_token_stride == 0
                 || params.attention_input_token_stride == (mNumAttnHeads + 2 * mNumAttnKVHeads) * getHeadSize(),
             "Strided attention_input is not supported by the unfused context MHA path.");
+        // This fallback kernel does not apply QK norm, so fused QK-norm weights must not slip through.
+        TLLM_CHECK_WITH_INFO(params.q_norm_weight == nullptr && params.k_norm_weight == nullptr,
+            "Fused QK norm preprocessing is not supported by the unfused context MHA path.");
         // FIXME: a temporary solution to make sure the padding part of key/value buffer is 0
         // NOTE: pointer subtraction is used below since there could be some extra gap due to alignment.
         //  Otherwise, we could do cudaMemsetAsync(workspaceViews.kBuf, 0, k_buf_2_size + v_buf_2_size, stream).
@@ -2510,6 +2513,10 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
         params.workspace, cpWorkspaceLayout, cpMaxPaddedSequenceLength, mNumHeads, mNumKVHeads, mHeadSize);
 
     T* attention_input = const_cast<T*>(params.attention_input);
+    // Ulysses/CP preprocess (invokeCpTranspose) assumes a packed qkv layout and cannot honor a row stride.
+    TLLM_CHECK_WITH_INFO(mCpSize == 1 || params.attention_input_token_stride == 0
+            || params.attention_input_token_stride == (mNumAttnHeads + 2 * mNumAttnKVHeads) * getHeadSize(),
+        "Strided (gate-tail) attention_input is not supported with Ulysses/context parallelism (mCpSize > 1).");
     if (mCpSize > 1 && mAttnTpSize > 1 && mAttnCpSize == 1)
     {
         this->template ulyssesGenerationPreprocess<T>(
@@ -2634,6 +2641,9 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
     TLLM_CHECK_WITH_INFO(params.attention_input_token_stride == 0
             || params.attention_input_token_stride == (mNumAttnHeads + 2 * mNumAttnKVHeads) * getHeadSize(),
         "Strided attention_input is not supported by the masked MHA generation path.");
+    // This fallback kernel does not apply QK norm, so fused QK-norm weights must not slip through.
+    TLLM_CHECK_WITH_INFO(params.q_norm_weight == nullptr && params.k_norm_weight == nullptr,
+        "Fused QK norm preprocessing is not supported by the masked MHA generation path.");
     dispatch_params.mUnfuseQkvGemm = mUnfuseQkvGemm;
     dispatch_params.qkv_buf = attention_input;
     dispatch_params.qkv_bias = params.qkv_bias;

--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -247,6 +247,11 @@ bool AttentionOp::convertMMHAParamsToXQAParams(tensorrt_llm::kernels::XQAParams&
 
     xqaParams.output = generationsParams.context_buf;
     xqaParams.qkv = generationsParams.attention_input;
+    xqaParams.qkv_token_stride = generationsParams.attention_input_token_stride;
+    xqaParams.q_norm_weight = generationsParams.q_norm_weight;
+    xqaParams.k_norm_weight = generationsParams.k_norm_weight;
+    xqaParams.qk_norm_eps = generationsParams.qk_norm_eps;
+    xqaParams.qk_norm_use_gemma = generationsParams.qk_norm_use_gemma;
     xqaParams.cache_indir = generationsParams.cache_indir;
     xqaParams.attention_sinks = generationsParams.attention_sinks;
     xqaParams.kv_scale_orig_quant = generationsParams.kv_scale_orig_quant;
@@ -1761,12 +1766,29 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
 
         // Buffers.
         preprocessingParams.qkv_input = const_cast<T*>(attention_input);
+        // A strided qkv_input is only valid when the FMHA consumes the preprocessing outputs
+        // (separate q buffer / quantized qkv buffer), never the raw attention_input.
+        if (params.attention_input_token_stride != 0)
+        {
+            // Requires separate_q_kv_output below: the preprocessing kernel then writes Q packed
+            // into q_output and K/V into the KV cache, so nothing re-reads the strided input.
+            bool const fmha_reads_preprocessed_buffers = (mPagedKVCache && mPagedContextFMHA) || isCrossAttention();
+            TLLM_CHECK_WITH_INFO(
+                params.attention_input_token_stride == (mNumAttnHeads + 2 * mNumAttnKVHeads) * getHeadSize()
+                    || (fmha_reads_preprocessed_buffers && mCpSize == 1 && !mIsMLAEnabled && !useSageAttnSeparateQkv),
+                "Strided attention_input is not supported by this context attention configuration.");
+            preprocessingParams.input_token_stride = params.attention_input_token_stride;
+        }
         preprocessingParams.cross_kv_input = const_cast<T*>(params.cross_kv);
         preprocessingParams.quantized_qkv_output = workspaceViews.fp8QkvBuf;
         preprocessingParams.q_output = workspaceViews.qBuf;
         preprocessingParams.kv_cache_buffer = kv_cache_buffer;
         preprocessingParams.kv_cache_block_scales_buffer = kv_scale_cache_buffer;
         preprocessingParams.qkv_bias = params.qkv_bias;
+        preprocessingParams.q_norm_weight = params.q_norm_weight;
+        preprocessingParams.k_norm_weight = params.k_norm_weight;
+        preprocessingParams.qk_norm_eps = params.qk_norm_eps;
+        preprocessingParams.qk_norm_use_gemma = params.qk_norm_use_gemma;
         preprocessingParams.tokens_info = decoder_params.tokensInfo;
         preprocessingParams.seq_lens = params.context_lengths;
         // For self-attention, cache_seq_lens indicates whether chunked context is used
@@ -2102,6 +2124,9 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
     {
         TLLM_CHECK_DEBUG_WITH_INFO(params.logn_scaling_ptr == nullptr, "Unfused MHA does not support logn scaling");
         TLLM_CHECK_WITH_INFO(mAttentionChunkSize == std::nullopt, "Unfused MHA does not support chunked attention");
+        TLLM_CHECK_WITH_INFO(params.attention_input_token_stride == 0
+                || params.attention_input_token_stride == (mNumAttnHeads + 2 * mNumAttnKVHeads) * getHeadSize(),
+            "Strided attention_input is not supported by the unfused context MHA path.");
         // FIXME: a temporary solution to make sure the padding part of key/value buffer is 0
         // NOTE: pointer subtraction is used below since there could be some extra gap due to alignment.
         //  Otherwise, we could do cudaMemsetAsync(workspaceViews.kBuf, 0, k_buf_2_size + v_buf_2_size, stream).
@@ -2605,6 +2630,10 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
     }
 
     FusedQKVMaskedAttentionDispatchParams<T, KVCacheBuffer> dispatch_params{};
+    // The MMHA fallback reads the qkv buffer assuming a packed token stride.
+    TLLM_CHECK_WITH_INFO(params.attention_input_token_stride == 0
+            || params.attention_input_token_stride == (mNumAttnHeads + 2 * mNumAttnKVHeads) * getHeadSize(),
+        "Strided attention_input is not supported by the masked MHA generation path.");
     dispatch_params.mUnfuseQkvGemm = mUnfuseQkvGemm;
     dispatch_params.qkv_buf = attention_input;
     dispatch_params.qkv_bias = params.qkv_bias;

--- a/cpp/tensorrt_llm/common/attentionOp.h
+++ b/cpp/tensorrt_llm/common/attentionOp.h
@@ -67,7 +67,14 @@ public:
     {
     public:
         T const* attention_input = nullptr;
+        // Token stride (in elements) of attention_input. 0 means packed. May be larger when
+        // attention_input is a row-strided view into a wider tensor (e.g. fused QKV+gate GEMM output).
+        int32_t attention_input_token_stride = 0;
         T const* qkv_bias = nullptr;
+        T const* q_norm_weight = nullptr;
+        T const* k_norm_weight = nullptr;
+        float qk_norm_eps = 0.0f;
+        bool qk_norm_use_gemma = false;
         // Attention mask input, which has shape of [batch_size, attention_mask_stride].
         bool const* attention_mask = nullptr;
         // Attention sinks with shape of [num_heads_q] float.

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/xqaParams.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/xqaParams.h
@@ -35,6 +35,14 @@ struct XQAParams
     void* output = nullptr;
     void* output_sf = nullptr;
     void const* qkv = nullptr;
+    // Token stride (in elements) of qkv. 0 means packed. May be larger when qkv is a row-strided
+    // view into a wider tensor (e.g. fused QKV+gate GEMM output). Only supported by the TRTLLM-Gen
+    // path (Q is routed to a separate buffer by the preprocessing kernel).
+    int32_t qkv_token_stride = 0;
+    void const* q_norm_weight = nullptr;
+    void const* k_norm_weight = nullptr;
+    float qk_norm_eps = 0.0f;
+    bool qk_norm_use_gemma = false;
     int32_t const* cache_indir = nullptr;
     float const* attention_sinks = nullptr;
     float const* kv_scale_orig_quant = nullptr;

--- a/cpp/tensorrt_llm/kernels/unfusedAttentionKernels.h
+++ b/cpp/tensorrt_llm/kernels/unfusedAttentionKernels.h
@@ -132,6 +132,10 @@ struct QKVPreprocessingParams
     // Pool for FP4 KV cache block scales. Unused for other KV cache dtypes.
     KVCacheBuffer kv_cache_block_scales_buffer{};
     T const* qkv_bias{nullptr};
+    T const* q_norm_weight{nullptr};
+    T const* k_norm_weight{nullptr};
+    float qk_norm_eps{0.0f};
+    bool qk_norm_use_gemma{false};
 
     // Fuse the computation of FMHA quantization scales into the preprocessing kernels.
     // This can also be done in gptKernels.h if there is no preprocessing kernels.
@@ -211,6 +215,10 @@ struct QKVPreprocessingParams
     int multi_processor_count{0};
     int rotary_vision_start{0};
     int rotary_vision_length{0};
+    // Token stride (in elements) of qkv_input. 0 means packed (hidden_size). It may be larger when
+    // qkv_input is a row-strided view into a wider tensor (e.g. the [Q|K|V|Gate] output of a fused
+    // QKV+gate GEMM). Only supported with separate_q_kv_output (qkv_input is read-only then).
+    int input_token_stride{0};
     // Pre-compute on host.
     int half_rotary_dim{0};
     int q_hidden_size{0};
@@ -223,6 +231,10 @@ struct QKVPreprocessingParams
         q_hidden_size = head_num * size_per_head;
         kv_hidden_size = kv_head_num * size_per_head;
         hidden_size = q_hidden_size + 2 * kv_hidden_size;
+        if (input_token_stride == 0)
+        {
+            input_token_stride = hidden_size;
+        }
     }
 
     std::string toString() const
@@ -373,6 +385,15 @@ template <typename T, typename KVCacheBuffer>
 void invokeQKVPreprocessing(QKVPreprocessingParams<T, KVCacheBuffer> params, cudaStream_t stream)
 {
     params.setCommonParameters();
+    // A strided (non-packed) qkv_input is only supported when nothing is written back into it:
+    // separate_q_kv_output routes Q to q_output and K/V to the KV cache.
+    TLLM_CHECK_WITH_INFO(params.input_token_stride == params.hidden_size || params.separate_q_kv_output,
+        "Strided qkv_input requires separate_q_kv_output.");
+    TLLM_CHECK_WITH_INFO((params.q_norm_weight == nullptr) == (params.k_norm_weight == nullptr),
+        "QK norm weights must be provided together.");
+    TLLM_CHECK_WITH_INFO(params.q_norm_weight == nullptr
+            || (params.separate_q_kv_output && params.size_per_head == 256 && params.qk_norm_eps > 0.0f),
+        "Fused QK norm preprocessing requires separate output, head_size 256, and positive epsilon.");
     if (params.cache_type == KvCacheDataType::INT8)
     {
         invokeApplyBiasRopeUpdateKVCacheDispatch<T, int8_t, KVCacheBuffer>(params, stream);

--- a/cpp/tensorrt_llm/kernels/unfusedAttentionKernels.h
+++ b/cpp/tensorrt_llm/kernels/unfusedAttentionKernels.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include "tensorrt_llm/kernels/kvCacheUtils.h"
 #include "tensorrt_llm/kernels/mlaKernels.h"
 #include "tensorrt_llm/runtime/iTensor.h"
+#include <cuda_bf16.h>
 #include <cuda_runtime_api.h>
 
 #ifdef ENABLE_FP4
@@ -394,6 +395,9 @@ void invokeQKVPreprocessing(QKVPreprocessingParams<T, KVCacheBuffer> params, cud
     TLLM_CHECK_WITH_INFO(params.q_norm_weight == nullptr
             || (params.separate_q_kv_output && params.size_per_head == 256 && params.qk_norm_eps > 0.0f),
         "Fused QK norm preprocessing requires separate output, head_size 256, and positive epsilon.");
+    // The fused QK-norm RoPE path is implemented for bf16 only; other dtypes would skip the RMSNorm.
+    TLLM_CHECK_WITH_INFO((params.q_norm_weight == nullptr || std::is_same_v<T, __nv_bfloat16>),
+        "Fused QK norm preprocessing is only implemented for bf16 inputs.");
     if (params.cache_type == KvCacheDataType::INT8)
     {
         invokeApplyBiasRopeUpdateKVCacheDispatch<T, int8_t, KVCacheBuffer>(params, stream);

--- a/cpp/tensorrt_llm/kernels/unfusedAttentionKernels/unfusedAttentionKernels_2_template.h
+++ b/cpp/tensorrt_llm/kernels/unfusedAttentionKernels/unfusedAttentionKernels_2_template.h
@@ -403,7 +403,9 @@ __global__ void applyBiasRopeUpdateKVCache(QKVPreprocessingParams<T, KVCacheBuff
     int const hidden_idx = head_idx * params.size_per_head + head_dim_idx;
     int const kv_head_idx = head_idx / params.qheads_per_kv_head;
     int const hidden_idx_kv = kv_head_idx * params.size_per_head + head_dim_idx;
-    int const hidden_size = params.hidden_size;
+    // Token stride of qkv_input; equals hidden_size unless qkv_input is a row-strided view
+    // (only allowed with separate_q_kv_output, so qkv_input is never written back then).
+    int const input_token_stride = params.input_token_stride;
     int const src_k_offset = params.q_hidden_size;
     int const src_v_offset = src_k_offset + params.kv_head_num * params.size_per_head;
 
@@ -454,9 +456,11 @@ __global__ void applyBiasRopeUpdateKVCache(QKVPreprocessingParams<T, KVCacheBuff
             //   src QKV: [batch, time, 3, head_num, size_per_head]
             // head_num != kv_head_num:
             //   src QKV: [batch, time, head_num * size_per_head + 2 * kv_head_num * size_per_head]
-            auto const src_q_idx = static_cast<size_t>(global_token_idx) * hidden_size + hidden_idx;
-            auto const src_k_idx = static_cast<size_t>(global_token_idx) * hidden_size + src_k_offset + hidden_idx_kv;
-            auto const src_v_idx = static_cast<size_t>(global_token_idx) * hidden_size + src_v_offset + hidden_idx_kv;
+            auto const src_q_idx = static_cast<size_t>(global_token_idx) * input_token_stride + hidden_idx;
+            auto const src_k_idx
+                = static_cast<size_t>(global_token_idx) * input_token_stride + src_k_offset + hidden_idx_kv;
+            auto const src_v_idx
+                = static_cast<size_t>(global_token_idx) * input_token_stride + src_v_offset + hidden_idx_kv;
 
             VecType q, k, v, q_pair, k_pair;
             // key without position embedding
@@ -728,6 +732,68 @@ struct VecType<__nv_bfloat16>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#ifdef ENABLE_BF16
+__device__ __forceinline__ void applyQkNormRopeGptNeox(mmha::bf16_8_t& q, mmha::bf16_8_t& k,
+    mmha::bf16_8_t const& qPair, mmha::bf16_8_t const& kPair, __nv_bfloat16 const* qNormWeight,
+    __nv_bfloat16 const* kNormWeight, int headDimIdx, int rotatedHeadDimOffset, int headSize, float eps, bool useGemma,
+    float2 const* rotaryCoefCache, bool validRotaryDim, bool firstHalf)
+{
+    constexpr int kElementsPerVector = 8;
+    auto qFloat = mmha::convert_to_float(q);
+    auto kFloat = mmha::convert_to_float(k);
+    auto qPairFloat = mmha::convert_to_float(qPair);
+    auto kPairFloat = mmha::convert_to_float(kPair);
+    auto qWeightFloat = mmha::convert_to_float(*reinterpret_cast<mmha::bf16_8_t const*>(qNormWeight + headDimIdx));
+    auto kWeightFloat = mmha::convert_to_float(*reinterpret_cast<mmha::bf16_8_t const*>(kNormWeight + headDimIdx));
+    auto qPairWeightFloat = mmha::convert_to_float(
+        *reinterpret_cast<mmha::bf16_8_t const*>(qNormWeight + headDimIdx + rotatedHeadDimOffset));
+    auto kPairWeightFloat = mmha::convert_to_float(
+        *reinterpret_cast<mmha::bf16_8_t const*>(kNormWeight + headDimIdx + rotatedHeadDimOffset));
+
+    auto* qValues = reinterpret_cast<float*>(&qFloat);
+    auto* kValues = reinterpret_cast<float*>(&kFloat);
+    auto* qPairValues = reinterpret_cast<float*>(&qPairFloat);
+    auto* kPairValues = reinterpret_cast<float*>(&kPairFloat);
+    auto const* qWeightValues = reinterpret_cast<float const*>(&qWeightFloat);
+    auto const* kWeightValues = reinterpret_cast<float const*>(&kWeightFloat);
+    auto const* qPairWeightValues = reinterpret_cast<float const*>(&qPairWeightFloat);
+    auto const* kPairWeightValues = reinterpret_cast<float const*>(&kPairWeightFloat);
+
+    float qSumSquares = 0.0f;
+    float kSumSquares = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kElementsPerVector; ++i)
+    {
+        qSumSquares += qValues[i] * qValues[i];
+        kSumSquares += kValues[i] * kValues[i];
+    }
+    qSumSquares = tensorrt_llm::common::warpReduceSum(qSumSquares);
+    kSumSquares = tensorrt_llm::common::warpReduceSum(kSumSquares);
+    float const qRmsRcp = rsqrtf(qSumSquares / static_cast<float>(headSize) + eps);
+    float const kRmsRcp = rsqrtf(kSumSquares / static_cast<float>(headSize) + eps);
+
+#pragma unroll
+    for (int i = 0; i < kElementsPerVector; ++i)
+    {
+        float const qWeight = useGemma ? 1.0f + qWeightValues[i] : qWeightValues[i];
+        float const kWeight = useGemma ? 1.0f + kWeightValues[i] : kWeightValues[i];
+        float const qPairWeight = useGemma ? 1.0f + qPairWeightValues[i] : qPairWeightValues[i];
+        float const kPairWeight = useGemma ? 1.0f + kPairWeightValues[i] : kPairWeightValues[i];
+        qValues[i] *= qRmsRcp * qWeight;
+        kValues[i] *= kRmsRcp * kWeight;
+        qPairValues[i] *= qRmsRcp * qPairWeight;
+        kPairValues[i] *= kRmsRcp * kPairWeight;
+
+        float2 rotaryCoef = validRotaryDim ? rotaryCoefCache[i] : make_float2(1.0f, 0.0f);
+        rotaryCoef.y = firstHalf ? -rotaryCoef.y : rotaryCoef.y;
+        qValues[i] = qValues[i] * rotaryCoef.x + qPairValues[i] * rotaryCoef.y;
+        kValues[i] = kValues[i] * rotaryCoef.x + kPairValues[i] * rotaryCoef.y;
+    }
+    mmha::convert_from_float(&q, qFloat);
+    mmha::convert_from_float(&k, kFloat);
+}
+#endif
+
 template <typename T, typename TCache, int BLOCK_SIZE, int Dh, bool ADD_BIAS, bool STORE_QKV, bool FP8_OUTPUT,
     bool GEN_PHASE, typename KVCacheBuffer, RotaryPositionEmbeddingType ROTARY_TYPE>
 __global__ void applyBiasRopeUpdateKVCacheV2(QKVPreprocessingParams<T, KVCacheBuffer> params)
@@ -867,11 +933,11 @@ __global__ void applyBiasRopeUpdateKVCacheV2(QKVPreprocessingParams<T, KVCacheBu
         //   src QKV: [batch, time, 3, head_num, size_per_head]
         // head_num != kv_head_num:
         //   src QKV: [batch, time, head_num * size_per_head + 2 * kv_head_num * size_per_head]
-        auto const src_q_idx = static_cast<size_t>(bounded_global_token_idx) * params.hidden_size + hidden_idx;
+        auto const src_q_idx = static_cast<size_t>(bounded_global_token_idx) * params.input_token_stride + hidden_idx;
         auto const src_k_idx
-            = static_cast<size_t>(bounded_global_token_idx) * params.hidden_size + src_k_offset + hidden_idx_kv;
+            = static_cast<size_t>(bounded_global_token_idx) * params.input_token_stride + src_k_offset + hidden_idx_kv;
         auto const src_v_idx
-            = static_cast<size_t>(bounded_global_token_idx) * params.hidden_size + src_v_offset + hidden_idx_kv;
+            = static_cast<size_t>(bounded_global_token_idx) * params.input_token_stride + src_v_offset + hidden_idx_kv;
 
         auto q = *reinterpret_cast<VecT const*>(&params.qkv_input[src_q_idx]);
         auto k = *reinterpret_cast<VecT const*>(&params.qkv_input[src_k_idx]);
@@ -924,21 +990,37 @@ __global__ void applyBiasRopeUpdateKVCacheV2(QKVPreprocessingParams<T, KVCacheBu
         if constexpr (ROTARY_TYPE == RotaryPositionEmbeddingType::GPT_NEOX)
         {
             rotary_coef_cache_buffer += gptneox_rotary_dim_idx;
-#pragma unroll
-            for (int elt_id = 0; elt_id < ELTS_PER_VEC; elt_id++)
+            bool qk_norm_applied = false;
+#ifdef ENABLE_BF16
+            if constexpr (std::is_same_v<T, __nv_bfloat16>)
             {
-                GPTNeoXEltT& q_ = reinterpret_cast<GPTNeoXEltT*>(&q)[elt_id];
-                GPTNeoXEltT q_pair_ = reinterpret_cast<GPTNeoXEltT*>(&q_pair)[elt_id];
-                GPTNeoXEltT& k_ = reinterpret_cast<GPTNeoXEltT*>(&k)[elt_id];
-                GPTNeoXEltT k_pair_ = reinterpret_cast<GPTNeoXEltT*>(&k_pair)[elt_id];
+                if (params.q_norm_weight != nullptr)
+                {
+                    applyQkNormRopeGptNeox(q, k, q_pair, k_pair, params.q_norm_weight, params.k_norm_weight,
+                        head_dim_idx, rotated_head_dim_offset, params.size_per_head, params.qk_norm_eps,
+                        params.qk_norm_use_gemma, rotary_coef_cache_buffer, valid_rotary_dim_idx, first_half);
+                    qk_norm_applied = true;
+                }
+            }
+#endif
+            if (!qk_norm_applied)
+            {
+#pragma unroll
+                for (int elt_id = 0; elt_id < ELTS_PER_VEC; elt_id++)
+                {
+                    GPTNeoXEltT& q_ = reinterpret_cast<GPTNeoXEltT*>(&q)[elt_id];
+                    GPTNeoXEltT q_pair_ = reinterpret_cast<GPTNeoXEltT*>(&q_pair)[elt_id];
+                    GPTNeoXEltT& k_ = reinterpret_cast<GPTNeoXEltT*>(&k)[elt_id];
+                    GPTNeoXEltT k_pair_ = reinterpret_cast<GPTNeoXEltT*>(&k_pair)[elt_id];
 
-                // Load cos/sin from cache.
-                float2 rotary_coef_cache
-                    = valid_rotary_dim_idx ? rotary_coef_cache_buffer[elt_id] : masked_rotary_cos_sin;
+                    // Load cos/sin from cache.
+                    float2 rotary_coef_cache
+                        = valid_rotary_dim_idx ? rotary_coef_cache_buffer[elt_id] : masked_rotary_cos_sin;
 
-                // Preprocess sin for second half rotary dim.
-                rotary_coef_cache.y = first_half ? -rotary_coef_cache.y : rotary_coef_cache.y;
-                mmha::apply_rotary_embedding_gptneox(q_, q_pair_, k_, k_pair_, rotary_coef_cache);
+                    // Preprocess sin for second half rotary dim.
+                    rotary_coef_cache.y = first_half ? -rotary_coef_cache.y : rotary_coef_cache.y;
+                    mmha::apply_rotary_embedding_gptneox(q_, q_pair_, k_, k_pair_, rotary_coef_cache);
+                }
             }
         }
         else if constexpr (ROTARY_TYPE == RotaryPositionEmbeddingType::GPTJ)
@@ -1451,7 +1533,7 @@ __global__ void updateKVCacheForCrossAttention(QKVPreprocessingParams<T, KVCache
             int global_token_idx = token_idx + decoder_seq_offset;
 
             // The memory offset.
-            auto const src_q_idx = static_cast<size_t>(global_token_idx) * params.hidden_size + hidden_idx;
+            auto const src_q_idx = static_cast<size_t>(global_token_idx) * params.input_token_stride + hidden_idx;
             auto const dst_q_idx = static_cast<size_t>(global_token_idx) * params.q_hidden_size + hidden_idx;
 
             // Only load Q tokens from decoder qkv input.
@@ -1611,17 +1693,24 @@ void invokeApplyBiasRopeUpdateKVCacheDispatch(QKVPreprocessingParams<T, KVCacheB
         || params.max_kv_seq_len > params.rotary_embedding_max_positions;
     bool const has_rotary_cos_sin_cache = params.rotary_coef_cache_buffer != nullptr;
     bool const has_sink_tokens = params.sink_token_len > 0;
-    bool const use_v1_for_mrope
-        = params.position_embedding_type == PositionEmbeddingType::kROPE_M && params.mrope_rotary_cos_sin == nullptr;
+    // Text-only requests for an mRoPE-configured model have scalar position IDs
+    // (all three mRoPE axes are identical), so there is no per-token mRoPE
+    // cos/sin buffer. Fused QK norm is implemented in V2 and can use the normal
+    // scalar-position cos/sin cache for this case. Multimodal requests provide
+    // mrope_rotary_cos_sin and also use V2.
+    bool const use_v1_for_mrope = params.position_embedding_type == PositionEmbeddingType::kROPE_M
+        && params.mrope_rotary_cos_sin == nullptr && params.q_norm_weight == nullptr;
     // V2 implementation requires multiple of paired 16 bytes for gpt-neox rotation.
     bool const support_rotary_for_v2 = (params.position_embedding_type != PositionEmbeddingType::kROPE_GPT_NEOX
                                            && params.position_embedding_type != PositionEmbeddingType::kLONG_ROPE)
         || params.rotary_embedding_dim % 16 == 0;
 
     // Use v2 kernel for absolute_position_embedding.
-    if (!absolute_position_embedding
-        && (long_seq_rotary_support || !has_rotary_cos_sin_cache || has_sink_tokens || !support_rotary_for_v2
-            || use_v1_for_mrope))
+    bool const requires_v1 = long_seq_rotary_support || !has_rotary_cos_sin_cache || has_sink_tokens
+        || !support_rotary_for_v2 || use_v1_for_mrope;
+    TLLM_CHECK_WITH_INFO(params.q_norm_weight == nullptr || !requires_v1,
+        "Fused QK norm preprocessing requires the V2 QKV preprocessing kernel.");
+    if (!absolute_position_embedding && requires_v1)
     {
         kernelV1Dispatch<T, TCache, KVCacheBuffer>(params, stream);
         return;

--- a/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
@@ -58,10 +58,15 @@ QKVPreprocessingParams<T, KVCacheBuffer> makeQKVPreprocessingParams(XQAParams co
     memset(&preprocessingParms, 0, sizeof(preprocessingParms));
     // Set parameters.
     preprocessingParms.qkv_input = static_cast<T*>(const_cast<void*>(params.qkv));
+    preprocessingParms.input_token_stride = params.qkv_token_stride;
     preprocessingParms.q_output = static_cast<T*>(xqa_q_input_ptr);
     preprocessingParms.kv_cache_buffer = kv_cache_buffer;
     preprocessingParms.kv_cache_block_scales_buffer = kv_cache_block_scales_buffer;
     preprocessingParms.qkv_bias = static_cast<T const*>(params.qkv_bias);
+    preprocessingParms.q_norm_weight = static_cast<T const*>(params.q_norm_weight);
+    preprocessingParms.k_norm_weight = static_cast<T const*>(params.k_norm_weight);
+    preprocessingParms.qk_norm_eps = params.qk_norm_eps;
+    preprocessingParms.qk_norm_use_gemma = params.qk_norm_use_gemma;
     // Prepare values for fmha.
     preprocessingParms.fmha_bmm1_scale = launchParams.bmm1_scale_ptr;
     preprocessingParms.fmha_bmm2_scale = launchParams.bmm2_scale_ptr;
@@ -339,6 +344,12 @@ template <typename T, typename KVCacheBuffer>
 void XqaDispatcher::runImpl(
     XQAParams params, KVCacheBuffer const& kv_cache_buffer, KVCacheBuffer const& kv_cache_block_scales_buffer)
 {
+    // Only the TRTLLM-Gen path supports a strided qkv input (the preprocessing kernel routes Q to a
+    // separate packed buffer that the FMHA reads); the legacy XQA kernels read qkv directly.
+    TLLM_CHECK_WITH_INFO(params.qkv_token_stride == 0 || mUseTllmGen
+            || params.qkv_token_stride
+                == (params.num_q_heads + 2 * params.num_kv_heads) * static_cast<int32_t>(params.head_size),
+        "Strided qkv input is not supported by the legacy XQA generation path.");
     if (mUseTllmGen)
     {
         TLLM_LOG_DEBUG("Running TRTLLM-GEN generation kernel.");

--- a/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
@@ -350,6 +350,8 @@ void XqaDispatcher::runImpl(
             || params.qkv_token_stride
                 == (params.num_q_heads + 2 * params.num_kv_heads) * static_cast<int32_t>(params.head_size),
         "Strided qkv input is not supported by the legacy XQA generation path.");
+    TLLM_CHECK_WITH_INFO(params.q_norm_weight == nullptr || mUseTllmGen,
+        "Fused QK norm preprocessing is not supported by the legacy XQA generation path.");
     if (mUseTllmGen)
     {
         TLLM_LOG_DEBUG("Running TRTLLM-GEN generation kernel.");

--- a/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
@@ -179,7 +179,9 @@ void initBindings(nb::module_& m)
         nb::arg("relative_attention_bias") = std::nullopt, nb::arg("relative_attention_max_distance") = 0,
         nb::arg("spec_decoding_target_max_draft_tokens") = std::nullopt, nb::arg("quant_scale_qkv") = std::nullopt,
         nb::arg("dsv4_inv_rope_cos_sin_cache") = std::nullopt, nb::arg("enable_dsv4_epilogue_fusion") = false,
-        "Multi-head attention operation", nb::call_guard<nb::gil_scoped_release>());
+        nb::arg("q_norm_weight") = std::nullopt, nb::arg("k_norm_weight") = std::nullopt, nb::arg("qk_norm_eps") = 0.0,
+        nb::arg("qk_norm_use_gemma") = false, "Multi-head attention operation",
+        nb::call_guard<nb::gil_scoped_release>());
 
     m.def(
         "get_helix_workspace_size_per_rank",

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -380,7 +380,9 @@ public:
         std::optional<torch::Tensor> relative_attention_bias,
         std::optional<torch::Tensor> quant_scale_qkv = std::nullopt,
         std::optional<torch::Tensor> dsv4_inv_rope_cos_sin_cache = std::nullopt,
-        bool enable_dsv4_epilogue_fusion = false) const
+        bool enable_dsv4_epilogue_fusion = false, std::optional<torch::Tensor> q_norm_weight = std::nullopt,
+        std::optional<torch::Tensor> k_norm_weight = std::nullopt, double qk_norm_eps = 0.0,
+        bool qk_norm_use_gemma = false) const
         = 0;
 };
 
@@ -450,10 +452,20 @@ public:
         std::optional<torch::Tensor> flash_mla_num_splits, bool trtllm_gen_jit_warmup,
         std::optional<int64_t> compressed_kv_cache_pool_ptr, bool const is_cross, std::optional<torch::Tensor> cross_kv,
         std::optional<torch::Tensor> relative_attention_bias, std::optional<torch::Tensor> quant_scale_qkv,
-        std::optional<torch::Tensor> dsv4_inv_rope_cos_sin_cache, bool enable_dsv4_epilogue_fusion) const override
+        std::optional<torch::Tensor> dsv4_inv_rope_cos_sin_cache, bool enable_dsv4_epilogue_fusion,
+        std::optional<torch::Tensor> q_norm_weight, std::optional<torch::Tensor> k_norm_weight, double qk_norm_eps,
+        bool qk_norm_use_gemma) const override
     {
         auto stream = at::cuda::getCurrentCUDAStream(qkv_or_q.get_device());
         T* attention_input = static_cast<T*>(qkv_or_q.slice(0, token_offset).data_ptr());
+        // qkv_or_q may be a row-strided view into a wider tensor (e.g. fused QKV+gate GEMM output
+        // laid out as [Q|K|V|Gate]); pass the token stride so kernels index it correctly.
+        int32_t attention_input_token_stride = 0;
+        if (qkv_or_q.dim() == 2 && !qkv_or_q.is_contiguous())
+        {
+            TORCH_CHECK(qkv_or_q.stride(1) == 1, "qkv_or_q innermost dim must be contiguous");
+            attention_input_token_stride = static_cast<int32_t>(qkv_or_q.stride(0));
+        }
         T* k_ptr = nullptr;
         T* v_ptr = nullptr;
         AttentionOutT* context_buf = static_cast<AttentionOutT*>(output.slice(0, token_offset).data_ptr());
@@ -477,6 +489,35 @@ public:
             }
         }
 
+        T const* q_norm_weight_ptr = nullptr;
+        T const* k_norm_weight_ptr = nullptr;
+        TORCH_CHECK(q_norm_weight.has_value() == k_norm_weight.has_value(),
+            "q_norm_weight and k_norm_weight must be provided together");
+        if (q_norm_weight.has_value())
+        {
+            TORCH_CHECK(qkv_or_q.scalar_type() == at::ScalarType::BFloat16,
+                "Fused QK norm preprocessing currently supports BF16 attention input only");
+            TORCH_CHECK(op.getHeadSize() == 256, "Fused QK norm preprocessing currently requires head_size == 256");
+            TORCH_CHECK(
+                op.isRoPE() && op.mPositionEmbeddingType != tensorrt_llm::kernels::PositionEmbeddingType::kROPE_GPTJ,
+                "Fused QK norm preprocessing requires a GPT-NeoX-compatible RoPE mode");
+            TORCH_CHECK(qk_norm_eps > 0.0, "qk_norm_eps must be positive");
+            auto const& qNormWeight = q_norm_weight.value();
+            auto const& kNormWeight = k_norm_weight.value();
+            TORCH_CHECK(qNormWeight.is_cuda() && kNormWeight.is_cuda(), "QK norm weights must be CUDA tensors");
+            TORCH_CHECK(
+                qNormWeight.get_device() == qkv_or_q.get_device() && kNormWeight.get_device() == qkv_or_q.get_device(),
+                "QK norm weights must be on the same device as q");
+            TORCH_CHECK(qNormWeight.scalar_type() == qkv_or_q.scalar_type()
+                    && kNormWeight.scalar_type() == qkv_or_q.scalar_type(),
+                "QK norm weights must have the same dtype as q");
+            TORCH_CHECK(
+                qNormWeight.is_contiguous() && kNormWeight.is_contiguous(), "QK norm weights must be contiguous");
+            TORCH_CHECK(qNormWeight.numel() == op.getHeadSize() && kNormWeight.numel() == op.getHeadSize(),
+                "QK norm weights must contain exactly head_size elements");
+            q_norm_weight_ptr = static_cast<T const*>(qNormWeight.data_ptr());
+            k_norm_weight_ptr = static_cast<T const*>(kNormWeight.data_ptr());
+        }
         void* workspace_ptr = workspace.data_ptr();
         [[maybe_unused]] MlaParams<T> mla_params;
         if (op.isMLAEnabled())
@@ -791,6 +832,11 @@ public:
 
         AttentionOp::EnqueueParams<T> common_enqueue_params;
         common_enqueue_params.attention_input = attention_input;
+        common_enqueue_params.attention_input_token_stride = attention_input_token_stride;
+        common_enqueue_params.q_norm_weight = q_norm_weight_ptr;
+        common_enqueue_params.k_norm_weight = k_norm_weight_ptr;
+        common_enqueue_params.qk_norm_eps = static_cast<float>(qk_norm_eps);
+        common_enqueue_params.qk_norm_use_gemma = qk_norm_use_gemma;
         common_enqueue_params.attention_sinks = attention_sinks_ptr;
         common_enqueue_params.rotary_inv_freq = rotary_inv_freq_ptr;
         common_enqueue_params.rotary_cos_sin = rotary_cos_sin_ptr;
@@ -1084,7 +1130,9 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
     std::optional<int64_t> compressed_kv_cache_pool_ptr, bool const is_cross, std::optional<torch::Tensor> cross_kv,
     std::optional<torch::Tensor> relative_attention_bias, int64_t relative_attention_max_distance,
     std::optional<int64_t> spec_decoding_target_max_draft_tokens, std::optional<torch::Tensor> quant_scale_qkv,
-    std::optional<torch::Tensor> dsv4_inv_rope_cos_sin_cache, bool enable_dsv4_epilogue_fusion)
+    std::optional<torch::Tensor> dsv4_inv_rope_cos_sin_cache, bool enable_dsv4_epilogue_fusion,
+    std::optional<torch::Tensor> q_norm_weight, std::optional<torch::Tensor> k_norm_weight, double qk_norm_eps,
+    bool qk_norm_use_gemma)
 {
     TLLM_LOG_TRACE("Attention op starts at layer %d", local_layer_idx);
     // Use these tensors to infer if the attention is using KV cache
@@ -1384,7 +1432,8 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
             num_sparse_topk_value, sparse_mla_topk_lens, cu_q_seqlens, cu_kv_seqlens, fmha_scheduler_counter,
             mla_bmm1_scale, mla_bmm2_scale, quant_q_buffer, flash_mla_tile_scheduler_metadata, flash_mla_num_splits,
             trtllm_gen_jit_warmup, compressed_kv_cache_pool_ptr, is_cross, cross_kv, relative_attention_bias,
-            quant_scale_qkv, dsv4_inv_rope_cos_sin_cache, enable_dsv4_epilogue_fusion);
+            quant_scale_qkv, dsv4_inv_rope_cos_sin_cache, enable_dsv4_epilogue_fusion, q_norm_weight, k_norm_weight,
+            qk_norm_eps, qk_norm_use_gemma);
     }
 
     if ((num_generations > 0) && (attn_input_type != AttentionInputType::ContextOnly))
@@ -1407,7 +1456,8 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
             num_sparse_topk_value, sparse_mla_topk_lens, cu_q_seqlens, cu_kv_seqlens, fmha_scheduler_counter,
             mla_bmm1_scale, mla_bmm2_scale, quant_q_buffer, flash_mla_tile_scheduler_metadata, flash_mla_num_splits,
             trtllm_gen_jit_warmup, compressed_kv_cache_pool_ptr, is_cross, cross_kv, relative_attention_bias,
-            quant_scale_qkv, dsv4_inv_rope_cos_sin_cache, enable_dsv4_epilogue_fusion);
+            quant_scale_qkv, dsv4_inv_rope_cos_sin_cache, enable_dsv4_epilogue_fusion, q_norm_weight, k_norm_weight,
+            qk_norm_eps, qk_norm_use_gemma);
     }
 
     TLLM_LOG_TRACE("Attention op stops at layer %d", local_layer_idx);

--- a/cpp/tensorrt_llm/thop/attentionOp.h
+++ b/cpp/tensorrt_llm/thop/attentionOp.h
@@ -95,7 +95,10 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
     std::optional<torch::Tensor> relative_attention_bias = std::nullopt, int64_t relative_attention_max_distance = 0,
     std::optional<int64_t> spec_decoding_target_max_draft_tokens = std::nullopt,
     std::optional<torch::Tensor> quant_scale_qkv = std::nullopt,
-    std::optional<torch::Tensor> dsv4_inv_rope_cos_sin_cache = std::nullopt, bool enable_dsv4_epilogue_fusion = false);
+    std::optional<torch::Tensor> dsv4_inv_rope_cos_sin_cache = std::nullopt, bool enable_dsv4_epilogue_fusion = false,
+    std::optional<torch::Tensor> q_norm_weight = std::nullopt,
+    std::optional<torch::Tensor> k_norm_weight = std::nullopt, double qk_norm_eps = 0.0,
+    bool qk_norm_use_gemma = false);
 
 struct KvCachePoolPointers
 {

--- a/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
@@ -142,6 +142,10 @@ class FallbackFmha(Fmha):
             relative_attention_max_distance=forward_args.relative_attention_max_distance,
             skip_softmax_threshold_scale_factor_prefill=forward_args.skip_softmax_kernel_params.threshold_scale_factor_prefill,
             skip_softmax_threshold_scale_factor_decode=forward_args.skip_softmax_kernel_params.threshold_scale_factor_decode,
+            q_norm_weight=attn.q_norm_weight,
+            k_norm_weight=attn.k_norm_weight,
+            qk_norm_eps=attn.qk_norm_eps,
+            qk_norm_use_gemma=attn.qk_norm_use_gemma,
             # --- Module config (TrtllmAttention) ---
             rotary_inv_freq=attn.rotary_inv_freq,
             rotary_cos_sin=attn.rotary_cos_sin,

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -607,6 +607,10 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         fwd: AttentionForwardArgs,
     ) -> Tuple[bool, str]:
         is_mla_enable = attn.is_mla_enable
+        if q.dim() == 2 and not q.is_contiguous():
+            # Row-strided qkv views (gate-tail [Q|K|V|G] layout) are only handled by
+            # the fallback thop path, which passes the token stride to its kernels.
+            return False, "Strided qkv input is only supported by the fallback path."
         sparse_params = attn.sparse_params
         has_skip_softmax = sparse_params is not None and sparse_params.algorithm == "skip_softmax"
         has_sparse_attention = sparse_params is not None and not has_skip_softmax

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -1071,6 +1071,11 @@ class AttentionBackend(Generic[TMetadata]):
         return False
 
     @classmethod
+    def support_strided_fused_qkv(cls) -> bool:
+        """Whether fused QKV may have a wider token stride end to end."""
+        return False
+
+    @classmethod
     def support_mla(cls) -> bool:
         return False
 

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1805,6 +1805,13 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         return True
 
     @classmethod
+    def support_strided_fused_qkv(cls) -> bool:
+        # The gate-tail layout passes a [Q|K|V] view whose token stride still
+        # includes the trailing gate. TRTLLM-Gen preprocesses that view into a
+        # packed Q buffer, while legacy XQA/MMHA generation reads QKV directly.
+        return cls.is_sm_version_trtllm_gen_kernel(get_sm_version())
+
+    @classmethod
     def support_mla(cls) -> bool:
         return True
 

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1235,6 +1235,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         )
         self.position_embedding_type = int(
             pos_embd_params.type) if pos_embd_params is not None else 0
+        self.q_norm_weight: Optional[torch.Tensor] = None
+        self.k_norm_weight: Optional[torch.Tensor] = None
+        self.qk_norm_eps = 0.0
+        self.qk_norm_use_gemma = False
         self.skip_softmax_stat = torch.zeros(2,
                                              dtype=torch.uint32,
                                              device='cuda')
@@ -1260,6 +1264,28 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         self.fmha_libs: List[Fmha] = []
         if not skip_create_weights_in_init:
             self.update_quant_config(self.quant_config)
+
+    def configure_qk_norm_preprocessing(
+        self,
+        pos_embd_params: PositionalEmbeddingParams,
+        q_norm_weight: torch.Tensor,
+        k_norm_weight: torch.Tensor,
+        eps: float,
+        use_gemma: bool,
+    ) -> None:
+        """Configure QK RMSNorm + RoPE in the THOP preprocessing kernel."""
+        assert not self.is_mla_enable
+        assert pos_embd_params.rope is not None
+        self.rope_params = pos_embd_params.rope
+        self.rotary_inv_freq, self.rotary_cos_sin = self.rope_params.create_rope_const_params(
+        )
+        self.position_embedding_type = int(pos_embd_params.type)
+        self.q_norm_weight = q_norm_weight
+        self.k_norm_weight = k_norm_weight
+        self.qk_norm_eps = eps
+        self.qk_norm_use_gemma = use_gemma
+        # FMHA library support depends on the positional-embedding mode.
+        self.fmha_libs = []
 
     def update_quant_config(self, new_quant_config: Optional[QuantConfig]):
         self.quant_config = new_quant_config or QuantConfig()
@@ -1497,6 +1523,16 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             raise ValueError(
                 "DSv4 epilogue fusion requires caller-provided output and "
                 "output_sf buffers.")
+
+        has_strided_fused_qkv = (q.dim() == 2 and k is None and v is None
+                                 and q.stride(1) == 1
+                                 and q.stride(0) != q.shape[1])
+        if has_strided_fused_qkv and metadata.num_contexts > 0:
+            assert not self.is_mla_enable
+            # The raw row-strided QKV view cannot feed the context FMHA
+            # directly. Force preprocessing to materialize packed Q and append
+            # K/V before context attention, including fresh-prefill requests.
+            metadata.use_paged_context_fmha = True
 
         if forward_args.output is None:
             is_gen_only = (forward_args.attention_input_type ==

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -469,7 +469,15 @@ class Attention(nn.Module):
         # HF layout to [Q|K|V|G]. Q/K/V then form one contiguous slice of the GEMM output,
         # which removes the q/gate de-interleave copies and the q,k,v re-concat before the
         # fused qk-norm-rope kernel; the attention op consumes [Q|K|V] as a row-strided view.
-        self._gate_tail_layout_enabled = bool(self.attn_output_gate)
+        # Gate-tail is a self-attention decode/generation fast path that has no
+        # LoRA-aware code path: forward would add the interleaved-layout LoRA QKV
+        # contribution onto the [Q|K|V|G] base output and then assert on non-empty
+        # lora_params. Disable the layout entirely when LoRA is configured so those
+        # requests keep the correct interleaved path.
+        lora_configured = (config is not None
+                           and config.lora_config is not None)
+        self._gate_tail_layout_enabled = bool(self.attn_output_gate
+                                              and not lora_configured)
         self._gate_tail_layout_active = False
         # Guards the one-shot gate-tail weight permutation so it runs once per set
         # of freshly loaded qkv weights. Reset by reload orchestrators (full reload

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1,4 +1,5 @@
 import math
+import os
 import weakref
 from typing import List, Optional, Tuple, Union
 
@@ -464,6 +465,16 @@ class Attention(nn.Module):
         if self.attn_output_gate:
             logger.info_once("using attn output gate!", key="attn_output_gate")
 
+        # Opt-in [Q|K|V|G] gate-tail layout: the fused QKV(+gate) weight rows are permuted at
+        # load time (see post_load_weights) from the per-head-interleaved [q0|g0|q1|g1|...|K|V]
+        # HF layout to [Q|K|V|G]. Q/K/V then form one contiguous slice of the GEMM output,
+        # which removes the q/gate de-interleave copies and the q,k,v re-concat before the
+        # fused qk-norm-rope kernel; the attention op consumes [Q|K|V] as a row-strided view.
+        self._gate_tail_layout_requested = (
+            self.attn_output_gate
+            and os.environ.get("TRTLLM_ATTN_GATE_TAIL_LAYOUT", "0") == "1")
+        self._gate_tail_layout_active = False
+
         # [Chunked Attention]
         # Chunked attention is applied to context requests only. Chunked attention will be
         # applied when this field is specified and mMaskType == CAUSAL.
@@ -690,6 +701,53 @@ class Attention(nn.Module):
                                 or self.o_proj.has_fp8_block_scales
                                 or self.o_proj.has_fp8_rowwise
                                 or self.o_proj.has_w4a8_nvfp4_fp8)
+
+    def post_load_weights(self):
+        self._maybe_permute_gate_tail_layout()
+
+    def _maybe_permute_gate_tail_layout(self):
+        """Permute qkv_proj weight rows from [q0|g0|q1|g1|...|K|V] to [Q|K|V|G].
+
+        Load-time-only transform enabling the copy-free gate path in forward. Only
+        engaged for plain (unquantized) weights with the TRTLLM backend and the fused
+        qk-norm-rope kernel, where the strided [Q|K|V] view is supported end to end.
+        """
+        if not self._gate_tail_layout_requested or self._gate_tail_layout_active:
+            return
+        has_quant = (self.quant_config is not None
+                     and self.quant_config.layer_quant_mode.has_any_quant(
+                         exclude_kv_cache=True))
+        supported = (self.attn_backend == "TRTLLM" and self.support_fused_qkv
+                     and getattr(self, "fuse_qk_norm_rope", False)
+                     and not getattr(self, "skip_rope", False) and not has_quant
+                     and self.mapping.cp_size == 1
+                     and self.qkv_proj.weight.dtype
+                     in (torch.bfloat16, torch.float16, torch.float32))
+        if not supported:
+            logger.warning_once(
+                "TRTLLM_ATTN_GATE_TAIL_LAYOUT requested but not supported for "
+                "this attention configuration; keeping interleaved layout.",
+                key="gate_tail_layout_unsupported")
+            return
+        device = self.qkv_proj.weight.device
+        d = self.head_dim
+        q_gate_rows = torch.arange(2 * self.q_size,
+                                   device=device).view(self.num_heads, 2, d)
+        perm = torch.cat([
+            q_gate_rows[:, 0, :].reshape(-1),  # Q
+            torch.arange(2 * self.kv_size, device=device) +
+            2 * self.q_size,  # K, V
+            q_gate_rows[:, 1, :].reshape(-1),  # gate
+        ])
+        with torch.no_grad():
+            self.qkv_proj.weight.data.copy_(
+                self.qkv_proj.weight.data.index_select(0, perm))
+            if self.qkv_proj.bias is not None:
+                self.qkv_proj.bias.data.copy_(
+                    self.qkv_proj.bias.data.index_select(0, perm))
+        self._gate_tail_layout_active = True
+        logger.info_once("gate-tail [Q|K|V|G] qkv layout engaged",
+                         key="gate_tail_layout_engaged")
 
     def split_qkv(self, q, k=None, v=None):
         if k is None and v is None:
@@ -984,14 +1042,24 @@ class Attention(nn.Module):
                 qkv = qkv + qkv_lora
 
         if self.attn_output_gate:
-            q_gate, k, v = qkv.split(
-                [self.q_size * 2, self.kv_size, self.kv_size], dim=-1)
-            orig_shape = q_gate.shape[:-1]
-            # Single line: view -> chunk -> reshape both q and gate
-            q, gate = [
-                t.reshape(*orig_shape, -1) for t in torch.chunk(
-                    q_gate.view(*orig_shape, self.num_heads, -1), 2, dim=-1)
-            ]
+            if self._gate_tail_layout_active:
+                # Weights were permuted at load time so the GEMM output is [Q|K|V|G].
+                # Keep the full tensor: the in-place fused qk-norm-rope treats the gate
+                # tail as pass-through V heads, and q/gate become copy-free views.
+                assert not bool(
+                    lora_params
+                ), "gate-tail QKV layout is incompatible with LoRA"
+                q, k, v = qkv, None, None
+                gate = qkv[:, self.q_size + 2 * self.kv_size:]
+            else:
+                q_gate, k, v = qkv.split(
+                    [self.q_size * 2, self.kv_size, self.kv_size], dim=-1)
+                orig_shape = q_gate.shape[:-1]
+                # Single line: view -> chunk -> reshape both q and gate
+                q, gate = [
+                    t.reshape(*orig_shape, -1) for t in torch.chunk(
+                        q_gate.view(*orig_shape, self.num_heads, -1), 2, dim=-1)
+                ]
         else:
             q, k, v = qkv, None, None
 
@@ -1010,6 +1078,11 @@ class Attention(nn.Module):
 
         q, k, v = self.apply_rope(q, k, v, position_ids)
         q, k, v = self.convert_qkv(q, k, v)
+
+        if self.attn_output_gate and self._gate_tail_layout_active:
+            # Drop the gate tail: the attention op consumes the [Q|K|V] slice as a
+            # row-strided view (token stride = full GEMM output width).
+            q = q[:, :self.q_size + 2 * self.kv_size]
 
         if attention_sinks is not None:
             assert self.attn_backend == "TRTLLM", (

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1,5 +1,4 @@
 import math
-import os
 import weakref
 from typing import List, Optional, Tuple, Union
 
@@ -465,14 +464,12 @@ class Attention(nn.Module):
         if self.attn_output_gate:
             logger.info_once("using attn output gate!", key="attn_output_gate")
 
-        # Opt-in [Q|K|V|G] gate-tail layout: the fused QKV(+gate) weight rows are permuted at
+        # [Q|K|V|G] gate-tail layout: the fused QKV(+gate) weight rows are permuted at
         # load time (see post_load_weights) from the per-head-interleaved [q0|g0|q1|g1|...|K|V]
         # HF layout to [Q|K|V|G]. Q/K/V then form one contiguous slice of the GEMM output,
         # which removes the q/gate de-interleave copies and the q,k,v re-concat before the
         # fused qk-norm-rope kernel; the attention op consumes [Q|K|V] as a row-strided view.
-        self._gate_tail_layout_requested = (
-            self.attn_output_gate
-            and os.environ.get("TRTLLM_ATTN_GATE_TAIL_LAYOUT", "0") == "1")
+        self._gate_tail_layout_enabled = bool(self.attn_output_gate)
         self._gate_tail_layout_active = False
 
         # [Chunked Attention]
@@ -712,7 +709,7 @@ class Attention(nn.Module):
         engaged for plain (unquantized) weights with the TRTLLM backend and the fused
         qk-norm-rope kernel, where the strided [Q|K|V] view is supported end to end.
         """
-        if not self._gate_tail_layout_requested or self._gate_tail_layout_active:
+        if not self._gate_tail_layout_enabled or self._gate_tail_layout_active:
             return
         has_quant = (self.quant_config is not None
                      and self.quant_config.layer_quant_mode.has_any_quant(
@@ -725,8 +722,8 @@ class Attention(nn.Module):
                      in (torch.bfloat16, torch.float16, torch.float32))
         if not supported:
             logger.warning_once(
-                "TRTLLM_ATTN_GATE_TAIL_LAYOUT requested but not supported for "
-                "this attention configuration; keeping interleaved layout.",
+                "Gate-tail QKV layout is not supported for this attention "
+                "configuration; keeping the interleaved layout.",
                 key="gate_tail_layout_unsupported")
             return
         device = self.qkv_proj.weight.device

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -471,6 +471,11 @@ class Attention(nn.Module):
         # fused qk-norm-rope kernel; the attention op consumes [Q|K|V] as a row-strided view.
         self._gate_tail_layout_enabled = bool(self.attn_output_gate)
         self._gate_tail_layout_active = False
+        # Guards the one-shot gate-tail weight permutation so it runs once per set
+        # of freshly loaded qkv weights. Reset by reload orchestrators (full reload
+        # via ModelLoader._reset_weights_transformed, partial/RLHF reload via
+        # pre_reload_weights) so re-loaded weights get permuted again.
+        self._weights_transformed = False
 
         # [Chunked Attention]
         # Chunked attention is applied to context requests only. Chunked attention will be
@@ -700,18 +705,32 @@ class Attention(nn.Module):
                                 or self.o_proj.has_w4a8_nvfp4_fp8)
 
     def post_load_weights(self):
+        # Staged post-load hooks: transform_weights performs the one-shot weight
+        # permutation, cache_derived_state restores the Python-side state derived
+        # from the (possibly already-permuted) weights.
+        self.transform_weights()
+        self.cache_derived_state()
+
+    def transform_weights(self):
         self._maybe_permute_gate_tail_layout()
 
-    def _maybe_permute_gate_tail_layout(self):
-        """Permute qkv_proj weight rows from [q0|g0|q1|g1|...|K|V] to [Q|K|V|G].
+    def cache_derived_state(self):
+        self._refresh_gate_tail_layout_state()
 
-        Load-time-only transform enabling the copy-free gate path in forward.
-        Engaged for plain weights and per-tensor FP8 QDQ weights with a backend
-        that supports the strided [Q|K|V] view in both context and generation
-        paths. The FP8 weight scale is scalar and does not need to be permuted.
+    def pre_reload_weights(self):
+        # A weight reload rebinds qkv_proj with fresh checkpoint-order (interleaved)
+        # bytes, so the one-shot gate-tail permutation must run again. Full reloads
+        # reset this guard via ModelLoader._reset_weights_transformed; partial (RLHF)
+        # reloads invoke this hook once per update cycle.
+        self._weights_transformed = False
+
+    def _gate_tail_layout_supported(self):
+        """Whether the copy-free gate-tail [Q|K|V|G] layout applies here.
+
+        Determined purely by config, weight dtype and backend capability, so it
+        yields the same answer in a fresh process that only restores derived state
+        (e.g. a GMS read-only reader).
         """
-        if not self._gate_tail_layout_enabled or self._gate_tail_layout_active:
-            return
         has_quant = getattr(self.qkv_proj, "has_any_quant", False)
         has_fp8_qdq = getattr(self.qkv_proj, "has_fp8_qdq", False)
         weight_scale = getattr(self.qkv_proj, "weight_scale", None)
@@ -722,36 +741,66 @@ class Attention(nn.Module):
               and weight_scale is not None and weight_scale.numel() == 1)
         supports_strided_qkv = getattr(self.attn, "support_strided_fused_qkv",
                                        lambda: False)()
-        supported = (self.attn_backend == "TRTLLM" and self.support_fused_qkv
-                     and supports_strided_qkv
-                     and getattr(self, "fuse_qk_norm_rope", False)
-                     and not getattr(self, "skip_rope", False)
-                     and self.mapping.cp_size == 1 and has_supported_weight)
-        if not supported:
-            logger.warning_once(
-                "Gate-tail QKV layout is not supported for this attention "
-                "configuration; keeping the interleaved layout.",
-                key="gate_tail_layout_unsupported")
+        return (self.attn_backend == "TRTLLM" and self.support_fused_qkv
+                and supports_strided_qkv
+                and getattr(self, "fuse_qk_norm_rope", False)
+                and not getattr(self, "skip_rope", False)
+                and self.mapping.cp_size == 1 and has_supported_weight)
+
+    def _maybe_permute_gate_tail_layout(self):
+        """Permute qkv_proj weight rows from [q0|g0|q1|g1|...|K|V] to [Q|K|V|G].
+
+        One-shot weight transform (``transform_weights`` stage) enabling the
+        copy-free gate path in forward. Guarded by ``_weights_transformed`` so it
+        runs once per set of freshly loaded weights; reload orchestrators reset that
+        guard before rebinding new bytes. Engaged for plain weights and per-tensor
+        FP8 QDQ weights with a backend that supports the strided [Q|K|V] view in both
+        context and generation paths. The FP8 weight scale is scalar and does not
+        need to be permuted.
+        """
+        if self._weights_transformed:
             return
-        device = self.qkv_proj.weight.device
-        d = self.head_dim
-        q_gate_rows = torch.arange(2 * self.q_size,
-                                   device=device).view(self.num_heads, 2, d)
-        perm = torch.cat([
-            q_gate_rows[:, 0, :].reshape(-1),  # Q
-            torch.arange(2 * self.kv_size, device=device) +
-            2 * self.q_size,  # K, V
-            q_gate_rows[:, 1, :].reshape(-1),  # gate
-        ])
-        with torch.no_grad():
-            self.qkv_proj.weight.data.copy_(
-                self.qkv_proj.weight.data.index_select(0, perm))
-            if self.qkv_proj.bias is not None:
-                self.qkv_proj.bias.data.copy_(
-                    self.qkv_proj.bias.data.index_select(0, perm))
-        self._gate_tail_layout_active = True
-        logger.info_once("gate-tail [Q|K|V|G] qkv layout engaged",
-                         key="gate_tail_layout_engaged")
+        if self._gate_tail_layout_enabled:
+            if self._gate_tail_layout_supported():
+                device = self.qkv_proj.weight.device
+                d = self.head_dim
+                q_gate_rows = torch.arange(2 * self.q_size, device=device).view(
+                    self.num_heads, 2, d)
+                perm = torch.cat([
+                    q_gate_rows[:, 0, :].reshape(-1),  # Q
+                    torch.arange(2 * self.kv_size, device=device) +
+                    2 * self.q_size,  # K, V
+                    q_gate_rows[:, 1, :].reshape(-1),  # gate
+                ])
+                with torch.no_grad():
+                    self.qkv_proj.weight.data.copy_(
+                        self.qkv_proj.weight.data.index_select(0, perm))
+                    if self.qkv_proj.bias is not None:
+                        self.qkv_proj.bias.data.copy_(
+                            self.qkv_proj.bias.data.index_select(0, perm))
+                logger.info_once("gate-tail [Q|K|V|G] qkv layout engaged",
+                                 key="gate_tail_layout_engaged")
+            else:
+                logger.warning_once(
+                    "Gate-tail QKV layout is not supported for this attention "
+                    "configuration; keeping the interleaved layout.",
+                    key="gate_tail_layout_unsupported")
+        self._weights_transformed = True
+
+    def _refresh_gate_tail_layout_state(self):
+        """Recompute the forward-time gate-tail activation from loaded weights.
+
+        Runs on every load path, including GMS read-only sharing where the weights
+        arrive already permuted and only Python-side derived state must be restored.
+        """
+        active = (self._gate_tail_layout_enabled
+                  and self._gate_tail_layout_supported())
+        if active and not self._weights_transformed:
+            # Weights published by a GMS writer are already in [Q|K|V|G] layout;
+            # mark the transform guard so a later transform_weights() does not
+            # permute them a second time.
+            self._weights_transformed = True
+        self._gate_tail_layout_active = active
 
     def split_qkv(self, q, k=None, v=None):
         if k is None and v is None:

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -706,15 +706,18 @@ class Attention(nn.Module):
         """Permute qkv_proj weight rows from [q0|g0|q1|g1|...|K|V] to [Q|K|V|G].
 
         Load-time-only transform enabling the copy-free gate path in forward. Only
-        engaged for plain (unquantized) weights with the TRTLLM backend and the fused
-        qk-norm-rope kernel, where the strided [Q|K|V] view is supported end to end.
+        engaged for plain (unquantized) weights with a backend that supports the
+        strided [Q|K|V] view in both context and generation paths.
         """
         if not self._gate_tail_layout_enabled or self._gate_tail_layout_active:
             return
         has_quant = (self.quant_config is not None
                      and self.quant_config.layer_quant_mode.has_any_quant(
                          exclude_kv_cache=True))
+        supports_strided_qkv = getattr(self.attn, "support_strided_fused_qkv",
+                                       lambda: False)()
         supported = (self.attn_backend == "TRTLLM" and self.support_fused_qkv
+                     and supports_strided_qkv
                      and getattr(self, "fuse_qk_norm_rope", False)
                      and not getattr(self, "skip_rope", False) and not has_quant
                      and self.mapping.cp_size == 1

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -705,24 +705,28 @@ class Attention(nn.Module):
     def _maybe_permute_gate_tail_layout(self):
         """Permute qkv_proj weight rows from [q0|g0|q1|g1|...|K|V] to [Q|K|V|G].
 
-        Load-time-only transform enabling the copy-free gate path in forward. Only
-        engaged for plain (unquantized) weights with a backend that supports the
-        strided [Q|K|V] view in both context and generation paths.
+        Load-time-only transform enabling the copy-free gate path in forward.
+        Engaged for plain weights and per-tensor FP8 QDQ weights with a backend
+        that supports the strided [Q|K|V] view in both context and generation
+        paths. The FP8 weight scale is scalar and does not need to be permuted.
         """
         if not self._gate_tail_layout_enabled or self._gate_tail_layout_active:
             return
-        has_quant = (self.quant_config is not None
-                     and self.quant_config.layer_quant_mode.has_any_quant(
-                         exclude_kv_cache=True))
+        has_quant = getattr(self.qkv_proj, "has_any_quant", False)
+        has_fp8_qdq = getattr(self.qkv_proj, "has_fp8_qdq", False)
+        weight_scale = getattr(self.qkv_proj, "weight_scale", None)
+        has_supported_weight = (
+            not has_quant and self.qkv_proj.weight.dtype
+            in (torch.bfloat16, torch.float16, torch.float32)
+        ) or (has_fp8_qdq and self.qkv_proj.weight.dtype == torch.float8_e4m3fn
+              and weight_scale is not None and weight_scale.numel() == 1)
         supports_strided_qkv = getattr(self.attn, "support_strided_fused_qkv",
                                        lambda: False)()
         supported = (self.attn_backend == "TRTLLM" and self.support_fused_qkv
                      and supports_strided_qkv
                      and getattr(self, "fuse_qk_norm_rope", False)
-                     and not getattr(self, "skip_rope", False) and not has_quant
-                     and self.mapping.cp_size == 1
-                     and self.qkv_proj.weight.dtype
-                     in (torch.bfloat16, torch.float16, torch.float32))
+                     and not getattr(self, "skip_rope", False)
+                     and self.mapping.cp_size == 1 and has_supported_weight)
         if not supported:
             logger.warning_once(
                 "Gate-tail QKV layout is not supported for this attention "

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -14,11 +14,13 @@
 # limitations under the License.
 
 import math
+import os
 from typing import Optional
 
 import torch
 from transformers import PretrainedConfig
 
+from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend.interface import PositionalEmbeddingParams
@@ -178,6 +180,13 @@ class QKNormRoPEAttention(Attention):
         rope_fusion &= (not self.fuse_qk_norm_rope and not skip_rope
                         and not attn_output_gate and not use_gemma_rms_norm)
         self.is_qk_norm = is_qk_norm
+        self._gate_tail_fused_preprocess_requested = (
+            bool(attn_output_gate) and fuse_qk_norm_rope and is_qk_norm
+            and use_gemma_rms_norm and not skip_rope
+            and os.environ.get("TRTLLM_ATTN_GATE_TAIL_LAYOUT", "0") == "1"
+            and os.environ.get("TRTLLM_ATTN_GATE_TAIL_FUSED_PREPROCESS",
+                               "0") == "1")
+        self._gate_tail_fused_preprocess_active = False
         assert not (fuse_qk_norm_rope and skip_rope
                     ), "Fusing qk norm and skipping rope is not supported"
 
@@ -212,6 +221,42 @@ class QKNormRoPEAttention(Attention):
                               use_gemma=use_gemma_rms_norm)
         self.aux_stream = torch.cuda.Stream()
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
+
+    def post_load_weights(self):
+        super().post_load_weights()
+        if not self._gate_tail_fused_preprocess_requested:
+            return
+
+        supported = (self._gate_tail_layout_active and self.mapping.cp_size == 1
+                     and self.head_dim == 256
+                     and self.qkv_proj.weight.dtype == torch.bfloat16
+                     and self.q_norm.weight is not None
+                     and self.k_norm.weight is not None
+                     and self.q_norm.weight.dtype == torch.bfloat16
+                     and self.k_norm.weight.dtype == torch.bfloat16
+                     and self.pos_embd_params is not None
+                     and self.pos_embd_params.rope is not None
+                     and self.pos_embd_params.is_neox
+                     and hasattr(self.attn, "configure_qk_norm_preprocessing"))
+        if not supported:
+            logger.warning_once(
+                "TRTLLM_ATTN_GATE_TAIL_FUSED_PREPROCESS requested but not "
+                "supported for this attention configuration; keeping the "
+                "standalone fused QK-norm/RoPE kernel.",
+                key="gate_tail_fused_preprocess_unsupported")
+            return
+
+        self.attn.configure_qk_norm_preprocessing(
+            self.pos_embd_params,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            self.q_norm.variance_epsilon,
+            self.use_gemma_rms_norm,
+        )
+        self._gate_tail_fused_preprocess_active = True
+        logger.info_once(
+            "gate-tail QK-norm/RoPE fused into attention preprocessing",
+            key="gate_tail_fused_preprocess_engaged")
 
     def apply_qk_norm(self, q, k):
 
@@ -258,18 +303,28 @@ class QKNormRoPEAttention(Attention):
                 torch.int32)
             mrope_section1, mrope_section2 = mrope_section[1], mrope_section[2]
         else:
-            position_ids_arg = position_ids.reshape(-1).contiguous().to(
-                torch.int32)
+            # position_ids is identical for every layer; cache the flattened int32
+            # copy on the tensor object so the cast runs once per forward instead
+            # of once per layer (fresh position_ids objects are created each step).
+            position_ids_arg = getattr(position_ids, "_tllm_flat_int32", None)
+            if position_ids_arg is None:
+                position_ids_arg = position_ids.reshape(-1).contiguous().to(
+                    torch.int32)
+                position_ids._tllm_flat_int32 = position_ids_arg
             mrope_section1, mrope_section2 = 0, 0
 
+        # The kernel never touches V heads, so any extra trailing dims (e.g. the gate
+        # tail of the [Q|K|V|G] layout) are declared as pass-through V heads.
+        num_heads_v = (qkv.shape[-1] // self.head_dim - self.num_heads -
+                       self.num_key_value_heads)
         torch.ops.trtllm.fused_qk_norm_rope(
-            qkv, self.num_heads, self.num_key_value_heads,
-            self.num_key_value_heads, self.head_dim, rotary_dim,
-            self.q_norm.variance_epsilon, self.q_norm.weight,
-            self.k_norm.weight, self.pos_embd_params.rope.theta,
-            self.pos_embd_params.is_neox, position_ids_arg, factor, low, high,
-            attention_factor, self.is_qk_norm, self.use_gemma_rms_norm,
-            use_mrope, mrope_section1, mrope_section2)
+            qkv, self.num_heads, self.num_key_value_heads, num_heads_v,
+            self.head_dim, rotary_dim, self.q_norm.variance_epsilon,
+            self.q_norm.weight, self.k_norm.weight,
+            self.pos_embd_params.rope.theta, self.pos_embd_params.is_neox,
+            position_ids_arg, factor, low, high, attention_factor,
+            self.is_qk_norm, self.use_gemma_rms_norm, use_mrope, mrope_section1,
+            mrope_section2)
         return qkv, None, None
 
     def apply_rope(self, q: torch.Tensor, k: Optional[torch.Tensor],
@@ -278,6 +333,13 @@ class QKNormRoPEAttention(Attention):
         The apply_rope method is called in the forward method of the Attention class.
         The apply_rope method is overridden in this class to apply QK norm and RoPE to the input tensor.
         """
+        # The attention preprocessing kernel applies QK norm and RoPE while it
+        # writes packed Q and the paged KV cache. Keep the raw gate-tail tensor
+        # here so no intermediate Q/K global-memory round trip is introduced.
+        if self._gate_tail_fused_preprocess_active:
+            assert k is None and v is None
+            return q, None, None
+
         # Apply QK norm before RoPE.
         if not self.fuse_qk_norm_rope:
             q, k, v = self.split_qkv(q, k, v)

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import math
-import os
 from typing import Optional
 
 import torch
@@ -180,12 +179,11 @@ class QKNormRoPEAttention(Attention):
         rope_fusion &= (not self.fuse_qk_norm_rope and not skip_rope
                         and not attn_output_gate and not use_gemma_rms_norm)
         self.is_qk_norm = is_qk_norm
-        self._gate_tail_fused_preprocess_requested = (
-            bool(attn_output_gate) and fuse_qk_norm_rope and is_qk_norm
-            and use_gemma_rms_norm and not skip_rope
-            and os.environ.get("TRTLLM_ATTN_GATE_TAIL_LAYOUT", "0") == "1"
-            and os.environ.get("TRTLLM_ATTN_GATE_TAIL_FUSED_PREPROCESS",
-                               "0") == "1")
+        self._gate_tail_fused_preprocess_enabled = (bool(attn_output_gate)
+                                                    and fuse_qk_norm_rope
+                                                    and is_qk_norm
+                                                    and use_gemma_rms_norm
+                                                    and not skip_rope)
         self._gate_tail_fused_preprocess_active = False
         assert not (fuse_qk_norm_rope and skip_rope
                     ), "Fusing qk norm and skipping rope is not supported"
@@ -224,7 +222,7 @@ class QKNormRoPEAttention(Attention):
 
     def post_load_weights(self):
         super().post_load_weights()
-        if not self._gate_tail_fused_preprocess_requested:
+        if not self._gate_tail_fused_preprocess_enabled:
             return
 
         supported = (self._gate_tail_layout_active and self.mapping.cp_size == 1
@@ -240,9 +238,9 @@ class QKNormRoPEAttention(Attention):
                      and hasattr(self.attn, "configure_qk_norm_preprocessing"))
         if not supported:
             logger.warning_once(
-                "TRTLLM_ATTN_GATE_TAIL_FUSED_PREPROCESS requested but not "
-                "supported for this attention configuration; keeping the "
-                "standalone fused QK-norm/RoPE kernel.",
+                "Gate-tail fused QK-norm/RoPE preprocessing is not supported "
+                "for this attention configuration; keeping the standalone "
+                "fused QK-norm/RoPE kernel.",
                 key="gate_tail_fused_preprocess_unsupported")
             return
 

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -227,7 +227,7 @@ class QKNormRoPEAttention(Attention):
 
         supported = (self._gate_tail_layout_active and self.mapping.cp_size == 1
                      and self.head_dim == 256
-                     and self.qkv_proj.weight.dtype == torch.bfloat16
+                     and self.qkv_proj.dtype == torch.bfloat16
                      and self.q_norm.weight is not None
                      and self.k_norm.weight is not None
                      and self.q_norm.weight.dtype == torch.bfloat16

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -220,13 +220,21 @@ class QKNormRoPEAttention(Attention):
         self.aux_stream = torch.cuda.Stream()
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
 
-    def post_load_weights(self):
-        super().post_load_weights()
-        if not self._gate_tail_fused_preprocess_enabled:
-            return
+    def cache_derived_state(self):
+        super().cache_derived_state()
+        self._configure_gate_tail_fused_preprocess()
 
-        supported = (self._gate_tail_layout_active and self.mapping.cp_size == 1
-                     and self.head_dim == 256
+    def _configure_gate_tail_fused_preprocess(self):
+        """Restore the fused QK-norm/RoPE preprocessing config on the attention op.
+
+        Derived-state stage: recomputed from the currently loaded weights on every
+        load path, including GMS read-only sharing (which only runs
+        cache_derived_state, not the weight transform). Depends on the base gate-tail
+        layout already being resolved by ``super().cache_derived_state()``.
+        """
+        supported = (self._gate_tail_fused_preprocess_enabled
+                     and self._gate_tail_layout_active
+                     and self.mapping.cp_size == 1 and self.head_dim == 256
                      and self.qkv_proj.dtype == torch.bfloat16
                      and self.q_norm.weight is not None
                      and self.k_norm.weight is not None
@@ -237,11 +245,13 @@ class QKNormRoPEAttention(Attention):
                      and self.pos_embd_params.is_neox
                      and hasattr(self.attn, "configure_qk_norm_preprocessing"))
         if not supported:
-            logger.warning_once(
-                "Gate-tail fused QK-norm/RoPE preprocessing is not supported "
-                "for this attention configuration; keeping the standalone "
-                "fused QK-norm/RoPE kernel.",
-                key="gate_tail_fused_preprocess_unsupported")
+            self._gate_tail_fused_preprocess_active = False
+            if self._gate_tail_fused_preprocess_enabled:
+                logger.warning_once(
+                    "Gate-tail fused QK-norm/RoPE preprocessing is not supported "
+                    "for this attention configuration; keeping the standalone "
+                    "fused QK-norm/RoPE kernel.",
+                    key="gate_tail_fused_preprocess_unsupported")
             return
 
         self.attn.configure_qk_norm_preprocessing(

--- a/tests/unittest/_torch/attention/test_gate_tail_layout.py
+++ b/tests/unittest/_torch/attention/test_gate_tail_layout.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+import tensorrt_llm._torch.attention_backend.trtllm as trtllm_backend
+from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttention
+from tensorrt_llm._torch.modules.attention import Attention
+
+
+@pytest.mark.parametrize(
+    "sm, expected", [(90, False), (100, True), (103, True), (120, False), (121, False)]
+)
+def test_strided_fused_qkv_backend_capability(monkeypatch, sm, expected):
+    monkeypatch.setattr(trtllm_backend, "get_sm_version", lambda: sm)
+    assert TrtllmAttention.support_strided_fused_qkv() is expected
+
+
+def _make_gate_tail_attention(support_strided_fused_qkv: bool) -> Attention:
+    attention = object.__new__(Attention)
+    nn.Module.__init__(attention)
+    attention._gate_tail_layout_enabled = True
+    attention._gate_tail_layout_active = False
+    attention.attn_backend = "TRTLLM"
+    attention.support_fused_qkv = True
+    attention.fuse_qk_norm_rope = True
+    attention.skip_rope = False
+    attention.quant_config = None
+    attention.mapping = SimpleNamespace(cp_size=1)
+    attention.num_heads = 2
+    attention.head_dim = 2
+    attention.q_size = 4
+    attention.kv_size = 2
+    attention.attn = SimpleNamespace(support_strided_fused_qkv=lambda: support_strided_fused_qkv)
+
+    attention.qkv_proj = nn.Linear(1, 12, bias=False)
+    with torch.no_grad():
+        attention.qkv_proj.weight.copy_(torch.arange(12).reshape(12, 1))
+    return attention
+
+
+@pytest.mark.parametrize("supported", [False, True])
+def test_gate_tail_layout_respects_backend_capability(supported):
+    attention = _make_gate_tail_attention(supported)
+    attention._maybe_permute_gate_tail_layout()
+
+    expected_rows = [0, 1, 4, 5, 8, 9, 10, 11, 2, 3, 6, 7] if supported else list(range(12))
+    torch.testing.assert_close(
+        attention.qkv_proj.weight[:, 0], torch.tensor(expected_rows, dtype=torch.float32)
+    )
+    assert attention._gate_tail_layout_active is supported

--- a/tests/unittest/_torch/attention/test_gate_tail_layout.py
+++ b/tests/unittest/_torch/attention/test_gate_tail_layout.py
@@ -20,7 +20,11 @@ def test_strided_fused_qkv_backend_capability(monkeypatch, sm, expected):
     assert TrtllmAttention.support_strided_fused_qkv() is expected
 
 
-def _make_gate_tail_attention(support_strided_fused_qkv: bool) -> Attention:
+def _make_gate_tail_attention(
+    support_strided_fused_qkv: bool,
+    *,
+    quant_kind: str = "none",
+) -> Attention:
     attention = object.__new__(Attention)
     nn.Module.__init__(attention)
     attention._gate_tail_layout_enabled = True
@@ -40,6 +44,14 @@ def _make_gate_tail_attention(support_strided_fused_qkv: bool) -> Attention:
     attention.qkv_proj = nn.Linear(1, 12, bias=False)
     with torch.no_grad():
         attention.qkv_proj.weight.copy_(torch.arange(12).reshape(12, 1))
+    attention.qkv_proj.has_any_quant = quant_kind != "none"
+    attention.qkv_proj.has_fp8_qdq = quant_kind == "fp8_qdq"
+    if quant_kind == "fp8_qdq":
+        attention.qkv_proj.weight = nn.Parameter(
+            attention.qkv_proj.weight.to(torch.float8_e4m3fn),
+            requires_grad=False,
+        )
+        attention.qkv_proj.weight_scale = nn.Parameter(torch.tensor(0.125), requires_grad=False)
     return attention
 
 
@@ -53,3 +65,24 @@ def test_gate_tail_layout_respects_backend_capability(supported):
         attention.qkv_proj.weight[:, 0], torch.tensor(expected_rows, dtype=torch.float32)
     )
     assert attention._gate_tail_layout_active is supported
+
+
+def test_gate_tail_layout_supports_fp8_qdq():
+    attention = _make_gate_tail_attention(True, quant_kind="fp8_qdq")
+    original_weight_scale = attention.qkv_proj.weight_scale.clone()
+    attention._maybe_permute_gate_tail_layout()
+
+    expected_rows = torch.tensor([0, 1, 4, 5, 8, 9, 10, 11, 2, 3, 6, 7], dtype=torch.float32)
+    torch.testing.assert_close(attention.qkv_proj.weight[:, 0].float(), expected_rows)
+    torch.testing.assert_close(attention.qkv_proj.weight_scale, original_weight_scale)
+    assert attention._gate_tail_layout_active
+
+
+def test_gate_tail_layout_rejects_other_quantization():
+    attention = _make_gate_tail_attention(True, quant_kind="unsupported")
+    attention._maybe_permute_gate_tail_layout()
+
+    torch.testing.assert_close(
+        attention.qkv_proj.weight[:, 0], torch.arange(12, dtype=torch.float32)
+    )
+    assert not attention._gate_tail_layout_active


### PR DESCRIPTION
It's a successor version of #16024 

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for strided fused QKV inputs in supported attention paths.
  * Added optional fused Q/K RMSNorm preprocessing, including Gemma-style normalization.
  * Added gate-tail QKV layout support for compatible attention configurations.
  * Exposed new normalization options through the attention API.
* **Bug Fixes**
  * Added validation and clearer fallback behavior for unsupported layouts, data types, and configurations.
* **Tests**
  * Added coverage for gate-tail layouts, backend capability detection, and quantized weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->