### PR TITLE
[None][infra] Fix CBTS skip-rate calculation method

### DIFF
--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -807,7 +807,8 @@ def getCbtsResult(pipeline, testFilter, globalVars)
         pipeline.echo("CBTS: scope=${result.scope}, " +
                       "stages=${result.affected_stages.size()}")
         def runStatus = (testFilter[(IS_POST_MERGE)] ?: false) ? "post_merge" : "pre_merge"
-        _cbtsReportDecision(pipeline, globalVars, runStatus, "", output)
+        def multiGpuScheduled = (testFilter[(MULTI_GPU_FILE_CHANGED)] ?: false) as boolean
+        _cbtsReportDecision(pipeline, globalVars, runStatus, "", output, multiGpuScheduled)
         return result
     } catch (InterruptedException e) {
         throw e
@@ -819,10 +820,15 @@ def getCbtsResult(pipeline, testFilter, globalVars)
 
 // Post one CBTS decision record to OpenSearch (best-effort; never blocks CI).
 // decisionJson null for deferred; reason used only then. Context/creds via env.
-def _cbtsReportDecision(pipeline, globalVars, String status, String reason, String decisionJson)
+// multiGpuScheduled: true when multi-GPU pre-merge stages will actually run,
+// so they are included in the skip-rate denominator.
+def _cbtsReportDecision(pipeline, globalVars, String status, String reason, String decisionJson, boolean multiGpuScheduled = false)
 {
     try {
         def args = "--status ${status}"
+        if (multiGpuScheduled) {
+            args += " --multi-gpu-scheduled"
+        }
         if (decisionJson != null) {
             pipeline.writeFile(file: "${LLM_ROOT}/cbts_decision.json", text: decisionJson)
             args += " --decision cbts_decision.json"

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -912,7 +912,7 @@ def getCbtsResult(pipeline, testFilter, globalVars)
                       "stages=${result.affected_stages.size()}")
         def runStatus = (testFilter[(IS_POST_MERGE)] ?: false) ? "post_merge" : "pre_merge"
         def multiGpuRequired = (testFilter[(MULTI_GPU_FILE_CHANGED)] ?: false) as boolean
-        def multiGpuLabelGateOpen = !multiGpuRequired ||
+        def multiGpuLabelGateOpen = multiGpuRequired &&
             _cbtsMultiGpuLabelGateOpen(pipeline, globalVars)
         _cbtsReportDecision(pipeline, globalVars, runStatus, "", output,
                             multiGpuRequired, multiGpuLabelGateOpen)

--- a/jenkins/scripts/cbts/tools/report_cbts_decision.py
+++ b/jenkins/scripts/cbts/tools/report_cbts_decision.py
@@ -25,6 +25,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,16 +35,30 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # jenkins/scripts/
 logger = logging.getLogger("report_cbts_decision")
 
 
+_MULTI_GPU_RE = re.compile(r"\d+_GPUs")
+
+
+def _is_multi_gpu_stage(name: str) -> bool:
+    return bool(_MULTI_GPU_RE.search(name))
+
+
 def _case_counts(
-    affected: list[str], kept_per_stage: dict, status: str, repo_root: str
+    affected: list[str],
+    kept_per_stage: dict,
+    status: str,
+    repo_root: str,
+    multi_gpu_scheduled: bool = True,
 ) -> tuple[int, int]:
-    """(cbts_cases, total_cases): cases CBTS runs vs all cases in the mode.
+    r"""(cbts_cases, total_cases): cases CBTS runs vs all cases in the mode.
 
     cbts = sum over hit stages of the Layer-3-kept count (or full if a stage
     wasn't narrowed). total = full case count over the whole trigger-mode
     universe: all non-Post-Merge stages for pre_merge, all stages for
-    post_merge. Only meaningful when CBTS ran; returns (0, 0) otherwise or on
-    any failure so the record still posts.
+    post_merge. When multi_gpu_scheduled is False (pre_merge only), stages
+    whose name matches /\d+_GPUs/ are excluded from both counts — they will
+    not be scheduled by Jenkins and should not inflate the denominator.
+    Only meaningful when CBTS ran; returns (0, 0) otherwise or on any failure
+    so the record still posts.
     """
     if status not in ("pre_merge", "post_merge"):
         return 0, 0
@@ -66,10 +81,22 @@ def _case_counts(
             )
 
         post = status == "post_merge"
+
+        def scheduled(name: str) -> bool:
+            # Post-Merge stages are already gated by the `post` flag below.
+            # For pre_merge, additionally exclude multi-GPU stages when not triggered.
+            return post or multi_gpu_scheduled or not _is_multi_gpu_stage(name)
+
         cbts = sum(
-            kept_per_stage.get(name, full(stages[name])) for name in affected if name in stages
+            kept_per_stage.get(name, full(stages[name]))
+            for name in affected
+            if name in stages and scheduled(name)
         )
-        total = sum(full(st) for name, st in stages.items() if post or "Post-Merge" not in name)
+        total = sum(
+            full(st)
+            for name, st in stages.items()
+            if (post or "Post-Merge" not in name) and scheduled(name)
+        )
         return cbts, total
     except Exception as exc:  # noqa: BLE001 - case rate is best-effort
         logger.info("CBTS case-count failed (non-fatal): %s", exc)
@@ -83,6 +110,7 @@ def build_document(
     pr_number: str,
     cbts_cases: int,
     total_cases: int,
+    multi_gpu_scheduled: bool = True,
 ) -> dict:
     """Build the typed OpenSearch doc (field prefixes: s_=str, l_=int, d_=float, flat_=dict)."""
     scope = decision.get("scope")
@@ -105,6 +133,7 @@ def build_document(
         "l_total_cases": total_cases,
         "l_cbts_cases": cbts_cases,
         "d_case_skip_rate": round(case_skip_rate, 4),
+        "b_multi_gpu_scheduled": multi_gpu_scheduled,
         "flat_detail": {
             "hit_stages": affected,
             "scopes": list(decision.get("scopes") or []),
@@ -122,6 +151,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--decision", default=None, help="Path to cbts/main.py decision JSON.")
     parser.add_argument("--pr-number", default="", help="PR / MR number for s_pr_number.")
     parser.add_argument("--repo-root", default=".", help="Repo root (for the case-rate counts).")
+    parser.add_argument(
+        "--multi-gpu-scheduled",
+        action="store_true",
+        default=False,
+        help="Pass when multi-GPU pre-merge stages will actually run (multi_gpu_file_changed=true). "
+        "Omit to exclude those stages from the skip-rate denominator.",
+    )
     args = parser.parse_args(argv)
 
     # Lazy import: any failure surfaces here and is caught by the __main__
@@ -136,9 +172,16 @@ def main(argv: list[str] | None = None) -> int:
         decision.get("affected_stage_test_counts") or {},
         args.status,
         args.repo_root,
+        multi_gpu_scheduled=args.multi_gpu_scheduled,
     )
     doc = build_document(
-        decision, args.status, args.reason, args.pr_number, cbts_cases, total_cases
+        decision,
+        args.status,
+        args.reason,
+        args.pr_number,
+        cbts_cases,
+        total_cases,
+        multi_gpu_scheduled=args.multi_gpu_scheduled,
     )
     OpenSearchDB.add_id_of_json(doc)
     ok = OpenSearchDB.postToOpenSearchDB(doc, CBTS_PROJECT_NAME)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- CBTS skip-rate calculation now groups scheduled stages by stage family.
- The implementation handles affected, force-kept, sanity, pytest-shard, OnDemand, Post-Merge, and multi-GPU stages.
- Multi-GPU reporting separates `multiGpuRequired` from `multiGpuLabelGateOpen`.
- OpenSearch filtering limits split counts to scheduled affected stages.
- Stage-selection documentation matches the baseline and affected-stage intersection logic.
- Existing `_cbtsReportDecision` callers remain compatible with the optional multi-GPU parameters.
- No unrelated configuration or test-list changes were identified.

## QA Engineer Review

- Added six CPU-only unit tests in `tests/unittest/scripts/test_report_cbts_decision.py`:
  - `test_multi_gpu_scheduled_requires_policy_and_label_gate`
  - `test_case_counts_use_scheduled_unsharded_pre_merge_universe`
  - `test_case_counts_include_selected_multi_gpu_when_gate_is_open`
  - `test_case_counts_include_coverage_multi_gpu_at_full_size`
  - `test_build_document_filters_unscheduled_stages_and_persists_valid_rate`
  - `test_main_posts_case_skip_rate_to_opensearch`
- These tests are not listed in `tests/integration/test_lists/test-db/` or `tests/integration/test_lists/qa/`.
- Verdict: needs follow-up. CBTS coverage data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
