### PR TITLE
[https://nvbugs/6467675][fix] Bump ETCD_VER from v3.6.9 to v3.7.0 in docker/common/install_etcd.sh; binary…

### DIFF
--- a/docker/common/install_etcd.sh
+++ b/docker/common/install_etcd.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-ETCD_VER=v3.6.9
+ETCD_VER=v3.7.0
 
 # choose either URL
 DOWNLOAD_URL=https://storage.googleapis.com/etcd


### PR DESCRIPTION
## Summary
- **Root cause**: etcd v3.6.9 vendors golang.org/x/crypto v0.48.0 (CVE GHSA-q4h4-gmj2-qvw2), which container scanners flag; no v3.6.x point release bumps this transitive dep.
- **Fix**: Bump ETCD_VER from v3.6.9 to v3.7.0 in docker/common/install_etcd.sh; binary tarballs at the same storage.googleapis.com URL structure (verified 200 for both amd64 and arm64), no CLI-usage changes.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6467675


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled etcd installation to version 3.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->