### PR TITLE
[TRTLLM-14287][feat] Qwen Image CFG parallelism support

### DIFF
--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -182,7 +182,7 @@ For full documentation, see the [Visual Generation](./visual-generation.md) page
 | **Wan 2.1** | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | **Wan 2.2** | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | **LTX-2** | Yes | Yes | No | Yes | Yes | No | No | Yes | Yes | Yes | Yes | No |
-| **Qwen-Image** [^2] | Yes | Yes | No | No | Yes | No | Yes | Yes | Yes | Yes | Yes | No |
+| **Qwen-Image** | Yes | Yes | No | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | No |
 | **Qwen-Image-Layered** [^3] | No | No | No | No | No | No | Yes | Yes | No | No | No | No |
 | **Qwen-Image-Edit-2511** | Yes | Yes | No | Yes | No | No | Yes | Yes | No | No | No | No |
 | **Cosmos3** | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes |

--- a/docs/source/models/visual-generation.md
+++ b/docs/source/models/visual-generation.md
@@ -54,7 +54,7 @@ Models are auto-detected from the checkpoint directory. Diffusers-format models 
 | **Wan 2.1 VSA** [^2] | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes | Yes |
 | **Wan 2.2** | Yes | Yes | Yes [^3] | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No |
 | **LTX-2** | Yes | Yes | Yes [^4] | Yes | Yes | Yes | No | No | Yes | Yes | Yes | Yes | No | No |
-| **Qwen-Image** [^5] | Yes | Yes | No | No | No | Yes | No | Yes | Yes | Yes | Yes | Yes | No | No |
+| **Qwen-Image** [^5] | Yes | Yes | No | No | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | No | No |
 | **Qwen-Image-Layered** [^6] | No | No | No | No | No | No | No | Yes | Yes | No | No | No | No | No |
 | **Qwen-Image-Edit-2511** | Yes | Yes | No | No | Yes | No | No | Yes | Yes | No | No | No | No | No |
 | **Cosmos3** | Yes | Yes | No | No | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes | No |
@@ -67,7 +67,7 @@ Models are auto-detected from the checkpoint directory. Diffusers-format models 
 
 [^4]: LTX-2 has no built-in TeaCache coefficient table in TRT-LLM; set `teacache.coefficients` explicitly when enabling TeaCache.
 
-[^5]: Qwen-Image ships a native BF16 implementation with per-module numerical parity against `diffusers.QwenImagePipeline` (cosine similarity >= 0.999 on the full 20B transformer) and supports `trtllm-serve` / `/v1/images/generations`. VisualGen supports FP8 blockwise and NVFP4 dynamic quantization from BF16 checkpoints, as well as direct loading of statically quantized FP8 and NVFP4 ModelOpt checkpoints.
+[^5]: Qwen-Image ships a native BF16 implementation with per-module numerical parity against `diffusers.QwenImagePipeline` (cosine similarity >= 0.999 on the full 20B transformer) and supports `trtllm-serve` / `/v1/images/generations`. VisualGen supports FP8 blockwise and NVFP4 dynamic quantization from BF16 checkpoints, as well as direct loading of statically quantized FP8 and NVFP4 ModelOpt checkpoints. Qwen-Image also supports CFG parallelism for true CFG with `cfg_size=2`, running positive and negative prompt transformer passes on separate ranks before gathering and applying the standard true-CFG rescale.
 
 [^6]: Qwen-Image-Layered supports baseline BF16 image-conditioned layer decomposition and returns the generated RGBA layer stack as a saveable image grid. FP8 blockwise, NVFP4, cache acceleration, attention-parallel/Sage/VSA backends, Tensor Parallelism, and `trtllm-serve` image-edit routing are not enabled for this pipeline yet.
 

--- a/docs/source/models/visual-generation.md
+++ b/docs/source/models/visual-generation.md
@@ -54,7 +54,7 @@ Models are auto-detected from the checkpoint directory. Diffusers-format models 
 | **Wan 2.1 VSA** [^2] | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes | Yes |
 | **Wan 2.2** | Yes | Yes | Yes [^3] | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No |
 | **LTX-2** | Yes | Yes | Yes [^4] | Yes | Yes | Yes | No | No | Yes | Yes | Yes | Yes | No | No |
-| **Qwen-Image** [^5] | Yes | Yes | No | No | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | No | No |
+| **Qwen-Image** | Yes | Yes | No | No | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | No | No |
 | **Qwen-Image-Layered** [^6] | No | No | No | No | No | No | No | Yes | Yes | No | No | No | No | No |
 | **Qwen-Image-Edit-2511** | Yes | Yes | No | No | Yes | No | No | Yes | Yes | No | No | No | No | No |
 | **Cosmos3** | Yes | Yes | No | No | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes | No |
