### PR TITLE
[https://nvbugs/6463829][fix] Replace `isinstance(self.mpi_session, MpiPoolSession)` with the polymorphic…

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -573,7 +573,10 @@ class GenerationExecutorProxy(GenerationExecutor):
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
-        if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
+        # Use the polymorphic predicate: the module-level ``MpiPoolSession``
+        # symbol may be rebound to a factory at runtime by test infrastructure,
+        # breaking ``isinstance``.
+        if not self.mpi_session.is_comm_session() and len(status) == 3:
             worker_process_identities: List[WorkerProcessIdentity] = status[2]
             self._worker_process_monitor.register(worker_process_identities)
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -378,8 +378,6 @@ full:sm100/unittest/bindings SKIP (Disable for Blackwell)
 kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2Llama::test_chunked_prefill SKIP (https://nvbugs/6428002)
 kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2Llama::test_eviction_with_block_reuse SKIP (https://nvbugs/6462303)
 llmapi/test_llm_api_pytorch_bart.py::test_bart_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-on-greedy-tp2-bart-large-cnn] SKIP (https://nvbugs/6463812)
-llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[cudagraph] SKIP (https://nvbugs/6463829)
-llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[eager] SKIP (https://nvbugs/6463829)
 llmapi/test_llm_examples.py::test_llmapi_speculative_decoding_eagle3 SKIP (https://nvbugs/6075431)
 perf/test_perf.py::test_perf[bart_large_cnn-plugin-float16-bs:8-input_output_len:60,20] SKIP # (https://nvidia.slack.com/archives/C059LSY62BT/p1704525727177449)
 perf/test_perf.py::test_perf[flan_t5_base-bench-float16-input_output_len:128,20] SKIP


### PR DESCRIPTION
## Summary
- **Root cause**: Test session-reuse infrastructure monkey-patches module-level MpiPoolSession symbol with a factory function, breaking isinstance() at proxy.py:576
- **Fix**: Replace `isinstance(self.mpi_session, MpiPoolSession)` with the polymorphic `not self.mpi_session.is_comm_session()` predicate defined on the MpiSession base class, which survives module-symbol rebinding.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6463829


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker initialization compatibility across supported communication session types.
  * Enhanced reliability for distributed generation execution.

* **Tests**
  * Removed obsolete waivers for Mixtral MoE routed-expert FP8 multi-LoRA scenarios across eager and CUDA graph execution modes.
  * These scenarios are now covered by the standard integration test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->