### PR TITLE
[https://nvbugs/6395830][fix] Qwen-VL mRoPE: move seq-slot delta cache update to model device

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -154,7 +154,14 @@ def _prepare_qwen_vl_mrope_config(
         if len(delta_tensors) != num_seq_slots:
             raise RuntimeError(
                 "Missing MRoPE position deltas for seq-slot cache update")
-        deltas = torch.cat(delta_tensors, dim=0)
+        # `delta_tensors` originate from per-request `multimodal_data` and may
+        # be CPU-resident when the owning model's `multimodal_data_device_paths`
+        # does not cover `mrope_config.*` (or a path skips the engine's H2D
+        # move), while the seq-slot cache and `seq_slots` live on the model
+        # device. `index_copy_` requires all tensors on the same device.
+        deltas = torch.cat(delta_tensors,
+                           dim=0).to(device=mrope_position_deltas_cache.device,
+                                     non_blocking=True)
         mrope_position_deltas_cache.index_copy_(0, seq_slots, deltas)
 
     if position_ids is not None \

--- a/tensorrt_llm/_torch/models/modeling_qwen_image_bench.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen_image_bench.py
@@ -40,10 +40,16 @@ _QWEN_IMAGE_BENCH_PLACEHOLDERS = MultimodalPlaceholderMetadata(
 class _QwenImageBenchModelMixin:
     @property
     def multimodal_data_device_paths(self) -> List[str]:
+        # Keep the mrope_config entries in sync with `_Qwen3_5VLModel`
+        # (modeling_qwen3_5.py): the shared Qwen-VL mRoPE seq-slot cache path
+        # consumes `mrope_position_deltas` on the model device, so the engine
+        # must move them H2D along with the rest of the multimodal payload.
         return [
             "image.pixel_values",
             "video.pixel_values_videos",
             "multimodal_embedding",
+            "mrope_config.mrope_position_ids",
+            "mrope_config.mrope_position_deltas",
         ]
 
     @property


### PR DESCRIPTION
## Background / motivation

Running the Qwen3.6-27B dense VL checkpoint **text-only** through the PyTorch backend crashes at startup during KV-cache capacity estimation:

```
RuntimeError: Expected all tensors to be on the same device, but got source
is on cpu, different from other tensors on cuda:0
  (when checking argument in method wrapper_CUDA_index_copy_)
```

Stack (Qwen3.6-27B-NVFP4, tp1, CUTEDSL, text prompt):
```
py_executor_creator.create_py_executor
  -> kv_cache_creator.configure_kv_cache_capacity   # dummy-request probe
  -> model.forward -> modeling_qwen3vl.prepare_mrope_config
  -> modeling_qwen2vl._prepare_qwen_vl_mrope_config
  -> mrope_position_deltas_cache.index_copy_(0, seq_slots, deltas)  # CRASH
```

## Root cause

Checkpoints carrying `language_model_only: false` with the dense `Qwen3_5ForConditionalGeneration` architecture match `is_qwen_image_bench_config` and are routed to **`QwenImageBenchModel`**. That model's `multimodal_data_device_paths` was missing the `mrope_config.mrope_position_ids` / `mrope_config.mrope_position_deltas` entries that its sibling `_Qwen3_5VLModel` lists, so the engine's H2D move (`MultimodalParams.to_device` with `target_keywords`) skips the mRoPE tensors. The deltas then reach the GPU seq-slot cache write (introduced in #11943) still CPU-resident, and the device-strict `index_copy_` fails.

Why other Qwen-VL configs are unaffected:
- **MoE VL checkpoints** (`Qwen3_5MoeForConditionalGeneration`, e.g. Qwen3.6-35B-A3B) can never match the image-bench detection (it requires the dense arch), route to `Qwen3_5MoeVLModel` whose device paths include the mRoPE keys, and run clean — verified on the pre-fix tree with the identical single-GPU command.
- Dense VL checkpoints **without** `language_model_only: false` route to `Qwen3_5VLModel`, which also lists the mRoPE keys.

## Summary

Two complementary changes:

1. **`QwenImageBenchModel.multimodal_data_device_paths`**: add the two `mrope_config.*` entries, matching `_Qwen3_5VLModel`, so mRoPE tensors ride the engine's pinned async H2D move like every other Qwen-VL model (covers real multimodal requests as well as the text-only dummy probe).
2. **`_prepare_qwen_vl_mrope_config`** (shared Qwen-VL mRoPE library): normalize `deltas` onto the cache device before `index_copy_` as a defensive backstop for any path that still reaches the write branch with CPU tensors. No-op when devices already match.

## Impact

- Fixes text-only startup (and CPU-origin mRoPE tensors generally) for the image-bench-routed dense VL checkpoints.
- No behavior change for models whose device paths already cover mRoPE (`.to()` is a no-op).
- Negligible cost: `deltas` is one element per seq slot.

## Test

- Qwen3.6-27B-NVFP4 (dense VL -> image-bench route), single GPU, `--moe_backend CUTEDSL`, text prompts: previously crashed in `configure_kv_cache_capacity`; with this PR startup completes and generation produces coherent output.
- Qwen3.6-35B-A3B-NVFP4 (MoE VL route), identical command on the pre-fix tree: runs clean, confirming the failure is specific to the image-bench route's missing device paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
