### PR TITLE
[https://nvbugs/6467696][fix] Change `license_checker@v0.3.0` → `license_checker@v0.3.1` on…

### DIFF
--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -516,7 +516,7 @@ def launchReleaseCheck(pipeline, globalVars)
                     variable: 'DEFAULT_GIT_URL'
                 )
             ]) {
-                sh "go install ${DEFAULT_GIT_URL}/TensorRT/Infrastructure/licensechecker/cmd/license_checker@v0.3.0"
+                sh "go install ${DEFAULT_GIT_URL}/TensorRT/Infrastructure/licensechecker/cmd/license_checker@v0.3.1"
             }
         }
         sh "cd ${LLM_ROOT}/cpp && /go/bin/license_checker -config ../jenkins/license_cpp.json include tensorrt_llm"


### PR DESCRIPTION
## Summary
- **Root cause**: Jenkins release-check step pinned `license_checker@v0.3.0`, whose transitive dep go-git/v5 v5.18.0 has CVE GHSA-389r-gv7p-r3rp (fixed in go-git v5.19.0).
- **Fix**: Change `license_checker@v0.3.0` → `license_checker@v0.3.1` on jenkins/L0_MergeRequest.groovy:519; repro.py accepts any non-v0.3.0 tag as PASS. Verified EXIT_CODE=0.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6467696


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Release Check pipeline’s license-check tooling to the latest supported version.
  * No changes were made to the overall release validation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->