### PR TITLE
[https://nvbugs/6484986][test] add UCX cancellation regression coverage

### DIFF
--- a/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/ucx_utils/ucxCacheCommunicator.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -70,9 +70,11 @@ function(add_gtest test_name test_src)
   gtest_discover_tests(
     ${test_name}
     PROPERTIES ${test_properties}
-    DISCOVERY_MODE PRE_TEST # WAR for DLL discovery on windows.
-    DISCOVERY_TIMEOUT 30) # Longer timeout needed because discovery
-                          # can be slow on Windows
+               DISCOVERY_MODE
+               PRE_TEST # WAR for DLL discovery on windows.
+               DISCOVERY_TIMEOUT
+               30) # Longer timeout needed because discovery can be slow on
+                   # Windows
   add_dependencies(google-tests ${test_name})
 endfunction()
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION &
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION &
 # AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -39,6 +39,7 @@ add_custom_target(google-tests)
 
 function(add_gtest test_name test_src)
   set(options NO_GTEST_MAIN NO_TLLM_LINKAGE)
+  set(oneValueArgs TIMEOUT)
   cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}"
                         ${ARGN})
   add_executable(${test_name} ${test_src})
@@ -61,12 +62,17 @@ function(add_gtest test_name test_src)
   target_compile_definitions(${test_name}
                              PUBLIC TOP_LEVEL_DIR="${TOP_LEVEL_DIR}")
 
+  set(test_properties ENVIRONMENT "CUDA_MODULE_LOADING=LAZY")
+  if(ARGS_TIMEOUT)
+    list(APPEND test_properties TIMEOUT "${ARGS_TIMEOUT}")
+  endif()
+
   gtest_discover_tests(
     ${test_name}
-    PROPERTIES ENVIRONMENT "CUDA_MODULE_LOADING=LAZY" DISCOVERY_MODE
-               PRE_TEST # WAR for DLL discovery on windows.
-               DISCOVERY_TIMEOUT 30) # Longer timeout needed because discovery
-                                     # can be slow on Windows
+    PROPERTIES ${test_properties}
+    DISCOVERY_MODE PRE_TEST # WAR for DLL discovery on windows.
+    DISCOVERY_TIMEOUT 30) # Longer timeout needed because discovery
+                          # can be slow on Windows
   add_dependencies(google-tests ${test_name})
 endfunction()
 

--- a/cpp/tests/unit_tests/executor/CMakeLists.txt
+++ b/cpp/tests/unit_tests/executor/CMakeLists.txt
@@ -27,7 +27,7 @@ add_gtest(loraConfigTest loraConfigTest.cpp)
 add_gtest(coalesceTest coalesceTest.cpp)
 add_gtest(genUniqueAgentNameTest genUniqueAgentNameTest.cpp)
 target_link_libraries(genUniqueAgentNameTest PRIVATE ${Python3_LIBRARIES})
-add_gtest(ucxCommTest ucxCommTest.cpp)
+add_gtest(ucxCommTest ucxCommTest.cpp TIMEOUT 60)
 target_link_libraries(ucxCommTest PRIVATE ${Python3_LIBRARIES})
 target_link_libraries(serializeUtilsTest PRIVATE ${Python3_LIBRARIES})
 

--- a/cpp/tests/unit_tests/executor/ucxCommTest.cpp
+++ b/cpp/tests/unit_tests/executor/ucxCommTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,11 +43,14 @@
 #include "tensorrt_llm/runtime/common.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include "gtest/gtest.h"
+#include <atomic>
+#include <chrono>
 #include <csignal>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <future>
 #include <gmock/gmock.h>
 #include <memory>
 #include <random>
@@ -90,6 +93,42 @@ class UcxCommTest : public ::testing::Test
 
 using DataContext = tensorrt_llm::executor::kv_cache::DataContext;
 using TransceiverTag = tensorrt_llm::batch_manager::TransceiverTag;
