### PR TITLE
[None][fix] Add on_rewind hook to KV cache connector for specdec rewind

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/connectors/kv_cache_connector.py
+++ b/tensorrt_llm/_torch/pyexecutor/connectors/kv_cache_connector.py
@@ -255,6 +255,21 @@ class KvCacheConnectorScheduler(ABC):
             block_ids: The KV cacheblock IDs that were allocated.
         """
 
+    def on_rewind(self, request: LlmRequest, live_block_ids: List[int]):
+        """Notify the scheduler that a request's KV cache was rewound.
+
+        Called after ``rewind_kv_cache`` frees blocks due to speculative-decoding
+        rejection.  The scheduler should trim any per-request block bookkeeping
+        to match ``live_block_ids`` (the post-rewind cache indices).
+
+        Default implementation is a no-op; connectors that track per-request
+        block state (e.g. KVBM) override this to trim stale freed block ids.
+
+        Args:
+            request: The request whose KV cache was rewound.
+            live_block_ids: The post-rewind live cache block IDs for the request.
+        """
+
     def wait_for_initialization(self):
         """
         Some connectors need to wait for some resources to be initialized.
@@ -343,7 +358,7 @@ class KvCacheConnectorSchedulerOutputRequest:
             computed_position = len(tokens) - 1
             num_scheduled_tokens = 1 + get_draft_token_length(
                 req
-            )  # Specdec with draft tokens is not supported yet.
+            )  # Account for the next token plus any spec-dec draft tokens.
 
         # Get retention priority for each new block only if retention config is provided
         # (for priority-based offload filtering)
@@ -410,6 +425,32 @@ class KvCacheConnectorSchedulerOutputManager:
 
     def record_new_matched_tokens(self, request: LlmRequest, num_new_matched_tokens: int):
         self.external_loads[request.request_id] = num_new_matched_tokens
+
+    def on_rewind(self, req: LlmRequest, kv_cache_manager: "KVCacheManager"):
+        """Re-sync connector bookkeeping after speculative-decoding rewind.
+
+        When draft tokens are rejected and ``rewindKVCache`` frees blocks that
+        crossed a block boundary, the per-request ``block_ids`` list must be
+        trimmed to drop the now-freed block ids.  Without this, the connector
+        retains stale references to freed blocks, which can cause incorrect
+        saves/loads and hangs in ``get_finished`` (cross-rank intersection
+        never completes).
+
+        ``tokens`` is only shrunk (never extended) here: ``on_rewind`` runs
+        after sampling has already appended accepted tokens to the request,
+        so ``req.get_tokens(0)`` may be longer than the stored list.  Extending
+        ``tokens`` would suppress those accepted tokens from the next
+        ``build_scheduler_output``'s ``new_tokens`` delta.  We only trim if the
+        rewind actually shortened the token list (e.g. rejected draft tokens
+        were rolled back).
+        """
+        req_state = self.requests.get(req.request_id)
+        if req_state is None:
+            return
+        req_state.block_ids = list(kv_cache_manager.get_cache_indices(req))
+        live_tokens = list(req.get_tokens(0))
+        if len(live_tokens) < len(req_state.tokens):
+            req_state.tokens = live_tokens
 
 
 class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
@@ -500,6 +541,18 @@ class KvCacheConnectorManager(KvCacheConnectorManagerCpp):
         self._scheduler_output = self.scheduler_output_manager.build_scheduler_output(
             scheduled_batch, self.new_async_requests, kv_cache_manager
         )
