### PR TITLE
[https://nvbugs/6462303][fix] Import `MpiPoolSession` under a second private alias (`_RealMpiPoolSession`)…

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -28,8 +28,12 @@ import zmq.asyncio
 from tensorrt_llm.logger import logger
 
 from .._utils import customized_gc_thresholds, mpi_rank, nvtx_range_debug
-from ..llmapi.mpi_session import (MpiCommSession, MpiPoolSession, MpiSession,
-                                  RemoteMpiCommSessionClient,
+# Alias unaffected by test-infra monkey-patching of ``MpiPoolSession`` (which
+# replaces the module-level name with a factory function for pool reuse).
+from ..llmapi.mpi_session import MpiCommSession
+from ..llmapi.mpi_session import MpiPoolSession
+from ..llmapi.mpi_session import MpiPoolSession as _RealMpiPoolSession
+from ..llmapi.mpi_session import (MpiSession, RemoteMpiCommSessionClient,
                                   validate_session_world_size)
 from ..llmapi.tracer import enable_llm_tracer, get_tracer, global_tracer
 from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
@@ -573,7 +577,8 @@ class GenerationExecutorProxy(GenerationExecutor):
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
-        if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
+        if isinstance(self.mpi_session,
+                      _RealMpiPoolSession) and len(status) == 3:
             worker_process_identities: List[WorkerProcessIdentity] = status[2]
             self._worker_process_monitor.register(worker_process_identities)
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -376,7 +376,6 @@ full:RTX_PRO_6000_Blackwell_Server_Edition/perf/test_perf.py::test_perf[quant:w4
 full:sm100/examples/test_nemotron.py::test_llm_nemotron_3_8b_1gpu[bfloat16-fp8] SKIP (megatron-core 0.8 is not supported in python 3.12)
 full:sm100/unittest/bindings SKIP (Disable for Blackwell)
 kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2Llama::test_chunked_prefill SKIP (https://nvbugs/6428002)
-kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2Llama::test_eviction_with_block_reuse SKIP (https://nvbugs/6462303)
 llmapi/test_llm_api_pytorch_bart.py::test_bart_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-on-greedy-tp2-bart-large-cnn] SKIP (https://nvbugs/6463812)
 llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[cudagraph] SKIP (https://nvbugs/6463829)
 llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[eager] SKIP (https://nvbugs/6463829)


### PR DESCRIPTION
## Summary
- **Root cause**: `isinstance(self.mpi_session, MpiPoolSession)` used the module-level `MpiPoolSession` name, which the test-suite session-reuse infra monkey-patches to a factory function; `isinstance()` against a non-class raises `TypeError`.
- **Fix**: Import `MpiPoolSession` under a second private alias (`_RealMpiPoolSession`) that the test infra never patches, and use it for the isinstance check; construction still uses the patched name so pool reuse is preserved. Waiver removed.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6462303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executor worker initialization to remain reliable when runtime session components are replaced during testing.
  * Removed an outdated integration-test waiver, allowing the cache eviction and block reuse scenario to run normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->