### PR TITLE
[None][feat] Append git commit hash to version for editable installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 import os
 import platform
+import re
+import subprocess
+import sys
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -69,6 +72,23 @@ def get_version():
 
     if version is None:
         raise RuntimeError(f"Could not set version from {version_file}")
+
+    # For develop / editable installs (`pip install -e .` or
+    # `python setup.py develop`), append the git commit hash as a PEP 440
+    # local version segment so the installed package is identifiable,
+    # e.g. "1.3.0rc21+58d8964d13".
+    is_develop = any(arg in sys.argv for arg in ("develop", "editable_wheel"))
+    if is_develop:
+        try:
+            commit = subprocess.check_output(
+                ["git", "rev-parse", "--short=10", "HEAD"],
+                cwd=Path(__file__).resolve().parent,
+                stderr=subprocess.DEVNULL).decode().strip()
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+            commit = ""
+        commit = re.sub(r"[^A-Za-z0-9.]", "", commit)
+        if commit:
+            version = f"{version}+{commit}"
 
     return version
 


### PR DESCRIPTION
## Description

For develop/editable installs (`pip install -e .` or `python setup.py develop`), append the git commit hash as a PEP 440 local version segment, e.g. `1.3.0rc21+58d8964d13`, mirroring how PyTorch dev builds are versioned.

This makes an editable-installed `tensorrt_llm` identifiable from `tensorrt_llm.__version__` alone — useful when multiple source checkouts/branches are in play (e.g. one editable install per worktree) and you need to know which commit a running server or benchmark was built from.

Behavior:
- Only affects `develop` / `editable_wheel` invocations; regular wheel builds keep the plain version.
- Falls back silently to the plain version if git is unavailable or the checkout has no HEAD.

## Test Coverage

Manually verified: `pip install -e .` yields `tensorrt_llm.__version__ == "<version>+<10-char-hash>"`; a regular wheel build keeps the unsuffixed version.

## PR Checklist
- [x] PR title follows the required format
- [x] PR description is explained
- [x] Commit is signed off (DCO)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development and editable installations now include the current source revision in the application version when available.
  * Version information remains compatible with standard package versioning.
  * Installations continue to work normally when revision details cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->