### PR TITLE
[https://nvbugs/6479863][fix] Split the DeepSeek V4 branch on SM 100–119 by `quant_config.quant_algo`…

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -347,10 +347,14 @@ class ModelConfig(Generic[TConfig]):
         if moe_backend.upper() != "AUTO":
             return moe_backend
 
+        quant_algo = quant_config.quant_algo if quant_config is not None else None
+        is_fp8_block_scales = quant_algo in (QuantAlgo.FP8_BLOCK_SCALES,
+                                             "FP8_BLOCK_SCALES")
+
         if architecture in _DEEPSEEK_V4_ARCHITECTURES:
             sm_version = get_sm_version()
             if 100 <= sm_version < 120:
-                return "TRTLLM"
+                return "WIDEEP" if is_fp8_block_scales else "TRTLLM"
 
         if architecture == "GptOssForCausalLM":
             sm_version = get_sm_version()
@@ -362,9 +366,6 @@ class ModelConfig(Generic[TConfig]):
             else:
                 return "CUTLASS"  # Fallback to CUTLASS for other SM versions (e.g., SM120)
 
-        quant_algo = quant_config.quant_algo if quant_config is not None else None
-        is_fp8_block_scales = quant_algo in (QuantAlgo.FP8_BLOCK_SCALES,
-                                             "FP8_BLOCK_SCALES")
         if is_fp8_block_scales and is_sm_100f():
             return "TRTLLM"
 


### PR DESCRIPTION
## Summary
- **Root cause**: DeepSeek V4 branch of `resolve_moe_backend` dispatched purely by SM range and ignored `quant_config.quant_algo`, so Flash-Base FP8_BLOCK_SCALES was mis-routed to TRTLLM.
- **Fix**: Split the DeepSeek V4 branch on SM 100–119 by `quant_config.quant_algo`: return "WIDEEP" for FP8_BLOCK_SCALES, "TRTLLM" otherwise (NVFP4/MXFP4/W4A8_* unchanged). First call site passes `quant_config=None`, which naturally falls through to today's "TRTLLM" hint used only for ModelOpt quant-config parsing.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6479863


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DeepSeek-V4 mixture-of-experts backend selection for FP8 block-scaled quantization.
  * Ensured compatible hardware configurations use the appropriate optimized backend while preserving existing fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->