### PR TITLE
[None][fix] SA spec dec: promote accepted hybrid recurrent states in-worker

### DIFF
--- a/tensorrt_llm/_torch/speculative/sa_worker.py
+++ b/tensorrt_llm/_torch/speculative/sa_worker.py
@@ -31,6 +31,7 @@ import torch
 
 from tensorrt_llm._utils import prefer_pinned
 
+from ..pyexecutor.mamba_cache_manager import MambaHybridCacheManager
 from ..pyexecutor.sampler import TorchSampler
 from .interface import SpecMetadata, SpecWorkerBase
 from .spec_sampler_base import SampleStateSpec, SpecSamplerBase
@@ -179,6 +180,20 @@ class SAWorker(SpecWorkerBase):
         accepted_tokens, num_accepted_tokens = self._sample_and_accept_draft_tokens(
             input_ids, logits, spec_metadata, attn_metadata
         )
+
+        # Hybrid (SSM/recurrent) models: promote the accepted step's
+        # recurrent state from the verification scratch buffers into the
+        # live pools — verification never writes the pools in place (a
+        # rejected draft would corrupt them). Same call site as the other
+        # one-engine workers (dflash/eagle3); no-op for pure-attention
+        # models via the isinstance gate.
+        num_gens = batch_size - num_contexts
+        if num_gens > 0 and isinstance(attn_metadata.kv_cache_manager, MambaHybridCacheManager):
+            attn_metadata.kv_cache_manager.update_mamba_states(
+                attn_metadata=attn_metadata,
+                num_accepted_tokens=num_accepted_tokens,
+                state_indices=attn_metadata.mamba_metadata.state_indices,
+            )
 
         # Step 3-4: Extend SA and generate next draft tokens using GPU kernel
         next_draft_tokens = self._generate_draft_tokens(

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -50,6 +50,7 @@ l0_h100:
   - unittest/_torch/sampler -k "not test_speculative_d2h_parity_real_predictor"
   - unittest/_torch/speculative/test_eagle3.py
   - unittest/_torch/speculative/test_rejection_buffers_guard.py
+  - unittest/_torch/speculative/test_sa_hybrid_state_promotion.py
   - unittest/_torch/speculative/hw_agnostic
   - unittest/_torch/thop/parallel
   - unittest/_torch/thop/parallel_hw_agnostic

--- a/tests/unittest/_torch/speculative/test_sa_hybrid_state_promotion.py
+++ b/tests/unittest/_torch/speculative/test_sa_hybrid_state_promotion.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for SAWorker promoting accepted recurrent states on
+hybrid (SSM) models.
+
+Verification writes per-step recurrent states to the cache manager's
+speculative scratch buffers, never the live pools; the worker must promote
+the accepted step via ``update_mamba_states`` after acceptance (mirroring
+the dflash/eagle3 one-engine workers), or hybrid models silently corrupt
+their recurrent state under standalone SA speculative decoding.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import MixedMambaHybridCacheManager
+from tensorrt_llm._torch.speculative.sa_worker import SAWorker
+
+
+def _make_worker() -> SAWorker:
+    spec_config = SimpleNamespace(max_draft_len=4, max_matching_ngram_size=2)
+    worker = SAWorker(spec_config)
+    # Stub out everything around the state-promotion call site; the mocked
+    # sampler return values flow into update_mamba_states unchanged.
+    worker._execute_guided_decoder_if_present = mock.MagicMock()
+    worker._sample_and_accept_draft_tokens = mock.MagicMock(
+        return_value=(mock.sentinel.accepted_tokens, mock.sentinel.num_accepted_tokens)
+    )
+    worker._generate_draft_tokens = mock.MagicMock(return_value=mock.sentinel.next_draft_tokens)
+    worker._prepare_next_new_tokens = mock.MagicMock(return_value=mock.sentinel.next_new_tokens)
+    return worker
+
+
+def _make_metadata(kv_cache_manager, num_seqs: int, num_contexts: int):
+    attn_metadata = SimpleNamespace(
+        num_seqs=num_seqs,
+        num_contexts=num_contexts,
+        kv_cache_manager=kv_cache_manager,
+        mamba_metadata=SimpleNamespace(state_indices=mock.sentinel.state_indices),
+    )
+    spec_metadata = SimpleNamespace(
+        runtime_draft_len=4,
+        batch_indices_cuda=mock.sentinel.batch_indices_cuda,
+    )
+    return attn_metadata, spec_metadata
+
+
+def _run_forward(worker, attn_metadata, spec_metadata):
+    return worker._forward_impl(
+        input_ids=mock.sentinel.input_ids,
+        position_ids=mock.sentinel.position_ids,
+        hidden_states=mock.sentinel.hidden_states,
+        logits=mock.sentinel.logits,
+        attn_metadata=attn_metadata,
+        spec_metadata=spec_metadata,
+    )
+
+
+def test_hybrid_manager_promotes_accepted_states():
+    worker = _make_worker()
+    manager = mock.MagicMock(spec=MixedMambaHybridCacheManager)
+    attn_metadata, spec_metadata = _make_metadata(manager, num_seqs=2, num_contexts=0)
+
+    result = _run_forward(worker, attn_metadata, spec_metadata)
+
+    manager.update_mamba_states.assert_called_once_with(
+        attn_metadata=attn_metadata,
+        num_accepted_tokens=mock.sentinel.num_accepted_tokens,
+        state_indices=mock.sentinel.state_indices,
+    )
+    assert result["new_tokens"] is mock.sentinel.accepted_tokens
+
+
+def test_hybrid_manager_context_only_batch_skips_promotion():
+    worker = _make_worker()
+    manager = mock.MagicMock(spec=MixedMambaHybridCacheManager)
+    attn_metadata, spec_metadata = _make_metadata(manager, num_seqs=2, num_contexts=2)
+
+    _run_forward(worker, attn_metadata, spec_metadata)
+
+    manager.update_mamba_states.assert_not_called()
+
+
+def test_pure_attention_manager_skips_promotion():
+    worker = _make_worker()
+    manager = mock.MagicMock()  # not a MambaHybridCacheManager
+    attn_metadata, spec_metadata = _make_metadata(manager, num_seqs=2, num_contexts=0)
+
+    _run_forward(worker, attn_metadata, spec_metadata)
+
+    manager.update_mamba_states.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

`SAWorker` (standalone suffix-automaton speculative decoding) never commits accepted verification-step recurrent states for SSM/hybrid models. Verification writes per-step states into the cache manager's `SpeculativeState` scratch buffers — the live pools are read-only during verify, since a rejected draft must not corrupt them — but nothing promotes the accepted step back into the live pools afterwards. The result is silent recurrent-state corruption on any hybrid (Mamba/GDN/linear-attention) model running standalone SA spec-dec.

Fix: call `update_mamba_states` right after on-device acceptance, at the same call site the other one-engine workers (dflash, eagle3, mtp_dynamic_tree) already use. The call is gated on `isinstance(attn_metadata.kv_cache_manager, MambaHybridCacheManager)` and `num_gens > 0`, so pure-attention models and context-only batches are unaffected.

## Test Coverage

New `tests/unittest/_torch/speculative/test_sa_hybrid_state_promotion.py` (mock-based, no GPU/model needed, <1s):
- hybrid cache manager + generation batch → `update_mamba_states` called exactly once with the sampler's `num_accepted_tokens` and the metadata's `state_indices`
- hybrid cache manager + context-only batch → not called
- pure-attention cache manager → not called

The promotion test fails against the pre-fix worker and passes with the fix. Added to the H100 L0 pre-merge list (`l0_h100.yml`) alongside the other speculative unit tests.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Dev Engineer Review**

- Updated `tensorrt_llm/_torch/speculative/sa_worker.py` to import `MambaHybridCacheManager` and, in `SAWorker._forward_impl`, call `attn_metadata.kv_cache_manager.update_mamba_states(...)` immediately after `_sample_and_accept_draft_tokens` (i.e., after accepted/verified tokens are determined).
- Promotion is gated to hybrid generation batches only: `num_gens = batch_size - attn_metadata.num_contexts` and `num_gens > 0`, plus `isinstance(attn_metadata.kv_cache_manager, MambaHybridCacheManager)`. Context-only batches (`num_contexts > 0`) and pure-attention (non-`MambaHybridCacheManager`) managers skip promotion.
- The call promotes the accepted verification-step recurrent state using `attn_metadata`, `num_accepted_tokens`, and `state_indices=attn_metadata.mamba_metadata.state_indices`.

**QA Engineer Review**

- Added `tests/unittest/_torch/speculative/test_sa_hybrid_state_promotion.py` with 3 new tests:
  - `test_hybrid_manager_promotes_accepted_states`: asserts `update_mamba_states` is called once with `attn_metadata`, `num_accepted_tokens`, and `state_indices`, and that `result["new_tokens"]` returns the mocked accepted tokens.
  - `test_hybrid_manager_context_only_batch_skips_promotion`: asserts `update_mamba_states` is not called when `num_contexts > 0`.
  - `test_pure_attention_manager_skips_promotion`: asserts `update_mamba_states` is not called when the KV cache manager is not a `MambaHybridCacheManager`.
- Added `unittest/_torch/speculative/test_sa_hybrid_state_promotion.py` to `tests/integration/test_lists/test-db/l0_h100.yml` under the `l0_h100` list.
- Verdict: sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

