### PR TITLE
[https://nvbugs/6442074][fix] Unbreak main: DSparkWorker forward rename + test stub _forward_impl

### DIFF
--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -404,7 +404,7 @@ class DSparkWorker(SpecWorkerBase):
         )
         return block_logits
 
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,

--- a/tests/unittest/_torch/speculative/test_rejection_buffers_guard.py
+++ b/tests/unittest/_torch/speculative/test_rejection_buffers_guard.py
@@ -201,6 +201,9 @@ class _Worker(SpecWorkerBase):
     def max_draft_len(self) -> int:
         return K
 
+    def _forward_impl(self, *args: object, **kwargs: object) -> None:
+        raise NotImplementedError
+
 
 def _dispatch_meta(**over):
     base = dict(


### PR DESCRIPTION
Main is broken since d9739743 (the `SpecWorkerBase.__init_subclass__` guard from #16382) crossed in flight with two later additions:

- `dspark.py` defines `forward` → import-time `TypeError` for `import tensorrt_llm` (via `speculative/utils.py` module-level import)
- `test_rejection_buffers_guard.py`'s `_Worker` stub lacks `_forward_impl` → `TypeError` at instantiation (3 tests)

This PR carries both fixes. The dspark rename is cherry-picked from #16577 — full credit @brnguyen2. Swept current main: these are the only two violations. Neither fix can pass CI alone (each PR's CI merge still contains the other breakage), hence one combined PR.

## Test plan
- [x] Sweep of current main for all `SpecWorkerBase` subclasses / `forward` overrides — only these two sites
- [x] Local H100 validation: `import tensorrt_llm` + dspark import chain OK; `test_rejection_buffers_guard.py` 16/16; `test_force_accepted_tokens.py` 22/22

## Links
- Bug: https://nvbugs/6442074
- Supersedes/combines: #16577
