### PR TITLE
[None][feat] lightweight GPU memory diagnostics for CUDA OOMs

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -90,6 +90,7 @@ from .scheduler import (RequestScheduler, ScheduledRequests,
                         SerializableSchedulerOutput, WaitingQueue,
                         create_waiting_queue)
 from .scheduler.adp_router import ADPRouter
+from .trace_log_utils import log_mem_history, log_mem_snapshot
 
 if TYPE_CHECKING:
     from ray.actor import ActorHandle
@@ -113,6 +114,7 @@ PROFILE_TRACE_ENV_VAR_NAME = "TLLM_TORCH_PROFILE_TRACE"
 # Format: comma-separated rank IDs, e.g. "0,1,3", or "all" for all ranks.
 # Default: "0" (only rank 0 prints, matching existing behavior).
 PROFILE_LOG_RANKS_ENV_VAR_NAME = "TLLM_PROFILE_LOG_RANKS"
+_RUNTIME_MEM_SNAPSHOT_INTERVAL_NS = 1_000_000_000
 
 
 class PPCommTag(IntEnum):
@@ -591,6 +593,9 @@ class PyExecutor:
         self.print_log = self.llm_args.print_iter_log
         self.enable_iter_perf_stats = self.llm_args.enable_iter_perf_stats
         self.enable_iter_req_stats = self.llm_args.enable_iter_req_stats
+        self._runtime_mem_profile_enabled = os.environ.get(
+            "TLLM_LOG_MEM_PROFILE", "") == "1"
+        self._last_runtime_mem_snapshot_ns: Optional[int] = None
         self.stream_interval = self.llm_args.stream_interval
         self.perf_manager = PerfMetricsManager(
             enabled=getattr(self.llm_args, 'return_perf_metrics', False))
@@ -1188,6 +1193,7 @@ class PyExecutor:
                  customized_gc_thresholds(self.garbage_collection_gen0_threshold):
                 self.event_loop()
         except Exception as e:
+            self._log_runtime_oom(e, "event_loop")
             logger.error(f"Error in event loop: {e}")
             logger.error(traceback.format_exc())
             # Stash the original error so local consumers
@@ -1644,6 +1650,8 @@ class PyExecutor:
         def profile_step():
             nonlocal it, enabled, start_time, start_event_1, end_event_1, start_event_2, end_event_2, prev_device_step_time
             calibrator.post_step(it)
+            if getattr(self, "_runtime_mem_profile_enabled", False):
+                self._maybe_log_runtime_mem_snapshot()
             if (self.iter_counter in self.profile_stop_iters
                     and not self.is_warmup):
                 assert enabled, "Inconsistent CUDA profiling state"
@@ -1761,6 +1769,62 @@ class PyExecutor:
                 calibrator.stop()
                 torch.cuda.synchronize()
                 torch.cuda.cudart().cudaProfilerStop()
+
+    def _maybe_log_runtime_mem_snapshot(self) -> None:
+        if not getattr(self, "_runtime_mem_profile_enabled", False):
+            return
+
+        now_ns = time.monotonic_ns()
+        last_ns = self._last_runtime_mem_snapshot_ns
+        if (last_ns is not None
+                and now_ns - last_ns < _RUNTIME_MEM_SNAPSHOT_INTERVAL_NS):
+            return
+        self._last_runtime_mem_snapshot_ns = now_ns
+
+        if self.dist.pp_size > 1:
+            loop = "pp"
+        elif self.disable_overlap_scheduler:
+            loop = "non_overlap"
+        else:
+            loop = "overlap"
+
+        kv_fields = {}
+        if self.kv_cache_manager is not None:
+            try:
+                kv_stats = self.kv_cache_manager.get_kv_cache_stats()
+                kv_fields = {
+                    "kv_used_blocks": kv_stats.used_num_blocks,
+                    "kv_free_blocks": kv_stats.free_num_blocks,
+                    "kv_max_blocks": kv_stats.max_num_blocks,
+                }
+            except Exception:
+                pass
+
+        log_mem_snapshot(
+            "runtime/before_iter",
+            iter=self.iter_counter,
+            loop=loop,
+            active_requests=len(self.active_requests),
+            prev_scheduled_requests=self.num_scheduled_requests,
+            **kv_fields,
+        )
+
+    def _log_runtime_oom(self, error, phase: str) -> None:
+        try:
+            if (not isinstance(error, torch.OutOfMemoryError)
+                    and "out of memory" not in str(error).lower()):
+                return
+
+            tag = f"oom/runtime/{phase}"
+            log_mem_snapshot(
+                tag,
+                force=True,
+                iter=getattr(self, "iter_counter", None),
+                active_requests=len(getattr(self, "active_requests", ())),
+            )
+            log_mem_history(tag)
+        except Exception:
+            pass
 
     def _get_init_iter_stats(self, num_new_active_requests,
                              new_active_requests_queue_latency_ms):
