### PR TITLE
[https://nvbugs/6433809][test] Guard Cutlass MoE TorchBind schema arity

### DIFF
--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -39,6 +39,7 @@ l0_h100:
   - unittest/_torch/modules/test_moe_host_sharer.py
   - unittest/_torch/modules/fused_moe/test_deepgemm_fused_gather_finalize.py
   - unittest/_torch/modules/fused_moe/test_deepgemm_fused_expand_quant.py
+  - unittest/_torch/modules/moe/test_cutlass_moe_op_smoke.py::test_cutlass_moe_op_run_moe_matches_torchbind_schema_arity
   # ------------- MoE: test_moe_backend (by backend) ---------------
   # ------------- MoE: test_single_gpu (by backend) ---------------
   - unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "CUTLASS and not None"

--- a/tests/unittest/_torch/modules/moe/test_cutlass_moe_op_smoke.py
+++ b/tests/unittest/_torch/modules/moe/test_cutlass_moe_op_smoke.py
@@ -66,6 +66,80 @@ class _ModuleStub:
         self.unpadded_hidden_size = hidden_size
 
 
+class _FusedMoeRunnerCapture:
+    def __init__(self) -> None:
+        self.run_moe_args: tuple[object, ...] | None = None
+
+    def run_moe(self, *args: object) -> torch.Tensor:
+        self.run_moe_args = args
+        return torch.empty(0)
+
+
+class _MoERunnerStub:
+    def __init__(self, fused_moe_runner: _FusedMoeRunnerCapture) -> None:
+        self.fused_moe_runner = fused_moe_runner
+
+
+def _get_fused_moe_runner_schema(method_name: str) -> torch.FunctionSchema:
+    class_name = "__torch__.torch.classes.trtllm.FusedMoeRunner"
+    schemas = [
+        schema
+        for schema in torch._C._jit_get_custom_class_schemas()
+        if schema.name == method_name and str(schema.arguments[0].type) == class_name
+    ]
+    assert len(schemas) == 1, f"Expected one FusedMoeRunner.{method_name} schema, found {schemas}"
+    return schemas[0]
+
+
+@pytest.mark.skipif(
+    not _TRTLLM_AVAILABLE,
+    reason="Requires the built TensorRT-LLM C++ extension for its TorchBind schema.",
+)
+def test_cutlass_moe_op_run_moe_matches_torchbind_schema_arity() -> None:
+    """The Python caller must supply every argument required by TorchBind."""
+    from tensorrt_llm._torch.modules.fused_moe.ops.moe_op_cutlass import CutlassMoEOp
+
+    x = torch.empty(1, 1)
+    token_selected_slots = torch.empty(1, 1, dtype=torch.int32)
+    token_final_scales = torch.empty(1, 1)
+    w3_w1_weight = torch.empty(1, 2, 1)
+    w2_weight = torch.empty(1, 1, 1)
+    module = _ModuleStub(
+        w3_w1_weight=w3_w1_weight,
+        w2_weight=w2_weight,
+        top_k=1,
+        hidden_size=1,
+        activation_type=0,
+    )
+
+    runner_capture = _FusedMoeRunnerCapture()
+    op = CutlassMoEOp()
+    op.moe_runner = _MoERunnerStub(runner_capture)
+    op.gemm_tactics = [0, 0]
+    op.compute_moe(
+        module=module,
+        x=x,
+        token_selected_slots=token_selected_slots,
+        token_final_scales=token_final_scales,
+        w3_w1_weight=w3_w1_weight,
+        w3_w1_bias=None,
+        w2_weight=w2_weight,
+        w2_bias=None,
+        output_dtype=x.dtype,
+        quant_scales=[],
+        use_all_to_all=False,
+    )
+
+    schema = _get_fused_moe_runner_schema("run_moe")
+    expected_arg_count = len(schema.arguments) - 1  # Exclude the bound runner (`self`).
+    assert runner_capture.run_moe_args is not None
+    actual_arg_count = len(runner_capture.run_moe_args)
+    assert actual_arg_count == expected_arg_count, (
+        f"CutlassMoEOp supplied {actual_arg_count} arguments to FusedMoeRunner.run_moe, "
+        f"but its TorchBind schema requires {expected_arg_count}: {schema}"
+    )
+
+
 @requires_cuda_and_op
 def test_cutlass_moe_op_run_moe_no_lora_smoke():
     from tensorrt_llm._torch.modules.fused_moe.ops.moe_op_cutlass import CutlassMoEOp


### PR DESCRIPTION
## Description

[NVBug 6433809](https://nvbugspro.nvidia.com/bug/6433809) exposed a Python/TorchBind ABI regression in the Cutlass MoE path: the rc19/rc20 Python caller supplied 36 positional arguments while the loaded `FusedMoeRunner.run_moe` schema required 43, so TP4/EP4 WideEP initialization failed at the first omitted argument (`_37`).

Main already contains the production correction from #15330. This PR adds the missing regression guard:

- execute the real `CutlassMoEOp.compute_moe` Python call path with a capture runner;
- compare the supplied positional arity with the live TorchBind `FusedMoeRunner.run_moe` schema; and
- enroll that specific contract test in the H100 pre-merge test database.

This catches future C++ schema extensions that are not reflected in the Python caller without requiring a heavyweight model load.

## Test Coverage

- Exact rc.4 image before the caller correction: contract test failed as expected with `supplied 36 arguments ... schema requires 43`.
- Same exact image with the corrected caller mounted: `1 passed`.
- Exact TP4/EP4 WideEP configuration on four GB200 GPUs crossed executor initialization with zero `_37` errors and zero failed executor ranks, then registered `dynamo.prefill.generate`.
- `pre-commit run --files tests/unittest/_torch/modules/moe/test_cutlass_moe_op_smoke.py tests/integration/test_lists/test-db/l0_h100.yml` — passed all applicable hooks.
- Focused Python compilation, Ruff, Ruff format, YAML parsing/selector uniqueness, repository legacy lint, and `git diff --check` — passed.

The workstation's standalone pytest environment is missing `nvtx`, so local collection stops in the repository-wide `conftest` before reaching this test. The exact-image pytest A/B result above exercises the test itself; CI supplies the built extension and runtime dependencies.

## PR Checklist

- [x] I reviewed the checklist in the repository PR template. This change adds no API, dependency, ownership, or architecture-documentation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the Cutlass MoE smoke-test suite on H100 environments.
  * Added validation that MoE execution calls remain compatible with the registered TorchBind interface.
  * Improved detection of argument mismatches in CUDA/TensorRT-LLM MoE integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->