### PR TITLE
[None][fix] Fix unfused RoPE for yarn models: double rotation and GPT-OSS pairing

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -60,7 +60,10 @@ class AttentionBlock(Attention):
                 beta_fast=pretrained_config.rope_scaling['beta_fast'],
                 beta_slow=pretrained_config.rope_scaling['beta_slow'],
                 duplicate_data=False),
-            is_neox=False,
+            # GPT-OSS applies NeoX-style (rotate-half) RoPE, matching the HF
+            # reference. The fused kernel ignores this flag for yarn (which
+            # masked the wrong value); the unfused path honors it.
+            is_neox=True,
         )
 
         super().__init__(

--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -64,7 +64,8 @@ class PositionEmbeddingType(IntEnum):
 
     def is_rope(self) -> bool:
         return self in [
-            self.rope_gptj, self.rope_gpt_neox, self.long_rope, self.mrope
+            self.rope_gptj, self.rope_gpt_neox, self.long_rope, self.mrope,
+            self.yarn
         ]
 
     def is_mrope(self) -> bool:

--- a/tests/unittest/_torch/modules/test_rotary_embedding.py
+++ b/tests/unittest/_torch/modules/test_rotary_embedding.py
@@ -245,3 +245,83 @@ class TestFromConfigDuplicateData:
         rp = RopeParams.from_config(self._make_config(qk_rope_head_dim=64))
         assert rp.duplicate_data is True
         assert rp.dim == 64
+
+
+class TestUnfusedRopeOwnership:
+    """With rope_fusion=False the Python rotary module owns RoPE; the backend
+    must receive no position-embedding params. yarn is not listed in
+    PositionEmbeddingType.is_rope(), which used to leak the params through and
+    made the attention kernel rotate a second time (double RoPE)."""
+
+    def test_unfused_yarn_rope_is_applied_exactly_once(self):
+        from tensorrt_llm._torch.attention_backend.interface import \
+            PositionalEmbeddingParams
+        from tensorrt_llm._torch.model_config import ModelConfig
+        from tensorrt_llm._torch.modules.attention import Attention
+        from tensorrt_llm.functional import PositionEmbeddingType
+
+        yarn_params = PositionalEmbeddingParams(
+            type=PositionEmbeddingType.yarn,
+            rope=RopeParams(
+                dim=32,
+                theta=150000,
+                scale_type=RotaryScalingType.yarn,
+                scale=32.0,
+                max_positions=1024,
+                original_max_positions=256,
+                beta_fast=32,
+                beta_slow=1,
+                duplicate_data=False,
+            ),
+            is_neox=True,
+        )
+        attn = Attention(
+            hidden_size=256,
+            num_attention_heads=8,
+            num_key_value_heads=8,
+            max_position_embeddings=1024,
+            bias=False,
+            pos_embd_params=yarn_params,
+            rope_fusion=False,
+            layer_idx=0,
+            dtype=torch.bfloat16,
+            config=ModelConfig(),
+        )
+
+        assert attn.rotary_emb is not None
+        # 0 means the kernel side received no position embedding.
+        assert attn.attn.position_embedding_type == 0
+
+    def test_unfused_yarn_rotation_matches_fused_kernel_convention(self):
+        """The unfused (Python) yarn rotation must match the NeoX rotate-half
+        convention the fused kernel applies with the same cos/sin table."""
+        head_dim = 64
+        num_pos, num_heads = 64, 4
+        rope_params = RopeParams(
+            dim=head_dim,
+            theta=150000,
+            scale_type=RotaryScalingType.yarn,
+            scale=32.0,
+            max_positions=1024,
+            original_max_positions=256,
+            beta_fast=32,
+            beta_slow=1,
+            duplicate_data=False,
+        )
+        emb = RotaryEmbedding(rope_params, head_dim=head_dim, is_neox=True)
+        torch.manual_seed(0)
+        q = torch.randn(num_pos, num_heads * head_dim)
+        positions = torch.arange(num_pos).cuda()
+        # Single-target call takes the pure-torch path.
+        q_unfused = emb(positions, [q.cuda()])[0].cpu()
+
+        # Reference: NeoX rotate-half with the exact table the kernel reads.
+        table = emb.rotary_cos_sin.cpu()  # (max_pos, 2, head_dim/2)
+        cos = table[:num_pos, 0, :].unsqueeze(1)
+        sin = table[:num_pos, 1, :].unsqueeze(1)
+        qh = q.view(num_pos, num_heads, head_dim)
+        q1, q2 = qh[..., :head_dim // 2], qh[..., head_dim // 2:]
+        q_ref = torch.cat((q1 * cos - q2 * sin, q2 * cos + q1 * sin),
+                          dim=-1).reshape(num_pos, -1)
+
+        torch.testing.assert_close(q_unfused, q_ref, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Description

  With `rope_fusion=False`, GPT-OSS (and any yarn-scaled model on the unfused
  path) generates position-dependent garbage: short outputs look fine, long
  generations degrade into fragments. Two independent bugs stack on this path,
  and both are needed for a correct rotation — one fix controls *how many
  times* RoPE is applied, the other *how* it is applied.

  ### Bug 1: RoPE applied twice (yarn missing from `is_rope()`)

  `create_attention` hands `pos_embd_params` to the backend whenever the
  embedding type is not in `PositionEmbeddingType.is_rope()`. yarn was missing
  from that list, so with `rope_fusion=False` the Python `RotaryEmbedding`
  rotated q/k once and the C++ QKV preprocess (which maps yarn onto its NeoX
  rotation branch) rotated them again before writing the KV cache. The cached
  K ends up mscale²-scaled and rotated by twice the angle, so the error grows
  with position.

  **Fix**: add `yarn` to `is_rope()`. The existing condition then keeps the
  rope params away from the backend on the unfused path, and the existing
  "rope types must carry rope params" validation now covers yarn too.

  ### Bug 2: wrong pairing convention (GPT-OSS `is_neox=False`)

  GPT-OSS applies NeoX-style (rotate-half) RoPE, matching the HF reference,
  but declared `is_neox=False` (GPT-J interleaved). The fused kernel ignores
  this flag for yarn and always rotates NeoX-style, which masked the wrong
  value since the model landed (#6645); the unfused path honors the flag and
  paired the rotary dims incorrectly.

  **Fix**: `is_neox=True`. No effect on the fused path (the flag is unused
  there). `modeling_mistral.py` also declares `is_neox=False` for yarn and may
  deserve the same audit.

  ### Why both are required

  Fixing only Bug 2 still double-rotates; fixing only Bug 1 leaves the single
  rotation incorrectly paired. Either alone still produces garbage.

  ## Evidence (GPT-OSS-20B)

  - Post-fix, the unfused K cache is bitwise-aligned with the fused path at
    every position (cos = 1.0, norm ratio = 1.0). Pre-fix it decayed to
    cos = −0.18 by position 150 with a norm ratio equal to the yarn mscale
    (1.3466) — the fingerprint of a second yarn rotation.
  - AIME25 avg pass@1 (n=8, official sampling): **70.83 fused vs 70.00  
  - unfused** (parity within noise). Pre-fix unfused scored 0.
  - Affects any code path that disables rope fusion for a yarn model, e.g.
    sparse-attention methods that require unfused RoPE.

  ## Test Coverage

  Two regression tests in `tests/unittest/_torch/modules/test_rotary_embedding.py`
  (registered in `l0_h100.yml`):
  - unfused yarn ⇒ the backend receives no position-embedding params (RoPE
    cannot be applied twice);
  - the unfused yarn rotation matches the fused kernel's NeoX rotate-half
    convention on the same cos/sin table (bit-level comparison).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected YARN rotary positional embedding behavior for GPT-OSS models.
  * Prevented duplicate application of YARN embeddings when rotary fusion is disabled.
  * Improved numerical correctness for unfused YARN rotary calculations.

* **Tests**
  * Added coverage validating YARN embedding configuration and output accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->