### PR TITLE
[https://nvbugs/6435642][fix] detect killed MPI executor workers

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -46,6 +46,7 @@ from .utils import (EngineDeadError, ErrorResponse, RequestError,
                     get_spawn_proxy_process_env, is_llm_response,
                     print_alive_threads)
 from .worker import GenerationExecutorWorker, worker_main
+from .worker_process_monitor import WorkerProcessIdentity, WorkerProcessMonitor
 
 __all__ = [
     "GenerationExecutorProxy",
@@ -176,6 +177,7 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         self.dispatch_result_thread: Optional[ManagedThread] = None
         self.rpc_client: Optional[RPCClient] = None
+        self._worker_process_monitor = WorkerProcessMonitor()
         self._start_executor_workers(worker_kwargs)
 
         # Create RPC client after workers are started (worker starts RPC server)
@@ -224,6 +226,19 @@ class GenerationExecutorProxy(GenerationExecutor):
                 return True
         return False
 
+    def _check_mpi_workers(self) -> bool:
+        """Check OS process handles and MPI futures for worker death."""
+        dead_worker = self._worker_process_monitor.find_dead_worker()
+        if dead_worker is not None:
+            self._set_fatal_error(
+                RuntimeError("MPI worker rank "
+                             f"{dead_worker.rank} (pid {dead_worker.pid}) "
+                             "exited unexpectedly"))
+            if not self.doing_shutdown:
+                self.pre_shutdown()
+            return True
+        return self._check_mpi_futures()
+
     def _drain_error_queue(self) -> bool:
         """Drain all queued errors, skipping per-request errors.
 
@@ -266,7 +281,7 @@ class GenerationExecutorProxy(GenerationExecutor):
         if self._drain_error_queue():
             return self._fatal_error is None and not self.doing_shutdown
 
-        if self._check_mpi_futures():
+        if self._check_mpi_workers():
             return False
 
         return True
@@ -343,9 +358,10 @@ class GenerationExecutorProxy(GenerationExecutor):
     def _error_monitor_loop(self) -> None:
         """Background thread that reaps a dead engine and drives pre_shutdown.
 
-        Checks MPI worker futures, remote-session worker-death notifications,
-        and the error queue using the shared ``_check_mpi_futures()``,
-        ``_check_remote_worker_death()`` and ``_drain_error_queue()`` helpers.
+        Checks local MPI worker process handles and futures, remote-session
+        worker-death notifications, and the error queue using the shared
+        ``_check_mpi_workers()``, ``_check_remote_worker_death()`` and
+        ``_drain_error_queue()`` helpers.
 
         Propagation to pending requests is event-driven via
         ``_handle_worker_death`` (the MPI future done-callback) where futures
@@ -355,7 +371,7 @@ class GenerationExecutorProxy(GenerationExecutor):
         """
         while not self.doing_shutdown and self._fatal_error is None:
             try:
-                if self._check_mpi_futures():
+                if self._check_mpi_workers():
                     logger.error("Error monitor: MPI worker crash detected, "
                                  "shutting down")
                     return
@@ -537,7 +553,7 @@ class GenerationExecutorProxy(GenerationExecutor):
 
         while True:
             if self.worker_init_status_queue.poll(1):
-                ready_signal, error_trace = self.worker_init_status_queue.get()
+                status = self.worker_init_status_queue.get()
                 # Send ACK to the worker
                 self.worker_init_status_queue.put("ACK")
                 logger.info("get signal from executor worker")
@@ -547,6 +563,7 @@ class GenerationExecutorProxy(GenerationExecutor):
                 raise RuntimeError("Executor worker died during initialization")
             self._handle_background_error()
 
+        ready_signal, error_trace = status[:2]
         if ready_signal != GenerationExecutorProxy.READY_SIGNAL:
             logger.error(f"Executor worker initialization error: {error_trace}")
             # Only abort a session this proxy created; an externally owned
@@ -555,6 +572,10 @@ class GenerationExecutorProxy(GenerationExecutor):
                 self.mpi_session.shutdown_abort(reason=ready_signal)
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
+
+        if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
+            worker_process_identities: List[WorkerProcessIdentity] = status[2]
+            self._worker_process_monitor.register(worker_process_identities)
 
     def _abort_all_requests(self):
         # The results can be finished during this loop, so self._results may be changed.
@@ -570,6 +591,8 @@ class GenerationExecutorProxy(GenerationExecutor):
             return
         else:
             self.doing_shutdown = True
+
+        self._worker_process_monitor.close()
 
         # Wake the error monitor thread immediately so it exits cleanly
         if hasattr(self, '_shutdown_event'):

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -28,6 +28,7 @@ from .request import CancellingRequest, GenerationRequest
 from .rpc_worker_mixin import RpcWorkerMixin
 from .utils import (ErrorResponse, IntraProcessQueue, RequestError,
                     WorkerCommIpcAddrs)
+from .worker_process_monitor import capture_worker_process_identity
 
 __all__ = [
     "GenerationExecutorWorker",
@@ -311,6 +312,8 @@ def worker_main(
     #         error to the error_queue in the main thread.
 
     mpi_comm().barrier()
+    worker_process_identities = mpi_comm().allgather(
+        capture_worker_process_identity(mpi_rank()))
     logger_debug(f"Worker {mpi_rank()} ready to setup backend...\n", "green")
 
     try:
@@ -351,7 +354,7 @@ def worker_main(
                     worker.set_result_queue(result_queue)
 
                 # Send ready signal with confirmation
-                ready_msg = (ready_signal, None)
+                ready_msg = (ready_signal, None, worker_process_identities)
                 if not worker_init_status_queue.notify_with_retry(ready_msg):
                     logger.warning(
                         "Failed to deliver ready signal to proxy, continuing anyway"

--- a/tensorrt_llm/executor/worker_process_monitor.py
+++ b/tensorrt_llm/executor/worker_process_monitor.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Linux process-liveness monitoring for locally spawned executor workers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import select
+import socket
+import threading
+from typing import Dict, List, NamedTuple, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerProcessIdentity(NamedTuple):
+    """Stable identity for one executor worker process."""
+
+    rank: int
+    pid: int
+    start_time: Optional[int]
+    hostname: str
+    pid_namespace: Optional[int]
+
+
+def _read_process_state(pid: int) -> Optional[tuple[str, int]]:
+    """Read the Linux process state and start time from ``/proc``.
+
+    Returns:
+        A ``(state, start_time)`` tuple, or ``None`` when the process does not
+        exist or procfs is unavailable.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", encoding="utf-8") as stat_file:
+            stat = stat_file.read()
+    except (FileNotFoundError, ProcessLookupError):
+        return None
+
+    # The second field is parenthesized and may contain spaces or parentheses.
+    command_end = stat.rfind(")")
+    if command_end < 0:
+        return None
+    fields = stat[command_end + 2 :].split()
+    if len(fields) <= 19:
+        return None
+    return fields[0], int(fields[19])
+
+
+def _read_pid_namespace(pid: int) -> Optional[int]:
+    """Return the inode identifying a Linux PID namespace."""
+    try:
+        return os.stat(f"/proc/{pid}/ns/pid").st_ino
+    except OSError:
+        return None
+
+
+def capture_worker_process_identity(rank: int, pid: Optional[int] = None) -> WorkerProcessIdentity:
+    """Capture the calling worker's rank, PID, and Linux start time."""
+    pid = pid if pid is not None else os.getpid()
+    try:
+        process_state = _read_process_state(pid)
+    except (OSError, ValueError):
+        process_state = None
+    start_time = process_state[1] if process_state is not None else None
+    return WorkerProcessIdentity(
+        rank=rank,
+        pid=pid,
+        start_time=start_time,
+        hostname=socket.gethostname(),
+        pid_namespace=_read_pid_namespace(pid),
+    )
+
+
+class WorkerProcessMonitor:
+    """Monitor locally spawned workers without relying on MPI futures.
+
+    Linux pidfds are used when Python exposes ``os.pidfd_open``.  A procfs
+    identity check is retained as a fallback for older Python versions.  If
+    neither mechanism is available, the worker is left to the existing MPI
+    future/error-queue checks.
+    """
+
+    def __init__(self) -> None:
+        self._pidfd_to_identity: Dict[int, WorkerProcessIdentity] = {}
+        self._procfs_identities: List[WorkerProcessIdentity] = []
+        self._dead_identity: Optional[WorkerProcessIdentity] = None
+        self._poller = select.poll() if hasattr(select, "poll") else None
+        self._lock = threading.Lock()
+        self._local_hostname = socket.gethostname()
+        self._local_pid_namespace = _read_pid_namespace(os.getpid())
+
+    def register(self, identities: List[WorkerProcessIdentity]) -> None:
+        """Register locally spawned worker identities for liveness checks."""
+        with self._lock:
+            self._close_unlocked()
+            pidfd_open = getattr(os, "pidfd_open", None)
+            for identity in identities:
+                if identity.hostname != self._local_hostname:
+                    continue
+                if identity.pid_namespace != self._local_pid_namespace:
+                    continue
+                if pidfd_open is not None and self._poller is not None:
+                    try:
+                        pidfd = pidfd_open(identity.pid)
+                    except ProcessLookupError:
+                        self._dead_identity = identity
+                        continue
+                    except OSError as error:
+                        logger.debug("pidfd_open(%d) failed: %s", identity.pid, error)
+                    else:
+                        if identity.start_time is not None:
+                            try:
+                                process_state = _read_process_state(identity.pid)
+                            except (OSError, ValueError) as error:
+                                logger.debug(
+                                    "Failed to validate process identity for pid %d: %s",
+                                    identity.pid,
+                                    error,
+                                )
+                            else:
+                                if (
+                                    process_state is None
+                                    or process_state[0] == "Z"
+                                    or process_state[1] != identity.start_time
+                                ):
+                                    os.close(pidfd)
+                                    self._dead_identity = identity
+                                    continue
+                        self._pidfd_to_identity[pidfd] = identity
+                        self._poller.register(
+                            pidfd, select.POLLIN | select.POLLERR | select.POLLHUP
+                        )
+                        continue
+
+                if identity.start_time is not None:
+                    self._procfs_identities.append(identity)
+
+    def find_dead_worker(self) -> Optional[WorkerProcessIdentity]:
+        """Return the first worker known to have exited, if any."""
+        with self._lock:
+            if self._dead_identity is not None:
+                return self._dead_identity
+
+            if self._poller is not None:
+                for pidfd, _ in self._poller.poll(0):
+                    identity = self._pidfd_to_identity.get(pidfd)
+                    if identity is not None:
+                        self._dead_identity = identity
+                        return identity
+
+            for identity in self._procfs_identities:
+                try:
+                    process_state = _read_process_state(identity.pid)
+                except (OSError, ValueError) as error:
+                    logger.debug(
+                        "Failed to check process state for pid %d: %s", identity.pid, error
+                    )
+                    continue
+                if (
+                    process_state is None
+                    or process_state[0] == "Z"
+                    or process_state[1] != identity.start_time
+                ):
+                    self._dead_identity = identity
+                    return identity
+            return None
+
+    def close(self) -> None:
+        """Close all process handles and reset the monitor."""
+        with self._lock:
+            self._close_unlocked()
+
+    def _close_unlocked(self) -> None:
+        for pidfd in self._pidfd_to_identity:
+            if self._poller is not None:
+                try:
+                    self._poller.unregister(pidfd)
+                except (KeyError, OSError):
+                    pass
+            try:
+                os.close(pidfd)
+            except OSError:
+                pass
+        self._pidfd_to_identity.clear()
+        self._procfs_identities.clear()
+        self._dead_identity = None

--- a/tests/unittest/executor/test_fatal_error_health_check.py
+++ b/tests/unittest/executor/test_fatal_error_health_check.py
@@ -31,6 +31,8 @@ import importlib.util
 import logging
 import pathlib
 import signal
+import subprocess
+import sys
 import threading
 import time
 from concurrent.futures import Future
@@ -53,6 +55,19 @@ _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 classify_error = _mod.classify_error
 ErrorBudget = _mod.ErrorBudget
+
+_monitor_path = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "tensorrt_llm"
+    / "executor"
+    / "worker_process_monitor.py"
+)
+_monitor_spec = importlib.util.spec_from_file_location("worker_process_monitor", _monitor_path)
+_monitor_mod = importlib.util.module_from_spec(_monitor_spec)
+_monitor_spec.loader.exec_module(_monitor_mod)
+WorkerProcessMonitor = _monitor_mod.WorkerProcessMonitor
+_read_process_state = _monitor_mod._read_process_state
+capture_worker_process_identity = _monitor_mod.capture_worker_process_identity
 
 
 # ---------------------------------------------------------------------------
@@ -166,6 +181,7 @@ class ConcreteProxyExecutor(ConcreteExecutor):
         self.request_queue = Mock()
         self.workers_started: bool = True
         self._abort_all_requests_called: bool = False
+        self._worker_process_monitor = WorkerProcessMonitor()
 
     def _check_mpi_futures(self) -> bool:
         """Return True if any MPI worker future has completed."""
@@ -197,13 +213,29 @@ class ConcreteProxyExecutor(ConcreteExecutor):
                 break
         return drained
 
+    def _check_mpi_workers(self) -> bool:
+        """Return True if an OS process handle or MPI future is dead."""
+        dead_worker = self._worker_process_monitor.find_dead_worker()
+        if dead_worker is not None:
+            self._set_fatal_error(
+                RuntimeError(
+                    "MPI worker rank "
+                    f"{dead_worker.rank} (pid {dead_worker.pid}) "
+                    "exited unexpectedly"
+                )
+            )
+            if not self.doing_shutdown:
+                self.pre_shutdown()
+            return True
+        return self._check_mpi_futures()
+
     def check_health(self) -> bool:
         """Check executor health including MPI worker liveness."""
         if self.doing_shutdown or self._fatal_error is not None:
             return False
         if self._drain_error_queue():
             return self._fatal_error is None and not self.doing_shutdown
-        if self._check_mpi_futures():
+        if self._check_mpi_workers():
             return False
         return True
 
@@ -211,7 +243,7 @@ class ConcreteProxyExecutor(ConcreteExecutor):
         """Background loop using shared helpers."""
         while not self.doing_shutdown and self._fatal_error is None:
             try:
-                if self._check_mpi_futures():
+                if self._check_mpi_workers():
                     return
                 self._drain_error_queue()
                 if self._fatal_error is not None:
@@ -235,6 +267,7 @@ class ConcreteProxyExecutor(ConcreteExecutor):
         if self.doing_shutdown:
             return
         self.doing_shutdown = True
+        self._worker_process_monitor.close()
         self._pre_shutdown_called = True
         self._shutdown_event.set()
         self._abort_all_requests_called = True
@@ -487,10 +520,114 @@ class TestGenerationExecutor:
 
 
 # ---------------------------------------------------------------------------
-# GenerationExecutorProxy: check_health with MPI futures
+# WorkerProcessMonitor: pidfd and procfs liveness detection
+# ---------------------------------------------------------------------------
+class TestWorkerProcessMonitor:
+    """Tests for the production OS process-liveness monitor."""
+
+    @pytest.fixture
+    def identity(self):
+        return capture_worker_process_identity(rank=3)
+
+    def test_pidfd_exit_is_detected(self, identity):
+        monitor = WorkerProcessMonitor()
+        poller = Mock()
+        poller.poll.return_value = [(42, 1)]
+        monitor._poller = poller
+
+        with (
+            patch.object(_monitor_mod.os, "pidfd_open", return_value=42, create=True),
+            patch.object(_monitor_mod.os, "close"),
+        ):
+            monitor.register([identity])
+            assert monitor.find_dead_worker() == identity
+            monitor.close()
+
+        poller.register.assert_called_once()
+        poller.unregister.assert_called_once_with(42)
+
+    def test_exit_before_pidfd_registration_is_detected(self, identity):
+        monitor = WorkerProcessMonitor()
+        with patch.object(
+            _monitor_mod.os, "pidfd_open", side_effect=ProcessLookupError, create=True
+        ):
+            monitor.register([identity])
+            assert monitor.find_dead_worker() == identity
+
+    def test_pid_reuse_before_pidfd_registration_is_detected(self, identity):
+        if identity.start_time is None:
+            identity = identity._replace(start_time=100)
+        monitor = WorkerProcessMonitor()
+        with (
+            patch.object(_monitor_mod.os, "pidfd_open", return_value=42, create=True),
+            patch.object(
+                _monitor_mod,
+                "_read_process_state",
+                return_value=("S", identity.start_time + 1),
+            ),
+            patch.object(_monitor_mod.os, "close") as close,
+        ):
+            monitor.register([identity])
+            assert monitor.find_dead_worker() == identity
+
+        close.assert_called_once_with(42)
+
+    def test_procfs_start_time_change_is_detected(self, identity):
+        if identity.start_time is None:
+            identity = identity._replace(start_time=100)
+        monitor = WorkerProcessMonitor()
+        with (
+            patch.object(_monitor_mod.os, "pidfd_open", None, create=True),
+            patch.object(
+                _monitor_mod, "_read_process_state", return_value=("S", identity.start_time + 1)
+            ),
+        ):
+            monitor.register([identity])
+            assert monitor.find_dead_worker() == identity
+
+    def test_procfs_read_error_does_not_report_death(self, identity):
+        if identity.start_time is None:
+            identity = identity._replace(start_time=100)
+        monitor = WorkerProcessMonitor()
+        with (
+            patch.object(_monitor_mod.os, "pidfd_open", None, create=True),
+            patch.object(
+                _monitor_mod, "_read_process_state", side_effect=PermissionError("denied")
+            ),
+        ):
+            monitor.register([identity])
+            assert monitor.find_dead_worker() is None
+
+    def test_remote_worker_is_not_registered(self, identity):
+        monitor = WorkerProcessMonitor()
+        remote_identity = identity._replace(hostname="remote-host")
+        with patch.object(
+            _monitor_mod.os, "pidfd_open", return_value=42, create=True
+        ) as pidfd_open:
+            monitor.register([remote_identity])
+
+        pidfd_open.assert_not_called()
+        assert monitor.find_dead_worker() is None
+
+    def test_different_pid_namespace_is_not_registered(self, identity):
+        monitor = WorkerProcessMonitor()
+        namespace = monitor._local_pid_namespace
+        other_namespace = 1 if namespace is None else namespace + 1
+        other_identity = identity._replace(pid_namespace=other_namespace)
+        with patch.object(
+            _monitor_mod.os, "pidfd_open", return_value=42, create=True
+        ) as pidfd_open:
+            monitor.register([other_identity])
+
+        pidfd_open.assert_not_called()
+        assert monitor.find_dead_worker() is None
+
+
+# ---------------------------------------------------------------------------
+# GenerationExecutorProxy: check_health with MPI worker liveness
 # ---------------------------------------------------------------------------
 class TestProxyCheckHealth:
-    """Tests for GenerationExecutorProxy's check_health with MPI futures."""
+    """Tests for GenerationExecutorProxy's MPI worker health checks."""
 
     @pytest.fixture
     def executor(self):
@@ -522,6 +659,39 @@ class TestProxyCheckHealth:
         executor._set_fatal_error(RuntimeError("parent"))
         executor.mpi_futures = [Future()]
         assert executor.check_health() is False
+
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"), reason="pidfd/procfs worker monitoring is Linux-only"
+    )
+    def test_killed_process_detected_while_future_remains_pending(self, executor):
+        """A SIGKILLed worker is fatal even when its MPI future stays pending."""
+        process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        future = Future()
+        try:
+            process_state = _read_process_state(process.pid)
+            assert process_state is not None
+            identity = capture_worker_process_identity(rank=0, pid=process.pid)
+            assert identity.start_time == process_state[1]
+            executor._worker_process_monitor.register([identity])
+            executor.mpi_futures = [future]
+            assert executor.check_health() is True
+
+            process.kill()
+            process.wait(timeout=5)
+
+            deadline = time.monotonic() + 5
+            while executor.check_health() and time.monotonic() < deadline:
+                time.sleep(0.01)
+
+            assert executor.check_health() is False
+            assert future.done() is False
+            assert "rank 0" in str(executor._fatal_error)
+            assert executor._pre_shutdown_called
+        finally:
+            executor._worker_process_monitor.close()
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=5)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Have executor workers report a stable process identity containing rank, PID, Linux process start time, hostname, and PID namespace.
- Monitor locally spawned `MpiPoolSession` workers with pidfds, with a `/proc` identity check as fallback.
- Treat detected worker death as fatal in both `GenerationExecutorProxy.check_health()` and the background error monitor, then initiate the existing nonblocking shutdown path.
- Protect registration against PID reuse and avoid monitoring workers from a different host or PID namespace.

