### PR TITLE
[https://nvbugs/6463828][fix] Replace the concrete-type check with the polymorphic…

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -573,7 +573,9 @@ class GenerationExecutorProxy(GenerationExecutor):
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
-        if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
+        # Comm-based sessions bind to externally-owned processes we cannot
+        # monitor; only register PIDs for pool sessions that spawned them.
+        if not self.mpi_session.is_comm_session() and len(status) == 3:
             worker_process_identities: List[WorkerProcessIdentity] = status[2]
             self._worker_process_monitor.register(worker_process_identities)
 


### PR DESCRIPTION
## Summary
- **Root cause**: `isinstance(self.mpi_session, MpiPoolSession)` raised `TypeError` because the test-suite monkey-patch in `tests/test_common/session_reuse.py` replaces `tensorrt_llm.executor.proxy.MpiPoolSession` with a factory function (not a type), and the actual session is a `_ReusableSession` wrapper (not a subclass) that delegates via `__getattr__`.
- **Fix**: Replace the concrete-type check with the polymorphic `MpiSession.is_comm_session()` — returns False for `MpiPoolSession` (register PIDs), True for comm-based sessions (skip). The `_ReusableSession` wrapper transparently forwards the method to its real `MpiPoolSession` via `__getattr__`.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6463828


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker process tracking during startup across different MPI session types.
  * Ensured operating system process identities are registered consistently when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->