### PR TITLE
[TRTLLM-14054][fix] LMHead: pass true full dims to Linear for quantized TP>1

### DIFF
--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -58,9 +58,19 @@ class LMHead(Linear):
         else:
             self.padding_size = 0
 
+        # Linear re-shards only the dim selected by tensor_parallel_mode, so
+        # only that dim may be passed as local*tp (to carry the ceil-div
+        # padding); the other dim must be the true full size — Linear keeps it
+        # as-is, and quant_method.create_weights sizes the (packed) quantized
+        # weight and scales from it.
+        in_features_full = (local_in_features * tp_size if tensor_parallel_mode
+                            == TensorParallelMode.ROW else embedding_dim)
+        out_features_full = (local_out_features *
+                             tp_size if tensor_parallel_mode
+                             == TensorParallelMode.COLUMN else num_embeddings)
         super().__init__(
-            local_in_features * tp_size,
-            local_out_features * tp_size,
+            in_features_full,
+            out_features_full,
             bias=False,
             dtype=dtype,
             mapping=mapping,


### PR DESCRIPTION
## Description

`LMHead.__init__` passed `local_{in,out}_features * tp_size` for **both** dims to `Linear.__init__`, but `Linear` only re-shards the dim selected by `tensor_parallel_mode` — the unsharded dim arrived tp_size-× inflated.

The dense path never hit this because `LMHead` re-creates a dense weight from corrected local dims after `super().__init__`. The quantized path, however, sizes its (packed) weight and scales inside `Linear.__init__` via `quant_method.create_weights`, so it saw the inflated dim: under COLUMN (vocab-parallel) TP2, the NVFP4-quantized `lm_head` of Qwen3.6-35B-A3B-NVFP4 got its packed weight allocated as `[vocab/2, hidden]` instead of `[vocab/2, hidden/2]`, and weight load failed on every rank:

```
RuntimeError: The size of tensor a (2048) must match the size of tensor b (1024) at non-singleton dimension 1
```

**Fix:** pass `local * tp_size` only on the sharded dim (it carries the ceil-div vocab/hidden padding); pass the true full size on the other dim.

This unblocks TP>1 for any model with a quantized `lm_head` (any quant algo whose weights are created in `Linear.__init__`); it was hit while bringing up Qwen3.6-35B-A3B-NVFP4 under TP2 for the perf work in #16313 / #16314, and the TP2 measurements in #16353 were taken with this fix applied.

## Test Coverage

- Exercised end-to-end on Qwen3.6-35B-A3B-NVFP4 (NVFP4 `lm_head`, vocab-parallel): TP2 previously failed weight load on both ranks with the `RuntimeError` above; with the fix the server loads and serves, and both ranks' `lm_head` shards were verified to hold the correct packed shape and calibrated scales (`[124160, 1024]` packed + `124160×128` scales per rank).
- TP1 allocation is unchanged by construction (both selectors reduce to the same full dims): packed `[248320, 1024]` + `248320×128` scales, byte-identical to before the fix.
- Dense LMHead TP paths are covered by the existing `tests/unittest/_torch/multi_gpu/test_embedding.py` and are unaffected (the dense weight is re-created from local dims after `super().__init__`).

## PR Checklist

- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language model output layer handling for tensor-parallel configurations.
  - Fixed weight shape and padding behavior for sharded, packed, and quantized models.
  - Enhanced compatibility and reliability when loading or running models with different parallelization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->