### PR TITLE
[https://nvbugs/6468821][infra] Split slow B300 attention unit tests

### DIFF
--- a/tests/integration/test_lists/test-db/l0_b300.yml
+++ b/tests/integration/test_lists/test-db/l0_b300.yml
@@ -16,11 +16,7 @@ l0_b300:
       backend: pytorch
   tests:
   # ------------- PyTorch tests ---------------
-  - >-
-    unittest/_torch/attention
-    --ignore=unittest/_torch/attention/sparse/test_cute_dsl_fp8_paged_mqa_logits.py
-    --ignore=unittest/_torch/attention/sparse/test_cute_dsl_fp4_paged_mqa_logits.py
-    --ignore=unittest/_torch/attention/sparse/test_cute_dsl_gvr_topk_decode.py
+  - unittest/_torch/attention --ignore=unittest/_torch/attention/sparse/test_cute_dsl_fp8_paged_mqa_logits.py --ignore=unittest/_torch/attention/sparse/test_cute_dsl_fp4_paged_mqa_logits.py --ignore=unittest/_torch/attention/sparse/test_cute_dsl_gvr_topk_decode.py
   - unittest/_torch/attention/sparse/test_cute_dsl_fp8_paged_mqa_logits.py
   - unittest/_torch/attention/sparse/test_cute_dsl_fp4_paged_mqa_logits.py
   - unittest/_torch/attention/sparse/test_cute_dsl_gvr_topk_decode.py

--- a/tests/integration/test_lists/test-db/l0_b300.yml
+++ b/tests/integration/test_lists/test-db/l0_b300.yml
@@ -16,7 +16,14 @@ l0_b300:
       backend: pytorch
   tests:
   # ------------- PyTorch tests ---------------
-  - unittest/_torch/attention # 200s
+  - >-
+    unittest/_torch/attention
+    --ignore=unittest/_torch/attention/sparse/test_cute_dsl_fp8_paged_mqa_logits.py
+    --ignore=unittest/_torch/attention/sparse/test_cute_dsl_fp4_paged_mqa_logits.py
+    --ignore=unittest/_torch/attention/sparse/test_cute_dsl_gvr_topk_decode.py
+  - unittest/_torch/attention/sparse/test_cute_dsl_fp8_paged_mqa_logits.py
+  - unittest/_torch/attention/sparse/test_cute_dsl_fp4_paged_mqa_logits.py
+  - unittest/_torch/attention/sparse/test_cute_dsl_gvr_topk_decode.py
   - unittest/_torch/thop/parallel TIMEOUT (90)
   - unittest/_torch/thop/serial
   - unittest/_torch/executor # 250s


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `tests/integration/test_lists/test-db/l0_b300.yml` to restructure the `l0_b300` `pre_merge` PyTorch attention selection: `unittest/_torch/attention` now excludes three slow CuTe DSL sparse attention tests via `--ignore`, and the excluded sparse tests are then added back as standalone list entries.
- Kept the change scoped to the intended `l0_b300` pre-merge PyTorch test list to preserve coverage while reducing aggregate attention runtime and enabling independent Jenkins sharding of the slow cases.
- Config remains consistent with the expected test-list schema; YAML/test-list validation passed via pre-commit. No API, dependency, or public entity changes were introduced.

## QA Engineer Review

- Modified: `tests/integration/test_lists/test-db/l0_b300.yml`
  - Removed the three following sparse CuTe DSL attention tests from the aggregate `unittest/_torch/attention` run by adding `--ignore` exclusions:
    - `unittest/_torch/attention/sparse/test_cute_dsl_fp8_paged_mqa_logits.py`
    - `unittest/_torch/attention/sparse/test_cute_dsl_fp4_paged_mqa_logits.py`
    - `unittest/_torch/attention/sparse/test_cute_dsl_gvr_topk_decode.py`
  - Added the same three tests back as separate standalone entries in the list.
- Verdict: **needs follow-up** (CBTS coverage data is unavailable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Split the three slow CuTe DSL attention test files out of the aggregate B300 attention entry. The aggregate entry ignores those files, and each file remains covered through a standalone CI entry so Jenkins can shard them independently.

The measured serial file profile attributed 2,721 of 4,257 seconds to these three files. Separating them reduces the aggregate attention invocation while preserving test coverage.

## Test Coverage

- Parsed l0_b300.yml and confirmed four distinct attention CI entries.
- Confirmed all three standalone test paths exist.
- Ran pre-commit against l0_b300.yml; all applicable hooks passed, including YAML and test-list validation.

## PR Checklist

- PR description clearly explains what and why.
- PR follows the TRT-LLM coding guidelines to the best of my knowledge.
- Existing tests remain covered through standalone CI entries.
- No API changes are introduced.
- No new dependencies are introduced.
- CODEOWNERS changes are not required.
- Documentation and architecture updates are not required.
- [x] Please check this after reviewing the above items as appropriate for this PR.