### PR TITLE
[https://nvbugs/6463987][perf] Revert NGC PyTorch 26.05 stack upgrade for GB300 GLM-5-fp4 ctx_only NVFP4 regression

### DIFF
--- a/docker/common/install_tensorrt.sh
+++ b/docker/common/install_tensorrt.sh
@@ -4,13 +4,13 @@ set -ex
 
 TRT_VER="10.16.1.11"
 # Align with the pre-installed cuDNN / cuBLAS / NCCL versions from
-# https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-26-05.html#rel-26-05
+# https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-26-04.html#rel-26-04
 CUDA_VER="13.2" # 13.2.1
 # Keep the installation for cuDNN if users want to install PyTorch with source codes.
 # PyTorch 2.x can compile with cuDNN v9.
-CUDNN_VER="9.22.0.52-1"
-NCCL_VER="2.30.4-1+cuda13.2"
-CUBLAS_VER="13.4.1.2-1"
+CUDNN_VER="9.21.0.82-1"
+NCCL_VER="2.29.7-1+cuda13.2"
+CUBLAS_VER="13.4.0.1-1"
 # Align with the pre-installed CUDA / NVCC / NVRTC versions from
 # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 NVRTC_VER="13.2.78-1"

--- a/jenkins/current_image_tags.properties
+++ b/jenkins/current_image_tags.properties
@@ -13,8 +13,8 @@
 #     images are adopted from PostMerge pipelines, the abbreviated commit hash is used instead.
 IMAGE_NAME=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm
 
-LLM_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-26.05-py3-x86_64-ubuntu24.04-trt10.16.1.11-skip-tritondevel-202607151440-16194
-LLM_SBSA_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-26.05-py3-sbsa-ubuntu24.04-trt10.16.1.11-skip-tritondevel-202607151440-16194
-LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-13.2.1-devel-rocky8-x86_64-rocky8-py310-trt10.16.1.11-skip-tritondevel-202607151440-16194
-LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-13.2.1-devel-rocky8-x86_64-rocky8-py312-trt10.16.1.11-skip-tritondevel-202607151440-16194
-LLM_SBSA_WHEEL_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-13.2.1-devel-ubuntu24.04-sbsa-ubuntu24.04-py312-trt10.16.1.11-skip-tritondevel-202607151440-16194
+LLM_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-26.04-py3-x86_64-ubuntu24.04-trt10.16.1.11-skip-tritondevel-202607100544-16206
+LLM_SBSA_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-26.04-py3-aarch64-ubuntu24.04-trt10.16.1.11-skip-tritondevel-202607100544-16206
+LLM_ROCKYLINUX8_PY310_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-13.2.1-devel-rocky8-x86_64-rocky8-py310-trt10.16.1.11-skip-tritondevel-202607100544-16206
+LLM_ROCKYLINUX8_PY312_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-13.2.1-devel-rocky8-x86_64-rocky8-py312-trt10.16.1.11-skip-tritondevel-202607100544-16206
+LLM_SBSA_WHEEL_DOCKER_IMAGE=urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:cuda-13.2.1-devel-ubuntu24.04-sbsa-ubuntu24.04-py312-trt10.16.1.11-skip-tritondevel-202607100544-16206

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,13 +22,13 @@ pandas
 h5py==3.12.1
 StrEnum
 sentencepiece>=0.1.99
-# https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-26-05.html#rel-26-05 uses 2.12.0a0.
-torch>=2.11.0,<=2.13.0a0
+# https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-26-04.html#rel-26-04 uses 2.12.0a0.
+torch>=2.11.0,<=2.12.0a0
 torchvision
 nvidia-modelopt[torch]~=0.37.0
-# https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-26-05.html#rel-26-05 uses 2.30.4
+# https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/rel-26-04.html#rel-26-04 uses 2.29.7
 # torch 2.11.0+cu130 depends on nvidia-nccl-cu13==2.28.9
-nvidia-nccl-cu13>=2.28.9,<=2.30.4
+nvidia-nccl-cu13>=2.28.9,<=2.29.7
 nvidia-cuda-nvrtc
 transformers==5.5.4
 prometheus_client


### PR DESCRIPTION
## Description

Fixes a ~32% output-token-throughput regression on GB300 for
`ctx_only-gb300_glm-5-fp4_1k1k_con1_ctx1_dep2_gen1_tep4_eplb0_mtp3_ccb-NIXL`
by reverting the version pins from PR #15087 (NGC PyTorch 26.04 → 26.05
container upgrade).

- **Bug**: https://nvbugs/6463987
- **Culprit**: #15087 (commit `02cedf6e4e`, [TRTLLMINF-127][infra] Upgrade dependencies for NGC PyTorch 26.05 stack)
- **Test case**: `ctx_only-gb300_glm-5-fp4_1k1k_con1_ctx1_dep2_gen1_tep4_eplb0_mtp3_ccb-NIXL`

## Measured perf (3-rep same-node medians, oci-aga GB300)

| Wheel | median (tok/s) | reps | CV |
|---|---|---|---|
| good `1662a877` | 4.07 | [4.04, 4.23, 4.07] | 1.8% |
| bad  `46bf21b1` | 2.75 | [2.84, 2.72, 2.75] | 1.8% |
| ToT  `3fe4ceb9` (post-merge 2844) | 2.58 | [2.58, 2.56, 2.63] | 1.3% |
| **fix (this PR)** | **4.16** | [4.15, 4.23, 4.16] | 1.0% |

Fix clears the (good+bad)/2 = 3.41 threshold by **+22%** and recovers
**+61%** over current ToT.

## Root cause

PR #15087 bumped cuBLAS 13.4.0.1 → 13.4.1.2, cuDNN 9.21 → 9.22, and
NCCL 2.29.7 → 2.30.4 in a single container-image swap. The
`bug_profile` module ranking (from the automated triage) points at
cuBLAS 13.4.1.2's NVFP4 heuristic selecting a slower kernel path on
GB300 for this shape (primary); NCCL 2.30's attention-DP allgather
changes contribute a tertiary effect. Startup time actually got FASTER
between good and bad (7m10s → 5m50s), which rules out JIT/warmup and
pins the loss to steady-state prefill GEMMs.

## Changes (infra only, three files, no source touched)

- `docker/common/install_tensorrt.sh`: cuBLAS 13.4.1.2 → 13.4.0.1,
  cuDNN 9.22.0.52 → 9.21.0.82, NCCL 2.30.4 → 2.29.7. Comment URLs back
  to the 26.04 release notes.
- `jenkins/current_image_tags.properties`: container image tags back
  to the 26.04 base (`202607100544-16206`) for x86, sbsa, and both
  rockylinux variants.
- `requirements.txt`: torch upper bound 2.13.0a0 → 2.12.0a0,
  `nvidia-nccl-cu13` upper bound 2.30.4 → 2.29.7.

## Test plan

- [ ] CI: `L0_PostMerge` GB300 GLM-5-fp4 perf-sanity should recover
      to good-commit levels.
- [ ] Adjacent perf-sanity cases on the same container should be
      unaffected or improved (the container revert is symmetric).
- [ ] Functional CI on x86 + sbsa; verify wheel builds against the
      26.04 base image tags.

🤖 Generated with [Repair Bot](https://tensorrt-llm-repair-bot.sc2-paas.nvidia.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated NVIDIA CUDA, cuDNN, NCCL, and cuBLAS component versions for improved alignment with the supported PyTorch release.
  * Refined PyTorch and NCCL version constraints to ensure compatible installations.

* **Build and Deployment**
  * Updated container and wheel image references to the latest validated build set across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->