### PR TITLE
[https://nvbugs/6463829][fix] Fix fp8 MoE test

### DIFF
--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -553,7 +553,17 @@ public:
             reinterpret_cast<float const*>(swiglu_beta.has_value() ? swiglu_beta.value().const_data_ptr() : nullptr),
             reinterpret_cast<float const*>(swiglu_limit.has_value() ? swiglu_limit.value().const_data_ptr() : nullptr));
 
-        setRunnerProfiles(profile_ids);
+        // ===== Routed-expert LoRA activation flags =====
+        // LoRA is activated by the per-request (fc1_lora_ranks) or slot-indexed
+        // (fc1_slot_lora_ranks) schema. Computed before tactic selection so a
+        // GEMM2 fused-finalize tactic can be excluded when LoRA is active (the
+        // routed-expert LoRA delta occupies the GEMM2 epilogue that the FINALIZE
+        // fusion would use).
+        bool const lora_per_request = fc1_lora_ranks.has_value();
+        bool const lora_slot_indexed = fc1_slot_lora_ranks.has_value();
+        bool const lora_active = lora_per_request || lora_slot_indexed;
+
+        setRunnerProfiles(profile_ids, lora_active);
 
         auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
 
@@ -573,10 +583,8 @@ public:
         }
 
         // ===== Routed-expert LoRA setup =====
-        // LoRA is activated by the per-request schema (fc1_lora_ranks).
-        bool const lora_per_request = fc1_lora_ranks.has_value();
-        bool const lora_slot_indexed = fc1_slot_lora_ranks.has_value();
-        bool const lora_active = lora_per_request || lora_slot_indexed;
+        // Activation flags (lora_per_request / lora_slot_indexed / lora_active)
+        // were computed above, before tactic selection.
         bool const is_gated_act = isGatedActivation(base_activation_type);
         if (lora_active)
         {
@@ -1140,7 +1148,7 @@ private:
         }
     }
 