@@ -66,8 +66,6 @@ Models are auto-detected from the checkpoint directory. Diffusers-format models 
 [^3]: Wan 2.2 has two stage transformers; TeaCache requires explicit `teacache.coefficients` (high-noise) and `teacache.coefficients_2` (low-noise). There is no built-in coefficient table for Wan 2.2.
 
 [^4]: LTX-2 has no built-in TeaCache coefficient table in TRT-LLM; set `teacache.coefficients` explicitly when enabling TeaCache.
-
-[^5]: Qwen-Image ships a native BF16 implementation with per-module numerical parity against `diffusers.QwenImagePipeline` (cosine similarity >= 0.999 on the full 20B transformer) and supports `trtllm-serve` / `/v1/images/generations`. VisualGen supports FP8 blockwise and NVFP4 dynamic quantization from BF16 checkpoints, as well as direct loading of statically quantized FP8 and NVFP4 ModelOpt checkpoints. Qwen-Image also supports CFG parallelism for true CFG with `cfg_size=2`, running positive and negative prompt transformer passes on separate ranks before gathering and applying the standard true-CFG rescale.
 
 [^6]: Qwen-Image-Layered supports baseline BF16 image-conditioned layer decomposition and returns the generated RGBA layer stack as a saveable image grid. FP8 blockwise, NVFP4, cache acceleration, attention-parallel/Sage/VSA backends, Tensor Parallelism, and `trtllm-serve` image-edit routing are not enabled for this pipeline yet.
 

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
@@ -18,6 +18,7 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import torch
 import torch.distributed as dist
+from torch.distributed import ProcessGroup
 
 from tensorrt_llm._torch.visual_gen.output import CudaPhaseTimer, PipelineOutput
 from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
@@ -85,6 +86,7 @@ class QwenImagePipeline(BasePipeline):
         # load_standard_components() once the VAE is loaded.
         self.vae_scale_factor = 8
         self.tokenizer_max_length = 1024
+        self._logged_cfg_disabled_parallel_warning = False
 
     @property
     def dtype(self):
@@ -155,13 +157,16 @@ class QwenImagePipeline(BasePipeline):
         ``forward`` path so CUDA graphs / torch.compile / VAE kernels
         all get triggered with the runtime shape.
         """
+        vgm = self.pipeline_config.visual_gen_mapping
+        cfg_size = vgm.cfg_size if vgm else 1
+        warmup_true_cfg_scale = 4.0 if cfg_size > 1 else 1.0
         with torch.no_grad():
             self.forward(
                 prompt="warmup",
                 height=height,
                 width=width,
                 num_inference_steps=max(steps, 2),
-                true_cfg_scale=1.0,
+                true_cfg_scale=warmup_true_cfg_scale,
                 seed=42,
                 max_sequence_length=64,
             )
@@ -412,12 +417,26 @@ class QwenImagePipeline(BasePipeline):
         noise_norm = torch.norm(comb, dim=-1, keepdim=True)
         return comb * (cond_norm / noise_norm)
 
-    def _cfg_parallel_state(self, do_true_cfg: bool) -> Tuple[bool, int, int, object]:
+    def _cfg_parallel_state(
+        self, do_true_cfg: bool
+    ) -> Tuple[bool, int, int, Optional[ProcessGroup]]:
         vgm = self.pipeline_config.visual_gen_mapping
         cfg_size = vgm.cfg_size if vgm else 1
         cfg_rank = vgm.cfg_rank if vgm else 0
         cfg_pg = vgm.cfg_group if vgm else None
         do_cfg_parallel = do_true_cfg and cfg_size > 1
+        if (
+            cfg_size > 1
+            and not do_true_cfg
+            and cfg_rank == 0
+            and not getattr(self, "_logged_cfg_disabled_parallel_warning", False)
+        ):
+            logger.warning(
+                "Qwen-Image configured with cfg_size=%d but true CFG is disabled; "
+                "CFG-parallel ranks will redundantly compute the same request path.",
+                cfg_size,
+            )
+            self._logged_cfg_disabled_parallel_warning = True
         if do_cfg_parallel:
             if cfg_size != 2:
                 raise ValueError(

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
@@ -565,8 +565,7 @@ class QwenImagePipeline(BasePipeline):
         # Denoise loop.
         timer.mark_denoise_start()
         logger.info("Denoising (%d steps)...", len(timesteps))
-        pipeline_config = getattr(self, "pipeline_config", None)
-        cuda_graph_enabled = getattr(getattr(pipeline_config, "cuda_graph", None), "enable", False)
+        cuda_graph_enabled = self.pipeline_config.cuda_graph.enable
         for i, t in enumerate(timesteps):
             timestep = t.expand(latents.shape[0]).to(latents.dtype)
             if do_cfg_parallel:

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
@@ -159,14 +159,14 @@ class QwenImagePipeline(BasePipeline):
         """
         vgm = self.pipeline_config.visual_gen_mapping
         cfg_size = vgm.cfg_size if vgm else 1
