### PR TITLE
[None][fix] Keep chunked-MoE size vectors identical across attention-DP ranks

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
@@ -640,9 +640,16 @@ class ExternalCommMoEScheduler(MoEScheduler):
                     x_list[idx_chunk] = x_list[0]
                     router_logits_list[idx_chunk] = router_logits_list[0]
                     input_ids_list[idx_chunk] = input_ids_list[0]
-                    all_rank_num_tokens_list[idx_chunk][moe.mapping.tp_rank] = (
-                        all_rank_num_tokens_list[0][moe.mapping.tp_rank]
-                    )
+            # Mirror the empty-chunk substitution above into the work list:
+            # all_rank_num_tokens_list feeds the varsize collectives, so every
+            # rank must patch EVERY empty entry, not just its own -- the size
+            # vectors have to be identical on all ranks. all_rank_chunk_size_list
+            # is the untouched ground truth used to detect the empty chunks.
+            for idx_chunk in range(num_chunks):
+                vec = all_rank_num_tokens_list[idx_chunk]
+                for j in range(len(vec)):
+                    if all_rank_chunk_size_list[j][idx_chunk] == 0:
+                        vec[j] = all_rank_chunk_size_list[j][0]
             x_list = tuple(x_list)
             router_logits_list = tuple(router_logits_list)
             input_ids_list = tuple(input_ids_list)


### PR DESCRIPTION
## Description

Under attention-DP, when a heavy prefill exceeds `moe_config.max_num_tokens` the MoE forward is chunked. On the varsize allgather/reduce-scatter comm lane (the fallback whenever the alltoall lane cannot run chunked, e.g. DeepEP on multi-node IB), the collectives cannot take an empty chunk, so a rank whose chunk is empty re-sends its chunk-0 data instead — but the size-vector update in `_forward_multiple_chunks` only patched the **local rank's** entry of `all_rank_num_tokens_list`. Different ranks then derive **different size vectors for the same collective**, and NCCL deadlocks: all GPUs spin at 100%, no error until the watchdog aborts (~300 s).

The fix patches **every** rank's empty entries from `all_rank_chunk_size_list` (the shared ground truth all ranks compute identically), so the per-chunk size vectors are identical across ranks. This is a no-op for the alltoall lanes, whose existing 0→1 substitution already yields identical vectors.

## Test Coverage

Reproduced deterministically with Qwen3.5-397B-A17B (NVFP4) wide-EP EP16 (attention-DP) across 2×8 B200 over InfiniBand, 32k-ISL prefills with `moe_config.max_num_tokens=32768`: the run deadlocks at the second chunked iteration without this patch and completes 210k+ iterations cleanly with it (same wheel A/B). Accuracy sanity of the same setup is unaffected (single-chunk paths untouched).

Trigger conditions covered: attention-DP + chunked MoE (cap exceeded) + at least one rank with fewer tokens than chunks (mixed prefill/decode across DP ranks — the steady state of any real serving workload).

## PR Checklist

- [x] The PR title follows the required format.
- [x] The PR description explains the issue and the fix.
- [x] Relevant reviewers are aware (mirror of an internal fix, validated as described above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Fixed a deadlock in chunked MoE execution under attention-DP when varsize allgather/reduce-scatter collectives encounter empty chunks.
- In `tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py` (`ExternalCommMoEScheduler._forward_multiple_chunks`), expanded the DP empty-chunk substitution so that for every chunk index `idx_chunk` and every DP rank `j`:
  - If `all_rank_chunk_size_list[j][idx_chunk] == 0`, the code patches `all_rank_num_tokens_list[idx_chunk][j]` to `all_rank_chunk_size_list[j][0]`.
  - This mirrors the empty-chunk substitution behavior across ranks, ensuring all ranks build identical per-chunk varsize “size vectors” even when a chunk is empty locally.
- Verified related scope: the earlier per-chunk substitution that swaps local `x_list/router_logits_list/input_ids_list` from empty chunks to chunk-0 remains in place; the change specifically updates the DP collective shape inputs (`all_rank_num_tokens_list`) to eliminate rank divergence.
- Confirmed change does not affect the single-chunk or Alltoall paths (Alltoall uses a separate guard that substitutes 1 token for an all-zero rank).

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->