### PR TITLE
[None][infra] Use main as waive target branch in push event

### DIFF
--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -330,7 +330,11 @@ def mergeWaiveList(pipeline, globalVars)
 
     // Get TOT waive list
     LLM_TOT_ROOT = "llm-tot"
-    targetBranch = env.gitlabTargetBranch ? env.gitlabTargetBranch : globalVars[TARGET_BRANCH]
+    def targetBranch = env.gitlabTargetBranch ? env.gitlabTargetBranch : globalVars[TARGET_BRANCH]
+    if (env.gitlabTargetBranch == env.gitlabSourceBranch) {
+        // The pipeline is triggered by a GitLab push, not a merge request. Use main as target branch to get the TOT waive list.
+        targetBranch = "main"
+    }
     echo "Target branch: ${targetBranch}"
 
     def targetBranchTOTCommit = ""

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -331,7 +331,7 @@ def mergeWaiveList(pipeline, globalVars)
     // Get TOT waive list
     LLM_TOT_ROOT = "llm-tot"
     def targetBranch = env.gitlabTargetBranch ? env.gitlabTargetBranch : globalVars[TARGET_BRANCH]
-    if (env.gitlabTargetBranch == env.gitlabSourceBranch) {
+    if (env.gitlabActionType == "PUSH" && env.gitlabTargetBranch == env.gitlabSourceBranch) {
         // The pipeline is triggered by a GitLab push, not a merge request. Use main as target branch to get the TOT waive list.
         targetBranch = "main"
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge request pipeline handling for push-triggered builds.
  * TOT waive-list retrieval now correctly uses the main branch when source and target branches are identical.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

We trigger the L0_PostMerge pipeline by gitlab push webhook event. When we want to trigger the L0_PostMerge from a internal branch in gitlab repo, the “Merge Test Waive List” stage will fail in this case. Because the stage needs to read the TOT waive list of target branch from Github, while there is no such target branch in Github. 

In this PR, we change the target branch of “Merge Test Waive List” stage  to main branch when it's trigger by a push event.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Before:
[Build link](https://prod.blsm.nvidia.com/sw-tensorrt-top-1/blue/organizations/jenkins/LLM%2Fhelpers%2Fweimin_dev%2FL0_PostMerge/detail/L0_PostMerge/2/pipeline/66/)

The “Merge Test Waive List” stage  failed on fetch TOT waive list from Github:

<img width="1101" height="628" alt="image" src="https://github.com/user-attachments/assets/e4f08bbe-5e07-49e1-9791-a07415fe0e44" />

With this PR:

[Build link](https://prod.blsm.nvidia.com/sw-tensorrt-top-1/blue/organizations/jenkins/LLM%2Fhelpers%2Fweimin_dev%2FL0_PostMerge/detail/L0_PostMerge/7/pipeline/66/)


<img width="943" height="696" alt="image" src="https://github.com/user-attachments/assets/24d01298-ad53-40b9-a1a6-e0265496dd7b" />



## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
