### PR TITLE
[TRTLLM-13948][test] Migrate DeepSeek R1/V3.2 disagg perf cases to transceiver V2

### DIFF
--- a/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -88,5 +89,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_1k1k_con2048_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_1k1k_con2048_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_1k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_1k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -91,6 +92,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -88,5 +89,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -90,6 +91,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_128k8k_con1_ctx1_pp8_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_128k8k_con1_ctx1_pp8_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -88,5 +89,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp0_ccb-NIXL.yaml
@@ -81,6 +81,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 4608
       backend: NIXL
+      transceiver_runtime: PYTHON
     stream_interval: 20
   ctx:
     print_iter_log: true
@@ -101,3 +102,4 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 4608
       backend: NIXL
+      transceiver_runtime: PYTHON

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con1024_ctx1_dep4_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con1024_ctx1_dep4_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     stream_interval: 100
     num_postprocess_workers: 4
   ctx:
@@ -90,3 +91,4 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb288_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb288_mtp3_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -93,5 +94,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con3072_ctx1_dep4_gen1_dep4_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con3072_ctx1_dep4_gen1_dep4_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
@@ -67,6 +67,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,6 +62,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -97,5 +98,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_1k1k_con2048_ctx1_dep4_gen1_dep4_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_1k1k_con2048_ctx1_dep4_gen1_dep4_eplb0_mtp1_ccb-NIXL.yaml
@@ -64,6 +64,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -98,5 +99,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -65,6 +65,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -102,5 +103,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
@@ -69,6 +69,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -106,6 +107,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -102,5 +103,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -70,6 +70,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 120000
       backend: NIXL
+      transceiver_runtime: PYTHON
     num_postprocess_workers: 8
     stream_interval: 10
   ctx:
@@ -97,3 +98,4 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 120000
       backend: NIXL
+      transceiver_runtime: PYTHON

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
@@ -67,6 +67,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,6 +62,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -97,5 +98,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
@@ -67,6 +67,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -98,4 +99,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con1_ctx1_pp4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con1_ctx1_pp4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,6 +62,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -64,7 +64,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
-      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -92,7 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
-      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -64,6 +64,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -91,6 +92,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con64_ctx1_pp4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con64_ctx1_pp4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -64,6 +64,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_1k1k_con3072_ctx1_dep4_gen1_dep4_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_1k1k_con3072_ctx1_dep4_gen1_dep4_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -61,6 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -89,5 +90,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,7 +63,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
-      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -91,6 +90,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
-      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_1k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
@@ -67,6 +67,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,6 +62,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -97,5 +98,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_1k1k_con2048_ctx1_dep4_gen1_dep4_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_1k1k_con2048_ctx1_dep4_gen1_dep4_eplb0_mtp1_ccb-NIXL.yaml
@@ -64,6 +64,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -98,5 +99,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -65,6 +65,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -102,5 +103,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
@@ -69,6 +69,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -106,6 +107,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -66,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -102,5 +103,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -70,6 +70,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 120000
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     num_postprocess_workers: 8
     stream_interval: 10
@@ -98,4 +99,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 120000
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
@@ -67,6 +67,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,6 +62,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -97,5 +98,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
@@ -67,6 +67,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -98,4 +99,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -74,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -101,6 +102,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_128k8k_con1_ctx1_pp8_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_128k8k_con1_ctx1_pp8_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -72,6 +72,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -99,5 +100,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_128k8k_con64_ctx1_pp8_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_128k8k_con64_ctx1_pp8_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -74,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -100,5 +101,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_128k8k_ctx1_pp4_gen8_pp4_bs2_eplb0_mtp0_con2-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_128k8k_ctx1_pp4_gen8_pp4_bs2_eplb0_mtp0_con2-NIXL.yaml
@@ -71,6 +71,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     stream_interval: 20
     num_postprocess_workers: 4
     allreduce_strategy: MNNVL
