### PR TITLE
[None][perf] Precompute GDN cache reset indices once per forward

### DIFF
--- a/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
@@ -1036,14 +1036,12 @@ class Qwen3NextGatedDeltaNet(nn.Module):
 
         state_indices_p, state_indices_d = torch.split(state_indices, batch_split_size)
         if num_prefills > 0:
-            # PyExecutor guarantees prefill requests are placed before decode requests
-            has_initial_states_p = has_initial_states[:num_prefills]
-            ssm_states[state_indices_p[~has_initial_states_p]] = torch.zeros(
-                (), dtype=ssm_states.dtype, device=ssm_states.device
-            )
-            conv_states[state_indices_p[~has_initial_states_p]] = torch.zeros(
-                (), dtype=conv_states.dtype, device=conv_states.device
-            )
+            # Zero conv/ssm cache slots for prefill sequences with no initial
+            # state. Indices are precomputed once per forward in prepare();
+            reset_state_indices = mamba_metadata.reset_state_indices
+            if reset_state_indices is not None:
+                ssm_states.index_fill_(0, reset_state_indices, 0)
+                conv_states.index_fill_(0, reset_state_indices, 0)
 
         is_target_verify = (
             num_decodes > 0

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -264,6 +264,12 @@ class Mamba2Metadata:
                                             dtype=torch.long,
                                             device="cuda")
 
+        # Slots that are reset for prefill sequences.
+        self._reset_pos_cpu = torch.zeros(max_batch_size,
+                                          dtype=torch.long,
+                                          pin_memory=prefer_pinned())
+        self.reset_state_indices = None
+
     def _prepare_replay_work_items(self, kv_cache_manager, batch_size: int,
                                    num_contexts: int):
         self.replay_num_decodes = 0
@@ -327,6 +333,9 @@ class Mamba2Metadata:
 
         kv_cache_manager = attn_metadata.kv_cache_manager
         request_ids = attn_metadata.request_ids
+
+        # Recomputed below for prefill batches, None means "no slots to reset".
+        self.reset_state_indices = None
 
         if (kv_cache_manager is not None
                 and hasattr(kv_cache_manager, 'get_state_indices')
@@ -425,6 +434,22 @@ class Mamba2Metadata:
             # Keep a host boolean gate for chunk metadata construction.
             self.use_initial_states = bool(
                 self.has_initial_states_cpu[:num_contexts].any())
+
+            # Select the reset slots on the host mask, stage the positions
+            # through the pinned buffer, then gather the slot ids on-device.
+            # Done once here since it is identical for every GDN layer.
+            reset_pos_cpu = torch.nonzero(
+                ~self.has_initial_states_cpu[:num_contexts], as_tuple=True)[0]
+            num_reset = reset_pos_cpu.numel()
+            if num_reset > 0:
+                self._reset_pos_cpu[:num_reset].copy_(reset_pos_cpu)
+                reset_pos = self._reset_pos_cpu[:num_reset].to(
+                    self.state_indices.device, non_blocking=True)
+                # index_fill_ needs int64 indices.
+                self.reset_state_indices = self.state_indices[:
+                                                              num_contexts].index_select(
+                                                                  0, reset_pos
+                                                              ).to(torch.long)
 
             if self.use_initial_states:
                 _extra = compute_extra_chunks_cpu(attn_metadata.seq_lens,


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description


TTFT improvement

 Qwen3.5-35B-A3B-FP8, 1 H100 400W, BS=1, ISL=10K / OSL=1
  
  | Config | Before | After | Δ |
  |--------|-------:|------:|---:|
  | piecewise = off | 268.7 ms | 263.0 ms | 2.1% |
  | piecewise = on | 282.7 ms | 278.0 ms | 1.7% |

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

Existing Qwen3.5 accuracy tests in `tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B`

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
