### PR TITLE
[None][fix] Widen Ulysses async-barrier timeout 10s->60s for multi-node warmup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -385,6 +385,9 @@
 /tensorrt_llm/_torch/visual_gen @NVIDIA/trt-llm-torch-visual-gen-devs
 /tensorrt_llm/_torch/visual_gen/attention_backend @NVIDIA/trt-llm-torch-attention-devs @NVIDIA/trt-llm-torch-visual-gen-devs
 /tensorrt_llm/_torch/visual_gen/modules/attention.py @NVIDIA/trt-llm-torch-attention-devs @NVIDIA/trt-llm-torch-visual-gen-devs
+/cpp/tensorrt_llm/thop/asyncUlyssesOp.cpp @NVIDIA/trt-llm-torch-visual-gen-devs
+/cpp/tensorrt_llm/thop/ulysses* @NVIDIA/trt-llm-torch-visual-gen-devs
+/cpp/tensorrt_llm/kernels/ulysses* @NVIDIA/trt-llm-torch-visual-gen-devs
 /tensorrt_llm/media @NVIDIA/trt-llm-torch-visual-gen-devs
 /tensorrt_llm/visual_gen @NVIDIA/trt-llm-torch-visual-gen-devs @NVIDIA/trt-llm-runtime-devs
 /tests/integration/defs/examples/test_visual_gen.py @NVIDIA/trt-llm-torch-visual-gen-devs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -385,8 +385,7 @@
 /tensorrt_llm/_torch/visual_gen @NVIDIA/trt-llm-torch-visual-gen-devs
 /tensorrt_llm/_torch/visual_gen/attention_backend @NVIDIA/trt-llm-torch-attention-devs @NVIDIA/trt-llm-torch-visual-gen-devs
 /tensorrt_llm/_torch/visual_gen/modules/attention.py @NVIDIA/trt-llm-torch-attention-devs @NVIDIA/trt-llm-torch-visual-gen-devs
-/cpp/tensorrt_llm/thop/asyncUlyssesOp.cpp @NVIDIA/trt-llm-torch-visual-gen-devs
-/cpp/tensorrt_llm/thop/ulysses* @NVIDIA/trt-llm-torch-visual-gen-devs
+/cpp/tensorrt_llm/thop/*lysses* @NVIDIA/trt-llm-torch-visual-gen-devs
 /cpp/tensorrt_llm/kernels/ulysses* @NVIDIA/trt-llm-torch-visual-gen-devs
 /tensorrt_llm/media @NVIDIA/trt-llm-torch-visual-gen-devs
 /tensorrt_llm/visual_gen @NVIDIA/trt-llm-torch-visual-gen-devs @NVIDIA/trt-llm-runtime-devs

--- a/cpp/tensorrt_llm/thop/asyncUlyssesOp.cpp
+++ b/cpp/tensorrt_llm/thop/asyncUlyssesOp.cpp
@@ -241,11 +241,13 @@ public:
     {
         TLLM_CHECK_WITH_INFO(
             mCanonicalHandle, "emitBarrier: no slot allocated yet — _prepare must precede the first _async barrier.");
-        // 10s timeout: on hang, the kernel traps with rank+channel diagnostic instead of spinning silently
-        // until SLURM wall-clock kills. Generous enough to absorb first-touch IPC + first cuda_graph
-        // capture jitter. channel=0: V/Q/K issues all run on the same per-device side stream so
-        // they FIFO-serialize; channel multiplexing only matters across distinct streams.
-        mCanonicalHandle->barrier(/*channel=*/0, /*timeout_ms=*/10000);
+        // barrier() takes MILLISECONDS (its "microseconds" timeout-error text is mislabeled).
+        // 60 s absorbs the one-time first-touch warmup barrier stall (~10-20 s on 16-GPU
+        // cfg2xuly8) and still traps a real hang with a rank+channel diagnostic before the
+        // SLURM wall-clock. channel=0: V/Q/K issues share one per-device side stream and
+        // FIFO-serialize, so channel multiplexing (needed only across distinct streams) is moot.
+        size_t const barrierTimeoutMs = 60000;
+        mCanonicalHandle->barrier(/*channel=*/0, /*timeout_ms=*/barrierTimeoutMs);
     }
 
 private:

