### PR TITLE
[https://nvbugs/6463812][fix] Import MpiPoolSession from its source module (tensorrt_llm.llmapi.mpi_session)…

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -573,6 +573,10 @@ class GenerationExecutorProxy(GenerationExecutor):
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
+        # Re-import to bypass the test-suite monkey-patch of the module-level
+        # name (see tests/test_common/session_reuse.py) so isinstance always
+        # receives the real class rather than the factory shim.
+        from ..llmapi.mpi_session import MpiPoolSession
         if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
             worker_process_identities: List[WorkerProcessIdentity] = status[2]
             self._worker_process_monitor.register(worker_process_identities)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -377,7 +377,6 @@ full:sm100/examples/test_nemotron.py::test_llm_nemotron_3_8b_1gpu[bfloat16-fp8] 
 full:sm100/unittest/bindings SKIP (Disable for Blackwell)
 kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2Llama::test_chunked_prefill SKIP (https://nvbugs/6428002)
 kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2Llama::test_eviction_with_block_reuse SKIP (https://nvbugs/6462303)
-llmapi/test_llm_api_pytorch_bart.py::test_bart_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-on-greedy-tp2-bart-large-cnn] SKIP (https://nvbugs/6463812)
 llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[cudagraph] SKIP (https://nvbugs/6463829)
 llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[eager] SKIP (https://nvbugs/6463829)
 llmapi/test_llm_examples.py::test_llmapi_speculative_decoding_eagle3 SKIP (https://nvbugs/6075431)


### PR DESCRIPTION
## Summary
- **Root cause**: tests/test_common/session_reuse.py rebinds proxy.MpiPoolSession to a factory function, so isinstance(self.mpi_session, MpiPoolSession) raises TypeError.
- **Fix**: Import MpiPoolSession from its source module (tensorrt_llm.llmapi.mpi_session) inline at the check site so isinstance always receives the concrete class, and remove the corresponding waiver.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6463812


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executor startup reliability when running in environments with customized test configurations.

* **Tests**
  * Re-enabled an end-to-end text generation integration test, expanding validation coverage for encoder-decoder models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->