### PR TITLE
[https://nvbugs/6464991][fix] Drop the isinstance check and gate the register() call only on len(status)==3…

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -573,7 +573,7 @@ class GenerationExecutorProxy(GenerationExecutor):
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
-        if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
+        if len(status) == 3:
             worker_process_identities: List[WorkerProcessIdentity] = status[2]
             self._worker_process_monitor.register(worker_process_identities)
 


### PR DESCRIPTION
## Summary
- **Root cause**: session-reuse hook monkey-patches proxy.MpiPoolSession to a function, so isinstance(self.mpi_session, MpiPoolSession) raises TypeError on the second and later tests sharing the worker.
- **Fix**: Drop the isinstance check and gate the register() call only on len(status)==3; keep the MpiPoolSession import (still used at construction).
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6464991


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker initialization monitoring across supported MPI session types.
  * Worker process identities are now registered consistently when initialization status data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->