### PR TITLE
[TRTLLM-14352][perf] Fuse Qwen3.5/3.6 attention preprocessing (QK-nor…

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -1,5 +1,7 @@
 # Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
 # Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/configs/qwen3_next.py
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # coding=utf-8
 # Copyright 2024 The Qwen team, Alibaba Group and the HuggingFace Inc. team. All rights reserved.
 #
@@ -489,6 +491,7 @@ class Qwen3NextAttention(Qwen3Attention):
                          fuse_qk_norm_rope=fuse_qk_norm_rope,
                          attn_output_gate=True,
                          use_gemma_rms_norm=True)
+        self._fuse_qk_norm_rope_gate = True
 
 
 class Qwen3NextFullAttentionDecoderLayer(DecoderLayer):

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import weakref
 from typing import List, Optional, Tuple, Union
@@ -696,6 +699,42 @@ class Attention(nn.Module):
             q, k, v = q.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         return q, k, v
 
+    def preprocess_qkv(
+        self, qkv: torch.Tensor, position_ids: Optional[torch.Tensor]
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor],
+               Optional[torch.Tensor]]:
+        """Transform the fused QKV projection into attention inputs.
+
+        Splits out the optional attention output gate and applies RoPE (plus
+        any subclass-specific processing such as QK norm, via apply_rope).
+        Subclasses may override this to fuse these steps into a single kernel.
+
+        Returns:
+            tuple: (q, k, v, gate). k and v are None when q holds the fused
+            QKV tensor; gate is None when attn_output_gate is disabled.
+        """
+        gate = None
+        if self.attn_output_gate:
+            q_gate, k, v = qkv.split(
+                [self.q_size * 2, self.kv_size, self.kv_size], dim=-1)
+            orig_shape = q_gate.shape[:-1]
+            # Single line: view -> chunk -> reshape both q and gate
+            q, gate = [
+                t.reshape(*orig_shape, -1) for t in torch.chunk(
+                    q_gate.view(*orig_shape, self.num_heads, -1), 2, dim=-1)
+            ]
+        else:
+            q, k, v = qkv, None, None
+        q, k, v = self.apply_rope(q, k, v, position_ids)
+        return q, k, v, gate
+
+    def apply_output_gate(self, attention_output: torch.Tensor,
+                          gate: torch.Tensor) -> torch.Tensor:
+        """Apply the attention output gate."""
+        if gate.shape != attention_output.shape:
+            gate = gate.reshape(attention_output.shape)
+        return attention_output * torch.sigmoid(gate)
+
     def convert_qkv(self, q, k, v):
         if k is None and v is None and not self.support_fused_qkv:
             q, k, v = self.split_qkv(q)
@@ -983,18 +1022,6 @@ class Attention(nn.Module):
             if qkv_lora is not None:
                 qkv = qkv + qkv_lora
 
-        if self.attn_output_gate:
-            q_gate, k, v = qkv.split(
-                [self.q_size * 2, self.kv_size, self.kv_size], dim=-1)
-            orig_shape = q_gate.shape[:-1]
-            # Single line: view -> chunk -> reshape both q and gate
-            q, gate = [
-                t.reshape(*orig_shape, -1) for t in torch.chunk(
-                    q_gate.view(*orig_shape, self.num_heads, -1), 2, dim=-1)
-            ]
-        else:
-            q, k, v = qkv, None, None
-
         # For dynamic tree spec decoding with Python RoPE, adjust position_ids
         # to use tree offsets (same as C++ kernel: past_seq_len + offset).
         if (not self.rope_fusion
@@ -1008,7 +1035,7 @@ class Attention(nn.Module):
             position_ids = self._adjust_position_ids_for_spec_dec(
                 position_ids, attn_metadata)
 
-        q, k, v = self.apply_rope(q, k, v, position_ids)
+        q, k, v, gate = self.preprocess_qkv(qkv, position_ids)
         q, k, v = self.convert_qkv(q, k, v)
 
         if attention_sinks is not None:
@@ -1034,8 +1061,7 @@ class Attention(nn.Module):
         )
 
         if self.attn_output_gate:
-            gate = torch.sigmoid(gate)
-            attn_output = attn_output * gate
+            attn_output = self.apply_output_gate(attn_output, gate)
 
         attn_output = _helix_cp_output_projection(self.o_proj, attn_output,
                                                   attn_metadata,

--- a/tensorrt_llm/_torch/modules/fused_ops/fused_qk_norm_rope_gate.py
+++ b/tensorrt_llm/_torch/modules/fused_ops/fused_qk_norm_rope_gate.py
@@ -1,0 +1,348 @@
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/kernels/ops/attention/fused_qk_rmsnorm_rope_gate.py
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fused Qwen3.5 full-attention preprocessing and output gating.
+
+The projection produces interleaved ``[q0, gate0, q1, gate1, ..., K, V]``.
+The preprocessing kernel reads that layout directly and writes packed
+``[Q, K, V]`` while applying per-head Gemma RMSNorm and NeoX RoPE to Q/K.
+Gate deinterleave is fused into the same pass.  Keeping the checkpoint layout
+unchanged avoids coupling the optimization to weight loading, quantization,
+LoRA, or attention-backend fallback behavior.
+"""
+
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fused_qkv_gemma_rmsnorm_rope_gate_kernel(
+    qkv_ptr,
+    qkv_out_ptr,
+    gate_out_ptr,
+    q_weight_ptr,
+    k_weight_ptr,
+    cos_sin_ptr,
+    positions_ptr,
+    num_tokens,
+    max_positions,
+    qkv_stride_token,
+    qkv_out_stride_token,
+    gate_out_stride_token,
+    cos_sin_stride_position,
+    num_q_heads: tl.constexpr,
+    num_kv_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    rotary_dim: tl.constexpr,
+    half_rotary: tl.constexpr,
+    head_block: tl.constexpr,
+    rotary_block: tl.constexpr,
+    eps: tl.constexpr,
+    output_fp16: tl.constexpr,
+    has_pass_through: tl.constexpr,
+    use_mrope: tl.constexpr,
+    mrope_section1: tl.constexpr,
+    mrope_section2: tl.constexpr,
+):
+    token = tl.program_id(0).to(tl.int64)
+    head = tl.program_id(1)
+    q_size = num_q_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    output_dtype = tl.float16 if output_fp16 else tl.bfloat16
+
+    if head < num_q_heads + num_kv_heads:
+        is_k = head >= num_q_heads
+        local_head = tl.where(is_k, head - num_q_heads, head)
+        if is_k:
+            input_base = qkv_ptr + token * qkv_stride_token + 2 * q_size + local_head * head_dim
+            output_base = (
+                qkv_out_ptr + token * qkv_out_stride_token + q_size + local_head * head_dim
+            )
+            weight_ptr = k_weight_ptr
+        else:
+            input_base = qkv_ptr + token * qkv_stride_token + local_head * 2 * head_dim
+            output_base = qkv_out_ptr + token * qkv_out_stride_token + local_head * head_dim
+            weight_ptr = q_weight_ptr
+
+        head_offsets = tl.arange(0, head_block)
+        head_mask = head_offsets < head_dim
+        x = tl.load(input_base + head_offsets, mask=head_mask, other=0.0).to(tl.float32)
+        weight = tl.load(weight_ptr + head_offsets, mask=head_mask, other=0.0).to(tl.float32)
+        inverse_rms = tl.rsqrt(tl.sum(x * x, axis=0) / head_dim + eps)
+        normalized = (x * inverse_rms * (weight + 1.0)).to(output_dtype).to(tl.float32)
+
+        if has_pass_through:
+            pass_mask = head_mask & (head_offsets >= rotary_dim)
+            tl.store(output_base + head_offsets, normalized, mask=pass_mask)
+
+        rotary_offsets = tl.arange(0, rotary_block)
+        rotary_mask = rotary_offsets < half_rotary
+        x_first = tl.load(input_base + rotary_offsets, mask=rotary_mask, other=0.0).to(tl.float32)
+        x_second = tl.load(
+            input_base + half_rotary + rotary_offsets, mask=rotary_mask, other=0.0
+        ).to(tl.float32)
+        weight_first = tl.load(weight_ptr + rotary_offsets, mask=rotary_mask, other=0.0).to(
+            tl.float32
+        )
+        weight_second = tl.load(
+            weight_ptr + half_rotary + rotary_offsets, mask=rotary_mask, other=0.0
+        ).to(tl.float32)
+        x_first = (x_first * inverse_rms * (weight_first + 1.0)).to(output_dtype).to(tl.float32)
+        x_second = (x_second * inverse_rms * (weight_second + 1.0)).to(output_dtype).to(tl.float32)
+
+        if use_mrope:
+            section = tl.where(
+                (rotary_offsets % 3 == 1) & (rotary_offsets < mrope_section1 * 3),
+                1,
+                tl.where(
+                    (rotary_offsets % 3 == 2) & (rotary_offsets < mrope_section2 * 3),
+                    2,
+                    0,
+                ),
+            )
+            position = tl.load(
+                positions_ptr + section * num_tokens + token,
+                mask=rotary_mask,
+                other=0,
+            ).to(tl.int64)
+        else:
+            position = tl.load(positions_ptr + token).to(tl.int64)
+        position_is_valid = (position >= 0) & (position < max_positions)
+        tl.device_assert(position_is_valid, "position is outside the RoPE table")
+        safe_position = tl.where(position_is_valid, position, 0)
+        cos_sin_base = cos_sin_ptr + safe_position * cos_sin_stride_position
+        cos = tl.load(cos_sin_base + rotary_offsets, mask=rotary_mask, other=0.0).to(tl.float32)
+        sin = tl.load(cos_sin_base + half_rotary + rotary_offsets, mask=rotary_mask, other=0.0).to(
+            tl.float32
+        )
+        cos = tl.where(position_is_valid, cos, float("nan"))
+        sin = tl.where(position_is_valid, sin, float("nan"))
+        tl.store(
+            output_base + rotary_offsets,
+            x_first * cos - x_second * sin,
+            mask=rotary_mask,
+        )
+        tl.store(
+            output_base + half_rotary + rotary_offsets,
+            x_second * cos + x_first * sin,
+            mask=rotary_mask,
+        )
+
+        if not is_k:
+            gate_input = input_base + head_dim
+            gate_output = gate_out_ptr + token * gate_out_stride_token + local_head * head_dim
+            gate = tl.load(gate_input + head_offsets, mask=head_mask, other=0.0)
+            tl.store(gate_output + head_offsets, gate, mask=head_mask)
+    else:
+        local_head = head - num_q_heads - num_kv_heads
+        head_offsets = tl.arange(0, head_block)
+        head_mask = head_offsets < head_dim
+        input_base = (
+            qkv_ptr + token * qkv_stride_token + 2 * q_size + kv_size + local_head * head_dim
+        )
+        output_base = (
+            qkv_out_ptr + token * qkv_out_stride_token + q_size + kv_size + local_head * head_dim
+        )
+        value = tl.load(input_base + head_offsets, mask=head_mask, other=0.0)
+        tl.store(output_base + head_offsets, value, mask=head_mask)
+
+
+def fused_qkv_gemma_rmsnorm_rope_gate(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin: torch.Tensor,
+    positions: torch.Tensor,
+    eps: float,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+    mrope_section: Optional[Tuple[int, int, int]] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Prepare packed QKV and gate with one Triton kernel.
+
+    Args:
+        qkv: ``[num_tokens, 2 * q_size + 2 * kv_size]`` BF16/FP16 projection
+            output in per-head interleaved Q/G layout.
+        q_weight: ``[head_dim]`` raw Gemma RMSNorm Q weights.
+        k_weight: ``[head_dim]`` raw Gemma RMSNorm K weights.
+        cos_sin: ``[max_positions, 2, rotary_dim // 2]`` FP32 NeoX table.
+        positions: Flattenable ``[num_tokens]`` plain-RoPE positions, or
+            ``[3, ..., num_tokens]`` interleaved-MRoPE positions.
+        eps: RMSNorm epsilon.
+        num_q_heads: Local query-head count.
+        num_kv_heads: Local key/value-head count.
+        head_dim: Per-head Q/K/V dimension.
+        rotary_dim: Prefix dimension receiving NeoX RoPE.
+        mrope_section: Temporal/height/width rotary-half dimensions. ``None``
+            selects plain RoPE; a tuple selects Qwen-style interleaved MRoPE.
+
+    Returns:
+        Packed QKV ``[num_tokens, q_size + 2 * kv_size]`` and gate
+        ``[num_tokens, num_q_heads, head_dim]``.
+    """
+    assert qkv.dim() == 2 and qkv.stride(-1) == 1
+    assert qkv.dtype in (torch.bfloat16, torch.float16)
+    assert q_weight.shape == (head_dim,) and k_weight.shape == (head_dim,)
+    assert q_weight.device == qkv.device and k_weight.device == qkv.device
+    assert cos_sin.dtype == torch.float32 and cos_sin.is_contiguous()
+    assert cos_sin.device == qkv.device and positions.device == qkv.device
+    assert rotary_dim > 0 and rotary_dim <= head_dim and rotary_dim % 2 == 0
+    assert cos_sin.shape == (cos_sin.shape[0], 2, rotary_dim // 2)
+    assert cos_sin.shape[0] > 0
+
+    num_tokens = qkv.shape[0]
+    use_mrope = mrope_section is not None
+    if use_mrope:
+        assert len(mrope_section) == 3
+        assert sum(mrope_section) == rotary_dim // 2
+        assert positions.numel() == 3 * num_tokens
+        positions = positions.reshape(3, num_tokens)
+    else:
+        assert positions.numel() == num_tokens
+        positions = positions.reshape(-1)
+    assert positions.is_contiguous()
+    assert positions.dtype in (torch.int32, torch.int64)
+
+    q_size = num_q_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    assert qkv.shape[1] == 2 * q_size + 2 * kv_size
+
+    qkv_out = torch.empty((num_tokens, q_size + 2 * kv_size), dtype=qkv.dtype, device=qkv.device)
+    gate_out = torch.empty((num_tokens, num_q_heads, head_dim), dtype=qkv.dtype, device=qkv.device)
+    if num_tokens == 0:
+        return qkv_out, gate_out
+
+    half_rotary = rotary_dim // 2
+    head_block = triton.next_power_of_2(head_dim)
+    rotary_block = triton.next_power_of_2(half_rotary)
+    grid = (num_tokens, num_q_heads + 2 * num_kv_heads)
+    _fused_qkv_gemma_rmsnorm_rope_gate_kernel[grid](
+        qkv,
+        qkv_out,
+        gate_out,
+        q_weight,
+        k_weight,
+        cos_sin,
+        positions,
+        num_tokens,
+        cos_sin.shape[0],
+        qkv.stride(0),
+        qkv_out.stride(0),
+        gate_out.stride(0),
+        cos_sin.stride(0),
+        num_q_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        rotary_dim=rotary_dim,
+        half_rotary=half_rotary,
+        head_block=head_block,
+        rotary_block=rotary_block,
+        eps=eps,
+        output_fp16=qkv.dtype == torch.float16,
+        has_pass_through=rotary_dim < head_dim,
+        use_mrope=use_mrope,
+        mrope_section1=mrope_section[1] if use_mrope else 0,
+        mrope_section2=mrope_section[2] if use_mrope else 0,
+        num_warps=4,
+    )
+    return qkv_out, gate_out
+
+
+@triton.jit
+def _fused_sigmoid_mul_kernel(
+    output_ptr,
+    attention_ptr,
+    gate_ptr,
+    output_stride_token,
+    attention_stride_token,
+    gate_stride_token,
+    gate_stride_head,
+    hidden_size: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    token = tl.program_id(0).to(tl.int64)
+    block = tl.program_id(1)
+    offsets = block * block_size + tl.arange(0, block_size)
+    mask = offsets < hidden_size
+    head = offsets // head_dim
+    dim = offsets - head * head_dim
+
+    attention = tl.load(
+        attention_ptr + token * attention_stride_token + offsets,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    gate = tl.load(
+        gate_ptr + token * gate_stride_token + head * gate_stride_head + dim,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    tl.store(
+        output_ptr + token * output_stride_token + offsets,
+        attention * tl.sigmoid(gate),
+        mask=mask,
+    )
+
+
+def fused_sigmoid_mul(
+    attention_output: torch.Tensor,
+    gate: torch.Tensor,
+    *,
+    inplace: bool = False,
+) -> torch.Tensor:
+    """Compute ``attention_output * sigmoid(gate)`` in one kernel."""
+    assert attention_output.dim() == 2 and attention_output.stride(-1) == 1
+    num_tokens, hidden_size = attention_output.shape
+    if gate.dim() == 3:
+        assert gate.shape[0] == num_tokens
+        assert gate.shape[1] * gate.shape[2] == hidden_size
+        assert gate.stride(-1) == 1
+        head_dim = gate.shape[2]
+        gate_stride_token = gate.stride(0)
+        gate_stride_head = gate.stride(1)
+    else:
+        assert gate.dim() == 2 and gate.shape == attention_output.shape
+        assert gate.stride(-1) == 1
+        head_dim = hidden_size
+        gate_stride_token = gate.stride(0)
+        gate_stride_head = hidden_size
+
+    output = attention_output if inplace else torch.empty_like(attention_output)
+    if num_tokens == 0:
+        return output
+
+    max_block_size = 1024 if num_tokens < 1024 else 2048
+    block_size = min(triton.next_power_of_2(hidden_size), max_block_size)
+    grid = (num_tokens, triton.cdiv(hidden_size, block_size))
+    _fused_sigmoid_mul_kernel[grid](
+        output,
+        attention_output,
+        gate,
+        output.stride(0),
+        attention_output.stride(0),
+        gate_stride_token,
+        gate_stride_head,
+        hidden_size=hidden_size,
+        head_dim=head_dim,
+        block_size=block_size,
+        num_warps=4,
+    )
+    return output

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,13 +19,17 @@ from typing import Optional
 import torch
 from transformers import PretrainedConfig
 
+from tensorrt_llm.functional import RotaryScalingType
 from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend.interface import PositionalEmbeddingParams
 from ..model_config import ModelConfig
 from ..modules.attention import Attention
+from ..modules.fused_ops.fused_qk_norm_rope_gate import (
+    fused_qkv_gemma_rmsnorm_rope_gate, fused_sigmoid_mul)
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
+from ..utils import is_torch_compiling
 
 
 # Move out from this class
@@ -172,6 +176,7 @@ class QKNormRoPEAttention(Attention):
         # Gemma-style RMSNorm (scale by (1 + weight)) is supported by the fused
         # qk_norm_rope kernel via the use_gemma flag threaded through below.
         self.use_gemma_rms_norm = use_gemma_rms_norm
+        self._fuse_qk_norm_rope_gate = False
 
         # If fuse_qk_norm_rope is true, do not apply fused RoPE in attention OP, and self.rotary_emb
         # will be skipped in the overridden apply_rope.
@@ -213,6 +218,87 @@ class QKNormRoPEAttention(Attention):
         self.aux_stream = torch.cuda.Stream()
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
 
+    def _get_qk_norm_rotary_dim(self) -> int:
+        partial_rotary_factor = getattr(self.pretrained_config,
+                                        "partial_rotary_factor", 1.0)
+        return int(self.head_dim * partial_rotary_factor)
+
+    def _can_use_fused_qk_norm_rope_gate(
+            self, qkv: torch.Tensor,
+            position_ids: Optional[torch.Tensor]) -> bool:
+        if not self._fuse_qk_norm_rope_gate or is_torch_compiling():
+            return False
+        if torch.version.hip is not None or qkv.device.type != "cuda":
+            return False
+        if qkv.dim() != 2 or qkv.stride(-1) != 1:
+            return False
+        if qkv.dtype not in (torch.bfloat16, torch.float16):
+            return False
+        if position_ids is None or position_ids.dim() > 3:
+            return False
+        if position_ids.dtype not in (torch.int32, torch.int64):
+            return False
+        use_mrope = position_ids.dim() == 3
+        if use_mrope and not (getattr(
+                self.pos_embd_params, "mrope_interleaved", False) and getattr(
+                    self.pos_embd_params, "mrope_section", None) is not None
+                              and position_ids.shape[0] == 3):
+            return False
+        expected_positions = qkv.shape[0] * (3 if use_mrope else 1)
+        if position_ids.numel() != expected_positions:
+            return False
+        if not (self.attn_output_gate and self.fuse_qk_norm_rope
+                and self.is_qk_norm and self.use_gemma_rms_norm
+                and not self.skip_rope):
+            return False
+        if self.pos_embd_params is None or self.pos_embd_params.rope is None:
+            return False
+        if not self.pos_embd_params.is_neox or self.rotary_emb is None:
+            return False
+        rope = self.pos_embd_params.rope
+        if rope.scale_type not in (RotaryScalingType.none,
+                                   RotaryScalingType.mrope):
+            return False
+        if rope.scale != 1.0:
+            return False
+        rotary_dim = self._get_qk_norm_rotary_dim()
+        return (rotary_dim == rope.dim and rotary_dim > 0
+                and rotary_dim <= self.head_dim and rotary_dim % 2 == 0)
+
+    def preprocess_qkv(self, qkv, position_ids):
+        """Fuse gate split + gemma QK norm + RoPE into a single Triton kernel
+        when supported; otherwise fall back to the generic unfused path."""
+        if not self._can_use_fused_qk_norm_rope_gate(qkv, position_ids):
+            return super().preprocess_qkv(qkv, position_ids)
+        use_mrope = position_ids.dim() == 3
+        positions = position_ids.reshape(
+            3, -1) if use_mrope else position_ids.reshape(-1)
+        qkv, gate = fused_qkv_gemma_rmsnorm_rope_gate(
+            qkv,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            self.rotary_emb.rotary_cos_sin,
+            positions.contiguous(),
+            self.q_norm.variance_epsilon,
+            self.num_heads,
+            self.num_key_value_heads,
+            self.head_dim,
+            self._get_qk_norm_rotary_dim(),
+            tuple(self.pos_embd_params.mrope_section) if use_mrope else None,
+        )
+        return qkv, None, None, gate
+
+    def apply_output_gate(self, attention_output, gate):
+        if (self._fuse_qk_norm_rope_gate and not is_torch_compiling()
+                and torch.version.hip is None
+                and attention_output.device.type == "cuda"
+                and attention_output.dim() == 2
+                and attention_output.stride(-1) == 1 and gate.dim() in (2, 3)
+                and gate.stride(-1) == 1
+                and gate.numel() == attention_output.numel()):
+            return fused_sigmoid_mul(attention_output, gate, inplace=True)
+        return super().apply_output_gate(attention_output, gate)
+
     def apply_qk_norm(self, q, k):
 
         def q_l2norm():
@@ -238,9 +324,7 @@ class QKNormRoPEAttention(Attention):
         factor, low, high, attention_factor = compute_yarn_parameters(
             self.pretrained_config)
 
-        partial_rotary_factor = self.pretrained_config.partial_rotary_factor if hasattr(
-            self.pretrained_config, "partial_rotary_factor") else 1.0
-        rotary_dim = int(self.head_dim * partial_rotary_factor)
+        rotary_dim = self._get_qk_norm_rotary_dim()
 
         # Interleaved mRoPE: position_ids is 3D [3, ...] (temporal/height/width)
         # and each rotary half-dim picks a section per

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -127,6 +127,7 @@ l0_b200:
   - unittest/_torch/modules/fused_ops/test_rmsnorm_fp4_quant.py
   - unittest/_torch/modules/fused_ops/test_gelu_tanh_mul_fp4_quant.py
   - unittest/_torch/modules/fused_ops/test_rmsnorm_residual_add.py
+  - unittest/_torch/modules/fused_ops/test_fused_qk_norm_rope_gate.py
   - unittest/_torch/modules/test_gemma4_fused_qkv_prep.py
   - unittest/_torch/modules/test_awq_quantization.py
   - unittest/_torch/modules/test_triton_linear.py

--- a/tests/unittest/_torch/modules/fused_ops/test_fused_qk_norm_rope_gate.py
+++ b/tests/unittest/_torch/modules/fused_ops/test_fused_qk_norm_rope_gate.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.modules.attention import Attention
+from tensorrt_llm._torch.modules.fused_ops.fused_qk_norm_rope_gate import (
+    fused_qkv_gemma_rmsnorm_rope_gate,
+    fused_sigmoid_mul,
+)
+
+
+def _make_cos_sin(max_positions: int, rotary_dim: int, theta: float = 1_000_000.0):
+    inverse_frequency = 1.0 / (
+        theta ** (torch.arange(0, rotary_dim, 2, dtype=torch.float32, device="cuda") / rotary_dim)
+    )
+    positions = torch.arange(max_positions, dtype=torch.float32, device="cuda")
+    frequency = torch.outer(positions, inverse_frequency)
+    return torch.stack((frequency.cos(), frequency.sin()), dim=1).contiguous()
+
+
+def _reference(
+    qkv,
+    q_weight,
+    k_weight,
+    cos_sin,
+    positions,
+    eps,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    rotary_dim,
+    mrope_section=None,
+):
+    num_tokens = qkv.shape[0]
+    q_size = num_q_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    q_gate, k, v = qkv.split((2 * q_size, kv_size, kv_size), dim=-1)
+    q_gate = q_gate.view(num_tokens, num_q_heads, 2 * head_dim)
+    q = q_gate[..., :head_dim]
+    gate = q_gate[..., head_dim:]
+    k = k.view(num_tokens, num_kv_heads, head_dim)
+
+    def _gemma_norm(x, weight):
+        x_float = x.float()
+        inverse_rms = torch.rsqrt(x_float.square().mean(dim=-1, keepdim=True) + eps)
+        return (x_float * inverse_rms * (weight.float() + 1.0)).to(qkv.dtype)
+
+    q = _gemma_norm(q, q_weight)
+    k = _gemma_norm(k, k_weight)
+    half_rotary = rotary_dim // 2
+    if mrope_section is None:
+        selected = cos_sin[positions.long()]
+        cos = selected[:, 0].unsqueeze(1)
+        sin = selected[:, 1].unsqueeze(1)
+    else:
+        positions = positions.reshape(3, num_tokens).long()
+        rotary_offsets = torch.arange(half_rotary, device=qkv.device)
+        sections = torch.zeros_like(rotary_offsets)
+        sections[(rotary_offsets % 3 == 1) & (rotary_offsets < mrope_section[1] * 3)] = 1
+        sections[(rotary_offsets % 3 == 2) & (rotary_offsets < mrope_section[2] * 3)] = 2
+        token_offsets = torch.arange(num_tokens, device=qkv.device).unsqueeze(1)
+        selected_positions = positions[sections.unsqueeze(0), token_offsets]
+        cos = cos_sin[selected_positions, 0, rotary_offsets].unsqueeze(1)
+        sin = cos_sin[selected_positions, 1, rotary_offsets].unsqueeze(1)
+
+    def _rope(x):
+        x_first = x[..., :half_rotary].float()
+        x_second = x[..., half_rotary:rotary_dim].float()
+        first = x_first * cos - x_second * sin
+        second = x_second * cos + x_first * sin
+        return torch.cat((first, second, x[..., rotary_dim:].float()), dim=-1).to(qkv.dtype)
+
+    q = _rope(q).reshape(num_tokens, q_size)
+    k = _rope(k).reshape(num_tokens, kv_size)
+    return torch.cat((q, k, v), dim=-1), gate
+
+
+@pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
+@pytest.mark.parametrize(
+    "num_tokens,num_q_heads,num_kv_heads,head_dim,rotary_dim",
+    (
+        (1, 8, 2, 128, 128),
+        (7, 8, 2, 256, 128),
+        (65, 16, 4, 256, 256),
+        (333, 16, 4, 256, 256),
+    ),
+)
+def test_fused_qkv_gemma_rmsnorm_rope_gate_matches_reference(
+    dtype, num_tokens, num_q_heads, num_kv_heads, head_dim, rotary_dim
+):
+    torch.manual_seed(1234)
+    q_size = num_q_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    width = 2 * q_size + 2 * kv_size
+    storage = torch.randn((num_tokens, width + 37), dtype=dtype, device="cuda")
+    qkv = storage[:, :width]
+    q_weight = torch.randn((head_dim,), dtype=dtype, device="cuda") * 0.1
+    k_weight = torch.randn((head_dim,), dtype=dtype, device="cuda") * 0.1
+    cos_sin = _make_cos_sin(2048, rotary_dim)
+    positions = torch.randint(0, 2048, (num_tokens,), dtype=torch.int32, device="cuda")
+    eps = 1e-6
+
+    actual_qkv, actual_gate = fused_qkv_gemma_rmsnorm_rope_gate(
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin,
+        positions,
+        eps,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+    )
+    expected_qkv, expected_gate = _reference(
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin,
+        positions,
+        eps,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+    )
+
+    torch.testing.assert_close(actual_qkv, expected_qkv, atol=0.02, rtol=0.02)
+    torch.testing.assert_close(actual_gate, expected_gate, atol=0, rtol=0)
+    torch.testing.assert_close(actual_qkv[:, q_size + kv_size :], qkv[:, 2 * q_size + kv_size :])
+
+
+@pytest.mark.parametrize("inplace", (False, True))
+def test_fused_sigmoid_mul_supports_strided_gate(inplace):
+    torch.manual_seed(7)
+    num_tokens, num_heads, head_dim = 17, 8, 128
+    attention = torch.randn((num_tokens, num_heads * head_dim), dtype=torch.bfloat16, device="cuda")
+    gate_storage = torch.randn(
+        (num_tokens, num_heads, 2 * head_dim), dtype=torch.bfloat16, device="cuda"
+    )
+    gate = gate_storage[..., :head_dim]
+    expected = attention.float() * torch.sigmoid(gate.reshape(num_tokens, -1).float())
+    actual = fused_sigmoid_mul(attention.clone(), gate, inplace=inplace)
+    torch.testing.assert_close(actual.float(), expected, atol=0.02, rtol=0.02)
+
+
+@pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
+def test_fused_qkv_gemma_rmsnorm_rope_gate_supports_interleaved_mrope(dtype):
+    torch.manual_seed(2026)
+    num_tokens, num_q_heads, num_kv_heads = 37, 16, 2
+    head_dim, rotary_dim = 256, 64
+    mrope_section = (11, 11, 10)
+    q_size = num_q_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    qkv = torch.randn((num_tokens, 2 * q_size + 2 * kv_size), dtype=dtype, device="cuda")
+    q_weight = torch.randn((head_dim,), dtype=dtype, device="cuda") * 0.1
+    k_weight = torch.randn((head_dim,), dtype=dtype, device="cuda") * 0.1
+    cos_sin = _make_cos_sin(4096, rotary_dim, theta=10_000_000.0)
+    base_positions = torch.randint(0, 4000, (num_tokens,), dtype=torch.int32, device="cuda")
+    positions = torch.stack(
+        (base_positions, base_positions + 3, base_positions + 7), dim=0
+    ).unsqueeze(1)
+    eps = 1e-6
+
+    actual_qkv, actual_gate = fused_qkv_gemma_rmsnorm_rope_gate(
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin,
+        positions,
+        eps,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        mrope_section,
+    )
+    expected_qkv, expected_gate = _reference(
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin,
+        positions,
+        eps,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        mrope_section,
+    )
+
+    torch.testing.assert_close(actual_qkv, expected_qkv, atol=0.02, rtol=0.02)
+    torch.testing.assert_close(actual_gate, expected_gate, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("num_tokens", (1, 37, 333))
+def test_fused_qkv_gemma_rmsnorm_rope_gate_matches_production_thop(num_tokens):
+    torch.manual_seed(9027)
+    num_q_heads, num_kv_heads = 16, 2
+    head_dim, rotary_dim = 256, 64
+    mrope_section = (11, 11, 10)
+    q_size = num_q_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    qkv = torch.randn(
+        (num_tokens, 2 * q_size + 2 * kv_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    q_weight = torch.randn((head_dim,), dtype=torch.bfloat16, device="cuda") * 0.1
+    k_weight = torch.randn((head_dim,), dtype=torch.bfloat16, device="cuda") * 0.1
+    cos_sin = _make_cos_sin(4096, rotary_dim, theta=10_000_000.0)
+    base_positions = torch.randint(0, 4000, (num_tokens,), dtype=torch.int32, device="cuda")
+    positions = torch.stack(
+        (base_positions, base_positions + 3, base_positions + 7), dim=0
+    ).contiguous()
+
+    q_gate, k, v = qkv.split((2 * q_size, kv_size, kv_size), dim=-1)
+    q, expected_gate = [
+        value.reshape(num_tokens, -1)
+        for value in torch.chunk(q_gate.view(num_tokens, num_q_heads, 2 * head_dim), 2, dim=-1)
+    ]
+    expected_qkv = torch.cat((q, k, v), dim=-1)
+    torch.ops.trtllm.fused_qk_norm_rope(
+        expected_qkv,
+        num_q_heads,
+        num_kv_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        1e-6,
+        q_weight,
+        k_weight,
+        10_000_000.0,
+        True,
+        positions,
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+        True,
+        True,
+        True,
+        mrope_section[1],
+        mrope_section[2],
+    )
+
+    actual_qkv, actual_gate = fused_qkv_gemma_rmsnorm_rope_gate(
+        qkv,
+        q_weight,
+        k_weight,
+        cos_sin,
+        positions,
+        1e-6,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        mrope_section,
+    )
+
+    torch.testing.assert_close(actual_qkv, expected_qkv, atol=0.02, rtol=0.02)
+    torch.testing.assert_close(actual_gate.reshape(num_tokens, -1), expected_gate, atol=0, rtol=0)
+
+
+def test_output_gate_fallback_flattens_fused_gate():
+    torch.manual_seed(17)
+    attention = torch.randn((5, 256), dtype=torch.bfloat16, device="cuda")
+    gate = torch.randn((5, 2, 128), dtype=torch.bfloat16, device="cuda")
+    expected = attention * torch.sigmoid(gate.reshape_as(attention))
+    actual = Attention.apply_output_gate(None, attention, gate)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_fused_sigmoid_mul_supports_flat_gate():
+    torch.manual_seed(11)
+    attention = torch.randn((9, 512), dtype=torch.float16, device="cuda")
+    gate = torch.randn_like(attention)
+    expected = attention.float() * torch.sigmoid(gate.float())
+    actual = fused_sigmoid_mul(attention, gate)
+    torch.testing.assert_close(actual.float(), expected, atol=0.005, rtol=0.005)


### PR DESCRIPTION
…m + RoPE + gate) into a single Triton kernel

<img width="1454" height="912" alt="image" src="https://github.com/user-attachments/assets/4dfe6f6f-c18d-4fde-96df-830832654d16" />
<img width="1454" height="672" alt="image" src="https://github.com/user-attachments/assets/14e17852-5c67-475c-b08e-1384a1669843" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optimized fused attention path combining QK normalization, rotary position processing, and output gating.
  - Added support for interleaved multi-dimensional rotary positioning in the fused path.
  - Added optional in-place output gating for improved performance and reduced memory use.

- **Bug Fixes**
  - Improved attention gating behavior while retaining compatibility with existing fallback processing.

- **Tests**
  - Added comprehensive coverage across supported data types, tensor layouts, rotary configurations, token counts, and in-place operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
