### PR TITLE
[None][perf] Gate NCCL NVLS on NVML fabric state, not IMEX availability

### DIFF
--- a/cpp/include/tensorrt_llm/runtime/ipcNvlsMemory.h
+++ b/cpp/include/tensorrt_llm/runtime/ipcNvlsMemory.h
@@ -52,14 +52,25 @@ void MPI_group_barrier(std::set<int> ranks);
 //! fabric/IMEX plane is not provisioned. The result is cached.
 bool ipcNvlsSupported();
 
-//! \brief Whether the NVLink fabric/IMEX plane is provisioned so that NVLS
-//! multicast memory can actually be *bound* (not merely statically supported).
-//! Extends ipcNvlsSupported() with a live fabric probe (getMemHandleType() must
-//! resolve to CU_MEM_HANDLE_TYPE_FABRIC). Use this to decide whether NCCL may
-//! attempt NVLS: on an unprovisioned node the static multicast attribute is a
-//! false positive and NCCL aborts during init, so callers should disable
-//! NCCL_NVLS when this returns false. The (heavy) result is cached.
-bool ipcNvlsFabricUsable();
+//! \brief Whether NVLS multicast memory can actually be *bound* in this session
+//! (not merely statically supported). Extends ipcNvlsSupported() with NVML's
+//! fabric state: Fabric Manager must have configured the NVLink switch fabric
+//! (state COMPLETED). For single-node sessions the IMEX plane is intentionally
+//! not required -- NVLS binds work over POSIX-FD handles without it. Multi-node
+//! sessions additionally require a provisioned fabric/IMEX plane, because
+//! cross-node multicast memory can only be shared via FABRIC handles. Use this
+//! to decide whether NCCL may attempt NVLS: on a node whose fabric is not
+//! configured the static multicast attribute is a false positive and NCCL
+//! aborts during init, so callers should disable NCCL_NVLS when this returns
+//! false. The result is cached.
+bool ipcNvlsUsable();
+
+//! \brief Disable NCCL NVLS (setenv NCCL_NVLS_ENABLE=0, no-overwrite) when
+//! ipcNvlsUsable() says it cannot work in this session, warning with the
+//! reason. Call before the first ncclCommInitRank: NCCL caches the env var on
+//! first read, so the decision is process-wide. A pre-existing NCCL_NVLS_ENABLE
+//! setting skips the probe and the warning. No-op on Windows.
+void maybeDisableNcclNvls();
 
 IpcNvlsHandle* ipcNvlsAllocate(size_t size, std::set<int> ranks);
 

--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -162,13 +162,7 @@ std::shared_ptr<ncclComm_t> getComm(std::set<int> const& group)
 #else
     setenv("NCCL_RUNTIME_CONNECT", "0", 0);
     setenv("NCCL_GRAPH_REGISTER", "0", 0);
-    // NCCL aborts during init if it tries NVLS multicast but the fabric/IMEX
-    // plane can't bind it. Disable NVLS when the fabric is not usable so NCCL
-    // falls back to NVLink P2P. No-overwrite preserves an explicit user setting.
-    if (!tensorrt_llm::runtime::ipcNvlsFabricUsable())
-    {
-        setenv("NCCL_NVLS_ENABLE", "0", 0);
-    }
+    tensorrt_llm::runtime::maybeDisableNcclNvls();
 #endif // _WIN32
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;

--- a/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cu
+++ b/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cu
@@ -24,6 +24,8 @@
 #endif
 #if ENABLE_MULTI_DEVICE
 #include "tensorrt_llm/common/nvmlWrapper.h"
+
+#include <cstdlib>
 #endif
 #include <unistd.h>
 
@@ -145,10 +147,69 @@ private:
     MPI_Comm mGroupComm;
 };
 
