### PR TITLE
[None][perf] Avoid implicit device-scalar syncs in DeepSeek-V4 ctx sparse metadata

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -274,6 +274,7 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
         super().__post_init__()
         self.num_total_compressed_tokens = {}
         self.max_ctx_compressed_tokens = {}
+        self._ctx_output_sizes: Optional[Dict[int, int]] = None
         sparse_metadata_params = self.sparse_metadata_params
         if not isinstance(sparse_metadata_params, DeepSeekV4MetadataParams):
             raise ValueError("DeepSeek-V4 sparse attention metadata params are not set")
@@ -736,12 +737,18 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
         kv_lens_slice = kv_lens[:num_requests]
         cached_slice = cached_token_lens[:num_requests]
 
+        # Host-side per-ratio ctx compressed-token counts (Python ints), so
+        # _compute_ctx_compressed_position_ids never reads a device scalar
+        # (implicit D2H + stream sync) for its arange size / slice bound.
+        ctx_output_sizes: Optional[Dict[int, int]] = None
         if num_contexts > 0:
             # Prefill path: need per-request tensor ops for ctx scalar metadata.
+            ctx_output_sizes = {}
             for compress_ratio in self.compress_ratio_set:
                 new_comp_kv_lens = kv_lens_slice // compress_ratio - cached_slice // compress_ratio
                 cu_new = new_comp_kv_lens.cumsum(0)
                 num_ctx_compressed_tokens = cu_new[num_contexts - 1].item()
+                ctx_output_sizes[compress_ratio] = num_ctx_compressed_tokens
                 num_gen_compressed_tokens = num_generations * (
                     (num_gen_tokens_per_seq + compress_ratio - 1) // compress_ratio
                 )
@@ -760,12 +767,15 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
                 )
                 self.max_ctx_compressed_tokens[compress_ratio] = 0
 
+        # Cached for on_update_kv_lens(); see the reuse gate there.
+        self._ctx_output_sizes = ctx_output_sizes
+
         # 2) CUDA-side: fill *_cuda buffers on device.
         kv_lens_cuda = (
             self.cached_token_lens_cuda[:num_requests] + self._seq_lens_cuda[:num_requests]
         )
         cached_tokens_cuda = self.cached_token_lens_cuda[:num_requests]
-        self.prepare_compressed_kv_metadata(kv_lens_cuda, cached_tokens_cuda)
+        self.prepare_compressed_kv_metadata(kv_lens_cuda, cached_tokens_cuda, ctx_output_sizes)
 
         self._compute_compressed_mask(
             self.new_comp_kv_lens_cuda,
@@ -780,6 +790,7 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
         self,
         kv_lens: torch.Tensor,
         cached_tokens: torch.Tensor,
+        ctx_output_sizes: Optional[Dict[int, int]] = None,
     ):
         """Compute per-ratio compressed KV lens and position IDs on device.
 
@@ -788,6 +799,12 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
         Args:
             kv_lens: Total KV lengths per request (device tensor, [batch_size]).
             cached_tokens: Cached token counts per request (device tensor, [batch_size]).
+            ctx_output_sizes: Optional per-ratio host-computed ctx
+                compressed-token counts (Python ints); avoids implicit
+                device-scalar reads (D2H + stream sync) in the ctx position-id
+                computation. prepare() always passes it; on_update_kv_lens()
+                reuses the cached copy unless the extend_ctx path may have
+                mutated ctx-row kv_lens on device.
         """
         batch_size = kv_lens.shape[0]
         num_contexts = self.num_contexts
@@ -811,6 +828,7 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
                 self.compressed_position_ids_cuda,
                 num_contexts,
                 self._compress_ratios_sorted,
+                ctx_output_sizes,
             )
 
         if self.num_gen_tokens_per_seq > 0 and num_generations > 0:
@@ -847,7 +865,13 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
             num_gen_tokens // self.num_generations if self.num_generations > 0 else 0
         )
 
-        self.prepare_compressed_kv_metadata(kv_lens, cached_tokens)
+        # Reuse prepare()'s host-computed ctx sizes unless the extend_ctx path
+        # (num_chunked_ctx_requests > 0) may have mutated ctx-row kv_lens on
+        # device; every other path only changes gen rows.
+        ctx_output_sizes = (
+            self._ctx_output_sizes if getattr(self, "num_chunked_ctx_requests", 0) == 0 else None
+        )
+        self.prepare_compressed_kv_metadata(kv_lens, cached_tokens, ctx_output_sizes)
 
         self._compute_compressed_mask(
             self.new_comp_kv_lens_cuda,
@@ -1003,14 +1027,24 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
         compressed_position_ids_bufs: Dict[int, torch.Tensor],
         num_contexts: int,
         compress_ratios: list,
+        ctx_output_sizes: Optional[Dict[int, int]] = None,
     ):
