### PR TITLE
[https://nvbugs/6478692][fix] Pass `max_workers=16` to `_build` in `EPDVariant.nano_omni_fp8` (mirroring…

### DIFF
--- a/tests/integration/defs/accuracy/test_epd_disagg_multimodal.py
+++ b/tests/integration/defs/accuracy/test_epd_disagg_multimodal.py
@@ -207,6 +207,9 @@ class EPDVariant:
             ),
             max_batch_size=64,
             expected_quant_algo=QuantAlgo.FP8,
+            # Default 128 workers trips a native-library abort in the CPU-side
+            # multimodal preprocessing path on H100 (nvbugs/6478692).
+            max_workers=16,
         )
 
     @classmethod

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -14,7 +14,6 @@ accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_tp_pp_symm
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_tp_pp_symmetric[MMLU-tp2pp2] SKIP (https://nvbugs/6428069)
 accuracy/test_disaggregated_serving.py::TestQwen3NextInstruct::test_auto_dtype[use_py_transceiver=False] SKIP (https://nvbugs/6535790)
 accuracy/test_disaggregated_serving.py::TestQwen3_30B_A3B::test_mixed_ctx_gen_model[ctxpp2gentp2] SKIP (https://nvbugs/5748664)
-accuracy/test_epd_disagg_multimodal.py::TestVideoMMEEPD::test_disaggregated_videomme[nemotron_nano_v3_omni_fp8] SKIP (https://nvbugs/6478692)
 accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[nvfp4-4-attn_dp_off-trtllm] SKIP (https://nvbugs/6367792)
 accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_mtp[nvfp4_ws8_80gb-trtllm] SKIP (https://nvbugs/6450341)
 accuracy/test_llm_api_autodeploy.py::TestQwen3_5_397B_MoE::test_bf16_small[4] SKIP (https://nvbugs/6507114)


### PR DESCRIPTION
## Summary
- **Root cause**: `nano_omni_fp8` did not override `max_workers`, defaulting to `VideoMME.MAX_BATCH_SIZE=128`, which oversubscribed the CPU-side multimodal preprocessing/hashing path on H100 and tripped a native-library SIGABRT.
- **Fix**: Pass `max_workers=16` to `_build` in `EPDVariant.nano_omni_fp8` (mirroring `qwen3vl_2b`), and remove the corresponding entry from `waives.txt`.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6478692


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for multimodal processing on H100 hardware by limiting parallel workers.
  * Re-enabled the disaggregated video multimodal accuracy test so it runs as part of validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->