### PR TITLE
[https://nvbugs/6435112][test] Unwaive Wan 2.2 I2V perf sanity test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -341,7 +341,6 @@ perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_8k1k_c
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL] SKIP (https://nvbugs/6517846)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL] SKIP (https://nvbugs/6490049)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL] SKIP (https://nvbugs/6490049)
-perf/test_visual_gen_perf_sanity.py::test_visual_gen_e2e[vg_upload-wan22_i2v_a14b_blackwell-wan22_i2v_a14b_nvfp4_trtllm_cfg2_ulysses4] SKIP (https://nvbugs/6422339)
 test_doc.py::test_url_validity SKIP (https://nvbugs/6215684)
 test_e2e.py::test_draft_token_tree_quickstart_advanced_eagle3[Llama-3.1-8b-Instruct-llama-3.1-model/Llama-3.1-8B-Instruct-EAGLE3-LLaMA3.1-Instruct-8B] SKIP (https://nvbugs/6490033)
 test_e2e.py::test_draft_token_tree_quickstart_advanced_eagle3_depth_1_tree[Llama-3.1-8b-Instruct-llama-3.1-model/Llama-3.1-8B-Instruct-EAGLE3-LLaMA3.1-Instruct-8B] SKIP (https://nvbugs/6490033)


### PR DESCRIPTION
## Summary

- Remove the waiver for the Wan 2.2 I2V A14B NVFP4 TRT-LLM Ulysses-4 VisualGen perf-sanity test.
- Keep the test enabled in the B200 VisualGen perf-sanity test list.
- Leave all other waivers associated with NVBug 6422339 unchanged.

## Background

NVBug 6435112 tracks an NCCL ALLTOALL_BASE watchdog timeout in this exact test. The repair bot reran the test multiple times on B200 x8 against current main and all attempts passed, so this PR re-enables the test for full CI validation.

## NVBug context

This test was initially waived under NVBug 6422339, which groups multiple failures from Post-Merge #2824. NVBug 6435112 tracks this specific Wan 2.2 I2V NCCL timeout, so this PR is titled under 6435112 while removing the existing waiver linked to 6422339. Other 6422339 waivers are unchanged.

## Validation

- `pre-commit run --files tests/integration/test_lists/waives.txt`

## CI

Please run `DGX_B200-8_GPUs-PyTorch-VisualGen-PerfSanity-Post-Merge-1` to validate the previously flaky distributed test before closing NVBug 6435112.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an obsolete skip waiver for a visual generation performance sanity test, allowing the test case to run normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->