### PR TITLE
[None][perf] Remove blocking cudaStreamSynchronize

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
@@ -248,6 +248,15 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
     _msa_eager_proxy_plan: Optional[tuple] = None
     _msa_eager_gqa_plan: Optional[tuple] = None
     _msa_eager_dense_plan: Optional[tuple] = None
+    # Eager (prefill/mixed) per-token valid-block count. It is layer-invariant
+    # (a function of qo/kv lengths and page size), so it is computed on the host
+    # and staged to the device once per step via a non-blocking copy_, then
+    # reused by every sparse layer's indexer. _msa_eager_all_blocks_empty caches
+    # the host-side empty-selection result so the indexer can short-circuit without
+    # a device read. _msa_eager_n_valid_buf is the persistent backing store for the view.
+    _msa_eager_n_valid_buf: Optional[torch.Tensor] = None
+    _msa_eager_n_valid_blocks: Optional[torch.Tensor] = None
+    _msa_eager_all_blocks_empty: bool = False
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -331,6 +340,17 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
     def msa_eager_dense_plan(self) -> Optional[tuple]:
         """Prebuilt dense GQA plan for the eager (prefill/mixed) path."""
         return self._msa_eager_dense_plan
+
+    @property
+    def msa_eager_n_valid_blocks(self) -> Optional[torch.Tensor]:
+        """Device int32 valid-block count for the eager path, or None if no eager
+        step was prepared (a decode step or a structural test)."""
+        return self._msa_eager_n_valid_blocks
+
+    @property
+    def msa_eager_all_blocks_empty(self) -> bool:
+        """Whether the eager step has no valid KV blocks for any query token."""
+        return self._msa_eager_all_blocks_empty
 
     def _msa_main_kv_is_fp8(self) -> bool:
         """Whether the main paged K/V cache is stored as FP8 E4M3.
@@ -528,6 +548,20 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
             capture_graph=capture_graph,
         )
 
+    def _ensure_eager_n_valid_buffer(self, total_q: int, device: torch.device) -> torch.Tensor:
+        """Return a persistent device int32 buffer for the eager valid-block count.
+
+        The eager path is never CUDA-graph captured, so a plain device tensor,
+        grown on demand and reused across steps, is sufficient. It is sized to
+        the worst-case per-step query-token count.
+        """
+        buf = self._msa_eager_n_valid_buf
+        if buf is None or buf.numel() < total_q or buf.device != device:
+            cap = max(int(total_q), int(getattr(self, "max_num_tokens", 0) or 0), 1)
+            buf = torch.empty(cap, dtype=torch.int32, device=device)
+            self._msa_eager_n_valid_buf = buf
+        return buf
+
     def prepare(self) -> None:
         super().prepare()
         self._msa_corrected_kv_lens_cpu = None
@@ -629,6 +663,8 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
         self._msa_eager_proxy_plan = None
         self._msa_eager_gqa_plan = None
         self._msa_eager_dense_plan = None
+        self._msa_eager_n_valid_blocks = None
+        self._msa_eager_all_blocks_empty = False
         if not self._msa_fields_ready:
             return
         # Geometry is captured in __post_init__; skip when it is unavailable.
@@ -699,11 +735,22 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
 
         if not is_decode:
             # Prefill and mixed batches run eagerly, so keep the plain plan
-            # tuples and leave the graph-safe owners reset. The indexer computes
-            # its own per-query valid-block count on the eager path.
+            # tuples and leave the graph-safe owners reset.
             self._msa_eager_proxy_plan = proxy_plan
             self._msa_eager_gqa_plan = gqa_plan
             self._msa_eager_dense_plan = dense_plan
+            # Stage the valid-block count to the device once for the whole step
+            # (see _msa_eager_n_valid_blocks). The empty-selection check runs
+            # here on the host, so run_indexer can short-circuit cheaply.
+            n_valid_host = per_token_valid_blocks(
+                qo_lens_cpu, kv_lens_cpu, qo_offset_cpu, causal=True, block_size=page_size
+            )
+            total_q = int(n_valid_host.shape[0])
+            self._msa_eager_all_blocks_empty = total_q == 0 or int(n_valid_host.max().item()) <= 0
+            if total_q > 0:
+                dev_buf = self._ensure_eager_n_valid_buffer(total_q, device)
+                dev_buf[:total_q].copy_(n_valid_host.to(torch.int32), non_blocking=True)
+                self._msa_eager_n_valid_blocks = dev_buf[:total_q]
             return
 
         required_max_k_tiles = int(proxy_plan[3]["max_k_tiles"])
@@ -956,13 +1003,11 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
         metadata.msa_write_idx_k(self.layer_idx, idx_k_view)
         idx_k_cache = metadata.msa_idx_k_cache(self.layer_idx)
 
-        # One selection path: decode passes the prebuilt graph-safe proxy plan
-        # plus the proxy scratch shaped to the live query count. Prefill and
-        # mixed batches pass the prebuilt eager proxy plan and let the kernel
-        # allocate the score buffer and the indexer compute the per-query
-        # valid-block count. Only when neither is present (for example a
-        # standalone test that skips prepare) does select_blocks build the proxy
-        # plan inline.
+        # One selection path. Decode passes the graph-safe proxy plan plus the
+        # proxy scratch shaped to the live query count. Prefill and mixed batches
+        # pass the eager proxy plan and the device-staged valid-block count. When
+        # neither is present (a standalone test that skips prepare) select_blocks
+        # plans inline and computes the valid-block count itself.
         proxy_plan = metadata.msa_decode_proxy_plan
         if proxy_plan is not None:
             # proxy_plan is (has_mixed, split, batch, decode_dict, prefill);
@@ -975,7 +1020,17 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
         else:
             proxy_plan = metadata.msa_eager_proxy_plan
             max_score = None
-            n_valid_blocks = None
+            # The empty case was resolved on the host, so short-circuit here.
+            if metadata.msa_eager_all_blocks_empty:
+                return torch.full(
+                    (num_tokens, config.num_kv_heads, MSA_REQUIRED_TOPK),
+                    -1,
+                    dtype=torch.int32,
+                    device=idx_q.device,
+                )
+            n_valid_blocks = metadata.msa_eager_n_valid_blocks
+            if n_valid_blocks is not None:
+                n_valid_blocks = n_valid_blocks[:num_tokens]
         return self.indexer.select_blocks(
             idx_q_view,
             idx_k_cache,

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_indexer.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_indexer.py
@@ -134,13 +134,11 @@ class MsaIndexer:
     ) -> torch.Tensor:
         """Return [total_q, num_kv_heads, topk] selected block indices.
 
