### PR TITLE
[None][fix] Prevent special tokens leaking into detokenized output on slow tokenizers

### DIFF
--- a/tensorrt_llm/tokenizer/tokenizer.py
+++ b/tensorrt_llm/tokenizer/tokenizer.py
@@ -207,19 +207,8 @@ class TransformersTokenizer(TokenizerBase):
 
     def __init__(self, tokenizer):
         self.tokenizer = tokenizer
-        if hasattr(self.tokenizer, "all_special_tokens"):
-            self._all_special_tokens_set = set(
-                self.tokenizer.all_special_tokens)
-        else:
-            self._all_special_tokens_set = set()
-        # Cache of special-token ids used by convert_ids_to_tokens to work
-        # around an O(N*K) bug in transformers 5.x's slow tokenizer path
-        # (see convert_ids_to_tokens below).  Computed once here so we don't
-        # rebuild it on every per-token streaming call.
-        try:
-            self._all_special_ids_set = set(self.tokenizer.all_special_ids)
-        except (AttributeError, NotImplementedError):
-            self._all_special_ids_set = set()
+        # (ids, strings) special-token sets, computed lazily on first detok.
+        self._special_tokens_sets = None
 
     def __reduce__(self):
         # In multi-node scenarios, AutoTokenizer.from_pretrained with
@@ -344,23 +333,30 @@ class TransformersTokenizer(TokenizerBase):
         inner = self.tokenizer
         if (isinstance(ids, int) or not skip_special_tokens
                 or getattr(inner, "is_fast", False)):
-            # Single id: no loop.  Fast tokenizer: tokenization_utils_tokenizers
-            # already caches all_special_ids before the loop.  Without skip:
-            # the buggy branch is short-circuited.
+            # Fast / no-skip / single-id paths skip the slow O(N*K) branch below.
             return inner.convert_ids_to_tokens(
                 ids, skip_special_tokens=skip_special_tokens)
-        # Slow PreTrainedTokenizer.convert_ids_to_tokens in transformers 5.x
-        # tests `index in self.all_special_ids` inside the per-id loop, and
-        # `all_special_ids` is an @property that rebuilds the list on every
-        # access via convert_tokens_to_ids(self.all_special_tokens).  The fast
-        # subclass already hoists this out of the loop (see
-        # tokenization_utils_tokenizers.py), but the slow base class wasn't
-        # updated.  Mirror that fix using the set we cached in __init__,
-        # which keeps streaming detokenization at O(1) all-special-ids cost
-        # per call regardless of batch size or stream_interval.
+        # Slow path rebuilds all_special_ids per id; cache it: O(N*K) -> O(N).
         tokens = inner.convert_ids_to_tokens(ids, skip_special_tokens=False)
-        special_ids = self._all_special_ids_set
+        special_ids = self._special_tokens()[0]
         return [t for idx, t in zip(ids, tokens) if int(idx) not in special_ids]
