### PR TITLE
[None][feat] Add BaseMultimodalDummyInputsBuilder to minimaxm3_vl

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_minimaxm3_vl.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm3_vl.py
@@ -2071,9 +2071,14 @@ def get_minimax_m3_vl_input_processor_cls():
     path. Re-type by dynamic subclassing here so the registered class
     inherits from the base.
     """
-    from tensorrt_llm.inputs.registry import BaseMultimodalInputProcessor
+    from tensorrt_llm.inputs.registry import (
+        BaseMultimodalDummyInputsBuilder,
+        BaseMultimodalInputProcessor,
+    )
 
-    class _Registered(MiniMaxM3VLInputProcessor, BaseMultimodalInputProcessor):
+    class _Registered(
+        MiniMaxM3VLInputProcessor, BaseMultimodalInputProcessor, BaseMultimodalDummyInputsBuilder
+    ):
         pass
 
     _Registered.__name__ = "MiniMaxM3VLInputProcessor"


### PR DESCRIPTION
## Background

`MiniMaxM3VLInputProcessor` was missing `BaseMultimodalDummyInputsBuilder` as a base class, causing the following error at runtime:

```
AttributeError: 'MiniMaxM3VLInputProcessor' object has no attribute 'get_preferred_media_io_kwargs'
```

## Summary

Add `BaseMultimodalDummyInputsBuilder` to the dynamically constructed `_Registered` class in `get_minimax_m3_vl_input_processor_cls()`, alongside the existing `BaseMultimodalInputProcessor` base.

## Impact

No functional change beyond fixing the missing attribute — no new configuration, no API surface change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**

- Updated the dynamically registered MiniMax M3 VL input processor to inherit from `BaseMultimodalDummyInputsBuilder` alongside `BaseMultimodalInputProcessor`.
- This resolves the missing `get_preferred_media_io_kwargs` interface required by the multimodal pipeline.
- Change is narrowly scoped, introduces no configuration or public API changes, and has no apparent performance or error-handling impact.

**QA Engineer Review**

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->