### PR TITLE
[https://nvbugs/6468821][fix] Rename the dynamic-tree worker's `forward` override to `_forward_impl`…

### DIFF
--- a/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
+++ b/tensorrt_llm/_torch/speculative/mtp_dynamic_tree.py
@@ -636,7 +636,7 @@ class MTPEagleDynamicTreeWorker(MTPEagleWorker):
     # Top-level forward                                                   #
     # ------------------------------------------------------------------ #
     @nvtx_range("mtp_dyn.forward")
-    def forward(
+    def _forward_impl(
         self,
         input_ids,
         position_ids,


### PR DESCRIPTION
## Summary
- **Root cause**: MTPEagleDynamicTreeWorker overrode SpecWorkerBase.forward, which __init_subclass__ forbids, raising TypeError at import and making `import tensorrt_llm` fail so the attention test collected 0 items.
- **Fix**: Rename the dynamic-tree worker's `forward` override to `_forward_impl`, matching the SpecWorkerBase contract and its parent MTPEagleWorker._forward_impl, so the base `forward` wrapper (with metadata cleanup) is preserved.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6468821


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Renamed `MTPEagleDynamicTreeWorker.forward(...)` to `_forward_impl(...)` without changing its signature or implementation.
- Aligns the worker with the `SpecWorkerBase` contract and the existing `MTPEagleWorker` pattern, preventing the import-time `TypeError` while preserving base-wrapper metadata cleanup.
- No configuration, test-list, performance, or error-handling changes.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->