+
+TEST_F(UcxCommTest, recvConnectCancellation)
+{
+    try
+    {
+        auto connectionManager = makeOneUcxConnectionManager();
+        ASSERT_NE(connectionManager, nullptr);
+
+        std::atomic<bool> transferTerminate{false};
+        TransceiverTag::Id id;
+        auto receiveFuture = std::async(std::launch::async,
+            [&]() {
+                return connectionManager->recvConnect(
+                    DataContext{TransceiverTag::kID_TAG, transferTerminate}, &id, sizeof(id));
+            });
+
+        constexpr auto kReceiveStartPeriod = std::chrono::milliseconds{100};
+        constexpr auto kCancellationTimeout = std::chrono::seconds{5};
+        ASSERT_EQ(receiveFuture.wait_for(kReceiveStartPeriod), std::future_status::timeout);
+
+        transferTerminate.store(true, std::memory_order_relaxed);
+        ASSERT_EQ(receiveFuture.wait_for(kCancellationTimeout), std::future_status::ready);
+        EXPECT_EQ(receiveFuture.get(), nullptr);
+    }
+    catch (std::exception const& e)
+    {
+        std::string error = e.what();
+        if (error.find("UCX wrapper library is not open correctly") != std::string::npos
+            || error.find("Unable to load UCX wrapper library symbol") != std::string::npos)
+        {
+            GTEST_SKIP() << "UCX wrapper library is not open correctly. Skip this test case.";
+        }
+
+        throw e;
+    }
+}
 
 TEST_F(UcxCommTest, Basic)
 {

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -396,7 +396,6 @@ unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_tinyllama_logits_processor_2
 unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_tinyllama_logits_processor_tp2pp2 SKIP (https://nvbugs/6427411)
 unittest/llmapi/test_llm_pytorch.py::test_gqa_nemo_lora[None] SKIP (https://nvbugs/6162504)
 unittest/llmapi/test_llm_pytorch.py::test_gqa_nemo_lora[cuda_graph_config0] SKIP (https://nvbugs/6162504)
-unittest/llmapi/test_llm_pytorch.py::test_llm_context_only_timed_out[None] SKIP (https://nvbugs/6484986)
 unittest/llmapi/test_llm_pytorch.py::test_llm_context_only_timed_out_kv_cache_exhausted[None-UCX-1000] SKIP (https://nvbugs/6490004)
 unittest/llmapi/test_llm_pytorch.py::test_llm_context_only_timed_out_kv_cache_exhausted[None-UCX-100] SKIP (https://nvbugs/6488811)
 unittest/llmapi/test_memory_profiling.py::test_profile_kvcache SKIP (https://nvbugs/5580781)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -397,7 +397,6 @@ unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_tinyllama_logits_processor_t
 unittest/llmapi/test_llm_pytorch.py::test_gqa_nemo_lora[None] SKIP (https://nvbugs/6162504)
 unittest/llmapi/test_llm_pytorch.py::test_gqa_nemo_lora[cuda_graph_config0] SKIP (https://nvbugs/6162504)
 unittest/llmapi/test_llm_pytorch.py::test_llm_context_only_timed_out_kv_cache_exhausted[None-UCX-1000] SKIP (https://nvbugs/6490004)
-unittest/llmapi/test_llm_pytorch.py::test_llm_context_only_timed_out_kv_cache_exhausted[None-UCX-100] SKIP (https://nvbugs/6488811)
 unittest/llmapi/test_memory_profiling.py::test_profile_kvcache SKIP (https://nvbugs/5580781)
 unittest/tools/test_layer_wise_benchmarks.py::test_performance_alignment[1] SKIP (https://nvbugs/6487836)
 unittest/tools/test_test_to_stage_mapping.py::test_cli_functionality[txt] SKIP (https://nvbugs/6482297)


### PR DESCRIPTION
## Summary

- Add a focused regression test for cancellation of a pending UCX `recvConnect()` during shutdown.
- Bound the regression test with a 60-second CTest timeout so a recurrence is reported as a test timeout instead of hanging the executor test group.
- Remove the two test waivers associated with [NVBUG#6484986](https://nvbugspro.nvidia.com/bug/6484986) and [NVBUG#6488811](https://nvbugspro.nvidia.com/bug/6488811).

## Context

The production fix for the UCX shutdown deadlock is now present on `main` through [PR #13055](https://github.com/NVIDIA/TensorRT-LLM/pull/13055). Its `recvConnect()` implementation keeps the receive state alive through the UCXX callback, observes the existing transfer-termination flag, cancels the outstanding receive, and returns without waiting indefinitely for asynchronous cancellation completion.

After rebasing onto that implementation, this PR no longer replaces the production cancellation logic. It retains the regression coverage and waiver cleanup needed to verify the reported failures remain fixed.

## Changes

- Add `UcxCommTest.recvConnectCancellation`, which starts a pending receive, requests termination, and verifies that `recvConnect()` returns `nullptr` within five seconds.
- Extend `add_gtest()` with an optional `TIMEOUT` property and set `ucxCommTest` to 60 seconds, ensuring a cancellation regression fails cleanly.
- Remove the waiver for `unittest/llmapi/test_llm_pytorch.py::test_llm_context_only_timed_out[None]` (NVBUG#6484986).
- Remove the waiver for `unittest/llmapi/test_llm_pytorch.py::test_llm_context_only_timed_out_kv_cache_exhausted[None-UCX-100]` (NVBUG#6488811).
- Keep the separate `[None-UCX-1000]` waiver associated with NVBUG#6490004.

## Verification

Current rebased head: `0fded855f` on `main` commit `121cf56ae`.

- `python3 scripts/check_test_list.py --check-duplicate-waives --validate`: **PASSED** with 2,035 unique test entries and no duplicate waivers.
- `git diff --check upstream/main...HEAD`: **PASSED**.
- **Waiver-removal verification (current post-rebase head):** targeted `A100X-PyTorch-1` [pipeline #49822](http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=49822) completed successfully on commit `0fded855f` with 132 passed, 0 failed, and 15 skipped tests.
  - [`unittest/llmapi/test_llm_pytorch.py::test_llm_context_only_timed_out[None]`](http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/test_log?job_name=LLM%2Fmain%2FL0_MergeRequest_PR&build_id=49822&stage_name=A100X-PyTorch-1&turtle_name=unittest%2Fllmapi%2Ftest_llm_pytorch.py%3A%3Atest_llm_context_only_timed_out%5BNone%5D): **PASSED**
  - [`unittest/llmapi/test_llm_pytorch.py::test_llm_context_only_timed_out_kv_cache_exhausted[None-UCX-100]`](http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/test_log?job_name=LLM%2Fmain%2FL0_MergeRequest_PR&build_id=49822&stage_name=A100X-PyTorch-1&turtle_name=unittest%2Fllmapi%2Ftest_llm_pytorch.py%3A%3Atest_llm_context_only_timed_out_kv_cache_exhausted%5BNone-UCX-100%5D): **PASSED**
- Historical targeted `A100X-PyTorch-1` verification on pre-rebase commit `5cba0c29b`: [pipeline #49109](http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=49109) completed with 133 passed, 0 failed, and 14 skipped tests; both affected cases also passed.

The two exact post-rebase per-test records in build 49822 report `PASSED` on A100X. They executed in the targeted stage rather than being skipped or waived, so the NVBUG#6484986 and NVBUG#6488811 waivers can remain removed.