### PR TITLE
[None][infra] Select UCX env for perf sanity by cluster name

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1859,7 +1859,8 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                         --script-prefix ${scriptLaunchPrefixPathLocal} \\
                         --srun-args ${scriptLaunchSrunArgsPathLocal} \\
                         --split-group ${splitId} \\
-                        --stage-name ${stageName}
+                        --stage-name ${stageName} \\
+                        --cluster-name ${partition.clusterName}
                     """
                 } else {
                     if(nodeCount > 1) {

--- a/jenkins/scripts/perf/cluster_env.py
+++ b/jenkins/scripts/perf/cluster_env.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Cluster+GPU-aware environment settings for PerfSanity SLURM jobs.
+
+UCX transport selection depends primarily on the cluster's network fabric
+(IB vs RoCE vs TCP-only), not just the GPU model. The same CI stage can land
+on different clusters (frontend "auto:*" platforms are load-balanced across
+backend clusters in bloom's SlurmConfig), so the rules below are keyed on
+(cluster name, GPU type) instead of GPU type alone.
+
+Cluster names follow SlurmPartition.clusterName in the bloom Jenkins shared
+library (src/com/nvidia/bloom/SlurmConfig.groovy), e.g. "gcp-nrt", "aws-cmh",
+"aws-dfw", "oci-hsg", "nsc-svg", "dlcluster", "computelabSC01". In CI,
+L0_Test.groovy passes the resolved cluster via --cluster-name; for local
+submission it can be given explicitly or is best-effort detected from the
+Slurm frontend. Slurm's own ClusterName carries a deployment suffix (e.g.
+bloom "oci-nrt" -> slurm.conf "oci-nrt-cs-001"), so rules use prefix
+wildcards to match both forms; pass --cluster-name explicitly if a cluster
+breaks this naming convention.
+"""
+
+from fnmatch import fnmatch
+
+# Applied on every cluster before any cluster-specific export: clear settings
+# that may leak in from the outer environment and break UCX transport
+# auto-selection.
+BASE_UCX_UNSET = "unset UCX_CUDA_IPC_ENABLE_MNNVL UCX_TLS UCX_NET_DEVICES"
+
+# (cluster_pattern, gpu_pattern, extra_export) — evaluated in order, first
+# match wins; the matched export is appended after BASE_UCX_UNSET (empty
+# string = base unset only). Patterns are shell-style wildcards, matched
+# case-insensitively. Cluster patterns are prefix wildcards so they match
+# both the bloom name (CI, e.g. "aws-cmh") and the cluster's own slurm.conf
+# ClusterName (local detection, e.g. "nsc-svg" -> "nsc-svg-slurm-1").
+UCX_ENV_RULES = [
+    # nsc-svg: UCX picks wrong RDMA devices; pin the usable mlx5 ports.
+    (
+        "nsc-svg*",
+        "*",
+        "export UCX_NET_DEVICES="
+        "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1",
+    ),
+    # aws-cmh: UCX transport auto-selection hangs on this fabric; pin the
+    # working transport set explicitly.
+    ("aws-cmh*", "*", "export UCX_TLS=cuda_ipc,cuda_copy,sm,self,tcp"),
+    # aws-dfw: gdr_copy is broken on this cluster; exclude it.
+    ("aws-dfw*", "*", "export UCX_TLS=^gdr_copy"),
+    # Default: base unset only.
+    ("*", "*", ""),
+]
+
+# Ordered so composite names win over their substrings (GB200 before B200,
+# GB300 before B300).
+KNOWN_GPU_TYPES = ("GB300", "GB200", "GB10X", "B300", "B200", "H200", "H100", "A100")
+
+
+def gpu_type_from_stage_name(stage_name):
+    """Extract the GPU type token from a CI stage name.
+
+    E.g. "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-1" -> "GB300",
+    "DGX_B200-8_GPUs-PyTorch-PerfSanity-1" -> "B200".
+    """
+    upper = (stage_name or "").upper()
+    for gpu in KNOWN_GPU_TYPES:
+        if gpu in upper:
+            return gpu
+    return ""
+
+
+def gpu_type_from_supported_gpus(supported_gpus):
+    """Pick the GPU type from a config yaml's metadata.supported_gpus list."""
+    gpus = {str(gpu).upper() for gpu in supported_gpus or []}
+    for gpu in KNOWN_GPU_TYPES:
+        if gpu in gpus:
+            return gpu
+    return ""
+
+
+def get_ucx_tls_cmd(cluster_name, gpu_type):
+    """Return the shell prefix that sets UCX env vars for (cluster, GPU)."""
+    cluster = (cluster_name or "").lower()
+    gpu = (gpu_type or "").upper()
+    extra = ""
+    for cluster_pat, gpu_pat, cmd in UCX_ENV_RULES:
+        if fnmatch(cluster, cluster_pat.lower()) and fnmatch(gpu, gpu_pat.upper()):
+            extra = cmd
+            break
+    if extra:
+        return f"{BASE_UCX_UNSET} && {extra} &&"
+    return f"{BASE_UCX_UNSET} &&"

