### PR TITLE
[https://nvbugs/6474894][fix] Harden fused RMSNorm+NVFP4-quant: smem bound and large-N fallback

### DIFF
--- a/cpp/tensorrt_llm/thop/rmsNormFp4Quant.cpp
+++ b/cpp/tensorrt_llm/thop/rmsNormFp4Quant.cpp
@@ -74,6 +74,14 @@ std::vector<at::Tensor> fused_add_rmsnorm_fp4_quantize(at::Tensor const& hidden_
     auto const k = input_shape[rank - 1];
     int64_t const sf_vec_size = 16;
     TORCH_CHECK(k % sf_vec_size == 0, "hidden_size must be divisible by 16");
+    // Rows larger than one CTA-pass are staged in dynamic shared memory
+    // (rmsNormFp4QuantKernels.cu); without a cudaFuncSetAttribute opt-in the
+    // launch is limited to the default 48KB. Reject with a clear error instead
+    // of failing inside cudaLaunchKernelEx; callers must use the unfused path
+    // (see RMSNorm._unfused_nvfp4_quant).
+    TORCH_CHECK(k * hidden_states.element_size() <= 46 * 1024,
+        "hidden_size too large for the fused RMSNorm+NVFP4 kernel's shared-memory staging: ", k,
+        " elements; use the unfused RMSNorm + fp4_quantize path");
 
     std::vector<int64_t> quant_shape(input_shape.begin(), input_shape.end());
     quant_shape[rank - 1] = k / 2;
@@ -181,6 +189,14 @@ std::vector<at::Tensor> fused_rmsnorm_fp4_quantize(at::Tensor const& hidden_stat
     auto const k = input_shape[rank - 1];
     int64_t const sf_vec_size = 16;
     TORCH_CHECK(k % sf_vec_size == 0, "hidden_size must be divisible by 16");
+    // Rows larger than one CTA-pass are staged in dynamic shared memory
+    // (rmsNormFp4QuantKernels.cu); without a cudaFuncSetAttribute opt-in the
+    // launch is limited to the default 48KB. Reject with a clear error instead
+    // of failing inside cudaLaunchKernelEx; callers must use the unfused path
+    // (see RMSNorm._unfused_nvfp4_quant).
+    TORCH_CHECK(k * hidden_states.element_size() <= 46 * 1024,
+        "hidden_size too large for the fused RMSNorm+NVFP4 kernel's shared-memory staging: ", k,
+        " elements; use the unfused RMSNorm + fp4_quantize path");
     // Element stride between consecutive logical rows. For a contiguous tensor
     // this equals k, so input_row_stride==0 (packed) and behavior is identical.
     int64_t const row_stride = hidden_states.stride(rank - 2);

--- a/tensorrt_llm/_torch/modules/rms_norm.py
+++ b/tensorrt_llm/_torch/modules/rms_norm.py
@@ -29,6 +29,11 @@ from ..utils import Fp4QuantizedTensor, is_nvfp4_marlin_enabled
 # (cpp/tensorrt_llm/thop/fusedAddRMSNormQuant.cpp).
 _WS_MIN_N = 2048
 _WS_MAX_N = 16384
+# The reduce_fusion kernels stage one row in dynamic shared memory; without a
+# cudaFuncSetAttribute opt-in the launch is limited to the default 48KB (minus
+# the kernel's small static buffers). Stay safely below it and fall back to
+# the unfused path for larger hidden sizes.
+_REDUCE_FUSION_MAX_N_BYTES = 46 * 1024
 # Row-count crossover for the layer-boundary add+RMSNorm+quant edge: below this
 # the one-CTA-per-row reduce_fusion kernel (fused_add_rmsnorm_fp4_quantize) is
 # faster; at/above it the warp-specialized kernel's DMA-ahead pipeline wins.
@@ -264,10 +269,18 @@ class RMSNorm(nn.Module):
             return self._fused_nvfp4_quant_ws(hidden_states, residual, sf_scale,
                                               return_norm_out)
 
+        # The reduce_fusion kernels stage one row in dynamic shared memory;
+        # hidden sizes beyond the default launch limit cannot use them (see
+        # _REDUCE_FUSION_MAX_N_BYTES). Take a same-arity unfused slow path.
+        n_bytes = hidden_states.shape[-1] * hidden_states.element_size()
+        if n_bytes > _REDUCE_FUSION_MAX_N_BYTES:
+            return self._unfused_nvfp4_quant(hidden_states, residual, sf_scale,
+                                             return_norm_out)
+
         if residual is not None:
             results = torch.ops.trtllm.fused_add_rmsnorm_fp4_quantize(
-                hidden_states,
-                residual,
+                hidden_states.contiguous(),
+                residual.contiguous(),
                 self.weight,
                 sf_scale,
                 float(self.variance_epsilon),
@@ -352,6 +365,60 @@ class RMSNorm(nn.Module):
         if self.return_hp_output:
             outputs.append(bf16_hs)
         return tuple(outputs)
+
+    def _unfused_nvfp4_quant(
+        self,
+        hidden_states: torch.Tensor,
+        residual: Optional[torch.Tensor],
+        sf_scale: torch.Tensor,
+        return_norm_out: bool,
+    ):
+        """Unfused slow path with the same return arity as _fused_nvfp4_quant,
+        for hidden sizes the fused kernels cannot launch (see
+        _REDUCE_FUSION_MAX_N_BYTES): the production unfused kernels — the
+        flashinfer (add+)RMSNorm forward() itself uses, then the standalone
+        fp4_quantize the fusion replaces."""
+        use_flashinfer = IS_FLASHINFER_AVAILABLE and hidden_states.dtype in (
+            torch.float16, torch.bfloat16)
+        if use_flashinfer:
+            from ..custom_ops import (flashinfer_fused_add_rmsnorm,
+                                      flashinfer_rmsnorm)
+            if residual is not None:
+                # flashinfer_fused_add_rmsnorm mutates both args in place
+                # (input -> normed, residual -> input+residual); clone so the
+                # caller's tensors keep the no-mutation contract of the fused
+                # path.
+                normed = hidden_states.contiguous().clone()
+                residual_out = residual.contiguous().clone()
+                flashinfer_fused_add_rmsnorm(normed, residual_out, self.weight,
+                                             self.variance_epsilon)
+            else:
+                residual_out = hidden_states
+                normed = flashinfer_rmsnorm(hidden_states.contiguous(),
+                                            self.weight, self.variance_epsilon)
+        else:
+            if residual is not None:
+                residual_out = (hidden_states + residual).contiguous()
+            else:
+                residual_out = hidden_states
+            normed = residual_out.to(torch.float32)
+            variance = normed.pow(2).mean(-1, keepdim=True)
+            normed = normed * torch.rsqrt(variance + self.variance_epsilon)
+            normed = (self.weight * normed.to(hidden_states.dtype)).contiguous()
+
+        act_fp4, act_sf = torch.ops.trtllm.fp4_quantize(normed, sf_scale, 16,
+                                                        False)
+        want_norm = return_norm_out or self.return_hp_output
+        norm_out = normed if want_norm else None
+        fp4 = Fp4QuantizedTensor(act_fp4,
+                                 act_sf,
+                                 unquantized_hidden_states=norm_out)
+        if residual is not None:
+            outputs = [fp4, residual_out]
+            if self.return_hp_output:
+                outputs.append(norm_out)
+            return tuple(outputs)
+        return (fp4, norm_out) if return_norm_out else fp4
 
     def skip_forward(
         self,

--- a/tests/unittest/_torch/modules/test_fused_rmsnorm_fp4_quantize.py
+++ b/tests/unittest/_torch/modules/test_fused_rmsnorm_fp4_quantize.py
@@ -37,7 +37,7 @@ import pytest
 import torch
 
 from tensorrt_llm._torch.flashinfer_utils import IS_FLASHINFER_AVAILABLE
-from tensorrt_llm._torch.utils import ceil_div, pad_up, unswizzle_sf
+from tensorrt_llm._torch.utils import Fp4QuantizedTensor, ceil_div, pad_up, unswizzle_sf
 from tests.unittest.utils.util import getSMVersion
 
 
@@ -211,7 +211,7 @@ def assert_fp4_bitexact_from_norm(
 # --------------------------------------------------------------------------- #
 @skip_unless_add_rmsnorm
 @pytest.mark.parametrize("m", [1, 16, 64, 128])
-@pytest.mark.parametrize("n", [32, 128, 512, 7168])
+@pytest.mark.parametrize("n", [32, 128, 512, 7168, 12288])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_fused_add_rmsnorm_fp4_quantize_vs_separate(m, n, dtype):
     torch.manual_seed(42)
@@ -464,3 +464,45 @@ def test_rmsnorm_ws_kernel_gate(m, n, residual, contiguous, expect_ws):
         hs = torch.empty((m, n + 32), dtype=torch.bfloat16, device="meta")[:, :n]
         assert not hs.is_contiguous()
     assert norm._ws_kernel_eligible(hs, res) is expect_ws
+
+
+# --------------------------------------------------------------------------- #
+# Oversized hidden dim: fused kernels reject; RMSNorm falls back unfused.      #
+# --------------------------------------------------------------------------- #
+_HUGE_N = 24576  # > 46KB/2B of bf16 -> beyond the kernels' smem staging limit
+
+
+@skip_unless_add_rmsnorm
+def test_fused_ops_reject_oversized_hidden():
+    m = 4
+    hs = torch.randn(m, _HUGE_N, dtype=torch.bfloat16, device="cuda")
+    res = torch.randn_like(hs)
+    w = torch.randn(_HUGE_N, dtype=torch.bfloat16, device="cuda")
+    sf_scale = torch.ones(1, dtype=torch.float32, device="cuda")
+    with pytest.raises(RuntimeError, match="shared-memory staging"):
+        torch.ops.trtllm.fused_add_rmsnorm_fp4_quantize(hs, res, w, sf_scale, 1e-6, False)
+    with pytest.raises(RuntimeError, match="shared-memory staging"):
+        torch.ops.trtllm.fused_rmsnorm_fp4_quantize(hs, w, sf_scale, 1e-6, False)
+
+
+@skip_unless_add_rmsnorm
+def test_rmsnorm_oversized_hidden_falls_back_unfused():
+    from tensorrt_llm._torch.modules.rms_norm import RMSNorm
+
+    m = 4
+    norm = RMSNorm(
+        hidden_size=_HUGE_N, eps=1e-6, dtype=torch.bfloat16, device="cuda", quantize_type="nvfp4"
+    )
+    hs = torch.randn(m, _HUGE_N, dtype=torch.bfloat16, device="cuda")
+    res = torch.randn_like(hs)
+    norm_ref = rms_norm_ref(
+        (hs.float() + res.float()).to(torch.bfloat16), norm.weight, norm.variance_epsilon
+    )
+    norm.nvfp4_scale = make_sf_scale(norm_ref)
+
+    fp4, residual_out = norm(hs, res)
+    assert isinstance(fp4, Fp4QuantizedTensor)
+    assert torch.equal(residual_out, (hs + res))
+    fp4_ref, _ = fp4_quantize_ref(norm_ref, norm.nvfp4_scale)
+    match = (fp4.fp4_tensor.view(torch.uint8) == fp4_ref.view(torch.uint8)).float().mean().item()
+    assert match > _FP4_MATCH_THRESHOLD


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards for oversized hidden dimensions that could exceed fused FP4 quantization memory limits.
  * Automatically falls back to an unfused RMSNorm and FP4 quantization path when necessary.
  * Added an option to disable fused NVFP4 quantization through an environment setting.
  * Preserved quantized output behavior and improved coverage for large hidden dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Hardening follow-ups from the NVBug 6474894/6473374 triage of the fused (add+)RMSNorm+NVFP4-quantize path:

- The reduce_fusion kernels stage one row in dynamic shared memory; for hidden sizes beyond the default 48KB launch limit (bf16 hidden >= ~23K) the launch failed with an opaque cudaLaunchKernelEx "invalid argument". Both thop ops now reject such shapes with a clear TORCH_CHECK, and RMSNorm falls back to a same-arity unfused slow path (plain RMSNorm + standalone fp4_quantize) so oversized models keep working.
- Force contiguity on the fused-add branch inputs (defensive; the thop already rejects non-contiguous tensors).
- Tests: extend the fused_add matrix to n=12288 (multi-CTA-pass region was previously uncovered above 7168), and add tests for the oversized-hidden rejection, the unfused fallback, and the kill switch.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
