### PR TITLE
[TRTLLM-14497][feat] Add BF16/FP8 refit for qwen3.5_397b

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -5191,6 +5191,7 @@ def launchTestJobs(pipeline, testFilter)
         "DGX_B200-8_GPUs-PyTorch-2": ["auto:dgx-b200-flex", "l0_dgx_b200", 2, 4, 8, 1, true],
         "DGX_B200-8_GPUs-PyTorch-3": ["auto:dgx-b200-flex", "l0_dgx_b200", 3, 4, 8, 1, true],
         "DGX_B200-8_GPUs-PyTorch-4": ["auto:dgx-b200-flex", "l0_dgx_b200", 4, 4, 8, 1, true],
+        "DGX_B200-8_GPUs-PyTorch-Ray-1": ["auto:dgx-b200-flex", "l0_dgx_b200", 1, 1, 8, 1, true],
         "DGX_B200-8_GPUs-AutoDeploy-Post-Merge-1": ["auto:dgx-b200-flex", "l0_dgx_b200", 1, 1, 8, 1, true],
         "DGX_B200-4_GPUs-Verl-Post-Merge-1": ["auto:dgx-b200-flex", "l0_verl", 1, 1, 4, 1, true],
         "B300-PyTorch-1": ["auto:dgx-b300-flex", "l0_b300", 1, 2, 1, 1, true],

--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -374,7 +374,7 @@ class MnnvlMemory:
                     is_active = pynvml.nvmlDeviceGetNvLinkState(handle, link_idx)
                     if is_active:
                         active_links += 1
-            except pynvml.NVMLError_NotSupported:
+            except (pynvml.NVMLError_NotSupported, pynvml.NVMLError_InvalidArgument):
                 continue
         return (
             active_links == available_links and available_links > 0

--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_mapper.py
@@ -36,6 +36,15 @@ class BaseWeightMapper(ABC):
         self._model = None
         self._config = None
 
+    def begin_update_weights(self) -> None:
+        """Prepare mapper-owned state for an incremental weight update."""
+
+    def finalize_update_weights(self) -> None:
+        """Validate and release mapper-owned incremental update state."""
+
+    def abort_update_weights(self) -> None:
+        """Release mapper-owned state after a failed incremental update."""
+
     @abstractmethod
     def map_weights(self) -> None:
         """

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
@@ -664,9 +664,7 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
                 remapped_weights[name] = tensor
         return remapped_weights
 
-    def preprocess_weights(self,
-                           weights: dict,
-                           allow_partial_loading: bool = False) -> dict:
+    def preprocess_weights(self, weights: dict, allow_partial_loading: bool = False) -> dict:
         is_consumable = isinstance(weights, ConsumableWeightsDict)
         quant_algo = self.config.quant_config.quant_algo
 
@@ -701,7 +699,8 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
             packed_weights = self._remap_dense_mlp_weights(packed_weights)
 
         processed_weights = super().preprocess_weights(
-            packed_weights, allow_partial_loading=allow_partial_loading)
+            packed_weights, allow_partial_loading=allow_partial_loading
+        )
         if is_consumable and not isinstance(processed_weights, ConsumableWeightsDict):
             return ConsumableWeightsDict(processed_weights)
         return processed_weights

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
@@ -85,7 +85,8 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
                 preview += f", ... ({len(pending)} tensors total)"
             raise RuntimeError(
                 "Cannot finalize Qwen3.5 weight update with incomplete "
-                f"linear-attention projection groups: {preview}")
+                f"linear-attention projection groups: {preview}"
+            )
         self._update_weights_active = False
 
     def abort_update_weights(self) -> None:
@@ -98,8 +99,7 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         self.abort_update_weights()
         super().cleanup()
 
-    def _stage_partial_split_projections(self, weights: dict,
-                                         quant_algo: QuantAlgo | None) -> dict:
+    def _stage_partial_split_projections(self, weights: dict, quant_algo: QuantAlgo | None) -> dict:
         """Emit complete QKVZ and BA groups from incremental input.
 
         Packed broadcast boundaries are byte based and may split projections
@@ -118,8 +118,7 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
                 ready_weights[name] = tensor
                 continue
             if name in self._partial_split_weights:
-                raise RuntimeError(
-                    f"Duplicate Qwen3.5 partial weight received: {name}")
+                raise RuntimeError(f"Duplicate Qwen3.5 partial weight received: {name}")
             self._partial_split_weights[name] = tensor
 
         grouped_names = defaultdict(dict)
@@ -131,8 +130,7 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
 
         consumed_names = set()
         for (prefix, suffix), names in grouped_names.items():
-            if (quant_algo == QuantAlgo.FP8_BLOCK_SCALES
-                    and suffix == "weight_scale_inv"):
+            if quant_algo == QuantAlgo.FP8_BLOCK_SCALES and suffix == "weight_scale_inv":
                 # DeepSeek-format block scales must be emitted with the FP8
                 # weights that consume them below.
                 continue
@@ -150,15 +148,15 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
                     quant_algo == QuantAlgo.FP8_BLOCK_SCALES
                     and suffix == "weight"
                     and any(
-                        self._partial_split_weights[name].dtype
-                        == torch.float8_e4m3fn for name in required_names))
+                        self._partial_split_weights[name].dtype == torch.float8_e4m3fn
+                        for name in required_names
+                    )
+                )
                 if requires_block_scales:
-                    scale_names = grouped_names.get(
-                        (prefix, "weight_scale_inv"), {})
+                    scale_names = grouped_names.get((prefix, "weight_scale_inv"), {})
                     if required.issubset(scale_names):
                         consumed_names.update(required_names)
-                        consumed_names.update(
-                            scale_names[key] for key in required)
+                        consumed_names.update(scale_names[key] for key in required)
                 else:
                     consumed_names.update(required_names)
 
@@ -236,14 +234,12 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
             # stacked weights get misrouted into the fused path and crash the
             # quantized loader.
             per_expert_pattern = re.compile(r"^\d+\.(?:gate_proj|up_proj|down_proj)\.")
-            has_per_expert_tensors = any(
-                per_expert_pattern.match(name) for name in module_weights)
+            has_per_expert_tensors = any(per_expert_pattern.match(name) for name in module_weights)
             has_stacked_expert_tensors = any(
-                name in ("gate_up_proj", "down_proj")
-                and getattr(value, "ndim", None) == 3
-                for name, value in module_weights.items())
-            uses_fused_expert_tensors = (
-                has_stacked_expert_tensors and not has_per_expert_tensors)
+                name in ("gate_up_proj", "down_proj") and getattr(value, "ndim", None) == 3
+                for name, value in module_weights.items()
+            )
+            uses_fused_expert_tensors = has_stacked_expert_tensors and not has_per_expert_tensors
             updated_module_weights = {}
             for weight_name, weight_value in module_weights.items():
                 if has_per_expert_tensors and weight_name in ("gate_up_proj", "down_proj"):
@@ -677,7 +673,8 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         normalized_weights = self._normalize_weight_names(weights)
         if allow_partial_loading:
             normalized_weights = self._stage_partial_split_projections(
-                normalized_weights, quant_algo)
+                normalized_weights, quant_algo
+            )
         normalized_weights, is_modelopt_pb_wo = self._normalize_scale_names(
             normalized_weights, quant_algo
         )

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import math
 import re
 from collections import defaultdict
@@ -61,6 +64,88 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
     _DENSE_MLP_PATTERN = re.compile(
         r"^((?:model|mtp)\.layers\.\d+\.mlp)\.(gate_proj|up_proj|down_proj|gate_up_proj)(\..+)$"
     )
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._partial_split_weights: dict[str, object] = {}
+        self._update_weights_active = False
+
+    def begin_update_weights(self) -> None:
+        """Start a new incremental update and discard stale staging state."""
+        self._partial_split_weights.clear()
+        self._update_weights_active = True
+
+    def finalize_update_weights(self) -> None:
+        """Reject incomplete BF16 projection groups before transforms run."""
+        if self._partial_split_weights:
+            pending = sorted(self._partial_split_weights)
+            self.abort_update_weights()
+            preview = ", ".join(pending[:8])
+            if len(pending) > 8:
+                preview += f", ... ({len(pending)} tensors total)"
+            raise RuntimeError(
+                "Cannot finalize Qwen3.5 weight update with incomplete "
+                f"linear-attention projection groups: {preview}")
+        self._update_weights_active = False
+
+    def abort_update_weights(self) -> None:
+        """Discard tensors retained for an incomplete incremental update."""
+        self._partial_split_weights.clear()
+        self._update_weights_active = False
+
+    def cleanup(self) -> None:
+        """Release staged tensors and references held by the base mapper."""
+        self.abort_update_weights()
+        super().cleanup()
+
+    def _stage_partial_bf16_split_projections(self,
+                                              weights: dict) -> dict:
+        """Emit only complete QKVZ and BA groups from incremental BF16 input.
+
+        Packed broadcast boundaries are byte based and may split projections
+        that must be fused before the normal Qwen3Next mapping runs. Retain
+        those tensors on each inference rank until their complete fusion group
+        is available. Non-projection tensors pass through immediately.
+        """
+        if not self._update_weights_active:
+            self.begin_update_weights()
+
+        ready_weights = {}
+        for name, tensor in weights.items():
+            if self._SPLIT_PROJ_PATTERN.match(name) is None:
+                ready_weights[name] = tensor
+                continue
+            if name in self._partial_split_weights:
+                raise RuntimeError(
+                    f"Duplicate Qwen3.5 partial weight received: {name}")
+            self._partial_split_weights[name] = tensor
+
+        grouped_names = defaultdict(dict)
+        for name in self._partial_split_weights:
+            match = self._SPLIT_PROJ_PATTERN.match(name)
+            assert match is not None
+            prefix, projection_name, suffix = match.groups()
+            grouped_names[(prefix, suffix)][projection_name] = name
+
+        consumed_names = set()
+        for names in grouped_names.values():
+            qkvz_names = {"qkv", "q", "k", "v", "z"} & names.keys()
+            if "qkv" in qkvz_names:
+                required = {"qkv", "z"}
+            elif qkvz_names:
+                required = {"q", "k", "v", "z"}
+            else:
+                required = set()
+            if required and required.issubset(names):
+                consumed_names.update(names[key] for key in required)
+
+            required_ba = {"b", "a"}
+            if required_ba.issubset(names):
+                consumed_names.update(names[key] for key in required_ba)
+
+        for name in consumed_names:
+            ready_weights[name] = self._partial_split_weights.pop(name)
+        return ready_weights
 
     def _normalize_weight_names(self, weights: dict) -> dict:
         normalized_weights = {}
@@ -128,10 +213,14 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
             # stacked weights get misrouted into the fused path and crash the
             # quantized loader.
             per_expert_pattern = re.compile(r"^\d+\.(?:gate_proj|up_proj|down_proj)\.")
-            has_per_expert_tensors = any(per_expert_pattern.match(name) for name in module_weights)
+            has_per_expert_tensors = any(
+                per_expert_pattern.match(name) for name in module_weights)
+            has_stacked_expert_tensors = any(
+                name in ("gate_up_proj", "down_proj")
+                and getattr(value, "ndim", None) == 3
+                for name, value in module_weights.items())
             uses_fused_expert_tensors = (
-                "gate_up_proj" in module_weights and not has_per_expert_tensors
-            )
+                has_stacked_expert_tensors and not has_per_expert_tensors)
             updated_module_weights = {}
             for weight_name, weight_value in module_weights.items():
                 if has_per_expert_tensors and weight_name in ("gate_up_proj", "down_proj"):
@@ -556,11 +645,16 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
                 remapped_weights[name] = tensor
         return remapped_weights
 
-    def preprocess_weights(self, weights: dict) -> dict:
+    def preprocess_weights(self,
+                           weights: dict,
+                           allow_partial_loading: bool = False) -> dict:
         is_consumable = isinstance(weights, ConsumableWeightsDict)
         quant_algo = self.config.quant_config.quant_algo
 
         normalized_weights = self._normalize_weight_names(weights)
+        if allow_partial_loading and quant_algo is None:
+            normalized_weights = self._stage_partial_bf16_split_projections(
+                normalized_weights)
         normalized_weights, is_modelopt_pb_wo = self._normalize_scale_names(
             normalized_weights, quant_algo
         )
@@ -586,7 +680,8 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         if not getattr(self.config.pretrained_config, "num_experts", 0):
             packed_weights = self._remap_dense_mlp_weights(packed_weights)
 
-        processed_weights = super().preprocess_weights(packed_weights)
+        processed_weights = super().preprocess_weights(
+            packed_weights, allow_partial_loading=allow_partial_loading)
         if is_consumable and not isinstance(processed_weights, ConsumableWeightsDict):
             return ConsumableWeightsDict(processed_weights)
         return processed_weights

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
@@ -98,14 +98,16 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         self.abort_update_weights()
         super().cleanup()
 
-    def _stage_partial_bf16_split_projections(self,
-                                              weights: dict) -> dict:
-        """Emit only complete QKVZ and BA groups from incremental BF16 input.
+    def _stage_partial_split_projections(self, weights: dict,
+                                         quant_algo: QuantAlgo | None) -> dict:
+        """Emit complete QKVZ and BA groups from incremental input.
 
         Packed broadcast boundaries are byte based and may split projections
         that must be fused before the normal Qwen3Next mapping runs. Retain
         those tensors on each inference rank until their complete fusion group
