### PR TITLE
[https://nvbugs/6445316][fix] Renamed the worker's forward method to _forward_impl (matching every sibling…

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
+++ b/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
@@ -636,7 +636,7 @@ class MTPEagleDynamicTreeWorker(MTPEagleWorker):
     # Top-level forward                                                   #
     # ------------------------------------------------------------------ #
     @nvtx_range("mtp_dyn.forward")
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,


### PR DESCRIPTION
## Summary
- **Root cause**: MTPEagleDynamicTreeWorker overrode SpecWorkerBase.forward, which __init_subclass__ forbids, raising TypeError at import and breaking all test collection.
- **Fix**: Renamed the worker's forward method to _forward_impl (matching every sibling worker); committed ONLY the single file to avoid prior LFS scope-creep.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6445316


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Dev Engineer Review
- Renamed `MTPEagleDynamicTreeWorker.forward` to `_forward_impl` without changing its signature, implementation, or NVTX decorator.
- Resolves the import-time `TypeError` enforced by `SpecWorkerBase.__init_subclass__`.
- Scope is limited to the intended single-line method rename; no configuration, test-list, or unrelated API changes.

### QA Engineer Review
- No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->