### PR TITLE
[#16342][fix] Abort MPI job on rank initialization failure

### DIFF
--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -329,11 +329,16 @@ def worker_main(
         logger.error(f"Failed to initialize executor on rank {mpi_rank()}: {e}")
         logger.error(traceback.format_exc())
         logger_debug(f"error: {traceback.format_exc()}", "red")
-        if is_leader:
-            # Send error message with confirmation
-            error_msg = (e, traceback.format_exc())
-            if not worker_init_status_queue.notify_with_retry(error_msg):
-                logger.error("Failed to deliver error message to proxy")
+        if not is_leader:
+            # Rank 0 may be blocked in a collective that the failed rank can
+            # no longer enter. Abort the MPI job so the proxy exits promptly.
+            mpi_comm().Abort(1)
+            raise
+
+        # Send error message with confirmation
+        error_msg = (e, traceback.format_exc())
+        if not worker_init_status_queue.notify_with_retry(error_msg):
+            logger.error("Failed to deliver error message to proxy")
         return
 
     # Optionally disable GC (default: not disabled)

--- a/tests/unittest/executor/test_worker_init_failure.py
+++ b/tests/unittest/executor/test_worker_init_failure.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock
+
+import pytest
+
+from tensorrt_llm.executor import worker as worker_module
+
+
+class _FailingWorker:
+    def __init__(self, *args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("worker initialization failed")
+
+
+def test_nonleader_init_failure_aborts_mpi(monkeypatch):
+    comm = Mock()
+    monkeypatch.setattr(worker_module, "mpi_comm", lambda: comm)
+    monkeypatch.setattr(worker_module, "mpi_rank", lambda: 3)
+    monkeypatch.setattr(worker_module, "set_mpi_session_cpp", Mock())
+
+    with pytest.raises(RuntimeError, match="worker initialization failed"):
+        worker_module.worker_main(
+            engine=Mock(),
+            worker_queues=Mock(),
+            log_level="info",
+            worker_cls=_FailingWorker,
+        )
+
+    assert comm.barrier.call_count == 2
+    comm.Abort.assert_called_once_with(1)


### PR DESCRIPTION
## Description

Fixes #16342.

If executor construction fails on a non-leader rank, that rank currently returns while rank 0 may remain blocked in an MPI collective the failed rank can no longer enter. Abort the MPI communicator from the failed non-leader rank so the executor process fails promptly. Rank 0 retains the existing initialization-error reporting path through the worker status queue.

This changes only process-level failure handling during worker initialization. It does not change APIs or the normal execution path.

## Test Coverage

- Focused regression: `tests/unittest/executor/test_worker_init_failure.py::test_nonleader_init_failure_aborts_mpi` passed.
- Real four-rank MPI integration test with an injected rank 3 constructor failure: rank 3 called `MPI_Abort`, and the MPI job exited with code 1 before the 20-second timeout.
- Python compilation and `git diff --check` passed on the upstream port.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] PR follows the TensorRT-LLM coding guidelines to the best of my knowledge.
- [x] Test coverage is provided for the new failure path.
- [x] No API change or new dependency.
- [x] No CODEOWNERS, documentation, or architecture-diagram update is required.