### PR TITLE
[https://nvbugs/6484343][fix] Renamed `MTPEagleDynamicTreeWorker.forward` → `_forward_impl`; the base…

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
+++ b/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
@@ -636,7 +636,7 @@ class MTPEagleDynamicTreeWorker(MTPEagleWorker):
     # Top-level forward                                                   #
     # ------------------------------------------------------------------ #
     @nvtx_range("mtp_dyn.forward")
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,


### PR DESCRIPTION
## Summary
- **Root cause**: MTPEagleDynamicTreeWorker defined a `forward` method, which SpecWorkerBase.__init_subclass__ (guard from nvbugs/6442074) forbids, raising TypeError at import and collecting 0 tests.
- **Fix**: Renamed `MTPEagleDynamicTreeWorker.forward` → `_forward_impl`; the base wrapper now drives it. No internal callers of self.forward exist, so the rename is safe.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6484343


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**

- Renamed `MTPEagleDynamicTreeWorker.forward` to `_forward_impl` to satisfy the `SpecWorkerBase.__init_subclass__` guard.
- Preserved the method signature, implementation, and NVTX label (`mtp_dyn.forward`), avoiding behavioral or performance changes.
- The base wrapper now targets the renamed implementation, with no remaining internal `self.forward` callers.
- No configuration or test-list files were changed.
- Verdict: sufficient.

**QA Engineer Review**

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->