### PR TITLE
[None][feat] Generic Mixed Modality Support

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -15,10 +15,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import itertools
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     ClassVar,
     Dict,
     Hashable,
@@ -27,6 +29,8 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
+    Union,
 )
 
 import torch
@@ -38,14 +42,125 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams, MultimodalRuntimeDa
 from tensorrt_llm.logger import logger
 
 from .modeling_multimodal_utils import (
-    EncoderGroup,
     _cache_multimodal_embeddings,
-    _lengths_by_modality,
-    _reorder_embeds_by_manifest,
     find_input_mm_embeds,
     fuse_input_embeds,
     get_multimodal_embeddings,
 )
+
+
+@dataclass(frozen=True)
+class EncoderGroup:
+    """Modalities that share a single encoder call.
+
+    Batching all items in a group into one encoder invocation amortizes
+    fixed costs (kernel launches, dispatch) across items. The framework
+    splits the output back per-modality and reorders it into prompt order
+    via each request's `mm_item_order` manifest.
+
+    Contract between `build_batched_input` and `encoder_fn`:
+
+    * `build_batched_input` must concatenate items across requests in
+      `modalities` order (all items for the first modality across requests,
+      then all items for the second modality, etc.).
+    * Within a modality, items must appear in the same per-request iteration
+      order that `_lengths_by_modality` uses (i.e. the order of
+      `multimodal_params` passed in).
+    * `encoder_fn` must return one tensor whose rows correspond 1:1 to the
+      input layout produced by `build_batched_input`, so the framework can
+      split the output by `_lengths_by_modality` and reorder into prompt
+      order via each request's `mm_item_order` manifest.
+    """
+
+    modalities: Tuple[str, ...]
+    """Ordered modality names that share this encoder. Defines the row
+    layout of the encoder output tensor: first all items of
+    `modalities[0]`, then all items of `modalities[1]`, etc."""
+
+    encoder_fn: Callable[..., torch.Tensor]
+    """Encoder call invoked as `encoder_fn(**build_batched_input(params))`.
+    Returns a single tensor with one row per embedding, laid out per the
+    contract above."""
+
+    build_batched_input: Callable[[List[MultimodalParams]], Dict[str, Any]]
+    """Builds the kwargs dict passed to `encoder_fn`. Responsible for
+    concatenating raw per-item tensors from `multimodal_data` across
+    requests in the order described in the class docstring."""
+
+
+def _lengths_by_modality(
+    multimodal_params: List[MultimodalParams],
+    modalities: Tuple[str, ...],
+) -> Dict[str, List[int]]:
+    """Invert prompt-ordered `multimodal_embedding_lengths` (number of
+    embedding rows per item) into per-modality per-item lengths, matching
+    the per-modality item order used by `EncoderGroup.build_batched_input`.
+    """
+    by_modality: Dict[str, List[int]] = {m: [] for m in modalities}
+    for mp in multimodal_params:
+        flat = mp.multimodal_data.get("multimodal_embedding_lengths") or []
+        if mp.mm_item_order:
+            for entry, length in zip(mp.mm_item_order, flat, strict=True):
+                if entry["modality"] in by_modality:
+                    by_modality[entry["modality"]].append(length)
+            continue
+        # Raw-prompt entrypoints (non chat-parsing) do not attach a manifest,
+        # so this is the single enforcement point that a >1-modality request
+        # must carry `mm_item_order` to make prompt-order reordering possible.
+        present = [m for m in modalities if mp.multimodal_data.get(m) is not None]
+        if len(present) > 1:
+            raise ValueError(
+                "Request with multiple modalities present "
+                f"({present}) must carry mm_item_order on MultimodalParams."
+            )
+        if present:
+            by_modality[present[0]].extend(flat)
+    return by_modality
+
+
+def _reorder_embeds_by_manifest(
+    multimodal_params: List[MultimodalParams],
+    per_modality_embeds: Dict[str, torch.Tensor],
+    per_modality_lengths: Dict[str, List[int]],
+) -> torch.Tensor:
+    """Slice per-modality tensors item-by-item and concat in prompt order."""
+    per_modality_row_starts: Dict[str, List[int]] = {
+        m: list(itertools.accumulate(lens, initial=0)) for m, lens in per_modality_lengths.items()
+    }
+
+    slices: List[torch.Tensor] = []
+    # `entry["index"]` is per-request per-modality; advance a cursor to
+    # translate it into a global item index within `per_modality_embeds`.
+    per_modality_cursor: Dict[str, int] = {m: 0 for m in per_modality_embeds}
+    for mp in multimodal_params:
+        manifest = mp.mm_item_order or _synthesize_single_modality_manifest(
+            mp, per_modality_embeds.keys()
+        )
+        req_counts: Dict[str, int] = {}
+        for entry in manifest:
+            m = entry["modality"]
+            if m not in per_modality_embeds:
+                continue
+            i = per_modality_cursor[m] + entry["index"]
+            starts = per_modality_row_starts[m]
+            slices.append(per_modality_embeds[m][starts[i] : starts[i + 1]])
+            req_counts[m] = req_counts.get(m, 0) + 1
+        for m, c in req_counts.items():
+            per_modality_cursor[m] += c
+    return torch.cat(slices, dim=0)
+
+
+def _synthesize_single_modality_manifest(
+    mp: MultimodalParams,
+    modalities: Iterable[str],
+) -> List[Dict[str, Union[str, int]]]:
+    """Trivial manifest for requests with only one modality present."""
+    flat = mp.multimodal_data.get("multimodal_embedding_lengths") or []
+    for m in modalities:
+        if mp.multimodal_data.get(m) is not None:
+            return [{"modality": m, "index": i} for i in range(len(flat))]
+    return []
+
 
 if TYPE_CHECKING:
     from ..pyexecutor.llm_request import LlmRequest
@@ -157,12 +272,11 @@ class MultimodalModelMixin:
 
         return module._apply(convert)
 
