### PR TITLE
[None][perf] Various Gemma4 related perf fixes

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -648,7 +648,7 @@ class FlashInferAttentionMetadata(AttentionMetadata):
         self._host_pool_indices: Dict[int, torch.Tensor] = {}
         self._host_paged_kv_indices: Optional[torch.Tensor] = None
         self._host_paged_kv_indptr_decode: Optional[torch.Tensor] = None
-        self._max_num_blocks = 0
+        self._max_num_blocks_per_seq = 0
 
         # VSWA (Variable Sliding Window Attention): models with per-layer
         # max_attention_window create separate V2 pool groups with independent
@@ -668,18 +668,16 @@ class FlashInferAttentionMetadata(AttentionMetadata):
             )
 
             # Maximum block count across ALL pools: sizes the VSWA pool
-            # buffers below and bounds the per-request width of the
-            # persistent trtllm-gen decode block tables (a request can
-            # never reference more blocks than its pool holds).  Computed
-            # for every model, not just VSWA — non-VSWA managers have a
-            # single pool, so this stays blocks_in_primary_pool for them.
+            # buffers below. Computed for every model, not just VSWA —
+            # non-VSWA managers have a single pool, so this stays
+            # blocks_in_primary_pool for them.
             max_num_blocks = blocks_in_primary_pool
             if hasattr(self.kv_cache_manager, 'layer_offsets'):
                 for lid in self.kv_cache_manager.layer_offsets:
                     lbuf = self.kv_cache_manager.get_buffers(lid)
                     if lbuf is not None:
                         max_num_blocks = max(max_num_blocks, lbuf.shape[0])
-            self._max_num_blocks = max_num_blocks
+            self._max_num_blocks_per_seq = self.kv_cache_manager.max_blocks_per_seq
 
             # Layers may share one page-index list only when they are in the
             # same pool AND have the same page-index scale: VSWA splits pools,
@@ -1007,9 +1005,9 @@ class FlashInferAttentionMetadata(AttentionMetadata):
         gen_num_blocks = np.asarray(self.num_blocks[self.num_contexts:],
                                     dtype=np.int64)
         max_n = int(gen_num_blocks.max())
-        if max_n > self._max_num_blocks:
-            # A request can never reference more blocks than any pool
-            # holds; defensive guard for inconsistent metadata.
+        if max_n > self._max_num_blocks_per_seq:
+            # A request can never reference more than max_blocks_per_seq;
+            # defensive guard for inconsistent metadata.
             return None
         block_tables = wrappers.decode_block_tables
         if (self.is_cuda_graph and block_tables is not None
@@ -1021,12 +1019,12 @@ class FlashInferAttentionMetadata(AttentionMetadata):
             if self.is_cuda_graph:
                 # Allocated once at capture warmup; full capacity width so
                 # replays never need a wider table.
-                width = self._max_num_blocks
+                width = self._max_num_blocks_per_seq
             else:
                 # Eager path replans (and re-reads the table) every step,
                 # so the buffer may grow geometrically as sequences do.
                 width = min(max(64, 1 << (max_n - 1).bit_length()),
-                            self._max_num_blocks)
+                            self._max_num_blocks_per_seq)
             try:
                 block_tables = torch.zeros((self.max_num_requests, width),
                                            dtype=torch.int32,

--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import functools
 import math
 import os
@@ -207,6 +221,10 @@ class FlashInferWrappers:
                                                         repr=False)
     host_decode_block_tables: Optional[torch.Tensor] = field(default=None,
                                                              repr=False)
+    # Remember the previously populated rectangle so a smaller subsequent batch can clear stale rows
+    # and columns before narrowing future updates.
+    decode_block_table_active_rows: int = field(default=0, repr=False)
+    decode_block_table_active_width: int = field(default=0, repr=False)
 
 
 @dataclass(kw_only=True)