-        warmup_true_cfg_scale = 4.0 if cfg_size > 1 else 1.0
+        warmup_cfg_scale = 4.0 if cfg_size > 1 else 1.0
         with torch.no_grad():
             self.forward(
                 prompt="warmup",
                 height=height,
                 width=width,
                 num_inference_steps=max(steps, 2),
-                true_cfg_scale=warmup_true_cfg_scale,
+                negative_prompt_cfg_scale=warmup_cfg_scale,
                 seed=42,
                 max_sequence_length=64,
             )
@@ -409,30 +409,30 @@ class QwenImagePipeline(BasePipeline):
         return neg_prompt_embeds, neg_prompt_embeds_mask
 
     @staticmethod
-    def _combine_true_cfg(
-        noise_pred: torch.Tensor, neg_noise_pred: torch.Tensor, true_cfg_scale: float
+    def _combine_negative_prompt_cfg(
+        noise_pred: torch.Tensor, neg_noise_pred: torch.Tensor, cfg_scale: float
     ) -> torch.Tensor:
-        comb = neg_noise_pred + true_cfg_scale * (noise_pred - neg_noise_pred)
+        comb = neg_noise_pred + cfg_scale * (noise_pred - neg_noise_pred)
         cond_norm = torch.norm(noise_pred, dim=-1, keepdim=True)
         noise_norm = torch.norm(comb, dim=-1, keepdim=True)
         return comb * (cond_norm / noise_norm)
 
     def _cfg_parallel_state(
-        self, do_true_cfg: bool
+        self, use_negative_prompt_cfg: bool
     ) -> Tuple[bool, int, int, Optional[ProcessGroup]]:
         vgm = self.pipeline_config.visual_gen_mapping
         cfg_size = vgm.cfg_size if vgm else 1
         cfg_rank = vgm.cfg_rank if vgm else 0
         cfg_pg = vgm.cfg_group if vgm else None
-        do_cfg_parallel = do_true_cfg and cfg_size > 1
+        do_cfg_parallel = use_negative_prompt_cfg and cfg_size > 1
         if (
             cfg_size > 1
-            and not do_true_cfg
+            and not use_negative_prompt_cfg
             and cfg_rank == 0
             and not getattr(self, "_logged_cfg_disabled_parallel_warning", False)
         ):
             logger.warning(
-                "Qwen-Image configured with cfg_size=%d but true CFG is disabled; "
+                "Qwen-Image configured with cfg_size=%d but negative-prompt CFG is disabled; "
                 "CFG-parallel ranks will redundantly compute the same request path.",
                 cfg_size,
             )
@@ -475,7 +475,7 @@ class QwenImagePipeline(BasePipeline):
             height=params.height,
             width=params.width,
             num_inference_steps=params.num_inference_steps,
-            true_cfg_scale=params.guidance_scale,
+            negative_prompt_cfg_scale=params.guidance_scale,
             seed=params.seed,
             max_sequence_length=params.max_sequence_length,
         )
@@ -488,7 +488,7 @@ class QwenImagePipeline(BasePipeline):
         height: int = 1328,
         width: int = 1328,
         num_inference_steps: int = 50,
-        true_cfg_scale: float = 4.0,
+        negative_prompt_cfg_scale: float = 4.0,
         seed: int = 42,
         max_sequence_length: int = 1024,
         sigmas: Optional[list] = None,
@@ -496,7 +496,7 @@ class QwenImagePipeline(BasePipeline):
         """Text-to-image generation.
 
         Implementation mirrors ``diffusers.QwenImagePipeline.__call__``
-        with the FlowMatchEuler sampler and real CFG (``true_cfg_scale``).
+        with the FlowMatchEuler sampler and negative-prompt CFG.
         """
         pipeline_start = time.time()
         timer = CudaPhaseTimer()
@@ -506,8 +506,10 @@ class QwenImagePipeline(BasePipeline):
             prompt = [prompt]
         batch_size = len(prompt)
 
-        do_true_cfg = true_cfg_scale > 1.0
-        do_cfg_parallel, cfg_size, cfg_rank, cfg_pg = self._cfg_parallel_state(do_true_cfg)
+        use_negative_prompt_cfg = negative_prompt_cfg_scale > 1.0
+        do_cfg_parallel, cfg_size, cfg_rank, cfg_pg = self._cfg_parallel_state(
+            use_negative_prompt_cfg
+        )
 
         device = self.device
         generator = torch.Generator(device=device).manual_seed(seed)
