### PR TITLE
[None][feat] support multi-token bad words in bad_token_ids

### DIFF
--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -140,7 +140,7 @@ class SamplingParams:
         pad_id (int, optional): The pad token id. Defaults to None.
         max_tokens (int): The maximum number of tokens to generate. Defaults to 32.
         bad (str, List[str], optional): A string or a list of strings that redirect the generation when they are generated, so that the bad strings are excluded from the returned output. Defaults to None.
-        bad_token_ids (List[int], optional): A list of token ids that redirect the generation when they are generated, so that the bad ids are excluded from the returned output. Defaults to None.
+        bad_token_ids (List[Union[int, List[int]]], optional): A list of bad token id sequences that redirect the generation when they are generated, so that the bad ids are excluded from the returned output. Each element is either a single token id or a list of token ids forming a multi-token bad word. Defaults to None.
         stop (str, List[str], optional): A string or a list of strings that stop the generation when they are generated. The returned output will not contain the stop strings unless include_stop_str_in_output is True. Defaults to None.
         stop_token_ids (List[int], optional): A list of token ids that stop the generation when they are generated. Defaults to None.
         include_stop_str_in_output (bool): Whether to include the stop strings in output text. Defaults to False.
@@ -221,7 +221,7 @@ class SamplingParams:
     pad_id: Optional[int] = None
     max_tokens: int = 32
     bad: Optional[Union[str, List[str]]] = None
-    bad_token_ids: Optional[List[int]] = None
+    bad_token_ids: Optional[List[Union[int, List[int]]]] = None
     _bad_word_ids: Optional[List[List[int]]] = field(default=None, init=False, repr=False)
     stop: Optional[Union[str, List[str]]] = None
     stop_token_ids: Optional[List[int]] = None
@@ -437,7 +437,7 @@ class SamplingParams:
     def _get_bad_words(self) -> List[List[int]]:
         words = []
         if self.bad_token_ids:
-            words = [[i] for i in self.bad_token_ids]
+            words = [[i] if isinstance(i, int) else list(i) for i in self.bad_token_ids]
 
         if self.bad is None:
             return words

--- a/tests/unittest/api_stability/references_committed/sampling_params.yaml
+++ b/tests/unittest/api_stability/references_committed/sampling_params.yaml
@@ -84,7 +84,7 @@ methods:
         annotation: Union[List[str], str, NoneType]
         default: null
       bad_token_ids:
-        annotation: Optional[List[int]]
+        annotation: Optional[List[Union[int, List[int]]]]
         default: null
       # Logits processor and guided decoding
       logits_processor:

--- a/tests/unittest/llmapi/test_bad_token_ids.py
+++ b/tests/unittest/llmapi/test_bad_token_ids.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from tensorrt_llm.sampling_params import SamplingParams
+
+
+def test_bad_token_ids_single_tokens() -> None:
+    sp = SamplingParams(bad_token_ids=[5, 7])
+    assert sp._get_bad_words() == [[5], [7]]
+
+
+def test_bad_token_ids_multi_token_sequences() -> None:
+    # A user can now block a multi-token bad word explicitly.
+    sp = SamplingParams(bad_token_ids=[[10, 11], 5])
+    assert sp._get_bad_words() == [[10, 11], [5]]


### PR DESCRIPTION
## Description

Follow-up to the review discussion on #16239 (thanks @tongyuantongyu).

`SamplingParams.bad_token_ids` only accepted single token ids — each id became a one-token bad word (`words = [[i] for i in self.bad_token_ids]`). So a user could **not** explicitly block a *multi-token* bad word, which is the principled, user-controlled way to handle position-dependent tokenizations (rather than the string API guessing).

## Change

Accept `List[Union[int, List[int]]]`: each element is either a single token id or an explicit multi-token sequence. The downstream backend already consumes multi-token bad-word sequences (the `bad` string path produces them), so this is purely surfacing existing capability. Backward compatible — plain `List[int]` still works.

Updated the docstring and the `api_stability` reference for the field annotation.

## Test

`tests/unittest/llmapi/test_bad_token_ids.py`: single-token ids still map to 1-token bad words; multi-token sequences pass through as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded bad-token filtering to support multi-token word sequences in addition to individual token IDs.
  * Existing single-token configurations remain supported.

* **Tests**
  * Added coverage for single-token entries and mixed single- and multi-token sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->