+// Returns true when NVML reports the GPU's NVLink fabric registration as
+// completed successfully, i.e. Fabric Manager has configured the NVSwitch
+// fabric this device is attached to. This is the driver's own record of the
+// precondition for NVLS multicast binds. Note the distinction from IMEX:
+// fabric *handles* (cuMemCreate with CU_MEM_HANDLE_TYPE_FABRIC) additionally
+// need the IMEX plane, but single-node NVLS binds work over POSIX-FD handles
+// and only need the switch fabric itself to be configured.
+static bool nvlinkFabricConfigured()
+{
+    // Static for the process; cached because each query is a full
+    // nvmlInit/nvmlShutdown cycle and this runs on every NVLS allocation via
+    // getMemHandleType(). An exception during the first attempt propagates and
+    // the query is retried on the next call.
+    static bool const configured = []() -> bool
+    {
+        int device_id;
+        TLLM_CUDA_CHECK(cudaGetDevice(&device_id));
+
+        auto nvml = tensorrt_llm::common::NVMLWrapper::getInstance();
+        tensorrt_llm::common::NvmlManager nvmlManager;
+
+        nvmlDevice_t nvml_device;
+        NVMLCHECK(nvml->nvmlDeviceGetHandleByIndex(device_id, &nvml_device));
+
+        nvmlGpuFabricState_t fabric_state;
+        nvmlReturn_t fabric_status;
+        if (nvml->hasGpuFabricInfoV())
+        {
+            nvmlGpuFabricInfoV_t fabric_info_v;
+            memset(&fabric_info_v, 0, sizeof(fabric_info_v));
+            fabric_info_v.version = nvmlGpuFabricInfo_v2;
+            NVMLCHECK(nvml->nvmlDeviceGetGpuFabricInfoV(nvml_device, &fabric_info_v));
+            fabric_state = fabric_info_v.state;
+            fabric_status = fabric_info_v.status;
+        }
+        else if (nvml->hasGpuFabricInfo())
+        {
+            nvmlGpuFabricInfo_t fabric_info;
+            NVMLCHECK(nvml->nvmlDeviceGetGpuFabricInfo(nvml_device, &fabric_info));
+            fabric_state = fabric_info.state;
+            fabric_status = fabric_info.status;
+        }
+        else
+        {
+            TLLM_LOG_TRACE("checking fabric state... NVML fabric info APIs not available.");
+            return false;
+        }
+
+        if (fabric_state != NVML_GPU_FABRIC_STATE_COMPLETED || fabric_status != NVML_SUCCESS)
+        {
+            TLLM_LOG_TRACE("checking fabric state... fabric state is NOT COMPLETE: state=%u status=%u.", fabric_state,
+                fabric_status);
+            return false;
+        }
+        return true;
+    }();
+    return configured;
+}
+
 // Returns CU_MEM_HANDLE_TYPE_FABRIC when fabric-handle memory can actually be
 // allocated and exported on the current device (i.e. the fabric/IMEX plane is
-// provisioned), else CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR. Used both to pick
-// the NVLS allocation handle type and by ipcNvlsFabricUsable() to gauge usability.
+// provisioned), else CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR. Used to pick
+// the NVLS allocation handle type.
 static CUmemAllocationHandleType getMemHandleType()
 {
     int device_id;
@@ -163,41 +224,9 @@ static CUmemAllocationHandleType getMemHandleType()
         return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
     }
 
-    auto nvml = tensorrt_llm::common::NVMLWrapper::getInstance();
-    tensorrt_llm::common::NvmlManager nvmlManager;
-
-    nvmlDevice_t nvml_device;
-    NVMLCHECK(nvml->nvmlDeviceGetHandleByIndex(device_id, &nvml_device));
-
-    nvmlGpuFabricState_t fabric_state;
-    nvmlReturn_t fabric_status;
-    if (nvml->hasGpuFabricInfoV())
+    // Fabric handles additionally require the switch fabric to be configured.
+    if (!nvlinkFabricConfigured())
     {
-        nvmlGpuFabricInfoV_t fabric_info_v;
-        memset(&fabric_info_v, 0, sizeof(fabric_info_v));
-        fabric_info_v.version = nvmlGpuFabricInfo_v2;
-        NVMLCHECK(nvml->nvmlDeviceGetGpuFabricInfoV(nvml_device, &fabric_info_v));
-        fabric_state = fabric_info_v.state;
-        fabric_status = fabric_info_v.status;
-    }
-    else if (nvml->hasGpuFabricInfo())
-    {
-        nvmlGpuFabricInfo_t fabric_info;
-        NVMLCHECK(nvml->nvmlDeviceGetGpuFabricInfo(nvml_device, &fabric_info));
-        fabric_state = fabric_info.state;
-        fabric_status = fabric_info.status;
-    }
-    else
-    {
-        TLLM_LOG_TRACE("checking fabric support... NVML fabric info APIs not available.");
-        return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-    }
-
-    // Check if the fabric is fully initialized.
-    if (fabric_state != NVML_GPU_FABRIC_STATE_COMPLETED || fabric_status != NVML_SUCCESS)
-    {
-        TLLM_LOG_TRACE("checking fabric support... fabric state is NOT COMPLETE: state=%u status=%u.", fabric_state,
-            fabric_status);
         return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
     }
 
