### PR TITLE
[None][perf] Optimize fusedQKNormRope Kernel

### DIFF
--- a/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
+++ b/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,6 +174,12 @@ __global__ void fusedQKNormRopeKernel(
     // pos_id is selected per rotary half-dim (interleaved mRoPE); for plain RoPE
     // selectMRopePosId always returns position_ids[tokenIdx].
 
+    // Hoist log2(base) and the loop-invariant constants out of the per-thread
+    // per-elem loop. powf(base, -2*hd/rd) == exp2f(-2*hd/rd * log2(base)); base
+    // and rotary_dim are kernel-uniform, so one MUFU.LG2 per warp instead of
+    // one per (thread, iter). Uses the fast __log2f intrinsic (a few ULPs of
+    // error, absorbed by bf16 downcast at store time).
+    float const neg2_log2base_over_rd = -2.0f * __log2f(base) / static_cast<float>(rotary_dim);
     // TODO: cos sin calculation could be halved.
     if constexpr (interleave)
     {
@@ -191,7 +197,7 @@ __global__ void fusedQKNormRopeKernel(
 
             int dim_idx = laneId * numElemsPerThread + i;
             int half_dim = dim_idx / 2;
-            float freq = powf(base, -2.0f * half_dim / static_cast<float>(rotary_dim));
+            float freq = exp2f(static_cast<float>(half_dim) * neg2_log2base_over_rd);
 
             if (factor != 1.0f)
             {
@@ -234,7 +240,7 @@ __global__ void fusedQKNormRopeKernel(
             int dim_idx = laneId * numElemsPerThread + i;
             dim_idx = (dim_idx * 2) % rotary_dim;
             int half_dim = dim_idx / 2;
-            float freq = powf(base, -2.0f * half_dim / static_cast<float>(rotary_dim));
+            float freq = exp2f(static_cast<float>(half_dim) * neg2_log2base_over_rd);
 
             if (factor != 1.0f)
             {

--- a/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
+++ b/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
@@ -157,11 +157,24 @@ __global__ void fusedQKNormRopeKernel(
         // Compute RMS normalization factor
         float rms_rcp = rsqrtf(sumOfSquares / static_cast<float>(head_dim) + eps);
 
+        // Coalesced load: each thread pulls its numElemsPerThread contiguous bf16
+        // weights with a single vec_T load (uint2 for head_dim=128) instead of
+        // numElemsPerThread scalar strided 2-byte loads. Across the warp this is
+        // one aligned 256-byte request per warp — matches the qkv-load pattern.
+        __nv_bfloat16 const* w_base = isQ ? q_weight : k_weight;
+        vec_T w_vec = *reinterpret_cast<vec_T const*>(&w_base[laneId * numElemsPerThread]);
+        float weights_f[numElemsPerThread];
+        for (int i = 0; i < vecSize; i++)
+        {
+            float2 vals = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162*>(reinterpret_cast<uint*>(&w_vec) + i));
+            weights_f[2 * i] = vals.x;
+            weights_f[2 * i + 1] = vals.y;
+        }
+
         // Normalize elements
         for (int i = 0; i < numElemsPerThread; i++)
         {
-            int dim = laneId * numElemsPerThread + i;
-            float weight = isQ ? __bfloat162float(q_weight[dim]) : __bfloat162float(k_weight[dim]);
+            float weight = weights_f[i];
             // Gemma RMSNorm scales by (1 + weight); standard RMSNorm scales by weight.
             elements[i] *= rms_rcp * (use_gemma ? (1.0f + weight) : weight);
         }
@@ -180,6 +193,11 @@ __global__ void fusedQKNormRopeKernel(
     // one per (thread, iter). Uses the fast __log2f intrinsic (a few ULPs of
     // error, absorbed by bf16 downcast at store time).
     float const neg2_log2base_over_rd = -2.0f * __log2f(base) / static_cast<float>(rotary_dim);
+    // rotary_dim is even by contract; when it's also a power of 2 (always in
+    // practice — 64/128/256) '% rotary_dim' becomes '& (rotary_dim - 1)'.
+    // The bool is warp-uniform → predicated select, no branch divergence.
+    int const rd_mask = rotary_dim - 1;
+    bool const rd_is_pow2 = ((rotary_dim & rd_mask) == 0);
     // TODO: cos sin calculation could be halved.
     if constexpr (interleave)
     {
@@ -238,7 +256,7 @@ __global__ void fusedQKNormRopeKernel(
             }
 
             int dim_idx = laneId * numElemsPerThread + i;
-            dim_idx = (dim_idx * 2) % rotary_dim;
+            dim_idx = rd_is_pow2 ? ((dim_idx * 2) & rd_mask) : ((dim_idx * 2) % rotary_dim);
             int half_dim = dim_idx / 2;
             float freq = exp2f(static_cast<float>(half_dim) * neg2_log2base_over_rd);
 

--- a/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
+++ b/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
@@ -157,24 +157,11 @@ __global__ void fusedQKNormRopeKernel(
         // Compute RMS normalization factor
         float rms_rcp = rsqrtf(sumOfSquares / static_cast<float>(head_dim) + eps);
 
-        // Coalesced load: each thread pulls its numElemsPerThread contiguous bf16
-        // weights with a single vec_T load (uint2 for head_dim=128) instead of
-        // numElemsPerThread scalar strided 2-byte loads. Across the warp this is
-        // one aligned 256-byte request per warp — matches the qkv-load pattern.
-        __nv_bfloat16 const* w_base = isQ ? q_weight : k_weight;
-        vec_T w_vec = *reinterpret_cast<vec_T const*>(&w_base[laneId * numElemsPerThread]);
-        float weights_f[numElemsPerThread];
-        for (int i = 0; i < vecSize; i++)
-        {
-            float2 vals = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162*>(reinterpret_cast<uint*>(&w_vec) + i));
-            weights_f[2 * i] = vals.x;
-            weights_f[2 * i + 1] = vals.y;
-        }
-
         // Normalize elements
         for (int i = 0; i < numElemsPerThread; i++)
         {
-            float weight = weights_f[i];
+            int dim = laneId * numElemsPerThread + i;
+            float weight = isQ ? __bfloat162float(q_weight[dim]) : __bfloat162float(k_weight[dim]);
             // Gemma RMSNorm scales by (1 + weight); standard RMSNorm scales by weight.
             elements[i] *= rms_rcp * (use_gemma ? (1.0f + weight) : weight);
         }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Optimized RoPE frequency computation in `fusedQKNormRopeKernel` by hoisting the `-2 * __log2f(base) / rotary_dim` factor out of the hot per-iteration path, then using `exp2f(half_dim * neg2_log2base_over_rd)` instead of `powf` (via a precomputed coefficient `neg2_log2base_over_rd`).
  - Improved the non-interleaved rotary-dimension mapping by adding a fast path when `rotary_dim` is a power of two (`rd_is_pow2`): uses a bitmask-based remapping (`((dim_idx * 2) & rd_mask)`), otherwise uses modulo mapping (`((dim_idx * 2) % rotary_dim)`).
  - Minor housekeeping: updated the copyright year range.
- **Reported Impact**
  - Throughput: **~2.90%–5.66%** improvement across six cosmos3 configurations.
  - Accuracy: **0.784 → 0.788**, described as within reported evaluation noise.
- **Test/CI Notes**
  - Existing unit tests that cover this kernel/optimization are referenced in `tests/unittest/_torch/thop/parallel_hw_agnostic/test_fused_qk_norm_rope.py`.
  - Multiple CI runs failed; one run was aborted (no further failure details provided).

## Dev Engineer Review

- **Correctness**
  - Replaces `powf(base, x)` with an equivalent `exp2f(x * __log2f(base))` form; acceptable numerical drift is expected/claimed due to reduced precision handling (e.g., bf16 store/downcast).
  - Non-interleaved mapping change is conditional on `rotary_dim` being a power of two:
    - Uses bitmask remapping when `rd_is_pow2`.
    - Uses modulo remapping otherwise.
  - Main risk is validating that the computed `rd_is_pow2`/`rd_mask` logic matches all supported `rotary_dim` values to avoid incorrect indexing/remapping.
- **Performance**
  - Reduces transcendental work by computing the `__log2f(base)`-derived factor once per warp/uniform context instead of repeatedly in the loop.
  - Avoids modulo overhead in the power-of-two case via bitmasking.
- **Consistency / API / Scope**
  - Scope appears localized to `cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu`.
  - No exported/public interfaces changed.
- **CI/Regression Watch-outs**
  - Given the reported CI failures and the numerical sensitivity of RoPE, it’s advisable to correlate any failing cases with the `powf`→`exp2f` path and/or the power-of-two remapping branch for `rotary_dim`.

## QA Engineer Review

- **No test changes.**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

`FusedQKNormRope` gets used heavily in the cosmos3-reasoner / qwen3-VL, and through nsys profiling it was found that this kernel had the second most total GPU time.

<img width="1276" height="473" alt="image" src="https://github.com/user-attachments/assets/446a0fe8-9847-4a3a-a6af-69d66ee82174" />

Through profiling the kernel with Nsight Compute, it was found that this particular line was the culprit for a large chunk of warp stalls

<img width="1585" height="844" alt="image" src="https://github.com/user-attachments/assets/1f650158-4443-4c19-aa23-35ec86bdd398" />

Many of those stalls are due to short scoreboard dependencies, and specifically special math instructions (i.e MUFU) being one of the primary reasons for those. 

`powf(base, y)` gets compiled to something like: `exp2f(y * log2f(x))`, two MUFU ops per call. Since `base` is a kernel-uniform scalar argument, the log2f(base) was being redundantly re-executed on every (thread, iter) ~128 times per warp for a head_dim=128 warp even though its value never changes.

This patch:
  * Factors `neg2_log2base_over_rd = -2.0f * __log2f(base) / rotary_dim` above the interleave branches - one MUFU.LG2 per warp instead of ~128, executed on the uniform datapath.
  * Rewrites the per-iteration `powf(base, -2.0f * half_dim / rotary_dim)` as `exp2f(half_dim * neg2_log2base_over_rd)` in both the interleave and non-interleave paths. One MUFU op per element instead of the powf's implicit log2f+mul+exp2f pipeline.
  * Same idea for dim_idx % rotary_dim - this was stalling due to ALU saturation, refactor to allow for a fastpath when rotary_dim is a power of 2 with bitwise AND operation

## Perf Measurements


### Throughput summary across all 6 configs

| Config | Baseline (tok/s) | Optimized (tok/s) | Δ (%) |
|---|---:|---:|---:|
| cosmos3-super nvFP4 fps=1 | 1,175.41 | 1,241.98 | **+5.66%** |
| cosmos3-super nvFP4 fps=8 | 187.55 | 195.86 | **+4.43%** |
| cosmos3-super FP8 fps=1 | 938.66 | 976.73 | **+4.06%** |
| cosmos3-super FP8 fps=8 | 152.55 | 156.98 | **+2.90%** |
| cosmos3-nano FP8 fps=1 | 2,167.87 | 2,241.20 | **+3.38%** |
| cosmos3-nano FP8 fps=8 | 384.94 | 396.77 | **+3.07%** |


## Accuracy (cosmos-accuracy, super nvFP4, cp=1):
  baseline:   0.784
  optimized:  0.788   (delta within eval noise)


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