-    void setRunnerProfiles(torch::optional<c10::ArrayRef<int64_t>> profile_ids)
+    void setRunnerProfiles(torch::optional<c10::ArrayRef<int64_t>> profile_ids, bool lora_active = false)
     {
         if (mUseDeepSeekFP8BlockScaling)
         {
@@ -1163,6 +1171,26 @@ private:
             best_gemm2_profile
                 = profile_ids.value()[1] == -1 ? best_gemm2_profile : mGemm2Profiles.at(profile_ids.value()[1]);
         }
+
+        // Routed-expert MoE LoRA is incompatible with the GEMM2 fused-finalize
+        // epilogue: the LoRA delta is applied in the GEMM2 epilogue that the
+        // FINALIZE fusion would otherwise occupy (see setupTmaWarpSpecializedInputs
+        // in moe_kernels.cu). The GEMM2 tactic autotuner profiles with LoRA off
+        // (runGemmProfile forces USE_LORA=false) and can therefore select a
+        // FINALIZE tactic, and a cached runner may still expose FINALIZE tactics
+        // if it was first constructed with fused finalize enabled. Downgrade the
+        // selected tactic to the equivalent non-fused (NONE) epilogue when LoRA
+        // is active. Every FINALIZE config is a copy of a valid non-FINALIZE
+        // config with the fusion flag flipped (see MoeGemmRunner::getConfigs), so
+        // clearing the flag yields a supported tactic with the same tile shape.
+        if (lora_active
+            && best_gemm2_profile.epilogue_fusion_type
+                == tensorrt_llm::cutlass_extensions::CutlassGemmConfig::EpilogueFusionType::FINALIZE)
+        {
+            best_gemm2_profile.epilogue_fusion_type
+                = tensorrt_llm::cutlass_extensions::CutlassGemmConfig::EpilogueFusionType::NONE;
+        }
+
         mKernelRunner->setTactic(best_gemm1_profile, best_gemm2_profile);
     }
 

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -415,10 +415,12 @@ class CutlassFusedMoE(MoE):
         """
         if not self._moe_lora_enabled or max_num_tokens <= 0:
             return
-        # MoE LoRA only runs on the unquantized fp16/bf16 path (the C++ op
-        # rejects quantized weights), so a quantized layer can never reach the
-        # LoRA scratch; skip and let the (impossible) runtime path error loudly.
-        if getattr(self, "has_any_quant", False):
+        # MoE LoRA runs on the unquantized fp16/bf16 path or the per-tensor FP8
+        # (qdq) path (see moeOp.cpp). Any other quant mode (FP8 block-scale,
+        # NVFP4, MXFP8, integer WoQ) is rejected by the C++ op, so a layer in
+        # those modes can never reach the LoRA scratch; skip and let the runtime
+        # path error loudly.
+        if getattr(self, "has_any_quant", False) and not self.has_fp8_qdq:
             return
         # Weights must exist to read the runner's weight dtype. If they have not
         # been created yet, skip; the lazy sizing + in-capture guard still
@@ -434,27 +436,35 @@ class CutlassFusedMoE(MoE):
         assert max_lora_size > 0, (
             "reserve_moe_lora_cuda_graph_workspace requires max_lora_size > 0 "
             f"(got {max_lora_size}).")
-        # MoE LoRA only runs on the unquantized fp16/bf16 path, so the MoERunner
-        # instance key below (all-False quant flags, x/weight/out == self.dtype)
-        # must match the key the runtime fused_moe op uses on the same layer;
-        # otherwise the reservation lands on a different cached C++ runner.
-        assert self.dtype in (torch.float16, torch.bfloat16), (
-            "MoE LoRA requires fp16/bf16 activations to reserve a deterministic "
-            f"FusedMoeRunner key; got {self.dtype}.")
+
+        # The reservation must land on the *same* cached C++ FusedMoeRunner that
+        # the runtime torch.ops.trtllm.fused_moe op uses on this layer, so the
+        # MoERunner instance key must match the runtime key exactly. The runtime
+        # key uses the activation dtype the op sees:
+        #   - per-tensor FP8 (qdq): quantize_input casts activations to e4m3, so
+        #     x/weight are fp8 and the output (LoRA compute) dtype is self.dtype;
+        #   - unquantized fp16/bf16: x/weight/output all equal self.dtype.
+        # Every quant flag in the key is False for both (per-tensor FP8 is not
+        # block-scaled / MXFP8 / W4). If a runtime call ever uses a different
+        # key, the C++ capture guard surfaces a clear error rather than
+        # corrupting replay.
+        weight_dtype = self.w3_w1_weight.dtype
+        if self.has_fp8_qdq:
+            act_dtype = torch.float8_e4m3fn
+            output_dtype = self.dtype
+        else:
+            assert self.dtype in (torch.float16, torch.bfloat16), (
+                "MoE LoRA requires fp16/bf16 activations to reserve a "
+                f"deterministic FusedMoeRunner key; got {self.dtype}.")
+            act_dtype = self.dtype
+            output_dtype = self.dtype
 
         from ...custom_ops.torch_custom_ops import MoERunner
 
-        # Build the MoERunner with the same instance key the functional
-        # torch.ops.trtllm.fused_moe op uses, so we reserve on the *same* cached
-        # C++ FusedMoeRunner that capture will use. For the unquantized LoRA
-        # path x/weight/output dtypes all equal self.dtype and every quant flag
-        # is False. If a runtime call ever uses a different key, the C++
-        # capture guard surfaces a clear error rather than corrupting replay.
-        weight_dtype = self.w3_w1_weight.dtype
         runner = MoERunner(
-            x_dtype=self.dtype,
+            x_dtype=act_dtype,
             weight_dtype=weight_dtype,
-            output_dtype=self.dtype,
+            output_dtype=output_dtype,
             top_k=self.routing_method.experts_per_token,
             tp_size=self.tp_size,
             tp_rank=self.tp_rank,

--- a/tests/unittest/_torch/lora/test_moe_lora_grouped_gemm.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_grouped_gemm.py
@@ -19,14 +19,22 @@ surface the eager-only tests in `test_moe_lora_op.py` cannot reach:
      on-device fed by captured H2D copies of the stable pinned slot tables, so
      reassigning a slot's adapter in place is reflected on replay WITHOUT
      re-capture (mirroring attention LoRA and the normal decode loop).
+  5. CUDA-graph workspace reservation for both base-weight modes MoE LoRA
+     supports: unquantized bf16 and per-tensor FP8 (qdq).
 
 They require a CUDA GPU and the built `trtllm::fused_moe` op.
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
 from tensorrt_llm._torch.peft.lora.moe_layout import make_per_expert_lora, reference_swiglu_moe_lora
+from tensorrt_llm._torch.utils import ActivationType
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+from tests.unittest.utils.util import skip_pre_ada
 
 _TRTLLM_AVAILABLE = hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "fused_moe")
 
@@ -146,7 +154,9 @@ def _slot_kwargs(token_to_slot, adapter_sets, rank):
     )
 
 
-def _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, output_dtype, lora_kwargs):
+def _call_fused_moe(
+    x, w3_w1, w2, topk_ids, topk_scores, output_dtype, lora_kwargs, quant_scales=None
+):
     common = dict(
         input=x,
         token_selected_experts=topk_ids,
@@ -156,7 +166,7 @@ def _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, output_dtype, lora_kwar
         fc2_expert_weights=w2,
         fc2_expert_biases=None,
         output_dtype=output_dtype,
-        quant_scales=[],
+        quant_scales=quant_scales if quant_scales is not None else [],
     )
     common.update(lora_kwargs)
     return torch.ops.trtllm.fused_moe(**common)[0]
@@ -323,7 +333,6 @@ def test_reserve_prevents_growth_across_captures():
     (TRTLLM-12507).
     """
     from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