-        """Context-only compressed position IDs (eager, data-dependent shapes)."""
+        """Context-only compressed position IDs (eager, data-dependent shapes).
+
+        ctx_output_sizes (host ints) keeps the arange size and slice bound off
+        the device; the 0-dim-CUDA fallback costs two implicit D2H syncs per
+        ratio.
+        """
         device = past_kv_lens_bufs[compress_ratios[0]].device
         for compress_ratio in compress_ratios:
             past_kv = past_kv_lens_bufs[compress_ratio]
             cu_new_comp = cu_new_comp_kv_bufs[compress_ratio]
 
-            total_ctx_comp = cu_new_comp[num_contexts]
+            total_ctx_comp = (
+                ctx_output_sizes[compress_ratio]
+                if ctx_output_sizes is not None
+                else cu_new_comp[num_contexts]
+            )
             ctx_idx = torch.arange(total_ctx_comp, dtype=torch.int32, device=device)
             ctx_cu = cu_new_comp[: num_contexts + 1].to(torch.int32)
             ctx_req = torch.searchsorted(ctx_cu[1:], ctx_idx, right=True)

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py
@@ -449,6 +449,50 @@ def test_mixed_context_generation_position_ids_follow_compact_output():
     assert actual_position_ids == [0, 4, 4, 4]
 
 
