### PR TITLE
[https://nvbugs/6463831][fix] Replace `isinstance(self.mpi_session, MpiPoolSession)` with `not…

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -573,7 +573,10 @@ class GenerationExecutorProxy(GenerationExecutor):
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
-        if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
+        # Use the polymorphic predicate: the module-level ``MpiPoolSession``
+        # symbol may be rebound to a factory at runtime by test infrastructure
+        # (tests/test_common/session_reuse.py), breaking ``isinstance``.
+        if not self.mpi_session.is_comm_session() and len(status) == 3:
             worker_process_identities: List[WorkerProcessIdentity] = status[2]
             self._worker_process_monitor.register(worker_process_identities)
 


### PR DESCRIPTION
## Summary
- **Root cause**: isinstance(self.mpi_session, MpiPoolSession) raises TypeError when tests/test_common/session_reuse.py monkey-patches the module-level MpiPoolSession symbol with a factory function.
- **Fix**: Replace `isinstance(self.mpi_session, MpiPoolSession)` with `not self.mpi_session.is_comm_session()`, the polymorphic predicate already defined on MpiSession base class — immune to module-level symbol rebinding, matches the same session set.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6463831


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker-process initialization across MPI session types.
  * Prevented test and runtime session substitutions from causing incorrect session detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->