--- a/cpp/tensorrt_llm/thop/asyncUlyssesOp.cpp
+++ b/cpp/tensorrt_llm/thop/asyncUlyssesOp.cpp
@@ -237,17 +237,17 @@ public:
 
     // Phase 2 (fence): PT symm-mem barrier on the current CUDA stream.
     // Any allocated slot's handle works — they all belong to the same group.
-    void emitBarrier()
+    void emitBarrier(int64_t timeoutMs)
     {
         TLLM_CHECK_WITH_INFO(
             mCanonicalHandle, "emitBarrier: no slot allocated yet — _prepare must precede the first _async barrier.");
         // barrier() takes MILLISECONDS (its "microseconds" timeout-error text is mislabeled).
-        // 60 s absorbs the one-time first-touch warmup barrier stall (~10-20 s on 16-GPU
-        // cfg2xuly8) and still traps a real hang with a rank+channel diagnostic before the
-        // SLURM wall-clock. channel=0: V/Q/K issues share one per-device side stream and
-        // FIFO-serialize, so channel multiplexing (needed only across distinct streams) is moot.
-        size_t const barrierTimeoutMs = 60000;
-        mCanonicalHandle->barrier(/*channel=*/0, /*timeout_ms=*/barrierTimeoutMs);
+        // Default 60 s (caller-supplied via TLLM_ULYSSES_ASYNC_BARRIER_TIMEOUT_MS) absorbs the
+        // one-time first-touch warmup barrier stall (~10-20 s on 16-GPU cfg2xuly8) and still
+        // traps a real hang with a rank+channel diagnostic before the SLURM wall-clock.
+        // channel=0: V/Q/K issues share one per-device side stream and FIFO-serialize, so
+        // channel multiplexing (needed only across distinct streams) is moot.
+        mCanonicalHandle->barrier(/*channel=*/0, /*timeout_ms=*/timeoutMs);
     }
 
 private:
@@ -477,10 +477,10 @@ void ulysses_a2a_async_push(
 // Step 2b (caller's comm stream): emit a symm-mem barrier on channel 0.
 // Pairs with `ulysses_a2a_async_push`; one call per deferred push (e.g.
 // V/Q/K -> 3 barriers at join).
-void ulysses_a2a_async_barrier(c10::intrusive_ptr<c10d::ProcessGroup> const& pg)
+void ulysses_a2a_async_barrier(c10::intrusive_ptr<c10d::ProcessGroup> const& pg, int64_t timeout_ms)
 {
     auto op = getOrCreateOp(pg);
-    op->emitBarrier();
+    op->emitBarrier(timeout_ms);
 }
 
 } // namespace
@@ -502,7 +502,7 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
     m.def(
         "ulysses_a2a_async_push(__torch__.torch.classes.trtllm.SendHandle send_h, "
         "__torch__.torch.classes.c10d.ProcessGroup pg) -> ()");
