### PR TITLE
[#16767][fix] Fix DSpark rolling-window slot collision in disaggregated serving

### DIFF
--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -112,9 +112,13 @@ class DSparkSpecMetadata(SpecMetadata):
                     worker._ctx_len[slot] = 0
                     worker._kv_windows[slot].zero_()
                     worker._free_slots.append(slot)
-            # Unknown request IDs (e.g. synthetic warmup requests) default to slot 0.
+            # Unknown request IDs (synthetic warmup / CUDA-graph padding, ADP idle
+            # requests, or disagg seed forwards without a real id) map to the
+            # dedicated throwaway scratch row so they cannot overwrite a live
+            # request's rolling window (they previously aliased to slot 0).
+            scratch = worker._scratch_slot
             mapping = torch.tensor(
-                [worker._req_to_slot.get(rid, 0) for rid in self.request_ids],
+                [worker._req_to_slot.get(rid, scratch) for rid in self.request_ids],
                 dtype=torch.long,
                 device="cpu",
                 pin_memory=prefer_pinned(),
@@ -212,6 +216,10 @@ class DSparkWorker(SpecWorkerBase):
         self._req_to_slot = {}  # request_id -> slot index
         self._free_slots = deque()  # available slot indices
         self._batch_to_slot: Optional[torch.Tensor] = None  # [max_batch] long, cuda
+        # Index of the throwaway "scratch" window row that absorbs padded /
+        # unknown request IDs (set in ``_lazy_init`` to ``max_batch``); it is
+        # never handed out through ``_free_slots``.
+        self._scratch_slot = 0
 
         # The generation draft path is the batched, host-sync-free
         # ``_draft_gen_block_batched`` + ``DSparkDraftModel.forward_batched`` +
@@ -244,19 +252,30 @@ class DSparkWorker(SpecWorkerBase):
         self._win = int(draft_model._attn_params["window_size"])
         head_dim = int(draft_model._attn_params["head_dim"])
 
+        # Real requests occupy slots ``[0, max_batch)``; one extra "scratch" row
+        # at index ``max_batch`` absorbs padded / unknown request IDs (CUDA-graph
+        # padding, ADP idle requests, or disagg seed forwards that arrive without
+        # a real request id) so they can never overwrite a live request's rolling
+        # window. Previously such IDs aliased to slot 0 and corrupted whichever
+        # real request occupied it. The scratch row is never handed out through
+        # ``_free_slots`` and its contents are throwaway.
+        self._scratch_slot = max_batch
+        num_rows = max_batch + 1
+
         self._kv_windows = torch.zeros(
-            (max_batch, num_stages, self._win, head_dim),
+            (num_rows, num_stages, self._win, head_dim),
             dtype=torch.bfloat16,
             device="cuda",
         )
-        self._ctx_len = torch.zeros(max_batch, dtype=torch.long, device="cuda")
+        self._ctx_len = torch.zeros(num_rows, dtype=torch.long, device="cuda")
         self._batch_to_slot = torch.zeros(max_batch, dtype=torch.long, device="cuda")
         self._free_slots = deque(range(max_batch))
         self._req_to_slot = {}
         self._win_inited = True
         logger.info(
             f"DSpark: allocated rolling KV windows "
-            f"[{max_batch}, {num_stages}, {self._win}, {head_dim}]"
+            f"[{num_rows}, {num_stages}, {self._win}, {head_dim}] "
+            f"({max_batch} request slots + 1 scratch row)"
         )
 
     def _assign_slot(self, req_id: int, reset: bool) -> int:

--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -29,6 +29,7 @@ from tensorrt_llm._utils import prefer_pinned
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
+from ..pyexecutor.llm_request import ATTENTION_DP_DUMMY_REQUEST_ID
 from .interface import SpecMetadata, SpecWorkerBase
 
 if TYPE_CHECKING:
@@ -112,6 +113,24 @@ class DSparkSpecMetadata(SpecMetadata):
                     worker._ctx_len[slot] = 0
                     worker._kv_windows[slot].zero_()
                     worker._free_slots.append(slot)
+            # Assign a persistent rolling-window slot to every real generation
+            # request that never ran a context/seed forward on this worker. In
+            # disaggregated serving the prompt is prefilled (and the window
+            # seeded) on the *context* server, so ``_seed_context_windows`` never
+            # runs on the generation server and ``_req_to_slot`` stays empty;
+            # without this, all concurrent gen requests fall through to the shared
+            # scratch row below and corrupt each other's draft window at batch
+            # size > 1 (GitHub #16767). Context-prefix entries are left to
+            # ``_seed_context_windows``; the ADP-idle (id 0) and CUDA-graph
+            # padding dummies are kept on the scratch row.
+            num_contexts = max(0, len(self.request_ids) - self.num_generations)
+            for rid in self.request_ids[num_contexts:]:
+                if (
+                    rid != ATTENTION_DP_DUMMY_REQUEST_ID
+                    and rid < worker._graph_dummy_id_floor
+                    and rid not in worker._req_to_slot
+                ):
+                    worker._assign_slot(rid, reset=False)
             # Unknown request IDs (synthetic warmup / CUDA-graph padding, ADP idle
             # requests, or disagg seed forwards without a real id) map to the
             # dedicated throwaway scratch row so they cannot overwrite a live
@@ -261,6 +280,17 @@ class DSparkWorker(SpecWorkerBase):
         # ``_free_slots`` and its contents are throwaway.
         self._scratch_slot = max_batch
         num_rows = max_batch + 1
+
+        # CUDA-graph padding requests carry ids in
+        # ``[CUDA_GRAPH_DUMMY_REQUEST_ID - runtime_draft_len, CUDA_GRAPH_DUMMY_REQUEST_ID]``,
+        # while real request ids start at ``max_batch_size`` and grow, so a simple
+        # floor cleanly separates them. Together with ``ATTENTION_DP_DUMMY_REQUEST_ID``
+        # (0) these dummies must route to the scratch row (see ``prepare()``) and
+        # never consume a real slot. Imported lazily to break the
+        # dspark -> cuda_graph_runner -> speculative.utils -> dspark import cycle.
+        from ..pyexecutor.cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
+
+        self._graph_dummy_id_floor = CUDA_GRAPH_DUMMY_REQUEST_ID - self.max_draft_len
 
         self._kv_windows = torch.zeros(
             (num_rows, num_stages, self._win, head_dim),

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
@@ -121,6 +121,8 @@ def test_worker_lazy_init_window_buffers():
     assert worker._kv_windows.shape == (9, 3, 128, 64)
     assert worker._ctx_len.shape == (9,)
     assert worker._scratch_slot == 8
+    # Dummy-id floor separates real request ids from CUDA-graph padding ids.
+    assert worker._graph_dummy_id_floor == (1 << 64) - 1 - worker.max_draft_len
     # The scratch row is never handed out through the free pool.
     assert list(worker._free_slots) == list(range(8))
     assert worker._batch_to_slot is not None
@@ -289,6 +291,68 @@ def test_prepare_maps_unknown_request_to_scratch_row_not_slot_zero():
     # The live request's rolling window and position are untouched.
     assert int(worker._ctx_len[s_real]) == 17
     assert torch.all(worker._kv_windows[s_real] == 1.0)
+
+
+def test_prepare_assigns_slots_to_disagg_generation_requests():
+    """Disagg gen requests (never seeded here) get distinct slots, not one shared row.
+
+    Regression for GitHub #16767: on the disaggregated generation server the
+    prompt is prefilled (and the DSpark window seeded) on the *context* server,
+    so ``_seed_context_windows`` never runs here and ``_req_to_slot`` stays empty.
+    ``prepare()`` must therefore assign each real generation request its own
+    rolling-window slot instead of collapsing them all onto the shared scratch
+    row (which corrupts drafts and collapses accept length at batch size > 1).
+    """
+    worker = _make_worker()
+    meta = _make_metadata(max_num_requests=4)
+    worker._lazy_init(_fake_draft_model(), meta)
+    meta._dspark_worker = worker
+
+    # All-generation batch (num_contexts == 0), no prior seeding.
+    meta.request_ids = [1000, 1001]
+    meta.num_generations = 2
+    meta.prepare()
+
+    s0 = worker._req_to_slot[1000]
+    s1 = worker._req_to_slot[1001]
+    assert s0 != s1
+    assert s0 != worker._scratch_slot and s1 != worker._scratch_slot
+    assert worker._batch_to_slot[:2].tolist() == [s0, s1]
+
+    # Stable across steps: the same ids keep their slots (no churn / reassignment).
+    meta.prepare()
+    assert worker._req_to_slot[1000] == s0
+    assert worker._req_to_slot[1001] == s1
+    assert worker._batch_to_slot[:2].tolist() == [s0, s1]
+
+
+def test_prepare_keeps_dummy_generation_requests_on_scratch_row():
+    """ADP-idle (id 0) and CUDA-graph padding dummies never consume a real slot."""
+    from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
+    from tensorrt_llm._torch.pyexecutor.llm_request import ATTENTION_DP_DUMMY_REQUEST_ID
+
+    worker = _make_worker()
+    meta = _make_metadata(max_num_requests=4)
+    worker._lazy_init(_fake_draft_model(), meta)
+    meta._dspark_worker = worker
+
+    graph_dummy = CUDA_GRAPH_DUMMY_REQUEST_ID - worker.max_draft_len
+    meta.request_ids = [1000, ATTENTION_DP_DUMMY_REQUEST_ID, graph_dummy]
+    meta.num_generations = 3
+    meta.prepare()
+
+    s_real = worker._req_to_slot[1000]
+    assert s_real != worker._scratch_slot
+    # Dummies are neither registered nor given a real slot; they map to scratch.
+    assert ATTENTION_DP_DUMMY_REQUEST_ID not in worker._req_to_slot
+    assert graph_dummy not in worker._req_to_slot
+    assert worker._batch_to_slot[:3].tolist() == [
+        s_real,
+        worker._scratch_slot,
+        worker._scratch_slot,
+    ]
+    # Exactly one real slot consumed.
+    assert list(worker._free_slots) == [1, 2, 3]
 
 
 def test_forward_mixed_batch_routes_through_base_entries(monkeypatch):

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
@@ -117,8 +117,11 @@ def test_worker_lazy_init_window_buffers():
     dm = _fake_draft_model(num_stages=3, window_size=128, head_dim=64)
     meta = _make_metadata(max_num_requests=8)
     worker._lazy_init(dm, meta)
-    assert worker._kv_windows.shape == (8, 3, 128, 64)
-    assert worker._ctx_len.shape == (8,)
+    # max_batch (8) request slots + 1 scratch row for padded / unknown IDs.
+    assert worker._kv_windows.shape == (9, 3, 128, 64)
+    assert worker._ctx_len.shape == (9,)
+    assert worker._scratch_slot == 8
+    # The scratch row is never handed out through the free pool.
     assert list(worker._free_slots) == list(range(8))
     assert worker._batch_to_slot is not None
     assert worker._batch_to_slot.shape == (8,)
@@ -253,6 +256,39 @@ def test_prepare_frees_stale_slots_on_batched_path():
     assert 100 not in worker._req_to_slot
     assert sa in worker._free_slots
     assert int(worker._ctx_len[sa]) == 0
+
+
+def test_prepare_maps_unknown_request_to_scratch_row_not_slot_zero():
+    """Padded / unknown request IDs route to the scratch row, never a live slot.
+
+    Regression for the rolling-window aliasing bug (GitHub #16767): an unknown
+    request id (CUDA-graph padding, ADP idle request, or a disagg seed forward
+    without a real id) must not overwrite the request that owns slot 0.
+    """
+    worker = _make_worker()
+    meta = _make_metadata(max_num_requests=4)
+    worker._lazy_init(_fake_draft_model(), meta)
+    meta._dspark_worker = worker
+
+    # A live request takes the first free slot (0) and populates its window.
+    s_real = worker._assign_slot(100, reset=True)
+    assert s_real == 0
+    worker._ctx_len[s_real] = 17
+    worker._kv_windows[s_real].fill_(1.0)
+
+    # Batch contains the live request plus an unknown id (e.g. graph padding).
+    meta.request_ids = [100, 999]
+    meta.prepare()
+
+    # The unknown id maps to the scratch row, not to slot 0.
+    assert worker._batch_to_slot[:2].tolist() == [s_real, worker._scratch_slot]
+    assert worker._scratch_slot != s_real
+    # It is not silently registered as a real request and did not consume a slot.
+    assert 999 not in worker._req_to_slot
+    assert list(worker._free_slots) == [1, 2, 3]
+    # The live request's rolling window and position are untouched.
+    assert int(worker._ctx_len[s_real]) == 17
+    assert torch.all(worker._kv_windows[s_real] == 1.0)
 
 
 def test_forward_mixed_batch_routes_through_base_entries(monkeypatch):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated DSpark rolling-window request→slot mapping to prevent speculative-decoding accept-length collapse under disaggregated serving by routing padded/unknown/idle request IDs to a dedicated scratch row instead of slot 0.
- Added `DSparkWorker._scratch_slot` and changed lazy allocation of rolling-window KV/context tensors to include one extra scratch row (`max_batch + 1`), with CUDA-graph dummy/padding IDs routed below a computed dummy-ID floor to the scratch row.
- Updated `DSparkSpecMetadata.prepare()` host-side slot assignment:
  - `_batch_to_slot` no longer defaults missing/unknown request IDs to slot 0; it maps them to the scratch slot.
  - For real unseeded disaggregated generation request IDs, assigns persistent distinct rolling-window slots via `worker._assign_slot(..., reset=False)`.
  - Excludes dummy/ADP-idle and CUDA-graph padding requests from consuming real slots (they stay on the scratch row).
- Preserved aggregated-mode behavior.
- End-to-end DEP8 validation remains pending.

## QA Engineer Review

Unit test updates in `tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py`:

- Added `test_prepare_maps_unknown_request_to_scratch_row_not_slot_zero`
- Added `test_prepare_assigns_slots_to_disagg_generation_requests`
- Added `test_prepare_keeps_dummy_generation_requests_on_scratch_row`

These validate scratch-row routing, distinct persistent slot assignment for unseeded disaggregated generation requests, dummy-request exclusion from real slot allocation, and updated buffer initialization expectations.

Verdict: sufficient for the DSpark slot-routing logic; **needs follow-up** for DEP8 end-to-end validation and any required CI/manual-QA test-list registration (not indicated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixes the DSpark speculative-decoding accept-length (AL) collapse under **disaggregated serving** reported in #16767.

**Root cause.** DSpark assigns each request a rolling-KV-window slot only inside `_seed_context_windows`, which runs only when `num_contexts > 0`. On the disaggregated **generation** server, transferred requests arrive as *generation* requests (prefill runs on the context server), so `_seed_context_windows` never runs there, `DSparkWorker._req_to_slot` stays empty, and every real generation request falls through to a single shared fallback rolling-window row. At generation batch size 1 that row is effectively private (AL correct), but at batch size > 1 all concurrent requests collide on it and corrupt each other's draft context, collapsing AL (e.g. ~1.4 vs ~4.5 at draft length 7 in a DEP8 repro). The `request_id=0` noted in the issue is the incidental attention-DP idle-dummy id (`ATTENTION_DP_DUMMY_REQUEST_ID`), not the mechanism.

This PR has two commits:

1. **Scratch-row hardening** — `DSparkWorker` allocates one extra scratch window row (index `max_batch`, never handed out through `_free_slots`); `DSparkSpecMetadata.prepare()` routes padded/unknown request IDs (CUDA-graph padding, ADP idle) to it instead of aliasing slot 0.
2. **Disagg slot assignment** — `prepare()` now assigns each real generation-tail request its own persistent rolling-window slot when seeding never mapped it, skipping the ADP-idle (id 0) and CUDA-graph padding dummies (which stay on the scratch row). Context-prefix entries are still left to `_seed_context_windows`, so **aggregated mode is unchanged**.

The generation server never prompt-seeds the window in either mode (batch-1 disagg also runs unseeded and reaches AL ~4.5, building the window from generation back-fill), so unique per-request slots fully address the collapse — no KV/window transfer from the context server is required.

## Test Coverage

Hardware-agnostic unit tests in `tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py` (all pass on B200):
- `test_prepare_maps_unknown_request_to_scratch_row_not_slot_zero` — unknown/padding IDs route to the scratch row, live slot untouched.
- `test_prepare_assigns_slots_to_disagg_generation_requests` — disagg gen requests (never seeded here) get distinct, stable, non-scratch slots.
- `test_prepare_keeps_dummy_generation_requests_on_scratch_row` — ADP-idle (id 0) and CUDA-graph padding dummies never consume a real slot.
- updated `test_worker_lazy_init_window_buffers` — scratch row + dummy-id floor.

## Validation status

- ✅ DSpark hardware-agnostic worker unit tests (B200).
- ⏳ End-to-end DEP8 disagg re-run to confirm LBS16 accept length recovers toward the LBS1 curve — **pending** (reason this PR is opened as a draft).

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
