### PR TITLE
[https://nvbugs/6464169][fix] Rename `forward` → `_forward_impl` (signature unchanged); the base…

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
+++ b/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
@@ -636,7 +636,7 @@ class MTPEagleDynamicTreeWorker(MTPEagleWorker):
     # Top-level forward                                                   #
     # ------------------------------------------------------------------ #
     @nvtx_range("mtp_dyn.forward")
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,


### PR DESCRIPTION
## Summary
- **Root cause**: MTPEagleDynamicTreeWorker overrode SpecWorkerBase.forward, which SpecWorkerBase.__init_subclass__ (nvbugs/6442074) forbids, raising TypeError at import and breaking every pytest collection (0 items, rc=4).
- **Fix**: Rename `forward` → `_forward_impl` (signature unchanged); the base SpecWorkerBase.forward wrapper calls `self._forward_impl(*args, **kwargs)` inside its metadata-cleanup try/finally, matching Eagle3OneModelWorker's pattern. Committed ONLY the Python file to avoid the prior scope-creep rejection.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6464169


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**

- Renamed `MTPEagleDynamicTreeWorker.forward` to `_forward_impl` without changing its signature or implementation logic.
- This avoids overriding the forbidden `SpecWorkerBase.forward` method while preserving the base wrapper’s metadata-cleanup behavior.
- Scope is limited to the intended Python file; no configuration or test-list changes were made.
- The change is consistent with the stated import-time `TypeError` fix and has low regression risk.

**QA Engineer Review**

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->