@@ -1039,6 +1057,10 @@ class FlashInferAttentionMetadata(AttentionMetadata):
         # completed.
         block_tables[:num_gens, :max_n].copy_(
             host_block_tables[:num_gens, :max_n], non_blocking=True)
+        # Seed the extent used by `prepare()` to clear entries if the first graph replay has fewer
+        # requests or a narrower block table.
+        wrappers.decode_block_table_active_rows = num_gens
+        wrappers.decode_block_table_active_width = max_n
         return block_tables[:num_gens]
 
     def _clean_cached_plans(self, *, defer_plan: bool):
@@ -1310,7 +1332,7 @@ class FlashInferAttentionMetadata(AttentionMetadata):
         if (self.is_cuda_graph and self._vswa_layer_to_pool is not None
                 and self._vswa_pool_indices_cache is not None
                 and self.num_generations > 0):
-            decode_blocks = self.num_blocks[self.num_contexts:]
+            decode_blocks = num_blocks[self.num_contexts:]
             head_dim_to_pool = getattr(self, '_vswa_head_dim_to_pool', None)
             for plan_params, wrappers in self._plan_params_to_wrappers.items():
                 if plan_params.attention_mask_data is not None:
@@ -1323,34 +1345,62 @@ class FlashInferAttentionMetadata(AttentionMetadata):
                            if head_dim_to_pool else None)
                 if pool_id is None:
                     continue
-                pool_buf = self._vswa_pool_indices_cache[pool_id]
                 batch_size, table_width = block_tables.shape
                 rows = min(batch_size, self.num_generations)
-                # Vectorized equivalent of a per-request copy loop: row i
-                # gets pool_buf[offset + row_starts[i] :] for its first
-                # min(num_blocks_per_row[i], table_width) columns, zero-
-                # padded — one gather + where instead of ~batch slice
-                # copies per pool per step.
-                num_blocks_per_row = torch.tensor(
-                    decode_blocks[:rows],
-                    dtype=torch.int64).to(device=block_tables.device,
-                                          non_blocking=True)
-                row_starts = torch.cumsum(num_blocks_per_row,
-                                          dim=0) - num_blocks_per_row
-                columns = torch.arange(table_width,
-                                       dtype=torch.int64,
-                                       device=block_tables.device)
-                mask = columns.unsqueeze(0) < num_blocks_per_row.clamp(
-                    max=table_width).unsqueeze(1)
-                source_indices = (self.num_context_blocks +
-                                  row_starts.unsqueeze(1) +
-                                  columns.unsqueeze(0)).clamp(
-                                      max=pool_buf.numel() - 1)
-                new_block_tables = torch.zeros_like(block_tables)
-                new_block_tables[:rows] = torch.where(
-                    mask, pool_buf[source_indices.reshape(-1)].view(
-                        rows, table_width), new_block_tables[:rows])
-                block_tables.copy_(new_block_tables)
+                num_blocks_per_row = decode_blocks[:rows]
+                active_width = min(int(num_blocks_per_row.max()), table_width)
+                # Include the previous live extent once when the batch or its longest sequence
+                # shrinks. The zero-filled copy below clears entries that are no longer live; the
+                # next update can shrink.
+                update_rows = min(
+                    batch_size,
+                    max(rows, wrappers.decode_block_table_active_rows))
+                update_width = min(
+                    table_width,
+                    max(active_width, wrappers.decode_block_table_active_width))
+                host_block_tables = wrappers.host_decode_block_tables
+                if (host_block_tables is None
+                        or host_block_tables.size(0) < update_rows
+                        or host_block_tables.size(1) < update_width):
+                    # Grow geometrically to avoid reallocating whenever the longest sequence
+                    # acquires one more KV-cache block.
+                    host_width = min(
+                        max(64, 1 << (update_width - 1).bit_length()),
+                        table_width)
+                    host_block_tables = torch.zeros(
+                        (self.max_num_requests, host_width),
+                        dtype=torch.int32,
+                        pin_memory=prefer_pinned())
+                    wrappers.host_decode_block_tables = host_block_tables
+
+                # Build only the live (or previously live) rectangle on the host. This preserves
+                # padded-row zeroing when batch size shrinks without launching full-capacity
+                # `arange`, `gather`, `where`, `zero`, and copy kernels on every decode step.
+                host_table = host_block_tables[:update_rows, :update_width]
+                host_table.zero_()
+                host_pool_indices = self._host_pool_indices[pool_id]
+                # Pool indices are flattened as context blocks followed by each generation request's
+                # blocks.
+                source_offset = self.num_context_blocks
+                # This loop scales with the number of generation requests. Vectorizing ragged
+                # rows would require padded mask or index tensor, so keep contiguous row copies
+                # until profiling identifies this as a CPU bottleneck.
+                for row, num_blocks_for_row in enumerate(num_blocks_per_row):
+                    num_blocks_for_row = int(num_blocks_for_row)
+                    copy_width = min(num_blocks_for_row, table_width)
+                    host_table[row, :copy_width].copy_(
+                        host_pool_indices[source_offset:source_offset +
+                                          copy_width])
+                    # Advance by the uncropped count so the next request starts at the correct
+                    # offset even if this row hit `table_width`.
+                    source_offset += num_blocks_for_row
+                # Keep the graph-captured device address stable and transfer only the compact
+                # rectangle prepared in pinned host memory.
+                block_tables[:update_rows, :update_width].copy_(
+                    host_block_tables[:update_rows, :update_width],
+                    non_blocking=True)
+                wrappers.decode_block_table_active_rows = rows
+                wrappers.decode_block_table_active_width = active_width
                 kv_lens_buf = getattr(decode_wrapper, '_kv_lens_buffer', None)
                 if kv_lens_buf is not None:
                     decode_kv_lens = _to_int32_tensor(

--- a/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
@@ -629,11 +629,11 @@ class Gemma4VisionPatchEmbedder(nn.Module):
         self, pixel_position_ids: torch.Tensor, padding_positions: torch.Tensor
     ) -> torch.Tensor:
         clamped = pixel_position_ids.clamp(min=0)
