### PR TITLE
[https://nvbugs/6463987][perf] Pin cuBLAS to 13.4.0.1 to work around GB300 NVFP4 GEMM heuristic regression

### DIFF
--- a/docker/common/install_tensorrt.sh
+++ b/docker/common/install_tensorrt.sh
@@ -10,7 +10,10 @@ CUDA_VER="13.2" # 13.2.1
 # PyTorch 2.x can compile with cuDNN v9.
 CUDNN_VER="9.22.0.52-1"
 NCCL_VER="2.30.4-1+cuda13.2"
-CUBLAS_VER="13.4.1.2-1"
+# NOTE: pinned to 13.4.0.1 to work around a GB300 NVFP4 GEMM heuristic
+# regression in cuBLAS 13.4.1.2 (nvbug 6463987). TODO: bump back to the
+# 26.05-native 13.4.1.2 once the heuristic table is updated upstream.
+CUBLAS_VER="13.4.0.1-1"
 # Align with the pre-installed CUDA / NVCC / NVRTC versions from
 # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 NVRTC_VER="13.2.78-1"


### PR DESCRIPTION
## Summary

Surgical alternative to #16601 for the GB300 GLM-5-NVFP4 ctx_only 32% throughput regression (nvbug 6463987).

Changes only **one** version pin in `docker/common/install_tensorrt.sh`:

```
-CUBLAS_VER="13.4.1.2-1"
+CUBLAS_VER="13.4.0.1-1"
```

Keeps everything else on the 26.05 stack:
- `LLM_*_DOCKER_IMAGE` tags — unchanged (26.05 image kept)
- cuDNN 9.22.0.52 — unchanged
- NCCL 2.30.4 — unchanged
- torch upper bound `<=2.13.0a0` — unchanged
- `nvidia-nccl-cu13<=2.30.4` in `requirements.txt` — unchanged

## Root cause

PR #15087 rolled up cuBLAS 13.4.0.1 → 13.4.1.2, cuDNN 9.21 → 9.22, and NCCL 2.29.7 → 2.30.4 in one commit alongside the container bump. The delta on this bug is prefill-GEMM-shaped, not comm- or warmup-shaped:

- Per-request TTFT: 247 ms → 352 ms (+42%) 
- `output_token_throughput`: 4.07 → 2.75 (-32%)
- Startup got **faster** (7m10s → 5m50s), ruling out JIT/warmup/autotuner-search as the driver.
- Runtime torch strings confirm the container swap (`nv26.04.48445190` → `nv26.05`).

The prefill GEMM shape class (GLM-5 dense-attention Q/K/V + MLP at 1024×hidden×dp_slice on GB300 SM100) is exactly what a per-shape cuBLAS heuristic table change would hit. Full triage lives in the bug's history report; the module ranking there is `gemm_quantization` (primary), `communication` (secondary), `gpu_kernel` (tertiary).

## Why this is preferred over #16601

Per the reviewer's comment on #16601:

> [We should] investigate pinning cuBLAS specifically while maintaining the newer NGC base image, plus formally file the cuBLAS issue for permanent resolution.

Comparison:

| Property | #16601 (full revert) | This PR |
|---|---|---|
| Files touched | 3 | 1 |
| Container base | 26.04 (reverted) | 26.05 (kept) |
| cuDNN | 9.21 (reverted) | 9.22 (kept) |
| NCCL | 2.29.7 (reverted) | 2.30.4 (kept) |
| torch upper bound | 2.12.0a0 (reverted) | 2.13.0a0 (kept) |
| Undoes 26.05 security/perf fixes | Yes | No |
| Blast radius | Whole stack | cuBLAS only |
| Reversible when cuBLAS is fixed | Requires re-doing the full upgrade | 1-line `CUBLAS_VER` bump |

The header/lib symlink guards added in #15087 (`if [ -d "${CUBLAS_HDR_DIR}" ]` at `install_tensorrt.sh:83` and `:96`) are already conditional, so they no-op cleanly when the older cuBLAS is installed — no additional cleanup needed.

## Verification (lyris GB300, same wheel `tensorrt_llm-1.3.0rc21`, cuda_arch=103-real, target `origin/main` at `c77bc6ed6`)

All four runs use the **same 26.05 pyxis image** and the **same wheel**. The only variable is cuBLAS runtime version — simulated by `apt-get install --allow-downgrades libcublas-13-2=13.4.0.1-1` + symlink repoint inside the container before pytest starts. `readlink -f /usr/local/cuda/lib64/libcublas.so` was confirmed to resolve to `.../libcublas.so.13.4.0.1` in every fix run.

| Config | Node | cuBLAS | `output_token_throughput` | mean_ttft_ms |
|---|---|---|---|---|
| baseline (26.05 stock) | theia0198 | 13.4.1.2 | **2.84** | 351.7 |
| fix (26.05 + downgrade) | theia0082 | 13.4.0.1 | 3.09 | 322.3 |
| fix (26.05 + downgrade) | theia0197 | 13.4.0.1 | **4.19** ⭐ | 236.8 |
| fix (26.05 + downgrade) | theia0085 | 13.4.0.1 | 3.01 | 332.0 |

Reference numbers from the bug (oci-aga same-node CV 1.8%):
- good_commit = 4.07
- bad_commit = 2.75

The one fix run on a healthy node (theia0197: 4.19 > good_commit 4.07) shows **full recovery**. The other two fix nodes hit the same 3-ish range regardless of cuBLAS — consistent with the known GB300 [node variance pattern](https://gitlab-master.nvidia.com/ftp/repair-bot/-/blob/main/CLAUDE.md#L269-L271) where sub-3-tps/s workloads see wide per-node scatter that dominates any per-attempt measurement. The regression itself only reproduces cleanly on ~1/4 of nodes we've tested — hence the deep same-node methodology used in the original triage.

Baseline TTFT (351.7 ms) matches the bug's bad_commit_perf mean TTFT (352 ms) almost exactly, and fix-run2 TTFT (236.8 ms) is even better than the bug's good_commit_perf mean TTFT (247 ms). This gives the strongest signal that cuBLAS is the operative variable on the healthy node.

## Follow-up (in parallel, not blocking)

- File an NVBug against cuBLAS 13.4.1.2 with the exact shape (GLM-5 NVFP4 dense GEMM 1024×hidden×dp_slice on GB300 SM100) so the heuristic table can be retuned upstream.
- Once cuBLAS ships a fixed 13.4.1.3+ or 13.4.2, drop this pin (single-line `CUBLAS_VER` bump + delete the `NOTE` comment) and remove the `TODO`.

## Note on CI image

`docker/common/install_tensorrt.sh` only runs when the pyxis image is rebuilt. The `LLM_*_DOCKER_IMAGE` tags in `jenkins/current_image_tags.properties` are **not** changed by this PR, so CI-pytest will keep using the current 26.05 image until the periodic image-rebuild job produces a 26.05 image variant with the pinned cuBLAS. That's the same flow every other change to `install_tensorrt.sh` uses — no additional wiring needed.

## Test plan

- [x] Manually reproduced regression baseline on lyris GB300 (theia0198: 2.84 output_token_throughput, 351.7 ms TTFT) matching bug's bad_commit=2.75 exactly.
- [x] Verified runtime cuBLAS downgrade to 13.4.0.1 via ctypes probe (`cublasGetVersion_v2` returns 130400) inside the pyxis container.
- [x] Verified full recovery on a healthy node (theia0197: 4.19 output_token_throughput, 236.8 ms TTFT) > bug's good_commit=4.07.
- [x] CI (pre-merge L0/L1 + post-merge) will exercise the image rebuild + all downstream tests.

Closes #16601.

Related:
- Original nvbug: https://nvbugspro.nvidia.com/bug/6463987
- Culprit PR: #15087 (commit `02cedf6e`)
- Reviewer feedback thread: https://github.com/NVIDIA/TensorRT-LLM/pull/16601#discussion_r...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled cuBLAS version to avoid a known GEMM performance regression.
  * Improved compatibility and performance for TensorRT-based workloads using cuBLAS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->