### PR TITLE
[None][chore] Remove disagg-devs co-ownership of mla.py in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -443,7 +443,6 @@
 # ===== DISAGG BLAST-RADIUS CO-OWNS (Tier-1) =====
 # Last-match cross-cutting: adds disagg-devs to shared files that can silently break disagg e2e.
 /tensorrt_llm/_torch/pyexecutor/resource_manager.py @NVIDIA/trt-llm-kv-cache-manager-devs @NVIDIA/trt-llm-disagg-devs
-/tensorrt_llm/_torch/modules/mla.py @NVIDIA/trt-llm-torch-attention-devs @NVIDIA/trt-llm-disagg-devs
 /tensorrt_llm/_torch/pyexecutor/py_executor.py @NVIDIA/trt-llm-runtime-devs @NVIDIA/trt-llm-disagg-devs
 /tensorrt_llm/_torch/pyexecutor/model_engine.py @NVIDIA/trt-llm-runtime-devs @NVIDIA/trt-llm-disagg-devs
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership assignments for disaggregated execution components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

The "DISAGG BLAST-RADIUS CO-OWNS (Tier-1)" section added in #16321 co-owns `tensorrt_llm/_torch/modules/mla.py` with `@NVIDIA/trt-llm-disagg-devs`. Because CODEOWNERS is last-match-wins, this entry overrides the existing `mla.py` rule and requests a disagg-devs review on every `mla.py` change — including attention-internal changes with no disagg surface (e.g. #15806, a 4-line DSA indexer change), which adds review noise and merge latency on a hot file.

This PR removes the `mla.py` entry from that section, so `mla.py` falls back to the existing `@NVIDIA/trt-llm-torch-attention-devs` rule. The other Tier-1 co-owned files (`resource_manager.py`, `py_executor.py`, `model_engine.py`) are unchanged.

## Test Coverage

N/A — CODEOWNERS-only change; no code paths affected.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.