### PR TITLE
[None][feat] add BaseMultimodalDummyInputsBuilder to MiniMaxM3VL input processor

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_minimaxm3_vl.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm3_vl.py
@@ -2071,9 +2071,14 @@ def get_minimax_m3_vl_input_processor_cls():
     path. Re-type by dynamic subclassing here so the registered class
     inherits from the base.
     """
-    from tensorrt_llm.inputs.registry import BaseMultimodalInputProcessor
+    from tensorrt_llm.inputs.registry import (
+        BaseMultimodalDummyInputsBuilder,
+        BaseMultimodalInputProcessor,
+    )
 
-    class _Registered(MiniMaxM3VLInputProcessor, BaseMultimodalInputProcessor):
+    class _Registered(
+        MiniMaxM3VLInputProcessor, BaseMultimodalInputProcessor, BaseMultimodalDummyInputsBuilder
+    ):
         pass
 
     _Registered.__name__ = "MiniMaxM3VLInputProcessor"


### PR DESCRIPTION
## Background

The MiniMaxM3VL input processor registration was missing `BaseMultimodalDummyInputsBuilder` in its MRO, which is required for dummy-input generation during model registration.

## Summary

- Add `BaseMultimodalDummyInputsBuilder` to the dynamically-registered `_Registered` class in `get_minimax_m3_vl_input_processor_cls()` alongside the existing `BaseMultimodalInputProcessor`.

## Test plan

- [ ] Verify model registration succeeds without errors
- [ ] Confirm dummy input builder is callable via the registered processor class