### PR TITLE
[TRTLLMINF-188][test] Validate merged post-merge approval workflow

### DIFF
--- a/.github/TRTLLMINF-188-WORKFLOW-TEST.md
+++ b/.github/TRTLLMINF-188-WORKFLOW-TEST.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# TRTLLMINF-188 workflow verification marker
+
+This marker exists only to validate the merged post-merge approval-label
+workflow on an isolated draft pull request. Do not merge this pull request.
+
+Revision: 1

--- a/.github/TRTLLMINF-188-WORKFLOW-TEST.md
+++ b/.github/TRTLLMINF-188-WORKFLOW-TEST.md
@@ -8,4 +8,4 @@ SPDX-License-Identifier: Apache-2.0
 This marker exists only to validate the merged post-merge approval-label
 workflow on an isolated draft pull request. Do not merge this pull request.
 
-Revision: 1
+Revision: 2


### PR DESCRIPTION
## Description

Ephemeral draft PR used only to verify the merged default-branch post-merge
approval-label workflow.

The only change is a non-executable marker file. This PR must not be merged.
No `/bot` command, Blossom workflow, Jenkins job, or downstream CI workload
will be triggered.

Related implementation:
[NVIDIA/TensorRT-LLM#16318](https://github.com/NVIDIA/TensorRT-LLM/pull/16318).

## Test Coverage

- Apply `ci: post-merge approved` as an active
  `NVIDIA/trt-llm-ci-approvers` member.
- Verify the default-branch Guard succeeds, retains the label, and creates no
  denial comment.
- Change only `Revision: 1` to `Revision: 2` in a second signed-off commit.
- Verify the label remains and no `synchronize` Guard run is created.
- Remove the label and close this draft PR without merging.

Negative-actor and cancellation behavior was already validated in an isolated
personal fork and will not be repeated against upstream.

## PR Checklist

- [x] This is an isolated, marker-only workflow test and must not be merged.