### PR TITLE
[https://nvbugs/6476233][test] waive DeepSeek V3.2 tests on DGX H200

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -234,6 +234,8 @@ full:B300/disaggregated/test_disaggregated.py::test_disaggregated_ctxpp2_genpp2[
 full:B300/test_e2e.py::test_qwen_e2e_cpprunner_large_new_tokens[DeepSeek-R1-Distill-Qwen-1.5B-DeepSeek-R1-Distill-Qwen-1.5B] SKIP (https://nvbugs/6414760)
 full:B300/unittest/_torch/attention/test_attention_backends.py::test_attention_backend[gpt_oss_gqa_hd64_gptj_swa128-ctx-bf16-HND-p32-v1] SKIP (https://nvbugs/6468821)
 full:DGX_B300/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_4gpus[ep4-mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=False] SKIP (https://nvbugs/6432831)
+full:DGX_H200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[disable_skip_indexer] SKIP (https://nvbugs/6476233)
+full:DGX_H200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[latency_default] SKIP (https://nvbugs/6476233)
 full:GB200/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_eagle3[eagle3_one_model=False-overlap_scheduler=False] SKIP (https://nvbugs/6402500)
 full:GB200/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_guided_decoding_with_eagle3[llguidance-eagle3_one_model=False] SKIP (https://nvbugs/6402500)
 full:GB200/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_guided_decoding_with_eagle3[xgrammar-eagle3_one_model=False] SKIP (https://nvbugs/6402500)


### PR DESCRIPTION
## What changed

- Waive `TestDeepSeekV32::test_fp8_blockscale[disable_skip_indexer]` on `DGX_H200`.
- Waive `TestDeepSeekV32::test_fp8_blockscale[latency_default]` on `DGX_H200`.
- Scope both entries with `full:DGX_H200/` so other platforms retain coverage.

## Why

The two DeepSeek V3.2 FP8-block-scale parameterizations are currently affected by GPU out-of-memory failures on DGX H200. NVBug 6476233 tracks the underlying issue. These platform-specific waivers provide a conservative CI unblock while preserving coverage on unaffected platforms.

## Impact

DGX H200 skips the two affected parameterizations. Other GPU platforms are unchanged.

## Validation

- Rebased onto `NVIDIA/TensorRT-LLM:main` at `634abb850f8f4e89e0b06c8cb44b5bc80698a4c7`.
- `git diff --check` passes.
- Verified both entries use the documented platform-scoped waiver format.
- Commit includes the required DCO sign-off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test waivers for two parameterized DeepSeek V3.2 FP8 block-scale accuracy test scenarios.
  * Both scenarios reference the applicable NVIDIA bug report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->