@@ -516,7 +518,7 @@ class QwenImagePipeline(BasePipeline):
         logger.info("Encoding prompt...")
         prompt_embeds, prompt_embeds_mask = self._encode_prompt(prompt, device, max_sequence_length)
         neg_prompt_embeds = neg_prompt_embeds_mask = None
-        if do_true_cfg:
+        if use_negative_prompt_cfg:
             negative_prompt = self._normalize_negative_prompt(negative_prompt, batch_size)
             neg_prompt_embeds, neg_prompt_embeds_mask = self._encode_prompt(
                 negative_prompt, device, max_sequence_length
@@ -586,7 +588,9 @@ class QwenImagePipeline(BasePipeline):
                 )[0].contiguous()
                 gather_list = [torch.empty_like(noise_pred_local) for _ in range(cfg_size)]
                 dist.all_gather(gather_list, noise_pred_local, group=cfg_pg)
-                noise_pred = self._combine_true_cfg(gather_list[0], gather_list[1], true_cfg_scale)
+                noise_pred = self._combine_negative_prompt_cfg(
+                    gather_list[0], gather_list[1], negative_prompt_cfg_scale
+                )
             else:
                 noise_pred = self.transformer(
                     hidden_states=latents,
@@ -597,7 +601,7 @@ class QwenImagePipeline(BasePipeline):
                     return_dict=False,
                 )[0]
 
-            if do_true_cfg and not do_cfg_parallel:
+            if use_negative_prompt_cfg and not do_cfg_parallel:
                 if cuda_graph_enabled:
                     # CUDA graph outputs are graph-owned buffers; the negative CFG
                     # replay may reuse the same pool before guidance consumes this one.
@@ -611,7 +615,9 @@ class QwenImagePipeline(BasePipeline):
                     img_shapes=img_shapes,
                     return_dict=False,
                 )[0]
-                noise_pred = self._combine_true_cfg(noise_pred, neg_noise_pred, true_cfg_scale)
+                noise_pred = self._combine_negative_prompt_cfg(
+                    noise_pred, neg_noise_pred, negative_prompt_cfg_scale
+                )
 
             latents_dtype = latents.dtype
             latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
+import torch.distributed as dist
 
 from tensorrt_llm._torch.visual_gen.output import CudaPhaseTimer, PipelineOutput
 from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
@@ -371,6 +372,64 @@ class QwenImagePipeline(BasePipeline):
     def default_generation_params(self) -> dict:
         return dict(_DEFAULT_GENERATION_PARAMS)
 