+
+    def _special_tokens(self) -> Tuple[set, set]:
+        """(ids, strings) special-token sets, computed once on first detok.
+
+        Deferred from __init__, which is too early: an input processor may
+        register specials after wrapping but before serving (e.g. gemma4's
+        <|video|>). Detok starts later and nothing mutates specials mid-stream,
+        so a first-use cache is correct and O(1) per streamed token.
+        """
+        if self._special_tokens_sets is None:
+            inner = self.tokenizer
+            try:
+                self._special_tokens_sets = (set(inner.all_special_ids),
+                                             set(inner.all_special_tokens))
+            except (AttributeError, NotImplementedError):
+                self._special_tokens_sets = (set(), set())
+        return self._special_tokens_sets
 
     def convert_tokens_to_string(
             self,
@@ -372,10 +368,13 @@ class TransformersTokenizer(TokenizerBase):
         if self.is_fast or not self.get_added_vocab():
             return self.tokenizer.convert_tokens_to_string(tokens)
 
+        special_tokens = ()
+        if skip_special_tokens:
+            special_tokens = self._special_tokens()[1]
         sub_texts: List[str] = []
         current_sub_text: List[str] = []
         for token in tokens:
-            if skip_special_tokens and token in self._all_special_tokens_set:
+            if skip_special_tokens and token in special_tokens:
                 continue
             if token in self.get_added_vocab():
                 if current_sub_text:

--- a/tensorrt_llm/tokenizer/tokenizer.py
+++ b/tensorrt_llm/tokenizer/tokenizer.py
@@ -201,19 +201,8 @@ class TransformersTokenizer(TokenizerBase):
 
     def __init__(self, tokenizer):
         self.tokenizer = tokenizer
-        if hasattr(self.tokenizer, "all_special_tokens"):
-            self._all_special_tokens_set = set(
-                self.tokenizer.all_special_tokens)
-        else:
-            self._all_special_tokens_set = set()
-        # Cache of special-token ids used by convert_ids_to_tokens to work
-        # around an O(N*K) bug in transformers 5.x's slow tokenizer path
-        # (see convert_ids_to_tokens below).  Computed once here so we don't
-        # rebuild it on every per-token streaming call.
-        try:
-            self._all_special_ids_set = set(self.tokenizer.all_special_ids)
-        except (AttributeError, NotImplementedError):
-            self._all_special_ids_set = set()
+        # (ids, strings) special-token sets, computed lazily on first detok.
+        self._special_tokens_sets = None
 
     def __reduce__(self):
         # In multi-node scenarios, AutoTokenizer.from_pretrained with
@@ -338,23 +327,30 @@ class TransformersTokenizer(TokenizerBase):
         inner = self.tokenizer
         if (isinstance(ids, int) or not skip_special_tokens
                 or getattr(inner, "is_fast", False)):
-            # Single id: no loop.  Fast tokenizer: tokenization_utils_tokenizers
-            # already caches all_special_ids before the loop.  Without skip:
-            # the buggy branch is short-circuited.
+            # Fast / no-skip / single-id paths skip the slow O(N*K) branch below.
             return inner.convert_ids_to_tokens(
                 ids, skip_special_tokens=skip_special_tokens)
-        # Slow PreTrainedTokenizer.convert_ids_to_tokens in transformers 5.x
-        # tests `index in self.all_special_ids` inside the per-id loop, and
-        # `all_special_ids` is an @property that rebuilds the list on every
-        # access via convert_tokens_to_ids(self.all_special_tokens).  The fast
-        # subclass already hoists this out of the loop (see
-        # tokenization_utils_tokenizers.py), but the slow base class wasn't
-        # updated.  Mirror that fix using the set we cached in __init__,
-        # which keeps streaming detokenization at O(1) all-special-ids cost
-        # per call regardless of batch size or stream_interval.
+        # Slow path rebuilds all_special_ids per id; cache it: O(N*K) -> O(N).
         tokens = inner.convert_ids_to_tokens(ids, skip_special_tokens=False)
-        special_ids = self._all_special_ids_set
+        special_ids = self._special_tokens()[0]
         return [t for idx, t in zip(ids, tokens) if int(idx) not in special_ids]
+
+    def _special_tokens(self) -> Tuple[set, set]:
+        """(ids, strings) special-token sets, computed once on first detok.
+
+        Deferred from __init__, which is too early: an input processor may
+        register specials after wrapping but before serving (e.g. gemma4's
+        <|video|>). Detok starts later and nothing mutates specials mid-stream,
+        so a first-use cache is correct and O(1) per streamed token.
+        """
+        if self._special_tokens_sets is None:
+            inner = self.tokenizer
+            try:
+                self._special_tokens_sets = (set(inner.all_special_ids),
+                                             set(inner.all_special_tokens))
+            except (AttributeError, NotImplementedError):
+                self._special_tokens_sets = (set(), set())
+        return self._special_tokens_sets
 
     def convert_tokens_to_string(
             self,
@@ -366,10 +362,13 @@ class TransformersTokenizer(TokenizerBase):
         if self.is_fast or not self.get_added_vocab():
             return self.tokenizer.convert_tokens_to_string(tokens)
 
+        special_tokens = ()
+        if skip_special_tokens:
+            special_tokens = self._special_tokens()[1]
         sub_texts: List[str] = []
         current_sub_text: List[str] = []
         for token in tokens:
-            if skip_special_tokens and token in self._all_special_tokens_set:
+            if skip_special_tokens and token in special_tokens:
                 continue
             if token in self.get_added_vocab():
                 if current_sub_text:

--- a/tests/unittest/llmapi/test_tokenizer_decode.py
+++ b/tests/unittest/llmapi/test_tokenizer_decode.py
@@ -17,8 +17,81 @@ from tokenizers import Tokenizer
 from tokenizers.decoders import ByteFallback, Fuse, Sequence
 from tokenizers.models import WordLevel
 from transformers import PreTrainedTokenizerFast
+from transformers.tokenization_utils import PreTrainedTokenizer
 
 from tensorrt_llm.tokenizer import TransformersTokenizer
+
+
+class _ToySlowTokenizer(PreTrainedTokenizer):
+    """A minimal genuine *slow* tokenizer (``is_fast`` is False).
+
+    The slow ``convert_ids_to_tokens`` path is the only one that filters
+    special tokens in TransformersTokenizer's wrapper; fast tokenizers delegate
+    straight to the backend.  This toy tokenizer lets us exercise that path
+    deterministically without downloading weights.
+    """
+
+    def __init__(self, **kwargs):
+        self._vocab = {f"tok{i}": i for i in range(64)}
+        self._ids = {v: k for k, v in self._vocab.items()}
+        super().__init__(**kwargs)
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self._vocab)
+
+    def get_vocab(self):
+        return dict(self._vocab)
+
+    def _convert_token_to_id(self, token):
+        return self._vocab.get(token, 0)
+
+    def _convert_id_to_token(self, index):
+        return self._ids.get(int(index), "tok0")
+
+    def _tokenize(self, text):
+        return text.split()
+
+
+def test_convert_ids_to_tokens_reflects_special_tokens_registered_after_wrap() -> None:
+    # Specials registered after wrapping (before first detok) must be reflected.
+    inner = _ToySlowTokenizer()
+    inner.add_special_tokens(
+        {
+            "bos_token": "tok1",
+            "eos_token": "tok2",
+            "additional_special_tokens": ["tok5"],
+        }
+    )
+    tokenizer = TransformersTokenizer(inner)
+    assert inner.is_fast is False
+
+    inner.add_special_tokens({"additional_special_tokens": ["tok5", "tok42"]})
+
+    ids = [10, 42, 11, 5, 12]
+    got = tokenizer.convert_ids_to_tokens(ids, skip_special_tokens=True)
+    assert got == inner.convert_ids_to_tokens(ids, skip_special_tokens=True)
+    assert got == ["tok10", "tok11", "tok12"]
+
+
+def test_convert_tokens_to_string_reflects_special_tokens_registered_after_wrap() -> None:
+    # The same must hold for convert_tokens_to_string's skip path.
+    inner = _ToySlowTokenizer()
+    inner.add_special_tokens(
+        {
+            "bos_token": "tok1",
+            "eos_token": "tok2",
+            "additional_special_tokens": ["tok5"],
+        }
+    )
+    tokenizer = TransformersTokenizer(inner)
+    assert inner.is_fast is False
+
+    inner.add_special_tokens({"additional_special_tokens": ["tok5", "tok42"]})
+
+    tokens = ["tok10", "tok42", "tok11"]
+    got = tokenizer.convert_tokens_to_string(tokens, skip_special_tokens=True)
+    assert got == "tok10 tok11"
 
 
 def test_hf_decode_incrementally_recovers_from_invalid_prefix() -> None:


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This pull request refactors how special tokens are handled in the `TransformersTokenizer` class to ensure that any special tokens registered after the tokenizer is wrapped are correctly recognized during detokenization. It also adds new tests to verify this behavior, especially for slow tokenizers. The changes improve correctness and efficiency, particularly when handling streamed detokenization and special tokens.

### Special Token Handling Improvements

* Changed special-token set computation in `TransformersTokenizer` to be lazy and cached on first detokenization, instead of computed at initialization. This ensures that special tokens registered after wrapping (but before serving) are recognized, and improves performance by avoiding repeated computation. (`tensorrt_llm/tokenizer/tokenizer.py`) [[1]](diffhunk://#diff-139d8fb04b0aa8c7549928e36afdf8e9f9710aff8acbbda044bd31fc7ac9fcc0L200-R201) [[2]](diffhunk://#diff-139d8fb04b0aa8c7549928e36afdf8e9f9710aff8acbbda044bd31fc7ac9fcc0L337-R350)
* Updated the `convert_ids_to_tokens` and `convert_tokens_to_string` methods to use the new cached special-token sets, ensuring correctness when skipping special tokens. (`tensorrt_llm/tokenizer/tokenizer.py`) [[1]](diffhunk://#diff-139d8fb04b0aa8c7549928e36afdf8e9f9710aff8acbbda044bd31fc7ac9fcc0L337-R350) [[2]](diffhunk://#diff-139d8fb04b0aa8c7549928e36afdf8e9f9710aff8acbbda044bd31fc7ac9fcc0R361-R367)

### Testing Enhancements

* Added a minimal "slow" tokenizer class (`_ToySlowTokenizer`) and two new tests to verify that special tokens registered after wrapping are properly recognized and skipped during detokenization and string conversion. (`tests/unittest/llmapi/test_tokenizer_decode.py`)

These changes ensure that the tokenizer wrapper behaves correctly with dynamic special token registration and that performance is maintained for streamed detokenization.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review
- **Correctness:** Refactored `TransformersTokenizer` special-token handling to avoid stale, init-time snapshots when special tokens are registered/modified after the wrapper is constructed. Replaced eager caching with a lazy, first-use cache (`self._special_tokens_sets`) derived from `inner.all_special_ids` / `inner.all_special_tokens`.
- **Behavior changes:**
  - `convert_ids_to_tokens(..., skip_special_tokens=True)` now uses a slow-path filter driven by the memoized special-id set from `self._special_tokens()[0]`, so newly registered special tokens are correctly skipped.
  - `convert_tokens_to_string(..., skip_special_tokens=True)` consults memoized special-token strings from `self._special_tokens()[1]` for the wrapper’s custom detokenization/skip path.
- **Caching/performance:** Special-token sets are computed once on first use and reused, removing repeated O(K) rebuilding overhead and still preserving correct behavior for late special-token registration.
- **Robustness/error handling:** The lazy helper falls back to empty sets if the wrapped tokenizer doesn’t provide the required `all_special_ids` / `all_special_tokens` attributes (handling `AttributeError` / `NotImplementedError`).
- **CI notes:** Multiple CI runs show mixed outcomes (some L0 failures, some successes). The added targeted unit tests specifically cover the late-special-token registration + skip behavior to help validate the refactor.

## QA Engineer Review
- **Test changes:** `tests/unittest/llmapi/test_tokenizer_decode.py`
  - Added `_ToySlowTokenizer(PreTrainedTokenizer)` to force deterministic slow-path behavior.
  - Added `test_convert_ids_to_tokens_reflects_special_tokens_registered_after_wrap`
  - Added `test_convert_tokens_to_string_reflects_special_tokens_registered_after_wrap`
- **Coverage mapping (tests/integration/test_lists/):** No references to the new test names were found in `tests/integration/test_lists/`.
- **Verdict:** needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->