-        is available. Non-projection tensors pass through immediately.
+        is available. Block-FP8 QKVZ tensors are dequantized into the temporary
+        BF16 runtime representation, so their weights and scales must be
+        released together. Non-projection tensors pass through immediately.
         """
         if not self._update_weights_active:
             self.begin_update_weights()
@@ -128,7 +130,13 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
             grouped_names[(prefix, suffix)][projection_name] = name
 
         consumed_names = set()
-        for names in grouped_names.values():
+        for (prefix, suffix), names in grouped_names.items():
+            if (quant_algo == QuantAlgo.FP8_BLOCK_SCALES
+                    and suffix == "weight_scale_inv"):
+                # DeepSeek-format block scales must be emitted with the FP8
+                # weights that consume them below.
+                continue
+
             qkvz_names = {"qkv", "q", "k", "v", "z"} & names.keys()
             if "qkv" in qkvz_names:
                 required = {"qkv", "z"}
@@ -137,7 +145,22 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
             else:
                 required = set()
             if required and required.issubset(names):
-                consumed_names.update(names[key] for key in required)
+                required_names = [names[key] for key in required]
+                requires_block_scales = (
+                    quant_algo == QuantAlgo.FP8_BLOCK_SCALES
+                    and suffix == "weight"
+                    and any(
+                        self._partial_split_weights[name].dtype
+                        == torch.float8_e4m3fn for name in required_names))
+                if requires_block_scales:
+                    scale_names = grouped_names.get(
+                        (prefix, "weight_scale_inv"), {})
+                    if required.issubset(scale_names):
+                        consumed_names.update(required_names)
+                        consumed_names.update(
+                            scale_names[key] for key in required)
+                else:
+                    consumed_names.update(required_names)
 
             required_ba = {"b", "a"}
             if required_ba.issubset(names):
@@ -652,9 +675,9 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         quant_algo = self.config.quant_config.quant_algo
 
         normalized_weights = self._normalize_weight_names(weights)
-        if allow_partial_loading and quant_algo is None:
-            normalized_weights = self._stage_partial_bf16_split_projections(
-                normalized_weights)
+        if allow_partial_loading:
+            normalized_weights = self._stage_partial_split_projections(
+                normalized_weights, quant_algo)
         normalized_weights, is_modelopt_pb_wo = self._normalize_scale_names(
             normalized_weights, quant_algo
         )

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_next_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_next_weight_mapper.py
@@ -157,7 +157,10 @@ class Qwen3NextHfWeightMapper(Qwen2MoeHfWeightMapper):
             f"Cannot map {key} with shape {tuple(t.shape)} onto the dense "
             f"in_proj layout ({rows} rows expected)")
 
-    def preprocess_weights(self, weights: dict) -> dict:
+    def preprocess_weights(self,
+                           weights: dict,
+                           allow_partial_loading: bool = False) -> dict:
+        _ = allow_partial_loading
         config = self.config.pretrained_config
         tp_size = self.config.mapping.tp_size
         tp_rank = self.config.mapping.tp_rank

--- a/tensorrt_llm/_torch/models/modeling_qwen3_5.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_5.py
@@ -695,13 +695,19 @@ class _Qwen3_5VLModel(Qwen3VLModelBase):
             "mrope_config.mrope_position_deltas",
         ]
 
-    def load_weights(self, weights: Dict[str, torch.Tensor], weight_mapper: BaseWeightMapper):
+    def load_weights(
+        self,
+        weights: Dict[str, torch.Tensor],
+        weight_mapper: BaseWeightMapper,
+        allow_partial_loading: bool = False,
+    ):
         # None under MM E/P disagg or disable_mm_encoder.
         if self.mm_encoder is not None:
-            self.mm_encoder.load_weights(weights)
+            self.mm_encoder.load_weights(
+                weights, allow_partial_loading=allow_partial_loading
+            )
 
-        weight_mapper = Qwen3_5MoeHfWeightMapper()
-        # Hand the mapper the inner LM's model_config, not the VLM wrapper's:
+        # Hand the persistent mapper the inner LM's model_config, not the VLM wrapper's:
         # only the inner config went through the Qwen3.5 quant-dict
         # normalization applied in the inner LM's __init__ (HF->TRT-LLM key
         # translation + synthesis of the fused in_proj_qkvz FP8 entry). With
@@ -709,12 +715,23 @@ class _Qwen3_5VLModel(Qwen3VLModelBase):
         # dequantizes the GDN in_proj projections to bf16 and drops their
         # calibrated scales; the FP8-built module then re-casts with
         # weight_scale=1.0 and quantizes activations dynamically every step.
-        weight_mapper.init_model_and_config(self.llm, self.llm.model_config)
+        if not isinstance(weight_mapper, Qwen3_5MoeHfWeightMapper):
+            raise TypeError(
+                "Qwen3.5 VLM requires Qwen3_5MoeHfWeightMapper, got "
+                f"{type(weight_mapper).__name__}")
+        if weight_mapper.model is not self.llm:
+            weight_mapper.init_model_and_config(self.llm,
+                                                self.llm.model_config)
         filtered_weights = {k: v for k, v in weights.items() if not k.startswith("model.visual.")}
         params_map = {
             r"^model\.language_model\.(.*)$": r"model.\1",
         }
-        self.llm.load_weights(filtered_weights, weight_mapper, params_map=params_map)
+        self.llm.load_weights(
+            filtered_weights,
+            weight_mapper,
+            params_map=params_map,
+            allow_partial_loading=allow_partial_loading,
+        )
 
 
 # TODO(TRTLLM-13417): Add tests for disaggregated support.

--- a/tensorrt_llm/_torch/models/modeling_qwen3_5.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_5.py
@@ -703,9 +703,7 @@ class _Qwen3_5VLModel(Qwen3VLModelBase):
     ):
         # None under MM E/P disagg or disable_mm_encoder.
         if self.mm_encoder is not None:
-            self.mm_encoder.load_weights(
-                weights, allow_partial_loading=allow_partial_loading
-            )
+            self.mm_encoder.load_weights(weights, allow_partial_loading=allow_partial_loading)
 
         # Hand the persistent mapper the inner LM's model_config, not the VLM wrapper's:
         # only the inner config went through the Qwen3.5 quant-dict
@@ -717,11 +715,10 @@ class _Qwen3_5VLModel(Qwen3VLModelBase):
         # weight_scale=1.0 and quantizes activations dynamically every step.
         if not isinstance(weight_mapper, Qwen3_5MoeHfWeightMapper):
             raise TypeError(
-                "Qwen3.5 VLM requires Qwen3_5MoeHfWeightMapper, got "
-                f"{type(weight_mapper).__name__}")
+                f"Qwen3.5 VLM requires Qwen3_5MoeHfWeightMapper, got {type(weight_mapper).__name__}"
+            )
         if weight_mapper.model is not self.llm:
-            weight_mapper.init_model_and_config(self.llm,
-                                                self.llm.model_config)
+            weight_mapper.init_model_and_config(self.llm, self.llm.model_config)
         filtered_weights = {k: v for k, v in weights.items() if not k.startswith("model.visual.")}
         params_map = {
             r"^model\.language_model\.(.*)$": r"model.\1",

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 # Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
 # Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/configs/qwen3_next.py
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
@@ -143,10 +146,15 @@ class Qwen3NextGate(nn.Module):
             hidden_states, self.weight.t(), bias=None, out_dtype=self.out_dtype)
         return logits
 
-    def load_weights(self, weights: List[Dict]):
+    def load_weights(self,
+                     weights: List[Dict],
+                     allow_partial_loading: bool = False):
         assert len(weights) == 1
-
-        self.weight.copy_(weights[0]["weight"][:])
+        weight = weights[0].get("weight")
+        if not allow_partial_loading:
+            assert weight is not None
+        if weight is not None:
+            self.weight.copy_(weight[:])
 
     @property
     def routing_method(self) -> BaseMoeRoutingMethod:
@@ -1098,7 +1106,8 @@ class Qwen3NextForCausalLM(SpecDecOneEngineForCausalLM[Qwen3NextModel,
                      weight_mapper: BaseWeightMapper,
                      params_map: Optional[Dict[str, str]] = None,
                      allow_partial_loading: bool = False):
-        new_weights = weight_mapper.preprocess_weights(weights)
+        new_weights = weight_mapper.preprocess_weights(
+            weights, allow_partial_loading=allow_partial_loading)
         # `new_weights` aliases the source tensors for every key
         # `preprocess_weights` did not rewrite -- the routed experts, i.e. most
         # of a MoE checkpoint. Holding `weights` too would pin them, so

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -1073,7 +1073,11 @@ class Qwen3VisionModelBase(nn.Module):
     def post_config(self):
         self.config = self.model_config.pretrained_config.vision_config
 
-    def load_weights(self, weights: Dict[str, torch.Tensor]):
+    def load_weights(
+        self,
+        weights: Dict[str, torch.Tensor],
+        allow_partial_loading: bool = False,
+    ):
         visual_weights = filter_weights("model.visual", weights)
         converted_weights = {}
 
@@ -1098,7 +1102,12 @@ class Qwen3VisionModelBase(nn.Module):
             r"(.*?)mlp.linear_fc2.(.*)": r"\1mlp.down_proj.\2",
         }
         self.visual.config.num_attention_heads = self.visual.config.num_heads
-        _load_weights_impl(self.visual, converted_weights, params_map=pattern_mapping)
+        _load_weights_impl(
+            self.visual,
+            converted_weights,
+            params_map=pattern_mapping,
+            allow_partial_loading=allow_partial_loading,
+        )
 
     @torch.inference_mode()
     def encode_batched(

--- a/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
+++ b/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
@@ -296,6 +296,10 @@ def _flashinfer_gdn_decode(
     assert T_per_seq == 1, (
         f"_flashinfer_gdn_decode expects standard decode (T_per_seq == 1), got "
         f"{T_per_seq}; _can_use_flashinfer_gdn_decode should keep T == N")
+    # TP8 leaves eight BF16 ``a`` values per Qwen3.5 GDN shard. Odd shards can
+    # start 16 bytes into fused projection storage, but CuTe requires 32B.
+    if a_bat.data_ptr() % 32:
+        a_bat = a_bat.clone(memory_format=torch.contiguous_format)
     _fi_gdn_decode_bf16_state_t1(
         A_log=A_log,
         a=a_bat,

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -1317,6 +1317,25 @@ class ModelLoader:
                                 allow_partial_loading=allow_partial_loading)
         torch.cuda.current_stream().synchronize()
 
+    def begin_update_weights(self) -> None:
+        """Start an incremental update session on the persistent mapper."""
+        if self.weight_mapper is None:
+            raise RuntimeError(
+                "Cannot update weights: weight_mapper was not initialized")
+        self.weight_mapper.begin_update_weights()
+
+    def finalize_update_weights(self) -> None:
+        """Validate and close the persistent mapper update session."""
+        if self.weight_mapper is None:
+            raise RuntimeError(
+                "Cannot update weights: weight_mapper was not initialized")
+        self.weight_mapper.finalize_update_weights()
+
+    def abort_update_weights(self) -> None:
+        """Discard persistent mapper state after a failed update session."""
+        if self.weight_mapper is not None:
+            self.weight_mapper.abort_update_weights()
+
     def cleanup(self) -> None:
         """Release backend resources acquired during :meth:`load`.
 

--- a/tensorrt_llm/llmapi/rlhf_utils.py
+++ b/tensorrt_llm/llmapi/rlhf_utils.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import base64
 import gc
 from typing import Optional
