### PR TITLE
[None][refactor] Mixed Modality Support for Nemotron Nano Omni V3

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -95,6 +95,21 @@ def _lengths_by_modality(
     """Invert prompt-ordered `multimodal_embedding_lengths` (number of
     embedding rows per item) into per-modality per-item lengths, matching
     the per-modality item order used by `EncoderGroup.build_batched_input`.
+
+    Glossary used below:
+
+    * **group** — one `EncoderGroup` entry (a single tuple of modalities
+      that share an encoder call). E.g. Qwen3-VL registers one group
+      `("image", "video")`; Nano registers three groups
+      `("image",)`, `("video",)`, `("audio",)`.
+    * **group-local modalities** — the `modalities` tuple of the group
+      whose encoder is being invoked (this function's `modalities` arg).
+    * **cross-group mix** — a single request whose items span modalities
+      belonging to two *different* groups (e.g. one image + one audio
+      item for Nano, where image and audio live in separate groups).
+    * **multi-group model** — a model that registers more than one
+      `EncoderGroup`, so its group-local `modalities` tuples are each
+      strictly narrower than the full request-level modality set.
     """
     by_modality: Dict[str, List[int]] = {m: [] for m in modalities}
     for mp in multimodal_params:
@@ -107,13 +122,16 @@ def _lengths_by_modality(
         # Raw-prompt entrypoints (non chat-parsing) do not attach a manifest,
         # so this is the single enforcement point that a >1-modality request
         # must carry `mm_item_order` to make prompt-order reordering possible.
-        present = [m for m in modalities if mp.multimodal_data.get(m) is not None]
+        # Check the *request-level* modality set so multi-group models (each
+        # group with a single modality) still catch cross-group mixes — the
+        # group-local `modalities` tuple can have length 1 and never trip.
+        present = [m for m in _MM_DATA_INPUT_MODALITY_KEYS if mp.multimodal_data.get(m) is not None]
         if len(present) > 1:
             raise ValueError(
                 "Request with multiple modalities present "
                 f"({present}) must carry mm_item_order on MultimodalParams."
             )
-        if present:
+        if present and present[0] in by_modality:
             by_modality[present[0]].extend(flat)
     return by_modality
 

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -43,9 +43,8 @@ def _is_mm_disagg() -> bool:
 
 def has_raw_multimodal_payload(param: MultimodalParams) -> bool:
     multimodal_data = param.multimodal_data or {}
-    modality_type = multimodal_data.get("modality_type")
-    return (modality_type in ("image", "video", "audio")
-            and multimodal_data.get(modality_type) is not None)
+    return any(
+        multimodal_data.get(m) is not None for m in ("image", "video", "audio"))
 
 
 # Processor *output* keys that transformers 5.x's

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -3,6 +3,7 @@ import copy
 import math
 import re
 from dataclasses import dataclass
+from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -43,6 +44,11 @@ from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
 from ..model_config import ModelConfig
 from .modeling_auto import AutoModelForCausalLM
+from .modeling_multimodal_mixin import (
+    EncoderGroup,
+    MultimodalModelMixin,
+    encode_multimodal_by_groups,
+)
 from .modeling_multimodal_utils import (
     _is_mm_disagg,
     find_input_mm_embeds,
@@ -705,29 +711,19 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         if self.video_pruning_rate <= 0:
             return mm_embedding, None
 
-        modality_types = [
-            multimodal_data["modality_type"] for multimodal_data in multimodal_data_lst
+        video_sizes_list = [
+            (mm_data.get("video") or {}).get("video_size") for mm_data in multimodal_data_lst
         ]
-        # Skip EVS if there is no video modality.
-        if "video" not in modality_types:
+        if not any(video_sizes_list):
             return mm_embedding, None
 
-        video_size_list = [
-            multimodal_data[modality_type].get("video_size") if modality_type == "video" else None
-            for modality_type, multimodal_data in zip(modality_types, multimodal_data_lst)
-        ]
         mm_embedding_evs = []
         num_tokens_in_videos = []
-        # Iterate over batch.
-        for modality_type, mm_embed, video_sizes in zip(
-            modality_types, mm_embedding, video_size_list
-        ):
-            # Skip EVS if modality type is not video.
-            if modality_type != "video":
+        for mm_embed, video_sizes in zip(mm_embedding, video_sizes_list):
+            if video_sizes is None:
                 mm_embedding_evs.append(mm_embed)
                 num_tokens_in_videos.append(None)
             else:
-                # Iterate over each video in the batch.
                 mm_embed, num_tokens_per_frames = self.apply_evs_per_video(mm_embed, video_sizes)
                 mm_embedding_evs.append(mm_embed)
                 num_tokens_in_videos.append(num_tokens_per_frames)
@@ -750,18 +746,28 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         }
         plan: List[str] = []
         for multimodal_data in multimodal_data_list:
-            modality_type = multimodal_data["modality_type"]
-            data = multimodal_data[modality_type]
-            if modality_type == "image":
+            # This encoder emits one row per param, so a mixed image+video
+            # param has no place to route. `_encode_vision` (mixin path)
+            # splits mixed params into virtual per-modality params before
+            # calling here.
+            image_data = multimodal_data.get("image")
+            video_data = multimodal_data.get("video")
+            if (image_data is not None) == (video_data is not None):
+                raise ValueError(
+                    "NanoV2VLVisionEncoder expects exactly one of image / video "
+                    f"per param, got image={image_data is not None}, video={video_data is not None}."
+                )
+            if image_data is not None:
+                data = image_data
                 modality = "dynamic_image" if "image_sizes" in data else "fixed_tile"
-            elif modality_type == "video" and (
-                self.video_temporal_patch_size > 1 or isinstance(data["pixel_values"], list)
-            ):
-                modality = "video_temporal"
             else:
-                # T==1 video with a tensor `pixel_values` is shape-identical
-                # to a fixed-tile image, so it rides the same encoder.
-                modality = "fixed_tile"
+                data = video_data
+                # T==1 video with tensor pixel_values shape-matches a fixed tile.
+                modality = (
+                    "video_temporal"
+                    if self.video_temporal_patch_size > 1 or isinstance(data["pixel_values"], list)
+                    else "fixed_tile"
+                )
             plan.append(modality)
             buckets[modality].append(data)
 
@@ -932,23 +938,44 @@ class NanoV2VLMultimodalEncoder(NanoV2VLVisionEncoder):
 
     def forward(self, multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
         for param in multimodal_params:
-            modality_type = param.multimodal_data["modality_type"]
-            if modality_type == "audio":
+            if param.multimodal_data.get("audio") is not None:
                 # EPD encoder-only handoff does not own the Nano audio encoder.
                 raise NotImplementedError(
                     "NanoV2VL MultimodalEncoder currently supports image/video inputs, not audio."
                 )
-            audio_data = param.multimodal_data[modality_type].get("audio")
-            if audio_data is not None:
+            video = param.multimodal_data.get("video")
+            if video is not None and video.get("audio") is not None:
                 # TODO(TRTLLM-13129): Add audio support for encoder handoff.
                 raise NotImplementedError(
                     "NanoV2VL MultimodalEncoder does not yet encode audio extracted from video."
                 )
 
-        mm_embeddings, _ = super().forward(multimodal_params)
-        if not mm_embeddings:
-            return []
-        return [torch.cat(mm_embeddings, dim=0)]
+        # One `EncoderGroup` per modality — matches how the parent's
+        # forward emits one row block per param and lets the framework
+        # do the per-modality reorder in one place.
+        def _encoder_fn(multimodal_params, modality):
+            views = [
+                MultimodalParams(
+                    multimodal_data={
+                        "modality_type": modality,
+                        modality: p.multimodal_data[modality],
+                    }
+                )
+                for p in multimodal_params
+            ]
+            embeds, _ = super(NanoV2VLMultimodalEncoder, self).forward(views)
+            return torch.cat(embeds, dim=0)
+
+        pack = lambda params: {"multimodal_params": params}  # noqa: E731
+        return [
+            encode_multimodal_by_groups(
+                (
+                    EncoderGroup(("image",), partial(_encoder_fn, modality="image"), pack),
+                    EncoderGroup(("video",), partial(_encoder_fn, modality="video"), pack),
+                ),
+                multimodal_params,
+            )
+        ]
 
 
 class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInputsBuilder):
@@ -1882,7 +1909,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
 
     def _process_images(
         self, images: List[Image.Image | torch.Tensor], text_prompt: str
-    ) -> Tuple[Dict[str, Any], torch.Tensor]:
+    ) -> Tuple[Dict[str, Any], str]:
         # Multiple images can be processed in one call.
         processed_images = self.processor(images=images, return_tensors="pt").to(self.device)
 
@@ -1901,14 +1928,11 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             )
             processed_query += image_repl + part
 
-        input_ids = self.tokenizer.encode(
-            processed_query, add_special_tokens=False, return_tensors="pt"
-        )
-        return processed_images, input_ids
+        return processed_images, processed_query
 
     def _process_images_dynamic(
         self, images: List[Image.Image | torch.Tensor], text_prompt: str
-    ) -> Tuple[Dict[str, Any], torch.Tensor]:
+    ) -> Tuple[Dict[str, Any], str]:
         """Process images using dynamic resolution tiling.
 
         Converts images to raw tensors and computes target sizes; resize,
@@ -1950,17 +1974,13 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             )
             processed_query += image_repl + part
 
-        input_ids = self.tokenizer.encode(
-            processed_query, add_special_tokens=False, return_tensors="pt"
-        )
-
         processed_data = {
             "pixel_values": raw_tensors,
             "num_patches": torch.tensor([len(images)]),
             "image_sizes": image_sizes,
             "num_tokens_per_image": num_tokens_per_image,
         }
-        return processed_data, input_ids
+        return processed_data, processed_query
 
     def _process_videos_frames(
         self, videos: List[List[Image.Image | torch.Tensor]]
@@ -2107,7 +2127,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         split_text_prompt: List[str],
         num_tokens_per_frame_lst: List[List[int] | None],
         frame_separators_lst: List[List[str]],
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    ) -> Tuple[str, Optional[torch.Tensor]]:
         # Process videos one by one to get correct processed_query.
         processed_query = []
         evs_token_ids: List[int] = []
@@ -2146,17 +2166,6 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         # Append the last part of the text prompt.
         processed_query.append(split_text_prompt[-1])
 
-        # Tokenize processed query.
-        input_ids_lst = [
-            self.tokenizer.encode(
-                query,
-                add_special_tokens=False,
-                return_tensors="pt",
-            )
-            for query in processed_query
-        ]
-        input_ids = torch.cat(input_ids_lst, dim=1)
-
         if self.video_pruning_rate > 0:
             evs_token_ids.extend(
                 self.tokenizer.encode(split_text_prompt[-1], add_special_tokens=False)
@@ -2165,7 +2174,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         else:
             evs_ids = None
 
-        return input_ids, evs_ids
+        return "".join(processed_query), evs_ids
 
     def _compute_token_numbers_per_video(self, video_size_lst: List[Tuple]) -> List[List[int]]:
         """Compute the number of embedding tokens per tubelet (or per frame when T=1).
