### PR TITLE
[https://nvbugs/6482576][fix] Fall back to disagg_request_id in Python NIXL decode receiver

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -1494,13 +1494,23 @@ class Receiver(ReceiverBase):
 
     def _build_recv_req_info(self, task: KVRecvTask) -> RecvReqInfo:
         self_ri = self._registrar.self_rank_info
-        assert task._params.ctx_request_id is not None, (
-            f"ctx_request_id is None for task unique_rid={task._unique_rid}"
-        )
         assert task._unique_rid is not None, "KVRecvTask unique_rid is None"
+        # Some requests arrive with ctx_request_id None while disagg_request_id
+        # is set; disagg_request_id is the receive-session key, so fall back to
+        # it instead of failing here (nvbugs/6482576).
+        sender_req_id = task._params.ctx_request_id
+        if sender_req_id is None:
+            sender_req_id = task._params.disagg_request_id
+        if sender_req_id is None:
+            # Not an assert: must survive python -O so a None id never reaches
+            # RecvReqInfo.sender_req_id / the wire.
+            raise ValueError(
+                "both ctx_request_id and disagg_request_id are None for task "
+                f"unique_rid={task._unique_rid}"
+            )
         # Receiver's cached prefix is implicit in block_ids size; sender derives dst_start.
         return RecvReqInfo(
-            sender_req_id=task._params.ctx_request_id,
+            sender_req_id=sender_req_id,
             instance_name=self_ri.instance_name,
             instance_rank=self_ri.instance_rank,
             block_ids_per_layer_groups=task._kv_slice.block_ids_per_layer_groups,

--- a/tests/unittest/disaggregated/test_request_id.py
+++ b/tests/unittest/disaggregated/test_request_id.py
@@ -1,9 +1,13 @@
-"""Tests for _get_request_id in ExecutorRequestQueue.
+"""Tests for disaggregated request-id handling.
 
-Demonstrates the known bug: disagg_request_id=0 is falsy and gets skipped.
+Covers ExecutorRequestQueue._get_request_id and the Receiver's sender_req_id
+fallback in the native KV transceiver (nvbugs/6482576).
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 
 def _make_queue(max_batch_size=128):
@@ -56,3 +60,48 @@ def test_get_request_id_zero_bug():
     # BUG: should return 0, but returns auto-incremented id instead
     assert rid != 0, "If this fails, the bug has been fixed — update this test"
     assert rid == 128  # falls through to auto-increment
+
+
+# --------------------------------------------------------------------------- #
+# Receiver._build_recv_req_info: sender_req_id fallback (nvbugs/6482576)
+# --------------------------------------------------------------------------- #
+def _make_recv_task(ctx_request_id, disagg_request_id, unique_rid=123):
+    """Minimal stand-in for KVRecvTask with only the fields the method reads."""
+    return SimpleNamespace(
+        _params=SimpleNamespace(ctx_request_id=ctx_request_id, disagg_request_id=disagg_request_id),
+        _unique_rid=unique_rid,
+        _kv_slice=SimpleNamespace(block_ids_per_layer_groups=[], mamba_state_index=None),
+        _aux_slot=None,
+        slice_id=0,
+    )
+
+
+def _build_recv_req_info(tfr, task):
+    """Call the unbound Receiver method against a mocked registrar."""
+    recv_self = SimpleNamespace(
+        _registrar=SimpleNamespace(
+            self_rank_info=SimpleNamespace(instance_name="gen-0", instance_rank=0)
+        )
+    )
+    return tfr.Receiver._build_recv_req_info(recv_self, task)
+
+
+def test_build_recv_req_info_prefers_ctx_request_id():
+    """Normal disagg flow: ctx_request_id keys the sender's TxSession."""
+    tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
+    info = _build_recv_req_info(tfr, _make_recv_task(ctx_request_id=7, disagg_request_id=99))
+    assert info.sender_req_id == 7
+
+
+def test_build_recv_req_info_falls_back_to_disagg_request_id():
+    """nvbugs/6482576: fall back to disagg_request_id when ctx_request_id is None."""
+    tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
+    info = _build_recv_req_info(tfr, _make_recv_task(ctx_request_id=None, disagg_request_id=99))
+    assert info.sender_req_id == 99
+
+
+def test_build_recv_req_info_both_ids_none_raises():
+    """Raise when neither request id is available (survives python -O)."""
+    tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
+    with pytest.raises(ValueError):
+        _build_recv_req_info(tfr, _make_recv_task(ctx_request_id=None, disagg_request_id=None))


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This pull request improves the handling of request IDs in the disaggregated receiver logic and adds new tests to ensure correct fallback behavior when `ctx_request_id` is missing. The changes address a known bug (nvbugs/6482576) where the receiver could crash if `ctx_request_id` is `None`, by falling back to `disagg_request_id` instead. Additionally, tests are updated and expanded to cover these scenarios.

**Bug fix and fallback logic:**
- Modified `_build_recv_req_info` in `transfer.py` to fall back to `disagg_request_id` when `ctx_request_id` is `None`, preventing receiver crashes on certain requests. An assertion ensures at least one ID is present.

**Test improvements:**
- Updated the test module docstring and added new tests in `test_request_id.py` to verify the receiver's fallback logic and assertion for missing IDs. [[1]](diffhunk://#diff-270342a1c42c633ac5f958e820da793f658770f397c8892b23b2dc4dbaad5e62L1-R11) [[2]](diffhunk://#diff-270342a1c42c633ac5f958e820da793f658770f397c8892b23b2dc4dbaad5e62R63-R107)

These changes make the receiver more robust and ensure test coverage for the new behavior.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review
- Fixed `Receiver._build_recv_req_info` sender request-id handling for disaggregated (NIXL decode) receiver flows by preferring `task._params.ctx_request_id` and falling back to `task._params.disagg_request_id` when `ctx_request_id` is `None` (nvbugs/6482576).
- Replaced the prior `ctx_request_id` non-`None` assertion with explicit error handling: if both `ctx_request_id` and `disagg_request_id` are `None`, the code now raises `ValueError` to prevent `None` from reaching `RecvReqInfo.sender_req_id`/the wire (still keeps `task._unique_rid` non-`None` assertion).
- No public API/config changes were made; no updates were made to test-list/config/waive files.

## QA Engineer Review
- Test changes in `tests/unittest/disaggregated/test_request_id.py`:
  - Added tests:
    - `test_build_recv_req_info_prefers_ctx_request_id`
    - `test_build_recv_req_info_falls_back_to_disagg_request_id`
    - `test_build_recv_req_info_both_ids_none_raises`
  - Added local helpers to construct a minimal receive-task and exercise `Receiver._build_recv_req_info` as an unbound method with a mocked registrar.
- Integration/CI coverage lists (`tests/integration/test_lists/`, `test-db/`, `qa/`, `waives.txt`) were not updated since this is unit-test coverage only.
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->