@@ -239,7 +268,7 @@ static CUmemAllocationHandleType getMemHandleType()
         return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
     }
 
-    TLLM_LOG_TRACE("fabric status: device=%d, state=%u status=%u", device_id, fabric_state, fabric_status);
+    TLLM_LOG_TRACE("fabric handles usable: device=%d", device_id);
 
     CUCHECK(cuMemRelease(imported_handle));
     CUCHECK(cuMemRelease(handle));
@@ -491,58 +520,125 @@ bool ipcNvlsSupported()
 #endif
 }
 
-bool ipcNvlsFabricUsable()
+namespace
+{
+
+enum class NvlsUsability
+{
+    kUsable,
+    kNotSupported,        // static multicast capability missing (nothing to warn about)
+    kFabricNotConfigured, // NVML fabric state not COMPLETED: binds would fail
+    kMultiNodeNeedsImex,  // cross-node FABRIC handles unavailable
+};
+
+// Why NVLS is (not) usable in this session; see ipcNvlsUsable() in the header
+// for the full rationale. Static for the process, so compute once and cache.
+NvlsUsability nvlsUsability()
 {
 #if ENABLE_MULTI_DEVICE
-    // Extends ipcNvlsSupported() with a live fabric probe. The probe is
-    // relatively heavy (it allocates and exports fabric-handle memory), so
-    // compute it once and cache it.
-    static bool const usable = []() -> bool
+    static NvlsUsability const usability = []() -> NvlsUsability
     {
         if (!ipcNvlsSupported())
         {
-            return false;
+            return NvlsUsability::kNotSupported;
         }
 #if !ENABLE_NVSHMEM
-        // The multicast attribute is a false positive when the fabric/IMEX plane
-        // is not provisioned (e.g. nvidia-imex not running): NVLS multicast
-        // cannot actually be bound there. getMemHandleType() does the real test
-        // -- it resolves to FABRIC only if fabric-handle memory can be allocated
-        // and exported. On any probe error, assume usable so an unrelated
-        // failure never disables a healthy NVLS setup.
+        // On any probe error, assume usable so an unrelated failure never
+        // disables a healthy setup.
         try
         {
-            if (getMemHandleType() != CU_MEM_HANDLE_TYPE_FABRIC)
+            // An unconfigured switch fabric makes the multicast attribute a
+            // false positive: the bind then fails and poisons the CUDA context
+            // with a sticky error (the startup hang PR #15302 fixed).
+            if (!nvlinkFabricConfigured())
             {
-                TLLM_LOG_WARNING(
-                    "\n"
-                    "**************************************************************************\n"
-                    "* NVLS (NVLink SHARP) DISABLED for NCCL -- falling back to NVLink P2P     *\n"
-                    "**************************************************************************\n"
-                    "* The GPU advertises multicast support, but the NVLink fabric/IMEX plane *\n"
-                    "* is NOT provisioned on this node, so NVLS multicast memory cannot be    *\n"
-                    "* bound. Collectives will still work over NVLink P2P, but NVLS-           *\n"
-                    "* accelerated NCCL is off and performance may be reduced. (Single-node   *\n"
-                    "* NVLS over POSIX-FD, e.g. MNNVL allreduce, is unaffected.)              *\n"
-                    "*                                                                        *\n"
-                    "* To enable NVLS: start nvidia-imex and expose                           *\n"
-                    "* /dev/nvidia-caps-imex-channels to the container. Set                   *\n"
-                    "* NCCL_NVLS_ENABLE=1 explicitly to override this fallback.               *\n"
-                    "**************************************************************************");
-                return false;
+                return NvlsUsability::kFabricNotConfigured;
+            }
+            // Cross-node NVLS shares multicast memory via FABRIC handles (a
+            // POSIX FD cannot leave the machine), so a multi-node session
+            // additionally needs the IMEX plane. localSession() is materialized
+            // during MPI initialization, so these size reads are local and
+            // non-collective.
+            bool const multiNode = COMM_SESSION.getSize() != LOCAL_COMM_SESSION.getSize();
+            if (multiNode && getMemHandleType() != CU_MEM_HANDLE_TYPE_FABRIC)
+            {
+                return NvlsUsability::kMultiNodeNeedsImex;
             }
         }
         catch (std::exception const& e)
         {
-            TLLM_LOG_DEBUG("NVLS fabric probe could not run, assuming usable: %s", e.what());
+            TLLM_LOG_DEBUG("NVLink fabric state probe could not run, assuming usable: %s", e.what());
         }
 #endif // !ENABLE_NVSHMEM
-        return true;
+        return NvlsUsability::kUsable;
     }();
-    return usable;
+    return usability;
 #else
-    return false;
+    return NvlsUsability::kNotSupported;
 #endif
+}
+
+[[maybe_unused]] void warnNvlsDisabledForNccl(char const* reason, char const* remedy)
+{
+    TLLM_LOG_WARNING(
+        "\n"
+        "**************************************************************************\n"
+        "* NVLS (NVLink SHARP) DISABLED for NCCL -- falling back to NVLink P2P    *\n"
+        "**************************************************************************\n"
+        "%s"
+        "* Collectives will still work over NVLink P2P, but NVLS-accelerated      *\n"
+        "* NCCL is off and performance may be reduced. (TRT-LLM's own single-node *\n"
+        "* NVLS over POSIX-FD, e.g. MNNVL allreduce, is unaffected.)              *\n"
+        "*                                                                        *\n"
+        "%s"
+        "* Set NCCL_NVLS_ENABLE=1 explicitly to override this fallback.           *\n"
+        "**************************************************************************",
+        reason, remedy);
+}
+
+} // namespace
+
+bool ipcNvlsUsable()
+{
+    return nvlsUsability() == NvlsUsability::kUsable;
+}
+
+void maybeDisableNcclNvls()
+{
+#if ENABLE_MULTI_DEVICE && !defined(_WIN32)
+    // NCCL aborts during init if it tries NVLS multicast in a session that
+    // cannot bind it, so decide before the first ncclCommInitRank. The decision
+    // is process-wide by necessity: NCCL caches NCCL_NVLS_ENABLE on first read,
+    // so per-communicator toggling would not take effect anyway. An explicit
+    // user setting skips the probe and the warning entirely; setenv's
+    // no-overwrite flag would preserve it regardless.
+    if (getenv("NCCL_NVLS_ENABLE") != nullptr)
+    {
+        return;
+    }
+    switch (nvlsUsability())
+    {
+    case NvlsUsability::kUsable: return;
+    case NvlsUsability::kNotSupported: break;
+    case NvlsUsability::kFabricNotConfigured:
+        warnNvlsDisabledForNccl(
+            "* The GPU advertises multicast support, but the driver does not report   *\n"
+            "* a successfully configured NVLink fabric (NVML fabric state is not      *\n"
+            "* COMPLETED), so NVLS multicast binds cannot be trusted on this node.    *\n",
+            "* To enable NVLS: make sure nvidia-fabricmanager is running and healthy  *\n"
+            "* on the host.                                                            *\n");
+        break;
+    case NvlsUsability::kMultiNodeNeedsImex:
+        warnNvlsDisabledForNccl(
+            "* This is a multi-node session, and cross-node NVLS multicast memory     *\n"
+            "* requires fabric handles, but the fabric/IMEX plane is NOT provisioned  *\n"
+            "* on this node.                                                          *\n",
+            "* To enable NVLS: start nvidia-imex and expose                            *\n"
+            "* /dev/nvidia-caps-imex-channels to the container.                        *\n");
+        break;
+    }
+    setenv("NCCL_NVLS_ENABLE", "0", 0);
+#endif // ENABLE_MULTI_DEVICE && !defined(_WIN32)
 }
 
 IpcNvlsHandle* ipcNvlsAllocate(size_t size, std::set<int> group)

