### PR TITLE
[None][chore] Remove unused server_endpoint field from RankInfo

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/native/rank_info.py
+++ b/tensorrt_llm/_torch/disaggregation/native/rank_info.py
@@ -21,7 +21,6 @@ class RankInfo:
     pp_rank: int
     layer_num_per_pp: List[int]
     sender_endpoints: List[str]
-    server_endpoint: str
     self_endpoint: str
     transfer_engine_info: bytes
 
@@ -74,7 +73,6 @@ class RankInfo:
             device_id=device_id,
             layer_num_per_pp=[len(kvm.pp_layers)],
             sender_endpoints=[],
-            server_endpoint="",
             self_endpoint="",
             transfer_engine_info=bytes(),
             attention=AttentionInfo(

--- a/tests/unittest/disaggregated/region/test_block.py
+++ b/tests/unittest/disaggregated/region/test_block.py
@@ -43,7 +43,6 @@ def make_rankinfo(
         device_id=0,
         layer_num_per_pp=[1],
         sender_endpoints=[],
-        server_endpoint="",
         self_endpoint="",
         transfer_engine_info=b"",
         attention=AttentionInfo(

--- a/tests/unittest/disaggregated/test_peer.py
+++ b/tests/unittest/disaggregated/test_peer.py
@@ -110,7 +110,6 @@ def make_rankinfo(
         cp_rank=cp_rank,
         device_id=0,
         layer_num_per_pp=layer_num_per_pp,
-        server_endpoint="",
         self_endpoint="",
         transfer_engine_info=b"",
         attention=AttentionInfo(

--- a/tests/unittest/disaggregated/test_pool_matching.py
+++ b/tests/unittest/disaggregated/test_pool_matching.py
@@ -142,7 +142,6 @@ def _rank_info(
         cp_rank=0,
         device_id=0,
         layer_num_per_pp=layer_num_per_pp,
-        server_endpoint="",
         self_endpoint="",
         transfer_engine_info=b"",
         attention=AttentionInfo(

--- a/tests/unittest/disaggregated/test_rank_info.py
+++ b/tests/unittest/disaggregated/test_rank_info.py
@@ -33,7 +33,6 @@ def test_rank_info_construction():
         pp_rank=0,
         layer_num_per_pp=[32],
         sender_endpoints=["tcp://10.0.0.1:5000"],
-        server_endpoint="tcp://10.0.0.1:5000",
         self_endpoint="tcp://10.0.0.1:5001",
         transfer_engine_info=b"\x00\x01\x02",
     )
@@ -54,7 +53,6 @@ def test_rank_info_msgpack_roundtrip():
         pp_rank=0,
         layer_num_per_pp=[32],
         sender_endpoints=["tcp://10.0.0.1:5000"],
-        server_endpoint="tcp://10.0.0.1:5000",
         self_endpoint="tcp://10.0.0.1:5001",
         transfer_engine_info=b"\x00\x01\x02",
     )
@@ -82,7 +80,6 @@ def test_rank_info_roundtrip_with_aux_meta():
         pp_rank=0,
         layer_num_per_pp=[32],
         sender_endpoints=["tcp://10.0.0.1:5000"],
-        server_endpoint="tcp://10.0.0.1:5000",
         self_endpoint="tcp://10.0.0.1:5001",
         transfer_engine_info=b"",
         aux_meta=meta,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Removed the unused `RankInfo.server_endpoint` field and its production initialization.
- Updated all affected test constructors consistently; endpoint handling remains through `disagg_info_endpoint`, `sender_endpoints`, and `self_endpoint`.
- No configuration or test-list files were changed.
- Serialization round-trip tests remain in place for the updated payload schema.
- Verdict: sufficient.

## QA Engineer Review

Modified test helpers and tests:
- `make_rankinfo()` in `tests/unittest/disaggregated/region/test_block.py`
- `make_rankinfo()` in `tests/unittest/disaggregated/test_peer.py`
- `_rank_info()` in `tests/unittest/disaggregated/test_pool_matching.py`
- `test_rank_info_construction`
- `test_rank_info_msgpack_roundtrip`
- `test_rank_info_roundtrip_with_aux_meta`

These changes are covered by the existing disaggregated unit-test suite. No test-list files were modified.  
Verdict: sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

`RankInfo.server_endpoint` is a vestigial field: production code only ever initializes it to an empty string (`RankInfo.from_kv_cache_manager`) and nothing reads it. The rank-0 info-server address it was presumably meant to carry is instead delivered out-of-band via `ContextPhaseParams.disagg_info_endpoint`. The live endpoint fields are `sender_endpoints` (per-rank Sender control channels) and `self_endpoint` (Receiver channel).

This PR drops the field and removes the dummy values passed in unit test constructors. Note this changes the msgpack payload of `RankInfo`, which is an internal wire format exchanged between context/generation instances running the same build.

## Test Coverage

Existing unit tests cover the touched constructors and the serialization round-trip:
- `tests/unittest/disaggregated/test_rank_info.py`
- `tests/unittest/disaggregated/test_peer.py`
- `tests/unittest/disaggregated/test_pool_matching.py`
- `tests/unittest/disaggregated/region/test_block.py`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.