### PR TITLE
[https://nvbugs/6432953][fix] Fix MPI world heap corruption during teardown

### DIFF
--- a/cpp/tensorrt_llm/runtime/utils/mpiUtils.cpp
+++ b/cpp/tensorrt_llm/runtime/utils/mpiUtils.cpp
@@ -597,9 +597,16 @@ MpiComm::~MpiComm() noexcept
 #if ENABLE_MULTI_DEVICE
     if (mFreeComm && mComm)
     {
-        if (MPI_Comm_free(&mComm) != MPI_SUCCESS)
+        // Calling MPI_Comm_free after MPI has been finalized is undefined behavior.
+        // We need this check to prevent heap corruption during program exit when
+        // static MpiComm objects are created.
+        int finalized = 0;
+        if (MPI_Finalized(&finalized) == MPI_SUCCESS && !finalized)
         {
-            TLLM_LOG_ERROR("MPI_Comm_free failed");
+            if (MPI_Comm_free(&mComm) != MPI_SUCCESS)
+            {
+                TLLM_LOG_ERROR("MPI_Comm_free failed");
+            }
         }
     }
 #endif // ENABLE_MULTI_DEVICE


### PR DESCRIPTION
## Description

<!--
Please explain the issue and the solution in short.
-->

This fixes a heap corruption issue at program exit. The problematic test case was `test_Mpicomm` in `test_ut_bindings.py`. We create static lifetime `MpIComm` objects in functions like `split()`. The destructors for these get called during program teardown. The destructor frees the `MpiComm`, but you can't do this after MPI is finalized; it's undefined behavior and causes heap corruption. The fix is to just skip the free in this case. No need to worry about the memory leaking since the objects are only destroyed when the program is exiting anyways.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Existing tests. They weren't waived, so no need to make changes to waives.txt.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown stability for MPI-based operations.
  * Prevented invalid communicator cleanup after MPI has been finalized, reducing the risk of crashes or memory corruption during program exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->