### PR TITLE
[https://nvbugs/6461799][fix] Import `MpiPoolSession` from its source module…

### DIFF
--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -573,6 +573,9 @@ class GenerationExecutorProxy(GenerationExecutor):
             raise RuntimeError(
                 "Executor worker returned error") from ready_signal
 
+        # Import from the source module: test infrastructure (session_reuse.py)
+        # monkey-patches this module's MpiPoolSession attribute to a factory.
+        from ..llmapi.mpi_session import MpiPoolSession
         if isinstance(self.mpi_session, MpiPoolSession) and len(status) == 3:
             worker_process_identities: List[WorkerProcessIdentity] = status[2]
             self._worker_process_monitor.register(worker_process_identities)


### PR DESCRIPTION
## Summary
- **Root cause**: `tests/test_common/session_reuse.py` monkey-patches `MpiPoolSession` in the `tensorrt_llm.executor.proxy` module namespace with a factory function, so `isinstance(self.mpi_session, MpiPoolSession)` at proxy.py:576 raises `TypeError: isinstance() arg 2 must be a type` because the second argument is a function, not a class.
- **Fix**: Import `MpiPoolSession` from its source module (`tensorrt_llm.llmapi.mpi_session`) at the use site so the class reference is resolved fresh from the source module (immune to attribute-level monkeypatching in `tensorrt_llm.executor.proxy`); leaves the constructor-call site at proxy.py:130 unchanged so session-reuse still intercepts pool creation.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6461799


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executor worker startup compatibility in runtime-configured environments.
  * Enhanced reliability when launching workloads through customized execution setups.

* **Chores**
  * Strengthened internal validation and testing support without changing public APIs or standard execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->