-    from tensorrt_llm._torch.utils import ActivationType
 
     device = torch.device("cuda")
     dtype = torch.bfloat16
@@ -404,6 +413,245 @@ def test_reserve_prevents_growth_across_captures():
     assert torch.isfinite(out2).all()
     torch.testing.assert_close(out1, ref1, rtol=_RTOL, atol=_ATOL)
     torch.testing.assert_close(out2, ref2, rtol=_RTOL, atol=_ATOL)
+
+
+# -- Per-tensor FP8 (qdq) base weights ---------------------------------------
+#
+# MoE LoRA also runs on per-tensor FP8 base weights: the kernel dequantizes the
+# FP8 activations to the bf16/fp16 LoRA compute type before the LoRA GEMM. The
+# runtime op then sees FP8 activations and FP8 weights with a bf16 output, which
+# is a different FusedMoeRunner cache key than the unquantized bf16 path.
+
+_FP8_E4M3_MAX = 448.0
+
+
+def _quant_per_tensor_fp8(t):
+    """Per-tensor symmetric FP8 (e4m3) quantization. Returns (t_fp8, dequant)
+    with t ~= t_fp8.float() * dequant."""
+    amax = t.detach().abs().max().float().clamp(min=1e-6)
+    dequant = amax / _FP8_E4M3_MAX
+    t_fp8 = (t.float() / dequant).clamp(-_FP8_E4M3_MAX, _FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+    return t_fp8, dequant
+
+
+def _build_fp8_moe_inputs(x, w3_w1, w2):
+    """Quantize the bf16 base MoE inputs to per-tensor FP8 (qdq).
+
+    Returns (x_fp8, w3_w1_fp8, w2_fp8, quant_scales), where quant_scales holds
+    the four entries moeOp.cpp::getQuantParams consumes, in order: fc1_dequant
+    (per-expert), fc2_quant (scalar), fc2_dequant (per-expert), fc1_input_dequant
+    (scalar). fc2_quant is 1.0 because at these shapes the SwiGLU intermediate
+    stays inside the e4m3 range, so no calibrated activation scale is needed.
+    """
+
+    def _per_expert(w):
+        w_fp8 = torch.empty_like(w, dtype=torch.float8_e4m3fn)
+        scales = torch.empty(w.shape[0], dtype=torch.float32, device=w.device)
+        for e in range(w.shape[0]):
+            w_fp8[e], scales[e] = _quant_per_tensor_fp8(w[e])
+        return w_fp8, scales
+
+    x_fp8, input_dequant = _quant_per_tensor_fp8(x)
+    w3_w1_fp8, w3_w1_scale = _per_expert(w3_w1)
+    w2_fp8, w2_scale = _per_expert(w2)
+    quant_scales = [
+        (w3_w1_scale * input_dequant).to(torch.float32),
+        torch.tensor(1.0, dtype=torch.float32, device=x.device),
+        w2_scale.to(torch.float32),
+        input_dequant.to(torch.float32).reshape(()),
+    ]
+    return x_fp8, w3_w1_fp8, w2_fp8, quant_scales
+
+
+def _make_fp8_qdq_moe_layer(w3_w1_fp8, top_k, dtype=torch.bfloat16):
+    """A CutlassFusedMoE carrying just the state
+    reserve_moe_lora_cuda_graph_workspace reads, with a real FP8-qdq QuantConfig
+    so has_fp8_qdq and has_any_quant report what they do on a loaded layer. The
+    tests drive the real method rather than restating its key derivation.
+    """
+    layer = CutlassFusedMoE.__new__(CutlassFusedMoE)
+    layer._moe_lora_enabled = True
+    layer._weights_created = True  # gates the has_* quant properties
+    layer.quant_config = QuantConfig(quant_algo=QuantAlgo.FP8)
+    layer.dtype = dtype
+    layer.w3_w1_weight = w3_w1_fp8
+    layer.routing_method = SimpleNamespace(experts_per_token=top_k)
+    layer.tp_size = 1
+    layer.tp_rank = 0
+    layer.ep_size = 1
+    layer.ep_rank = 0
+    layer.cluster_size = 1
+    layer.cluster_rank = 0
+    layer.use_fused_finalize = True
+    layer.activation_type = int(ActivationType.Swiglu)
+    layer.is_gated_activation = True
+    return layer
+
+
+@requires_cuda_and_op
+@skip_pre_ada
+def test_fp8_qdq_reserve_resolves_to_runtime_runner():
+    """An FP8-qdq layer must reserve on the same cached C++ FusedMoeRunner the
+    runtime op resolves to.
+
+    The runner cache is keyed by (x_dtype, weight_dtype, output_dtype) plus the
+    quant flags. On the FP8-qdq path the op sees FP8 activations, because the
+    layer quantizes x to e4m3 before the call, with a bf16 output, so the
+    reservation must key on the FP8 activation dtype rather than self.dtype.
+    Keying on self.dtype leaves both calls succeeding on two different cached
+    runners, so the assertions inspect the cache instead of the output.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k, rank = 4, 2, 8
+    max_lora_size = 2
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+    x_fp8, w3_w1_fp8, w2_fp8, quant_scales = _build_fp8_moe_inputs(x, w3_w1, w2)
+
+    layer = _make_fp8_qdq_moe_layer(w3_w1_fp8, top_k, dtype=dtype)
+    CutlassFusedMoE.reserve_moe_lora_cuda_graph_workspace(layer, num_tokens, rank, max_lora_size)
+
+    assert len(MoERunner.runner_dict) == 1, (
+        f"reservation must build exactly one cached runner; got {list(MoERunner.runner_dict)}"
+    )
+    ((reserved_key, reserved_runner),) = MoERunner.runner_dict.items()
+    assert reserved_key[:3] == (torch.float8_e4m3fn, torch.float8_e4m3fn, dtype), (
+        f"FP8-qdq reservation keyed on {reserved_key[:3]}; expected FP8 activations "
+        f"and weights with a {dtype} output, matching what the runtime op sees."
+    )
+
+    # The runtime op derives its own key from the tensors it is handed, so a
+    # mismatch caches a second runner.
+    adapters = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=1100
+    )
+    token_to_slot = torch.zeros(num_tokens, dtype=torch.int32)
+    slot_kwargs = _slot_kwargs(token_to_slot, [adapters], rank)
+    out = _call_fused_moe(
+        x_fp8,
+        w3_w1_fp8,
+        w2_fp8,
+        topk_ids,
+        topk_scores,
+        dtype,
+        dict(slot_kwargs),
+        quant_scales=quant_scales,
+    )
+
+    assert torch.isfinite(out).all()
+    assert len(MoERunner.runner_dict) == 1, (
+        "the FP8-qdq runtime call cached a second FusedMoeRunner, so the "
+        "reservation pre-sized LoRA scratch on a runner capture never uses: "
+        f"reserved {reserved_key}, cache now holds {list(MoERunner.runner_dict)}"
+    )
+    assert MoERunner.runner_dict[reserved_key] is reserved_runner, (
+        "the cached C++ runner was rebuilt instead of reused, discarding the reserved LoRA scratch"
+    )
+
+
+@requires_cuda_and_op
+@skip_pre_ada
+def test_fp8_qdq_reserve_prevents_growth_across_captures():
+    """FP8-qdq counterpart of test_reserve_prevents_growth_across_captures, going
+    through the layer's own reserve method.
+
+    Reserving the worst case up front, then capturing two graphs at growing slot
+    counts (1 then 2) on the same cached runner, must not reallocate the LoRA
+    scratch. Once a capture has been observed the C++ op rejects any growth, so
+    a reservation that missed this runner fails the second capture outright
+    instead of corrupting replay.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k, rank = 4, 2, 8
+    max_lora_size = 2
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+    x_fp8, w3_w1_fp8, w2_fp8, quant_scales = _build_fp8_moe_inputs(x, w3_w1, w2)
+
+    layer = _make_fp8_qdq_moe_layer(w3_w1_fp8, top_k, dtype=dtype)
+    CutlassFusedMoE.reserve_moe_lora_cuda_graph_workspace(layer, num_tokens, rank, max_lora_size)
+
+    baseline = _call_fused_moe(
+        x_fp8, w3_w1_fp8, w2_fp8, topk_ids, topk_scores, dtype, {}, quant_scales=quant_scales
+    ).clone()
+
+    adapter_a = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=1200
+    )
+    adapter_b = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=1300
+    )
+
+    # Capture #1: one active slot.
+    tts1 = torch.zeros(num_tokens, dtype=torch.int32)
+    sk1 = _slot_kwargs(tts1, [adapter_a], rank)
+    graph1, captured1 = _warmup_and_capture(
+        lambda: _call_fused_moe(
+            x_fp8,
+            w3_w1_fp8,
+            w2_fp8,
+            topk_ids,
+            topk_scores,
+            dtype,
+            dict(sk1),
+            quant_scales=quant_scales,
+        )
+    )
+
+    # Capture #2: two active slots on the same cached runner, with no cache clear
+    # in between.
+    tts2 = (torch.arange(num_tokens) % 2).to(torch.int32)
+    sk2 = _slot_kwargs(tts2, [adapter_a, adapter_b], rank)
+    graph2, captured2 = _warmup_and_capture(
+        lambda: _call_fused_moe(
+            x_fp8,
+            w3_w1_fp8,
+            w2_fp8,
+            topk_ids,
+            topk_scores,
+            dtype,
+            dict(sk2),
+            quant_scales=quant_scales,
+        )
+    )
+
+    assert len(MoERunner.runner_dict) == 1, (
+        "the FP8-qdq LoRA captures must all share the reserved runner; cache holds "
+        f"{list(MoERunner.runner_dict)}"
+    )
+
+    graph1.replay()
+    graph2.replay()
+    torch.cuda.synchronize()
+
+    out1 = captured1.clone()
+    out2 = captured2.clone()
+    assert torch.isfinite(out1).all()
+    assert torch.isfinite(out2).all()
+
+    # Numerics for the FP8 + LoRA math are covered in test_moe_lora_op.py; here
+    # it is enough that each replayed graph applied its own LoRA routing.
+    def _mean_abs(p, q):
+        return (p.float() - q.float()).abs().mean().item()
+
+    assert _mean_abs(out1, baseline) > 1e-3, "captured FP8 graph applied no LoRA delta"
+    assert _mean_abs(out2, baseline) > 1e-3, "captured FP8 graph applied no LoRA delta"
+    assert _mean_abs(out1, out2) > 1e-3, (
+        "the two captures routed different adapter slots but produced the same "
+        "output, so the slot tables were not honored on replay"
+    )
 
 
 def _set_slot_ptrs_inplace(slot_kwargs, adapters, slot_index=0):