@@ -6445,6 +6509,7 @@ class PyExecutor:
         """
         error_responses: Dict[int, LlmResponse] = {}
         error_msg = error_msg or "error"
+        self._log_runtime_oom(error_msg, "handled")
 
         budget_fatal = (self._error_budget.consume(error_msg)
                         if charge_budget else False)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -47,6 +47,7 @@ from .guided_decoder import CapturableGuidedDecoder, GuidedDecoder
 from .model_engine import PyTorchModelEngine
 from .model_loader import ModelLoader, _construct_checkpoint_loader
 from .py_executor import PyExecutor
+from .trace_log_utils import log_mem_snapshot
 
 _MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS = (90, 100, 103, 120, 121)
 _MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS = (90, 100, 103, 120)
@@ -56,6 +57,8 @@ _MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS_STR = "/".join(
 _MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS_STR = "/".join(
     f"SM{sm_version}"
     for sm_version in _MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS)
+_STARTUP_FREE_MEMORY_WARN_RATIO = 0.9
+_STARTUP_USED_MEMORY_WARN_BYTES = 2 * (1 << 30)
 
 
 class _ExecutorMemoryMonitor:
@@ -68,12 +71,36 @@ class _ExecutorMemoryMonitor:
         free_gpu_memory_bytes_post: int
 
     def __init__(self):
-        self._total_gpu_memory_bytes = torch.cuda.mem_get_info()[1]
+        free_gpu_memory_bytes, self._total_gpu_memory_bytes = torch.cuda.mem_get_info(
+        )
         self._samples: list["_ExecutorMemoryMonitor._GpuMemoryUsageSample"] = []
+        self._warn_if_gpu_not_empty(free_gpu_memory_bytes)
+        log_mem_snapshot("startup/baseline")
 
     @staticmethod
     def _bytes_to_gib(bytes: int) -> float:
         return bytes / (1024)**3
+
+    def _warn_if_gpu_not_empty(self, free_gpu_memory_bytes: int) -> None:
+        total = self._total_gpu_memory_bytes
+        if total <= 0:
+            return
+        used = total - free_gpu_memory_bytes
+        if (free_gpu_memory_bytes / total >= _STARTUP_FREE_MEMORY_WARN_RATIO
+                or used < _STARTUP_USED_MEMORY_WARN_BYTES):
+            return
+
+        try:
+            process_info = " ".join(
+                torch.cuda.list_gpu_processes().splitlines())
+        except Exception as error:
+            process_info = f"unavailable ({type(error).__name__})"
+        logger.warning(
+            "GPU is not empty at executor startup: "
+            f"{self._bytes_to_gib(free_gpu_memory_bytes):.2f} GiB free of "
+            f"{self._bytes_to_gib(total):.2f} GiB total "
+            f"({self._bytes_to_gib(used):.2f} GiB already used). "
+            f"Visible GPU processes: {process_info}")
 
     memory_type_friendly_names = {
         ExecutorMemoryType.SAMPLER:
@@ -176,9 +203,11 @@ class _ExecutorMemoryMonitor:
                 free_gpu_memory_bytes_pre=free_gpu_memory_bytes_pre)
             if explanation is None:
                 raise  # not an OOM
+            log_mem_snapshot(f"oom/{current_stage.value}", force=True)
             raise RuntimeError(explanation) from e
         else:
             free_gpu_memory_bytes_post = torch.cuda.mem_get_info()[0]
+            log_mem_snapshot(f"stage/{current_stage.value}")
             self._samples.append(
                 self._GpuMemoryUsageSample(
                     creation_stage=current_stage,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -47,7 +47,8 @@ from .guided_decoder import CapturableGuidedDecoder, GuidedDecoder
 from .model_engine import PyTorchModelEngine
 from .model_loader import ModelLoader, _construct_checkpoint_loader
 from .py_executor import PyExecutor
-from .trace_log_utils import log_mem_snapshot
+from .trace_log_utils import (log_mem_history, log_mem_snapshot,
+                              reset_mem_history)
 
 _MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS = (90, 100, 103, 120, 121)
 _MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS = (90, 100, 103, 120)
@@ -71,6 +72,7 @@ class _ExecutorMemoryMonitor:
         free_gpu_memory_bytes_post: int
 
     def __init__(self):
+        reset_mem_history()
         free_gpu_memory_bytes, self._total_gpu_memory_bytes = torch.cuda.mem_get_info(
         )
         self._samples: list["_ExecutorMemoryMonitor._GpuMemoryUsageSample"] = []
@@ -204,6 +206,7 @@ class _ExecutorMemoryMonitor:
             if explanation is None:
                 raise  # not an OOM
             log_mem_snapshot(f"oom/{current_stage.value}", force=True)
+            log_mem_history(f"oom/{current_stage.value}")
             raise RuntimeError(explanation) from e
         else:
             free_gpu_memory_bytes_post = torch.cuda.mem_get_info()[0]

--- a/tensorrt_llm/_torch/pyexecutor/trace_log_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/trace_log_utils.py
@@ -9,19 +9,49 @@ can import freely without creating circular dependencies.
 """
 
 import os
+import time
+from collections import deque
 
 import torch
 
 from tensorrt_llm.logger import logger
 
 _GIB = 1 << 30
+_MEM_HISTORY_CAPACITY = 64
+_MEM_HISTORY: deque[tuple[int, str]] = deque(maxlen=_MEM_HISTORY_CAPACITY)
+
+
+def reset_mem_history() -> None:
+    """Clear snapshots left by a previous executor in this process."""
+    _MEM_HISTORY.clear()
+
+
+def log_mem_history(reason: str) -> None:
+    """Log bounded pre-failure snapshots from oldest to newest."""
+    try:
+        history = tuple(_MEM_HISTORY)
+        if not history:
+            return
+        now_ns = time.monotonic_ns()
+        for index, (timestamp_ns, snapshot) in enumerate(history):
+            age_ms = (now_ns - timestamp_ns) / 1_000_000
+            logger.warning(
+                f"[mem-history/{reason}] index={index} entries={len(history)} "
+                f"age_ms={age_ms:.2f} snapshot={snapshot}"
+            )
+    except Exception as error:
+        try:
+            logger.warning(f"[mem-history/{reason}] history unavailable: {type(error).__name__}")
+        except Exception:
+            pass
 
 
 def log_mem_snapshot(tag: str, *, force: bool = False) -> None:
     """Log a compact snapshot of Torch and whole-device GPU memory.
 
-    Routine snapshots are gated by ``TLLM_LOG_MEM_PROFILE=1``. ``force=True``
-    bypasses the gate for failure-path diagnostics.
+    Routine snapshots are gated by ``TLLM_LOG_MEM_PROFILE=1`` and retained in
+    a bounded history. ``force=True`` bypasses the gate for one current
+    failure-path snapshot and is not retained.
 
     Prints these fields:
 
@@ -29,14 +59,15 @@ def log_mem_snapshot(tag: str, *, force: bool = False) -> None:
     - ``torch_reserved``      = :func:`torch.cuda.memory_reserved`
     - ``torch_alloc_peak``    = :func:`torch.cuda.max_memory_allocated`
     - ``torch_reserved_peak`` = :func:`torch.cuda.max_memory_reserved`
-    - ``free``                = ``cuMemGetInfo().free``
-    - ``total``               = ``cuMemGetInfo().total``
+    - ``device_free``         = ``cuMemGetInfo().free``
+    - ``device_total``        = ``cuMemGetInfo().total``
 
     ``device_gap_estimate`` is the signed difference between whole-device used
     memory and this process's Torch reserved memory. It can include other
     processes and non-Torch allocations, so it is not an ownership ledger.
     """
-    if not force and os.environ.get("TLLM_LOG_MEM_PROFILE", "") != "1":
+    profile_enabled = os.environ.get("TLLM_LOG_MEM_PROFILE", "") == "1"
+    if not force and not profile_enabled:
         return
     try:
         device = torch.cuda.current_device()
@@ -59,6 +90,8 @@ def log_mem_snapshot(tag: str, *, force: bool = False) -> None:
             f"device_total={total / _GIB:.2f}GiB "
             f"device_gap_estimate={device_gap_estimate / _GIB:.2f}GiB"
         )
