### PR TITLE
[None][feat] Default GLM-5 to the Python KV-cache transceiver (duplicate of #16524 for parallel CI)

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -28,7 +28,7 @@
 import copy
 import math
 import os
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import torch
 import triton
@@ -1892,6 +1892,33 @@ class DeepseekV3Model(DecoderModel):
 @register_auto_model("DeepseekV3ForCausalLM")
 class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
                                                         PretrainedConfig]):
+
+    @classmethod
+    def get_preferred_transceiver_runtime(cls,
+                                          pretrained_config: Any = None
+                                          ) -> Optional[Literal["PYTHON"]]:
+        """GLM-5 family checkpoints default to the Python (v2) KV-cache
+        transceiver.
+
+        This implementation class is shared by DeepSeek-V3/V3.2 and the GLM-5
+        family — both GLM-5 and GLM-5.2 declare ``GlmMoeDsaForCausalLM`` /
+        ``glm_moe_dsa`` — so the preference is differentiated per checkpoint:
+        only GLM checkpoints opt into the Python transceiver.
+        The MLA backbone transfers a large latent KV, which the Python
+        transceiver handles better in disaggregated serving. This is only
+        adopted when the user leaves
+        ``cache_transceiver_config.transceiver_runtime`` at 'auto' and the
+        effective backend is NIXL; otherwise the C++ transceiver is used.
+        """
+        if pretrained_config is None:
+            return None
+        architectures = getattr(pretrained_config, 'architectures', None) or []
+        # model_type is checked as a fallback: it is 'glm_moe_dsa' on GLM
+        # checkpoints until __init__ rewrites it to 'deepseek_v32'.
+        if ("GlmMoeDsaForCausalLM" in architectures or getattr(
+                pretrained_config, 'model_type', None) == 'glm_moe_dsa'):
+            return "PYTHON"
+        return None
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
         self.mapping_with_cp = None

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp4ep4_gentp4ep4_glm5_nvfp4_dp_tllm.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp4ep4_gentp4ep4_glm5_nvfp4_dp_tllm.yaml
@@ -20,7 +20,8 @@ context_servers:
   cuda_graph_config: null
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384
 generation_servers:
   num_instances: 1
@@ -55,5 +56,6 @@ generation_servers:
     - 1024
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384

--- a/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_1k1k_con1_ctx1_dep4_gen1_tep4_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_1k1k_con1_ctx1_dep4_gen1_tep4_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_1k1k_con4096_ctx1_dep4_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_1k1k_con4096_ctx1_dep4_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -93,5 +94,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_1k1k_con512_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_1k1k_con512_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_8k1k_con1024_ctx1_dep4_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_8k1k_con1024_ctx1_dep4_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -93,5 +94,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_8k1k_con512_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_glm-5-fp4_8k1k_con512_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_1k1k_con1_ctx1_dep2_gen1_tep4_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_1k1k_con1_ctx1_dep2_gen1_tep4_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_1k1k_con4096_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_1k1k_con4096_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -93,5 +94,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_1k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_1k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con1024_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con1024_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -93,5 +94,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con1_ctx1_dep2_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con1_ctx1_dep2_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -3338,3 +3338,55 @@ class TestTransceiverRuntimeAutoResolution:
         # An explicit backend bypasses the env vars entirely.
         assert CacheTransceiverConfig(
             backend="UCX")._resolve_default_backend() == ("UCX", None)