@@ -92,5 +93,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     moe_config:
       backend: TRTLLM

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -74,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -72,6 +72,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -100,5 +101,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -74,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_8k1k_ctx1_gen3_tep8_bs32_eplb0_mtp0_con1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_8k1k_ctx1_gen3_tep8_bs32_eplb0_mtp0_con1_ccb-NIXL.yaml
@@ -74,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     stream_interval: 20
     num_postprocess_workers: 4
     allreduce_strategy: MNNVL
@@ -95,3 +96,4 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -76,6 +76,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -113,5 +114,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
@@ -80,6 +80,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -117,6 +118,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -77,6 +77,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -113,5 +114,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -70,6 +70,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 120000
       backend: NIXL
+      transceiver_runtime: PYTHON
     num_postprocess_workers: 8
     stream_interval: 10
   ctx:
@@ -97,3 +98,4 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 120000
       backend: NIXL
+      transceiver_runtime: PYTHON

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
@@ -78,6 +78,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -112,5 +113,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -73,6 +73,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -108,5 +109,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
@@ -78,6 +78,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -109,4 +110,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb200_wideep_deepseek-r1-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_con1024_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_wideep_deepseek-r1-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_con1024_ccb-NIXL.yaml
@@ -80,6 +80,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     stream_interval: 20
     num_postprocess_workers: 4
     speculative_config:
@@ -104,6 +105,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     speculative_config:
       decoding_type: MTP
       num_nextn_predict_layers: 3

--- a/tests/scripts/perf/disaggregated/gb200_wideep_deepseek-v32-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_con1024_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_wideep_deepseek-v32-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_con1024_ccb-NIXL.yaml
@@ -87,6 +87,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     stream_interval: 20
     num_postprocess_workers: 4
     speculative_config:
@@ -112,6 +113,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     speculative_config:
       decoding_type: MTP
       num_nextn_predict_layers: 3

--- a/tests/scripts/perf/disaggregated/gb200_wideep_stress-deepseek-r1-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_wideep_stress-deepseek-r1-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_ccb-NIXL.yaml
@@ -97,6 +97,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     stream_interval: 20
     num_postprocess_workers: 4
     speculative_config:
@@ -121,6 +122,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     speculative_config:
       decoding_type: MTP
       num_nextn_predict_layers: 3

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con1_ctx1_pp4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con1_ctx1_pp4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -73,6 +73,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -100,5 +101,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -75,6 +75,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -102,6 +103,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -75,7 +75,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
-      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -103,7 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
-      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con64_ctx1_pp4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con64_ctx1_pp4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -75,6 +75,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -74,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -72,6 +72,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -100,5 +101,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -74,7 +74,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
-      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -102,6 +101,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
-      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -74,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -76,6 +76,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -113,5 +114,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
@@ -80,6 +80,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -117,6 +118,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -77,6 +77,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -113,5 +114,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -70,6 +70,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 120000
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
     num_postprocess_workers: 8
     stream_interval: 10
@@ -98,4 +99,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 120000
       backend: NIXL
+      transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
@@ -78,6 +78,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -112,5 +113,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -73,6 +73,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -108,5 +109,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
@@ -78,6 +78,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -109,4 +110,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb300_wideep_deepseek-r1-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_con1024_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_wideep_deepseek-r1-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_con1024_ccb-NIXL.yaml
@@ -80,6 +80,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     stream_interval: 20
     num_postprocess_workers: 4
     speculative_config:
@@ -104,6 +105,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     speculative_config:
       decoding_type: MTP
       num_nextn_predict_layers: 3

--- a/tests/scripts/perf/disaggregated/gb300_wideep_deepseek-v32-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_con1024_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_wideep_deepseek-v32-fp4_8k1k_ctx2_gen1_dep32_bs128_eplb288_mtp3_con1024_ccb-NIXL.yaml
@@ -87,6 +87,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     stream_interval: 20
     num_postprocess_workers: 4
     speculative_config:
@@ -112,6 +113,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     speculative_config:
       decoding_type: MTP
       num_nextn_predict_layers: 3


### PR DESCRIPTION
## Description

