### PR TITLE
[https://nvbugs/6478697][fix] Renamed mtp_dynamic_tree.py:639 `forward` → `_forward_impl` (matching…

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
+++ b/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
@@ -636,7 +636,7 @@ class MTPEagleDynamicTreeWorker(MTPEagleWorker):
     # Top-level forward                                                   #
     # ------------------------------------------------------------------ #
     @nvtx_range("mtp_dyn.forward")
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,


### PR DESCRIPTION
## Summary
- **Root cause**: MTPEagleDynamicTreeWorker (added by #15582) overrode SpecWorkerBase.forward, which the __init_subclass__ guard (nvbugs/6442074) forbids, raising TypeError at import and breaking all pytest collection (0 items).
- **Fix**: Renamed mtp_dynamic_tree.py:639 `forward` → `_forward_impl` (matching MTPWorker), letting the base SpecWorkerBase.forward wrapper provide the cleanup finally block; staged ONLY that one file to avoid the LFS-blob corruption that rejected both prior attempts.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6478697


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Dev Engineer Review

- Renamed `MTPEagleDynamicTreeWorker.forward` to `_forward_impl` to comply with the `SpecWorkerBase.__init_subclass__` guard.
- Preserved the existing implementation, signature, NVTX decoration, and dynamic-tree behavior.
- Allows the inherited `SpecWorkerBase.forward` wrapper to handle spec-dec attention-metadata cleanup and restores pytest collection.
- No configuration, test-list, or test-code changes.

### QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->