### PR TITLE
[https://nvbugs/6478707][fix] detect v2 inside remove_functionalize_inner, resolve each mutates_args via…

### DIFF
--- a/tensorrt_llm/_torch/compilation/utils.py
+++ b/tensorrt_llm/_torch/compilation/utils.py
@@ -183,7 +183,9 @@ def inplace_info():
             2: "output_sf"
         },
         "mla_custom_op_inplace": {
-            1: "output"
+            1: "output",
+            2: "dsv4_output",
+            3: "dsv4_output_sf",
         },
         "mla_dsa_attn_inplace": {
             1: "output"


### PR DESCRIPTION
## Summary
- **Root cause**: remove_copy_pass never treated auto_functionalized_v2 HOP nodes as v2, so kwargs["output"] raised KeyError since v2 stores mutable args in `_all_bases`
- **Fix**: detect v2 inside remove_functionalize_inner, resolve each mutates_args via `_<arg>_base_index` into `_all_bases` (None-safe), and register the two additional mla_custom_op_inplace mutable args (dsv4_output, dsv4_output_sf) in inplace_info
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6478707


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `remove_copy_pass` handling for `auto_functionalized_v2` nodes to resolve mutable arguments through `_all_bases` using `_<arg>_base_index`, including `None` handling.
- Registered `dsv4_output` and `dsv4_output_sf` as mutable outputs for `mla_custom_op_inplace`.
- Addresses `KeyError` failures caused by v2 nodes storing mutable arguments indirectly.
- No configuration, public API, or test-list changes identified.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->