### PR TITLE
[None][perf] Overlap DSA heuristic prev_topk write-back on the aux stream

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/module.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/module.py
@@ -1219,10 +1219,8 @@ def forward_sparse_attn(
     self._fused_kv_norm_active = False
     self._fused_kv_norm_hoisted = False
 
-    # Join the aux-stream heuristic prev_topk write-back forked in
-    # sparse_attn_indexer, now that this layer's core attention is
-    # enqueued (the copy overlaps with it). Must stay within this
-    # layer's forward: CUDA graph capture rejects unjoined forks.
+    # Join the prev_topk copy forked in sparse_attn_indexer; CUDA graph
+    # capture requires the join within the same layer's forward.
     if self.indexer is not None:
         self.indexer.maybe_join_prev_topk_copy()
 

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -23,8 +23,8 @@ from tensorrt_llm._torch.cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
 from tensorrt_llm._torch.distributed.ops import allgather
 from tensorrt_llm._torch.modules.layer_norm import LayerNorm
 from tensorrt_llm._torch.modules.linear import Linear
-from tensorrt_llm._torch.modules.multi_stream_utils import \
-    maybe_execute_in_parallel
+from tensorrt_llm._torch.modules.multi_stream_utils import (
+    do_multi_stream, maybe_execute_in_parallel)
 from tensorrt_llm._torch.modules.rotary_embedding import RotaryEmbedding
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._torch.utils import Fp4QuantizedTensor, maybe_compile
@@ -1750,6 +1750,11 @@ class Indexer(nn.Module):
         self.use_fp4 = sparse_params.indexer_k_dtype == "fp4"
         self.aux_stream = aux_stream
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
+        # Fork/join pair for the aux-stream heuristic prev_topk write-back:
+        # [0] orders the copy after the top-k kernel, [1] is waited on by
+        # maybe_join_prev_topk_copy() in the owning MLA layer.
+        self.prev_topk_copy_events = [torch.cuda.Event(), torch.cuda.Event()]
+        self._prev_topk_copy_pending = False
         self.use_cute_dsl_topk = (sparse_params.use_cute_dsl_topk
                                   and IS_CUTLASS_DSL_AVAILABLE)
         self.use_cute_dsl_paged_mqa_logits = (
@@ -2819,14 +2824,51 @@ class Indexer(nn.Module):
                 decode_topk = topk_indices_buffer[
                     num_ctx_tokens:num_ctx_tokens + num_gen_tokens]
                 last_mtp_topk = decode_topk[next_n - 1::next_n]
-                metadata.heuristic_prev_topk[
-                    local_layer, :num_generations].copy_(last_mtp_topk)
+                prev_topk_dst = metadata.heuristic_prev_topk[
+                    local_layer, :num_generations]
+                if do_multi_stream() and self.aux_stream is not None:
+                    # Fork the write-back onto the aux stream so the strided
+                    # gather copy overlaps with this layer's core sparse
+                    # attention instead of sitting on the critical path.
+                    # Nothing in this step reads it back — the next consumer
+                    # is the next decode step's pre_idx for this same layer.
+                    # Source and destination are persistent stable-address
+                    # buffers, so no record_stream bookkeeping is needed. The
+                    # fork MUST be joined within this layer's forward via
+                    # maybe_join_prev_topk_copy(): that both keeps CUDA graph
+                    # capture free of unjoined forks (cudaStreamEndCapture
+                    # rejects them) and restores ordering before the next
+                    # layer overwrites the shared topk_indices_buffer rows
+                    # this copy reads.
+                    self.prev_topk_copy_events[0].record()
+                    with torch.cuda.stream(self.aux_stream):
+                        self.prev_topk_copy_events[0].wait()
+                        prev_topk_dst.copy_(last_mtp_topk)
+                        self.prev_topk_copy_events[1].record()
+                    self._prev_topk_copy_pending = True
+                else:
+                    prev_topk_dst.copy_(last_mtp_topk)
 
         elif has_decode and metadata.skip_indexer_for_gen_reqs:
             # Fill topk_indices_buffer with pre-defined dense topk indices
             topk_indices_buffer[num_ctx_tokens:num_tokens, :] = \
                 metadata.topk_indices_buffer[num_ctx_tokens:num_tokens, :]
         return topk_indices_buffer
+
+    def maybe_join_prev_topk_copy(self) -> None:
+        """Join the aux-stream heuristic prev_topk write-back, if forked.
+
+        Called by the owning MLA layer after this layer's core sparse
+        attention has been enqueued, so the copy forked in
+        sparse_attn_indexer overlaps with it. Joining within the same
+        layer's forward keeps every fork matched with a join inside a
+        single captured region (CUDA graph capture rejects unjoined
+        forks) and orders the copy's read of topk_indices_buffer before
+        the next layer's indexer overwrites those rows.
+        """
+        if self._prev_topk_copy_pending:
+            self.prev_topk_copy_events[1].wait()
+            self._prev_topk_copy_pending = False
 
     def _weight_scale(self, weights: torch.Tensor,
                       q_scale: torch.Tensor) -> torch.Tensor:

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa/indexer.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa/indexer.py
@@ -685,9 +685,7 @@ class Indexer(nn.Module):
         self.use_fp4 = sparse_params.indexer_k_dtype == "fp4"
         self.aux_stream = aux_stream
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
-        # Fork/join pair for the aux-stream heuristic prev_topk write-back:
-        # [0] orders the copy after the top-k kernel, [1] is waited on by
-        # maybe_join_prev_topk_copy() in the owning MLA layer.
+        # Fork/join events for the aux-stream prev_topk write-back.
         self.prev_topk_copy_events = [torch.cuda.Event(), torch.cuda.Event()]
         self._prev_topk_copy_pending = False
         self.use_cute_dsl_topk = sparse_params.use_cute_dsl_topk and IS_CUTLASS_DSL_AVAILABLE

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa/module.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa/module.py
@@ -387,10 +387,8 @@ def _forward_dsa_attn(
             indexer_intermediates=indexer_intermediates,
         )
 
-    # Join the aux-stream heuristic prev_topk write-back forked in
-    # sparse_attn_indexer, now that this layer's core attention is
-    # enqueued (the copy overlaps with it). Must stay within this
-    # layer's forward: CUDA graph capture rejects unjoined forks.
+    # Join the prev_topk copy forked in sparse_attn_indexer; CUDA graph
+    # capture requires the join within the same layer's forward.
     if self.mqa.indexer is not None:
         self.mqa.indexer.maybe_join_prev_topk_copy()
 

--- a/tensorrt_llm/_torch/modules/mla.py
+++ b/tensorrt_llm/_torch/modules/mla.py
@@ -1724,6 +1724,13 @@ class MLA(nn.Module):
                 position_ids=gen_position_ids,
             )
 
+        # Join the aux-stream heuristic prev_topk write-back forked in
+        # sparse_attn_indexer, now that this layer's core attention is
+        # enqueued (the copy overlaps with it). Must stay within this
+        # layer's forward: CUDA graph capture rejects unjoined forks.
+        if self.mqa.indexer is not None:
+            self.mqa.indexer.maybe_join_prev_topk_copy()
+
     def forward_impl_with_deepseek_v4(
         self,
         position_ids: Optional[torch.Tensor],
@@ -1990,6 +1997,13 @@ class MLA(nn.Module):
                 enable_dsv4_epilogue_fusion=enable_dsv4_epilogue_fusion,
                 dsv4_epilogue_output=dsv4_epilogue_output,
             )
+
+        # Join the aux-stream heuristic prev_topk write-back forked in
+        # sparse_attn_indexer, now that this layer's core attention is
+        # enqueued (the copy overlaps with it). Must stay within this
+        # layer's forward: CUDA graph capture rejects unjoined forks.
+        if self.indexer is not None:
+            self.indexer.maybe_join_prev_topk_copy()
 
     def forward_context_default(
         self,


### PR DESCRIPTION
## Description

`Indexer.sparse_attn_indexer` writes each decode step's top-k back to `metadata.heuristic_prev_topk` (the next step's `pre_idx` hint). This copy is a strided gather on the main stream, once per indexer layer per decode step, and nothing in the current step reads it. This PR forks the copy onto the indexer's existing aux stream right after the top-k kernel and joins it in the same layer's MLA forward after core sparse attention is enqueued, so the copy overlaps with the layer's heaviest decode work instead of delaying it.

Notes:

- Fork and join stay within one layer's forward: CUDA graph capture rejects unjoined forks, and the join restores ordering before the next layer overwrites the `topk_indices_buffer` rows the copy reads.
- Source and destination are persistent graph-pool buffers, so the captured copy is valid on every replay; no `record_stream` needed.
- Gated on `do_multi_stream()`, same policy as `maybe_execute_in_parallel`. Eager execution keeps the original inline copy.
- Covers both consumers: `forward_dsa_attn` (V3.2) and `forward_impl_with_deepseek_v4`. Shared DSA indexer layers (`indexer is None`) are unchanged.
- Also benefits the GVR top-k e2e wiring (#16420), which consumes the same feedback loop.

## Test Coverage

- Standalone CUDA graph smoke test: capture with the same-layer join succeeds and replayed feedback values are step-correct across replays; capture without the join fails with `cudaErrorStreamCaptureUnjoined`.
- Existing e2e: `test_fp8_blockscale[heuristic_topk_mtp1]` (TestDeepSeekV32, `cuda_graph=True`) exercises the forked path on Blackwell.

## Performance

nsys per-iteration A/B: DeepSeek-V4 Pro FP4, 8xB200, TEP8, BS=1, ISL 64K, OSL 2048, MTP=0, `enable_heuristic_topk: true`, CUDA graphs ON. Arms differ only in this PR's files on the same C++ build; ABBA run order; nsys window = decode iters 500-550 (49 per-iteration deltas per run).

| per-iter decode | base | this PR | delta |
|---|---:|---:|---:|
| 10% trimmed mean | 10.6501 ms | 10.6351 ms | **-15.0 µs/iter** |
| median | 10.6488 ms | 10.6335 ms | -15.3 µs |
| min | 10.600 ms | 10.575 ms | -25 µs |

Mann-Whitney U z = -4.60 (p ≈ 4e-6); all four runs direction-consistent. In the base traces 0/300 feedback copies overlap other-stream work; with this PR 300/300 overlap core sparse attention and the join adds no main-stream bubble.

-15 µs/iter over 30 indexer layers ≈ 0.5 µs/layer, i.e. the copy-kernel duration leaving the critical path. That is 0.14-0.23% of TPOT for this config and ≤ ~0.4% for any realistic config, below what e2e timing can resolve. A matching e2e TPOT A/B (DeepSeek-V3.2-Exp FP4, 8xB200, TEP8, BS=1, MTP=3, ISL ~68.7K, 10 warm pairs) reads -0.42% mean / -0.16% median, SE ≈ 0.7% — statistically zero, consistent with the per-iteration bound.

Note (2026-08-12): an earlier revision reported +2-4% e2e TPOT gains (MTP=0/1/2). Those numbers are retracted as measurement artifacts — their baselines are inconsistent with later same-node reruns, and the magnitude is 10-20x above the per-iteration bound above.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added auxiliary-stream fork/join handling for heuristic TopK copies in DSA and DeepSeek-V4 paths.
- Preserved synchronous copying when `do_multi_stream()` is disabled.
- Added `Indexer.maybe_join_prev_topk_copy()` with pending-state cleanup.
- Placed joins after core attention enqueue to preserve stream ordering.
- Preserved CUDA graph capture and persistent-buffer usage.
- Left shared DSA indexer layers unchanged.
- No configuration or test-list changes were identified.
- Reported a 15 µs per-iteration nsys improvement. End-to-end TPOT results were statistically null and consistent with the estimated 0.14–0.23% effect. Earlier 2–4% results were retracted as measurement artifacts.
- Fix `#17416` initializes `in_mtp_draft_loop` in the synthetic metadata stub.
- Later CI run `#65523` succeeded after the rebase and inclusion of fix `#17416`.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