@@ -52,6 +55,7 @@ class WorkerExtension:
         """
         try:
             if not hasattr(self.engine.model_engine.model, "first_pre_reload_weights"):
+                self.engine.model_engine.model_loader.begin_update_weights()
                 for module in self.engine.model_engine.model.modules():
                     if hasattr(module, "pre_reload_weights") and not getattr(
                         module, "_weights_removed", False
@@ -127,6 +131,7 @@ class WorkerExtension:
                 torch.cuda.ipc_collect()
             else:
                 logger.info("Finalize update weights")
+                self.engine.model_engine.model_loader.finalize_update_weights()
                 for module in self.engine.model_engine.model.modules():
                     if hasattr(module, "process_weights_after_loading") and not getattr(
                         module, "_weights_removed", False
@@ -152,6 +157,9 @@ class WorkerExtension:
                 torch.cuda.empty_cache()
 
         except Exception as e:
+            self.engine.model_engine.model_loader.abort_update_weights()
+            if hasattr(self.engine.model_engine.model, "first_pre_reload_weights"):
+                delattr(self.engine.model_engine.model, "first_pre_reload_weights")
             logger.error("Encountered an error in update_weights")
             raise e
 

--- a/tensorrt_llm/llmapi/rlhf_utils.py
+++ b/tensorrt_llm/llmapi/rlhf_utils.py
@@ -3,7 +3,8 @@
 
 import base64
 import gc
-from typing import Optional
+from contextlib import contextmanager
+from typing import Iterator, Optional
 
 import torch
 
@@ -12,6 +13,43 @@ from tensorrt_llm._ray_utils import control_action_decorator
 from tensorrt_llm._torch.modules.fused_moe.moe_load_balancer import MoeLoadBalancer
 from tensorrt_llm._torch.utils import get_device_uuid
 from tensorrt_llm.logger import logger
+
+
+@contextmanager
+def _preserve_cuda_graph_refit_caches(model: torch.nn.Module) -> Iterator[None]:
+    """Keep refit-derived tensor addresses stable across post-load hooks.
+
+    Qwen3.5 eager fusion caches ``weight + 1`` for Gemma RMSNorm in the plain
+    tensor attribute ``_fused_norm_weight``. Its post-load hook recomputes that
+    cache by assigning a new tensor, but a CUDA Graph captured before refit
+    continues to reference the original allocation. Preserve that allocation
+    during refit and copy the refreshed value into it after post-load hooks run.
+    """
+    cached_tensors = []
+    for module in model.modules():
+        cached = getattr(module, "_fused_norm_weight", None)
+        if isinstance(cached, torch.Tensor):
+            cached_tensors.append((module, cached))
+
+    yield
+
+    for module, original in cached_tensors:
+        refreshed = getattr(module, "_fused_norm_weight", None)
+        if refreshed is original:
+            continue
+        if not isinstance(refreshed, torch.Tensor):
+            raise RuntimeError("Refit removed the CUDA-Graph-visible _fused_norm_weight cache")
+        if (
+            refreshed.shape != original.shape
+            or refreshed.dtype != original.dtype
+            or refreshed.device != original.device
+        ):
+            raise RuntimeError(
+                "Refit changed the shape, dtype, or device of the CUDA-Graph-visible "
+                "_fused_norm_weight cache"
+            )
+        original.copy_(refreshed)
+        module._fused_norm_weight = original
 
 
 class WorkerExtension:
@@ -35,6 +73,22 @@ class WorkerExtension:
 
         >>> llm._collective_rpc("update_weights", args=(ipc_handles,))
     """
+
+    def finalize_weight_update(self) -> None:
+        """Finalize a refit and refresh post-load state safely for CUDA Graph replay."""
+        model_engine = self.engine.model_engine
+        model = model_engine.model
+        with _preserve_cuda_graph_refit_caches(model):
+            model_engine.model_loader.finalize_update_weights()
+            for module in model.modules():
+                if hasattr(module, "process_weights_after_loading") and not getattr(
+                    module, "_weights_removed", False
+                ):
+                    module.process_weights_after_loading()
+                if hasattr(module, "post_load_weights") and not getattr(
+                    module, "_weights_removed", False
+                ):
+                    module.post_load_weights()
 
     @control_action_decorator
     def update_weights(self, ipc_handles: Optional[dict] = None):
@@ -131,16 +185,7 @@ class WorkerExtension:
                 torch.cuda.ipc_collect()
             else:
                 logger.info("Finalize update weights")
-                self.engine.model_engine.model_loader.finalize_update_weights()
-                for module in self.engine.model_engine.model.modules():
-                    if hasattr(module, "process_weights_after_loading") and not getattr(
-                        module, "_weights_removed", False
-                    ):
-                        module.process_weights_after_loading()
-                    if hasattr(module, "post_load_weights") and not getattr(
-                        module, "_weights_removed", False
-                    ):
-                        module.post_load_weights()
+                self.finalize_weight_update()
                 moe_load_balancer = getattr(self.engine.model_engine, "moe_load_balancer", None)
                 if isinstance(moe_load_balancer, MoeLoadBalancer):
                     moe_load_balancer.register_weight_slots_after_to_cuda()

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -144,6 +144,7 @@ l0_a10:
   - unittest/llmapi/test_reasoning_parser.py
   - unittest/llmapi/test_serialization.py
   - unittest/llmapi/test_utils.py
+  - unittest/llmapi/test_rlhf_utils.py
   - unittest/llmapi/test_llm_args.py
   - unittest/llmapi/test_kv_cache_dtype_override.py
   - unittest/llmapi/test_additional_model_outputs.py -m "gpu1"

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -122,6 +122,7 @@ l0_dgx_b200:
     - unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py -m "part2"
     - unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py -m "part3"
     - unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py -m "part4"
+    - unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py -m "part5"
     - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_fp8_4gpus[tp4-fp8kv=False-attn_backend=TRTLLM-torch_compile=False]
     - accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_fp8_4gpus[tp2pp2-fp8kv=False-attn_backend=TRTLLM-torch_compile=False]
     - disaggregated/test_disaggregated.py::test_disaggregated_ctxpp2_genpp2[TinyLlama-1.1B-Chat-v1.0]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -137,6 +137,21 @@ l0_dgx_b200:
         lte: 8
     wildcards:
       gpu:
+        - '*b200*'
+      linux_distribution_name: ubuntu*
+    terms:
+      stage: pre_merge
+      backend: pytorch
+      orchestrator: ray
+  tests:
+    - unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py::test_llm_partial_update_weights_qwen35_35b_bf16_tp8_cuda_graph
+- condition:
+    ranges:
+      system_gpu_count:
+        gte: 8
+        lte: 8
+    wildcards:
+      gpu:
       - '*b200*'
       linux_distribution_name: ubuntu*
       cpu: x86_64

--- a/tests/unittest/_torch/modeling/test_qwen3_5_partial_loading.py
+++ b/tests/unittest/_torch/modeling/test_qwen3_5_partial_loading.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.models.checkpoints.hf.qwen3_5_weight_mapper import Qwen3_5MoeHfWeightMapper
+from tensorrt_llm._torch.models.modeling_qwen3_5 import _Qwen3_5VLModel
+from tensorrt_llm._torch.models.modeling_qwen3vl import Qwen3VisionModelBase
+from tensorrt_llm.quantization import QuantAlgo
+
+
+def test_qwen35_vl_propagates_partial_loading_to_vision_encoder():
+    model = SimpleNamespace(
+        mm_encoder=MagicMock(),
+        llm=MagicMock(),
+    )
+    model.llm.model_config = MagicMock()
+    mapper = Qwen3_5MoeHfWeightMapper()
+    mapper._model = model.llm
+    mapper._config = model.llm.model_config
+
+    _Qwen3_5VLModel.load_weights(
+        model,
+        {},
+        mapper,
+        allow_partial_loading=True,
+    )
+
+    model.mm_encoder.load_weights.assert_called_once_with(
+        {}, allow_partial_loading=True
+    )
+    assert model.llm.load_weights.call_args.kwargs["allow_partial_loading"] is True
+
+
+class _VisualStub(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(num_heads=2)
+
+
+def test_qwen3_vision_loader_propagates_partial_loading():
+    model = Qwen3VisionModelBase.__new__(Qwen3VisionModelBase)
+    nn.Module.__init__(model)
+    model.visual = _VisualStub()
+    weights = {
+        "model.visual.blocks.0.attn.qkv.weight": torch.empty(6, 2),
+    }
+
+    with patch(
+        "tensorrt_llm._torch.models.modeling_qwen3vl._load_weights_impl"
+    ) as load_weights_impl:
+        model.load_weights(weights, allow_partial_loading=True)
+
+    assert load_weights_impl.call_args.kwargs["allow_partial_loading"] is True
+    converted_weights = load_weights_impl.call_args.args[1]
+    assert converted_weights["blocks.0.attn.q_proj.weight"].shape == (2, 2)
+    assert converted_weights["blocks.0.attn.k_proj.weight"].shape == (2, 2)
+    assert converted_weights["blocks.0.attn.v_proj.weight"].shape == (2, 2)
+
+
+def test_qwen35_partial_block_fp8_qkvz_waits_for_weights_and_scales():
+    mapper = Qwen3_5MoeHfWeightMapper()
+    prefix = "model.layers.0.linear_attn.in_proj_"
+    qkv_weight = torch.empty(4, 2, dtype=torch.float8_e4m3fn)
+    z_weight = torch.empty(2, 2, dtype=torch.float8_e4m3fn)
+    qkv_scale = torch.empty(3, 1, dtype=torch.float32)
+    z_scale = torch.empty(1, 1, dtype=torch.float32)
+
+    mapper.begin_update_weights()
+    assert not mapper._stage_partial_split_projections(
+        {f"{prefix}qkv.weight": qkv_weight}, QuantAlgo.FP8_BLOCK_SCALES)
+    assert not mapper._stage_partial_split_projections(
+        {f"{prefix}z.weight": z_weight}, QuantAlgo.FP8_BLOCK_SCALES)
+    assert not mapper._stage_partial_split_projections(
+        {f"{prefix}qkv.weight_scale_inv": qkv_scale},
+        QuantAlgo.FP8_BLOCK_SCALES,
+    )
+    ready = mapper._stage_partial_split_projections(
+        {f"{prefix}z.weight_scale_inv": z_scale},
+        QuantAlgo.FP8_BLOCK_SCALES,
+    )
+
+    assert ready == {
+        f"{prefix}qkv.weight": qkv_weight,
+        f"{prefix}z.weight": z_weight,
+        f"{prefix}qkv.weight_scale_inv": qkv_scale,
+        f"{prefix}z.weight_scale_inv": z_scale,
+    }
+    mapper.finalize_update_weights()
+
+
+def test_qwen35_partial_bf16_qkvz_does_not_wait_for_scales():
+    mapper = Qwen3_5MoeHfWeightMapper()
+    prefix = "model.layers.0.linear_attn.in_proj_"
+    qkv_weight = torch.empty(4, 2, dtype=torch.bfloat16)
+    z_weight = torch.empty(2, 2, dtype=torch.bfloat16)
+
+    mapper.begin_update_weights()
+    assert not mapper._stage_partial_split_projections(
+        {f"{prefix}qkv.weight": qkv_weight}, QuantAlgo.FP8_BLOCK_SCALES)
+    ready = mapper._stage_partial_split_projections(
+        {f"{prefix}z.weight": z_weight}, QuantAlgo.FP8_BLOCK_SCALES)
+
+    assert ready == {
+        f"{prefix}qkv.weight": qkv_weight,
+        f"{prefix}z.weight": z_weight,
+    }
+    mapper.finalize_update_weights()

--- a/tests/unittest/_torch/modeling/test_qwen3_5_partial_loading.py
+++ b/tests/unittest/_torch/modeling/test_qwen3_5_partial_loading.py
@@ -30,14 +30,11 @@ def test_qwen35_vl_propagates_partial_loading_to_vision_encoder():
         allow_partial_loading=True,
     )
 
-    model.mm_encoder.load_weights.assert_called_once_with(
-        {}, allow_partial_loading=True
-    )
+    model.mm_encoder.load_weights.assert_called_once_with({}, allow_partial_loading=True)
     assert model.llm.load_weights.call_args.kwargs["allow_partial_loading"] is True
 
 
 class _VisualStub(nn.Module):
-
     def __init__(self):
         super().__init__()
         self.config = SimpleNamespace(num_heads=2)
@@ -73,9 +70,11 @@ def test_qwen35_partial_block_fp8_qkvz_waits_for_weights_and_scales():
 
     mapper.begin_update_weights()
     assert not mapper._stage_partial_split_projections(
-        {f"{prefix}qkv.weight": qkv_weight}, QuantAlgo.FP8_BLOCK_SCALES)
+        {f"{prefix}qkv.weight": qkv_weight}, QuantAlgo.FP8_BLOCK_SCALES
+    )
     assert not mapper._stage_partial_split_projections(
-        {f"{prefix}z.weight": z_weight}, QuantAlgo.FP8_BLOCK_SCALES)
+        {f"{prefix}z.weight": z_weight}, QuantAlgo.FP8_BLOCK_SCALES
+    )
     assert not mapper._stage_partial_split_projections(
         {f"{prefix}qkv.weight_scale_inv": qkv_scale},
         QuantAlgo.FP8_BLOCK_SCALES,
@@ -102,9 +101,11 @@ def test_qwen35_partial_bf16_qkvz_does_not_wait_for_scales():
 
     mapper.begin_update_weights()
     assert not mapper._stage_partial_split_projections(
-        {f"{prefix}qkv.weight": qkv_weight}, QuantAlgo.FP8_BLOCK_SCALES)
+        {f"{prefix}qkv.weight": qkv_weight}, QuantAlgo.FP8_BLOCK_SCALES
+    )
     ready = mapper._stage_partial_split_projections(
-        {f"{prefix}z.weight": z_weight}, QuantAlgo.FP8_BLOCK_SCALES)
+        {f"{prefix}z.weight": z_weight}, QuantAlgo.FP8_BLOCK_SCALES
+    )
 
     assert ready == {
         f"{prefix}qkv.weight": qkv_weight,

--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
@@ -1,7 +1,7 @@
 import base64
-import gc
 import importlib.util
 import multiprocessing
+import os
 import pickle
 import re
 import subprocess
@@ -17,7 +17,12 @@ from _torch.ray_orchestrator.single_gpu.test_llm_update_weights import (
     run_generate,
 )
 from torch.multiprocessing.reductions import reduce_tensor
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    Qwen3_5MoeForConditionalGeneration,
+)
 from utils.llm_data import llm_models_root
 from utils.torch_ref import RefHFModel
 from utils.util import skip_pre_blackwell, skip_pre_hopper
