### PR TITLE
[https://nvbugs/6395830][fix] Qwen-VL mRoPE: move seq-slot delta cach…

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -154,7 +154,14 @@ def _prepare_qwen_vl_mrope_config(
         if len(delta_tensors) != num_seq_slots:
             raise RuntimeError(
                 "Missing MRoPE position deltas for seq-slot cache update")
-        deltas = torch.cat(delta_tensors, dim=0)
+        # `delta_tensors` originate from per-request `multimodal_data` and may
+        # be CPU-resident when the owning model's `multimodal_data_device_paths`
+        # does not cover `mrope_config.*` (or a path skips the engine's H2D
+        # move), while the seq-slot cache and `seq_slots` live on the model
+        # device. `index_copy_` requires all tensors on the same device.
+        deltas = torch.cat(delta_tensors,
+                           dim=0).to(device=mrope_position_deltas_cache.device,
+                                     non_blocking=True)
         mrope_position_deltas_cache.index_copy_(0, seq_slots, deltas)
 
     if position_ids is not None \

--- a/tensorrt_llm/_torch/models/modeling_qwen_image_bench.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen_image_bench.py
@@ -40,10 +40,16 @@ _QWEN_IMAGE_BENCH_PLACEHOLDERS = MultimodalPlaceholderMetadata(
 class _QwenImageBenchModelMixin:
     @property
     def multimodal_data_device_paths(self) -> List[str]:
+        # Keep the mrope_config entries in sync with `_Qwen3_5VLModel`
+        # (modeling_qwen3_5.py): the shared Qwen-VL mRoPE seq-slot cache path
+        # consumes `mrope_position_deltas` on the model device, so the engine
+        # must move them H2D along with the rest of the multimodal payload.
         return [
             "image.pixel_values",
             "video.pixel_values_videos",
             "multimodal_embedding",
+            "mrope_config.mrope_position_ids",
+            "mrope_config.mrope_position_deltas",
         ]
 
     @property


### PR DESCRIPTION
…e update to model device

Text-only startup of the Qwen3.6-27B dense VL checkpoint crashes during KV-cache capacity estimation in the shared Qwen-VL mRoPE path (`_prepare_qwen_vl_mrope_config`):

    mrope_position_deltas_cache.index_copy_(0, seq_slots, deltas)
    RuntimeError: Expected all tensors to be on the same device, but got
    source is on cpu, different from other tensors on cuda:0

Root cause: checkpoints carrying `language_model_only: false` with the dense `Qwen3_5ForConditionalGeneration` arch are routed to `QwenImageBenchModel`, whose `multimodal_data_device_paths` was missing the `mrope_config.mrope_position_ids` / `mrope_config.mrope_position_deltas` entries that its sibling `_Qwen3_5VLModel` lists. The engine's H2D move (`MultimodalParams.to_device` with `target_keywords`) therefore skips the mRoPE tensors, leaving the deltas CPU-resident when the GPU seq-slot cache write (introduced in #11943) consumes them. MoE VL checkpoints (`Qwen3_5MoeForConditionalGeneration`) never match the image-bench route and are unaffected.

Fix both layers:
- `QwenImageBenchModel.multimodal_data_device_paths`: add the two `mrope_config.*` entries, matching `_Qwen3_5VLModel`, so mRoPE tensors ride the engine's pinned async H2D move like every other Qwen-VL model.
- `_prepare_qwen_vl_mrope_config`: normalize `deltas` onto the cache device before `index_copy_` as a defensive backstop for any path that still reaches the write branch with CPU tensors (no-op when devices already match).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device handling for multimodal position data during processing.
  * Enhanced reliability of multimodal cache updates by ensuring related data is transferred consistently to the required device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
