### PR TITLE
[None][fix] DSpark: all-reduce draft MoE output under non-attention-DP TP

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_dspark.py
+++ b/tensorrt_llm/_torch/models/modeling_dspark.py
@@ -793,11 +793,24 @@ class DSparkDraftModel(nn.Module):
         moe_all_rank_num_tokens = (
             all_rank_num_tokens if all_rank_num_tokens is not None else [num_tokens]
         )
+        # The draft captured-context MoE must mirror the target DeepseekV4MoE's TP
+        # reduction policy. Under attention DP each rank is data-parallel (owns a
+        # distinct set of requests) and needs no cross-rank reduction; but under
+        # plain tensor parallelism (attention_dp off, tp_size > 1) the expert-sharded
+        # MoE output must be all-reduced across ranks -- exactly what the target MoE
+        # does (enable_allreduce = not (POST_MOE_FUSION or tp_size == 1)). Previously
+        # this was hard-coded to False, which dropped the reduction on the non-ADP
+        # path, corrupting the draft block proposals and roughly halving DSpark
+        # acceptance length whenever attention_dp was disabled.
+        moe_enable_allreduce = (
+            not self.model_config.mapping.enable_attention_dp
+            and self.model_config.mapping.tp_size > 1
+        )
         moe_out = stage.mlp(
             layer_input.reshape(num_tokens, hidden),
             input_ids=moe_input_ids,
             all_rank_num_tokens=moe_all_rank_num_tokens,
-            final_all_reduce_params=AllReduceParams(enable_allreduce=False),
+            final_all_reduce_params=AllReduceParams(enable_allreduce=moe_enable_allreduce),
             do_finalize=True,
         ).reshape(T, block, hidden)
         h = stage.hc_ffn.post_mapping(

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_attention.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_attention.py
@@ -167,6 +167,9 @@ def test_forward_stage_honors_enable_fused_hc(monkeypatch, enable_fused_hc):
     model = types.SimpleNamespace(
         use_real_mla=False,
         _attn_params={"window_size": 2, "head_dim": 1},
+        model_config=types.SimpleNamespace(
+            mapping=types.SimpleNamespace(enable_attention_dp=False, tp_size=8)
+        ),
     )
 
     actual = DSparkDraftModel._forward_stage(
@@ -184,6 +187,10 @@ def test_forward_stage_honors_enable_fused_hc(monkeypatch, enable_fused_hc):
         stage.mlp.call_args.args[0],
         normed_ffn_input.reshape(num_requests * block_size, hidden_size),
     )
+    # Non-attention-DP multi-GPU (enable_attention_dp=False, tp_size>1): the draft
+    # MoE must all-reduce its TP-sharded output, mirroring the target MoE. The
+    # attention-DP and single-GPU paths keep it disabled.
+    assert stage.mlp.call_args.kwargs["final_all_reduce_params"].enable_allreduce is True
     if enable_fused_hc:
         assert events == ["fused", "ffn_post"]
         hc_ffn.fused_hc.assert_called_once()


### PR DESCRIPTION
## Description

`DSparkDraftModel._forward_stage` hard-coded the captured-context MoE's `final_all_reduce_params` to `enable_allreduce=False`. That is correct under attention DP (each rank is data-parallel and needs no cross-rank reduction), but under plain tensor parallelism (`enable_attention_dp=False`, `tp_size > 1`) the expert-sharded MoE output must be all-reduced across ranks — exactly what the target `DeepseekV4MoE` does (`enable_allreduce = not (POST_MOE_FUSION or tp_size == 1)`).

Dropping the reduction on the non-attention-DP path corrupted the DSpark draft block proposals and roughly **halved DSpark acceptance length (AL)** whenever `attention_dp` was disabled. Strict target-verify keeps the generated output correct, so the only visible symptom was degraded speculative-decoding acceptance / throughput (and it was easy to misattribute to the MoE backend).

**Fix:** gate the draft MoE all-reduce on `(not enable_attention_dp and tp_size > 1)`, mirroring the target MoE. The attention_dp and single-GPU paths keep `enable_allreduce=False` and are byte-for-byte unchanged.

### Root-cause isolation (how we know it's this and not the MoE backend)
- MoE backend is **not** the cause: CUTLASS+ADP ≈ MegaMoE-DeepGEMM+ADP; TRTLLM / MegaMoE MoE also show the same low AL when attention_dp is off.
- Sampler type, DSpark confidence truncation, draft-token argmax reduction (draft head is full-vocab, per-rank argmax on both paths), and target-verify were all ruled out.
- Per-layer residual dumps show the **target** forward is numerically ~equivalent under attention_dp on/off (`Δnorm < 0.65%`, layer 0 identical); only the **draft** block proposals diverge, and only *after* the first (non-draft-MoE) block position — pointing squarely at the draft captured-context MoE.

## Test Coverage

Measured on DeepSeek-V4-Pro-DSpark, 8×B300 (TP=EP=8), CUTLASS MoE, DL7, GSM8K, greedy, N=4:

| attention_dp | AL chat | AL thinking |
|---|---|---|
| off, **before** fix | 2.05 | 2.55 |
| off, **after** fix  | **4.00** | **4.98** |
| on (unchanged by fix) | ~3.4 | ~5.1 |

The change is a distributed-only numerical-correctness fix that requires an 8-GPU DeepSeek-V4 run to observe, so no standalone unit test is added; existing DSpark tests continue to pass. Recommend safeguarding via the DSpark AL / accuracy sweep with `enable_attention_dp=False` in CI.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mixture-of-experts processing for tensor-parallel configurations.
  * Enabled the expected cross-rank reduction behavior when attention data parallelism is disabled, improving consistency across parallel execution setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->