### PR TITLE
[None][fix] Keep ADP ranks in collective lockstep on request errors and fail fast on desync

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4154,6 +4154,12 @@ class PyExecutor:
                 # collective fires every iter regardless of future restructuring.
                 self._handle_kv_transfer_timeouts_synced()
 
+                # Flush outside ``if can_queue`` as well: buffered responses
+                # (e.g. non-fatal error responses from _handle_errors) must
+                # still reach the client when no rank can queue a batch, and
+                # all DP ranks must enter the tp_gather in lockstep.
+                self._flush_pending_transfer_responses()
+
                 if self.kv_cache_transceiver and self.async_transfer_manager.has_any_inflight_requests(
                 ):
                     self._check_kv_transfer_timeout()
@@ -6524,7 +6530,26 @@ class PyExecutor:
                 request for request in self.active_requests
                 if request not in requests
             ]
-        self._enqueue_responses(list(error_responses.items()))
+        if is_fatal or not (self.enable_attention_dp
+                            and self.dist.world_size != 1):
+            # Drain any previously buffered responses along with the error
+            # responses: on the fatal path the executor loop exits before
+            # reaching the next _flush_pending_transfer_responses point, so
+            # anything left in the buffer would never be delivered and the
+            # client would wait until its own timeout.
+            pending = self._pending_transfer_responses
+            self._pending_transfer_responses = []
+            self._enqueue_responses(pending + list(error_responses.items()))
+        else:
+            # Under attention DP, _enqueue_responses performs a tp_gather
+            # that every rank must enter in the same order. Non-fatal errors
+            # (e.g. a failed disagg KV transfer) are observed by a single
+            # rank, so enqueueing here would pair this rank's gather against
+            # a different collective on its peers — typically the per-step
+            # tp_allgather(batch_size) — corrupting both sides. Buffer the
+            # responses instead; every rank flushes the buffer together at
+            # _flush_pending_transfer_responses.
+            self._pending_transfer_responses.extend(error_responses.items())
         for request in failed_requests:
             self._terminate_request(request)
 
@@ -6643,7 +6668,7 @@ class PyExecutor:
                             # enqueueing garbage responses.
                             raise RuntimeError(
                                 f"_enqueue_responses: TP collective desync — "
-                                f"gathered a {type(resp).__name__} ({resp!r}) "
+                                f"gathered a {type(resp).__name__} "
                                 f"instead of a response list. A peer rank "
                                 f"entered a different collective (e.g. "
                                 f"tp_allgather(batch_size)); check for "

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -6629,8 +6629,27 @@ class PyExecutor:
                 gather_responses = []
                 if responses_list is not None:
                     for resp in responses_list:
-                        if resp is not None:
-                            gather_responses.extend(resp)
+                        if resp is None:
+                            continue
+                        if not isinstance(resp, (list, tuple)):
+                            # A non-list contribution means the TP collective
+                            # was matched against a *different* collective on
+                            # a peer rank (collectives pair by call order, not
+                            # by type). A common mismatch partner is the
+                            # per-step tp_allgather(batch_size), which makes
+                            # the stray payload an int. The gathered data is
+                            # corrupt on every rank, so fail fast instead of
+                            # raising an opaque TypeError below or silently
+                            # enqueueing garbage responses.
+                            raise RuntimeError(
+                                f"_enqueue_responses: TP collective desync — "
+                                f"gathered a {type(resp).__name__} ({resp!r}) "
+                                f"instead of a response list. A peer rank "
+                                f"entered a different collective (e.g. "
+                                f"tp_allgather(batch_size)); check for "
+                                f"per-rank-divergent callers of "
+                                f"_enqueue_responses.")
+                        gather_responses.extend(resp)
                     responses = gather_responses
         logger.debug(
             f'after gather, rank = {self.dist.rank}, responses = {responses}')

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4098,7 +4098,8 @@ class PyExecutor:
                 self.is_shutdown = True
                 self._handle_errors(error_msg,
                                     requests=None,
-                                    charge_budget=False)
+                                    charge_budget=False,
+                                    fatal_is_collective_aligned=True)
                 return
 
         if not (self.enable_attention_dp and self.dist.world_size != 1):
@@ -7183,7 +7184,8 @@ class PyExecutor:
                        error_msg: Optional[str] = None,
                        *,
                        requests: Optional[List[LlmRequest]] = None,
