### PR TITLE
[None][perf] disagg: enable overlap scheduler on the context (prefill) server (WIP)

### DIFF
--- a/examples/disaggregated/slurm/simple_example/ctx_extra-llm-api-config.yaml
+++ b/examples/disaggregated/slurm/simple_example/ctx_extra-llm-api-config.yaml
@@ -1,5 +1,12 @@
-# The overlap scheduler for context servers is currently disabled, as it is
-# not yet supported in disaggregated context server architectures.
+# The overlap scheduler IS supported on the disaggregated context server
+# (the executor's `_executor_loop_overlap` already defers the KV-cache send
+# until the sampled result is resolved). It is disabled by default because it
+# is not beneficial when the context server is not host-bound: the overlap loop
+# defers each request's first-token + KV handoff to the generation server by one
+# iteration, which lands on the TTFT critical path, while hiding little host CPU
+# (the dominant context-side costs -- schedule / fetch bookkeeping and KV-transfer
+# stalls -- are not the kind the overlap scheduler can hide). Set to False to
+# enable it for host-bound context regimes.
 disable_overlap_scheduler: True
 cache_transceiver_config:
   backend: UCX


### PR DESCRIPTION
> **Status: DRAFT / WIP.** This PR tracks enabling the overlap scheduler on the disaggregated **context (prefill)** server. This first commit corrects a stale code comment; the perf fix described below is in progress.

## Background
The disaggregated context server runs with `disable_overlap_scheduler=True` by default, with a comment claiming overlap is *"not yet supported in disaggregated context server architectures."* **That comment is stale.** A code trace shows the overlap scheduler **is** implemented for the context path: `_executor_loop_overlap` keeps a one-step-late `previous_batch` buffer and already defers the KV-cache send until the sampled result is resolved:

```python
# tensorrt_llm/_torch/pyexecutor/py_executor.py  (_executor_loop_overlap)
if self.previous_batch is not None and should_process_previous_batch:
    self._update_requests(self.previous_batch.sample_state)          # resolve prev step's first token
    self._send_kv_async(self.previous_batch.scheduled_requests.all_requests())  # THEN send KV + first_gen_tokens
```

This is exactly the SGLang disagg-prefill approach (resolve-then-send). So enabling it is a config flip, not a from-scratch build-out. **This commit corrects the comment.**

## Verification (DSv4-Pro disagg, c3120, GB300, ctx dep4 + attention_dp + mtp3)
Flipping `disable_overlap_scheduler: false` on the context server:

**It runs and is correct:**
- 100% request success at c3120 with attention_dp (the `should_process_previous_batch` ADP path is fine at scale).
- **GSM8K temp=0 accuracy parity: 0.975 (195/200) with overlap ON == 0.975 with overlap OFF.** No corruption.

**nsys proves overlap is genuinely active** (CTX rank-0, cuda+nvtx+python-gil, iters 1000–1040). During the `_fetch_new_requests` / `_handle_responses` host phases:
| host phase | OFF: iters with concurrent GPU | ON: iters with concurrent GPU |
|---|---|---|
| `_fetch_new_requests` | **0 / 40** | **9 / 40** (~22% of range) |
| `_handle_responses` | **0 / 40** | **9 / 40** |

OFF is perfectly serialized (0/40, textbook non-overlap); ON shows real concurrent GPU execution during host work. Categorical → overlap is running in ON, not OFF.

## But it is a net **regression** at c3120 (why it stays off by default)
| metric | overlap OFF | overlap ON | Δ |
|---|---|---|---|
| req/s | 155.1 | 150.1 | **−3.2%** |
| TTFT p50 | 8.98 s | 10.07 s | **+12%** |
| output tok/s | 53,677 | 52,312 | −2.5% |
| aggregate GPU busy% (nsys) | **55.7%** | 44.5% | lower under ON |

Root cause: the overlap loop processes each step's result one iteration late, so a context request's **first-token + KV handoff to the generation server is deferred by ~1 context iteration**, landing directly on the TTFT critical path — while the host CPU it can hide is small (the dominant context-side costs are `_schedule` / `_fetch_new_requests` bookkeeping and multi-hundred-ms KV-transfer stalls, neither of which the overlap scheduler is designed to hide). Overlap is built to hide **decode-token sampling/result-consumption**, which is not the bottleneck on a prefill server.

## Planned fix (in progress)
Decouple the two halves of the handoff so the deferral leaves the critical path:
- **Send the KV block-ids as soon as the forward's KV is ready** (before the sampling readback) → the generation server starts the *slow* KV pull ~1 iteration earlier.
- **Send `first_gen_tokens` when resolved** (one step late, but it is tiny and off the critical path — GEN doesn't need it until the KV pull completes).

This overlaps the slow KV transfer instead of deferring it, which should turn ctx-overlap net-neutral-to-positive. It requires splitting `respond_and_send_async` (block-ids now / token later) in the cache transceiver + the disagg handoff protocol — commits to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
