### PR TITLE
[https://nvbugs/6480574][fix] mpi_session: guard MpiPoolSession.shutdown against partial init

### DIFF
--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -61,6 +61,7 @@ class MPINodeState:
 
 def external_mpi_comm_available(model_world_size: int) -> bool:
     """Check if the current process is launched by mpirun and does not use MPIPoolExecutor to spawn processes.
+
     e.g. mpirun -np 4 python script.py
     """
     if ENABLE_MULTI_DEVICE:
@@ -241,7 +242,9 @@ class MpiPoolSession(MpiSession):
                  n_workers: int,
                  wait_shutdown: bool = False,
                  env_overrides: Optional[Dict[str, str]] = None):
-        """Args:
+        """Create a pool session that spawns and manages MPI worker processes.
+
+        Args:
         n_workers: number of MPI workers to spawn.
         wait_shutdown: when True, ``shutdown()`` blocks until the spawned
             worker processes have actually exited. ``MPIPoolExecutor.shutdown``
@@ -292,12 +295,12 @@ class MpiPoolSession(MpiSession):
             wait = False
         if self.mpi_pool is not None:
             logger.info(
-                f"MpiPoolSession.shutdown: joining {self.n_workers} worker(s) "
-                f"(wait={wait})")
+                "MpiPoolSession.shutdown: joining "
+                f"{getattr(self, 'n_workers', '?')} worker(s) (wait={wait})")
             self.mpi_pool.shutdown(wait=wait)
             logger.info("MpiPoolSession.shutdown: done")
             self.mpi_pool = None
-            if self._wait_shutdown:
+            if getattr(self, '_wait_shutdown', False):
                 self._wait_workers_exit()
 
     def _collect_worker_identities(self) -> Tuple:

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -414,7 +414,6 @@ unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_se
 unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_self_attention[int8-2-1560] SKIP (https://nvbugs/6198760)
 unittest/auto_deploy/multigpu/custom_ops SKIP (https://nvbugs/6403920)
 unittest/disaggregated/test_kv_transfer.py::test_transfer_worker_v2[tp4_pp1_to_tp2_pp2] SKIP (https://nvbugs/6426834)
-unittest/executor/test_proxy_fast_death.py::test_pool_session_shutdown_never_blocks_after_release SKIP (https://nvbugs/6480574)
 unittest/executor/test_rpc.py::TestRpcCorrectness::test_incremental_task_async SKIP (https://nvbugs/5741476)
 unittest/executor/test_rpc_proxy.py SKIP (https://nvbugs/5605741)
 unittest/executor/test_rpc_worker.py SKIP (https://nvbugs/5605741)


### PR DESCRIPTION
## Summary

`MpiPoolSession.shutdown()` reads `self.n_workers` (in a log line) and `self._wait_shutdown` **unguarded**, but it is reachable on a session that never completed `__init__`:

- from `__del__` → `shutdown_abort()` → `shutdown()` on a partially-constructed object, and
- from the released-session path, e.g. `tests/unittest/executor/test_proxy_fast_death.py::test_pool_session_shutdown_never_blocks_after_release`, which builds the object with `MpiPoolSession.__new__(MpiPoolSession)`.

In those states the attributes are absent and `shutdown()` raises `AttributeError: 'MpiPoolSession' object has no attribute 'n_workers'` (then `... '_wait_shutdown'`). The `_pool_dead` check immediately above already uses `getattr(self, '_pool_dead', False)` defensively for exactly this reason.

## Fix

Guard both accesses with `getattr(...)`, matching the existing `_pool_dead` style, so a released or partially-constructed session shuts down cleanly instead of raising.

## Why main is currently red

This is a **cross-PR merge skew**, each half green on its own:

- the unguarded `self.n_workers` log line was added by #16456 (2026-07-16), and
- the `__new__`-based test that trips it was added by #16312 (2026-07-20).

Neither failed in isolation; the combination on `main` fails **deterministically**. `main` has been red on `test_pool_session_shutdown_never_blocks_after_release` since #16312 landed, and the fix is a small robustness guard.

## Test

`test_proxy_fast_death.py` now passes in full (**23 passed**, was 1 failed):

```
python -m pytest tests/unittest/executor/test_proxy_fast_death.py -q
# 23 passed
```

(No behavior change for fully-initialized sessions: `n_workers` / `_wait_shutdown` are always set by `__init__`; the guards only affect objects that bypass it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and organization of API documentation.
  * Clarified session initialization and external communication examples.

* **Bug Fixes**
  * Improved shutdown logging when the worker count is unavailable.
  * Preserved existing worker cleanup and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->