@@ -50,6 +55,115 @@ def release_shared_cuda_memory():
     torch.cuda.empty_cache()
 
 
+def _decoder_weight_group(name: str) -> str:
+    """Group the same parameter across repeated decoder layers."""
+    return re.sub(r"^model\.layers\.\d+\.", "", name)
+
+
+def _run_multi_gpu_update_weights(
+    *,
+    model_dir: str,
+    hf_model: RefHFModelWithIPCHandles,
+    device_ids: List[int],
+    llm_kwargs: dict,
+    sampling_params: SamplingParams,
+    partial: bool,
+    weight_group: Callable[[str], str] = _decoder_weight_group,
+    prompts_texts: Optional[List[str]] = None,
+    tokenizer_dir: Optional[str] = None,
+    warm_before_update: bool = False,
+    generate_fn: Callable = run_generate,
+) -> None:
+    """Run the shared warm/update/finalize/reference-comparison workflow."""
+    if prompts_texts is None:
+        prompts_texts = [
+            "Hello, my name is",
+            "The president of the United States is",
+            "The capital of France is",
+            "The future of AI is",
+        ]
+
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_dir or model_dir)
+    prompts = [tokenizer.encode(prompt) for prompt in prompts_texts]
+    del tokenizer
+
+    with LLM(
+        model=model_dir,
+        ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
+        tensor_parallel_size=len(device_ids),
+        load_format="dummy",
+        pipeline_parallel_size=1,
+        **llm_kwargs,
+    ) as llm:
+        if warm_before_update:
+            llm.generate(prompts, sampling_params)
+
+        if partial:
+            groups = sorted(
+                {
+                    weight_group(name)
+                    for name, _ in hf_model.all_weights[hf_model.device_id]
+                }
+            )
+            for group in groups:
+                ipc_handles = hf_model.get_weight_ipc_handles_serialized(
+                    device_ids,
+                    weight_filter=lambda name, group=group: (
+                        weight_group(name) == group
+                    ),
+                )
+                llm._collective_rpc("update_weights", (ipc_handles,))
+        else:
+            ipc_handles = hf_model.get_weight_ipc_handles_serialized(device_ids)
+            llm._collective_rpc("update_weights", (ipc_handles,))
+
+        llm._collective_rpc("update_weights", (None,))
+        llm_logits, ref_logits = generate_fn(
+            llm, hf_model, prompts, sampling_params
+        )
+        compare_logits(llm_logits, ref_logits)
+
+
+def _run_fp8_update_weights(
+    model_dir: str, fp8_model_dir: str, partial: bool
+) -> None:
+    model_dir = str(llm_models_root() / model_dir)
+    fp8_model_dir = str(llm_models_root() / fp8_model_dir)
+    num_hidden_layers = 1
+    hf_model = RefHFModelWithIPCHandles(
+        fp8_model_dir, num_hidden_layers=num_hidden_layers
+    )
+
+    llm_kwargs = {
+        "kv_cache_config": KvCacheConfig(
+            enable_block_reuse=True, free_gpu_memory_fraction=0.1
+        ),
+        "model_kwargs": {
+            "num_hidden_layers": num_hidden_layers,
+            "quantization_config": {
+                "activation_scheme": "dynamic",
+                "fmt": "e4m3",
+                "quant_method": "fp8",
+                "weight_block_size": [128, 128],
+            },
+        },
+    }
+    if "Qwen3/Qwen3-30B-A3B" in model_dir:
+        llm_kwargs["moe_config"] = {"backend": "DEEPGEMM"}
+
+    _run_multi_gpu_update_weights(
+        model_dir=model_dir,
+        hf_model=hf_model,
+        device_ids=[0, 1],
+        llm_kwargs=llm_kwargs,
+        sampling_params=SamplingParams(
+            temperature=0, return_generation_logits=True, max_tokens=1024
+        ),
+        partial=partial,
+        tokenizer_dir=fp8_model_dir,
+    )
+
+
 @pytest.mark.part0
 @skip_pre_blackwell
 @pytest.mark.parametrize(
@@ -60,63 +174,7 @@ def release_shared_cuda_memory():
     ],
 )
 def test_llm_update_weights_fp8(model_dir, fp8_model_dir):
-    model_dir = str(llm_models_root() / model_dir)
-    fp8_model_dir = str(llm_models_root() / fp8_model_dir)
-    additional_kwargs = {}
-    if "Qwen3/Qwen3-30B-A3B" in model_dir:
-        additional_kwargs["moe_config"] = {
-            "backend": "DEEPGEMM",
-        }
-        # moe_intermediate_size is 768, and FP8 block scaling needs each
-        # MoE TP shard to stay a multiple of the 128 block size, so MoE TP
-        # is capped at 2 (768 / 2 = 384) and EP covers the rest of tp=4.
-        additional_kwargs["moe_tensor_parallel_size"] = 2
-        additional_kwargs["moe_expert_parallel_size"] = 2
-    num_hidden_layers = 1
-    hf_model = RefHFModelWithIPCHandles(fp8_model_dir, num_hidden_layers=num_hidden_layers)
-    tokenizer = AutoTokenizer.from_pretrained(fp8_model_dir)
-    kv_cache_config = KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1)
-    with LLM(
-        model=model_dir,
-        ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
-        tensor_parallel_size=4,
-        load_format="dummy",
-        pipeline_parallel_size=1,
-        kv_cache_config=kv_cache_config,
-        model_kwargs={
-            "num_hidden_layers": num_hidden_layers,
-            "quantization_config": {
-                "activation_scheme": "dynamic",
-                "fmt": "e4m3",
-                "quant_method": "fp8",
-                "weight_block_size": [128, 128],
-            },
-        },
-        **additional_kwargs,
-    ) as llm:
-        # Generate texts from the prompts.
-        prompts_texts = [
-            "Hello, my name is",
-            "The president of the United States is",
-            "The capital of France is",
-            "The future of AI is",
-        ]
-        prompts = [tokenizer.encode(prompt) for prompt in prompts_texts]
-        del tokenizer
-        sampling_params = SamplingParams(
-            temperature=0, return_generation_logits=True, max_tokens=1024
-        )
-
-        ipc_handles = hf_model.get_weight_ipc_handles_serialized([0, 1, 2, 3])
-
-        llm._collective_rpc("update_weights", (ipc_handles,))
-        # Finalize the update weights
-        llm._collective_rpc("update_weights", (None,))
-
-        llm_logits, ref_logits = run_generate(llm, hf_model, prompts, sampling_params)
-        compare_logits(llm_logits, ref_logits)
-
-    del hf_model
+    _run_fp8_update_weights(model_dir, fp8_model_dir, partial=False)
 
 
 @pytest.mark.part1
@@ -129,82 +187,201 @@ def test_llm_update_weights_fp8(model_dir, fp8_model_dir):
     ],
 )
 def test_llm_partial_update_weights_fp8(model_dir, fp8_model_dir):
-    model_dir = str(llm_models_root() / model_dir)
-    fp8_model_dir = str(llm_models_root() / fp8_model_dir)
-    additional_kwargs = {}
-    if "Qwen3/Qwen3-30B-A3B" in model_dir:
-        additional_kwargs["moe_config"] = {
-            "backend": "DEEPGEMM",
-        }
-        # moe_intermediate_size is 768, and FP8 block scaling needs each
-        # MoE TP shard to stay a multiple of the 128 block size, so MoE TP
-        # is capped at 2 (768 / 2 = 384) and EP covers the rest of tp=4.
-        additional_kwargs["moe_tensor_parallel_size"] = 2
-        additional_kwargs["moe_expert_parallel_size"] = 2
-    num_hidden_layers = 1
-    hf_model = RefHFModelWithIPCHandles(fp8_model_dir, num_hidden_layers=num_hidden_layers)
-    tokenizer = AutoTokenizer.from_pretrained(fp8_model_dir)
-    kv_cache_config = KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1)
-    with LLM(
-        model=model_dir,
-        ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
-        tensor_parallel_size=4,
-        load_format="dummy",
-        pipeline_parallel_size=1,
-        kv_cache_config=kv_cache_config,
-        model_kwargs={
-            "num_hidden_layers": num_hidden_layers,
-            "quantization_config": {
-                "activation_scheme": "dynamic",
-                "fmt": "e4m3",
-                "quant_method": "fp8",
-                "weight_block_size": [128, 128],
-            },
-        },
-        **additional_kwargs,
-    ) as llm:
-        # Generate texts from the prompts.
-        prompts_texts = [
-            "Hello, my name is",
-            "The president of the United States is",
-            "The capital of France is",
-            "The future of AI is",
-        ]
-        prompts = [tokenizer.encode(prompt) for prompt in prompts_texts]
-        del tokenizer
+    _run_fp8_update_weights(model_dir, fp8_model_dir, partial=True)
 