+        if profile_enabled and not force:
+            _MEM_HISTORY.append((time.monotonic_ns(), message))
         if force:
             logger.warning(message)
         else:

--- a/tensorrt_llm/_torch/pyexecutor/trace_log_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/trace_log_utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Gated trace/log utilities for pyexecutor.
 
 Leaf module — no other pyexecutor file is imported here, so any consumer
@@ -14,10 +17,11 @@ from tensorrt_llm.logger import logger
 _GIB = 1 << 30
 
 
-def log_mem_snapshot(tag: str) -> None:
-    """Log Torch alloc/reserved + alloc/reserved peak + free/total GPU memory.
+def log_mem_snapshot(tag: str, *, force: bool = False) -> None:
+    """Log a compact snapshot of Torch and whole-device GPU memory.
 
-    Gated by ``TLLM_LOG_MEM_PROFILE=1``; default OFF (zero overhead).
+    Routine snapshots are gated by ``TLLM_LOG_MEM_PROFILE=1``. ``force=True``
+    bypasses the gate for failure-path diagnostics.
 
     Prints these fields:
 
@@ -28,29 +32,40 @@ def log_mem_snapshot(tag: str) -> None:
     - ``free``                = ``cuMemGetInfo().free``
     - ``total``               = ``cuMemGetInfo().total``
 
-    Derived quantities the reader may need:
-
-    - ``used      = total - free`` — whole-process GPU consumption
-    - ``slack     = reserved - alloc`` — Torch caching allocator free blocks
-    - ``non_torch = used - reserved`` — bytes outside Torch (KV pool C++
-      cudaMalloc, NCCL buffers, cuBLAS workspace, CUDA driver context,
-      CUDA graph mempool, etc.)
+    ``device_gap_estimate`` is the signed difference between whole-device used
+    memory and this process's Torch reserved memory. It can include other
+    processes and non-Torch allocations, so it is not an ownership ledger.
     """
-    if os.environ.get("TLLM_LOG_MEM_PROFILE", "") != "1":
+    if not force and os.environ.get("TLLM_LOG_MEM_PROFILE", "") != "1":
         return
-    free, total = torch.cuda.mem_get_info()
-    alloc = torch.cuda.memory_allocated()
-    reserved = torch.cuda.memory_reserved()
-    alloc_peak = torch.cuda.max_memory_allocated()
-    reserved_peak = torch.cuda.max_memory_reserved()
-    logger.info(
-        f"[mem-profile/{tag}] "
-        f"torch_alloc={alloc / _GIB:.2f}GiB "
-        f"torch_reserved={reserved / _GIB:.2f}GiB "
-        f"torch_alloc_peak={alloc_peak / _GIB:.2f}GiB "
-        f"torch_reserved_peak={reserved_peak / _GIB:.2f}GiB "
-        f"free={free / _GIB:.2f}GiB total={total / _GIB:.2f}GiB"
-    )
+    try:
+        device = torch.cuda.current_device()
+        free, total = torch.cuda.mem_get_info()
+        alloc = torch.cuda.memory_allocated()
+        reserved = torch.cuda.memory_reserved()
+        alloc_peak = torch.cuda.max_memory_allocated()
+        reserved_peak = torch.cuda.max_memory_reserved()
+        device_used = total - free
+        device_gap_estimate = device_used - reserved
+        message = (
+            f"[mem-profile/{tag}] "
+            f"rank={logger.rank} device={device} "
+            f"torch_alloc={alloc / _GIB:.2f}GiB "
+            f"torch_reserved={reserved / _GIB:.2f}GiB "
+            f"torch_alloc_peak={alloc_peak / _GIB:.2f}GiB "
+            f"torch_reserved_peak={reserved_peak / _GIB:.2f}GiB "
+            f"device_used={device_used / _GIB:.2f}GiB "
+            f"device_free={free / _GIB:.2f}GiB "
+            f"device_total={total / _GIB:.2f}GiB "
+            f"device_gap_estimate={device_gap_estimate / _GIB:.2f}GiB"
+        )
+        if force:
+            logger.warning(message)
+        else:
+            logger.info(message)
+    except Exception as error:
+        # A diagnostic must not replace the failure it is trying to explain.
+        logger.warning(f"[mem-profile/{tag}] snapshot unavailable: {type(error).__name__}")
 
 
 def log_tensor_size(tag: str, tensor: torch.Tensor, **extra) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/trace_log_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/trace_log_utils.py
@@ -18,6 +18,7 @@ from tensorrt_llm.logger import logger
 
 _GIB = 1 << 30
 _MEM_HISTORY_CAPACITY = 64
+_MAX_NVML_PROCESSES = 8
 _MEM_HISTORY: deque[tuple[int, str]] = deque(maxlen=_MEM_HISTORY_CAPACITY)
 
 
@@ -46,12 +47,73 @@ def log_mem_history(reason: str) -> None:
             pass
 
 
+def _format_nvml_process_fields(device: int) -> str:
+    """Return best-effort per-process GPU memory fields for an OOM log."""
+    initialized = False
+    try:
+        import pynvml
+
+        pynvml.nvmlInit()
+        initialized = True
+
+        raw_uuid = str(torch.cuda.get_device_properties(device).uuid)
+        if not raw_uuid or raw_uuid == "None":
+            raise RuntimeError("CUDA device UUID is unavailable")
+        device_uuid = raw_uuid if raw_uuid.startswith(("GPU-", "MIG-")) else f"GPU-{raw_uuid}"
+        handle = pynvml.nvmlDeviceGetHandleByUUID(device_uuid)
+        processes = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
+
+        process_memory: dict[int, int] = {}
+        unavailable_count = 0
+        for process in processes:
+            used = process.usedGpuMemory
+            if used is None or used < 0:
+                unavailable_count += 1
+                continue
+            pid = int(process.pid)
+            process_memory[pid] = max(process_memory.get(pid, 0), int(used))
+
+        self_pid = os.getpid()
+        self_used = process_memory.get(self_pid, 0)
+        nonself_used = sum(used for pid, used in process_memory.items() if pid != self_pid)
+        sorted_processes = sorted(process_memory.items(), key=lambda item: (-item[1], item[0]))
+        shown_processes = sorted_processes[:_MAX_NVML_PROCESSES]
+        process_list = ",".join(f"{pid}:{used / _GIB:.2f}GiB" for pid, used in shown_processes)
+        if not process_list:
+            process_list = "none"
+
+        status = "partial" if unavailable_count else "ok"
+        fields = (
+            f" nvml_status={status}"
+            f" nvml_self_found={int(self_pid in process_memory)}"
+            f" nvml_self_used={self_used / _GIB:.2f}GiB"
+            f" nvml_nonself_used={nonself_used / _GIB:.2f}GiB"
+            f" nvml_process_count={len(process_memory)}"
+            f" nvml_processes={process_list}"
+        )
+        omitted_count = len(sorted_processes) - len(shown_processes)
+        if omitted_count:
+            fields += f" nvml_processes_omitted={omitted_count}"
+        if unavailable_count:
+            fields += f" nvml_processes_unavailable={unavailable_count}"
+        return fields
+    except Exception as error:
+        return f" nvml_status=unavailable nvml_error={type(error).__name__}"
+    finally:
+        if initialized:
+            try:
+                pynvml.nvmlShutdown()
+            except Exception:
+                pass
+
+
 def log_mem_snapshot(tag: str, *, force: bool = False, **extra) -> None:
     """Log a compact snapshot of Torch and whole-device GPU memory.
 
     Routine snapshots are gated by ``TLLM_LOG_MEM_PROFILE=1`` and retained in
     a bounded history. ``force=True`` bypasses the gate for one current
