### PR TITLE
[None][fix] pin multi-node PerfSanity pytest run to the submit-selected test

### DIFF
--- a/jenkins/scripts/perf/submit.py
+++ b/jenkins/scripts/perf/submit.py
@@ -400,6 +400,27 @@ def get_pytest_commands(script_prefix_lines, runtime_mode):
     return ("", worker_pytest_command, disagg_server_pytest_command, benchmark_pytest_command)
 
 
+def pin_pytest_to_selected_test(script_prefix_lines, selected_test_line):
+    """Make pytest run exactly the test selected above.
+
+    The inbound pytestCommand still carries the pytest-split args
+    (--splitting-algorithm/--splits/--group), which pick a test by historical
+    durations and can disagree with the lines[split_group - 1] choice used
+    for job sizing and testOutputDir — server logs then land in another
+    test's folder. Point --test-list at a single-test list (written by the
+    launch script at runtime) and drop the split args so both always agree.
+    """
+    idx, line = next(
+        (i, ln) for i, ln in enumerate(script_prefix_lines) if "export pytestCommand=" in ln
+    )
+    full_list_path = re.search(r'--test-list[=\s]+([^\s"]+)', line).group(1)
+    selected_list_path = os.path.join(os.path.dirname(full_list_path), "selected_test_list.txt")
+    line = re.sub(r'--test-list[=\s]+[^\s"]+', f"--test-list={selected_list_path}", line)
+    line = re.sub(r'\s*--(?:splitting-algorithm|splits|group)[=\s]+[^\s"]+', "", line)
+    script_prefix_lines[idx] = line
+    script_prefix_lines.append(f"printf '%s\\n' '{selected_test_line}' > {selected_list_path}")
+
+
 def get_test_output_dir(script_prefix_lines, test_case_name):
     """Build the per-test output directory from the inbound pytestCommand.
 
@@ -487,6 +508,8 @@ def main():
     with open(args.script_prefix, "r") as f:
         script_prefix_content = f.read()
     script_prefix_lines = script_prefix_content.split("\n")
+
+    pin_pytest_to_selected_test(script_prefix_lines, sel)
 
     with open(args.srun_args, "r") as f:
         srun_args_content = f.read()


### PR DESCRIPTION


submit.py sizes the SLURM job, picks the config yaml, and derives testOutputDir from lines[split_group - 1] of the test list, but the pytestCommand it embeds still carries the pytest-split args (--splitting-algorithm least_duration --splits N --group M), which assign tests to groups by historical durations. When the two selections disagree, the sbatch script redirects gen_server_*.log / ctx_server_*.log into one test's folder while pytest runs a different test, whose gen_only benchmark then fails with "missing 'prev_device_step_time'" because its own folder never receives the worker logs.

Rewrite the generated pytestCommand to point --test-list at a single-test list written by the launch script at runtime and drop the split args, so the launch script and pytest always agree on the test. Also fail generation when the stage's --splits count differs from the test-list length instead of silently skipping tests.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
