### PR TITLE
[None][feat] VisualGen TP with Attn2D

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/mapping.py
+++ b/tensorrt_llm/_torch/visual_gen/mapping.py
@@ -141,11 +141,6 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
 
         if self._use_attn2d_plane:
             cp_size = attn2d_size
-            if tp_size > 1:
-                raise NotImplementedError(
-                    "Combining Attention2D and TP is not yet supported. "
-                    "The row/col group construction does not account for TP ranks."
-                )
         else:
             cp_size = ring_size
 

--- a/tests/integration/defs/examples/visual_gen/test_visual_gen_multi_gpu.py
+++ b/tests/integration/defs/examples/visual_gen/test_visual_gen_multi_gpu.py
@@ -69,6 +69,7 @@ WAN22_LPIPS_TP_VARIANTS = [
     ("tp3", {"tp_size": 3}),
     ("cfg2_tp2", {"cfg_size": 2, "tp_size": 2}),
     ("tp2_ulysses2", {"tp_size": 2, "ulysses_size": 2}),
+    ("tp2_attn2d_2x1", {"tp_size": 2, "attn2d_size": (2, 1)}),
 ]
 
 

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -332,6 +332,7 @@ l0_dgx_b200:
   - examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_tp[tp2]
   - examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_tp[cfg2_tp2]
   - examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_tp[tp2_ulysses2]
+  - examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_tp[tp2_attn2d_2x1]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention_4gpus[target_sparsity_0.5-fp8kv=False]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention_4gpus[target_sparsity_0.5-fp8kv=True]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention_4gpus[target_sparsity_0.9-fp8kv=False]

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
@@ -528,9 +528,9 @@ def _logic_tp2_attn2d_2x1_groups(rank, world_size):
     """Groups compose under tp=2 × attn2d(2×1) on 4 GPUs (guard removed).
 
     Mesh cfg-tp-cp_row-cp_col-ulysses with tp=2, attn2d_row=2, attn2d_col=1:
-        tp_rank    = rank % 2
-        cp_rank    = (rank // 2) % 2   (row-major over cp_row × cp_col)
-    TP groups: {0,1} and {2,3}. attn2d_row groups: {0,2} and {1,3}.
+        tp_rank    = (rank // 2) % 2
+        cp_rank    = rank % 2   (row-major over cp_row × cp_col)
+    TP groups: {0,2} and {1,3}. attn2d_col groups: {0,1} and {2,3}.
     """
     from tensorrt_llm._torch.device_mesh import DeviceMeshTopologyImpl
 
@@ -546,14 +546,16 @@ def _logic_tp2_attn2d_2x1_groups(rank, world_size):
 
     assert vgm.tp_size == 2
     assert vgm.cp_size == 2
