### PR TITLE
[None][perf] Remove spurious sync in sparse fmha forward

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
@@ -60,6 +60,31 @@ def _cache_device(meta) -> torch.device:
     return torch.device(f"cuda:{torch.cuda.current_device()}")
 
 
+def _stage_sparse_plan_kv_lens_host(plan: tuple, kv_lens_cpu: torch.Tensor) -> None:
+    """Keep the sparse-prefill plan's kv_segment_lens on the host.
+
+    The fmha_sm100 sparse-prefill plan (MM-SA-Nv) rebuilds its KV page table
+    every sparse layer in sparse_fmha._build_page_table, which reads
+    plan["kv_segment_lens"] on the host via .tolist(). The planner stores it on
+    the device, so that read is a blocking D2H sync per sparse layer. Store a
+    host copy of the per-request KV lengths (already available as kv_lens_cpu)
+    instead; the page table still builds on the device from kv_indices, so no
+    copy is added. Mirrors the in-place plan-dict edits in on_update_kv_lens.
+
+    Only the sparse-prefill sub-plan is MM-SA-Nv. Decode and dense plans keep
+    their device kv_segment_lens for the kernel.
+    """
+    has_mixed, split = plan[0], plan[1]
+    # Non-mixed batches are one sparse plan (plan[3]). Mixed batches place the
+    # sparse prefill rows in the second sub-plan (plan[4]), after split decode
+    # rows.
+    sparse_dict = plan[4] if has_mixed else plan[3]
+    if sparse_dict is None or not sparse_dict.get("MM-SA-Nv"):
+        return
+    lens = kv_lens_cpu[split:] if has_mixed else kv_lens_cpu
+    sparse_dict["kv_segment_lens"] = lens.to(torch.int32).contiguous()
+
+
 def _worst_case_proxy_max_k_tiles(
     fmha_sm100,
     *,
@@ -739,6 +764,8 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
             self._msa_eager_proxy_plan = proxy_plan
             self._msa_eager_gqa_plan = gqa_plan
             self._msa_eager_dense_plan = dense_plan
+            # Avoid the per-layer page-table D2H sync in sparse prefill.
+            _stage_sparse_plan_kv_lens_host(gqa_plan, kv_lens_cpu)
             # Stage the valid-block count to the device once for the whole step
             # (see _msa_eager_n_valid_blocks). The empty-selection check runs
             # here on the host, so run_indexer can short-circuit cheaply.


### PR DESCRIPTION
## Description

This MR removes spurious syncs in sparse fmha forward
Before: Blocking D2H copy due to `kv_segment_lens` living on GPU
After: `kv_segment_lens` lives on CPU as passed by TRTLLM.

No changes to MSA repo.

For ISL=8192 and OSL=1 @ c=1, request latency in ms:

Before:
```
[Latency] P50    : 257.6939
[Latency] P90    : 261.0175
[Latency] P95    : 261.7910
[Latency] P99    : 262.7895
[Latency] MINIMUM: 256.4940
[Latency] MAXIMUM: 262.7895
[Latency] AVERAGE: 258.1691
```

After:
```
[Latency] P50    : 249.3527
[Latency] P90    : 250.5275
[Latency] P95    : 250.7692
[Latency] P99    : 252.6669
[Latency] MINIMUM: 248.4402
[Latency] MAXIMUM: 252.6669
[Latency] AVERAGE: 249.5198
```



## Test Coverage
```
$ pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=True] -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
