### PR TITLE
[TRTLLM-13945][refactor] Refactor Qwen-Image static quant loading

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -911,19 +911,39 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
                         module._buffers.clear()
                         module.create_weights()
 
-    def _non_serialized_quant_parameter_names(self) -> set[str]:
-        """Return shared Linear parameters absent from ModelOpt checkpoints."""
-        non_serialized = set()
+    def _create_weights_for_loading(self) -> None:
+        device = self._weight_loading_device()
+        for _, module in self.named_modules():
+            if callable(getattr(module, "create_weights", None)):
+                module.create_weights()
+                module.to(device)
+
+    def _allowed_missing_checkpoint_parameter_names(self) -> set[str]:
+        """Return local-only parameters omitted by static ModelOpt checkpoints."""
+        allowed_missing = set()
         for module_name, module in self.named_modules():
             if not isinstance(module, Linear) or module.quant_config is None:
                 continue
             prefix = f"{module_name}." if module_name else ""
-            non_serialized.update(
+            allowed_missing.update(
                 f"{prefix}{param_name}"
                 for param_name in _NON_SERIALIZED_QUANT_PARAM_NAMES
                 if module._parameters.get(param_name) is not None
             )
-        return non_serialized
+        return allowed_missing
+
+    def _validate_checkpoint_keys(self, weights: Dict[str, torch.Tensor]) -> None:
+        expected = {name for name, _ in self.named_parameters()}
+        provided = set(weights)
+        missing = sorted((expected - provided) - self._allowed_missing_checkpoint_parameter_names())
+        unexpected = sorted(provided - expected)
+
+        # Dynamic quantization creates scale parameters while loading Linear
+        # modules, so those keys are expected to be absent from BF16 checkpoints.
+        if missing and not self.model_config.dynamic_weight_quant:
+            raise RuntimeError(f"Missing keys when loading transformer: {missing[:5]}...")
+        if unexpected:
+            raise RuntimeError(f"Unexpected keys when loading transformer: {unexpected[:5]}...")
 
     def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
         """Load HF ``transformer/*.safetensors`` state_dict.
@@ -933,25 +953,8 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
         """
         weights = _remap_checkpoint_keys(weights)
 
-        device = self._weight_loading_device()
-        for _, module in self.named_modules():
-            if callable(getattr(module, "create_weights", None)):
-                module.create_weights()
-                module.to(device)
-
-        expected = {name for name, _ in self.named_parameters()}
-        provided = set(weights)
-        # WAN uses the same shared Linear methods but does not perform this
-        # model-vs-checkpoint key check. Exempt only their known non-serialized
-        # parameters while retaining strict validation for real Qwen weights.
-        missing = sorted((expected - provided) - self._non_serialized_quant_parameter_names())
-        unexpected = sorted(provided - expected)
-        # Dynamic quantization creates scale parameters while loading Linear
-        # modules, so those keys are expected to be absent from BF16 checkpoints.
-        if missing and not self.model_config.dynamic_weight_quant:
-            raise RuntimeError(f"Missing keys when loading transformer: {missing[:5]}...")
-        if unexpected:
-            raise RuntimeError(f"Unexpected keys when loading transformer: {unexpected[:5]}...")
+        self._create_weights_for_loading()
+        self._validate_checkpoint_keys(weights)
 
         loader = DynamicLinearWeightLoader(self.model_config)
         for name, module in self.named_modules():

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -919,7 +919,7 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
                 module.to(device)
 
     def _allowed_missing_checkpoint_parameter_names(self) -> set[str]:
-        """Return local-only parameters omitted by static ModelOpt checkpoints."""
+        """Return local-only parameters omitted by checkpoints."""
         allowed_missing = set()
         for module_name, module in self.named_modules():
             if not isinstance(module, Linear) or module.quant_config is None:
@@ -935,12 +935,11 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
     def _validate_checkpoint_keys(self, weights: Dict[str, torch.Tensor]) -> None:
         expected = {name for name, _ in self.named_parameters()}
         provided = set(weights)
-        missing = sorted((expected - provided) - self._allowed_missing_checkpoint_parameter_names())
+        allowed_missing = self._allowed_missing_checkpoint_parameter_names()
+        missing = sorted((expected - provided) - allowed_missing)
         unexpected = sorted(provided - expected)
 
-        # Dynamic quantization creates scale parameters while loading Linear
-        # modules, so those keys are expected to be absent from BF16 checkpoints.
-        if missing and not self.model_config.dynamic_weight_quant:
+        if missing:
             raise RuntimeError(f"Missing keys when loading transformer: {missing[:5]}...")
         if unexpected:
             raise RuntimeError(f"Unexpected keys when loading transformer: {unexpected[:5]}...")

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -54,6 +54,18 @@ _NON_SERIALIZED_QUANT_PARAM_NAMES = (
     "inv_kv_scales",
 )
 
+_DYNAMIC_GENERATED_QUANT_PARAM_NAMES = (
+    "input_scale",
+    "weight_scale",
+    "weight_scale_2",
+)
+
+_DYNAMIC_SOURCE_WEIGHT_DTYPES = (
+    torch.bfloat16,
+    torch.float16,
+    torch.float32,
+)
+
 
 def _remap_checkpoint_keys(weights: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
     remapped = {}
@@ -918,16 +930,27 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
                 module.create_weights()
                 module.to(device)
 
-    def _allowed_missing_checkpoint_parameter_names(self) -> set[str]:
+    def _allowed_missing_checkpoint_parameter_names(
+        self, weights: Optional[Dict[str, torch.Tensor]] = None
+    ) -> set[str]:
         """Return local-only parameters omitted by checkpoints."""
         allowed_missing = set()
         for module_name, module in self.named_modules():
             if not isinstance(module, Linear) or module.quant_config is None:
                 continue
             prefix = f"{module_name}." if module_name else ""
+            param_names = _NON_SERIALIZED_QUANT_PARAM_NAMES
+            if (
+                weights is not None
+                and self.model_config.dynamic_weight_quant
+                and (checkpoint_weight := weights.get(f"{prefix}weight")) is not None
+                and checkpoint_weight.dtype in _DYNAMIC_SOURCE_WEIGHT_DTYPES
+            ):
+                param_names = param_names + _DYNAMIC_GENERATED_QUANT_PARAM_NAMES
+
             allowed_missing.update(
                 f"{prefix}{param_name}"
-                for param_name in _NON_SERIALIZED_QUANT_PARAM_NAMES
+                for param_name in param_names
                 if module._parameters.get(param_name) is not None
             )
         return allowed_missing
@@ -935,7 +958,7 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
     def _validate_checkpoint_keys(self, weights: Dict[str, torch.Tensor]) -> None:
         expected = {name for name, _ in self.named_parameters()}
         provided = set(weights)
-        allowed_missing = self._allowed_missing_checkpoint_parameter_names()
+        allowed_missing = self._allowed_missing_checkpoint_parameter_names(weights)
         missing = sorted((expected - provided) - allowed_missing)
         unexpected = sorted(provided - expected)
 

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
@@ -229,7 +229,7 @@ def test_static_quant_load_allows_only_missing_non_serialized_parameters(
         for module_name in quantized_module_names
         for suffix in non_serialized_suffixes
     }
-    assert model._non_serialized_quant_parameter_names() == non_serialized
+    assert model._allowed_missing_checkpoint_parameter_names() == non_serialized
     assert non_serialized <= expected.keys()
     if quant_algo == QuantAlgo.FP8:
         assert not any(name.endswith(".alpha") for name in expected)
@@ -268,7 +268,7 @@ def test_static_fp8_loads_serialized_weights_and_derives_inverse_scale() -> None
     """Static FP8 loading copies checkpoint tensors and derives inverse input scales."""
     model = _tiny_static_quant_model(QuantAlgo.FP8)
     expected = dict(model.named_parameters())
-    non_serialized = model._non_serialized_quant_parameter_names()
+    non_serialized = model._allowed_missing_checkpoint_parameter_names()
     checkpoint = {
         name: torch.zeros_like(param)
         for name, param in expected.items()

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
@@ -142,11 +142,23 @@ def test_transformer_applies_quant_config_ignore_list() -> None:
     assert isinstance(model.transformer_blocks[1].attn.add_q_proj.quant_method, NVFP4LinearMethod)
 
 
-def test_dynamic_quant_load_rejects_missing_serialized_parameters() -> None:
+@pytest.mark.parametrize(
+    "quant_algo",
+    [QuantAlgo.NVFP4, QuantAlgo.FP8, QuantAlgo.FP8_BLOCK_SCALES],
+    ids=["nvfp4", "fp8", "fp8-block"],
+)
+def test_dynamic_quant_load_rejects_missing_serialized_parameters(
+    quant_algo: QuantAlgo,
+) -> None:
     """Dynamic loading still rejects missing real checkpoint tensors."""
+    group_size = {
+        QuantAlgo.NVFP4: 16,
+        QuantAlgo.FP8_BLOCK_SCALES: 128,
+    }.get(quant_algo)
     model_config = DiffusionModelConfig(
         quant_config=QuantConfig(
-            quant_algo=QuantAlgo.NVFP4,
+            quant_algo=quant_algo,
+            group_size=group_size,
             exclude_modules=[
                 "transformer_blocks.0*",
                 "img_in",
@@ -154,24 +166,72 @@ def test_dynamic_quant_load_rejects_missing_serialized_parameters() -> None:
             ],
         ),
         dynamic_weight_quant=True,
-        force_dynamic_quantization=True,
+        force_dynamic_quantization=quant_algo == QuantAlgo.NVFP4,
     )
-    model = QwenImageTransformer2DModel(model_config=model_config, num_layers=2)
+    model = QwenImageTransformer2DModel(
+        model_config=model_config,
+        patch_size=1,
+        in_channels=16,
+        out_channels=16,
+        num_layers=2,
+        attention_head_dim=16,
+        num_attention_heads=1,
+        joint_attention_dim=16,
+        axes_dims_rope=(4, 6, 6),
+    )
     expected = dict(model.named_parameters())
-    non_serialized = model._allowed_missing_checkpoint_parameter_names()
-    required_key = "transformer_blocks.1.attn.to_q.weight"
+    quantized_modules = {
+        name: module
+        for name, module in model.named_modules()
+        if isinstance(module, Linear)
+        and module.quant_config is not None
+        and module.quant_config.quant_algo == quant_algo
+    }
+    omitted_dynamic_suffixes = {
+        "alpha",
+        "input_scale",
+        "inv_input_scale",
+        "weight_scale",
+        "weight_scale_2",
+        "kv_scales",
+        "inv_kv_scales",
+    }
+    omitted_dynamic_params = set()
+
+    checkpoint = {}
+    for name, param in expected.items():
+        module_name, _, param_name = name.rpartition(".")
+        if module_name in quantized_modules and param_name in omitted_dynamic_suffixes:
+            omitted_dynamic_params.add(name)
+            continue
+        if module_name in quantized_modules and param_name == "weight":
+            module = quantized_modules[module_name]
+            checkpoint[name] = torch.zeros(
+                (module.out_features, module.in_features), dtype=torch.bfloat16
+            )
+        else:
+            checkpoint[name] = param.detach()
+
+    non_serialized = model._allowed_missing_checkpoint_parameter_names(checkpoint)
+    assert omitted_dynamic_params == non_serialized
+    required_key = "transformer_blocks.0.attn.to_q.weight"
+    quantized_required_key = "transformer_blocks.1.attn.to_q.weight"
     assert required_key in expected
     assert required_key not in non_serialized
-
-    checkpoint = {
-        name: param.detach() for name, param in expected.items() if name not in non_serialized
-    }
+    assert quantized_required_key in expected
+    assert quantized_required_key not in non_serialized
     model._validate_checkpoint_keys(checkpoint)
 
     checkpoint.pop(required_key)
     with pytest.raises(RuntimeError, match="Missing keys") as exc_info:
         model._validate_checkpoint_keys(checkpoint)
     assert required_key in str(exc_info.value)
+
+    quantized_checkpoint = checkpoint.copy()
+    quantized_checkpoint[required_key] = expected[required_key].detach()
+    quantized_checkpoint[quantized_required_key] = expected[quantized_required_key].detach()
+    with pytest.raises(RuntimeError, match="Missing keys"):
+        model._validate_checkpoint_keys(quantized_checkpoint)
 
 
 @pytest.mark.parametrize("quant_algo", [QuantAlgo.NVFP4, QuantAlgo.FP8], ids=["nvfp4", "fp8"])

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
@@ -142,6 +142,38 @@ def test_transformer_applies_quant_config_ignore_list() -> None:
     assert isinstance(model.transformer_blocks[1].attn.add_q_proj.quant_method, NVFP4LinearMethod)
 
 
+def test_dynamic_quant_load_rejects_missing_serialized_parameters() -> None:
+    """Dynamic loading still rejects missing real checkpoint tensors."""
+    model_config = DiffusionModelConfig(
+        quant_config=QuantConfig(
+            quant_algo=QuantAlgo.NVFP4,
+            exclude_modules=[
+                "transformer_blocks.0*",
+                "img_in",
+                "proj_out",
+            ],
+        ),
+        dynamic_weight_quant=True,
+        force_dynamic_quantization=True,
+    )
+    model = QwenImageTransformer2DModel(model_config=model_config, num_layers=2)
+    expected = dict(model.named_parameters())
+    non_serialized = model._allowed_missing_checkpoint_parameter_names()
+    required_key = "transformer_blocks.1.attn.to_q.weight"
+    assert required_key in expected
+    assert required_key not in non_serialized
+
+    checkpoint = {
+        name: param.detach() for name, param in expected.items() if name not in non_serialized
+    }
+    model._validate_checkpoint_keys(checkpoint)
+
+    checkpoint.pop(required_key)
+    with pytest.raises(RuntimeError, match="Missing keys") as exc_info:
+        model._validate_checkpoint_keys(checkpoint)
+    assert required_key in str(exc_info.value)
+
+
 @pytest.mark.parametrize("quant_algo", [QuantAlgo.NVFP4, QuantAlgo.FP8], ids=["nvfp4", "fp8"])
 def test_static_quant_excludes_high_precision_layers(quant_algo: QuantAlgo) -> None:
     """Layers in the checkpoint's ``ignore`` list build as unquantized.


### PR DESCRIPTION
## Summary
- Refactor Qwen-Image weight loading so `load_weights()` delegates weight creation and checkpoint key validation to focused helpers.
- Rename the static ModelOpt helper-parameter allowance to `_allowed_missing_checkpoint_parameter_names()` and keep the existing FP8/NVFP4 tests aligned.
- Preserve the current strict static checkpoint validation behavior.

## Testing
- `SKIP=type-check,clang-format,ruff-legacy pre-commit run -a`
- In `1:5.0` container, verified `/home/scratch.jingyux_coreai/models/qwen-image-nvfp4` is mounted and contains `model_index.json`, `transformer`, `vae`, etc.
- Attempted a 128x128 one-step Qwen-Image NVFP4 smoke run from that checkpoint. It failed before model load at `import tensorrt_llm` with `libth_common.so: undefined symbol: _ZN3c1013MessageLoggerC1EPKciib`, which points to a compiled binding/container mismatch in the no-build runtime rather than this Python refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen-Image checkpoint loading with stricter validation of missing and unexpected parameters.
  * Preserved support for approved missing parameters during static quantized model loading.
  * Improved reliability when loading dynamically quantized models by reporting incomplete or incompatible checkpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->