@@ -2206,101 +2215,86 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
     def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
+        # Each `_process_*` helper below returns the *expanded prompt string*
+        # (not tokenized ids) so mixed-modality requests can chain image →
+        # video → audio expansions on one running prompt and tokenize once
+        # at the end. Single-modality requests take the same path (one
+        # expansion → tokenize), so single-modality behavior is unchanged.
         text_prompt, mm_data = inputs.get("prompt"), inputs.get("multi_modal_data", {})
         images = mm_data.get("image", None)
         videos = mm_data.get("video", None)
         audios = mm_data.get("audio", None)
-        # TODO(TRTLLM-11390): Functionally support multiple modalities in the same request.
-        if sum([images is not None, videos is not None, audios is not None]) > 1:
-            raise ValueError(
-                "NanoV2VL does not support different modalities in the same prompt yet."
-            )
 
-        if images is None and videos is None and audios is None:
-            input_ids = self.tokenizer.encode(
-                text_prompt, add_special_tokens=False, return_tensors="pt"
-            )
-            return input_ids[0].to(torch.int32).tolist(), {}
+        multimodal_data: Dict[str, Any] = {}
+        prompt = text_prompt
 
-        modality_type = None
-        modality_data = dict()
-        input_ids = None
         if images is not None:
-            modality_type = "image"
             if self.dynamic_tiler is not None:
-                # Dynamic resolution path.
-                processed_data, input_ids = self._process_images_dynamic(images, text_prompt)
-                modality_data["pixel_values"] = processed_data["pixel_values"]
-                modality_data["num_patches"] = processed_data["num_patches"]
-                modality_data["image_sizes"] = processed_data["image_sizes"]
-                modality_data["num_tokens_per_image"] = processed_data["num_tokens_per_image"]
+                image_data, prompt = self._process_images_dynamic(images, prompt)
             else:
-                # Existing fixed-tile path.
-                processed_images, input_ids = self._process_images(images, text_prompt)
-                modality_data["pixel_values"] = processed_images["pixel_values"].to(self.dtype)
-                modality_data["num_patches"] = processed_images["num_patches"].sum(
-                    dim=0, keepdim=True
-                )
-            modality_data["video_size"] = None
-            # During model inference, the image/video modality data can be mixed during inflight-batching.
-            # Store input_ids for image modality here when EVS is enabled,
-            # which will be used in merge_evs_mm_embeds later.
-            modality_data["evs_ids"] = (
-                input_ids[0].to(torch.int32) if self.video_pruning_rate > 0 else None
-            )
-        elif videos is not None:
-            modality_type = "video"
-            video_frames, video_metadatas, video_audios = (
-                [video_data.frames for video_data in videos],
-                [video_data.metadata for video_data in videos],
-                [getattr(video_data, "audio", None) for video_data in videos],
-            )
-            num_videos = len(video_frames)
-            processed_images = self._process_videos_frames(video_frames)
+                processed_images, prompt = self._process_images(images, prompt)
+                image_data = {
+                    "pixel_values": processed_images["pixel_values"].to(self.dtype),
+                    "num_patches": processed_images["num_patches"].sum(dim=0, keepdim=True),
+                }
+            image_data["video_size"] = None
+            multimodal_data["image"] = image_data
 
-            # Num_tokens_per_frame_lst is a dummy one when EVS is enabled.
+        if videos is not None:
+            video_frames, video_metadatas, video_audios = (
+                [v.frames for v in videos],
+                [v.metadata for v in videos],
+                [getattr(v, "audio", None) for v in videos],
+            )
+            processed_images = self._process_videos_frames(video_frames)
             num_tokens_per_frame_lst = self._compute_token_numbers_per_video(
                 processed_images["video_size"]
             )
-            # Special video tokens will be added to match training behaviors.
             frame_separators_lst = self._get_frame_separators(
                 processed_images["video_size"], video_metadatas
             )
-
-            text_prompt, audio_data = self._extract_audio_from_video(text_prompt, video_audios)
-
-            split_text_prompt = text_prompt.split(self.video_context_token)
-            if len(split_text_prompt) - 1 != num_videos:
+            prompt, audio_data = self._extract_audio_from_video(prompt, video_audios)
+            split_prompt = prompt.split(self.video_context_token)
+            if len(split_prompt) - 1 != len(video_frames):
                 raise ValueError(
-                    f"Number of {self.video_context_token} tokens ({len(split_text_prompt) - 1})"
-                    f"doesn't match the number of videos ({num_videos})"
+                    f"Number of {self.video_context_token} tokens ({len(split_prompt) - 1})"
+                    f"doesn't match the number of videos ({len(video_frames)})"
                 )
