### PR TITLE
[None][feat] Default GPT-OSS to the Python KV-cache transceiver

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 import torch
 from torch import nn
@@ -551,6 +551,13 @@ class Transformer(DecoderModel):
 
 @register_auto_model("GptOssForCausalLM")
 class GptOssForCausalLM(SpecDecOneEngineForCausalLM[Transformer, GptOssConfig]):
+
+    @classmethod
+    def get_preferred_transceiver_runtime(
+        cls,
+        pretrained_config: Any = None,
+    ) -> Literal["PYTHON"]:
+        return "PYTHON"
 
     params_map = {
         # TRTLLM module name : GptOss module name

--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -556,7 +556,7 @@ class GptOssForCausalLM(SpecDecOneEngineForCausalLM[Transformer, GptOssConfig]):
     def get_preferred_transceiver_runtime(
         cls,
         pretrained_config: Any = None,
-    ) -> Literal["PYTHON"]:
+    ) -> Optional[Literal["CPP", "PYTHON"]]:
         return "PYTHON"
 
     params_map = {

--- a/tests/unittest/_torch/modeling/test_modeling_gpt_oss.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gpt_oss.py
@@ -47,6 +47,10 @@ configs = """
 """
 
 
+def test_gpt_oss_prefers_python_transceiver() -> None:
+    assert GptOssForCausalLM.get_preferred_transceiver_runtime() == "PYTHON"
+
+
 def dump_config_json(dst_dir):
     if os.path.exists(dst_dir):
         shutil.rmtree(dst_dir)


### PR DESCRIPTION
## Description

Built on top of #16164 (per-model transceiver runtime auto selection): opt GPT-OSS into the Python KV-cache transceiver by default.

`GptOssForCausalLM` now overrides `get_preferred_transceiver_runtime()` to return `"PYTHON"`. Disaggregated deployments that leave `transceiver_runtime` at its default `auto` (backend NIXL/DEFAULT) use the Python transceiver (`KvCacheTransceiverV2`) out of the box. Explicit user settings always take precedence, and incompatible backends fall back to the C++ transceiver per the #16164 resolution semantics. No effect on non-disaggregated deployments.

## Test Coverage

- New unit test: `test_modeling_gpt_oss.py::test_gpt_oss_prefers_python_transceiver` pins the model preference.
- The resolution chain (auto → model hook → backend compatibility) is covered by the #16164 unit tests (`TestTransceiverRuntimeAutoResolution`).
- Verified end-to-end with `test_disaggregated_gpt_oss_120b_harmony`: startup logs show `Resolved transceiver_runtime='auto' to 'PYTHON' for GptOssForCausalLM` and `Using KvCacheTransceiverV2`; explicit `CPP` override verified to bypass the preference.


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPT-OSS runtime compatibility by selecting the Python transceiver runtime.

* **Tests**
  * Added coverage to verify the preferred transceiver runtime is selected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->