### PR TITLE
[None][infra] Add blossom-ci authorized users

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -309,6 +309,7 @@ jobs:
         "shuyixiong",
         "shyeh25",
         "SimengLiu-nv",
+        "siyidNV",
         "sklevtsov-nvidia",
         "StanleySun639",
         "stnie",


### PR DESCRIPTION
## Description

`/bot run` issued by `siyidNV` is currently skipped by the Authorization gate of the Blossom-CI workflow because the account is not in the hardcoded allowlist. This PR adds `siyidNV` (NVIDIA employee, siyid@nvidia.com, CoreAI) to the authorized users list so CI can be triggered on my PRs, starting with #16424 which is pending CI.

## Test Coverage

Infra-only change to the CI authorization allowlist (one line, alphabetically inserted). No code paths affected; no tests applicable.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)