### PR TITLE
[None][perf] enable async Ulysses for FLUX.1 self-attention

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/flux/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/attention.py
@@ -63,17 +63,29 @@ class FluxJointAttention(Attention):
         config: Optional[DiffusionModelConfig] = None,
         layer_idx: int = 0,
         module_name: Optional[str] = None,
+        enable_async_ulysses: bool = True,
     ):
+        config = config or DiffusionModelConfig()
         # Opt in to the fused DiT QK-norm + RoPE kernel (per-head template), but
         # only when TP=1: the fused op asserts tp_size == 1
         # (apply_packed_qk_norm_rope), so under TP>1 we fall back to the unfused
         # F.rms_norm + apply_rotary_emb path. Mirrors WAN's gating.
-        tp_size = config.mapping.tp_size if config and config.mapping else 1
+        tp_size = config.mapping.tp_size if config.mapping else 1
+        vgm = config.visual_gen_mapping
+        ulysses_size = vgm.ulysses_size if vgm is not None else 1
+        use_async_ulysses = bool(
+            enable_async_ulysses
+            and added_kv_proj_dim is None
+            and ulysses_size > 1
+            and config.parallel.async_ulysses
+        )
+        qkv_mode = QKVMode.SEPARATE_QKV if use_async_ulysses else QKVMode.FUSE_QKV
+
         super().__init__(
             hidden_size=hidden_size,
             num_attention_heads=num_attention_heads,
             head_dim=head_dim,
-            qkv_mode=QKVMode.FUSE_QKV,
+            qkv_mode=qkv_mode,
             qk_norm=True,
             qk_norm_mode="per_head",
             eps=eps,
@@ -83,8 +95,10 @@ class FluxJointAttention(Attention):
             config=config,
             layer_idx=layer_idx,
             module_name=module_name,
+            async_ulysses=use_async_ulysses,
         )
 
+        self._use_async_ulysses = use_async_ulysses
         self.pre_only = pre_only
         self.added_kv_proj_dim = added_kv_proj_dim
 
@@ -259,6 +273,79 @@ class FluxJointAttention(Attention):
             return self._prepare_qkv_fused(hidden_states, encoder_hidden_states, image_rotary_emb)
         return self._prepare_qkv_unfused(hidden_states, encoder_hidden_states, image_rotary_emb)
 
