### PR TITLE
[https://nvbugs/6442074][fix] Rename MTPEagleDynamicTreeWorker.forward to _forward_impl

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
+++ b/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
@@ -636,7 +636,7 @@ class MTPEagleDynamicTreeWorker(MTPEagleWorker):
     # Top-level forward                                                   #
     # ------------------------------------------------------------------ #
     @nvtx_range("mtp_dyn.forward")
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,


### PR DESCRIPTION
## Summary
- Fix an import-time `TypeError` on current main: `MTPEagleDynamicTreeWorker` (merged in #15582) overrides `SpecWorkerBase.forward`, which is rejected by the `__init_subclass__` guard added in #16382 (https://nvbugs/6442074). Since `speculative/utils.py` imports `mtp_dynamic_tree` at module level, any import of the PyTorch backend fails.
- #15582's CI ran before the guard landed, so this semantic conflict only surfaced after merge.

## Changes
- `tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py`: rename the `forward` override to `_forward_impl` per the guard's contract (1 line). `SpecWorkerBase.forward` now wraps it with the guaranteed spec-dec attn-metadata cleanup, same as `Eagle3OneModelDynamicTreeWorker`.

## Test plan
- [x] Reproduced the failure on main tip: `python -c "import tensorrt_llm._torch.speculative.utils"` raises the guard TypeError
- [x] Verified the same import passes the class-definition guard with this fix (A/B on the same tree)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**

- Renamed `MTPEagleDynamicTreeWorker.forward` to `_forward_impl`, satisfying the `SpecWorkerBase.__init_subclass__` guard.
- Preserved the method body, parameters, and NVTX label (`mtp_dyn.forward`).
- `SpecWorkerBase.forward` remains the public entry point, preserving speculative-decoding attention-metadata cleanup.
- No configuration or test-list changes.

**QA Engineer Review**

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->