-        Plan/run split, mirroring the sparse GQA. When `proxy_plan` is None
-        (prefill and focused tests) the proxy plan is built inline and the
-        per-query valid-block count is derived here; when provided (CUDA-graph
-        decode) the proxy runs from the prebuilt plan into the preallocated
-        `max_score` buffer with a precomputed `n_valid_blocks`, so there is
-        no host sync inside the captured region. The same top-k selection serves
-        both, and generation is the one-query-token-per-request special case.
+        Plan/run split, mirroring the sparse GQA. Both production paths pass a
+        prebuilt `proxy_plan` and a precomputed device `n_valid_blocks` (decode
+        from the graph-safe scratch, eager from the step-level device buffer);
+        decode additionally runs into the preallocated `max_score` buffer inside
+        the captured region.
         """
         config = self.config
 
@@ -168,6 +166,7 @@ class MsaIndexer:
                 max_score=max_score,
                 sm_scale=idx_sm_scale,
             )
+
         max_score_kv = _group_max_reduce(max_score, config)
 
         if n_valid_blocks is None:
@@ -178,8 +177,8 @@ class MsaIndexer:
                 causal=True,
                 block_size=int(idx_k_paged.shape[2]),
             )
-            # The empty-selection guard uses a host sync, so it only runs on the
-            # eager path; a decode batch always has valid blocks.
+            # Empty-selection guard. n_valid_blocks is a host tensor on
+            # this path, so the .item() read does not sync the device.
             if n_valid_blocks.numel() == 0 or int(n_valid_blocks.max().item()) <= 0:
                 return torch.full(
                     (idx_q.shape[0], config.num_kv_heads, MSA_REQUIRED_TOPK),


### PR DESCRIPTION
## Description

There is an H2D copy in `select_blocks_from_maxscore` which turned out to be blocking.
```
nvb = n_valid_blocks.to(device=device, dtype=torch.long)
```

This MR creates the tensor on the device once per step so that such copy is no longer needed. Above line remains unchanged as issue is fixed at the source (tensor created on device instead of host).

For ISL=8192, OSL=1, c=1, request latency in ms:

Before:
```
[Latency] P50    : 298.2450
[Latency] P90    : 299.1159
[Latency] P95    : 299.5864
[Latency] P99    : 300.5684
[Latency] MINIMUM: 296.7526
[Latency] MAXIMUM: 300.5684
[Latency] AVERAGE: 298.3305
```
After removing sync:
```
[Latency] P50    : 269.5668
[Latency] P90    : 270.2923
[Latency] P95    : 272.9274
[Latency] P99    : 276.2878
[Latency] MINIMUM: 268.4211
[Latency] MAXIMUM: 276.2878
[Latency] AVERAGE: 269.7271
```

## Test Coverage

```
$ pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=True] -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
