### PR TITLE
[None][perf] Fuse MiniMax-M3 MSA block selection

### DIFF
--- a/cpp/tensorrt_llm/kernels/minimaxM3SelectBlocks.cu
+++ b/cpp/tensorrt_llm/kernels/minimaxM3SelectBlocks.cu
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/minimaxM3SelectBlocks.h"
+
+#include "tensorrt_llm/kernels/moeTopKFuncs.cuh"
+
+#include <cmath>
+#include <cooperative_groups.h>
+#include <cstdint>
+#include <cuda_runtime.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+namespace
+{
+
+namespace cg = cooperative_groups;
+
+constexpr int kTopK = 16;
+constexpr int kWarpSize = 32;
+constexpr int kThreadsPerBlock = 256;
+constexpr int kWarpsPerBlock = kThreadsPerBlock / kWarpSize;
+constexpr float kInitScore = 1.0e30F;
+constexpr float kLocalScore = 1.0e29F;
+
+__global__ void minimaxM3SelectBlocksKernel(float const* __restrict__ scores, int64_t headStride, int64_t blockStride,
+    int64_t queryStride, int32_t const* __restrict__ nValidBlocks, int32_t* __restrict__ output, int32_t numKvHeads,
+    int32_t numBlocks, int32_t totalQueries, int32_t initBlocks, int32_t localBlocks)
+{
+    auto const warp = cg::tiled_partition<kWarpSize>(cg::this_thread_block());
+    int32_t const warpInBlock = threadIdx.x / kWarpSize;
+    int32_t const outputRow = blockIdx.x * kWarpsPerBlock + warpInBlock;
+    int32_t const numOutputRows = totalQueries * numKvHeads;
+    if (outputRow >= numOutputRows)
+    {
+        return;
+    }
+
+    int32_t const query = outputRow / numKvHeads;
+    int32_t const kvHead = outputRow % numKvHeads;
+    int32_t const rawValidBlocks = nValidBlocks[query];
+    int32_t const validBlocks = max(0, min(rawValidBlocks, numBlocks));
+    int64_t const localStart
+        = max(static_cast<int64_t>(rawValidBlocks) - static_cast<int64_t>(localBlocks), static_cast<int64_t>(0));
+
+    using RedType = reduce_topk::TopKRedType<float>;
+    RedType localTopK[kTopK];
+#pragma unroll
+    for (int32_t rank = 0; rank < kTopK; ++rank)
+    {
+        localTopK[rank] = RedType{-INFINITY, RedType::kMaxIdx};
+    }
+
+    for (int32_t block = warp.thread_rank(); block < validBlocks; block += kWarpSize)
+    {
+        int64_t const offset = static_cast<int64_t>(kvHead) * headStride + static_cast<int64_t>(block) * blockStride
+            + static_cast<int64_t>(query) * queryStride;
+        float score = scores[offset];
+        if (block < initBlocks)
+        {
+            score = kInitScore;
+        }
+        // Match the PyTorch reference's second torch.where: local forcing
+        // overwrites init forcing if the two ranges overlap.
+        if (block >= localStart)
+        {
+            score = kLocalScore;
+        }
+
+        RedType const candidate{score, block};
+        if (candidate.compValIdx > localTopK[kTopK - 1].compValIdx)
+        {
+            int32_t insertion = kTopK - 1;
+#pragma unroll
+            for (int32_t rank = kTopK - 2; rank >= 0; --rank)
+            {
+                if (candidate.compValIdx > localTopK[rank].compValIdx)
+                {
+                    localTopK[rank + 1] = localTopK[rank];
+                    insertion = rank;
+                }
+            }
+            localTopK[insertion] = candidate;
+        }
+    }
+
+    float localScores[kTopK];
+    int32_t localIndices[kTopK];
+#pragma unroll
+    for (int32_t rank = 0; rank < kTopK; ++rank)
+    {
+        RedType::unpack(localScores[rank], localIndices[rank], localTopK[rank].compValIdx);
+    }
+
+    float selectedScores[kTopK];
+    int32_t selectedIndices[kTopK];
+    reduce_topk::reduceTopK<kTopK>(warp, selectedScores, selectedIndices, localScores, localIndices, -INFINITY);
+
+    if (warp.thread_rank() == 0)
+    {
+#pragma unroll
+        for (int32_t rank = 0; rank < kTopK; ++rank)
+        {
+            if (selectedScores[rank] == -INFINITY)
+            {
+                selectedIndices[rank] = -1;
+            }
+        }
+
+        // MSA consumes block IDs in ascending order. Sort the sixteen selected
+        // IDs in registers, treating -1 padding as greater than every valid ID.
+#pragma unroll
+        for (int32_t rank = 1; rank < kTopK; ++rank)
+        {
+            int32_t const candidate = selectedIndices[rank];
+            int32_t const candidateKey = candidate < 0 ? numBlocks : candidate;
+            int32_t insertion = rank;
+            while (insertion > 0)
+            {
+                int32_t const previous = selectedIndices[insertion - 1];
+                int32_t const previousKey = previous < 0 ? numBlocks : previous;
+                if (previousKey <= candidateKey)
+                {
+                    break;
+                }
+                selectedIndices[insertion] = previous;
+                --insertion;
+            }
+            selectedIndices[insertion] = candidate;
+        }
+
+#pragma unroll
+        for (int32_t rank = 0; rank < kTopK; ++rank)
+        {
+            output[static_cast<int64_t>(outputRow) * kTopK + rank] = selectedIndices[rank];
+        }
+    }
+}
+
+} // namespace
+
+void invokeMinimaxM3SelectBlocks(float const* scores, int64_t headStride, int64_t blockStride, int64_t queryStride,
+    int32_t const* nValidBlocks, int32_t* output, int32_t numKvHeads, int32_t numBlocks, int32_t totalQueries,
+    int32_t initBlocks, int32_t localBlocks, cudaStream_t stream)
+{
+    int32_t const numOutputRows = totalQueries * numKvHeads;
+    if (numOutputRows == 0)
+    {
+        return;
+    }
+    int32_t const gridSize = (numOutputRows + kWarpsPerBlock - 1) / kWarpsPerBlock;
+    minimaxM3SelectBlocksKernel<<<gridSize, kThreadsPerBlock, 0, stream>>>(scores, headStride, blockStride, queryStride,
+        nValidBlocks, output, numKvHeads, numBlocks, totalQueries, initBlocks, localBlocks);
+}
+
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/minimaxM3SelectBlocks.h
+++ b/cpp/tensorrt_llm/kernels/minimaxM3SelectBlocks.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+
+void invokeMinimaxM3SelectBlocks(float const* scores, int64_t headStride, int64_t blockStride, int64_t queryStride,
+    int32_t const* nValidBlocks, int32_t* output, int32_t numKvHeads, int32_t numBlocks, int32_t totalQueries,
+    int32_t initBlocks, int32_t localBlocks, cudaStream_t stream);
+
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(
   IndexerKCacheGatherOp.cpp
   IndexerKCacheScatterOp.cpp
   IndexerTopKOp.cpp
+  minimaxM3SelectBlocksOp.cpp
   mlaRopeInplaceOp.cpp
   ncclCommunicatorOp.cpp
   allocateOutput.cpp

--- a/cpp/tensorrt_llm/thop/minimaxM3SelectBlocksOp.cpp
+++ b/cpp/tensorrt_llm/thop/minimaxM3SelectBlocksOp.cpp
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/minimaxM3SelectBlocks.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <limits>
+#include <torch/extension.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace torch_ext
+{
+
+torch::Tensor minimaxM3SelectBlocks(torch::Tensor const& scores, torch::Tensor const& nValidBlocks, int64_t topK,
+    int64_t initBlocks, int64_t localBlocks)
+{
+    constexpr int64_t kRequiredTopK = 16;
+    constexpr int64_t kMaxBlockIndex = 65'535;
+
+    TORCH_CHECK(scores.is_cuda(), "minimax_m3_select_blocks expects CUDA scores");
+    TORCH_CHECK(scores.scalar_type() == torch::kFloat32, "minimax_m3_select_blocks expects float32 scores, got ",
+        scores.scalar_type());
+    TORCH_CHECK(scores.dim() == 3, "scores must be [num_kv_heads, num_blocks, total_queries]");
+    TORCH_CHECK(scores.stride(0) >= 0 && scores.stride(1) >= 0 && scores.stride(2) >= 0,
+        "scores must have non-negative strides");
+
+    TORCH_CHECK(nValidBlocks.is_cuda(), "minimax_m3_select_blocks expects CUDA n_valid_blocks");
+    TORCH_CHECK(nValidBlocks.device() == scores.device(), "scores and n_valid_blocks must be on the same device");
+    TORCH_CHECK(nValidBlocks.scalar_type() == torch::kInt32,
+        "minimax_m3_select_blocks expects int32 n_valid_blocks, got ", nValidBlocks.scalar_type());
+    TORCH_CHECK(
+        nValidBlocks.dim() == 1 && nValidBlocks.size(0) == scores.size(2), "n_valid_blocks must be [total_queries]");
+    TORCH_CHECK(nValidBlocks.is_contiguous(), "n_valid_blocks must be contiguous");
+
+    TORCH_CHECK(topK == kRequiredTopK, "minimax_m3_select_blocks supports topk=16, got ", topK);
+    TORCH_CHECK(initBlocks >= 0, "init_blocks must be non-negative");
+    TORCH_CHECK(localBlocks >= 0, "local_blocks must be non-negative");
+    TORCH_CHECK(scores.size(1) <= kMaxBlockIndex, "minimax_m3_select_blocks supports at most ", kMaxBlockIndex,
+        " blocks, got ", scores.size(1));
+    TORCH_CHECK(scores.size(0) <= std::numeric_limits<int32_t>::max()
+            && scores.size(1) <= std::numeric_limits<int32_t>::max()
+            && scores.size(2) <= std::numeric_limits<int32_t>::max(),
+        "minimax_m3_select_blocks dimensions exceed int32 range");
+    TORCH_CHECK(scores.size(0) * scores.size(2) <= std::numeric_limits<int32_t>::max(),
+        "minimax_m3_select_blocks output rows exceed int32 range");
+    TORCH_CHECK(initBlocks <= std::numeric_limits<int32_t>::max() && localBlocks <= std::numeric_limits<int32_t>::max(),
+        "minimax_m3_select_blocks forcing ranges exceed int32 range");
+
+    auto output = torch::empty({scores.size(2), scores.size(0), topK}, scores.options().dtype(torch::kInt32));
+    auto const stream = at::cuda::getCurrentCUDAStream(scores.get_device());
+    tensorrt_llm::kernels::invokeMinimaxM3SelectBlocks(scores.data_ptr<float>(), scores.stride(0), scores.stride(1),
+        scores.stride(2), nValidBlocks.data_ptr<int32_t>(), output.data_ptr<int32_t>(),
+        static_cast<int32_t>(scores.size(0)), static_cast<int32_t>(scores.size(1)),
+        static_cast<int32_t>(scores.size(2)), static_cast<int32_t>(initBlocks), static_cast<int32_t>(localBlocks),
+        stream);
+    return output;
+}
+
+} // namespace torch_ext
+
+TRTLLM_NAMESPACE_END
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def(
+        "minimax_m3_select_blocks(Tensor scores, Tensor n_valid_blocks, int topk, int init_blocks, int "
+        "local_blocks) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("minimax_m3_select_blocks", &tensorrt_llm::torch_ext::minimaxM3SelectBlocks);
+}

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_utils.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_utils.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple
 
 import torch
 
-from .common import _INIT_SCORE, _LOCAL_SCORE, write_kv_slots
+from .common import write_kv_slots
 
 # fmha_sm100 ships only head_dim 128 variants and the MiniMax-M3 checkpoint
 # selects topk 16. Callers enforce these early so a misconfiguration fails
@@ -195,34 +195,10 @@ def select_blocks_from_maxscore(
     [total_q, num_kv_heads, topk] int32 ascending block ids with -1 tail
     padding.
     """
-    num_kv_heads, n_blocks, total_q = max_score_kv.shape
-    device = max_score_kv.device
-    scores = max_score_kv.permute(2, 0, 1).to(torch.float32).clone()
-    block_ids = torch.arange(n_blocks, device=device, dtype=torch.long)
-    nvb = n_valid_blocks.to(device=device, dtype=torch.long)
-
-    if init_blocks > 0:
-        init_mask = block_ids.view(1, 1, -1) < init_blocks
-        scores = torch.where(init_mask, torch.full_like(scores, _INIT_SCORE), scores)
-    if local_blocks > 0:
-        local_start = (nvb - local_blocks).clamp_min(0)
-        local_mask = (block_ids.view(1, -1) >= local_start.view(-1, 1)) & (
-            block_ids.view(1, -1) < nvb.view(-1, 1)
-        )
-        scores = torch.where(local_mask.unsqueeze(1), torch.full_like(scores, _LOCAL_SCORE), scores)
-    block_valid = block_ids.view(1, -1) < nvb.view(-1, 1)
-    scores = scores.masked_fill(~block_valid.unsqueeze(1), float("-inf"))
-
-    k = min(topk, n_blocks)
-    vals, idx = scores.topk(k=k, dim=-1)
-    idx = torch.where(vals != float("-inf"), idx, torch.full_like(idx, -1))
-    sort_key = torch.where(idx < 0, torch.full_like(idx, n_blocks), idx)
-    sort_key, _ = torch.sort(sort_key, dim=-1)
-    idx = torch.where(sort_key >= n_blocks, torch.full_like(sort_key, -1), sort_key)
-    if k < topk:
-        pad = torch.full((total_q, num_kv_heads, topk - k), -1, dtype=idx.dtype, device=device)
-        idx = torch.cat([idx, pad], dim=-1)
-    return idx.to(torch.int32)
+    nvb = n_valid_blocks.to(device=max_score_kv.device, dtype=torch.int32).contiguous()
+    return torch.ops.trtllm.minimax_m3_select_blocks(
+        max_score_kv, nvb, topk, init_blocks, local_blocks
+    )
 
 
 __all__ = [

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -276,6 +276,12 @@ def _register_fake():
         # In-place operation, no return value (void function)
         pass
 
+    @torch.library.register_fake("trtllm::minimax_m3_select_blocks")
+    def _(scores, n_valid_blocks, topk, init_blocks, local_blocks):
+        del n_valid_blocks, init_blocks, local_blocks
+        return scores.new_empty((scores.shape[2], scores.shape[0], topk),
+                                dtype=torch.int32)
+
     @torch.library.register_fake("trtllm::userbuffers_allreduce_finalize")
     def _(input, force_applying_finalize):
         return torch.empty_like(input)

--- a/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_selector.py
+++ b/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_selector.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for the fused MiniMax-M3 MSA block selector."""
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.common import _INIT_SCORE, _LOCAL_SCORE
+from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.msa_utils import (
+    select_blocks_from_maxscore,
+)
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def _reference_select_blocks(
+    max_score_kv: torch.Tensor,
+    *,
+    topk: int,
+    n_valid_blocks: torch.Tensor,
+    init_blocks: int,
+    local_blocks: int,
+) -> torch.Tensor:
+    num_kv_heads, n_blocks, total_q = max_score_kv.shape
+    device = max_score_kv.device
+    scores = max_score_kv.permute(2, 0, 1).to(torch.float32).clone()
+    block_ids = torch.arange(n_blocks, device=device, dtype=torch.long)
+    nvb = n_valid_blocks.to(device=device, dtype=torch.long)
+
+    if init_blocks > 0:
+        init_mask = block_ids.view(1, 1, -1) < init_blocks
+        scores = torch.where(init_mask, torch.full_like(scores, _INIT_SCORE), scores)
+    if local_blocks > 0:
+        local_start = (nvb - local_blocks).clamp_min(0)
+        local_mask = (block_ids.view(1, -1) >= local_start.view(-1, 1)) & (
+            block_ids.view(1, -1) < nvb.view(-1, 1)
+        )
+        scores = torch.where(local_mask.unsqueeze(1), torch.full_like(scores, _LOCAL_SCORE), scores)
+    block_valid = block_ids.view(1, -1) < nvb.view(-1, 1)
+    scores = scores.masked_fill(~block_valid.unsqueeze(1), float("-inf"))
+
+    k = min(topk, n_blocks)
+    vals, idx = scores.topk(k=k, dim=-1)
+    idx = torch.where(vals != float("-inf"), idx, torch.full_like(idx, -1))
+    sort_key = torch.where(idx < 0, torch.full_like(idx, n_blocks), idx)
+    sort_key, _ = torch.sort(sort_key, dim=-1)
+    idx = torch.where(sort_key >= n_blocks, torch.full_like(sort_key, -1), sort_key)
+    if k < topk:
+        pad = torch.full(
+            (total_q, num_kv_heads, topk - k),
+            -1,
+            dtype=idx.dtype,
+            device=device,
+        )
+        idx = torch.cat([idx, pad], dim=-1)
+    return idx.to(torch.int32)
+
+
+@pytest.mark.parametrize("num_kv_heads", [1, 4])
+@pytest.mark.parametrize("num_blocks", [1, 8, 16, 17, 127, 1024, 1537])
+def test_fused_selector_matches_reference_random(num_kv_heads, num_blocks):
+    total_q = 19
+    generator = torch.Generator(device="cuda").manual_seed(num_blocks)
+    scores = torch.randn(
+        num_kv_heads,
+        num_blocks,
+        total_q,
+        generator=generator,
+        device="cuda",
+        dtype=torch.float32,
+    )
+    n_valid_blocks = torch.randint(
+        0,
+        num_blocks + 1,
+        (total_q,),
+        generator=generator,
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    expected = _reference_select_blocks(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=0,
+        local_blocks=1,
+    )
+    actual = select_blocks_from_maxscore(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=0,
+        local_blocks=1,
+    )
+
+    assert actual.dtype == torch.int32
+    assert actual.shape == (total_q, num_kv_heads, 16)
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("init_blocks", "local_blocks"),
+    [(0, 0), (0, 1), (2, 3), (16, 1), (20, 0), (0, 20)],
+)
+def test_fused_selector_matches_reference_forced_and_padded(init_blocks, local_blocks):
+    scores = (
+        torch.tensor(
+            [
+                [
+                    float("-inf"),
+                    4.0,
+                    3.0,
+                    2.0,
+                    1.0,
+                    0.0,
+                    -1.0,
+                    -2.0,
+                    -3.0,
+                    -4.0,
+                    -5.0,
+                    -6.0,
+                    -7.0,
+                    -8.0,
+                    -9.0,
+                    -10.0,
+                    -11.0,
+                    -12.0,
+                    -13.0,
+                    -14.0,
+                ]
+            ],
+            device="cuda",
+            dtype=torch.float32,
+        )
+        .unsqueeze(-1)
+        .expand(-1, -1, 5)
+    )
+    n_valid_blocks = torch.tensor([0, 1, 7, 16, 20], dtype=torch.int32)
+
+    expected = _reference_select_blocks(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
+    )
+    actual = select_blocks_from_maxscore(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
+    )
+
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize("fill_value", [0.0, 1.0e30, 1.0e29])
+def test_fused_selector_matches_reference_equal_score_ties(fill_value):
+    scores = torch.full((2, 64, 3), fill_value, device="cuda", dtype=torch.float32)
+    n_valid_blocks = torch.tensor([15, 32, 64], dtype=torch.int32)
+
+    expected = _reference_select_blocks(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=20,
+        local_blocks=0,
+    )
+    actual = select_blocks_from_maxscore(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=20,
+        local_blocks=0,
+    )
+
+    assert torch.equal(actual, expected)
+
+
+def test_fused_selector_matches_reference_nonfinite_and_validity_bounds():
+    scores = (
+        torch.tensor(
+            [
+                float("nan"),
+                float("inf"),
+                float("-inf"),
+                -1.0,
+                0.0,
+                1.0,
+                float("nan"),
+                float("-inf"),
+                2.0,
+                3.0,
+                4.0,
+                5.0,
+                6.0,
+                7.0,
+                8.0,
+                9.0,
+                10.0,
+                11.0,
+                12.0,
+                13.0,
+            ],
+            device="cuda",
+            dtype=torch.float32,
+        )
+        .view(1, 20, 1)
+        .expand(-1, -1, 4)
+    )
+    n_valid_blocks = torch.tensor([-3, 0, 17, 25], dtype=torch.int32)
+
+    expected = _reference_select_blocks(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=0,
+        local_blocks=1,
+    )
+    actual = select_blocks_from_maxscore(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=0,
+        local_blocks=1,
+    )
+
+    assert torch.equal(actual, expected)
+
+
+def test_fused_selector_supports_strided_scores_and_cuda_validity():
+    generator = torch.Generator(device="cuda").manual_seed(7)
+    backing = torch.randn(2, 73, 22, generator=generator, device="cuda")
+    scores = backing[:, 1:72:2, ::2]
+    assert not scores.is_contiguous()
+    n_valid_blocks = torch.tensor(
+        [0, 1, 3, 8, 15, 16, 17, 20, 30, 35, 36], device="cuda", dtype=torch.int32
+    )
+
+    expected = _reference_select_blocks(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=2,
+        local_blocks=3,
+    )
+    actual = select_blocks_from_maxscore(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=2,
+        local_blocks=3,
+    )
+
+    assert torch.equal(actual, expected)
+
+
+def test_fused_selector_cuda_graph_replay_updates_inputs():
+    scores = torch.randn(1, 64, 4, device="cuda")
+    n_valid_blocks = torch.tensor([16, 32, 48, 64], device="cuda", dtype=torch.int32)
+
+    for _ in range(3):
+        output = select_blocks_from_maxscore(
+            scores,
+            topk=16,
+            n_valid_blocks=n_valid_blocks,
+            init_blocks=0,
+            local_blocks=1,
+        )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = select_blocks_from_maxscore(
+            scores,
+            topk=16,
+            n_valid_blocks=n_valid_blocks,
+            init_blocks=0,
+            local_blocks=1,
+        )
+
+    scores.copy_(torch.arange(64, device="cuda", dtype=torch.float32).view(1, 64, 1))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    expected = _reference_select_blocks(
+        scores,
+        topk=16,
+        n_valid_blocks=n_valid_blocks,
+        init_blocks=0,
+        local_blocks=1,
+    )
+    assert torch.equal(output, expected)


### PR DESCRIPTION
@coderabbitai summary

## Description

MiniMax-M3 MSA block selection currently runs validity masking, forced-block handling, top-k, and sorting as separate PyTorch operations. This PR replaces that sequence with one CUDA custom op that returns ascending `int32` block IDs with `-1` padding.

Matched serving A/B results:
- GB200: +14.6% output throughput and -11.2% median TPOT
- GB300: +17.1% output throughput and -12.2% median TPOT

## Test Coverage

- `python -m pytest -q tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_selector.py` (26 passed)
- `tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=True]` (passed; MMLU 84.80%, GSM8K 90.60%)
- Unit coverage includes bit-exact block IDs, forced/padded blocks, ties/nonfinite scores, validity bounds, strided inputs, and CUDA graph replay.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