-            input_ids, evs_ids = self._process_video_prompts(
-                split_text_prompt, num_tokens_per_frame_lst, frame_separators_lst
+            prompt, evs_ids = self._process_video_prompts(
+                split_prompt, num_tokens_per_frame_lst, frame_separators_lst
             )
             pv = processed_images["pixel_values"]
-            modality_data["pixel_values"] = (
-                [v.to(self.dtype) for v in pv] if isinstance(pv, list) else pv.to(self.dtype)
-            )
-            modality_data["num_patches"] = processed_images["num_patches"].sum(dim=0, keepdim=True)
-            modality_data["video_size"] = processed_images["video_size"]
-            modality_data["evs_ids"] = evs_ids
+            video_data = {
+                "pixel_values": [v.to(self.dtype) for v in pv]
+                if isinstance(pv, list)
+                else pv.to(self.dtype),
+                "num_patches": processed_images["num_patches"].sum(dim=0, keepdim=True),
+                "video_size": processed_images["video_size"],
+                "evs_ids": evs_ids,
+            }
             if audio_data is not None:
-                modality_data["audio"] = audio_data
-        elif audios is not None:
-            modality_type = "audio"
-            input_ids, modality_data = self._process_audio(text_prompt, audios)
-            modality_data["evs_ids"] = (
-                input_ids[0].to(torch.int32) if self.video_pruning_rate > 0 else None
-            )
+                video_data["audio"] = audio_data
+            multimodal_data["video"] = video_data
 
-        # Will package inputs for language model forward in AGGREGATE mode.
-        multimodal_data = {}
-        multimodal_data["modality_type"] = modality_type
-        multimodal_data[modality_type] = modality_data
-        return input_ids[0].to(torch.int32).tolist(), {
-            "multimodal_data": multimodal_data,
-        }
+        if audios is not None:
+            audio_data, prompt = self._process_audio(prompt, audios)
+            multimodal_data["audio"] = audio_data
+
+        input_ids = self.tokenizer.encode(prompt, add_special_tokens=False, return_tensors="pt")
+        if not multimodal_data:
+            return input_ids[0].to(torch.int32).tolist(), {}
+
+        # Legacy `modality_type` disambiguates the single-modality bucket for
+        # code paths (EVS merge, encoder-only EPD) that predate the mixin's
+        # per-modality dispatch. Mixed requests carry `mm_item_order` from
+        # chat parsing, which the mixin uses instead.
+        modalities = [m for m in ("image", "video", "audio") if m in multimodal_data]
+        if len(modalities) == 1:
+            m = modalities[0]
+            multimodal_data["modality_type"] = m
+            if self.video_pruning_rate > 0 and m != "video":
+                multimodal_data[m]["evs_ids"] = input_ids[0].to(torch.int32)
+        return input_ids[0].to(torch.int32).tolist(), {"multimodal_data": multimodal_data}
 
     def build_disagg_prefill_multimodal_inputs(
         self, inputs: Union[TextPrompt, TokensPrompt], mm_handles: List[Dict[str, Any]]
@@ -2411,19 +2405,14 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         self,
         text: str,
         audios: List[Union[np.ndarray, Tuple[np.ndarray, int]]],
-    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+    ) -> Tuple[Dict[str, torch.Tensor], str]:
         if self._audio_extractor is None:
             raise ValueError(
                 "Audio inputs were passed in, but no audio preprocessing was configured "
                 "due to the absence of a `sound_config` in the model config."
             )
-
         expanded_text, audio_inputs = self._prepare_audio_features(text, audios)
-
-        input_ids = self.tokenizer.encode(
-            expanded_text, add_special_tokens=False, return_tensors="pt"
-        )
-        return input_ids, audio_inputs
+        return audio_inputs, expanded_text
 
     def _extract_audio_from_video(
         self,
@@ -2474,23 +2463,53 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         audios: List[np.ndarray],
         extractor: "ParakeetExtractor",
     ) -> str:
-        """Replace each audio placeholder token with the expanded start/context/end sequence."""
-        parts = [x for x in re.split(f"({re.escape(self._sound_context_token)})", text) if x]
-        token_count = parts.count(self._sound_context_token)
+        """Replace each unexpanded audio placeholder token with the
+        `<so_start>...<so_end>` sequence.
+
+        The counter is state-aware: `<so_embedding>` tokens inside an
+        existing `<so_start>...<so_end>` block are ignored, so a mixed
+        request that has both video-embedded audio and standalone audio
+        parts does not double-count already-expanded blocks from a prior
+        `_expand_audio_placeholders` call.
+        """
+        delimiter_re = re.compile(
+            f"({re.escape(self._sound_start)}"
+            f"|{re.escape(self._sound_end)}"
+            f"|{re.escape(self._sound_context_token)})"
+        )
+        parts = [x for x in delimiter_re.split(text) if x]
+
+        # Count unexpanded `<so_embedding>` tokens (those outside any
+        # `<so_start>...<so_end>` block) so the check matches the audios
+        # this call is responsible for.
+        in_block = False
+        token_count = 0
+        for part in parts:
+            if part == self._sound_start:
+                in_block = True
+            elif part == self._sound_end:
+                in_block = False
+            elif part == self._sound_context_token and not in_block:
+                token_count += 1
         if token_count != len(audios):
             raise ValueError(
                 "Number of audio tokens in text does not match the number "
                 f"of audios (tokens={token_count}, audios={len(audios)})."
             )
+
+        in_block = False
         audio_idx = 0
         for idx, part in enumerate(parts):
-            if part == self._sound_context_token:
+            if part == self._sound_start:
+                in_block = True
+            elif part == self._sound_end:
+                in_block = False
+            elif part == self._sound_context_token and not in_block:
                 audio = audios[audio_idx]
                 num_tokens = extractor.audio_token_count(len(audio))
-                expanded = (
+                parts[idx] = (
                     f"{self._sound_start}{self._sound_context_token * num_tokens}{self._sound_end}"
                 )
-                parts[idx] = expanded
                 audio_idx += 1
         return "".join(parts)
 
@@ -2580,6 +2599,13 @@ _NANO_VL_PLACEHOLDER_METADATA = MultimodalPlaceholderMetadata(
     },
     placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
     placeholders_separator="\n",
+    # Nano's chat template counts modalities and emits `<image>*N + <video>*N +
+    # <so_embedding>*N` regardless of chat-part send order (and produces the
+    # numbered `<image N><image>` form for multi-image prompts). Declare that
+    # ordering so `mm_item_order` reflects the prompt Nano's Jinja actually
+    # produces, keeping the framework's `mm_item_order == prompt order`
+    # invariant intact for mixed-modality requests.
+    prompt_modality_order=("image", "video", "audio"),
 )
 
 
@@ -2597,7 +2623,7 @@ _NANO_VL_PLACEHOLDER_METADATA = MultimodalPlaceholderMetadata(
     model_type="NemotronH_Nano_Omni_Reasoning_V3",
     placeholder_metadata=_NANO_VL_PLACEHOLDER_METADATA,
 )
-class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
+class NemotronH_Nano_VL_V2(MultimodalModelMixin, transformers.PreTrainedModel):
     _supports_flash_attn = True
 
     def __init__(self, model_config: ModelConfig):
@@ -2826,12 +2852,17 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         message, not deep encoder failure.
         """
         needs_vision_encoder = any(
-            param.multimodal_data["modality_type"] in ("image", "video") for param in raw_ctx_params
+            p.multimodal_data.get(m) is not None for p in raw_ctx_params for m in ("image", "video")
         )
         if needs_vision_encoder and self.vision_encoder is None:
             raise ValueError("Raw image/video inputs require a local NanoV2VL vision encoder.")
+        # Sound encoder is also needed for audio nested under a video's
+        # `multimodal_data["video"]["audio"]` — the video group interleaves
+        # those rows and would silently drop them if the encoder is missing.
         needs_sound_encoder = any(
-            param.multimodal_data["modality_type"] == "audio" for param in raw_ctx_params
+            p.multimodal_data.get("audio") is not None
+            or (p.multimodal_data.get("video") or {}).get("audio") is not None
+            for p in raw_ctx_params
         )
         if needs_sound_encoder and self.sound_encoder is None:
             raise ValueError("Raw audio inputs require a local NanoV2VL sound encoder.")
@@ -3038,96 +3069,92 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
         return torch.cat(parts, dim=0)
 
-    def _encode_multimodal(self, multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
-        """Dispatch multimodal encoding to the appropriate encoder.
+    def _vision_view(self, param: MultimodalParams, modality: str) -> MultimodalParams:
+        """Wrap one param's image or video bucket in a single-modality view.
 
-        Returns a single-element `List[torch.Tensor]` (all per-request
-        embeddings concatenated) to conform to the contract expected by
-        `get_multimodal_embeddings`, which enables chunked-prefill caching.
-        Per-request `num_tokens_in_video` (needed by EVS) is stashed in
-        each param's `multimodal_data` dict as a side-channel.
-
-        Image and video params are batched into single ``vision_encoder``
-        calls; all audio inputs (standalone audio params and audio extracted
-        from video) are batched into a single ``sound_encoder`` call.
-        Per-video audio interleaving and EVS token-count stashing happen in
-        the second pass that walks params in input order.
+        `NanoV2VLVisionEncoder.forward` bucket-dispatches on the legacy
+        `modality_type` key and emits one row block per param, so a
+        mixed-modality param has no valid output shape. Each group
+        encoder_fn feeds views of its own modality.
         """
-        # Collect all image, video, and audio inputs in a single pass, then
-        # run each encoder once over its bucket.
-        image_params: List[MultimodalParams] = []
-        video_params: List[MultimodalParams] = []
-        audio_data_list: List[dict] = []
-        for param in multimodal_params:
-            modality_type = param.multimodal_data["modality_type"]
-            if modality_type == "image":
-                image_params.append(param)
-            elif modality_type == "video":
-                video_params.append(param)
-                if self.sound_encoder is not None:
-                    audio_data = param.multimodal_data["video"].get("audio")
-                    if audio_data is not None:
-                        audio_data_list.append(audio_data)
-            elif modality_type == "audio":
-                audio_data_list.append(param.multimodal_data["audio"])
-
-        image_embeds: List[torch.Tensor] = []
-        if image_params:
-            image_embeds, _ = self.vision_encoder(image_params)
-        video_embeds: List[torch.Tensor] = []
-        video_num_tokens: Optional[List[List[int] | None]] = None
-        if video_params:
-            video_embeds, video_num_tokens = self.vision_encoder(video_params)
-        audio_outputs: List[Tuple[torch.Tensor, List[int]]] = (
-            self._encode_audio(audio_data_list) if audio_data_list else []
+        return MultimodalParams(
+            multimodal_data={"modality_type": modality, modality: param.multimodal_data[modality]}
         )
 
-        # Walk params in input order, drawing pre-computed outputs by
-        # incrementing per-modality cursors.
-        mm_embeddings: List[torch.Tensor] = []
-        image_idx = 0
-        video_idx = 0
-        audio_idx = 0
-        for param in multimodal_params:
-            modality_type = param.multimodal_data["modality_type"]
-            if modality_type == "image":
-                mm_embeddings.append(image_embeds[image_idx])
-                image_idx += 1
-            elif modality_type == "video":
-                vision_emb = video_embeds[video_idx]
-                num_tokens = video_num_tokens[video_idx] if video_num_tokens is not None else None
-                video_idx += 1
-                if num_tokens is not None:
-                    param.multimodal_data["num_tokens_in_video"] = num_tokens
-                # If audio was extracted from video, interleave it per-video so
-                # the combined tensor matches input_ids order
-                # (v1_img_context, v1_sound_context, v2_img_context, ...).
-                audio_data = param.multimodal_data["video"].get("audio")
-                if audio_data is not None and self.sound_encoder is not None:
-                    audio_emb, per_clip_audio_counts = audio_outputs[audio_idx]
-                    audio_idx += 1
-                    vision_emb = self._interleave_video_audio_embeddings(
-                        vision_emb,
-                        audio_emb,
-                        per_clip_audio_counts,
-                        has_audio=audio_data["has_audio"],
-                        audio_num_clips=audio_data["audio_num_clips"],
-                        video_sizes=param.multimodal_data["video"].get("video_size", []),
-                        evs_num_tokens=num_tokens,
-                    )
-                mm_embeddings.append(vision_emb)
-            elif modality_type == "audio":
-                audio_emb, _ = audio_outputs[audio_idx]
-                audio_idx += 1
-                mm_embeddings.append(audio_emb)
-            else:
-                raise ValueError(f"Unknown modality: {modality_type}")
+    def _encode_image_group(self, multimodal_params: List[MultimodalParams]) -> torch.Tensor:
+        """Image group encoder_fn: one `vision_encoder` call over image items."""
+        embeds, _ = self.vision_encoder([self._vision_view(p, "image") for p in multimodal_params])
+        return torch.cat(embeds, dim=0)
 
-        if not mm_embeddings:
-            return []
-        # `get_multimodal_embeddings` requires a single concatenated tensor
-        # in input-param order so it can split per-request and cache.
-        return [torch.cat(mm_embeddings, dim=0)]
+    def _encode_video_group(self, multimodal_params: List[MultimodalParams]) -> torch.Tensor:
+        """Video group encoder_fn: one `vision_encoder` call over video items.
+
+        Video-with-embedded-audio (`multimodal_data["video"]["audio"]`) is
+        encoded and interleaved per-video here because it shares the
+        video item's prompt-token run; standalone audio parts go through
+        the audio group. Stashes `num_tokens_in_video` on each video
+        param for the EVS post-step.
+        """
+        video_embeds, video_num_tokens = self.vision_encoder(
+            [self._vision_view(p, "video") for p in multimodal_params]
+        )
+        embedded_audio = [p.multimodal_data["video"].get("audio") for p in multimodal_params]
+        audio_outputs = (
+            self._encode_audio([a for a in embedded_audio if a is not None])
+            if any(embedded_audio) and self.sound_encoder is not None
+            else []
+        )
+        rows: List[torch.Tensor] = []
+        audio_cursor = 0
+        for i, (p, emb) in enumerate(zip(multimodal_params, video_embeds)):
+            nt = video_num_tokens[i] if video_num_tokens is not None else None
+            if nt is not None:
+                p.multimodal_data["num_tokens_in_video"] = nt
+            a = embedded_audio[i]
+            if a is not None and self.sound_encoder is not None:
+                audio_emb, per_clip_counts = audio_outputs[audio_cursor]
+                audio_cursor += 1
+                emb = self._interleave_video_audio_embeddings(
+                    emb,
+                    audio_emb,
+                    per_clip_counts,
+                    has_audio=a["has_audio"],
+                    audio_num_clips=a["audio_num_clips"],
+                    video_sizes=p.multimodal_data["video"].get("video_size", []),
+                    evs_num_tokens=nt,
+                )
+            rows.append(emb)
+        return torch.cat(rows, dim=0)
+
+    def _encode_audio_group(self, multimodal_params: List[MultimodalParams]) -> torch.Tensor:
+        """Audio group encoder_fn: one `sound_encoder` call over standalone audio items."""
+        outs = self._encode_audio([p.multimodal_data["audio"] for p in multimodal_params])
+        return torch.cat([emb for emb, _ in outs], dim=0)
+
+    @property
+    def mm_encoder_groups(self) -> Tuple[EncoderGroup, ...]:
+        # One `EncoderGroup` per underlying encoder call. RADIO cannot
+        # batch image + video in a single ViT forward (dynamic-image,
+        # fixed-tile, and video-temporal have different preprocessing),
+        # so image and video get separate groups even though they share
+        # the `vision_encoder` module. `build_batched_input` is trivial
+        # because our encoder_fns consume the group-filtered params list
+        # directly rather than plain concatenated tensors.
+        pack = lambda params: {"multimodal_params": params}  # noqa: E731
+        return (
+            EncoderGroup(("image",), self._encode_image_group, pack),
+            EncoderGroup(("video",), self._encode_video_group, pack),
+            EncoderGroup(("audio",), self._encode_audio_group, pack),
+        )
+
+    def encode_multimodal_inputs(
+        self, multimodal_params: List[MultimodalParams], **_: Any
+    ) -> torch.Tensor:
+        # Raw encoder hook per the `MultimodalModelMixin` contract. Cache
+        # bookkeeping belongs to callers (`_get_or_encode_multimodal_embeddings`,
+        # `_dispatch_cross_iter_prefetch`), not here — wrapping in
+        # `get_multimodal_embeddings` would double-cache.
+        return encode_multimodal_by_groups(self.mm_encoder_groups, list(multimodal_params))
 
     @torch.inference_mode()
     def forward(
@@ -3159,11 +3186,15 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             if raw_ctx_params:
                 self._check_encoders_exist(raw_ctx_params)
                 mm_embedding = get_multimodal_embeddings(
-                    encoder_forward_fn=self._encode_multimodal,
+                    encoder_forward_fn=partial(encode_multimodal_by_groups, self.mm_encoder_groups),
                     multimodal_params=ctx_params,
                 )
             # E/P prefill: encoder already ran; use attached embeddings.
             else:
+                # Attached-embedding params drop the raw bucket keys and only
+                # keep the legacy `modality_type` tag as a modality hint, so
+                # detection here uses that tag rather than a bucket-key check
+                # (which works for the raw path above but is always None here).
                 if self.video_pruning_rate > 0 and any(
                     param.has_content() and param.multimodal_data.get("modality_type") == "video"
                     for param in ctx_params
@@ -3177,7 +3208,25 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                 mm_embedding = get_attached_multimodal_embeddings(ctx_params)
             # Adjust input_ids in videos if EVS is applied.
             if self.video_pruning_rate > 0:
-                # Retrieve per-video count stashed by `_encode_multimodal`.
+                # `merge_evs_mm_embeds` reads the legacy `modality_type` tag,
+                # which the input processor only emits for single-modality
+                # requests. Mixed-modality + EVS would additionally need
+                # per-item retained-token metadata that the current
+                # `evs_ids` layout does not carry. Reject clearly here
+                # rather than KeyError deep in the merge.
+                if any(
+                    p.has_content()
+                    and sum(
+                        p.multimodal_data.get(m) is not None for m in ("image", "video", "audio")
+                    )
+                    > 1
+                    for p in ctx_params
+                ):
+                    raise ValueError(
+                        "EVS video pruning is not supported for mixed-modality "
+                        "requests (image/video/audio in the same prompt)."
+                    )
+                # Retrieve per-video count stashed by `_encode_vision`.
                 num_tokens_in_videos = [
                     param.multimodal_data.get("num_tokens_in_video")
                     for param in ctx_params

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -691,7 +691,7 @@ class MultimodalPlaceholderPlacement(enum.Enum):
 @dataclass(frozen=True)
 class MultimodalPlaceholderMetadata:
     """
-    Metadata for the multimodal placeholder. It has 5 components:
+    Metadata for the multimodal placeholder. It has 6 components:
         - placeholder_map:
             A mapping from modality to placeholder string.
             Modality can be "image", "video", "audio", etc.
@@ -715,12 +715,21 @@ class MultimodalPlaceholderMetadata:
             user's message.
             When False (default), placeholders are bulk-prepended or appended
             according to placeholder_placement.
+        - prompt_modality_order:
+            Fixed modality-major order the chat template emits placeholders in
+            when it regroups them (e.g. Nano's Jinja counts modalities and
+            emits image → video → audio regardless of chat-part send order).
+            When set, `MultimodalDataTracker.item_order()` returns items sorted
+            by this priority so the framework's `mm_item_order == prompt order`
+            invariant holds. `None` (default) keeps chat-part send order for
+            templates that preserve it.
     """
     placeholder_map: Dict[str, str] = field(default_factory=dict)
     placeholder_placement: MultimodalPlaceholderPlacement = MultimodalPlaceholderPlacement.AFTER_TEXT
     placeholders_separator: str = "\n"
     content_format: Optional[ContentFormat] = None
     interleave_placeholders: bool = False
+    prompt_modality_order: Optional[Tuple[str, ...]] = None
 
 
 class MultimodalPlaceholderRegistry:
@@ -801,6 +810,14 @@ class MultimodalPlaceholderRegistry:
             return None
         return self._multimodal_placeholder_by_model_type[
             model_type].content_format
+
+    def get_prompt_modality_order(self,
+                                  model_type: str) -> Optional[Tuple[str, ...]]:
+        """Modality-major order the model's template emits placeholders in, or None to preserve send order."""
+        if model_type not in self._multimodal_placeholder_by_model_type:
+            return None
+        return self._multimodal_placeholder_by_model_type[
+            model_type].prompt_modality_order
 
     def get_registered_image_model_types(self) -> Tuple[str, ...]:
         return (

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -476,8 +476,24 @@ class MultimodalDataTracker:
         `index` is the item's position in `multi_modal_data[modality]`;
         `placeholder` is the exact string the input processor will look
         for when splicing this item's encoder embedding.
+
+        Items are recorded in chat-part send order. When the model's chat
+        template regroups placeholders by modality (declared via
+        `MultimodalPlaceholderMetadata.prompt_modality_order`), sort by
+        that priority so the returned list matches what the template
+        actually emits — preserving per-modality send order as the tie
+        break.
         """
-        return list(self._item_order)
+        prompt_order = MULTIMODAL_PLACEHOLDER_REGISTRY.get_prompt_modality_order(
+            self._model_type)
+        if not prompt_order:
+            return list(self._item_order)
+        rank = {m: i for i, m in enumerate(prompt_order)}
+        return sorted(
+            self._item_order,
+            key=lambda e:
+            (rank.get(e["modality"], len(prompt_order)), e["index"]),
+        )
 
 
 def add_multimodal_placeholders(

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -417,7 +417,7 @@ def test_nemotron_nano_v2_vl_image_batch_equivalence(nano_llm_model):
 
     Two distinct image+prompt requests are sent (a) together in one
     `generate` call so the engine batches them in a single forward step
-    (and thus a single `_encode_multimodal` invocation with two
+    (and thus a single `_encode_image_group` invocation with two
     multimodal_params), and (b) separately in two `generate` calls. With
     greedy decoding, the resulting token IDs must be identical and the
     logprobs must match within bf16 tolerance. This is intended to detect
@@ -558,67 +558,6 @@ def test_nemotron_nano_v2_vl_video_batch_equivalence(nano_llm_model):
         )
 
 
-class TestEncodeMultimodalDispatch:
-    def _make_mock_model(self):
-        """Create a minimal mock with the attributes `_encode_multimodal` needs."""
-        model = mock.MagicMock(spec=NemotronH_Nano_VL_V2)
-        model.vision_encoder = mock.MagicMock(spec=NanoV2VLVisionEncoder)
-        model.sound_encoder = mock.MagicMock(spec=ProjectedParakeet)
-        return model
-
-    @staticmethod
-    def _assert_compatible_with_chunked_prefill(multimodal_embeddings):
-        # NOTE: `multimodal_embeddings` is expected to be the output of `_encode_multimodal`.
-        # The below checks help verify that we can make use of `get_multimodal_embeddings` and its
-        # caching feature. Otherwise, we would be re-encoding the items each chunk during chunked
-        # prefill.
-        assert len(multimodal_embeddings) == 1
-        assert isinstance(multimodal_embeddings[0], torch.Tensor)
-
-    def test_encode_multimodal_dispatches_audio(self):
-        model = self._make_mock_model()
-        fake_audio_embeds = torch.randn(10, 128)
-        # All audio is encoded via the batched `_encode_audio` helper.
-        model._encode_audio = mock.MagicMock(return_value=[(fake_audio_embeds, [10])])
-
-        mm_param = mock.MagicMock()
-        audio_data = {"foo": "bar"}
-        mm_param.multimodal_data = {"modality_type": "audio", "audio": audio_data}
-
-        # Call the real method on our mock
-        result = NemotronH_Nano_VL_V2._encode_multimodal(model, [mm_param])
-
-        model._encode_audio.assert_called_once_with([audio_data])
-        model.vision_encoder.assert_not_called()
-        self._assert_compatible_with_chunked_prefill(result)
-        assert torch.equal(result[0], fake_audio_embeds)
-
-    def test_encode_multimodal_dispatches_image(self):
-        model = self._make_mock_model()
-        fake_image_embeds = torch.randn(10, 128)
-        model.vision_encoder.return_value = ([fake_image_embeds], [None])
-
-        mm_param = mock.MagicMock()
-        mm_param.multimodal_data = {
-            "modality_type": "image",
-            "image": {"pixel_values": torch.randn(1, 100, 768)},
-        }
-
-        result = NemotronH_Nano_VL_V2._encode_multimodal(model, [mm_param])
-
-        model.vision_encoder.assert_called_once_with([mm_param])
-        self._assert_compatible_with_chunked_prefill(result)
-
-    def test_encode_multimodal_unknown_modality_raises(self):
-        """Unknown modality raises ValueError."""
-        model = self._make_mock_model()
-        mm_param = mock.MagicMock()
-        mm_param.multimodal_data = {"modality_type": "smell"}
-
-        with pytest.raises(ValueError, match="Unknown modality"):
-            NemotronH_Nano_VL_V2._encode_multimodal(model, [mm_param])
-
-
 class TestSoundPlaceholderInjection:
     """Test the sound placeholder token's injection points.
 
@@ -686,125 +625,6 @@ class TestSoundPlaceholderInjection:
             f"  Expected: {expected!r}\n"
             f"  Got:      {result!r}"
         )
-
-
-class TestEncodeMultimodalAudioOrder:
-    """Test video / audio embedding order in multi-item scenarios."""
-
-    def _make_video_param(self, *, has_audio: bool) -> MultimodalParams:
-        """Create a MultimodalParams for a video, optionally with audio."""
-        audio_data = None
-        if has_audio:
-            audio_data = {
-                "input_audio_features": torch.randn(1, 80, 100),
-                "feature_attention_mask": torch.ones(1, 100),
-                "has_audio": [True],
-                "audio_num_clips": torch.tensor([1]),
-            }
-        video_payload = {"audio": audio_data} if audio_data else {}
-        param = MagicMock(spec=MultimodalParams)
-        param.multimodal_data = {
-            "modality_type": "video",
-            "video": video_payload,
-        }
-        return param
-
-    def test_multi_video_audio_interleaving(self):
-        # Two videos with audio: each returned embedding should be
-        # [vision_i, audio_i], not [vision_1 + vision_2, audio_1 + audio_2]."""
-        hidden = 16
-        v1_len, a1_len = 10, 3
-        v2_len, a2_len = 8, 4
-
-        v1_emb = torch.randn(v1_len, hidden)
-        a1_emb = torch.randn(a1_len, hidden)
-        v2_emb = torch.randn(v2_len, hidden)
-        a2_emb = torch.randn(a2_len, hidden)
-
-        # All video params are encoded in a single batched call; the encoder
-        # returns one embedding per param, in input order.
-        vision_return = (
-            [v1_emb, v2_emb],
-            [list(range(v1_len)), list(range(v2_len))],
-        )
-
-        # All audio (across both videos) is encoded in a single batched call;
-        # the helper returns one (emb, per_clip_counts) per input in order.
-        audio_returns = [(a1_emb, [a1_len]), (a2_emb, [a2_len])]
-
-        params = [
-            self._make_video_param(has_audio=True),
-            self._make_video_param(has_audio=True),
-        ]
-
-        # Build a minimal mock of NemotronH_Nano_VL_V2 with only the attributes `_encode_multimodal`
-        # touches.
-        model = MagicMock()
-        model.vision_encoder = MagicMock(return_value=vision_return)
-        model.sound_encoder = MagicMock()  # not None -> audio path taken
-        model._encode_audio = MagicMock(return_value=audio_returns)
-        # Mock the interleaver to simply concatenate vision + audio, since this test only verifies
-        # per-param dispatch, not interleaving math.
-        model._interleave_video_audio_embeddings = MagicMock(
-            side_effect=lambda v, a, *args, **kwargs: torch.cat([v, a], dim=0)
-        )
-
-        # Call the real method, bound to our mock.
-        # `_encode_multimodal` now returns a single-element list whose tensor
-        # concatenates per-request embeddings in order.
-        result = NemotronH_Nano_VL_V2._encode_multimodal(model, params)
-
-        assert len(result) == 1, "Should return a single concatenated tensor"
-        combined = result[0]
-
-        # First video: [v1, a1]
-        expected_0 = torch.cat([v1_emb, a1_emb], dim=0)
-        assert torch.equal(combined[: v1_len + a1_len], expected_0), (
-            "Video 1 slice should be [vision_1, audio_1]"
-        )
-
-        # Second video: [v2, a2]
-        expected_1 = torch.cat([v2_emb, a2_emb], dim=0)
-        assert torch.equal(combined[v1_len + a1_len :], expected_1), (
-            "Video 2 slice should be [vision_2, audio_2]"
-        )
-
-    def test_video_without_audio_skips_audio_concat(self):
-        """A video param with no audio should return vision-only embeddings."""
-        hidden = 16
-        v_len = 6
-        v_emb = torch.randn(v_len, hidden)
-
-        param = self._make_video_param(has_audio=False)
-
-        model = MagicMock()
-        model.vision_encoder = MagicMock(return_value=([v_emb], [list(range(v_len))]))
-        model.sound_encoder = MagicMock()
-        model._encode_audio = MagicMock()
-
-        result = NemotronH_Nano_VL_V2._encode_multimodal(model, [param])
-
-        assert len(result) == 1
-        assert torch.equal(result[0], v_emb), "Vision-only video should not have audio appended"
-        model._encode_audio.assert_not_called()
-
-    def test_no_audio_concat_when_sound_encoder_is_none(self):
-        hidden = 16
-        v_len = 5
-        v_emb = torch.randn(v_len, hidden)
-
-        param = self._make_video_param(has_audio=True)
-
-        model = MagicMock()
-        model.vision_encoder = MagicMock(return_value=([v_emb], [list(range(v_len))]))
-        model.sound_encoder = None  # no audio support
-        model._encode_audio = MagicMock()
-
-        result = NemotronH_Nano_VL_V2._encode_multimodal(model, [param])
-
-        assert len(result) == 1
-        assert torch.equal(result[0], v_emb)
-        model._encode_audio.assert_not_called()
 
 
 class TestInterleaveVideoAudioEmbeddings:
@@ -1011,108 +831,15 @@ class TestEncodeAudio:
         assert NemotronH_Nano_VL_V2._encode_audio(model, []) == []
 
 
-class TestEncodeMultimodalContract:
-    """Verify `_encode_multimodal` conforms to the contract expected by `get_multimodal_embeddings`.
-
-    The key assumption is that the `encoder_forward_fn` passed to it returns something whose length
-    is 1, and can be indexed by `[0]` to return a single `torch.Tensor`.
-    """
-
-    HIDDEN = 128
-
-    def _make_mock_model(self):
-        model = mock.MagicMock(spec=NemotronH_Nano_VL_V2)
-        model.vision_encoder = mock.MagicMock(spec=NanoV2VLVisionEncoder)
-        model.sound_encoder = mock.MagicMock(spec=ProjectedParakeet)
-        return model
-
-    def _make_mm_param(self, modality_type, **extra):
-        # Mirror the shape produced by the input processor: a nested dict keyed
-        # by `modality_type` holds per-modality side-channel data (e.g. audio
-        # payload for video). Extra kwargs override / extend that nested dict.
-        param = mock.MagicMock()
-        nested = extra.pop(modality_type, {})
-        param.multimodal_data = {
-            "modality_type": modality_type,
-            modality_type: nested,
-            **extra,
-        }
-        return param
-
-    def test_returns_list_with_a_single_element(self):
-        model = self._make_mock_model()
-        model.vision_encoder.return_value = ([torch.randn(5, self.HIDDEN)], [None])
-
-        param = self._make_mm_param("image")
-        result = NemotronH_Nano_VL_V2._encode_multimodal(model, [param])
-
-        assert isinstance(result, list)
-        assert len(result) == 1
-
-    def test_single_concatenated_tensor_for_multiple_multimodal_items(self):
-        """Multiple multimodal items must be concatenated into a single tensor.
-
-        `get_multimodal_embeddings` requires `len(embeddings) == 1` and splits by per-request token
-        counts in order to cache the embeddings.
-
-        Image params are batched into a single `vision_encoder` call that
-        returns a per-param embedding list.
-        """
-        model = self._make_mock_model()
-        emb_a = torch.randn(5, self.HIDDEN)
-        emb_b = torch.randn(3, self.HIDDEN)
-        model.vision_encoder.return_value = ([emb_a, emb_b], [None, None])
-
-        params = [self._make_mm_param("image"), self._make_mm_param("image")]
-        result = NemotronH_Nano_VL_V2._encode_multimodal(model, params)
-
-        # All image params go through a single batched vision_encoder call.
-        assert model.vision_encoder.call_count == 1
-        assert model.vision_encoder.call_args.args == (params,)
-        assert len(result) == 1
-        assert result[0].shape == (8, self.HIDDEN)
-        # Verify concatenation order is preserved.
-        assert torch.equal(result[0][:5], emb_a)
-        assert torch.equal(result[0][5:], emb_b)
-
-    def test_mixed_modalities_still_single_tensor(self):
-        """Image + audio requests produce one concatenated tensor."""
-        model = self._make_mock_model()
-        img_emb = torch.randn(5, self.HIDDEN)
-        audio_emb = torch.randn(3, self.HIDDEN)
-        model.vision_encoder.return_value = ([img_emb], [None])
-        model._encode_audio = mock.MagicMock(return_value=[(audio_emb, [3])])
-
-        params = [
-            self._make_mm_param("image"),
-            self._make_mm_param("audio", audio={}),
-        ]
-        result = NemotronH_Nano_VL_V2._encode_multimodal(model, params)
-
-        assert len(result) == 1
-        assert result[0].shape == (8, self.HIDDEN)
-
-    def test_empty_params_returns_empty_list(self):
-        model = self._make_mock_model()
-        result = NemotronH_Nano_VL_V2._encode_multimodal(model, [])
-        assert result == []
-
-
 class TestChunkedPrefillCaching:
-    """Verify that `_encode_multimodal` output is compatible with `get_multimodal_embeddings`.
+    """Verify chunked-prefill caching still works through the group encoder path.
 
-    Specifically, we want to test that the caching functionality is exercised and not skipped due
-    to the return type not being compatible.
-
-    The test structure for each modality:
-
-    1. Build `MultimodalParams` with a real `MultimodalRuntimeData` (past_seen_token_num=0,
-       simulating the first chunk).
-    2. Call `get_multimodal_embeddings` with the real _encode_multimodal wired to mock sub-encoders
-       -> encoder MUST be invoked.
-    3. Verify embeddings were cached in `multimodal_data`.
-    4. Call `get_multimodal_embeddings` again with the SAME params (simulating a second chunk) ->
-       encoder must NOT be invoked.
+    On the first chunk `get_multimodal_embeddings` runs the encoder and
+    caches the returned tensor into `multimodal_data["multimodal_embedding"]`.
+    A second call with the same params must skip the encoder. The
+    encoder_fn here is `encode_multimodal_by_groups` bound to the model's
+    three per-modality groups — the shape all Nemotron production forwards
+    take.
     """
 
     HIDDEN = 128
@@ -1124,35 +851,56 @@ class TestChunkedPrefillCaching:
         model.sound_encoder = mock.MagicMock(spec=ProjectedParakeet)
         return model
 
-    def _make_param_with_runtime(self, modality_type, num_tokens, **extra):
-        """Build a real MultimodalParams with runtime data for caching."""
-        # Single contiguous mm block of `num_tokens` tokens, none cached yet:
-        # mask = all-True over the chunk, cumsum = [1, 2, ..., num_tokens].
+    def _make_param_with_runtime(self, modality, num_tokens, **extra):
+        """`MultimodalParams` with per-modality bucket + runtime metadata.
+
+        `multimodal_embedding_lengths` is required for the group encoder path:
+        `_lengths_by_modality` uses it to slice the encoder output back into
+        per-modality tensors. Single-item request → single-entry list.
+        """
         embed_mask_cumsum = torch.arange(1, num_tokens + 1, dtype=torch.int64)
         runtime = MultimodalRuntimeData(
             past_seen_token_num=0,
             chunk_end_pos=num_tokens,
             embed_mask_cumsum=embed_mask_cumsum,
         )
-        # Mirror the nested shape produced by the input processor: a dict
-        # keyed by `modality_type` holds per-modality side-channel data.
-        nested = extra.pop(modality_type, {})
+        nested = extra.pop(modality, {})
         return MultimodalParams(
             multimodal_data={
-                "modality_type": modality_type,
-                modality_type: nested,
+                "modality_type": modality,
+                modality: nested,
+                "multimodal_embedding_lengths": [num_tokens],
                 **extra,
             },
             multimodal_runtime=runtime,
         )
 
     def _make_encoder_fn(self, model):
-        """Wrap `_encode_multimodal` as a callable for get_multimodal_embeddings."""
+        """Route through `encode_multimodal_by_groups` with real group methods
+        bound to the mock's stubbed sub-encoders — matches the production
+        `NemotronH_Nano_VL_V2.forward` path.
 
-        def encoder_fn(params):
-            return NemotronH_Nano_VL_V2._encode_multimodal(model, params)
+        The group encoder_fns are invoked via `**build_batched_input(...)`,
+        which spreads the pack dict as kwargs — so the wrappers must accept
+        `multimodal_params` by keyword.
+        """
+        from tensorrt_llm._torch.models.modeling_multimodal_mixin import (
+            EncoderGroup,
+            encode_multimodal_by_groups,
+        )
 
-        return encoder_fn
+        def _pack(params):
+            return {"multimodal_params": params}
+
+        def _run_group(method):
+            return lambda multimodal_params: method(model, multimodal_params)
+
+        groups = (
+            EncoderGroup(("image",), _run_group(NemotronH_Nano_VL_V2._encode_image_group), _pack),
+            EncoderGroup(("video",), _run_group(NemotronH_Nano_VL_V2._encode_video_group), _pack),
+            EncoderGroup(("audio",), _run_group(NemotronH_Nano_VL_V2._encode_audio_group), _pack),
+        )
+        return lambda params: encode_multimodal_by_groups(groups, params)
 
     @pytest.mark.parametrize("modality", ["image", "video"])
     def test_vision_encoder_not_called_on_second_chunk(self, modality):
@@ -1163,7 +911,7 @@ class TestChunkedPrefillCaching:
         param = self._make_param_with_runtime(modality, self.NUM_TOKENS)
         encoder_fn = self._make_encoder_fn(model)
 
-        # First call: encoder must run and cache the result.
+        # First call: encoder runs and caches.
         result = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param],
@@ -1171,33 +919,26 @@ class TestChunkedPrefillCaching:
         assert len(result) == 1
         assert result[0].shape == (self.NUM_TOKENS, self.HIDDEN)
         assert model.vision_encoder.call_count == 1
-
-        # Embedding is now cached in multimodal_data.
         assert "multimodal_embedding" in param.multimodal_data
 
-        # Second call: encoder must NOT run - embeddings come from cache.
+        # Second call: comes from cache.
         result2 = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param],
         )
         assert model.vision_encoder.call_count == 1, (
-            "`vision_encoder` was called again on the second chunk. "
-            "Caching is broken - `_encode_multimodal` likely violates the "
-            "`get_multimodal_embeddings` return type contract."
+            "`vision_encoder` was called again on the second chunk. Caching is broken."
         )
-        assert len(result2) == 1
         assert torch.equal(result2[0], result[0])
 
     def test_audio_encoder_not_called_on_second_chunk(self):
         model = self._make_mock_model()
         fake_emb = torch.randn(self.NUM_TOKENS, self.HIDDEN)
-        # Audio is encoded via the batched `_encode_audio` helper.
         model._encode_audio = mock.MagicMock(return_value=[(fake_emb, [self.NUM_TOKENS])])
 
         param = self._make_param_with_runtime("audio", self.NUM_TOKENS, audio={})
         encoder_fn = self._make_encoder_fn(model)
 
-        # First call.
         result = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param],
@@ -1205,15 +946,12 @@ class TestChunkedPrefillCaching:
         assert len(result) == 1
         assert model._encode_audio.call_count == 1
 
-        # Second call - should use cache.
         result2 = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param],
         )
         assert model._encode_audio.call_count == 1, (
-            "`_encode_audio` was called again on the second chunk. "
-            "Caching is broken - `_encode_multimodal` likely violates the "
-            "`get_multimodal_embeddings` return type contract."
+            "`_encode_audio` was called again on the second chunk. Caching is broken."
         )
         assert torch.equal(result2[0], result[0])
 
@@ -1222,14 +960,12 @@ class TestChunkedPrefillCaching:
         model = self._make_mock_model()
         emb_a = torch.randn(5, self.HIDDEN)
         emb_b = torch.randn(3, self.HIDDEN)
-        # All image params are encoded in a single batched call.
         model.vision_encoder.return_value = ([emb_a, emb_b], [None, None])
 
         param_a = self._make_param_with_runtime("image", 5)
         param_b = self._make_param_with_runtime("image", 3)
         encoder_fn = self._make_encoder_fn(model)
 
-        # First call: encoder runs once for the whole image batch.
         result = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param_a, param_b],
@@ -1239,19 +975,14 @@ class TestChunkedPrefillCaching:
         assert model.vision_encoder.call_count == 1, (
             "image params should be encoded in a single batched vision_encoder call"
         )
-
-        # Both should be cached.
         assert "multimodal_embedding" in param_a.multimodal_data
         assert "multimodal_embedding" in param_b.multimodal_data
 
-        # Second call: encoder must not run again.
         result2 = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param_a, param_b],
         )
         assert model.vision_encoder.call_count == 1, (
-            "`vision_encoder` was called again on the second chunk. "
-            "Caching is broken - `_encode_multimodal` likely violates the "
-            "`get_multimodal_embeddings` return type contract."
+            "`vision_encoder` was called again on the second chunk. Caching is broken."
         )
         assert torch.equal(result2[0], result[0])

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -541,9 +541,9 @@ class TestAudioInputProcessor:
         proc = _make_audio_processor()
         audio = np.random.randn(16000).astype(np.float32)
         text = f"Listen: {AUDIO_PLACEHOLDER}"
-        input_ids, audio_inputs = proc._process_audio(text, [(audio, 16000)])
+        audio_inputs, expanded_text = proc._process_audio(text, [(audio, 16000)])
 
-        assert isinstance(input_ids, torch.Tensor)
+        assert isinstance(expanded_text, str)
         assert {
             "input_audio_features",
             "feature_attention_mask",

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -539,9 +539,9 @@ class TestAudioInputProcessor:
         proc = _make_audio_processor()
         audio = np.random.randn(16000).astype(np.float32)
         text = f"Listen: {AUDIO_PLACEHOLDER}"
-        input_ids, audio_inputs = proc._process_audio(text, [(audio, 16000)])
+        audio_inputs, expanded_text = proc._process_audio(text, [(audio, 16000)])
 
-        assert isinstance(input_ids, torch.Tensor)
+        assert isinstance(expanded_text, str)
         assert {
             "input_audio_features",
             "feature_attention_mask",

--- a/tests/unittest/_torch/multimodal/test_encoder_group.py
+++ b/tests/unittest/_torch/multimodal/test_encoder_group.py
@@ -71,6 +71,23 @@ class TestLengthsByModality:
         with pytest.raises(ValueError):
             _lengths_by_modality([mp], ("image", "video"))
 
+    def test_cross_group_multi_modality_without_manifest_raises(self):
+        # Multi-group models register one single-modality group per encoder.
+        # A raw request (no ``mm_item_order``) with items from two of those
+        # groups must be rejected — the group-local ``modalities`` tuple is
+        # length 1 and can never trip the guard on its own, so the check
+        # widens to the request-level modality set.
+        mp = _mp(embedding_lengths=[4, 3], buckets={"image": {}, "audio": {}})
+        with pytest.raises(ValueError, match="mm_item_order"):
+            _lengths_by_modality([mp], ("image",))
+
+    def test_single_modality_outside_group_is_skipped(self):
+        # Request has only audio; called on the image group. Must silently
+        # return the group's empty bucket rather than KeyError on
+        # ``by_modality["audio"]``.
+        mp = _mp(embedding_lengths=[3], buckets={"audio": {}})
+        assert _lengths_by_modality([mp], ("image",)) == {"image": []}
+
 
 class TestSynthesizeSingleModalityManifest:
     def test_image_only(self):

--- a/tests/unittest/_torch/multimodal/test_nemotron_nano_encoder_groups.py
+++ b/tests/unittest/_torch/multimodal/test_nemotron_nano_encoder_groups.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Encoder-group tests for `NemotronH_Nano_VL_V2` with stubbed vision /
+sound encoders.
+
+Runs in pre-merge CI — no weights required. Exercises the three
+per-modality encoder groups and their `encoder_fn` plumbing directly on
+the class:
+
+* `mm_encoder_groups` returns one group per underlying encoder call
+  (image, video, audio) — the invariant that keeps `EncoderGroup`'s
+  "one encoder invocation per group" contract honest for RADIO, whose
+  image and video sub-paths cannot share a single ViT forward.
+* `_encode_image_group` / `_encode_video_group` wrap each incoming
+  param in a single-modality virtual param (`modality_type` legacy tag
+  set), which is the workaround for
+  `NanoV2VLVisionEncoder.forward`'s exactly-one-of-image/video
+  assertion.
+* `_encode_video_group` stashes per-video EVS retained-token counts on
+  the caller's `multimodal_data` for the downstream `merge_evs_mm_embeds`.
+* `_encode_audio_group` concatenates `_encode_audio` outputs in
+  request order.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock
+
+import torch
+
+from tensorrt_llm._torch.models.modeling_nemotron_nano import NemotronH_Nano_VL_V2
+from tensorrt_llm.inputs.multimodal import MultimodalParams
+
+
+def _make_multimodal_params(
+    *,
+    image: Optional[Dict[str, Any]] = None,
+    video: Optional[Dict[str, Any]] = None,
+    audio: Optional[Dict[str, Any]] = None,
+) -> MultimodalParams:
+    """Build a `MultimodalParams` with only the requested buckets populated."""
+    data: Dict[str, Any] = {}
+    if image is not None:
+        data["image"] = image
+    if video is not None:
+        data["video"] = video
+    if audio is not None:
+        data["audio"] = audio
+    return MultimodalParams(multimodal_data=data, mm_item_order=None)
+
+
+def _marker_tensor(marker: int, n: int, dim: int = 4) -> torch.Tensor:
+    """Column-0 carries the marker so ordering can be asserted."""
+    t = torch.zeros((n, dim))
+    t[:, 0] = float(marker)
+    return t
+
+
+def _model_with_stubs() -> NemotronH_Nano_VL_V2:
+    """Bypass `__init__` and inject stubbed encoders.
+
+    Stubbed `vision_encoder` reads `marker` + `rows` off the virtual param's
+    bucket and returns marker tensors. Stubbed `_encode_audio` does the same
+    for audio inputs.
+    """
+    m = NemotronH_Nano_VL_V2.__new__(NemotronH_Nano_VL_V2)
+
+    def _vision(
+        virtuals: List[MultimodalParams],
+    ) -> Tuple[List[torch.Tensor], List[Optional[torch.Tensor]]]:
+        embeds: List[torch.Tensor] = []
+        for v in virtuals:
+            mt = v.multimodal_data["modality_type"]
+            bucket = v.multimodal_data[mt]
+            embeds.append(_marker_tensor(bucket["marker"], bucket["rows"]))
+        return embeds, [None] * len(virtuals)
+
+    m.vision_encoder = MagicMock(side_effect=_vision)
+    m._encode_audio = lambda audio_data_list: [
+        (_marker_tensor(a["marker"], a["rows"]), [a["rows"]]) for a in audio_data_list
+    ]
+    m.sound_encoder = MagicMock()  # non-None so video-embedded-audio can run
+    return m
+
+
+class TestMmEncoderGroups:
+    def test_property_registers_three_per_modality_groups(self) -> None:
+        groups = _model_with_stubs().mm_encoder_groups
+        assert [g.modalities for g in groups] == [
+            ("image",),
+            ("video",),
+            ("audio",),
+        ]
+
+    def test_image_group_wraps_virtual_params_and_concats(self) -> None:
+        m = _model_with_stubs()
+        params = [
+            _make_multimodal_params(image={"marker": 1, "rows": 3}),
+            _make_multimodal_params(image={"marker": 2, "rows": 2}),
+        ]
+        out = m._encode_image_group(params)
+        assert torch.equal(out[:, 0], torch.tensor([1.0, 1.0, 1.0, 2.0, 2.0]))
+        # Each virtual param carries only the image bucket + legacy modality_type.
+        virtuals = m.vision_encoder.call_args_list[0][0][0]
+        for v in virtuals:
+            assert v.multimodal_data["modality_type"] == "image"
+            assert set(v.multimodal_data.keys()) == {"modality_type", "image"}
+
+    def test_video_group_stashes_num_tokens_in_video(self) -> None:
+        m = _model_with_stubs()
+        # Return per-video EVS retained counts alongside embeddings.
+        m.vision_encoder = MagicMock(
+            side_effect=lambda virtuals: ([_marker_tensor(9, 5)], [torch.tensor([3, 2])])
+        )
+        p = _make_multimodal_params(video={"marker": 9, "rows": 5, "video_size": []})
+        m._encode_video_group([p])
+        assert torch.equal(p.multimodal_data["num_tokens_in_video"], torch.tensor([3, 2]))
+
+    def test_audio_group_concats_encode_audio_outputs(self) -> None:
+        m = _model_with_stubs()
+        params = [
+            _make_multimodal_params(audio={"marker": 7, "rows": 4}),
+            _make_multimodal_params(audio={"marker": 8, "rows": 3}),
+        ]
+        out = m._encode_audio_group(params)
+        assert torch.equal(out[:, 0], torch.tensor([7.0, 7.0, 7.0, 7.0, 8.0, 8.0, 8.0]))
+
+    def test_video_group_skips_audio_when_video_has_no_audio(self) -> None:
+        # Video-only (no embedded audio) must not touch the sound encoder.
+        m = _model_with_stubs()
+        m._encode_audio = MagicMock()
+        m._encode_video_group([_make_multimodal_params(video={"marker": 5, "rows": 4})])
+        m._encode_audio.assert_not_called()
+
+    def test_video_group_skips_audio_when_sound_encoder_missing(self) -> None:
+        # Video carries embedded audio but the worker has no sound encoder —
+        # the audio path must be skipped rather than crashing.
+        m = _model_with_stubs()
+        m.sound_encoder = None
+        m._encode_audio = MagicMock()
+        m._encode_video_group(
+            [
+                _make_multimodal_params(
+                    video={
+                        "marker": 5,
+                        "rows": 4,
+                        "audio": {"has_audio": [True], "audio_num_clips": torch.tensor([1])},
+                    }
+                )
+            ]
+        )
+        m._encode_audio.assert_not_called()
+
+    def test_video_group_interleaves_when_embedded_audio_present(self) -> None:
+        # Video with an embedded audio stream must invoke both `_encode_audio`
+        # and `_interleave_video_audio_embeddings` (the row-layout stitch that
+        # matches the video item's `<img_context>*N <so_embedding>*M` prompt run).
+        m = _model_with_stubs()
+        m._encode_audio = MagicMock(return_value=[(_marker_tensor(0, 3), [3])])
+        m._interleave_video_audio_embeddings = MagicMock(side_effect=lambda emb, *a, **kw: emb)
+        m._encode_video_group(
+            [
+                _make_multimodal_params(
+                    video={
+                        "marker": 5,
+                        "rows": 4,
+                        "audio": {"has_audio": [True], "audio_num_clips": torch.tensor([1])},
+                    }
+                )
+            ]
+        )
+        m._encode_audio.assert_called_once()
+        m._interleave_video_audio_embeddings.assert_called_once()


### PR DESCRIPTION
## Description

Onboards **Nemotron Nano V3 Omni** onto the generic `MultimodalModelMixin` / `EncoderGroup` framework and adds the machinery required for models whose chat template regroups placeholders by modality (Nano's Jinja).

The framework PR ([#16337](https://github.com/NVIDIA/TensorRT-LLM/pull/16337) — "Generic Mixed Modality Support") was previously folded in here; that has since merged to `main` and this branch was rebased on top, so the diff is now scoped strictly to Nemotron + one small framework hook.

## Contents

### 1. Nemotron Nano V3 Omni migration (`tensorrt_llm/_torch/models/modeling_nemotron_nano.py`)
* `NemotronH_Nano_VL_V2` inherits `MultimodalModelMixin` and registers three per-modality `EncoderGroup`s (`("image",)`, `("video",)`, `("audio",)`) — one group per underlying encoder call (RADIO's image and video sub-paths cannot share a single ViT forward).
* Deletes the old `_encode_multimodal` orchestrator; replaced by `_encode_image_group`, `_encode_video_group`, `_encode_audio_group`. Video-with-embedded-audio interleave stays local to the video group.
* Input processor accepts mixed modality: `_process_images` / `_process_images_dynamic` / `_process_video_prompts` / `_process_audio` now return expanded prompt strings, and `call_with_text_prompt` chains all three and tokenizes once at the end.
* Bucket-key detection replaces `modality_type` reads in `NanoV2VLVisionEncoder.forward`, `apply_evs`, and `_check_encoders_exist`. `modality_type` is preserved for single-modality requests so the untouched EVS-merge path keeps working. Mixed + EVS raises a clear `ValueError` rather than a deep `KeyError`.
* EPD encoder-only wrapper (`NanoV2VLMultimodalEncoder.forward`) routes through `encode_multimodal_by_groups` with per-modality virtual params so the encoder output is modality-major (not input-order), fixing a latent cross-request row-scramble bug on mixed EPD batches.

### 2. Framework hook: `prompt_modality_order` on placeholder metadata
Nano's Jinja regroups placeholders by hardcoded modality order regardless of chat-part send order, so `mm_item_order` (built by chat parsing in send order) disagrees with the actual prompt order. That breaks the framework's `mm_item_order == prompt order` invariant on mixed-modality requests.

Adds a single new optional field on `MultimodalPlaceholderMetadata`:
```python
prompt_modality_order: Optional[Tuple[str, ...]] = None   # e.g. ("image", "video", "audio")
```
`MultimodalDataTracker.item_order()` sorts by this priority when set (per-modality send index as tie break), so the manifest is built in the correct order from the start — no rebuild-then-fix. Default `None` preserves send order for all other models.

Nano declares `prompt_modality_order=("image", "video", "audio")`.

## PR Checklist
- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Refactors Nemotron NanoV2VL (`NemotronH_Nano_VL_V2`) to inherit from `MultimodalModelMixin` and route multimodal encoding through the generic `EncoderGroup` / `encode_multimodal_by_groups` framework (separate image/video/audio encoder groups, request-order concatenation, and modality-specific grouping/wrapping).
- Updates raw multimodal detection (`has_raw_multimodal_payload`) to consider `multimodal_data["image"|"video"|"audio"]` presence based on any non-`None` values, rather than relying on `modality_type`.
- Adjusts `_lengths_by_modality` enforcement for raw (non-manifest) inputs to derive the request-level modality set by scanning supported raw keys (`image`, `video`, `audio`) present in each `MultimodalParams`; raises when cross-group/multi-modality is detected without `mm_item_order`, and only appends lengths for modalities that exist in the target `by_modality` map.
- Reworks Nemotron NanoV2VL preprocessing/prompt building so multimodal prompts stay as text (`processed_query` remains prompt text) until a single final tokenizer `encode` after assembling all modalities; preserves legacy `multimodal_data["modality_type"]` only for strictly single-modality requests.
- Adds modality-aware prompt ordering support:
  - Introduces `prompt_modality_order` on `MultimodalPlaceholderMetadata`.
  - Adds `MultimodalPlaceholderRegistry.get_prompt_modality_order()`.
  - Updates `MultimodalDataTracker.item_order()` to sort the prompt-order manifest using the configured modality-major order when provided.
- Improves correctness of multimodal routing / EVS:
  - EVS pruning and vision-group sizing are driven by raw `multimodal_data["video"]` metadata (instead of scanning `modality_type` lists).
  - Forward-time validation rejects mixed-modality requests (image/video/audio together) when EVS video pruning is enabled.
  - Encoder-only EPD handoff explicitly rejects any audio found in `param.multimodal_data` to ensure audio is only handled by the audio encoder group (including cases where audio could be extracted from video).
- Unit-test coverage updates include the multimodal caching path: removes older `_encode_multimodal` dispatch/audio-order tests and rewrites caching tests to validate `get_multimodal_embeddings` caching when exercised via the grouped encoder path (`encode_multimodal_by_groups` with per-modality group methods).
- Includes targeted fixes mentioned in the change summary for EVS, multi-image prompts, and mixed EPD batch handling.

## QA Engineer Review

- Test changes (unit tests only):
  - `tests/unittest/_torch/multimodal/test_encoder_group.py`
    - Added `TestLengthsByModality.test_cross_group_multi_modality_without_manifest_raises`
    - Added `TestLengthsByModality.test_single_modality_outside_group_is_skipped`
  - `tests/unittest/_torch/multimodal/test_nemotron_nano_encoder_groups.py`
    - Added `TestMmEncoderGroups` and helper functions:
      - `test_property_registers_three_per_modality_groups`
      - `test_image_group_wraps_virtual_params_and_concats`
      - `test_video_group_stashes_num_tokens_in_video`
      - `test_audio_group_concats_encode_audio_outputs`
      - `test_video_group_skips_audio_when_video_has_no_audio`
      - `test_video_group_skips_audio_when_sound_encoder_missing`
      - `test_video_group_interleaves_when_embedded_audio_present`
  - `tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py`
    - Removed `TestEncodeMultimodalDispatch` and `TestEncodeMultimodalAudioOrder`
    - Replaced/rewrote caching/contract coverage with a revised `TestChunkedPrefillCaching` suite for the grouped encoder path.

- Coverage in `test-db/` / `qa/` / manual QA:
  - Not verified from the provided data.
- Verdict: **needs follow-up** (CI previously reported a failing L0 Merge Request pipeline; follow-up CI completion status is not confirmed from the provided context).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->