### PR TITLE
[https://nvbugs/6435642][fix] avoid isinstance(MpiPoolSession) crash under session-reuse test infra

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -573,7 +573,14 @@ class GenerationExecutorProxy(GenerationExecutor):
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
-        if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
+        # Re-import MpiPoolSession from its origin module rather than using the
+        # module-level name above: test infra (tests/test_common/session_reuse.py)
+        # monkeypatches this module's ``MpiPoolSession`` attribute to a pool-reuse
+        # factory function for bare LLM(...) tests, and isinstance() against a
+        # non-type raises TypeError.
+        from ..llmapi.mpi_session import MpiPoolSession as _MpiPoolSessionCls
+        if isinstance(self.mpi_session,
+                      _MpiPoolSessionCls) and len(status) == 3:
             worker_process_identities: List[WorkerProcessIdentity] = status[2]
             self._worker_process_monitor.register(worker_process_identities)
 


### PR DESCRIPTION
## Description

`_start_executor_workers()` in `tensorrt_llm/executor/proxy.py` (added by #16338, merged 2026-07-14) does:

```python
if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
```

`tests/test_common/session_reuse.py` — an existing, default-on pytest speedup for bare `LLM(...)` tests that reuses MPI worker pools across tests — monkeypatches this module's `MpiPoolSession` **attribute** to a pool-reuse `factory` **function**, so it can intercept `MpiPoolSession(n_workers=...)` construction calls at `self.mpi_session = MpiPoolSession(n_workers=model_world_size)` (line 130).

Under that patch, `isinstance(x, MpiPoolSession)` raises:
```
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```
because a function isn't a valid `isinstance()` type argument — crashing **every** MPI-mode `LLM`/executor test run under `tests/unittest/` (session-reuse is wired in globally via `pytest.ini`'s `-p test_common.session_reuse_hooks`), not anything specific to one test file.

## Fix

Re-import `MpiPoolSession` from its origin module (`tensorrt_llm.llmapi.mpi_session`) at the check site, instead of relying on this module's module-level name — which must stay monkeypatchable for the pool-reuse factory to keep intercepting the *construction* call at line 130. The origin module's own `MpiPoolSession` attribute is never patched (only `tensorrt_llm.executor.proxy` and `tensorrt_llm.llmapi.llm`'s references are), so this always resolves to the real class.

## Test Coverage

Verified locally on 2×B200:
- `tests/unittest/auto_deploy/multigpu/smoke/test_ad_build_small_multi.py` (the test that surfaced the bare `TypeError` in CI) — both cases pass, including the reused-pool path (2nd invocation is ~4x faster, confirming reuse still works).
- `tests/unittest/auto_deploy/multigpu/custom_ops/test_ad_dist_strategies.py::test_allreduce_strategies[AUTO/TWOSHOT]` — pass.
- `tests/unittest/llmapi/test_mpi_session.py`, `tests/unittest/executor/test_proxy_fast_death.py`, `tests/unittest/executor/test_base_worker.py` — 28/28 pass, no regressions on the non-reuse path.

So this is a classic cross-PR integration bug: #16338's author added a new isinstance check without being aware that #15777 (merged the day before, unrelated area) had already made MpiPoolSession a name that test infrastructure legitimately monkeypatches. Neither PR is
  wrong in isolation — the interaction between them is what broke, and it wouldn't have been caught by either PR's own tests since neither one's test suite exercises the other's code path in a way that surfaces the conflict.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executor startup reliability when using externally provided worker sessions.
  * Fixed an edge case that could cause incorrect initialization behavior in test and customized runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->