### PR TITLE
[https://nvbugs/6442594][fix] Extend the M3 override signature to accept `num_blocks_per_seq…

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/cache_manager.py
@@ -13,7 +13,7 @@ Provides:
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import torch
 
@@ -417,6 +417,7 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         *,
         pool_id: int = 0,
         is_kv_aggregate: bool = True,
+        num_blocks_per_seq: Optional[Sequence[int]] = None,
     ):
         """Return per-request slot ids in ``[0, num_slots)`` directly.
 
@@ -434,8 +435,11 @@ class MiniMaxM3KVCacheManagerV2(KVCacheManagerV2):
         padding contract.
         """
         res = []
-        for req_id in request_ids:
+        for req_idx, req_id in enumerate(request_ids):
             idx_tensor = torch.as_tensor(self.kv_cache_map[req_id].get_base_page_indices(pool_id))
+            if num_blocks_per_seq is not None:
+                num_blocks = min(idx_tensor.numel(), num_blocks_per_seq[req_idx])
+                idx_tensor = idx_tensor[:num_blocks]
             res.append(
                 (
                     torch.where(

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -235,7 +235,6 @@ full:B300/accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_nvfp4_multi_gp
 full:B300/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=True-enable_chunked_prefill=True-v2_kv_cache=True] SKIP (https://nvbugs/6422343)
 full:B300/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_auto_dtype[tp_size=8-ep_size=8] SKIP (https://nvbugs/6445375)
 full:B300/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8[tp_size=4-ep_size=4] SKIP (https://nvbugs/6424188)
-full:B300/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8_piecewise_cuda_graph[tp_size=8-ep_size=8] SKIP (https://nvbugs/6442594)
 full:B300/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[tp_size=4-ep_size=4] SKIP (https://nvbugs/6445375)
 full:B300/accuracy/test_llm_api_pytorch_multimodal.py::TestExaone4_5_33B::test_auto_dtype[forced_chunked_prefill] SKIP (https://nvbugs/6422318)
 full:B300/accuracy/test_llm_api_pytorch_multimodal.py::TestExaone4_5_33B::test_auto_dtype[full_budget] SKIP (https://nvbugs/6422318)


### PR DESCRIPTION
## Summary
- **Root cause**: M3 subclass override didn't accept `num_blocks_per_seq` kwarg that base class now unconditionally forwards.
- **Fix**: Extend the M3 override signature to accept `num_blocks_per_seq: Optional[Sequence[int]] = None` and mirror the base's per-request slicing (`idx_tensor[:min(numel, num_blocks_per_seq[req_idx])]`), while preserving the M3-specific bypass of `index_scale // kv_factor` conversion.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6442594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sparse attention cache handling by supporting per-sequence block limits.
  * Ensured cache indices are safely truncated while preserving padding behavior for incomplete sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->