### PR TITLE
[None][fix] Size KV cache pool ratio for the sliding-window straddle block

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_life_cycle_registry.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_life_cycle_registry.py
@@ -50,6 +50,27 @@ class AttnLifeCycle(NamedTuple):
             BlockOrdinal(max(start, (history_length + 1 - self.window_size) // tokens_per_block)),
         )
 
+    def sliding_window_floor_blocks(self, tokens_per_block: int) -> int:
+        """Minimum blocks a windowed pool must reserve per request.
+
+        As a sliding window advances during decode it crosses block boundaries and its
+        span oscillates between M-1 and M blocks; the pool must hold the peak
+            M = num_sink_blocks + (window_size + tokens_per_block - 2) // tokens_per_block + 1
+        Full attention (``window_size is None``) has no window and returns 0.
+
+        This is a *floor* on a request's resident-block count, not a cap: a decode
+        request peaks exactly at M, while a prefill request still writing its input
+        blocks needs at least M. Callers take ``max(single_history_snapshot, this)``
+        (capped at the sequence's total blocks) so a windowed pool is never sized below
+        the straddle that a one-shot ``num_blocks - len(get_stale_range(...))`` snapshot
+        can miss.
+        """
+        if self.window_size is None:
+            return 0
+        return (
+            self.num_sink_blocks + (self.window_size + tokens_per_block - 2) // tokens_per_block + 1
+        )
+
 
 class SsmLifeCycle(NamedTuple):
     def get_stale_range(

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -84,7 +84,6 @@ from ._utils import (
     typed_len,
     typed_map,
     typed_range,
-    unwrap_optional,
 )
 
 if TYPE_CHECKING:
@@ -871,18 +870,24 @@ class StorageManager:
         if capacity < history_length:
             warnings.warn("Bad sampling for capacity and history_length")
             capacity = history_length
-        num_blocks = div_up(capacity, tokens_per_block)
         num_bytes = filled_list(0.0, self.num_pool_groups)
-        ssm_lc_idx = self._life_cycles.ssm_life_cycle_id
         for lc_idx, lc in typed_enumerate(self._life_cycles.get()):
             pg_idx = self.get_pool_group_index(lc_idx)
             slot_size = self.slot_size(pg_idx)
             num_required_blocks: int
-            if lc_idx == ssm_lc_idx:
-                num_required_blocks = 1
+            if isinstance(lc, AttnLifeCycle):
+                # Floor the single-history snapshot by the sliding-window straddle peak:
+                # a window transiently spans one extra block at each block-boundary
+                # crossing, which a bare `num_blocks - len(get_stale_range(...))` snapshot
+                # misses -- under-provisioning small-window pools. Prefill-shaped lengths
+                # keep the larger snapshot (their in-flight input blocks).
+                num_blocks = div_up(capacity, tokens_per_block)
+                snapshot = num_blocks - len(lc.get_stale_range(history_length, tokens_per_block))
+                floor = min(num_blocks, lc.sliding_window_floor_blocks(tokens_per_block))
+                num_required_blocks = max(snapshot, floor, 1)
             else:
-                stale = lc.get_stale_range(history_length, tokens_per_block)
-                num_required_blocks = max(num_blocks - len(stale), 1)
+                # SSM: one dedicated block per request.
+                num_required_blocks = 1
             num_bytes[pg_idx] += num_required_blocks * sum(slot_size)
         total = sum(num_bytes)
         assert total > 0
@@ -914,24 +919,23 @@ class StorageManager:
         """
         max_slots = filled_list(0, self.num_pool_groups)
 
-        def swa_floor_blocks(lc: AttnLifeCycle) -> int:
-            window = unwrap_optional(lc.window_size)
-            # Handle oscillation of slot count required by SWA while the window slides.
-            return lc.num_sink_blocks + (window + tokens_per_block - 2) // tokens_per_block + 1
-
         # Full-attention lifecycles share the largest SWA floor: all attention
-        # lifecycles see the same seq_len, so this is a valid lower bound.
+        # lifecycles see the same seq_len, so this is a valid lower bound. The floor
+        # handles the oscillation of the slot count required while the window slides
+        # (see AttnLifeCycle.sliding_window_floor_blocks).
         floor_num_blocks = 1
         for _, lc in self.life_cycles.attention_life_cycles():
             if lc.window_size is not None:
-                floor_num_blocks = max(floor_num_blocks, swa_floor_blocks(lc))
+                floor_num_blocks = max(
+                    floor_num_blocks, lc.sliding_window_floor_blocks(tokens_per_block)
+                )
         for lc_idx, lc in self.life_cycles.items():
             pg_idx = self.get_pool_group_index(lc_idx)
             if not isinstance(lc, AttnLifeCycle):
                 # SSM / non-attention: 1 slot floor per life cycle.
                 max_slots[pg_idx] += 1
             elif lc.window_size is not None:
-                max_slots[pg_idx] += swa_floor_blocks(lc)
+                max_slots[pg_idx] += lc.sliding_window_floor_blocks(tokens_per_block)
             else:
                 max_slots[pg_idx] += floor_num_blocks
         for batch in constraints:
@@ -956,6 +960,8 @@ class StorageManager:
                 # SSM: always 1 dedicated block per request, never shared.
                 num_slots[pg_idx] += len(batch.kv_caches)
                 continue
+            # Every non-SSM life cycle is an attention life cycle.
+            assert isinstance(lc, AttnLifeCycle)
             # Shared sys blocks (counted once): union of non-stale sys blocks across all requests.
             # A sys block needs memory if it's non-stale for ANY request.
             # = sys_blocks - (blocks stale for ALL requests within [0, sys_blocks))
@@ -968,9 +974,14 @@ class StorageManager:
             num_slots[pg_idx] += sys_blocks - len(stale_intersection)
             # Per-request unique blocks (excluding shared sys blocks already counted above).
             for kv in batch.kv_caches:
-                total_blocks = div_up(kv.capacity, tokens_per_block)
                 stale = lc.get_stale_range(kv.history_length, tokens_per_block)
-                non_stale = total_blocks - len(stale)
+                total_blocks = div_up(kv.capacity, tokens_per_block)
+                # Floor the single-history snapshot by the sliding-window straddle peak
+                # (see AttnLifeCycle.sliding_window_floor_blocks): a window transiently
+                # spans one extra block at each boundary crossing, which the bare snapshot
+                # misses. Prefill-shaped requests keep the larger snapshot (input blocks).
+                floor = min(total_blocks, lc.sliding_window_floor_blocks(tokens_per_block))
+                non_stale = max(total_blocks - len(stale), floor)
                 # Non-stale sys blocks for this request.
                 non_stale_sys = sys_blocks - len(intersect(stale, sys_range))
                 unique_non_stale = max(0, non_stale - non_stale_sys)

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -65,6 +65,7 @@ if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
     )
     from kv_cache_manager_v2._copy_engine import CopyTask, batched_copy
     from kv_cache_manager_v2._exceptions import OutOfPagesError
+    from kv_cache_manager_v2._life_cycle_registry import AttnLifeCycle
     from kv_cache_manager_v2._storage._core import CacheLevelStorage, PoolGroupBase, SlotAllocator
     from kv_cache_manager_v2._storage_manager import StorageManager
     from kv_cache_manager_v2._utils import (
@@ -118,6 +119,7 @@ else:
     )
     from tensorrt_llm.runtime.kv_cache_manager_v2._copy_engine import CopyTask, batched_copy
     from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import OutOfPagesError
+    from tensorrt_llm.runtime.kv_cache_manager_v2._life_cycle_registry import AttnLifeCycle
     from tensorrt_llm.runtime.kv_cache_manager_v2._storage._core import (
         CacheLevelStorage,
         PoolGroupBase,
@@ -2399,6 +2401,80 @@ class TestInitRatioConfig(unittest.TestCase):
         # Windowed layers need fewer blocks than non-windowed at history=2048.
         self.assertLess(ratio[0], ratio[1])
         manager.shutdown()
+
+    def test_sliding_window_floor_blocks_and_straddle(self):
+        """The straddle floor lifts decode requests to the peak but preserves prefill.
+
+        sliding_window_floor_blocks reports the straddle-inclusive window span; flooring
+        the single-history snapshot with it (capped at the sequence's blocks) provisions
+        decode requests for the straddle while leaving prefill-shaped and full-attention
+        requests unchanged.
+
+        A sliding window straddles one extra block at each block-boundary crossing, so
+        its resident count oscillates between an aligned minimum M-1 and a straddle peak
+        M = num_sink_blocks + ceil((window - 1) / tpb) + 1. A bare
+        `div_up(capacity, tpb) - len(get_stale_range(history, tpb))` snapshot samples one
+        alignment and can return M-1, starving small-window pools (a window-11 DSA indexer
+        got 1 block instead of 2 -- a 2x under-count).
+        """
+        tpb = 128
+
+        def div_up(a: int, b: int) -> int:
+            return (a + b - 1) // b
+
+        # (window, sink_tokens, expected straddle peak = sink + ceil((w-1)/tpb) + 1)
+        peak_cases = [
+            (11, 0, 2),  # DSA indexer window: aligned min 1, straddle peak 2 (2x under)
+            (131, 0, 3),  # SWA window under MTP3: aligned min 2, straddle peak 3
+            (128, 0, 2),  # exactly one block still straddles to 2
+            (256, 0, 3),  # two blocks straddle to 3
+            (1, 0, 1),  # single-token window
+            (131, 128, 4),  # a sink block adds to the peak
+        ]
+        for window, sink, expected_peak in peak_cases:
+            lc = AttnLifeCycle.make(window, sink, tpb)
+            self.assertEqual(
+                lc.sliding_window_floor_blocks(tpb), expected_peak, f"window={window} sink={sink}"
+            )
+        # Full attention has no window, hence no straddle floor.
+        self.assertEqual(AttnLifeCycle.make(None, None, tpb).sliding_window_floor_blocks(tpb), 0)
+
+        # The call-site composition: non_stale = max(snapshot, min(total_blocks, floor)).
+        def resident_blocks(lc, history: int, capacity: int) -> int:
+            total = div_up(capacity, tpb)
+            snapshot = total - len(lc.get_stale_range(history, tpb))
+            floor = min(total, lc.sliding_window_floor_blocks(tpb))
+            return max(snapshot, floor)
+
+        indexer = AttnLifeCycle.make(11, 0, tpb)  # window < one block
+        swa = AttnLifeCycle.make(131, 0, tpb)
+        full = AttnLifeCycle.make(None, None, tpb)
+        cap = 100 * tpb
+
+        # (a) Decode request whose snapshot lands on the aligned minimum -> floored to peak.
+        self.assertEqual(resident_blocks(indexer, cap - 4, cap), 2)  # snapshot 1 -> 2
+        self.assertEqual(resident_blocks(swa, cap - 4, cap), 3)  # snapshot 2 -> 3
+
+        # (b) Prefill-shaped request (history 0) keeps its in-flight input blocks and is
+        #     NOT collapsed to the window. This is what lets the typical_step's context
+        #     request provision the windowed pools; a bare min(total, floor) would starve
+        #     them (and drive the scratch-reuse subtraction negative).
+        prefill_cap = 64 * tpb
+        self.assertEqual(resident_blocks(indexer, 0, prefill_cap), 64)
+        self.assertEqual(resident_blocks(swa, 0, prefill_cap), 64)
+        self.assertEqual(resident_blocks(full, 0, prefill_cap), 64)
+
+        # (c) The straddle floor is the tight peak of the pure-window residency: it equals
+        #     the maximum snapshot over a full block of decode, never more.
+        for lc, expected_peak in ((indexer, 2), (swa, 3)):
+            snaps = [
+                div_up(h, tpb) - len(lc.get_stale_range(h, tpb))  # capacity == history
+                for h in range(cap - 2 * tpb, cap)
+            ]
+            self.assertEqual(min(lc.sliding_window_floor_blocks(tpb), div_up(cap, tpb)), max(snaps))
+
+        # (d) Full attention is never inflated: floor 0 -> exactly the snapshot (all blocks).
+        self.assertEqual(resident_blocks(full, 10 * tpb - 1, 10 * tpb), 10)
 
     def test_typical_step_short_sequences(self):
         """typical_step with short sequences: ratio reflects buffer size difference."""


### PR DESCRIPTION
## Description

The initial GPU pool-ratio solver in `kv_cache_manager_v2` (`ratio_from_batch` and `ratio_from_length` → `_compute_slots_for_batch`) estimates each pool's per-request resident block count from a single-history snapshot `div_up(capacity, tpb) - len(get_stale_range(history, tpb))`. For a sliding-window life cycle this samples one alignment of the window and can return the aligned minimum, missing the extra block the window straddles at each block-boundary crossing during decode. The constraint-floor path already accounted for this oscillation (`swa_floor_blocks`); the ratio path did not, so the two disagreed and small-window pools were under-provisioned.

Concretely, for a DeepSeek-V4 (DSA) deployment at 256K context / dep32 the window-11 indexer pool was sized for 1 block per decode request instead of its true peak of 2 (a 2× under-count). Because the ratio weights blocks by block size and the indexer's block is the largest of the three KV pools, this halved its memory share and made it the binding pool — capping the achievable decode batch well below the compressed-cache-bound maximum and forcing operators to hand-set `kv_cache_config.pool_ratio`.

Fix: add `AttnLifeCycle.sliding_window_peak_blocks()` — the straddle-inclusive peak span `num_sink_blocks + div_up(window_size - 1, tokens_per_block) + 1` (0 for full attention), the same value `swa_floor_blocks` already computed — and floor the ratio path's per-request snapshot with it, capped at the sequence's total blocks:

```
non_stale = max(snapshot, min(total_blocks, sliding_window_peak_blocks))
```

The change is monotonic: it lifts decode-shaped requests that sampled the aligned minimum up to the straddle peak, while leaving prefill-shaped requests (which keep their larger input-block snapshot) and full-attention pools unchanged. `swa_floor_blocks` now calls the shared method, so the ratio path and the constraint-floor path use one source of truth for the windowed oscillation. No public API or config change — this only corrects the internal initial-pool-ratio sizing.

## Test Coverage

- `tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py::TestInitRatioConfig::test_sliding_window_peak_blocks_and_straddle_floor` — verifies the straddle-peak formula across window/sink sizes, that a decode request landing on the aligned minimum is floored up to the peak, that a prefill-shaped request keeps its input blocks (not collapsed to the window), that the floor equals the maximum pure-window snapshot (tight), and that full-attention pools are unchanged.
- Existing `TestInitRatioConfig`, `TestScratchReuse`, and `TestComplexModels` suites continue to pass — the change is monotonic and leaves their sampled alignments unchanged.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