+
+
+class TestGlm5TransceiverPreference:
+    """GLM-5 defaults to the Python KV-cache transceiver in disagg.
+
+    DeepseekV3ForCausalLM is shared by DeepSeek-V3/V3.2 and GLM-5
+    (GlmMoeDsaForCausalLM); the preference must apply to GLM checkpoints
+    only.
+    """
+
+    @staticmethod
+    def _pretrained_config(architectures, model_type):
+        from unittest.mock import MagicMock
+        cfg = MagicMock()
+        cfg.architectures = architectures
+        cfg.model_type = model_type
+        return cfg
+
+    @pytest.mark.parametrize("architectures,model_type,expected", [
+        (["GlmMoeDsaForCausalLM"], "glm_moe_dsa", "PYTHON"),
+        (["DeepseekV3ForCausalLM"], "deepseek_v3", None),
+        (["DeepseekV32ForCausalLM"], "deepseek_v32", None),
+    ])
+    def test_preference_per_architecture(self, architectures, model_type,
+                                         expected):
+        from tensorrt_llm._torch.models.modeling_deepseekv3 import \
+            DeepseekV3ForCausalLM
+        cfg = self._pretrained_config(architectures, model_type)
+        assert DeepseekV3ForCausalLM.get_preferred_transceiver_runtime(
+            cfg) == expected
+
+    def test_no_config_defers_to_cpp(self):
+        """Without a pretrained config the class defers to the C++ default."""
+        from tensorrt_llm._torch.models.modeling_deepseekv3 import \
+            DeepseekV3ForCausalLM
+        assert DeepseekV3ForCausalLM.get_preferred_transceiver_runtime() is None
+
+    def test_glm5_resolves_auto_to_python_on_nixl(self):
+        """GLM-5 on NIXL adopts the Python transceiver from 'auto'.
+
+        End-to-end through _resolve_transceiver_runtime_auto with the real
+        model class and a GLM pretrained config.
+        """
+        from tensorrt_llm._torch.models.modeling_deepseekv3 import \
+            DeepseekV3ForCausalLM
+        args = TorchLlmArgs(
+            model="/tmp/dummy_model",
+            cache_transceiver_config=CacheTransceiverConfig(backend="NIXL"),
+        )
+        cfg = self._pretrained_config(["GlmMoeDsaForCausalLM"], "glm_moe_dsa")
+        _resolve_transceiver_runtime_auto(args, DeepseekV3ForCausalLM, cfg)
+        assert args.cache_transceiver_config.transceiver_runtime == "PYTHON"

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -3356,11 +3356,17 @@ class TestGlm5TransceiverPreference:
         cfg.model_type = model_type
         return cfg
 
-    @pytest.mark.parametrize("architectures,model_type,expected", [
-        (["GlmMoeDsaForCausalLM"], "glm_moe_dsa", "PYTHON"),
-        (["DeepseekV3ForCausalLM"], "deepseek_v3", None),
-        (["DeepseekV32ForCausalLM"], "deepseek_v32", None),
-    ])
+    @pytest.mark.parametrize(
+        "architectures,model_type,expected",
+        [
+            (["GlmMoeDsaForCausalLM"], "glm_moe_dsa", "PYTHON"),
+            (["DeepseekV3ForCausalLM"], "deepseek_v3", None),
+            (["DeepseekV32ForCausalLM"], "deepseek_v32", None),
+            # Each predicate in isolation: the architecture match and the
+            # model_type fallback must each suffice on their own.
+            (["GlmMoeDsaForCausalLM"], "deepseek_v32", "PYTHON"),
+            (["DeepseekV32ForCausalLM"], "glm_moe_dsa", "PYTHON"),
+        ])
     def test_preference_per_architecture(self, architectures, model_type,
                                          expected):
         from tensorrt_llm._torch.models.modeling_deepseekv3 import \


### PR DESCRIPTION
…in disagg

GLM-5 and GLM-5.2 (GlmMoeDsaForCausalLM / glm_moe_dsa) share the DeepseekV3ForCausalLM implementation class; override get_preferred_transceiver_runtime() to opt GLM checkpoints into the Python (v2) transceiver, differentiated per checkpoint so DeepSeek-V3/ V3.2 keep the C++ default. The preference is adopted only when the user leaves cache_transceiver_config.transceiver_runtime at 'auto' and the effective backend is NIXL.

Set transceiver_runtime: PYTHON explicitly in the GLM-5 perf-sanity disaggregated NIXL configs, and switch the GLM-5 disagg stress-test config from backend DEFAULT to NIXL + PYTHON so the TRTLLM_USE_UCX_KVCACHE=1 fallback cannot silently revert it to the C++ transceiver.

Add unit tests covering the per-architecture preference and the end-to-end 'auto' resolution for GLM-5 on NIXL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GLM-5-family models now automatically prefer the Python cache-transceiver runtime when using NIXL.
  * Added explicit Python runtime settings across GLM-5 disaggregated serving and performance configurations.

* **Tests**
  * Added coverage for GLM-5 runtime selection, DeepSeek V3 behavior, missing configuration handling, and end-to-end runtime resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
