### PR TITLE
[https://nvbugs/6438658][fix] Account for resume utilization in KV constraints

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -267,6 +267,7 @@ class KVCacheManager:
             constraints=config.constraints,
             initial_pool_ratio=config.initial_pool_ratio,
             event_manager=event_manager,
+            max_util_for_resume=config.max_util_for_resume,
         )
         self._living_kv_caches = set[rawref.ref[_KVCache]]()
         decay = 0.9999

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -219,6 +219,7 @@ class StorageManager:
         constraints: list[BatchDesc] | None = None,
         initial_pool_ratio: list[float] | None = None,
         event_manager: "KVCacheEventManager | None" = None,
+        max_util_for_resume: float = 1.0,
     ) -> None:
         self.__rawref__ = rawref.NULL
         self._event_manager = event_manager
@@ -245,7 +246,10 @@ class StorageManager:
 
         constraints_for_min_slots = [] if initial_pool_ratio is not None else constraints or []
         self._min_slots = self._compute_min_slots_from_constraints(
-            constraints_for_min_slots, tokens_per_block, swa_scratch_reuse
+            constraints_for_min_slots,
+            tokens_per_block,
+            swa_scratch_reuse,
+            max_util_for_resume,
         )
 
         # Compute init_ratio from explicit config, typical_batch, constraints, or fallback.
@@ -907,10 +911,12 @@ class StorageManager:
         constraints: list[BatchDesc],
         tokens_per_block: int,
         swa_scratch_reuse: SwaScratchReuseConfig | None,
+        max_util_for_resume: float,
     ) -> TypedIndexList[PoolGroupIndex, int]:
         """Compute the minimum slots per pool group across all constraints (element-wise max).
 
-        All returned elements are positive.
+        All returned elements are positive. Constraint-derived floors include
+        headroom for the utilization gate checked by ``_KVCache.resume``.
         """
         max_slots = filled_list(0, self.num_pool_groups)
 
@@ -937,7 +943,8 @@ class StorageManager:
         for batch in constraints:
             slots = self._compute_slots_for_batch(batch, tokens_per_block, swa_scratch_reuse)
             for pg_idx in typed_range(self.num_pool_groups):
-                max_slots[pg_idx] = max(max_slots[pg_idx], slots[pg_idx])
+                scaled_slots = math.ceil(slots[pg_idx] / max_util_for_resume)
+                max_slots[pg_idx] = max(max_slots[pg_idx], scaled_slots)
         return max_slots
 
     def _compute_slots_for_batch(

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -2443,6 +2443,31 @@ class TestInitRatioConfig(unittest.TestCase):
         mgr_unconstrained.shutdown()
         mgr_constrained.shutdown()
 
+    def test_constraint_reserves_resume_headroom(self):
+        """A full constraint batch must stay below the resume utilization gate."""
+        num_requests = 32
+        constraint = BatchDesc(kv_caches=[KVCacheDesc(capacity=1, history_length=0)] * num_requests)
+        granularity = 2 << 20
+        gpu_quota = round_up(num_requests * self.PG0_SLOT_SIZE, granularity) + round_up(
+            num_requests * self.PG1_SLOT_SIZE, granularity
+        )
+        cfg = self._make_config(gpu_quota=gpu_quota, constraints=[constraint])
+        cfg.max_util_for_resume = 0.95
+        manager = KVCacheManager(cfg)
+        stream_holder = CachedCudaStream()
+        stream = cast(CudaStream, stream_holder.handle)
+
+        kv_caches = []
+        for _ in range(num_requests):
+            kv_cache = manager.create_kv_cache()
+            self.assertTrue(kv_cache.resume(stream))
+            kv_cache.capacity = 1
+            kv_caches.append(kv_cache)
+
+        for kv_cache in kv_caches:
+            kv_cache.close()
+        manager.shutdown()
+
     def test_initial_pool_ratio_overrides_typical_step_and_constraints(self):
         """Explicit initial_pool_ratio takes precedence over inferred sizing inputs."""
         typical = BatchDesc(kv_caches=[KVCacheDesc(capacity=4096, history_length=4000)] * 32)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved KV cache capacity planning to reserve sufficient headroom for resuming cached requests.
  - Prevented constraint-based allocations from reaching utilization levels that could block cache resumption.

- **Tests**
  - Added coverage verifying that constrained KV caches can resume successfully, including after being reduced to minimal capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Constraint-derived pool floors currently reserve the exact slot count required by each constrained batch. However, `_KVCache.resume()` rejects a resume when projected utilization exceeds `max_util_for_resume`, so a supposedly supported constraint can still fail before the pool is full.

Pass `max_util_for_resume` into `StorageManager` and scale constraint-derived minimum slot counts by the inverse utilization threshold. This preserves sufficient headroom for constrained batches to resume. Explicit user-provided pool ratios continue to take precedence over inferred constraints.

## Test Coverage

- Added `test_constraint_reserves_resume_headroom` to exercise a complete constrained batch at `max_util_for_resume=0.95`.
- `python3 -m py_compile` passed for all changed files.
- Relevant pre-commit checks passed.
- The focused pytest test was not run locally because pytest is not installed in this checkout's Python environment.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
