### PR TITLE
[None][docs] define Python native KV transfer ownership contract

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,13 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Design Notes
+
+This directory contains draft engineering design notes and implementation
+plans. They are review artifacts, not part of the published Sphinx user
+documentation under `docs/source`. Each note records its own status and target
+scope.
+
+- [Python native disaggregated KV transfer ownership and lifecycle](disagg-kv-transfer-ownership/README.md)

--- a/docs/design/disagg-kv-transfer-ownership/README.md
+++ b/docs/design/disagg-kv-transfer-ownership/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Python Native Disaggregated KV Transfer Ownership and Lifecycle
 
 | Field | Value |
@@ -5,7 +10,7 @@
 | **Owner** | Chien-Chun Hung |
 | **Status** | Draft design contract |
 | **Created** | 2026-07-08 |
-| **Last updated** | 2026-07-08 |
+| **Last updated** | 2026-07-13 |
 | **Implementation baseline** | [PR #15618](https://github.com/NVIDIA/TensorRT-LLM/pull/15618), merged as [`3bf37d2`](https://github.com/NVIDIA/TensorRT-LLM/commit/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d) |
 | **Primary target** | Python native KV cache transceiver with NIXL, direct and bounce paths |
 | **Detailed plan** | [`implementation-plan.md`](implementation-plan.md) |
@@ -29,11 +34,13 @@ quiescent.
 This document defines the target ownership contract for the Python native
 transceiver:
 
-- The unit of physical ownership is an **endpoint-local context per KV slice**,
-  with an exact per-writer ledger. A request-level handle aggregates slices for
-  user-visible completion.
-- `TransferWorker` owns a registry that strongly retains transfer contexts.
-  `LlmRequest` and session objects are associated consumers, not the root owners.
+- The unit of physical ownership is an **endpoint-local address unit**: a
+  receiver target slice or sender source chunk. Receive contexts carry the
+  exact per-writer ledger, and a request-level handle aggregates local contexts
+  for user-visible completion.
+- `TransferWorker` owns a registry that strongly retains each canonical
+  endpoint-transfer record, its handle/gate, and its contexts. `LlmRequest` and
+  session objects are associated consumers, not the root owners.
 - A context owns leases for every allocation and asynchronous operation that can
   outlive request/session cleanup.
 - Logical completion and physical retirement are independent states.
@@ -55,11 +62,13 @@ The following decisions are normative for the implementation plan.
 
 1. **One transfer does not have a single cross-process owner.** Sender and
    receiver each have an endpoint-local context correlated by protocol identity.
-2. **Physical ownership is per KV slice.** Each receive context contains a
-   per-writer ledger; a request-level handle aggregates one or more slice
-   contexts.
-3. **The registry is the root owner.** Request or session removal cannot destroy
-   an active context.
+2. **Physical ownership is per endpoint-local address unit.** A receive context
+   owns one advertised target slice; a send context owns one fixed operation or
+   dynamically scheduled source chunk. A request-level handle aggregates those
+   local contexts.
+3. **The registry is the root owner.** It strongly owns one canonical
+   endpoint-transfer record, its handle/gate, and all contexts for a transfer
+   generation. Request or session removal cannot destroy that lifecycle state.
 4. **KV ownership is allocator-enforced.** A strong reference to `LlmRequest` is
    not a sufficient KV lease if `free_resources()` can independently recycle its
    blocks.
@@ -71,17 +80,29 @@ The following decisions are normative for the implementation plan.
    access before any message containing its address is sent.
 8. **Quarantine is containment, not evidence.** Wall-clock expiry never makes an
    in-doubt allocation safe to reuse.
-9. **Identity is generation-safe.** Results are matched by transfer, slice,
-   generation, and exact writer identity, not merely by writer count.
+9. **Identity is transfer-generation-safe.** Every lifecycle/control message is
+   matched by endpoint epochs, transfer, and a strictly increasing admission
+   generation allocated by the admission initiator. Endpoint-owned replay state
+   prevents a retired generation from recreating a transfer record. Writer
+   results additionally carry slice plus exact writer stream/operation identity;
+   no mutation is keyed only by request ID or writer count.
 10. **Shutdown drains before deregistration or unmapping.** If quiescence cannot
     be proven, memory remains mapped and shutdown reports a non-drained state.
-11. **Wire changes are negotiated.** New generation, writer, or mode fields
-    require capability/version negotiation or explicit mixed-version rejection
-    before address publication.
+11. **Wire changes are negotiated.** New transfer-generation, writer, stream,
+    or mode fields require capability/version negotiation or explicit
+    mixed-version rejection before address publication.
 12. **Non-KV auxiliary transfers are a separate audit.** This project covers all
     resources used to perform KV transfer, including KV descriptors and bounce
     gather/scatter plans, but does not claim to own independent auxiliary-buffer
     transfers.
+13. **Handle enrollment closes cancellation races.** Context admission and
+    request-handle enrollment are one transaction. Cancellation closes the
+    handle to new contexts before it snapshots and cancels existing contexts.
+14. **Initial binding closes the local cancellation race.** Before a canonical
+    handle exists, the request/session owns a one-shot admission token.
+    Admission atomically binds that token to the registry-owned handle, while
+    cancellation either aborts the pending token or forwards to the bound
+    handle; it cannot fall between those states.
 
 ## Background
 
@@ -99,10 +120,16 @@ source KV pages
     -> CUDA scatter into destination KV pages
 ```
 
-The feature is opt-in through `kv_cache_bounce_size_mb`; zero disables it. It is
-constructed only by the Python native transceiver. The sender may still fall
-back to the direct fragmented path when a transfer is not bounceable or no slot
-is available.
+`kv_cache_bounce_size_mb > 0` requests the feature; zero disables it. Requested
+does not imply active: the Python-native factory returns `NoBounceTransport` if
+the fabric-VMM arena cannot be constructed or fitted, and an active transport
+still falls back per transfer when a request is ineligible or no slot is
+available. The merged baseline has a bounce-configured integration test marked
+as GB200/GB300-eligible and scheduled on GB200, but it does not assert that the
+transport or transfer actually engaged bounce. PR #16116 proposes that positive
+signal. Treat those MNNVL cells as candidates, not proven active-bounce coverage,
+until an equivalent assertion lands. Other environments may also run only the
+direct fallback.
 
 The merged
 [`bounce.TransferContext`](https://github.com/NVIDIA/TensorRT-LLM/blob/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d/tensorrt_llm/_torch/disaggregation/native/bounce/core.py#L61-L175)
@@ -114,28 +141,29 @@ the general context is introduced.
 
 ### Related work
 
-Status snapshot: 2026-07-08.
+Status snapshot: 2026-07-13.
 
 | Work | Relationship to this design |
 |---|---|
 | [PR #15618](https://github.com/NVIDIA/TensorRT-LLM/pull/15618) | Merged Python/native bounce implementation and baseline for this follow-up. |
 | [Transfer-owner review on #15618](https://github.com/NVIDIA/TensorRT-LLM/pull/15618#pullrequestreview-4612079358) and [follow-up acknowledgement](https://github.com/NVIDIA/TensorRT-LLM/pull/15618#pullrequestreview-4630057518) | Review provenance for the comprehensive ownership follow-up. |
-| [PR #16116](https://github.com/NVIDIA/TensorRT-LLM/pull/16116) | Open post-merge follow-up intended to exercise the Python bounce configuration. It is validation-adjacent, not ownership work. |
+| [PR #16116](https://github.com/NVIDIA/TensorRT-LLM/pull/16116) | Open post-merge follow-up adding positive active-bounce validation and partial bounce-only lifecycle containment: it proposes orphaning/quarantining in-flight receive reservations during cancellation/session close and propagating local gather/build failures. It does not provide direct-path or allocator-enforced KV ownership, generation-safe routing, or bounded safe reclamation. |
 | [PR #15780](https://github.com/NVIDIA/TensorRT-LLM/pull/15780) | Open draft proposing an independent C++ NIXL bounce implementation with a different arena and credit protocol. Useful lifecycle prior art; not a shared implementation target. |
 | [PR #15139](https://github.com/NVIDIA/TensorRT-LLM/pull/15139) | Merged C++/V1 precedent for rank-consistent terminal-state consensus. This design adopts the logical/physical separation for Python native transfers. |
 | [PR #15356](https://github.com/NVIDIA/TensorRT-LLM/pull/15356) | Merged bounded polling/admission work. Draining must remain non-blocking to the executor hot path. |
-| [PRs #15238](https://github.com/NVIDIA/TensorRT-LLM/pull/15238) and [#15737](https://github.com/NVIDIA/TensorRT-LLM/pull/15737) | Open inputs to the C++ cancellation chain: gated NIXL in-flight cancellation/quiescence containment and sender liveness hardening. They are conceptual precedents, not Python-native dependencies. |
+| [PR #15238](https://github.com/NVIDIA/TensorRT-LLM/pull/15238) | Open input to the C++ cancellation chain for gated NIXL in-flight cancellation and quiescence containment. It is a conceptual precedent, not a Python-native dependency. |
+| [PR #15737](https://github.com/NVIDIA/TensorRT-LLM/pull/15737) | Merged sender-liveness hardening for disaggregated KV transfer. It is operationally adjacent, not a replacement for endpoint-local ownership. |
 | [PRs #15794](https://github.com/NVIDIA/TensorRT-LLM/pull/15794), [#15795](https://github.com/NVIDIA/TensorRT-LLM/pull/15795), [#15798](https://github.com/NVIDIA/TensorRT-LLM/pull/15798), and [#15799](https://github.com/NVIDIA/TensorRT-LLM/pull/15799) | Open draft C++-transceiver cancellation chain plus PyExecutor integration: buffer ownership, detached-owner/fatal cleanup, negotiation, and a generation-safe peer-protocol design. This work aligns conceptually but fills the Python-native gap. |
 | [PR #15738](https://github.com/NVIDIA/TensorRT-LLM/pull/15738) | Open draft default-on policy for a qualified C++ NIXL/UCX configuration. It explicitly excludes the Python transceiver, so this work is complementary. |
-| [Chunked KV transfer design](../chunked-kv-transfer/README.md) and [PR #15727](https://github.com/NVIDIA/TensorRT-LLM/pull/15727) | Open Python pipelined/chunked transfer consumer. The owner must support multiple independently progressing chunks/slices and overlapping prefill/transfer lifetimes. |
+| [PR #15727](https://github.com/NVIDIA/TensorRT-LLM/pull/15727) | Open Python pipelined/chunked transfer consumer. The owner must support multiple independently progressing chunks/slices and overlapping prefill/transfer lifetimes. |
 | [PR #15803](https://github.com/NVIDIA/TensorRT-LLM/pull/15803) | Open draft C++-transceiver/V1 work and prior art for explicit KV transfer leases, descriptor lifetime, and constrained early release. It is not an available shared primitive. |
 
-The adjacent
-[`disagg-inflight-cancel-poison`](../disagg-inflight-cancel-poison/README.md)
-design owns cancellation consensus and process-health policy across a wider
-runtime matrix. This note owns the physical resource-lifetime contract for the
-Python native transfer path. Cancellation intent enters this design as a logical
-event; it never authorizes physical release by itself.
+The adjacent cancellation chain represented by PRs #15238, #15794, #15795,
+#15798, and #15799 owns cancellation consensus and process-health policy across
+a wider runtime matrix.
+This note owns the physical resource-lifetime contract for the Python native
+transfer path. Cancellation intent enters this design as a logical event; it
+never authorizes physical release by itself.
 
 ## Problem Statement
 
@@ -186,10 +214,12 @@ a Python object-lifetime issue.
 
 #### Timeout and quarantine do not prove retirement
 
-`mark_orphaned()` exists in the bounce state object but has no production
-callers through the transport interface. Timeout, cancellation, partial
-publication, and session destruction do not consistently transition the
-physical owner into a drain or containment state.
+At the pinned PR #15618 baseline, `mark_orphaned()` exists in the bounce state
+object but has no production callers through the transport interface. PR #16116
+proposes callers for cancellation/session close, but that is bounce-only
+containment: direct destination KV and sender resources remain uncovered, and
+quarantine still does not prove safe reclamation. Timeout, partial publication,
+and other session-destruction paths therefore still need the general owner.
 
 The allocator's fixed-duration quarantine, if wired into production, would also
 not be a transport guarantee. An elapsed grace period cannot prove that a
@@ -225,10 +255,11 @@ completion, and a stale result can collide with a later reuse of the same
 | **Transceiver runtime** | Python native `KvCacheTransceiverV2`. Here, “V2” names the transceiver, not necessarily the KV manager. |
 | **Network backend** | NIXL/DEFAULT as supported by the Python transceiver. |
 | **Transfer path** | Direct fragmented transfer, bounce transfer, and per-writer fallback between them. |
-| **Bounce configuration** | Disabled (`kv_cache_bounce_size_mb == 0`) and enabled (`> 0`). |
+| **Bounce configuration** | Not requested (`kv_cache_bounce_size_mb == 0`), requested but factory-inactive (`> 0` with `NoBounceTransport` fallback), and arena-active with per-transfer bounce/direct fallback. |
+| **Active-bounce hardware validation** | GB200/GB300 MNNVL are candidate cells in the existing test marker, with the merged baseline scheduled on GB200; neither counts as active-bounce coverage without a positive transport-active and per-transfer engagement assertion. Other hardware remains in direct-path scope and needs the same positive evidence before a bounce rollout. |
 | **KV manager** | Python KV manager V2 and the C++-backed V1 manager exposed to Python. |
 | **Direction** | Context-side send and generation-side receive. |
-| **Fan-in/topology** | Single writer and every multi-writer topology supported by the Python transceiver, including TP/ADP fan-in and multiple slices/chunks. |
+| **Fan-in/topology** | Single writer and every multi-writer topology supported by the Python transceiver, including TP/PP/ADP overlap or fan-in and multiple slices/chunks. |
 | **Executor** | PyTorch backend and AutoDeploy when they select the Python transceiver. |
 | **Resources** | KV allocations, bounce-slot leases, CUDA gather/scatter work, transfer descriptor/plan storage, NIXL operation state, result delivery state, and registration/mapping shutdown dependencies. |
 
@@ -258,14 +289,23 @@ safety applies.
 | Term | Meaning |
 |---|---|
 | **Logical outcome** | Request-visible success, failure, or cancellation. It controls scheduling and notification, not memory reuse. |
-| **Physical retirement** | Proof that no network or CUDA accessor can touch the leased resource generation, followed by exactly-once lease release. |
+| **Physical retirement** | Proof that no network or CUDA accessor can touch the leased allocation generation, followed by exactly-once lease release. |
 | **Lease** | A token that prevents an allocator, arena, or manager from reusing or destroying a resource while the token is live. |
 | **Publication** | Any attempt to send an address or descriptor to a writer that could cause the writer to access it. |
+| **Admission control** | An address-free protocol record that admits, rejects, skips, or creation-closes one transfer generation. Sending it is not address publication. |
+| **Generation skip** | An authenticated admission control used only when local state positively proves normal admission never became observable and no address can be published; the peer must acknowledge it before replay floors advance. |
 | **Terminal evidence** | Positive evidence, defined by the backend contract, that a specific operation cannot perform later memory access. |
 | **Quiescence** | A per-operation or backend-wide guarantee that no relevant asynchronous access can occur later. |
 | **Quarantine** | Removal from reuse while quiescence is unknown. It does not become safe through elapsed time. |
-| **Generation** | A nonce distinguishing successive uses of the same request/slice or arena slot identity. |
+| **Transfer generation** | A strictly increasing admission sequence allocated by the admission initiator within its endpoint epoch. Every slice in that attempt and every request-level lifecycle control share it. |
+| **Allocation generation** | An allocator-issued incarnation of a KV block or bounce slot. It is carried by the resource lease and is independent of the transfer generation. |
+| **Endpoint replay state** | Endpoint-epoch-owned anti-replay state: a contiguous retired-generation floor plus a bounded sparse window for newer live or out-of-order-retired generations. |
+| **Target slice** | The receiver address set published and physically retired as one unit. |
+| **Source chunk** | A sender scheduling/lease unit. In dynamic chunking it need not be one-to-one with the receiver target slice. |
+| **Creation close** | Phase 1 acknowledgement that an endpoint producer cannot create another local context for a transfer generation. It does not prove that a published address cannot be accessed. |
+| **Submission fence** | Phase 3 acknowledgement that a peer cannot later submit against the covered published operation/stream addresses. |
 | **Consumer** | The request/session-facing observer that receives logical completion. It is not the physical owner. |
+| **Transfer admission token** | A one-shot request/session gate whose state is `PENDING`, `BOUND(handle)`, or `ABORTED`; it serializes local cancellation with initial canonical-handle admission. |
 
 ## Normative Safety Contract
 
@@ -290,15 +330,23 @@ The following are explicitly **not** terminal evidence:
 
 ### Required invariants
 
-**O1 — Register before publication.** All leases and the complete planned
-writer-operation ledger, including candidate direct and bounce ranges, MUST be
-installed in the registry before publication begins.
+**O1 — Prepare each endpoint before its access boundary.** On the receiver, the
+destination KV snapshot/lease, optional receive-bounce lease, exact authorized
+writer cohort, fixed-operation manifest or bounded operation-stream ledger, and
+receive context MUST be registered before target addresses are published. On
+the sender, a preparation transaction MUST own the source KV snapshot/lease
+before it resolves source addresses. The optional send-bounce lease, descriptor
+storage, and send context MUST be committed before those addresses are used by
+gather or NIXL. The sender-side precondition occurs after it receives the target
+advertisement; it is not a cross-process prerequisite for receiver publication.
 
-**O2 — Mark possible access first.** Before the system attempts to send any
-message containing an address, `publication_started()` MUST atomically set the
-writer operation's exposure state to `MAY_ACCESS` and access state to
-`POSSIBLE`. A send error may revert to `NEVER_EXPOSED`/`QUIESCED` only when the
-messaging layer positively guarantees non-delivery.
+**O2 — Mark possible access first.** Before the receiver attempts to send a
+target advertisement containing an address, `publication_started()` MUST pass
+through the request handle's cancellation gate and atomically set that writer
+operation or authorized operation stream's exposure state to `MAY_ACCESS` and
+access state to `POSSIBLE`. An advertisement-send error may revert to
+`NEVER_EXPOSED`/`QUIESCED` only when the messaging layer positively guarantees
+non-delivery.
 
 **O3 — Request lifetime is not resource lifetime.** Closing an `LlmRequest`,
 `TxSession`, `RxSession`, future, or request-level transfer handle MUST NOT
@@ -309,26 +357,74 @@ predicate. It MAY trigger retirement when that predicate is already satisfied.
 be reported immediately, but physical retirement MUST wait for all possible
 accessors.
 
-**O5 — Exact operation accounting.** A receive context MUST track every planned
-writer-operation identity, generation, and candidate direct/bounce range. The
-actual target mode is recorded after sender selection. Writer count alone is
-insufficient.
+**O5 — Exact writer and operation accounting.** Before publication, a receive
+context MUST track every authorized peer writer and use one of two negotiated
+forms:
 
-**O6 — Registry-first result routing.** Results MUST be routed to the transfer
-registry before optional session lookup or notification. A missing consumer MUST
-NOT cause a physical result to be dropped.
+- A fixed manifest lists every writer-operation identity, its exact expected
+  logical source-to-target KV mapping, and its authorized candidate
+  direct/bounce ranges and descriptor/scatter-segment envelope.
+- A dynamic operation stream pre-authorizes one exact writer, target slice,
+  required logical source-to-target mapping, candidate range, stream ID,
+  monotonically increasing operation-sequence domain, and maximum
+  operation/descriptor-segment/byte budget. Each sender chunk gets a distinct
+  `(writer_stream_id, operation_sequence)` before local submission. An
+  authenticated end-of-stream record carries the final sequence high-water mark
+  and closes both future enrollment and future submission. The sender may emit
+  it only after every sequence through that mark has made an irreversible
+  decision: already `SUBMITTED` with owned status, or terminal
+  `NO_REMOTE_ACCESS`. The receiver validates every operation subrange and does
+  not retire the stream target until end-of-stream (or an acknowledged
+  submission fence) and quiescence for every submitted operation through that
+  high-water mark.
 
-**O7 — Allocator-enforced KV leases.** Lease acquisition MUST atomically validate
-and pin `(pool, block, allocation_generation)` before raw pointers are resolved
-or descriptors are constructed. `free_resources()` atomically drops request
-ownership and marks leased blocks pending-free. A generation becomes reusable
-only when request ownership is gone and its transfer-lease count reaches zero.
-Overlapping slice leases are reference-counted, and KV-manager shutdown obeys
-the same rule. Holding only block IDs or a Python request reference is
-insufficient.
+The stream form supports a monolithic receiver target with a sender-determined
+chunk count, as in PR #15727, without pretending the receiver knows all chunks
+before publication. Actual target mode is recorded per operation after sender
+selection. Duplicate advertisements and operation identities are idempotent;
+contradictory reuse is rejected. Writer count alone is insufficient. Fixed
+manifests have negotiated operation-count, descriptor/scatter-segment, and
+authorized-byte limits, and both forms obey the per-transfer context/slice and
+endpoint-global metadata limits in O19.
+
+Fixed-mode success requires the normalized delivered source-to-target mapping
+to equal each operation's expected mapping and the manifest's complete mapping.
+In-range undercoverage, gaps, duplicate segments, aggregate-byte mismatch, and
+unintended within- or cross-writer overlap are invalid even when every segment
+is individually authorized. Full target coverage with permuted source intervals
+or wrong bounce offsets is also invalid. The initial implementation rejects
+cross-writer overlap; a future explicit overlap mode would need deterministic
+idempotent semantics and separate negotiation/validation.
+
+Dynamic-stream success likewise requires the normalized union of all operations
+through the authenticated high-water mark to equal the stream's required
+logical source-to-target mapping. A sequence-complete stream with in-range
+undercoverage, a mapping permutation, or a coverage gap fails; lowering the
+high-water mark cannot redefine the required target.
+
+**O6 — Registry-first result routing.** Every KV writer-operation result MUST be
+routed to the transfer registry before optional session lookup or notification.
+A missing consumer MUST NOT cause a physical result to be dropped. Independent
+auxiliary results remain with their separate owner.
+
+**O7 — Allocator-enforced KV leases.** The KV manager MUST provide one atomic
+`snapshot_and_lease(request, slice_spec)` operation under its allocation lock.
+It validates that the request still owns each current allocation, increments
+the transfer-lease count, and returns immutable descriptors containing at least
+`(logical_kv_range, pool, block, allocation_generation, address, size)`. The
+stable logical coordinate binds each physical source/destination interval to the
+manifest's source-to-target mapping. Context construction and range
+authorization use those lease tokens; copying block IDs and acquiring a lease
+later is forbidden because it leaves an ABA window. `free_resources()`
+atomically drops request ownership and marks leased blocks pending-free. An
+allocation generation becomes reusable only when request ownership is gone and
+its transfer-lease count reaches zero. Overlapping slice leases are
+reference-counted, and KV-manager shutdown obeys the same rule. Holding only
+block IDs or a Python request reference is insufficient.
 
 **O8 — Exactly-once retirement.** Duplicate, reordered, late, or contradictory
-events MUST NOT double-release a lease or advance another generation.
+events MUST NOT double-release a lease, advance another transfer generation, or
+release another allocation generation.
 
 **O9 — Safe uncertainty.** When quiescence is unknown, resources MUST remain
 leased or quarantined. Admission may fail due to exhausted safe capacity; reuse
@@ -341,9 +437,11 @@ CUDA work that can touch it is complete. If shutdown also removes registrations
 used by auxiliary transfers, those independent owners MUST drain as an external
 precondition; draining only the KV registry is insufficient.
 
-**O11 — No blocking under the context lock.** Network operations, CUDA
-synchronization, allocator callbacks, and consumer callbacks MUST execute
-outside the context state lock.
+**O11 — No blocking under lifecycle locks.** The only permitted nested
+lifecycle-lock order is admission token, then registry, then handle, then
+context; registry/remote paths never acquire a token gate. Network operations,
+CUDA synchronization, allocator callbacks, and consumer callbacks MUST execute
+outside all of those state locks.
 
 **O12 — Bounded executor polling.** Ownership draining MUST preserve the bounded
 polling behavior established by PR #15356. Waiting for physical retirement MUST
@@ -354,17 +452,213 @@ every descriptor segment MUST be validated as a subset of the correct leased
 allocation generation and the writer's authorized candidate range. Validation
 includes device, required alignment, non-negative size, integer overflow,
 aggregate byte count, and per-writer subrange boundaries. A lifetime lease does
-not authorize out-of-range access.
+not authorize out-of-range access. Before fixed-mode success, normalize the
+actual source-to-target segment pairs and require the exact expected
+per-operation and manifest mapping with no permutation, gap, duplicate, or
+overlap under the negotiated policy. Bounce validation includes the expected
+bounce-source offset paired with each destination interval.
+
+**O14 — Endpoint-local transactional preparation.** `prepare_send()` and
+`prepare_receive()` MUST be all-or-nothing construction transactions. A
+preparation object owns partial KV/bounce leases until registry insertion
+commits. The receiver may unwind only before its target-publication boundary.
+The sender may unwind unused local resources until its own gather/NIXL launch
+boundary even though the receiver already published a target. It then reports
+quiescent `NO_REMOTE_ACCESS`; if that result is lost, the receiver remains in
+doubt but the unused sender resources need not. After an endpoint crosses its
+own boundary, failure follows normal fail-closed context retirement and never
+uses construction rollback to release possibly accessible memory.
+
+**O15 — Independent auxiliary cleanup.** KV logical completion or cancellation
+MUST NOT release a generation-first auxiliary slot or close the session that
+owns it while an auxiliary RMA may still target that slot. Auxiliary transfer
+ownership remains a separate audit, so it keeps an independent safe-to-clean
+gate. Any configuration that cannot provide that gate is excluded from the
+ownership rollout until the auxiliary path is covered.
+
+**O16 — Atomic handle enrollment, access gating, and closure.** A
+`TransferHandle` has an `OPEN`, `SEALED`, or `ABORTED` admission/access state;
+the separate logical outcome records whether an abort reason is failure,
+cancellation, or shutdown.
+Endpoint context insertion and handle enrollment MUST commit atomically with
+respect to `cancel()` and `seal()`. Every publication, gather, NIXL, or scatter
+boundary obtains the same handle gate before the context lock, verifies that
+the handle is not `ABORTED` and the context's logical state still authorizes
+that accessor, then marks it possible before releasing the locks. An accepted
+cancellation, first logical failure, or shutdown changes the handle to
+`ABORTED` and snapshots its enrolled contexts while holding that gate, then
+performs context/peer callbacks outside it. If an access boundary wins the gate,
+the abort observes an already-possible accessor and drains it; if the abort wins,
+the boundary is rejected even before its context callback runs. A preparation
+racing abort either enrolls and is included in it, or transactionally unwinds
+before publication/local access. Failure/cancellation also starts the applicable
+peer operation/stream close or submission-fence protocol; missing acknowledgement
+keeps remote targets in doubt.
+
+All contexts in one handle share one `transfer_generation`. The local
+producer/session is the only sealing authority. It seals only after atomically
+enrolling the complete required local context set: either an immutable expected
+target-slice/source-chunk manifest, or a validated final-chunk proof enrolled
+with the final send context. Receiver planning may provide its target manifest
+up front; incremental sender chunks cannot seal merely because the currently
+known contexts completed. Logical success requires a sealed handle whose
+declared contexts all succeeded.
+
+**O17 — Atomic, capacity-reserved pre-cancellation.** Validated remote
+cancellation and lifecycle-record/context creation MUST serialize under the
+registry lock. Before a peer is authorized to send lifecycle controls or
+addresses for a transfer generation, admission reserves a registry-owned
+`TransferHandle`/control-state slot. Cancellation either closes that live handle
+or marks its zero-context record pre-cancelled; preparation under the same lock
+observes the state and cannot cross an access boundary. A control for an
+unnegotiated identity is a protocol violation: poison and close that endpoint
+session in O(1), rejecting every later admission on it. A replacement requires
+full negotiation and may retain the endpoint epoch only if its existing
+`EndpointEpochState`/replay window survives; otherwise it uses a fresh epoch.
+Do not create unbounded per-identity deny state for arbitrary controls.
+
+Capacity is backpressured before authorizing a new transfer generation, so every
+valid pre-cancel has reserved durable state. A pre-cancelled or otherwise closed
+handle remains until local producer sealing or an acknowledged session/endpoint
+creation fence proves that no later context can be created, and until all
+physical contexts retire. Age alone cannot prune it. The registry never drops a
+live lifecycle record to admit new work.
+
+**O18 — Durable endpoint anti-replay state.** The endpoint that initiates
+transfer admission MUST allocate `transfer_generation` monotonically from
+endpoint-epoch state that survives session, request, and transfer-record
+cleanup. On that endpoint, counter advancement, replay-window live-entry
+reservation, canonical record creation, and admission-token binding commit in
+one registry transaction after capacity checks; a pre-commit rejection consumes
+no generation. Once committed, a generation is never rolled back. If its normal
+admission control will not be sent, the initiator sends an authenticated
+generation-skip record and obtains the peer acknowledgement before sending a
+higher-generation admission control. A cumulative contiguous closed watermark
+may compress skips, but the receiver rejects one that crosses any locally live,
+published, or otherwise unclosed generation. If normal admission control was
+sent or its delivery is ambiguous but no target address was published, the
+initiator retries/deduplicates normal admission and rejection or abandonment
+uses the authenticated creation-close/reject exchange; it cannot relabel the
+generation as skipped without positive non-delivery proof. Once any target
+address was published, neither skip nor creation close retires the record or
+memory; full operation/stream closure and physical quiescence remain mandatory.
+Both endpoint replay trackers mark an empty/fully retired generation retired
+before its slot can compact. Both peers bind the admission to the negotiated
+endpoint-epoch pair.
+Session negotiation authenticates the initiator epoch, initial generation
+floor, and maximum outstanding-generation window. The registry retains,
+independently of individual transfer records, a contiguous retired-generation
+floor and a bounded sparse set for newer live or out-of-order-retired
+generations. Admission outside the negotiated window, at or below the retired
+floor, or naming an already-retired sparse entry is rejected. Advertisement,
+result, and control messages for such a generation can never recreate a
+canonical record. The initiator does not send admission outside the peer's
+negotiated window. For an in-window admission, the peer reserves its replay
+entry before evaluating later metadata/resource capacity; a rejection marks
+that entry closed and returns an authenticated close/reject acknowledgement.
+
+Out-of-order retirement marks the sparse entry and advances the floor only when
+all preceding generations are retired or explicitly closed by the negotiated
+creation-close protocol. A missing generation consumes the negotiated replay
+window and eventually backpressures new admission; it is never evicted to make
+progress. The sparse set compacts as the contiguous floor advances, keeping
+healthy sequential churn O(maximum outstanding generations). Recreating the
+endpoint owner MUST allocate a new, non-reused endpoint epoch. Messages from an
+older epoch cannot bootstrap a new session or mutate the new endpoint, so its
+old generation window may be discarded only after the new epoch is installed
+and session admission enforces that epoch binding. Reconnecting with the same
+endpoint epoch MUST resume the existing local replay state; negotiation cannot
+reset the window or advance its retired floor past a locally live/unclosed
+generation, and an inconsistent peer claim rejects the session.
+
+**O19 — Bounded metadata admission.** Configured endpoint limits and negotiated
+per-transfer envelopes MUST bound canonical records, contexts/slices, fixed
+writer operations, dynamic-stream operations, descriptor/scatter-plan segments,
+authorized bytes, and replay entries. A fixed manifest reserves its actual
+operation/authorized-byte counts and the worst-case descriptor/scatter segments
+permitted by its envelope; a dynamic stream reserves its negotiated maximum
+envelope. The registry atomically reserves all required worst-case metadata
+credits before their first applicable boundary: record/control/replay credits
+at admission before the peer is authorized, and context/manifest/stream credits
+before the first address publication or sender local launch. Oversized plans or
+unavailable credits fail/backpressure before that boundary, and a partial
+preparation returns its credits transactionally. Live work never overshoots a
+limit, and capacity reserved for an already-admitted control or stream cannot
+be evicted to admit another transfer. Unused and retired credits return only at
+their defined boundary. For a dynamic stream, unused envelope credits may
+return only when an authenticated end-of-stream or submission-fence result both
+irrevocably closes future enrollment/submission and establishes the exact final
+operation set/high-water mark. A fence that only prevents future submission
+cannot classify unreported prior operations as unused; those credits remain
+reserved until exact ledger reconciliation or backend quiescence provides the
+required evidence. Credits backing materialized operations remain until those
+entries retire.
+
+**O20 — Atomic local admission and cancellation binding.** Before transfer
+admission is scheduled, the request/session MUST create one
+`TransferAdmissionToken` in the same request-lifecycle transition that makes
+transfer scheduling eligible. Cancellation that wins before this transition
+makes the request ineligible and prevents token creation. After creation, local
+cancellation, request cleanup, and `admit_and_bind()` serialize on that token.
+If cancellation wins while the token is `PENDING`, it changes the token to
+`ABORTED` and later admission fails before peer authorization, publication, or
+local launch. If admission wins, it creates or resolves the canonical registry
+record and changes the token directly from `PENDING` to `BOUND(handle)` before
+the peer is authorized; a racing or later cancellation observes that handle
+and aborts its shared access gate.
+
+The token gate precedes the registry lock, and the registry never acquires a
+request/session lock while holding a lifecycle lock. On the initiating endpoint,
+a failed admission before the atomic generation/record/token commit consumes no
+generation and returns all provisional credits. A committed generation whose
+normal admission control is not sent is converted into an authenticated
+generation skip; a higher-generation admission control cannot be sent until the
+peer acknowledges it. If normal admission control was sent but no address was
+published, abandonment uses the authenticated creation-close/reject exchange.
+After address publication, abandonment follows the full physical-retirement
+contract instead. Thus neither endpoint leaves an unretired replay gap or treats
+an address-bearing transfer as empty. After binding, dropping the token or any
+request-facing handle reference cannot destroy the registry-owned record,
+handle, gate, or contexts.
+
+`begin_shutdown()` is the third participant in this arbitration. Under the
+registry lock it atomically changes endpoint admission to `CLOSED` and snapshots
+all already-committed records. `admit_and_bind()` that loses this race changes
+its still-pending token to `ABORTED(shutdown)` and cannot create a record or
+authorize the peer. A record that wins admission is visible in the shutdown
+snapshot. Its later peer-authorization boundary passes through the same handle
+gate: it is either marked possible before shutdown aborts the handle and is then
+owned/drained, or it is rejected without sending authorization. No record or
+peer authorization may appear after the shutdown snapshot unaccounted.
+
+**O21 — No unbudgeted healthy-path admission round trip.** Session capability
+negotiation is amortized. Per-transfer generation, epoch, fixed-envelope, and
+admission fields MUST piggyback on the existing address-free KV request and
+target-advertisement response: the receiver commits admission before sending
+that existing response, whose target advertisement also confirms acceptance.
+The normal path does not add a separate admission request/ack RTT. Generation
+skip, creation-close, rejection, cancellation, and shutdown-fence
+acknowledgements are exceptional-path controls and may add messages. If an
+implementation cannot preserve this piggybacking, its additional RTT is an
+explicit design/performance change that must be budgeted and qualified before
+that cohort can claim the healthy-path non-regression expectation.
 
 ## Ownership Model
 
 ```mermaid
 flowchart TB
-    TW["TransferWorker"] --> TR["TransferRegistry (strong context owner)"]
-    TR --> SC["SendTransferContext per slice"]
-    TR --> RC["RecvTransferContext per slice"]
-    RH["LlmRequest / session / request handle"] -. "consumer association" .-> SC
-    RH -. "consumer association" .-> RC
+    TW["TransferWorker"] --> TR["TransferRegistry (root owner)"]
+    TR --> ES["EndpointEpochState and replay window"]
+    TR --> ER["EndpointTransferRecord per transfer generation"]
+    ER --> TH["canonical TransferHandle"]
+    ER --> TG["shared durable access gate"]
+    ER --> SC["SendTransferContext per fixed operation/source chunk"]
+    ER --> RC["RecvTransferContext per target slice"]
+    RH["LlmRequest / session"] --> AT["TransferAdmissionToken"]
+    AT -. "BOUND consumer reference" .-> TH
+    SC --> TG
+    RC --> TG
+    TH --> TG
     SC --> SKV["source KV lease"]
     SC --> SB["optional send-bounce lease"]
     SC --> GE["gather event and plan"]
@@ -380,30 +674,43 @@ flowchart TB
 
 ### Ownership granularity
 
-The physical context key is conceptually:
+The endpoint-local physical context key is conceptually:
 
 ```text
-(transfer_id, slice_id, generation, sender_endpoint_epoch, receiver_endpoint_epoch)
+(role, local_endpoint_epoch, admission_authority_epoch,
+ transfer_id, transfer_generation, local_context_id)
 ```
 
-A **slice** is the smallest address set that is published and physically retired
-as one unit. One receive context contains one ledger entry per planned writer
-operation; a writer that issues multiple NIXL operations for the slice has a
-distinct operation ID for each. One request-level `TransferHandle` aggregates
-all slice contexts needed to compute the logical request outcome. This supports
-chunked and pipelined transfers without making a single request-wide context
-serialize independent slices.
+`local_context_id` is the target-slice ID on the receiver and the fixed-operation
+or source-chunk ID on the sender; those IDs need not match. `role` prevents a
+simultaneous local send and receive from sharing an identity.
+`admission_authority_epoch` names the endpoint that allocated the monotonic
+generation; the full registry identity also binds the negotiated endpoint-epoch
+pair. A receive context contains ledger entries keyed by
+`(peer_endpoint_epoch, peer_rank, writer_operation_or_stream_id)`. A writer that
+issues multiple NIXL operations for the target uses a distinct fixed operation
+ID or stream sequence for each. Lookup resolves the endpoint-local context
+first, then validates the exact peer operation. One request-level
+`TransferHandle` aggregates all local contexts in one transfer generation. Its
+sealing proof defines the complete required local context set needed to compute
+the logical request outcome. This supports fan-in, peer restart, and chunked or
+pipelined transfers without serializing independent units or allowing early
+completion before a later chunk enrolls.
 
 ### Component responsibilities
 
 | Component | Owns | Must not own or decide |
 |---|---|---|
-| `TransferRegistry` | Strong references to live contexts; identity lookup; shutdown drain accounting. | Request scheduling or KV allocation policy. |
+| `TransferRegistry` | Endpoint-epoch replay state; exactly one canonical `EndpointTransferRecord` per admitted transfer generation; identity/replay lookup; shutdown drain accounting. | Request scheduling or KV allocation policy. |
+| `EndpointEpochState` | Stable local endpoint epoch, monotonic generation allocation when this endpoint initiates admission, and a retired floor/bounded sparse live-or-retired window for each negotiated admission authority and endpoint-epoch pair. | Per-context resources or request outcome. |
+| `EndpointTransferRecord` | Canonical handle, durable access gate, context membership, sealing/pre-cancel state, and operation/stream replay identities until its full retirement predicate holds. | KV allocator policy or remote resources. |
 | `SendTransferContext` | Source KV lease, optional send-bounce lease, gather fence/plan, descriptor storage, NIXL operation, result-delivery state. | Receiver resources or request object destruction. |
 | `RecvTransferContext` | Destination KV lease, optional receive-bounce lease, writer ledger, scatter fence/plan, detachable consumer callback. | Source resources or distributed request consensus. |
-| `TransferHandle` | Request-facing aggregation and logical cancellation/notification. | Physical lease release. |
+| `TransferHandle` | Registry-owned request-facing facade for context aggregation, sealing, logical cancellation/notification, and the shared access gate. | Physical lease release. |
+| `TransferAdmissionToken` | One-shot local arbitration between request/session cancellation and initial binding to the canonical handle. | Physical resources, record retirement, or remote control routing. |
+| Shared access gate | Durable admission/access serialization retained by the record and each context. | Context membership or resource release. |
 | `BounceTransport` | Arena mappings, registrations, allocators, streams, and lease issuance. | End-to-end transfer outcome. |
-| KV manager | Underlying KV allocation and enforcement of active transfer leases. | Network completion inference. |
+| KV manager | Underlying KV allocation; atomic allocation-generation-bearing snapshot/lease issuance; enforcement of active transfer leases. | Network completion inference. |
 | NIXL agent | Submission/progress and documented quiescence evidence. | KV block reuse. |
 
 The current `bounce.TransferContext` should become an implementation detail such
@@ -411,7 +718,27 @@ as `RecvBounceContext` or be replaced by `RecvBounceLease` state. Expanding it
 into the general owner would couple direct transfer, request notification, KV
 allocation, and transport arena internals into the bounce package.
 
+Before admission, the request/session holds a one-shot
+`TransferAdmissionToken`; after atomic binding it exposes only a
+consumer-facing reference to the canonical `TransferHandle`. Dropping either
+does not drop the handle or gate. To avoid an ownership cycle, the
+`EndpointTransferRecord` owns context membership and the gate, while contexts
+retain only the gate, not the record/handle. The gate owns no contexts.
+Retirement first removes every settled context from the record.
+It then marks the generation retired in `EndpointEpochState` before dropping
+the record, and only after local producer sealing or an acknowledged creation
+fence proves that no later context can appear and every open stream and
+pre-cancel obligation is settled. The endpoint replay floor/window, not the
+deleted record, rejects later admission or advertisement replay. Queue-held
+retired contexts may keep the already-closed gate alive but cannot recreate
+membership or physical leases.
+
 ### Resource retirement matrix
+
+In this matrix, “every writer operation” also requires every dynamic writer
+stream to be closed by authenticated end-of-stream or an acknowledged
+submission fence. An open stream remains a possible future accessor even when
+all currently known operations are quiescent.
 
 | Resource | Earliest safe release |
 |---|---|
@@ -425,6 +752,8 @@ allocation, and transport arena internals into the bounce package.
 | Descriptor/plan backing storage | The backend has copied it synchronously, or every asynchronous consumer is quiescent. |
 | Gather/scatter CUDA event | Completion has been observed and no queued work or callback still references it. |
 | Transfer context | All physical leases are released exactly once; only lightweight result-delivery/tombstone state may remain. |
+| `EndpointTransferRecord` and gate | Local producer sealing or an acknowledged creation fence proves no later context can be created; every context is retired; every stream and pre-cancel obligation is settled; and its generation is atomically marked retired in endpoint replay state before record removal. |
+| Endpoint replay entry | Its generation is at or below the contiguous retired floor. Sparse entries compact only when every preceding generation is retired or explicitly creation-closed; endpoint recreation uses a new epoch. |
 | Arena registration and VMM mapping | All contexts that can access that arena are retired; all local CUDA work is complete; and any missing per-operation network evidence is replaced by backend-wide quiescence. |
 
 Resources MAY be released independently at their earliest safe boundary. For
@@ -435,7 +764,9 @@ until all of its responsibilities are settled.
 ### Relationship to `LlmRequest`
 
 The request and transfer lifetimes largely overlap, so they should be associated
-through `TransferHandle`. They must not be collapsed into one owner:
+through a `TransferAdmissionToken` that atomically binds to the registry-owned
+canonical `TransferHandle`. After binding, the request/session holds only a
+consumer-facing reference. They must not be collapsed into one owner:
 
 - a request can become logically terminal before DMA or scatter retires;
 - one request can own several independently progressing slices;
@@ -446,9 +777,78 @@ through `TransferHandle`. They must not be collapsed into one owner:
 
 Request cleanup does not perform a check-then-free against `TransferHandle`.
 Instead, `free_resources()` atomically drops request ownership in the KV manager;
-leased generations become pending-free and are reclaimed automatically when the
-last transfer lease is released. This avoids a race between checking the handle
-and acquiring a new lease.
+leased allocation generations become pending-free and are reclaimed
+automatically when the last transfer lease is released. This avoids a race
+between checking the handle and acquiring a new lease. Dropping the
+consumer-facing handle reference likewise cannot destroy the canonical
+endpoint-transfer record or its access gate.
+
+### Cancellation API contract
+
+The current `KvCacheTransceiver.cancel_request()` boolean combines two different
+questions: whether logical cancellation was accepted and whether KV is already
+safe to free. The ownership implementation separates them. Cancellation returns
+a structured result with the logical outcome and an aggregate physical
+disposition of `RETIRED`, `DRAINING`, or `IN_DOUBT`. `DRAINING` or `IN_DOUBT`
+never delays the request-visible cancellation result.
+
+Local cancellation is routed through the request's `TransferAdmissionToken`.
+While admission is pending, cancellation aborts that token; after binding, the
+token forwards to the canonical `TransferHandle`, which carries the role,
+negotiated local/admission-authority endpoint epochs, transfer ID, transfer
+generation, and complete declared local context set. A bare request/transfer ID
+is not a valid registry lookup key. A stale token/handle or delayed cancellation
+for a prior transfer generation is idempotently rejected and cannot affect a
+current context.
+
+Context preparation, registry insertion, and handle enrollment form one commit
+transaction under the registry-to-handle lock order. Every context access
+boundary uses the handle-to-context order. Accepted `cancel()` aborts the handle
+and snapshots its contexts while holding the same gate, so a boundary cannot
+pass between handle abort and later context callbacks. A failed enrollment
+rolls back the unexposed context and its leases. After abort, no context can
+newly publish an address or launch gather/NIXL/scatter work; an accessor that
+won the gate first remains owned and drains normally.
+
+Remote cancellation follows the same rule. `CANCEL_SESSION` and any future
+lifecycle-control message carry the negotiated protocol version, sender and
+receiver endpoint epochs, transfer ID, and transfer generation. The registry
+validates that envelope before session lookup. Under the registry lock it either
+aborts the canonical handle or marks its admitted zero-context record
+pre-cancelled, keyed by the full endpoint/transfer identity and never a bare
+`unique_rid`. Context creation checks that same record in its commit transaction,
+so a racing cancellation cannot be lost. A consumer that attaches later receives
+the same aborted handle through its original token or an explicitly authorized
+attach path rather than constructing a replacement.
+
+Pre-cancel state cannot expire by age. It retires only after local producer
+sealing or the negotiated Phase 1 creation-close acknowledgement makes later
+context creation impossible. Capacity was reserved when the transfer generation
+was admitted; exhaustion backpressures admission before the peer is authorized
+and emits configured/used/remaining capacity, oldest-age, rejection, and
+creation-close retirement metrics. A prior-generation record cannot cancel a
+later transfer generation.
+
+Once the endpoint has allocator-enforced leases, PyExecutor may immediately
+drop request ownership of KV. The KV manager's `free_resources()` makes the
+affected allocation generations pending-free, while the registry-owned leases
+prevent reuse until retirement.
+This permission is resource-specific: it does not close an `RxSession` or free a
+generation-first auxiliary slot whose independent owner has not retired.
+PyExecutor MUST NOT poll KV transfer task state and interpret a boolean as proof
+of KV memory safety. Physical status remains available for diagnostics,
+capacity accounting, and shutdown.
+
+The structured lifecycle result is a Python-native integration, not a required
+behavior change for the C++ transceiver. PyExecutor selects a lifecycle-capable
+adapter when constructing `KvCacheTransceiverV2`; other implementations keep the
+existing boolean contract. The selection is explicit per transceiver instance,
+not a runtime union inferred from a returned value.
+
+Phase 1 applies this behavior to the receive side only after the destination KV
+lease exists. The context-side sender retains the legacy cleanup gate until the
+source lease lands in Phase 2; Phase 1 therefore cannot claim complete
+sender-side cancellation ownership.
 
 ## State Model
 
@@ -466,12 +866,16 @@ Logical failure may occur on the first writer failure. Logical cancellation may
 occur on client cancellation, deadline, consensus outcome, or shutdown. Neither
 transition implies physical retirement.
 
-Logical success requires every required writer to succeed and all required
-scatter work to complete successfully.
+Logical success requires a sealed handle, every required fixed operation or
+closed dynamic writer stream to succeed through its declared high-water mark,
+every fixed manifest and dynamic stream to satisfy its exact expected mapping,
+and all required scatter work to complete successfully.
 
-The first logical terminal outcome wins. For example, cancellation already
-reported to the consumer is not overwritten by a later writer failure. Later
-events still update physical and process-health state.
+The first logical terminal outcome wins. Failure, cancellation, or shutdown
+atomically aborts the handle gate before callbacks, so later chunks cannot
+enroll or cross access boundaries. For example, cancellation already reported
+to the consumer is not overwritten by a later writer failure. Later events still
+update physical and process-health state for already-possible accessors.
 
 ### Physical access, target, and data state
 
@@ -496,6 +900,12 @@ MAY_ACCESS -> NEVER_EXPOSED  (only with positive non-delivery proof)
 positive per-operation evidence or a backend-wide drain that covers the
 operation. A generic failure without that guarantee remains `POSSIBLE`.
 
+For a dynamic writer stream, individual operations have these states, while the
+advertised target remains `POSSIBLE` for future operations until authenticated
+end-of-stream or an acknowledged submission fence closes both enrollment and
+submission. Quiescence of the currently known operations alone cannot retire an
+open stream target.
+
 **Target mode:** `PENDING`, `DIRECT`, `BOUNCE`, `NO_REMOTE_ACCESS`, or `UNKNOWN`.
 The pre-publication plan contains authorized direct and bounce candidate ranges;
 the actual mode is selected later.
@@ -515,32 +925,76 @@ accessors with their own state:
 
 ```text
 PLANNED -> MAY_ACCESS -> QUIESCED
+PLANNED -> QUIESCED  (positive proof that launch/queue/submission did not occur)
 ```
 
-The context and required leases MUST exist before deriving raw pointers or
-constructing plans. The accessor enters `MAY_ACCESS` before CUDA launch, queue
-publication, or NIXL submission. Synchronous failure before launch may move
-directly to `QUIESCED`; an exception after an ambiguous launch/submission stays
-`MAY_ACCESS` until positive evidence arrives. Worker death does not imply
-quiescence.
+The preparation transaction and required leases MUST exist before resolving raw
+addresses or constructing plans. The context MUST be committed before a plan or
+address becomes observable to an asynchronous accessor. The accessor enters
+`MAY_ACCESS` through the handle-to-context cancellation gate before CUDA launch,
+queue publication, or NIXL submission. `OPEN` and `SEALED` handles permit an
+already-enrolled context to cross a planned boundary only when its context state
+also permits the accessor; `ABORTED` does not.
+Synchronous failure before launch may move directly to `QUIESCED`; an exception
+after an ambiguous launch/submission stays `MAY_ACCESS` until positive evidence
+arrives. Worker death does not imply quiescence.
 
 ### Publication contract
 
-Network send cannot be made atomic with local cancellation. The safe ordering
-is:
+Network send cannot be made atomic with local cancellation. The receiver and
+sender therefore have separate ordered boundaries.
 
-1. Acquire all required KV and bounce leases.
-2. Create the exact writer-operation plan and authorized candidate ranges.
-3. Register the context.
-4. Under the context lock, atomically set the selected writer operation's
-   exposure state to `MAY_ACCESS` and access state to `POSSIBLE`.
-5. Release the lock and attempt to publish its addresses.
-6. Record send/submission outcome without weakening `MAY_ACCESS` unless
-   non-delivery is proven.
+Receiver target publication:
 
-Cancellation before any writer enters `MAY_ACCESS` can retire immediately.
-Cancellation after that boundary changes the logical outcome and starts drain;
-it does not release memory.
+1. Atomically snapshot/lease destination KV and reserve any receive-bounce
+   candidate.
+2. Build either the exact fixed-operation manifest or the exact authorized
+   writer-stream ledger and candidate ranges, then transactionally insert the
+   receive context into the registry.
+3. For each writer operation/stream, under the handle cancellation gate and then
+   the context lock, set exposure to `MAY_ACCESS` and access to `POSSIBLE`
+   before attempting to send any target address.
+4. Release the lock, publish the advertisement, and record the messaging outcome
+   without weakening `MAY_ACCESS` unless non-delivery is proven. The
+   advertisement carries its target slice plus exact fixed operation ID or
+   writer-stream ID. Replaying the same advertisement cannot launch a second
+   stream/operation.
+
+Sender local access and submission:
+
+1. Validate and deduplicate the received transfer, target-slice, and fixed
+   operation or writer-stream identity.
+2. Begin a preparation transaction. For a dynamic stream, reserve its next
+   operation sequence and subrange inside that transaction; neither is externally
+   visible yet, and both remain within the advertised stream budget.
+3. Atomically snapshot/lease source KV, resolve addresses only from that lease
+   token, reserve any selected send-bounce slot, and build descriptor/plan
+   storage. Commit the operation sequence, send context, and handle enrollment
+   together before using an address asynchronously. A pre-boundary failure
+   either rolls back an unexposed reservation or records a terminal gap that
+   prevents successful end-of-stream validation.
+4. Through the handle cancellation gate, mark gather `MAY_ACCESS` before launch.
+   If the sender falls back to direct, record that mode without constructing a
+   gather accessor.
+5. Through the same gate, mark the NIXL operation `MAY_ACCESS` before submission
+   and retain the source or send-bounce lease through definitive quiescence as
+   required by the path.
+6. Record and deliver the result without coupling sender resource retirement to
+   receiver session lifetime. For a dynamic stream, atomically enroll the final
+   operation before sealing the sender handle. Emit authenticated end-of-stream
+   only after every sequence through its high-water mark is already submitted or
+   terminal `NO_REMOTE_ACCESS`; the transition closes future submission before
+   the message is sent. A missing/duplicate sequence or later submission attempt
+   prevents logical success and fails closed.
+
+Cancellation can retire an endpoint context immediately only when each remote
+operation was `NEVER_EXPOSED` or its access state is `QUIESCED` (including
+positive `NO_REMOTE_ACCESS` evidence), every dynamic stream is closed to future
+submission, **and** every local gather, NIXL, scatter, or queued accessor is
+`PLANNED` or `QUIESCED`. Otherwise cancellation changes only the logical outcome
+and starts drain; it does not release memory. In particular, a sender gather may
+already be active before NIXL submission, so proof that no remote operation was
+submitted is insufficient for immediate retirement.
 
 For partial fan-out publication, operations that never crossed the boundary
 become `NEVER_EXPOSED`; operations that crossed it drain independently. The
@@ -572,32 +1026,62 @@ A failed transfer is never scattered into usable KV. Partial direct writes need
 not be rolled back; the destination KV lease remains until all writers drain,
 then the failed allocation may be recycled.
 
-### Identity and result routing
+### Identity, control, and result routing
 
-A result must identify:
+Every wire message that can mutate lifecycle state, including cancellation,
+must carry a common identity envelope with:
 
 - protocol version/capability;
 - transfer ID;
-- slice ID;
-- generation/attempt nonce;
-- exact writer identity and writer-operation ID;
+- monotonic transfer admission generation shared by every slice in the attempt;
 - sender and receiver endpoint/instance epochs, because ranks can be reused
   after restart;
+- lifecycle scope: transfer-wide, or the exact target slice for a slice-scoped
+  message.
+
+Every writer-scoped advertisement, result, or control also identifies the exact
+writer and either a fixed writer-operation ID or a writer-stream ID. A dynamic
+operation result/control additionally carries its operation sequence. The
+target advertisement therefore names the ledger authorization that the sender
+must echo; it never publishes an address with only a transfer/request ID. If a
+writer needs multiple fixed NIXL operations, each is advertised with a distinct
+preplanned ID. Replaying an identical advertisement is idempotent and launches
+at most one fixed operation or stream; a conflicting replay fails closed.
+
+A writer result additionally identifies:
+
+- source chunk/slice identity when it differs from the target slice;
 - actual direct/bounce mode;
 - quiescence evidence and data outcome;
 - validated scatter metadata when bounce succeeded.
 
-The registry validates identity before any request/session lookup. Duplicate
-results are idempotent. Unexpected writer operations, contradictory duplicates,
-and wrong generations cannot advance any live context. Valid quiescence evidence
-may advance physical access state even when result payload or scatter metadata
-is invalid; that invalid data fails the logical transfer and suppresses scatter.
+For a dynamic stream, an authenticated end-of-stream control/result carries the
+final operation-sequence high-water mark and aggregate source-to-target
+mapping/byte coverage.
+End-of-stream is accepted only when every covered sequence is already submitted
+or terminal `NO_REMOTE_ACCESS`; it atomically closes future enrollment and
+submission but does not make submitted operations quiescent. Missing,
+duplicate-conflicting, out-of-budget, overlapping, or out-of-range operations
+fail the logical transfer and remain owned according to their physical state.
+
+The registry validates every state-mutating envelope before any request/session
+lookup. Duplicate results and control messages are idempotent. Unexpected writer
+operations, contradictory duplicates, wrong transfer generations, and stale
+remote cancellations cannot advance any live context. Valid quiescence evidence may
+advance physical access state even when result payload or scatter metadata is
+invalid; that invalid data fails the logical transfer and suppresses scatter.
 All ranges are checked against the registered authorization before use.
 
 Creating a context with an already-live identity MUST fail rather than replace
-the existing context. Generations MUST NOT be reused within an endpoint epoch.
-Retired identities may leave bounded diagnostic tombstones; pruning a tombstone
-does not authorize generation reuse or resource reclamation.
+the existing context. Transfer generations MUST NOT be reused within an endpoint
+epoch. Before deleting a retired canonical record, the registry atomically
+marks its generation retired in the endpoint replay window. A later admission,
+advertisement, result, or control at or below the contiguous retired floor, or
+for an out-of-order retired sparse entry, is rejected before record creation.
+Bounded diagnostic tombstones may retain richer error context, but pruning them
+does not remove this compact anti-replay state or authorize resource
+reclamation. Pre-cancel tombstones follow the stronger O17 retention rule and
+are not age-pruned diagnostic entries.
 
 A result may advance access state to `QUIESCED` only when the sender has positive
 evidence that its NIXL operation cannot perform later DMA. It is not enough to
@@ -629,7 +1113,8 @@ Some gen-first ADP flows broadcast discovery/request messages before the active
 DP cohort is known. Before publishing memory addresses, the implementation MUST
 either:
 
-1. select the exact writer-operation cohort through an address-free handshake;
+1. select the exact fixed-operation or authorized writer-stream cohort through
+   an address-free handshake;
    or
 2. register every recipient as a potential writer operation and obtain a
    quiescent `NO_REMOTE_ACCESS` acknowledgement from every non-participant.
@@ -640,8 +1125,8 @@ count is not an acceptable substitute.
 
 ### Threading and callbacks
 
-State changes are serialized per context. The implementation must not hold a
-context or registry lock while:
+State changes are serialized per context. The implementation must not hold an
+admission-token, registry, handle, or context lock while:
 
 - sending or receiving network messages;
 - waiting for NIXL;
@@ -658,45 +1143,129 @@ but cannot interrupt physical finalization.
 Names are illustrative; behavior is normative.
 
 ```python
+class TransferAdmissionToken:
+    def cancel(self, reason: str) -> CancellationResult: ...
+
+
 class TransferRegistry:
+    def admit_and_bind(
+        self, token: TransferAdmissionToken, admission: TransferAdmission
+    ) -> TransferHandle: ...
     def prepare_send(self, plan: SendPlan) -> SendTransferContext: ...
     def prepare_receive(self, plan: RecvPlan) -> RecvTransferContext: ...
     def route_result(self, result: WriterOperationResult) -> None: ...
-    def cancel_consumer(self, transfer_id: TransferId, reason: str) -> None: ...
+    def route_control(self, control: LifecycleControlMessage) -> None: ...
     def begin_shutdown(self) -> None: ...
     def drain(self, deadline: float | None) -> DrainResult: ...
 
 
 class RecvTransferContext:
     def publication_started(
-        self, operation: WriterOperationId
+        self, authorization: WriterAuthorizationId
     ) -> PublicationToken: ...
     def mark_never_published(
-        self, operation: WriterOperationId, proof: NonDeliveryProof
+        self, authorization: WriterAuthorizationId, proof: NonDeliveryProof
     ) -> None: ...
     def record_result(self, result: WriterOperationResult) -> None: ...
+    def record_stream_end(self, end: WriterStreamEnd) -> None: ...
     def record_global_quiescence(self, evidence: QuiescenceEvidence) -> None: ...
     def cancel_consumer(self, reason: str) -> None: ...
     def detach_consumer(self) -> None: ...
 
 
 class KVTransferLease:
+    @property
+    def ranges(self) -> tuple[LeasedRange, ...]: ...
+
     def release(self) -> None: ...
+
+
+class KVLeaseProvider:
+    def snapshot_and_lease(
+        self, request: LlmRequest, slice_spec: SliceSpec
+    ) -> KVTransferLease: ...
+
+
+class TransferHandle:
+    def seal(self, proof: SliceSetProof) -> None: ...
+    def record_failure(self, reason: str) -> LifecycleResult: ...
+    def cancel(self, reason: str) -> CancellationResult: ...
 ```
 
 Required properties:
 
 - Methods are thread-safe and idempotent.
-- Registry insertion rejects a duplicate live identity.
-- Resource release is private to the context.
+- `admit_and_bind()` reserves capacity, creates exactly one canonical
+  `EndpointTransferRecord`/handle per full identity, and moves the one-shot
+  token directly from `PENDING` to `BOUND(handle)` before the peer is authorized
+  to send addresses or lifecycle controls. An identical retry through the same
+  token returns the same handle. A different token for an already-live identity,
+  or any conflicting/retired identity, is rejected and cannot attach to or
+  replace canonical state; any future consumer-attach API must authorize that
+  role explicitly without granting replacement cancellation authority.
+- `admit_and_bind()` classifies the generation against endpoint replay state
+  while holding the token gate and then the registry lock. It rejects an
+  aborted token and generations at/below the retired floor or in the sparse
+  retired set, returns the canonical live handle only for an exact retry through
+  that same bound token, and backpressures a new generation that would exceed
+  the bounded replay window.
+- On the admission initiator, generation allocation is part of that successful
+  commit; pre-commit rejection does not advance the counter. A committed
+  generation whose admission control is not sent must be acknowledged as a
+  generation skip before a higher admission control is sent. If admission was
+  sent but no address published, peer rejection/abandonment uses authenticated
+  creation-close/reject on both endpoints. After address publication, those
+  empty-generation controls cannot retire the record or its resources.
+- `begin_shutdown()` closes registry admission and snapshots committed records
+  under the registry lock. A losing pending token becomes shutdown-aborted; a
+  winning record is in the snapshot. Peer authorization is a handle-gated
+  boundary, so it either becomes owned before abort or is suppressed afterward.
+- `prepare_send()` and `prepare_receive()` resolve the canonical record from the
+  full identity in their plan; callers cannot inject a replacement handle.
+- Registry insertion and handle enrollment are one preparation commit with a
+  registry-to-handle lock order. Access boundaries use handle-to-context order.
+  `SEALED` rejects new enrollment but permits planned boundaries; `ABORTED`
+  rejects both enrollment and every later boundary.
+- `SliceSetProof` is an immutable expected target-slice/source-chunk manifest or
+  an atomically enrolled final-chunk proof. Only the endpoint's local
+  producer/session may seal its handle; a timer, currently known chunk count, or
+  consumer completion is not sufficient.
+- `WriterAuthorizationId` is a `FixedOperationId` or `WriterStreamId`, so the
+  publication interface marks either negotiated authorization possible.
+- Fixed-operation manifests and bounded dynamic writer streams are explicit
+  negotiated modes. Stream end closes enrollment and submission only after
+  every covered sequence is submitted or terminal `NO_REMOTE_ACCESS`; it does
+  not imply quiescence for submitted operations.
+- After transactional construction commits, resource release is private to the
+  context. Receiver preparation may unwind only before target publication;
+  sender preparation may unwind only before its local gather/NIXL launch.
 - Request-facing handles cannot force physical retirement.
 - `KVTransferLease` prevents allocator reuse even if request cleanup runs.
+- `KVTransferLease.ranges` is an immutable allocator-produced snapshot carrying
+  logical KV coordinates and allocation generations; contexts do not
+  reconstruct it from copied block IDs or positional order.
 - `BounceTransport` issues optional `SendBounceLease` and `RecvBounceLease`
   objects; it remains the arena owner.
 - `NoBounceTransport` issues no bounce lease, but the direct path still creates
   send/receive contexts and KV leases.
 - Invariant violations retain resources and emit diagnostics rather than trying
   to recover through reuse.
+- `CancellationResult` reports logical cancellation separately from physical
+  state. `DrainResult` and the transceiver-level `ShutdownResult` distinguish a
+  fully drained endpoint from a retryable non-drained endpoint.
+- Local cancellation uses the one-shot admission token and, after binding, its
+  transfer-generation-bound `TransferHandle`; no lifecycle mutation looks up a
+  context by bare request/transfer ID.
+- Pre-cancel lookup and handle/context insertion serialize in the registry. A
+  live unmatched pre-cancel tombstone cannot be evicted to admit new work.
+- The registry retains the canonical record/handle/gate after every consumer
+  reference is dropped. It removes the record only after no later local context
+  can be created and all contexts, streams, and pre-cancel state satisfy their
+  retirement predicates, atomically marking the generation retired in endpoint
+  replay state before deletion.
+- Endpoint replay state outlives transfer records and sessions within one
+  endpoint epoch. Out-of-order retired entries compact only by advancing a
+  contiguous floor; a gap backpressures admission rather than being evicted.
 
 ### NIXL status contract
 
@@ -720,54 +1289,111 @@ per-operation cancel/recovery API may remain a later liveness improvement.
 
 ## Shutdown Contract
 
+`KvCacheTransceiverV2` is the top-level owner of shutdown progress. Its
+`shutdown(deadline)` returns a `ShutdownResult` rather than treating initiation
+as finalization. `DRAINED` permits dependent teardown. `RETRYABLE_IN_DOUBT`
+requires the caller to retain the transceiver, worker, registry, KV managers,
+and registrations and to retry drain or escalate process health; it does not
+permit resource-manager teardown.
+
 Shutdown follows this order:
 
-1. Stop admitting requests and publishing new addresses.
+1. Stop request transfer-eligibility/token creation, then atomically close
+   registry admission and snapshot all committed records. A pending
+   `admit_and_bind()` either committed before the snapshot or is rejected with
+   its token shutdown-aborted. Gate and suppress any peer authorization or
+   address publication that did not already become possible.
 2. Mark remaining consumers failed/cancelled, but keep result listeners,
    transfer workers, and CUDA completion workers alive.
-3. Drain endpoint contexts until the shutdown deadline.
-4. For network operations still in doubt, request backend-wide quiescence
-   through a
-   documented `quiesce()`/drain operation.
-5. Synchronize remaining gather/scatter work.
-6. Release transfer leases and remove retired contexts.
-7. Stop listeners and completion workers.
-8. Confirm that any non-KV registration owners, including auxiliary transfer
-   paths, have independently drained; then deregister memory and destroy VMM
-   mappings.
-9. Destroy the backend agent.
+3. Start draining endpoint contexts while registrations and progress workers
+   remain available.
+4. For every fixed operation or dynamic stream that may have received an
+   address but is not closed to future submission, establish a documented
+   submission fence. Its acknowledgement MUST guarantee that the peer cannot
+   later submit against that advertisement. A terminal `NO_REMOTE_ACCESS`
+   result closes its fixed operation; authenticated end-of-stream closes future
+   enrollment/submission for a dynamic stream, but neither substitutes for
+   quiescence of already-submitted work.
+5. For submitted or still-in-doubt network operations, request per-operation or
+   backend-wide quiescence through a documented `quiesce()`/drain operation
+   before the deadline.
+6. If the deadline expires without the required operation/stream closure or
+   submission fence and quiescence evidence, return a non-drained result and
+   stop teardown at this point.
+7. Synchronize remaining gather/scatter work.
+8. Release transfer leases and remove retired contexts.
+9. Confirm that any non-KV registration owners, including auxiliary transfer
+   paths, have independently drained while shared listeners, progress, and
+   completion workers remain alive. If this barrier misses the deadline, return
+   a non-drained result and stop teardown at this point.
+10. Stop listeners and completion workers; then deregister memory and destroy
+    VMM mappings.
+11. Destroy the backend agent.
 
-The backend likely needs two phases: quiesce while registrations are still
-usable, followed by final destruction after deregistration. If the deadline
-expires and quiescence cannot be proven, shutdown returns a non-drained result
-and must not deregister, unmap, or reuse the affected memory. The worker remains
-alive and retryable, and listeners/completion workers remain available for a
-later drain attempt. Destructors MUST NOT perform fallback unmapping. The caller
-may escalate process health through the adjacent cancellation/poison policy, but
+Draining only operations that are already visible to the local backend is not
+sufficient. For example, a sender may pause after receiving a target address
+and submit against it later. Until a terminal result or acknowledged
+peer/session/endpoint fence makes that future submission impossible, the
+advertised target remains live and shutdown is non-drained.
+
+The transport likely needs three ordered phases: fence future submission while
+control paths are live, quiesce submitted work while registrations are usable,
+then perform final destruction after deregistration. If the deadline expires
+and either fencing or quiescence cannot be proven, shutdown returns
+`RETRYABLE_IN_DOUBT` and must not deregister, unmap, reuse, or drop the affected
+memory owners. The transceiver does not enter its final `_shutdown` state. The
+worker remains alive and retryable, and listeners/completion workers remain
+available for a later drain attempt. `PyExecutor` and executor-creation cleanup
+MUST inspect this result and MUST NOT call KV-manager shutdown while any lease
+is live. Destructors MUST NOT perform fallback unmapping. The caller may
+escalate process health through the adjacent cancellation/poison policy, but
 in-process cleanup fails closed.
 
 ## Protocol and Rolling Upgrade Contract
 
 PR #15618 changed advertisement and result framing without a general protocol
-negotiation layer. This follow-up must not add generation or mode fields with
-another implicit same-version assumption.
+negotiation layer. This follow-up must not add transfer-generation,
+endpoint-epoch, stream/mode, or cancellation/control fields with another
+implicit same-version assumption.
 
 Before any address is published, peers must either:
 
 1. negotiate a protocol version/capability set that includes the required
-   identity and result fields; or
+   identity, result, and lifecycle-control fields; or
 2. reject the mixed-version session explicitly.
 
-Silent downgrade is not allowed when it would remove generation-safe identity,
-exact writer accounting, or quiescence/mode reporting. The negotiation approach
-should align with the protocol work in PRs #15798 and #15799 where practical,
-without coupling this Python implementation to the C++ transceiver internals.
+Silent downgrade is not allowed when it would remove transfer-generation-safe
+identity, exact writer/stream accounting, or quiescence/mode reporting. The
+negotiation approach should align with the protocol work in PRs #15798 and
+#15799 where practical, without coupling this Python implementation to the C++
+transceiver internals.
 
-If implementation Phase 1 initially retains the existing wire identity, it must
-prove and enforce that transfer IDs and tombstones cannot be reused during the
-lifetime of any late result, including worker recreation. If that proof is not
-available, generation and protocol negotiation move into Phase 1. One of those
-two conditions is a hard Phase 1 exit criterion, not optional follow-up work.
+Phase 1 MUST introduce the negotiated transfer generation and both endpoint
+epochs on every lifecycle-mutating advertisement, result, and control message.
+The existing `unique_rid`-only identity is not a permitted compatibility mode,
+regardless of an attempted non-reuse proof. Peers that do not negotiate this
+identity are rejected before address publication.
+
+The protocol assigns one endpoint as the admission initiator. Its transfer
+generation is monotonically allocated within its endpoint epoch, and the
+negotiated maximum outstanding-generation window bounds peer replay state.
+Admission outside that window is backpressured. Reconnecting without the
+existing endpoint replay state requires a fresh endpoint epoch; a delayed
+message from the old epoch cannot open or attach to the new session.
+
+Healthy per-transfer admission fields ride the existing KV request/target
+response; they do not create another request/ack exchange before address
+publication. Capability negotiation is session-scoped. Exceptional skip/close
+and rejection acknowledgements remain explicit, retryable controls.
+
+Phase 1 negotiation also covers transfer admission, the initial replay
+floor/window, fixed-manifest/context capacity envelopes, and the
+creation-close/cancel acknowledgement used to retire zero-context lifecycle
+state. Phase 2 adds the bounded dynamic-stream/end-of-stream contract. Phase 3
+adds the stronger submission fence for published addresses. A peer that lacks
+the capability required by the selected phase is excluded before that phase's
+access boundary; no control is interpreted using a weaker earlier-phase
+meaning.
 
 ## Implementation and Validation
 

--- a/docs/design/disagg-kv-transfer-ownership/README.md
+++ b/docs/design/disagg-kv-transfer-ownership/README.md
@@ -1,0 +1,776 @@
+# Python Native Disaggregated KV Transfer Ownership and Lifecycle
+
+| Field | Value |
+|---|---|
+| **Owner** | Chien-Chun Hung |
+| **Status** | Draft design contract |
+| **Created** | 2026-07-08 |
+| **Last updated** | 2026-07-08 |
+| **Implementation baseline** | [PR #15618](https://github.com/NVIDIA/TensorRT-LLM/pull/15618), merged as [`3bf37d2`](https://github.com/NVIDIA/TensorRT-LLM/commit/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d) |
+| **Primary target** | Python native KV cache transceiver with NIXL, direct and bounce paths |
+| **Detailed plan** | [`implementation-plan.md`](implementation-plan.md) |
+
+## Executive Summary
+
+PR #15618 introduced an opt-in bounce path for the Python native KV cache
+transceiver. It gathers fragmented sender KV into a contiguous arena, performs a
+coalesced NIXL write, and scatters the contiguous receive region back to the
+destination KV blocks. The PR also added a receive-side `TransferContext` that
+waits for fan-in writers and scatter completion before releasing a bounce slot.
+
+That context closes an important part of the normal-path bounce lifetime, but it
+is not an end-to-end transfer owner. Ownership remains split across
+`LlmRequest`, `RxSession`, sender worker stack frames, bounce allocators, CUDA
+events, NIXL status objects, and KV cache managers. Cancellation, timeout,
+partial publication, fan-in failure, and shutdown can therefore make logical
+request completion happen before every physical memory accessor is known to be
+quiescent.
+
+This document defines the target ownership contract for the Python native
+transceiver:
+
+- The unit of physical ownership is an **endpoint-local context per KV slice**,
+  with an exact per-writer ledger. A request-level handle aggregates slices for
+  user-visible completion.
+- `TransferWorker` owns a registry that strongly retains transfer contexts.
+  `LlmRequest` and session objects are associated consumers, not the root owners.
+- A context owns leases for every allocation and asynchronous operation that can
+  outlive request/session cleanup.
+- Logical completion and physical retirement are independent states.
+- Cancellation, timeout, session destruction, elapsed quarantine time, and an
+  ambiguous transport failure are not proof of quiescence.
+- Direct, bounce, and mixed fan-in paths follow the same contract.
+- In-doubt memory remains unavailable for reuse until terminal evidence or
+  backend-wide quiescence exists. The initial implementation chooses safety over
+  bounded reclamation.
+
+The functional scope is the Python transceiver. This is not necessarily a
+Python-files-only change: allocator-enforced KV leases or definitive NIXL status
+may require small C++/nanobind extensions. The separate C++
+`CacheTransceiver` is not an implementation target.
+
+## Design Decisions
+
+The following decisions are normative for the implementation plan.
+
+1. **One transfer does not have a single cross-process owner.** Sender and
+   receiver each have an endpoint-local context correlated by protocol identity.
+2. **Physical ownership is per KV slice.** Each receive context contains a
+   per-writer ledger; a request-level handle aggregates one or more slice
+   contexts.
+3. **The registry is the root owner.** Request or session removal cannot destroy
+   an active context.
+4. **KV ownership is allocator-enforced.** A strong reference to `LlmRequest` is
+   not a sufficient KV lease if `free_resources()` can independently recycle its
+   blocks.
+5. **The contract covers direct and bounce paths.** Bounce being disabled or a
+   sender falling back to direct transfer does not bypass ownership tracking.
+6. **Logical completion is separate from physical retirement.** A request may
+   fail promptly while its memory remains leased and unavailable for reuse.
+7. **Address publication is conservative.** A writer is considered capable of
+   access before any message containing its address is sent.
+8. **Quarantine is containment, not evidence.** Wall-clock expiry never makes an
+   in-doubt allocation safe to reuse.
+9. **Identity is generation-safe.** Results are matched by transfer, slice,
+   generation, and exact writer identity, not merely by writer count.
+10. **Shutdown drains before deregistration or unmapping.** If quiescence cannot
+    be proven, memory remains mapped and shutdown reports a non-drained state.
+11. **Wire changes are negotiated.** New generation, writer, or mode fields
+    require capability/version negotiation or explicit mixed-version rejection
+    before address publication.
+12. **Non-KV auxiliary transfers are a separate audit.** This project covers all
+    resources used to perform KV transfer, including KV descriptors and bounce
+    gather/scatter plans, but does not claim to own independent auxiliary-buffer
+    transfers.
+
+## Background
+
+### Bounce transfer introduced by PR #15618
+
+KV cache pages are often physically fragmented. A direct NIXL transfer may
+therefore require many descriptors. The bounce path introduced by
+[PR #15618](https://github.com/NVIDIA/TensorRT-LLM/pull/15618) changes the data
+path to:
+
+```text
+source KV pages
+    -> CUDA gather into a contiguous sender bounce slot
+    -> coalesced NIXL WRITE into a contiguous receiver bounce slot
+    -> CUDA scatter into destination KV pages
+```
+
+The feature is opt-in through `kv_cache_bounce_size_mb`; zero disables it. It is
+constructed only by the Python native transceiver. The sender may still fall
+back to the direct fragmented path when a transfer is not bounceable or no slot
+is available.
+
+The merged
+[`bounce.TransferContext`](https://github.com/NVIDIA/TensorRT-LLM/blob/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d/tensorrt_llm/_torch/disaggregation/native/bounce/core.py#L61-L175)
+tracks a receive bounce slot, writer results, scatter state, and settlement. It
+does not hold source or destination KV leases, the sender bounce lease, the NIXL
+operation, or the publication identity. In this design, that class is treated as
+an internal receive-bounce state object and should be renamed accordingly when
+the general context is introduced.
+
+### Related work
+
+Status snapshot: 2026-07-08.
+
+| Work | Relationship to this design |
+|---|---|
+| [PR #15618](https://github.com/NVIDIA/TensorRT-LLM/pull/15618) | Merged Python/native bounce implementation and baseline for this follow-up. |
+| [Transfer-owner review on #15618](https://github.com/NVIDIA/TensorRT-LLM/pull/15618#pullrequestreview-4612079358) and [follow-up acknowledgement](https://github.com/NVIDIA/TensorRT-LLM/pull/15618#pullrequestreview-4630057518) | Review provenance for the comprehensive ownership follow-up. |
+| [PR #16116](https://github.com/NVIDIA/TensorRT-LLM/pull/16116) | Open post-merge follow-up intended to exercise the Python bounce configuration. It is validation-adjacent, not ownership work. |
+| [PR #15780](https://github.com/NVIDIA/TensorRT-LLM/pull/15780) | Open draft proposing an independent C++ NIXL bounce implementation with a different arena and credit protocol. Useful lifecycle prior art; not a shared implementation target. |
+| [PR #15139](https://github.com/NVIDIA/TensorRT-LLM/pull/15139) | Merged C++/V1 precedent for rank-consistent terminal-state consensus. This design adopts the logical/physical separation for Python native transfers. |
+| [PR #15356](https://github.com/NVIDIA/TensorRT-LLM/pull/15356) | Merged bounded polling/admission work. Draining must remain non-blocking to the executor hot path. |
+| [PRs #15238](https://github.com/NVIDIA/TensorRT-LLM/pull/15238) and [#15737](https://github.com/NVIDIA/TensorRT-LLM/pull/15737) | Open inputs to the C++ cancellation chain: gated NIXL in-flight cancellation/quiescence containment and sender liveness hardening. They are conceptual precedents, not Python-native dependencies. |
+| [PRs #15794](https://github.com/NVIDIA/TensorRT-LLM/pull/15794), [#15795](https://github.com/NVIDIA/TensorRT-LLM/pull/15795), [#15798](https://github.com/NVIDIA/TensorRT-LLM/pull/15798), and [#15799](https://github.com/NVIDIA/TensorRT-LLM/pull/15799) | Open draft C++-transceiver cancellation chain plus PyExecutor integration: buffer ownership, detached-owner/fatal cleanup, negotiation, and a generation-safe peer-protocol design. This work aligns conceptually but fills the Python-native gap. |
+| [PR #15738](https://github.com/NVIDIA/TensorRT-LLM/pull/15738) | Open draft default-on policy for a qualified C++ NIXL/UCX configuration. It explicitly excludes the Python transceiver, so this work is complementary. |
+| [Chunked KV transfer design](../chunked-kv-transfer/README.md) and [PR #15727](https://github.com/NVIDIA/TensorRT-LLM/pull/15727) | Open Python pipelined/chunked transfer consumer. The owner must support multiple independently progressing chunks/slices and overlapping prefill/transfer lifetimes. |
+| [PR #15803](https://github.com/NVIDIA/TensorRT-LLM/pull/15803) | Open draft C++-transceiver/V1 work and prior art for explicit KV transfer leases, descriptor lifetime, and constrained early release. It is not an available shared primitive. |
+
+The adjacent
+[`disagg-inflight-cancel-poison`](../disagg-inflight-cancel-poison/README.md)
+design owns cancellation consensus and process-health policy across a wider
+runtime matrix. This note owns the physical resource-lifetime contract for the
+Python native transfer path. Cancellation intent enters this design as a logical
+event; it never authorizes physical release by itself.
+
+## Problem Statement
+
+### Current ownership is fragmented
+
+The present path has several partial owners:
+
+- `LlmRequest` carries request state and allocated block identifiers.
+- `AsyncTransferManager` retains context-side requests during asynchronous send
+  work, but does not provide a symmetric allocator lease for receiver loading.
+- `RxSession` owns request-facing receive state and callbacks.
+- Sender worker stack frames hold the NIXL status and release sender bounce slots
+  in local cleanup.
+- `VmmBounceTransport` owns arena allocators, registrations, CUDA streams, and
+  receive bounce contexts.
+- KV managers remain the authority that can return blocks to their pools.
+
+No object has both the information and authority to answer: **which asynchronous
+accessors can still touch which allocation generation?**
+
+### Concrete remaining hazards
+
+#### Released bounce address can still be advertised
+
+The current
+[`dispatch_task()` sequence](https://github.com/NVIDIA/TensorRT-LLM/blob/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d/tensorrt_llm/_torch/disaggregation/native/transfer.py#L1522-L1589)
+reserves a receive slot, then separately finds the session, changes task state,
+and publishes the address. Concurrent
+[`RxSession.cancel()`](https://github.com/NVIDIA/TensorRT-LLM/blob/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d/tensorrt_llm/_torch/disaggregation/native/transfer.py#L1985-L2006)
+can observe the task as not transferring and release the reservation between
+those steps. Dispatch may then advertise an address that has already returned to
+the allocator, creating a potential cross-request overwrite if a remote writer
+uses the stale address after the slot is reused.
+
+#### First fan-in failure can outlive its session
+
+The first failed writer currently
+[`fail()`s the task immediately](https://github.com/NVIDIA/TensorRT-LLM/blob/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d/tensorrt_llm/_torch/disaggregation/native/transfer.py#L1898-L1912).
+Failed-session cleanup can remove the `RxSession`, while
+[`_process_kv_agent_result()`](https://github.com/NVIDIA/TensorRT-LLM/blob/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d/tensorrt_llm/_torch/disaggregation/native/transfer.py#L1684-L1710)
+drops later results when that session is absent.
+
+For an all-bounce transfer this can strand the receive slot. For a mixed or
+direct transfer, a sibling writer may still be writing destination KV. If
+request cleanup recycles those blocks before that sibling is quiescent, this
+creates a potential physical GPU memory use-after-release/ABA hazard, not merely
+a Python object-lifetime issue.
+
+#### Timeout and quarantine do not prove retirement
+
+`mark_orphaned()` exists in the bounce state object but has no production
+callers through the transport interface. Timeout, cancellation, partial
+publication, and session destruction do not consistently transition the
+physical owner into a drain or containment state.
+
+The allocator's fixed-duration quarantine, if wired into production, would also
+not be a transport guarantee. An elapsed grace period cannot prove that a
+one-sided operation will not access the region later.
+
+#### Shutdown order can destroy live memory
+
+Sender workers use an unbounded transfer wait but are joined with a finite
+deadline. The enclosing
+[`TransferWorker.shutdown()`](https://github.com/NVIDIA/TensorRT-LLM/blob/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d/tensorrt_llm/_torch/disaggregation/native/transfer.py#L2297-L2339)
+invokes the current
+[`VmmBounceTransport.close()`](https://github.com/NVIDIA/TensorRT-LLM/blob/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d/tensorrt_llm/_torch/disaggregation/native/bounce/impl.py#L382-L394)
+which stops the scatter worker, deregisters arenas, and destroys their mappings.
+This occurs before the
+[`BaseTransferAgent.shutdown()` quiescence contract](https://github.com/NVIDIA/TensorRT-LLM/blob/3bf37d25387c2b99ef6dba4555ed432bcedfcf4d/tensorrt_llm/_torch/disaggregation/base/agent.py#L85-L121)
+is invoked. A sender worker, remote RMA, or queued scatter may still reference
+those ranges.
+
+#### Count-based fan-in is not identity-safe
+
+The current receive context records distinct peer ranks until
+`len(_writer_ok) >= num_writers`. It does not retain the exact advertised writer
+set or a transfer generation. An unexpected distinct writer can count toward
+completion, and a stale result can collide with a later reuse of the same
+`(request_id, slice_id)` key.
+
+## Scope and Applicability
+
+### In scope
+
+| Axis | In-scope variants |
+|---|---|
+| **Transceiver runtime** | Python native `KvCacheTransceiverV2`. Here, “V2” names the transceiver, not necessarily the KV manager. |
+| **Network backend** | NIXL/DEFAULT as supported by the Python transceiver. |
+| **Transfer path** | Direct fragmented transfer, bounce transfer, and per-writer fallback between them. |
+| **Bounce configuration** | Disabled (`kv_cache_bounce_size_mb == 0`) and enabled (`> 0`). |
+| **KV manager** | Python KV manager V2 and the C++-backed V1 manager exposed to Python. |
+| **Direction** | Context-side send and generation-side receive. |
+| **Fan-in/topology** | Single writer and every multi-writer topology supported by the Python transceiver, including TP/ADP fan-in and multiple slices/chunks. |
+| **Executor** | PyTorch backend and AutoDeploy when they select the Python transceiver. |
+| **Resources** | KV allocations, bounce-slot leases, CUDA gather/scatter work, transfer descriptor/plan storage, NIXL operation state, result delivery state, and registration/mapping shutdown dependencies. |
+
+The ownership path must be active even when bounce is disabled. The bounce
+configuration changes which leases exist; it does not select whether lifetime
+safety applies.
+
+### Non-goals
+
+- Replacing or porting the design into the separate C++ `CacheTransceiver`.
+- Unifying the Python bounce implementation with the independent C++ bounce
+  implementation in PR #15780.
+- Redesigning rank consensus, scheduler cancellation, or request admission.
+- Making `LlmRequest` the low-level transfer state machine.
+- Creating one distributed object that owns both processes.
+- Retrying or resuming a failed model request.
+- Rolling back KV bytes written before a transfer fails.
+- Optimizing gather/scatter kernels, descriptor coalescing, or arena sizing.
+- Enabling bounce by default.
+- Transparent recovery from a crashed peer without transport or process-level
+  quiescence evidence.
+- Independent non-KV auxiliary-buffer transfer ownership. Such paths require a
+  separate audit against the same invariant.
+
+## Terminology
+
+| Term | Meaning |
+|---|---|
+| **Logical outcome** | Request-visible success, failure, or cancellation. It controls scheduling and notification, not memory reuse. |
+| **Physical retirement** | Proof that no network or CUDA accessor can touch the leased resource generation, followed by exactly-once lease release. |
+| **Lease** | A token that prevents an allocator, arena, or manager from reusing or destroying a resource while the token is live. |
+| **Publication** | Any attempt to send an address or descriptor to a writer that could cause the writer to access it. |
+| **Terminal evidence** | Positive evidence, defined by the backend contract, that a specific operation cannot perform later memory access. |
+| **Quiescence** | A per-operation or backend-wide guarantee that no relevant asynchronous access can occur later. |
+| **Quarantine** | Removal from reuse while quiescence is unknown. It does not become safe through elapsed time. |
+| **Generation** | A nonce distinguishing successive uses of the same request/slice or arena slot identity. |
+| **Consumer** | The request/session-facing observer that receives logical completion. It is not the physical owner. |
+
+## Normative Safety Contract
+
+The load-bearing invariant is:
+
+> For every asynchronous accessor and every memory range it may read or write,
+> the range's allocation generation and registration MUST remain unchanged from
+> before its address becomes observable until there is positive evidence that
+> the accessor can no longer touch it.
+
+The following are explicitly **not** terminal evidence:
+
+- client cancellation;
+- request or session destruction;
+- scheduler timeout;
+- elapsed quarantine duration;
+- release of a local request handle without an abort guarantee;
+- loss of the result message;
+- an ambiguous `False` from a bounded wait that conflates in-progress and
+  terminal failure;
+- local CUDA synchronization when a remote RMA may still be active.
+
+### Required invariants
+
+**O1 — Register before publication.** All leases and the complete planned
+writer-operation ledger, including candidate direct and bounce ranges, MUST be
+installed in the registry before publication begins.
+
+**O2 — Mark possible access first.** Before the system attempts to send any
+message containing an address, `publication_started()` MUST atomically set the
+writer operation's exposure state to `MAY_ACCESS` and access state to
+`POSSIBLE`. A send error may revert to `NEVER_EXPOSED`/`QUIESCED` only when the
+messaging layer positively guarantees non-delivery.
+
+**O3 — Request lifetime is not resource lifetime.** Closing an `LlmRequest`,
+`TxSession`, `RxSession`, future, or request-level transfer handle MUST NOT
+directly release transfer-owned resources or bypass the context retirement
+predicate. It MAY trigger retirement when that predicate is already satisfied.
+
+**O4 — Logical and physical state are independent.** Failure or cancellation MAY
+be reported immediately, but physical retirement MUST wait for all possible
+accessors.
+
+**O5 — Exact operation accounting.** A receive context MUST track every planned
+writer-operation identity, generation, and candidate direct/bounce range. The
+actual target mode is recorded after sender selection. Writer count alone is
+insufficient.
+
+**O6 — Registry-first result routing.** Results MUST be routed to the transfer
+registry before optional session lookup or notification. A missing consumer MUST
+NOT cause a physical result to be dropped.
+
+**O7 — Allocator-enforced KV leases.** Lease acquisition MUST atomically validate
+and pin `(pool, block, allocation_generation)` before raw pointers are resolved
+or descriptors are constructed. `free_resources()` atomically drops request
+ownership and marks leased blocks pending-free. A generation becomes reusable
+only when request ownership is gone and its transfer-lease count reaches zero.
+Overlapping slice leases are reference-counted, and KV-manager shutdown obeys
+the same rule. Holding only block IDs or a Python request reference is
+insufficient.
+
+**O8 — Exactly-once retirement.** Duplicate, reordered, late, or contradictory
+events MUST NOT double-release a lease or advance another generation.
+
+**O9 — Safe uncertainty.** When quiescence is unknown, resources MUST remain
+leased or quarantined. Admission may fail due to exhausted safe capacity; reuse
+is forbidden.
+
+**O10 — Drain before teardown.** A KV or bounce registration/mapping MUST NOT be
+destroyed until every relevant network accessor is quiescent (or backend-wide
+quiescence substitutes for missing per-operation evidence) **and** all local
+CUDA work that can touch it is complete. If shutdown also removes registrations
+used by auxiliary transfers, those independent owners MUST drain as an external
+precondition; draining only the KV registry is insufficient.
+
+**O11 — No blocking under the context lock.** Network operations, CUDA
+synchronization, allocator callbacks, and consumer callbacks MUST execute
+outside the context state lock.
+
+**O12 — Bounded executor polling.** Ownership draining MUST preserve the bounded
+polling behavior established by PR #15356. Waiting for physical retirement MUST
+NOT block the main executor loop.
+
+**O13 — Range authorization.** Before NIXL submission or gather/scatter launch,
+every descriptor segment MUST be validated as a subset of the correct leased
+allocation generation and the writer's authorized candidate range. Validation
+includes device, required alignment, non-negative size, integer overflow,
+aggregate byte count, and per-writer subrange boundaries. A lifetime lease does
+not authorize out-of-range access.
+
+## Ownership Model
+
+```mermaid
+flowchart TB
+    TW["TransferWorker"] --> TR["TransferRegistry (strong context owner)"]
+    TR --> SC["SendTransferContext per slice"]
+    TR --> RC["RecvTransferContext per slice"]
+    RH["LlmRequest / session / request handle"] -. "consumer association" .-> SC
+    RH -. "consumer association" .-> RC
+    SC --> SKV["source KV lease"]
+    SC --> SB["optional send-bounce lease"]
+    SC --> GE["gather event and plan"]
+    SC --> NS["NIXL operation status"]
+    RC --> DKV["destination KV lease"]
+    RC --> RB["optional receive-bounce lease"]
+    RC --> WL["exact writer ledger"]
+    RC --> SE["scatter job, plan, and event"]
+    BT["BounceTransport"] --> BA["arenas, registrations, streams, allocators"]
+    SB -. "lease prevents reuse" .-> BA
+    RB -. "lease prevents reuse" .-> BA
+```
+
+### Ownership granularity
+
+The physical context key is conceptually:
+
+```text
+(transfer_id, slice_id, generation, sender_endpoint_epoch, receiver_endpoint_epoch)
+```
+
+A **slice** is the smallest address set that is published and physically retired
+as one unit. One receive context contains one ledger entry per planned writer
+operation; a writer that issues multiple NIXL operations for the slice has a
+distinct operation ID for each. One request-level `TransferHandle` aggregates
+all slice contexts needed to compute the logical request outcome. This supports
+chunked and pipelined transfers without making a single request-wide context
+serialize independent slices.
+
+### Component responsibilities
+
+| Component | Owns | Must not own or decide |
+|---|---|---|
+| `TransferRegistry` | Strong references to live contexts; identity lookup; shutdown drain accounting. | Request scheduling or KV allocation policy. |
+| `SendTransferContext` | Source KV lease, optional send-bounce lease, gather fence/plan, descriptor storage, NIXL operation, result-delivery state. | Receiver resources or request object destruction. |
+| `RecvTransferContext` | Destination KV lease, optional receive-bounce lease, writer ledger, scatter fence/plan, detachable consumer callback. | Source resources or distributed request consensus. |
+| `TransferHandle` | Request-facing aggregation and logical cancellation/notification. | Physical lease release. |
+| `BounceTransport` | Arena mappings, registrations, allocators, streams, and lease issuance. | End-to-end transfer outcome. |
+| KV manager | Underlying KV allocation and enforcement of active transfer leases. | Network completion inference. |
+| NIXL agent | Submission/progress and documented quiescence evidence. | KV block reuse. |
+
+The current `bounce.TransferContext` should become an implementation detail such
+as `RecvBounceContext` or be replaced by `RecvBounceLease` state. Expanding it
+into the general owner would couple direct transfer, request notification, KV
+allocation, and transport arena internals into the bounce package.
+
+### Resource retirement matrix
+
+| Resource | Earliest safe release |
+|---|---|
+| Source KV, bounce writer | Gather fence completed; NIXL subsequently reads only the send-bounce slot. |
+| Source KV, direct writer | The NIXL operation is definitively quiescent. |
+| Send-bounce slot | The NIXL operation reading it is definitively quiescent. |
+| Receive-bounce slot | Every writer operation that may have received its address is quiescent, and scatter either completed or was conclusively suppressed. |
+| Destination KV, direct writer | Every direct writer operation targeting those blocks is quiescent. |
+| Destination KV, bounce writer | All bounce writers are quiescent and successful scatter completed, or scatter was conclusively suppressed because the data outcome failed. |
+| Destination KV, mixed fan-in | All direct writers are quiescent, all bounce writers are quiescent, and scatter completed or was conclusively suppressed. |
+| Descriptor/plan backing storage | The backend has copied it synchronously, or every asynchronous consumer is quiescent. |
+| Gather/scatter CUDA event | Completion has been observed and no queued work or callback still references it. |
+| Transfer context | All physical leases are released exactly once; only lightweight result-delivery/tombstone state may remain. |
+| Arena registration and VMM mapping | All contexts that can access that arena are retired; all local CUDA work is complete; and any missing per-operation network evidence is replaced by backend-wide quiescence. |
+
+Resources MAY be released independently at their earliest safe boundary. For
+example, bounce gather completion can release source KV while the send-bounce
+lease remains active through NIXL completion. The context remains registered
+until all of its responsibilities are settled.
+
+### Relationship to `LlmRequest`
+
+The request and transfer lifetimes largely overlap, so they should be associated
+through `TransferHandle`. They must not be collapsed into one owner:
+
+- a request can become logically terminal before DMA or scatter retires;
+- one request can own several independently progressing slices;
+- transport result handling must survive session removal;
+- retaining a request object does not necessarily prevent explicit KV
+  `free_resources()`;
+- transport workers should not mutate scheduler-facing request state directly.
+
+Request cleanup does not perform a check-then-free against `TransferHandle`.
+Instead, `free_resources()` atomically drops request ownership in the KV manager;
+leased generations become pending-free and are reclaimed automatically when the
+last transfer lease is released. This avoids a race between checking the handle
+and acquiring a new lease.
+
+## State Model
+
+One enum must not conflate request outcome with memory safety.
+
+### Logical outcome
+
+```text
+ACTIVE -> SUCCEEDED
+ACTIVE -> FAILED
+ACTIVE -> CANCELLED
+```
+
+Logical failure may occur on the first writer failure. Logical cancellation may
+occur on client cancellation, deadline, consensus outcome, or shutdown. Neither
+transition implies physical retirement.
+
+Logical success requires every required writer to succeed and all required
+scatter work to complete successfully.
+
+The first logical terminal outcome wins. For example, cancellation already
+reported to the consumer is not overwritten by a later writer failure. Later
+events still update physical and process-health state.
+
+### Physical access, target, and data state
+
+Each writer operation tracks separate dimensions rather than one overloaded
+terminal enum.
+
+**Exposure state:**
+
+```text
+PLANNED -> NEVER_EXPOSED
+PLANNED -> MAY_ACCESS
+MAY_ACCESS -> NEVER_EXPOSED  (only with positive non-delivery proof)
+```
+
+- `PLANNED`: leases exist, but publication has not started.
+- `NEVER_EXPOSED`: positive proof exists that no address was observable. It is a
+  physically terminal exposure state.
+- `MAY_ACCESS`: publication started, submission may be active, or outcome is
+  uncertain.
+
+**Access state:** `NOT_STARTED`, `POSSIBLE`, or `QUIESCED`. `QUIESCED` requires
+positive per-operation evidence or a backend-wide drain that covers the
+operation. A generic failure without that guarantee remains `POSSIBLE`.
+
+**Target mode:** `PENDING`, `DIRECT`, `BOUNCE`, `NO_REMOTE_ACCESS`, or `UNKNOWN`.
+The pre-publication plan contains authorized direct and bounce candidate ranges;
+the actual mode is selected later.
+
+**Data outcome:** `UNKNOWN`, `SUCCESS`, `FAILURE`, `ABORTED`, or `INVALID`.
+Physical quiescence and data validity are independent. For example, a valid
+quiescence-bearing NIXL result with malformed scatter metadata makes the data outcome
+`INVALID` and suppresses scatter, but it can still prove that the network
+accessor is `QUIESCED`. Backend-wide drain after a lost result can produce
+`QUIESCED` with data outcome `UNKNOWN`; the logical transfer fails and no
+scatter occurs.
+
+### Local accessor state
+
+Gather, each sender-side NIXL operation, and scatter are local asynchronous
+accessors with their own state:
+
+```text
+PLANNED -> MAY_ACCESS -> QUIESCED
+```
+
+The context and required leases MUST exist before deriving raw pointers or
+constructing plans. The accessor enters `MAY_ACCESS` before CUDA launch, queue
+publication, or NIXL submission. Synchronous failure before launch may move
+directly to `QUIESCED`; an exception after an ambiguous launch/submission stays
+`MAY_ACCESS` until positive evidence arrives. Worker death does not imply
+quiescence.
+
+### Publication contract
+
+Network send cannot be made atomic with local cancellation. The safe ordering
+is:
+
+1. Acquire all required KV and bounce leases.
+2. Create the exact writer-operation plan and authorized candidate ranges.
+3. Register the context.
+4. Under the context lock, atomically set the selected writer operation's
+   exposure state to `MAY_ACCESS` and access state to `POSSIBLE`.
+5. Release the lock and attempt to publish its addresses.
+6. Record send/submission outcome without weakening `MAY_ACCESS` unless
+   non-delivery is proven.
+
+Cancellation before any writer enters `MAY_ACCESS` can retire immediately.
+Cancellation after that boundary changes the logical outcome and starts drain;
+it does not release memory.
+
+For partial fan-out publication, operations that never crossed the boundary
+become `NEVER_EXPOSED`; operations that crossed it drain independently. The
+request may fail immediately, but the context retires only after all possible
+accessors do.
+
+### Direct, bounce, and fallback mode
+
+The receiver may offer a bounce target while the sender later chooses direct
+fallback. Until the actual mode is known, the receiver conservatively holds both
+the destination KV lease and any offered receive-bounce lease.
+
+The writer-operation ledger records target mode independently from exposure,
+access, and data state. The mode is initially `PENDING` and normally becomes:
+
+- `DIRECT`: destination KV access retires when the writer operation is quiescent.
+- `BOUNCE`: receive-bounce access retires when the writer operation is quiescent; successful
+  writers contribute a validated scatter plan.
+
+`NEVER_EXPOSED` is not a transfer mode. It is a physical exposure state proving
+that neither candidate target was observable to that writer.
+
+`NO_REMOTE_ACCESS` means the address may have been exposed, but the sender has
+positive evidence that it did not submit a remote operation. `UNKNOWN` means the
+backend or a global drain established quiescence without reconstructing which
+candidate target was used.
+
+A failed transfer is never scattered into usable KV. Partial direct writes need
+not be rolled back; the destination KV lease remains until all writers drain,
+then the failed allocation may be recycled.
+
+### Identity and result routing
+
+A result must identify:
+
+- protocol version/capability;
+- transfer ID;
+- slice ID;
+- generation/attempt nonce;
+- exact writer identity and writer-operation ID;
+- sender and receiver endpoint/instance epochs, because ranks can be reused
+  after restart;
+- actual direct/bounce mode;
+- quiescence evidence and data outcome;
+- validated scatter metadata when bounce succeeded.
+
+The registry validates identity before any request/session lookup. Duplicate
+results are idempotent. Unexpected writer operations, contradictory duplicates,
+and wrong generations cannot advance any live context. Valid quiescence evidence
+may advance physical access state even when result payload or scatter metadata
+is invalid; that invalid data fails the logical transfer and suppresses scatter.
+All ranges are checked against the registered authorization before use.
+
+Creating a context with an already-live identity MUST fail rather than replace
+the existing context. Generations MUST NOT be reused within an endpoint epoch.
+Retired identities may leave bounded diagnostic tombstones; pruning a tombstone
+does not authorize generation reuse or resource reclamation.
+
+A result may advance access state to `QUIESCED` only when the sender has positive
+evidence that its NIXL operation cannot perform later DMA. It is not enough to
+report that the request was cancelled or that a bounded wait elapsed.
+
+### Lost results and quarantine
+
+In the first implementation, a receive context whose quiescence-bearing result is lost
+remains in doubt until backend-wide or driver-level teardown explicitly revokes
+the relevant registrations and prevents later DMA. Merely losing Python objects,
+running destructors, or entering generic process-control teardown is not
+evidence. The memory is not reused. This can reduce capacity and eventually
+reject admission, but it does not trade memory safety for a timer.
+
+Bounded in-process reclamation requires one of:
+
+- reliable result acknowledgement and retry;
+- a receiver query that obtains per-operation quiescence evidence;
+- a peer/session epoch transition with a backend guarantee that old operations
+  cannot access current registrations; or
+- backend-wide quiescence.
+
+Those are liveness improvements, not permission to weaken the baseline safety
+contract.
+
+### Unknown writer cohort
+
+Some gen-first ADP flows broadcast discovery/request messages before the active
+DP cohort is known. Before publishing memory addresses, the implementation MUST
+either:
+
+1. select the exact writer-operation cohort through an address-free handshake;
+   or
+2. register every recipient as a potential writer operation and obtain a
+   quiescent `NO_REMOTE_ACCESS` acknowledgement from every non-participant.
+
+If neither is implemented, that topology is excluded from the first ownership
+rollout even though it remains an eventual design target. An expected writer
+count is not an acceptable substitute.
+
+### Threading and callbacks
+
+State changes are serialized per context. The implementation must not hold a
+context or registry lock while:
+
+- sending or receiving network messages;
+- waiting for NIXL;
+- synchronizing CUDA work;
+- allocating or freeing KV/bounce memory;
+- invoking request/session callbacks.
+
+Queue entries for gather/scatter work hold a strong context reference rather
+than only raw slot IDs and callbacks. Consumer callback exceptions are recorded
+but cannot interrupt physical finalization.
+
+## Proposed Interfaces
+
+Names are illustrative; behavior is normative.
+
+```python
+class TransferRegistry:
+    def prepare_send(self, plan: SendPlan) -> SendTransferContext: ...
+    def prepare_receive(self, plan: RecvPlan) -> RecvTransferContext: ...
+    def route_result(self, result: WriterOperationResult) -> None: ...
+    def cancel_consumer(self, transfer_id: TransferId, reason: str) -> None: ...
+    def begin_shutdown(self) -> None: ...
+    def drain(self, deadline: float | None) -> DrainResult: ...
+
+
+class RecvTransferContext:
+    def publication_started(
+        self, operation: WriterOperationId
+    ) -> PublicationToken: ...
+    def mark_never_published(
+        self, operation: WriterOperationId, proof: NonDeliveryProof
+    ) -> None: ...
+    def record_result(self, result: WriterOperationResult) -> None: ...
+    def record_global_quiescence(self, evidence: QuiescenceEvidence) -> None: ...
+    def cancel_consumer(self, reason: str) -> None: ...
+    def detach_consumer(self) -> None: ...
+
+
+class KVTransferLease:
+    def release(self) -> None: ...
+```
+
+Required properties:
+
+- Methods are thread-safe and idempotent.
+- Registry insertion rejects a duplicate live identity.
+- Resource release is private to the context.
+- Request-facing handles cannot force physical retirement.
+- `KVTransferLease` prevents allocator reuse even if request cleanup runs.
+- `BounceTransport` issues optional `SendBounceLease` and `RecvBounceLease`
+  objects; it remains the arena owner.
+- `NoBounceTransport` issues no bounce lease, but the direct path still creates
+  send/receive contexts and KV leases.
+- Invariant violations retain resources and emit diagnostics rather than trying
+  to recover through reuse.
+
+### NIXL status contract
+
+The lifecycle owner needs at least:
+
+```text
+IN_PROGRESS
+QUIESCED_SUCCESS
+QUIESCED_FAILURE
+QUIESCED_ABORTED
+IN_DOUBT
+```
+
+The current Python-facing boolean wait is insufficient for bounded drain if it
+maps both timeout/in-progress and failure to `False`. The adapter may expose a
+tri-state poll plus a separate quiescence guarantee, or a richer enum such as
+the above. Exact names are not important; distinguishing “still possible” from
+“cannot access memory” is mandatory. This classification is correctness
+infrastructure required by the first retirement implementation. A richer
+per-operation cancel/recovery API may remain a later liveness improvement.
+
+## Shutdown Contract
+
+Shutdown follows this order:
+
+1. Stop admitting requests and publishing new addresses.
+2. Mark remaining consumers failed/cancelled, but keep result listeners,
+   transfer workers, and CUDA completion workers alive.
+3. Drain endpoint contexts until the shutdown deadline.
+4. For network operations still in doubt, request backend-wide quiescence
+   through a
+   documented `quiesce()`/drain operation.
+5. Synchronize remaining gather/scatter work.
+6. Release transfer leases and remove retired contexts.
+7. Stop listeners and completion workers.
+8. Confirm that any non-KV registration owners, including auxiliary transfer
+   paths, have independently drained; then deregister memory and destroy VMM
+   mappings.
+9. Destroy the backend agent.
+
+The backend likely needs two phases: quiesce while registrations are still
+usable, followed by final destruction after deregistration. If the deadline
+expires and quiescence cannot be proven, shutdown returns a non-drained result
+and must not deregister, unmap, or reuse the affected memory. The worker remains
+alive and retryable, and listeners/completion workers remain available for a
+later drain attempt. Destructors MUST NOT perform fallback unmapping. The caller
+may escalate process health through the adjacent cancellation/poison policy, but
+in-process cleanup fails closed.
+
+## Protocol and Rolling Upgrade Contract
+
+PR #15618 changed advertisement and result framing without a general protocol
+negotiation layer. This follow-up must not add generation or mode fields with
+another implicit same-version assumption.
+
+Before any address is published, peers must either:
+
+1. negotiate a protocol version/capability set that includes the required
+   identity and result fields; or
+2. reject the mixed-version session explicitly.
+
+Silent downgrade is not allowed when it would remove generation-safe identity,
+exact writer accounting, or quiescence/mode reporting. The negotiation approach
+should align with the protocol work in PRs #15798 and #15799 where practical,
+without coupling this Python implementation to the C++ transceiver internals.
+
+If implementation Phase 1 initially retains the existing wire identity, it must
+prove and enforce that transfer IDs and tombstones cannot be reused during the
+lifetime of any late result, including worker recreation. If that proof is not
+available, generation and protocol negotiation move into Phase 1. One of those
+two conditions is a hard Phase 1 exit criterion, not optional follow-up work.
+
+## Implementation and Validation
+
+See [`implementation-plan.md`](implementation-plan.md) for the performance and
+capacity contract, observability requirements, phased implementation plan,
+validation matrix, risks, alternatives, and phase gates.

--- a/docs/design/disagg-kv-transfer-ownership/implementation-plan.md
+++ b/docs/design/disagg-kv-transfer-ownership/implementation-plan.md
@@ -1,0 +1,291 @@
+# Implementation Plan for Python Native Disaggregated KV Transfer Ownership
+
+[< Back to ownership contract](README.md)
+
+| Field | Value |
+|---|---|
+| **Owner** | Chien-Chun Hung |
+| **Status** | Draft implementation plan |
+| **Created** | 2026-07-08 |
+| **Last updated** | 2026-07-08 |
+
+## Performance and Capacity Contract
+
+Ownership safety must not undo the performance purpose of bounce transfer.
+
+- Direct transfer adds no data copy and no new CUDA synchronization.
+- Context lookup and result processing are O(1) average; metadata is O(writers)
+  per slice.
+- Locks are per context or sharded; no global lock is held across NIXL or CUDA
+  work.
+- Executor polling remains bounded and non-blocking.
+- Source KV is released at its earliest safe per-path boundary, enabling chunked
+  early release rather than pinning the whole request until all slices finish.
+- Bounce arena sizing remains configuration-driven and opt-in.
+
+Fail-closed retention can consume KV or bounce capacity. This is intentional
+under uncertainty and must be visible operationally. It is preferable to an
+invisible cross-request overwrite. Bounded reclamation is a follow-up enabled by
+stronger transport/protocol evidence.
+
+## Observability
+
+At minimum, expose counters or structured logs for:
+
+- active send and receive contexts;
+- contexts logically terminal but physically draining;
+- in-doubt context count, bytes, age, and reason;
+- active source/destination KV leases;
+- active send/receive bounce leases;
+- direct, bounce, and fallback writers;
+- duplicate, unexpected, contradictory, and stale-generation results;
+- partial-publication failures;
+- shutdown drain duration and non-drained context count;
+- admission failures caused by safely retained capacity.
+
+Logs identify transfer ID, slice, generation, writer identity, path, logical
+outcome, physical state, and held leases without logging raw data contents.
+
+## Implementation Plan
+
+The work should land as a chain of focused PRs rather than one large refactor.
+Size estimates are directional and include only production code unless noted.
+
+### Phase 1 — Receiver safety foundation
+
+**Size:** Medium-large; approximately 7–10 production files, 600–1,000
+production lines, and 700–1,200 test lines. Generation negotiation or a new V1
+lease binding can increase this estimate.
+
+- Add `TransferRegistry` and `RecvTransferContext` above the bounce package.
+- Split logical outcome, exposure, access, target, and data state.
+- Create the exact writer-operation plan and range authorization before
+  publication.
+- Move the publication boundary before message send.
+- Route all results through the registry before session lookup.
+- Drain late sibling results after logical failure/session removal.
+- Replace timed bounce reuse with indefinite in-doubt retention.
+- Rename or narrow the current bounce-only `TransferContext`.
+- Add a minimum allocator-enforced destination-KV lease before resolving or
+  publishing destination pointers; Phase 1 cannot claim direct-path safety
+  without it.
+- Treat any failure lacking documented quiescence evidence as in doubt.
+- Preselect the exact ADP writer cohort or exclude that topology from the first
+  rollout.
+- Add safe interim shutdown behavior: no unmap if contexts remain in doubt.
+- Meet the hard identity gate: add generation/versioning or prove and enforce
+  non-reuse across late results and worker recreation.
+
+Likely files:
+
+- `tensorrt_llm/_torch/disaggregation/native/transfer.py`
+- `tensorrt_llm/_torch/disaggregation/transceiver.py`
+- `tensorrt_llm/_torch/disaggregation/native/bounce/core.py`
+- `tensorrt_llm/_torch/disaggregation/native/bounce/impl.py`
+- a new native transfer-context/registry module
+- unit and fault-injection tests
+
+Phase 1 is a receiver-safety milestone, not completion of the comprehensive
+sender-and-receiver contract.
+
+### Phase 2 — Complete KV leases and sender context
+
+**Size:** Large; approximately 8–12 files, 500–1,000 production lines, and
+600–1,000 test lines. A small C++/nanobind extension may be required.
+
+- Complete the common source/destination `KVTransferLease` contract for both KV
+  managers.
+- Support atomic pending-free and overlapping reference-counted slice leases.
+- Acquire source leases before gather or direct submission.
+- Add `SendTransferContext` and track gather, NIXL, send-bounce, descriptor, and
+  result-delivery state independently.
+- Integrate with or generalize `AsyncTransferManager` rather than creating a
+  second request-retention mechanism.
+- Permit per-chunk source release at the earliest safe boundary without forcing
+  request-wide pinning; PR #15803 provides C++-side prior art for the lease
+  shape.
+- Cover direct, bounce, and mixed-mode fan-in.
+
+### Phase 3 — Two-phase shutdown and backend quiescence
+
+**Size:** Medium; approximately 300–600 production lines and 400–700 test lines.
+
+- Add backend quiesce/drain and reorder shutdown before
+  deregistration/unmapping.
+- Keep non-drained workers retryable; prohibit destructor fallback unmapping.
+- Include independent auxiliary-transfer owners in the shared-registration
+  shutdown barrier.
+- Preserve independent earliest-safe release boundaries and retain only
+  lightweight result-delivery/tombstone state after GPU leases retire.
+- Add the required lifecycle metrics.
+
+### Phase 4 — Protocol and liveness hardening
+
+**Size:** Medium; approximately 200–500 production lines plus protocol tests.
+
+- Add result acknowledgement/retry or receiver query for bounded recovery from
+  message loss.
+- Add a richer per-operation query/abort API beyond the minimum quiescence
+  classification required by Phase 1.
+- Consider per-operation abort only if the backend can guarantee no later memory
+  access after acknowledgement.
+
+The core effort is approximately 1,500–3,000 production lines plus substantial
+concurrency and integration tests. The C++ `CacheTransceiver` remains untouched;
+cross-language work is limited to shared KV-manager or NIXL binding contracts
+that the Python runtime consumes.
+
+## Validation Plan
+
+### Deterministic unit and fault-injection tests
+
+- Cancel immediately before, during, and after address publication.
+- Writer A fails, the consumer/session closes, and writer B reports later.
+- Mixed direct/bounce fan-in where one writer fails.
+- Partial multi-writer publication where only a subset may have seen addresses.
+- Timeout followed by late success and late failure.
+- Duplicate, unexpected, contradictory, and stale-generation results.
+- Gather launch, descriptor construction, NIXL submission, result-send, and
+  scatter exceptions.
+- Consumer callback exception during physical finalization.
+- Attempted source KV reuse while direct NIXL read is blocked.
+- Attempted destination KV reuse while direct write or scatter is blocked.
+- Attempted send/receive bounce reuse while NIXL or scatter is active.
+- Shutdown with blocked NIXL status, lost quiescence result, and queued/running
+  scatter; assert that deregistration and unmapping do not occur.
+- Exactly-once release under concurrent cancel/result and reordered duplicates.
+- Lease acquisition racing request `free_resources()`.
+- Overlapping slice leases on the same KV allocation generation.
+- Malformed, overflowing, misaligned, or out-of-range NIXL and scatter metadata.
+- Synchronous pre-submit failure versus ambiguous NIXL submission failure.
+- Quiesced `NO_REMOTE_ACCESS` and quiesced-with-unknown-data outcomes.
+- Global NIXL quiescence while scatter remains queued or active.
+- KV registry drained while an independent auxiliary transfer remains active.
+- Non-drained shutdown followed by a successful retry.
+- Duplicate context identity insertion.
+- Gather/scatter worker death or asynchronous CUDA failure.
+- Sender GPU lease retirement while result delivery remains pending.
+
+Tests must use barriers/hooks rather than probabilistic sleeps for the critical
+publication and teardown races.
+
+### Configuration matrix
+
+- bounce disabled and enabled;
+- Python KV manager V2 and C++-backed V1;
+- single writer and multi-writer TP/ADP fan-in;
+- direct, bounce, and per-writer fallback;
+- single slice and chunked/multi-slice transfer;
+- PyTorch executor and AutoDeploy with Python transceiver;
+- bounce-ineligible/non-attention layer-group fallback;
+- normal completion, cancellation, timeout, peer failure, and shutdown.
+
+### Performance validation
+
+- Direct-path throughput and CPU overhead with ownership enabled.
+- Bounce throughput and gather/scatter overlap.
+- Context-registry lock contention under high concurrency.
+- Source KV early-release timing for chunked transfer.
+- Memory high-water mark with normal drain and deliberately in-doubt contexts.
+- Shutdown drain latency.
+
+### Acceptance criteria
+
+The design is implemented only when all of the following are true:
+
+1. No address can be published without a registered context and live leases.
+2. Session/request removal cannot drop a physical quiescence result.
+3. KV and bounce allocators cannot reuse leased generations.
+4. Every release path is idempotent and tied to quiescence evidence.
+5. Direct, bounce, and mixed transfers share the same ownership path.
+6. Timers alone never authorize reuse.
+7. Shutdown cannot deregister or unmap memory while a context may access it.
+8. New identity fields are negotiated or mixed versions are rejected before
+   DMA addresses are exchanged.
+9. The executor remains responsive while contexts drain.
+10. In-doubt capacity and shutdown state are observable.
+11. Lease acquisition and `free_resources()` cannot race into block reuse.
+12. Every NIXL/gather/scatter range is authorized by a live generation lease.
+13. Every local CUDA/NIXL accessor is independently tracked through quiescence.
+14. Phase 1 either provides generation-safe identity or enforces non-reuse
+    across worker recreation and all possible late results.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Lock-order deadlock across registry, session, allocator, CUDA, and callbacks | Per-context serialization; no blocking operations or callbacks under lifecycle locks; lock-order tests. |
+| KV over-pinning or leaked leases | Exactly-once release, active-lease metrics, oldest-context diagnostics, and fault-injection coverage. |
+| Capacity exhaustion from indefinite retention | Fail admission visibly; expose bytes/age/reason; add reliable result recovery or backend quiescence before bounded reclaim. |
+| Treating failure as quiescence incorrectly | Track quiescence separately from data outcome and preserve an explicit in-doubt state. |
+| Mixed direct/bounce accounting error | Record actual mode per exact writer and retain both candidate leases until mode is known. |
+| Stale result advances a new transfer | Generation and endpoint epoch, tombstones, exact writer validation, and negotiated protocol. |
+| Main-loop latency regression | Preserve bounded polling; perform draining on transfer/completion workers; benchmark registry contention. |
+| Shutdown hangs indefinitely | Use an explicit deadline and return non-drained status, but never convert deadline expiry into unsafe unmap/reuse. |
+| Rolling-upgrade incompatibility | Capability/version negotiation or pre-DMA rejection; no silent downgrade of safety fields. |
+| Behavioral divergence between KV managers | One conformance test suite for the common lease API; implementation-specific adapters only below it. |
+| Scope expands into cancellation consensus | Keep logical consensus in the adjacent cancellation design; consume its outcome through `TransferHandle`. |
+
+## Alternatives Considered
+
+### Expand the current bounce `TransferContext`
+
+Rejected as the general architecture. That object is naturally scoped to a
+receive bounce slot. Making it own direct writers, source KV, sender status,
+request aggregation, and KV-manager leases would invert module boundaries and
+make ownership disappear when bounce is disabled.
+
+### Make `LlmRequest` the owner
+
+Rejected. Its logical lifetime may end before physical retirement; it aggregates
+multiple slices; and a live object reference does not necessarily prevent
+allocator-level `free_resources()`. It remains an associated consumer through a
+request-level handle.
+
+### Treat timeout or fixed quarantine as safe reclamation
+
+Rejected. Wall-clock duration is not proof that one-sided RMA has stopped. A
+timer may trigger diagnostics, fail admission, or escalate process health; it
+cannot authorize memory reuse.
+
+### Solve only the bounce path
+
+Rejected. Sender fallback can mix bounce and direct writers, and destination KV
+is the resource at risk when a direct writer outlives logical failure. The
+general owner must sit above `BounceTransport`.
+
+### Unify Python and C++ transceivers now
+
+Rejected for this project. Their implementations, flow control, and active
+bounce proposals differ. They should share invariants and, where useful,
+allocator/protocol primitives, but not be forced into one implementation before
+the Python safety gap is closed.
+
+## Open Implementation Questions and Phase Gates
+
+These do not change the safety contract, but they determine phase sequencing.
+
+1. Which exact NIXL states guarantee no later DMA after success, failure, abort,
+   and peer loss?
+2. Can the advertisement messaging layer prove non-delivery after a send error?
+   If not, every attempted send remains `MAY_ACCESS`.
+3. Can `unique_rid` be reused across worker recreation or retry? If yes or not
+   provably no, generation/version work is a Phase 1 prerequisite.
+4. What supplies a stable endpoint epoch across rank/process restart?
+5. Can existing V1 block pinning enforce leases through explicit
+   `free_resources()`, or is a new nanobind API required?
+6. What is the smallest V2 KV-manager lease surface that supports per-slice early
+   release without request-wide over-pinning?
+7. Does the NIXL wrapper need a separate `quiesce()` operation before final
+   shutdown so registrations can remain valid during drain?
+8. Is result acknowledgement/retry required for the first production rollout,
+   or is observable indefinite retention acceptable for all Python-native
+   direct and bounce transfers?
+9. Which independent auxiliary-buffer paths can outlive their request/session?
+   They need a follow-up audit before the broader transceiver can claim complete
+   ownership coverage.
+10. Can every claimed TP/ADP topology identify its exact potential writer cohort
+    before address fan-out, or which cells must be gated initially?
+
+No answer to these questions may weaken the invariant by interpreting
+uncertainty as retirement.

--- a/docs/design/disagg-kv-transfer-ownership/implementation-plan.md
+++ b/docs/design/disagg-kv-transfer-ownership/implementation-plan.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Implementation Plan for Python Native Disaggregated KV Transfer Ownership
 
 [< Back to ownership contract](README.md)
@@ -7,44 +12,137 @@
 | **Owner** | Chien-Chun Hung |
 | **Status** | Draft implementation plan |
 | **Created** | 2026-07-08 |
-| **Last updated** | 2026-07-08 |
+| **Last updated** | 2026-07-13 |
 
 ## Performance and Capacity Contract
 
 Ownership safety must not undo the performance purpose of bounce transfer.
 
 - Direct transfer adds no data copy and no new CUDA synchronization.
-- Context lookup and result processing are O(1) average; metadata is O(writers)
-  per slice.
+- Registry/identity lookup and fixed-operation state transitions are O(1)
+  average. Per-segment bounds checks are O(segments), and fixed exact-mapping
+  normalization is O(segments log segments) unless canonical wire ordering
+  permits a linear scan. Dynamic-stream interval insertion/overlap validation is
+  O(log(operations + segments)), and end-of-stream coverage/compaction is
+  O(operations + segments), all within negotiated bounds. Metadata is
+  O(contexts + writers + operations + segments) per transfer and bounded by
+  fixed-manifest or dynamic-stream envelopes plus endpoint-global capacity.
 - Locks are per context or sharded; no global lock is held across NIXL or CUDA
   work.
 - Executor polling remains bounded and non-blocking.
+- Session capability negotiation is amortized, and healthy per-transfer
+  admission piggybacks on the existing KV request/target response without a new
+  request/ack RTT.
 - Source KV is released at its earliest safe per-path boundary, enabling chunked
   early release rather than pinning the whole request until all slices finish.
-- Bounce arena sizing remains configuration-driven and opt-in.
+- Bounce arena sizing remains configuration-driven and opt-in; requested,
+  transport-active, and per-transfer-engaged states are distinguished.
 
 Fail-closed retention can consume KV or bounce capacity. This is intentional
 under uncertainty and must be visible operationally. It is preferable to an
 invisible cross-request overwrite. Bounded reclamation is a follow-up enabled by
 stronger transport/protocol evidence.
 
+### Expected metric impact
+
+This is primarily a correctness and capacity-recovery project, not a NIXL
+bandwidth optimization. On a healthy transfer, the expected data path is
+unchanged. The owner adds host metadata, lookup, and state transitions, but no
+new direct-path CUDA copy, kernel, synchronization, or device arena. When the
+requested bounce transport is active, the configured send/receive arenas
+introduced by PR #15618 remain the only preallocated bounce storage.
+
+| Scenario | Expected impact |
+|---|---|
+| Healthy direct or bounce transfer | With admission piggybacked on the existing request/target response, throughput, TTFT, and transfer-task latency should remain within benchmark noise. CPU time and host memory rise slightly with O(contexts + writer operations + descriptor/scatter segments + lifecycle records + outstanding generations) metadata and state transitions. An implementation that adds a per-transfer RTT must declare and qualify that separate behavior. |
+| Chunked bounce send | Unique transfer-leased source-KV byte-seconds/high-water mark can decrease because a slice may release source KV after gather completes rather than at request-wide completion; the pending-free subset shows actual admission capacity recovered after request cleanup. |
+| Chunked direct send | Unique transfer-leased source-KV retention can decrease when each slice is released after its NIXL operation becomes definitively quiescent. There is no extra copy. |
+| Known-terminal failure that currently strands state | Registry-first routing should recover pending-free KV and unique bounce-slot capacity as soon as the last physical accessor retires, reducing excess post-logical retention, admission loss, and fault-period goodput degradation. |
+| Known-terminal direct/mixed failure that currently frees KV too early | The owner intentionally increases lease duration and possibly unique/pending-free high-water marks to the true quiescence boundary. That increase closes unsafe reuse and must not be classified as a regression. |
+| Lost result or ambiguous transport failure | Exact unique bounce-slot bytes and unique/pending-free KV bytes remain unavailable, so high-water marks, admission failures, and tail latency can worsen as safe capacity is exhausted. This is an intentional safety tradeoff until bounded recovery exists. |
+| Many dynamic streams reserve maximum envelopes but materialize little work | Host allocation may stay low while reserved credits reduce admissible concurrency and goodput. Reservation utilization/slack and reservation-caused rejection determine whether a configured envelope is rollout-safe. |
+| Shutdown with in-flight work | Graceful shutdown may take longer or return non-drained. Unsafe deregistration/unmapping events must fall to zero. |
+
+The main capacity metrics are:
+
+```text
+lease_token_byte_seconds = sum(token_range_bytes * token_lifetime)
+unique_transfer_leased_byte_seconds = integral(union of ranges with transfer_leases > 0)
+pending_free_kv_blocked_byte_seconds = integral(bytes with request_owners == 0 and transfer_leases > 0)
+reservation_utilization(kind) = materialized_credits(kind) / reserved_credits(kind)
+reservation_slack(kind) = reserved_credits(kind) - materialized_credits(kind)
+post_logical_retention = max(0, last_lease_release - logical_terminal_time)
+early_release_lead(resource) = max(0, logical_terminal_time - lease_release_time)
+```
+
+Lease-token byte-seconds intentionally count overlapping tokens and measure
+ownership bookkeeping. Unique transfer-leased bytes deduplicate overlapping
+ranges by allocation generation. Pending-free blocked KV bytes are the subset
+whose reuse is prevented solely by transfer leases; KV capacity-recovery and
+admission claims use that subset rather than token sums. Token metrics may be
+attributed to each operation path, but deduplicated unique and pending-free
+capacity gauges are path-neutral. An optional path breakdown must use mutually
+exclusive `direct_only`, `bounce_only`, and `mixed` allocation-generation
+classes so its series remain additive. `post_logical_retention`
+measures failure/cancellation drain without becoming negative when a source
+chunk retires early. Per-resource `early_release_lead` and lease duration
+measure that intended early release. Improvements should be claimed only for
+the applicable scenario. A normal-path latency or bandwidth improvement is not
+an expected outcome of ownership alone.
+
 ## Observability
 
 At minimum, expose counters or structured logs for:
 
 - active send and receive contexts;
+- active fixed-operation manifests and dynamic writer streams, including open
+  streams and their enrolled/high-water-mark operation counts;
+- configured, reserved, materialized, and remaining context/slice,
+  fixed-manifest operation/descriptor-segment/authorized-byte, and
+  dynamic-stream operation/segment/byte capacity, plus reservation utilization,
+  unused slack, envelope/global-capacity rejection, and reservation-caused
+  rejection;
 - contexts logically terminal but physically draining;
 - in-doubt context count, bytes, age, and reason;
+- pre-cancel tombstone count, oldest age, capacity rejections/backpressure, and
+  fence-based retirement;
+- configured, used, and remaining canonical lifecycle-record/control-state
+  capacity;
+- configured, used, and remaining endpoint replay-window capacity, retired-floor
+  advancement, sparse generation gaps, oldest gap age, and backpressure;
 - active source/destination KV leases;
 - active send/receive bounce leases;
-- direct, bounce, and fallback writers;
-- duplicate, unexpected, contradictory, and stale-generation results;
+- lease-token bytes/byte-seconds by endpoint and operation path; path-neutral
+  unique transfer-leased bytes/byte-seconds and pending-free KV
+  bytes/byte-seconds blocked solely by transfer leases, optionally split only
+  into mutually exclusive `direct_only`, `bounce_only`, and `mixed` classes;
+- bounce requested, transport active/inactive, and direct, bounce, or fallback
+  writers so configured-but-inactive runs cannot claim bounce coverage;
+- gather, NIXL, scatter, registry lookup, and lifecycle-lock wait latency;
+- transfer admission latency and bounded capacity-rejection latency;
+- healthy piggyback and exceptional skip/close/reject control-message counts and
+  round-trip latency, so an accidental normal-path RTT is visible;
+- logical completion time, last lease release, post-logical retention, and
+  per-resource early-release lead;
+- duplicate, unexpected, contradictory, and stale-transfer-generation results;
 - partial-publication failures;
 - shutdown drain duration and non-drained context count;
+- rollback requested, blocked/non-drained, and completed;
 - admission failures caused by safely retained capacity.
 
-Logs identify transfer ID, slice, generation, writer identity, path, logical
-outcome, physical state, and held leases without logging raw data contents.
+Aggregate metrics and benchmark records use low-cardinality dimensions for
+ownership mode, negotiated protocol/capability bucket, rollout cohort,
+KV-manager implementation, and executor. Operation/token metrics also use path;
+deduplicated capacity gauges omit it unless they use the mutually exclusive
+classes above. Request/transfer identities remain in structured logs rather
+than metric labels. Logs identify transfer ID, target slice, transfer
+generation, writer/stream/operation identity, path, logical outcome, physical
+state, and held leases without logging raw data contents.
+
+The existing sender `transfer_latency_ms` timer begins after bounce gather and
+the receive task completes after scatter. Raw NIXL throughput can therefore hide
+gather/scatter and lifecycle overhead. Benchmarks must report stage timings and
+end-to-end TTFT/goodput in addition to the existing NIXL interval.
 
 ## Implementation Plan
 
@@ -53,28 +151,123 @@ Size estimates are directional and include only production code unless noted.
 
 ### Phase 1 — Receiver safety foundation
 
-**Size:** Medium-large; approximately 7–10 production files, 600–1,000
-production lines, and 700–1,200 test lines. Generation negotiation or a new V1
-lease binding can increase this estimate.
+**Size:** Very large; approximately 18–28 production files, 2,000–3,500
+production lines, and 2,000–3,500 test lines. Metrics export or a new V1 lease
+binding can increase this estimate. Phase 1 should normally be a short stack:
+identity/admission/replay and fixed envelopes; receive contexts plus KV leases;
+then cancellation, shutdown veto, and minimum metrics. None is independently
+rollout-safe until the full Phase 1 gate passes.
 
-- Add `TransferRegistry` and `RecvTransferContext` above the bounce package.
+- Add `TransferRegistry`, registry-owned canonical `EndpointTransferRecord`,
+  durable `EndpointEpochState`, access gate/handle, and `RecvTransferContext`
+  above the bounce package. Requests/sessions hold only consumer references;
+  contexts retain the shared gate without forming a record-context ownership
+  cycle.
+- Create a one-shot `TransferAdmissionToken` atomically with the request/session
+  state transition that enables transfer scheduling. Implement token-to-registry
+  `admit_and_bind()` so local cancellation either prevents token creation,
+  aborts pending admission, or observes/aborts the canonical bound handle before
+  any peer authorization.
+- Make `begin_shutdown()` close registry admission and snapshot all committed
+  records in one registry transaction. A racing pending token is
+  shutdown-aborted if it loses; a winning record is included, and its later
+  peer-authorization boundary is handle-gated and either owned or suppressed.
+- Assign one negotiated admission initiator. Allocate its transfer generation
+  monotonically within its stable endpoint epoch, committing counter advancement
+  only with replay-entry reservation, canonical record creation, and token
+  binding after capacity checks. Negotiate the authenticated initial floor and
+  maximum outstanding-generation window, and maintain a contiguous retired
+  floor plus bounded sparse live/out-of-order-retired window per negotiated
+  endpoint-epoch pair. Atomically mark a generation retired before deleting its
+  canonical record; backpressure gaps/window exhaustion rather than evicting
+  anti-replay state. Convert every committed generation whose normal admission
+  control is not sent into an authenticated generation-skip record, and block
+  higher-generation admission control until its acknowledgement. A cumulative
+  skip watermark cannot cross a locally live/published/unclosed generation. If
+  admission control was sent but no address published and the peer rejects,
+  reserve/close the peer replay entry first and retire both sides through an
+  authenticated creation-close/reject acknowledgement. After address
+  publication, require the full operation/stream closure and physical-retirement
+  predicate instead.
+- Piggyback generation/epoch/fixed-envelope admission on the existing KV
+  request and target-advertisement response. Commit the receiver record before
+  that response; do not add a separate healthy admission acknowledgement.
 - Split logical outcome, exposure, access, target, and data state.
-- Create the exact writer-operation plan and range authorization before
-  publication.
+- Key contexts by role, local endpoint epoch, and admission-authority epoch; key
+  receive ledger entries by peer epoch, writer rank, and fixed-operation or
+  writer-stream ID.
+- Create the exact writer cohort, fixed-operation manifest, and range
+  authorization, including expected logical source-to-target segment mappings,
+  before publication. Dynamic sender-determined chunk streams are excluded from
+  Phase 1 rollout and land in Phase 2.
+- Negotiate per-transfer context/slice and fixed-manifest
+  operation/descriptor-segment/authorized-byte limits. Reserve actual
+  operation/authorized-byte credits and the worst-case permitted segment
+  envelope atomically against configured endpoint-global capacity before
+  publication; reject an oversized plan or exhausted pool without partial
+  exposure.
 - Move the publication boundary before message send.
-- Route all results through the registry before session lookup.
+- Put target slice and exact fixed writer-operation identity in each
+  advertisement. Deduplicate replay before local work so one advertisement can
+  launch at most one operation.
+- Route every KV writer-operation result through the registry before session
+  lookup; keep auxiliary results on their independent ownership path.
+- Route remote cancellation and every state-mutating control message through the
+  same transfer-generation/endpoint-epoch validation. Replace bare-`unique_rid`
+  pre-cancellation state with registry-atomic transfer-generation-aware
+  records. Reserve control-state capacity at admission, before the peer may send
+  lifecycle messages. An arbitrary unnegotiated control poisons/closes the
+  endpoint session in O(1); it does not allocate an unbounded deny entry.
+- Add a minimum negotiated generation/epoch-scoped creation-close/cancel-ack
+  handshake in Phase 1. The peer acknowledges only after its local producer gate
+  prevents later context creation; retry/deduplicate the acknowledgement and use
+  it to retire zero-context pre-cancel state. This is not the Phase 3 submission
+  fence and cannot retire any published address.
+- Retain unmatched pre-cancel state until producer sealing or acknowledged
+  creation close, enforce capacity through pre-admission backpressure, and
+  export configured/used/remaining capacity plus count/age/rejection metrics.
 - Drain late sibling results after logical failure/session removal.
 - Replace timed bounce reuse with indefinite in-doubt retention.
 - Rename or narrow the current bounce-only `TransferContext`.
-- Add a minimum allocator-enforced destination-KV lease before resolving or
-  publishing destination pointers; Phase 1 cannot claim direct-path safety
-  without it.
+- Add an allocator-atomic `snapshot_and_lease(request, slice_spec)` operation for
+  destination KV before copying block IDs, resolving pointers, or publishing
+  addresses. Construct the receive context and wire slice from the immutable,
+  allocation-generation-bearing lease snapshot; Phase 1 cannot claim
+  direct-path safety without it.
+- Add a Python-native lifecycle cancellation adapter with a structured
+  logical/physical result. Select it explicitly for `KvCacheTransceiverV2`
+  without changing the C++ transceiver's boolean contract. Let PyExecutor drop
+  destination-KV ownership while the lease makes it pending-free, but preserve
+  independent session/auxiliary cleanup gates; retain the sender-side legacy
+  gate until Phase 2.
+- Make receiver context insertion and `TransferHandle` enrollment atomic with
+  respect to handle abort/sealing. Gate every access boundary on the durable
+  gate before taking the context lock, abort the gate on first failure,
+  cancellation, or shutdown before enumerating contexts, and unwind a losing
+  preparation before target publication.
+- Define one monotonic transfer-attempt generation shared by every slice. Let
+  only the receiver producer/session seal its handle, using an immutable
+  expected-slice manifest after all fixed contexts are atomically enrolled.
 - Treat any failure lacking documented quiescence evidence as in doubt.
 - Preselect the exact ADP writer cohort or exclude that topology from the first
   rollout.
-- Add safe interim shutdown behavior: no unmap if contexts remain in doubt.
-- Meet the hard identity gate: add generation/versioning or prove and enforce
-  non-reuse across late results and worker recreation.
+- Preserve a separate auxiliary-slot cleanup gate, or exclude generation-first
+  configurations that transfer auxiliary data from Phase 1.
+- Add the minimum transceiver `ShutdownResult`, caller-retention contract, and
+  PyExecutor/creator/KV-manager teardown veto. If a context remains in doubt,
+  Phase 1 must keep its worker, registry, manager, registration, and mapping
+  alive; it cannot defer that safety boundary to Phase 3.
+- Add negotiated transfer generation and both endpoint epochs to every
+  lifecycle-mutating advertisement, result, and control message. Reject peers
+  with the legacy `unique_rid`-only identity before address publication.
+- Bind every admission to the negotiated endpoint-epoch pair. Recreating an
+  endpoint without its replay window requires a fresh, non-reused epoch, and
+  old-epoch traffic cannot bootstrap a replacement session.
+- Ship minimum capacity diagnostics with the fail-closed path: in-doubt
+  count/bytes/oldest age/reason, lease-token and unique transfer-leased
+  KV/bounce bytes, pending-free KV bytes, post-logical retention, per-resource
+  early-release lead, and admission/fallback failures caused by retained
+  capacity.
 
 Likely files:
 
@@ -82,6 +275,12 @@ Likely files:
 - `tensorrt_llm/_torch/disaggregation/transceiver.py`
 - `tensorrt_llm/_torch/disaggregation/native/bounce/core.py`
 - `tensorrt_llm/_torch/disaggregation/native/bounce/impl.py`
+- `tensorrt_llm/_torch/disaggregation/native/perf_logger.py` or the selected
+  serving-metrics adapter
+- destination KV-manager adapter/binding and PyExecutor cancellation integration
+- `tensorrt_llm/_torch/pyexecutor/py_executor.py`,
+  `tensorrt_llm/_torch/pyexecutor/py_executor_creator.py`, and KV-manager teardown
+  adapters for the minimum non-drained shutdown veto
 - a new native transfer-context/registry module
 - unit and fault-injection tests
 
@@ -90,8 +289,10 @@ sender-and-receiver contract.
 
 ### Phase 2 — Complete KV leases and sender context
 
-**Size:** Large; approximately 8–12 files, 500–1,000 production lines, and
-600–1,000 test lines. A small C++/nanobind extension may be required.
+**Size:** Large; approximately 12–18 files, 1,000–1,800 production lines, and
+1,200–2,200 test lines. A small C++/nanobind extension may be required. Split
+source-lease/sender-context work from the dynamic-stream protocol when review or
+validation scope would otherwise become too broad.
 
 - Complete the common source/destination `KVTransferLease` contract for both KV
   managers.
@@ -99,29 +300,78 @@ sender-and-receiver contract.
 - Acquire source leases before gather or direct submission.
 - Add `SendTransferContext` and track gather, NIXL, send-bounce, descriptor, and
   result-delivery state independently.
+- Extend atomic `TransferHandle` enrollment to sender contexts and reject a
+  losing preparation before gather or NIXL launch.
+- Retain the sender's canonical record/gate independently of its request-facing
+  handle reference, and abort it on first failure/cancellation before admitting
+  another chunk.
+- Add a negotiated bounded dynamic-writer-stream mode for sender-determined
+  chunks: advertise one authorized writer/target/range/stream, assign a distinct
+  operation sequence per chunk, validate the operation/segment/byte budget, and
+  reserve its worst-case metadata envelope before publication, then close
+  enrollment with an authenticated end-of-stream high-water mark.
+- Use an ordered interval/coverage structure so dynamic operation insertion and
+  overlap checks are O(log(operations + segments)), while end-of-stream
+  validation is one O(operations + segments) pass bounded by the negotiated
+  maximum.
+- Track reserved versus materialized operation/segment/byte credits and unused
+  slack. Return only unused envelope credits when authenticated close makes
+  future materialization impossible and establishes the exact final operation
+  set, or after backend quiescence permits fail-closed record retirement; retain
+  credits backing materialized entries through their retirement.
+- Atomically enroll the final sender context with its final-slice proof before
+  sealing the sender handle. Keep the receiver target leased until the stream is
+  closed/fenced and every operation through the high-water mark is quiescent.
+- Emit end-of-stream only after every covered sequence is already submitted or
+  terminal `NO_REMOTE_ACCESS`; atomically close future submission first. A
+  failed/cancelled stream uses terminal per-operation decisions or remains open
+  until the applicable fence, never normal sealing as a shortcut.
+- Deduplicate repeated stream advertisements and operation results, and fail
+  closed on missing, conflicting, out-of-range, or out-of-budget sequences.
 - Integrate with or generalize `AsyncTransferManager` rather than creating a
   second request-retention mechanism.
+- Remove the remaining sender-side safe-to-free cancellation gate once source
+  leases make request cleanup pending-free.
 - Permit per-chunk source release at the earliest safe boundary without forcing
   request-wide pinning; PR #15803 provides C++-side prior art for the lease
   shape.
 - Cover direct, bounce, and mixed-mode fan-in.
 
-### Phase 3 — Two-phase shutdown and backend quiescence
+### Phase 3 — Submission fencing and safe shutdown
 
-**Size:** Medium; approximately 300–600 production lines and 400–700 test lines.
+**Size:** Large; approximately 8–14 production files, 700–1,300 production
+lines, and 800–1,500 test lines. This phase should normally be split into a
+fence-protocol PR and a shutdown-integration PR.
 
-- Add backend quiesce/drain and reorder shutdown before
-  deregistration/unmapping.
-- Keep non-drained workers retryable; prohibit destructor fallback unmapping.
+- Add a negotiated peer/session/endpoint submission-fence capability and
+  transfer-generation/endpoint-epoch/fixed-operation-or-stream-scoped
+  request/ack framing for advertisements without a terminal result. An
+  acknowledgement closes future submission against all covered advertisements.
+  This strengthens the Phase 1 creation-close handshake after addresses may have
+  been exposed.
+- Add retry/idempotency handling for lost, delayed, duplicated, contradictory,
+  and stale-epoch fence messages. Mixed-version peers that cannot provide the
+  required fence are non-drained rather than silently downgraded.
+- After fencing, add backend quiesce/drain for submitted or in-doubt work and
+  reorder both before deregistration/unmapping.
+- Extend the Phase 1 non-drained result and teardown veto with backend-wide
+  quiescence, full retry/drain behavior, and process-health escalation.
 - Include independent auxiliary-transfer owners in the shared-registration
   shutdown barrier.
 - Preserve independent earliest-safe release boundaries and retain only
   lightweight result-delivery/tombstone state after GPU leases retire.
-- Add the required lifecycle metrics.
+- Add shutdown/quiesce-specific lifecycle metrics beyond the Phase 1 minimum.
+
+Likely files include `tensorrt_llm/_torch/disaggregation/transceiver.py`,
+`tensorrt_llm/_torch/disaggregation/native/transfer.py`,
+`tensorrt_llm/_torch/disaggregation/base/agent.py`,
+`tensorrt_llm/_torch/pyexecutor/py_executor.py`,
+`tensorrt_llm/_torch/pyexecutor/py_executor_creator.py`, and KV-manager teardown
+adapters in `tensorrt_llm/_torch/pyexecutor/_util.py`.
 
 ### Phase 4 — Protocol and liveness hardening
 
-**Size:** Medium; approximately 200–500 production lines plus protocol tests.
+**Size:** Medium; approximately 300–700 production lines plus protocol tests.
 
 - Add result acknowledgement/retry or receiver query for bounded recovery from
   message loss.
@@ -130,64 +380,363 @@ sender-and-receiver contract.
 - Consider per-operation abort only if the backend can guarantee no later memory
   access after acknowledgement.
 
-The core effort is approximately 1,500–3,000 production lines plus substantial
+The core effort is approximately 4,000–7,300 production lines plus substantial
 concurrency and integration tests. The C++ `CacheTransceiver` remains untouched;
 cross-language work is limited to shared KV-manager or NIXL binding contracts
 that the Python runtime consumes.
+
+## Rollout and Rollback
+
+Ownership selection is an endpoint-session capability decided before context
+creation and before any address is published. A temporary internal deployment
+gate may select eligible canaries, but `kv_cache_bounce_size_mb` is not that
+gate: bounce-disabled direct transfers need the same lifetime safety.
+
+Rollout proceeds by configuration cohort:
+
+1. Land deterministic tests and allocator conformance tests before enabling any
+   production cohort.
+2. Enable Phase 1 only where the exact writer cohort is known, both peers
+   negotiate the ownership protocol, the destination KV manager implements the
+   atomic lease contract, Phase 1 creation-close/cancel acknowledgement,
+   monotonic generation/replay-window contract, and fixed-manifest/context
+   capacity envelopes, and the minimum capacity metrics are available.
+   Unsupported ADP cohorts, mixed versions, and generation-first auxiliary paths
+   without an independent safe cleanup gate fail before address publication.
+   Sender-determined dynamic chunk streams remain excluded until Phase 2.
+3. Canary direct and bounce paths separately for each KV manager, then expand to
+   fan-in, fallback, AutoDeploy, and chunked configurations as their matrix cells
+   pass. A bounce canary requires positive transport-active and per-transfer
+   bounce-engaged signals; configuration alone is not evidence.
+4. Promote toward default-on only after the safety, capacity-recovery, and
+   quantitative performance gates pass for the applicable cells.
+
+Rollback never changes the owner of an active transfer. Stop new admission,
+drain or fail closed all contexts negotiated under the new protocol, and only
+then select another mode for newly negotiated sessions. If drain is non-terminal,
+retain the owners and escalate process health; do not bypass leases to complete
+rollback. A legacy path may remain available for explicitly excluded canary
+cohorts during rollout, but it is not an in-place recovery mechanism for an
+ownership failure. Rollback reports a blocked/non-drained result while any
+context cannot retire and increments the corresponding low-cardinality cohort
+metric.
 
 ## Validation Plan
 
 ### Deterministic unit and fault-injection tests
 
+- Cancel locally immediately before transfer-eligibility/token creation and
+  before/during `admit_and_bind()` with barriers. Cancellation prevents
+  scheduling, aborts the pending token with no peer authorization, or observes
+  and aborts the canonical bound handle; no unbound interval is permitted.
+  Repeat request cleanup while admission is paused.
+- Race `begin_shutdown()` with transfer-eligibility/token creation,
+  `admit_and_bind()` before and after registry insertion, and the peer
+  authorization boundary. Every run must either reject/shutdown-abort the token
+  with no record/authorization or include the canonical record and any possible
+  authorization in the shutdown snapshot and drain set.
 - Cancel immediately before, during, and after address publication.
+- Race cancellation against receiver and sender preparation/handle enrollment
+  with barriers; assert that the context is either enrolled and cancelled or
+  fully unwound before its publication/local-launch boundary. Reject slice
+  creation after handle sealing.
+- Close the handle, pause cancellation before it obtains a context lock, and
+  race publication/gather/NIXL/scatter boundary entry; assert that the closed
+  handle gate rejects every new boundary while previously admitted accessors
+  remain owned.
+- Drop every request/session-facing handle reference while a context is blocked,
+  then race abort with an access boundary. The registry-owned record/gate must
+  remain live. After current contexts retire but before producer sealing or a
+  creation fence, reject a delayed slice and advertisement replay instead of
+  creating a replacement handle.
+- Fully retire and delete a canonical record, reuse its former target
+  allocation, then deliver delayed duplicate admission and target-advertisement
+  messages. Endpoint replay state must reject both before record creation or
+  local launch. Retire generations out of order, verify sparse entries block
+  replay, then close the gap and verify contiguous-floor compaction.
+- Fill the negotiated generation window behind one missing generation and
+  verify admission rejects in the same worker iteration without sleep/retry or
+  eviction and within the frozen wall-time ceiling. Recreate an endpoint with a
+  fresh epoch and prove that old-epoch traffic cannot bootstrap its session. An
+  arbitrary unnegotiated control must poison the current session in O(1), after
+  which all admission fails until fresh negotiation. Reconnect with the same
+  epoch and a peer-claimed floor beyond a locally live/gapped generation;
+  reject the inconsistent session without resetting local replay state.
+- Repeatedly fail initiating admission before the generation/record/token
+  commit and prove that the counter/floor/window do not advance. Then inject
+  failures after local commit but before admission-control send, peer-side
+  rejection after admission control but before address publication, ambiguous
+  admission-control delivery, and abandonment after address publication. Lose,
+  delay, or duplicate the generation-skip acknowledgement and prove
+  higher-generation admission-control send remains blocked. Ambiguous normal
+  admission must retry/deduplicate and creation-close rather than becoming a
+  skip. Reject a contradictory cumulative watermark crossing a live or
+  published record. After authenticated skip or pre-publication close/reject,
+  both replay states advance/compact; post-publication abandonment retains the
+  record/resources until full physical retirement.
+- Race first logical failure against next-chunk enrollment and gather/NIXL
+  launch; the failure must abort the shared gate before callbacks, reject new
+  work, and retain already-possible accessors through quiescence.
+- Race cancellation with final-slice enrollment and handle sealing. Cover
+  missing, duplicate, reordered, and conflicting final chunks; success requires
+  the immutable manifest or final-slice proof to name the complete slice set.
 - Writer A fails, the consumer/session closes, and writer B reports later.
 - Mixed direct/bounce fan-in where one writer fails.
 - Partial multi-writer publication where only a subset may have seen addresses.
 - Timeout followed by late success and late failure.
-- Duplicate, unexpected, contradictory, and stale-generation results.
+- Duplicate, unexpected, contradictory, and stale-transfer-generation results.
+- Duplicate and reorder target advertisements. Assert that an identical fixed
+  operation or writer-stream advertisement launches at most once and a
+  conflicting replay fails closed.
+- Exercise a dynamic writer stream with out-of-order results and authenticated
+  end-of-stream. Cover a missing sequence, conflicting duplicate, out-of-range
+  subrange, operation/segment/byte budget overflow, forged/premature
+  end-of-stream, sequence-complete but in-range undercoverage/gaps, and
+  a full-coverage source-to-target permutation. Also cover an open stream whose
+  currently known operations are all quiescent; none may cause early target
+  retirement or logical success.
+- Pause an enrolled sequence before NIXL submission and attempt end-of-stream.
+  The close must wait for an irreversible `SUBMITTED`/`NO_REMOTE_ACCESS`
+  decision or reject later submission. Backend drain before that decision must
+  not permit target unmapping. Repeat for failed and cancelled streams.
 - Gather launch, descriptor construction, NIXL submission, result-send, and
   scatter exceptions.
+- Cancel while gather is active but before NIXL submission; assert that source
+  KV and any send-bounce resources remain leased until gather quiesces.
 - Consumer callback exception during physical finalization.
 - Attempted source KV reuse while direct NIXL read is blocked.
 - Attempted destination KV reuse while direct write or scatter is blocked.
 - Attempted send/receive bounce reuse while NIXL or scatter is active.
 - Shutdown with blocked NIXL status, lost quiescence result, and queued/running
   scatter; assert that deregistration and unmapping do not occur.
+- Publish a target, pause the sender before NIXL submission, and start receiver
+  shutdown. Assert that a drain of currently submitted operations cannot unmap
+  the target; retirement requires a terminal `NO_REMOTE_ACCESS` result or an
+  acknowledged submission fence that prevents later use of the advertisement.
+- Lose, delay, duplicate, reorder, contradict, and replay a submission-fence
+  acknowledgement from a stale endpoint epoch. Only the matching negotiated
+  acknowledgement may close future submission; mixed-version or unresolved
+  peers keep shutdown non-drained.
+- Exercise new/new negotiation independently for Phase 1 identity,
+  creation-close, fixed-envelope, and replay-window capabilities; Phase 2
+  dynamic-stream/end-of-stream capability; and Phase 3 submission fencing.
+  For each phase, reject new/legacy, missing, unknown, and downgraded capability
+  combinations before that phase's publication/local-launch boundary.
+- Count protocol messages on healthy admission and assert generation/epoch and
+  fixed-envelope fields use the existing KV request/target response with no
+  standalone admission acknowledgement. Verify skip/close/reject controls occur
+  only in their exceptional scenarios.
+- Publish a target, then deliver a valid Phase 1 creation-close acknowledgement.
+  It may close future context creation but must not retire the published target,
+  satisfy a submission fence, or permit shutdown while later sender submission
+  remains possible. Only terminal operation evidence or the negotiated Phase 3
+  fence plus quiescence may release the target.
 - Exactly-once release under concurrent cancel/result and reordered duplicates.
 - Lease acquisition racing request `free_resources()`.
+- Raw block-ID snapshot racing `free_resources()` and block reuse; assert that
+  only the allocator-atomic allocation-generation-bearing snapshot can create a
+  context.
 - Overlapping slice leases on the same KV allocation generation.
+- Overlap direct and bounce-path lease tokens on one allocation generation.
+  Per-path token series may count both, while path-neutral unique/pending-free
+  gauges count the range once; any `direct_only`/`bounce_only`/`mixed` breakdown
+  must sum exactly to the path-neutral gauge.
 - Malformed, overflowing, misaligned, or out-of-range NIXL and scatter metadata.
+- Fixed-manifest segments that are individually in range but truncate expected
+  coverage, leave a gap, duplicate/overlap within or across writers, mismatch
+  aggregate bytes, or permute equal-sized source-to-target intervals while
+  retaining full target coverage. Cover direct descriptors and wrong
+  bounce-source offsets in scatter metadata. All fail logical success and
+  suppress usable scatter while physical access still drains. Equivalent
+  differently segmented inputs that normalize to the exact expected mapping
+  pass.
+- Fixed manifests and transfer context/slice sets at, below, and above their
+  configured operation/descriptor-segment/authorized-byte/context limits.
+  Concurrent admissions must atomically reserve credits without overshoot;
+  rejection occurs before publication/local launch, completes in the same
+  bounded worker iteration, and transactional unwind returns every credit.
+- Open many dynamic streams with maximum envelopes but materialize only a small
+  fraction of their operations/segments/bytes. Verify reserved/materialized
+  credits, utilization/slack, reservation-caused rejection, and prompt return of
+  unused credits after authenticated close establishes the exact operation set,
+  without releasing materialized entries early. A future-submission-only fence
+  must retain slack until ledger reconciliation or backend quiescence.
 - Synchronous pre-submit failure versus ambiguous NIXL submission failure.
 - Quiesced `NO_REMOTE_ACCESS` and quiesced-with-unknown-data outcomes.
 - Global NIXL quiescence while scatter remains queued or active.
 - KV registry drained while an independent auxiliary transfer remains active.
 - Non-drained shutdown followed by a successful retry.
 - Duplicate context identity insertion.
+- Retry identical admission through the same token and receive the same handle;
+  attempt the live identity through a different token and reject it without
+  attaching cancellation authority or replacing canonical state.
+- Partial KV/bounce acquisition, plan-validation failure, and duplicate registry
+  insertion before the receiver target-publication or sender local-launch
+  boundary; assert endpoint-local transactional unwind with no leaked lease.
+  Repeat after each endpoint's boundary and assert fail-closed retention instead
+  of rollback.
+- Simultaneous local send/receive identities, fan-in writers from different peer
+  epochs, and a stale peer epoch targeting a new local transfer generation.
+- Keep the local endpoint epoch fixed while the remote admission authority
+  restarts with a fresh epoch and repeats a transfer ID/generation value. The
+  new full identity may be admitted, while delayed old-authority traffic is
+  rejected without colliding with the new record or replay window.
+- Delayed cancellation through a stale handle after request ID reuse; assert
+  that it cannot change the current transfer generation.
+- Remote cancellation arriving before context creation, followed by the matching
+  transfer generation; assert that the transfer-generation-aware pre-cancel
+  tombstone applies.
+- Race remote cancellation against registry/handle/context creation; assert
+  that either the live handle closes or the preparation observes the tombstone,
+  with no access boundary in between. Fill the tombstone table and assert
+  that every already-admitted generation has reserved cancellation state and
+  new admission backpressures before overflow. Deliver a valid cancellation at
+  full occupancy and verify it is recorded. Lose, delay, duplicate, and replay
+  the Phase 1 creation-close acknowledgement; retire zero-context state only
+  after the matching acknowledgement or local producer sealing.
+- Old-transfer-generation remote cancellation arriving after request ID reuse; assert
+  that neither the live context nor its session changes state.
+- Logical cancellation followed immediately by request cleanup while the
+  physical disposition remains `DRAINING` or `IN_DOUBT`.
+- Generation-first cancellation while auxiliary RMA remains active; assert that
+  KV may become pending-free but the session and auxiliary slot remain live.
 - Gather/scatter worker death or asynchronous CUDA failure.
-- Sender GPU lease retirement while result delivery remains pending.
+- Bounce send with NIXL blocked after gather; assert that the slice's source-KV
+  lease retires while its send-bounce lease remains live.
+- Direct send with NIXL definitively quiescent and result delivery blocked;
+  assert that source KV retires before result delivery.
+- Multi-slice send with one slice quiescent and a sibling blocked; assert that
+  the first slice retires without waiting for sibling or request completion.
+- Non-drained transceiver shutdown retained by PyExecutor; assert that executor
+  and creator cleanup cannot shut down the KV manager until a retry drains.
+- Request rollback with live direct and bounce contexts. Assert that admission
+  and mode switching remain blocked and each context keeps its negotiated owner.
+  Hold one context `IN_DOUBT` and require a visible blocked/non-drained rollback
+  without resource release; after terminal evidence drains every context, only
+  newly admitted sessions may negotiate the replacement mode.
 
 Tests must use barriers/hooks rather than probabilistic sleeps for the critical
 publication and teardown races.
 
 ### Configuration matrix
 
-- bounce disabled and enabled;
+- bounce not requested, requested but factory-inactive, and arena-active;
+- positive bounce-engagement evidence on candidate GB200/GB300 MNNVL fabric-VMM
+  cells; the merged config-enabled GB200 test is not proof, and
+  configured-but-inactive runs count as direct fallback;
 - Python KV manager V2 and C++-backed V1;
-- single writer and multi-writer TP/ADP fan-in;
+- phase-matched new/new negotiation plus new/legacy, missing-capability,
+  unknown-capability, and downgrade rejection;
+- single writer and multi-writer TP/PP/ADP overlap or fan-in;
 - direct, bounce, and per-writer fallback;
 - single slice and chunked/multi-slice transfer;
+- fixed manifests and dynamic streams at small, midpoint, and negotiated-maximum
+  operation-count/descriptor-segment/authorized-byte budgets, including
+  out-of-order and end-of-stream load, plus per-transfer context/slice limits;
+- high-concurrency maximum-envelope dynamic streams with low actual
+  operation/segment/byte materialization;
+- empty, midpoint, near-capacity, and full endpoint-global
+  context/operation/segment/authorized-byte credit occupancy;
+- empty, midpoint, near-capacity, and full lifecycle-record/pre-cancel occupancy;
+- sequential and out-of-order retirement at empty, midpoint, near-capacity, and
+  full endpoint replay-window occupancy;
 - PyTorch executor and AutoDeploy with Python transceiver;
+- context-first scheduling, plus generation-first only after its independent
+  auxiliary-slot cleanup gate is validated;
 - bounce-ineligible/non-attention layer-group fallback;
 - normal completion, cancellation, timeout, peer failure, and shutdown.
 
 ### Performance validation
 
-- Direct-path throughput and CPU overhead with ownership enabled.
-- Bounce throughput and gather/scatter overlap.
-- Context-registry lock contention under high concurrency.
-- Source KV early-release timing for chunked transfer.
-- Memory high-water mark with normal drain and deliberately in-doubt contexts.
-- Shutdown drain latency.
+Use an A/B build or runtime gate on the same commit and compare against the
+merged PR #15618 behavior. Hold model, hardware, NIXL backend, request trace,
+arena size, and scheduler configuration constant. Cover direct, bounce, and
+fallback paths across representative transfer sizes, concurrency, fan-in, both
+KV managers, and PyTorch/AutoDeploy cells. Run warmup plus enough independent
+benchmark runs to report 95% confidence intervals, using runs rather than
+individual requests as the sampling unit. Freeze workload definitions and gates
+before examining implementation results. Record the low-cardinality ownership
+mode, protocol bucket, rollout cohort, KV manager, executor, transport-active
+state, and observed writer path for every aggregate. Reclassify an intended
+bounce cell that lacks positive engagement evidence as direct fallback and do
+not use it to approve bounce rollout.
+
+Report:
+
+- request throughput and completed-request goodput;
+- p50/p95/p99 TTFT and end-to-end transfer-task latency;
+- gather, NIXL, and scatter latency/overlap, with the existing raw NIXL timer
+  reported separately;
+- host CPU time per completed transfer and registry/lifecycle-lock contention;
+- per-transfer healthy admission control message count plus exceptional
+  skip/close/reject RTT and retry count;
+- active host metadata by context/stream/tombstone/replay-window occupancy,
+  retired-floor advancement and gap age, end-of-stream processing time,
+  reserved/materialized credits, reservation utilization/slack and caused
+  rejection, admission/rejection latency, per-path lease-token bytes,
+  path-neutral unique transfer-leased bytes, pending-free KV bytes blocked
+  solely by transfer leases, and each corresponding byte-seconds/high-water
+  mark;
+- post-logical retention, per-resource early-release lead, lease duration, and
+  capacity-recovery time;
+- admission failures and goodput during known-terminal and deliberately
+  ambiguous fault injection;
+- shutdown drain latency and non-drained bytes.
+
+Initial go/no-go thresholds are scoped by scenario.
+
+Healthy/no-fault matrix cells:
+
+- throughput/goodput 95% confidence-interval lower bound is no worse than -2%;
+- the upper 95% confidence bound of relative p50/p95 TTFT and end-to-end transfer
+  latency regression is at most 3%, and the p99 bound is at most 5%;
+- the upper 95% confidence bound of host CPU time per completed transfer
+  regression is at most 5%;
+- the direct path adds zero CUDA copies, kernels, or synchronizations;
+- ownership adds no device arena beyond an active PR #15618 send/receive bounce
+  arena pair;
+- host metadata has frozen measured per-entry budgets for contexts, writer
+  operations, descriptor/scatter segments, lifecycle records, and
+  live/sparse-retired generation entries; repeated waves, replay gaps, and floor
+  compaction stay within the resulting O(contexts + writer operations +
+  segments + lifecycle records + outstanding generations) budget;
+- across predeclared small/midpoint/maximum fixed-manifest, context-set,
+  dynamic-stream, lifecycle-record, and replay-window sizes—including
+  out-of-order gaps and floor compaction—host bytes and CPU/close processing fit
+  the frozen per-entry complexity budget with no statistically significant
+  unexplained superlinear term;
+- at each declared supported concurrency, maximum-envelope/low-materialization
+  streams have zero reservation-caused rejection; otherwise that envelope or
+  concurrency is excluded from the rollout cohort. Report utilization/slack and
+  goodput at and beyond the declared boundary;
+- before the configured backpressure threshold, the upper 95% confidence bound
+  for p95 admission-latency regression at near-capacity lifecycle-record and
+  replay-window/metadata-credit occupancy is at most 5%; at capacity, rejection
+  performs no sleep/retry, completes in the same admission-worker iteration and
+  within one configured bounded-poll budget, and does not overshoot configured
+  record/replay/context/operation/segment/byte limits. Report p95/p99 wall time and
+  freeze an absolute per-cohort ceiling before implementation results are seen.
+
+Known-terminal fault cells:
+
+- after each fixed-concurrency fault wave drains, active context/lease counts and
+  retained bytes return to their pre-wave baseline with no monotonic growth;
+- once the final required terminal/completion evidence is observed, leases are
+  released in the same state-machine call or the next completion-worker
+  iteration, as applicable;
+- delayed-result tests recover all leased capacity.
+
+Ambiguous-result fault cells:
+
+- exactly the affected bytes remain retained and observable, with no unsafe
+  reuse, unmap, or cross-request corruption;
+- fault-period goodput and latency are reported, but the healthy-path
+  non-regression thresholds do not apply because safe capacity exhaustion is an
+  expected outcome.
+
+If stable benchmark noise is wider than a threshold, calibrate and document a
+replacement before implementation measurements are used for approval. Do not
+relax a gate after seeing a regression without a separate review.
 
 ### Acceptance criteria
 
@@ -195,7 +744,7 @@ The design is implemented only when all of the following are true:
 
 1. No address can be published without a registered context and live leases.
 2. Session/request removal cannot drop a physical quiescence result.
-3. KV and bounce allocators cannot reuse leased generations.
+3. KV and bounce allocators cannot reuse leased allocation generations.
 4. Every release path is idempotent and tied to quiescence evidence.
 5. Direct, bounce, and mixed transfers share the same ownership path.
 6. Timers alone never authorize reuse.
@@ -205,26 +754,144 @@ The design is implemented only when all of the following are true:
 9. The executor remains responsive while contexts drain.
 10. In-doubt capacity and shutdown state are observable.
 11. Lease acquisition and `free_resources()` cannot race into block reuse.
-12. Every NIXL/gather/scatter range is authorized by a live generation lease.
+12. Every NIXL/gather/scatter range is authorized by a live allocation-generation
+    lease.
 13. Every local CUDA/NIXL accessor is independently tracked through quiescence.
-14. Phase 1 either provides generation-safe identity or enforces non-reuse
-    across worker recreation and all possible late results.
+14. Phase 1 negotiates and validates one monotonic, attempt-wide transfer
+    generation plus both endpoint epochs on every lifecycle-mutating wire
+    message; legacy identity is rejected before address publication.
+15. Contexts are built only from allocator-atomic,
+    allocation-generation-bearing KV lease snapshots; copied block IDs are
+    never used to acquire a later lease.
+16. Local role/epoch plus admission-authority epoch identifies the context,
+    while exact peer epoch/rank/operation identifies each fan-in ledger entry.
+17. Logical cancellation and dropping KV request ownership do not wait for KV
+    physical retirement, and pending-free KV cannot be reused while its lease
+    remains live.
+18. A non-drained shutdown result keeps the transceiver and KV managers alive and
+    can be retried without destructor fallback cleanup.
+19. The applicable quantitative normal-path and fault-period performance gates
+    pass with the required stage and end-to-end metrics.
+20. Unsupported topology or mixed-version cohorts are rejected before address
+    publication. Rollback never changes an active transfer's owner and reports a
+    visible blocked/non-drained state until every old-mode context retires.
+21. Preparation failure unwinds every partial lease before that endpoint's
+    publication/launch boundary, while failure after its boundary follows
+    fail-closed retirement.
+22. Cancellation is routed through a transfer-generation-bound handle; a bare
+    or reused request/transfer ID cannot mutate lifecycle state.
+23. KV cleanup never releases an independently active auxiliary slot; unsupported
+    generation-first configurations are rejected before publication.
+24. Bounce source KV retires after gather, direct source KV retires after NIXL
+    quiescence, and one slice never waits for unrelated sibling completion.
+25. Every remote lifecycle-control message is transfer-generation/epoch
+    validated before session lookup; pre-cancel tombstones cannot cross transfer
+    generations, and an arbitrary unnegotiated control closes the endpoint
+    session without allocating per-identity state.
+26. First failure, accepted cancellation, or shutdown atomically aborts context
+    admission and every later publication/local-launch boundary. Sealing is
+    performed only by the local producer/session with a complete immutable
+    manifest or atomically enrolled final-chunk proof.
+27. Immediate retirement requires every remote exposure and every local
+    gather/NIXL/scatter accessor to be terminal; proof that no remote operation
+    was submitted is insufficient while a local gather remains active.
+28. Shutdown fences future submission against every published address before it
+    treats backend quiescence as sufficient to deregister or unmap memory.
+29. Every target advertisement identifies its target slice and exact fixed
+    operation or bounded writer stream. Duplicate advertisements are
+    idempotent. End-of-stream closes future submission only after every covered
+    sequence is submitted or terminal `NO_REMOTE_ACCESS`; dynamic streams cannot
+    retire until that close/fencing plus operation quiescence through the
+    high-water mark, and logical success additionally requires the exact
+    normalized required source-to-target mapping.
+30. Pre-cancel lookup and context creation serialize in the registry. Capacity
+    is reserved at admission for every valid cancellation; unmatched state
+    remains until producer sealing or the Phase 1 creation-close acknowledgement
+    and uses pre-admission backpressure rather than unsafe eviction.
+31. Bounce correctness/performance cells record positive transport-active and
+    per-transfer engagement evidence; `kv_cache_bounce_size_mb > 0` alone does
+    not count as bounce coverage.
+32. The registry strongly retains exactly one canonical endpoint-transfer
+    record, handle, and gate after consumer cleanup and until no later local
+    context can be created and all physical obligations retire; it atomically
+    marks the generation retired before removing that record.
+33. Endpoint-epoch replay state rejects delayed admission/advertisement after
+    record deletion, bounds out-of-order generations with a retired floor and
+    sparse window, backpressures gaps without eviction or admission-worker
+    retry/sleep, and requires a fresh non-reused endpoint epoch when that state
+    is recreated.
+34. Fixed manifests, dynamic streams, and context/slice sets reserve negotiated
+    operation/segment/byte metadata credits against endpoint-global limits
+    before exposure; overload fails without overshoot or retry/sleep in the same
+    bounded admission-worker iteration, and retirement returns credits exactly
+    once.
+35. Capacity telemetry distinguishes overlapping lease-token bytes, unique
+    transfer-leased allocation-generation bytes, and pending-free KV bytes
+    blocked solely by transfer leases; KV recovery/admission claims use the last
+    measure, while bounce claims use unique leased slot bytes. Deduplicated
+    gauges are path-neutral or use only mutually exclusive direct/bounce/mixed
+    classes; per-path token metrics are not summed as unique capacity.
+36. Local cancellation and initial admission serialize through a one-shot token:
+    cancellation either prevents transfer eligibility/token creation, rejects
+    pending admission before peer authorization, or aborts the canonical bound
+    handle, with no lost-cancel interval.
+37. Phase-specific new/new negotiation succeeds, while missing/downgraded/legacy
+    capabilities fail before the relevant access boundary; a Phase 1 creation
+    close never substitutes for a Phase 3 submission fence after publication.
+38. Dynamic-stream telemetry distinguishes reserved from materialized
+    operation/segment/byte credits, exposes slack and reservation-caused
+    rejection, and proves declared rollout concurrency without slack-induced
+    rejection; authenticated close returns only credits that cannot materialize.
+39. Shutdown atomically closes registry admission and snapshots committed
+    records; a racing pending token is shutdown-aborted or its canonical record
+    and any possible peer authorization are included in drain, never omitted.
+40. Fixed-mode success requires the exact normalized per-operation and manifest
+    source-to-target KV mapping; in-range gaps, undercoverage,
+    duplicate/overlap, aggregate mismatch, and full-coverage source permutation
+    fail rather than producing corrupted KV.
+41. Initiator pre-commit rejection consumes no transfer generation. Every
+    committed generation whose admission control is not sent is bilaterally
+    acknowledged as skipped before a higher admission control is sent. A
+    generation rejected after admission control but before address publication
+    is creation-closed; after publication it follows full physical retirement.
+    Repeated admission failure cannot create artificial peer replay gaps.
+42. Session negotiation is amortized and healthy admission fields piggyback on
+    the existing KV request/target response; no new normal-path per-transfer RTT
+    is introduced, or the cohort is separately budgeted and qualified.
 
 ## Risks and Mitigations
 
 | Risk | Mitigation |
 |---|---|
-| Lock-order deadlock across registry, session, allocator, CUDA, and callbacks | Per-context serialization; no blocking operations or callbacks under lifecycle locks; lock-order tests. |
+| Lock-order deadlock across admission token, registry, session, allocator, CUDA, and callbacks | Token-to-registry-to-handle-to-context order; no blocking operations or callbacks under lifecycle locks; lock-order tests. |
+| Local cancellation races initial handle binding | One-shot admission token with token-to-registry lock order; bind the canonical handle before peer authorization; deterministic race tests. |
+| Shutdown races pending admission or peer authorization | Close admission and snapshot under one registry lock; shutdown-abort losing tokens; gate authorization through the bound handle; deterministic boundary races. |
 | KV over-pinning or leaked leases | Exactly-once release, active-lease metrics, oldest-context diagnostics, and fault-injection coverage. |
 | Capacity exhaustion from indefinite retention | Fail admission visibly; expose bytes/age/reason; add reliable result recovery or backend quiescence before bounded reclaim. |
 | Treating failure as quiescence incorrectly | Track quiescence separately from data outcome and preserve an explicit in-doubt state. |
 | Mixed direct/bounce accounting error | Record actual mode per exact writer and retain both candidate leases until mode is known. |
-| Stale result advances a new transfer | Generation and endpoint epoch, tombstones, exact writer validation, and negotiated protocol. |
+| Individually valid fixed segments leave incomplete, overlapping, or permuted KV | Manifest the exact logical source-to-target mapping, normalize delivered pairs, reject gaps/duplicates/overlap/aggregate mismatch/permutation, and test direct plus bounce pairings. |
+| Dynamic stream closes early, undercovers or permutes the target, or grows without bound | Authenticate end-of-stream, require irreversible submission decisions before close, enforce sequence/operation/segment/byte budgets, validate the exact required source-to-target mapping independent of the claimed high-water mark, and retain the target while the stream is open. |
+| Stale result advances a new transfer | Endpoint epochs, monotonic generation, durable retired floor/replay window, exact writer validation, and negotiated protocol. |
+| Retired transfer is recreated by delayed admission | Endpoint-owned retired floor plus bounded sparse replay window; mark retirement before record deletion; reject old epochs before session creation. |
+| Replay-window gap exhausts host capacity | Bound outstanding generations, expose floor/gap/window metrics, and backpressure admission without evicting anti-replay state. |
+| Failed admission burns generations and fills peer replay capacity | Allocate the generation only in the successful local admission commit; acknowledge a skip before sending a higher admission control; creation-close rejection only before address publication; use full retirement afterward; repeat/lost-ack tests. |
+| Admission protocol adds a healthy-path RTT | Piggyback fields on the existing KV request/target response, count normal/exceptional controls, and separately budget any cohort that cannot preserve the exchange. |
+| Fixed manifests, descriptor plans, or context fan-out exhaust host metadata | Negotiate per-transfer operation/segment/byte/context envelopes, reserve endpoint-global credits before address publication, reject oversize/over-capacity plans, and test concurrent no-overshoot accounting. |
+| Worst-case stream reservations suppress useful concurrency | Export reserved/materialized credits and slack, benchmark maximum-envelope/low-materialization concurrency, tune or gate supported envelopes, and return unused credits only after authenticated close. |
+| Pre-cancel state exhausts host capacity | Reserve a lifecycle/control slot per admitted generation, export configured/used/remaining capacity, backpressure before admission, and retire only after producer sealing or Phase 1 creation close. |
+| Request cleanup drops the access gate | Registry-own one canonical record/handle/gate through no-future-context proof and physical retirement; contexts retain only the shared gate, which owns no contexts. |
+| First failure races another chunk | Atomically abort the shared gate before callbacks and reject later enrollment/access while already-possible work drains. |
 | Main-loop latency regression | Preserve bounded polling; perform draining on transfer/completion workers; benchmark registry contention. |
 | Shutdown hangs indefinitely | Use an explicit deadline and return non-drained status, but never convert deadline expiry into unsafe unmap/reuse. |
 | Rolling-upgrade incompatibility | Capability/version negotiation or pre-DMA rejection; no silent downgrade of safety fields. |
+| Creation-close acknowledgement is mistaken for a submission fence | Distinct message/capability types and predicates; after-publication tests prove Phase 1 close cannot release a target or authorize teardown. |
 | Behavioral divergence between KV managers | One conformance test suite for the common lease API; implementation-specific adapters only below it. |
 | Scope expands into cancellation consensus | Keep logical consensus in the adjacent cancellation design; consume its outcome through `TransferHandle`. |
+| Metrics add hot-path overhead | Use O(1) counters/histograms, batch export, and benchmark instrumentation-on overhead; never scan the full registry per transfer. |
+| Bounce configuration silently exercises direct fallback | Require transport-active and per-transfer path signals in tests, benchmarks, and canary telemetry. |
+| A caller drops a non-drained worker or shuts down its KV manager | Structured `ShutdownResult`, strong caller retention, retry tests, and a hard teardown precondition on zero live leases. |
+| Rollback bypasses an active owner | Negotiate mode before publication, stop admission, and drain existing contexts before selecting a mode for new sessions. |
 
 ## Alternatives Considered
 
@@ -269,23 +936,51 @@ These do not change the safety contract, but they determine phase sequencing.
    and peer loss?
 2. Can the advertisement messaging layer prove non-delivery after a send error?
    If not, every attempted send remains `MAY_ACCESS`.
-3. Can `unique_rid` be reused across worker recreation or retry? If yes or not
-   provably no, generation/version work is a Phase 1 prerequisite.
-4. What supplies a stable endpoint epoch across rank/process restart?
+3. Which endpoint-owned counter/state implementation provides monotonic transfer
+   generation allocation and the bounded replay window across session/worker
+   recreation, and what maximum outstanding-generation window supports expected
+   concurrency without excessive reservation?
+4. What allocates a unique endpoint restart epoch, keeps it stable for one
+   endpoint lifetime, and prevents its reuse after rank/process restart?
 5. Can existing V1 block pinning enforce leases through explicit
    `free_resources()`, or is a new nanobind API required?
 6. What is the smallest V2 KV-manager lease surface that supports per-slice early
    release without request-wide over-pinning?
 7. Does the NIXL wrapper need a separate `quiesce()` operation before final
    shutdown so registrations can remain valid during drain?
-8. Is result acknowledgement/retry required for the first production rollout,
+8. Which peer/session/endpoint primitive can acknowledge a submission fence and
+   guarantee that an old target advertisement cannot be used afterward?
+9. Is result acknowledgement/retry required for the first production rollout,
    or is observable indefinite retention acceptable for all Python-native
    direct and bounce transfers?
-9. Which independent auxiliary-buffer paths can outlive their request/session?
+10. Which independent auxiliary-buffer paths can outlive their request/session?
    They need a follow-up audit before the broader transceiver can claim complete
    ownership coverage.
-10. Can every claimed TP/ADP topology identify its exact potential writer cohort
+11. Can every claimed TP/PP/ADP topology identify its exact potential writer cohort
     before address fan-out, or which cells must be gated initially?
+12. Which existing serving metrics surface should export lifecycle histograms and
+    retained-capacity gauges without adding per-transfer registry scans?
+13. How should the internal rollout gate and negotiated capability be represented
+    without making the safety contract depend on the bounce-size option?
+14. Which `SliceSetProof` form does each endpoint use: an immutable manifest or
+    a final-chunk proof atomically enrolled with the final context? For PR
+    #15727-style scheduling, how is the final marker authenticated and tied to
+    the sender's operation-sequence high-water mark?
+15. What conservative operation-count, descriptor-segment, and byte budget can
+    be authorized before opening a dynamic writer stream without constraining
+    valid chunk schedules?
+16. Which non-GB200/GB300 environments can positively validate an active
+    fabric-VMM bounce arena rather than only the direct fallback?
+17. Which Phase 1 control/acknowledgement closes future context creation for a
+    transfer generation, and how is it retried independently from the stronger
+    Phase 3 fence that closes future submission to published addresses?
+18. What fixed-manifest operation/descriptor-segment/authorized-byte,
+    per-transfer context/slice, and endpoint-global metadata-credit limits cover
+    production fan-out without allowing one transfer to monopolize host
+    capacity?
+19. What canonical logical KV coordinate encodes source-to-target mappings across
+    TP/PP/ADP, layer groups, and both KV managers so validation never depends on
+    physical descriptor order?
 
 No answer to these questions may weaken the invariant by interpreting
 uncertainty as retirement.


### PR DESCRIPTION
## Summary

- document the Python-native KV-transfer lifetime gaps remaining after #15618 and the partial overlap with #16116
- define a registry-owned endpoint lifecycle record spanning KV and bounce leases, asynchronous CUDA/NIXL work, identity/replay, cancellation, and shutdown
- scope a phased implementation, rollout/configuration gates, deterministic fault tests, and expected performance/capacity impact

## Scope

This targets Python-native `KvCacheTransceiverV2` direct, bounce, and fallback paths. The separate C++ `CacheTransceiver` is a non-goal; small KV-manager or NIXL binding changes may still be required to enforce leases and expose definitive quiescence.

## Validation

- completed iterative `trtllm-review` self-review passes through a final clean pass covering lifecycle/protocol correctness, documentation/scope, and performance/capacity
- `pre-commit run --files docs/design/README.md docs/design/disagg-kv-transfer-ownership/README.md docs/design/disagg-kv-transfer-ownership/implementation-plan.md`
- `git diff --check 54d484fd3`

Documentation only; no runtime or GPU tests were required.
