### PR TITLE
[https://nvbugs/6272598][fix] Replace the positive `isinstance(..., MpiPoolSession)` check with a negative…

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -573,7 +573,9 @@ class GenerationExecutorProxy(GenerationExecutor):
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
-        if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
+        if not isinstance(
+                self.mpi_session,
+            (MpiCommSession, RemoteMpiCommSessionClient)) and len(status) == 3:
             worker_process_identities: List[WorkerProcessIdentity] = status[2]
             self._worker_process_monitor.register(worker_process_identities)
 


### PR DESCRIPTION
## Summary
- **Root cause**: `isinstance(self.mpi_session, MpiPoolSession)` raises TypeError because tests/test_common/session_reuse.py monkey-patches MpiPoolSession in tensorrt_llm.executor.proxy to a factory function (not a class).
- **Fix**: Replace the positive `isinstance(..., MpiPoolSession)` check with a negative check against `(MpiCommSession, RemoteMpiCommSessionClient)`, mirroring the existing pattern in the same function.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6272598


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker startup monitoring across supported MPI session modes.
  * Ensured worker process identities are registered consistently, except for remote and standard MPI communication sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->