### PR TITLE
[None][test] Attribute test_unittests_v2 failures to the specific failing test

### DIFF
--- a/jenkins/scripts/generate_timeout_xml.py
+++ b/jenkins/scripts/generate_timeout_xml.py
@@ -39,20 +39,26 @@ def parse_xml_classname_name_file_from_testname(testname, stage_name):
     if testname.startswith(stage_name + "/"):
         testname = testname[len(stage_name) + 1 :]
 
+    # A unittest record is normally the wrapper case (e.g.
+    # "unittest/_torch/thop/parallel"), but if it carries the specific inner test
+    # that was running (".../test_x.py::test_name[...]"), surface that file+test
+    # instead of flattening the timeout to the whole wrapper case.
+    is_unittest_wrapper = testname.startswith("unittest/") and ".py::" not in testname
+
     # Get file name
-    if testname.startswith("unittest/"):
+    if is_unittest_wrapper:
         file = "test_unittests.py"
     else:
         file = testname.split("::")[0]
 
     # Get test name
-    if testname.startswith("unittest/"):
+    if is_unittest_wrapper:
         name = "test_unittests_v2[" + testname + "]"
     else:
         name = testname.split("::")[-1]
 
     # Get class name
-    if testname.startswith("unittest/"):
+    if is_unittest_wrapper:
         classname = stage_name + ".test_unittests"
     elif len(testname.split("::")) == 3:
         classname = (

--- a/tests/integration/defs/test_unittests.py
+++ b/tests/integration/defs/test_unittests.py
@@ -63,6 +63,25 @@ def merge_report(base_file, extra_file, output_file, is_retry=False):
     base.write(output_file, encoding="UTF-8", xml_declaration=True)
 
 
+def _junit_culprits(xml_path):
+    """Names of failed/errored tests in a JUnit report, so a whole-case failure
+    still names the specific culprit test(s) for CI/triage attribution."""
+    import xml.etree.ElementTree as ElementTree
+    try:
+        root = ElementTree.parse(xml_path).getroot()
+    except (OSError, ElementTree.ParseError):
+        return []
+    culprits = []
+    for tc in root.iter('testcase'):
+        if not tc.get('name'):
+            continue
+        kind = 'FAILED' if tc.find('failure') is not None else (
+            'ERROR' if tc.find('error') is not None else None)
+        if kind:
+            culprits.append(f"{kind} {tc.get('classname', '')}::{tc.get('name')}")
+    return culprits
+
+
 def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
     import pandas as pd
     import pynvml
@@ -300,4 +319,13 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
                 os.rename(parallel_output_xml, output_xml)
                 assert False, "no report generated, fatal failure happened in unittests (retry phase)"
 
-    assert passed, "failure reported in unittests"
+    if not passed:
+        culprits = _junit_culprits(output_xml)
+        # Tests still running when a fatal OOM/timeout killed the run (nodeids
+        # left behind by --periodic-save-unfinished-test) — the likely culprit.
+        unfinished = os.path.join(output_dir, "unfinished_test.txt")
+        if os.path.exists(unfinished):
+            with open(unfinished, encoding="utf-8") as f:
+                culprits += [f"IN-FLIGHT {ln.strip()}" for ln in f if ln.strip()]
+        raise AssertionError("failure reported in unittests" + (
+            "; culprit test(s): " + ", ".join(culprits) if culprits else ""))


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unittest wrapper entries in generated test reports.
  * Ensured test report details remain consistent across wrapper and standard tests.

* **Tests**
  * Enhanced integration test failures with clearer diagnostic messages.
  * Failure reports now identify failed, errored, and unfinished test cases when available.
  * Added safe handling for missing or unreadable test report files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

`test_unittests_v2` runs many files in a single pytest-xdist case, so a failure — especially an OOM or timeout that kills the run — was reported only as the opaque wrapper case (e.g. `test_unittests_v2[unittest/_torch/thop/parallel]`), giving CI and triage no signal about which test actually broke.

Relates to (motivation, not fixed here): https://nvbugs/6435126, https://nvbugs/6435127, https://nvbugs/6422443 — all reported as the whole `thop/parallel` case because the failing test wasn't surfaced.

This makes the failure attribute to the specific test:

- **Failure message** (`tests/integration/defs/test_unittests.py`): on failure, append the culprit `file::test` — failed/errored tests parsed from the run's JUnit report, plus tests still in flight from `unfinished_test.txt` (`--periodic-save-unfinished-test`). Degrades cleanly when a fatal kill left no named result.
- **Timeout report** (`jenkins/scripts/generate_timeout_xml.py`): stop flattening every `unittest/*` timeout record to the wrapper case; when the in-flight record already carries the specific inner test (`.../test_x.py::test_name[...]`), surface that file+test. This covers stage-wall-clock kills, since the inner `unfinished_test.txt` shares `${outputPath}` with the stage-level file.

Module -> owner routing remains the triage bot's responsibility; this only hands it a concrete test to route instead of the whole wrapper case.

## Test Coverage

No behavior change on success; only failure/timeout paths gain the culprit `file::test`, and bare wrapper records keep the old output (backward-compatible). The two helpers were exercised on synthetic inputs: a JUnit report containing failed/errored plus catastrophic no-name testcase nodes; an `unfinished_test.txt` with in-flight nodeids; and `generate_timeout_xml` wrapper-record vs inner-test-record cases.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] PR follows TRT-LLM coding guidelines.
- [x] No API changes; no new dependencies.
- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