-        sampling_params = SamplingParams(
-            temperature=0, return_generation_logits=True, max_tokens=1024
+
+# The real Qwen3.5-397B architecture repeats three Gated DeltaNet layers and
+# one full-attention layer. Four layers are therefore the smallest prefix that
+# exercises every decoder-layer type without changing the production ordering.
+_QWEN35_397B_REDUCED_LAYERS = 4
+_QWEN35_397B_LAYER_TYPES = [
+    "linear_attention",
+    "linear_attention",
+    "linear_attention",
+    "full_attention",
+]
+_QWEN35_397B_TP_SIZE = 4
+
+
+def _qwen35_397b_bf16_model_dir() -> str:
+    """Resolve the real BF16 checkpoint, with a local override for bring-up."""
+    model_dir = os.environ.get("QWEN35_397B_BF16_MODEL_DIR")
+    if model_dir:
+        return model_dir
+    return str(llm_models_root() / "Qwen3.5-397B-A17B")
+
+
+def _qwen35_397b_reduced_config(model_dir: str):
+    """Preserve 397B tensor shapes while dropping repeated model depth."""
+    config = AutoConfig.from_pretrained(model_dir)
+    text_config = config.text_config
+    text_config.num_hidden_layers = _QWEN35_397B_REDUCED_LAYERS
+    text_config.layer_types = list(_QWEN35_397B_LAYER_TYPES)
+
+    # MTP refit is independent of the rollout-model refit under test and costs
+    # roughly one additional 397B decoder layer.
+    if hasattr(text_config, "mtp_num_hidden_layers"):
+        text_config.mtp_num_hidden_layers = 0
+
+    # Text-only generation still constructs the VLM wrapper. One vision block
+    # covers its partial-loading path without retaining all 27 repeated blocks.
+    config.vision_config.depth = 1
+    return config
+
+
+def _qwen35_397b_model_kwargs() -> dict:
+    """Apply the same nested reductions to TRT-LLM's composite config."""
+    return {
+        "text_config": {
+            "num_hidden_layers": _QWEN35_397B_REDUCED_LAYERS,
+            "layer_types": list(_QWEN35_397B_LAYER_TYPES),
+            "mtp_num_hidden_layers": 0,
+        },
+        "vision_config": {"depth": 1},
+    }
+
+
+class RefQwen35_397BModelWithIPCHandles(RefHFModelWithIPCHandles):
+    """Reduced-depth, exact-width BF16 397B reference model.
+
+    Unlike the generic helper, the source-device IPC entries alias the HF
+    parameters instead of cloning them. update_weights only reads these
+    allocations, so this saves one complete reduced-model copy on cuda:0 while
+    keeping the reference model available for logits comparison.
+    """
+
+    def __init__(
+        self,
+        model_dir: str,
+        device_id: int = 0,
+        device_ids: Optional[List[int]] = None,
+    ):
+        self.device_id = device_id
+        config = _qwen35_397b_reduced_config(model_dir)
+        self.model = Qwen3_5MoeForConditionalGeneration.from_pretrained(
+            model_dir,
+            config=config,
+            torch_dtype=torch.bfloat16,
+            attn_implementation="eager",
+            low_cpu_mem_usage=True,
+        ).eval().to(f"cuda:{device_id}")
+        self.all_weights = {}
+        self.device_uuid = [
+            get_device_uuid(i) for i in range(torch.cuda.device_count())
+        ]
+        self._replicate_weights_to_devices(
+            list(range(torch.cuda.device_count()))
+            if device_ids is None
+            else device_ids
         )
 
-        def common_filter(filter_name: str) -> Callable[[str], bool]:
-            def filter_fn(name: str) -> bool:
-                return name.endswith(filter_name)
+    def _replicate_weights_to_devices(self, device_ids: List[int]) -> None:
+        source_weights = [
+            (name, parameter.detach())
+            for name, parameter in self.model.named_parameters()
+        ]
+        self.all_weights[self.device_id] = source_weights
+        for device_id in device_ids:
+            if device_id == self.device_id:
+                continue
+            self.all_weights[device_id] = [
+                (name, parameter.to(f"cuda:{device_id}"))
+                for name, parameter in source_weights
+            ]
 
-            return filter_fn
 
-        # Generate filter_list from model weight keys by removing layer prefix
-        # e.g., "model.layers.41.input_layernorm.weight" -> "input_layernorm.weight"
-        layer_prefix_pattern = re.compile(r"^model\.layers\.\d+\.")
-        filter_set = set()
-        for name, _ in hf_model.all_weights[hf_model.device_id]:
-            suffix = layer_prefix_pattern.sub("", name)
-            filter_set.add(suffix)
-        filter_list = list(filter_set)
+def _qwen35_397b_weight_group(name: str) -> str:
+    """Group repeated layers/experts while separating projection families.
 
-        for filter_name in filter_list:
-            weight_filter = common_filter(filter_name=filter_name)
-            ipc_handles = hf_model.get_weight_ipc_handles_serialized(
-                [0, 1, 2, 3], weight_filter=weight_filter
-            )
-            llm._collective_rpc("update_weights", (ipc_handles,))
-        # Finalize the update weights
-        llm._collective_rpc("update_weights", (None,))
+    This produces a practical number of update RPCs and deliberately places
+    QKV, Z, B, A, gate-up, and down projections in separate invocations. It
+    therefore exercises mapper state across incremental calls rather than
+    relying on checkpoint or dictionary order to keep fusion groups together.
+    """
+    name = re.sub(r"(\.layers\.)\d+\.", r"\1*.", name)
+    name = re.sub(r"(\.blocks\.)\d+\.", r"\1*.", name)
+    name = re.sub(r"(\.experts\.)\d+\.", r"\1*.", name)
+    return name
 
-        llm_logits, ref_logits = run_generate(llm, hf_model, prompts, sampling_params)
-        compare_logits(llm_logits, ref_logits)
 
-    del hf_model
+def _run_generate_qwen35_397b(llm, hf_model, prompts, sampling_params):
+    """Compare short generations without allocating 2K-token 248K-vocab logits."""
+    llm_responses = []
+    llm_logits = []
+    for output in llm.generate(prompts, sampling_params):
+        llm_logits.append(output.outputs[0].generation_logits)
+        llm_responses.append(output.outputs[0].token_ids)
+
+    prompt_max_len = max(len(prompt) for prompt in prompts)
+    response_max_len = max(len(response) for response in llm_responses)
+    input_ids, attention_mask, position_ids = RefHFModel.pad_data(
+        prompts,
+        llm_responses,
+        prompt_max_len=prompt_max_len,
+        response_max_len=response_max_len,
+    )
+    ref_logits = hf_model.generate_batch_with_padding(
+        input_ids,
+        attention_mask,
+        position_ids,
+        llm_responses,
+        prompt_max_len=prompt_max_len,
+        micro_batch_size=1,
+        return_logits=True,
+    )
+    return llm_logits, ref_logits
+
+
+def _run_qwen35_397b_bf16_update(partial: bool) -> None:
+    model_dir = _qwen35_397b_bf16_model_dir()
+    if not os.path.isdir(model_dir):
+        pytest.skip(f"Model directory {model_dir} does not exist")
+
+    device_ids = list(range(_QWEN35_397B_TP_SIZE))
+    hf_model = RefQwen35_397BModelWithIPCHandles(
+        model_dir, device_ids=device_ids
+    )
+    _run_multi_gpu_update_weights(
+        model_dir=model_dir,
+        hf_model=hf_model,
+        device_ids=device_ids,
+        llm_kwargs={
+            "max_batch_size": 2,
+            "max_seq_len": 256,
+            "max_num_tokens": 256,
+            "kv_cache_config": KvCacheConfig(
+                enable_block_reuse=True, free_gpu_memory_fraction=0.05
+            ),
+            "model_kwargs": _qwen35_397b_model_kwargs(),
+            "moe_config": MoeConfig(backend="TRTLLM"),
+        },
+        sampling_params=SamplingParams(
+            temperature=0, return_generation_logits=True, max_tokens=8
+        ),
+        partial=partial,
+        weight_group=_qwen35_397b_weight_group,
+        prompts_texts=["Hello, my name is", "The future of AI is"],
+        warm_before_update=True,
+        generate_fn=_run_generate_qwen35_397b,
+    )
+
+
+@pytest.mark.part0
+@pytest.mark.gpu4
+@pytest.mark.high_cuda_memory
+@skip_pre_blackwell
+def test_llm_update_weights_qwen35_397b_bf16():
+    """One-shot BF16 refit of a reduced-depth, exact-shape 397B model."""
+    _run_qwen35_397b_bf16_update(partial=False)
+
+
+@pytest.mark.part1
+@pytest.mark.gpu4
+@pytest.mark.high_cuda_memory
+@skip_pre_blackwell
+def test_llm_partial_update_weights_qwen35_397b_bf16():
+    """Incremental BF16 refit with GDN and MoE fusion groups split across RPCs."""
+    _run_qwen35_397b_bf16_update(partial=True)
 
 
 class RefNVFP4ModelWithIPCHandles(RefHFModel):
@@ -358,11 +535,10 @@ class RefNVFP4ModelWithIPCHandles(RefHFModel):
 
         assert not fusion_buffer, f"Incomplete fusion groups: {list(fusion_buffer.keys())}"
 
-        # Only populate the owning device. Extra replicas are materialized
-        # lazily by ``get_weight_ipc_handles_serialized`` so that GPUs never
-        # asked for via IPC don't hold NVFP4 quantized tensors that persist
-        # across parametrize IDs.
         self.all_weights[self.device_id] = model_weights
+        for i in range(torch.cuda.device_count()):
+            if i != self.device_id:
+                self.all_weights[i] = [(n, p.to(f"cuda:{i}")) for n, p in model_weights]
 
         with torch.no_grad():
             param_dict = dict(self.model.named_parameters())
@@ -464,10 +640,6 @@ class RefNVFP4ModelWithIPCHandles(RefHFModel):
         device_list = list(range(torch.cuda.device_count())) if device_ids is None else device_ids
 
         for device in device_list:
-            if device not in self.all_weights:
-                src = self.all_weights[self.device_id]
-                self.all_weights[device] = [(n, p.to(f"cuda:{device}")) for n, p in src]
-
             all_handles = []
             for item in self.all_weights[device]:
                 name, p = item
@@ -509,7 +681,7 @@ def test_llm_update_weights_nvfp4(model_dir, kv_cache_dtype):
     with LLM(
         model=model_dir,
         ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
-        tensor_parallel_size=4,
+        tensor_parallel_size=2,
         load_format="dummy",
         pipeline_parallel_size=1,
         kv_cache_config=kv_cache_config,
@@ -534,15 +706,13 @@ def test_llm_update_weights_nvfp4(model_dir, kv_cache_dtype):
             temperature=0, return_generation_logits=True, max_tokens=1024
         )
 
-        ipc_handles = hf_model.get_weight_ipc_handles_serialized([0, 1, 2, 3])
+        ipc_handles = hf_model.get_weight_ipc_handles_serialized([0, 1])
         llm._collective_rpc("update_weights", (ipc_handles,))
         llm._collective_rpc("update_weights", (None,))
 
         llm_logits, ref_logits = run_generate(llm, hf_model, prompts, sampling_params)
         # Use a looser threshold because NVFP4 logits are compared against a BF16 reference.
         compare_logits(llm_logits, ref_logits, threshold=0.8)
-
-    del hf_model
 
 
 @pytest.mark.part3
@@ -572,7 +742,7 @@ def test_llm_partial_update_weights_nvfp4(model_dir, kv_cache_dtype):
     with LLM(
         model=model_dir,
         ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
-        tensor_parallel_size=4,
+        tensor_parallel_size=2,
         load_format="dummy",
         pipeline_parallel_size=1,
         kv_cache_config=kv_cache_config,
@@ -615,7 +785,7 @@ def test_llm_partial_update_weights_nvfp4(model_dir, kv_cache_dtype):
         for filter_name in filter_list:
             weight_filter = common_filter(filter_name=filter_name)
             ipc_handles = hf_model.get_weight_ipc_handles_serialized(
-                [0, 1, 2, 3], weight_filter=weight_filter
+                [0, 1], weight_filter=weight_filter
             )
             llm._collective_rpc("update_weights", (ipc_handles,))
         llm._collective_rpc("update_weights", (None,))
@@ -623,8 +793,6 @@ def test_llm_partial_update_weights_nvfp4(model_dir, kv_cache_dtype):
         llm_logits, ref_logits = run_generate(llm, hf_model, prompts, sampling_params)
         # Use a looser threshold because NVFP4 logits are compared against a BF16 reference.
         compare_logits(llm_logits, ref_logits, threshold=0.8)
-
-    del hf_model
 
 
 @pytest.fixture
@@ -762,8 +930,6 @@ def _nemotron_h_body():
 
         llm_logits, ref_logits = run_generate(llm, hf_model, prompts, sampling_params)
         compare_logits(llm_logits, ref_logits)
-
-    del hf_model
 
 
 def _nemotron_h_subprocess_entry(result_queue):

--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
@@ -1,4 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import base64
+import gc
 import importlib.util
 import json
 import multiprocessing
@@ -30,12 +34,14 @@ from utils.torch_ref import RefHFModel
 from utils.util import skip_pre_blackwell, skip_pre_hopper
 
 from tensorrt_llm import LLM
+from tensorrt_llm._ray_utils import control_action_decorator
 from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.torch_quant import (
     _dequantize_nvfp4,
     _quantize_nvfp4,
 )
 from tensorrt_llm._torch.utils import get_device_uuid
-from tensorrt_llm.llmapi import KvCacheConfig, MoeConfig, SamplingParams
+from tensorrt_llm.llmapi import CudaGraphConfig, KvCacheConfig, MoeConfig, SamplingParams
+from tensorrt_llm.llmapi.rlhf_utils import WorkerExtension
 
 # Ray-backed LLM teardown only fires from RayExecutor.shutdown(), which runs
 # after pytest-threadleak's per-test snapshot — see the matching docstring in
@@ -102,17 +108,12 @@ def _run_multi_gpu_update_weights(
 
         if partial:
             groups = sorted(
-                {
-                    weight_group(name)
-                    for name, _ in hf_model.all_weights[hf_model.device_id]
-                }
+                {weight_group(name) for name, _ in hf_model.all_weights[hf_model.device_id]}
             )
             for group in groups:
                 ipc_handles = hf_model.get_weight_ipc_handles_serialized(
                     device_ids,
-                    weight_filter=lambda name, group=group: (
-                        weight_group(name) == group
-                    ),
+                    weight_filter=lambda name, group=group: (weight_group(name) == group),
                 )
                 llm._collective_rpc("update_weights", (ipc_handles,))
         else:
@@ -120,26 +121,18 @@ def _run_multi_gpu_update_weights(
             llm._collective_rpc("update_weights", (ipc_handles,))
 
         llm._collective_rpc("update_weights", (None,))
-        llm_logits, ref_logits = generate_fn(
-            llm, hf_model, prompts, sampling_params
-        )
+        llm_logits, ref_logits = generate_fn(llm, hf_model, prompts, sampling_params)
         compare_logits(llm_logits, ref_logits)
 
 
-def _run_fp8_update_weights(
-    model_dir: str, fp8_model_dir: str, partial: bool
-) -> None:
+def _run_fp8_update_weights(model_dir: str, fp8_model_dir: str, partial: bool) -> None:
     model_dir = str(llm_models_root() / model_dir)
     fp8_model_dir = str(llm_models_root() / fp8_model_dir)
     num_hidden_layers = 1
-    hf_model = RefHFModelWithIPCHandles(
-        fp8_model_dir, num_hidden_layers=num_hidden_layers
-    )
+    hf_model = RefHFModelWithIPCHandles(fp8_model_dir, num_hidden_layers=num_hidden_layers)
 
     llm_kwargs = {
-        "kv_cache_config": KvCacheConfig(
-            enable_block_reuse=True, free_gpu_memory_fraction=0.1
-        ),
+        "kv_cache_config": KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1),
         "model_kwargs": {
             "num_hidden_layers": num_hidden_layers,
             "quantization_config": {
@@ -192,77 +185,85 @@ def test_llm_partial_update_weights_fp8(model_dir, fp8_model_dir):
     _run_fp8_update_weights(model_dir, fp8_model_dir, partial=True)
 
 
-# The real Qwen3.5-397B architecture repeats three Gated DeltaNet layers and
-# one full-attention layer. Four layers are therefore the smallest prefix that
-# exercises every decoder-layer type without changing the production ordering.
-_QWEN35_397B_REDUCED_LAYERS = 4
-_QWEN35_397B_LAYER_TYPES = [
+_QWEN35_35B_TP8 = 8
+_QWEN35_35B_REDUCED_LAYERS = 4
+_QWEN35_35B_LAYER_TYPES = [
     "linear_attention",
     "linear_attention",
     "linear_attention",
     "full_attention",
 ]
-_QWEN35_397B_TP_SIZE = int(os.environ.get("QWEN35_397B_TP_SIZE", "4"))
+_QWEN35_35B_TP8_EXTENSION = (
+    "_torch.ray_orchestrator.multi_gpu.test_llm_update_weights_multi_gpu."
+    "Qwen35_35BTP8WorkerExtension"
+)
 
 
-def _qwen35_397b_bf16_model_dir() -> str:
+def _qwen35_35b_bf16_model_dir() -> str:
     """Resolve the real BF16 checkpoint, with a local override for bring-up."""
-    model_dir = os.environ.get("QWEN35_397B_BF16_MODEL_DIR")
+    model_dir = os.environ.get("QWEN35_35B_BF16_MODEL_DIR")
     if model_dir:
         return model_dir
-    return str(llm_models_root() / "Qwen3.5-397B-A17B")
+    return str(llm_models_root() / "Qwen3.5-35B-A3B")
 
 
-def _qwen35_397b_fp8_model_dir() -> str:
+def _qwen35_35b_fp8_model_dir() -> str:
     """Resolve the real block-FP8 checkpoint, with a local override."""
-    model_dir = os.environ.get("QWEN35_397B_FP8_MODEL_DIR")
+    model_dir = os.environ.get("QWEN35_35B_FP8_MODEL_DIR")
     if model_dir:
         return model_dir
-    return str(llm_models_root() / "Qwen3.5-397B-A17B-FP8")
+    return str(llm_models_root() / "Qwen3.5-35B-A3B-FP8")
 
 
-def _qwen35_397b_reduced_config(model_dir: str):
-    """Preserve 397B tensor shapes while dropping repeated model depth."""
+def _qwen35_35b_test_config(model_dir: str):
+    """Keep the exact 35B width while reducing depth for refit-test memory."""
     config = AutoConfig.from_pretrained(model_dir)
     text_config = config.text_config
-    text_config.num_hidden_layers = _QWEN35_397B_REDUCED_LAYERS
-    text_config.layer_types = list(_QWEN35_397B_LAYER_TYPES)
 
-    # MTP refit is independent of the rollout-model refit under test and costs
-    # roughly one additional 397B decoder layer.
+    text_config.num_hidden_layers = _QWEN35_35B_REDUCED_LAYERS
+    text_config.layer_types = _QWEN35_35B_LAYER_TYPES
+
+    # MTP refit is independent of the rollout-model refit under test.
     if hasattr(text_config, "mtp_num_hidden_layers"):
         text_config.mtp_num_hidden_layers = 0
 
-    # Transformers' fine-grained FP8 MoE wrapper eagerly evaluates its
-    # intermediate_size fallback even when moe_intermediate_size is present.
+    # Transformers eagerly evaluates this fallback even when
+    # moe_intermediate_size is present.
     if not hasattr(text_config, "intermediate_size"):
         text_config.intermediate_size = text_config.moe_intermediate_size
 
-    # Text-only generation still constructs the VLM wrapper. One vision block
-    # covers its partial-loading path without retaining all 27 repeated blocks.
+    # Text-only generation still constructs the VLM wrapper.
     config.vision_config.depth = 1
     return config
 
 
-def _qwen35_397b_model_kwargs() -> dict:
-    """Apply the same nested reductions to TRT-LLM's composite config."""
+def _qwen35_35b_model_kwargs() -> dict:
+    """Apply the same depth, MTP, and vision reductions to TRT-LLM."""
     return {
         "text_config": {
-            "num_hidden_layers": _QWEN35_397B_REDUCED_LAYERS,
-            "layer_types": list(_QWEN35_397B_LAYER_TYPES),
+            "num_hidden_layers": _QWEN35_35B_REDUCED_LAYERS,
+            "layer_types": _QWEN35_35B_LAYER_TYPES,
             "mtp_num_hidden_layers": 0,
         },
         "vision_config": {"depth": 1},
     }
 
 
-class RefQwen35_397BModelWithIPCHandles(RefHFModelWithIPCHandles):
-    """Reduced-depth, exact-width BF16 or FP8 397B reference model.
+def _qwen35_35b_is_test_weight(name: str) -> bool:
+    """Select checkpoint weights used by the reduced-depth text model."""
+    if name.startswith("model.visual.") or ".mtp." in name:
+        return False
+    layer_match = re.search(r"\.layers\.(\d+)\.", name)
+    return not (layer_match and int(layer_match.group(1)) >= _QWEN35_35B_REDUCED_LAYERS)
+
+
+class RefQwen35_35BModelWithIPCHandles(RefHFModelWithIPCHandles):
+    """Production-width BF16 35B reference model for exact-logit comparison.
 
     Unlike the generic helper, the source-device IPC entries alias the HF
     parameters instead of cloning them. update_weights only reads these
-    allocations, so this saves one complete reduced-model copy on cuda:0 while
-    keeping the reference model available for logits comparison.
+    allocations, saving one complete model copy on cuda:0 while keeping the
+    reference model available for logits comparison.
     """
 
     def __init__(
@@ -272,41 +273,39 @@ class RefQwen35_397BModelWithIPCHandles(RefHFModelWithIPCHandles):
         device_ids: Optional[List[int]] = None,
     ):
         self.device_id = device_id
-        config = _qwen35_397b_reduced_config(model_dir)
-        self.model = Qwen3_5MoeForConditionalGeneration.from_pretrained(
-            model_dir,
-            config=config,
-            torch_dtype=torch.bfloat16,
-            attn_implementation="eager",
-            low_cpu_mem_usage=True,
-        ).eval().to(f"cuda:{device_id}")
+        config = _qwen35_35b_test_config(model_dir)
+        self.model = (
+            Qwen3_5MoeForConditionalGeneration.from_pretrained(
+                model_dir,
+                config=config,
+                torch_dtype=torch.bfloat16,
+                attn_implementation="eager",
+                low_cpu_mem_usage=True,
+            )
+            .eval()
+            .to(f"cuda:{device_id}")
+        )
         self.all_weights = {}
-        self.device_uuid = [
-            get_device_uuid(i) for i in range(torch.cuda.device_count())
-        ]
+        self.device_uuid = [get_device_uuid(i) for i in range(torch.cuda.device_count())]
         self._replicate_weights_to_devices(
-            list(range(torch.cuda.device_count()))
-            if device_ids is None
-            else device_ids
+            list(range(torch.cuda.device_count())) if device_ids is None else device_ids
         )
 
     def _replicate_weights_to_devices(self, device_ids: List[int]) -> None:
         source_weights = [
-            (name, parameter.detach())
-            for name, parameter in self.model.named_parameters()
+            (name, parameter.detach()) for name, parameter in self.model.named_parameters()
         ]
         self.all_weights[self.device_id] = source_weights
         for device_id in device_ids:
             if device_id == self.device_id:
                 continue
             self.all_weights[device_id] = [
-                (name, parameter.to(f"cuda:{device_id}"))
-                for name, parameter in source_weights
+                (name, parameter.to(f"cuda:{device_id}")) for name, parameter in source_weights
             ]
 
 
-class RefQwen35_397BFP8CheckpointWithIPCHandles(RefHFModelWithIPCHandles):
-    """Expose exact reduced-depth checkpoint tensors through CUDA IPC.
+class RefQwen35_35BFP8CheckpointWithIPCHandles(RefHFModelWithIPCHandles):
+    """Expose exact production-width checkpoint tensors through CUDA IPC.
 
     Transformers currently does not ingest Qwen3.5's per-expert block-FP8
     checkpoint layout: it reports the split expert weights/scales as
@@ -317,9 +316,7 @@ class RefQwen35_397BFP8CheckpointWithIPCHandles(RefHFModelWithIPCHandles):
 
     def __init__(self, model_dir: str, device_ids: List[int]):
         self.device_id = device_ids[0]
-        self.device_uuid = [
-            get_device_uuid(i) for i in range(torch.cuda.device_count())
-        ]
+        self.device_uuid = [get_device_uuid(i) for i in range(torch.cuda.device_count())]
         self.all_weights = {device_id: [] for device_id in device_ids}
 
         with open(os.path.join(model_dir, "model.safetensors.index.json")) as f:
@@ -327,14 +324,8 @@ class RefQwen35_397BFP8CheckpointWithIPCHandles(RefHFModelWithIPCHandles):
 
         selected_by_shard = {}
         for name, shard in weight_map.items():
-            layer_match = re.match(
-                r"model\.language_model\.layers\.(\d+)\.", name
-            )
-            if layer_match and int(layer_match.group(1)) >= _QWEN35_397B_REDUCED_LAYERS:
-                continue
-            if name.startswith("model.visual.") or ".mtp." in name:
-                continue
-            selected_by_shard.setdefault(shard, []).append(name)
+            if _qwen35_35b_is_test_weight(name):
+                selected_by_shard.setdefault(shard, []).append(name)
 
         for shard, names in sorted(selected_by_shard.items()):
             with safe_open(
@@ -343,12 +334,10 @@ class RefQwen35_397BFP8CheckpointWithIPCHandles(RefHFModelWithIPCHandles):
                 for name in sorted(names):
                     weight = checkpoint.get_tensor(name)
                     for device_id in device_ids:
-                        self.all_weights[device_id].append(
-                            (name, weight.to(f"cuda:{device_id}"))
-                        )
+                        self.all_weights[device_id].append((name, weight.to(f"cuda:{device_id}")))
 
 
-def _qwen35_397b_weight_group(name: str) -> str:
+def _qwen35_35b_weight_group(name: str) -> str:
     """Group repeated layers/experts while separating projection families.
 
     This produces a practical number of update RPCs and deliberately places
@@ -362,7 +351,75 @@ def _qwen35_397b_weight_group(name: str) -> str:
     return name
 
 
-def _run_generate_qwen35_397b(llm, hf_model, prompts, sampling_params):
+def _qwen35_35b_selected_checkpoint_names(model_dir: str) -> List[str]:
+    """Return the production-width text weights used by the reduced-depth test."""
+    with open(os.path.join(model_dir, "model.safetensors.index.json")) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    return sorted(name for name in weight_map if _qwen35_35b_is_test_weight(name))
+
+
+def _qwen35_35b_load_checkpoint_group(
+    model_dir: str, weight_group: str, device: torch.device
+) -> List[Tuple[str, torch.Tensor]]:
+    """Load one incremental update group onto a Ray worker's local GPU."""
+    with open(os.path.join(model_dir, "model.safetensors.index.json")) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    selected_by_shard = {}
+    for name in _qwen35_35b_selected_checkpoint_names(model_dir):
+        if _qwen35_35b_weight_group(name) == weight_group:
+            selected_by_shard.setdefault(weight_map[name], []).append(name)
+
+    weights = []
+    for shard, names in sorted(selected_by_shard.items()):
+        with safe_open(os.path.join(model_dir, shard), framework="pt", device="cpu") as checkpoint:
+            weights.extend((name, checkpoint.get_tensor(name).to(device)) for name in sorted(names))
+    return weights
+
+
+def _return_local_weight(tensor: torch.Tensor, *_: object) -> torch.Tensor:
+    """Return a worker-local tensor through the refit handle interface."""
+    return tensor
+
+
+class Qwen35_35BTP8WorkerExtension(WorkerExtension):
+    """Refit helpers that also work when TP8 spans two Ray nodes."""
+
+    def get_test_device_name(self) -> str:
+        return torch.cuda.get_device_name(self.device_id)
+
+    @control_action_decorator
+    def update_weights_from_local_checkpoint(
+        self, model_dir: str, weight_group: Optional[str] = None
+    ) -> None:
+        """Load a bucket beside each worker, avoiding cross-node CUDA IPC."""
+        if weight_group is None:
+            WorkerExtension.update_weights.__wrapped__(self, None)
+            return
+
+        local_weights = _qwen35_35b_load_checkpoint_group(
+            model_dir,
+            weight_group,
+            torch.device("cuda", self.device_id),
+        )
+        device_uuid = get_device_uuid(self.device_id)
+        handles = {
+            device_uuid: [
+                (
+                    name,
+                    (
+                        _return_local_weight,
+                        (weight, None, None, None, None, None, None),
+                    ),
+                )
+                for name, weight in local_weights
+            ]
+        }
+        WorkerExtension.update_weights.__wrapped__(self, handles)
+
+
+def _run_generate_qwen35_35b(llm, hf_model, prompts, sampling_params):
     """Compare short generations without allocating 2K-token 248K-vocab logits."""
     llm_responses = []
     llm_logits = []
@@ -390,13 +447,19 @@ def _run_generate_qwen35_397b(llm, hf_model, prompts, sampling_params):
     return llm_logits, ref_logits
 
 
-def _run_qwen35_397b_update(model_dir: str, partial: bool) -> None:
+def _run_qwen35_35b_update(
+    model_dir: str,
+    partial: bool,
+    tp_size: int = 4,
+    explicit_cuda_graph: bool = False,
+) -> None:
     if not os.path.isdir(model_dir):
         pytest.skip(f"Model directory {model_dir} does not exist")
 
-    device_ids = list(range(_QWEN35_397B_TP_SIZE))
-    hf_model = RefQwen35_397BModelWithIPCHandles(
-        model_dir, device_ids=device_ids
+    device_ids = list(range(tp_size))
+    hf_model = RefQwen35_35BModelWithIPCHandles(model_dir, device_ids=device_ids)
+    cuda_graph_config = (
+        CudaGraphConfig(batch_sizes=[1, 2], max_batch_size=2) if explicit_cuda_graph else None
     )
     _run_multi_gpu_update_weights(
         model_dir=model_dir,
@@ -407,56 +470,53 @@ def _run_qwen35_397b_update(model_dir: str, partial: bool) -> None:
             "max_seq_len": 256,
             "max_num_tokens": 256,
             "kv_cache_config": KvCacheConfig(
-                enable_block_reuse=True, free_gpu_memory_fraction=0.05
+                enable_block_reuse=True,
+                free_gpu_memory_fraction=0.05,
+                mamba_ssm_cache_dtype="bfloat16",
             ),
-            "model_kwargs": _qwen35_397b_model_kwargs(),
+            **({"cuda_graph_config": cuda_graph_config} if cuda_graph_config is not None else {}),
+            "model_kwargs": _qwen35_35b_model_kwargs(),
             "moe_config": MoeConfig(backend="TRTLLM"),
         },
-        sampling_params=SamplingParams(
-            temperature=0, return_generation_logits=True, max_tokens=8
-        ),
+        sampling_params=SamplingParams(temperature=0, return_generation_logits=True, max_tokens=8),
         partial=partial,
-        weight_group=_qwen35_397b_weight_group,
+        weight_group=_qwen35_35b_weight_group,
         prompts_texts=["Hello, my name is", "The future of AI is"],
         warm_before_update=True,
-        generate_fn=_run_generate_qwen35_397b,
+        generate_fn=_run_generate_qwen35_35b,
     )
 
 
-def _run_qwen35_397b_bf16_update(partial: bool) -> None:
-    _run_qwen35_397b_update(_qwen35_397b_bf16_model_dir(), partial)
+def _run_qwen35_35b_bf16_update(
+    partial: bool,
+    tp_size: int = 4,
+    explicit_cuda_graph: bool = False,
+) -> None:
+    _run_qwen35_35b_update(_qwen35_35b_bf16_model_dir(), partial, tp_size, explicit_cuda_graph)
 
 
-def _run_qwen35_397b_fp8_update(partial: bool) -> None:
-    model_dir = _qwen35_397b_fp8_model_dir()
+def _run_qwen35_35b_fp8_update(partial: bool) -> None:
+    model_dir = _qwen35_35b_fp8_model_dir()
     if not os.path.isdir(model_dir):
         pytest.skip(f"Model directory {model_dir} does not exist")
 
-    device_ids = list(range(_QWEN35_397B_TP_SIZE))
-    checkpoint = RefQwen35_397BFP8CheckpointWithIPCHandles(
-        model_dir, device_ids
-    )
+    device_ids = list(range(4))
+    checkpoint = RefQwen35_35BFP8CheckpointWithIPCHandles(model_dir, device_ids)
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
-    prompts = [
-        tokenizer.encode(prompt)
-        for prompt in ["Hello, my name is", "The future of AI is"]
-    ]
+    prompts = [tokenizer.encode(prompt) for prompt in ["Hello, my name is", "The future of AI is"]]
     del tokenizer
-    sampling_params = SamplingParams(
-        temperature=0, return_generation_logits=True, max_tokens=8
-    )
+    sampling_params = SamplingParams(temperature=0, return_generation_logits=True, max_tokens=8)
 
     def generate_logits(llm):
         return [
-            output.outputs[0].generation_logits
-            for output in llm.generate(prompts, sampling_params)
+            output.outputs[0].generation_logits for output in llm.generate(prompts, sampling_params)
         ]
 
     def update(llm, incremental: bool) -> None:
         if incremental:
             groups = sorted(
                 {
-                    _qwen35_397b_weight_group(name)
+                    _qwen35_35b_weight_group(name)
                     for name, _ in checkpoint.all_weights[checkpoint.device_id]
                 }
             )
@@ -464,7 +524,7 @@ def _run_qwen35_397b_fp8_update(partial: bool) -> None:
                 ipc_handles = checkpoint.get_weight_ipc_handles_serialized(
                     device_ids,
                     weight_filter=lambda name, group=group: (
-                        _qwen35_397b_weight_group(name) == group
+                        _qwen35_35b_weight_group(name) == group
                     ),
                 )
                 llm._collective_rpc("update_weights", (ipc_handles,))
@@ -482,10 +542,8 @@ def _run_qwen35_397b_fp8_update(partial: bool) -> None:
         max_batch_size=2,
         max_seq_len=256,
         max_num_tokens=256,
-        kv_cache_config=KvCacheConfig(
-            enable_block_reuse=True, free_gpu_memory_fraction=0.05
-        ),
-        model_kwargs=_qwen35_397b_model_kwargs(),
+        kv_cache_config=KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.05),
+        model_kwargs=_qwen35_35b_model_kwargs(),
         moe_config=MoeConfig(backend="TRTLLM"),
     ) as llm:
         # Compile CUDA graphs before refit, then use the first exact-checkpoint
@@ -498,41 +556,150 @@ def _run_qwen35_397b_fp8_update(partial: bool) -> None:
         compare_logits(updated_logits, reference_logits)
 
 
+def _attach_to_tp8_ray_cluster(monkeypatch) -> None:
+    """Attach to a cluster with eight GPUs when the driver has only four."""
+    test_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+    python_path = os.environ.get("PYTHONPATH")
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        f"{test_root}{os.pathsep}{python_path}" if python_path else test_root,
+    )
+    monkeypatch.setenv("TLLM_RAY_FORCE_LOCAL_CLUSTER", "0")
+
+    import ray
+
+    if not ray.is_initialized():
+        try:
+            ray.init(address="auto", ignore_reinit_error=True)
+        except ConnectionError:
+            pytest.skip(
+                "TP8 requires either eight local B200s or an attached Ray cluster with eight B200s"
+            )
+
+    available_gpus = int(ray.cluster_resources().get("GPU", 0))
+    if available_gpus < _QWEN35_35B_TP8:
+        pytest.skip(f"TP8 requires eight cluster GPUs, found {available_gpus}")
+
+
+def _run_qwen35_35b_tp8_multinode_update() -> None:
+    """Run the TP8 CUDA Graph test with checkpoint buckets local to each worker."""
+    model_dir = _qwen35_35b_bf16_model_dir()
+    if not os.path.isdir(model_dir):
+        pytest.skip(f"Model directory {model_dir} does not exist")
+
+    groups = sorted(
+        {
+            _qwen35_35b_weight_group(name)
+            for name in _qwen35_35b_selected_checkpoint_names(model_dir)
+        }
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    prompts = [tokenizer.encode(prompt) for prompt in ["Hello, my name is", "The future of AI is"]]
+    del tokenizer
+    sampling_params = SamplingParams(temperature=0, return_generation_logits=True, max_tokens=8)
+
+    def generate_logits(llm):
+        return [
+            output.outputs[0].generation_logits for output in llm.generate(prompts, sampling_params)
+        ]
+
+    def update(llm) -> None:
+        for group in groups:
+            llm._collective_rpc("update_weights_from_local_checkpoint", (model_dir, group))
+        llm._collective_rpc("update_weights_from_local_checkpoint", (model_dir, None))
+
+    with LLM(
+        model=model_dir,
+        ray_worker_extension_cls=_QWEN35_35B_TP8_EXTENSION,
+        tensor_parallel_size=_QWEN35_35B_TP8,
+        load_format="dummy",
+        pipeline_parallel_size=1,
+        max_batch_size=2,
+        max_seq_len=256,
+        max_num_tokens=256,
+        cuda_graph_config=CudaGraphConfig(batch_sizes=[1, 2], max_batch_size=2),
+        kv_cache_config=KvCacheConfig(
+            enable_block_reuse=True,
+            free_gpu_memory_fraction=0.05,
+            mamba_ssm_cache_dtype="bfloat16",
+        ),
+        model_kwargs=_qwen35_35b_model_kwargs(),
+        moe_config=MoeConfig(backend="TRTLLM"),
+    ) as llm:
+        device_names = llm._collective_rpc("get_test_device_name")
+        assert all("B200" in name.upper() for name in device_names), (
+            f"TP8 alignment coverage requires B200 GPUs, got {device_names}"
+        )
+
+        # Capture before refit, then replay the same graph after two identical
+        # cross-bucket updates. The 35B TP8 layout executes the alignment clone.
+        llm.generate(prompts, sampling_params)
+        update(llm)
+        reference_logits = generate_logits(llm)
+        update(llm)
+        updated_logits = generate_logits(llm)
+        compare_logits(updated_logits, reference_logits)
+
+
+@pytest.mark.high_cuda_memory
+@skip_pre_blackwell
+def test_llm_partial_update_weights_qwen35_35b_bf16_tp8_cuda_graph(
+    monkeypatch,
+):
+    """Exercise TP8's BF16 alignment clone through CUDA Graph replay."""
+    if torch.cuda.device_count() >= _QWEN35_35B_TP8:
+        device_names = [
+            torch.cuda.get_device_name(device_id) for device_id in range(_QWEN35_35B_TP8)
+        ]
+        assert all("B200" in name.upper() for name in device_names), (
+            f"TP8 alignment coverage requires B200 GPUs, got {device_names}"
+        )
+        _run_qwen35_35b_bf16_update(
+            partial=True,
+            tp_size=_QWEN35_35B_TP8,
+            explicit_cuda_graph=True,
+        )
+        return
+
+    _attach_to_tp8_ray_cluster(monkeypatch)
+    _run_qwen35_35b_tp8_multinode_update()
+
 
 @pytest.mark.part0
 @pytest.mark.gpu4
 @pytest.mark.high_cuda_memory
 @skip_pre_blackwell
-def test_llm_update_weights_qwen35_397b_bf16():
-    """One-shot BF16 refit of a reduced-depth, exact-shape 397B model."""
-    _run_qwen35_397b_bf16_update(partial=False)
+def test_llm_update_weights_qwen35_35b_bf16():
+    """One-shot BF16 refit of the production-width 35B model."""
+    _run_qwen35_35b_bf16_update(partial=False)
 
 
 @pytest.mark.part1
 @pytest.mark.gpu4
 @pytest.mark.high_cuda_memory
 @skip_pre_blackwell
-def test_llm_partial_update_weights_qwen35_397b_bf16():
+def test_llm_partial_update_weights_qwen35_35b_bf16():
     """Incremental BF16 refit with GDN and MoE fusion groups split across RPCs."""
-    _run_qwen35_397b_bf16_update(partial=True)
+    _run_qwen35_35b_bf16_update(partial=True)
 
 
 @pytest.mark.part0
 @pytest.mark.gpu4
 @pytest.mark.high_cuda_memory
 @skip_pre_blackwell
-def test_llm_update_weights_qwen35_397b_fp8():
-    """One-shot block-FP8 refit of a reduced-depth, exact-shape 397B model."""
-    _run_qwen35_397b_fp8_update(partial=False)
+def test_llm_update_weights_qwen35_35b_fp8():
+    """One-shot block-FP8 refit of the production-width 35B model."""
+    _run_qwen35_35b_fp8_update(partial=False)
 
 
 @pytest.mark.part1
 @pytest.mark.gpu4
 @pytest.mark.high_cuda_memory
 @skip_pre_blackwell
-def test_llm_partial_update_weights_qwen35_397b_fp8():
+def test_llm_partial_update_weights_qwen35_35b_fp8():
     """Incremental block-FP8 refit with weights and scales split across RPCs."""
-    _run_qwen35_397b_fp8_update(partial=True)
+    _run_qwen35_35b_fp8_update(partial=True)
+
 
 class RefNVFP4ModelWithIPCHandles(RefHFModel):
     """Reference model that loads bf16 weights from HuggingFace, quantizes

--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
@@ -1,5 +1,6 @@
 import base64
 import importlib.util
+import json
 import multiprocessing
 import os
 import pickle
@@ -16,6 +17,7 @@ from _torch.ray_orchestrator.single_gpu.test_llm_update_weights import (
     compare_logits,
     run_generate,
 )
+from safetensors import safe_open
 from torch.multiprocessing.reductions import reduce_tensor
 from transformers import (
     AutoConfig,
@@ -200,7 +202,7 @@ _QWEN35_397B_LAYER_TYPES = [
     "linear_attention",
     "full_attention",
 ]
-_QWEN35_397B_TP_SIZE = 4
+_QWEN35_397B_TP_SIZE = int(os.environ.get("QWEN35_397B_TP_SIZE", "4"))
 
 
 def _qwen35_397b_bf16_model_dir() -> str:
@@ -209,6 +211,14 @@ def _qwen35_397b_bf16_model_dir() -> str:
     if model_dir:
         return model_dir
     return str(llm_models_root() / "Qwen3.5-397B-A17B")
+
+
+def _qwen35_397b_fp8_model_dir() -> str:
+    """Resolve the real block-FP8 checkpoint, with a local override."""
+    model_dir = os.environ.get("QWEN35_397B_FP8_MODEL_DIR")
+    if model_dir:
+        return model_dir
+    return str(llm_models_root() / "Qwen3.5-397B-A17B-FP8")
 
 
 def _qwen35_397b_reduced_config(model_dir: str):
@@ -222,6 +232,11 @@ def _qwen35_397b_reduced_config(model_dir: str):
     # roughly one additional 397B decoder layer.
     if hasattr(text_config, "mtp_num_hidden_layers"):
         text_config.mtp_num_hidden_layers = 0
+
+    # Transformers' fine-grained FP8 MoE wrapper eagerly evaluates its
+    # intermediate_size fallback even when moe_intermediate_size is present.
+    if not hasattr(text_config, "intermediate_size"):
+        text_config.intermediate_size = text_config.moe_intermediate_size
 
     # Text-only generation still constructs the VLM wrapper. One vision block
     # covers its partial-loading path without retaining all 27 repeated blocks.
@@ -242,7 +257,7 @@ def _qwen35_397b_model_kwargs() -> dict:
 
 
 class RefQwen35_397BModelWithIPCHandles(RefHFModelWithIPCHandles):
-    """Reduced-depth, exact-width BF16 397B reference model.
+    """Reduced-depth, exact-width BF16 or FP8 397B reference model.
 
     Unlike the generic helper, the source-device IPC entries alias the HF
     parameters instead of cloning them. update_weights only reads these
@@ -290,6 +305,49 @@ class RefQwen35_397BModelWithIPCHandles(RefHFModelWithIPCHandles):
             ]
 
 
+class RefQwen35_397BFP8CheckpointWithIPCHandles(RefHFModelWithIPCHandles):
+    """Expose exact reduced-depth checkpoint tensors through CUDA IPC.
+
+    Transformers currently does not ingest Qwen3.5's per-expert block-FP8
+    checkpoint layout: it reports the split expert weights/scales as
+    unexpected and initializes fused expert parameters. Refit must consume
+    the checkpoint representation, so load the selected safetensors entries
+    directly rather than silently testing randomly initialized BF16 tensors.
+    """
+
+    def __init__(self, model_dir: str, device_ids: List[int]):
+        self.device_id = device_ids[0]
+        self.device_uuid = [
+            get_device_uuid(i) for i in range(torch.cuda.device_count())
+        ]
+        self.all_weights = {device_id: [] for device_id in device_ids}
+
+        with open(os.path.join(model_dir, "model.safetensors.index.json")) as f:
+            weight_map = json.load(f)["weight_map"]
+
+        selected_by_shard = {}
+        for name, shard in weight_map.items():
+            layer_match = re.match(
+                r"model\.language_model\.layers\.(\d+)\.", name
+            )
+            if layer_match and int(layer_match.group(1)) >= _QWEN35_397B_REDUCED_LAYERS:
+                continue
+            if name.startswith("model.visual.") or ".mtp." in name:
+                continue
+            selected_by_shard.setdefault(shard, []).append(name)
+
+        for shard, names in sorted(selected_by_shard.items()):
+            with safe_open(
+                os.path.join(model_dir, shard), framework="pt", device="cpu"
+            ) as checkpoint:
+                for name in sorted(names):
+                    weight = checkpoint.get_tensor(name)
+                    for device_id in device_ids:
+                        self.all_weights[device_id].append(
+                            (name, weight.to(f"cuda:{device_id}"))
+                        )
+
+
 def _qwen35_397b_weight_group(name: str) -> str:
     """Group repeated layers/experts while separating projection families.
 
@@ -332,8 +390,7 @@ def _run_generate_qwen35_397b(llm, hf_model, prompts, sampling_params):
     return llm_logits, ref_logits
 
 
-def _run_qwen35_397b_bf16_update(partial: bool) -> None:
-    model_dir = _qwen35_397b_bf16_model_dir()
+def _run_qwen35_397b_update(model_dir: str, partial: bool) -> None:
     if not os.path.isdir(model_dir):
         pytest.skip(f"Model directory {model_dir} does not exist")
 
@@ -366,6 +423,82 @@ def _run_qwen35_397b_bf16_update(partial: bool) -> None:
     )
 
 
+def _run_qwen35_397b_bf16_update(partial: bool) -> None:
+    _run_qwen35_397b_update(_qwen35_397b_bf16_model_dir(), partial)
+
+
+def _run_qwen35_397b_fp8_update(partial: bool) -> None:
+    model_dir = _qwen35_397b_fp8_model_dir()
+    if not os.path.isdir(model_dir):
+        pytest.skip(f"Model directory {model_dir} does not exist")
+
+    device_ids = list(range(_QWEN35_397B_TP_SIZE))
+    checkpoint = RefQwen35_397BFP8CheckpointWithIPCHandles(
+        model_dir, device_ids
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    prompts = [
+        tokenizer.encode(prompt)
+        for prompt in ["Hello, my name is", "The future of AI is"]
+    ]
+    del tokenizer
+    sampling_params = SamplingParams(
+        temperature=0, return_generation_logits=True, max_tokens=8
+    )
+
+    def generate_logits(llm):
+        return [
+            output.outputs[0].generation_logits
+            for output in llm.generate(prompts, sampling_params)
+        ]
+
+    def update(llm, incremental: bool) -> None:
+        if incremental:
+            groups = sorted(
+                {
+                    _qwen35_397b_weight_group(name)
+                    for name, _ in checkpoint.all_weights[checkpoint.device_id]
+                }
+            )
+            for group in groups:
+                ipc_handles = checkpoint.get_weight_ipc_handles_serialized(
+                    device_ids,
+                    weight_filter=lambda name, group=group: (
+                        _qwen35_397b_weight_group(name) == group
+                    ),
+                )
+                llm._collective_rpc("update_weights", (ipc_handles,))
+        else:
+            ipc_handles = checkpoint.get_weight_ipc_handles_serialized(device_ids)
+            llm._collective_rpc("update_weights", (ipc_handles,))
+        llm._collective_rpc("update_weights", (None,))
+
+    with LLM(
+        model=model_dir,
+        ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
+        tensor_parallel_size=len(device_ids),
+        load_format="dummy",
+        pipeline_parallel_size=1,
+        max_batch_size=2,
+        max_seq_len=256,
+        max_num_tokens=256,
+        kv_cache_config=KvCacheConfig(
+            enable_block_reuse=True, free_gpu_memory_fraction=0.05
+        ),
+        model_kwargs=_qwen35_397b_model_kwargs(),
+        moe_config=MoeConfig(backend="TRTLLM"),
+    ) as llm:
+        # Compile CUDA graphs before refit, then use the first exact-checkpoint
+        # update as the reference for an identical one-shot or partial update.
+        llm.generate(prompts, sampling_params)
+        update(llm, incremental=False)
+        reference_logits = generate_logits(llm)
+        update(llm, incremental=partial)
+        updated_logits = generate_logits(llm)
+        compare_logits(updated_logits, reference_logits)
+
+
+
 @pytest.mark.part0
 @pytest.mark.gpu4
 @pytest.mark.high_cuda_memory
@@ -383,6 +516,23 @@ def test_llm_partial_update_weights_qwen35_397b_bf16():
     """Incremental BF16 refit with GDN and MoE fusion groups split across RPCs."""
     _run_qwen35_397b_bf16_update(partial=True)
 
+
+@pytest.mark.part0
+@pytest.mark.gpu4
+@pytest.mark.high_cuda_memory
+@skip_pre_blackwell
+def test_llm_update_weights_qwen35_397b_fp8():
+    """One-shot block-FP8 refit of a reduced-depth, exact-shape 397B model."""
+    _run_qwen35_397b_fp8_update(partial=False)
+
+
+@pytest.mark.part1
+@pytest.mark.gpu4
+@pytest.mark.high_cuda_memory
+@skip_pre_blackwell
+def test_llm_partial_update_weights_qwen35_397b_fp8():
+    """Incremental block-FP8 refit with weights and scales split across RPCs."""
+    _run_qwen35_397b_fp8_update(partial=True)
 
 class RefNVFP4ModelWithIPCHandles(RefHFModel):
     """Reference model that loads bf16 weights from HuggingFace, quantizes

--- a/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
+++ b/tests/unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py
@@ -665,7 +665,7 @@ def test_llm_partial_update_weights_qwen35_35b_bf16_tp8_cuda_graph(
     _run_qwen35_35b_tp8_multinode_update()
 
 
-@pytest.mark.part0
+@pytest.mark.part5
 @pytest.mark.gpu4
 @pytest.mark.high_cuda_memory
 @skip_pre_blackwell
@@ -674,7 +674,7 @@ def test_llm_update_weights_qwen35_35b_bf16():
     _run_qwen35_35b_bf16_update(partial=False)
 
 
-@pytest.mark.part1
+@pytest.mark.part5
 @pytest.mark.gpu4
 @pytest.mark.high_cuda_memory
 @skip_pre_blackwell
@@ -683,7 +683,7 @@ def test_llm_partial_update_weights_qwen35_35b_bf16():
     _run_qwen35_35b_bf16_update(partial=True)
 
 
-@pytest.mark.part0
+@pytest.mark.part5
 @pytest.mark.gpu4
 @pytest.mark.high_cuda_memory
 @skip_pre_blackwell
@@ -692,7 +692,7 @@ def test_llm_update_weights_qwen35_35b_fp8():
     _run_qwen35_35b_fp8_update(partial=False)
 
 
-@pytest.mark.part1
+@pytest.mark.part5
 @pytest.mark.gpu4
 @pytest.mark.high_cuda_memory
 @skip_pre_blackwell

--- a/tests/unittest/llmapi/test_rlhf_utils.py
+++ b/tests/unittest/llmapi/test_rlhf_utils.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+from torch import nn
+
+from tensorrt_llm.llmapi.rlhf_utils import WorkerExtension
+
+
+@torch.no_grad()
+def test_refit_refreshes_fused_norm_cache_in_place() -> None:
+    model = nn.Module()
+    model.norm = nn.Module()
+    original = torch.tensor([0.5, 1.0], dtype=torch.bfloat16)
+    model.norm._fused_norm_weight = original
+    original_ptr = original.data_ptr()
+
+    def post_load_weights() -> None:
+        model.norm._fused_norm_weight = torch.tensor([1.5, 2.0], dtype=torch.bfloat16)
+
+    model.norm.post_load_weights = post_load_weights
+    model_loader = MagicMock()
+    extension = WorkerExtension.__new__(WorkerExtension)
+    extension.engine = SimpleNamespace(
+        model_engine=SimpleNamespace(model=model, model_loader=model_loader)
+    )
+
+    extension.finalize_weight_update()
+
+    model_loader.finalize_update_weights.assert_called_once_with()
+
+    assert model.norm._fused_norm_weight.data_ptr() == original_ptr
+    torch.testing.assert_close(
+        model.norm._fused_norm_weight,
+        torch.tensor([1.5, 2.0], dtype=torch.bfloat16),
+        atol=0.0,
+        rtol=0.0,
+    )

--- a/tests/unittest/pytest.ini
+++ b/tests/unittest/pytest.ini
@@ -24,6 +24,7 @@ markers =
     part2
     part3
     part4
+    part5
     cpu_only: this test does not require a GPU to run
     gpu2: this test uses 2 GPUs
     gpu4: this test uses 4 GPUs


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for incremental and partial weight updates for Qwen3.5 models, including vision-language and MoE variants.
  * Supports BF16 and FP8 checkpoint updates, with improved handling of staged projection weights and scaling data.
  * Added safer update-session controls to finalize or discard incomplete updates.

* **Bug Fixes**
  * Improved reliability for GPU kernels when tensor memory alignment is unsuitable.
  * Corrected weight loading behavior for supplied model configurations and multimodal checkpoints.

* **Tests**
  * Added coverage for partial loading and multi-GPU weight updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This change enables incremental BF16 weight refit for the Qwen3.5-397B rollout model.
  NeMo-RL transfers a model update through multiple size-bounded buckets, so related Gated
  DeltaNet projections_Q/K/V/Z and B/A_may arrive in separate reload() calls. Qwen3.5 must
  retain incomplete projection groups across calls, fuse them only when complete, and
  validate the complete update before post-load transformations run. The implementation
  introduces explicit begin/finalize/abort lifecycle boundaries and preserves in-place
  parameter storage required by CUDA Graph replay.

  The model-specific behavior is isolated to Qwen3_5MoeHfWeightMapper. The MLPerf 397B
  model is currently the only model requiring this cross-bucket staging because of its
  Qwen3.5 Gated DeltaNet projection layout and BF16 MoE representation. Other weight
  mappers inherit no-op lifecycle methods, so their successful loading and refit behavior
  is unchanged. The generic RLHF worker owns the lifecycle calls because only the transport
  layer knows the first bucket, finalization boundary, and failure boundary; placing a
  397B-specific type check there would couple generic update infrastructure to one model.

  The change also fixes a TP8 alignment issue for a small GDN tensor view that can begin on
  a 16-byte boundary on odd TP shards, while the CuTe kernel requires 32-byte alignment.
  Aligned configurations retain the existing zero-copy path.

  Validation covers reduced-depth, production-width Qwen3.5-397B BF16 refit with warm CUDA-
  graph execution and post-refit Hugging Face reference-logit comparison:

  - TP4 one-shot refit
  - TP4 incremental/partial refit
  - Two-node TP8 one-shot refit (Not committed due to multi-node)
  - Two-node TP8 incremental/partial refit (Not committed due to multi-node)

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
