### PR TITLE
[None][feat] Support llm-compressor compressed-tensors NVFP4 checkpoi…

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3_5.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_5.py
@@ -91,6 +91,18 @@ def _translate_mtp_pattern(name, n_hidden_layers):
     return None
 
 
+def _regex_targets_mtp(regex: str) -> bool:
+    """Whether a compressed-tensors re: exclude regex targets the HF
+    mtp.* namespace.  llm-compressor checkpoints mark the whole MTP layer
+    unquantized with a single re:^mtp.* entry; detecting such a regex lets
+    the caller translate it into a TRT-LLM model.layers.<n> subtree
+    exclusion (ModelOpt instead emits explicit mtp.layers.0* globs)."""
+    try:
+        return re.match(regex, "mtp.layers.0.self_attn.o_proj") is not None
+    except re.error:
+        return False
+
+
 # --- Config adapters --------------------------------------------------------
 #
 # These run from `load_pretrained_config` in
@@ -449,6 +461,20 @@ def _normalize_qwen35_exclude_modules(model_config, keep_lm_head_quant=False):
         # Drop vision tensors (not part of the language model graph)
         if name.startswith("model.visual"):
             continue
+        # compressed-tensors (llm-compressor) checkpoints express excludes as
+        # re: regexes.  RedHatAI Qwen3.5/3.6 NVFP4 checkpoints mark the
+        # whole MTP layer unquantized with a single re:^mtp.* entry.
+        # is_module_excluded_from_quantization matches re: patterns against
+        # TRT-LLM runtime names, but ^mtp.* is HF-namespaced and never
+        # matches model.layers.<n>...; translate it to a subtree exclusion
+        # of the MTP layer (mapped to model.layers.<num_hidden_layers>).
+        if (
+            name.startswith("re:")
+            and n_hidden_layers is not None
+            and _regex_targets_mtp(name[len("re:") :])
+        ):
+            normalized.add(f"model.layers.{n_hidden_layers}*")
+            continue
         # Translate MTP-namespace patterns to TRT-LLM paths so the MTP
         # layer (which the checkpoint stores unquantized) gets correctly
         # excluded from the global NVFP4/FP8 quant_config.
@@ -652,6 +678,48 @@ _QWEN3_5_VL_PLACEHOLDER_METADATA = MultimodalPlaceholderMetadata(
 )
 
 
+def _normalize_compressed_tensors_names(
+    weights: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Rename llm-compressor (compressed-tensors) NVFP4 tensors to the ModelOpt
+    names the MoE / Linear NVFP4 loaders expect.
+
+    compressed-tensors stores an NVFP4 Linear as:
+        weight_packed, weight_scale, weight_global_scale, input_global_scale
+    ModelOpt (NVIDIA Qwen3.6-NVFP4) stores it as:
+        weight,        weight_scale, weight_scale_2,      input_scale
+    (weight_scale -- the per-group FP8 scale -- is already identical.)
+
+    Guarded on the presence of a "*.weight_packed" key so ModelOpt checkpoints
+    pass through untouched (they never contain weight_packed).
+    """
+    if not any(k.endswith(".weight_packed") for k in weights):
+        return weights
+    # weight_scale (per-group FP8) is byte-identical between the two formats and
+    # keeps its name. The two *global* FP32 scalars are reciprocals, though:
+    # compressed-tensors stores a *quantization* scale (amax -> FP4*FP8 range),
+    # ModelOpt stores the *dequantization* scale. Invert them on rename.
+    #   weight_global_scale -> weight_scale_2 = 1 / weight_global_scale
+    #   input_global_scale  -> input_scale    = 1 / input_global_scale
+    invert = {
+        ".weight_global_scale": ".weight_scale_2",
+        ".input_global_scale": ".input_scale",
+    }
+    out: Dict[str, torch.Tensor] = {}
+    for k, v in weights.items():
+        renamed = False
+        for old_suffix, new_suffix in invert.items():
+            if k.endswith(old_suffix):
+                k = k[: -len(old_suffix)] + new_suffix
+                v = (1.0 / v.float()).to(v.dtype)
+                renamed = True
+                break
+        if not renamed and k.endswith(".weight_packed"):
+            k = k[: -len(".weight_packed")] + ".weight"
+        out[k] = v
+    return out
+
+
 class _Qwen3_5VLModel(Qwen3VLModelBase):
     """Shared VLM wrapper composing the Qwen3 vision encoder with a Qwen3.5
     (Qwen3Next-based) text decoder.
@@ -705,6 +773,7 @@ class _Qwen3_5VLModel(Qwen3VLModelBase):
         # weight_scale=1.0 and quantizes activations dynamically every step.
         weight_mapper.init_model_and_config(self.llm, self.llm.model_config)
         filtered_weights = {k: v for k, v in weights.items() if not k.startswith("model.visual.")}
+        filtered_weights = _normalize_compressed_tensors_names(filtered_weights)
         params_map = {
             r"^model\.language_model\.(.*)$": r"model.\1",
         }


### PR DESCRIPTION
<img width="1800" height="1200" alt="pareto_2ckpt_conc" src="https://github.com/user-attachments/assets/2829553e-28e9-4f23-97da-98f960c683ec" />

The diff comes from RedHat didn't quantize QKV B A layers.

The Qwen3.5/3.6 loader assumed ModelOpt-style NVFP4 tensor names (weight / weight_scale / weight_scale
_2 / input_scale). llm-compressor (compressed-tensors, "nvfp4-pack-quantized") names the same tensors weight_packed / weight_scale / weight_global_scale / input_global_scale, so the fused-MoE and Linear NVFP4 loaders could not find the expert weights and asserted (`w1_weight is not None`).

Normalize compressed-tensors NVFP4 names to the ModelOpt names in `_Qwen3_5VLModel.load_weights`. The per-group FP8 `weight_scale` is byte-identical between the two formats and is left unchanged; the two global FP32 scalars are reciprocals -- compressed-tensors stores a quantization scale, ModelOpt a dequantization scale -- so they are inverted on rename (weight_scale_2 = 1/weight_global_scale, input_scale = 1/input_global_scale). The pass is guarded on the presence of a "*.weight_packed" key, so ModelOpt checkpoints (e.g. NVIDIA Qwen3.6-NVFP4) pass through untouched.

Validated on RedHatAI/Qwen3.6-35B-A3B-NVFP4 (B200, TP1, TRTLLM MoE): the model loads and produces coherent output (17*23=391); the NVIDIA Qwen3.6-NVFP4 path is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of Qwen3.5 vision-language model checkpoints using NVFP4 quantization.
  * Added compatibility for compressed tensor naming and scale formats, helping ensure quantized weights and their associated scaling data load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