+
+    def on_rewind(self, req: LlmRequest, kv_cache_manager: "KVCacheManager"):
+        """Notify the connector that a request's KV cache was rewound.
+
+        Trims the Python-side ``scheduler_output_manager`` bookkeeping and
+        notifies the external scheduler (e.g. KVBM leader) so it can trim
+        its own per-request slot state.
+        """
+        self.scheduler_output_manager.on_rewind(req, kv_cache_manager)
+        if self.scheduler is not None:
+            live_block_ids = kv_cache_manager.get_cache_indices(req)
+            self.scheduler.on_rewind(req, live_block_ids)
 
     def take_scheduled_requests_pending_load(self, scheduled_requests: ScheduledRequests):
         """

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -837,8 +837,7 @@ def create_py_executor(
                 "(e.g. Eagle) is not supported yet. The connector's per-request "
                 "block bookkeeping is not trimmed after rewind, which can cause "
                 "hangs in get_finished. See "
-                "https://github.com/NVIDIA/TensorRT-LLM/issues/16448"
-            )
+                "https://github.com/NVIDIA/TensorRT-LLM/issues/16448")
 
         try:
             module = importlib.import_module(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -831,6 +831,15 @@ def create_py_executor(
                 "KV connector is not supported with attention data parallelism (enable_attention_dp=True)."
             )
 
+        if spec_config is not None and not spec_config.is_linear_tree:
+            raise NotImplementedError(
+                "KV cache connector with non-linear-tree speculative decoding "
+                "(e.g. Eagle) is not supported yet. The connector's per-request "
+                "block bookkeeping is not trimmed after rewind, which can cause "
+                "hangs in get_finished. See "
+                "https://github.com/NVIDIA/TensorRT-LLM/issues/16448"
+            )
+
         try:
             module = importlib.import_module(
                 kv_connector_config.connector_module)

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1044,6 +1044,8 @@ class KVCacheManager(BaseResourceManager):
                     continue
                 if request.py_rewind_len > 0:
                     self.rewind_kv_cache(request, request.py_rewind_len)
+                    if self.kv_connector_manager is not None:
+                        self.kv_connector_manager.on_rewind(request, self)
                 # Symmetric companion to prepare_resources's reserve_slack
                 # add_token loop: when _kv_reserve_draft_tokens (e.g. dynamic
                 # tree's K*max_draft_len) exceeds the runtime draft length,
@@ -1055,6 +1057,8 @@ class KVCacheManager(BaseResourceManager):
                 extra_rewind = self._kv_reserve_draft_tokens - runtime_draft_len
                 if extra_rewind > 0:
                     self.rewind_kv_cache(request, extra_rewind)
+                    if self.kv_connector_manager is not None:
+                        self.kv_connector_manager.on_rewind(request, self)
 
         # For context requests, store completed context blocks for KV cache reuse.
         # We wait until context_remaining_length == 0 (all chunks processed) before

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1042,9 +1042,11 @@ class KVCacheManager(BaseResourceManager):
                 if request.state in (LlmRequestState.GENERATION_COMPLETE,
                                      LlmRequestState.CONTEXT_INIT):
                     continue
+                should_notify_connector = (self.kv_connector_manager is not None
+                                           and not self.is_draft)
                 if request.py_rewind_len > 0:
                     self.rewind_kv_cache(request, request.py_rewind_len)
-                    if self.kv_connector_manager is not None:
+                    if should_notify_connector:
                         self.kv_connector_manager.on_rewind(request, self)
                 # Symmetric companion to prepare_resources's reserve_slack
                 # add_token loop: when _kv_reserve_draft_tokens (e.g. dynamic
@@ -1057,7 +1059,7 @@ class KVCacheManager(BaseResourceManager):
                 extra_rewind = self._kv_reserve_draft_tokens - runtime_draft_len
                 if extra_rewind > 0:
                     self.rewind_kv_cache(request, extra_rewind)
-                    if self.kv_connector_manager is not None:
+                    if should_notify_connector:
                         self.kv_connector_manager.on_rewind(request, self)
 
         # For context requests, store completed context blocks for KV cache reuse.

--- a/tests/unittest/_torch/test_connector.py
+++ b/tests/unittest/_torch/test_connector.py
@@ -15,7 +15,7 @@
 
 import pickle
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import cloudpickle
 import mpi4py
@@ -26,6 +26,8 @@ from tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector import (
     AsyncRequests, KvCacheConnectorManager,
     KvCacheConnectorSchedulerOutputManager)
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
+from tensorrt_llm._torch.pyexecutor.resource_manager import (CacheTypeCpp,
+                                                             KVCacheManager)
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 
 cloudpickle.register_pickle_by_value(sys.modules[__name__])
@@ -301,6 +303,55 @@ def test_scheduler_output_on_rewind_trims_stale_block_ids():
     assert manager.requests[req.request_id].tokens == [10, 11, 13]
 
 
+def _make_kv_cache_manager_for_update_resources(is_draft: bool):
+    manager = object.__new__(KVCacheManager)
+    manager.kv_cache_type = CacheTypeCpp.SELF
+    manager.is_draft = is_draft
+    manager.kv_connector_manager = MagicMock()
+    manager._kv_reserve_draft_tokens = 0
+    manager.rewind_kv_cache = MagicMock()
+    return manager
+
+
+def _make_generation_request_for_rewind(rewind_len: int):
+    req = MagicMock()
+    req.state = LlmRequestState.GENERATION_IN_PROGRESS
+    req.py_rewind_len = rewind_len
+    req.py_num_accepted_draft_tokens = 0
+    return req
+
+
+def test_update_resources_notifies_connector_only_from_target_kv_manager():
+    req = _make_generation_request_for_rewind(rewind_len=1)
+    scheduled_batch = ScheduledRequests()
+    scheduled_batch.generation_requests = [req]
+
+    manager = _make_kv_cache_manager_for_update_resources(is_draft=False)
+
+    with patch(
+            "tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2._update_kv_cache_draft_token_location"
+    ):
+        manager.update_resources(scheduled_batch)
+
+    manager.rewind_kv_cache.assert_called_once_with(req, 1)
+    manager.kv_connector_manager.on_rewind.assert_called_once_with(req, manager)
+
+
+def test_update_resources_draft_kv_manager_does_not_notify_connector():
+    req = _make_generation_request_for_rewind(rewind_len=1)
+    scheduled_batch = ScheduledRequests()
+    scheduled_batch.generation_requests = [req]
+
+    manager = _make_kv_cache_manager_for_update_resources(is_draft=True)
+    manager._kv_reserve_draft_tokens = 2
+
+    manager.update_resources(scheduled_batch)
+
+    assert manager.rewind_kv_cache.call_count == 2
+    manager.rewind_kv_cache.assert_any_call(req, 1)
+    manager.kv_connector_manager.on_rewind.assert_not_called()
+
+
 def test_connector_manager_on_rewind_forwards_to_scheduler():
     """KvCacheConnectorManager.on_rewind must forward live_block_ids to the
     external scheduler on rank 0."""
@@ -311,33 +362,22 @@ def test_connector_manager_on_rewind_forwards_to_scheduler():
 
     req = MagicMock()
     req.request_id = 42
+    req.get_tokens.return_value = [1, 2, 3]
 
     kv_cache_manager = MagicMock()
     kv_cache_manager.get_cache_indices.return_value = [0, 1]
 
+    req_state = manager.scheduler_output_manager.requests[42]
+    req_state.block_ids = [0, 1, 2]
+    req_state.tokens = [1, 2, 3, 4]
+
     manager.on_rewind(req, kv_cache_manager)
 
-    # scheduler_output_manager.on_rewind always runs (trims Python state).
-    assert manager.scheduler_output_manager.requests.get(42) is not None or True
+    assert req_state.block_ids == [0, 1]
+    assert req_state.tokens == [1, 2, 3]
 
     # scheduler.on_rewind must be called with the post-rewind live block ids.
     scheduler.on_rewind.assert_called_once()
     forwarded_req, forwarded_ids = scheduler.on_rewind.call_args.args
+    assert forwarded_req is req
     assert forwarded_ids == [0, 1]
-
-
-def test_py_executor_creator_guard_non_linear_tree_specdec():
-    """create_py_executor must raise NotImplementedError when a KV connector is
-    used with non-linear-tree speculative decoding (e.g. Eagle)."""
-    # Minimal args with non-linear-tree specdec + kv connector.
-    # We can't easily construct a full TorchLlmArgs, so we test the guard
-    # logic indirectly by checking that the guard condition exists.
-    import inspect
-
-    from tensorrt_llm._torch.pyexecutor.py_executor_creator import \
-        create_py_executor
-    source = inspect.getsource(create_py_executor)
-    assert "is_linear_tree" in source, \
-        "Guard for non-linear-tree specdec + connector not found"
-    assert "NotImplementedError" in source, \
-        "NotImplementedError guard not found in create_py_executor"

--- a/tests/unittest/_torch/test_connector.py
+++ b/tests/unittest/_torch/test_connector.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -250,3 +250,52 @@ def test_scheduler_output_block_hashes_read_through():
     assert kv_cache_manager.commit_and_get_block_hashes.call_count == 2
     for call in kv_cache_manager.commit_and_get_block_hashes.call_args_list:
         assert call.args == (req, )
+
+
+def test_scheduler_output_on_rewind_trims_stale_block_ids():
+    """on_rewind must trim block_ids/tokens after speculative-decoding rewind.
+
+    Regression test for the hang caused by stale freed block ids retained
+    in KvCacheConnectorSchedulerOutputRequest after rewindKVCache frees
+    blocks crossing a block boundary.
+    """
+    req = MagicMock()
+    req.request_id = 42
+
+    kv_cache_manager = MagicMock()
+    # Simulate 3 blocks allocated, then rewind frees the last block.
+    kv_cache_manager.get_cache_indices.side_effect = [
+        [0, 1, 2],  # before rewind
+        [0, 1],  # after rewind: last block freed
+        [0, 1, 3],  # after next alloc (new block id 3)
+    ]
+
+    # Tokens: 3 blocks * block_size, then rewind removes last block's tokens,
+    # then a new token is appended.
+    req.get_tokens.side_effect = [
+        [10, 11, 12],  # before rewind
+        [10, 11],  # after rewind (shorter)
+        [10, 11, 13],  # after next step (accepted token added)
+    ]
+
+    manager = KvCacheConnectorSchedulerOutputManager()
+
+    # Build initial state: 3 blocks, 3 tokens.
+    scheduled_batch = ScheduledRequests()
+    scheduled_batch.generation_requests = [req]
+    manager.build_scheduler_output(scheduled_batch, AsyncRequests({}, {}),
+                                   kv_cache_manager)
+    assert manager.requests[req.request_id].block_ids == [0, 1, 2]
+    assert manager.requests[req.request_id].tokens == [10, 11, 12]
+
+    # Rewind: frees block 2, tokens shrink.
+    manager.on_rewind(req, kv_cache_manager)
+    assert manager.requests[req.request_id].block_ids == [0, 1]
+    assert manager.requests[req.request_id].tokens == [10, 11]
+
+    # Next step: new block 3 allocated, new token 13 appended.
+    manager.build_scheduler_output(scheduled_batch, AsyncRequests({}, {}),
+                                   kv_cache_manager)
+    assert manager.requests[req.request_id].block_ids == [0, 1, 3]
+    # Token 13 is a new token, not a re-emit of the trimmed ones.
+    assert manager.requests[req.request_id].tokens == [10, 11, 13]

--- a/tests/unittest/_torch/test_connector.py
+++ b/tests/unittest/_torch/test_connector.py
@@ -299,3 +299,45 @@ def test_scheduler_output_on_rewind_trims_stale_block_ids():
     assert manager.requests[req.request_id].block_ids == [0, 1, 3]
     # Token 13 is a new token, not a re-emit of the trimmed ones.
     assert manager.requests[req.request_id].tokens == [10, 11, 13]
+
+
+def test_connector_manager_on_rewind_forwards_to_scheduler():
+    """KvCacheConnectorManager.on_rewind must forward live_block_ids to the
+    external scheduler on rank 0."""
+    worker = MagicMock()
+    scheduler = MagicMock()
+
+    manager = KvCacheConnectorManager(worker, scheduler=scheduler)
+
+    req = MagicMock()
+    req.request_id = 42
+
+    kv_cache_manager = MagicMock()
+    kv_cache_manager.get_cache_indices.return_value = [0, 1]
+
+    manager.on_rewind(req, kv_cache_manager)
+
+    # scheduler_output_manager.on_rewind always runs (trims Python state).
+    assert manager.scheduler_output_manager.requests.get(42) is not None or True
+
+    # scheduler.on_rewind must be called with the post-rewind live block ids.
+    scheduler.on_rewind.assert_called_once()
+    forwarded_req, forwarded_ids = scheduler.on_rewind.call_args.args
+    assert forwarded_ids == [0, 1]
+
+
+def test_py_executor_creator_guard_non_linear_tree_specdec():
+    """create_py_executor must raise NotImplementedError when a KV connector is
+    used with non-linear-tree speculative decoding (e.g. Eagle)."""
+    # Minimal args with non-linear-tree specdec + kv connector.
+    # We can't easily construct a full TorchLlmArgs, so we test the guard
+    # logic indirectly by checking that the guard condition exists.
+    import inspect
+
+    from tensorrt_llm._torch.pyexecutor.py_executor_creator import \
+        create_py_executor
+    source = inspect.getsource(create_py_executor)
+    assert "is_linear_tree" in source, \
+        "Guard for non-linear-tree specdec + connector not found"
+    assert "NotImplementedError" in source, \
+        "NotImplementedError guard not found in create_py_executor"


### PR DESCRIPTION
## Problem

When a KV cache connector is used with speculative decoding, rejected draft tokens cause `rewindKVCache` to free blocks. If the rewind crosses a block boundary (`releaseLastBlock` is called), the connector's per-request `block_ids` list is never trimmed — it only grows monotonically. The stale freed block ids cause `get_finished`'s cross-rank `mpi_allgather` + `set.intersection` to never complete, leading to **hangs**.

This is more likely with Eagle (larger draft trees → more blocks freed) but can also occur with MTP when the partial block has fewer tokens than the draft count.

## Fix

Add an `on_rewind` hook that propagates post-rewind live block ids through the connector stack:

- **`KvCacheConnectorScheduler` ABC**: new `on_rewind` default no-op method
- **`KvCacheConnectorSchedulerOutputManager.on_rewind`**: trims `block_ids` and `tokens` to match post-rewind state
- **`KvCacheConnectorManager.on_rewind`**: delegates to `scheduler_output_manager` and external scheduler (rank 0 only)
- **`resource_manager.py`**: calls `kv_connector_manager.on_rewind()` after each `rewind_kv_cache`
- **`py_executor_creator.py`**: raises `NotImplementedError` for non-linear-tree specdec + connector until external connectors implement `on_rewind`
- **Unit test**: covers the full `[0,1,2]→[0,1]→[0,1,3]` rewind cycle

## Related issue

Closes #16448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speculative-decoding rollback so KV-cache bookkeeping stays consistent after rewinding rejected draft tokens, avoiding stale cache references and incorrect token/block scheduling in subsequent steps.

* **Compatibility**
  * Added a validation error when using KV cache connectors with unsupported non-linear-tree speculative decoding, failing fast with a clear message.

* **Tests**
  * Added regression tests covering rewind trimming behavior, correct forwarding of post-rewind state to the scheduler, and the new speculative-decoding guard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->