### PR TITLE
[TRTLLMINF-216][infra] use main as default target branch in L0_MergeRequest_PR

### DIFF
--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -186,7 +186,7 @@ def globalVars = [
     (CACHED_CHANGED_FILE_LIST): null,
     (ACTION_INFO): gitlabParamsFromBot.get('action_info', null),
     (IMAGE_KEY_TO_TAG): [:],
-    (TARGET_BRANCH): gitlabParamsFromBot.get('target_branch', null),
+    (TARGET_BRANCH): gitlabParamsFromBot.get('target_branch', 'main'),
 ]
 
 // If not running all test stages in the L0 pre-merge, we will not update the GitLab status at the end.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Merge request processing now defaults the target branch to `main` when no target branch is provided.
  * Downstream automation receives a consistent target branch value instead of an empty value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

When L0_PostMerge is triggered without any parameters, such as manually run from the Jenkins web page or by a Jenkins cron trigger, the pipeline should use reasonable default parameters and run normally. However, the current default value of target_branch in the gitlabTriggerPhrase parameters is null. As a result, when the pipeline is triggered without no parameters, the target_branch used by the Merge Test Waive List stage is set to null, causing this stage to fail.

This PR changes the default value of target_branch in the gitlabTriggerPhrase parameters to main, so that L0_PostMerge can run normally when triggered without parameters.

## Test Coverage

Before:

The “Merge Test Waive List” stage failed on fetch TOT waive list from Github:

<img width="1101" height="628" alt="image" src="https://github.com/user-attachments/assets/dab83880-9f66-46ca-b3ba-550d1268fa25" />

With this PR:

<img width="943" height="696" alt="image" src="https://github.com/user-attachments/assets/933b23aa-1fb4-4404-b2d7-f3ac7ab18b1c" />



We manually trigger a post-merge (via `run with parameter` menu in jenkins web console ) without multi-gpu tests, [the result](https://prod.blsm.nvidia.com/sw-tensorrt-top-1/blue/organizations/jenkins/LLM%2Fhelpers%2Fweimin_dev%2FL0_PostMerge/detail/L0_PostMerge/5/pipeline/24) is same as [the gitlab-push-webhook-triggered version](https://prod.blsm.nvidia.com/sw-tensorrt-top-1/blue/organizations/jenkins/LLM%2Fmain%2FL0_PostMerge/detail/L0_PostMerge/2839/pipeline/23)

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
