### PR TITLE
[https://nvbugs/6437342][fix] Add `--dist=loadfile` to the child pytest cmd list so all tests in one file…

### DIFF
--- a/tests/unittest/auto_deploy/standalone/test_standalone_package.py
+++ b/tests/unittest/auto_deploy/standalone/test_standalone_package.py
@@ -271,6 +271,14 @@ class TestStandalonePackage:
             "pytest",
             os.path.join(tests_dir, "singlegpu"),
             "-q",
+            # loadfile: all tests in one file run on the same worker in
+            # file-declaration order. Without it xdist's default `load` mode
+            # dynamically interleaves tests across workers, so module-level
+            # torch.manual_seed(...) no longer produces a stable RNG state at
+            # each test entry — occasionally tripping tight numerical
+            # tolerances in flashinfer_mla / gemm_fusion. See the comment in
+            # tests/.../rope/test_rope_op_variants.py:28.
+            "--dist=loadfile",
             # Parallelize across CPU workers; pytest-xdist is in [dev] extras.
             "-n",
             "4",


### PR DESCRIPTION
## Summary
- **Root cause**: pytest -n 4 subprocess uses xdist's default `--dist=load` which dispatches tests dynamically across workers, breaking module-level torch.manual_seed(0) determinism and intermittently tripping tight tolerances in numerical child tests (flashinfer_mla, gemm_fusion) and mem_get_info-based assertions (piecewise_memory).
- **Fix**: Add `--dist=loadfile` to the child pytest cmd list so all tests in one file run on the same worker in file-declaration order; keep `-n 4` for wall-clock, but restore deterministic in-file execution so per-test RNG state is reproducible.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6437342


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution stability by enforcing deterministic ordering for standalone parallel test runs.
  * Reduced intermittent numerical tolerance failures caused by inconsistent test ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->