### PR DESCRIPTION
## Description

This MR fixes https://nvbugspro.nvidia.com/bug/6463829. While the issue is not readily reproducible, it's plausible.

**_Plausible root cause:_**
- MoERunner caches C++ `FusedMoeRunner` objects in a process-wide dict, and the cache key omitted `use_fused_finalize`.
- That flag is baked in at construction: it decides whether finalize-fusion GEMM2 tactics are enumerated at all. So a LoRA-enabled Mixtral layer, which asks for finalize fusion off because the LoRA delta occupies the GEMM2 epilogue, could be handed the finalize-enabled runner an earlier non-LoRA FP8 MoE model had built in the same reused MPI worker.
- The autotuner then legitimately ranked a FINALIZE tactic first and the kernel asserted. Reused workers plus noisy tactic timings are why it looked like a flake.

**_Fix:_**
- The cache key is now the full C++ constructor argument list in constructor order, passed through as FusedMoeRunner(*instance_key) so key and constructor cannot drift apart
- A LoRA layer therefore gets its own runner whose tactic menu never contains a finalize-fusion entry.
- The FINALIZE-to-NONE normalization in setRunnerProfiles stays as a safety net, since the flag is fixed at construction while LoRA is per call and other callers such as WideEP do not couple the two.
- The CUDA-graph reservation in fused_moe_cutlass.py now forwards the same flag and derives the FP8-qdq activation dtype, so it reserves on the runner the runtime op actually uses.