+@pytest.mark.parametrize(
+    "compress_ratio,cached_tokens,kv_lens",
+    [
+        pytest.param(1, [0], [4096], id="cr1_single"),
+        pytest.param(4, [0, 75, 4000], [4096, 4171, 8096], id="cr4_multi_boundary"),
+        pytest.param(128, [0], [64], id="cr128_empty_output"),
+        pytest.param(128, [973632, 8064], [990016, 8192], id="cr128_chunked_long_ctx"),
+    ],
+)
+def test_ctx_position_ids_host_sizes_match_device_scalar_fallback(
+    compress_ratio, cached_tokens, kv_lens
+):
+    """Host-int ctx_output_sizes must reproduce the device-scalar fallback exactly.
+
+    prepare() threads host-computed ctx compressed-token counts into
+    _compute_ctx_compressed_position_ids so the arange size and slice bound
+    are Python ints (no implicit D2H + stream sync). Both paths must produce
+    identical position IDs, including the untouched padding tail.
+    """
+    num_contexts = len(kv_lens)
+    cached = torch.tensor(cached_tokens, dtype=torch.int32, device=DEVICE)
+    kv = torch.tensor(kv_lens, dtype=torch.int32, device=DEVICE)
+    past = (cached // compress_ratio).to(torch.int32)
+    new_comp = (kv // compress_ratio).to(torch.int32) - past
+    cu = F.pad(torch.cumsum(new_comp, dim=0), (1, 0)).to(torch.int32)
+    total = int(cu[num_contexts].item())
+
+    def _run(ctx_output_sizes):
+        out = torch.full((total + 8,), -1, dtype=torch.int32, device=DEVICE)
+        DeepseekV4TrtllmAttentionMetadata._compute_ctx_compressed_position_ids(
+            {compress_ratio: past},
+            {compress_ratio: cu},
+            {compress_ratio: out},
+            num_contexts,
+            [compress_ratio],
+            ctx_output_sizes,
+        )
+        return out
+
+    golden = _run(None)
+    fast = _run({compress_ratio: total})
+    assert torch.equal(golden, fast)
+
+
 def precompute_freqs_cis(
     dim, seqlen, original_seq_len, base, factor, beta_fast, beta_slow
 ) -> torch.Tensor:


### PR DESCRIPTION
## Background

On a DeepSeek-V4-Pro disaggregated **context** worker (GB300, dep8, MTP3, overlap scheduler, 16384-token prefill chunks), nsys shows `_prepare_inputs` taking **268 ms/step, 92% of which is a single `cudaStreamSynchronize`**. The sync is triggered by implicit device-scalar reads in the DSV4 sparse-attention metadata path:

`_compute_ctx_compressed_position_ids` sizes a `torch.arange` and bounds a slice with a **0-dim CUDA tensor** (`cu_new_comp[num_contexts]`). Each such read is a 4-byte D2H copy + `cudaStreamSynchronize`; with the overlap scheduler the first read per step drains the entire compute-stream queue (~250 ms of queued forward work). The path executes:

- once per step from `prepare()` (2 reads x 3 compress ratios = 6 syncs), and
- twice more per step via `on_update_kv_lens()` — `model_engine._preprocess_inputs` calls it unconditionally for every batch, and the spec-decode+overlap branch calls it again — adding 12 more syncs,

for **18 device-scalar reads per step**. The executor thread holds the GIL for up to ~290 ms per step while blocked, delaying KV-transfer/response threads.

## Changes

- `prepare()` already computes the per-ratio ctx compressed-token counts on **host** tensors. Thread them through `prepare_compressed_kv_metadata()` into `_compute_ctx_compressed_position_ids` as Python ints (`ctx_output_sizes`), mirroring the existing gen-path `gen_output_offsets` precedent ("avoid tensor-scalar slice").
- Cache `ctx_output_sizes` on the metadata so `on_update_kv_lens()` reuses it when no device-side mutation can have changed ctx-row kv_lens (`num_chunked_ctx_requests == 0`). Only the agg extend_ctx path adjusts ctx rows on device (`previous_kv_lens_offsets`); it falls back to the original device-scalar path.
- Unit test: host-int path is element-wise identical to the device-scalar fallback across ratios {1,4,128}, including empty-output (ratio-128, short ctx) and long-context chunked-prefill boundaries. Also verified sync-free with `torch.cuda.set_sync_debug_mode("error")` on GB300.

## Validation (nsys A/B on the same benchmark config, ctx iters 210-230)

| Metric | Baseline | This PR | 
|---|---:|---:|
| Whole-trace `cudaStreamSynchronize` | 360 calls / 4721.7 ms | **0 / 0 ms** |
| 4-byte D2H readbacks (steady state) | 360 | **0** |
| `_prepare_inputs` avg | 268.3 ms | **19.96 ms** |
| Steady-state GPU idle (19 steps) | 282.2 ms | **48.3 ms** |
| Longest executor-thread GIL hold | 292.7 ms | **19.78 ms** |
| GPU busy | 99.1% | 99.8% |

The full agentx e2e benchmark (990K ISL conversation traces, conc 144) runs to completion with the patch (hot-patched via bind-mount before this PR); position-id outputs are bit-identical by construction and by test.

## Impact assessment

- This ctx workload is GPU-bound, so end-to-end throughput is expected to be **neutral** here; the win is freeing the executor thread/GIL (~250 ms/step), lower jitter, and removing the same exposed sync in agg mixed ctx+gen batches.
- The device-scalar fallback is preserved for the agg extend_ctx case (`num_chunked_ctx_requests > 0`) and for any caller that does not pass `ctx_output_sizes`, so behavior there is unchanged.
- No API changes; DSV4 sparse-attention internal metadata only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated DeepSeek-V4 sparse-attention metadata to avoid implicit device-scalar synchronization by optionally using host-computed per-context compressed-token counts (`ctx_output_sizes`) when context row lengths are known to be unchanged.
- Added an internal cache (`_ctx_output_sizes`) populated during `prepare()` (when `num_contexts > 0`) and reused in `on_update_kv_lens()` only for the safe eligibility case (`num_chunked_ctx_requests == 0`); otherwise it preserves the existing device-scalar fallback by passing `None`.
- Extended internal method signatures (`prepare_compressed_kv_metadata(..., ctx_output_sizes=...)` and `_compute_ctx_compressed_position_ids(..., ctx_output_sizes=...)`) to drive context-only compressed position-id sizing from host values while retaining the original fallback behavior for aggregate extend-context cases and callers without host counts.
- Added unit coverage to ensure the host-size path produces element-wise identical compressed context position-id tensors to the device-scalar fallback (including the unchanged padding tail), across compression ratios and edge conditions relevant to the context portion.
- No configuration files were modified.

## QA Engineer Review

- Added test: `test_ctx_position_ids_host_sizes_match_device_scalar_fallback` in `tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py`.
- Test coverage mapping: not confirmed in `tests/integration/test_lists/`, `tests/qa/`, or `tests/waives.txt` from the available repository inspection.
- Verdict: needs follow-up
<!-- end of auto-generated comment: release notes by coderabbit.ai -->