### PR TITLE
[https://nvbugs/6442073][fix] Enforce a fixed max_seq_len for Qwen's AttentionOp caching purposes

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_multimodal_encoder.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_encoder.py
@@ -1,4 +1,4 @@
-# Copyright 2024 NVIDIA CORPORATION & AFFILIATES
+# Copyright 2024-2026 NVIDIA CORPORATION & AFFILIATES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,6 +63,14 @@ class MultimodalEncoderMixin:
             max_num_tokens=max_num_tokens,
             kv_cache_manager=None,
         )
+
+    def set_attn_max_seq_len(self, max_seq_len: int) -> None:
+        """Set an optional stable per-segment attention capacity.
+
+        Specialized encoders may override this hook. Keeping it separate from
+        ``setup_attn_metadata`` preserves that method's existing override
+        contract for external encoders.
+        """
 
 
 class VisionTower(nn.Module):

--- a/tensorrt_llm/_torch/models/modeling_multimodal_encoder.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_encoder.py
@@ -68,7 +68,7 @@ class MultimodalEncoderMixin:
         """Set an optional stable per-segment attention capacity.
 
         Specialized encoders may override this hook. Keeping it separate from
-        ``setup_attn_metadata`` preserves that method's existing override
+        `setup_attn_metadata` preserves that method's existing override
         contract for external encoders.
         """
 

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -84,8 +84,8 @@ PAD_INDEX = -100  # NOTE: refer to https://github.com/huggingface/transformers/b
 
 
 def _prepare_qwen_vl_vision_attn_metadata(
-        seq_lens: List[int],
-        attn_metadata: AttentionMetadata) -> AttentionMetadata:
+        seq_lens: List[int], attn_metadata: AttentionMetadata, *,
+        max_seq_len: int) -> AttentionMetadata:
     seq_lens = [int(seq_len) for seq_len in seq_lens]
     if not seq_lens:
         raise ValueError(
@@ -96,6 +96,17 @@ def _prepare_qwen_vl_vision_attn_metadata(
         raise ValueError(
             f"Qwen VL vision attention segment length must be nonnegative, got {min_seq_len}"
         )
+
+    if max_seq_len <= 0:
+        raise ValueError(
+            f"Qwen VL vision attention max_seq_len must be positive, got {max_seq_len}"
+        )
+    actual_max_seq_len = max(seq_lens)
+    if actual_max_seq_len > max_seq_len:
+        raise ValueError(
+            "Qwen VL vision attention segment length exceeds the configured "
+            f"maximum: actual={actual_max_seq_len}, maximum={max_seq_len}. "
+            "Increase encoder_max_num_tokens or reduce the input max_pixels.")
 
     num_segments = len(seq_lens)
     seq_lens_torch = torch.tensor(seq_lens,
@@ -114,7 +125,9 @@ def _prepare_qwen_vl_vision_attn_metadata(
                                non_blocking=True)
     attn_metadata.cu_q_seqlens = cu_seqlens
     attn_metadata.cu_kv_seqlens = cu_seqlens
-    attn_metadata.max_seq_len = max(seq_lens)
+    # Keep the native attention-op cache key stable across image resolutions.
+    # Actual segment lengths remain available through seq_lens / cu_seqlens.
+    attn_metadata.max_seq_len = max_seq_len
     # The vision tower runs no-cache, context-only attention and supplies its
     # own `cu_seqlens` above, so the heavy KV-oriented `prepare()` (kv_lens /
     # prompt_lens / host_request_types setup) is unnecessary host work.
@@ -1411,6 +1424,7 @@ class Qwen2_5_VisionModel(torch.nn.Module, MultimodalEncoderMixin):
             self.model_config.attn_backend).Metadata
         self.full_attn_metadata: Optional[AttentionMetadata] = None
         self.window_attn_metadata: Optional[AttentionMetadata] = None
+        self.set_attn_max_seq_len(self.model_config.max_num_tokens)
         # Pre-allocated `arange` for the vision block's `rope_position_ids`;
         # per-call code slices `[:seq_len]` instead of a fresh `(seq_len,) int32`
         # + H->D copy. Sized by `setup_attn_metadata` (engine-driven); `forward`
@@ -1438,11 +1452,24 @@ class Qwen2_5_VisionModel(torch.nn.Module, MultimodalEncoderMixin):
                       kv_cache_manager=None)
         self.full_attn_metadata = self.metadata_cls(**kwargs)
         self.window_attn_metadata = self.metadata_cls(**kwargs)
+        self.set_attn_max_seq_len(max_num_tokens)
         # Size the vision-block ``rope_position_ids`` scratch to the encoder
         # token budget; ``forward`` grows it on the rare miss above the budget.
         self._rope_position_ids_buffer = torch.arange(max_num_tokens,
                                                       dtype=torch.int32,
                                                       device=self.device)
+
+    def set_attn_max_seq_len(self, max_seq_len: int) -> None:
+        if max_seq_len <= 0:
+            raise ValueError(
+                f"Qwen VL vision attention max_seq_len must be positive, got {max_seq_len}"
+            )
+        self._full_attn_max_seq_len = max_seq_len
+        vit_merger_window_size = (self.window_size // self.spatial_merge_size //
+                                  self.patch_size)
+        self._window_attn_max_seq_len = min(
+            self._full_attn_max_seq_len,
+            vit_merger_window_size**2 * self.spatial_merge_unit)
 
     def get_rotary_pos_emb_window_data(
         self, grid_rows: List[List[int]]
@@ -1604,15 +1631,18 @@ class Qwen2_5_VisionModel(torch.nn.Module, MultimodalEncoderMixin):
 
         return cos_thw, sin_thw, window_index_thw, tuple(seq_lens_thw)
 
-    def prepare_attn_metadata(
-            self,
-            seq_lens: List[int],
-            attn_metadata: Optional[AttentionMetadata] = None):
+    def prepare_attn_metadata(self,
+                              seq_lens: List[int],
+                              attn_metadata: Optional[AttentionMetadata] = None,
+                              *,
+                              max_seq_len: int) -> AttentionMetadata:
         if attn_metadata is None:
             raise RuntimeError(
                 "Vision encoder AttentionMetadata is not initialized. "
                 "It must be set up before the encoder forward runs.")
-        return _prepare_qwen_vl_vision_attn_metadata(seq_lens, attn_metadata)
+        return _prepare_qwen_vl_vision_attn_metadata(seq_lens,
+                                                     attn_metadata,
+                                                     max_seq_len=max_seq_len)
 
     @property
     def device(self) -> torch.device:
@@ -1667,9 +1697,13 @@ class Qwen2_5_VisionModel(torch.nn.Module, MultimodalEncoderMixin):
         hidden_states = hidden_states[window_index, :, :].reshape(seq_len, -1)
 
         self.full_attn_metadata = self.prepare_attn_metadata(
-            seq_lens, self.full_attn_metadata)
+            seq_lens,
+            self.full_attn_metadata,
+            max_seq_len=self._full_attn_max_seq_len)
         self.window_attn_metadata = self.prepare_attn_metadata(
-            window_seq_lens, self.window_attn_metadata)
+            window_seq_lens,
+            self.window_attn_metadata,
+            max_seq_len=self._window_attn_max_seq_len)
 
         for layer_num, block in enumerate(self.blocks):
             if layer_num in self.fullatt_block_indexes:

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -809,6 +809,7 @@ class Qwen3VisionModel(torch.nn.Module, MultimodalEncoderMixin):
         self.metadata_cls = get_attention_backend(self.model_config.attn_backend).Metadata
 
         self.attn_metadata: Optional[AttentionMetadata] = None
