### PR TITLE
[https://nvbugs/6442074][fix] DSparkWorker: rename forward to _forward_impl

### DIFF
--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -404,7 +404,7 @@ class DSparkWorker(SpecWorkerBase):
         )
         return block_logits
 
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,


### PR DESCRIPTION
d97397437f added `__init_subclass__` to `SpecWorkerBase` requiring subclasses to implement `_forward_impl` instead of overriding `forward` directly, but did not update `DSparkWorker`. This causes a `TypeError` at import time on any build that includes both that commit and the DSpark PR (#15808).

Fix: rename `DSparkWorker.forward` → `DSparkWorker._forward_impl`. Callers go through `SpecWorkerBase.forward` which wraps `_forward_impl`, so no call sites need updating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal speculative decoding execution flow without changing observable behavior or generated outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->