### PR TITLE
[https://nvbugs/6484714][fix] Rewrote both docstrings with a summary line + blank line + body; appended a…

### DIFF
--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -64,7 +64,8 @@ class MPINodeState:
 
 
 def external_mpi_comm_available(model_world_size: int) -> bool:
-    """Check if the current process is launched by mpirun and does not use MPIPoolExecutor to spawn processes.
+    """Check if launched by mpirun without using MPIPoolExecutor to spawn processes.
+
     e.g. mpirun -np 4 python script.py
     """
     if ENABLE_MULTI_DEVICE:


### PR DESCRIPTION
## Summary
- **Root cause**: Post-Merge Release Check (pre-commit -a) hit D205 regressions in two mpi_session.py docstrings and end-of-file-fixer flagged two tracked files missing a trailing newline.
- **Fix**: Rewrote both docstrings with a summary line + blank line + body; appended a single `\n` to `.test_durations` and to `excel_table_test.jpg`. Verified via `.repair-bot/repro.py` → EXIT_CODE=0 and via `pre-commit run --files ...` → all hooks pass.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6484714


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how MPI process detection works when launched with `mpirun`.
  * Expanded session configuration guidance for shutdown behavior and environment overrides.
  * Clarified that parent process environment variables remain unchanged.

* **Tests**
  * Updated integration test metadata formatting without changing recorded test-duration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->