+        self._fixed_max_seq_len = self.model_config.max_num_tokens
 
         # Vision block's `rope_position_ids` scratch. Registered empty here;
         # `setup_attn_metadata` allocates it as an `arange` (see there).
@@ -834,6 +835,7 @@ class Qwen3VisionModel(torch.nn.Module, MultimodalEncoderMixin):
             max_num_tokens=max_num_tokens,
             kv_cache_manager=None,
         )
+        self.set_attn_max_seq_len(max_num_tokens)
         # Pre-allocate the vision-block ``rope_position_ids`` as an ``arange``
         # sized to the encoder's ``max_num_tokens`` (engine-driven) so per-call
         # code just slices ``[:seq_len]`` instead of allocating a fresh
@@ -842,6 +844,13 @@ class Qwen3VisionModel(torch.nn.Module, MultimodalEncoderMixin):
         self._rope_position_ids_buffer = torch.arange(
             max_num_tokens, dtype=torch.int32, device=self.device
         )
+
+    def set_attn_max_seq_len(self, max_seq_len: int) -> None:
+        if max_seq_len <= 0:
+            raise ValueError(
+                f"Qwen VL vision attention max_seq_len must be positive, got {max_seq_len}"
+            )
+        self._fixed_max_seq_len = max_seq_len
 
     @staticmethod
     @lru_cache(maxsize=1024)
@@ -961,13 +970,15 @@ class Qwen3VisionModel(torch.nn.Module, MultimodalEncoderMixin):
         self,
         seq_lens: List[int],
         attn_metadata: Optional[AttentionMetadata] = None,
-    ):
+    ) -> AttentionMetadata:
         if attn_metadata is None:
             raise RuntimeError(
                 "Vision encoder AttentionMetadata is not initialized. "
                 "It must be set up before the encoder forward runs."
             )
