### PR TITLE
[https://nvbugs/6467687][fix] Bump the jupyter_server minimum to >=2.20.0 and update the WAR comment to…

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -9,5 +9,5 @@ numpy>=2.0.0,<2.4 # numba 0.63.1 requires numpy<2.4
 mistune>=3.2.1
 # WAR against https://github.com/advisories/GHSA-rch3-82jr-f9w9
 notebook>=7.5.6
-# WAR against https://github.com/advisories/GHSA-rch3-82jr-f9w9
-jupyter_server>=2.18.0
+# WAR against https://github.com/advisories/GHSA-fcw5-x6j4-ccmp
+jupyter_server>=2.20.0


### PR DESCRIPTION
## Summary
- **Root cause**: constraints.txt pins jupyter_server>=2.18.0, which allows the CVE-affected 2.18.2 to resolve; CVE GHSA-fcw5-x6j4-ccmp is fixed in 2.20.0.
- **Fix**: Bump the jupyter_server minimum to >=2.20.0 and update the WAR comment to reference GHSA-fcw5-x6j4-ccmp.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6467687


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Jupyter Server requirement to a newer secure version, addressing a known security advisory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->