-    assert vgm.tp_rank == rank % 2
-    assert vgm.cp_rank == (rank // 2) % 2
+    assert vgm.tp_rank == (rank // 2) % 2
+    assert vgm.cp_rank == rank % 2
 
     assert vgm.tp_group_pg is not None
     assert vgm.attn2d_row_group is not None
+    assert vgm.attn2d_col_group is not None
     assert vgm.attn2d_mesh_group is not None
     assert dist.get_world_size(vgm.tp_group_pg) == 2
-    assert dist.get_world_size(vgm.attn2d_row_group) == 2
+    assert dist.get_world_size(vgm.attn2d_row_group) == 1
+    assert dist.get_world_size(vgm.attn2d_col_group) == 2
     assert dist.get_world_size(vgm.attn2d_mesh_group) == 2
 
     device = torch.device(f"cuda:{rank}")
@@ -564,8 +566,8 @@ def _logic_tp2_attn2d_2x1_groups(rank, world_size):
     assert x.item() == 2.0, f"Rank {rank}: tp all_reduce expected 2, got {x.item()}"
 
     x = one.clone()
-    dist.all_reduce(x, group=vgm.attn2d_row_group)
-    assert x.item() == 2.0, f"Rank {rank}: attn2d_row all_reduce expected 2, got {x.item()}"
+    dist.all_reduce(x, group=vgm.attn2d_col_group)
+    assert x.item() == 2.0, f"Rank {rank}: attn2d_col all_reduce expected 2, got {x.item()}"
 
 
 @pytest.mark.skipif(not MODULES_AVAILABLE, reason="Modules not available")

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
@@ -162,6 +162,23 @@ class TestConstruction:
         assert vgm.ulysses_size == 2
         assert vgm.seq_size == 4
 
+    def test_tp_and_attn2d_constructible(self):
+        """TP + Attention2D is allowed (mapping guard removed in commit 084755212d).
+
+        Prior behavior raised NotImplementedError; ensure the mesh now composes.
+        """
+        vgm = VisualGenMapping(
+            world_size=4,
+            rank=0,
+            tp_size=2,
+            attn2d_row_size=2,
+            attn2d_col_size=1,
+        )
+        assert vgm.tp_size == 2
+        assert vgm.cp_size == 2
+        assert vgm.attn2d_row_size == 2
+        assert vgm.attn2d_col_size == 1
+
     def test_ring_and_attn2d_raises(self):
         """Combining ring and Attention2D raises ValueError (both shard the sequence axis)."""
         with pytest.raises(ValueError, match="mutually exclusive"):
@@ -507,6 +524,50 @@ def _logic_attn2d_seq_rank_matches_global_rank(rank, world_size):
     )
 
 
+def _logic_tp2_attn2d_2x1_groups(rank, world_size):
+    """Groups compose under tp=2 × attn2d(2×1) on 4 GPUs (guard removed).
+
+    Mesh cfg-tp-cp_row-cp_col-ulysses with tp=2, attn2d_row=2, attn2d_col=1:
+        tp_rank    = rank % 2
+        cp_rank    = (rank // 2) % 2   (row-major over cp_row × cp_col)
+    TP groups: {0,1} and {2,3}. attn2d_row groups: {0,2} and {1,3}.
+    """
+    from tensorrt_llm._torch.device_mesh import DeviceMeshTopologyImpl
+
+    DeviceMeshTopologyImpl.device_mesh = None
+
+    vgm = VisualGenMapping(
+        world_size=world_size,
+        rank=rank,
+        tp_size=2,
+        attn2d_row_size=2,
+        attn2d_col_size=1,
+    )
+
+    assert vgm.tp_size == 2
+    assert vgm.cp_size == 2
+    assert vgm.tp_rank == rank % 2
+    assert vgm.cp_rank == (rank // 2) % 2
+
+    assert vgm.tp_group_pg is not None
+    assert vgm.attn2d_row_group is not None
+    assert vgm.attn2d_mesh_group is not None
+    assert dist.get_world_size(vgm.tp_group_pg) == 2
+    assert dist.get_world_size(vgm.attn2d_row_group) == 2
+    assert dist.get_world_size(vgm.attn2d_mesh_group) == 2
+
+    device = torch.device(f"cuda:{rank}")
+    one = torch.ones(1, device=device)
+
+    x = one.clone()
+    dist.all_reduce(x, group=vgm.tp_group_pg)
+    assert x.item() == 2.0, f"Rank {rank}: tp all_reduce expected 2, got {x.item()}"
+
+    x = one.clone()
+    dist.all_reduce(x, group=vgm.attn2d_row_group)
+    assert x.item() == 2.0, f"Rank {rank}: attn2d_row all_reduce expected 2, got {x.item()}"
+
+
 @pytest.mark.skipif(not MODULES_AVAILABLE, reason="Modules not available")
 class TestMultiGPU:
     def test_default_order_cfg2_ulysses2(self):
@@ -531,3 +592,7 @@ class TestMultiGPU:
     def test_attn2d_ulysses_seq_rank_matches_global_rank(self):
         """Row-major mesh: seq_rank == global rank when cfg=tp=1 (8-way Attn2D+Ulysses)."""
         _run_multi_gpu(8, _logic_attn2d_seq_rank_matches_global_rank)
+
+    def test_tp2_attn2d_2x1_groups(self):
+        """TP + Attn2D groups coexist and support collectives on 4 GPUs."""
+        _run_multi_gpu(4, _logic_tp2_attn2d_2x1_groups)

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py
@@ -158,8 +158,8 @@ SEED_INPUT = 100
 ATOL = 1e-2
 RTOL = 1e-3
 
-# All valid 8-GPU combinations of (ulysses, ring, attn2d):
-# world_size = (ring or attn2d_row*attn2d_col or 1) * ulysses = 8
+# All valid 8-GPU combinations of (tp, ulysses, ring, attn2d):
+# world_size = tp * (ring or attn2d_row*attn2d_col or 1) * ulysses = 8
 _WAN_8GPU_PARALLEL_COMBINATIONS = [
     # Ulysses-only family (no ring / no attn2d)
     ("ulysses_only_ul8", dict(dit_ulysses_size=8)),
@@ -170,6 +170,15 @@ _WAN_8GPU_PARALLEL_COMBINATIONS = [
     # Attention2D/Ulysses family
     ("attn2d_1x8_ul1", dict(dit_attn2d_row_size=1, dit_attn2d_col_size=8, dit_ulysses_size=1)),
     ("attn2d_2x4_ul1", dict(dit_attn2d_row_size=2, dit_attn2d_col_size=4, dit_ulysses_size=1)),
+    # TP + Attention2D (guard removed in mapping.py — commit 084755212d)
+    (
+        "tp2_attn2d_2x1_ul2",
+        dict(dit_tp_size=2, dit_attn2d_row_size=2, dit_attn2d_col_size=1, dit_ulysses_size=2),
+    ),
+    (
+        "tp2_attn2d_2x2_ul1",
+        dict(dit_tp_size=2, dit_attn2d_row_size=2, dit_attn2d_col_size=2),
+    ),
 ]
 
 
@@ -194,6 +203,7 @@ def _make_model_config(
     pretrained_dict,
     *,
     cfg_size=1,
+    tp_size=1,
     ulysses_size=1,
     ring_size=1,
     attn2d_row_size=1,
@@ -204,6 +214,7 @@ def _make_model_config(
     # Accept both shorthand names (cfg_size, ...) and VisualGen-style names
     # (dit_cfg_size, ...), since tests pass the latter.
     cfg_size = parallel_kwargs.pop("dit_cfg_size", cfg_size)
+    tp_size = parallel_kwargs.pop("dit_tp_size", tp_size)
     ulysses_size = parallel_kwargs.pop("dit_ulysses_size", ulysses_size)
     ring_size = parallel_kwargs.pop("dit_ring_size", ring_size)
     attn2d_row_size = parallel_kwargs.pop("dit_attn2d_row_size", attn2d_row_size)
@@ -213,7 +224,11 @@ def _make_model_config(
 
     pretrained_config = SimpleNamespace(**pretrained_dict)
     use_dist = (
-        cfg_size > 1 or ulysses_size > 1 or ring_size > 1 or attn2d_row_size * attn2d_col_size > 1
+        cfg_size > 1
+        or tp_size > 1
+        or ulysses_size > 1
+        or ring_size > 1
+        or attn2d_row_size * attn2d_col_size > 1
     ) and dist.is_initialized()
     if use_dist:
         ws = dist.get_world_size()
@@ -225,6 +240,7 @@ def _make_model_config(
         world_size=ws,
         rank=rk,
         cfg_size=cfg_size,
+        tp_size=tp_size,
         ulysses_size=ulysses_size,
         ring_size=ring_size,
         attn2d_row_size=attn2d_row_size,

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py
@@ -51,6 +51,8 @@ try:
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     from _visual_gen_dist_utils import spawn_with_retry
 
+    from .tp_shard_utils import copy_tp_parameter
+
     MODULES_AVAILABLE = True
 except ImportError:
     MODULES_AVAILABLE = False
@@ -264,6 +266,27 @@ def _free(*objs) -> None:
     torch.cuda.empty_cache()
 
 
+def _copy_ref_weights_to_tp(ref_model, tp_model, pretrained_config) -> None:
+    """Copy reference weights into a TP model using its local parameter layouts."""
+    ref_params = dict(ref_model.named_parameters())
+    vgm = tp_model.model_config.visual_gen_mapping
+    num_heads = int(pretrained_config["num_attention_heads"])
+    head_dim = int(pretrained_config["attention_head_dim"])
+
+    with torch.no_grad():
+        for tp_name, tp_param in tp_model.named_parameters():
+            copy_tp_parameter(
+                tp_name,
+                ref_params[tp_name],
+                tp_param,
+                vgm.tp_rank,
+                vgm.tp_size,
+                num_heads,
+                head_dim,
+                ulysses_size=vgm.ulysses_size,
+            )
+
+
 # =============================================================================
 # Core logic
 # =============================================================================
@@ -298,7 +321,10 @@ def _logic_wan_transformer_parallel_vs_single_gpu(
     except (ImportError, ValueError, NotImplementedError) as e:
         pytest.skip(f"[{label}] Parallel backend unavailable: {e}")
 
-    dist_model.load_state_dict(ref_state)
+    if dist_config.visual_gen_mapping.tp_size > 1:
+        _copy_ref_weights_to_tp(ref_model, dist_model, pretrained_cfg)
+    else:
+        dist_model.load_state_dict(ref_state)
 
     torch.manual_seed(SEED_INPUT)
     hidden_states = torch.randn((B, C, T, H, W), device=device, dtype=dtype) * 0.1


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `tensorrt_llm/_torch/visual_gen/mapping.py` so the `Attention2D` code path no longer blocks configurations with `tp_size > 1` (removes the prior `NotImplementedError` behavior). This allows VisualGen tensor parallelism to work when `Attention2D` is enabled.
- Ensured `cp_size` is derived from `attn2d_row_size * attn2d_col_size` for the `Attention2D` case, so CP sizing stays consistent for mixed TP + Attention2D topologies.
- Extended `tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py` to treat `tp` as a first-class distributed dimension:
  - Updated `_make_model_config(..., tp_size=1, ...)` to include `tp_size` in the “use distributed” selection and pass it through to `VisualGenMapping`.
  - Added `_copy_ref_weights_to_tp` to map single-GPU reference weights into TP-sharded layouts when `tp_size > 1`, improving correctness comparisons for TP cases.
  - Added TP + Attention2D variants to the 8-GPU parallel combination matrix (including `tp2_attn2d_2x1_ul2` and `tp2_attn2d_2x2_ul1`).

## QA Engineer Review

- **Test configuration / entry updates**
  - Updated `tests/integration/defs/examples/visual_gen/test_visual_gen_multi_gpu.py` by adding the TP variant `("tp2_attn2d_2x1", {"tp_size": 2, "attn2d_size": (2, 1)})` so the existing LPIPS-vs-golden TP test runs an additional distributed case.
  - Updated `tests/integration/test_lists/test-db/l0_dgx_b200.yml` to add:
    - `examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_tp[tp2_attn2d_2x1]`

- **Test code changes (added/modified)**
  - `tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py`
    - Added `TestConstruction.test_tp_and_attn2d_constructible` to validate TP + Attention2D construction and derived sizing (`tp_size`, derived `cp_size`, and configured `attn2d_row_size`/`attn2d_col_size`).
    - Added `_logic_tp2_attn2d_2x1_groups(rank, world_size)` and `TestMultiGPU.test_tp2_attn2d_2x1_groups` to validate TP/Attention2D process-group setup (including expected group existence/world sizes) and collective correctness for the TP2 + Attention2D(2x1) topology.
  - `tests/unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py`
    - Modified `_make_model_config` to accept `tp_size` and propagate it into `VisualGenMapping`.
    - Added `_copy_ref_weights_to_tp` and used it in the TP comparison path.

- **Coverage linkage**
  - The new integration TP+Attention2D case is linked via `l0_dgx_b200` test-db entry for `test_wan22_t2v_lpips_against_golden_tp[tp2_attn2d_2x1]`.

- **Verdict:** needs follow-up (CI failures were reported in the provided context; no passing/completion confirmation is included here).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Removes an (unnecessary) conditional blocking TP with Attn2D in VisualGen. Adds LPIPS test config to ensure correctness.
## Test Coverage

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
