### PR TITLE
[None][fix] laguna: honour attention_factor as final YaRN scaling coefficient

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_laguna.py
+++ b/tensorrt_llm/_torch/models/modeling_laguna.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Laguna / Laguna-XS model for TensorRT-LLM PyTorch backend."""
 
+import math
 from typing import Dict, List, Optional, Type
 
 import torch
@@ -304,7 +305,14 @@ class LagunaAttention(QKNormRoPEAttention):
             rp.beta_slow = float(rp_dict.get("beta_slow", 1.0))
             attention_factor = rp_dict.get("attention_factor")
             if attention_factor is not None:
-                rp.mscale = float(attention_factor)
+                attention_factor = float(attention_factor)
+                # attention_factor is the FINAL YaRN scaling (HF semantics).
+                # create_sinusoidal_positions_yarn applies get_mscale(factor, rp.mscale)
+                # = 0.1*rp.mscale*ln(factor)+1 (mscale_all_dim=0), so setting mscale to the
+                # final value routes it through the log twice. Invert to reproduce it exactly.
+                rp.mscale = (
+                    ((attention_factor - 1.0) / (0.1 * math.log(rp.scale))) if rp.scale > 1 else 1.0
+                )
             rp.original_max_positions = int(
                 rp_dict.get("original_max_position_embeddings", config.max_position_embeddings)
             )


### PR DESCRIPTION
_build_rope_from_flat_dict set rp.mscale = attention_factor, but create_sinusoidal_positions_yarn routes mscale through 0.1*mscale*ln(factor)+1, so the HF final scaling got the log applied twice (factor 64 +12.2%, factor 32 +8.9%). Invert so create_sinusoidal reproduces attention_factor exactly, and import math for the log. 

This doesn't actually appear to have caused too much divergence in practice, but it's worth addressing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YaRN RoPE scaling behavior for Laguna attention.
  * Added safeguards for scaling values at or below 1.0.
  * Updated scaling calculations to better match Hugging Face semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
