### PR TITLE
[https://nvbugs/6467688][fix] Bump the floor to `mistune>=3.3.0` and update the WAR comment to reference the…

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -5,8 +5,8 @@ nvidia-cutlass-dsl>=4.4.2
 # The `nvidia-cutlass-dsl` package does not pin numpy at all, which can be problematic in certain CI
 # stages.
 numpy>=2.0.0,<2.4 # numba 0.63.1 requires numpy<2.4
-# WAR against https://github.com/advisories/GHSA-8mp2-v27r-99xp
-mistune>=3.2.1
+# WAR against https://github.com/advisories/GHSA-qcq2-496w-v96p
+mistune>=3.3.0
 # WAR against https://github.com/advisories/GHSA-rch3-82jr-f9w9
 notebook>=7.5.6
 # WAR against https://github.com/advisories/GHSA-rch3-82jr-f9w9


### PR DESCRIPTION
## Summary
- **Root cause**: `constraints.txt` pins `mistune>=3.2.1`, which allows the vulnerable 3.2.1 version (CVE GHSA-qcq2-496w-v96p) to satisfy the floor.
- **Fix**: Bump the floor to `mistune>=3.3.0` and update the WAR comment to reference the new advisory `GHSA-qcq2-496w-v96p` to match sibling-line convention.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6467688


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Mistune version to 3.3.0.
  * Updated the associated security advisory reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->