### PR TITLE
[None][fix] Make FlashInfer sampling op wrappers opaque to Dynamo

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler/ops/flashinfer.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler/ops/flashinfer.py
@@ -30,13 +30,29 @@ signature; explicit ``seed``/``offset`` take precedence over ``generator``):
   capture (a ``torch.Generator`` advances host-side at launch time, so its
   state would be frozen into the graph and every replay would reuse the same
   random values).
+
+Every op is ``@_compiler_disable``d: nothing inside flashinfer is opaque to
+Dynamo (its kernels sit behind a ``functools.cache``-d lazy JIT bootstrap and
+its own custom-op registration is a no-op), so tracing in turns each
+untraceable builtin of the bootstrap into a warn-once plus a permanent
+per-call graph break. Disabling keeps one clean graph break per op and
+preserves the bootstrap's cache fast path.
 """
 
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 import torch
 
 from tensorrt_llm._torch.flashinfer_utils import IS_FLASHINFER_AVAILABLE, get_env_enable_pdl
+
+_OpT = TypeVar("_OpT", bound=Callable[..., Any])
+
+
+def _compiler_disable(fn: _OpT) -> _OpT:
+    """``torch.compiler.disable``, typed: the torch stub is untyped and would
+    fail mypy strict (untyped-decorator) if applied directly."""
+    return cast(_OpT, torch.compiler.disable(fn))
+
 
 if IS_FLASHINFER_AVAILABLE:
     import flashinfer.sampling
@@ -57,6 +73,7 @@ else:
 SeedOrTensor = Union[int, torch.Tensor]
 
 
+@_compiler_disable
 def top_k_top_p_sampling_from_logits_op(
     logits: torch.Tensor,
     top_k: torch.Tensor,
@@ -86,6 +103,7 @@ def top_k_top_p_sampling_from_logits_op(
     return tokens
 
 
+@_compiler_disable
 def sampling_from_probs_op(
     probs: torch.Tensor,
     *,
@@ -110,6 +128,7 @@ def sampling_from_probs_op(
     return tokens
 
 
+@_compiler_disable
 def top_k_sampling_from_probs_op(
     probs: torch.Tensor,
     top_k: torch.Tensor,
@@ -136,6 +155,7 @@ def top_k_sampling_from_probs_op(
     return tokens
 
 
+@_compiler_disable
 def top_p_sampling_from_probs_op(
     probs: torch.Tensor,
     top_p: torch.Tensor,
@@ -168,6 +188,7 @@ def top_p_sampling_from_probs_op(
 # the PDL env decision.
 
 
+@_compiler_disable
 def softmax_op(
     logits: torch.Tensor,
     temperature: Optional[torch.Tensor],
@@ -178,6 +199,7 @@ def softmax_op(
     return probs
 
 
+@_compiler_disable
 def top_k_mask_logits_op(
     logits: torch.Tensor,
     top_k: torch.Tensor,
@@ -186,6 +208,7 @@ def top_k_mask_logits_op(
     return masked
 
 
+@_compiler_disable
 def top_p_renorm_probs_op(
     probs: torch.Tensor,
     top_p: torch.Tensor,
@@ -194,6 +217,7 @@ def top_p_renorm_probs_op(
     return renormed
 
 
+@_compiler_disable
 def compute_probs_from_logits_op(
     logits: torch.Tensor,
     temperatures: torch.Tensor,


### PR DESCRIPTION
## Description

The `@torch.compile`d spec-decode sampling functions in `sampling_utils.py` (`compute_probs_from_logits`, `sampling_batch_spec_dec_one_model`, `sampling_batch_spec_dec_one_model_for_rejection`) inline the plain-Python FlashInfer op wrappers in `sampler/ops/flashinfer.py`, and nothing below those wrappers is opaque to Dynamo:

- FlashInfer's sampling kernels are reached through `get_sampling_module()`, a `functools.cache`-wrapped lazy JIT bootstrap.
- FlashInfer's own `register_custom_op`/`register_fake_op` are deliberate no-ops (`flashinfer/utils.py`, citing `torch.library.custom_op` overhead), so the kernel entry points are plain closures over an FFI module.

Dynamo ignores `functools.cache`/`lru_cache` wrappers and traces the wrapped body directly (`torch/_dynamo/variables/functions.py`, `WrapperUserFunctionVariable`). Tracing the JIT bootstrap hits untraceable builtins (`posix.stat`, `datetime.now`, `_thread.allocate_lock`, `sys._getframe`, plus nested `lru_cache`d helpers), each emitting a warn-once `UserWarning` and a **permanent graph break**. Because the cache wrapper is bypassed inside the compiled artifact, the break-site calls (file stat, module re-load) re-execute eagerly on every invocation of the compiled sampler, defeating the bootstrap's cache fast path. In any MTP/spec-decode serving log this shows up as a burst of `Dynamo does not know how to trace the builtin ...` / `functools.lru_cache-wrapped function` warnings per rank.

Fix: decorate every wrapper in `sampler/ops/flashinfer.py` with `@torch.compiler.disable`. Each wrapper becomes a single clean graph break, the warnings disappear, and FlashInfer's `functools.cache` fast path is restored. The kernels already executed eagerly after the old graph breaks, so numerics and CUDA-graph behavior are unchanged. Registering the wrappers as `torch.library.custom_op` instead is not viable: the merged dual-mode randomness signature (`torch.Generator` + `Union[int, torch.Tensor]` seed/offset, intentional as of #16365) uses parameter types unsupported by the custom-op schema. This follows the existing `@torch.compiler.disable` pattern used for the cute_dsl fmha wrappers.

## Test Coverage

A/B on GB300 (torch 2.12 / flashinfer 0.6.15), calling `sampling_batch_spec_dec_one_model` and `sampling_batch_spec_dec_one_model_for_rejection` under `torch.compile` with fixed `seed`/`offset` tensors — identical script, stock image vs. this patch bind-mounted:

| Metric | Baseline | Patched |
|---|---|---|
| `Dynamo does not know how to trace the builtin` warnings | 4 | **0** |
| `functools.lru_cache-wrapped` warnings | 6 | **0** |
| Sampled tokens (both entry points) | — | **bit-identical** to baseline |
| Filtered-probs checksum | 8.000000142 | 8.000000142 |
| Steady-state host time per call | 280.5 us | **195.1 us** |
| First-call compile time | 62.3 s + 2.1 s | 45.4 s + 0.2 s |

Existing tests covering these paths: `tests/unittest/_torch/sampler/` and the speculative one-model sampling tests.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Expanded `tensorrt_llm/_torch/pyexecutor/sampler/ops/flashinfer.py` module docstring to document the rationale: preventing TorchDynamo from tracing FlashInfer’s lazy JIT bootstrap/cache initialization during Python wrapper execution.
- Added a private signature-preserving `_compiler_disable` helper that applies `torch.compiler.disable(fn)` while preserving the wrapped callable type via `cast`.
- Decorated the module-level FlashInfer sampling/probability wrapper ops with `@_compiler_disable` (without changing their function signatures or internal FlashInfer call logic):
  - `top_k_top_p_sampling_from_logits_op`
  - `sampling_from_probs_op`
  - `top_k_sampling_from_probs_op`
  - `top_p_sampling_from_probs_op`
  - `softmax_op`
  - `top_k_mask_logits_op`
  - `top_p_renorm_probs_op`
  - `compute_probs_from_logits_op`
- No other exported/public declarations or operator logic were changed; this is intended to reduce Dynamo-related warnings while keeping numerics and CUDA-graph behavior stable.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->