### PR TITLE
[https://nvbugs/6499882][fix] Seed _multi_frontend_ipc_dir in bare proxy test helper

### DIFF
--- a/tests/unittest/executor/test_proxy_fast_death.py
+++ b/tests/unittest/executor/test_proxy_fast_death.py
@@ -53,6 +53,7 @@ def _bare_proxy():
     proxy._results = {}
     # Set so the __del__ -> shutdown() path is a clean no-op at GC time.
     proxy.workers_started = False
+    proxy._multi_frontend_ipc_dir = None
     return proxy
 
 


### PR DESCRIPTION
The three `test_shutdown_*` tests in `test_proxy_fast_death.py` build a `GenerationExecutorProxy` via `__new__` (bypassing `__init__`) and call `shutdown()`, which reads `self._multi_frontend_ipc_dir` — an attribute only seeded in `__init__`. The bare-proxy helper never set it, so the tests raised `AttributeError`.

Seed `_multi_frontend_ipc_dir = None` in `_bare_proxy()`.

NVBug: https://nvbugspro.nvidia.com/bug/6499882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated the `_bare_proxy()` test helper to initialize `proxy._multi_frontend_ipc_dir = None`, matching what `GenerationExecutorProxy.__init__` would normally establish.
- Prevents `shutdown()`/GC cleanup from failing when `GenerationExecutorProxy` instances are created via `__new__` in `test_proxy_fast_death.py`.
- No changes to runtime logic, configuration, public APIs, or test-list entries.

## QA Engineer Review

- Touched `tests/unittest/executor/test_proxy_fast_death.py` by modifying the `_bare_proxy()` helper only.
- No test functions were added, removed, or modified; the existing shutdown tests:
  - `test_shutdown_does_not_block_on_dead_engine`
  - `test_shutdown_keeps_blocking_semantics_when_engine_alive`
  - `test_shutdown_does_not_shut_down_external_session`
  are the ones unblocked by the helper initialization.
- No changes to `tests/integration/test_lists/` (and therefore no CI/manual QA coverage list updates were required).
- Verdict: sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->