### PR TITLE
[https://nvbugs/6329052][fix] Skip DeepSeek-V3-Lite disagg conditional test pre-Hopper

### DIFF
--- a/tests/integration/defs/disaggregated/test_workers.py
+++ b/tests/integration/defs/disaggregated/test_workers.py
@@ -667,6 +667,11 @@ def test_workers_conditional_disaggregation(disaggregated_test_root,
         asyncio.run(tester.test_multi_round_request(prompts))
 
 
+@pytest.mark.skipif(
+    get_sm_version() < 90,
+    reason="DeepSeek-V3-Lite MLA disaggregation is not supported pre-Hopper "
+    "(SM<90): L40S OOMs on the full weights and A100/SM80 lacks MLA FMHA "
+    "kernels. https://nvbugs/6329052")
 @pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-bf16'],
                          indirect=True)
 def test_workers_conditional_disaggregation_deepseek_v3_lite_bf16(


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This pull request updates the conditional disaggregation test for DeepSeek-V3-Lite-bf16 to ensure it only runs on supported hardware. Specifically, it adds a version check to skip the test on older GPUs that lack required features, and removes redundant waivers from the test waiver list.

Test logic improvements:

* Added a `@pytest.mark.skipif` decorator to `test_workers_conditional_disaggregation_deepseek_v3_lite_bf16` in `test_workers.py` to skip the test for SM versions < 90, with a clear reason and bug reference. This prevents failures on unsupported hardware.

Test waiver list cleanup:

* Removed waivers for `test_workers_conditional_disaggregation_deepseek_v3_lite_bf16` from `tests/integration/test_lists/waives.txt` for both A100 and L40S platforms, since the new skip logic makes them unnecessary [[1]](diffhunk://#diff-621bd2af82a3b97c7a5948368d36c14582ffdf73361deb7f42d2ff395b22167eL209) [[2]](diffhunk://#diff-621bd2af82a3b97c7a5948368d36c14582ffdf73361deb7f42d2ff395b22167eL324).

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**
- Added a `pytest.mark.skipif` for DeepSeek-V3-Lite BF16 conditional disaggregation on GPUs with SM versions below 90.
- The condition correctly excludes pre-Hopper hardware due to insufficient memory or unavailable MLA FMHA support while retaining Hopper and Blackwell coverage.
- Removed the corresponding A100 and L40S waivers.
- No API, performance, error-handling, or configuration inconsistencies identified.

**QA Engineer Review**
- Modified the DeepSeek-V3-Lite BF16 conditional disaggregation test.
- The test is covered by the existing integration test configuration; A100 and L40S waiver entries were removed.
- Verdict: sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->