### PR TITLE
[None][fix] Use spec-aware sample batch for ResizeKVCache in spec-dec

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -773,7 +773,14 @@ class ResizeKVCache(BaseTransform):
             )
 
         # Run a forward pass to get the extra memory usage
-        cm.info.set_max_num_tokens_sample()
+        if cm._spec_config is not None:
+            # Spec-dec resize must use the same extend-only shape the runtime captures
+            # (matching compile_model's InsertCachedAttention/cudagraph path). Otherwise a
+            # max_num_tokens // max_batch_size == 1 sample is classified decode-only and the
+            # eagle wrapper rejects it (decode without drafting is not supported).
+            cm.info.set_capture_batch(max_draft_len=cm._spec_config.max_draft_len)
+        else:
+            cm.info.set_max_num_tokens_sample()
         try:
             if cm._spec_config is not None:
                 mod(**cm.named_args, cache_seq_interface=cm)


### PR DESCRIPTION
## Description

Fixes #13348.

`ResizeKVCache._apply_to_full_model` runs its resize forward pass with
`set_max_num_tokens_sample()`, which builds a `[batch_size, max_num_tokens // max_batch_size]`
sample. When that quotient is `1` (e.g. `max_num_tokens=512` with `max_batch_size` defaulted to
`512`), `nest_sequences` classifies the batch as **decode-only**, and the Eagle wrapper rejects it:

```
AssertionError: decode without drafting is not supported inside the eagle wrapper
```

When a spec-dec config is present, this builds an **extend-only** sample via
`set_capture_batch(max_draft_len=cm._spec_config.max_draft_len)` (`1 + max_draft_len` tokens per
sequence) so the resize forward exercises the same shape the runtime captures. This mirrors the
pattern already used in `compile_model.py` (`set_capture_batch(batch_size=bs,
max_draft_len=spec_config.max_draft_len)`) — `ResizeKVCache` was simply inconsistent with it. The
non-spec-dec path is unchanged.

This implements the fix proposed in the issue. @govind-ramnarayan — this is your self-assigned
issue; opening it as a draft in case it's useful, happy to defer or hand it back if you're already on it.

## Test Coverage

The repro is `tests/integration/defs/examples/test_ad_speculative_decoding.py::test_autodeploy_eagle3_one_model_acceptance_rate` with `max_batch_size` unset (1×H100), which the issue notes is only collected on the `gramnarayan/mtp-enable-cudagraph` branch. I don't have H100 access to run it locally; relying on CI (AutoDeploy stages) / maintainer validation. `/bot run --extra-stage` for the AutoDeploy stages would exercise the spec-dec resize path.

## PR Checklist

- [x] Change follows `CODING_GUIDELINES.md`
- [x] Commit is DCO signed-off
> Note: not validated on H100 (no local hardware access) — requesting reviewer validation; see Test Coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KV-cache resizing for speculative decoding scenarios.
  * Aligned resize preparation with runtime capture settings to support consistent model execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
