### PR TITLE
[https://nvbugs/6226016][fix] Avoid trusting request-controlled router tokenizers

### DIFF
--- a/tensorrt_llm/serve/router_utils.py
+++ b/tensorrt_llm/serve/router_utils.py
@@ -217,6 +217,8 @@ class BlockHashMixin:
     def _get_tokenizer(self, model: str):
         if model not in self._tokenizers:
             model_path = self._tokenizer_dir or model
+            # Only an operator-configured tokenizer directory may run remote
+            # tokenizer code; request model values are client-controlled.
             trust_remote_code = self._tokenizer_dir is not None
             if self._custom_tokenizer:
                 from tensorrt_llm.tokenizer import load_custom_tokenizer

--- a/tensorrt_llm/serve/router_utils.py
+++ b/tensorrt_llm/serve/router_utils.py
@@ -217,15 +217,18 @@ class BlockHashMixin:
     def _get_tokenizer(self, model: str):
         if model not in self._tokenizers:
             model_path = self._tokenizer_dir or model
+            trust_remote_code = self._tokenizer_dir is not None
             if self._custom_tokenizer:
                 from tensorrt_llm.tokenizer import load_custom_tokenizer
 
-                self._tokenizers[model] = load_custom_tokenizer(self._custom_tokenizer, model_path)
+                self._tokenizers[model] = load_custom_tokenizer(
+                    self._custom_tokenizer, model_path, trust_remote_code=trust_remote_code
+                )
             else:
                 from tensorrt_llm.tokenizer import TransformersTokenizer
 
                 tokenizer = TransformersTokenizer.from_pretrained(
-                    model_path, trust_remote_code=True
+                    model_path, trust_remote_code=trust_remote_code
                 )
                 self._tokenizers[model] = tokenizer.tokenizer
         return self._tokenizers[model]

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -1768,7 +1768,9 @@ def test_block_hash_mixin_routes_through_transformers_tokenizer():
     DeepSeek-V3 Metaspace, ``_fallback_to_fast_tokenizer`` for DeepSeek-V3.2
     on transformers >= 5.x). Without this routing, ``trtllm-serve`` would
     tokenize prompts differently from the rest of TRT-LLM when computing
-    block hashes for cache hits.
+    block hashes for cache hits. The request's model is client-controlled, so
+    it must not enable remote tokenizer code unless an operator configured a
+    fixed tokenizer directory.
     """
 
     class _Probe(BlockHashMixin):
@@ -1784,11 +1786,25 @@ def test_block_hash_mixin_routes_through_transformers_tokenizer():
             return_value=wrapper) as routed:
         out = probe._get_tokenizer("dummy/model")
 
-    routed.assert_called_once_with("dummy/model", trust_remote_code=True)
+    routed.assert_called_once_with("dummy/model", trust_remote_code=False)
     # The cached tokenizer must be the raw HF tokenizer used by _tokenize,
     # not the TransformersTokenizer wrapper.
     assert out is inner
     assert probe._tokenizers["dummy/model"] is inner
+
+    fixed_probe = _Probe()
+    fixed_probe._init_block_hashing(tokenizer_dir="/trusted/tokenizer")
+
+    fixed_inner = mock.MagicMock()
+    fixed_wrapper = mock.MagicMock(tokenizer=fixed_inner)
+    with mock.patch(
+            "tensorrt_llm.tokenizer.TransformersTokenizer.from_pretrained",
+            return_value=fixed_wrapper) as routed:
+        fixed_out = fixed_probe._get_tokenizer("dummy/model")
+
+    routed.assert_called_once_with("/trusted/tokenizer", trust_remote_code=True)
+    assert fixed_out is fixed_inner
+    assert fixed_probe._tokenizers["dummy/model"] is fixed_inner
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Hardened `BlockHashMixin._get_tokenizer` by setting `trust_remote_code = (self._tokenizer_dir is not None)`, aligning tokenizer loading behavior with whether the tokenizer directory is operator-configured vs request-controlled.
- Propagates `trust_remote_code` consistently to both loading paths:
  - `load_custom_tokenizer(..., trust_remote_code=trust_remote_code)` when using an operator-provided `tokenizer_dir`.
  - `TransformersTokenizer.from_pretrained(..., trust_remote_code=trust_remote_code)` for the standard HF loading path.
- Updated `test_block_hash_mixin_routes_through_transformers_tokenizer` to verify:
  - Default mode (no explicit `tokenizer_dir`): `TransformersTokenizer.from_pretrained(..., trust_remote_code=False)`.
  - `tokenizer_dir` mode: `TransformersTokenizer.from_pretrained(..., trust_remote_code=True)`.
  - Caching/returned objects in `_Probe._tokenizers[model]` are the underlying raw HF tokenizer object (`.tokenizer`), not the `TransformersTokenizer` wrapper, in both modes.
- No public API/config changes identified.

## QA Engineer Review

- Modified test: `test_block_hash_mixin_routes_through_transformers_tokenizer` (`tests/unittest/disaggregated/test_router.py`)
  - Strengthened assertions covering `trust_remote_code` handling and tokenizer caching/identity (raw HF tokenizer object).
  - Covered in `tests/integration/test_lists/test-db/` via inclusion of `unittest/disaggregated/test_router.py` in:
    - `l0_h100.yml`
    - `l0_a10.yml`
  - Verdict: sufficient
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Harden kv-cache-aware router tokenizer loading for the request-controlled `model` path.

Previously, when `tokenizer_dir` was unset, `_get_tokenizer()` used the request's `model` value as the tokenizer source while still allowing trusted remote code. That meant a client-provided model reference could point at a malicious Hugging Face tokenizer repo and cause custom tokenizer Python code to be loaded by the router.

This change keeps online standard tokenizer loading available, but only enables `trust_remote_code` when the tokenizer source comes from an operator-configured `tokenizer_dir`. Request-derived model paths now load with `trust_remote_code=False` for both custom and Transformers tokenizer paths, while explicitly configured tokenizer directories preserve the existing custom-tokenizer behavior.

## Test Coverage

- `python -m pytest tests/unittest/disaggregated/test_router.py -k block_hash_mixin_routes_through_transformers_tokenizer`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