Migrate all existing DeepSeek disaggregated perf test configs to cache transceiver V2 by adding `transceiver_runtime: PYTHON` under `cache_transceiver_config` (NIXL backend), so that a single CI round can identify any per-case perf regression before we make V2 the default.

This PR consolidates the perf portions of #16152 (R1), #16255 (V3.2), and #16390 (V3-Lite), and supersedes them, with the following differences:

- **Accuracy-test changes are excluded** — they are tracked separately in #16344.
- **Changes to `tests/integration/defs/disaggregated/test_configs/` are excluded** — functional e2e configs, separate concern.
- **No new V3-Lite perf case is added** (originally in #16390): adding a net-new e2e perf test conflicts with the ongoing effort to trim CI coverage, and a brand-new case has no historical baseline to detect regressions against.
- **The GB300 R1 128k8k case reverted in #16152 (known perf regression) is intentionally kept migrated here** to re-confirm the regression with fresh CI data. If it regresses again, only this case will be reverted before merge.

Changes (80 files, 160 insertions, pure config additions):
- `tests/scripts/perf-sanity/disaggregated/`: 47 files (R1 x27, V3.2 x20) — run by CI perf-sanity stages.
- `tests/scripts/perf/disaggregated/`: 33 files (R1 x17, V3.2 x16) — QA/local perf catalog, not scheduled by CI; merged together once perf-sanity results are confirmed.

UCX configs and DeepSeek-V4 configs (already on V2) are untouched.

## Test Coverage

35 active DeepSeek entries (17 configs) in the current test-db

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
Migrates DeepSeek R1 and V3.2 disaggregated performance test configurations to cache transceiver V2 by adding `transceiver_runtime: PYTHON` under `worker_config.{gen,ctx}.cache_transceiver_config` for the NIXL-backed cases (preserving existing `backend: NIXL` and buffering-related fields). Applies broadly across disaggregated perf-sanity and performance catalog YAMLs (80 total files affected), while keeping UCX and DeepSeek-V4 configurations unchanged. Accuracy/e2e functional configs and the new V3-Lite performance case are excluded; the reverted GB300 R1 128k8k case remains included for revalidation.

## Dev Engineer Review
- **Config correctness & consistency:** Added `transceiver_runtime: PYTHON` in both required locations (`worker_config.gen.cache_transceiver_config` and `worker_config.ctx.cache_transceiver_config`) for the affected NIXL disaggregated DeepSeek R1/V3.2 performance YAMLs; no other functional keys in the shown hunks appear changed (e.g., `backend: NIXL`, `max_tokens_in_buffer`, etc. preserved).
- **Scope control:** Changes are limited to disaggregated performance/perf-sanity YAML configurations under `tests/scripts/` and do not touch UCX or DeepSeek-V4 configs, aligning with the stated migration scope (cache transceiver V2 via runtime selector).
- **Risk note:** CI runs were reported as failing/partly tested, but no per-test failure details were provided in the comments summary; this migration is narrowly scoped, but the existing failures suggest follow-up validation is needed.

## QA Engineer Review
- **Test files touched:** Yes—YAML test/config assets under `tests/scripts/perf-sanity/disaggregated/` and `tests/scripts/perf/disaggregated/` were updated to include the new `transceiver_runtime: PYTHON` selector for NIXL cache transceiver behavior.
- **Test list / test-db / qa / waives.txt changes:** Not evidenced in the provided diff outputs; no `tests/integration/test_lists/` entries were shown as modified.
- **Coverage vs test lists:** At least one affected DeepSeek disagg performance sanity case (GB300 DeepSeek-R1 FP4 128k8k, `...ccb-NIXL`) is referenced by `tests/integration/test_lists/qa/llm_perf_disagg.yml` / `llm_perf_multinode.txt` as a `perf/test_perf_sanity.py::test_e2e[disagg-e2e-...ccb-NIXL]` target. Full mapping of all updated YAMLs to test-list entries was not exhaustively confirmed from the provided context.
- **Verdict:** needs follow-up (prior CI runs for related disaggregated performance sanity stages reported `FAILURE`/`Partly Tested`, and detailed failure diagnostics were not included).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->