-        return _prepare_qwen_vl_vision_attn_metadata(seq_lens, attn_metadata)
+        return _prepare_qwen_vl_vision_attn_metadata(
+            seq_lens, attn_metadata, max_seq_len=self._fixed_max_seq_len
+        )
 
     @torch.inference_mode()
     def forward(

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2636,7 +2636,7 @@ class PyTorchModelEngine(ModelEngine):
         Mirrors `_set_up_attn_metadata` for the LLM backbone: encoders opt in
         by inheriting `MultimodalEncoderMixin`, and the engine drives the construction
         so the sizes match ``llm_args.get_encoder_runtime_sizes()`` rather
-        than being hardcoded inside each encoder's ``__init__``. The optional
+        than being hardcoded inside each encoder's `__init__`. The optional
         per-segment capacity combines the encoder token budget with the input
         processor's largest supported item.
         """

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -27,7 +27,8 @@ from tensorrt_llm.inputs.multimodal import (MultimodalParams,
                                             _has_mm_payload_keys,
                                             check_mm_embed_cumsum_if_needed,
                                             strip_mm_data_for_generation)
-from tensorrt_llm.inputs.registry import (BaseMultimodalInputProcessor,
+from tensorrt_llm.inputs.registry import (BaseMultimodalDummyInputsBuilder,
+                                          BaseMultimodalInputProcessor,
                                           create_input_processor,
                                           create_input_processor_with_hash)
 from tensorrt_llm.llmapi.llm_args import (CudaGraphConfig, DecodingBaseConfig,
@@ -2635,13 +2636,23 @@ class PyTorchModelEngine(ModelEngine):
         Mirrors `_set_up_attn_metadata` for the LLM backbone: encoders opt in
         by inheriting `MultimodalEncoderMixin`, and the engine drives the construction
         so the sizes match ``llm_args.get_encoder_runtime_sizes()`` rather
-        than being hardcoded inside each encoder's ``__init__``.
+        than being hardcoded inside each encoder's ``__init__``. The optional
+        per-segment capacity combines the encoder token budget with the input
+        processor's largest supported item.
         """
+        max_seq_len = self.encoder_max_num_tokens
+        if isinstance(self.input_processor, BaseMultimodalDummyInputsBuilder):
+            max_tokens_per_item = (
+                self.input_processor.get_mm_max_tokens_per_item())
+            max_seq_len = max(max_seq_len,
+                              max(max_tokens_per_item.values(), default=0))
+
         for module in self.model.modules():
             if isinstance(module, MultimodalEncoderMixin):
                 module.setup_attn_metadata(
                     max_num_requests=self.encoder_batch_size,
                     max_num_tokens=self.encoder_max_num_tokens)
+                module.set_attn_max_seq_len(max_seq_len)
 
     def _set_up_spec_metadata(
             self,

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -270,8 +270,6 @@ full:H100/accuracy/test_llm_api_pytorch.py::TestNemotronV3Ultra::test_nvfp4_marl
 full:H100/accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention_4gpus[target_sparsity_0.9-fp8kv=False] SKIP (https://nvbugs/6523809)
 full:H100/accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16[tp1-CUTLASS] SKIP (https://nvbugs/6273850)
 full:H100/accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16_mtp SKIP (https://nvbugs/6529871)
-full:H100/accuracy/test_llm_api_pytorch_multimodal.py::TestQwen3_5_27B_VL::test_auto_dtype SKIP (https://nvbugs/6442075)
-full:H100/accuracy/test_llm_api_pytorch_multimodal.py::TestQwen3_5_35B_A3B_VL::test_auto_dtype SKIP (https://nvbugs/6442073)
 full:H100/disaggregated/test_disaggregated.py::test_disaggregated_logprobs_serving[llama-3.1-8b-instruct] SKIP (https://nvbugs/6275959)
 full:H100/disaggregated/test_disaggregated.py::test_disaggregated_mixed_stress_test[req10k-conc512-qwen3_32b_fp8_mixed_stress] SKIP (https://nvbugs/6440089)
 full:H100/disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_32b_fp8_stress] SKIP (https://nvbugs/6312828)

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -11,6 +11,8 @@ import torch
 
 import tensorrt_llm
 from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.modeling_multimodal_encoder import \
+    MultimodalEncoderMixin
 from tensorrt_llm._torch.models.modeling_multimodal_mixin import \
     MultimodalModelMixin
 from tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector import \

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -39,6 +39,7 @@ from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm._torch.speculative.spec_sampler_base import \
     SampleStateTensorsSpec
 from tensorrt_llm.bindings.executor import KvCacheConfig
+from tensorrt_llm.inputs.registry import BaseMultimodalDummyInputsBuilder
 from tensorrt_llm.llmapi import (CudaGraphConfig, SADecodingConfig,
                                  SamplingParams)
 from tensorrt_llm.mapping import CpType, Mapping
@@ -1114,6 +1115,73 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
         spec_metadata.write_padding_onehot_draft_probs.assert_called_once_with(
             [generation.py_seq_slot], 0)
         kv_cache_manager.shutdown()
+
+    def test_multimodal_encoder_max_seq_len_uses_processor_capacity(
+            self) -> None:
+
+        class CapturingEncoder(torch.nn.Module, MultimodalEncoderMixin):
+
+            def __init__(self) -> None:
+                super().__init__()
+                self.setup_args = None
+                self.max_seq_len = None
+
+            def setup_attn_metadata(self, max_num_requests: int,
+                                    max_num_tokens: int) -> None:
+                self.setup_args = (max_num_requests, max_num_tokens)
+
+            def set_attn_max_seq_len(self, max_seq_len: int) -> None:
+                self.max_seq_len = max_seq_len
+
+        cases = [({
+            "image": 65536
+        }, 65536), ({
+            "image": 4096
+        }, 16384), ({}, 16384)]
+        for demand, expected_max_seq_len in cases:
+            with self.subTest(demand=demand):
+                encoder = CapturingEncoder()
+                model_engine = PyTorchModelEngine.__new__(PyTorchModelEngine)
+                model_engine.model = torch.nn.Sequential(encoder)
+                model_engine.encoder_batch_size = 32
+                model_engine.encoder_max_num_tokens = 16384
+                model_engine.input_processor = Mock(
+                    spec=BaseMultimodalDummyInputsBuilder)
+                model_engine.input_processor.get_mm_max_tokens_per_item.return_value = demand
+
+                model_engine._set_up_multimodal_encoder_attn_metadata()
+
+                self.assertEqual(encoder.setup_args, (32, 16384))
+                self.assertEqual(encoder.max_seq_len, expected_max_seq_len)
+
+    def test_multimodal_encoder_max_seq_len_falls_back_without_dummy_builder(
+            self) -> None:
+
+        class CapturingEncoder(torch.nn.Module, MultimodalEncoderMixin):
+
+            def __init__(self) -> None:
+                super().__init__()
+                self.setup_args = None
+                self.max_seq_len = None
+
+            def setup_attn_metadata(self, max_num_requests: int,
+                                    max_num_tokens: int) -> None:
+                self.setup_args = (max_num_requests, max_num_tokens)
+
+            def set_attn_max_seq_len(self, max_seq_len: int) -> None:
+                self.max_seq_len = max_seq_len
+
+        encoder = CapturingEncoder()
+        model_engine = PyTorchModelEngine.__new__(PyTorchModelEngine)
+        model_engine.model = torch.nn.Sequential(encoder)
+        model_engine.encoder_batch_size = 32
+        model_engine.encoder_max_num_tokens = 16384
+        model_engine.input_processor = Mock()
+
+        model_engine._set_up_multimodal_encoder_attn_metadata()
+
+        self.assertEqual(encoder.setup_args, (32, 16384))
+        self.assertEqual(encoder.max_seq_len, 16384)
 
     def test_pad_generation_requests(self) -> None:
         model_engine, kv_cache_manager = create_model_engine_and_kvcache()

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -1116,8 +1116,7 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
             [generation.py_seq_slot], 0)
         kv_cache_manager.shutdown()
 
-    def test_multimodal_encoder_max_seq_len_uses_processor_capacity(
-            self) -> None:
+    def test_multimodal_encoder_max_seq_len(self) -> None:
 
         class CapturingEncoder(torch.nn.Module, MultimodalEncoderMixin):
 
@@ -1133,55 +1132,38 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
             def set_attn_max_seq_len(self, max_seq_len: int) -> None:
                 self.max_seq_len = max_seq_len
 
-        cases = [({
-            "image": 65536
-        }, 65536), ({
-            "image": 4096
-        }, 16384), ({}, 16384)]
-        for demand, expected_max_seq_len in cases:
-            with self.subTest(demand=demand):
+        encoder_batch_size = 32
+        encoder_max_num_tokens = 16384
+        processor_max_num_tokens = 65536
+        cases = [
+            ({
+                "image": processor_max_num_tokens
+            }, processor_max_num_tokens),
+            ({
+                "image": 4096
+            }, encoder_max_num_tokens),
+            ({}, encoder_max_num_tokens),
+            (None, encoder_max_num_tokens),
+        ]
+        for max_tokens_per_item, expected_max_seq_len in cases:
+            with self.subTest(max_tokens_per_item=max_tokens_per_item):
                 encoder = CapturingEncoder()
                 model_engine = PyTorchModelEngine.__new__(PyTorchModelEngine)
                 model_engine.model = torch.nn.Sequential(encoder)
-                model_engine.encoder_batch_size = 32
-                model_engine.encoder_max_num_tokens = 16384
-                model_engine.input_processor = Mock(
-                    spec=BaseMultimodalDummyInputsBuilder)
-                model_engine.input_processor.get_mm_max_tokens_per_item.return_value = demand
+                model_engine.encoder_batch_size = encoder_batch_size
+                model_engine.encoder_max_num_tokens = encoder_max_num_tokens
+                if max_tokens_per_item is None:
+                    model_engine.input_processor = Mock()
+                else:
+                    model_engine.input_processor = Mock(
+                        spec=BaseMultimodalDummyInputsBuilder)
+                    model_engine.input_processor.get_mm_max_tokens_per_item.return_value = max_tokens_per_item
 
                 model_engine._set_up_multimodal_encoder_attn_metadata()
 
-                self.assertEqual(encoder.setup_args, (32, 16384))
+                self.assertEqual(encoder.setup_args,
+                                 (encoder_batch_size, encoder_max_num_tokens))
                 self.assertEqual(encoder.max_seq_len, expected_max_seq_len)
-
-    def test_multimodal_encoder_max_seq_len_falls_back_without_dummy_builder(
-            self) -> None:
-
-        class CapturingEncoder(torch.nn.Module, MultimodalEncoderMixin):
-
-            def __init__(self) -> None:
-                super().__init__()
-                self.setup_args = None
-                self.max_seq_len = None
-
-            def setup_attn_metadata(self, max_num_requests: int,
-                                    max_num_tokens: int) -> None:
-                self.setup_args = (max_num_requests, max_num_tokens)
-
-            def set_attn_max_seq_len(self, max_seq_len: int) -> None:
-                self.max_seq_len = max_seq_len
-
-        encoder = CapturingEncoder()
-        model_engine = PyTorchModelEngine.__new__(PyTorchModelEngine)
-        model_engine.model = torch.nn.Sequential(encoder)
-        model_engine.encoder_batch_size = 32
-        model_engine.encoder_max_num_tokens = 16384
-        model_engine.input_processor = Mock()
-
-        model_engine._set_up_multimodal_encoder_attn_metadata()
-
-        self.assertEqual(encoder.setup_args, (32, 16384))
-        self.assertEqual(encoder.max_seq_len, 16384)
 
     def test_pad_generation_requests(self) -> None:
         model_engine, kv_cache_manager = create_model_engine_and_kvcache()

--- a/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
@@ -23,10 +23,11 @@ from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.checkpoints.hf.qwen2vl_weight_mapper import \
     Qwen2VLHfWeightMapper
 from tensorrt_llm._torch.models.modeling_qwen2vl import (
-    Qwen2_5_VLModel, Qwen2VisionModelBase, Qwen2VLInputProcessorBase,
-    Qwen2VLModel, _prepare_qwen_vl_mrope_config)
-from tensorrt_llm._torch.models.modeling_qwen3vl import \
-    Qwen3VLInputProcessorBase
+    Qwen2_5_VisionModel, Qwen2_5_VLModel, Qwen2VisionModelBase,
+    Qwen2VLInputProcessorBase, Qwen2VLModel, _prepare_qwen_vl_mrope_config,
+    _prepare_qwen_vl_vision_attn_metadata)
+from tensorrt_llm._torch.models.modeling_qwen3vl import (
+    Qwen3VisionModel, Qwen3VLInputProcessorBase)
 from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 
@@ -496,6 +497,96 @@ def test_prepare_qwen_vl_mrope_config_pure_generation_reads_deltas_only():
         torch.tensor([[11], [22]], device="cuda", dtype=torch.int32))
 
 
+class _StubVisionAttentionMetadata:
+    """CPU-only metadata stub for Qwen vision sequence preparation."""
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self._seq_lens = torch.empty(0, dtype=torch.int32)
+        self.seq_lens_cuda = torch.empty(0, dtype=torch.int32)
+        self.prepare_encoder_only_calls = 0
+
+    @property
+    def seq_lens(self) -> torch.Tensor:
+        return self._seq_lens
+
+    @seq_lens.setter
+    def seq_lens(self, value: torch.Tensor) -> None:
+        self._seq_lens = value
+        self.seq_lens_cuda = value
+
+    def prepare_encoder_only(self) -> None:
+        self.prepare_encoder_only_calls += 1
+
+
+def test_qwen_vision_metadata_uses_fixed_max_seq_len() -> None:
+    metadata = _StubVisionAttentionMetadata()
+
+    _prepare_qwen_vl_vision_attn_metadata([256], metadata, max_seq_len=65536)
+    assert metadata.max_seq_len == 65536
+    assert metadata.seq_lens.tolist() == [256]
+    assert metadata.cu_q_seqlens.tolist() == [0, 256]
+
+    _prepare_qwen_vl_vision_attn_metadata([128, 512],
+                                          metadata,
+                                          max_seq_len=65536)
+    assert metadata.max_seq_len == 65536
+    assert metadata.seq_lens.tolist() == [128, 512]
+    assert metadata.cu_q_seqlens.tolist() == [0, 128, 640]
+    assert metadata.cu_kv_seqlens.tolist() == [0, 128, 640]
+    assert metadata.prepare_encoder_only_calls == 2
+
+
+def test_qwen_vision_metadata_allows_segment_at_fixed_max_seq_len() -> None:
+    metadata = _StubVisionAttentionMetadata()
+
+    _prepare_qwen_vl_vision_attn_metadata([65536], metadata, max_seq_len=65536)
+
+    assert metadata.max_seq_len == 65536
+    assert metadata.seq_lens.tolist() == [65536]
+
+
+def test_qwen_vision_metadata_rejects_segment_above_fixed_max_seq_len() -> None:
+    metadata = _StubVisionAttentionMetadata()
+
+    with pytest.raises(ValueError, match=r"exceeds.*maximum=65536"):
+        _prepare_qwen_vl_vision_attn_metadata([128, 65537],
+                                              metadata,
+                                              max_seq_len=65536)
+
+    assert metadata.prepare_encoder_only_calls == 0
+
+
+def test_qwen3_vision_prepare_metadata_passes_fixed_max_seq_len() -> None:
+    model = Qwen3VisionModel.__new__(Qwen3VisionModel)
+    torch.nn.Module.__init__(model)
+    model._fixed_max_seq_len = 65536
+    metadata = _StubVisionAttentionMetadata()
+
+    model.prepare_attn_metadata([256, 1024], metadata)
+
+    assert metadata.max_seq_len == 65536
+    assert metadata.seq_lens.tolist() == [256, 1024]
+
+
+def test_qwen2_5_window_attention_uses_tighter_fixed_max_seq_len() -> None:
+    model = Qwen2_5_VisionModel.__new__(Qwen2_5_VisionModel)
+    torch.nn.Module.__init__(model)
+    model.window_size = 100
+    model.spatial_merge_size = 2
+    model.spatial_merge_unit = 4
+    model.patch_size = 14
+    model.metadata_cls = _StubVisionAttentionMetadata
+    model.patch_embed = SimpleNamespace(proj=SimpleNamespace(
+        weight=torch.empty(1)))
+
+    model.setup_attn_metadata(max_num_requests=8, max_num_tokens=16)
+    model.set_attn_max_seq_len(65536)
+
+    assert model._full_attn_max_seq_len == 65536
+    assert model._window_attn_max_seq_len == 36
+
+
 # ---------------------------------------------------------------------------
 # Deterministic dummy-input sizing (Qwen2/2.5/3-VL input processors).
 #
@@ -692,6 +783,15 @@ def test_mm_max_tokens_per_item_is_image_only(processor_cls):
     assert demand["image"] == proc._num_vision_tokens(width=cap_size["width"],
                                                       height=cap_size["height"])
     assert demand["image"] > 0
+
+
+def test_qwen3_processor_max_pixels_maps_to_fixed_attention_capacity() -> None:
+    proc = _make_dummy_processor(Qwen3VLInputProcessorBase,
+                                 patch_size=16,
+                                 spatial_merge_size=2,
+                                 max_pixels=16_777_216)
+
+    assert proc.get_mm_max_tokens_per_item() == {"image": 65_536}
 
 
 @pytest.mark.parametrize("processor_cls", _DUMMY_PROCESSORS)

--- a/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
@@ -562,7 +562,7 @@ def test_qwen2_5_window_attention_uses_tighter_fixed_max_seq_len() -> None:
     hf_config = Qwen2_5_VLConfig.from_dict(copy.deepcopy(QWEN2_5_VL_7B_CONFIG))
     model_config = ModelConfig(pretrained_config=hf_config,
                                skip_create_weights_in_init=True)
-    model = Qwen2_5_VisionModel(model_config)
+    model = Qwen2VisionModelBase(model_config, Qwen2_5_VisionModel).visual
     model.metadata_cls = _StubVisionAttentionMetadata
 
     max_num_requests = 8

--- a/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen2_5vl.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import copy
 import os
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -26,8 +27,8 @@ from tensorrt_llm._torch.models.modeling_qwen2vl import (
     Qwen2_5_VisionModel, Qwen2_5_VLModel, Qwen2VisionModelBase,
     Qwen2VLInputProcessorBase, Qwen2VLModel, _prepare_qwen_vl_mrope_config,
     _prepare_qwen_vl_vision_attn_metadata)
-from tensorrt_llm._torch.models.modeling_qwen3vl import (
-    Qwen3VisionModel, Qwen3VLInputProcessorBase)
+from tensorrt_llm._torch.models.modeling_qwen3vl import \
+    Qwen3VLInputProcessorBase
 from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.inputs.multimodal import MultimodalParams
 
@@ -557,34 +558,23 @@ def test_qwen_vision_metadata_rejects_segment_above_fixed_max_seq_len() -> None:
     assert metadata.prepare_encoder_only_calls == 0
 
 
-def test_qwen3_vision_prepare_metadata_passes_fixed_max_seq_len() -> None:
-    model = Qwen3VisionModel.__new__(Qwen3VisionModel)
-    torch.nn.Module.__init__(model)
-    model._fixed_max_seq_len = 65536
-    metadata = _StubVisionAttentionMetadata()
-
-    model.prepare_attn_metadata([256, 1024], metadata)
-
-    assert metadata.max_seq_len == 65536
-    assert metadata.seq_lens.tolist() == [256, 1024]
-
-
 def test_qwen2_5_window_attention_uses_tighter_fixed_max_seq_len() -> None:
-    model = Qwen2_5_VisionModel.__new__(Qwen2_5_VisionModel)
-    torch.nn.Module.__init__(model)
-    model.window_size = 100
-    model.spatial_merge_size = 2
-    model.spatial_merge_unit = 4
-    model.patch_size = 14
+    hf_config = Qwen2_5_VLConfig.from_dict(copy.deepcopy(QWEN2_5_VL_7B_CONFIG))
+    model_config = ModelConfig(pretrained_config=hf_config,
+                               skip_create_weights_in_init=True)
+    model = Qwen2_5_VisionModel(model_config)
     model.metadata_cls = _StubVisionAttentionMetadata
-    model.patch_embed = SimpleNamespace(proj=SimpleNamespace(
-        weight=torch.empty(1)))
 
-    model.setup_attn_metadata(max_num_requests=8, max_num_tokens=16)
-    model.set_attn_max_seq_len(65536)
+    max_num_requests = 8
+    max_num_tokens = 16
+    fixed_max_seq_len = 65_536
+    expected_window_max_seq_len = 64
+    model.setup_attn_metadata(max_num_requests=max_num_requests,
+                              max_num_tokens=max_num_tokens)
+    model.set_attn_max_seq_len(fixed_max_seq_len)
 
-    assert model._full_attn_max_seq_len == 65536
-    assert model._window_attn_max_seq_len == 36
+    assert model._full_attn_max_seq_len == fixed_max_seq_len
+    assert model._window_attn_max_seq_len == expected_window_max_seq_len
 
 
 # ---------------------------------------------------------------------------
@@ -783,15 +773,6 @@ def test_mm_max_tokens_per_item_is_image_only(processor_cls):
     assert demand["image"] == proc._num_vision_tokens(width=cap_size["width"],
                                                       height=cap_size["height"])
     assert demand["image"] > 0
-
-
-def test_qwen3_processor_max_pixels_maps_to_fixed_attention_capacity() -> None:
-    proc = _make_dummy_processor(Qwen3VLInputProcessorBase,
-                                 patch_size=16,
-                                 spatial_merge_size=2,
-                                 max_pixels=16_777_216)
-
-    assert proc.get_mm_max_tokens_per_item() == {"image": 65_536}
 
 
 @pytest.mark.parametrize("processor_cls", _DUMMY_PROCESSORS)

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3vl.py
@@ -4,6 +4,7 @@
 import copy
 import os
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import List, Optional
 
 import pytest
@@ -15,6 +16,7 @@ from transformers import Qwen3VLForConditionalGeneration as HFQwen3VLForConditio
 from utils.llm_data import llm_models_root
 
 from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models import modeling_qwen3vl
 from tensorrt_llm._torch.models.checkpoints.hf.qwen3vl_weight_mapper import Qwen3VLHfWeightMapper
 from tensorrt_llm._torch.models.modeling_qwen3vl import (
     Qwen3VisionModel,
@@ -471,6 +473,55 @@ def test_qwen3vl_init_preserves_caller_quant_config():
     assert model.mm_encoder.model_config.quant_config is not quant_config
     assert model.mm_encoder.model_config.quant_config.kv_cache_quant_algo is None
     assert model.mm_encoder.model_config.quant_config.quant_algo is None
+
+
+def test_qwen3_vision_prepare_metadata_passes_fixed_max_seq_len(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_max_seq_len = 65_536
+    seq_lens = [256, 1024]
+    metadata = object()
+    calls = []
+
+    def capture_prepare_attn_metadata(
+        actual_seq_lens: List[int],
+        actual_metadata: object,
+        *,
+        max_seq_len: int,
+    ) -> object:
+        calls.append((actual_seq_lens, actual_metadata, max_seq_len))
+        return actual_metadata
+
+    monkeypatch.setattr(
+        modeling_qwen3vl,
+        "_prepare_qwen_vl_vision_attn_metadata",
+        capture_prepare_attn_metadata,
+    )
+    model = Qwen3VisionModel.__new__(Qwen3VisionModel)
+    torch.nn.Module.__init__(model)
+    model.set_attn_max_seq_len(fixed_max_seq_len)
+
+    result = model.prepare_attn_metadata(seq_lens, metadata)
+
+    assert result is metadata
+    assert calls == [(seq_lens, metadata, fixed_max_seq_len)]
+
+
+def test_qwen3_processor_max_pixels_maps_to_fixed_attention_capacity() -> None:
+    max_pixels = 16_777_216
+    expected_max_tokens_per_item = {"image": 65_536}
+    processor = Qwen3VLInputProcessorBase.__new__(Qwen3VLInputProcessorBase)
+    processor._config = Qwen3VLConfig.from_dict(copy.deepcopy(QWEN3_VL_8B_CONFIG))
+    processor._processor = SimpleNamespace(
+        image_processor=SimpleNamespace(
+            size={
+                "shortest_edge": 3_136,
+                "longest_edge": max_pixels,
+            }
+        )
+    )
+
+    assert processor.get_mm_max_tokens_per_item() == expected_max_tokens_per_item
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stable attention capacity handling for multimodal vision encoders.
  - Improved Qwen2.5-VL and Qwen3-VL support across varying image resolutions.
  - Automatically derives encoder capacity from multimodal input token limits when available.

- **Bug Fixes**
  - Added validation for invalid or oversized attention sequences.
  - Improved fallback behavior when multimodal token limits are unavailable.

- **Tests**
  - Added coverage for fixed sequence lengths, window attention limits, capacity calculation, and fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

1. The accuracy test creates a long-lived engine and processes 900 MMMU examples over many batches.
2. The test configures an aggregate LLM/decoder engine token budget of 16,384 and an external request batch limit of
   32. The vision encoder inherits 16,384 as nominal metadata sizing, but does not currently enforce it as an admission
   limit.
3. Qwen vision turns each image or temporal video slice into an independent patch-token attention segment.
4. To support potentially many segments, Qwen raises the native request/sequence-slot capacity to 16,384. This provides
   very large practical headroom and explains the semaphore allocation; it is neither the count of active users nor a
   formally proven bound while the encoder token limit remains unenforced.
5. **[PRE-FIX BEHAVIOR]** Every encoder forward assigned the longest **actual** segment in that batch to
   `metadata.max_seq_len`.
6. Different image geometry could yield a previously unseen value of `max_seq_len`.
7. That value was part of the process-static native cache key, together with `layer_idx`.
8. A new value therefore caused up to 27 cache misses, one for each vision layer.
9. Preparing every missed operator allocated a roughly 1 MiB `int32` semaphore array under these capacities.
10. The map had no eviction path, so old operators and their owned arrays remained resident even after their request
    finished.
11. Memory usage therefore grew with the number of distinct batch maxima, not simply with current batch size.
12. Eventually another `reserveSemaphoreArray()` call could no longer allocate device memory, producing the observed
    OOM.

The dense and MoE models use the same 27-layer, 16-head Qwen vision tower, so both are exposed to this mechanism. Their text decoders leave different amounts of runtime memory headroom, which can make them fail at different points.

**[BRANCH FIX]** The fixed Qwen vision sequence-length solution applies to both models. It calculates the
processor-aware bound during model setup, validates each actual segment maximum against it, and assigns the stable
bound to metadata on every forward. The first pass creates one operator per vision layer; later resolutions reuse those
same entries.

**[PRE-EXISTING, PRESERVED BY THE BRANCH FIX]** Exact `seq_lens` and cumulative offsets remain dynamic, so attention correctness is unchanged.

A similar workaround for OOMs is implemented in RADIO: https://github.com/NVIDIA/TensorRT-LLM/blob/0d10ebe25b34509fcc70674fe49cca6261dd00b9/tensorrt_llm/_torch/models/modeling_radio.py#L746-L752

### Diagram 1 - Qwen Vision metadata capacities:

<img width="6752" height="4720" alt="qwen_vision_metadata_capacities" src="https://github.com/user-attachments/assets/eb0f23e1-bbf5-4eda-bea4-08e8c8b61def" />

### Diagram 2 - Qwen `AttentionOp` cache growth:

<img width="8680" height="5532" alt="qwen_attention_op_cache_growth" src="https://github.com/user-attachments/assets/b05fa6ea-fa42-47ab-b7e5-7960bb3537c4" />

## Test Coverage

```
pytest -sv tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py::TestQwen3_5_35B_A3B_VL
pytest -sv tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py::TestQwen3_5_27B_VL
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