--- a/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
+++ b/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
@@ -153,10 +153,7 @@ ncclComm_t NcclCommunicator::createComm(int worldSize, int rank, mpi::MpiComm co
         _putenv_s("NCCL_RUNTIME_CONNECT", "0");
 #else
     setenv("NCCL_RUNTIME_CONNECT", "0", 0);
-    if (getenv("NCCL_NVLS_ENABLE") == nullptr && !ipcNvlsFabricUsable())
-    {
-        setenv("NCCL_NVLS_ENABLE", "0", 0);
-    }
+    maybeDisableNcclNvls();
 #endif // _WIN32
     ncclUniqueId id;
     if (rank == 0)

--- a/cpp/tests/unit_tests/runtime/ipcNvlsMemoryTest.cpp
+++ b/cpp/tests/unit_tests/runtime/ipcNvlsMemoryTest.cpp
@@ -28,8 +28,8 @@ namespace
 #if ENABLE_MULTI_DEVICE
 // Recompute the static NVLS multicast capability exactly as ipcNvlsSupported()
 // must: CUDA driver >= 12010 and CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED on the
-// device. Deliberately does NO fabric/IMEX probe -- that is what
-// ipcNvlsFabricUsable() adds on top.
+// device. Deliberately does NO fabric-state check -- that is what
+// ipcNvlsUsable() adds on top.
 bool computeStaticNvlsCapability()
 {
     int driverVersion = -1;
@@ -79,7 +79,7 @@ protected:
 // PR #15302 folded a fabric probe into ipcNvlsSupported(), which on a
 // multicast-capable but fabric-unprovisioned node made it return false. That
 // wrongly disabled the single-node NVLS allocator (ipcNvlsAllocate) and fused
-// GEMM-allreduce. The fabric probe now lives in ipcNvlsFabricUsable(); if it
+// GEMM-allreduce. The fabric-state check now lives in ipcNvlsUsable(); if it
 // leaks back into ipcNvlsSupported() this assertion fails on such nodes.
 TEST_F(IpcNvlsMemoryTest, SupportedReflectsStaticCapabilityOnly)
 {
@@ -88,12 +88,13 @@ TEST_F(IpcNvlsMemoryTest, SupportedReflectsStaticCapabilityOnly)
 #endif // ENABLE_MULTI_DEVICE
 }
 
-// Fabric usability is a strict refinement of static capability, so it must
-// never be reported as usable when NVLS is not even statically supported.
-TEST_F(IpcNvlsMemoryTest, FabricUsableImpliesSupported)
+// Usability (static capability + configured NVLink fabric) is a strict
+// refinement of static capability, so it must never be reported as usable
+// when NVLS is not even statically supported.
+TEST_F(IpcNvlsMemoryTest, UsableImpliesSupported)
 {
 #if ENABLE_MULTI_DEVICE
-    if (tr::ipcNvlsFabricUsable())
+    if (tr::ipcNvlsUsable())
     {
         EXPECT_TRUE(tr::ipcNvlsSupported());
     }


### PR DESCRIPTION
The NCCL NVLS gate required getMemHandleType() to resolve to FABRIC, i.e. a fully provisioned IMEX plane. That is stricter than what an NVLS multicast bind actually needs: on single-node systems the bind works over POSIX-FD handles without IMEX, so nodes with a healthy switch fabric but no IMEX (e.g. HGX B200 containers without nvidia-imex) lost NVLS- accelerated NCCL for no reason.

Split the NVML fabric-state check out of getMemHandleType() and gate NCCL NVLS on it directly (ipcNvlsUsable, formerly ipcNvlsFabricUsable): the static multicast capability plus a COMPLETED NVLink fabric registration -- Fabric Manager has configured the switch -- is the actual precondition for a successful single-node bind. Multi-node sessions (detected by comparing the session size with the per-host local session size, both materialized at MPI init) keep the full IMEX requirement, because cross-node multicast memory can only be shared via FABRIC handles. The unprovisioned-fabric nodes that PR #15302 protects against (bind failure poisons the CUDA context and hangs startup) do not reach the COMPLETED state and stay disabled, with the warning split into a fabric-state variant and a multi-node IMEX variant. An explicit NCCL_NVLS_ENABLE setting now skips the check and the warning in getComm() as well, matching NcclCommunicator::createComm.

ipcNvlsSupported() and the ipcNvlsAllocate() path are untouched, so the single-node POSIX-FD allocator restored by PR #15882 is unaffected, and the ipcNvlsMemoryTest regression guards it added still pass.

Verified on 4xB200 (fabric state COMPLETED, no IMEX): a direct cuMulticastCreate/AddDevice/BindMem probe over POSIX-FD succeeds, and with NVLS enabled NCCL reports "NVLS multicast support is available" with 24 NVLS channels while the BART tp2 end-to-end test passes. On 4xH200 NVL (no NVSwitch, MULTICAST_SUPPORTED=0): NVLS stays disabled with no warning, BART tp2 passes, and ipcNvlsMemoryTest passes 2/2. Explicitly setting NCCL_NVLS_ENABLE=0 or =1 skips the probe and warning entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Behavior Change**
  * Updated NCCL NVLS eligibility gating to use NVML-reported NVLink fabric registration state (`COMPLETED`) via a new `ipcNvlsUsable()` path, replacing the previous IMEX/fabric-handle probe (`ipcNvlsFabricUsable()`).
  * **Single-node:** NVLS can be enabled when multicast support is available and the NVLink fabric state is `COMPLETED`, **even without IMEX** (POSIX-FD handle path).
  * **Multi-node:** kept conservative—multi-node sessions still require provisioned fabric/IMEX so FABRIC handles can support cross-node sharing.
  * **Unprovisioned fabrics:** NVLS remains disabled; warnings are differentiated between fabric-state not ready vs. multi-node IMEX/provisioning requirements.
  * Added `maybeDisableNcclNvls()` to set `NCCL_NVLS_ENABLE=0` (**no-overwrite**) and emit a targeted warning when NVLS can’t be safely bound for NCCL.
    * Ensures disablement is applied **before the first** `ncclCommInitRank` due to NCCL’s process-wide env caching.
    * Windows behavior is a documented no-op.
    * If `NCCL_NVLS_ENABLE` is explicitly set, the probe/warning is bypassed.

* **Implementation Notes**
  * Refactored NVLink fabric usability probing into a cached NVML-based check (`nvlinkFabricConfigured()`), and tightened handle-type gating so `CU_MEM_HANDLE_TYPE_FABRIC` is rejected unless NVLink fabric state is `COMPLETED`.
  * Communicator initialization paths now consistently call `maybeDisableNcclNvls()` (e.g., `opUtils.cpp` and `ncclCommunicator.cpp`) rather than duplicating the old `ipcNvlsFabricUsable()`-based logic.

* **Tests**
  * Updated unit tests and assertions to align with the clarified contract:
    * `ipcNvlsSupported()` reflects only static multicast capability (no fabric-state check).
    * `ipcNvlsUsable()` implies `ipcNvlsSupported()`.

## Dev Engineer Review

* **Correctness / API consistency**
  * Removed removed API `ipcNvlsFabricUsable()` and introduced `ipcNvlsUsable()` to separate **static capability** (`ipcNvlsSupported()`) from **session bind eligibility** (requires `COMPLETED` fabric state and, for multi-node, appropriate fabric/IMEX provisioning).
  * Centralized NCCL env disablement in `maybeDisableNcclNvls()` and ensured it is invoked early enough (before `ncclCommInitRank`) to account for NCCL env caching behavior.
  * Call-site coverage: NVLS disablement logic is invoked from both `opUtils.cpp` and `NcclCommunicator::createComm` (non-Windows), replacing prior scattered logic.

* **Robustness / performance**
  * NVML fabric-state probing is cached to avoid repeated live checks and to keep decisions consistent within a process.
  * Handle-type gating tightened: `CU_MEM_HANDLE_TYPE_FABRIC` is only considered when NVLink fabric registration is `COMPLETED`, preventing accidental FABRIC eligibility when fabric is unready.

* **Configurability / platform behavior**
  * Respects explicit `NCCL_NVLS_ENABLE` settings (probe/warning bypass via “no-overwrite” behavior).
  * `maybeDisableNcclNvls()` is a documented no-op on Windows.

## QA Engineer Review

* **Test changes**
  * Modified: `cpp/tests/unit_tests/runtime/ipcNvlsMemoryTest.cpp`
    * Updated regression documentation/comments to clarify that fabric-state checks occur in `ipcNvlsUsable()` (not `ipcNvlsSupported()`).
    * Replaced the previous fabric-specific implication assertion (`ipcNvlsFabricUsable()` ⇒ supported) with a general contract assertion:
      * `ipcNvlsUsable()` ⇒ `ipcNvlsSupported()` (ensuring usability is never reported when static multicast capability is absent).

* **Coverage mapping**
  * No changes were indicated to `tests/integration/test_lists/`, `test-db/`, or `qa/`.
  * Verdict: needs follow-up (CBTS/CI coverage mapping for this unit-test change not provided).

* **CI signals**
  * Multiple CI reruns failed; investigation/fixes were requested before rerunning CI again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