-    m.def("ulysses_a2a_async_barrier(__torch__.torch.classes.c10d.ProcessGroup pg) -> ()");
+    m.def("ulysses_a2a_async_barrier(__torch__.torch.classes.c10d.ProcessGroup pg, int timeout_ms=60000) -> ()");
 }
 
 // Both ops take/return a custom-class handle, not tensors, so the dispatcher

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
@@ -20,6 +20,7 @@ backend — compose around a real backend (VANILLA/TRTLLM/FA4/CUTEDSL).
 
 """
 
+import os
 from typing import TYPE_CHECKING, Callable, ClassVar, Dict, Optional
 
 import torch
@@ -118,6 +119,12 @@ class UlyssesAttention(AttentionBackend):
         # side stream so V/Q/K pushes FIFO together without intermediate
         # barrier kernels.
         self._pending_barriers: int = 0
+        # Symm-mem barrier timeout (ms) passed to ulysses_a2a_async_barrier.
+        # Default 60 s covers the one-time first-touch warmup stall on large
+        # multi-node runs; override via TLLM_ULYSSES_ASYNC_BARRIER_TIMEOUT_MS.
+        self._barrier_timeout_ms = int(
+            os.environ.get("TLLM_ULYSSES_ASYNC_BARRIER_TIMEOUT_MS", "60000")
+        )
         if async_ulysses:
             device = torch.cuda.current_device()
             if device not in UlyssesAttention._side_stream_by_device:
@@ -285,7 +292,7 @@ class UlyssesAttention(AttentionBackend):
         semantics, so the default stream sees a fully-synced recv buffer."""
         with torch.cuda.stream(self._async_side_stream):
             for _ in range(self._pending_barriers):
-                torch.ops.trtllm.ulysses_a2a_async_barrier(self._pg_boxed)
+                torch.ops.trtllm.ulysses_a2a_async_barrier(self._pg_boxed, self._barrier_timeout_ms)
             ev_done = torch.cuda.Event()
             ev_done.record()
         self._pending_barriers = 0


### PR DESCRIPTION
## What

The async-Ulysses symmetric-memory fence (`emitBarrier` in `asyncUlyssesOp.cpp`) used a 10 s timeout. On large multi-node runs (verified on 16-GPU cfg2xuly8 LTX-2), the one-time first-touch warmup barrier — the first cross-node CUDA-IPC symm-mem handshake plus the first kernel JIT on the critical path while peer ranks spin — takes 10–20 s, exceeding 10 s and raising a spurious `CUDASymmetricMemory::barrier ... failed to receive signal` FATAL during warmup. Steady-state barriers are sub-millisecond and unaffected.

## Fix

Widen the fence timeout to 60 s. Sweeping the timeout on real 16-GPU runs brackets the one-time warmup stall to (10 s, 20 s] — 10 s fails; 20 s and 30 s both complete cleanly — so 60 s is ~3x the measured maximum. It stays finite, so a genuine hang still traps with the rank+channel diagnostic well before the SLURM wall-clock, rather than spinning silently.

## Comment correction

PyTorch's `SymmetricMemory::barrier(channel, timeout_ms)` argument is in **milliseconds**; the barrier kernel's timeout-error text prints "microseconds", but that label is a torch-side mislabel. The prior comment ("10 s ... generous enough to absorb first-touch IPC") was both stale and, per the multi-node data, incorrect.

## Testing

- **Unit (2-rank, intra-node), direct measurement of the arg unit:** `timeout_ms=5000` waits ~1 s for a 1-s-late peer and passes; `timeout_ms=1000` trips at ~1.39 s. Confirms milliseconds.
- **Real 16-GPU cfg2xuly8 LTX-2, async-Ulysses eager:** 10 s FAILs at the warmup barrier; 20 s and 30 s each complete all denoise steps + VAE decode with zero barrier FATAL. 60 s is above that passing range (larger timeout only adds headroom).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

### Dev Engineer Review

- Increased the async-Ulysses symmetric-memory barrier timeout from 10 seconds to 60 seconds.
- Added caller-provided timeout support to `emitBarrier` and `ulysses_a2a_async_barrier`.
- Updated the Torch operator schema with a default `timeout_ms=60000` value.
- Passed the 60-second timeout from `UlyssesAttention` to asynchronous A2A barriers.
- Corrected comments to identify `SymmetricMemory::barrier` timeout values as milliseconds.
- Added CODEOWNERS entries for Ulysses-related VisualGen files.
- The changes address warmup failures caused by CUDA-IPC setup and kernel JIT delays on large multi-node runs.
- No test files or test-list files changed.

### QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->