### PR TITLE
[fix] Pool NCCL window outputs for FP4 allreduce

### DIFF
--- a/cpp/tensorrt_llm/thop/fp4Gemm.cpp
+++ b/cpp/tensorrt_llm/thop/fp4Gemm.cpp
@@ -136,7 +136,7 @@ at::Tensor fp4_bmm_impl(at::Tensor const& mat1, at::Tensor const& mat2, at::Tens
     at::Tensor const& mat2Scale, at::Tensor const& globalScale, FP4GemmType fp4GemmType,
     std::optional<c10::ScalarType> out_dtype, int64_t output_buffer_kind,
     tkc::CutlassGemmConfig const* maybe_config = nullptr, c10::optional<torch::List<int64_t>> group = c10::nullopt,
-    std::optional<at::Tensor> const& bias = std::nullopt)
+    std::optional<at::Tensor> const& bias = std::nullopt, std::optional<at::Tensor> const& output = std::nullopt)
 {
     if (fp4GemmType == FP4GemmType::W4A8_MXFP4_MXFP8)
     {
@@ -198,9 +198,33 @@ at::Tensor fp4_bmm_impl(at::Tensor const& mat1, at::Tensor const& mat2, at::Tens
     TORCH_CHECK(out_dtype == torch::kFloat || out_dtype == torch::kHalf || out_dtype == torch::kBFloat16,
         "out_dtype must be one of fp16/bf16/fp32. It defaults to fp16.");
 
-    std::vector<int64_t> out_shape = mat1.dim() == 2 ? std::vector<int64_t>{m, n} : std::vector<int64_t>{b, m, n};
-    auto [out, _] = torch_ext::allocate_output(
-        out_shape, out_dtype.value(), mat1.device(), static_cast<torch_ext::BufferKind>(output_buffer_kind), group);
+    std::vector<int64_t> const outShape
+        = mat1.dim() == 2 ? std::vector<int64_t>{m, n} : std::vector<int64_t>{b, m, n};
+    at::Tensor out;
+    if (output.has_value())
+    {
+        out = *output;
+        CHECK_TH_CUDA(out);
+        TORCH_CHECK(out.device() == mat1.device(), "output must reside on the same CUDA device as mat1");
+        TORCH_CHECK(out.is_contiguous(), "output must be contiguous");
+        if (mat1.dim() == 2)
+        {
+            TORCH_CHECK(out.dim() == 2 && out.size(0) >= m && out.size(1) == n, "output has shape ", out.sizes(),
+                "; expected at least [", m, ", ", n, "]");
+        }
+        else
+        {
+            TORCH_CHECK(out.sizes() == at::IntArrayRef(outShape), "output has shape ", out.sizes(), "; expected ",
+                outShape);
+        }
+        TORCH_CHECK(out.scalar_type() == out_dtype.value(), "output dtype must match out_dtype");
+    }
+    else
+    {
+        auto const allocated = torch_ext::allocate_output(
+            outShape, out_dtype.value(), mat1.device(), static_cast<torch_ext::BufferKind>(output_buffer_kind), group);
+        out = allocated.first;
+    }
 
     void const* bias_ptr = nullptr;
     if (bias.has_value())
@@ -309,6 +333,21 @@ public:
             output_buffer_kind, config, group, bias);
     }
 
+    // Run GEMM into caller-owned output storage.
+    void runGemmOut(at::Tensor const& mat1, at::Tensor const& mat2, at::Tensor const& mat1Scale,
+        at::Tensor const& mat2Scale, at::Tensor const& globalScale, at::Tensor const& output, int64_t configIdx,
+        std::optional<at::Tensor> const& bias = std::nullopt) const
+    {
+        tkc::CutlassGemmConfig const* config = nullptr;
+        if (configIdx != -1)
+        {
+            TORCH_CHECK(configIdx >= 0 && configIdx < getNumConfigs());
+            config = &mConfigs.at(configIdx);
+        }
+        fp4_bmm_impl(mat1, mat2, mat1Scale, mat2Scale, globalScale, mfp4GemmType, mOutputDtype,
+            static_cast<int>(torch_ext::BufferKind::Default), config, c10::nullopt, bias, output);
+    }
+
     at::ScalarType getOutputDtype() const
     {
         return mOutputDtype;
@@ -334,6 +373,7 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
     m.class_<tensorrt_llm::torch_ext::FP4GemmRunner>("FP4GemmRunner")
         .def(torch::init<at::ScalarType, int64_t>())
         .def("run_gemm", &tensorrt_llm::torch_ext::FP4GemmRunner::runGemm)
+        .def("run_gemm_out", &tensorrt_llm::torch_ext::FP4GemmRunner::runGemmOut)
         .def("get_num_configs", &tensorrt_llm::torch_ext::FP4GemmRunner::getNumConfigs);
 
     m.def(

--- a/tensorrt_llm/_torch/compilation/multi_stream/auto_multi_stream.py
+++ b/tensorrt_llm/_torch/compilation/multi_stream/auto_multi_stream.py
@@ -45,6 +45,7 @@ def estimate_time(node: Node) -> int:
     gemm_ops = {
         torch.ops.aten.mm.default,
         torch.ops.trtllm.nvfp4_gemm.default,
+        torch.ops.trtllm.nvfp4_gemm_out.default,
         torch.ops.trtllm.fp8_batched_gemm_trtllmgen.default,
         torch.ops.trtllm.w4a8_mxfp4_fp8_gemm.default,
         torch.ops.trtllm.finegrained_mixed_dtype_gemm.default,

--- a/tensorrt_llm/_torch/compilation/utils.py
+++ b/tensorrt_llm/_torch/compilation/utils.py
@@ -69,6 +69,9 @@ def inplace_info():
             1: "input",
             2: "residual"
         },
+        torch.ops.trtllm.nvfp4_gemm_out.default: {
+            1: "output"
+        },
         torch.ops.trtllm.flashinfer_fused_add_rmsnorm_quant.default: {
             1: "out",
             2: "residual"

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -608,6 +608,25 @@ class FP4GemmRunner(TunableRunner):
         )
         return out
 
+    def forward_out(
+        self,
+        inputs: List[torch.Tensor],
+        output: torch.Tensor,
+        tactic: int = -1,
+        bias: Optional[torch.Tensor] = None,
+    ) -> None:
+        mat1, mat2, mat1_scale, mat2_scale, global_scale = inputs
+        self.fp4_gemm_runner.run_gemm_out(
+            mat1,
+            mat2,
+            mat1_scale,
+            mat2_scale,
+            global_scale,
+            output,
+            tactic,
+            bias,
+        )
+
 
 class CublasLtFP4GemmRunner(TunableRunner):
     """CublasLt-based FP4 GEMM runner with auto-tuning support.
@@ -1195,6 +1214,21 @@ class NVFP4GemmUnifiedRunner(TunableRunner):
             raise ValueError(f"Invalid tactic: {tactic}")
 
 
+@lru_cache(maxsize=None)
+def _get_nvfp4_gemm_out_runners(
+    output_dtype: torch.dtype,
+) -> Tuple[NVFP4GemmUnifiedRunner, FP4GemmRunner]:
+    return (
+        NVFP4GemmUnifiedRunner(int(BufferKind.DEFAULT), output_dtype,
+                               ["cutlass"]),
+        FP4GemmRunner(
+            fp4_utils.FP4GemmType.W4A4_NVFP4_NVFP4,
+            int(BufferKind.DEFAULT),
+            output_dtype,
+        ),
+    )
+
+
 @fast_custom_op("trtllm::nvfp4_gemm", mutates_args=())
 def nvfp4_gemm(
     act_fp4: torch.Tensor,
@@ -1296,6 +1330,57 @@ def nvfp4_gemm(
         tactic=best_tactic,
         bias=bias,
     )
+
+
+@fast_custom_op("trtllm::nvfp4_gemm_out", mutates_args=("output", ))
+def nvfp4_gemm_out(
+    act_fp4: torch.Tensor,
+    weight: torch.Tensor,
+    act_sf: torch.Tensor,
+    weight_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    output: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+) -> None:
+    """Run the tuned CUTLASS NVFP4 GEMM into caller-owned storage."""
+    runner, output_runner = _get_nvfp4_gemm_out_runners(output.dtype)
+    inputs = [act_fp4, weight, act_sf, weight_scale, alpha]
+    tuner = AutoTuner.get()
+    try:
+        _, best_tactic = tuner.choose_one(
+            "trtllm::nvfp4_gemm::gemm",
+            [runner],
+            NVFP4GemmUnifiedRunner.tuning_config,
+            inputs,
+            bias=bias,
+        )
+    except IndexError as e:
+        raise RuntimeError(
+            "AutoTuner failed to find a CUTLASS tactic for caller-owned "
+            f"NVFP4 output with M={act_fp4.shape[0]}, "
+            f"K={act_fp4.shape[1] * 2}, N={weight.shape[0]}") from e
+
+    if best_tactic == -1:
+        best_tactic = ("cutlass", -1)
+    backend, sub_tactic = best_tactic
+    if backend != "cutlass":
+        raise RuntimeError(
+            f"caller-owned NVFP4 output requires CUTLASS, got {backend}")
+    output_runner.forward_out(
+        inputs, output, tactic=sub_tactic, bias=bias)
+
+
+@nvfp4_gemm_out.register_fake
+def _(
+    act_fp4: torch.Tensor,
+    weight: torch.Tensor,
+    act_sf: torch.Tensor,
+    weight_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    output: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+) -> None:
+    return None
 
 
 @nvfp4_gemm.register_fake
@@ -2081,9 +2166,13 @@ def _(
     return x.new_empty((b, d), dtype=o_dtype)
 
 
+_NcclWindowKey = Tuple[Tuple[int, ...], str, int, torch.dtype, int]
+
+
 class AllReduceRunner(TunableRunner):
     _prealloc_lock: ClassVar[threading.Lock] = threading.Lock()
     _prealloc_done: ClassVar[set] = set()
+    _preallocated_windows: ClassVar[dict[_NcclWindowKey, int]] = {}
     # Set from AllReduce.__init__ via extra_attrs when the model is built.
     _prealloc_max_num_tokens: ClassVar[Optional[int]] = None
     _prealloc_hidden_size: ClassVar[Optional[int]] = None
@@ -2119,6 +2208,58 @@ class AllReduceRunner(TunableRunner):
             self.input_uses_nccl_window,
         )
 
+    @staticmethod
+    def _nccl_window_key(
+        group: List[int],
+        device: torch.device,
+        dtype: torch.dtype,
+        hidden_size: int,
+    ) -> _NcclWindowKey:
+        return (
+            tuple(sorted(int(rank) for rank in group)),
+            device.type,
+            -1 if device.index is None else int(device.index),
+            dtype,
+            int(hidden_size),
+        )
+
+    @classmethod
+    def has_reserved_nccl_window(cls, input: torch.Tensor,
+                                 group: List[int]) -> bool:
+        key = cls._nccl_window_key(group, input.device, input.dtype,
+                                   input.size(-1))
+        with cls._prealloc_lock:
+            return bool(cls._preallocated_windows.get(key, 0))
+
+    @classmethod
+    def mark_nccl_window_preallocated(
+        cls, group: List[int], buffers: List[torch.Tensor]
+    ) -> Tuple[_NcclWindowKey, ...]:
+        """Suppress model-maximum preallocation for reserved signatures."""
+        keys = tuple(
+            dict.fromkeys(
+                cls._nccl_window_key(group, buffer.device, buffer.dtype,
+                                     buffer.size(-1))
+                for buffer in buffers))
+        with cls._prealloc_lock:
+            for key in keys:
+                cls._preallocated_windows[key] = (
+                    cls._preallocated_windows.get(key, 0) + 1)
+        return keys
+
+    @classmethod
+    def unmark_nccl_window_preallocated(
+        cls, keys: Tuple[_NcclWindowKey, ...]
+    ) -> None:
+        """Release signature markers owned by one engine pool."""
+        with cls._prealloc_lock:
+            for key in keys:
+                count = cls._preallocated_windows.get(key, 0)
+                if count <= 1:
+                    cls._preallocated_windows.pop(key, None)
+                else:
+                    cls._preallocated_windows[key] = count - 1
+
     @classmethod
     def _maybe_preallocate_buffers(cls,
                                    input_tensor: torch.Tensor,
@@ -2141,6 +2282,15 @@ class AllReduceRunner(TunableRunner):
                 # If capture status can't be queried, avoid prealloc to be safe.
                 return
 
+        prealloc_hidden_size = (
+            hidden_size if hidden_size is not None else input_tensor.size(-1))
+        prealloc_dtype = dtype if dtype is not None else input_tensor.dtype
+        preallocated_key = cls._nccl_window_key(
+            group, input_tensor.device, prealloc_dtype, prealloc_hidden_size)
+        with cls._prealloc_lock:
+            if cls._preallocated_windows.get(preallocated_key, 0):
+                return
+
         # If max_num_tokens and hidden_size are provided, pre-allocate at 2x
         # the model-configured size to give the NCCL window allocator extra
         # headroom beyond the nominal max shape.  dtype comes from the model
@@ -2151,7 +2301,7 @@ class AllReduceRunner(TunableRunner):
         if max_num_tokens is not None and hidden_size is not None:
             prealloc_input = torch.empty(
                 [2 * max_num_tokens, hidden_size],
-                dtype=dtype if dtype is not None else input_tensor.dtype,
+                dtype=prealloc_dtype,
                 device=input_tensor.device)
         else:
             prealloc_input = input_tensor
@@ -2159,8 +2309,7 @@ class AllReduceRunner(TunableRunner):
         num_tokens = int(prealloc_input.size(0))
         if num_tokens <= 0:
             return
-        group_key = tuple(group)
-        cache_key = (group_key, num_tokens)
+        cache_key = (preallocated_key, num_tokens)
         with cls._prealloc_lock:
             if cache_key in cls._prealloc_done:
                 return
@@ -2308,6 +2457,8 @@ def tunable_allreduce(
             return inputs
         if not isinstance(input_tensor,
                           torch.Tensor) or not input_tensor.is_cuda:
+            return inputs
+        if AllReduceRunner.has_reserved_nccl_window(input_tensor, group):
             return inputs
         nccl_symmetric_memory_window_tensor, actual_kind = torch.ops.trtllm.allocate_output(
             input_tensor, int(BufferKind.NCCL_WINDOW), group_list)

--- a/tensorrt_llm/_torch/distributed/nccl_window_tensor_pool.py
+++ b/tensorrt_llm/_torch/distributed/nccl_window_tensor_pool.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Engine-owned NCCL-window storage for zero-copy FP4 GEMM outputs."""
+
+import os
+from typing import Dict, List, Tuple
+
+import torch
+from torch import nn
+
+from tensorrt_llm.bindings.internal.thop import BufferKind
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
+
+_BufferSpec = Tuple[torch.device, torch.dtype, int]
+_Registration = Tuple[nn.Module, torch.Tensor, int, torch.dtype]
+_PreallocationKey = Tuple[Tuple[int, ...], str, int, torch.dtype, int]
+
+
+class NCCLWindowTensorPool:
+    """Own one persistent output buffer for each output signature.
+
+    The current FP4 application consumes each output before another eligible
+    GEMM with the same signature runs. That serialized lifetime lets all
+    eligible modules and CUDA graphs share one address. Supporting concurrent
+    producers will require an explicit workspace/lease contract instead.
+    """
+
+    def __init__(self, mapping: Mapping):
+        self.mapping = mapping
+        self.capacity = 0
+        self._registrations: List[_Registration] = []
+        self._buffers: List[torch.Tensor] = []
+        self._preallocation_keys: Tuple[_PreallocationKey, ...] = ()
+
+        requested = os.environ.get("TLLM_NCCL_WINDOW_TENSOR_POOL", "0") == "1"
+        zero_copy = os.environ.get("TLLM_NCCL_SYMMETRIC_ZERO_COPY", "1") == "1"
+        self.enabled = requested and zero_copy and mapping.tp_size > 1
+        self._log_stats = os.environ.get(
+            "TLLM_NCCL_WINDOW_TENSOR_POOL_LOG_STATS", "0") == "1"
+
+    def register(self, module: nn.Module, like: torch.Tensor,
+                 output_width: int, dtype: torch.dtype) -> None:
+        """Register a module buffer to bind when storage is reserved."""
+        if self.enabled:
+            self._registrations.append(
+                (module, like, int(output_width), dtype))
+
+    def disable(self) -> None:
+        self.clear()
+        self.enabled = False
+
+    def reserve(self, capacity: int) -> None:
+        """Allocate storage before tracing or CUDA-graph capture begins."""
+        if not self.enabled or not self._registrations:
+            return
+
+        capacity = int(capacity)
+        if capacity <= 0:
+            return
+        if self.capacity:
+            if capacity != self.capacity:
+                raise RuntimeError(
+                    "cannot resize NCCL-window output storage after reservation"
+                )
+            return
+
+        representatives: Dict[_BufferSpec, torch.Tensor] = {}
+        for _, like, output_width, dtype in self._registrations:
+            representatives.setdefault((like.device, dtype, output_width),
+                                       like)
+
+        buffers: Dict[_BufferSpec, torch.Tensor] = {}
+        ordered_specs = sorted(
+            representatives,
+            key=lambda spec: (spec[0].type, spec[0].index or -1,
+                              str(spec[1]), spec[2]),
+        )
+        for device, dtype, output_width in ordered_specs:
+            spec = (device, dtype, output_width)
+            output = self._allocate(representatives[spec], capacity,
+                                    output_width, dtype)
+            if output is not None:
+                buffers[spec] = output
+
+        # Keep allocation calls rank-symmetric and enable the optimization only
+        # when every signature received NCCL-window storage.
+        if len(buffers) != len(representatives):
+            return
+
+        for output in buffers.values():
+            self._preallocate_spare(output)
+
+        for module, like, output_width, dtype in self._registrations:
+            module._nccl_window_output = buffers[(like.device, dtype,
+                                                  output_width)]
+
+        self._buffers = list(buffers.values())
+        self.capacity = capacity
+
+        # The retained GEMM buffer and one cached all-reduce result buffer
+        # replace AllReduceRunner's much larger model-maximum preallocation.
+        self._preallocation_keys = self._mark_group_preallocated()
+        if self._log_stats:
+            logger.info(
+                "NCCL window Tensor pool reserved: "
+                f"capacity={self.capacity}, "
+                f"registrations={len(self._registrations)}, "
+                f"buffers={len(self._buffers)}")
+
+    def _allocate(self, like: torch.Tensor, capacity: int, output_width: int,
+                  dtype: torch.dtype) -> torch.Tensor | None:
+        output, actual_kind = torch.ops.trtllm.allocate_output(
+            like,
+            int(BufferKind.NCCL_WINDOW),
+            self.mapping.tp_group,
+            [capacity, output_width],
+            dtype,
+        )
+        if int(actual_kind) != int(BufferKind.NCCL_WINDOW):
+            return None
+        return output
+
+    def _preallocate_spare(self, output: torch.Tensor) -> None:
+        torch.ops.trtllm.preallocate_nccl_window_buffer(
+            output, self.mapping.tp_group, 1)
+
+    def _mark_group_preallocated(self) -> Tuple[_PreallocationKey, ...]:
+        from ..custom_ops.torch_custom_ops import AllReduceRunner
+
+        return AllReduceRunner.mark_nccl_window_preallocated(
+            self.mapping.tp_group, self._buffers)
+
+    def _unmark_group_preallocated(
+            self, keys: Tuple[_PreallocationKey, ...]) -> None:
+        from ..custom_ops.torch_custom_ops import AllReduceRunner
+
+        AllReduceRunner.unmark_nccl_window_preallocated(keys)
+
+    def clear(self) -> None:
+        """Drop module references before releasing retained Tensor wrappers."""
+        if self._log_stats and self.enabled:
+            logger.info(
+                "NCCL window Tensor pool cleared: "
+                f"capacity={self.capacity}, "
+                f"registrations={len(self._registrations)}, "
+                f"buffers={len(self._buffers)}")
+        keys = self._preallocation_keys
+        self._preallocation_keys = ()
+        if keys:
+            self._unmark_group_preallocated(keys)
+        for module, _, _, _ in self._registrations:
+            module._nccl_window_output = None
+        self._buffers.clear()
+        self._registrations.clear()
+        self.capacity = 0

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -13,7 +13,8 @@ from torch import nn
 from torch.nn.parameter import Parameter
 
 import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
-from tensorrt_llm._torch.custom_ops.torch_custom_ops import BufferKind
+from tensorrt_llm._torch.custom_ops.torch_custom_ops import (BufferKind,
+                                                             nvfp4_gemm_out)
 from tensorrt_llm._torch.peft.lora.layer import LoraLayer
 from tensorrt_llm._utils import is_device_integrated, mpi_disabled
 from tensorrt_llm.bindings import ipc_nvls_supported
@@ -1458,6 +1459,19 @@ class NVFP4LinearMethod(LinearMethodBase):
         if bias is not None and not fuse_bias_in_gemm:
             output = output + bias
         return output
+
+    def apply_out(self, module: Linear, input: torch.Tensor,
+                  output: torch.Tensor) -> None:
+        """Write a 2-D CUTLASS NVFP4 result into caller-owned storage."""
+        act_fp4, act_sf, alpha = self._input_prepare(module, input)
+        nvfp4_gemm_out(
+            act_fp4,
+            module.weight,
+            act_sf,
+            module.weight_scale,
+            alpha,
+            output,
+        )
 
     def apply_linear_allreduce(self, module: Linear, input: torch.Tensor,
                                bias: Optional[torch.Tensor], tp_rank: int,
@@ -3245,6 +3259,7 @@ class Linear(nn.Module):
         self.all_reduce = AllReduce(mapping=self.mapping,
                                     strategy=allreduce_strategy,
                                     dtype=self.dtype) if reduce_output else None
+        self.register_buffer("_nccl_window_output", None, persistent=False)
 
         self._weights_created = False
         self._weights_transformed = False
@@ -3368,6 +3383,20 @@ class Linear(nn.Module):
         return self.quant_config is not None and self.quant_config.layer_quant_mode.has_mxfp8(
         )
 
+    def _can_use_nccl_window_output(self) -> bool:
+        return (
+            self.tp_mode == TensorParallelMode.ROW and self.reduce_output
+            and self.all_reduce is not None
+            and isinstance(self.quant_method, NVFP4LinearMethod)
+            and self.quant_method.
+            supports_nccl_symmetric_memory_window_output
+            and self.nvfp4_allowed_backends == ['cutlass']
+            and self.weight.shape[0] == self.out_features
+            and self.bias is None
+            and not self.use_fused_gemm_allreduce
+            and (self.all_reduce.uses_nccl_symmetric_memory_window()
+                 or self.all_reduce.strategy == AllReduceStrategy.AUTO))
+
     def apply_linear(self,
                      input,
                      bias,
@@ -3427,23 +3456,34 @@ class Linear(nn.Module):
                     fuse_bias = self._maybe_fuse_bias_into_allreduce(
                         bias, all_reduce_params)
                     bias = None if fuse_bias else bias
-                    # Write GEMM output directly into the NCCL window buffer when
-                    # available so allreduce reads it without a copy. apply()
-                    # derives output_buffer_kind from supports_nccl_symmetric_memory_window_output
-                    # (ClassVar); a failed window allocation falls back gracefully
-                    # inside the C++ allocate_output.
-                    use_nccl_symmetric_memory_window = (
-                        self.all_reduce is not None and self.quant_method.
-                        supports_nccl_symmetric_memory_window_output
-                        and self.all_reduce.uses_nccl_symmetric_memory_window()
-                        and not (self.lora is not None and lora_params))
-                    if use_nccl_symmetric_memory_window:
-                        output = self.quant_method.apply(self, input, bias)
-                    else:
-                        output = self.apply_linear(input, bias, lora_params,
-                                                   layer_idx)
-                    output = self.all_reduce(
-                        output, all_reduce_params=all_reduce_params)
+                    scratch = self._nccl_window_output
+                    scratch_output_used = False
+                    if scratch is not None:
+                        input_tensor = (input.fp4_tensor if isinstance(
+                            input, Fp4QuantizedTensor) else input[0]
+                                        if isinstance(input, tuple) else input)
+                        if (input_tensor.dim() == 2 and input_tensor.shape[0]
+                                <= scratch.shape[0]):
+                            self.quant_method.apply_out(self, input, scratch)
+                            output = scratch.narrow(0, 0,
+                                                    input_tensor.shape[0])
+                            output = self.all_reduce(
+                                output, all_reduce_params=all_reduce_params)
+                            scratch_output_used = True
+                    if not scratch_output_used:
+                        use_nccl_symmetric_memory_window = (
+                            self.all_reduce is not None and self.quant_method.
+                            supports_nccl_symmetric_memory_window_output
+                            and self.all_reduce.
+                            uses_nccl_symmetric_memory_window() and not (
+                                self.lora is not None and lora_params))
+                        if use_nccl_symmetric_memory_window:
+                            output = self.quant_method.apply(self, input, bias)
+                        else:
+                            output = self.apply_linear(input, bias, lora_params,
+                                                       layer_idx)
+                        output = self.all_reduce(
+                            output, all_reduce_params=all_reduce_params)
             else:
                 output = self.apply_linear(input, bias, lora_params, layer_idx)
         elif self.tp_mode == TensorParallelMode.COLUMN:

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -49,8 +49,10 @@ from ..compilation.backend import Backend
 from ..compilation.utils import capture_piecewise_cuda_graph
 from ..distributed import Distributed
 from ..distributed.communicator import init_pp_comm
+from ..distributed.nccl_window_tensor_pool import NCCLWindowTensorPool
 from ..expert_statistic import ExpertStatistic
 from ..memory_buffer_utils import clear_memory_buffers, with_shared_pool
+from ..modules.linear import Linear
 from ..metadata import KVCacheParams
 from ..models.checkpoints.base_checkpoint_loader import BaseCheckpointLoader
 from ..models.modeling_multimodal_encoder import MultimodalEncoderMixin
@@ -297,6 +299,7 @@ class PyTorchModelEngine(ModelEngine):
             )
 
         self.mapping = mapping
+        self.nccl_window_tensor_pool = NCCLWindowTensorPool(mapping)
         if mapping.has_pp():
             init_pp_comm(mapping)
         # Start with the established pool size. Once the model is loaded we
@@ -405,6 +408,14 @@ class PyTorchModelEngine(ModelEngine):
             self.model_is_wrapped = True
         else:
             self.model_is_wrapped = False
+        if self.llm_args.lora_config is None:
+            for module in self.model.modules():
+                if (isinstance(module, Linear)
+                        and module._can_use_nccl_window_output()
+                        and module.mapping.tp_group
+                        == self.mapping.tp_group):
+                    self.nccl_window_tensor_pool.register(
+                        module, module.weight, module.out_features, module.dtype)
         self.sparse_attention_config = self.model.model_config.sparse_attention_config
         # In case that some tests use stub models and override `_load_model`.
         if not hasattr(self.model, 'extra_attrs'):
@@ -478,6 +489,9 @@ class PyTorchModelEngine(ModelEngine):
             'enable_userbuffers'].default
         torch_compile_max_num_streams = self.torch_compile_config.max_num_streams if self.torch_compile_config is not None else TorchCompileConfig.model_fields[
             'max_num_streams'].default
+        if torch_compile_enabled and torch_compile_max_num_streams > 1:
+            # One shared address requires serialized producer/consumer use.
+            self.nccl_window_tensor_pool.disable()
 
         self._torch_compile_enabled = torch_compile_enabled
         self._torch_compile_piecewise_cuda_graph = torch_compile_piecewise_cuda_graph
@@ -1067,15 +1081,22 @@ class PyTorchModelEngine(ModelEngine):
                 )
                 return
 
-        # Create AutoTuner singleton in eager context before any compiled forward.
-        # Otherwise the first get() can happen inside torch.compile tracing and
-        # trigger non-traceable code (time.time(), torch.cuda.*) in the cache.
-        AutoTuner.get()
-
         can_run_general_warmup = (
             not is_enc_dec and not self.is_draft_model
             and not self.mapping.has_cp_helix() and self.guided_decoder is None
             and not isinstance(kv_cache_manager, MambaHybridCacheManager))
+
+        # Reserve exactly the largest output requested by the warmup/capture
+        # plan. This avoids coupling the pool to max_num_tokens while still
+        # binding one stable address before torch.compile or CUDA graph capture.
+        requested_capacity = self._get_nccl_window_tensor_capacity(
+            resource_manager, can_run_general_warmup)
+        self.nccl_window_tensor_pool.reserve(requested_capacity)
+
+        # Create AutoTuner singleton in eager context before any compiled forward.
+        # Otherwise the first get() can happen inside torch.compile tracing and
+        # trigger non-traceable code (time.time(), torch.cuda.*) in the cache.
+        AutoTuner.get()
 
         log_mem_snapshot("warmup/before_warmup")
         if not is_enc_dec:
@@ -1367,6 +1388,40 @@ class PyTorchModelEngine(ModelEngine):
                 draft_len = 0
             mapping[graph_bs] = draft_len
         return mapping
+
+    def _get_nccl_window_tensor_capacity(
+            self, resource_manager: ResourceManager,
+            include_general_warmup: bool) -> int:
+        """Return the largest output shape requested before runtime.
+
+        General warmups cover eager context/chunked-prefill shapes; CUDA graph
+        captures cover generation shapes.  Deriving capacity from those actual
+        requests keeps the pool independent of the configured token ceiling.
+        """
+        requested_tokens: List[int] = []
+        if include_general_warmup:
+            requested_tokens.extend(
+                num_tokens for num_tokens, _ in
+                self._get_full_general_warmup_requests(resource_manager))
+
+        if self.cuda_graph_runner.enabled:
+            spec_resource_manager = resource_manager.get_resource_manager(
+                ResourceManagerType.SPEC_RESOURCE_MANAGER)
+            graphs_to_capture = self._get_graphs_to_capture(
+                self._cuda_graph_batch_sizes, spec_resource_manager)
+            if (self.is_draft_model and self.model_is_wrapped
+                    and isinstance(spec_resource_manager,
+                                   Eagle3ResourceManager)):
+                graphs_to_capture = [
+                    (batch_size, self.original_max_draft_len)
+                    for batch_size, _ in graphs_to_capture
+                ]
+            requested_tokens.extend(
+                batch_size * self.max_beam_width * (draft_len + 1)
+                for batch_size, draft_len in graphs_to_capture
+                if batch_size <= self.batch_size)
+
+        return max(requested_tokens, default=0)
 
     def _get_graphs_to_capture(
         self, cuda_graph_batch_sizes: list[int],
@@ -2275,6 +2330,10 @@ class PyTorchModelEngine(ModelEngine):
         self.model = None
 
         self._release_cuda_graphs()
+        nccl_window_tensor_pool = getattr(self, 'nccl_window_tensor_pool', None)
+        if nccl_window_tensor_pool is not None:
+            nccl_window_tensor_pool.clear()
+            self.nccl_window_tensor_pool = None
         self.input_processor = None
         self.input_processor_with_hash = None
 

--- a/tests/unittest/_torch/custom_ops/test_nvfp4_gemm_out.py
+++ b/tests/unittest/_torch/custom_ops/test_nvfp4_gemm_out.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from utils.util import skip_pre_blackwell
+
+import tensorrt_llm._torch.custom_ops  # noqa: F401
+from tensorrt_llm._torch.autotuner import autotune
+from tensorrt_llm._torch.compilation.backend import Backend
+
+
+def _make_operands(dtype: torch.dtype):
+    torch.manual_seed(0)
+    activation = torch.randn((4, 128), dtype=dtype, device="cuda")
+    weight = torch.randn((192, 128), dtype=dtype, device="cuda")
+    activation_scale = (448 * 6) / activation.abs().max().float()
+    weight_scale = (448 * 6) / weight.abs().max().float()
+    activation_fp4, activation_sf = torch.ops.trtllm.fp4_quantize(
+        activation, activation_scale, 16, False)
+    weight_fp4, weight_sf = torch.ops.trtllm.fp4_quantize(
+        weight, weight_scale, 16, False)
+    alpha = torch.reciprocal(activation_scale * weight_scale).reshape(1)
+    return activation_fp4, weight_fp4, activation_sf, weight_sf, alpha
+
+
+@skip_pre_blackwell
+def test_nvfp4_gemm_out_compile_and_cuda_graph():
+    operands = _make_operands(torch.bfloat16)
+
+    with torch.inference_mode(), autotune():
+        reference = torch.ops.trtllm.nvfp4_gemm(
+            *operands,
+            output_dtype=torch.bfloat16,
+            allowed_backends="cutlass",
+        )
+        eager_base = reference.new_empty((8, reference.size(1)))
+        torch.ops.trtllm.nvfp4_gemm_out(*operands, eager_base)
+        eager_output = eager_base.narrow(0, 0, reference.size(0))
+
+    torch.testing.assert_close(eager_output,
+                               reference,
+                               rtol=1e-2,
+                               atol=0.15)
+
+    def run_out(act_fp4, weight, act_sf, weight_sf, alpha, output):
+        torch.ops.trtllm.nvfp4_gemm_out(act_fp4, weight, act_sf, weight_sf,
+                                        alpha, output)
+        return output.narrow(0, 0, act_fp4.size(0))
+
+    compiled_base = reference.new_empty((8, reference.size(1)))
+    compiled = torch.compile(
+        run_out, backend=Backend(enable_inductor=False), fullgraph=True)
+    with torch.inference_mode():
+        compiled_result = compiled(*operands, compiled_base)
+    assert compiled_result.data_ptr() == compiled_base.data_ptr()
+    torch.testing.assert_close(compiled_result,
+                               reference,
+                               rtol=1e-2,
+                               atol=0.15)
+
+    graph_base = reference.new_empty((8, reference.size(1)))
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        torch.ops.trtllm.nvfp4_gemm_out(*operands, graph_base)
+    graph.replay()
+    torch.cuda.synchronize()
+    graph_output = graph_base.narrow(0, 0, reference.size(0))
+    torch.testing.assert_close(graph_output,
+                               reference,
+                               rtol=1e-2,
+                               atol=0.15)

--- a/tests/unittest/_torch/distributed/test_nccl_window_tensor_pool.py
+++ b/tests/unittest/_torch/distributed/test_nccl_window_tensor_pool.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.distributed.nccl_window_tensor_pool import \
+    NCCLWindowTensorPool
+from tensorrt_llm.mapping import Mapping
+
+
+class _FakeLinear(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("_nccl_window_output", None, persistent=False)
+
+
+def _make_pool(monkeypatch):
+    monkeypatch.setenv("TLLM_NCCL_WINDOW_TENSOR_POOL", "1")
+    monkeypatch.setenv("TLLM_NCCL_SYMMETRIC_ZERO_COPY", "1")
+    mapping = Mapping(world_size=2, rank=0, tp_size=2)
+    pool = NCCLWindowTensorPool(mapping)
+
+    allocations = []
+    spares = []
+    marked = []
+    unmarked = []
+
+    def _allocate(like, capacity, output_width, dtype):
+        allocations.append((capacity, output_width, dtype, like.device))
+        return torch.empty((capacity, output_width), dtype=dtype)
+
+    monkeypatch.setattr(pool, "_allocate", _allocate)
+    monkeypatch.setattr(pool, "_preallocate_spare", spares.append)
+
+    def _mark_group_preallocated():
+        marked.append(True)
+        return ("marker", )
+
+    monkeypatch.setattr(pool, "_mark_group_preallocated",
+                        _mark_group_preallocated)
+    monkeypatch.setattr(pool, "_unmark_group_preallocated", unmarked.append)
+    return pool, allocations, spares, marked, unmarked
+
+
+def test_reserve_uses_exact_capacity_and_shares_output_signatures(monkeypatch):
+    pool, allocations, spares, marked, _ = _make_pool(monkeypatch)
+    first = _FakeLinear()
+    second = _FakeLinear()
+    other_width = _FakeLinear()
+    like = torch.empty(0, dtype=torch.bfloat16)
+
+    pool.register(first, like, 16, torch.bfloat16)
+    pool.register(second, like, 16, torch.bfloat16)
+    pool.register(other_width, like, 32, torch.bfloat16)
+    pool.reserve(7)
+
+    assert allocations == [
+        (7, 16, torch.bfloat16, torch.device("cpu")),
+        (7, 32, torch.bfloat16, torch.device("cpu")),
+    ]
+    assert first._nccl_window_output is second._nccl_window_output
+    assert first._nccl_window_output.shape == (7, 16)
+    assert other_width._nccl_window_output.shape == (7, 32)
+    assert len(spares) == 2
+    assert marked == [True]
+    assert pool.capacity == 7
+    assert "_nccl_window_output" not in first.state_dict()
+
+    allocation_count = len(allocations)
+    pool.reserve(7)
+    assert len(allocations) == allocation_count
+    with pytest.raises(RuntimeError, match="cannot resize"):
+        pool.reserve(8)
+
+
+def test_reserve_is_all_or_nothing(monkeypatch):
+    pool, _, spares, marked, _ = _make_pool(monkeypatch)
+    first = _FakeLinear()
+    second = _FakeLinear()
+    like = torch.empty(0, dtype=torch.float16)
+
+    pool.register(first, like, 16, torch.float16)
+    pool.register(second, like, 32, torch.float16)
+
+    def _allocate(like, capacity, output_width, dtype):
+        if output_width == 16:
+            return torch.empty((capacity, output_width), dtype=dtype)
+        return None
+
+    monkeypatch.setattr(pool, "_allocate", _allocate)
+    pool.reserve(5)
+
+    assert first._nccl_window_output is None
+    assert second._nccl_window_output is None
+    assert pool.capacity == 0
+    assert not pool._buffers
+    assert not spares
+    assert not marked
+
+
+def test_clear_releases_module_references(monkeypatch):
+    pool, _, _, _, unmarked = _make_pool(monkeypatch)
+    module = _FakeLinear()
+    like = torch.empty(0, dtype=torch.float16)
+    pool.register(module, like, 16, torch.float16)
+    pool.reserve(3)
+
+    retained = module._nccl_window_output
+    assert retained is not None
+    assert retained.narrow(0, 0, 1).data_ptr() == retained.data_ptr()
+
+    pool.clear()
+
+    assert module._nccl_window_output is None
+    assert pool.capacity == 0
+    assert not pool._buffers
+    assert not pool._registrations
+    assert unmarked == [("marker", )]
+
+
+def test_disabled_pool_does_not_register_or_allocate(monkeypatch):
+    monkeypatch.delenv("TLLM_NCCL_WINDOW_TENSOR_POOL", raising=False)
+    mapping = Mapping(world_size=2, rank=0, tp_size=2)
+    pool = NCCLWindowTensorPool(mapping)
+    module = _FakeLinear()
+
+    pool.register(module, torch.empty(0), 16, torch.float32)
+    pool.reserve(4)
+
+    assert not pool.enabled
+    assert not pool._registrations
+    assert module._nccl_window_output is None


### PR DESCRIPTION
@coderabbitai summary

## Description

  Zero-copy FP4 row-parallel allreduce was still creating a fresh Python `Tensor`
  wrapper for each NCCL-window GEMM output. Although the underlying C++ allocator
  can reuse NCCL-window memory, repeatedly crossing the Python/C++ allocation
  boundary and recreating wrappers adds CPU-side overhead on the critical path.

  This change introduces an engine-owned `NCCLWindowTensorPool` for eligible
  NVFP4 CUTLASS row-parallel `Linear` outputs:

  - Allocates NCCL-window storage through the existing C++ allocator, preserving
    its registration and reuse contract.
  - Retains complete Python `Tensor` wrappers for the engine lifetime instead of
    recreating them per GEMM.
  - Shares one persistent buffer across serialized producers with the same
    `(device, dtype, output_width)` signature.
  - Reserves request-derived capacity before warmup, compilation, or CUDA-graph
    capture, so captured tensor addresses remain stable.
  - Writes GEMM results directly into the pooled tensor through
    `nvfp4_gemm_out`, then immediately consumes that tensor in allreduce.
  - Enables the pool for AUTO allreduce selection, so AUTO does not pay the
    allocating zero-copy path’s wrapper/allocation overhead.
  - Cleans up module references and allreduce preallocation state during engine
    teardown.

  This improves performance, especially for small models like: TP4 Llama-3.3-70B FP4 workload (512 ISL / 32 OSL)

  ## Test Coverage

  - `tests/unittest/_torch/distributed/test_nccl_window_tensor_pool.py`
    - exact request-derived reservation capacity;
    - sharing buffers by output signature;
    - all-or-nothing reservation behavior;
    - teardown releases retained module references;
    - disabled-pool behavior.

  - `tests/unittest/_torch/custom_ops/test_nvfp4_gemm_out.py`
    - caller-owned NVFP4 output matches allocating output;
    - `torch.compile` compatibility;
    - CUDA-graph capture/replay correctness.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
