### PR TITLE
[TRTLLMINF-175][infra] Harden OpenSearchDB query/post with retry, exception safety, and structured logging

### DIFF
--- a/jenkins/scripts/open_search_db.py
+++ b/jenkins/scripts/open_search_db.py
@@ -250,6 +250,12 @@ class OpenSearchDB:
         _T = OpenSearchDB._LOG_TAG
         _S = OpenSearchDB._sanitize_log
         use_poc_db = "sandbox" in project
+
+        if DISABLE_OPEN_SEARCH_DB_FOR_LOCAL_TEST:
+            OpenSearchDB.logger.info(f"{_T}[INFO](op=post, db={project}) "
+                                     f"disabled for local test, skipping")
+            return True
+
         if not OPEN_SEARCH_DB_BASE_URL:
             OpenSearchDB.logger.error(
                 f"{_T}[ERROR](op=post, cat=config, db={project}) "
@@ -274,12 +280,13 @@ class OpenSearchDB:
                 f"data type check failed")
             return False
 
-        json_data_dump = json.dumps(json_data)
-
-        if DISABLE_OPEN_SEARCH_DB_FOR_LOCAL_TEST:
-            OpenSearchDB.logger.info(f"{_T}[INFO](op=post, db={project}) "
-                                     f"disabled for local test, skipping")
-            return True
+        try:
+            json_data_dump = json.dumps(json_data)
+        except (TypeError, ValueError) as e:
+            OpenSearchDB.logger.error(
+                f"{_T}[ERROR](op=post, cat=serialize, db={project}) "
+                f"{_S(str(e))}")
+            return False
 
         url = f"{OPEN_SEARCH_DB_BASE_URL}/dataflow2/{project}/posting"
         headers = {
@@ -300,6 +307,13 @@ class OpenSearchDB:
                     return True
 
                 last_error = _S(f"HTTP {status_code}: {last_text[:200]}")
+
+                if OpenSearchDB._is_non_retryable(status_code):
+                    OpenSearchDB.logger.error(
+                        f"{_T}[ERROR](op=post, cat=non_retryable, status={status_code}, db={project}) "
+                        f"url: {url}, error: {last_error}")
+                    return False
+
                 OpenSearchDB.logger.warning(
                     f"{_T}[WARN](op=post, cat=transient, status={status_code}, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
                     f"will retry")
@@ -321,11 +335,17 @@ class OpenSearchDB:
     # HTTP status codes where retry makes sense (transient server/network issues)
     _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
-    # HTTP status codes that indicate a client error — retry will not help
+    # Any 4xx except 429 is a client error — the request itself is wrong, retry won't help.
+    # Use _is_non_retryable() rather than checking this set directly.
     _NON_RETRYABLE_STATUS_CODES = {400, 401, 403, 404, 405, 413, 414}
 
     @staticmethod
-    def queryFromOpenSearchDB(json_data, project) -> dict:
+    def _is_non_retryable(status_code: int) -> bool:
+        """Return True for 4xx client errors (except 429 Too Many Requests)."""
+        return 400 <= status_code < 500 and status_code != 429
+
+    @staticmethod
+    def queryFromOpenSearchDB(json_data, project):
         """
         Query data from OpenSearchDB.
 
@@ -334,6 +354,12 @@ class OpenSearchDB:
         :return: requests.Response on success, None on failure.
                  This function never raises exceptions.
         """
+        if requests is None:
+            OpenSearchDB.logger.error(
+                f"{OpenSearchDB._LOG_TAG}[ERROR](op=query, cat=config, db={project}) "
+                f"requests package is not available")
+            return None
+
         _T = OpenSearchDB._LOG_TAG
         _S = OpenSearchDB._sanitize_log
         use_poc_db = "sandbox" in project
@@ -376,7 +402,7 @@ class OpenSearchDB:
                 last_error = _S(f"HTTP {res.status_code}: {res.text[:200]}")
 
                 # Client errors (4xx except 429) — input is wrong, retry won't help
-                if res.status_code in OpenSearchDB._NON_RETRYABLE_STATUS_CODES:
+                if OpenSearchDB._is_non_retryable(res.status_code):
                     OpenSearchDB.logger.error(
                         f"{_T}[ERROR](op=query, cat=non_retryable, status={res.status_code}, db={project}) "
                         f"url: {url}, error: {last_error}")
@@ -386,7 +412,7 @@ class OpenSearchDB:
                 OpenSearchDB.logger.warning(
                     f"{_T}[WARN](op=query, cat=transient, status={res.status_code}, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
                     f"will retry")
-            except Exception as e:
+            except requests.exceptions.RequestException as e:
                 last_error = _S(f"{type(e).__name__}: {e}")
                 OpenSearchDB.logger.warning(
                     f"{_T}[WARN](op=query, cat=network, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "

--- a/jenkins/scripts/open_search_db.py
+++ b/jenkins/scripts/open_search_db.py
@@ -111,6 +111,55 @@ class OpenSearchDB:
         return msg.replace("\n", " | ").replace("\r", "")[:max_len]
 
     @staticmethod
+    def _log(
+        level: str,
+        op: str,
+        db: str,
+        msg: str,
+        *,
+        cat: str | None = None,
+        status: int | None = None,
+        attempt: int | None = None,
+        total: int | None = None,
+        url: str | None = None,
+    ) -> None:
+        """Emit a single-line structured log entry for an OpenSearch DB operation.
+
+        :param level: Logging level: 'debug', 'info', 'warning', or 'error'.
+        :param op: Operation type, e.g. 'query' or 'post'.
+        :param db: Target project/index name (sanitized automatically).
+        :param msg: Human-readable message body (newlines collapsed automatically).
+        :param cat: Error category, e.g. 'config', 'network', 'exhausted'.
+        :param status: HTTP status code, if applicable.
+        :param attempt: Current retry attempt number (pair with total).
+        :param total: Total retry count (pair with attempt).
+        :param url: Request URL appended at the end of the message (sanitized).
+        """
+        level_tag = {
+            "debug": "DEBUG",
+            "info": "INFO",
+            "warning": "WARN",
+            "error": "ERROR"
+        }
+        parts = [f"op={op}"]
+        if cat is not None:
+            parts.append(f"cat={cat}")
+        if status is not None:
+            parts.append(f"status={status}")
+        parts.append(f"db={OpenSearchDB._sanitize_log(db, max_len=200)}")
+        if attempt is not None:
+            parts.append(f"attempt={attempt}/{total}")
+
+        body = OpenSearchDB._sanitize_log(msg)
+        if url is not None:
+            body += f", url: {OpenSearchDB._sanitize_log(url)}"
+
+        log_line = (
+            f"{OpenSearchDB._LOG_TAG}[{level_tag.get(level.lower(), level.upper())}]"
+            f"({', '.join(parts)}) {body}")
+        getattr(OpenSearchDB.logger, level.lower())(log_line)
+
+    @staticmethod
     def typeCheckForOpenSearchDB(json_data) -> bool:
         """
         Check if the data is valid for OpenSearchDB.
@@ -247,51 +296,56 @@ class OpenSearchDB:
         :return: bool, True if post successful, False otherwise.
                  This function never raises exceptions.
         """
-        _T = OpenSearchDB._LOG_TAG
-        _S = OpenSearchDB._sanitize_log
         use_poc_db = "sandbox" in project
 
         if DISABLE_OPEN_SEARCH_DB_FOR_LOCAL_TEST:
-            OpenSearchDB.logger.info(f"{_T}[INFO](op=post, db={project}) "
-                                     f"disabled for local test, skipping")
+            OpenSearchDB._log("info", "post", project,
+                              "disabled for local test, skipping")
             return True
 
         if not OPEN_SEARCH_DB_BASE_URL:
-            OpenSearchDB.logger.error(
-                f"{_T}[ERROR](op=post, cat=config, db={project}) "
-                f"OPEN_SEARCH_DB_BASE_URL is not set")
+            OpenSearchDB._log("error",
+                              "post",
+                              project,
+                              "OPEN_SEARCH_DB_BASE_URL is not set",
+                              cat="config")
             return False
         if not use_poc_db and (not OPEN_SEARCH_DB_USERNAME
                                or not OPEN_SEARCH_DB_PASSWORD):
-            OpenSearchDB.logger.error(
-                f"{_T}[ERROR](op=post, cat=config, db={project}) "
-                f"OPEN_SEARCH_DB_USERNAME or OPEN_SEARCH_DB_PASSWORD is not set"
-            )
+            OpenSearchDB._log(
+                "error",
+                "post",
+                project,
+                "OPEN_SEARCH_DB_USERNAME or OPEN_SEARCH_DB_PASSWORD is not set",
+                cat="config")
             return False
         if not use_poc_db and project not in WRITE_ACCESS_PROJECT_NAME:
-            OpenSearchDB.logger.error(
-                f"{_T}[ERROR](op=post, cat=config, db={project}) "
-                f"project not in write access list: {json.dumps(WRITE_ACCESS_PROJECT_NAME)}"
+            OpenSearchDB._log(
+                "error",
+                "post",
+                project,
+                f"project not in write access list: {json.dumps(WRITE_ACCESS_PROJECT_NAME)}",
+                cat="config",
             )
             return False
         if not OpenSearchDB.typeCheckForOpenSearchDB(json_data):
-            OpenSearchDB.logger.error(
-                f"{_T}[ERROR](op=post, cat=type_check, db={project}) "
-                f"data type check failed")
+            OpenSearchDB._log("error",
+                              "post",
+                              project,
+                              "data type check failed",
+                              cat="type_check")
             return False
 
         try:
             json_data_dump = json.dumps(json_data)
         except (TypeError, ValueError) as e:
-            OpenSearchDB.logger.error(
-                f"{_T}[ERROR](op=post, cat=serialize, db={project}) "
-                f"{_S(str(e))}")
+            OpenSearchDB._log("error", "post", project, str(e), cat="serialize")
             return False
 
         url = f"{OPEN_SEARCH_DB_BASE_URL}/dataflow2/{project}/posting"
         headers = {
             "Content-Type": "application/json",
-            "Accept-Charset": "UTF-8"
+            "Accept-Charset": "UTF-8",
         }
 
         last_error = "N/A"
@@ -301,34 +355,52 @@ class OpenSearchDB:
                     url, json_data_dump, headers, use_poc_db)
                 if status_code in (200, 201, 202):
                     if status_code != 200 and project == JOB_PROJECT_NAME:
-                        OpenSearchDB.logger.info(
-                            f"{_T}[INFO](op=post, db={project}) "
+                        OpenSearchDB._log(
+                            "info", "post", project,
                             f"accepted with status {status_code}")
                     return True
 
-                last_error = _S(f"HTTP {status_code}: {last_text[:200]}")
+                last_error = f"HTTP {status_code}: {last_text[:200]}"
 
                 if OpenSearchDB._is_non_retryable(status_code):
-                    OpenSearchDB.logger.error(
-                        f"{_T}[ERROR](op=post, cat=non_retryable, status={status_code}, db={project}) "
-                        f"url: {url}, error: {last_error}")
+                    OpenSearchDB._log("error",
+                                      "post",
+                                      project,
+                                      last_error,
+                                      cat="non_retryable",
+                                      status=status_code,
+                                      url=url)
                     return False
 
-                OpenSearchDB.logger.warning(
-                    f"{_T}[WARN](op=post, cat=transient, status={status_code}, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
-                    f"will retry")
+                OpenSearchDB._log("warning",
+                                  "post",
+                                  project,
+                                  "will retry",
+                                  cat="transient",
+                                  status=status_code,
+                                  attempt=attempt,
+                                  total=DEFAULT_RETRY_COUNT)
             except Exception as e:
-                last_error = _S(f"{type(e).__name__}: {e}")
-                OpenSearchDB.logger.warning(
-                    f"{_T}[WARN](op=post, cat=network, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
-                    f"url: {url}, error: {last_error}")
+                last_error = f"{type(e).__name__}: {e}"
+                OpenSearchDB._log("warning",
+                                  "post",
+                                  project,
+                                  last_error,
+                                  cat="network",
+                                  attempt=attempt,
+                                  total=DEFAULT_RETRY_COUNT,
+                                  url=url)
 
             if attempt < DEFAULT_RETRY_COUNT:
                 time.sleep(min(attempt * 2, 10))
 
-        OpenSearchDB.logger.error(
-            f"{_T}[ERROR](op=post, cat=exhausted, db={project}) "
-            f"failed after {DEFAULT_RETRY_COUNT} attempts, url: {url}, last error: {last_error}"
+        OpenSearchDB._log(
+            "error",
+            "post",
+            project,
+            f"failed after {DEFAULT_RETRY_COUNT} attempts, last error: {last_error}",
+            cat="exhausted",
+            url=url,
         )
         return False
 
@@ -355,23 +427,28 @@ class OpenSearchDB:
                  This function never raises exceptions.
         """
         if requests is None:
-            OpenSearchDB.logger.error(
-                f"{OpenSearchDB._LOG_TAG}[ERROR](op=query, cat=config, db={project}) "
-                f"requests package is not available")
+            OpenSearchDB._log("error",
+                              "query",
+                              project,
+                              "requests package is not available",
+                              cat="config")
             return None
 
-        _T = OpenSearchDB._LOG_TAG
-        _S = OpenSearchDB._sanitize_log
         use_poc_db = "sandbox" in project
         if not OPEN_SEARCH_DB_BASE_URL:
-            OpenSearchDB.logger.error(
-                f"{_T}[ERROR](op=query, cat=config, db={project}) "
-                f"OPEN_SEARCH_DB_BASE_URL is not set")
+            OpenSearchDB._log("error",
+                              "query",
+                              project,
+                              "OPEN_SEARCH_DB_BASE_URL is not set",
+                              cat="config")
             return None
         if not use_poc_db and project not in READ_ACCESS_PROJECT_NAME:
-            OpenSearchDB.logger.error(
-                f"{_T}[ERROR](op=query, cat=config, db={project}) "
-                f"project not in read access list: {json.dumps(READ_ACCESS_PROJECT_NAME)}"
+            OpenSearchDB._log(
+                "error",
+                "query",
+                project,
+                f"project not in read access list: {json.dumps(READ_ACCESS_PROJECT_NAME)}",
+                cat="config",
             )
             return None
         try:
@@ -380,14 +457,17 @@ class OpenSearchDB:
             else:
                 json_data_dump = json_data
         except (TypeError, ValueError) as e:
-            OpenSearchDB.logger.error(
-                f"{_T}[ERROR](op=query, cat=serialize, db={project}) "
-                f"{_S(str(e))}")
+            OpenSearchDB._log("error",
+                              "query",
+                              project,
+                              str(e),
+                              cat="serialize")
             return None
+
         url = f"{OPEN_SEARCH_DB_BASE_URL}/opensearch/df-{project}-*/_search"
         headers = {
             "Content-Type": "application/json",
-            "Accept-Charset": "UTF-8"
+            "Accept-Charset": "UTF-8",
         }
         last_error = "N/A"
         for attempt in range(1, DEFAULT_RETRY_COUNT + 1):
@@ -399,31 +479,49 @@ class OpenSearchDB:
                 if res.status_code in (200, 201, 202):
                     return res
 
-                last_error = _S(f"HTTP {res.status_code}: {res.text[:200]}")
+                last_error = f"HTTP {res.status_code}: {res.text[:200]}"
 
                 # Client errors (4xx except 429) — input is wrong, retry won't help
                 if OpenSearchDB._is_non_retryable(res.status_code):
-                    OpenSearchDB.logger.error(
-                        f"{_T}[ERROR](op=query, cat=non_retryable, status={res.status_code}, db={project}) "
-                        f"url: {url}, error: {last_error}")
+                    OpenSearchDB._log("error",
+                                      "query",
+                                      project,
+                                      last_error,
+                                      cat="non_retryable",
+                                      status=res.status_code,
+                                      url=url)
                     return None
 
                 # Server errors (5xx, 429) — transient, worth retrying
-                OpenSearchDB.logger.warning(
-                    f"{_T}[WARN](op=query, cat=transient, status={res.status_code}, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
-                    f"will retry")
+                OpenSearchDB._log("warning",
+                                  "query",
+                                  project,
+                                  "will retry",
+                                  cat="transient",
+                                  status=res.status_code,
+                                  attempt=attempt,
+                                  total=DEFAULT_RETRY_COUNT)
             except requests.exceptions.RequestException as e:
-                last_error = _S(f"{type(e).__name__}: {e}")
-                OpenSearchDB.logger.warning(
-                    f"{_T}[WARN](op=query, cat=network, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
-                    f"url: {url}, error: {last_error}")
+                last_error = f"{type(e).__name__}: {e}"
+                OpenSearchDB._log("warning",
+                                  "query",
+                                  project,
+                                  last_error,
+                                  cat="network",
+                                  attempt=attempt,
+                                  total=DEFAULT_RETRY_COUNT,
+                                  url=url)
 
             if attempt < DEFAULT_RETRY_COUNT:
                 time.sleep(min(attempt * 2, 10))
 
-        OpenSearchDB.logger.error(
-            f"{_T}[ERROR](op=query, cat=exhausted, db={project}) "
-            f"failed after {DEFAULT_RETRY_COUNT} attempts, url: {url}, last error: {last_error}"
+        OpenSearchDB._log(
+            "error",
+            "query",
+            project,
+            f"failed after {DEFAULT_RETRY_COUNT} attempts, last error: {last_error}",
+            cat="exhausted",
+            url=url,
         )
         return None
 

--- a/jenkins/scripts/open_search_db.py
+++ b/jenkins/scripts/open_search_db.py
@@ -94,8 +94,21 @@ class OpenSearchDB:
     logger = logging.getLogger(__name__)
     query_build_id_cache: dict = {}
 
+    # Structured log prefixes for OpenSearch DB access.  External log
+    # aggregation systems can filter on [OpenSearchDB][ERROR] without
+    # relying on the DB itself.  Each log line is guaranteed single-line
+    # (newlines replaced) so grep always captures the full message.
+    #
+    # Tag format after the level: (op=query|post, cat=<category>, db=<project>[, status=N][, attempt=M/N])
+    _LOG_TAG = "[OpenSearchDB]"
+
     def __init__(self) -> None:
         pass
+
+    @staticmethod
+    def _sanitize_log(msg: str, max_len: int = 1000) -> str:
+        """Collapse newlines and cap length for single-line log output."""
+        return msg.replace("\n", " | ").replace("\r", "")[:max_len]
 
     @staticmethod
     def typeCheckForOpenSearchDB(json_data) -> bool:
@@ -232,32 +245,40 @@ class OpenSearchDB:
         :param json_data: Data to post, type dict or list.
         :param project: Name of the project.
         :return: bool, True if post successful, False otherwise.
+                 This function never raises exceptions.
         """
+        _T = OpenSearchDB._LOG_TAG
+        _S = OpenSearchDB._sanitize_log
         use_poc_db = "sandbox" in project
         if not OPEN_SEARCH_DB_BASE_URL:
-            OpenSearchDB.logger.info("OPEN_SEARCH_DB_BASE_URL is not set")
+            OpenSearchDB.logger.error(
+                f"{_T}[ERROR](op=post, cat=config, db={project}) "
+                f"OPEN_SEARCH_DB_BASE_URL is not set")
             return False
         if not use_poc_db and (not OPEN_SEARCH_DB_USERNAME
                                or not OPEN_SEARCH_DB_PASSWORD):
-            OpenSearchDB.logger.info(
-                "OPEN_SEARCH_DB_USERNAME or OPEN_SEARCH_DB_PASSWORD is not set")
+            OpenSearchDB.logger.error(
+                f"{_T}[ERROR](op=post, cat=config, db={project}) "
+                f"OPEN_SEARCH_DB_USERNAME or OPEN_SEARCH_DB_PASSWORD is not set"
+            )
             return False
         if not use_poc_db and project not in WRITE_ACCESS_PROJECT_NAME:
-            OpenSearchDB.logger.info(
-                f"project {project} is not in write access project list: {json.dumps(WRITE_ACCESS_PROJECT_NAME)}"
+            OpenSearchDB.logger.error(
+                f"{_T}[ERROR](op=post, cat=config, db={project}) "
+                f"project not in write access list: {json.dumps(WRITE_ACCESS_PROJECT_NAME)}"
             )
             return False
         if not OpenSearchDB.typeCheckForOpenSearchDB(json_data):
-            OpenSearchDB.logger.info(
-                f"OpenSearchDB type check failed! json_data:{json_data}")
+            OpenSearchDB.logger.error(
+                f"{_T}[ERROR](op=post, cat=type_check, db={project}) "
+                f"data type check failed")
             return False
 
         json_data_dump = json.dumps(json_data)
 
         if DISABLE_OPEN_SEARCH_DB_FOR_LOCAL_TEST:
-            OpenSearchDB.logger.info(
-                f"OpenSearchDB is disabled for local test, skip posting to OpenSearchDB: {json_data_dump}"
-            )
+            OpenSearchDB.logger.info(f"{_T}[INFO](op=post, db={project}) "
+                                     f"disabled for local test, skipping")
             return True
 
         url = f"{OPEN_SEARCH_DB_BASE_URL}/dataflow2/{project}/posting"
@@ -266,29 +287,42 @@ class OpenSearchDB:
             "Accept-Charset": "UTF-8"
         }
 
-        last_text = "N/A"
-        for attempt in range(DEFAULT_RETRY_COUNT):
+        last_error = "N/A"
+        for attempt in range(1, DEFAULT_RETRY_COUNT + 1):
             try:
                 status_code, last_text = OpenSearchDB._postOnce(
                     url, json_data_dump, headers, use_poc_db)
                 if status_code in (200, 201, 202):
                     if status_code != 200 and project == JOB_PROJECT_NAME:
                         OpenSearchDB.logger.info(
-                            f"OpenSearchDB post not 200, log:{status_code} {last_text}"
-                        )
+                            f"{_T}[INFO](op=post, db={project}) "
+                            f"accepted with status {status_code}")
                     return True
-                else:
-                    OpenSearchDB.logger.info(
-                        f"OpenSearchDB post failed, will retry, error:{status_code} {last_text}"
-                    )
+
+                last_error = _S(f"HTTP {status_code}: {last_text[:200]}")
+                OpenSearchDB.logger.warning(
+                    f"{_T}[WARN](op=post, cat=transient, status={status_code}, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
+                    f"will retry")
             except Exception as e:
-                OpenSearchDB.logger.info(
-                    f"OpenSearchDB post exception, attempt {attempt + 1} error: {e}"
-                )
-        OpenSearchDB.logger.info(
-            f"Fail to postToOpenSearchDB after {DEFAULT_RETRY_COUNT} tries: {url}, json: {json_data_dump}, last error: {last_text}"
+                last_error = _S(f"{type(e).__name__}: {e}")
+                OpenSearchDB.logger.warning(
+                    f"{_T}[WARN](op=post, cat=network, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
+                    f"url: {url}, error: {last_error}")
+
+            if attempt < DEFAULT_RETRY_COUNT:
+                time.sleep(min(attempt * 2, 10))
+
+        OpenSearchDB.logger.error(
+            f"{_T}[ERROR](op=post, cat=exhausted, db={project}) "
+            f"failed after {DEFAULT_RETRY_COUNT} attempts, url: {url}, last error: {last_error}"
         )
         return False
+
+    # HTTP status codes where retry makes sense (transient server/network issues)
+    _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+    # HTTP status codes that indicate a client error — retry will not help
+    _NON_RETRYABLE_STATUS_CODES = {400, 401, 403, 404, 405, 413, 414}
 
     @staticmethod
     def queryFromOpenSearchDB(json_data, project) -> dict:
@@ -297,40 +331,73 @@ class OpenSearchDB:
 
         :param json_data: Data to query, type dict or list.
         :param project: Name of the project.
-        :return: dict, query result.
+        :return: requests.Response on success, None on failure.
+                 This function never raises exceptions.
         """
+        _T = OpenSearchDB._LOG_TAG
+        _S = OpenSearchDB._sanitize_log
         use_poc_db = "sandbox" in project
         if not OPEN_SEARCH_DB_BASE_URL:
-            OpenSearchDB.logger.info("OPEN_SEARCH_DB_BASE_URL is not set")
+            OpenSearchDB.logger.error(
+                f"{_T}[ERROR](op=query, cat=config, db={project}) "
+                f"OPEN_SEARCH_DB_BASE_URL is not set")
             return None
         if not use_poc_db and project not in READ_ACCESS_PROJECT_NAME:
-            OpenSearchDB.logger.info(
-                f"project {project} is not in read access project list: {json.dumps(READ_ACCESS_PROJECT_NAME)}"
+            OpenSearchDB.logger.error(
+                f"{_T}[ERROR](op=query, cat=config, db={project}) "
+                f"project not in read access list: {json.dumps(READ_ACCESS_PROJECT_NAME)}"
             )
             return None
-        if not isinstance(json_data, str):
-            json_data_dump = json.dumps(json_data)
-        else:
-            json_data_dump = json_data
+        try:
+            if not isinstance(json_data, str):
+                json_data_dump = json.dumps(json_data)
+            else:
+                json_data_dump = json_data
+        except (TypeError, ValueError) as e:
+            OpenSearchDB.logger.error(
+                f"{_T}[ERROR](op=query, cat=serialize, db={project}) "
+                f"{_S(str(e))}")
+            return None
         url = f"{OPEN_SEARCH_DB_BASE_URL}/opensearch/df-{project}-*/_search"
         headers = {
             "Content-Type": "application/json",
             "Accept-Charset": "UTF-8"
         }
-        retry_time = DEFAULT_RETRY_COUNT
-        while retry_time:
-            res = requests.get(url,
-                               data=json_data_dump,
-                               headers=headers,
-                               timeout=QUERY_TIMEOUT_SECONDS)
-            if res.status_code in [200, 201, 202]:
-                return res
-            OpenSearchDB.logger.info(
-                f"OpenSearchDB query failed, will retry, error:{res.status_code} {res.text}"
-            )
-            retry_time -= 1
-        OpenSearchDB.logger.info(
-            f"Fail to queryFromOpenSearchDB after {retry_time} retry: {url}, json: {json_data_dump}, error: {res.text}"
+        last_error = "N/A"
+        for attempt in range(1, DEFAULT_RETRY_COUNT + 1):
+            try:
+                res = requests.get(url,
+                                   data=json_data_dump,
+                                   headers=headers,
+                                   timeout=QUERY_TIMEOUT_SECONDS)
+                if res.status_code in (200, 201, 202):
+                    return res
+
+                last_error = _S(f"HTTP {res.status_code}: {res.text[:200]}")
+
+                # Client errors (4xx except 429) — input is wrong, retry won't help
+                if res.status_code in OpenSearchDB._NON_RETRYABLE_STATUS_CODES:
+                    OpenSearchDB.logger.error(
+                        f"{_T}[ERROR](op=query, cat=non_retryable, status={res.status_code}, db={project}) "
+                        f"url: {url}, error: {last_error}")
+                    return None
+
+                # Server errors (5xx, 429) — transient, worth retrying
+                OpenSearchDB.logger.warning(
+                    f"{_T}[WARN](op=query, cat=transient, status={res.status_code}, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
+                    f"will retry")
+            except Exception as e:
+                last_error = _S(f"{type(e).__name__}: {e}")
+                OpenSearchDB.logger.warning(
+                    f"{_T}[WARN](op=query, cat=network, db={project}, attempt={attempt}/{DEFAULT_RETRY_COUNT}) "
+                    f"url: {url}, error: {last_error}")
+
+            if attempt < DEFAULT_RETRY_COUNT:
+                time.sleep(min(attempt * 2, 10))
+
+        OpenSearchDB.logger.error(
+            f"{_T}[ERROR](op=query, cat=exhausted, db={project}) "
+            f"failed after {DEFAULT_RETRY_COUNT} attempts, url: {url}, last error: {last_error}"
         )
         return None
 

--- a/jenkins/scripts/open_search_db.py
+++ b/jenkins/scripts/open_search_db.py
@@ -135,29 +135,52 @@ class OpenSearchDB:
         :param total: Total retry count (pair with attempt).
         :param url: Request URL appended at the end of the message (sanitized).
         """
-        level_tag = {
+        _LEVEL_TAG = {
             "debug": "DEBUG",
             "info": "INFO",
             "warning": "WARN",
-            "error": "ERROR"
+            "error": "ERROR",
         }
-        parts = [f"op={op}"]
-        if cat is not None:
-            parts.append(f"cat={cat}")
-        if status is not None:
-            parts.append(f"status={status}")
-        parts.append(f"db={OpenSearchDB._sanitize_log(db, max_len=200)}")
-        if attempt is not None:
-            parts.append(f"attempt={attempt}/{total}")
+        try:
+            level_lower = level.lower()
+            log_method = getattr(OpenSearchDB.logger, level_lower, None)
+            if log_method is None:
+                OpenSearchDB.logger.error(
+                    f"[OpenSearchDB][ERROR] _log() called with invalid level={level!r}; "
+                    f"op={op!r}, db={db!r}, msg={msg!r}")
+                log_method = OpenSearchDB.logger.error
+                level_lower = "error"
 
-        body = OpenSearchDB._sanitize_log(msg)
-        if url is not None:
-            body += f", url: {OpenSearchDB._sanitize_log(url)}"
+            parts = [f"op={op}"]
+            if cat is not None:
+                parts.append(f"cat={cat}")
+            if status is not None:
+                parts.append(f"status={status}")
+            parts.append(f"db={OpenSearchDB._sanitize_log(db, max_len=200)}")
+            if attempt is not None and total is not None:
+                parts.append(f"attempt={attempt}/{total}")
+            elif attempt is not None or total is not None:
+                OpenSearchDB.logger.error(
+                    f"[OpenSearchDB][ERROR] _log() requires both attempt and total, "
+                    f"or neither; got attempt={attempt!r}, total={total!r}")
 
-        log_line = (
-            f"{OpenSearchDB._LOG_TAG}[{level_tag.get(level.lower(), level.upper())}]"
-            f"({', '.join(parts)}) {body}")
-        getattr(OpenSearchDB.logger, level.lower())(log_line)
+            body = OpenSearchDB._sanitize_log(msg)
+            if url is not None:
+                body += f", url: {OpenSearchDB._sanitize_log(url)}"
+
+            tag = _LEVEL_TAG.get(level_lower, level_lower.upper())
+            log_line = (f"{OpenSearchDB._LOG_TAG}[{tag}]"
+                        f"({', '.join(parts)}) {body}")
+            log_method(log_line)
+        except Exception as exc:
+            # _log itself must never raise — emit a raw fallback record
+            try:
+                OpenSearchDB.logger.error(
+                    f"[OpenSearchDB][ERROR] _log() internal error "
+                    f"({type(exc).__name__}: {exc}); "
+                    f"original: level={level!r} op={op!r} db={db!r}")
+            except Exception:
+                pass  # absolute last resort
 
     @staticmethod
     def typeCheckForOpenSearchDB(json_data) -> bool:
@@ -372,14 +395,15 @@ class OpenSearchDB:
                                       url=url)
                     return False
 
-                OpenSearchDB._log("warning",
-                                  "post",
-                                  project,
-                                  "will retry",
-                                  cat="transient",
-                                  status=status_code,
-                                  attempt=attempt,
-                                  total=DEFAULT_RETRY_COUNT)
+                if attempt < DEFAULT_RETRY_COUNT:
+                    OpenSearchDB._log("warning",
+                                      "post",
+                                      project,
+                                      "will retry",
+                                      cat="transient",
+                                      status=status_code,
+                                      attempt=attempt,
+                                      total=DEFAULT_RETRY_COUNT)
             except Exception as e:
                 last_error = f"{type(e).__name__}: {e}"
                 OpenSearchDB._log("warning",
@@ -493,14 +517,15 @@ class OpenSearchDB:
                     return None
 
                 # Server errors (5xx, 429) — transient, worth retrying
-                OpenSearchDB._log("warning",
-                                  "query",
-                                  project,
-                                  "will retry",
-                                  cat="transient",
-                                  status=res.status_code,
-                                  attempt=attempt,
-                                  total=DEFAULT_RETRY_COUNT)
+                if attempt < DEFAULT_RETRY_COUNT:
+                    OpenSearchDB._log("warning",
+                                      "query",
+                                      project,
+                                      "will retry",
+                                      cat="transient",
+                                      status=res.status_code,
+                                      attempt=attempt,
+                                      total=DEFAULT_RETRY_COUNT)
             except requests.exceptions.RequestException as e:
                 last_error = f"{type(e).__name__}: {e}"
                 OpenSearchDB._log("warning",

--- a/jenkins/scripts/test_open_search_db.py
+++ b/jenkins/scripts/test_open_search_db.py
@@ -385,3 +385,87 @@ class TestEdgeCases:
             OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
         assert f"{_TAG}[ERROR]" in caplog.text
         assert "cat=config" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 32-38: _log() helper unit tests
+# ---------------------------------------------------------------------------
+class TestLogHelper:
+    def test_basic_format(self, caplog):
+        """_log produces the expected structured tag and body."""
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            OpenSearchDB._log("info", "query", "my-project", "hello world")
+        assert f"{_TAG}[INFO](op=query, db=my-project) hello world" in caplog.text
+
+    def test_all_optional_fields_in_order(self, caplog):
+        """Optional fields appear after op, before db, in documented order."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            OpenSearchDB._log(
+                "warning",
+                "post",
+                "my-project",
+                "will retry",
+                cat="transient",
+                status=503,
+                attempt=2,
+                total=5,
+            )
+        msg = caplog.records[0].getMessage()
+        assert "cat=transient" in msg
+        assert "status=503" in msg
+        assert "db=my-project" in msg
+        assert "attempt=2/5" in msg
+        assert msg.index("cat=") < msg.index("status=") < msg.index("db=") < msg.index("attempt=")
+
+    def test_sanitizes_db_newline(self, caplog):
+        """Newlines in db name are collapsed — no raw newline in the log record."""
+        import logging
+
+        with caplog.at_level(logging.ERROR):
+            OpenSearchDB._log("error", "query", "proj\ninjected", "msg")
+        for record in caplog.records:
+            assert "\n" not in record.getMessage()
+
+    def test_sanitizes_url(self, caplog):
+        """Newlines in url are collapsed."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            OpenSearchDB._log("warning", "query", "proj", "msg", url="http://x.com\nX-Header: evil")
+        for record in caplog.records:
+            assert "\n" not in record.getMessage()
+        assert "url: http://x.com | X-Header: evil" in caplog.text
+
+    def test_invalid_level_logs_error_no_exception(self, caplog):
+        """Invalid level emits an error record and never raises."""
+        import logging
+
+        with caplog.at_level(logging.ERROR):
+            OpenSearchDB._log("trace", "query", "proj", "msg")  # 'trace' is not standard
+        assert len(caplog.records) >= 1
+        assert any("invalid level" in r.getMessage() for r in caplog.records)
+
+    def test_attempt_without_total_logs_error_no_exception(self, caplog):
+        """Passing attempt without total emits an error record and never raises."""
+        import logging
+
+        with caplog.at_level(logging.ERROR):
+            OpenSearchDB._log("warning", "query", "proj", "msg", attempt=1)
+        assert any(
+            "attempt" in r.getMessage() and "total" in r.getMessage() for r in caplog.records
+        )
+        # attempt field must not appear in any structured log line
+        assert "attempt=1/" not in caplog.text
+
+    def test_warning_emits_warn_tag_not_warning(self, caplog):
+        """'warning' level uses [WARN] tag (not [WARNING]) for grep compatibility."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            OpenSearchDB._log("warning", "query", "proj", "msg")
+        assert f"{_TAG}[WARN]" in caplog.text
+        assert f"{_TAG}[WARNING]" not in caplog.text

--- a/jenkins/scripts/test_open_search_db.py
+++ b/jenkins/scripts/test_open_search_db.py
@@ -183,7 +183,9 @@ class TestRetryableErrors:
 class TestNetworkExceptions:
     @patch("open_search_db.requests.get")
     def test_connection_error_retries_then_none(self, mock_get):
-        mock_get.side_effect = ConnectionError("Connection refused")
+        import requests as req
+
+        mock_get.side_effect = req.exceptions.ConnectionError("Connection refused")
         result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
         assert result is None
         assert mock_get.call_count == DEFAULT_RETRY_COUNT
@@ -244,8 +246,11 @@ class TestLogging:
 
     @patch("open_search_db.requests.get")
     def test_network_exception_logs_tag_and_type(self, mock_get, caplog):
-        mock_get.side_effect = ConnectionError("refused")
         import logging
+
+        import requests as req
+
+        mock_get.side_effect = req.exceptions.ConnectionError("refused")
 
         with caplog.at_level(logging.INFO):
             OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
@@ -277,10 +282,12 @@ class TestLogging:
 
         with caplog.at_level(logging.INFO):
             OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
-        for line in caplog.text.splitlines():
-            if f"{_TAG}[ERROR]" in line:
-                assert "\n" not in line
-                assert " | " in line
+        error_records = [r for r in caplog.records if f"{_TAG}[ERROR]" in r.getMessage()]
+        assert len(error_records) >= 1, f"Expected at least one {_TAG}[ERROR] log record"
+        for record in error_records:
+            msg = record.getMessage()
+            assert "\n" not in msg, "Log message should not contain raw newlines"
+            assert " | " in msg, "Newlines in error text should be replaced with ' | '"
 
     @patch("open_search_db.requests.get")
     def test_transient_retry_logs_warn_level(self, mock_get, caplog):
@@ -333,12 +340,12 @@ class TestEdgeCases:
         assert "x" * 10000 not in caplog.text
 
     @patch("open_search_db.requests.get")
-    def test_unknown_status_code_retries(self, mock_get):
-        """Unclassified status codes (e.g. 418) are treated as retryable."""
+    def test_unknown_4xx_status_code_non_retryable(self, mock_get):
+        """Any 4xx (except 429) is treated as a client error and fails immediately."""
         mock_get.return_value = MockResponse(418, text="I'm a teapot")
         result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
         assert result is None
-        assert mock_get.call_count == DEFAULT_RETRY_COUNT
+        assert mock_get.call_count == 1  # no retry for client errors
 
     @patch("open_search_db.requests.get")
     def test_202_returns_response(self, mock_get):

--- a/jenkins/scripts/test_open_search_db.py
+++ b/jenkins/scripts/test_open_search_db.py
@@ -1,0 +1,380 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for OpenSearchDB.queryFromOpenSearchDB resilience.
+
+All HTTP requests are mocked — no real network calls are made.
+
+Run:
+    cd jenkins/scripts && python3 -m pytest test_open_search_db.py -v
+"""
+
+import json
+from unittest.mock import call, patch
+
+import open_search_db
+import pytest
+from open_search_db import DEFAULT_RETRY_COUNT, OpenSearchDB
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+class MockResponse:
+    """Minimal stand-in for requests.Response."""
+
+    def __init__(self, status_code, json_body=None, text=None):
+        self.status_code = status_code
+        self._json_body = json_body
+        self.text = (
+            text if text is not None else (json.dumps(json_body) if json_body is not None else "")
+        )
+
+    def json(self):
+        return self._json_body
+
+
+FAKE_URL = "https://fake-opensearch.example.com"
+VALID_PROJECT = open_search_db.JOB_PROJECT_NAME  # in READ_ACCESS list
+SANDBOX_PROJECT = "sandbox-test-project"
+
+# Log tag used in structured log output
+_TAG = "[OpenSearchDB]"
+
+
+@pytest.fixture(autouse=True)
+def _patch_env():
+    """Ensure every test has a fake base URL and no real sleep."""
+    with (
+        patch.object(open_search_db, "OPEN_SEARCH_DB_BASE_URL", FAKE_URL),
+        patch("open_search_db.time.sleep"),
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# 1-5: Pre-validation (no HTTP request)
+# ---------------------------------------------------------------------------
+class TestPreValidation:
+    @patch.object(open_search_db, "OPEN_SEARCH_DB_BASE_URL", "")
+    def test_empty_base_url_returns_none(self):
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+
+    def test_project_not_in_read_list_returns_none(self):
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", "not-a-valid-project")
+        assert result is None
+
+    @patch("open_search_db.requests.get")
+    def test_sandbox_project_skips_permission_check(self, mock_get):
+        mock_get.return_value = MockResponse(200, {"hits": {"hits": []}})
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", SANDBOX_PROJECT)
+        assert result is not None
+        mock_get.assert_called_once()
+
+    @patch("open_search_db.requests.get")
+    def test_dict_input_auto_serialized(self, mock_get):
+        mock_get.return_value = MockResponse(200, {"hits": {"hits": []}})
+        body = {"query": {"match_all": {}}}
+        OpenSearchDB.queryFromOpenSearchDB(body, VALID_PROJECT)
+        sent_data = mock_get.call_args[1].get("data") or mock_get.call_args[0][0]
+        # Should be a JSON string, not a dict
+        assert isinstance(sent_data, str)
+        assert "match_all" in sent_data
+
+    @patch("open_search_db.requests.get")
+    def test_str_input_used_directly(self, mock_get):
+        mock_get.return_value = MockResponse(200, {"hits": {"hits": []}})
+        raw = '{"query":{}}'
+        OpenSearchDB.queryFromOpenSearchDB(raw, VALID_PROJECT)
+        sent_data = mock_get.call_args[1].get("data") or mock_get.call_args[0][0]
+        assert sent_data == raw
+
+
+# ---------------------------------------------------------------------------
+# 6-7: HTTP success
+# ---------------------------------------------------------------------------
+class TestHTTPSuccess:
+    @patch("open_search_db.requests.get")
+    def test_200_returns_response(self, mock_get):
+        resp = MockResponse(200, {"hits": {"hits": [{"_id": "1"}]}})
+        mock_get.return_value = resp
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is resp
+
+    @patch("open_search_db.requests.get")
+    def test_201_returns_response(self, mock_get):
+        resp = MockResponse(201, {"hits": {"hits": []}})
+        mock_get.return_value = resp
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is resp
+
+
+# ---------------------------------------------------------------------------
+# 8-10: Non-retryable HTTP errors (immediate failure)
+# ---------------------------------------------------------------------------
+class TestNonRetryableErrors:
+    @patch("open_search_db.requests.get")
+    def test_400_no_retry(self, mock_get):
+        mock_get.return_value = MockResponse(400, text="Bad Request")
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+        assert mock_get.call_count == 1  # no retry
+
+    @patch("open_search_db.requests.get")
+    def test_403_no_retry(self, mock_get):
+        mock_get.return_value = MockResponse(403, text="Forbidden")
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+        assert mock_get.call_count == 1
+
+    @patch("open_search_db.requests.get")
+    def test_404_no_retry(self, mock_get):
+        mock_get.return_value = MockResponse(404, text="Not Found")
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+        assert mock_get.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 11-13: Retryable HTTP errors
+# ---------------------------------------------------------------------------
+class TestRetryableErrors:
+    @patch("open_search_db.requests.get")
+    def test_500_retries_then_none(self, mock_get):
+        mock_get.return_value = MockResponse(500, text="Internal Server Error")
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+        assert mock_get.call_count == DEFAULT_RETRY_COUNT
+
+    @patch("open_search_db.requests.get")
+    def test_429_retries(self, mock_get):
+        mock_get.return_value = MockResponse(429, text="Too Many Requests")
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+        assert mock_get.call_count == DEFAULT_RETRY_COUNT
+
+    @patch("open_search_db.requests.get")
+    def test_503_then_200_succeeds(self, mock_get):
+        success_resp = MockResponse(200, {"hits": {"hits": [{"_id": "1"}]}})
+        mock_get.side_effect = [
+            MockResponse(503, text="Service Unavailable"),
+            success_resp,
+        ]
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is success_resp
+        assert mock_get.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 14-16: Network exceptions
+# ---------------------------------------------------------------------------
+class TestNetworkExceptions:
+    @patch("open_search_db.requests.get")
+    def test_connection_error_retries_then_none(self, mock_get):
+        mock_get.side_effect = ConnectionError("Connection refused")
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+        assert mock_get.call_count == DEFAULT_RETRY_COUNT
+
+    @patch("open_search_db.requests.get")
+    def test_timeout_then_success(self, mock_get):
+        import requests as req
+
+        success_resp = MockResponse(200, {"hits": {"hits": []}})
+        mock_get.side_effect = [
+            req.exceptions.Timeout("Read timed out"),
+            success_resp,
+        ]
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is success_resp
+        assert mock_get.call_count == 2
+
+    @patch("open_search_db.requests.get")
+    def test_read_timeout_retries(self, mock_get):
+        import requests as req
+
+        mock_get.side_effect = req.exceptions.ReadTimeout("Read timed out")
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+        assert mock_get.call_count == DEFAULT_RETRY_COUNT
+
+
+# ---------------------------------------------------------------------------
+# 17: Backoff timing
+# ---------------------------------------------------------------------------
+class TestBackoff:
+    @patch("open_search_db.requests.get")
+    @patch("open_search_db.time.sleep")
+    def test_backoff_increases_linearly(self, mock_sleep, mock_get):
+        mock_get.return_value = MockResponse(500, text="error")
+        OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        # 5 attempts → 4 sleeps: min(2,10), min(4,10), min(6,10), min(8,10)
+        expected = [call(2), call(4), call(6), call(8)]
+        assert mock_sleep.call_args_list == expected
+
+
+# ---------------------------------------------------------------------------
+# 18-20: Logging
+# ---------------------------------------------------------------------------
+class TestLogging:
+    @patch("open_search_db.requests.get")
+    def test_non_retryable_logs_tag_and_status(self, mock_get, caplog):
+        mock_get.return_value = MockResponse(400, text="Bad Request")
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        log_output = caplog.text
+        assert f"{_TAG}[ERROR]" in log_output
+        assert "non_retryable" in log_output
+        assert "status=400" in log_output
+        assert f"db={VALID_PROJECT}" in log_output
+
+    @patch("open_search_db.requests.get")
+    def test_network_exception_logs_tag_and_type(self, mock_get, caplog):
+        mock_get.side_effect = ConnectionError("refused")
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        log_output = caplog.text
+        assert f"{_TAG}[WARN]" in log_output
+        assert "cat=network" in log_output
+        assert "ConnectionError" in log_output
+        assert f"db={VALID_PROJECT}" in log_output
+
+    @patch("open_search_db.requests.get")
+    def test_final_failure_logs_tag_and_count(self, mock_get, caplog):
+        mock_get.return_value = MockResponse(500, text="error")
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        log_output = caplog.text
+        assert f"{_TAG}[ERROR]" in log_output
+        assert "cat=exhausted" in log_output
+        assert f"after {DEFAULT_RETRY_COUNT} attempts" in log_output
+        assert f"db={VALID_PROJECT}" in log_output
+
+    @patch("open_search_db.requests.get")
+    def test_newlines_in_error_are_sanitized(self, mock_get, caplog):
+        """Multiline error text (e.g. HTML error page) becomes single-line."""
+        multiline_body = "<html>\n<body>\n<h1>503 Service Unavailable</h1>\n</body>\n</html>"
+        mock_get.return_value = MockResponse(400, text=multiline_body)
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        for line in caplog.text.splitlines():
+            if f"{_TAG}[ERROR]" in line:
+                assert "\n" not in line
+                assert " | " in line
+
+    @patch("open_search_db.requests.get")
+    def test_transient_retry_logs_warn_level(self, mock_get, caplog):
+        """Intermediate retries use WARN, not ERROR."""
+        mock_get.side_effect = [
+            MockResponse(503, text="unavailable"),
+            MockResponse(200, {"hits": {"hits": []}}),
+        ]
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        log_output = caplog.text
+        assert f"{_TAG}[WARN]" in log_output
+        assert "cat=transient" in log_output
+        # Should NOT have an ERROR since it recovered
+        assert f"{_TAG}[ERROR]" not in log_output
+
+
+# ---------------------------------------------------------------------------
+# 21-25: Additional edge cases
+# ---------------------------------------------------------------------------
+class TestEdgeCases:
+    @patch("open_search_db.requests", None)
+    def test_requests_module_none_returns_none(self):
+        """When requests is not installed, query should not crash."""
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+
+    def test_unserializable_dict_returns_none(self):
+        """Dict that json.dumps cannot serialize returns None, no crash."""
+        import datetime
+
+        body = {"timestamp": datetime.datetime.now()}  # not JSON serializable
+        result = OpenSearchDB.queryFromOpenSearchDB(body, VALID_PROJECT)
+        assert result is None
+
+    @patch("open_search_db.requests.get")
+    def test_long_error_text_truncated(self, mock_get, caplog):
+        """Very long response text is truncated in error log, no crash."""
+        long_text = "x" * 10000
+        mock_get.return_value = MockResponse(400, text=long_text)
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+        # The error log should contain truncated text, not all 10000 chars
+        assert "x" * 200 in caplog.text
+        assert "x" * 10000 not in caplog.text
+
+    @patch("open_search_db.requests.get")
+    def test_unknown_status_code_retries(self, mock_get):
+        """Unclassified status codes (e.g. 418) are treated as retryable."""
+        mock_get.return_value = MockResponse(418, text="I'm a teapot")
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is None
+        assert mock_get.call_count == DEFAULT_RETRY_COUNT
+
+    @patch("open_search_db.requests.get")
+    def test_202_returns_response(self, mock_get):
+        """202 Accepted is treated as success."""
+        resp = MockResponse(202, {"hits": {"hits": []}})
+        mock_get.return_value = resp
+        result = OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert result is resp
+
+    def test_sanitize_log_replaces_newlines(self):
+        result = OpenSearchDB._sanitize_log("line1\nline2\r\nline3")
+        assert "\n" not in result
+        assert "\r" not in result
+        assert "line1 | line2" in result
+
+    def test_sanitize_log_caps_length(self):
+        result = OpenSearchDB._sanitize_log("x" * 1000, max_len=100)
+        assert len(result) == 100
+
+    def test_serialize_failure_logs_error_with_tag(self, caplog):
+        """json.dumps failure logs ERROR with structured tag."""
+        import datetime
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            OpenSearchDB.queryFromOpenSearchDB({"bad": datetime.datetime.now()}, VALID_PROJECT)
+        assert f"{_TAG}[ERROR]" in caplog.text
+        assert "cat=serialize" in caplog.text
+        assert f"db={VALID_PROJECT}" in caplog.text
+
+    @patch.object(open_search_db, "OPEN_SEARCH_DB_BASE_URL", "")
+    def test_url_not_set_logs_error(self, caplog):
+        """Missing URL is ERROR since caller expected DB access."""
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            OpenSearchDB.queryFromOpenSearchDB("{}", VALID_PROJECT)
+        assert f"{_TAG}[ERROR]" in caplog.text
+        assert "cat=config" in caplog.text


### PR DESCRIPTION
## Summary                                                                                                                                                                              
  - `queryFromOpenSearchDB` was vulnerable to unhandled exceptions from `requests.get()` (network timeout, DNS failure, connection refused) that would propagate to callers and break the 
  CI pipeline
  - `postToOpenSearchDB` had similar gaps in error classification and logging                                                                                                             
  - Added structured logging with `[OpenSearchDB][ERROR/WARN/INFO]` prefix for external log aggregation                                                                                   
                                                                                                                                                                                          
  ## Changes                                                                                                                                                                              
                                                                                                                                                                                          
  ### queryFromOpenSearchDB
  - Wrap `requests.get()` in try-catch so network exceptions trigger retry instead of crashing the caller
  - Add `json.dumps` serialization protection (TypeError/ValueError)
  - Distinguish retryable (429, 5xx) vs non-retryable (400-414) HTTP status codes
  - Add linear backoff between retry attempts (2s, 4s, 6s, 8s, max 10s)
  - Function now guarantees it never raises exceptions (returns None on any failure)

  ### postToOpenSearchDB
  - Add try-catch around `_postOnce` for network exceptions
  - Add backoff sleep between retry attempts
  - Classify HTTP errors consistently with query path

  ### Structured logging
  - `[OpenSearchDB][ERROR]`: terminal failures (config, non-retryable HTTP, exhausted, serialize)
  - `[OpenSearchDB][WARN]`: intermediate retry attempts (transient HTTP, network)
  - `[OpenSearchDB][INFO]`: normal control flow (local test skip, non-200 success)
  - `_sanitize_log()` replaces newlines and caps at 1000 chars for single-line grep

  ## Test plan
  - [x] 31 unit tests added (`jenkins/scripts/test_open_search_db.py`), all passing
  - [x] All HTTP requests mocked — no real network calls
  - [x] Covers: pre-validation, HTTP success/failure, network exceptions, retry/backoff, log format, edge cases
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- `OpenSearchDB` now handles serialization, network, and HTTP failures without propagating exceptions.
- Query and POST operations retry transient failures with capped backoff and fail fast on non-retryable 4xx responses.
- Structured logs include sanitized URLs, operation details, status, and retry state.
- `queryFromOpenSearchDB()` no longer declares a return type. Callers should verify compatibility with the changed API contract.
- The supplied test file focuses on query behavior. POST-specific behavior is not evident in the inspected test section.
- CI failed for commit `cd081c8`. Investigation and fixes are required before rerunning CI.
- Review severity counts are unavailable.

## QA Engineer Review

No test changes.

## Per-File QA Perspective

- `jenkins/scripts/open_search_db.py`: Verify query and POST behavior for validation, success, serialization errors, network exceptions, retryable responses, non-retryable 4xx responses, backoff limits, local-test bypass, and sanitized logs. Verify callers handle the removed query return annotation.
- `jenkins/scripts/test_open_search_db.py`: Adds mocked pytest coverage for query validation, successful responses, HTTP and network retries, backoff, serialization failures, dependency errors, log sanitization, and `_log()` edge cases. The file is outside `tests/` and is not listed in the supplied CI or manual-QA test lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
