### PR TITLE
[TRTLLM-14054][perf] Qwen3.5-VL: pass the inner LM's normalized model_config to the weight mapper

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3_5.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_5.py
@@ -695,7 +695,15 @@ class _Qwen3_5VLModel(Qwen3VLModelBase):
             self.mm_encoder.load_weights(weights)
 
         weight_mapper = Qwen3_5MoeHfWeightMapper()
-        weight_mapper.init_model_and_config(self.llm, self.model_config)
+        # Hand the mapper the inner LM's model_config, not the VLM wrapper's:
+        # only the inner config went through the Qwen3.5 quant-dict
+        # normalization applied in the inner LM's __init__ (HF->TRT-LLM key
+        # translation + synthesis of the fused in_proj_qkvz FP8 entry). With
+        # the wrapper's un-normalized copy the mapper misses that FP8 entry,
+        # dequantizes the GDN in_proj projections to bf16 and drops their
+        # calibrated scales; the FP8-built module then re-casts with
+        # weight_scale=1.0 and quantizes activations dynamically every step.
+        weight_mapper.init_model_and_config(self.llm, self.llm.model_config)
         filtered_weights = {k: v for k, v in weights.items() if not k.startswith("model.visual.")}
         params_map = {
             r"^model\.language_model\.(.*)$": r"model.\1",


### PR DESCRIPTION
## Description

`_Qwen3_5VLModel.load_weights` handed `Qwen3_5MoeHfWeightMapper` the VLM wrapper's `model_config`, but only the **inner LM's** config goes through the Qwen3.5 quant-dict normalization applied in the inner LM's `__init__` (HF→TRT-LLM key translation + synthesis of the fused `in_proj_qkvz` FP8 entry).

With the wrapper's un-normalized copy, the mapper misses that FP8 entry, dequantizes the GDN `in_proj` projections to bf16 and drops their calibrated scales; the FP8-built module then re-casts the weights with `weight_scale=1.0` and quantizes activations dynamically in front of every GDN `in_proj` GEMM.

**Fix:** pass `self.llm.model_config`. The GDN `in_proj` weights stay FP8 with their calibrated scales, the projection runs on the static per-tensor FP8 path (`static_quantize_e4m3_per_tensor` + scaled-mm), and the per-call dynamic-quant chain disappears from both prefill and decode. One functional line plus a comment.

## Test Coverage

- `tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl_moe.py -k "test_construction_and_weight_loading_smoke or test_qwen35_moe_vl_resolves_model_and_mapper"` — 2 passed.
- Functional: greedy completions verified coherent, and byte-identical across independent server launches of the same build (load-path determinism); both TP ranks' GDN `in_proj` shards verified to hold FP8 weights with the checkpoint's calibrated scales.
- Perf: `trtllm-serve` + `benchmark_serving` on Qwen3.6-35B-A3B-NVFP4 (hybrid GDN + MoE), 2× B200 with TP2 + EP2, ISL 1024 / OSL 6144, random dataset with `--ignore-eos`, one point per concurrency (paired num_prompts 8…2048) over one shared server launch per side. Measured at base `8ef7190ebf` stacked on #16313 + #16314 + the LMHead TP2 load fix #16352 (needed to bring the TP2 server up at all), under a tuned serving config (TRTLLM MoE backend, CUDA-graph padding with max_batch_size 512); the A/B differs only by this PR's change. No shared files with any of those PRs — the change is independent at the code level.

| concurrency | before (tok/s) | this PR (tok/s) | delta |
|---|---|---|---|
| 1 | 331.22 | 382.96 | +15.62% |
| 2 | 628.48 | 712.48 | +13.37% |
| 4 | 1180.78 | 1374.39 | +16.40% |
| 8 | 2208.70 | 2540.62 | +15.03% |
| 16 | 3984.19 | 4490.79 | +12.72% |
| 32 | 7161.73 | 8064.49 | +12.61% |
| 64 | 12360.83 | 13571.48 | +9.79% |
| 128 | 19579.72 | 21250.80 | +8.53% |
| 256 | 17442.00 | 17304.34 | −0.79% |
| 512 | 16998.46 | 16993.55 | −0.03% |

Output throughput improves **+10.32%** on average across the 10-point curve — up to +16.4% at low concurrency, flat within run-to-run noise at the saturated top end. No latency trade-away at the top point: median TPOT/ITL flat, median TTFT at concurrency 512 improves 28% (6835 ms → 4911 ms; large-M prefill GEMMs no longer pay the per-call dynamic-quant chain).

## PR Checklist

- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen3.5 vision-language model weight loading with quantized configurations.
  * Prevented certain FP8 weights from being incorrectly converted to bfloat16, improving compatibility and preserving expected model behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->