### PR TITLE
[None][test] Make the session-reuse pool seam isinstance-transparent

### DIFF
--- a/tests/test_common/session_reuse.py
+++ b/tests/test_common/session_reuse.py
@@ -203,6 +203,37 @@ def _collect_worker_pids(real) -> tuple:
         return ()
 
 
+def _isinstance_transparent_shim(real_cls, factory):
+    """A seam replacement that intercepts construction but stays a real type.
+
+    The pool-creation seams used to hold a plain FUNCTION in place of
+    ``MpiPoolSession``. Library code that does ``isinstance(x,
+    MpiPoolSession)`` against the patched module attribute then raises
+    ``TypeError: isinstance() arg 2 must be a type`` — proxy.py's
+    killed-worker detection added exactly such a check and every bare
+    ``LLM()`` creation failed until it was worked around with an
+    exclusion-based match. This shim removes the hazard for good: a real
+    class whose metaclass routes construction to ``factory`` and
+    instance/subclass checks to ``real_cls``, so both usage patterns keep
+    working — including consumers added after this layer was written.
+    """
+
+    class _SeamMeta(type):
+        def __call__(cls, *args, **kwargs):
+            return factory(*args, **kwargs)
+
+        def __instancecheck__(cls, obj):
+            return isinstance(obj, real_cls)
+
+        def __subclasscheck__(cls, sub):
+            return issubclass(sub, real_cls)
+
+        def __repr__(cls):
+            return f"<session-reuse seam shim for {real_cls!r}>"
+
+    return _SeamMeta("MpiPoolSession", (), {})
+
+
 def _describe_mismatch(spawn_snap, now_snap, uses, max_uses):
     """One line naming WHY a cached pool cannot be handed out (observability)."""
     if uses >= max_uses:
@@ -361,7 +392,9 @@ class SessionReuseCache:
         for name in pending:
             mod = sys.modules[name]
             if getattr(mod, "MpiPoolSession", None) is real_cls:
-                mod.MpiPoolSession = rpc_factory if name == _RPC_PATCH_TARGET else factory
+                mod.MpiPoolSession = _isinstance_transparent_shim(
+                    real_cls, rpc_factory if name == _RPC_PATCH_TARGET else factory
+                )
             self._patched.add(name)
 
     # ---- cache operations ----

--- a/tests/unittest/llmapi/test_session_reuse.py
+++ b/tests/unittest/llmapi/test_session_reuse.py
@@ -295,3 +295,35 @@ def test_passing_item_keeps_reuse(reuse_cache, monkeypatch):
 
     s2 = reuse_cache.acquire(_FakePool, 2)
     assert s2._real is real  # pool survived and was reused
+
+
+def test_seam_shim_is_isinstance_transparent():
+    # Reproduces the #16338 breakage class: library code doing
+    # isinstance(x, MpiPoolSession) against the PATCHED seam attribute. A
+    # plain function there raised TypeError and killed every LLM creation;
+    # the shim must behave as a type that answers for the real class.
+    class _Real:
+        pass
+
+    made = []
+    shim = session_reuse._isinstance_transparent_shim(
+        _Real, lambda *a, **k: (made.append((a, k)), _Real())[1]
+    )
+    obj = shim(2, key="v")  # construction still routed to the factory
+    assert made == [((2,), {"key": "v"})]
+    assert isinstance(obj, shim)  # instance checks answer for the real class
+    assert isinstance(_Real(), shim)
+    assert not isinstance(object(), shim)
+    assert issubclass(_Real, shim)
+
+
+def test_patched_library_seam_survives_isinstance(reuse_cache):
+    # End to end against the real seam: whatever currently sits on
+    # tensorrt_llm.executor.proxy.MpiPoolSession (the real class, or the
+    # shim installed by the session-reuse plugin active in this test
+    # session), the proxy.py isinstance pattern must not raise. On the
+    # pre-fix code (function at the seam) this raises TypeError.
+    proxy = pytest.importorskip("tensorrt_llm.executor.proxy")
+    reuse_cache.install_pool_factory_if_loaded()
+    assert isinstance(object(), proxy.MpiPoolSession) in (False, True)
+    assert issubclass(type(object()), proxy.MpiPoolSession) in (False, True)


### PR DESCRIPTION
## Summary
- The session-reuse layer (#15777) replaces the `MpiPoolSession` attribute of three library modules with a factory **function** at test time. Any library code doing `isinstance(x, MpiPoolSession)` against a patched module then raises `TypeError: isinstance() arg 2 must be a type`.
- #16338 added exactly such a check in `proxy.py` (killed-worker detection). The combination broke every bare `LLM()` creation on post-7/15 bases: **~8000 test failures across 15+ builds and 12+ PRs in two days, including post-merge main** (e.g. build 48117 / PR #16319 as an innocent victim). #16444 worked around it consumer-side with an exclusion-based match.
- This PR removes the hazard **class** at its source: the seam now holds a real class whose metaclass routes construction to the reuse factory (`__call__`) and instance/subclass checks to the real `MpiPoolSession` (`__instancecheck__`/`__subclasscheck__`). Both usage patterns work, including isinstance consumers added in the future — no more whack-a-mole.
- Follow-up option: `_register_worker_processes` in `proxy.py` can revert its exclusion-based match back to the natural `isinstance(self.mpi_session, MpiPoolSession)` form.

## Changes
- `tests/test_common/session_reuse.py`: install an isinstance-transparent metaclass shim at the seams instead of a bare function.
- `tests/unittest/llmapi/test_session_reuse.py`: shim unit test (construction routing + instance/subclass transparency) and an end-to-end regression test against the real patched `tensorrt_llm.executor.proxy` seam (raises `TypeError` on pre-fix code).

## Test plan
- [x] `tests/unittest/llmapi/test_session_reuse.py` — 23 passed (21 existing + 2 new) with the session-reuse plugin active
- [x] Pre-merge CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session reuse compatibility with Python type checks.
  * Prevented errors when validating pooled sessions with `isinstance` or `issubclass`.

* **Tests**
  * Added coverage for transparent session construction and type-checking behavior.
  * Added end-to-end validation for the session reuse integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->