-                       charge_budget: bool = True) -> None:
+                       charge_budget: bool = True,
+                       fatal_is_collective_aligned: bool = False) -> None:
         """Fail requests and optionally initiate shutdown on fatal errors.
 
         When ``charge_budget`` is True (the default), classifies the error
@@ -7221,6 +7223,12 @@ class PyExecutor:
         error_msg = error_msg or "error"
         multi_rank_adp = (self.enable_attention_dp
                           and self.dist.world_size != 1)
+        # ``fatal_is_collective_aligned`` is set only by the synchronized caller
+        # (_handle_disagg_cache_errors_synced, after its world allreduce), which
+        # guarantees every ADP rank enters the fatal path in the same collective
+        # order. Do NOT infer it from ``self._fatal_error is not None``: a
+        # rank-local setter would then route into a tp_gather while peers are
+        # elsewhere, recreating the desync this path exists to prevent.
 
         budget_fatal = (self._error_budget.consume(error_msg)
                         if charge_budget else False)
@@ -7275,12 +7283,17 @@ class PyExecutor:
                                      client_id=getattr(item.request,
                                                        'client_id', None))))
 
-            if waiting_responses and not multi_rank_adp:
-                self._enqueue_responses(waiting_responses)
+            if not multi_rank_adp:
                 if waiting_responses:
+                    self._enqueue_responses(waiting_responses)
                     logger.info(
                         f"Drained {len(waiting_responses)} queued requests "
                         "on fatal error")
+            elif fatal_is_collective_aligned:
+                # Synchronized fatal: every ADP rank enters this drain gather
+                # together, so issue it even when this rank has no queued
+                # responses, to stay peer-aligned.
+                self._enqueue_responses(waiting_responses)
 
         failed_requests = (list(self.active_requests)
                            if requests is None else requests)
@@ -7302,14 +7315,19 @@ class PyExecutor:
         publish_immediately = False
         if is_fatal:
             if multi_rank_adp:
-                # A fatal exception can be observed by one ADP rank before its
-                # peers reach their next collective. Do not issue tp_gather
-                # here: it would desynchronize the group exactly like a
-                # rank-local non-fatal response. Escalate through the event
-                # loop wrapper, which wakes local response waiters without a
-                # collective; the distributed supervisor tears down peers.
-                logger.error(
-                    "Skipping rank-local fatal response gather under ADP")
+                if fatal_is_collective_aligned:
+                    # Synchronized fatal: all ranks agree and march through the
+                    # aligned publish/terminate collectives together, so publish
+                    # here instead of diverging.
+                    publish_immediately = True
+                else:
+                    # A novel rank-local fatal can be observed by one ADP rank
+                    # before its peers reach their next collective. Do not issue
+                    # tp_gather here: it would desynchronize the group exactly
+                    # like a rank-local non-fatal response. Skip the gather and
+                    # raise below; the distributed supervisor tears down peers.
+                    logger.error(
+                        "Skipping rank-local fatal response gather under ADP")
             else:
                 publish_immediately = True
         elif multi_rank_adp:
@@ -7347,7 +7365,10 @@ class PyExecutor:
 
         if self._fatal_error is not None:
             self.executor_request_queue.enqueue_shutdown_request()
-            if multi_rank_adp:
+            if multi_rank_adp and not fatal_is_collective_aligned:
+                # Only a novel rank-local fatal raises to force local teardown;
+                # a synchronized fatal has already published in lockstep and
+                # tears down every rank together via is_shutdown.
                 raise self._fatal_error
 
     def _terminate_request(self, request: LlmRequest):

--- a/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
+++ b/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
@@ -362,6 +362,7 @@ def test_peer_buffer_poison_triggers_world_consistent_fatal_cleanup(monkeypatch)
         "Disagg KV cache transfer buffer is poisoned; process restart is required",
         requests=None,
         charge_budget=False,
+        fatal_is_collective_aligned=True,
     )
 
 
@@ -376,6 +377,8 @@ def test_preclassified_fatal_error_keeps_adp_response_collectives_aligned():
     executor.executor_request_queue = Mock()
     executor.executor_request_queue.get_request_queue.return_value = raw_queue
     executor.active_requests = []
+    executor._pending_transfer_responses = []
+    executor._pending_response_terminations = []
     executor.gather_all_responses = False
     executor.enable_attention_dp = True
     executor.dist = SimpleNamespace(rank=1, world_size=2)
@@ -383,7 +386,11 @@ def test_preclassified_fatal_error_keeps_adp_response_collectives_aligned():
     executor._terminate_request = Mock()
 
     PyExecutor._handle_errors(
-        executor, "poisoned transfer buffer", requests=None, charge_budget=False
+        executor,
+        "poisoned transfer buffer",
+        requests=None,
+        charge_budget=False,
+        fatal_is_collective_aligned=True,
     )
 
     executor._error_budget.consume.assert_not_called()

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -2534,7 +2534,7 @@ class TestPendingTransferResponseFlush:
         """A queued client receives a rank-0 ADP error before cleanup."""
         executor = object.__new__(PyExecutor)
         request_id = 7
-        response = LlmResponse()
+        response = LlmResponse(request_id=request_id)
         response.request_id = request_id
         response.client_id = 42
         response.error_msg = "transfer failed"
@@ -2545,6 +2545,7 @@ class TestPendingTransferResponseFlush:
         executor.enable_attention_dp = False
         executor.gather_all_responses = False
         executor.dist = Mock(rank=0)
+        executor.dist.mapping.tp_group = [0]
         executor.responses = {}
         executor.response_cv = threading.Condition()
         executor.result_wait_queues = {request_id: result_queue}
@@ -2565,7 +2566,7 @@ class TestPendingTransferResponseFlush:
         profiler = MagicMock()
         profiler.__enter__.return_value = Mock()
         executor._profiler = Mock(return_value=profiler)
-        executor.hang_detector = Mock()
+        executor.hang_detector = MagicMock()
         executor.enable_iter_perf_stats = False
         executor._resource_governor_enabled = False
         executor._is_kv_manager_v2 = False


### PR DESCRIPTION
## Summary

Under attention DP, `_enqueue_responses` performs a `tp_gather`; collectives must be entered by every rank in the same order.  A request-scoped error can be observed by only one rank, so directly publishing its response can cross the peers' next collective (usually `tp_allgather(batch_size)`).

This change:

1. Buffers non-fatal ADP error responses and flushes them at shared executor-loop safepoints.
2. Uses one end-of-loop flush rather than a second flush in `can_queue` iterations.
3. Flushes before the retry and clean-scheduler-exit paths, so buffered client errors are not silently stranded.
4. Fails fast on malformed gathered response payloads, giving a clear collective-desynchronization error.
5. Avoids publishing a rank-local fatal error through a TP response gather; it shuts down locally instead of risking another rank-divergent collective.

## Test Coverage

Added focused unit coverage for buffered-response delivery, empty ADP participation, retry/shutdown exits, the single-flush behavior, and rank-local fatal handling.

Local macOS validation:

- `python3 -m py_compile` — passed
- `git diff --check` — passed
- Pytest cannot import the CUDA-dependent TensorRT-LLM runtime on macOS (`cuda-python` has no supported macOS bindings); full test execution needs CUDA/Linux CI.

## PR Checklist
- [x] PR title follows the required format
- [x] PR description clearly explains the issue and solution
- [x] Commits are signed off (DCO)
- [x] Coding guidelines followed (yapf clean)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- **Attention-DP synchronization:** Buffers non-fatal transfer responses and flushes them at synchronized executor safepoints.
- **Exit handling:** Flushes pending responses before shutdown, benchmark retries, completed executor passes, and overlap-loop exits.
- **Fatal errors:** Handles rank-local fatal errors locally and avoids divergent TP response gathers.
- **Collective validation:** Ignores `None` contributions and raises a bounded `RuntimeError` for malformed gathered payloads.
- **Scope:** No public API, configuration, or test-list changes.
- **Regression review:** The added collective remains synchronized because `can_queue` is TP-uniform under Attention-DP.

## QA Engineer Review

- **Added test coverage:** `TestPendingTransferResponseFlush` covers rank-local fatal errors, empty Attention-DP participation, buffered response delivery and clearing, rank-zero request termination, normal executor exits, benchmark retries, idle passes, and overlap-loop flushes.
- **Test-list coverage:** No `tests/integration/test_lists/` files changed. The unit tests are not listed in `test-db/` or `qa/` files.
- **Verdict:** sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->