### PR TITLE
[None][fix] Stage DSA indexer block_table H2D through pinned memory

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -1480,11 +1480,17 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
                               1) // tokens_per_block
         max_blocks_used = num_blocks_per_seq.max().item(
         ) if self.num_seqs > 0 else 1
-        # pool_indices already has correct values; set padding to -1
-        host_block_table = pool_indices[:, :max_blocks_used].clone()
-        for i in range(self.num_seqs):
-            if num_blocks_per_seq[i] < max_blocks_used:
-                host_block_table[i, num_blocks_per_seq[i]:] = -1
+        # pool_indices already has correct values; set padding to -1.
+        # Stage through a fresh pinned buffer: an async H2D from pageable
+        # memory would block the host behind the busy execution stream.
+        host_block_table = torch.empty((pool_indices.shape[0], max_blocks_used),
+                                       dtype=pool_indices.dtype,
+                                       pin_memory=prefer_pinned())
+        host_block_table.copy_(pool_indices[:, :max_blocks_used])
+        pad_cols = torch.arange(max_blocks_used, dtype=num_blocks_per_seq.dtype)
+        host_block_table.masked_fill_(
+            pad_cols.unsqueeze(0)
+            >= num_blocks_per_seq[:self.num_seqs].unsqueeze(1), -1)
         # Copy to GPU
         self.block_table[:self.num_seqs, :max_blocks_used].copy_(
             host_block_table, non_blocking=True)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `prepare_for_indexer_k_cache` to stage `block_table` in a freshly allocated pinned host-memory buffer for asynchronous host-to-device transfer, rather than cloning into pageable memory.
- Replaced the per-row Python loop that overwrote padding columns with `-1` with a vectorized `masked_fill_` approach (using a `pad_cols` vs `num_blocks_per_seq` mask), preserving byte-identical staged output.
- Improves overlap-scheduler performance by reducing host blocking during H2D copies and lowering blocked memcpy time.
- No public API, configuration, or test-list changes.
- Existing DSA/GLM/DeepSeek-V3.2 attention correctness tests cover the affected path.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

`DSAtrtllmAttentionMetadata.prepare_for_indexer_k_cache` stages the per-step
`block_table` H2D upload through `pool_indices[:, :max_blocks_used].clone()`.
`pool_indices` is the result of a chain of CPU tensor ops (`//`, `clamp`, `.to`),
so the clone is **pageable** host memory — and `cudaMemcpyAsync` from pageable
memory blocks the calling thread until the copy completes behind everything
already queued on the execution stream. Under the overlap scheduler that is up
to a full decode step.

Measured on GLM 5.2 GB300 disaggregated decode (nsys, runtime-API/correlation
analysis of the GEN workers):

- DEP8 / MTP3 / batch ≈ 36: the copy blocked the host **26 ms of every
  46 ms iteration** (78% of the 33.5 ms `_prepare_inputs`), leaving a 5-6 ms
  GPU bubble per step.
- DEP16 / MTP4 / batch ≈ 3: a subset of ADP ranks blocked 12-24 ms/iter in this
  copy; the per-step ADP allgathers then serialize **all** ranks to the slowest
  one (clean ranks showed it as an ~18 ms silent MPI wait inside
  `_prepare_inputs`).

Fix: stage through a freshly-allocated **pinned** buffer — the caching host
allocator holds it until the consuming copy completes, the same pattern as
`KVCacheManager._stage_block_offsets_for_copy` (nvbug 6293536) — and replace the
per-row Python `-1` padding loop with a vectorized `masked_fill_`.

A/B on GLM 5.2 GB300 disagg e2e (identical configs/seed, agentic coding-agent
load, steady state):

| metric | before | after |
|---|---|---|
| DEP8/MTP3 iter mean | 47.4 ms | 41.6 ms (**-12%**) |
| DEP8/MTP3 iter p99 | 109.9 ms | 48.0 ms |
| per-user speed p25/p50 (SSE) | 51.4 / 55.8 tok/s | 58.0 / 62.6 tok/s (**+12.8%**) |
| `_prepare_inputs` blocked-memcpy | 26.0 ms/iter | 0.56 ms |
| DEP16/MTP4 `_prepare_inputs` windows >8 ms | 28/30 iters | 0 |

The staged padding output is byte-identical to the previous code (verified over
200 randomized shapes).

## Test Coverage

- Covered by existing DSA/GLM/DeepSeek-V3.2 attention correctness tests that
  exercise `prepare_for_indexer_k_cache` (no functional change; staging buffer
  contents verified identical to the previous `clone()` path).
- Perf verified end-to-end on GLM 5.2 GB300 disaggregated serving (DEP8/MTP3
  and DEP16/MTP4 gen configs), numbers above.

## PR Checklist
- [x] PR title and description added
- [x] Signed-off commits (DCO)
