### PR TITLE
[NVBUG-6448152][test] TEST ONLY; DO NOT REVIEW: measure exact pre-change merge control

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @Library(['bloom-jenkins-shared-lib@main', 'trtllm-jenkins-shared-lib@main']) _
 
 import java.lang.InterruptedException
@@ -980,6 +996,8 @@ def getMountListForSlurmTest(SlurmCluster cluster, boolean useSbatch = false)
         throw new Exception("Unsupported container runtime: ${cluster.containerRuntime}")
     }
 
+    // TODO: Add mounts for different cache directories like pip, triton, etc.
+
     return mounts
 }
 
@@ -1208,6 +1226,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                     "--container-image=$containerImageArg",
                     "--container-workdir=$jobWorkspace",
                     "--container-mounts=$mounts",
+                    "--no-container-mount-home",
                     "--container-env=NVIDIA_IMEX_CHANNELS"
                 ]
                 envVarsToExport.each { varName, varValue ->


### PR DESCRIPTION
> [!CAUTION]
> Diagnostic only. Do not merge.

## Purpose

Measure NVBUG#6448152 at the exact `main` commit immediately before #15139 landed. This is the control half of a matched merge-boundary experiment.

- Historical source commit: `be7e978fa2197b51e2ecf918e5afe7cfa342050d`
- #15139 squash merge: `57bb6ee57acf2f1d51212ea35b872d090a7515bd`
- Diagnostic marker commit: `3a1035cb89b8cefb3bb0ef4e5c5a391fa085b59a`
- Paired treatment: #16556

The marker commit is empty and signed off. Its tree is byte-identical to `be7e978` (`11336eb5258ddbcf0b45f706488536cfcd1861a4`); this PR intentionally has no source-file changes.

## Targeted experiment

Run only:

- Stage: `GB300-12_GPUs-3_Nodes-PyTorch-Disagg-PerfSanity-CTX1-NODE1-GPU4-GEN1-NODE2-GPU8-Post-Merge-1`
- Test: `disagg_upload-e2e-gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL`
- Metric: output-token throughput
- Reported reference points: 1573.57 good; 817.33 bad

Trigger with test reuse disabled:

`/bot run --disable-reuse-test --stage-list "GB300-12_GPUs-3_Nodes-PyTorch-Disagg-PerfSanity-CTX1-NODE1-GPU4-GEN1-NODE2-GPU8-Post-Merge-1"`

## Interpretation

Compare only against the paired treatment based on `57bb6ee`, using the same stage and CI environment. A large control-to-treatment drop would attribute the regression to #15139 at its merge boundary. Similar results would show that #15139 is not the dominant cause under this environment.

## Validation and caveats

- The source difference between the historical pair is exactly #15139: two `cacheTransceiver` files.
- The workload YAML, selector, test-list, and Jenkins stage definitions are byte-identical across the pair.
- Jenkins must check out `3a1035cb89` directly, not a synthetic merge with current `main`.
- CI orchestration, container images, drivers, cluster state, and model storage are current. A build or infrastructure incompatibility is not a performance result.
- Repeat the pair before treating a small difference as causal.
- All applicable pre-commit hooks and DCO passed. Two repository-wide test-list hooks were skipped because this historical revision uses PEP 604 annotations that fail under the local hook's older Python before inspecting files; this empty commit changes no test-list files.