## Why

NVBug 6435642 tracks a failure mode where the `mpi4py.futures.server` process is killed by OOM/SIGKILL while its future remains pending and no error reaches the proxy error queue. The parent TRT-LLM/Dynamo worker therefore remains alive and continues reporting healthy even though inference capability is lost.

PR #12718 added the fatal-error propagation and shutdown foundation, but hard-killed MPI workers can bypass its future/error-queue checks. Active OS process-liveness monitoring closes that gap for the locally spawned `MpiPoolSession` topology.

## Impact

When an engine-core MPI worker is killed, `check_health()` now returns `False`, records a fatal error containing the worker rank and PID, and allows embedding runtimes such as Dynamo to remove and recover the failed worker instead of routing requests that will hang.

## Validation

- `pytest -q tests/unittest/executor/test_fatal_error_health_check.py --confcutdir=tests/unittest/executor -k 'not TestOpenAIHealthEndpoint'`
  - 72 passed, 1 skipped, 3 deselected
  - The real SIGKILL regression is Linux-only and was skipped on the macOS development host.
- Python bytecode compilation passed for all changed Python files.
- isort, YAPF, Ruff, Ruff formatting, and all applicable commit hooks passed.
- Two unrelated repository-wide test-list hooks were skipped because their cached Python interpreter cannot evaluate the existing `str | None` annotation in `scripts/check_test_list.py`.

NVBug: 6435642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved executor health monitoring to detect failed local worker processes, including cases where communication status remains pending.
  - Automatically records fatal worker failures and begins shutdown when a dead worker is detected.
  - Added platform-aware process liveness detection for more reliable failure identification.

- **Tests**
  - Added coverage for process monitoring, worker registration, and fatal health-check behavior after unexpected worker termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->