### PR TITLE
[TRTLLM-14551][perf] avoid GDN state reset host synchronization

### DIFF
--- a/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
@@ -89,6 +89,70 @@ def _extract_gdn_extra_attrs(layer_idx: str):
     return metadata, gdn_layer, extra_attrs.get("spec_metadata", None)
 
 
+@triton.jit
+def _reset_gdn_states_kernel(
+    ssm_states,
+    conv_states,
+    state_indices,
+    has_initial_states,
+    ssm_state_stride,
+    conv_state_stride,
+    NUM_CACHE_LINES: tl.constexpr,
+    SSM_STATE_SIZE: tl.constexpr,
+    CONV_STATE_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    request_idx = tl.program_id(0)
+    offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    state_idx = tl.load(state_indices + request_idx).to(tl.int64)
+    needs_reset = ~tl.load(has_initial_states + request_idx).to(tl.int1)
+    valid_state = (state_idx >= 0) & (state_idx < NUM_CACHE_LINES)
+    ssm_row_offset = state_idx * ssm_state_stride.to(tl.int64)
+    conv_row_offset = state_idx * conv_state_stride.to(tl.int64)
+
+    tl.store(
+        ssm_states + ssm_row_offset + offsets,
+        0.0,
+        mask=needs_reset & valid_state & (offsets < SSM_STATE_SIZE),
+    )
+    tl.store(
+        conv_states + conv_row_offset + offsets,
+        0.0,
+        mask=needs_reset & valid_state & (offsets < CONV_STATE_SIZE),
+    )
+
+
+def _reset_gdn_states(
+    ssm_states: torch.Tensor,
+    conv_states: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_states: torch.Tensor,
+) -> None:
+    num_requests = state_indices.shape[0]
+    if num_requests == 0:
+        return
+
+    ssm_state_size = ssm_states.numel() // ssm_states.shape[0]
+    conv_state_size = conv_states.numel() // conv_states.shape[0]
+    block_size = 256
+    grid = (
+        num_requests,
+        triton.cdiv(max(ssm_state_size, conv_state_size), block_size),
+    )
+    _reset_gdn_states_kernel[grid](
+        ssm_states,
+        conv_states,
+        state_indices,
+        has_initial_states,
+        ssm_states.stride(0),
+        conv_states.stride(0),
+        ssm_states.shape[0],
+        ssm_state_size,
+        conv_state_size,
+        block_size,
+    )
+
+
 @torch.library.custom_op("trtllm::gdn_custom_op_inplace", mutates_args=("output",))
 def gdn_custom_op_inplace(
     mixed_qkv: torch.Tensor,
@@ -1038,11 +1102,11 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         if num_prefills > 0:
             # PyExecutor guarantees prefill requests are placed before decode requests
             has_initial_states_p = has_initial_states[:num_prefills]
-            ssm_states[state_indices_p[~has_initial_states_p]] = torch.zeros(
-                (), dtype=ssm_states.dtype, device=ssm_states.device
-            )
-            conv_states[state_indices_p[~has_initial_states_p]] = torch.zeros(
-                (), dtype=conv_states.dtype, device=conv_states.device
+            _reset_gdn_states(
+                ssm_states,
+                conv_states,
+                state_indices_p,
+                has_initial_states_p,
             )
 
         is_target_verify = (

--- a/tests/unittest/_torch/modules/mamba/test_gdn_kernel_optimizations.py
+++ b/tests/unittest/_torch/modules/mamba/test_gdn_kernel_optimizations.py
@@ -481,6 +481,40 @@ def test_pack_gdn_decode_qkv(
 # ---- Tests for the GDN compile boundary and derived state ----
 
 
+@skip_no_cuda
+def test_reset_gdn_states_preserves_initialized_and_invalid_slots():
+    from tensorrt_llm._torch.modules.mamba.gdn_mixer import _reset_gdn_states
+
+    num_slots = 4
+    ssm_state_size = 6
+    conv_state_size = 8
+    state_pool = (
+        torch.arange(
+            num_slots * (ssm_state_size + conv_state_size),
+            device="cuda",
+            dtype=torch.float32,
+        )
+        .to(torch.bfloat16)
+        .reshape(num_slots, -1)
+    )
+    state_pool_before = state_pool.clone()
+    ssm_states = state_pool[:, :ssm_state_size].view(num_slots, 2, 3)
+    conv_states = state_pool[:, ssm_state_size:].view(num_slots, 2, 4)
+    state_indices = torch.tensor([1, 3, -1], device="cuda", dtype=torch.int32)
+    has_initial_states = torch.tensor([False, True, False], device="cuda", dtype=torch.bool)
+
+    _reset_gdn_states(
+        ssm_states,
+        conv_states,
+        state_indices,
+        has_initial_states,
+    )
+
+    torch.testing.assert_close(state_pool[1], torch.zeros_like(state_pool[1]))
+    for state_idx in (0, 2, 3):
+        torch.testing.assert_close(state_pool[state_idx], state_pool_before[state_idx])
+
+
 def test_gdn_custom_op_forwards_split_inputs(monkeypatch):
     """The compile boundary consumes split inputs and mutates its output."""
     import tensorrt_llm._torch.modules.mamba.gdn_mixer as gdn_mixer


### PR DESCRIPTION
GDN prefill reset currently selects cache slots with a CUDA boolean mask before assigning zeros. The boolean-indexed selection has a data-dependent output shape, which forces the host to obtain the selected element count and introduces a stream synchronization for every GDN layer.

Replace the two indexed assignments with a fixed-shape Triton launch. Each program reads the request's cache index and initialization flag on device, validates the cache slot, and clears both the SSM and convolution state rows in one kernel. Requests with initialized state or invalid sentinel indices remain untouched.

Add a CUDA unit test covering reset slots, preserved initialized slots, untouched unrelated slots, and the negative invalid-index sentinel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Replaced CUDA masked host-side/state reset logic in `Qwen3NextGatedDeltaNet.forward_core` with an on-device fixed-shape Triton kernel reset path:
  - Computes `state_indices = mamba_metadata.state_indices[: num_prefills + num_decodes]`, splits into `state_indices_p` (prefills) and decode portion.
  - When `num_prefills > 0`, calls `_reset_gdn_states(ssm_states, conv_states, state_indices_p, has_initial_states_p)` where `has_initial_states_p = mamba_metadata.has_initial_states[:num_prefills]`.
- Added Triton JIT kernel `_reset_gdn_states_kernel` and wrapper `_reset_gdn_states` in `tensorrt_llm/_torch/modules/mamba/gdn_mixer.py` to clear GDN state cache rows without host synchronization:
  - For each `request_idx`:
    - Loads `state_idx = state_indices[request_idx]` and `has_initial_states[request_idx]`.
    - Computes `needs_reset = ~has_initial_states` (reset only when initial state is not present).
    - Validates `state_idx` with `valid_state = (state_idx >= 0) & (state_idx < NUM_CACHE_LINES)` so sentinel `-1` is treated as invalid.
    - Zeros `ssm_states` and `conv_states` rows via masked `tl.store`:
      - Store mask includes `needs_reset & valid_state`
      - Additionally bounds by per-buffer sizes: `(offsets < SSM_STATE_SIZE)` / `(offsets < CONV_STATE_SIZE)`.
  - Wrapper `_reset_gdn_states`:
    - Derives `ssm_state_size = ssm_states.numel() // ssm_states.shape[0]` and `conv_state_size` similarly.
    - Launches 2D grid `(num_requests, triton.cdiv(max(ssm_state_size, conv_state_size), block_size))` with `block_size=256`.
    - Passes row addressing strides `ssm_states.stride(0)` / `conv_states.stride(0)` and `NUM_CACHE_LINES = ssm_states.shape[0]`.
- CI note from comments: L0 merge-request pipeline failed on multiple reruns, with NVIDIA team requesting review/fixes and rerun; no code changes beyond the reset-kernel/test are reflected here.

## QA Engineer Review

- Added CUDA-only unit test `test_reset_gdn_states_preserves_initialized_and_invalid_slots` in `tests/unittest/_torch/modules/mamba/test_gdn_kernel_optimizations.py`.
  - Coverage assertions:
    - Resets targeted non-initialized slot (`state_indices=[1,...]`, `has_initial_states=False` → `state_pool[1]` becomes zero).
    - Preserves initialized slot (`state_indices=[3,...]`, `has_initial_states=True` → `state_pool[3]` unchanged).
    - Preserves unrelated slots (`state_pool[0]`, `state_pool[2]` unchanged).
    - Handles invalid sentinel index (`state_indices includes -1` → no reset performed).
  - Verdict: needs follow-up (no verification that this unit test is included in `tests/integration/test_lists/` / test-db / qa coverage inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
