### PR TITLE
[NVBUG-6448152][test] TEST ONLY; DO NOT REVIEW: benchmark Python generation-first baseline

### DIFF
--- a/tests/integration/defs/perf/disagg_server_config.py
+++ b/tests/integration/defs/perf/disagg_server_config.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for generating perf-sanity disaggregated-server configs."""
+
+from typing import Any, Mapping, Optional
+
+_ALLOWED_SCHEDULE_STYLES = frozenset({"context_first", "generation_first"})
+
+
+def build_disagg_server_config(
+    hostname: str,
+    port: int,
+    num_ctx_servers: int,
+    num_gen_servers: int,
+    ctx_hostnames: list[str],
+    gen_hostnames: list[str],
+    server_config_extra: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build the runtime config with an optional schedule-style override."""
+    extras = dict(server_config_extra or {})
+    unsupported_keys = sorted(set(extras) - {"schedule_style"})
+    if unsupported_keys:
+        raise ValueError(
+            "server_config_extra supports only 'schedule_style'; "
+            f"unsupported keys: {unsupported_keys}"
+        )
+    if "schedule_style" in extras and extras["schedule_style"] not in _ALLOWED_SCHEDULE_STYLES:
+        raise ValueError(
+            "server_config_extra.schedule_style must be one of "
+            f"{sorted(_ALLOWED_SCHEDULE_STYLES)}, got {extras['schedule_style']!r}"
+        )
+
+    server_config = {
+        "hostname": hostname,
+        "port": port,
+        "backend": "pytorch",
+        "context_servers": {
+            "num_instances": num_ctx_servers,
+            "urls": ctx_hostnames,
+        },
+        "generation_servers": {
+            "num_instances": num_gen_servers,
+            "urls": gen_hostnames,
+        },
+    }
+    server_config.update(extras)
+    return server_config