-    #: Per-model registration of encoder-batching groups. Each
-    #: :class:`EncoderGroup` bundles a set of modalities that share one
-    #: encoder call. Set as a class attribute or on ``self`` in ``__init__``
-    #: (when ``encoder_fn`` binds to instance methods). When populated,
-    #: ``encode_multimodal_by_groups`` handles batching, splitting, and
-    #: prompt-order reordering generically.
+    # Per-model registration of encoder-batching groups. Each `EncoderGroup`
+    # bundles a set of modalities that share one encoder call. Set as a class
+    # attribute or on `self` in `__init__` (when `encoder_fn` binds to instance
+    # methods). When populated, `encode_multimodal_by_groups` handles batching,
+    # splitting, and prompt-order reordering generically.
     mm_encoder_groups: Sequence[EncoderGroup] = ()
 
     def encode_multimodal_inputs(
@@ -205,10 +319,9 @@ class MultimodalModelMixin:
             cursor = 0
             for m in group.modalities:
                 total = sum(lengths[m])
-                if total > 0:
-                    per_modality_embeds[m] = out[cursor : cursor + total]
-                    per_modality_lengths[m] = lengths[m]
-                    cursor += total
+                per_modality_embeds[m] = out[cursor : cursor + total]
+                cursor += total
+            per_modality_lengths.update(lengths)
         return _reorder_embeds_by_manifest(
             multimodal_params, per_modality_embeds, per_modality_lengths
         )

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -147,6 +147,20 @@ def _reorder_embeds_by_manifest(
             req_counts[m] = req_counts.get(m, 0) + 1
         for m, c in req_counts.items():
             per_modality_cursor[m] += c
+    if not slices:
+        # No items resolved for any request. This happens on the executor's
+        # KV-cache profiling pass: `_encode_dummy_inputs` runs the encoder on a
+        # worst-case dummy batch that carries the encoder tensors but no
+        # `multimodal_embedding_lengths`, so the per-modality lengths (and thus
+        # the sliced `per_modality_embeds`) come back empty. The encoder forward
+        # still ran (its activation is what peak-memory profiling captures), so
+        # return a correctly-typed empty embedding tensor instead of crashing on
+        # `torch.cat([])`. `per_modality_embeds` values are already zero-row
+        # slices of the encoder output, so their concat preserves dtype/device
+        # and the hidden dim.
+        if per_modality_embeds:
+            return torch.cat(list(per_modality_embeds.values()), dim=0)
+        return torch.empty(0)
     return torch.cat(slices, dim=0)
 
 

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -24,6 +24,7 @@ from typing import (
     Hashable,
     Iterable,
     Iterator,
+    List,
     Optional,
     Sequence,
 )
@@ -37,7 +38,10 @@ from tensorrt_llm.inputs.multimodal import MultimodalParams, MultimodalRuntimeDa
 from tensorrt_llm.logger import logger
 
 from .modeling_multimodal_utils import (
+    EncoderGroup,
     _cache_multimodal_embeddings,
+    _lengths_by_modality,
+    _reorder_embeds_by_manifest,
     find_input_mm_embeds,
     fuse_input_embeds,
     get_multimodal_embeddings,
@@ -153,6 +157,14 @@ class MultimodalModelMixin:
 
         return module._apply(convert)
 
+    #: Per-model registration of encoder-batching groups. Each
+    #: :class:`EncoderGroup` bundles a set of modalities that share one
+    #: encoder call. Set as a class attribute or on ``self`` in ``__init__``
+    #: (when ``encoder_fn`` binds to instance methods). When populated,
+    #: ``encode_multimodal_by_groups`` handles batching, splitting, and
+    #: prompt-order reordering generically.
+    mm_encoder_groups: Sequence[EncoderGroup] = ()
+
     def encode_multimodal_inputs(
         self,
         multimodal_params: Sequence[MultimodalParams],
@@ -164,6 +176,42 @@ class MultimodalModelMixin:
         positions but do not have rows here.
         """
         raise NotImplementedError
+
+    def encode_multimodal_by_groups(
+        self,
+        multimodal_params: List[MultimodalParams],
+    ) -> torch.Tensor:
+        """Generic encoder path for models that declare ``mm_encoder_groups``.
+
+        For each group present in the batch, one encoder call is issued over
+        all items across all requests belonging to that group's modalities
+        (arithmetic-intensity win). The output is split back per-modality
+        using the prompt-ordered ``multimodal_embedding_lengths`` already
+        stashed on ``multimodal_data``, then reordered into each request's
+        ``mm_item_order`` prompt sequence.
+        """
+        per_modality_embeds: Dict[str, torch.Tensor] = {}
+        per_modality_lengths: Dict[str, List[int]] = {}
+        for group in self.mm_encoder_groups:
+            group_params = [
+                mp
+                for mp in multimodal_params
+                if any(mp.multimodal_data.get(m) is not None for m in group.modalities)
+            ]
+            if not group_params:
+                continue
+            out = group.encoder_fn(**group.build_batched_input(group_params))
+            lengths = _lengths_by_modality(group_params, group.modalities)
+            cursor = 0
+            for m in group.modalities:
+                total = sum(lengths[m])
+                if total > 0:
+                    per_modality_embeds[m] = out[cursor : cursor + total]
+                    per_modality_lengths[m] = lengths[m]
+                    cursor += total
+        return _reorder_embeds_by_manifest(
+            multimodal_params, per_modality_embeds, per_modality_lengths
+        )
 
     @property
     def multimodal_token_ids(self) -> Optional[Sequence[int] | torch.Tensor]:

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -176,6 +176,45 @@ def _synthesize_single_modality_manifest(
     return []
 
 
+def encode_multimodal_by_groups(
+    mm_encoder_groups: Sequence["EncoderGroup"],
+    multimodal_params: List[MultimodalParams],
+) -> torch.Tensor:
+    """Run each group's encoder over its batched items and reorder into
+    per-request prompt order.
+
+    For each group present in the batch, one encoder call is issued over all
+    items across all requests belonging to that group's modalities
+    (arithmetic-intensity win). The output is split back per-modality using
+    the prompt-ordered `multimodal_embedding_lengths` already stashed on
+    `multimodal_data`, then reordered into each request's `mm_item_order`
+    prompt sequence.
+
+    Shared entry point for both the aggregated (`MultimodalModelMixin`) and
+    mm-encoder-only (`Qwen3VisionModelBase.forward`) paths so the ordering
+    contract lives in one place.
+    """
+    per_modality_embeds: Dict[str, torch.Tensor] = {}
+    per_modality_lengths: Dict[str, List[int]] = {}
+    for group in mm_encoder_groups:
+        group_params = [
+            mp
+            for mp in multimodal_params
+            if any(mp.multimodal_data.get(m) is not None for m in group.modalities)
+        ]
+        if not group_params:
+            continue
+        out = group.encoder_fn(**group.build_batched_input(group_params))
+        lengths = _lengths_by_modality(group_params, group.modalities)
+        cursor = 0
+        for m in group.modalities:
+            total = sum(lengths[m])
+            per_modality_embeds[m] = out[cursor : cursor + total]
+            cursor += total
+        per_modality_lengths.update(lengths)
+    return _reorder_embeds_by_manifest(multimodal_params, per_modality_embeds, per_modality_lengths)
+
+
 if TYPE_CHECKING:
     from ..pyexecutor.llm_request import LlmRequest
 
@@ -289,8 +328,9 @@ class MultimodalModelMixin:
     # Per-model registration of encoder-batching groups. Each `EncoderGroup`
     # bundles a set of modalities that share one encoder call. Set as a class
     # attribute or on `self` in `__init__` (when `encoder_fn` binds to instance
-    # methods). When populated, `encode_multimodal_by_groups` handles batching,
-    # splitting, and prompt-order reordering generically.
+    # methods). Consumers call the module-level `encode_multimodal_by_groups`
+    # with these groups; both the aggregated and mm-encoder-only paths share
+    # that helper so the ordering contract lives in one place.
     mm_encoder_groups: Sequence[EncoderGroup] = ()
 
     def encode_multimodal_inputs(
@@ -304,41 +344,6 @@ class MultimodalModelMixin:
         positions but do not have rows here.
         """
         raise NotImplementedError
-
-    def encode_multimodal_by_groups(
-        self,
-        multimodal_params: List[MultimodalParams],
-    ) -> torch.Tensor:
-        """Generic encoder path for models that declare ``mm_encoder_groups``.
-
-        For each group present in the batch, one encoder call is issued over
-        all items across all requests belonging to that group's modalities
-        (arithmetic-intensity win). The output is split back per-modality
-        using the prompt-ordered ``multimodal_embedding_lengths`` already
-        stashed on ``multimodal_data``, then reordered into each request's
-        ``mm_item_order`` prompt sequence.
-        """
-        per_modality_embeds: Dict[str, torch.Tensor] = {}
-        per_modality_lengths: Dict[str, List[int]] = {}
-        for group in self.mm_encoder_groups:
-            group_params = [
-                mp
-                for mp in multimodal_params
-                if any(mp.multimodal_data.get(m) is not None for m in group.modalities)
-            ]
-            if not group_params:
-                continue
-            out = group.encoder_fn(**group.build_batched_input(group_params))
-            lengths = _lengths_by_modality(group_params, group.modalities)
-            cursor = 0
-            for m in group.modalities:
-                total = sum(lengths[m])
-                per_modality_embeds[m] = out[cursor : cursor + total]
-                cursor += total
-            per_modality_lengths.update(lengths)
-        return _reorder_embeds_by_manifest(
-            multimodal_params, per_modality_embeds, per_modality_lengths
-        )
 
     @property
     def multimodal_token_ids(self) -> Optional[Sequence[int] | torch.Tensor]:

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -19,6 +19,7 @@
 import functools
 import math
 import os
+from dataclasses import dataclass
 from typing import (Any, Callable, Dict, List, Optional, Tuple, TypedDict,
                     Union, cast)
 
@@ -220,6 +221,98 @@ def _cache_multimodal_embeddings(
     logger.debug(
         f"Cached {len(split_embeddings)} multimodal embedding chunks in this iteration"
     )
+
+
+@dataclass
+class EncoderGroup:
+    """Modalities that share a single encoder call.
+
+    Batching all items in a group into one encoder invocation amortizes
+    fixed costs (kernel launches, dispatch) across items. The framework
+    splits the output back per-modality and reorders it into prompt order
+    via each request's ``mm_item_order`` manifest.
+
+    ``modalities`` order is authoritative: ``build_batched_input`` must cat
+    items in that order so the framework can split the encoder output back
+    with the same layout.
+    """
+    modalities: Tuple[str, ...]
+    encoder_fn: Callable[..., torch.Tensor]
+    build_batched_input: Callable[[List[MultimodalParams]], Dict[str, Any]]
+
+
+def _lengths_by_modality(
+    multimodal_params: List[MultimodalParams],
+    modalities: Tuple[str, ...],
+) -> Dict[str, List[int]]:
+    """Invert prompt-ordered ``multimodal_embedding_lengths`` into per-modality
+    per-item lengths, matching the per-modality item order used by
+    :attr:`EncoderGroup.build_batched_input`."""
+    by_modality: Dict[str, List[int]] = {m: [] for m in modalities}
+    for mp in multimodal_params:
+        flat = mp.multimodal_data.get("multimodal_embedding_lengths") or []
+        if mp.mm_item_order:
+            for entry, length in zip(mp.mm_item_order, flat, strict=True):
+                if entry["modality"] in by_modality:
+                    by_modality[entry["modality"]].append(length)
+            continue
+        present = [
+            m for m in modalities if mp.multimodal_data.get(m) is not None
+        ]
+        if len(present) > 1:
+            raise ValueError(
+                "Request with multiple modalities present "
+                f"({present}) must carry mm_item_order on MultimodalParams.")
+        if present:
+            by_modality[present[0]].extend(flat)
+    return by_modality
+
+
+def _reorder_embeds_by_manifest(
+    multimodal_params: List[MultimodalParams],
+    per_modality_embeds: Dict[str, torch.Tensor],
+    per_modality_lengths: Dict[str, List[int]],
+) -> torch.Tensor:
+    """Slice per-modality tensors item-by-item and concat in prompt order."""
+    # Prefix sums for O(1) per-item row lookup.
+    per_modality_row_starts: Dict[str, List[int]] = {}
+    for m, lens in per_modality_lengths.items():
+        cum = [0]
+        for L in lens:
+            cum.append(cum[-1] + L)
+        per_modality_row_starts[m] = cum
+
+    slices: List[torch.Tensor] = []
+    # ``entry["index"]`` is per-request per-modality; advance a cursor to
+    # translate it into a global item index within ``per_modality_embeds``.
+    per_modality_cursor: Dict[str, int] = {m: 0 for m in per_modality_embeds}
+    for mp in multimodal_params:
+        manifest = mp.mm_item_order or _synthesize_single_modality_manifest(
+            mp, per_modality_embeds.keys())
+        req_counts: Dict[str, int] = {}
+        for entry in manifest:
+            m = entry["modality"]
+            if m not in per_modality_embeds:
+                continue
+            i = per_modality_cursor[m] + entry["index"]
+            starts = per_modality_row_starts[m]
+            slices.append(per_modality_embeds[m][starts[i]:starts[i + 1]])
+            req_counts[m] = req_counts.get(m, 0) + 1
+        for m, c in req_counts.items():
+            per_modality_cursor[m] += c
+    return torch.cat(slices, dim=0)
+
+
+def _synthesize_single_modality_manifest(
+    mp: MultimodalParams,
+    modalities,
+) -> List[Dict[str, Union[str, int]]]:
+    """Trivial manifest for requests with only one modality present."""
+    flat = mp.multimodal_data.get("multimodal_embedding_lengths") or []
+    for m in modalities:
+        if mp.multimodal_data.get(m) is not None:
+            return [{"modality": m, "index": i} for i in range(len(flat))]
+    return []
 
 
 def _normalize_encoder_embeddings(

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -19,9 +19,8 @@
 import functools
 import math
 import os
-from dataclasses import dataclass
-from typing import (Any, Callable, Dict, Iterable, List, Optional, Tuple,
-                    TypedDict, Union, cast)
+from typing import (Any, Callable, Dict, List, Optional, Tuple, TypedDict,
+                    Union, cast)
 
 import torch
 import torch.nn.functional as F
@@ -221,98 +220,6 @@ def _cache_multimodal_embeddings(
     logger.debug(
         f"Cached {len(split_embeddings)} multimodal embedding chunks in this iteration"
     )
-
-
-@dataclass
-class EncoderGroup:
-    """Modalities that share a single encoder call.
-
-    Batching all items in a group into one encoder invocation amortizes
-    fixed costs (kernel launches, dispatch) across items. The framework
-    splits the output back per-modality and reorders it into prompt order
-    via each request's ``mm_item_order`` manifest.
-
-    ``modalities`` order is authoritative: ``build_batched_input`` must cat
-    items in that order so the framework can split the encoder output back
-    with the same layout.
-    """
-    modalities: Tuple[str, ...]
-    encoder_fn: Callable[..., torch.Tensor]
-    build_batched_input: Callable[[List[MultimodalParams]], Dict[str, Any]]
-
-
-def _lengths_by_modality(
-    multimodal_params: List[MultimodalParams],
-    modalities: Tuple[str, ...],
-) -> Dict[str, List[int]]:
-    """Invert prompt-ordered ``multimodal_embedding_lengths`` into per-modality
-    per-item lengths, matching the per-modality item order used by
-    :attr:`EncoderGroup.build_batched_input`."""
-    by_modality: Dict[str, List[int]] = {m: [] for m in modalities}
-    for mp in multimodal_params:
-        flat = mp.multimodal_data.get("multimodal_embedding_lengths") or []
-        if mp.mm_item_order:
-            for entry, length in zip(mp.mm_item_order, flat, strict=True):
-                if entry["modality"] in by_modality:
-                    by_modality[entry["modality"]].append(length)
-            continue
-        present = [
-            m for m in modalities if mp.multimodal_data.get(m) is not None
-        ]
-        if len(present) > 1:
-            raise ValueError(
-                "Request with multiple modalities present "
-                f"({present}) must carry mm_item_order on MultimodalParams.")
-        if present:
-            by_modality[present[0]].extend(flat)
-    return by_modality
-
-
-def _reorder_embeds_by_manifest(
-    multimodal_params: List[MultimodalParams],
-    per_modality_embeds: Dict[str, torch.Tensor],
-    per_modality_lengths: Dict[str, List[int]],
-) -> torch.Tensor:
-    """Slice per-modality tensors item-by-item and concat in prompt order."""
-    # Prefix sums for O(1) per-item row lookup.
-    per_modality_row_starts: Dict[str, List[int]] = {}
-    for m, lens in per_modality_lengths.items():
-        cum = [0]
-        for L in lens:
-            cum.append(cum[-1] + L)
-        per_modality_row_starts[m] = cum
-
-    slices: List[torch.Tensor] = []
-    # ``entry["index"]`` is per-request per-modality; advance a cursor to
-    # translate it into a global item index within ``per_modality_embeds``.
-    per_modality_cursor: Dict[str, int] = {m: 0 for m in per_modality_embeds}
-    for mp in multimodal_params:
-        manifest = mp.mm_item_order or _synthesize_single_modality_manifest(
-            mp, per_modality_embeds.keys())
-        req_counts: Dict[str, int] = {}
-        for entry in manifest:
-            m = entry["modality"]
-            if m not in per_modality_embeds:
-                continue
-            i = per_modality_cursor[m] + entry["index"]
-            starts = per_modality_row_starts[m]
-            slices.append(per_modality_embeds[m][starts[i]:starts[i + 1]])
-            req_counts[m] = req_counts.get(m, 0) + 1
-        for m, c in req_counts.items():
-            per_modality_cursor[m] += c
-    return torch.cat(slices, dim=0)
-
-
-def _synthesize_single_modality_manifest(
-    mp: MultimodalParams,
-    modalities: Iterable[str],
-) -> List[Dict[str, Union[str, int]]]:
-    """Trivial manifest for requests with only one modality present."""
-    flat = mp.multimodal_data.get("multimodal_embedding_lengths") or []
-    for m in modalities:
-        if mp.multimodal_data.get(m) is not None:
-            return [{"modality": m, "index": i} for i in range(len(flat))]
-    return []
 
 
 def _normalize_encoder_embeddings(

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -20,8 +20,8 @@ import functools
 import math
 import os
 from dataclasses import dataclass
-from typing import (Any, Callable, Dict, List, Optional, Tuple, TypedDict,
-                    Union, cast)
+from typing import (Any, Callable, Dict, Iterable, List, Optional, Tuple,
+                    TypedDict, Union, cast)
 
 import torch
 import torch.nn.functional as F
@@ -305,7 +305,7 @@ def _reorder_embeds_by_manifest(
 
 def _synthesize_single_modality_manifest(
     mp: MultimodalParams,
-    modalities,
+    modalities: Iterable[str],
 ) -> List[Dict[str, Union[str, int]]]:
     """Trivial manifest for requests with only one modality present."""
     flat = mp.multimodal_data.get("multimodal_embedding_lengths") or []

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -305,6 +305,9 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
         divided by ``spatial_merge_unit`` (the post-merger placeholder count)."""
         if isinstance(image, torch.Tensor):
             image_h, image_w = int(image.shape[-2]), int(image.shape[-1])
+        elif isinstance(image, np.ndarray):
+            # HWC uint8 from ImageMediaIO's "np" format.
+            image_h, image_w = int(image.shape[0]), int(image.shape[1])
         else:
             image_h, image_w = image.height, image.width
         encoder_tokens = self._num_vision_tokens(width=image_w,
@@ -320,6 +323,10 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
         if isinstance(first_frame, torch.Tensor):
             frame_h = int(first_frame.shape[-2])
             frame_w = int(first_frame.shape[-1])
+        elif isinstance(first_frame, np.ndarray):
+            # HWC uint8 from VideoMediaIO's "np" format.
+            frame_h = int(first_frame.shape[0])
+            frame_w = int(first_frame.shape[1])
         else:
             frame_h, frame_w = first_frame.height, first_frame.width
         encoder_tokens = self._num_vision_tokens(width=frame_w,

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -47,6 +47,7 @@ from .modeling_auto import AutoModelForCausalLM
 from .modeling_multimodal_encoder import MultimodalEncoderMixin
 from .modeling_multimodal_mixin import MultimodalModelMixin
 from .modeling_multimodal_utils import (
+    EncoderGroup,
     filter_mm_token_from_input_ids,
     find_input_mm_embeds,
     fuse_input_embeds,
@@ -1008,6 +1009,28 @@ class Qwen3VisionModel(torch.nn.Module, MultimodalEncoderMixin):
         return hidden_states, deepstack_feature_lists
 
 
+def _qwen3vl_build_batched_input(
+    multimodal_params: List[MultimodalParams],
+) -> Dict[str, Any]:
+    """Cat image items then video items across requests (matching the
+    ``EncoderGroup.modalities`` order) into one ViT input."""
+    pixels: List[torch.Tensor] = []
+    grids: List[torch.Tensor] = []
+    for m, pv_key, thw_key in (
+        ("image", "pixel_values", "image_grid_thw"),
+        ("video", "pixel_values_videos", "video_grid_thw"),
+    ):
+        for mp in multimodal_params:
+            bucket = mp.multimodal_data.get(m)
+            if bucket is not None:
+                pixels.append(bucket[pv_key])
+                grids.append(bucket[thw_key])
+    return {
+        "pixel_values": torch.cat(pixels, dim=0),
+        "grid_thw": torch.cat(grids, dim=0),
+    }
+
+
 class Qwen3VisionModelBase(nn.Module):
     def __init__(
         self,
@@ -1059,164 +1082,20 @@ class Qwen3VisionModelBase(nn.Module):
         self.visual.config.num_attention_heads = self.visual.config.num_heads
         _load_weights_impl(self.visual, converted_weights, params_map=pattern_mapping)
 
-    def _parse_and_batch_multimodal_data(
-        self, multimodal_params: List[MultimodalParams]
-    ) -> Tuple[Dict[str, Any], Dict[str, List[Any]]]:
-        # Only the request itself knows how its image and video items
-        # interleave in the prompt, so a mixed request must carry a manifest.
-        for mp in multimodal_params:
-            data = mp.multimodal_data or {}
-            if (
-                data.get("image") is not None
-                and data.get("video") is not None
-                and not mp.mm_item_order
-            ):
-                raise ValueError(
-                    "Qwen3-VL mixed-modality requests must carry mm_item_order on MultimodalParams."
-                )
-
-        # Any batch that contains both modalities — whether within a single
-        # request or spread across heterogeneous single-modality requests —
-        # goes through the modality-blind ViT via one cat'd stream.
-        has_image = any(mp.multimodal_data.get("image") is not None for mp in multimodal_params)
-        has_video = any(mp.multimodal_data.get("video") is not None for mp in multimodal_params)
-        if has_image and has_video:
-            return self._interleave_multimodal_data(multimodal_params)
-
-        pixel_values_list = []
-        pixel_values_videos_list = []
-        image_grid_thw_list = []
-        video_grid_thw_list = []
-
-        for multimodal_param in multimodal_params:
-            multimodal_data = multimodal_param.multimodal_data
-            # Process images if present
-            if multimodal_data.get("image") is not None:
-                pixel_values_list.append(multimodal_data["image"]["pixel_values"])
-                image_grid_thw_list.append(multimodal_data["image"]["image_grid_thw"])
-
-            # Process videos if present
-            if multimodal_data.get("video") is not None:
-                pixel_values_videos_list.append(multimodal_data["video"]["pixel_values_videos"])
-                video_grid_thw_list.append(multimodal_data["video"]["video_grid_thw"])
-
-        # Concatenate tensors
-        mm_content_dict = {}
-        if pixel_values_list:
-            mm_content_dict["pixel_values"] = (
-                torch.cat(pixel_values_list, dim=0)
-                if len(pixel_values_list) > 1
-                else pixel_values_list[0]
-            )
-        if pixel_values_videos_list:
-            mm_content_dict["pixel_values_videos"] = (
-                torch.cat(pixel_values_videos_list, dim=0)
-                if len(pixel_values_videos_list) > 1
-                else pixel_values_videos_list[0]
-            )
-
-        # Prepare extra data
-        mm_extra_data = {}
-        if image_grid_thw_list:
-            mm_extra_data["image_grid_thw"] = (
-                torch.cat(image_grid_thw_list, dim=0)
-                if len(image_grid_thw_list) > 1
-                else image_grid_thw_list[0]
-            )
-        if video_grid_thw_list:
-            mm_extra_data["video_grid_thw"] = (
-                torch.cat(video_grid_thw_list, dim=0)
-                if len(video_grid_thw_list) > 1
-                else video_grid_thw_list[0]
-            )
-
-        return mm_content_dict, mm_extra_data
-
-    def _interleave_multimodal_data(
-        self, multimodal_params: List[MultimodalParams]
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        """Build one prompt-order pixel_values + grid_thw for mixed batches.
-
-        The ViT is modality-blind (image = grid_thw row with t=1, video = t>1),
-        so we cat everything into a single stream in prompt order. Emits only
-        the "pixel_values" + "image_grid_thw" keys so forward() takes its
-        image branch uniformly over both modalities.
-        """
-        pixels: List[torch.Tensor] = []
-        grids: List[torch.Tensor] = []
-        for mp in multimodal_params:
-            data = mp.multimodal_data
-            order = mp.mm_item_order or []
-            img = data.get("image") or {}
-            vid = data.get("video") or {}
-            img_pv, img_thw = img.get("pixel_values"), img.get("image_grid_thw")
-            vid_pv = vid.get("pixel_values_videos")
-            vid_thw = vid.get("video_grid_thw")
-
-            # Single-modality request in a mixed batch — no interleave
-            # needed, just append its rows.
-            if not order or img_pv is None or vid_pv is None:
-                if img_pv is not None:
-                    pixels.append(img_pv)
-                    grids.append(img_thw)
-                if vid_pv is not None:
-                    pixels.append(vid_pv)
-                    grids.append(vid_thw)
-                continue
-
-            img_off = vid_off = 0
-            for entry in order:
-                modality = entry["modality"]
-                idx = entry["index"]
-                if modality == "image":
-                    thw = img_thw[idx]
-                    n = int(thw.prod().item())
-                    pixels.append(img_pv[img_off : img_off + n])
-                    img_off += n
-                elif modality == "video":
-                    thw = vid_thw[idx]
-                    n = int(thw.prod().item())
-                    pixels.append(vid_pv[vid_off : vid_off + n])
-                    vid_off += n
-                else:
-                    raise ValueError(f"Unknown modality in mm_item_order: {modality}")
-                grids.append(thw.unsqueeze(0))
-
-        return (
-            {"pixel_values": torch.cat(pixels, dim=0)},
-            {"image_grid_thw": torch.cat(grids, dim=0)},
-        )
-
     @torch.inference_mode()
-    def forward(self, multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
-        mm_content_data, mm_extra_data = self._parse_and_batch_multimodal_data(multimodal_params)
-        pixel_values = mm_content_data.get("pixel_values", None)
-        pixel_values_videos = mm_content_data.get("pixel_values_videos", None)
-
-        image_grid_thw = mm_extra_data.get("image_grid_thw", None)
-        video_grid_thw = mm_extra_data.get("video_grid_thw", None)
-
-        embeds: List[torch.Tensor] = []
-        if pixel_values is not None:
-            pixel_values = pixel_values.to(self.model_dtype)
-            image_embeds, deepstack_image_embeds = self.visual(
-                pixel_values, grid_thw=image_grid_thw
-            )
-            # NOTE: We concatenate deepstack_embeds to mm_embeds
-            # The shape will be [seq_len, hidden_dim * (num_deepstack_layers + 1)]
-            mixed_image_embeds = torch.cat([image_embeds] + deepstack_image_embeds, dim=1)
-            embeds.append(mixed_image_embeds)
-
-        if pixel_values_videos is not None:
-            pixel_values_videos = pixel_values_videos.to(self.model_dtype)
-            video_embeds, deepstack_video_embeds = self.visual(
-                pixel_values_videos, grid_thw=video_grid_thw
-            )
-            # NOTE: We concatenate deepstack_embeds to mm_embeds
-            # The shape will be [seq_len, hidden_dim * (num_deepstack_layers + 1)]
-            mixed_video_embeds = torch.cat([video_embeds] + deepstack_video_embeds, dim=1)
-            embeds.append(mixed_video_embeds)
-        return embeds
+    def encode_batched(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run the ViT on one concat'd batch and fold deepstack streams into
+        the hidden dim. Modality-agnostic — image and video items are
+        distinguished only by ``grid_thw`` rows (image ``t=1``, video ``t>1``).
+        """
+        pixel_values = pixel_values.to(self.model_dtype)
+        embeds, deepstack = self.visual(pixel_values, grid_thw=grid_thw)
+        # Shape: [seq_len, hidden_dim * (num_deepstack_layers + 1)]
+        return torch.cat([embeds] + deepstack, dim=1)
 
 
 class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
@@ -1225,14 +1104,13 @@ class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
     ) -> torch.Tensor:
         """Uniform encoder entry (``MultimodalModelMixin`` contract).
 
-        Runs the vision encoder over ``multimodal_params`` and returns the
-        embeddings as a single tensor (Qwen3-VL folds deepstack streams into
-        the hidden dim, so the single-tensor contract holds). Used by the
-        startup memory profiler to invoke the encoder directly; the model's
-        own ``forward`` keeps its custom deepstack fusion path.
+        Routes through the framework's ``encode_multimodal_by_groups`` so
+        one ViT call sees all image+video items in the batch, with the
+        result reordered per-request into prompt order.
         """
         mm_embeds = get_multimodal_embeddings(
-            encoder_forward_fn=self.mm_encoder.forward, multimodal_params=list(multimodal_params)
+            encoder_forward_fn=self.encode_multimodal_by_groups,
+            multimodal_params=list(multimodal_params),
         )
         return mm_embeds[0]
 
@@ -1333,6 +1211,16 @@ class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
             self.mm_encoder = Qwen3VisionModelBase(
                 copy.deepcopy(model_config), kwargs.get("vision_model_class", None)
             ).eval()
+            # One modality-blind ViT handles both image and video (image has
+            # `grid_thw.t==1`, video `t>1`). Batching them into a single
+            # encoder call is the whole arithmetic-intensity win.
+            self.mm_encoder_groups = (
+                EncoderGroup(
+                    modalities=("image", "video"),
+                    encoder_fn=self.mm_encoder.encode_batched,
+                    build_batched_input=_qwen3vl_build_batched_input,
+                ),
+            )
         elif model_config.disable_mm_encoder:
             logger.info(
                 f"{type(self).__name__}: multimodal encoder disabled "

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -1010,12 +1010,12 @@ class Qwen3VisionModel(torch.nn.Module, MultimodalEncoderMixin):
 
 
 def _qwen3vl_build_batched_input(
-    multimodal_params: List[MultimodalParams],
-) -> Dict[str, Any]:
+    multimodal_params: list[MultimodalParams],
+) -> dict[str, Any]:
     """Cat image items then video items across requests (matching the
     ``EncoderGroup.modalities`` order) into one ViT input."""
-    pixels: List[torch.Tensor] = []
-    grids: List[torch.Tensor] = []
+    pixels: list[torch.Tensor] = []
+    grids: list[torch.Tensor] = []
     for m, pv_key, thw_key in (
         ("image", "pixel_values", "image_grid_thw"),
         ("video", "pixel_values_videos", "video_grid_thw"),
@@ -1383,7 +1383,7 @@ class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
             # Raw image/video tensors: run local encoder.
             if has_raw_image_or_video_data and self.mm_encoder is not None:
                 mm_embeds = get_multimodal_embeddings(
-                    encoder_forward_fn=self.mm_encoder.forward,
+                    encoder_forward_fn=self.encode_multimodal_by_groups,
                     multimodal_params=mm_multimodal_params,
                 )
             # Raw image/video tensors on a worker with no encoder: bad route.

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -1111,6 +1111,18 @@ class Qwen3VisionModelBase(nn.Module):
         # Shape: [seq_len, hidden_dim * (num_deepstack_layers + 1)]
         return torch.cat([embeds] + deepstack, dim=1)
 
+    def forward(self, multimodal_params: List[MultimodalParams]):
+        """Standalone mm-encoder-only executor entry.
+
+        The disaggregated MM-encoder path (`_forward_step_mm_encoder_only`)
+        invokes the vision model's `forward()` and expects a list of embedding
+        tensors (it asserts a single element — mixed modality is unsupported
+        there). Build the batched ViT input the same way the encoder group does
+        and run one encode. Mirrors the `forward()` contract that
+        `Qwen2VisionModelBase` still exposes for this path.
+        """
+        return [self.encode_batched(**_qwen3vl_build_batched_input(multimodal_params))]
+
 
 class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
     def encode_multimodal_inputs(

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -45,9 +45,8 @@ from .checkpoints.base_weight_mapper import BaseWeightMapper
 from .checkpoints.hf.qwen3vl_weight_mapper import Qwen3VLHfWeightMapper
 from .modeling_auto import AutoModelForCausalLM
 from .modeling_multimodal_encoder import MultimodalEncoderMixin
-from .modeling_multimodal_mixin import MultimodalModelMixin
+from .modeling_multimodal_mixin import EncoderGroup, MultimodalModelMixin
 from .modeling_multimodal_utils import (
-    EncoderGroup,
     filter_mm_token_from_input_ids,
     find_input_mm_embeds,
     fuse_input_embeds,

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -303,11 +303,23 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
             videos = [video_data.frames for video_data in video_datas]
         else:
             videos = None
-        do_rescale = True
-        if images and isinstance(images[0], torch.Tensor):
-            do_rescale = False
-        if videos and isinstance(videos[0][0], torch.Tensor):
-            do_rescale = False
+        # HF's Qwen3-VL processor takes a single `do_rescale` kwarg that is
+        # applied to both images and videos. Mixed pre-rescale states leave
+        # the raw side at 0-255 while the pre-rescaled side gets skipped —
+        # the ViT then produces garbage for the raw modality. Fail fast; the
+        # default `get_preferred_media_io_kwargs` ships `np` for both, so a
+        # divergence here means a caller override drifted.
+        image_is_pre = not images or isinstance(images[0], torch.Tensor)
+        video_is_pre = not videos or isinstance(videos[0][0], torch.Tensor)
+        if image_is_pre != video_is_pre:
+            raise ValueError(
+                "Qwen3-VL requires image and video items to arrive in the same "
+                "pre-rescaled state (both torch.Tensor, or both uint8 numpy). "
+                f"Got image_is_pre_rescaled={image_is_pre}, "
+                f"video_is_pre_rescaled={video_is_pre}. Configure consistent "
+                "formats via `media_io_kwargs`."
+            )
+        do_rescale = not image_is_pre
 
         do_sample_frames = _decide_do_sample_frames(video_datas, mm_processor_kwargs)
 
@@ -398,9 +410,12 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
         return self.get_num_tokens_per_video(video=video, video_grid_thw=vgt)
 
     def get_preferred_media_io_kwargs(self) -> Dict[str, Dict[str, Any]]:
-        # uint8 HWC frames let the HF processor rescale/permute once, skipping
-        # the per-frame CHW-float conversion in the IO loader.
-        return {"video": {"format": "np"}}
+        # uint8 HWC arrays for both modalities so the HF processor rescales
+        # and normalizes uniformly in one pass. A single `do_rescale` kwarg
+        # controls both modalities; if they arrive in mismatched
+        # pre-rescale states (e.g. image=Tensor pre-rescaled, video=uint8
+        # np), the raw side is left at 0-255 and the ViT sees garbage.
+        return {"image": {"format": "np"}, "video": {"format": "np"}}
 
     def build_disagg_prefill_multimodal_inputs(
         self, inputs: TextPrompt, mm_handles: List[Dict[str, Any]]

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -4,7 +4,7 @@
 import copy
 import math
 import re
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -45,7 +45,11 @@ from .checkpoints.base_weight_mapper import BaseWeightMapper
 from .checkpoints.hf.qwen3vl_weight_mapper import Qwen3VLHfWeightMapper
 from .modeling_auto import AutoModelForCausalLM
 from .modeling_multimodal_encoder import MultimodalEncoderMixin
-from .modeling_multimodal_mixin import EncoderGroup, MultimodalModelMixin
+from .modeling_multimodal_mixin import (
+    EncoderGroup,
+    MultimodalModelMixin,
+    encode_multimodal_by_groups,
+)
 from .modeling_multimodal_utils import (
     filter_mm_token_from_input_ids,
     find_input_mm_embeds,
@@ -1111,17 +1115,34 @@ class Qwen3VisionModelBase(nn.Module):
         # Shape: [seq_len, hidden_dim * (num_deepstack_layers + 1)]
         return torch.cat([embeds] + deepstack, dim=1)
 
-    def forward(self, multimodal_params: List[MultimodalParams]):
+    @property
+    def mm_encoder_groups(self) -> Tuple[EncoderGroup, ...]:
+        """Single source of truth for Qwen3-VL's encoder-batching group.
+
+        One modality-blind ViT handles both image and video (image has
+        `grid_thw.t==1`, video `t>1`), so both modalities share one call.
+        Both the aggregated path (via `Qwen3VLModelBase.mm_encoder_groups`,
+        which delegates here) and the mm-encoder-only `forward` consume this.
+        """
+        return (
+            EncoderGroup(
+                modalities=("image", "video"),
+                encoder_fn=self.encode_batched,
+                build_batched_input=_qwen3vl_build_batched_input,
+            ),
+        )
+
+    def forward(self, multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
         """Standalone mm-encoder-only executor entry.
 
-        The disaggregated MM-encoder path (`_forward_step_mm_encoder_only`)
-        invokes the vision model's `forward()` and expects a list of embedding
-        tensors (it asserts a single element — mixed modality is unsupported
-        there). Build the batched ViT input the same way the encoder group does
-        and run one encode. Mirrors the `forward()` contract that
-        `Qwen2VisionModelBase` still exposes for this path.
+        `_forward_step_mm_encoder_only` invokes this and then splits the
+        returned tensor request-by-request using request-ordered
+        `split_lengths`, so the rows must be in request-then-prompt order.
+        Delegating to `encode_multimodal_by_groups` runs the same
+        modality-batched ViT the aggregated path uses and applies the
+        per-request `mm_item_order` reorder before returning.
         """
-        return [self.encode_batched(**_qwen3vl_build_batched_input(multimodal_params))]
+        return [encode_multimodal_by_groups(self.mm_encoder_groups, multimodal_params)]
 
 
 class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
@@ -1135,7 +1156,7 @@ class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
         result reordered per-request into prompt order.
         """
         mm_embeds = get_multimodal_embeddings(
-            encoder_forward_fn=self.encode_multimodal_by_groups,
+            encoder_forward_fn=partial(encode_multimodal_by_groups, self.mm_encoder_groups),
             multimodal_params=list(multimodal_params),
         )
         return mm_embeds[0]
@@ -1237,16 +1258,9 @@ class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
             self.mm_encoder = Qwen3VisionModelBase(
                 copy.deepcopy(model_config), kwargs.get("vision_model_class", None)
             ).eval()
-            # One modality-blind ViT handles both image and video (image has
-            # `grid_thw.t==1`, video `t>1`). Batching them into a single
-            # encoder call is the whole arithmetic-intensity win.
-            self.mm_encoder_groups = (
-                EncoderGroup(
-                    modalities=("image", "video"),
-                    encoder_fn=self.mm_encoder.encode_batched,
-                    build_batched_input=_qwen3vl_build_batched_input,
-                ),
-            )
+            # Reuse the encoder's own group definition so the aggregated and
+            # mm-encoder-only paths share a single source of truth.
+            self.mm_encoder_groups = self.mm_encoder.mm_encoder_groups
         elif model_config.disable_mm_encoder:
             logger.info(
                 f"{type(self).__name__}: multimodal encoder disabled "
@@ -1409,7 +1423,7 @@ class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
             # Raw image/video tensors: run local encoder.
             if has_raw_image_or_video_data and self.mm_encoder is not None:
                 mm_embeds = get_multimodal_embeddings(
-                    encoder_forward_fn=self.encode_multimodal_by_groups,
+                    encoder_forward_fn=partial(encode_multimodal_by_groups, self.mm_encoder_groups),
                     multimodal_params=mm_multimodal_params,
                 )
             # Raw image/video tensors on a worker with no encoder: bad route.

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -313,9 +313,9 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
         # the ViT then produces garbage for the raw modality. Fail fast; the
         # default `get_preferred_media_io_kwargs` ships `np` for both, so a
         # divergence here means a caller override drifted.
-        image_is_pre = not images or isinstance(images[0], torch.Tensor)
-        video_is_pre = not videos or isinstance(videos[0][0], torch.Tensor)
-        if image_is_pre != video_is_pre:
+        image_is_pre = bool(images) and isinstance(images[0], torch.Tensor)
+        video_is_pre = bool(videos) and isinstance(videos[0][0], torch.Tensor)
+        if images and videos and image_is_pre != video_is_pre:
             raise ValueError(
                 "Qwen3-VL requires image and video items to arrive in the same "
                 "pre-rescaled state (both torch.Tensor, or both uint8 numpy). "
@@ -323,7 +323,7 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
                 f"video_is_pre_rescaled={video_is_pre}. Configure consistent "
                 "formats via `media_io_kwargs`."
             )
-        do_rescale = not image_is_pre
+        do_rescale = not (image_is_pre if images else video_is_pre)
 
         do_sample_frames = _decide_do_sample_frames(video_datas, mm_processor_kwargs)
 

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -74,8 +74,9 @@ def convert_image_mode(image: Image.Image, to_mode: str) -> Image.Image:
 MediaModality = Literal["image", "video", "audio"]
 
 # Output representations supported by `ImageMediaIO`:
-# `"pt"` -> `torch.Tensor`, `"pil"` -> `PIL.Image.Image`.
-_SUPPORTED_IMAGE_FORMATS = ("pt", "pil")
+# `"pt"` -> `torch.Tensor`, `"np"` -> uint8 HWC `numpy.ndarray`,
+# `"pil"` -> `PIL.Image.Image`.
+_SUPPORTED_IMAGE_FORMATS = ("pt", "np", "pil")
 
 # Output representations supported by `VideoMediaIO`. See
 # `_load_video_by_cv2` for the per-format contract.
@@ -691,7 +692,7 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
         return await loop.run_in_executor(BaseMediaIO._executor, fn, *args)
 
 
-class ImageMediaIO(BaseMediaIO[Union[Image.Image, torch.Tensor]]):
+class ImageMediaIO(BaseMediaIO[Union[Image.Image, torch.Tensor, np.ndarray]]):
     """I/O for the image modality."""
 
     def __init__(self, format: str = "pt", device: str = "cpu") -> None:
@@ -700,20 +701,25 @@ class ImageMediaIO(BaseMediaIO[Union[Image.Image, torch.Tensor]]):
         self._format = format
         self._device = device
 
-    def _postprocess(self, image: Image.Image) -> Union[Image.Image, torch.Tensor]:
+    def _postprocess(self, image: Image.Image) -> Union[Image.Image, torch.Tensor, np.ndarray]:
         if self._format == "pt":
             from torchvision.transforms import ToTensor
 
             return ToTensor()(image).to(device=self._device)
+        if self._format == "np":
+            # uint8 HWC array; the downstream HF processor rescales/permutes.
+            return np.asarray(image)
         return image
 
-    def load_bytes(self, data: bytes) -> Union[Image.Image, torch.Tensor]:
+    def load_bytes(self, data: bytes) -> Union[Image.Image, torch.Tensor, np.ndarray]:
         return self._postprocess(_load_and_convert_image(BytesIO(data)))
 
-    def load_base64(self, media_type: str, data: str) -> Union[Image.Image, torch.Tensor]:
+    def load_base64(
+        self, media_type: str, data: str
+    ) -> Union[Image.Image, torch.Tensor, np.ndarray]:
         return self._postprocess(_load_and_convert_image(BytesIO(base64.b64decode(data))))
 
-    def load_file(self, url: str) -> Union[Image.Image, torch.Tensor]:
+    def load_file(self, url: str) -> Union[Image.Image, torch.Tensor, np.ndarray]:
         return self._postprocess(_load_and_convert_image(Path(_normalize_file_uri(url))))
 
 

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from typing import (Any, Callable, ClassVar, Dict, List, Optional, Protocol,
                     Tuple, Type, TypeVar, Union)
 
+import numpy as np
 import torch
 from PIL import Image
 from torch import Tensor, nn
@@ -535,6 +536,9 @@ class BaseMultimodalInputProcessor(ABC):
         """
         if isinstance(image, torch.Tensor):
             image_h, image_w = int(image.shape[-2]), int(image.shape[-1])
+        elif isinstance(image, np.ndarray):
+            # HWC uint8 from ImageMediaIO's "np" format.
+            image_h, image_w = int(image.shape[0]), int(image.shape[1])
         else:
             image_h, image_w = image.height, image.width
         return self.get_num_multimodal_tokens([(image_h, image_w)],
@@ -572,6 +576,10 @@ class BaseMultimodalInputProcessor(ABC):
         if isinstance(first_frame, torch.Tensor):
             frame_h = int(first_frame.shape[-2])
             frame_w = int(first_frame.shape[-1])
+        elif isinstance(first_frame, np.ndarray):
+            # HWC uint8 from VideoMediaIO's "np" format.
+            frame_h = int(first_frame.shape[0])
+            frame_w = int(first_frame.shape[1])
         else:
             frame_h, frame_w = first_frame.height, first_frame.width
 

--- a/tests/unittest/_torch/multimodal/test_encoder_group.py
+++ b/tests/unittest/_torch/multimodal/test_encoder_group.py
@@ -152,3 +152,23 @@ class TestReorderEmbedsByManifest:
         out = _reorder_embeds_by_manifest([mp], per_modality_embeds, per_modality_lengths)
         expected = torch.tensor([7.0] * 2 + [9.0] * 3)
         assert torch.equal(out[:, 0], expected)
+
+    def test_empty_bookkeeping_returns_typed_empty(self):
+        # Mirrors the executor KV-cache profiling pass: the dummy batch runs the
+        # encoder but carries no ``multimodal_embedding_lengths``, so per-modality
+        # lengths are empty and the sliced embeds are zero-row. Reorder must
+        # return a correctly-typed empty tensor, not crash on ``torch.cat([])``.
+        mp = _mp(buckets={"image": {}})  # modality present, no manifest, no lengths
+        hidden = 5
+        per_modality_embeds = {"image": torch.empty((0, hidden), dtype=torch.float16)}
+        per_modality_lengths = {"image": []}
+        out = _reorder_embeds_by_manifest([mp], per_modality_embeds, per_modality_lengths)
+        assert out.shape == (0, hidden)
+        assert out.dtype == torch.float16
+
+    def test_no_embeds_returns_empty(self):
+        # Defensive: no group produced embeddings at all — return an empty
+        # tensor rather than crashing.
+        mp = _mp(buckets={})
+        out = _reorder_embeds_by_manifest([mp], {}, {})
+        assert out.numel() == 0

--- a/tests/unittest/_torch/multimodal/test_encoder_group.py
+++ b/tests/unittest/_torch/multimodal/test_encoder_group.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the generic encoder-group primitives.
 
-Covers the pure helpers behind ``MultimodalModelMixin.encode_multimodal_by_groups``:
+Covers the pure helpers behind ``encode_multimodal_by_groups``:
 
 * ``_lengths_by_modality`` — invert prompt-ordered ``multimodal_embedding_lengths``
   into per-modality per-item lists using ``mm_item_order``.

--- a/tests/unittest/_torch/multimodal/test_encoder_group.py
+++ b/tests/unittest/_torch/multimodal/test_encoder_group.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the generic encoder-group primitives.
+
+Covers the pure helpers behind ``MultimodalModelMixin.encode_multimodal_by_groups``:
+
+* ``_lengths_by_modality`` — invert prompt-ordered ``multimodal_embedding_lengths``
+  into per-modality per-item lists using ``mm_item_order``.
+* ``_synthesize_single_modality_manifest`` — trivial manifest for single-modality
+  requests that don't carry an explicit one.
+* ``_reorder_embeds_by_manifest`` — slice per-modality tensors and concat in
+  each request's prompt-order manifest.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.models.modeling_multimodal_utils import (
+    _lengths_by_modality,
+    _reorder_embeds_by_manifest,
+    _synthesize_single_modality_manifest,
+)
+
+
+def _mp(*, mm_item_order=None, embedding_lengths=None, buckets=None):
+    """Minimal MultimodalParams stand-in — the helpers only touch
+    ``multimodal_data`` and ``mm_item_order``."""
+    data = dict(buckets or {})
+    if embedding_lengths is not None:
+        data["multimodal_embedding_lengths"] = embedding_lengths
+    return SimpleNamespace(multimodal_data=data, mm_item_order=mm_item_order)
+
+
+class TestLengthsByModality:
+    def test_mixed_manifest_image_video_image(self):
+        # Manifest order: image#0 (4 rows), video#0 (6), image#1 (2).
+        mp = _mp(
+            mm_item_order=[
+                {"modality": "image", "index": 0},
+                {"modality": "video", "index": 0},
+                {"modality": "image", "index": 1},
+            ],
+            embedding_lengths=[4, 6, 2],
+            buckets={"image": {}, "video": {}},
+        )
+        assert _lengths_by_modality([mp], ("image", "video")) == {
+            "image": [4, 2],
+            "video": [6],
+        }
+
+    def test_single_modality_no_manifest(self):
+        # No mm_item_order; flat list is already in per-modality order.
+        mp = _mp(embedding_lengths=[64, 64], buckets={"image": {}})
+        assert _lengths_by_modality([mp], ("image", "video")) == {
+            "image": [64, 64],
+            "video": [],
+        }
+
+    def test_length_mismatch_raises(self):
+        # ``strict=True`` inside the helper catches manifest/length divergence.
+        mp = _mp(
+            mm_item_order=[
+                {"modality": "image", "index": 0},
+                {"modality": "video", "index": 0},
+            ],
+            embedding_lengths=[4],  # one short
+            buckets={"image": {}, "video": {}},
+        )
+        with pytest.raises(ValueError):
+            _lengths_by_modality([mp], ("image", "video"))
+
+
+class TestSynthesizeSingleModalityManifest:
+    def test_image_only(self):
+        mp = _mp(embedding_lengths=[10, 20, 30], buckets={"image": {}})
+        assert _synthesize_single_modality_manifest(mp, ("image", "video")) == [
+            {"modality": "image", "index": 0},
+            {"modality": "image", "index": 1},
+            {"modality": "image", "index": 2},
+        ]
+
+    def test_no_group_modality_returns_empty(self):
+        # Request has audio but the group only covers image/video.
+        mp = _mp(embedding_lengths=[10], buckets={"audio": {}})
+        assert _synthesize_single_modality_manifest(mp, ("image", "video")) == []
+
+
+class TestReorderEmbedsByManifest:
+    @staticmethod
+    def _marker_tensor(marker, rows, hidden=2):
+        # Rows all share a marker so the reorder can be asserted by column-0.
+        return torch.full((rows, hidden), float(marker))
+
+    def test_mixed_image_video_image_in_one_request(self):
+        # Prompt: image#0 (4 rows, marker 10), video#0 (6, 20), image#1 (2, 30).
+        mp = _mp(
+            mm_item_order=[
+                {"modality": "image", "index": 0},
+                {"modality": "video", "index": 0},
+                {"modality": "image", "index": 1},
+            ],
+            buckets={"image": {}, "video": {}},
+        )
+        # Per-modality tensors are cat'd in encounter order — image items 0
+        # and 1 concatenated, then video item 0.
+        per_modality_embeds = {
+            "image": torch.cat([self._marker_tensor(10, 4), self._marker_tensor(30, 2)], dim=0),
+            "video": self._marker_tensor(20, 6),
+        }
+        per_modality_lengths = {"image": [4, 2], "video": [6]}
+        out = _reorder_embeds_by_manifest([mp], per_modality_embeds, per_modality_lengths)
+        # Expected column-0: 10 (×4), 20 (×6), 30 (×2) in prompt order.
+        expected = torch.tensor([10.0] * 4 + [20.0] * 6 + [30.0] * 2)
+        assert torch.equal(out[:, 0], expected)
+
+    def test_cross_request_cursors_advance_per_modality(self):
+        # Request A: [image#0 (2)]; Request B: [video#0 (3), image#0 (1)].
+        # Global per-modality indexing: image=[A#0, B#0], video=[B#0].
+        # Manifests use per-request indices — cursor must translate them.
+        mp_a = _mp(
+            mm_item_order=[{"modality": "image", "index": 0}],
+            buckets={"image": {}},
+        )
+        mp_b = _mp(
+            mm_item_order=[
+                {"modality": "video", "index": 0},
+                {"modality": "image", "index": 0},
+            ],
+            buckets={"image": {}, "video": {}},
+        )
+        per_modality_embeds = {
+            "image": torch.cat([self._marker_tensor(1, 2), self._marker_tensor(3, 1)], dim=0),
+            "video": self._marker_tensor(2, 3),
+        }
+        per_modality_lengths = {"image": [2, 1], "video": [3]}
+        out = _reorder_embeds_by_manifest([mp_a, mp_b], per_modality_embeds, per_modality_lengths)
+        # A: image#0 → marker 1 (×2). B: video#0 → 2 (×3), then image#0 → 3 (×1).
+        expected = torch.tensor([1.0] * 2 + [2.0] * 3 + [3.0] * 1)
+        assert torch.equal(out[:, 0], expected)
+
+    def test_single_modality_falls_back_to_synthesized_manifest(self):
+        # Two image items, no explicit manifest — reorder still works by
+        # synthesizing a trivial per-modality manifest from the request's
+        # multimodal_embedding_lengths.
+        mp = _mp(embedding_lengths=[2, 3], buckets={"image": {}})
+        per_modality_embeds = {
+            "image": torch.cat([self._marker_tensor(7, 2), self._marker_tensor(9, 3)], dim=0),
+        }
+        per_modality_lengths = {"image": [2, 3]}
+        out = _reorder_embeds_by_manifest([mp], per_modality_embeds, per_modality_lengths)
+        expected = torch.tensor([7.0] * 2 + [9.0] * 3)
+        assert torch.equal(out[:, 0], expected)

--- a/tests/unittest/_torch/multimodal/test_encoder_group.py
+++ b/tests/unittest/_torch/multimodal/test_encoder_group.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from tensorrt_llm._torch.models.modeling_multimodal_utils import (
+from tensorrt_llm._torch.models.modeling_multimodal_mixin import (
     _lengths_by_modality,
     _reorder_embeds_by_manifest,
     _synthesize_single_modality_manifest,

--- a/tests/unittest/_torch/multimodal/test_qwen3vl_mixed_modality_encoder.py
+++ b/tests/unittest/_torch/multimodal/test_qwen3vl_mixed_modality_encoder.py
@@ -1,231 +1,205 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Encoder-level tests for Qwen3-VL mixed-modality interleaving.
+"""Encoder-level tests for Qwen3-VL through the generic mm-encoder-group path.
 
-Exercises `Qwen3VisionModelBase._parse_and_batch_multimodal_data` and
-`forward` directly by constructing an instance without invoking __init__ and
-stubbing `self.visual` with a marker function whose output row values encode
-input row identities. This lets us assert that mixed image+video requests
-produce a single ViT call whose output rows arrive in prompt order.
+Constructs a minimal ``MultimodalModelMixin`` with the Qwen3-VL
+``EncoderGroup`` and a stub ``encode_batched`` marker function. Asserts that
+mixed image+video requests, heterogeneous single-modality batches, and
+cross-request batching all produce prompt-order embeddings via one ViT call.
 """
+
+from types import SimpleNamespace
 
 import pytest
 import torch
 
-from tensorrt_llm._torch.models.modeling_qwen3vl import Qwen3VisionModelBase
-from tensorrt_llm.inputs.multimodal import MultimodalParams
+from tensorrt_llm._torch.models.modeling_multimodal_mixin import MultimodalModelMixin
+from tensorrt_llm._torch.models.modeling_multimodal_utils import EncoderGroup
+from tensorrt_llm._torch.models.modeling_qwen3vl import _qwen3vl_build_batched_input
 
 
-class _FakeVisual:
-    """Marker ViT that returns a single-tensor pair mimicking Qwen3VL's
-    (image_embeds, deepstack_list) contract. Row i of the output is a
-    length-`hidden` tensor filled with a marker computed from the input
-    row's marker (via pooling `patches_per_item` rows and preserving order).
-    """
-
-    def __init__(self, hidden=4, deepstack_layers=0):
-        self.hidden = hidden
-        self.deepstack_layers = deepstack_layers
-
-    def __call__(self, pixel_values, grid_thw):
-        # `pixel_values` is [P_total, marker_dim]; each row's first column
-        # holds an integer identity marker. The "encoder" pools each item's
-        # patches into a single row per item (grid_thw specifies item extent).
-        out_rows = []
-        offset = 0
-        markers = pixel_values[:, 0].tolist()
-        for thw in grid_thw.tolist():
-            n = int(thw[0] * thw[1] * thw[2])
-            # Use the first patch's marker as the item's identity.
-            item_marker = markers[offset]
-            offset += n
-            # Emit ONE row per patch (real ViT output-length = P_total).
-            out_rows.extend([item_marker] * n)
-        base = torch.tensor(out_rows, dtype=torch.float32).unsqueeze(1).repeat(1, self.hidden)
-        deepstack = [torch.zeros_like(base) for _ in range(self.deepstack_layers)]
-        return base, deepstack
+def _encode_batched(pixel_values: torch.Tensor, grid_thw: torch.Tensor) -> torch.Tensor:
+    """Marker encoder: one output row per input patch, marker propagates via
+    column 0. Emulates a modality-blind ViT with no compression."""
+    return pixel_values.clone().repeat(1, 2)  # widen to hidden=marker_dim*2
 
 
-def _make_encoder():
-    enc = object.__new__(Qwen3VisionModelBase)
-    enc.model_dtype = torch.float32
-    enc.visual = _FakeVisual(hidden=4, deepstack_layers=0)
-    return enc
+class _StubModel(MultimodalModelMixin):
+    def __init__(self):
+        self.mm_encoder_groups = (
+            EncoderGroup(
+                modalities=("image", "video"),
+                encoder_fn=_encode_batched,
+                build_batched_input=_qwen3vl_build_batched_input,
+            ),
+        )
 
 
-def _make_param(image=None, video=None, order=None):
-    # `image`, `video`, and `order` default to `None` so a test can omit
-    # whichever fields it doesn't need — every case populates at least one.
+def _param(image=None, video=None, order=None, lengths=None):
     data = {}
     if image is not None:
         data["image"] = image
     if video is not None:
         data["video"] = video
-    return MultimodalParams(multimodal_data=data, mm_item_order=order)
+    if lengths is not None:
+        data["multimodal_embedding_lengths"] = lengths
+    return SimpleNamespace(multimodal_data=data, mm_item_order=order)
 
 
-def _make_item_patches(marker: int, patches: int, dim: int = 2):
-    # Row 0's first column encodes the item's marker.
-    t = torch.zeros((patches, dim), dtype=torch.float32)
+def _patches(marker: int, n: int, dim: int = 2) -> torch.Tensor:
+    t = torch.zeros((n, dim), dtype=torch.float32)
     t[:, 0] = float(marker)
     return t
 
 
-def test_image_only_single_modality_fallback_unchanged():
-    enc = _make_encoder()
-    params = [
-        _make_param(
-            image={
-                "pixel_values": _make_item_patches(marker=10, patches=4),
-                "image_grid_thw": torch.tensor([[1, 2, 2]]),
-            },
+def _encode(params):
+    return _StubModel().encode_multimodal_by_groups(params)
+
+
+def test_image_only_request():
+    out = _encode(
+        [
+            _param(
+                image={
+                    "pixel_values": _patches(10, 4),
+                    "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                },
+                lengths=[4],
+            ),
+        ]
+    )
+    assert torch.equal(out[:, 0], torch.full((4,), 10.0))
+
+
+def test_mixed_image_video_image_prompt_order():
+    # Prompt: image#0 (4 rows), video#0 (6), image#1 (2).
+    out = _encode(
+        [
+            _param(
+                image={
+                    "pixel_values": torch.cat([_patches(10, 4), _patches(30, 2)], dim=0),
+                    "image_grid_thw": torch.tensor([[1, 2, 2], [1, 1, 2]]),
+                },
+                video={
+                    "pixel_values_videos": _patches(20, 6),
+                    "video_grid_thw": torch.tensor([[2, 1, 3]]),
+                },
+                order=[
+                    {"modality": "image", "index": 0},
+                    {"modality": "video", "index": 0},
+                    {"modality": "image", "index": 1},
+                ],
+                lengths=[4, 6, 2],
+            ),
+        ]
+    )
+    expected = torch.tensor([10.0] * 4 + [20.0] * 6 + [30.0] * 2)
+    assert torch.equal(out[:, 0], expected)
+
+
+def test_mixed_without_manifest_raises():
+    """Mixed request must carry mm_item_order; the shared helper enforces this
+    once for every model that registers a multi-modality EncoderGroup."""
+    with pytest.raises(ValueError, match="mm_item_order"):
+        _encode(
+            [
+                _param(
+                    image={
+                        "pixel_values": _patches(1, 1),
+                        "image_grid_thw": torch.tensor([[1, 1, 1]]),
+                    },
+                    video={
+                        "pixel_values_videos": _patches(2, 1),
+                        "video_grid_thw": torch.tensor([[1, 1, 1]]),
+                    },
+                    lengths=[1, 1],
+                    # order deliberately omitted
+                )
+            ]
         )
-    ]
-    embeds = enc.forward(params)
-    assert len(embeds) == 1
-    # 4 patches, all marker 10.
-    assert embeds[0].shape == (4, 4)
-    assert torch.equal(embeds[0][:, 0], torch.full((4,), 10.0))
 
 
-def test_mixed_image_video_image_prompt_order_interleave():
-    enc = _make_encoder()
-    # Prompt order: image#0 (marker=10, 4 patches), video#0 (marker=20, 6
-    # patches), image#1 (marker=30, 2 patches).
-    params = [
-        _make_param(
-            image={
-                "pixel_values": torch.cat(
-                    [
-                        _make_item_patches(marker=10, patches=4),
-                        _make_item_patches(marker=30, patches=2),
+def test_batch_of_two_image_only_requests():
+    out = _encode(
+        [
+            _param(
+                image={
+                    "pixel_values": _patches(1, 2),
+                    "image_grid_thw": torch.tensor([[1, 1, 2]]),
+                },
+                lengths=[2],
+            ),
+            _param(
+                image={
+                    "pixel_values": _patches(2, 3),
+                    "image_grid_thw": torch.tensor([[1, 1, 3]]),
+                },
+                lengths=[3],
+            ),
+        ]
+    )
+    expected = torch.tensor([1.0] * 2 + [2.0] * 3)
+    assert torch.equal(out[:, 0], expected)
+
+
+def test_heterogeneous_batch_image_only_and_video_only():
+    """One image-only request + one video-only request go through the same
+    modality-blind ViT via the generic path — no per-request manifest needed
+    because neither individual request is mixed."""
+    out = _encode(
+        [
+            _param(
+                image={
+                    "pixel_values": _patches(1, 2),
+                    "image_grid_thw": torch.tensor([[1, 1, 2]]),
+                },
+                lengths=[2],
+            ),
+            _param(
+                video={
+                    "pixel_values_videos": _patches(2, 3),
+                    "video_grid_thw": torch.tensor([[1, 1, 3]]),
+                },
+                lengths=[3],
+            ),
+        ]
+    )
+    expected = torch.tensor([1.0] * 2 + [2.0] * 3)
+    assert torch.equal(out[:, 0], expected)
+
+
+def test_mixed_request_alongside_ordered_one_still_rejects_unordered():
+    """Even when a sibling request carries a valid manifest, a mixed request
+    without its own manifest must still raise — validation is per-request."""
+    with pytest.raises(ValueError, match="mm_item_order"):
+        _encode(
+            [
+                _param(
+                    image={
+                        "pixel_values": _patches(10, 2),
+                        "image_grid_thw": torch.tensor([[1, 1, 2]]),
+                    },
+                    video={
+                        "pixel_values_videos": _patches(20, 2),
+                        "video_grid_thw": torch.tensor([[1, 1, 2]]),
+                    },
+                    order=[
+                        {"modality": "image", "index": 0},
+                        {"modality": "video", "index": 0},
                     ],
-                    dim=0,
+                    lengths=[2, 2],
                 ),
-                "image_grid_thw": torch.tensor([[1, 2, 2], [1, 1, 2]]),
-            },
-            video={
-                "pixel_values_videos": _make_item_patches(marker=20, patches=6),
-                "video_grid_thw": torch.tensor([[2, 1, 3]]),
-            },
-            order=[
-                {"modality": "image", "index": 0},
-                {"modality": "video", "index": 0},
-                {"modality": "image", "index": 1},
-            ],
+                _param(
+                    image={
+                        "pixel_values": _patches(30, 1),
+                        "image_grid_thw": torch.tensor([[1, 1, 1]]),
+                    },
+                    video={
+                        "pixel_values_videos": _patches(40, 1),
+                        "video_grid_thw": torch.tensor([[1, 1, 1]]),
+                    },
+                    lengths=[1, 1],
+                    # No manifest on this request even though it has both modalities.
+                ),
+            ]
         )
-    ]
-    embeds = enc.forward(params)
-    assert len(embeds) == 1
-    # 4 + 6 + 2 = 12 rows in prompt order.
-    expected = torch.tensor([10.0] * 4 + [20.0] * 6 + [30.0] * 2, dtype=torch.float32)
-    assert embeds[0].shape == (12, 4)
-    assert torch.equal(embeds[0][:, 0], expected)
-
-
-def test_mixed_without_manifest_raises_tripwire():
-    """Guard: if both modalities show up but mm_item_order is absent the
-    encoder must NOT silently produce misordered embeddings."""
-    enc = _make_encoder()
-    params = [
-        _make_param(
-            image={
-                "pixel_values": _make_item_patches(marker=1, patches=1),
-                "image_grid_thw": torch.tensor([[1, 1, 1]]),
-            },
-            video={
-                "pixel_values_videos": _make_item_patches(marker=2, patches=1),
-                "video_grid_thw": torch.tensor([[1, 1, 1]]),
-            },
-            # order deliberately omitted
-        )
-    ]
-    with pytest.raises(ValueError, match="mm_item_order"):
-        enc.forward(params)
-
-
-def test_batch_of_two_requests_single_modality_each():
-    """Batching still works when each request in the batch is
-    single-modality (no manifest needed, no interleave path)."""
-    enc = _make_encoder()
-    params = [
-        _make_param(
-            image={
-                "pixel_values": _make_item_patches(marker=1, patches=2),
-                "image_grid_thw": torch.tensor([[1, 1, 2]]),
-            }
-        ),
-        _make_param(
-            image={
-                "pixel_values": _make_item_patches(marker=2, patches=3),
-                "image_grid_thw": torch.tensor([[1, 1, 3]]),
-            }
-        ),
-    ]
-    embeds = enc.forward(params)
-    assert len(embeds) == 1
-    expected = torch.tensor([1.0] * 2 + [2.0] * 3, dtype=torch.float32)
-    assert torch.equal(embeds[0][:, 0], expected)
-
-
-def test_batch_unordered_mixed_request_raises_even_alongside_ordered_one():
-    """A mixed-modality request without a manifest must still be rejected
-    per-request, even when a sibling request in the same batch carries a
-    valid manifest and would otherwise route the batch through the
-    interleave path."""
-    enc = _make_encoder()
-    params = [
-        _make_param(
-            image={
-                "pixel_values": _make_item_patches(marker=10, patches=2),
-                "image_grid_thw": torch.tensor([[1, 1, 2]]),
-            },
-            video={
-                "pixel_values_videos": _make_item_patches(marker=20, patches=2),
-                "video_grid_thw": torch.tensor([[1, 1, 2]]),
-            },
-            order=[
-                {"modality": "image", "index": 0},
-                {"modality": "video", "index": 0},
-            ],
-        ),
-        _make_param(
-            image={
-                "pixel_values": _make_item_patches(marker=30, patches=1),
-                "image_grid_thw": torch.tensor([[1, 1, 1]]),
-            },
-            video={
-                "pixel_values_videos": _make_item_patches(marker=40, patches=1),
-                "video_grid_thw": torch.tensor([[1, 1, 1]]),
-            },
-            # No manifest on this request even though it has both modalities.
-        ),
-    ]
-    with pytest.raises(ValueError, match="mm_item_order"):
-        enc.forward(params)
-
-
-def test_batch_of_image_only_and_video_only_requests_uses_interleave_path():
-    """Two single-modality requests of different modalities in one batch
-    ride the modality-blind interleave path (one ViT call), even though
-    neither individual request is mixed and neither carries a manifest.
-    """
-    enc = _make_encoder()
-    params = [
-        _make_param(
-            image={
-                "pixel_values": _make_item_patches(marker=1, patches=2),
-                "image_grid_thw": torch.tensor([[1, 1, 2]]),
-            }
-        ),
-        _make_param(
-            video={
-                "pixel_values_videos": _make_item_patches(marker=2, patches=3),
-                "video_grid_thw": torch.tensor([[1, 1, 3]]),
-            }
-        ),
-    ]
-    embeds = enc.forward(params)
-    assert len(embeds) == 1
-    expected = torch.tensor([1.0] * 2 + [2.0] * 3, dtype=torch.float32)
-    assert torch.equal(embeds[0][:, 0], expected)

--- a/tests/unittest/_torch/multimodal/test_qwen3vl_mixed_modality_encoder.py
+++ b/tests/unittest/_torch/multimodal/test_qwen3vl_mixed_modality_encoder.py
@@ -14,8 +14,7 @@ from typing import Optional
 import pytest
 import torch
 
-from tensorrt_llm._torch.models.modeling_multimodal_mixin import MultimodalModelMixin
-from tensorrt_llm._torch.models.modeling_multimodal_utils import EncoderGroup
+from tensorrt_llm._torch.models.modeling_multimodal_mixin import EncoderGroup, MultimodalModelMixin
 from tensorrt_llm._torch.models.modeling_qwen3vl import _qwen3vl_build_batched_input
 
 

--- a/tests/unittest/_torch/multimodal/test_qwen3vl_mixed_modality_encoder.py
+++ b/tests/unittest/_torch/multimodal/test_qwen3vl_mixed_modality_encoder.py
@@ -9,6 +9,7 @@ cross-request batching all produce prompt-order embeddings via one ViT call.
 """
 
 from types import SimpleNamespace
+from typing import Optional
 
 import pytest
 import torch
@@ -25,7 +26,7 @@ def _encode_batched(pixel_values: torch.Tensor, grid_thw: torch.Tensor) -> torch
 
 
 class _StubModel(MultimodalModelMixin):
-    def __init__(self):
+    def __init__(self) -> None:
         self.mm_encoder_groups = (
             EncoderGroup(
                 modalities=("image", "video"),
@@ -35,8 +36,13 @@ class _StubModel(MultimodalModelMixin):
         )
 
 
-def _param(image=None, video=None, order=None, lengths=None):
-    data = {}
+def _param(
+    image: Optional[dict] = None,
+    video: Optional[dict] = None,
+    order: Optional[list] = None,
+    lengths: Optional[list] = None,
+) -> SimpleNamespace:
+    data: dict = {}
     if image is not None:
         data["image"] = image
     if video is not None:
@@ -52,11 +58,11 @@ def _patches(marker: int, n: int, dim: int = 2) -> torch.Tensor:
     return t
 
 
-def _encode(params):
+def _encode(params: list) -> torch.Tensor:
     return _StubModel().encode_multimodal_by_groups(params)
 
 
-def test_image_only_request():
+def test_image_only_request() -> None:
     out = _encode(
         [
             _param(
@@ -71,7 +77,7 @@ def test_image_only_request():
     assert torch.equal(out[:, 0], torch.full((4,), 10.0))
 
 
-def test_mixed_image_video_image_prompt_order():
+def test_mixed_image_video_image_prompt_order() -> None:
     # Prompt: image#0 (4 rows), video#0 (6), image#1 (2).
     out = _encode(
         [
@@ -97,7 +103,7 @@ def test_mixed_image_video_image_prompt_order():
     assert torch.equal(out[:, 0], expected)
 
 
-def test_mixed_without_manifest_raises():
+def test_mixed_without_manifest_raises() -> None:
     """Mixed request must carry mm_item_order; the shared helper enforces this
     once for every model that registers a multi-modality EncoderGroup."""
     with pytest.raises(ValueError, match="mm_item_order"):
@@ -119,7 +125,7 @@ def test_mixed_without_manifest_raises():
         )
 
 
-def test_batch_of_two_image_only_requests():
+def test_batch_of_two_image_only_requests() -> None:
     out = _encode(
         [
             _param(
@@ -142,7 +148,7 @@ def test_batch_of_two_image_only_requests():
     assert torch.equal(out[:, 0], expected)
 
 
-def test_heterogeneous_batch_image_only_and_video_only():
+def test_heterogeneous_batch_image_only_and_video_only() -> None:
     """One image-only request + one video-only request go through the same
     modality-blind ViT via the generic path — no per-request manifest needed
     because neither individual request is mixed."""
@@ -168,7 +174,38 @@ def test_heterogeneous_batch_image_only_and_video_only():
     assert torch.equal(out[:, 0], expected)
 
 
-def test_mixed_request_alongside_ordered_one_still_rejects_unordered():
+def test_raw_inputs_route_through_encode_multimodal_by_groups() -> None:
+    """Regression: ``Qwen3VLModelBase.forward``'s raw image/video branch
+    routes through ``encode_multimodal_by_groups`` (via
+    ``get_multimodal_embeddings``). Confirms the callable used there
+    accepts a bare ``multimodal_params`` list and returns the same
+    prompt-order embedding tensor that direct invocation produces."""
+    stub = _StubModel()
+    params = [
+        _param(
+            image={
+                "pixel_values": _patches(11, 3),
+                "image_grid_thw": torch.tensor([[1, 1, 3]]),
+            },
+            video={
+                "pixel_values_videos": _patches(22, 5),
+                "video_grid_thw": torch.tensor([[1, 1, 5]]),
+            },
+            order=[
+                {"modality": "video", "index": 0},
+                {"modality": "image", "index": 0},
+            ],
+            lengths=[5, 3],
+        ),
+    ]
+    # Same callable signature `get_multimodal_embeddings` invokes at
+    # `modeling_qwen3vl.py`'s raw-MM branch.
+    out = stub.encode_multimodal_by_groups(params)
+    expected = torch.tensor([22.0] * 5 + [11.0] * 3)
+    assert torch.equal(out[:, 0], expected)
+
+
+def test_mixed_request_alongside_ordered_one_still_rejects_unordered() -> None:
     """Even when a sibling request carries a valid manifest, a mixed request
     without its own manifest must still raise — validation is per-request."""
     with pytest.raises(ValueError, match="mm_item_order"):

--- a/tests/unittest/_torch/multimodal/test_qwen3vl_mixed_modality_encoder.py
+++ b/tests/unittest/_torch/multimodal/test_qwen3vl_mixed_modality_encoder.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Encoder-level tests for Qwen3-VL through the generic mm-encoder-group path.
 
-Constructs a minimal ``MultimodalModelMixin`` with the Qwen3-VL
-``EncoderGroup`` and a stub ``encode_batched`` marker function. Asserts that
+Wires an `EncoderGroup` around a stub `encode_batched` marker function and
+drives the shared `encode_multimodal_by_groups` helper directly. Asserts that
 mixed image+video requests, heterogeneous single-modality batches, and
 cross-request batching all produce prompt-order embeddings via one ViT call.
+The same helper is what `Qwen3VisionModelBase.forward` (the mm-encoder-only
+disagg entrypoint) delegates to, so this suite covers both paths.
 """
 
 from types import SimpleNamespace
@@ -14,7 +16,10 @@ from typing import Optional
 import pytest
 import torch
 
-from tensorrt_llm._torch.models.modeling_multimodal_mixin import EncoderGroup, MultimodalModelMixin
+from tensorrt_llm._torch.models.modeling_multimodal_mixin import (
+    EncoderGroup,
+    encode_multimodal_by_groups,
+)
 from tensorrt_llm._torch.models.modeling_qwen3vl import _qwen3vl_build_batched_input
 
 
@@ -24,15 +29,13 @@ def _encode_batched(pixel_values: torch.Tensor, grid_thw: torch.Tensor) -> torch
     return pixel_values.clone().repeat(1, 2)  # widen to hidden=marker_dim*2
 
 
-class _StubModel(MultimodalModelMixin):
-    def __init__(self) -> None:
-        self.mm_encoder_groups = (
-            EncoderGroup(
-                modalities=("image", "video"),
-                encoder_fn=_encode_batched,
-                build_batched_input=_qwen3vl_build_batched_input,
-            ),
-        )
+_QWEN3VL_ENCODER_GROUPS = (
+    EncoderGroup(
+        modalities=("image", "video"),
+        encoder_fn=_encode_batched,
+        build_batched_input=_qwen3vl_build_batched_input,
+    ),
+)
 
 
 def _param(
@@ -58,7 +61,7 @@ def _patches(marker: int, n: int, dim: int = 2) -> torch.Tensor:
 
 
 def _encode(params: list) -> torch.Tensor:
-    return _StubModel().encode_multimodal_by_groups(params)
+    return encode_multimodal_by_groups(_QWEN3VL_ENCODER_GROUPS, params)
 
 
 def test_image_only_request() -> None:
@@ -173,13 +176,40 @@ def test_heterogeneous_batch_image_only_and_video_only() -> None:
     assert torch.equal(out[:, 0], expected)
 
 
+def test_heterogeneous_batch_video_first_then_image() -> None:
+    """Reviewer's mm-encoder-only regression case: `[video-only req0,
+    image-only req1]`. `_qwen3vl_build_batched_input` concatenates images
+    across requests first, then videos, so without prompt-order reordering
+    the encoder output would be `[img(req1), vid(req0)]` — request-ordered
+    downstream splits would then hand each request the other's rows.
+    Assert the shared helper reorders rows into request order."""
+    out = _encode(
+        [
+            _param(
+                video={
+                    "pixel_values_videos": _patches(20, 8),
+                    "video_grid_thw": torch.tensor([[1, 1, 8]]),
+                },
+                lengths=[8],
+            ),
+            _param(
+                image={
+                    "pixel_values": _patches(10, 5),
+                    "image_grid_thw": torch.tensor([[1, 1, 5]]),
+                },
+                lengths=[5],
+            ),
+        ]
+    )
+    expected = torch.tensor([20.0] * 8 + [10.0] * 5)
+    assert torch.equal(out[:, 0], expected)
+
+
 def test_raw_inputs_route_through_encode_multimodal_by_groups() -> None:
     """Regression: ``Qwen3VLModelBase.forward``'s raw image/video branch
     routes through ``encode_multimodal_by_groups`` (via
-    ``get_multimodal_embeddings``). Confirms the callable used there
-    accepts a bare ``multimodal_params`` list and returns the same
-    prompt-order embedding tensor that direct invocation produces."""
-    stub = _StubModel()
+    ``get_multimodal_embeddings``). Confirms the same callable signature
+    used there returns the expected prompt-order embedding tensor."""
     params = [
         _param(
             image={
@@ -197,9 +227,7 @@ def test_raw_inputs_route_through_encode_multimodal_by_groups() -> None:
             lengths=[5, 3],
         ),
     ]
-    # Same callable signature `get_multimodal_embeddings` invokes at
-    # `modeling_qwen3vl.py`'s raw-MM branch.
-    out = stub.encode_multimodal_by_groups(params)
+    out = encode_multimodal_by_groups(_QWEN3VL_ENCODER_GROUPS, params)
     expected = torch.tensor([22.0] * 5 + [11.0] * 3)
     assert torch.equal(out[:, 0], expected)
 

--- a/tests/unittest/llmapi/apps/test_chat_utils.py
+++ b/tests/unittest/llmapi/apps/test_chat_utils.py
@@ -608,7 +608,7 @@ class TestMmItemOrderReturn:
             ),
         ],
     )
-    def test_item_order(self, messages, expected):
+    def test_item_order(self, messages: list, expected: list) -> None:
         class _StubConfig:
             model_type = _MM_MODEL_TYPE
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved multimodal processing for mixed image and video inputs.
  * Preserved multimodal item order across prompts, batching, and server requests.
  * Added efficient batched vision encoding for compatible multimodal requests.
  * Added validation for missing ordering information in mixed-modality prompts.

* **Bug Fixes**
  * Corrected embedding ordering and multimodal hash/UUID alignment.

* **Tests**
  * Added coverage for mixed modalities, batching, ordering, validation, and chat parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Bring mixed modality support into the mixin:
* Introduce the concept of an `EncoderGroup` which the model specifies and supports batching multiple modality inputs for the same encoder
* Generic support for stacking and re-ordering embeddings via the `MultimodalParams.embedding_lengths` which are already in prompt order

Note: This also pulls in the changes from the base branch PR: https://github.com/NVIDIA/TensorRT-LLM/pull/15852

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
