### PR TITLE
[https://nvbugs/6480574][fix] seed attrs bypassed by __new__ in pool session shutdown test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -414,7 +414,6 @@ unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_se
 unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_self_attention[int8-2-1560] SKIP (https://nvbugs/6198760)
 unittest/auto_deploy/multigpu/custom_ops SKIP (https://nvbugs/6403920)
 unittest/disaggregated/test_kv_transfer.py::test_transfer_worker_v2[tp4_pp1_to_tp2_pp2] SKIP (https://nvbugs/6426834)
-unittest/executor/test_proxy_fast_death.py::test_pool_session_shutdown_never_blocks_after_release SKIP (https://nvbugs/6480574)
 unittest/executor/test_rpc.py::TestRpcCorrectness::test_incremental_task_async SKIP (https://nvbugs/5741476)
 unittest/executor/test_rpc_proxy.py SKIP (https://nvbugs/5605741)
 unittest/executor/test_rpc_worker.py SKIP (https://nvbugs/5605741)

--- a/tests/unittest/executor/test_proxy_fast_death.py
+++ b/tests/unittest/executor/test_proxy_fast_death.py
@@ -524,6 +524,14 @@ def test_pool_session_shutdown_never_blocks_after_release():
     pool = _Mock()
     pool._pool.thread = None  # no real manager thread to deregister
     session.mpi_pool = pool
+    # __init__ is bypassed above; seed the attributes that shutdown() reads
+    # so the test exercises the release/shutdown contract, not attribute
+    # lookup on a raw-constructed session. Keep them minimal:
+    #   * n_workers is only used by shutdown()'s log line.
+    #   * _wait_shutdown gates the post-shutdown worker-exit barrier;
+    #     the test targets the blocking-join guard, so leave it off.
+    session.n_workers = 1
+    session._wait_shutdown = False
 
     session.release_exit_joins()
     session.shutdown()  # owner asks for the default blocking shutdown


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for pool session shutdown behavior.
  * Verified that shutdown remains non-blocking after exit joins are released, avoiding waits on an inactive pool manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

`test_pool_session_shutdown_never_blocks_after_release` constructs a `MpiPoolSession` with `__new__()` and only sets `mpi_pool`, then calls `release_exit_joins()` and `shutdown()`. `MpiPoolSession.shutdown()` reads `self.n_workers` (log line) and `self._wait_shutdown` (post-shutdown worker barrier); on the raw-constructed session both are absent and the second attribute access raises `AttributeError` before the code under test runs.

Seed the two attributes on the mock session so the test exercises the release/shutdown contract instead of failing on attribute lookup. Keep `_wait_shutdown=False` because the test targets the blocking-join guard, not the identity-based worker-exit wait.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
