### PR TITLE
[https://nvbugs/6451032][fix] Reserve extra dflash context slot for dummy requests

### DIFF
--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -102,10 +102,10 @@ class DFlashSpecMetadata(SpecMetadata):
                     worker._ctx_len[slot] = 0
                     worker._free_slots.append(slot)
 
-            # Default to slot 0 for unknown request IDs (e.g. during warmup
-            # where synthetic requests may not have assigned slots).
+            # Route unknown request IDs (cuda graph padding or warmup dummies)
+            # to dummy slot to avoid corrupting real request's context
             mapping = torch.tensor(
-                [worker._req_to_slot.get(rid, 0) for rid in self.request_ids],
+                [worker._req_to_slot.get(rid, worker._dummy_slot) for rid in self.request_ids],
                 dtype=torch.long,
                 device="cpu",
                 pin_memory=prefer_pinned(),
@@ -184,12 +184,13 @@ class DFlashWorker(SpecWorkerBase):
         self._kv_rewind_bs = None
         self._batch_to_slot = None
         self._max_ctx = 0
-        self._ctx_k_buf = None  # [max_batch, L, max_ctx+block, nkv, hd]
+        self._ctx_k_buf = None  # [max_batch+1, L, max_ctx+block, nkv, hd]
         self._ctx_v_buf = None
 
         # Slot management (Python, updated in prepare() and eager mode)
         self._req_to_slot = {}  # request_id -> slot index
         self._free_slots = deque()  # available slot indices
+        self._dummy_slot = None  # for cudagraph padding or warmup dummy requests
 
         logger.info(
             f"DFlashWorker initialized with use_separate_draft_kv_cache={use_separate_draft_kv_cache}"
@@ -231,7 +232,13 @@ class DFlashWorker(SpecWorkerBase):
 
         dtype = draft_model.fc.weight.dtype if hasattr(draft_model, "fc") else torch.bfloat16
 
-        self._ctx_len = torch.zeros(max_batch, dtype=torch.long, device="cuda")
+        # Reserve slot index max_batch as a scratch slot for padding/unknown
+        # dummies; real requests only draw slots 0..max_batch-1, so dummy
+        # writes land here and can't corrupt a real request's context.
+        self._dummy_slot = max_batch
+        num_slots = max_batch + 1
+
+        self._ctx_len = torch.zeros(num_slots, dtype=torch.long, device="cuda")
         self._batch_to_slot = torch.zeros(max_batch, dtype=torch.long, device="cuda")
 
         self._free_slots = deque(range(max_batch))
@@ -250,7 +257,7 @@ class DFlashWorker(SpecWorkerBase):
         L = draft_model._num_attn_layers
         nkv = draft_model._num_kv_heads
         hd = draft_model._head_dim
-        kv_shape = (max_batch, L, self._max_ctx + self._resolved_block_size, nkv, hd)
+        kv_shape = (num_slots, L, self._max_ctx + self._resolved_block_size, nkv, hd)
         self._ctx_k_buf = torch.zeros(kv_shape, dtype=dtype, device="cuda")
         self._ctx_v_buf = torch.zeros(kv_shape, dtype=dtype, device="cuda")
         self._ctx_buf_inited = True
@@ -485,7 +492,10 @@ class DFlashWorker(SpecWorkerBase):
             # Rebuild batch_to_slot after prefill assigns new slots
             if self._ctx_buf_inited and spec_metadata.request_ids:
                 num_seqs = len(spec_metadata.request_ids)
-                mapping = [self._req_to_slot.get(rid, 0) for rid in spec_metadata.request_ids]
+                mapping = [
+                    self._req_to_slot.get(rid, self._dummy_slot)
+                    for rid in spec_metadata.request_ids
+                ]
                 self._batch_to_slot[:num_seqs].copy_(
                     torch.tensor(mapping, dtype=torch.long, device="cuda")
                 )

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -420,8 +420,6 @@ unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu
 unittest/_torch/modules/tests_lora_modules/test_nemotron_h_lora_sanity.py::TestNemotronHLoRA::test_lora_pp2_sanity SKIP (https://nvbugs/6428124)
 unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py -m "part4" SKIP (https://nvbugs/6437410)
 unittest/_torch/sampler/test_beam_search.py::test_beam_search_e2e[multi_process-TRTLLMSampler-cuda_graph_and_overlap-None-1-1-True-True-False] SKIP (https://nvbugs/6463819)
-unittest/_torch/speculative/hw_agnostic/test_dflash.py::test_dflash_qwen3_5_4b[False] SKIP (https://nvbugs/6451032)
-unittest/_torch/speculative/hw_agnostic/test_dflash.py::test_dflash_qwen3_5_4b[True] SKIP (https://nvbugs/6451032)
 unittest/_torch/speculative/test_eagle3.py::test_llama_eagle3[True-TRTLLM-True-False-True-True-True-False-False-False] SKIP (https://nvbugs/6451425)
 unittest/_torch/thop/parallel/test_fp8_rowwise_linear.py::test_fp8_rowwise_linear[dtype1] SKIP (https://nvbugs/6301807)
 unittest/_torch/thop/serial/test_moe.py::TestMoeFp4::test_no_autotune[use_score_as_input-RoutingDSv3-swiglu-1024-1024-1] SKIP (https://nvbugs/5908070)

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dflash.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dflash.py
@@ -85,7 +85,8 @@ def test_dflash_qwen3_8b(disable_overlap_scheduler: bool):
         dflash_model_dir=f"{models_path}/Qwen3-8B-DFlash-b16",
         disable_overlap_scheduler=disable_overlap_scheduler,
     )
-    _run_and_check(llm_config, min_avg_accepted=1.0)
+    # Expected acceptance is 1.77, use 1.5 to leave 15% margin
+    _run_and_check(llm_config, min_avg_accepted=1.5)
 
 
 @pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
@@ -101,7 +102,8 @@ def test_dflash_qwen3_5_4b(disable_overlap_scheduler: bool):
         dflash_model_dir=f"{models_path}/Qwen3.5-4B-DFlash",
         disable_overlap_scheduler=disable_overlap_scheduler,
     )
-    _run_and_check(llm_config, min_avg_accepted=1.0)
+    # Expected acceptance is 1.77, use 1.5 to leave 15% margin
+    _run_and_check(llm_config, min_avg_accepted=1.5)
 
 
 @pytest.mark.high_cuda_memory


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speculative decoding handling for unknown or temporary requests by assigning them to a dedicated scratch slot, preventing incorrect reuse of the first active slot.
  * Increased internal slot capacity to support safer request mapping during warmup, padding, and context processing.

* **Tests**
  * Removed waivers for DFlash Qwen3.5 integration tests, allowing both parameterized scenarios to run normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

**Problem**: DFlash keeps a per-request context K/V cache indexed by a slot. With cuda graph padding enabled, the padding requests defaulted to slot 0 corrupting whichever real request happened to occupy slot 0. This caused non-deterministic acceptance-length collapse (one request in a batch dropping from ~3.0 to ~0.55) and made `test_dflash_qwen3_5_4b` flaky.

**Solution**: Reserve one extra scratch slot for dummy requests. `_ctx_len` and the K/V buffers are now sized `max_batch + 1`, with` _dummy_slot = max_batch`. Real requests still only draw slots `0..max_batch-1`.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

`unittest/_torch/speculative/hw_agnostic/test_dflash.py::test_dflash_qwen3_5_4b`
Increase acceptance length threshold in dflash unit tests to catch future regressions early.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
