### PR TITLE
[https://nvbugs/6457853][fix] Allow trtllm-gen MoE autotuner when local_num_experts < top_k

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -128,6 +128,19 @@ def prepare_dummy_topk_and_hook(
     # experts and only ~1/ep_size of slots hit local.
     is_local = use_dp
 
+    def pad_with_remote_dummy_experts(topk_ids_local: torch.Tensor,
+                                      device: torch.device) -> torch.Tensor:
+        """Fill remaining slots with deterministic out-of-shard ids, mirroring
+        production rows when local_num_experts < top_k: a row's top_k picks
+        are distinct global experts, at most local_num_experts of them local.
+        """
+        num_tokens, k_local = topk_ids_local.shape
+        remote = (local_expert_offset + local_num_experts + torch.arange(
+            top_k - k_local, device=device, dtype=torch.int32)) % num_experts
+        return torch.cat(
+            [topk_ids_local,
+             remote.unsqueeze(0).expand(num_tokens, -1)], dim=1)
+
     def make_balanced_dummy_topk(
             num_tokens: int,
             device: torch.device) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -154,24 +167,26 @@ def prepare_dummy_topk_and_hook(
             n_target = local_num_experts if is_local else num_experts
             topk_ids[t, k] = (t + k * stride) % n_target  (+ local_expert_offset if is_local)
 
-        Stride is picked so each row's `top_k` entries stay distinct;
-        the assertion guards against degenerate (n_target < top_k) configs
-        that would produce in-row duplicates.
+        Stride is picked so each row's filled entries stay distinct; when
+        n_target < top_k (local regime only) the row is padded with
+        out-of-shard ids (see pad_with_remote_dummy_experts).
         """
         n_target = local_num_experts if is_local else num_experts
-        assert n_target >= top_k, (
-            f"make_balanced_dummy_topk requires n_target>={top_k}; "
-            f"got n_target={n_target}, is_local={is_local}, "
-            f"num_experts={num_experts}, local_num_experts={local_num_experts}")
-        stride = max(1, min(local_num_experts, n_target // top_k))
-        if stride * top_k > n_target:
-            stride = max(1, n_target // top_k)
-        base = torch.arange(top_k, device=device, dtype=torch.int32) * stride
+        assert is_local or n_target >= top_k, (
+            f"make_balanced_dummy_topk requires num_experts>={top_k} in "
+            f"the global regime; got num_experts={num_experts}")
+        k_fill = min(top_k, n_target)
+        stride = max(1, min(local_num_experts, n_target // k_fill))
+        if stride * k_fill > n_target:
+            stride = max(1, n_target // k_fill)
+        base = torch.arange(k_fill, device=device, dtype=torch.int32) * stride
         token_idx = torch.arange(num_tokens, device=device,
                                  dtype=torch.int32).unsqueeze(1)
         topk_ids = (base + token_idx) % n_target
         if is_local:
             topk_ids = topk_ids + local_expert_offset
+            if k_fill < top_k:
+                topk_ids = pad_with_remote_dummy_experts(topk_ids, device)
         topk_weights = torch.ones(num_tokens,
                                   top_k,
                                   dtype=torch.bfloat16,
@@ -261,9 +276,7 @@ def prepare_dummy_topk_and_hook(
             would observe.
         """
         if is_local:
-            assert local_num_experts >= top_k, (
-                f"random_local requires local_num_experts >= top_k; "
-                f"got local_num_experts={local_num_experts}, top_k={top_k}")
+            k_fill = min(top_k, local_num_experts)
             if (logits is None or logits.shape[0] != num_tokens
                     or logits.shape[-1] != local_num_experts):
                 logits = torch.randn(num_tokens,
@@ -272,9 +285,12 @@ def prepare_dummy_topk_and_hook(
                                      device=device)
             # Plain topk over local logits — bypasses the model's
             # routing_method on purpose (see docstring caveat re:
-            # grouped routings like DeepSeekV3 / Llama4).
-            topk_ids = torch.topk(logits.float(), top_k, dim=-1).indices.to(
+            # grouped routings like DeepSeekV3 / Llama4). If the shard has
+            # fewer than top_k experts, take all and pad (see helper).
+            topk_ids = torch.topk(logits.float(), k_fill, dim=-1).indices.to(
                 torch.int32) + local_expert_offset
+            if k_fill < top_k:
+                topk_ids = pad_with_remote_dummy_experts(topk_ids, device)
             topk_weights = torch.ones(num_tokens,
                                       top_k,
                                       dtype=torch.bfloat16,

--- a/tests/unittest/_torch/misc/test_autotuner.py
+++ b/tests/unittest/_torch/misc/test_autotuner.py
@@ -1265,3 +1265,59 @@ def test_cutedsl_nvfp4_heuristic_matches_full_sweep(monkeypatch):
         f"CuteDSL heuristic kernel ({heuristic_us:.2f} us) is "
         f">{cublas_tolerance:.2f}x slower than cuBLAS NVFP4 "
         f"({cublas_us:.2f} us) for M={m}, N={n}, K={k}")
+
+
+@pytest.mark.parametrize("distribution", ["random", "balanced"])
+def test_trtllm_gen_moe_dummy_topk_local_experts_less_than_topk(
+        distribution, monkeypatch):
+    """NVBugs 6457853: autotuner warmup must not fail on EP shards where
+    local_num_experts < top_k (e.g. gpt-oss-120b: 128 experts, top_k=4,
+    EP64 -> 2 local experts per rank, attention-DP => use_dp=True).
+    Dummy rows keep the production shape: top_k distinct ids per row, all
+    local experts present, remaining slots padded with out-of-shard ids."""
+    from tensorrt_llm._torch.custom_ops.trtllm_gen_custom_ops import \
+        prepare_dummy_topk_and_hook
+
+    monkeypatch.setenv("TRTLLM_GEN_MOE_AUTOTUNE_DUMMY_DISTRIBUTION",
+                       distribution)
+    num_tokens, top_k = 8, 4
+    num_experts, local_num_experts, local_expert_offset = 128, 2, 6
+    hidden_states = torch.randn(num_tokens,
+                                64,
+                                dtype=torch.bfloat16,
+                                device="cuda")
+    topk_ids = torch.randint(0,
+                             num_experts, (num_tokens, top_k),
+                             dtype=torch.int32,
+                             device="cuda")
+    topk_weights = torch.ones(num_tokens,
+                              top_k,
+                              dtype=torch.bfloat16,
+                              device="cuda")
+
+    with autotune():
+        _, dummy_weights, dummy_ids, _ = prepare_dummy_topk_and_hook(
+            topk_weights,
+            topk_ids,
+            hidden_states,
+            None,
+            1,
+            TuningConfig(),
+            top_k,
+            num_experts,
+            local_num_experts,
+            None,
+            None,
+            None,
+            local_expert_offset=local_expert_offset,
+            use_dp=True)
+
+    assert dummy_ids.shape == (num_tokens, top_k)
+    assert dummy_ids.dtype == torch.int32
+    assert dummy_weights.shape == (num_tokens, top_k)
+    shard = range(local_expert_offset, local_expert_offset + local_num_experts)
+    for row in dummy_ids.tolist():
+        assert len(set(row)) == top_k, f"duplicate ids in row {row}"
+        assert sum(x in shard for x in row) == local_num_experts, (
+            f"expected all {local_num_experts} local experts in row {row}")
+        assert all(0 <= x < num_experts for x in row), row


### PR DESCRIPTION
## Description

Fixes https://nvbugs/6457853 — gpt-oss-120b (128 experts, top_k=4) crashes at autotuner warmup when EP64 leaves 128/64 = 2 local experts per rank:

```
AssertionError: random_local requires local_num_experts >= top_k; got local_num_experts=2, top_k=4
```

To time MoE kernel tactics, the autotuner fabricates a dummy token→expert assignment instead of running the real router. Both dummy generators (`random` and `balanced`, per `TRTLLM_GEN_MOE_AUTOTUNE_DUMMY_DISTRIBUTION`) required `top_k` distinct LOCAL ids per row, which is impossible once `EP > num_experts / top_k`. The real inference path has no such limit: routing picks `top_k` distinct GLOBAL experts, of which at most `local_num_experts` live on any rank — so this was autotuner-only.

Fix: keep dummy rows production-shaped — fill `min(top_k, local_num_experts)` distinct local ids and pad the remaining slots with deterministic out-of-shard ids (remote slots do no local work). No in-row duplicates; zero behavior change when `local_num_experts >= top_k`.

Verified on main (b8604c46ce, GB200): the 1-GPU repro hits the exact assert on stock code and passes full autotune profiling with this fix; at TP64/EP64 on 16×4 GB200 NVL72, stock fails on all 64 ranks at warmup while the fixed run completes trtllm-bench cleanly (8×32k/8k requests, 48 min). The same A/B was also reproduced on 1.3.0rc18 and rc21.

## Test Coverage

- New: `tests/unittest/_torch/misc/test_autotuner.py::test_trtllm_gen_moe_dummy_topk_local_experts_less_than_topk[random|balanced]` — fails before the fix, passes after; checks rows are production-shaped (distinct ids, all local experts present, pad ids valid).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