-    failure-path snapshot and is not retained.
+    failure-path snapshot and is not retained. When profiling is enabled, a
+    forced snapshot also adds best-effort NVML process memory fields.
 
     Prints these fields:
 
@@ -79,6 +141,7 @@ def log_mem_snapshot(tag: str, *, force: bool = False, **extra) -> None:
         device_used = total - free
         device_gap_estimate = device_used - reserved
         extras = "".join(f" {key}={value}" for key, value in extra.items())
+        nvml_fields = _format_nvml_process_fields(device) if force and profile_enabled else ""
         message = (
             f"[mem-profile/{tag}] "
             f"rank={logger.rank} device={device} "
@@ -91,6 +154,7 @@ def log_mem_snapshot(tag: str, *, force: bool = False, **extra) -> None:
             f"device_total={total / _GIB:.2f}GiB "
             f"device_gap_estimate={device_gap_estimate / _GIB:.2f}GiB"
             f"{extras}"
+            f"{nvml_fields}"
         )
         if profile_enabled and not force:
             _MEM_HISTORY.append((time.monotonic_ns(), message))

--- a/tensorrt_llm/_torch/pyexecutor/trace_log_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/trace_log_utils.py
@@ -46,7 +46,7 @@ def log_mem_history(reason: str) -> None:
             pass
 
 