--- a/jenkins/scripts/perf/cluster_env.py
+++ b/jenkins/scripts/perf/cluster_env.py
@@ -58,8 +58,17 @@ KNOWN_GPU_TYPES = ("GB300", "GB200", "GB10X", "B300", "B200", "H200", "H100", "A
 def gpu_type_from_stage_name(stage_name):
     """Extract the GPU type token from a CI stage name.
 
-    E.g. "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-1" -> "GB300",
-    "DGX_B200-8_GPUs-PyTorch-PerfSanity-1" -> "B200".
+    Scans for the first match in KNOWN_GPU_TYPES (ordered longest-first to
+    avoid substring collisions, e.g. GB200 before B200).
+
+    Args:
+        stage_name: CI stage name string, e.g.
+            "DGX_B200-8_GPUs-PyTorch-PerfSanity-1". None or empty string
+            is accepted and returns "".
+
+    Returns:
+        A GPU type token such as "B200" or "GB300", or "" if no known GPU
+        type is found in the stage name.
     """
     upper = (stage_name or "").upper()
     for gpu in KNOWN_GPU_TYPES:
@@ -69,7 +78,16 @@ def gpu_type_from_stage_name(stage_name):
 
 
 def gpu_type_from_supported_gpus(supported_gpus):
-    """Pick the GPU type from a config yaml's metadata.supported_gpus list."""
+    """Pick the GPU type from a config yaml's metadata.supported_gpus list.
+
+    Args:
+        supported_gpus: List of GPU type strings from the config yaml
+            ``metadata.supported_gpus`` field. None or empty list returns "".
+
+    Returns:
+        The first matching GPU type token from KNOWN_GPU_TYPES, or "" if
+        none of the known types appear in the list.
+    """
     gpus = {str(gpu).upper() for gpu in supported_gpus or []}
     for gpu in KNOWN_GPU_TYPES:
         if gpu in gpus:
@@ -78,7 +96,28 @@ def gpu_type_from_supported_gpus(supported_gpus):
 
 
 def get_ucx_tls_cmd(cluster_name, gpu_type):
-    """Return the shell prefix that sets UCX env vars for (cluster, GPU)."""
+    """Return the shell prefix that sets UCX env vars for (cluster, GPU).
+
+    Evaluates UCX_ENV_RULES in order, matching cluster_name and gpu_type
+    against shell-style wildcard patterns (case-insensitive). Cluster
+    patterns are prefix wildcards that match both the bloom CI name (e.g.
+    "aws-cmh") and the cluster's own slurm.conf ClusterName (e.g.
+    "aws-cmh-cs-001"). The first matching rule wins.
+
+    Args:
+        cluster_name: Cluster name string (bloom CI name or detected via
+            scontrol). None or empty string matches only the catch-all "*"
+            rule.
+        gpu_type: GPU type token such as "B200" or "GB300". None or empty
+            string matches only the catch-all "*" rule.
+
+    Returns:
+        A shell command prefix string that unsets leaking UCX env vars and
+        optionally exports cluster-specific overrides, ending with "&&" so
+        it can be prepended directly to the worker command. Example:
+        ``"unset UCX_CUDA_IPC_ENABLE_MNNVL UCX_TLS UCX_NET_DEVICES &&
+        export UCX_TLS=cuda_ipc,cuda_copy,sm,self,tcp &&"``.
+    """
     cluster = (cluster_name or "").lower()
     gpu = (gpu_type or "").upper()
     extra = ""

--- a/jenkins/scripts/perf/cluster_env.py
+++ b/jenkins/scripts/perf/cluster_env.py
@@ -34,6 +34,16 @@ BASE_UCX_UNSET = "unset UCX_CUDA_IPC_ENABLE_MNNVL UCX_TLS UCX_NET_DEVICES"
 # both the bloom name (CI, e.g. "aws-cmh") and the cluster's own slurm.conf
 # ClusterName (local detection, e.g. "nsc-svg" -> "nsc-svg-slurm-1").
 UCX_ENV_RULES = [
+    # gcp-nrt: RoCE fabric; pin the usable rocep ports and set the RoCE GID /
+    # QoS parameters required on this fabric.
+    (
+        "gcp-nrt*",
+        "*",
+        "export UCX_NET_DEVICES="
+        "rocep145s0:1,rocep146s0:1,rocep152s0:1,rocep153s0:1,"
+        "rocep198s0:1,rocep199s0:1,rocep205s0:1,rocep206s0:1"
+        " UCX_IB_GID_INDEX=auto UCX_IB_TRAFFIC_CLASS=52 UCX_IB_SL=0",
+    ),
     # nsc-svg: UCX picks wrong RDMA devices; pin the usable mlx5 ports.
     (
         "nsc-svg*",

--- a/jenkins/scripts/perf/cluster_env.py
+++ b/jenkins/scripts/perf/cluster_env.py
@@ -44,6 +44,16 @@ UCX_ENV_RULES = [
         "rocep198s0:1,rocep199s0:1,rocep205s0:1,rocep206s0:1"
         " UCX_IB_GID_INDEX=auto UCX_IB_TRAFFIC_CLASS=52 UCX_IB_SL=0",
     ),
+    # oci-aga: avoid transports that fail on this VF fabric, disable DEVX to
+    # avoid UAR allocation failures, and pin the GPU-connected rail VFs.
+    (
+        "oci-aga*",
+        "*",
+        "export UCX_TLS=^tcp,rc_gda,gga UCX_IB_MLX5_DEVX=n "
+        "UCX_NET_DEVICES="
+        "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1 "
+        "UCX_IB_TRAFFIC_CLASS=96 TRTLLM_NIXL_NUM_THREADS=1",
+    ),
     # nsc-svg: UCX picks wrong RDMA devices; pin the usable mlx5 ports.
     (
         "nsc-svg*",

--- a/jenkins/scripts/perf/local/configs/example.conf
+++ b/jenkins/scripts/perf/local/configs/example.conf
@@ -18,6 +18,13 @@ account="${YOUR_SLURM_ACCOUNT:-your_account}"
 job_name="disagg_test"
 time_limit="04:00:00"
 
+# Cluster name for cluster-specific env settings (UCX_TLS etc.) — see
+# jenkins/scripts/perf/cluster_env.py for the rule table. Use the CI (bloom)
+# name, e.g. gcp-nrt, aws-cmh, aws-dfw, oci-hsg. If unset, submit.py falls
+# back to detecting the Slurm ClusterName from the frontend (prefix-matched
+# against the rules, e.g. detected "oci-nrt-cs-001" matches "oci-nrt*").
+# cluster_name="gcp-nrt"
+
 # Docker image — pick ONE of two modes. The script supports both; the rule is:
 #
 #   ┌──────────────────────┬──────────────────────┬────────────────────────────┐

--- a/jenkins/scripts/perf/local/run_disagg.sh
+++ b/jenkins/scripts/perf/local/run_disagg.sh
@@ -67,6 +67,7 @@ source "$config_file"
 : "${build_wheel_flag:=}"
 : "${capture_nsys_flag:=}"
 : "${time_limit:=02:00:00}"
+: "${cluster_name:=}"
 
 # Normalize test list: prefer 'test_ids' bash array if set, else fall back to
 # legacy single 'test_id'. Either declares a non-empty list at this point.
@@ -231,6 +232,7 @@ for idx in "${!test_ids[@]}"; do
         --mounts "$mounts" \
         --llm-models-root "$llm_models_path" \
         --time "$time_limit" \
+        ${cluster_name:+--cluster-name "$cluster_name"} \
         "${install_args[@]}" \
         $build_wheel_flag \
         $capture_nsys_flag; then

--- a/jenkins/scripts/perf/local/run_disagg.sh
+++ b/jenkins/scripts/perf/local/run_disagg.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Generate slurm_launch.sh for a local disaggregated perf-sanity run
 # and submit it via sbatch. Run this on a SLURM login node.
 #

--- a/jenkins/scripts/perf/local/submit.py
+++ b/jenkins/scripts/perf/local/submit.py
@@ -386,14 +386,15 @@ def detect_cluster_name():
         return name
     try:
         config_out = subprocess.check_output(
-            ["scontrol", "show", "config"],
+            ["/usr/bin/scontrol", "show", "config"],
             stderr=subprocess.DEVNULL,
             text=True,
             timeout=10,
         )
         for line in config_out.splitlines():
-            if line.strip().startswith("ClusterName"):
-                return line.split("=", 1)[1].strip()
+            key, separator, value = line.partition("=")
+            if key.strip() == "ClusterName" and separator:
+                return value.strip()
     except (OSError, subprocess.SubprocessError):
         pass
     return ""
@@ -717,10 +718,14 @@ def main():
         with open(config_yaml, "r") as f:
             config = yaml.safe_load(f)
 
-    # Detect GPU type from config metadata; cluster from CLI arg or frontend.
-    supported_gpus = config.get("metadata", {}).get("supported_gpus", [])
-    gpu_type = gpu_type_from_supported_gpus(supported_gpus)
-    cluster_name = args.cluster_name or detect_cluster_name()
+    # Detect GPU type and cluster only for disaggregated UCX selection.
+    if runtime_mode == "disaggregated":
+        supported_gpus = config.get("metadata", {}).get("supported_gpus", [])
+        gpu_type = gpu_type_from_supported_gpus(supported_gpus)
+        cluster_name = args.cluster_name or detect_cluster_name()
+    else:
+        gpu_type = ""
+        cluster_name = ""
 
     # Create timestamp
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/jenkins/scripts/perf/local/submit.py
+++ b/jenkins/scripts/perf/local/submit.py
@@ -11,6 +11,9 @@ from datetime import datetime
 
 import yaml
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from cluster_env import get_ucx_tls_cmd, gpu_type_from_supported_gpus  # noqa: E402
+
 
 def _import_precheck_config(llm_src):
     """Import the pure-stdlib precheck config module from the repo tree.
@@ -376,6 +379,26 @@ def partition_has_gpu_gres(partition):
         return False
 
 
+def detect_cluster_name():
+    """Best-effort Slurm cluster name detection on the submission frontend."""
+    name = os.environ.get("SLURM_CLUSTER_NAME", "")
+    if name:
+        return name
+    try:
+        config_out = subprocess.check_output(
+            ["scontrol", "show", "config"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=10,
+        )
+        for line in config_out.splitlines():
+            if line.strip().startswith("ClusterName"):
+                return line.split("=", 1)[1].strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return ""
+
+
 def generate_sbatch_params(args, hardware_config, work_dir):
     """Generate #SBATCH parameters."""
     total_nodes = hardware_config["total_nodes"]
@@ -625,6 +648,14 @@ def main():
         default=8000,
         help="Port the disagg server listens on (exported as DISAGG_SERVER_PORT)",
     )
+    parser.add_argument(
+        "--cluster-name",
+        default="",
+        help="Cluster name used with the GPU type to pick UCX env settings "
+        "(bloom SlurmPartition.clusterName, e.g. gcp-nrt, aws-cmh). If not "
+        "set, best-effort detected from SLURM_CLUSTER_NAME / scontrol; note "
+        "Slurm's own ClusterName may differ from the bloom name.",
+    )
 
     args = parser.parse_args()
 
@@ -686,10 +717,10 @@ def main():
         with open(config_yaml, "r") as f:
             config = yaml.safe_load(f)
 
-    # Detect GPU type from config metadata
+    # Detect GPU type from config metadata; cluster from CLI arg or frontend.
     supported_gpus = config.get("metadata", {}).get("supported_gpus", [])
-    is_b200 = "B200" in supported_gpus
-    is_gb300 = "GB300" in supported_gpus
+    gpu_type = gpu_type_from_supported_gpus(supported_gpus)
+    cluster_name = args.cluster_name or detect_cluster_name()
 
     # Create timestamp
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -878,12 +909,8 @@ def main():
                 f"TLLM_BENCHMARK_REQ_QUEUES_SIZE={queue_size} {gen_worker_env_vars}"
             )
 
-        if is_gb300:
-            ucx_tls_cmd = "export UCX_TLS=cuda_copy,cuda_ipc,sm,self,tcp &&"
-        elif is_b200:
-            ucx_tls_cmd = "export UCX_TLS=^ib &&"
-        else:
-            ucx_tls_cmd = "unset UCX_TLS UCX_NET_DEVICES &&"
+        ucx_tls_cmd = get_ucx_tls_cmd(cluster_name, gpu_type)
+        print(f"UCX env: cluster={cluster_name!r} gpu={gpu_type!r} -> {ucx_tls_cmd!r}")
         script_prefix_lines.extend(
             [
                 f'export CTX_WORKER_ENV_VARS="{ctx_worker_env_vars}"',

--- a/jenkins/scripts/perf/local/submit.py
+++ b/jenkins/scripts/perf/local/submit.py
@@ -386,7 +386,7 @@ def detect_cluster_name():
         return name
     try:
         config_out = subprocess.check_output(
-            ["/usr/bin/scontrol", "show", "config"],
+            ["scontrol", "show", "config"],
             stderr=subprocess.DEVNULL,
             text=True,
             timeout=10,

--- a/jenkins/scripts/perf/submit.py
+++ b/jenkins/scripts/perf/submit.py
@@ -24,6 +24,7 @@ import re
 import sys
 
 import yaml
+from cluster_env import get_ucx_tls_cmd, gpu_type_from_stage_name
 
 
 def _import_precheck_config(llm_src):
@@ -490,6 +491,13 @@ def main():
         help="1-indexed split group id. Selects the N-th test from the test list.",
     )
     parser.add_argument("--stage-name", default="", help="Stage name (for logging / GPU detect)")
+    parser.add_argument(
+        "--cluster-name",
+        default="",
+        help="Slurm cluster name as resolved by the Jenkins pipeline "
+        "(bloom SlurmPartition.clusterName, e.g. gcp-nrt, aws-cmh). "
+        "Used with the GPU type to pick UCX env settings.",
+    )
 
     args = parser.parse_args()
 
@@ -534,8 +542,7 @@ def main():
     ) = get_pytest_commands(script_prefix_lines, runtime_mode)
     test_output_dir = get_test_output_dir(script_prefix_lines, test_case_name)
 
-    is_gb300 = "GB300" in args.stage_name.upper()
-    is_b200 = "B200" in args.stage_name.upper() and "GB200" not in args.stage_name.upper()
+    gpu_type = gpu_type_from_stage_name(args.stage_name)
 
     if runtime_mode == "aggregated":
         # Aggregated (incl. ctx_only): single pytestCommand built from the
@@ -597,12 +604,8 @@ def main():
                 f"TLLM_BENCHMARK_REQ_QUEUES_SIZE={queue_size} {gen_worker_env_vars}"
             )
 
-        if is_gb300:
-            ucx_tls_cmd = "export UCX_TLS=cuda_copy,cuda_ipc,sm,self,tcp &&"
-        elif is_b200:
-            ucx_tls_cmd = "export UCX_TLS=^ib &&"
-        else:
-            ucx_tls_cmd = "unset UCX_TLS UCX_NET_DEVICES &&"
+        ucx_tls_cmd = get_ucx_tls_cmd(args.cluster_name, gpu_type)
+        print(f"UCX env: cluster={args.cluster_name!r} gpu={gpu_type!r} -> {ucx_tls_cmd!r}")
         ucx_tls_server_cmd = ucx_tls_cmd
 
         pytest_common_vars = ""

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -344,7 +344,6 @@ perf/test_perf_sanity.py::test_e2e[aggr_upload-qwen3_5_397b_fp4_blackwell-qwen3_
 perf/test_perf_sanity.py::test_e2e[aggr_upload-super_ad_blackwell-super_ad_ws1_1k1k] SKIP (https://nvbugs/6153575)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL] SKIP (https://nvbugs/6426890)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL] SKIP (https://nvbugs/6490049)
-perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL] SKIP (https://nvbugs/6478615)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL] SKIP (https://nvbugs/6374872)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL] SKIP (https://nvbugs/6490049)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL] SKIP (https://nvbugs/6490049)

--- a/tests/unittest/scripts/test_cluster_env.py
+++ b/tests/unittest/scripts/test_cluster_env.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+CLUSTER_ENV_PATH = REPO_ROOT / "jenkins" / "scripts" / "perf" / "cluster_env.py"
+
+
+@pytest.fixture(scope="module")
+def cluster_env_module() -> ModuleType:
+    """Load cluster_env.py without requiring jenkins to be a Python package."""
+    spec = importlib.util.spec_from_file_location("cluster_env", CLUSTER_ENV_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("stage_name", "expected_gpu"),
+    (
+        ("DGX_B200-8_GPUs-PyTorch-PerfSanity-1", "B200"),
+        ("DGX_GB200-4_GPUs-PyTorch-PerfSanity-1", "GB200"),
+        ("dgx_gb300-4_gpus-pytorch-perfsanity-1", "GB300"),
+        ("unknown-stage", ""),
+        ("", ""),
+    ),
+)
+def test_gpu_type_from_stage_name(
+    cluster_env_module: ModuleType, stage_name: str, expected_gpu: str
+) -> None:
+    assert cluster_env_module.gpu_type_from_stage_name(stage_name) == expected_gpu
+
+
+@pytest.mark.parametrize(
+    ("supported_gpus", "expected_gpu"),
+    (
+        (["B200"], "B200"),
+        (["b200", "gb200"], "GB200"),
+        (["GB300", "B300"], "GB300"),
+        (["L40S"], ""),
+        ([], ""),
+    ),
+)
+def test_gpu_type_from_supported_gpus(
+    cluster_env_module: ModuleType, supported_gpus: list[str], expected_gpu: str
+) -> None:
+    assert cluster_env_module.gpu_type_from_supported_gpus(supported_gpus) == expected_gpu
+
+
+@pytest.mark.parametrize(
+    ("cluster_name", "expected_export"),
+    (
+        (
+            "GCP-NRT-CS-001",
+            "export UCX_NET_DEVICES=rocep145s0:1,rocep146s0:1,rocep152s0:1,"
+            "rocep153s0:1,rocep198s0:1,rocep199s0:1,rocep205s0:1,rocep206s0:1 "
+            "UCX_IB_GID_INDEX=auto UCX_IB_TRAFFIC_CLASS=52 UCX_IB_SL=0",
+        ),
+        (
+            "nsc-svg-slurm-1",
+            "export UCX_NET_DEVICES=mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,"
+            "mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1",
+        ),
+        ("aws-cmh", "export UCX_TLS=cuda_ipc,cuda_copy,sm,self,tcp"),
+        ("aws-dfw-prod", "export UCX_TLS=^gdr_copy"),
+    ),
+)
+def test_get_ucx_tls_cmd_selects_cluster_rule(
+    cluster_env_module: ModuleType, cluster_name: str, expected_export: str
+) -> None:
+    command = cluster_env_module.get_ucx_tls_cmd(cluster_name, "B200")
+
+    assert command == f"{cluster_env_module.BASE_UCX_UNSET} && {expected_export} &&"
+
+
+@pytest.mark.parametrize("cluster_name", ("", "unknown-cluster"))
+def test_get_ucx_tls_cmd_uses_base_unset_for_unknown_cluster(
+    cluster_env_module: ModuleType, cluster_name: str
+) -> None:
+    command = cluster_env_module.get_ucx_tls_cmd(cluster_name, "GB300")
+
+    assert command == f"{cluster_env_module.BASE_UCX_UNSET} &&"

--- a/tests/unittest/scripts/test_cluster_env.py
+++ b/tests/unittest/scripts/test_cluster_env.py
@@ -81,6 +81,13 @@ def test_gpu_type_from_supported_gpus(
             "export UCX_NET_DEVICES=mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,"
             "mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1",
         ),
+        (
+            "oci-aga-cs-001",
+            "export UCX_TLS=^tcp,rc_gda,gga UCX_IB_MLX5_DEVX=n "
+            "UCX_NET_DEVICES="
+            "rdma_vf_rail0:1,rdma_vf_rail1:1,rdma_vf_rail2:1,rdma_vf_rail3:1 "
+            "UCX_IB_TRAFFIC_CLASS=96 TRTLLM_NIXL_NUM_THREADS=1",
+        ),
         ("aws-cmh", "export UCX_TLS=cuda_ipc,cuda_copy,sm,self,tcp"),
         ("aws-dfw-prod", "export UCX_TLS=^gdr_copy"),
     ),

--- a/tests/unittest/scripts/test_perf_submit.py
+++ b/tests/unittest/scripts/test_perf_submit.py
@@ -16,6 +16,7 @@
 
 import importlib.util
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 import yaml
@@ -29,10 +30,13 @@ DISAGG_CONFIG_DIR = REPO_ROOT / "tests" / "scripts" / "perf-sanity" / "disaggreg
 
 
 @pytest.fixture(params=SUBMIT_PATHS, ids=("ci", "local"))
-def submit_module(request):
+def submit_module(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    monkeypatch.syspath_prepend(str(request.param.parent))
     spec = importlib.util.spec_from_file_location(
         f"perf_submit_{request.param.parent.name}", request.param
     )
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module


### PR DESCRIPTION

UCX transport settings depend on the cluster's network fabric, not just the GPU model, and the same CI stage can land on different clusters (frontend auto:* platforms are load-balanced in bloom's SlurmConfig).

Add jenkins/scripts/perf/cluster_env.py with a (cluster, GPU) -> UCX env rule table shared by the CI and local submit scripts:
- all clusters: unset UCX_CUDA_IPC_ENABLE_MNNVL UCX_TLS UCX_NET_DEVICES
- nsc-svg: pin UCX_NET_DEVICES to the usable mlx5 ports
- aws-cmh: pin UCX_TLS=cuda_ipc,cuda_copy,sm,self,tcp
- aws-dfw: exclude gdr_copy

Cluster patterns are prefix wildcards so both the bloom clusterName (CI) and the cluster's slurm.conf ClusterName (e.g. oci-nrt -> oci-nrt-cs-001) match. L0_Test.groovy passes the resolved partition.clusterName via --cluster-name; the local path takes it from the run_disagg.sh cluster conf or --cluster-name, falling back to detection via SLURM_CLUSTER_NAME / scontrol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added cluster- and GPU-aware UCX environment selection for PerfSanity disaggregated jobs:
  - New module `jenkins/scripts/perf/cluster_env.py`:
    - `BASE_UCX_UNSET` clears `UCX_CUDA_IPC_ENABLE_MNNVL`, `UCX_TLS`, and `UCX_NET_DEVICES` to prevent UCX leakage from the parent environment.
    - `UCX_ENV_RULES` ordered first-match, case-insensitive wildcard rules keyed by `(cluster_name, gpu_type)` using **prefix wildcards** for cluster patterns to match both bloom cluster names and Slurm `ClusterName` variants.
    - Concrete rules include:
      - `gcp-nrt*`: pins `UCX_NET_DEVICES` to `rocep*` ports and sets IB/RoCE tuning vars.
      - `nsc-svg*`: pins `UCX_NET_DEVICES` to the correct mlx5 ports (`mlx5_*` set).
      - `aws-cmh*`: pins `UCX_TLS=cuda_ipc,cuda_copy,sm,self,tcp`.
      - `aws-dfw*`: excludes `gdr_copy` via `UCX_TLS=^gdr_copy`.
      - Default rule: base unset only.
    - GPU type extraction is constrained to `KNOWN_GPU_TYPES` via:
      - `gpu_type_from_stage_name(stage_name)` (substring scan, ordered to avoid collisions like GB200 vs B200)
      - `gpu_type_from_supported_gpus(supported_gpus)` (membership against `metadata.supported_gpus`)
- Propagated `--cluster-name` through CI and submit flows so UCX selection can use the resolved cluster name:
  - `jenkins/L0_Test.groovy`: passes `--cluster-name ${partition.clusterName}` into the generated multi-node `srun`/SLURM launch.
  - `jenkins/scripts/perf/submit.py`: adds `--cluster-name` (default `""`), derives `gpu_type` from `--stage-name`, and uses `get_ucx_tls_cmd(cluster_name, gpu_type)` when constructing the worker/gen/benchmark `pytestCommand*` env exports.
  - `jenkins/scripts/perf/local/submit.py`: adds `--cluster-name`, implements `detect_cluster_name()` (prefers `SLURM_CLUSTER_NAME`, otherwise parses `scontrol show config`’s `ClusterName`), derives `gpu_type` from `config.metadata.supported_gpus`, and uses `get_ucx_tls_cmd(cluster_name, gpu_type)`.
  - `jenkins/scripts/perf/local/run_disagg.sh`: introduces optional `cluster_name` config and conditionally includes `--cluster-name "$cluster_name"` in the `submit.py` invocation only when set.
  - `jenkins/scripts/perf/local/configs/example.conf`: documents the new `cluster_name` option and how it relates to `cluster_env.py` rules.
- Updated test-waiver list:
  - `tests/integration/test_lists/waives.txt`: removed the SKIP waiver for `perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL]` (nvbugs/6478615), per the intended fix from cluster-specific UCX selection.

## QA Engineer Review

- Test-list-only change:
  - Modified `tests/integration/test_lists/waives.txt`
    - Removed 1 `SKIP` entry for:
      - `perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL]` (nvbugs/6478615)
- Verdict: needs follow-up — CBTS coverage data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
