### PR TITLE
[https://nvbugs/6474892][fix] Rename MTPEagleDynamicTreeWorker.forward → _forward_impl (signature unchanged…

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
+++ b/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
@@ -636,7 +636,7 @@ class MTPEagleDynamicTreeWorker(MTPEagleWorker):
     # Top-level forward                                                   #
     # ------------------------------------------------------------------ #
     @nvtx_range("mtp_dyn.forward")
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,


### PR DESCRIPTION
## Summary
- **Root cause**: MTPEagleDynamicTreeWorker overrode SpecWorkerBase.forward, which SpecWorkerBase.__init_subclass__ forbids, raising TypeError at import time and breaking pytest collection for every test importing tensorrt_llm.
- **Fix**: Rename MTPEagleDynamicTreeWorker.forward → _forward_impl (signature unchanged, compatible with base's *args/**kwargs dispatch); committed ONLY that source file to avoid the prior LFS-binary pollution.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6474892


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Renamed `MTPEagleDynamicTreeWorker.forward` to `_forward_impl` without changing its signature or behavior.
- Resolves `SpecWorkerBase.__init_subclass__` import-time validation failures and restores pytest collection.
- No configuration, test-list, or unrelated files were changed.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->