-        one_hot = F.one_hot(clamped, num_classes=self.position_embedding_size)
-        one_hot = one_hot.permute(0, 2, 1, 3).to(self.position_embedding_table)
-        position_embeddings = one_hot @ self.position_embedding_table
-        position_embeddings = position_embeddings.sum(dim=1)
-        return torch.where(padding_positions.unsqueeze(-1), 0.0, position_embeddings)
+        position_embeddings = (
+            self.position_embedding_table[0, clamped[..., 0]]
+            + self.position_embedding_table[1, clamped[..., 1]]
+        )
+        return position_embeddings.masked_fill(padding_positions.unsqueeze(-1), 0.0)
 
     def forward(
         self,

--- a/tests/unittest/_torch/modeling/test_modeling_gemma4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma4.py
@@ -22,10 +22,13 @@ import math
 import unittest
 import unittest.mock
 from copy import deepcopy
+from typing import TYPE_CHECKING
 
 import torch
 from transformers import Gemma4Config, Gemma4TextConfig
 
+from tensorrt_llm._torch.attention_backend import FlashInferAttention, FlashInferAttentionMetadata
+from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.checkpoints.hf.gemma4_weight_mapper import Gemma4HfWeightMapper
 from tensorrt_llm._torch.models.modeling_gemma4 import (
@@ -38,6 +41,12 @@ from tensorrt_llm._torch.models.modeling_gemma4 import (
     Gemma4TextScaledWordEmbedding,
 )
 from tensorrt_llm.mapping import Mapping
+
+if TYPE_CHECKING:
+    from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
+
+_FLASHINFER_WORKSPACE_BYTES = 320 * 1024 * 1024
+_TRTLLM_GEN_TOKENS_PER_BLOCK = 32
 
 # ---------------------------------------------------------------------------
 # Small test configs
@@ -2224,6 +2233,327 @@ class TestGemma4CUDAGraph(unittest.TestCase):
     """Tests for Gemma4 attention with CUDA graph capture/replay."""
 
     _get_kv_cache_manager = staticmethod(_build_gemma4_kv_cache_manager)
+
+    def _make_trtllm_gen_decode_case(
+        self,
+        initial_page_counts: list[int],
+        *,
+        reserved_page_counts: list[int] | None = None,
+        max_pages: int = 64,
+        manager_batch_size: int | None = None,
+    ) -> tuple[
+        "KVCacheManagerV2",
+        list["FlashInferAttention"],
+        "FlashInferAttentionMetadata",
+        list[torch.Tensor],
+        list[torch.Tensor],
+        list[torch.Tensor],
+    ]:
+        """Build a two-pool Gemma4 trtllm-gen CUDA-graph decode case."""
+        batch_size = len(initial_page_counts)
+        if reserved_page_counts is None:
+            reserved_page_counts = initial_page_counts
+        if manager_batch_size is None:
+            manager_batch_size = batch_size
+
+        config = Gemma4TextConfig(**deepcopy(GEMMA4_E2B_REAL_DIMS_CONFIG))
+        kv_cache_manager = self._get_kv_cache_manager(
+            config,
+            num_blocks=max_pages,
+            tokens_per_block=_TRTLLM_GEN_TOKENS_PER_BLOCK,
+            batch_size=manager_batch_size,
+        )
+        self.addCleanup(kv_cache_manager.shutdown)
+        self.assertTrue(kv_cache_manager.is_vswa, "Expected VSWA manager")
+
+        request_ids = list(range(batch_size))
+        requests = kv_cache_manager.add_dummy_requests(
+            request_ids,
+            token_nums=[
+                (count - 1) * _TRTLLM_GEN_TOKENS_PER_BLOCK + 1 for count in reserved_page_counts
+            ],
+        )
+        if requests is None:
+            self.fail("Failed to allocate dummy requests for the test")
+
+        layer_indices = [
+            config.layer_types.index("sliding_attention"),
+            config.layer_types.index("full_attention"),
+        ]
+        layers = []
+        queries = []
+        keys = []
+        values = []
+        for layer_idx in layer_indices:
+            is_sliding = config.layer_types[layer_idx] == "sliding_attention"
+            head_dim = config.head_dim if is_sliding else config.global_head_dim
+            layers.append(
+                FlashInferAttention(
+                    layer_idx=layer_idx,
+                    num_heads=config.num_attention_heads,
+                    head_dim=head_dim,
+                    num_kv_heads=config.num_key_value_heads,
+                    flashinfer_backend="trtllm-gen",
+                )
+            )
+            queries.append(
+                torch.randn(
+                    batch_size,
+                    config.num_attention_heads * head_dim,
+                    dtype=config.torch_dtype,
+                    device="cuda",
+                )
+            )
+            keys.append(
+                torch.randn(
+                    batch_size,
+                    config.num_key_value_heads * head_dim,
+                    dtype=config.torch_dtype,
+                    device="cuda",
+                )
+            )
+            values.append(
+                torch.randn(
+                    batch_size,
+                    config.num_key_value_heads * head_dim,
+                    dtype=config.torch_dtype,
+                    device="cuda",
+                )
+            )
+
+            kv_buffer = kv_cache_manager.get_buffers(layer_idx)
+            self.assertIsNotNone(kv_buffer)
+            torch.nn.init.normal_(kv_buffer)
+
+        seq_lens = torch.ones(batch_size, dtype=torch.int)
+        metadata = FlashInferAttentionMetadata(
+            seq_lens=seq_lens,
+            num_contexts=0,
+            is_cuda_graph=True,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=[
+                    (count - 1) * _TRTLLM_GEN_TOKENS_PER_BLOCK for count in initial_page_counts
+                ],
+            ),
+            workspace_buffer=torch.empty(
+                _FLASHINFER_WORKSPACE_BYTES, dtype=torch.uint8, device="cuda"
+            ),
+            max_num_requests=batch_size,
+            max_num_tokens=batch_size,
+            kv_cache_manager=kv_cache_manager,
+            request_ids=request_ids,
+        )
+        metadata.prepare()
+        for layer, query, key, value in zip(layers, queries, keys, values, strict=True):
+            layer.forward(query, key, value, metadata)
+
+        return kv_cache_manager, layers, metadata, queries, keys, values
+
+    def _prepare_decode_page_counts(
+        self,
+        metadata: "FlashInferAttentionMetadata",
+        request_ids: list[int],
+        page_counts: list[int],
+        *,
+        preserve_cuda_graph_shape: bool = False,
+    ) -> None:
+        """Refresh decode metadata with one query token per request."""
+        self.assertTrue(all(count > 0 for count in page_counts))
+        seq_lens = torch.ones(len(page_counts), dtype=torch.int)
+        if preserve_cuda_graph_shape:
+            # Keep the captured device buffer at maximum batch size while shrinking the active
+            # host metadata, matching the stale-row condition handled by FlashInfer prepare().
+            metadata._seq_lens = seq_lens
+            metadata.on_update()
+        else:
+            metadata.seq_lens = seq_lens
+        metadata.request_ids = request_ids
+        metadata.kv_cache_params = KVCacheParams(
+            use_cache=True,
+            num_cached_tokens_per_seq=[
+                (count - 1) * _TRTLLM_GEN_TOKENS_PER_BLOCK for count in page_counts
+            ],
+        )
+        metadata.prepare()
+
+    def _expected_decode_block_table(
+        self,
+        metadata: "FlashInferAttentionMetadata",
+        head_dim: int,
+        page_counts: list[int],
+        *,
+        rows: int,
+        width: int,
+    ) -> torch.Tensor:
+        """Build the expected compact table from one VSWA pool's host indices."""
+        pool_id = metadata._vswa_head_dim_to_pool[head_dim]
+        pool_indices = metadata._host_pool_indices[pool_id].numpy()
+        expected = torch.zeros((rows, width), dtype=torch.int32)
+        source_offset = metadata.num_context_blocks
+        for row, page_count in enumerate(page_counts):
+            copy_width = min(page_count, width)
+            expected[row, :copy_width] = torch.from_numpy(
+                pool_indices[source_offset : source_offset + copy_width].copy()
+            )
+            source_offset += page_count
+        return expected
+
+    @torch.no_grad()
+    @unittest.mock.patch(
+        "tensorrt_llm.runtime.kv_cache_manager_v2._utils.assert_critical", lambda *a, **kw: None
+    )
+    def test_cuda_graph_trtllm_gen_block_table_transitions(self) -> None:
+        """Shrinking the active rectangle clears stale rows and columns."""
+        initial_page_counts = [8, 5, 3, 2]
+        _, _, metadata, _, _, _ = self._make_trtllm_gen_decode_case(initial_page_counts)
+
+        new_page_counts = [2, 1]
+        self._prepare_decode_page_counts(
+            metadata,
+            request_ids=[0, 1],
+            page_counts=new_page_counts,
+            preserve_cuda_graph_shape=True,
+        )
+        torch.cuda.synchronize()
+
+        for plan_params, wrappers in metadata._plan_params_to_wrappers.items():
+            with self.subTest(head_dim=plan_params.head_dim):
+                block_tables = wrappers.decode_wrapper._block_tables
+                expected = self._expected_decode_block_table(
+                    metadata,
+                    plan_params.head_dim,
+                    new_page_counts,
+                    rows=len(initial_page_counts),
+                    width=max(initial_page_counts),
+                )
+                torch.testing.assert_close(
+                    block_tables[: len(initial_page_counts), : max(initial_page_counts)].cpu(),
+                    expected,
+                    atol=0,
+                    rtol=0,
+                )
+                self.assertEqual(wrappers.decode_block_table_active_rows, len(new_page_counts))
+                self.assertEqual(wrappers.decode_block_table_active_width, max(new_page_counts))
+
+    @torch.no_grad()
+    @unittest.mock.patch(
+        "tensorrt_llm.runtime.kv_cache_manager_v2._utils.assert_critical", lambda *a, **kw: None
+    )
+    def test_cuda_graph_trtllm_gen_host_table_growth_keeps_device_pointer(self) -> None:
+        """Crossing 64 pages grows host staging without moving the graph buffer."""
+        initial_page_counts = [63, 2]
+        _, _, metadata, _, _, _ = self._make_trtllm_gen_decode_case(
+            initial_page_counts,
+            reserved_page_counts=[65, 2],
+            max_pages=512,
+        )
+
+        initial_state = {}
+        for plan_params, wrappers in metadata._plan_params_to_wrappers.items():
+            block_tables = wrappers.decode_wrapper._block_tables
+            self.assertGreaterEqual(block_tables.size(1), 65)
+            self.assertEqual(wrappers.host_decode_block_tables.size(1), 64)
+            initial_state[plan_params.head_dim] = (
+                block_tables.data_ptr(),
+                wrappers.host_decode_block_tables.data_ptr(),
+            )
+
+        new_page_counts = [65, 2]
+        self._prepare_decode_page_counts(metadata, [0, 1], new_page_counts)
+        torch.cuda.synchronize()
+
+        for plan_params, wrappers in metadata._plan_params_to_wrappers.items():
+            with self.subTest(head_dim=plan_params.head_dim):
+                block_tables = wrappers.decode_wrapper._block_tables
+                old_device_ptr, old_host_ptr = initial_state[plan_params.head_dim]
+                self.assertEqual(block_tables.data_ptr(), old_device_ptr)
+                self.assertNotEqual(wrappers.host_decode_block_tables.data_ptr(), old_host_ptr)
+                self.assertGreaterEqual(wrappers.host_decode_block_tables.size(1), 65)
+                expected = self._expected_decode_block_table(
+                    metadata,
+                    plan_params.head_dim,
+                    new_page_counts,
+                    rows=len(new_page_counts),
+                    width=max(new_page_counts),
+                )
+                torch.testing.assert_close(
+                    block_tables[: len(new_page_counts), : max(new_page_counts)].cpu(),
+                    expected,
+                    atol=0,
+                    rtol=0,
+                )
+
+    @torch.no_grad()
+    @unittest.mock.patch(
+        "tensorrt_llm.runtime.kv_cache_manager_v2._utils.assert_critical", lambda *a, **kw: None
+    )
+    def test_cuda_graph_trtllm_gen_request_turnover_matches_eager(self) -> None:
+        """A captured graph remains correct when long requests are replaced by short ones."""
+        initial_page_counts = [8, 4]
+        (
+            kv_cache_manager,
+            layers,
+            metadata,
+            queries,
+            keys,
+            values,
+        ) = self._make_trtllm_gen_decode_case(
+            initial_page_counts,
+            max_pages=64,
+            manager_batch_size=4,
+        )
+
+        new_request_ids = [100, 101]
+        new_page_counts = [2, 1]
+        new_requests = kv_cache_manager.add_dummy_requests(
+            new_request_ids,
+            token_nums=[
+                (count - 1) * _TRTLLM_GEN_TOKENS_PER_BLOCK + 1 for count in new_page_counts
+            ],
+        )
+        self.assertIsNotNone(new_requests)
+
+        for layer, query, key, value in zip(layers, queries, keys, values, strict=True):
+            layer.forward(query, key, value, metadata)
+
+        graph_outputs = []
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            for layer, query, key, value in zip(layers, queries, keys, values, strict=True):
+                graph_outputs.append(layer.forward(query, key, value, metadata))
+        torch.cuda.synchronize()
+
+        self._prepare_decode_page_counts(metadata, new_request_ids, new_page_counts)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        reference_metadata = FlashInferAttentionMetadata(
+            seq_lens=torch.ones(len(new_request_ids), dtype=torch.int),
+            num_contexts=0,
+            kv_cache_params=KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=[
+                    (count - 1) * _TRTLLM_GEN_TOKENS_PER_BLOCK for count in new_page_counts
+                ],
+            ),
+            max_num_requests=len(new_request_ids),
+            max_num_tokens=len(new_request_ids),
+            kv_cache_manager=kv_cache_manager,
+            request_ids=new_request_ids,
+        )
+        reference_metadata.prepare()
+        for layer_idx, (layer, query, key, value) in enumerate(
+            zip(layers, queries, keys, values, strict=True)
+        ):
+            reference_output = layer.forward(query, key, value, reference_metadata)
+            torch.testing.assert_close(
+                graph_outputs[layer_idx],
+                reference_output,
+                atol=1e-2,
+                rtol=0,
+                msg=f"Layer {layer.layer_idx}: request-turnover graph output diverges from eager",
+            )
 
     @torch.no_grad()
     @unittest.mock.patch(

--- a/tests/unittest/_torch/modeling/test_modeling_gemma4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma4.py
@@ -2453,6 +2453,7 @@ class TestGemma4CUDAGraph(unittest.TestCase):
         for plan_params, wrappers in metadata._plan_params_to_wrappers.items():
             block_tables = wrappers.decode_wrapper._block_tables
             self.assertGreaterEqual(block_tables.size(1), 65)
+            self.assertEqual(block_tables.size(1), metadata.kv_cache_manager.max_blocks_per_seq)
             self.assertEqual(wrappers.host_decode_block_tables.size(1), 64)
             initial_state[plan_params.head_dim] = (
                 block_tables.data_ptr(),


### PR DESCRIPTION
@coderabbitai summary

## Description

CUDA-graph decode rebuilt maximum-capacity VSWA block tables on the
GPU every step, even when only a small live rectangle was active.

This commit instead refreshes that rectangle from pinned host memory
to remove the page-table bottleneck, while preserving per-layer indices
and stable graph buffers.

Gemma4 vision also materialized one-hot tensors only to select position
embeddings. Index the embedding table directly to reduce transient GPU
memory during image preprocessing.

## Performance comparison

### 26B MoE, B200, NVFP4, ISL 1k/1k, single 512×512 image

| CONC | Requests | Baseline tok/s | Optimized tok/s | Throughput delta |
|---:|---:|---:|---:|---:|
| 1 | 10 | 175.19 | 184.29 | **+5.19%** |
| 32 | 96 | 2,873.59 | 3,493.45 | **+21.57%** |
| 64 | 192 | 4,350.26 | 5,594.95 | **+28.61%** |
| 128 | 384 | 5,596.63 | 8,019.20 | **+43.29%** |
| 256 | 768 | 6,874.29 | 10,201.41 | **+48.40%** |

### 31B dense, B200, NVFP4, ISL 1k/1k, single 512×512 image

| CONC | Requests | Baseline tok/s | Optimized tok/s | Throughput delta |
|---:|---:|---:|---:|---:|
| 1 | 10 | 109.60 | 114.34 | **+4.32%** |
| 32 | 96 | 2,145.21 | 2,263.92 | **+5.53%** |
| 64 | 192 | 3,005.39 | 3,230.72 | **+7.50%** |
| 128 | 384 | 3,787.52 | 4,143.70 | **+9.40%** |
| 256 | 768 | 3,856.20 | 4,304.04 | **+11.61%** |

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