+    def _forward_async_attention(
+        self,
+        hidden_states: torch.Tensor,
+        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]],
+        timestep: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Run async Ulysses for single-stream FLUX attention."""
+        if not hasattr(self.attn, "forward_async"):
+            raise ValueError(
+                "FLUX async Ulysses requires UlyssesAttention with async_ulysses=True."
+            )
+
+        batch_size, seq_len = hidden_states.shape[:2]
+        num_heads = self.local_num_attention_heads
+        num_kv_heads = self.local_num_key_value_heads
+        head_dim = self.head_dim
+        # FLUX uses per-head Q/K RMSNorm weights with shape [head_dim]. The
+        # split fused norm+RoPE op only supports full-dim weights
+        # [num_heads * head_dim], so keep the async path on the unfused
+        # per-head norm+RoPE sequence for now.
+
+        if isinstance(hidden_states, Fp4QuantizedTensor):
+            qkv_input = hidden_states
+        elif self._maybe_share_qkv_quantize and getattr(self.to_q, "input_scale", None) is not None:
+            x_2d = hidden_states.reshape(-1, hidden_states.shape[-1])
+            fp4, sf = torch.ops.trtllm.tunable_fp4_quantize(
+                x_2d, self.to_q.input_scale, self.to_q.scaling_vector_size, False
+            )
+            qkv_input = Fp4QuantizedTensor(fp4, sf, is_sf_swizzled=False)
+        else:
+            qkv_input = hidden_states
+
+        def compute_q():
+            q = self.to_q(qkv_input)
+            if q.dim() == 2:
+                q = q.view(batch_size, seq_len, -1)
+            q = q.view(batch_size, seq_len, num_heads, head_dim)
+            if self.qk_norm:
+                q = F.rms_norm(
+                    q,
+                    (q.shape[-1],),
+                    self.norm_q.weight,
+                    self.norm_q.variance_epsilon,
+                )
+            if image_rotary_emb is not None:
+                q = apply_rotary_emb(q, image_rotary_emb[0], image_rotary_emb[1])
+            return q
+
+        def compute_k():
+            k = self.to_k(qkv_input)
+            if k.dim() == 2:
+                k = k.view(batch_size, seq_len, -1)
+            k = k.view(batch_size, seq_len, num_kv_heads, head_dim)
+            if self.qk_norm:
+                k = F.rms_norm(
+                    k,
+                    (k.shape[-1],),
+                    self.norm_k.weight,
+                    self.norm_k.variance_epsilon,
+                )
+            if image_rotary_emb is not None:
+                k = apply_rotary_emb(k, image_rotary_emb[0], image_rotary_emb[1])
+            return k
+
+        def compute_v():
+            v = self.to_v(qkv_input)
+            if v.dim() == 2:
+                v = v.view(batch_size, seq_len, -1)
+            return v.view(batch_size, seq_len, num_kv_heads, head_dim)
+
+        out = self.attn.forward_async(compute_q, compute_k, compute_v, timestep=timestep)
+        return out.reshape(out.shape[0], out.shape[1], -1)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -282,12 +369,14 @@ class FluxJointAttention(Attention):
         is_dual_stream = encoder_hidden_states is not None and self.added_kv_proj_dim is not None
         txt_seq_len = encoder_hidden_states.shape[1] if is_dual_stream else 0
 
-        query, key, value = self._prepare_qkv(
-            hidden_states, encoder_hidden_states, image_rotary_emb
-        )
-
-        hidden_states = self._attn_impl(query, key, value, timestep=timestep)
-        hidden_states = hidden_states.to(query.dtype)
+        if self._use_async_ulysses and not is_dual_stream:
+            hidden_states = self._forward_async_attention(hidden_states, image_rotary_emb, timestep)
+        else:
+            query, key, value = self._prepare_qkv(
+                hidden_states, encoder_hidden_states, image_rotary_emb
+            )
+            hidden_states = self._attn_impl(query, key, value, timestep=timestep)
+            hidden_states = hidden_states.to(query.dtype)
 
         if is_dual_stream:
             encoder_hidden_states_out, hidden_states = hidden_states.split(
@@ -357,6 +446,7 @@ class Flux2ParallelSelfAttention(FluxJointAttention):
             config=config,
             layer_idx=layer_idx,
             module_name=module_name,
+            enable_async_ulysses=False,
         )
 
         # Output projection needs FULL dims (ROW parallel divides internally)

--- a/tensorrt_llm/_torch/visual_gen/models/flux/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/attention.py
@@ -31,6 +31,8 @@ from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode,
 from tensorrt_llm._utils import is_sm_100f
 from tensorrt_llm.quantization.mode import QuantAlgo
 
+_MAX_ASYNC_ULYSSES_SIZE = 4
+
 # =============================================================================
 # Joint Attention (shared by FLUX.1 and FLUX.2 dual-stream blocks)
 # =============================================================================
@@ -76,7 +78,7 @@ class FluxJointAttention(Attention):
         use_async_ulysses = bool(
             enable_async_ulysses
             and added_kv_proj_dim is None
-            and ulysses_size > 1
+            and 1 < ulysses_size <= _MAX_ASYNC_ULYSSES_SIZE
             and config.parallel.async_ulysses
         )
         qkv_mode = QKVMode.SEPARATE_QKV if use_async_ulysses else QKVMode.FUSE_QKV

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
@@ -38,11 +38,7 @@ try:
     from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.models.modeling_utils import QuantConfig
-    from tensorrt_llm.visual_gen.args import (
-        AttentionConfig,
-        ParallelConfig,
-        TorchCompileConfig,
-    )
+    from tensorrt_llm.visual_gen.args import AttentionConfig, ParallelConfig, TorchCompileConfig
 
     MODULES_AVAILABLE = True
 except ImportError:

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
@@ -444,8 +444,8 @@ def _logic_flux1_async_vs_sync_parity(rank, world_size, backend):
     torch.testing.assert_close(
         async_output["sample"],
         sync_output["sample"],
-        rtol=1e-2,
-        atol=1e-2,
+        rtol=1e-3,
+        atol=1e-3,
         msg=f"Rank {rank}: FLUX.1 async-Ulysses output differs from sync Ulysses",
     )
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py
@@ -38,7 +38,11 @@ try:
     from _visual_gen_dist_utils import spawn_with_retry
 
     from tensorrt_llm.models.modeling_utils import QuantConfig
-    from tensorrt_llm.visual_gen.args import AttentionConfig, TorchCompileConfig
+    from tensorrt_llm.visual_gen.args import (
+        AttentionConfig,
+        ParallelConfig,
+        TorchCompileConfig,
+    )
 
     MODULES_AVAILABLE = True
 except ImportError:
@@ -74,11 +78,11 @@ def cleanup_distributed():
         dist.destroy_process_group()
 
 
-def _distributed_worker(rank, world_size, backend, test_fn, port):
+def _distributed_worker(rank, world_size, backend, test_fn, port, fn_args):
     """Worker function that runs in each process. Module-level for pickling."""
     try:
         init_distributed_worker(rank, world_size, backend, port)
-        test_fn(rank, world_size)
+        test_fn(rank, world_size, *fn_args)
     except Exception as e:
         print(f"Rank {rank} failed with error: {e}")
         raise
@@ -86,7 +90,12 @@ def _distributed_worker(rank, world_size, backend, test_fn, port):
         cleanup_distributed()
 
 
-def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool = True):
+def run_test_in_distributed(
+    world_size: int,
+    test_fn: Callable,
+    *fn_args,
+    use_cuda: bool = True,
+):
     """Run a test function in a distributed environment."""
     if not MODULES_AVAILABLE:
         pytest.skip("Required modules not available")
@@ -98,7 +107,7 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, use_cuda: bool =
     spawn_with_retry(
         lambda port: mp.spawn(
             _distributed_worker,
-            args=(world_size, backend, test_fn, port),
+            args=(world_size, backend, test_fn, port, fn_args),
             nprocs=world_size,
             join=True,
         )
@@ -145,7 +154,12 @@ _FLUX2_TEST_CONFIG = dict(
 )
 
 
-def _make_model_config(pretrained_dict, ulysses_size=1, backend="VANILLA"):
+def _make_model_config(
+    pretrained_dict,
+    ulysses_size=1,
+    backend="VANILLA",
+    async_ulysses=False,
+):
     """Create DiffusionModelConfig for testing."""
     pretrained_config = SimpleNamespace(**pretrained_dict)
     if ulysses_size > 1 and dist.is_initialized():
@@ -163,6 +177,10 @@ def _make_model_config(pretrained_dict, ulysses_size=1, backend="VANILLA"):
         attention=AttentionConfig(backend=backend),
         visual_gen_mapping=vgm,
         cache=None,
+        parallel=ParallelConfig(
+            ulysses_size=ulysses_size,
+            async_ulysses=async_ulysses,
+        ),
         attention_metadata_state=(
             create_attention_metadata_state() if backend.upper() == "TRTLLM" else None
         ),
@@ -188,6 +206,37 @@ def _stabilize_model_weights(model):
             else:
                 # Bias/1D params: small values
                 p.data.uniform_(-0.01, 0.01)
+
+
+def _pack_async_state_for_sync(async_state, sync_state_keys):
+    """Translate separate async Q/K/V weights to the sync fused-QKV layout."""
+    packed_state = {}
+    for key in sync_state_keys:
+        if key in async_state:
+            packed_state[key] = async_state[key]
+        elif key.endswith(".qkv_proj.weight"):
+            prefix = key[: -len(".qkv_proj.weight")]
+            packed_state[key] = torch.cat(
+                [
+                    async_state[f"{prefix}.to_q.weight"],
+                    async_state[f"{prefix}.to_k.weight"],
+                    async_state[f"{prefix}.to_v.weight"],
+                ],
+                dim=0,
+            )
+        elif key.endswith(".qkv_proj.bias"):
+            prefix = key[: -len(".qkv_proj.bias")]
+            packed_state[key] = torch.cat(
+                [
+                    async_state[f"{prefix}.to_q.bias"],
+                    async_state[f"{prefix}.to_k.bias"],
+                    async_state[f"{prefix}.to_v.bias"],
+                ],
+                dim=0,
+            )
+        else:
+            raise KeyError(f"sync key {key!r} is missing from the async state")
+    return packed_state
 
 
 # =============================================================================
@@ -309,6 +358,99 @@ def _logic_flux1_ulysses_vs_single_gpu(rank, world_size):
         rtol=1e-2,
         atol=1e-2,
         msg=f"Rank {rank}: FLUX.1 Ulysses output differs from single-GPU reference",
+    )
+
+
+def _logic_flux1_async_vs_sync_parity(rank, world_size, backend):
+    """FLUX.1 async Ulysses matches the existing synchronous Ulysses path."""
+    from tensorrt_llm._torch.visual_gen.models.flux.transformer_flux import FluxTransformer2DModel
+
+    device = torch.device(f"cuda:{rank}")
+    compute_dtype = torch.bfloat16
+
+    torch.manual_seed(123)
+    async_config = _make_model_config(
+        _FLUX1_TEST_CONFIG,
+        ulysses_size=world_size,
+        backend=backend,
+        async_ulysses=True,
+    )
+    async_model = FluxTransformer2DModel(async_config).to(device).to(compute_dtype)
+    _stabilize_model_weights(async_model)
+    async_state = async_model.state_dict()
+
+    torch.manual_seed(123)
+    sync_config = _make_model_config(
+        _FLUX1_TEST_CONFIG,
+        ulysses_size=world_size,
+        backend=backend,
+        async_ulysses=False,
+    )
+    sync_model = FluxTransformer2DModel(sync_config).to(device).to(compute_dtype)
+    sync_model.load_state_dict(
+        _pack_async_state_for_sync(async_state, sync_model.state_dict().keys())
+    )
+
+    async_attn = async_model.single_transformer_blocks[0].attn
+    sync_attn = sync_model.single_transformer_blocks[0].attn
+    assert async_attn._use_async_ulysses is True, "async model did not enable async Ulysses"
+    assert sync_attn._use_async_ulysses is False, "sync model unexpectedly enabled async Ulysses"
+    assert async_attn.qkv_mode != sync_attn.qkv_mode, (
+        "test bug: async and sync models use the same QKV projection layout"
+    )
+
+    batch = 1
+    img_seq = 16
+    txt_seq = 8
+    torch.manual_seed(456)
+    hidden_states = torch.randn(batch, img_seq, 64, device=device, dtype=compute_dtype) * 0.1
+    encoder_hidden_states = (
+        torch.randn(batch, txt_seq, 256, device=device, dtype=compute_dtype) * 0.1
+    )
+    pooled_projections = torch.randn(batch, 128, device=device, dtype=compute_dtype) * 0.1
+    timestep = torch.tensor([0.5], device=device, dtype=compute_dtype)
+    img_ids = torch.randn(img_seq, 3, device=device)
+    txt_ids = torch.randn(txt_seq, 3, device=device)
+
+    with torch.no_grad():
+        sync_output = sync_model(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            pooled_projections=pooled_projections,
+            timestep=timestep,
+            img_ids=img_ids,
+            txt_ids=txt_ids,
+        )
+        async_output = async_model(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            pooled_projections=pooled_projections,
+            timestep=timestep,
+            img_ids=img_ids,
+            txt_ids=txt_ids,
+        )
+
+    assert sync_output["sample"].shape == async_output["sample"].shape, (
+        f"Rank {rank}: output shape mismatch"
+    )
+    assert not torch.isnan(async_output["sample"]).any(), f"Rank {rank}: NaN in async output"
+    assert not torch.isinf(async_output["sample"]).any(), f"Rank {rank}: Inf in async output"
+
+    diff = (async_output["sample"].float() - sync_output["sample"].float()).abs()
+    ref = sync_output["sample"].float().abs()
+    print(
+        f"\n[FLUX.1 rank={rank} backend={backend}] "
+        f"max_abs_diff={diff.max().item():.3e} "
+        f"max_rel_diff={(diff / ref.clamp(min=1e-6)).max().item():.3e} "
+        f"sync_abs_max={ref.max().item():.3e}"
+    )
+
+    torch.testing.assert_close(
+        async_output["sample"],
+        sync_output["sample"],
+        rtol=1e-2,
+        atol=1e-2,
+        msg=f"Rank {rank}: FLUX.1 async-Ulysses output differs from sync Ulysses",
     )
 
 
@@ -514,6 +656,15 @@ class TestFlux1Ulysses:
     def test_flux1_ulysses_vs_single_gpu(self):
         """FLUX.1 Ulysses 2-GPU output matches single-GPU reference."""
         run_test_in_distributed(world_size=2, test_fn=_logic_flux1_ulysses_vs_single_gpu)
+
+    @pytest.mark.parametrize("backend", ["VANILLA", "TRTLLM"])
+    def test_flux1_async_vs_sync_parity(self, backend):
+        """FLUX.1 async Ulysses matches synchronous Ulysses at size 2."""
+        run_test_in_distributed(
+            2,
+            _logic_flux1_async_vs_sync_parity,
+            backend,
+        )
 
 
 class TestFlux2Ulysses:

--- a/tests/unittest/_torch/visual_gen/test_flux_attention.py
+++ b/tests/unittest/_torch/visual_gen/test_flux_attention.py
@@ -16,6 +16,7 @@ Note: With random weights, attention can produce NaN due to numerical instabilit
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -57,6 +58,32 @@ class TestFluxAttentionBackend(unittest.TestCase):
                     config=self._create_config("VANILLA", tp_size=tp_size),
                 )
                 self.assertEqual(attn.fuse_qk_norm_rope, expected)
+
+    def test_async_ulysses_enabled_only_for_validated_sizes(self) -> None:
+        """Test FLUX async Ulysses is limited to the validated size range."""
+        from tensorrt_llm._torch.visual_gen.models.flux.attention import FluxJointAttention
+        from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
+
+        for ulysses_size, expected in ((1, False), (2, True), (4, True), (8, False)):
+            with self.subTest(ulysses_size=ulysses_size):
+                config = self._create_config("VANILLA")
+                config.visual_gen_mapping = SimpleNamespace(ulysses_size=ulysses_size)
+                config.parallel = SimpleNamespace(async_ulysses=True)
+
+                with patch.object(Attention, "__init__", return_value=None) as init:
+                    attn = FluxJointAttention(
+                        hidden_size=128,
+                        num_attention_heads=2,
+                        head_dim=64,
+                        config=config,
+                    )
+
+                self.assertEqual(attn._use_async_ulysses, expected)
+                self.assertEqual(
+                    init.call_args.kwargs["qkv_mode"],
+                    QKVMode.SEPARATE_QKV if expected else QKVMode.FUSE_QKV,
+                )
+                self.assertEqual(init.call_args.kwargs["async_ulysses"], expected)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_vanilla_backend_sanity(self):

--- a/tests/unittest/_torch/visual_gen/test_flux_attention.py
+++ b/tests/unittest/_torch/visual_gen/test_flux_attention.py
@@ -26,9 +26,10 @@ from tensorrt_llm._torch.visual_gen.config import (
     DiffusionModelConfig,
     create_attention_metadata_state,
 )
+from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
-from tensorrt_llm.visual_gen.args import AttentionConfig
+from tensorrt_llm.visual_gen.args import AttentionConfig, ParallelConfig
 
 
 class TestFluxAttentionBackend(unittest.TestCase):
@@ -43,6 +44,27 @@ class TestFluxAttentionBackend(unittest.TestCase):
             quant_config=QuantConfig(),
             mapping=Mapping(world_size=tp_size, tp_size=tp_size),
             attention=AttentionConfig(backend=backend),
+        )
+
+    def _create_async_config(
+        self, ulysses_size: int, async_ulysses: bool = True
+    ) -> DiffusionModelConfig:
+        """Create an async-Ulysses config without initializing distributed state."""
+        visual_gen_mapping = VisualGenMapping(
+            world_size=ulysses_size,
+            rank=0,
+            ulysses_size=ulysses_size,
+        )
+        return DiffusionModelConfig(
+            pretrained_config=SimpleNamespace(),
+            quant_config=QuantConfig(),
+            mapping=visual_gen_mapping.to_llm_mapping(),
+            attention=AttentionConfig(backend="VANILLA"),
+            visual_gen_mapping=visual_gen_mapping,
+            parallel=ParallelConfig(
+                ulysses_size=ulysses_size,
+                async_ulysses=async_ulysses,
+            ),
         )
 
     def test_fused_qk_norm_rope_enabled_only_for_tp1(self) -> None:
@@ -60,30 +82,41 @@ class TestFluxAttentionBackend(unittest.TestCase):
                 self.assertEqual(attn.fuse_qk_norm_rope, expected)
 
     def test_async_ulysses_enabled_only_for_validated_sizes(self) -> None:
-        """Test FLUX async Ulysses is limited to the validated size range."""
+        """Test FLUX async Ulysses uses only the validated sizes 2 and 4."""
         from tensorrt_llm._torch.visual_gen.models.flux.attention import FluxJointAttention
-        from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
+        from tensorrt_llm._torch.visual_gen.modules.attention import QKVMode
 
-        for ulysses_size, expected in ((1, False), (2, True), (4, True), (8, False)):
-            with self.subTest(ulysses_size=ulysses_size):
-                config = self._create_config("VANILLA")
-                config.visual_gen_mapping = SimpleNamespace(ulysses_size=ulysses_size)
-                config.parallel = SimpleNamespace(async_ulysses=True)
-
-                with patch.object(Attention, "__init__", return_value=None) as init:
+        with patch(
+            "tensorrt_llm._torch.visual_gen.modules.attention.wrap_parallel_attention",
+            side_effect=lambda attention, **_: attention,
+        ) as wrap_attention:
+            for ulysses_size, expected in ((1, False), (2, True), (4, True), (8, False)):
+                with self.subTest(ulysses_size=ulysses_size):
                     attn = FluxJointAttention(
-                        hidden_size=128,
-                        num_attention_heads=2,
+                        hidden_size=512,
+                        num_attention_heads=8,
                         head_dim=64,
-                        config=config,
+                        pre_only=True,
+                        config=self._create_async_config(
+                            ulysses_size, async_ulysses=ulysses_size > 1
+                        ),
                     )
+                    self.assertEqual(attn._use_async_ulysses, expected)
+                    expected_mode = QKVMode.SEPARATE_QKV if expected else QKVMode.FUSE_QKV
+                    self.assertEqual(attn.qkv_mode, expected_mode)
+                    self.assertEqual(wrap_attention.call_args.kwargs["async_ulysses"], expected)
 
-                self.assertEqual(attn._use_async_ulysses, expected)
-                self.assertEqual(
-                    init.call_args.kwargs["qkv_mode"],
-                    QKVMode.SEPARATE_QKV if expected else QKVMode.FUSE_QKV,
+            with self.subTest("dual_stream"):
+                attn = FluxJointAttention(
+                    hidden_size=512,
+                    num_attention_heads=8,
+                    head_dim=64,
+                    added_kv_proj_dim=512,
+                    config=self._create_async_config(2),
                 )
-                self.assertEqual(init.call_args.kwargs["async_ulysses"], expected)
+                self.assertFalse(attn._use_async_ulysses)
+                self.assertEqual(attn.qkv_mode, QKVMode.FUSE_QKV)
+                self.assertFalse(wrap_attention.call_args.kwargs["async_ulysses"])
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_vanilla_backend_sanity(self):


### PR DESCRIPTION
## Description

Enable the existing async Ulysses compute/communication overlap path for **FLUX.1 single-stream self-attention**. This is opt-in through the existing `parallel_config.async_ulysses` flag and does not add a new user-facing config.

When the path is eligible, FLUX.1 single-stream attention switches from fused QKV projection to separate Q/K/V projections so `UlyssesAttention.forward_async` can issue V, Q, and K work independently and overlap async all-to-all communication with projection, per-head RMSNorm, and RoPE compute.

Dual-stream FLUX attention remains on the existing synchronous path, and FLUX.2 single-stream attention is explicitly kept on the existing fused QKV+MLP path.

## Why `_MAX_ASYNC_ULYSSES_SIZE = 4`

The async path is currently validated and beneficial for `ulysses_size=2` and `ulysses_size=4` in the measured FLUX.1 B200 setup. The same benchmark showed `ulysses_size=8` regressing, so the implementation uses a private upper-bound guard:

```python
1 < ulysses_size <= _MAX_ASYNC_ULYSSES_SIZE
```

This prevents a deployment that enables `parallel_config.async_ulysses=True` from silently taking the slower async path at unvalidated sizes. The cap is intentionally conservative and internal; it can be raised later after the size-8 regression is root-caused or larger-size/backend-specific data shows the async path is safe and beneficial.

## Changes

- Add FLUX.1 async-Ulysses gating on `parallel.async_ulysses`, single-stream attention, and validated Ulysses sizes `2` and `4`.
- Use `QKVMode.SEPARATE_QKV` only for the async-eligible path; all other FLUX attention paths keep `QKVMode.FUSE_QKV`.
- Add FLUX-local Q/K/V closures for `UlyssesAttention.forward_async`, including shared FP4 input quant reuse when available.
- Preserve FLUX.1 per-head Q/K RMSNorm on the unfused norm/RoPE sequence because the split fused norm/RoPE op expects full-dim weights.
- Explicitly disable async Ulysses for `Flux2ParallelSelfAttention` because FLUX.2 single-stream attention uses fused QKV+MLP projection.
- Add unit coverage for gating, validated sizes, dual-stream fallback, and multi-GPU async-vs-sync numerical parity.

## Performance

Full HF-checkpoint VisualGen benchmark on B200 using `black-forest-labs/FLUX.1-dev`.

Setup:

- Container: `codex-trtllm-flux-async`
- Model cache: `/tmp/hf-home`
- Resolution: `512x512`
- Denoise steps: `4`
- Guidance scale: `3.5`
- Max sequence length: `512`
- Attention backend: `VANILLA`
- `torch.compile`: disabled
- CUDA graph: disabled
- Pipeline startup warmup: skipped
- Measurement: 1 warmup image + 3 measured images per sync/async case
- Main metric: VisualGen CUDA phase timer `denoise_s_median`

| Ulysses size | Mode | Denoise median | Generation median | Wall median |
| --- | --- | ---: | ---: | ---: |
| 2 | sync | 0.2970 s | 0.3364 s | 0.3496 s |
| 2 | async | 0.2656 s | 0.3042 s | 0.3117 s |
| 4 | sync | 0.3006 s | 0.3405 s | 0.3500 s |
| 4 | async | 0.2714 s | 0.3125 s | 0.3763 s |
| 8 | sync | 0.3084 s | 0.3480 s | 0.3550 s |
| 8 | async | 0.4416 s | 0.4862 s | 0.5010 s |

Relative denoise result:

| Ulysses size | Async latency delta | Speedup |
| --- | ---: | ---: |
| 2 | -10.6% | 1.12x |
| 4 | -9.7% | 1.11x |
| 8 | +43.2% | 0.70x |

## Test Coverage

- `python3 -m py_compile tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py tests/unittest/_torch/visual_gen/test_flux_attention.py tensorrt_llm/_torch/visual_gen/models/flux/attention.py`: pass.
- `git diff --check -- tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py`: pass.
- `pytest` collect-only for `test_flux1_async_vs_sync_parity`: pass; collected `VANILLA` and `TRTLLM` cases.
- GitHub Actions on latest pushed SHA `554d19c7b3`: `Release Checks`, `PR Checks`, `LLM API Compatibility`, and `PR Base Freshness` pass.

### Added Tests

- `tests/unittest/_torch/visual_gen/test_flux_attention.py::TestFluxAttentionBackend::test_async_ulysses_enabled_only_for_validated_sizes`
  - Covers `ulysses_size` values `1`, `2`, `4`, and `8`.
  - Verifies async is enabled only for validated sizes `2` and `4`.
  - Verifies dual-stream attention remains synchronous even when `async_ulysses=True`.
- `tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py::TestFlux1Ulysses::test_flux1_async_vs_sync_parity`
  - Runs with 2 ranks at `ulysses_size=2`.
  - Builds async `SEPARATE_QKV + forward_async` and sync `FUSE_QKV` models.
  - Packs async Q/K/V weights into the sync fused-QKV layout via `_pack_async_state_for_sync` for bit-identical model weights.
  - Compares full-model output across `VANILLA` and `TRTLLM` with `torch.testing.assert_close(rtol=1e-3, atol=1e-3)`.

### CI Placement

- The new multi-GPU parity test is in `tests/unittest/_torch/visual_gen/multi_gpu/test_flux_ulysses.py`.
- That file is included in `tests/integration/test_lists/test-db/l0_dgx_b200.yml`.
- `jenkins/L0_Test.groovy` maps `l0_dgx_b200` to B200 multi-GPU PyTorch stages, including `DGX_B200-2_GPUs-PyTorch-1`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work)).
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.