### PR TITLE
[None][perf] Add batched-pybind fast-path in TorchSampler.update_requests for gpt-oss-120b

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
@@ -2329,6 +2329,9 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         self.max_seq_len = args.max_seq_len
         self.max_tokens = args.max_total_draft_tokens + 1
         self.max_beam_width = args.max_beam_width
+        # Snapshot of `not self._use_beam_search` so the update_requests
+        # fast-path avoids a property call per iteration.
+        self._batch_fastpath_eligible: bool = self.max_beam_width == 1
         # The current maximum number of topk logprobs which can be stored in the sampler's store
         self.max_topk_logprobs = MAX_TOP_LOGPROBS
         # The maximum number of topk logprobs for the current batch of requests
@@ -3650,6 +3653,46 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 return beam_history_builder()
             else:
                 return None
+
+        # Fast-path (batched pybind): when the batch is greedy with no beam
+        # search, no logprobs, no draft tokens, no stop-words, and no
+        # speculative tree, collapse per-request pybind chatter into one
+        # batched add_new_tokens_to_requests call. Single-pass eligibility
+        # check with early-break; falls through when any invariant breaks.
+        if (
+            self._batch_fastpath_eligible
+            and logprobs_state_list is None
+            and self.get_spec_tree_manager(resource_manager) is None
+        ):
+            alive_reqs: list[LlmRequest] = []
+            tokens_flat: list[int] = []
+            fastpath_ok = True
+            new_tokens_step0 = new_tokens_list[0]
+            for req in state.requests:
+                if req.state == LlmRequestState.GENERATION_COMPLETE:
+                    continue
+                if get_draft_token_length(req) != 0 or req.py_stop_words_list:
+                    fastpath_ok = False
+                    break
+                alive_reqs.append(req)
+                tokens_flat.append(new_tokens_step0[req.py_seq_slot][DEFAULT_BEAM_IDX])
+            if fastpath_ok and alive_reqs:
+                add_new_tokens_to_requests(alive_reqs, tokens_flat, DEFAULT_BEAM_IDX)
+                _valid_finish_reasons = {
+                    FinishReason.END_ID,
+                    FinishReason.LENGTH,
+                    FinishReason.STOP_WORDS,
+                }
+                for req in alive_reqs:
+                    reason_val = finish_reasons[req.py_seq_slot][0][DEFAULT_BEAM_IDX]
+                    if reason_val != 0:
+                        reason = FinishReason(reason_val)
+                        if reason in _valid_finish_reasons:
+                            req.finish_by(reason, DEFAULT_BEAM_IDX)
+                    req.py_num_accepted_draft_tokens = 0
+                    req.py_rewind_len = 0
+                    req.py_decoding_iter += 1
+                return
 
         for req_idx, req in enumerate(state.requests):
             if req.state == LlmRequestState.GENERATION_COMPLETE:

--- a/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler/sampler.py
@@ -3674,6 +3674,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 if get_draft_token_length(req) != 0 or req.py_stop_words_list:
                     fastpath_ok = False
                     break
+                assert req.py_seq_slot is not None
                 alive_reqs.append(req)
                 tokens_flat.append(new_tokens_step0[req.py_seq_slot][DEFAULT_BEAM_IDX])
             if fastpath_ok and alive_reqs:
@@ -3684,6 +3685,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                     FinishReason.STOP_WORDS,
                 }
                 for req in alive_reqs:
+                    assert req.py_seq_slot is not None
                     reason_val = finish_reasons[req.py_seq_slot][0][DEFAULT_BEAM_IDX]
                     if reason_val != 0:
                         reason = FinishReason(reason_val)


### PR DESCRIPTION
## Summary

- **Root cause**: On `disagg-gen_only-*` workloads for `gpt-oss-120b-fp4` on GB200,
  the gen-worker per-iter bubble (~8.8 ms) is dominated by the host-side sampler
  tail in `TorchSampler.update_requests` — a Python loop that fires 256 per-request
  pybind chatter calls (`req.add_new_token` etc.) after `state.sampler_event.synchronize()`.
- **Fix**: Add a **batched-pybind fast-path** at `sampler.py:3654`. When the whole
  batch requires no beam search, no logprobs, no draft tokens, no stop-word
  lists, and no speculative-tree manager, collapse the per-request loop into a
  single batched `add_new_tokens_to_requests(...)` call plus one linear finish-reason
  scan. Cached eligibility flag (`_batch_fastpath_eligible`) is set once in
  `__init__` to avoid a property call per iter. Falls through to the unchanged
  per-request path on any invariant break; runs entirely post-`sampler_event.synchronize()`
  so CUDA-graph capture/replay is unaffected.
- **Perf metric**: `output_token_throughput` (higher is better)
- **Baseline (reproduce)**: 8934.14 tok/s
- **Fix median (3-rep same-node verify)**: **9135.99 tok/s** — `[9002.96, 9135.99, 9318.70]`, CV=1.73%
- **Gain vs baseline: +2.26%; gain vs verify-side ToT: +3.83%**

## Test plan

- [x] Reproduce baseline on Lyris GB200 (3 cross-node reps; all within 0.5% of median).
- [x] Apply fix, rebuild TRT-LLM wheel, run 3-rep same-node perf.
- [x] Confirm gain ≥ 2% and same-node CV ≤ 5%.
- [x] Programmatic anti-pattern scan clean (no debug artifacts, no test-infra edits,
  no `pytest.skip`/`time.sleep`, no CUDA-graph disable, no `except:` fallback).
- [x] Correctness argument: finish-reason filter matches `finish_if_reason`'s
  `{END_ID, LENGTH, STOP_WORDS}` set; bookkeeping (`py_num_accepted_draft_tokens=0`,
  `py_rewind_len=0`, `py_decoding_iter += 1`) mirrors the existing MTP=0 branch.
- [x] `add_new_tokens_to_requests` batched pybind is already used by `TRTLLMSampler`
  (see `sampler.py:5125`); no new C++ binding introduced.

## Automation

Automated fix generated by repair-bot `auto_perf_stabilize` workflow.
Run key: `perfstab-perf-test-perf-sanity-py-test-e2-c87588`
Test case: `perf/test_perf_sanity.py::test_e2e[disagg-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved generation efficiency for eligible decoding batches by processing sampled tokens in a single batched operation.
  - Reduced per-request processing overhead during decoding, which may improve throughput and response speed.
  - Preserved handling for supported completion conditions, including end-of-sequence, length limits, and stop-word termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->