### PR TITLE
[https://nvbugs/6478715][fix] Renamed the worker's forward() to _forward_impl() so the base…

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
+++ b/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
@@ -636,7 +636,7 @@ class MTPEagleDynamicTreeWorker(MTPEagleWorker):
     # Top-level forward                                                   #
     # ------------------------------------------------------------------ #
     @nvtx_range("mtp_dyn.forward")
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,


### PR DESCRIPTION
## Summary
- **Root cause**: MTPEagleDynamicTreeWorker overrode SpecWorkerBase.forward, which the __init_subclass__ guard (nvbugs/6442074) forbids, raising TypeError at import time and collecting 0 tests.
- **Fix**: Renamed the worker's forward() to _forward_impl() so the base SpecWorkerBase.forward wrapper drives it and retains its attn-metadata cleanup guarantee; no behavioral change. Staged ONLY the source file to avoid the LFS-binary pollution from prior rejected commits.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6478715


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Renamed `MTPEagleDynamicTreeWorker.forward()` to `_forward_impl()` so `SpecWorkerBase` can retain control of the guarded `forward()` wrapper and perform attention-metadata cleanup.
- No behavioral, configuration, or test-list changes were made.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->