+    @staticmethod
+    def _normalize_negative_prompt(
+        negative_prompt: Optional[Union[str, List[str]]], batch_size: int
+    ) -> List[str]:
+        if negative_prompt is None:
+            return [""] * batch_size
+        if isinstance(negative_prompt, str):
+            return [negative_prompt] * batch_size
+
+        negative_prompt = list(negative_prompt)
+        if len(negative_prompt) == 1 and batch_size != 1:
+            return negative_prompt * batch_size
+        if len(negative_prompt) != batch_size:
+            raise ValueError(
+                "negative_prompt must be a string, a singleton list, "
+                "or a list with the same length as prompt"
+            )
+        return negative_prompt
+
+    @staticmethod
+    def _select_cfg_inputs(
+        cfg_rank: int,
+        prompt_embeds: torch.Tensor,
+        prompt_embeds_mask: torch.Tensor,
+        neg_prompt_embeds: torch.Tensor,
+        neg_prompt_embeds_mask: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if cfg_rank == 0:
+            return prompt_embeds, prompt_embeds_mask
+        return neg_prompt_embeds, neg_prompt_embeds_mask
+
+    @staticmethod
+    def _combine_true_cfg(
+        noise_pred: torch.Tensor, neg_noise_pred: torch.Tensor, true_cfg_scale: float
+    ) -> torch.Tensor:
+        comb = neg_noise_pred + true_cfg_scale * (noise_pred - neg_noise_pred)
+        cond_norm = torch.norm(noise_pred, dim=-1, keepdim=True)
+        noise_norm = torch.norm(comb, dim=-1, keepdim=True)
+        return comb * (cond_norm / noise_norm)
+
+    def _cfg_parallel_state(self, do_true_cfg: bool) -> Tuple[bool, int, int, object]:
+        vgm = self.pipeline_config.visual_gen_mapping
+        cfg_size = vgm.cfg_size if vgm else 1
+        cfg_rank = vgm.cfg_rank if vgm else 0
+        cfg_pg = vgm.cfg_group if vgm else None
+        do_cfg_parallel = do_true_cfg and cfg_size > 1
+        if do_cfg_parallel:
+            if cfg_size != 2:
+                raise ValueError(
+                    f"Qwen-Image CFG parallel only supports cfg_size=2 "
+                    f"(cond/uncond), got cfg_size={cfg_size}"
+                )
+            if not dist.is_initialized():
+                raise RuntimeError("Qwen-Image CFG parallel requires torch.distributed")
+            if cfg_rank == 0:
+                logger.info("CFG parallel: cfg_size=2")
+        return do_cfg_parallel, cfg_size, cfg_rank, cfg_pg
+
     def infer(self, req):
         # Fan out by num_images_per_prompt so ``n > 1`` produces multiple
         # images in a single batched forward. Qwen-Image supports this
@@ -428,8 +487,8 @@ class QwenImagePipeline(BasePipeline):
             prompt = [prompt]
         batch_size = len(prompt)
 
-        has_neg = negative_prompt is not None
-        do_true_cfg = true_cfg_scale > 1.0 and has_neg
+        do_true_cfg = true_cfg_scale > 1.0
+        do_cfg_parallel, cfg_size, cfg_rank, cfg_pg = self._cfg_parallel_state(do_true_cfg)
 
         device = self.device
         generator = torch.Generator(device=device).manual_seed(seed)
@@ -439,8 +498,7 @@ class QwenImagePipeline(BasePipeline):
         prompt_embeds, prompt_embeds_mask = self._encode_prompt(prompt, device, max_sequence_length)
         neg_prompt_embeds = neg_prompt_embeds_mask = None
         if do_true_cfg:
-            if isinstance(negative_prompt, str):
-                negative_prompt = [negative_prompt] * batch_size
+            negative_prompt = self._normalize_negative_prompt(negative_prompt, batch_size)
             neg_prompt_embeds, neg_prompt_embeds_mask = self._encode_prompt(
                 negative_prompt, device, max_sequence_length
             )
@@ -492,21 +550,43 @@ class QwenImagePipeline(BasePipeline):
         cuda_graph_enabled = getattr(getattr(pipeline_config, "cuda_graph", None), "enable", False)
         for i, t in enumerate(timesteps):
             timestep = t.expand(latents.shape[0]).to(latents.dtype)
-            noise_pred = self.transformer(
-                hidden_states=latents,
-                timestep=timestep / 1000,
-                encoder_hidden_states_mask=prompt_embeds_mask,
-                encoder_hidden_states=prompt_embeds,
-                img_shapes=img_shapes,
-                return_dict=False,
-            )[0]
+            if do_cfg_parallel:
+                local_embeds, local_mask = self._select_cfg_inputs(
+                    cfg_rank,
+                    prompt_embeds,
+                    prompt_embeds_mask,
+                    neg_prompt_embeds,
+                    neg_prompt_embeds_mask,
+                )
+                noise_pred_local = self.transformer(
+                    hidden_states=latents,
+                    timestep=timestep / 1000,
+                    encoder_hidden_states_mask=local_mask,
+                    encoder_hidden_states=local_embeds,
+                    img_shapes=img_shapes,
+                    return_dict=False,
+                )[0].contiguous()
+                gather_list = [torch.empty_like(noise_pred_local) for _ in range(cfg_size)]
+                dist.all_gather(gather_list, noise_pred_local, group=cfg_pg)
+                noise_pred = self._combine_true_cfg(
+                    gather_list[0], gather_list[1], true_cfg_scale
+                )
+            else:
+                noise_pred = self.transformer(
+                    hidden_states=latents,
+                    timestep=timestep / 1000,
+                    encoder_hidden_states_mask=prompt_embeds_mask,
+                    encoder_hidden_states=prompt_embeds,
+                    img_shapes=img_shapes,
+                    return_dict=False,
+                )[0]
 
-            if do_true_cfg and cuda_graph_enabled:
-                # CUDA graph outputs are graph-owned buffers; the negative CFG
-                # replay may reuse the same pool before guidance consumes this one.
-                noise_pred = noise_pred.clone()
+            if do_true_cfg and not do_cfg_parallel:
+                if cuda_graph_enabled:
+                    # CUDA graph outputs are graph-owned buffers; the negative CFG
+                    # replay may reuse the same pool before guidance consumes this one.
+                    noise_pred = noise_pred.clone()
 
-            if do_true_cfg:
                 neg_noise_pred = self.transformer(
                     hidden_states=latents,
                     timestep=timestep / 1000,
@@ -515,10 +595,7 @@ class QwenImagePipeline(BasePipeline):
                     img_shapes=img_shapes,
                     return_dict=False,
                 )[0]
-                comb = neg_noise_pred + true_cfg_scale * (noise_pred - neg_noise_pred)
-                cond_norm = torch.norm(noise_pred, dim=-1, keepdim=True)
-                noise_norm = torch.norm(comb, dim=-1, keepdim=True)
-                noise_pred = comb * (cond_norm / noise_norm)
+                noise_pred = self._combine_true_cfg(noise_pred, neg_noise_pred, true_cfg_scale)
 
             latents_dtype = latents.dtype
             latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/pipeline_qwen_image.py
@@ -587,9 +587,7 @@ class QwenImagePipeline(BasePipeline):
                 )[0].contiguous()
                 gather_list = [torch.empty_like(noise_pred_local) for _ in range(cfg_size)]
                 dist.all_gather(gather_list, noise_pred_local, group=cfg_pg)
