### PR TITLE
[None][fix] Do not treat a bare fmha_v2_cu directory as completed generation

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -325,6 +325,11 @@ def generate_fmha_cu(project_dir, venv_python):
         move_if_updated(cu_file, dst_file)
         generated_files.add(str(dst_file.resolve()))
 
+    if not generated_files:
+        raise RuntimeError(
+            f"FMHA generation produced no *_sm*.cu files in {fmha_v2_cu_dir}; "
+            "generation may have failed silently.")
+
     # Remove extra files
     for root, _, files in os.walk(fmha_v2_cu_dir):
         for file in files:

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -264,7 +264,7 @@ def setup_conan(scripts_dir, venv_python):
     return venv_conan
 
 
-def fmha_generation_stamp(fmha_v2_cu_dir):
+def _fmha_generation_stamp(fmha_v2_cu_dir: Path) -> Path:
     # Written as the last step of generate_fmha_cu; its absence means a
     # previous generation was interrupted and the directory contents cannot
     # be trusted (the bare directory exists from the moment generation
@@ -275,7 +275,7 @@ def fmha_generation_stamp(fmha_v2_cu_dir):
 def generate_fmha_cu(project_dir, venv_python):
     fmha_v2_cu_dir = project_dir / "cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmha_v2_cu"
     fmha_v2_cu_dir.mkdir(parents=True, exist_ok=True)
-    fmha_generation_stamp(fmha_v2_cu_dir).unlink(missing_ok=True)
+    _fmha_generation_stamp(fmha_v2_cu_dir).unlink(missing_ok=True)
 
     fmha_v2_dir = project_dir / "cpp/kernels/fmha_v2"
 
@@ -332,7 +332,7 @@ def generate_fmha_cu(project_dir, venv_python):
             if file_path not in generated_files:
                 os.remove(file_path)
 
-    fmha_generation_stamp(fmha_v2_cu_dir).touch()
+    _fmha_generation_stamp(fmha_v2_cu_dir).touch()
 
 
 def create_cuda_stub_links(cuda_stub_dir: str, missing_libs: list[str]) -> str:
@@ -690,7 +690,7 @@ def main(*,
 
     fmha_v2_cu_dir = project_dir / "cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmha_v2_cu"
     if (clean or generate_fmha
-            or not fmha_generation_stamp(fmha_v2_cu_dir).exists()):
+            or not _fmha_generation_stamp(fmha_v2_cu_dir).exists()):
         generate_fmha_cu(project_dir, venv_python)
 
     with working_directory(build_dir):

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -264,9 +264,18 @@ def setup_conan(scripts_dir, venv_python):
     return venv_conan
 
 
+def fmha_generation_stamp(fmha_v2_cu_dir):
+    # Written as the last step of generate_fmha_cu; its absence means a
+    # previous generation was interrupted and the directory contents cannot
+    # be trusted (the bare directory exists from the moment generation
+    # starts).
+    return fmha_v2_cu_dir / ".generation_complete"
+
+
 def generate_fmha_cu(project_dir, venv_python):
     fmha_v2_cu_dir = project_dir / "cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmha_v2_cu"
     fmha_v2_cu_dir.mkdir(parents=True, exist_ok=True)
+    fmha_generation_stamp(fmha_v2_cu_dir).unlink(missing_ok=True)
 
     fmha_v2_dir = project_dir / "cpp/kernels/fmha_v2"
 
@@ -322,6 +331,8 @@ def generate_fmha_cu(project_dir, venv_python):
             file_path = os.path.realpath(os.path.join(root, file))
             if file_path not in generated_files:
                 os.remove(file_path)
+
+    fmha_generation_stamp(fmha_v2_cu_dir).touch()
 
 
 def create_cuda_stub_links(cuda_stub_dir: str, missing_libs: list[str]) -> str:
@@ -678,7 +689,8 @@ def main(*,
     source_dir = get_source_dir()
 
     fmha_v2_cu_dir = project_dir / "cpp/tensorrt_llm/kernels/contextFusedMultiHeadAttention/fmha_v2_cu"
-    if clean or generate_fmha or not fmha_v2_cu_dir.exists():
+    if (clean or generate_fmha
+            or not fmha_generation_stamp(fmha_v2_cu_dir).exists()):
         generate_fmha_cu(project_dir, venv_python)
 
     with working_directory(build_dir):


### PR DESCRIPTION
@coderabbitai summary

## Description

`generate_fmha_cu` creates the `fmha_v2_cu` output directory before the (minutes-long) kernel generation runs, but the build skips generation whenever that directory exists. An interrupted first generation (Ctrl-C, node failure, build timeout) leaves an empty/partial directory that every subsequent non-clean build trusts — launcher `.cu` sources are missing, and the build fails later at link time with undefined `run_fmha_v2_*` symbols.

Fixes this by writing a `.generation_complete` stamp as the last step of `generate_fmha_cu` (removed again as its first step) and keying the skip check on the stamp instead of the directory. The stamp is only created after validating that at least one `*_sm*.cu` file was produced, so a silent failure in the generator won't leave a misleading stamp. Existing checkouts regenerate once to acquire the stamp; the content-compare copy keeps mtimes of unchanged files so no recompilation results.

## Test Coverage

No automated tests — this code path requires a full FMHA kernel generation run which takes several minutes and depends on CUDA toolchain setup not present in CI. Manual verification:

- Interrupt an `fmha_v2_cu` generation mid-run, then rebuild without `--clean` — confirm generation restarts rather than skipping.
- Let generation complete fully, then rebuild — confirm generation is skipped (stamp present).
- Confirm a clean build from scratch still works end-to-end.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.