## Test Coverage

```
$ pytest tests/unittest/_torch/thop/serial/test_moe.py -s -v
$ pytest tests/unittest/_torch/modules/moe/test_cutlass_moe_op_smoke.py -s -v
$ pytest tests/unittest/_torch/modules/moe/test_moe_backend.py -k "cutlass or trtllm_bf16" -s -v
$ pytest tests/integration/defs/llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks -s -v
$ pytest tests/integration/defs/llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks -s -v
$ pytest tests/unittest/_torch/modules/fused_moe/test_deepgemm_fused_expand_quant.py -s -v
$ pytest tests/unittest/_torch/modules/moe/test_cutlass_moe_op_smoke.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_grouped_gemm.py -k fp8_qdq -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- In `cpp/tensorrt_llm/thop/moeOp.cpp`, compute routed-expert LoRA activation flags (`lora_per_request`, `lora_slot_indexed`, `lora_active`) before GEMM profile/tactic selection, and pass `lora_active` into `setRunnerProfiles`.
- In `setRunnerProfiles`, add a `lora_active` parameter and when LoRA is active, normalize GEMM2 `EpilogueFusionType::FINALIZE` to `EpilogueFusionType::NONE` to prevent fused-finalize tactics from being selected/reused with routed-expert LoRA; keep `FINALIZE-to-NONE` behavior as the safety net.
- In `tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py`, tighten `reserve_moe_lora_cuda_graph_workspace` to only reserve for unquantized fp16/bf16 and per-tensor FP8 (qdq), and construct the reservation `MoERunner` using the same activation dtype the runtime MoE-LoRA path uses (`torch.float8_e4m3fn` for FP8 QDQ).
- Runner/caching changes are aligned with the stated FP8 MoE LoRA / finalize cache-key issue; no public API surface (exported symbols) changes are indicated in the touched files.

## QA Engineer Review

Tests were added/updated under `tests/`.

- Modified tests/utilities:
  - `tests/unittest/_torch/lora/test_moe_lora_grouped_gemm.py::_call_fused_moe(...)` to accept optional `quant_scales` and forward it into `torch.ops.trtllm.fused_moe`.
- Added tests:
  - `tests/unittest/_torch/lora/test_moe_lora_grouped_gemm.py::test_fp8_qdq_reserve_resolves_to_runtime_runner`
  - `tests/unittest/_torch/lora/test_moe_lora_grouped_gemm.py::test_fp8_qdq_reserve_prevents_growth_across_captures`

Coverage in `tests/integration/test_lists/`:
- No references to the touched unit test file or the new FP8-QDQ test names were found in `tests/integration/test_lists/` during review.

Verdict: **insufficient** (needs follow-up to ensure CI/manual test lists include these new tests, if that’s intended).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->