-                noise_pred = self._combine_true_cfg(
-                    gather_list[0], gather_list[1], true_cfg_scale
-                )
+                noise_pred = self._combine_true_cfg(gather_list[0], gather_list[1], true_cfg_scale)
             else:
                 noise_pred = self.transformer(
                     hidden_states=latents,

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_infer.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_infer.py
@@ -83,7 +83,7 @@ def test_infer_forwards_generation_params():
     assert captured["height"] == 768
     assert captured["width"] == 1024
     assert captured["num_inference_steps"] == 7
-    assert captured["true_cfg_scale"] == 3.25
+    assert captured["negative_prompt_cfg_scale"] == 3.25
     assert captured["seed"] == 123
     assert captured["max_sequence_length"] == 256
 

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline.py
@@ -10,6 +10,8 @@ true-CFG path (dual cond/uncond forward plus the norm-preserving CFG
 combination) and the non-CFG path, on CPU.
 """
 
+from types import SimpleNamespace
+
 import torch
 
 from tensorrt_llm._torch.visual_gen.models.qwen_image import QwenImagePipeline
@@ -81,6 +83,7 @@ def _pipeline_with_test_doubles():
     pipe.vae_scale_factor = 8
     pipe.transformer = _RecordingTransformer()
     pipe.scheduler = _RecordingScheduler()
+    pipe.pipeline_config = SimpleNamespace(visual_gen_mapping=None)
     captured = {"encoded_prompts": []}
 
     def _encode_prompt(prompt, device, max_sequence_length):
@@ -138,7 +141,7 @@ def test_forward_runs_without_true_cfg():
         height=32,
         width=48,
         num_inference_steps=3,
-        true_cfg_scale=4.0,
+        true_cfg_scale=1.0,
         seed=123,
         max_sequence_length=16,
         sigmas=[1.0, 0.5, 0.25],
@@ -154,6 +157,36 @@ def test_forward_runs_without_true_cfg():
     assert pipe.transformer.calls[0]["hidden_states_shape"] == (1, 6, 4)
     assert torch.all(pipe.transformer.calls[0]["encoder_hidden_states"] > 0)
     assert len(pipe.scheduler.step_calls) == 3
+    assert torch.allclose(
+        pipe.scheduler.step_calls[0]["noise_pred"],
+        _expanded_noise([1, 2, 3, 4], batch_size=1, seq_len=6),
+    )
+
+
+def test_forward_defaults_missing_negative_prompt_to_empty_string_for_true_cfg():
+    pipe, captured = _pipeline_with_test_doubles()
+
+    output = pipe.forward(
+        prompt=["a cat"],
+        negative_prompt=None,
+        height=32,
+        width=48,
+        num_inference_steps=2,
+        true_cfg_scale=4.0,
+        seed=123,
+        max_sequence_length=16,
+        sigmas=[1.0, 0.5],
+    )
+
+    assert output.image.shape == (1, 32, 48, 3)
+    assert captured["encoded_prompts"] == [
+        (["a cat"], torch.device("cpu"), 16),
+        ([""], torch.device("cpu"), 16),
+    ]
+    assert len(pipe.transformer.calls) == 4
+    assert torch.all(pipe.transformer.calls[0]["encoder_hidden_states"] > 0)
+    assert torch.all(pipe.transformer.calls[1]["encoder_hidden_states"] > 0)
+    assert len(pipe.scheduler.step_calls) == 2
     assert torch.allclose(
         pipe.scheduler.step_calls[0]["noise_pred"],
         _expanded_noise([1, 2, 3, 4], batch_size=1, seq_len=6),

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline.py
@@ -132,7 +132,7 @@ def _expanded_noise(values, *, batch_size, seq_len, dtype=torch.float32):
     return pattern.view(1, 1, -1).expand(batch_size, seq_len, -1)
 
 
-def test_forward_runs_without_true_cfg():
+def test_forward_runs_without_negative_prompt_cfg():
     pipe, captured = _pipeline_with_test_doubles()
 
     output = pipe.forward(
@@ -141,7 +141,7 @@ def test_forward_runs_without_true_cfg():
         height=32,
         width=48,
         num_inference_steps=3,
-        true_cfg_scale=1.0,
+        negative_prompt_cfg_scale=1.0,
         seed=123,
         max_sequence_length=16,
         sigmas=[1.0, 0.5, 0.25],
@@ -163,7 +163,7 @@ def test_forward_runs_without_true_cfg():
     )
 
 
-def test_forward_defaults_missing_negative_prompt_to_empty_string_for_true_cfg():
+def test_forward_defaults_missing_negative_prompt_to_empty_string_for_cfg():
     pipe, captured = _pipeline_with_test_doubles()
 
     output = pipe.forward(
@@ -172,7 +172,7 @@ def test_forward_defaults_missing_negative_prompt_to_empty_string_for_true_cfg()
         height=32,
         width=48,
         num_inference_steps=2,
-        true_cfg_scale=4.0,
+        negative_prompt_cfg_scale=4.0,
         seed=123,
         max_sequence_length=16,
         sigmas=[1.0, 0.5],
@@ -193,7 +193,7 @@ def test_forward_defaults_missing_negative_prompt_to_empty_string_for_true_cfg()
     )
 
 
-def test_forward_runs_true_cfg_pipeline():
+def test_forward_runs_negative_prompt_cfg_pipeline():
     pipe, captured = _pipeline_with_test_doubles()
 
     output = pipe.forward(
@@ -202,7 +202,7 @@ def test_forward_runs_true_cfg_pipeline():
         height=32,
         width=48,
         num_inference_steps=2,
-        true_cfg_scale=3.0,
+        negative_prompt_cfg_scale=3.0,
         seed=123,
         max_sequence_length=16,
         sigmas=[1.0, 0.5],

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline.py
@@ -83,7 +83,9 @@ def _pipeline_with_test_doubles():
     pipe.vae_scale_factor = 8
     pipe.transformer = _RecordingTransformer()
     pipe.scheduler = _RecordingScheduler()
-    pipe.pipeline_config = SimpleNamespace(visual_gen_mapping=None)
+    pipe.pipeline_config = SimpleNamespace(
+        cuda_graph=SimpleNamespace(enable=False), visual_gen_mapping=None
+    )
     captured = {"encoded_prompts": []}
 
     def _encode_prompt(prompt, device, max_sequence_length):

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
@@ -185,10 +185,10 @@ def test_qwen_image_selects_cfg_inputs_by_rank():
     assert selected[1] is negative_mask
 
 
-def test_qwen_image_true_cfg_combination_keeps_reference_formula():
+def test_qwen_image_negative_prompt_cfg_combination_keeps_reference_formula():
     noise_pred = torch.tensor([[[2.0, 0.0]]])
     neg_noise_pred = torch.tensor([[[1.0, 0.0]]])
-    combined = QwenImagePipeline._combine_true_cfg(noise_pred, neg_noise_pred, 4.0)
+    combined = QwenImagePipeline._combine_negative_prompt_cfg(noise_pred, neg_noise_pred, 4.0)
     assert combined.shape == noise_pred.shape
     assert torch.allclose(combined, torch.tensor([[[2.0, 0.0]]]))
 

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
@@ -10,6 +10,7 @@ registry detection.
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -122,6 +123,59 @@ def test_transformer_load_weights_detects_mismatch():
     model = QwenImageTransformer2DModel(model_config=None, num_layers=2)
     with pytest.raises(RuntimeError, match=r"Missing keys|Unexpected keys"):
         model.load_weights({})
+
+
+def test_qwen_image_defaults_missing_negative_prompt_to_empty_string():
+    assert QwenImagePipeline._normalize_negative_prompt(None, 2) == ["", ""]
+    assert QwenImagePipeline._normalize_negative_prompt("low quality", 2) == [
+        "low quality",
+        "low quality",
+    ]
+    assert QwenImagePipeline._normalize_negative_prompt(["blur"], 2) == ["blur", "blur"]
+    assert QwenImagePipeline._normalize_negative_prompt(["a", "b"], 2) == ["a", "b"]
+    with pytest.raises(ValueError, match="negative_prompt"):
+        QwenImagePipeline._normalize_negative_prompt(["a", "b", "c"], 2)
+
+
+def test_qwen_image_cfg_parallel_state(monkeypatch):
+    pipeline = object.__new__(QwenImagePipeline)
+    pipeline.pipeline_config = SimpleNamespace(
+        visual_gen_mapping=SimpleNamespace(cfg_size=2, cfg_rank=1, cfg_group="cfg_pg")
+    )
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.visual_gen.models.qwen_image.pipeline_qwen_image.dist.is_initialized",
+        lambda: True,
+    )
+
+    assert pipeline._cfg_parallel_state(True) == (True, 2, 1, "cfg_pg")
+    assert pipeline._cfg_parallel_state(False) == (False, 2, 1, "cfg_pg")
+
+
+def test_qwen_image_selects_cfg_inputs_by_rank():
+    prompt = torch.tensor([1])
+    prompt_mask = torch.tensor([2])
+    negative = torch.tensor([3])
+    negative_mask = torch.tensor([4])
+
+    selected = QwenImagePipeline._select_cfg_inputs(
+        0, prompt, prompt_mask, negative, negative_mask
+    )
+    assert selected[0] is prompt
+    assert selected[1] is prompt_mask
+
+    selected = QwenImagePipeline._select_cfg_inputs(
+        1, prompt, prompt_mask, negative, negative_mask
+    )
+    assert selected[0] is negative
+    assert selected[1] is negative_mask
+
+
+def test_qwen_image_true_cfg_combination_keeps_reference_formula():
+    noise_pred = torch.tensor([[[2.0, 0.0]]])
+    neg_noise_pred = torch.tensor([[[1.0, 0.0]]])
+    combined = QwenImagePipeline._combine_true_cfg(noise_pred, neg_noise_pred, 4.0)
+    assert combined.shape == noise_pred.shape
+    assert torch.allclose(combined, torch.tensor([[[2.0, 0.0]]]))
 
 
 def test_transformer_applies_quant_config_ignore_list() -> None:

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
@@ -176,15 +176,11 @@ def test_qwen_image_selects_cfg_inputs_by_rank():
     negative = torch.tensor([3])
     negative_mask = torch.tensor([4])
 
-    selected = QwenImagePipeline._select_cfg_inputs(
-        0, prompt, prompt_mask, negative, negative_mask
-    )
+    selected = QwenImagePipeline._select_cfg_inputs(0, prompt, prompt_mask, negative, negative_mask)
     assert selected[0] is prompt
     assert selected[1] is prompt_mask
 
-    selected = QwenImagePipeline._select_cfg_inputs(
-        1, prompt, prompt_mask, negative, negative_mask
-    )
+    selected = QwenImagePipeline._select_cfg_inputs(1, prompt, prompt_mask, negative, negative_mask)
     assert selected[0] is negative
     assert selected[1] is negative_mask
 

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
@@ -150,6 +150,25 @@ def test_qwen_image_cfg_parallel_state(monkeypatch):
     assert pipeline._cfg_parallel_state(True) == (True, 2, 1, "cfg_pg")
     assert pipeline._cfg_parallel_state(False) == (False, 2, 1, "cfg_pg")
 
+    pipeline.pipeline_config = SimpleNamespace(visual_gen_mapping=None)
+    assert pipeline._cfg_parallel_state(True) == (False, 1, 0, None)
+
+    pipeline.pipeline_config = SimpleNamespace(
+        visual_gen_mapping=SimpleNamespace(cfg_size=3, cfg_rank=0, cfg_group="cfg_pg")
+    )
+    with pytest.raises(ValueError, match="cfg_size=3"):
+        pipeline._cfg_parallel_state(True)
+
+    pipeline.pipeline_config = SimpleNamespace(
+        visual_gen_mapping=SimpleNamespace(cfg_size=2, cfg_rank=0, cfg_group="cfg_pg")
+    )
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.visual_gen.models.qwen_image.pipeline_qwen_image.dist.is_initialized",
+        lambda: False,
+    )
+    with pytest.raises(RuntimeError, match="torch.distributed"):
+        pipeline._cfg_parallel_state(True)
+
 
 def test_qwen_image_selects_cfg_inputs_by_rank():
     prompt = torch.tensor([1])


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distributed CFG parallel generation for Qwen-Image pipelines.
  * Improved true classifier-free guidance with norm-based noise rescaling.
  * Added support for flexible negative prompt inputs, including validation for batch sizes.

* **Bug Fixes**
  * Improved guidance behavior when negative prompts are omitted.

* **Tests**
  * Added coverage for prompt handling, distributed CFG state, input selection, and guidance calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
| CFG=1 | CFG=2 |
|---|---|
| <img width="640" alt="qwen_cfg1_negative_prompt_direct_output" src="https://github.com/user-attachments/assets/3b6c6d9b-d656-4d0a-8073-73eabfc6f301" /> | <img width="640" alt="qwen_cfg2_negative_prompt_direct_output" src="https://github.com/user-attachments/assets/79f5854a-4062-46ac-a999-5047513d1ef8" /> |

Measured with explicit negative_prompt="", 1328x1328, 50 steps. 

  | Case | GPUs | Generation time |                                                                                                           
  |---|---:|---:|                                                                                                                             
  | CFG=1 true CFG, positive + negative serial | 1 | 16.22s |
  | CFG=2 CFG parallel | 2 | 8.51s |
                                   
  CFG=2 is about 1.91x faster. LPIPS is 0.00000000.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
