### PR TITLE
[TRTLLM-14575][fix] MoE: fp32 accumulation in deferred MoEAllReduce finalize

### DIFF
--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAllReduceFusionKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAllReduceFusionKernels.cu
@@ -557,11 +557,20 @@ __global__ void moefinalize_allreduce_fusion_kernel_oneshot_lamport(MoeFinalizeA
         }
 
         // * MoE finalize
-        ACC_TYPE accumulator;
+        // Accumulate the top-k weighted expert sum and the shared-expert add in
+        // fp32 (local `facc`), rounding to DType (bf16/fp16) only once when packing
+        // into `accumulator` for the 128-bit Lamport all-reduce store below.
+        // Accumulating directly in DType here rounds after every one of the top_k
+        // terms; across the many routed MoE layers this rounding bias is large
+        // enough to visibly degrade the routed output, and with attention-DP
+        // disabled + MTP speculative decoding it drifts the target hidden states
+        // enough to lower the acceptance length. The non-deferred in-kernel
+        // finalize (do_finalize=true) already accumulates in fp32; match it here.
+        float facc[kElemsPerAccess];
 #pragma unroll
         for (int i = 0; i < kElemsPerAccess; ++i)
         {
-            accumulator.unpacked[i] = static_cast<DType>(0);
+            facc[i] = 0.f;
         }
 
         for (int k = 0; k < top_k; k++)
@@ -583,17 +592,15 @@ __global__ void moefinalize_allreduce_fusion_kernel_oneshot_lamport(MoeFinalizeA
             permuted_data.packed
                 = reinterpret_cast<float4 const*>(params.allreduce_in)[thread_offset_across_token / kElemsPerAccess];
 
-            // * acc += scale(data)
+            // * acc += scale(data)  (fp32 accumulation)
 #pragma unroll
             for (int i = 0; i < kElemsPerAccess; ++i)
             {
-                // assume computation is done in ScaleType
-                accumulator.unpacked[i]
-                    += static_cast<DType>((static_cast<float>(permuted_data.unpacked[i]) * block_scale));
+                facc[i] += static_cast<float>(permuted_data.unpacked[i]) * block_scale;
             }
         }
 
-        // * Add shared expert output
+        // * Add shared expert output  (fp32 accumulation)
         if (params.shared_expert_output)
         {
             // * Load shared expert output
@@ -604,8 +611,16 @@ __global__ void moefinalize_allreduce_fusion_kernel_oneshot_lamport(MoeFinalizeA
 #pragma unroll
             for (int i = 0; i < kElemsPerAccess; ++i)
             {
-                accumulator.unpacked[i] += shared_expert_output.unpacked[i];
+                facc[i] += static_cast<float>(shared_expert_output.unpacked[i]);
             }
+        }
+
+        // Round the fp32 accumulator to DType once, packed for the Lamport AR store.
+        ACC_TYPE accumulator;
+#pragma unroll
+        for (int i = 0; i < kElemsPerAccess; ++i)
+        {
+            accumulator.unpacked[i] = static_cast<DType>(facc[i]);
         }
 
         // * AR Store


### PR DESCRIPTION
## Description

The deferred fused MoE finalize path (`do_finalize=false`) in
`moefinalize_allreduce_fusion_kernel_oneshot_lamport` accumulated the top-k
weighted expert sum and the shared-expert add directly in `DType` (bf16),
rounding after each of the `top_k` terms. The non-deferred in-kernel finalize
(`do_finalize=true`) accumulates the same sum in fp32, so the two combine paths
were not numerically equivalent.

The bf16 per-term rounding biases the routed MoE output. With attention-DP
disabled + MTP speculative decoding, the drift in the target hidden states is
large enough to lower the MTP acceptance length.

### Fix

Accumulate the top-k sum and the shared-expert add in a local fp32 array and
round to `DType` **once**, when packing into the accumulator for the 128-bit
Lamport all-reduce store. The Lamport transport is unchanged; the only added
work is a per-lane fp32 add, so the decode step time is unchanged.

### Measured impact

GLM-5.2 (NVFP4) with MTP speculative decoding — GB300, TP4/EP4, attention-DP
off, batch size 1, decode-only:

| deferred combine | MTP acceptance length | decode tok/s/user | step time |
| --- | --- | --- | --- |
| bf16 (before) | 2.28 | ~152.7 | ~14.9 ms |
| fp32 (this PR) | 2.99 | ~200.6 | ~14.9 ms |

≈ **+31% decode throughput at unchanged step time**, with the acceptance length
recovering to match the fp32 in-kernel finalize. Only decode is affected; the
prefill/context path already uses the non-deferred fp32 finalize.

## Test Coverage

The modified kernel `moefinalize_allreduce_fusion_kernel_oneshot_lamport` is
exercised by the existing MoE finalize / AllReduce-fusion paths. The
accuracy/perf impact above was measured on an end-to-end NVFP4 MoE + MTP decode
workload; output remains coherent.

## PR Checklist

- [x] Change is limited to the deferred finalize accumulation precision; no API
  or transport change.
- [x] Commit is DCO signed-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Updated the deferred fused MoE finalize path to accumulate top-k weighted expert outputs and shared-expert output in fp32.
- Converts to `DType` only once before the existing 128-bit Lamport all-reduce store, removing per-term rounding and fixing precision asymmetry.
- Lamport transport and public APIs are unchanged; no configuration or test-list changes were detected.
- The change is localized and consistent with the reported performance and acceptance-length improvements.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->