-def log_mem_snapshot(tag: str, *, force: bool = False) -> None:
+def log_mem_snapshot(tag: str, *, force: bool = False, **extra) -> None:
     """Log a compact snapshot of Torch and whole-device GPU memory.
 
     Routine snapshots are gated by ``TLLM_LOG_MEM_PROFILE=1`` and retained in
@@ -78,6 +78,7 @@ def log_mem_snapshot(tag: str, *, force: bool = False) -> None:
         reserved_peak = torch.cuda.max_memory_reserved()
         device_used = total - free
         device_gap_estimate = device_used - reserved
+        extras = "".join(f" {key}={value}" for key, value in extra.items())
         message = (
             f"[mem-profile/{tag}] "
             f"rank={logger.rank} device={device} "
@@ -89,6 +90,7 @@ def log_mem_snapshot(tag: str, *, force: bool = False) -> None:
             f"device_free={free / _GIB:.2f}GiB "
             f"device_total={total / _GIB:.2f}GiB "
             f"device_gap_estimate={device_gap_estimate / _GIB:.2f}GiB"
+            f"{extras}"
         )
         if profile_enabled and not force:
             _MEM_HISTORY.append((time.monotonic_ns(), message))
@@ -98,7 +100,10 @@ def log_mem_snapshot(tag: str, *, force: bool = False) -> None:
             logger.info(message)
     except Exception as error:
         # A diagnostic must not replace the failure it is trying to explain.
-        logger.warning(f"[mem-profile/{tag}] snapshot unavailable: {type(error).__name__}")
+        try:
+            logger.warning(f"[mem-profile/{tag}] snapshot unavailable: {type(error).__name__}")
+        except Exception:
+            pass
 
 
 def log_tensor_size(tag: str, tensor: torch.Tensor, **extra) -> None:

--- a/tests/unittest/_torch/executor/test_py_executor_creator_memory_monitor.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_memory_monitor.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock, call
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.pyexecutor import py_executor_creator
+from tensorrt_llm.llmapi.llm_args import ExecutorMemoryType
+
+
+def test_startup_monitor_warns_about_visible_gpu_processes(monkeypatch) -> None:
+    gib = 1 << 30
+    monkeypatch.setattr(torch.cuda, "mem_get_info", Mock(return_value=(50 * gib, 100 * gib)))
+    monkeypatch.setattr(
+        torch.cuda,
+        "list_gpu_processes",
+        Mock(return_value="GPU: 0\nprocess 123 uses 4096.000 MB GPU memory"),
+    )
+    warning = Mock()
+    snapshot = Mock()
+    monkeypatch.setattr(py_executor_creator.logger, "warning", warning)
+    monkeypatch.setattr(py_executor_creator, "log_mem_snapshot", snapshot)
+
+    py_executor_creator._ExecutorMemoryMonitor()
+
+    snapshot.assert_called_once_with("startup/baseline")
+    message = warning.call_args.args[0]
+    assert "50.00 GiB already used" in message
+    assert "process 123 uses 4096.000 MB GPU memory" in message
+    assert "\n" not in message
+
+
+def test_startup_monitor_skips_process_query_for_clean_gpu(monkeypatch) -> None:
+    gib = 1 << 30
+    monkeypatch.setattr(torch.cuda, "mem_get_info", Mock(return_value=(95 * gib, 100 * gib)))
+    process_query = Mock()
+    warning = Mock()
+    monkeypatch.setattr(torch.cuda, "list_gpu_processes", process_query)
+    monkeypatch.setattr(py_executor_creator.logger, "warning", warning)
+    monkeypatch.setattr(py_executor_creator, "log_mem_snapshot", Mock())
+
+    py_executor_creator._ExecutorMemoryMonitor()
+
+    process_query.assert_not_called()
+    warning.assert_not_called()
+
+
+def test_startup_monitor_logs_successful_stage(monkeypatch) -> None:
+    gib = 1 << 30
+    mem_get_info = Mock(
+        side_effect=[
+            (100 * gib, 100 * gib),
+            (80 * gib, 100 * gib),
+            (70 * gib, 100 * gib),
+        ]
+    )
+    snapshot = Mock()
+    monkeypatch.setattr(torch.cuda, "mem_get_info", mem_get_info)
+    monkeypatch.setattr(py_executor_creator, "log_mem_snapshot", snapshot)
+    monitor = py_executor_creator._ExecutorMemoryMonitor()
+
+    with monitor.observe_creation_stage(ExecutorMemoryType.SAMPLER):
+        pass
+
+    assert snapshot.call_args_list == [
+        call("startup/baseline"),
+        call("stage/sampler"),
+    ]
+    assert len(monitor._samples) == 1
+    assert monitor._samples[0].free_gpu_memory_bytes_pre == 80 * gib
+    assert monitor._samples[0].free_gpu_memory_bytes_post == 70 * gib
+
+
+def test_startup_monitor_forces_snapshot_without_masking_oom(monkeypatch) -> None:
+    gib = 1 << 30
+    monkeypatch.setattr(
+        torch.cuda,
+        "mem_get_info",
+        Mock(
+            side_effect=[
+                (100 * gib, 100 * gib),
+                (1 * gib, 100 * gib),
+            ]
+        ),
+    )
+    snapshot = Mock()
+    monkeypatch.setattr(py_executor_creator, "log_mem_snapshot", snapshot)
+    monitor = py_executor_creator._ExecutorMemoryMonitor()
+    oom = torch.OutOfMemoryError("CUDA out of memory")
+
+    with pytest.raises(RuntimeError) as raised:
+        with monitor.observe_creation_stage(ExecutorMemoryType.MODEL_ENGINE_MAIN):
+            raise oom
+
+    assert raised.value.__cause__ is oom
+    assert snapshot.call_args_list == [
+        call("startup/baseline"),
+        call("oom/model", force=True),
+    ]

--- a/tests/unittest/_torch/executor/test_py_executor_creator_memory_monitor.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_memory_monitor.py
@@ -20,11 +20,14 @@ def test_startup_monitor_warns_about_visible_gpu_processes(monkeypatch) -> None:
     )
     warning = Mock()
     snapshot = Mock()
+    reset_history = Mock()
     monkeypatch.setattr(py_executor_creator.logger, "warning", warning)
     monkeypatch.setattr(py_executor_creator, "log_mem_snapshot", snapshot)
+    monkeypatch.setattr(py_executor_creator, "reset_mem_history", reset_history)
 
     py_executor_creator._ExecutorMemoryMonitor()
 
+    reset_history.assert_called_once_with()
     snapshot.assert_called_once_with("startup/baseline")
     message = warning.call_args.args[0]
     assert "50.00 GiB already used" in message
@@ -86,7 +89,9 @@ def test_startup_monitor_forces_snapshot_without_masking_oom(monkeypatch) -> Non
         ),
     )
     snapshot = Mock()
+    history = Mock()
     monkeypatch.setattr(py_executor_creator, "log_mem_snapshot", snapshot)
+    monkeypatch.setattr(py_executor_creator, "log_mem_history", history)
     monitor = py_executor_creator._ExecutorMemoryMonitor()
     oom = torch.OutOfMemoryError("CUDA out of memory")
 
@@ -99,3 +104,4 @@ def test_startup_monitor_forces_snapshot_without_masking_oom(monkeypatch) -> Non
         call("startup/baseline"),
         call("oom/model", force=True),
     ]
+    history.assert_called_once_with("oom/model")

--- a/tests/unittest/_torch/executor/test_py_executor_memory_profile.py
+++ b/tests/unittest/_torch/executor/test_py_executor_memory_profile.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.pyexecutor import py_executor
+
+
+def _runtime_executor(*, enabled=True):
+    executor = object.__new__(py_executor.PyExecutor)
+    executor._runtime_mem_profile_enabled = enabled
+    executor._last_runtime_mem_snapshot_ns = None
+    executor.iter_counter = 7
+    executor.active_requests = [Mock(), Mock()]
+    executor.num_scheduled_requests = 3
+    executor.dist = SimpleNamespace(pp_size=1)
+    executor.disable_overlap_scheduler = False
+    executor.kv_cache_manager = Mock()
+    executor.kv_cache_manager.get_kv_cache_stats.return_value = SimpleNamespace(
+        used_num_blocks=8,
+        free_num_blocks=2,
+        max_num_blocks=10,
+    )
+    return executor
+
+
+def test_runtime_mem_snapshot_is_disabled_without_overhead(monkeypatch) -> None:
+    executor = _runtime_executor(enabled=False)
+    monotonic_ns = Mock()
+    snapshot = Mock()
+    monkeypatch.setattr(py_executor.time, "monotonic_ns", monotonic_ns)
+    monkeypatch.setattr(py_executor, "log_mem_snapshot", snapshot)
+
+    executor._maybe_log_runtime_mem_snapshot()
+
+    monotonic_ns.assert_not_called()
+    executor.kv_cache_manager.get_kv_cache_stats.assert_not_called()
+    snapshot.assert_not_called()
+
+
+def test_runtime_mem_snapshot_is_throttled_and_has_context(monkeypatch) -> None:
+    executor = _runtime_executor()
+    monkeypatch.setattr(
+        py_executor.time,
+        "monotonic_ns",
+        Mock(side_effect=[1_000_000_000, 1_500_000_000, 2_000_000_000]),
+    )
+    snapshot = Mock()
+    monkeypatch.setattr(py_executor, "log_mem_snapshot", snapshot)
+
+    executor._maybe_log_runtime_mem_snapshot()
+    executor._maybe_log_runtime_mem_snapshot()
+    executor._maybe_log_runtime_mem_snapshot()
+
+    expected = call(
+        "runtime/before_iter",
+        iter=7,
+        loop="overlap",
+        active_requests=2,
+        prev_scheduled_requests=3,
+        kv_used_blocks=8,
+        kv_free_blocks=2,
+        kv_max_blocks=10,
+    )
+    assert snapshot.call_args_list == [expected, expected]
+    assert executor.kv_cache_manager.get_kv_cache_stats.call_count == 2
+
+
+def test_runtime_oom_logs_current_snapshot_and_history(monkeypatch) -> None:
+    executor = _runtime_executor()
+    snapshot = Mock()
+    history = Mock()
+    monkeypatch.setattr(py_executor, "log_mem_snapshot", snapshot)
+    monkeypatch.setattr(py_executor, "log_mem_history", history)
+
+    executor._log_runtime_oom(torch.OutOfMemoryError("CUDA out of memory"), "forward")
+
+    snapshot.assert_called_once_with(
+        "oom/runtime/forward",
+        force=True,
+        iter=7,
+        active_requests=2,
+    )
+    history.assert_called_once_with("oom/runtime/forward")
+
+
+def test_non_oom_does_not_log_memory_diagnostics(monkeypatch) -> None:
+    executor = _runtime_executor()
+    snapshot = Mock()
+    history = Mock()
+    monkeypatch.setattr(py_executor, "log_mem_snapshot", snapshot)
+    monkeypatch.setattr(py_executor, "log_mem_history", history)
+
+    executor._log_runtime_oom(RuntimeError("invalid request"), "event_loop")
+
+    snapshot.assert_not_called()
+    history.assert_not_called()
+
+
+def test_handled_oom_logs_before_error_processing() -> None:
+    executor = _runtime_executor()
+    executor._log_runtime_oom = Mock()
+    executor._fatal_error = None
+    executor._error_budget = Mock(budget=1.0)
+    executor._error_budget.consume.return_value = False
+    executor.active_requests = []
+    executor._enqueue_responses = Mock()
+    calls = Mock()
+    calls.attach_mock(executor._log_runtime_oom, "diagnostic")
+    calls.attach_mock(executor._error_budget.consume, "budget")
+
+    py_executor.PyExecutor._handle_errors(executor, "CUDA out of memory")
+
+    assert calls.mock_calls[:2] == [
+        call.diagnostic("CUDA out of memory", "handled"),
+        call.budget("CUDA out of memory"),
+    ]
+
+
+def test_event_loop_oom_logs_and_reraises_original(monkeypatch) -> None:
+    executor = object.__new__(py_executor.PyExecutor)
+    oom = torch.OutOfMemoryError("CUDA out of memory")
+    executor._is_warmup = False
+    executor.garbage_collection_gen0_threshold = 0
+    executor.event_loop = Mock(side_effect=oom)
+    executor._log_runtime_oom = Mock()
+    executor._executor_loop_cleanup = Mock()
+    monkeypatch.setattr(py_executor, "host_profiler_context", lambda **_: nullcontext())
+    monkeypatch.setattr(py_executor, "customized_gc_thresholds", lambda _: nullcontext())
+
+    with pytest.raises(torch.OutOfMemoryError) as raised:
+        py_executor.PyExecutor._event_loop_wrapper(executor)
+
+    assert raised.value is oom
+    executor._log_runtime_oom.assert_called_once_with(oom, "event_loop")
+    executor._executor_loop_cleanup.assert_called_once_with()

--- a/tests/unittest/_torch/test_trace_log_utils.py
+++ b/tests/unittest/_torch/test_trace_log_utils.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -56,7 +58,9 @@ def test_mem_snapshot_logs_compact_counters(monkeypatch) -> None:
     monkeypatch.setenv("TLLM_LOG_MEM_PROFILE", "1")
     monkeypatch.setattr(trace_log_utils.logger, "rank", 3)
     info = Mock()
+    nvml_query = Mock()
     monkeypatch.setattr(trace_log_utils.logger, "info", info)
+    monkeypatch.setattr(trace_log_utils, "_format_nvml_process_fields", nvml_query)
     _mock_cuda_counters(monkeypatch)
 
     trace_log_utils.log_mem_snapshot("stage/model", iter=7, active_requests=2)
@@ -71,12 +75,15 @@ def test_mem_snapshot_logs_compact_counters(monkeypatch) -> None:
     )
     assert len(trace_log_utils._MEM_HISTORY) == 1
     assert trace_log_utils._MEM_HISTORY[0][1] == info.call_args.args[0]
+    nvml_query.assert_not_called()
 
 
 def test_forced_mem_snapshot_bypasses_gate(monkeypatch) -> None:
     monkeypatch.delenv("TLLM_LOG_MEM_PROFILE", raising=False)
     warning = Mock()
+    nvml_query = Mock()
     monkeypatch.setattr(trace_log_utils.logger, "warning", warning)
+    monkeypatch.setattr(trace_log_utils, "_format_nvml_process_fields", nvml_query)
     _mock_cuda_counters(monkeypatch)
 
     trace_log_utils.log_mem_snapshot("oom/model", force=True)
@@ -84,6 +91,103 @@ def test_forced_mem_snapshot_bypasses_gate(monkeypatch) -> None:
     assert warning.call_count == 1
     assert warning.call_args.args[0].startswith("[mem-profile/oom/model]")
     assert not trace_log_utils._MEM_HISTORY
+    nvml_query.assert_not_called()
+
+
+def test_forced_mem_snapshot_adds_nvml_fields_when_profile_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("TLLM_LOG_MEM_PROFILE", "1")
+    warning = Mock()
+    nvml_query = Mock(return_value=" nvml_status=ok nvml_process_count=2")
+    monkeypatch.setattr(trace_log_utils.logger, "warning", warning)
+    monkeypatch.setattr(trace_log_utils, "_format_nvml_process_fields", nvml_query)
+    _mock_cuda_counters(monkeypatch)
+
+    trace_log_utils.log_mem_snapshot("oom/model", force=True)
+
+    nvml_query.assert_called_once_with(2)
+    assert warning.call_args.args[0].endswith("nvml_status=ok nvml_process_count=2")
+    assert not trace_log_utils._MEM_HISTORY
+
+
+def test_nvml_process_fields_use_uuid_and_split_self_from_nonself(monkeypatch) -> None:
+    gib = 1 << 30
+    handle = object()
+    pynvml = SimpleNamespace(
+        nvmlInit=Mock(),
+        nvmlShutdown=Mock(),
+        nvmlDeviceGetHandleByUUID=Mock(return_value=handle),
+        nvmlDeviceGetComputeRunningProcesses=Mock(
+            return_value=[
+                SimpleNamespace(pid=101, usedGpuMemory=3 * gib),
+                SimpleNamespace(pid=202, usedGpuMemory=5 * gib),
+                SimpleNamespace(pid=303, usedGpuMemory=2 * gib),
+            ]
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", pynvml)
+    monkeypatch.setattr(trace_log_utils.os, "getpid", Mock(return_value=101))
+    monkeypatch.setattr(
+        trace_log_utils.torch.cuda,
+        "get_device_properties",
+        Mock(return_value=SimpleNamespace(uuid="01234567-89ab-cdef-0123-456789abcdef")),
+    )
+
+    fields = trace_log_utils._format_nvml_process_fields(2)
+
+    pynvml.nvmlDeviceGetHandleByUUID.assert_called_once_with(
+        "GPU-01234567-89ab-cdef-0123-456789abcdef"
+    )
+    pynvml.nvmlDeviceGetComputeRunningProcesses.assert_called_once_with(handle)
+    pynvml.nvmlShutdown.assert_called_once_with()
+    assert fields == (
+        " nvml_status=ok nvml_self_found=1 nvml_self_used=3.00GiB"
+        " nvml_nonself_used=7.00GiB nvml_process_count=3"
+        " nvml_processes=202:5.00GiB,101:3.00GiB,303:2.00GiB"
+    )
+
+
+def test_nvml_process_fields_bound_output_and_report_partial_data(monkeypatch) -> None:
+    gib = 1 << 30
+    processes = [
+        SimpleNamespace(pid=100 + index, usedGpuMemory=(10 - index) * gib) for index in range(10)
+    ]
+    processes.append(SimpleNamespace(pid=999, usedGpuMemory=None))
+    pynvml = SimpleNamespace(
+        nvmlInit=Mock(),
+        nvmlShutdown=Mock(),
+        nvmlDeviceGetHandleByUUID=Mock(return_value=object()),
+        nvmlDeviceGetComputeRunningProcesses=Mock(return_value=processes),
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", pynvml)
+    monkeypatch.setattr(trace_log_utils.os, "getpid", Mock(return_value=100))
+    monkeypatch.setattr(
+        trace_log_utils.torch.cuda,
+        "get_device_properties",
+        Mock(return_value=SimpleNamespace(uuid="GPU-device-uuid")),
+    )
+
+    fields = trace_log_utils._format_nvml_process_fields(0)
+
+    assert "nvml_status=partial" in fields
+    assert "nvml_process_count=10" in fields
+    assert "nvml_processes_omitted=2" in fields
+    assert "nvml_processes_unavailable=1" in fields
+    assert "100:10.00GiB" in fields
+    assert "107:3.00GiB" in fields
+    assert "108:2.00GiB" not in fields
+
+
+def test_nvml_process_fields_report_query_failure_without_raising(monkeypatch) -> None:
+    pynvml = SimpleNamespace(
+        nvmlInit=Mock(side_effect=RuntimeError("NVML unavailable")),
+        nvmlShutdown=Mock(),
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", pynvml)
+
+    fields = trace_log_utils._format_nvml_process_fields(0)
+
+    assert fields == " nvml_status=unavailable nvml_error=RuntimeError"
+    pynvml.nvmlShutdown.assert_not_called()
 
 
 def test_mem_history_is_bounded(monkeypatch) -> None:

--- a/tests/unittest/_torch/test_trace_log_utils.py
+++ b/tests/unittest/_torch/test_trace_log_utils.py
@@ -3,7 +3,16 @@
 
 from unittest.mock import Mock
 
+import pytest
+
 from tensorrt_llm._torch.pyexecutor import trace_log_utils
+
+
+@pytest.fixture(autouse=True)
+def _reset_mem_history():
+    trace_log_utils.reset_mem_history()
+    yield
+    trace_log_utils.reset_mem_history()
 
 
 def _mock_cuda_counters(monkeypatch) -> None:
@@ -40,6 +49,7 @@ def test_mem_snapshot_disabled_makes_no_cuda_calls(monkeypatch) -> None:
     trace_log_utils.log_mem_snapshot("disabled")
 
     assert all(not call.called for call in cuda_calls)
+    assert not trace_log_utils._MEM_HISTORY
 
 
 def test_mem_snapshot_logs_compact_counters(monkeypatch) -> None:
@@ -58,6 +68,8 @@ def test_mem_snapshot_logs_compact_counters(monkeypatch) -> None:
         "device_used=4.00GiB device_free=6.00GiB "
         "device_total=10.00GiB device_gap_estimate=2.00GiB"
     )
+    assert len(trace_log_utils._MEM_HISTORY) == 1
+    assert trace_log_utils._MEM_HISTORY[0][1] == info.call_args.args[0]
 
 
 def test_forced_mem_snapshot_bypasses_gate(monkeypatch) -> None:
@@ -70,6 +82,47 @@ def test_forced_mem_snapshot_bypasses_gate(monkeypatch) -> None:
 
     assert warning.call_count == 1
     assert warning.call_args.args[0].startswith("[mem-profile/oom/model]")
+    assert not trace_log_utils._MEM_HISTORY
+
+
+def test_mem_history_is_bounded(monkeypatch) -> None:
+    monkeypatch.setenv("TLLM_LOG_MEM_PROFILE", "1")
+    monkeypatch.setattr(trace_log_utils.logger, "info", Mock())
+    _mock_cuda_counters(monkeypatch)
+
+    for index in range(trace_log_utils._MEM_HISTORY_CAPACITY + 1):
+        trace_log_utils.log_mem_snapshot(f"stage/{index}")
+
+    assert len(trace_log_utils._MEM_HISTORY) == trace_log_utils._MEM_HISTORY_CAPACITY
+    assert trace_log_utils._MEM_HISTORY[0][1].startswith("[mem-profile/stage/1]")
+    assert trace_log_utils._MEM_HISTORY[-1][1].startswith("[mem-profile/stage/64]")
+
+
+def test_mem_history_logs_capture_age(monkeypatch) -> None:
+    monkeypatch.setenv("TLLM_LOG_MEM_PROFILE", "1")
+    monkeypatch.setattr(trace_log_utils.logger, "rank", 3)
+    monkeypatch.setattr(trace_log_utils.logger, "info", Mock())
+    warning = Mock()
+    monkeypatch.setattr(trace_log_utils.logger, "warning", warning)
+    monkeypatch.setattr(
+        trace_log_utils.time,
+        "monotonic_ns",
+        Mock(side_effect=[1_000_000_000, 3_500_000_000]),
+    )
+    _mock_cuda_counters(monkeypatch)
+
+    trace_log_utils.log_mem_snapshot("stage/model")
+    trace_log_utils.log_mem_history("oom/kv_cache")
+
+    warning.assert_called_once()
+    message = warning.call_args.args[0]
+    assert message.startswith(
+        "[mem-history/oom/kv_cache] index=0 entries=1 "
+        "age_ms=2500.00 snapshot=[mem-profile/stage/model]"
+    )
+    assert "rank=3 device=2" in message
+    assert "torch_reserved=2.00GiB" in message
+    assert "device_gap_estimate=2.00GiB" in message
 
 
 def test_mem_snapshot_collection_failure_does_not_raise(monkeypatch) -> None:

--- a/tests/unittest/_torch/test_trace_log_utils.py
+++ b/tests/unittest/_torch/test_trace_log_utils.py
@@ -59,14 +59,15 @@ def test_mem_snapshot_logs_compact_counters(monkeypatch) -> None:
     monkeypatch.setattr(trace_log_utils.logger, "info", info)
     _mock_cuda_counters(monkeypatch)
 
-    trace_log_utils.log_mem_snapshot("stage/model")
+    trace_log_utils.log_mem_snapshot("stage/model", iter=7, active_requests=2)
 
     assert info.call_args.args[0] == (
         "[mem-profile/stage/model] rank=3 device=2 "
         "torch_alloc=1.00GiB torch_reserved=2.00GiB "
         "torch_alloc_peak=3.00GiB torch_reserved_peak=4.00GiB "
         "device_used=4.00GiB device_free=6.00GiB "
-        "device_total=10.00GiB device_gap_estimate=2.00GiB"
+        "device_total=10.00GiB device_gap_estimate=2.00GiB "
+        "iter=7 active_requests=2"
     )
     assert len(trace_log_utils._MEM_HISTORY) == 1
     assert trace_log_utils._MEM_HISTORY[0][1] == info.call_args.args[0]

--- a/tests/unittest/_torch/test_trace_log_utils.py
+++ b/tests/unittest/_torch/test_trace_log_utils.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+from tensorrt_llm._torch.pyexecutor import trace_log_utils
+
+
+def _mock_cuda_counters(monkeypatch) -> None:
+    gib = 1 << 30
+    monkeypatch.setattr(trace_log_utils.torch.cuda, "current_device", Mock(return_value=2))
+    monkeypatch.setattr(
+        trace_log_utils.torch.cuda, "mem_get_info", Mock(return_value=(6 * gib, 10 * gib))
+    )
+    monkeypatch.setattr(trace_log_utils.torch.cuda, "memory_allocated", Mock(return_value=1 * gib))
+    monkeypatch.setattr(trace_log_utils.torch.cuda, "memory_reserved", Mock(return_value=2 * gib))
+    monkeypatch.setattr(
+        trace_log_utils.torch.cuda, "max_memory_allocated", Mock(return_value=3 * gib)
+    )
+    monkeypatch.setattr(
+        trace_log_utils.torch.cuda, "max_memory_reserved", Mock(return_value=4 * gib)
+    )
+
+
+def test_mem_snapshot_disabled_makes_no_cuda_calls(monkeypatch) -> None:
+    monkeypatch.delenv("TLLM_LOG_MEM_PROFILE", raising=False)
+    cuda_calls = []
+    for name in (
+        "current_device",
+        "mem_get_info",
+        "memory_allocated",
+        "memory_reserved",
+        "max_memory_allocated",
+        "max_memory_reserved",
+    ):
+        call = Mock()
+        monkeypatch.setattr(trace_log_utils.torch.cuda, name, call)
+        cuda_calls.append(call)
+
+    trace_log_utils.log_mem_snapshot("disabled")
+
+    assert all(not call.called for call in cuda_calls)
+
+
+def test_mem_snapshot_logs_compact_counters(monkeypatch) -> None:
+    monkeypatch.setenv("TLLM_LOG_MEM_PROFILE", "1")
+    monkeypatch.setattr(trace_log_utils.logger, "rank", 3)
+    info = Mock()
+    monkeypatch.setattr(trace_log_utils.logger, "info", info)
+    _mock_cuda_counters(monkeypatch)
+
+    trace_log_utils.log_mem_snapshot("stage/model")
+
+    assert info.call_args.args[0] == (
+        "[mem-profile/stage/model] rank=3 device=2 "
+        "torch_alloc=1.00GiB torch_reserved=2.00GiB "
+        "torch_alloc_peak=3.00GiB torch_reserved_peak=4.00GiB "
+        "device_used=4.00GiB device_free=6.00GiB "
+        "device_total=10.00GiB device_gap_estimate=2.00GiB"
+    )
+
+
+def test_forced_mem_snapshot_bypasses_gate(monkeypatch) -> None:
+    monkeypatch.delenv("TLLM_LOG_MEM_PROFILE", raising=False)
+    warning = Mock()
+    monkeypatch.setattr(trace_log_utils.logger, "warning", warning)
+    _mock_cuda_counters(monkeypatch)
+
+    trace_log_utils.log_mem_snapshot("oom/model", force=True)
+
+    assert warning.call_count == 1
+    assert warning.call_args.args[0].startswith("[mem-profile/oom/model]")
+
+
+def test_mem_snapshot_collection_failure_does_not_raise(monkeypatch) -> None:
+    warning = Mock()
+    monkeypatch.setattr(trace_log_utils.logger, "warning", warning)
+    monkeypatch.setattr(
+        trace_log_utils.torch.cuda,
+        "current_device",
+        Mock(side_effect=RuntimeError("CUDA unavailable")),
+    )
+
+    trace_log_utils.log_mem_snapshot("oom/model", force=True)
+
+    warning.assert_called_once_with("[mem-profile/oom/model] snapshot unavailable: RuntimeError")


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This PR adds lightweight GPU memory diagnostics to the PyTorch executor to make CUDA OOM failures easier to understand. It records memory snapshots during startup, warmup, and serving, retains a bounded history of recent snapshots, and dumps that history when an OOM is caught. Each snapshot compares PyTorch allocator usage with whole-device memory usage. When profiling is enabled, OOM snapshots also use NVML to report the memory owned by the current process and other compute processes on the same GPU. The diagnostics are best-effort, disabled by default, and do not modify memory state or replace the original exception.

Example OOM fields include:
```
torch_alloc
torch_reserved
torch_alloc_peak
torch_reserved_peak
device_used
device_free
device_total
device_gap_estimate
nvml_self_used
nvml_nonself_used
nvml_processes
```

### Usage

Enable profiling with:
```
TLLM_LOG_MEM_PROFILE=1
```
The executor will then emit startup and warmup snapshots, sample runtime memory at most once per second while iterations are running, and print the recent snapshot history together with NVML process information if a CUDA OOM occurs.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
Added unit tests for snapshot collection, disabled-path behavior, bounded history, runtime throttling, OOM reporting, NVML UUID mapping, process memory accounting, and failure handling. The implementation was also validated on a 4-GPU GB200 node with both a healthy serving run and a controlled foreign-process OOM. The OOM report identified the expected holder PID on every GPU, separated self and non-self memory usage, and preserved the original CUDA OOM.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