--- a/tests/integration/defs/perf/test_disagg_server_config.py
+++ b/tests/integration/defs/perf/test_disagg_server_config.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for perf-sanity disaggregated-server config generation."""
+
+import unittest
+
+try:
+    from .disagg_server_config import build_disagg_server_config
+except ImportError:
+    from disagg_server_config import build_disagg_server_config
+
+
+class TestBuildDisaggServerConfig(unittest.TestCase):
+    def test_no_extra_preserves_baseline_config(self):
+        config = build_disagg_server_config(
+            hostname="benchmark-host",
+            port=8123,
+            num_ctx_servers=1,
+            num_gen_servers=2,
+            ctx_hostnames=["ctx-host:8000"],
+            gen_hostnames=["gen-host-0:8001", "gen-host-1:8001"],
+        )
+
+        self.assertEqual(
+            config,
+            {
+                "hostname": "benchmark-host",
+                "port": 8123,
+                "backend": "pytorch",
+                "context_servers": {
+                    "num_instances": 1,
+                    "urls": ["ctx-host:8000"],
+                },
+                "generation_servers": {
+                    "num_instances": 2,
+                    "urls": ["gen-host-0:8001", "gen-host-1:8001"],
+                },
+            },
+        )
+
+    def test_applies_schedule_style_from_server_config_extra(self):
+        config = build_disagg_server_config(
+            hostname="benchmark-host",
+            port=8123,
+            num_ctx_servers=1,
+            num_gen_servers=1,
+            ctx_hostnames=["ctx-host:8000"],
+            gen_hostnames=["gen-host:8001"],
+            server_config_extra={"schedule_style": "generation_first"},
+        )
+
+        self.assertEqual(config["schedule_style"], "generation_first")
+        self.assertEqual(config["context_servers"]["urls"], ["ctx-host:8000"])
+        self.assertEqual(config["generation_servers"]["urls"], ["gen-host:8001"])
+
+    def test_rejects_unknown_or_reserved_extra_keys(self):
+        for extra in (
+            {"unexpected": "value"},
+            {"hostname": "redirected-host"},
+            {"port": 9000},
+            {"backend": "other"},
+            {"context_servers": {}},
+            {"generation_servers": {}},
+        ):
+            with (
+                self.subTest(extra=extra),
+                self.assertRaisesRegex(ValueError, "supports only 'schedule_style'"),
+            ):
+                build_disagg_server_config(
+                    hostname="benchmark-host",
+                    port=8123,
+                    num_ctx_servers=1,
+                    num_gen_servers=1,
+                    ctx_hostnames=["ctx-host:8000"],
+                    gen_hostnames=["gen-host:8001"],
+                    server_config_extra=extra,
+                )
+
+    def test_rejects_invalid_schedule_style(self):
+        with self.assertRaisesRegex(ValueError, "schedule_style must be one of"):
+            build_disagg_server_config(
+                hostname="benchmark-host",
+                port=8123,
+                num_ctx_servers=1,
+                num_gen_servers=1,
+                ctx_hostnames=["ctx-host:8000"],
+                gen_hostnames=["gen-host:8001"],
+                server_config_extra={"schedule_style": "unsupported"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -35,6 +35,7 @@ from tensorrt_llm._utils import get_free_port
 
 from ..conftest import get_llm_root, llm_models_root
 from ._model_paths import MODEL_PATH_DICT as _MODEL_PATH_DICT_BASE
+from .disagg_server_config import build_disagg_server_config
 from .perf_regression_utils import process_and_upload_test_results
 
 # Sanity-side path differs from test_perf for this key; preserve historical value.
@@ -1032,6 +1033,7 @@ class DisaggConfig:
         model_name: str,
         hardware: dict,
         server_env_var: str,
+        server_config_extra: Optional[Dict] = None,
     ):
         self.name = name
         self.disagg_serving_type = disagg_serving_type
@@ -1042,6 +1044,7 @@ class DisaggConfig:
         self.model_name = model_name
         self.hardware = hardware
         self.server_env_var = server_env_var
+        self.server_config_extra = dict(server_config_extra or {})
         self.num_ctx_servers = hardware.get("num_ctx_servers", 0)
         self.num_gen_servers = hardware.get("num_gen_servers", 0)
 
@@ -1231,19 +1234,18 @@ class DisaggTestCmds(NamedTuple):
         # where another process on the same node grabs the port.
         disagg_server_port = get_free_port()
 
-        server_config = {
-            "hostname": self.hostname,
-            "port": disagg_server_port,
-            "backend": "pytorch",
-            "context_servers": {
-                "num_instances": self.num_ctx_servers,
-                "urls": ctx_hostnames,
-            },
-            "generation_servers": {
-                "num_instances": self.num_gen_servers,
-                "urls": gen_hostnames,
-            },
-        }
+        server_config_extra = {}
+        if server_idx < len(self.server_configs):
+            server_config_extra = self.server_configs[server_idx][2].server_config_extra
+        server_config = build_disagg_server_config(
+            hostname=self.hostname,
+            port=disagg_server_port,
+            num_ctx_servers=self.num_ctx_servers,
+            num_gen_servers=self.num_gen_servers,
+            ctx_hostnames=ctx_hostnames,
+            gen_hostnames=gen_hostnames,
+            server_config_extra=server_config_extra,
+        )
         config_path = os.path.join(self.test_output_dir, f"server_config.{server_idx}.yaml")
         with open(config_path, "w") as f:
             yaml.dump(server_config, f)
@@ -1827,6 +1829,7 @@ class PerfSanityTestConfig:
                 model_name=model_name,
                 hardware=hardware,
                 server_env_var=server_env_var,
+                server_config_extra=config.get("server_config_extra", {}),
             )
 
             # server_configs is a list with one element (tuple of ctx, gen, disagg config)

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -28,6 +28,8 @@ hardware:
   gpus_per_node: 4
   num_ctx_servers: 1
   num_gen_servers: 1
+server_config_extra:
+  schedule_style: generation_first
 environment:
   container_mount: <container_mount>
   container_image: <container_image>
@@ -37,6 +39,7 @@ environment:
   work_dir: <full_path_to_work_dir>
   worker_env_var: TLLM_LOG_LEVEL=INFO TRTLLM_SERVER_DISABLE_GC=1 TRTLLM_WORKER_DISABLE_GC=1 TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS=1
     TRTLLM_ENABLE_PDL=1 ENROOT_ALLOW_DEV=yes
+  ctx_worker_env_var: TRTLLM_PYTHON_TRANSCEIVER_ASYNC_CTX_TERMINAL_CONSENSUS=0 TRTLLM_PYTHON_TRANSCEIVER_ASYNC_CTX_PEER_READY_CONSENSUS=0
   server_env_var: TRTLLM_SERVER_DISABLE_GC=1
 profiling:
   nsys_on: false
@@ -64,6 +67,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -91,6 +95,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001


### PR DESCRIPTION
> Diagnostic benchmark only — do not merge.

This establishes the generation-first baseline for the Python KV-cache transceiver before enabling asynchronous consensus.

Configuration:
- Python transceiver on both context and generation workers
- NIXL backend
- generation-first scheduling
- terminal consensus disabled
- readiness consensus disabled
- context TP1 / PP4 / CP1; generation attention-DP8
- 512-request GB300 DeepSeek-R1 128k/8k workload

The branch uses the exact same harness commit as the context-first baseline; only the explicit workload factor commit differs. A valid result requires 512/512 requests, zero failed requests, the exact Python runtime on both roles, and the official output-token-throughput metric. Any failed request censors throughput.

Target stage:
`GB300-12_GPUs-3_Nodes-PyTorch-Disagg-PerfSanity-CTX1-NODE1-GPU4-GEN1-NODE2-GPU8-Post-Merge-1`

Target selector:
`disagg_upload-e2e-gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL`
