### PR TITLE
[https://nvbugs/6482297][fix] Parse boolean stage-config fields in test_to_stage_mapping

### DIFF
--- a/scripts/test_to_stage_mapping.py
+++ b/scripts/test_to_stage_mapping.py
@@ -47,7 +47,7 @@ def _load_tests_file(path: str) -> List[str]:
 
 
 # Regex to parse Jenkins stage configurations from Groovy files
-# Matches patterns like: "Stage-Name": ["platform", "yaml_file", split_id, split_count, gpu_count]
+# Matches patterns like: "Stage-Name": ["platform", "yaml_file", split_id, split_count, gpu_count, node_count, runWithSbatch]
 #
 # Pattern breakdown:
 #   "(?P<stage>[^"]+)"     - Captures stage name in quotes (group 'stage')
@@ -56,10 +56,12 @@ def _load_tests_file(path: str) -> List[str]:
 #   "[^"]+"              - Matches platform string in quotes (ignored)
 #   ,\s*                 - Matches comma with optional whitespace
 #   "(?P<yml>[^"]+)"     - Captures yaml filename in quotes (group 'yml')
-#   (?:,\s*\d+)*         - Matches zero or more comma-separated numbers (split_id, split_count, gpu_count)
+#   (?:,\s*(?:\d+|true|false))* - Matches zero or more comma-separated numbers or
+#                          booleans (split_id, split_count, gpu_count, node_count, runWithSbatch)
 #   \s*\]                - Matches closing bracket with optional whitespace
 _STAGE_RE = re.compile(
-    r'"(?P<stage>[^"]+)"\s*:\s*\["[^"]+",\s*"(?P<yml>[^"]+)"(?:,\s*\d+)*\s*\]')
+    r'"(?P<stage>[^"]+)"\s*:\s*\["[^"]+",\s*"(?P<yml>[^"]+)"(?:,\s*(?:\d+|true|false))*\s*\]'
+)
 
 
 def _extract_terms(entry):
@@ -85,6 +87,8 @@ class StageQuery:
         yaml_to_stages = defaultdict(list)
         with open(path, 'r') as f:
             for line in f:
+                if line.lstrip().startswith('//'):
+                    continue
                 m = _STAGE_RE.search(line)
                 if m:
                     stage = m.group('stage')

--- a/tests/unittest/tools/test_test_to_stage_mapping.py
+++ b/tests/unittest/tools/test_test_to_stage_mapping.py
@@ -262,8 +262,15 @@ def test_backend_filtering_consistency(stage_query):
                 f"at least one stage containing '{backend.upper()}', " \
                 f"but got stages: {stages}"
 
-            # Check that test does NOT map to stages of other backends
-            other_backends = all_backends - {backend}
+            # Check that test does NOT map to stages of backends it is not
+            # declared under (tests may legitimately be listed under several
+            # backends across test-db files).
+            declared_backends = {
+                b.strip()
+                for _, _, b in stage_query.test_map[test_name]
+                if b and b.strip()
+            }
+            other_backends = all_backends - declared_backends
             for stage in stages:
                 stage_upper = stage.upper()
                 for other_backend in other_backends:


### PR DESCRIPTION

The stage-parsing regex in scripts/test_to_stage_mapping.py only accepted trailing numeric fields in Jenkins stage-config arrays, so the 47 stage entries carrying the runWithSbatch boolean (added by the Slurm test refactor #7176) were silently dropped from the test<->stage mapping, including all DGX_B200-PyTorch-* stages. It also matched commented-out stage lines. As a result, tests listed in l0_b200.yml resolved to no stage and test_cli_functionality failed whenever the seeded sample picked one of them.

- Accept true/false fields in the stage-config regex and skip //-commented lines when parsing L0_Test.groovy.
- Fix test_backend_filtering_consistency to tolerate tests legitimately listed under multiple backends (e.g. unittest/kv_cache_manager_v2_tests under both tensorrt and pytorch), which the parser fix exposed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Jenkins stage-mapping parsing to support configurations containing boolean values and varying numbers of numeric values.
  * Commented-out stage configuration lines are now ignored during parsing.
  * Improved backend consistency validation to accurately identify undeclared backends for each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
