### PR TITLE
[None][fix] Guard AutoDeploy sharding shape lookup

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -3100,6 +3100,11 @@ def detect_sharding_from_config(
     for lin_node in linear_nodes:
         # use node's weight name to get the module name
         weight_name = extract_weight_name(lin_node)
+        if not weight_name:
+            ad_logger.debug(
+                f"Could not find a weight name for linear node {lin_node.name}. Skipping."
+            )
+            continue
         # get the parent layer_subgraph
         layer_subgraph = [
             layer

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -919,30 +919,30 @@ def _precompute_weight_node_mapping(gm: GraphModule) -> None:
 
         # Forward-traverse through unary ops, tagging every node along the
         # way (intermediates like exp, neg, to.dtype AND the terminal consumer).
-        # Stops at multi-input nodes (the actual consumer) or dead ends.
-        current = node
-        while True:
+        # Stops each branch at multi-input nodes (the actual consumers) or dead
+        # ends. A shared parameter can have multiple consumers (for example tied
+        # embedding/lm_head weights), so follow every branch instead of picking
+        # an arbitrary first user.
+        stack = [node]
+        visited = set()
+        while stack:
+            current = stack.pop()
+            if current in visited:
+                continue
+            visited.add(current)
             if category not in current.meta:
                 current.meta[category] = []
-            current.meta[category].append(node)
+            if node not in current.meta[category]:
+                current.meta[category].append(node)
             if len(current.all_input_nodes) > 1:
-                break
+                continue
             if len(current.users) == 0:
                 ad_logger.debug(
                     f"Weight node {node.name} has no downstream consumer "
                     f"(chain ended at {current.name})"
                 )
-                break
-            current = next(iter(current.users))
-
-        # If the chain could not advance past the get_attr node itself
-        # (e.g. get_attr has 0 users, or get_attr directly feeds a
-        # multi-input consumer), tag each direct user as a fallback.
-        if current == node:
-            for user in node.users:
-                if category not in user.meta:
-                    user.meta[category] = []
-                user.meta[category].append(node)
+                continue
+            stack.extend(current.users)
 
 
 def get_user_if_pattern_match(node, ops, numusers, user_idx: int = 0):
@@ -1066,6 +1066,10 @@ def get_all_layer_subgraphs(
 
     # Pre-compute weight-to-consumer mapping for O(1) weight node lookup
     _precompute_weight_node_mapping(gm)
+
+    if len(linear_nodes) == 0:
+        ad_logger.warning("Could not find any linear nodes in the graph.")
+        return [], set()
 
     # Cache weight shapes for all linear nodes
     for lin_node in linear_nodes:
@@ -1572,12 +1576,18 @@ def get_weight_shape(node: Node, dim: Optional[int] = None) -> Optional[Union[in
     found, s = WeightBiasInfoCache.get_weight_shape(node)
     if not found:
         # Not in cache or caching not enabled - compute the shape
-        s = list(shape(extract_weight_nodes(node).weights[0].node))
-        if len(s) == 0:
+        weight_nodes = extract_weight_nodes(node).weights
+        if len(weight_nodes) == 0:
+            ad_logger.debug(f"Could not find a weight node for linear node {node.name}")
             s = None
-        elif is_fp4_op(node):
-            # FP4 weights are packed as uint8 type with 2 FP4 values per element
-            s[-1] *= 2
+        else:
+            weight_shape = shape(weight_nodes[0].node)
+            s = list(weight_shape) if weight_shape is not None else None
+            if s is not None and len(s) == 0:
+                s = None
+            elif s is not None and is_fp4_op(node):
+                # FP4 weights are packed as uint8 type with 2 FP4 values per element
+                s[-1] *= 2
         # Store in cache if caching is enabled
         WeightBiasInfoCache.set_weight_shape(node, s)
 
@@ -1585,8 +1595,10 @@ def get_weight_shape(node: Node, dim: Optional[int] = None) -> Optional[Union[in
         return None
     if dim is None:
         return s
-    else:
+
+    if -len(s) <= dim < len(s):
         return s[dim]
+    return None
 
 
 def get_layer_after_linear_node(
@@ -1636,6 +1648,12 @@ def get_layer_after_linear_node(
         LayerSubgraph containing opening nodes, subgraph nodes, and terminating node.
     """
 
+    def _linear_shape_dim(node: Node, dim: int) -> Optional[int]:
+        lin_node_shape = node.meta.get("lin_node_shape")
+        if lin_node_shape is None or not (-len(lin_node_shape) <= dim < len(lin_node_shape)):
+            return None
+        return lin_node_shape[dim]
+
     def boundary_condition(node: Node, dim: int) -> bool:
         if match_on_shapes:
             if is_any_lin_op(node):
@@ -1648,7 +1666,7 @@ def get_layer_after_linear_node(
                     attr_next="users",
                     include_root=False,
                 )
-                return node.meta["lin_node_shape"][dim] == embd and feeds_mla is None
+                return _linear_shape_dim(node, dim) == embd and feeds_mla is None
             return (
                 is_any_moe_op(node)
                 or is_op(node, ops=[torch.ops.aten.sym_size, torch.ops.aten.bmm])
@@ -1666,14 +1684,14 @@ def get_layer_after_linear_node(
         if match_on_shapes:
             if is_any_lin_op(node):
                 if dim == -1:
-                    in_dim = node.meta["lin_node_shape"][dim]
+                    in_dim = _linear_shape_dim(node, dim)
                     if in_dim == embd:
                         return True
                     if in_eagle_drafter and in_dim == 2 * embd:
                         # Eagle drafts feed attention with 2h-wide q/k/v inputs.
                         return any(is_any_attention_op(u) for u in node.users)
                     return False
-                return node.meta["lin_node_shape"][dim] == embd
+                return _linear_shape_dim(node, dim) == embd
             return False
         else:
             return is_any_lin_op(node)

--- a/tests/unittest/auto_deploy/singlegpu/utils/test_node_utils_sharding.py
+++ b/tests/unittest/auto_deploy/singlegpu/utils/test_node_utils_sharding.py
@@ -24,7 +24,12 @@ from torch.fx import GraphModule
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 — register custom ops
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding_ir import ShardableNode
-from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_any_split_op, is_any_view_op
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import (
+    get_all_layer_subgraphs,
+    get_weight_shape,
+    is_any_split_op,
+    is_any_view_op,
+)
 
 
 def _call_function_nodes(gm: GraphModule):
@@ -166,3 +171,54 @@ def test_enable_sharding_node_none_for_aten():
     aten_linear = [n for n in _call_function_nodes(gm) if n.target == torch.ops.aten.linear.default]
     assert len(aten_linear) == 1
     assert ShardableNode.from_node(aten_linear[0]) is None
+
+
+def test_get_weight_shape_shared_weight_used_by_embedding_and_linear():
+    class Shell(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.shared_weight = nn.Parameter(torch.randn(16, 8))
+
+    root = Shell()
+    graph = fx.Graph()
+    input_ids = graph.placeholder("input_ids")
+    x = graph.placeholder("x")
+    shared_weight = graph.get_attr("shared_weight")
+    shared_weight.meta["val"] = root.shared_weight
+    embedding = graph.call_function(
+        torch.ops.aten.embedding.default,
+        args=(shared_weight, input_ids, -1, False, False),
+    )
+    linear = graph.call_function(torch.ops.aten.linear.default, args=(x, shared_weight, None))
+    graph.output((embedding, linear))
+    gm = GraphModule(root, graph)
+    gm.graph.lint()
+
+    assert get_weight_shape(linear) == [16, 8]
+    assert get_weight_shape(linear, dim=-1) == 8
+
+
+def test_get_weight_shape_returns_none_for_linear_without_weight_node():
+    graph = fx.Graph()
+    x = graph.placeholder("x")
+    runtime_weight = graph.placeholder("runtime_weight")
+    linear = graph.call_function(torch.ops.aten.linear.default, args=(x, runtime_weight, None))
+    graph.output(linear)
+    gm = GraphModule(nn.Module(), graph)
+    gm.graph.lint()
+
+    assert get_weight_shape(linear) is None
+    assert get_weight_shape(linear, dim=-1) is None
+
+
+def test_get_all_layer_subgraphs_returns_empty_without_linear_nodes():
+    class NoLinear(nn.Module):
+        def forward(self, x):
+            return x + 1
+
+    gm = torch.fx.symbolic_trace(NoLinear())
+
+    layer_subgraphs, unprocessed_linear_nodes = get_all_layer_subgraphs(gm)
+
+    assert layer_subgraphs == []
+    assert unprocessed_linear_nodes == set()


### PR DESCRIPTION
## Summary
- Make AutoDeploy weight-to-consumer mapping follow every shared-weight consumer branch instead of choosing the first user.
- Return `None` for missing or malformed linear weight shapes and guard dimension indexing during layer-boundary analysis.
- Skip config-driven sharding entries that cannot resolve a backing weight name.

## Linked issue
Closes https://github.com/NVIDIA/TensorRT-LLM/issues/14681

## Tests run
- `ruff format tensorrt_llm/_torch/auto_deploy/utils/node_utils.py tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py tests/unittest/auto_deploy/singlegpu/utils/test_node_utils_sharding.py`
- `ruff check tensorrt_llm/_torch/auto_deploy/utils/node_utils.py tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py tests/unittest/auto_deploy/singlegpu/utils/test_node_utils_sharding.py`
- `python -m compileall -q tensorrt_llm/_torch/auto_deploy/utils/node_utils.py tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py tests/unittest/auto_deploy/singlegpu/utils/test_node_utils_sharding.py`
- Targeted node_utils sharding smoke script in `tensorrt-llm-issue-14681` conda env

## Follow-up notes
- Full pytest collection for `tests/unittest/auto_deploy/singlegpu/utils/test_node_utils_sharding.py` is blocked in the local macOS environment because TensorRT-LLM imports require CUDA Python bindings that are not available there.