### PR TITLE
[None][perf] Preallocate video decode buffer for HF zero-copy handoff

### DIFF
--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -478,37 +478,58 @@ def _load_video_by_cv2(
 
         indices = np.linspace(0, frame_count - 1, num_frames_to_sample, dtype=int).tolist()
 
-        H = int(vidcap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-        W = int(vidcap.get(cv2.CAP_PROP_FRAME_WIDTH))
-        # Preallocate the stacked buffer and let cvtColor write each RGB frame
-        # straight into its slice, so decode does one memory pass instead of a
-        # per-frame alloc + trailing np.stack.
-        stacked_rgb = np.empty((num_frames_to_sample, H, W, 3), dtype=np.uint8)
+        # Defer allocating the stacked buffer until the first frame is actually
+        # decoded: container metadata (CAP_PROP_FRAME_WIDTH/HEIGHT) can be 0
+        # or stale before the first decode for some codecs.
+        stacked_rgb: Optional[np.ndarray] = None
+        H = W = None
 
         target_set = set(indices)
         max_idx = indices[-1]
         bgr_scratch: Optional[np.ndarray] = None
         valid_indices: list[int] = []
+        # Log at most once per decode to avoid spamming when a whole stream is
+        # affected (e.g. every frame retrieves with a drifted shape).
+        skip_warned = False
         frame_idx = 0
         while frame_idx <= max_idx and vidcap.grab():
             if frame_idx in target_set:
                 # Reuse a single BGR buffer across retrieves; cv2 replaces its
                 # contents in place when the argument is shape-compatible.
                 ok, bgr_scratch = vidcap.retrieve(bgr_scratch)
-                if ok and bgr_scratch.shape[:2] == (H, W):
-                    cv2.cvtColor(
-                        bgr_scratch, cv2.COLOR_BGR2RGB, dst=stacked_rgb[len(valid_indices)]
+                if ok:
+                    fh, fw = bgr_scratch.shape[:2]
+                    if stacked_rgb is None:
+                        H, W = fh, fw
+                        stacked_rgb = np.empty((num_frames_to_sample, H, W, 3), dtype=np.uint8)
+                    if (fh, fw) == (H, W):
+                        cv2.cvtColor(
+                            bgr_scratch,
+                            cv2.COLOR_BGR2RGB,
+                            dst=stacked_rgb[len(valid_indices)],
+                        )
+                        valid_indices.append(frame_idx)
+                    elif not skip_warned:
+                        logger.warning(
+                            f"Skipping frame {frame_idx} and subsequent size-drifted frames: "
+                            f"shape={(fh, fw)} differs from first decoded shape=({H}, {W})."
+                        )
+                        skip_warned = True
+                elif not skip_warned:
+                    logger.warning(
+                        f"Skipping frame {frame_idx} and subsequent retrieve failures: retrieve returned ok=False."
                     )
-                    valid_indices.append(frame_idx)
+                    skip_warned = True
             frame_idx += 1
         vidcap.release()
 
-        if not valid_indices:
+        if stacked_rgb is None or not valid_indices:
             raise ValueError("Video has no readable frames.")
         stacked_rgb = stacked_rgb[: len(valid_indices)]
 
         if format == "pt":
-            stacked_f32 = stacked_rgb.astype(np.float32) * (1.0 / 255.0)
+            stacked_f32 = stacked_rgb.astype(np.float32)
+            stacked_f32 *= 1.0 / 255.0
             tensor_nchw = torch.from_numpy(stacked_f32).permute(0, 3, 1, 2).contiguous()
             if device != "cpu":
                 tensor_nchw = tensor_nchw.to(device)

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -421,12 +421,13 @@ def _load_video_by_cv2(
     tempfile required. Callers that have no stream-buffered backend
     available should spill to a tempfile themselves and pass a path.
 
-    `format` controls the per-frame return type:
-      `"pt"`    - list[torch.Tensor], dtype=float32, shape=(C, H, W), range
-                  [0, 1]; rescaled and permuted to CHW here.
-      `"np"` - list[np.ndarray], dtype=uint8, shape=(H, W, 3); returned as
-                  decoded, leaving rescale/permute to the HF processor.
-      `"pil"`   - list[PIL.Image], one per sampled frame.
+    `format` controls the return type:
+      `"pt"`  - list[torch.Tensor], dtype=float32, shape=(C, H, W), range
+                [0, 1]; rescaled and permuted to CHW here.
+      `"np"`  - np.ndarray of shape (N, H, W, 3), dtype=uint8; a single
+                contiguous 4D buffer that HF video processors pass through
+                without an extra frame-by-frame copy.
+      `"pil"` - list[PIL.Image], one per sampled frame.
     """
     assert format in ("pt", "np", "pil"), "format must be one of 'pt', 'np', 'pil'"
 
@@ -477,42 +478,45 @@ def _load_video_by_cv2(
 
         indices = np.linspace(0, frame_count - 1, num_frames_to_sample, dtype=int).tolist()
 
-        # Sequential forward scan — grab() without per-frame seek
+        H = int(vidcap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        W = int(vidcap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        # Preallocate the stacked buffer and let cvtColor write each RGB frame
+        # straight into its slice, so decode does one memory pass instead of a
+        # per-frame alloc + trailing np.stack.
+        stacked_rgb = np.empty((num_frames_to_sample, H, W, 3), dtype=np.uint8)
+
         target_set = set(indices)
         max_idx = indices[-1]
-        raw_frames: dict[int, np.ndarray] = {}
+        bgr_scratch: Optional[np.ndarray] = None
+        valid_indices: list[int] = []
         frame_idx = 0
-        while frame_idx <= max_idx:
-            grab_succeeded = vidcap.grab()
-            if not grab_succeeded:
-                break
+        while frame_idx <= max_idx and vidcap.grab():
             if frame_idx in target_set:
-                # cv2 decodes frames in BGR order; convert to RGB for downstream use
-                retrieve_succeeded, bgr_frame = vidcap.retrieve()
-                if retrieve_succeeded:
-                    raw_frames[frame_idx] = cv2.cvtColor(bgr_frame, cv2.COLOR_BGR2RGB)
+                # Reuse a single BGR buffer across retrieves; cv2 replaces its
+                # contents in place when the argument is shape-compatible.
+                ok, bgr_scratch = vidcap.retrieve(bgr_scratch)
+                if ok and bgr_scratch.shape[:2] == (H, W):
+                    cv2.cvtColor(
+                        bgr_scratch, cv2.COLOR_BGR2RGB, dst=stacked_rgb[len(valid_indices)]
+                    )
+                    valid_indices.append(frame_idx)
             frame_idx += 1
         vidcap.release()
 
-        if not raw_frames:
+        if not valid_indices:
             raise ValueError("Video has no readable frames.")
+        stacked_rgb = stacked_rgb[: len(valid_indices)]
 
-        valid_indices = [i for i in indices if i in raw_frames]
         if format == "pt":
-            # uint8 -> float32 + /255 rescale done once on the stacked buffer
-            # so the dtype conversion is a single memory pass and there's one
-            # Python torch call instead of one per frame.
-            stacked_uint8 = np.stack([raw_frames[i] for i in valid_indices])
-            stacked_f32 = stacked_uint8.astype(np.float32) * (1.0 / 255.0)
+            stacked_f32 = stacked_rgb.astype(np.float32) * (1.0 / 255.0)
             tensor_nchw = torch.from_numpy(stacked_f32).permute(0, 3, 1, 2).contiguous()
             if device != "cpu":
                 tensor_nchw = tensor_nchw.to(device)
             loaded_frames = list(torch.unbind(tensor_nchw, dim=0))
         elif format == "np":
-            # uint8 HWC frames as-is; the HF processor rescales/permutes.
-            loaded_frames = [raw_frames[i] for i in valid_indices]
+            loaded_frames = stacked_rgb
         else:  # "pil"
-            loaded_frames = [Image.fromarray(raw_frames[i]) for i in valid_indices]
+            loaded_frames = [Image.fromarray(frame) for frame in stacked_rgb]
 
         metadata = {
             "total_num_frames": frame_count,

--- a/tensorrt_llm/inputs/multimodal_data.py
+++ b/tensorrt_llm/inputs/multimodal_data.py
@@ -147,7 +147,8 @@ class VideoData(BaseModalityData):
     """Data class for video loading results.
 
     Attributes:
-        frames: List of video frames, either as PIL Images or PyTorch tensors.
+        frames: Video frames as a list of PIL Images, a list of PyTorch
+            tensors, or a single 4D numpy array of shape (N, H, W, 3).
         metadata: Dictionary containing video metadata including:
             - total_num_frames: Total number of frames in the video
             - fps: Original frames per second of the video
@@ -163,14 +164,14 @@ class VideoData(BaseModalityData):
             content without walking pixels.
     """
 
-    frames: list[Image.Image] | list[torch.Tensor]
+    frames: list[Image.Image] | list[torch.Tensor] | np.ndarray
     metadata: dict[str, Any]
     audio: AudioData | None = None
     raw_bytes_hash: str | None = None
 
     def __post_init__(self) -> None:
-        if not self.frames:
-            raise ValueError("frames list cannot be empty")
+        if len(self.frames) == 0:
+            raise ValueError("frames cannot be empty")
         if not isinstance(self.metadata, dict):
             raise TypeError("metadata must be a dictionary")
 

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -51,6 +51,7 @@ l0_a10:
   - unittest/inputs/test_url_validation.py
   - unittest/inputs/test_multimodal.py
   - unittest/inputs/test_multimodal_input_processor.py
+  - unittest/inputs/test_video_decode.py
   - unittest/others/test_convert_utils.py
   - unittest/others/test_lora_manager.py
   - unittest/others/test_lora_module_count.py

--- a/tests/unittest/inputs/test_video_decode.py
+++ b/tests/unittest/inputs/test_video_decode.py
@@ -5,13 +5,11 @@
 
 from __future__ import annotations
 
-import tempfile
-from pathlib import Path
-
 import numpy as np
 import pytest
 import torch
 from PIL import Image
+from transformers.video_utils import make_batched_videos
 
 pytest.importorskip("cv2")
 import cv2  # noqa: E402
@@ -20,17 +18,15 @@ from tensorrt_llm.inputs.media_io import _load_video_by_cv2  # noqa: E402
 
 
 @pytest.fixture(scope="module")
-def sample_video_path() -> str:
+def sample_video_path(tmp_path_factory: pytest.TempPathFactory) -> str:
     """Encode a tiny mp4 with distinguishable per-frame pixel values."""
     width, height, num_frames = 64, 64, 20
-    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as handle:
-        path = handle.name
-    writer = cv2.VideoWriter(path, cv2.VideoWriter_fourcc(*"mp4v"), 30, (width, height))
+    path = tmp_path_factory.mktemp("video_decode") / "sample.mp4"
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), 30, (width, height))
     for i in range(num_frames):
         writer.write(np.full((height, width, 3), (i * 10) % 256, dtype=np.uint8))
     writer.release()
-    yield path
-    Path(path).unlink(missing_ok=True)
+    return str(path)
 
 
 def test_np_format_returns_stacked_uint8_ndarray(sample_video_path: str) -> None:
@@ -63,9 +59,6 @@ def test_pil_format_returns_list_of_pil_images(sample_video_path: str) -> None:
 
 def test_np_format_hits_hf_video_processor_fast_path(sample_video_path: str) -> None:
     """HF `make_batched_videos` returns a 4D ndarray input without copying."""
-    pytest.importorskip("transformers")
-    from transformers.video_utils import make_batched_videos
-
     video = _load_video_by_cv2(sample_video_path, num_frames=10, fps=-1, format="np")
     batched = make_batched_videos([video.frames])
 

--- a/tests/unittest/inputs/test_video_decode.py
+++ b/tests/unittest/inputs/test_video_decode.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for `_load_video_by_cv2` return shapes and the HF passthrough."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+pytest.importorskip("cv2")
+import cv2  # noqa: E402
+
+from tensorrt_llm.inputs.media_io import _load_video_by_cv2  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def sample_video_path() -> str:
+    """Encode a tiny mp4 with distinguishable per-frame pixel values."""
+    width, height, num_frames = 64, 64, 20
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as handle:
+        path = handle.name
+    writer = cv2.VideoWriter(path, cv2.VideoWriter_fourcc(*"mp4v"), 30, (width, height))
+    for i in range(num_frames):
+        writer.write(np.full((height, width, 3), (i * 10) % 256, dtype=np.uint8))
+    writer.release()
+    yield path
+    Path(path).unlink(missing_ok=True)
+
+
+def test_np_format_returns_stacked_uint8_ndarray(sample_video_path: str) -> None:
+    video = _load_video_by_cv2(sample_video_path, num_frames=10, fps=-1, format="np")
+    assert isinstance(video.frames, np.ndarray)
+    assert video.frames.shape == (10, 64, 64, 3)
+    assert video.frames.dtype == np.uint8
+    assert video.frames.flags["C_CONTIGUOUS"]
+
+
+def test_pt_format_returns_list_of_chw_tensors(sample_video_path: str) -> None:
+    video = _load_video_by_cv2(sample_video_path, num_frames=10, fps=-1, format="pt")
+    assert isinstance(video.frames, list)
+    assert len(video.frames) == 10
+    for frame in video.frames:
+        assert isinstance(frame, torch.Tensor)
+        assert frame.shape == (3, 64, 64)
+        assert frame.dtype == torch.float32
+        assert 0.0 <= frame.min().item() and frame.max().item() <= 1.0
+
+
+def test_pil_format_returns_list_of_pil_images(sample_video_path: str) -> None:
+    video = _load_video_by_cv2(sample_video_path, num_frames=10, fps=-1, format="pil")
+    assert isinstance(video.frames, list)
+    assert len(video.frames) == 10
+    for frame in video.frames:
+        assert isinstance(frame, Image.Image)
+        assert frame.size == (64, 64)
+
+
+def test_np_format_hits_hf_video_processor_fast_path(sample_video_path: str) -> None:
+    """HF `make_batched_videos` returns a 4D ndarray input without copying."""
+    pytest.importorskip("transformers")
+    from transformers.video_utils import make_batched_videos
+
+    video = _load_video_by_cv2(sample_video_path, num_frames=10, fps=-1, format="np")
+    batched = make_batched_videos([video.frames])
+
+    assert len(batched) == 1
+    assert np.shares_memory(video.frames, batched[0])


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video data now supports a single 4D NumPy array in addition to lists of images or tensors.
  * NumPy video output provides stacked, contiguous frames for efficient downstream processing.
  * Video decoding supports more robust handling of unreadable or inconsistent frames.

* **Bug Fixes**
  * Improved validation and error reporting when video frames are empty.

* **Tests**
  * Added coverage for NumPy, PyTorch, and PIL video output formats and efficient video processing compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Decode into a preallocated (N, H, W, 3) uint8 buffer via cv2.cvtColor(..., dst=stacked_rgb[i]) and reuse a single BGR scratch across retrieves. `format="np"` returns the 4D ndarray directly, which HF video_utils.make_batched_videos passes through without an extra frame-by-frame copy.

When passed as a list of np frames, the underlying transformers code executes a suboptimal function to convert to a stacked array (convert_pil_frames_to_video) - which does a double copy - `frames.append(np.array(frame))` -> `np.stack(frames)`, when passed as a 4D batched array, this no longer gets executed.

## Perf

Benchmark: Cosmos3-Nano NVFP4 on 1× B200, `trtllm-serve` PyTorch backend with `max_batch_size=256`, `max_num_tokens=16384`, chunked prefill, cuda-graph padding, KV block reuse off, `TRTLLM_MEDIA_LOAD_WORKERS=TRTLLM_INPUT_PROC_WORKERS=8`. Client: `aiperf` at concurrency **32**, ISL=50 text + fps=4 / 30s / 374×374 `libx264` mp4 (`num_frames=120`, ~9.2k total ISL), OSL=100, 768 measured requests + 10-request warmup, `--use-server-token-count --streaming`.

| Metric | Baseline | Prestack | Δ |
| --- | ---: | ---: | ---: |
| Output token throughput (tok/s) | 500.5 | 519.2 | **+3.73%** |
| Time to first token (ms, avg) | 3,668 | 3,426 | **−6.59%** |
| Request latency (ms, avg) | 6,389 | 6,125 | **−4.14%** |
| Benchmark duration (s) | 153.4 | 147.9 | −3.60% |
| Inter-token latency (ms, avg) | 27.49 | 27.26 | −0.84% |

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
