### PR TITLE
[TRTLLM-14541][fix] VisualGen: deterministic autotuner tactics across runs and ranks

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -760,9 +760,17 @@ class AutoTunerProfilingCache:
             # Convert any simple object to string for JSON compatibility
             key_str = str(key)
             runner_id, tactic, min_time = value
-            tactic_str = repr(tactic)
+            # Enum tactics (e.g. Fp4QuantTactic) repr as "<Fp4QuantTactic.TRTLLM: -1>",
+            # which ast.literal_eval can't parse back -> load_cache crash. Serialize
+            # the underlying value (reload yields that value; an IntEnum compares
+            # equal to it and kernels take the int).
+            is_enum = isinstance(tactic, enum.Enum)
+            tactic_check = tactic.value if is_enum else tactic
+            tactic_str = repr(tactic_check)
             try:
-                assert tactic == ast.literal_eval(
+                # Verify the serialized value round-trips (compare against the
+                # value we store, not the enum member — else non-IntEnum fails).
+                assert tactic_check == ast.literal_eval(
                     tactic_str
                 ), f"Tactic is not compatible with json.dumps/json.loads"
             except Exception as e:

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -261,7 +261,8 @@ class TunableRunner(ABC):
 @contextlib.contextmanager
 def autotune(tune_mode: bool = True,
              cache_path: str = None,
-             skip_dynamic_tuning_buckets: bool = False):
+             skip_dynamic_tuning_buckets: bool = False,
+             post_tune_merge_dist: Optional[Distributed] = None):
     """Context manager for autotuning with distributed support.
 
     Args:
@@ -271,8 +272,21 @@ def autotune(tune_mode: bool = True,
             _optimization_profiles() so only actual input shapes from warmup
             are profiled. Useful for workloads (e.g. diffusion) where the
             LLM-oriented M-bucket sweep is unnecessary.
+        post_tune_merge_dist: Optional ``Distributed``. When set, tactics are
+            tuned per-rank independently and merged across ranks in one
+            collective at context exit (before the cache is saved) — for
+            pipelines whose warmup is not SPMD and so cannot use the per-op
+            distributed strategies.
     """
     autotuner = AutoTuner.get()
+    if post_tune_merge_dist is not None:
+        # Save the singleton's prior state: the full-world dist attached for the
+        # merge is temporary and must not leak into later sessions. Attach the
+        # real (world-sized) mapping now for a correct rank, but with no dist
+        # yet: _is_distributed() stays False so per-op sync is skipped while a
+        # non-SPMD pipeline tunes; the dist is attached at exit to merge.
+        prev_mapping, prev_dist = autotuner.mapping, autotuner._dist
+        autotuner.setup_distributed_state(post_tune_merge_dist.mapping, None)
     rank = autotuner.mapping.rank
 
     # if cache_path is provided, use the rank-specific file
@@ -303,10 +317,24 @@ def autotune(tune_mode: bool = True,
         if autotune_enabled:
             logger.info("[Autotuner] Autotuning process ends")
 
-        # save cache
-        if cache_path is not None:
-            logger.info(f"[Autotuner] Saving cache to {cache_path}")
-            autotuner.profiling_cache.save_cache(cache_path, rank)
+        try:
+            # Merge tactics across ranks in one collective before the cache is
+            # saved, so non-SPMD pipelines can tune independently and still agree.
+            if post_tune_merge_dist is not None:
+                autotuner.setup_distributed_state(post_tune_merge_dist.mapping,
+                                                  post_tune_merge_dist)
+                autotuner.post_tune_merge_tactics()
+
+            # save cache
+            if cache_path is not None:
+                logger.info(f"[Autotuner] Saving cache to {cache_path}")
+                autotuner.profiling_cache.save_cache(cache_path, rank)
+        finally:
+            # Restore the singleton's prior distributed state (see enter) so the
+            # temporary full-world state does not persist past this context.
+            if post_tune_merge_dist is not None:
+                autotuner.mapping = prev_mapping
+                autotuner._dist = prev_dist
 
 
 @dataclass
@@ -1961,6 +1989,19 @@ class AutoTuner:
                     merged_cache_data[key] = value
 
         self.profiling_cache.merge_cache_data(merged_cache_data)
+
+    def post_tune_merge_tactics(self) -> None:
+        """Merge tactics across ranks after tuning: all-gather every rank's whole
+        profiling cache and keep the fastest tactic per key. One-shot
+        (session-level, not per-op). Collective — all ranks must call it."""
+        if not self._is_distributed():
+            return
+        merged = dict()
+        for data in self._dist.tp_cp_allgather(obj=self.profiling_cache.cache):
+            for key, value in data.items():
+                if value[-1] < merged.get(key, [float('inf')])[-1]:
+                    merged[key] = value
+        self.profiling_cache.merge_cache_data(merged)
 
     def _broadcast_cache_data(
         self,

--- a/tensorrt_llm/_torch/visual_gen/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/visual_gen/cuda_graph_runner.py
@@ -72,6 +72,8 @@ class CUDAGraphRunner:
     ):
         self.config = config
         self.enabled = config.use_cuda_graph
+        # When False, uncaptured keys run eagerly instead of triggering capture.
+        self.allow_capture = True
         self._shared_pool = shared_pool
         self._extra_key_fns: Dict[str, ExtraKeyFn] = {}
 
@@ -194,6 +196,8 @@ class CUDAGraphRunner:
             key = self.get_graph_key(*args, **kwargs)
 
             if key not in self.graphs:
+                if not self.allow_capture:
+                    return fn(*args, **kwargs)
                 self.capture(key, fn, args, kwargs)
                 return self.replay(key, args, kwargs)
             else:

--- a/tensorrt_llm/_torch/visual_gen/mapping.py
+++ b/tensorrt_llm/_torch/visual_gen/mapping.py
@@ -18,6 +18,7 @@ from torch.distributed import ProcessGroup
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 from tensorrt_llm._torch.device_mesh import DeviceMeshTopologyImpl, SingleProcessGroup
+from tensorrt_llm._torch.distributed.communicator import Distributed, TorchDist
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
@@ -26,6 +27,29 @@ _DEVICE_MESH_DIM_ORDER_LEGACY = "cfg-tp-cp-ulysses"
 # Attention2D mesh: split CP into a 2D tile (cp_row × cp_col) so row/col
 # subgroups and seq flatten (cp_row, cp_col, ulysses) are well-defined.
 _DEVICE_MESH_DIM_ORDER_ATTN2D = "cfg-tp-cp_row-cp_col-ulysses"
+
+
+class _VisualGenAutotuneDist(TorchDist):
+    """Autotuner communicator whose collective spans the whole world.
+
+    VisualGen's device mesh has no TP axis over the tuned GEMMs (its parallelism
+    is on cfg/ulysses), so the mesh's tp group would gather a single rank. Gather
+    over the default world group instead, since every rank runs the transformer.
+    """
+
+    def __init__(self, mapping: Mapping):
+        # Skip TorchDist.__init__ on purpose: it registers a global comm
+        # singleton (set_torch_comm) and builds mesh/local subgroups via
+        # collectives — hijacking it here would clobber the real comm. The merge
+        # only needs a world-group all_gather (tp_cp_allgather below), which runs
+        # on the default group; Distributed.__init__ just records the mapping.
+        Distributed.__init__(self, mapping)
+        assert dist.is_initialized()
+
+    def tp_cp_allgather(self, obj: object) -> list[object]:
+        gathered: list[object] = [None] * dist.get_world_size()
+        dist.all_gather_object(gathered, obj)
+        return gathered
 
 
 class VisualGenMapping(DeviceMeshTopologyImpl):
@@ -554,4 +578,13 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
             world_size=self.tp_size,
             rank=self.tp_rank,
             tp_size=self.tp_size,
+        )
+
+    def to_autotuner_mapping(self) -> Mapping:
+        """Mapping that makes the autotuner treat all world ranks as one tuning
+        group (tp_size == world_size), so its post-tune cross-rank merge engages."""
+        return Mapping(
+            world_size=self.world_size,
+            rank=self._rank,
+            tp_size=self.world_size,
         )

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -1,3 +1,4 @@
+import contextlib
 import itertools
 import os
 import time
@@ -8,6 +9,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from pydantic import Field
 
+from tensorrt_llm._torch.autotuner import autotune
 from tensorrt_llm._torch.visual_gen.pipeline_registry import PipelineComponent
 from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.llmapi.utils import StrictBaseModel
@@ -17,6 +19,7 @@ from tensorrt_llm.mapping import Mapping
 from .cache import CacheDiTAccelerator, TeaCacheAccelerator
 from .checkpoints import WeightLoader
 from .cuda_graph_runner import CUDAGraphRunner, CUDAGraphRunnerConfig, SharedGraphPool
+from .mapping import _VisualGenAutotuneDist
 from .modules.vae.parallel_vae_interface import ParallelVAEFactory
 
 
@@ -205,6 +208,18 @@ class BasePipeline(nn.Module):
             logger.info(f"CUDA graph runner: wrapping {name}.forward{compile_note}")
             model.forward = runner.wrap(model.forward)
             self._cuda_graph_runners[name] = runner
+
+    @contextlib.contextmanager
+    def disallow_cuda_graph_capture(self):
+        """Run wrapped forwards eagerly instead of capturing new CUDA graphs."""
+        prev = {name: r.allow_capture for name, r in self._cuda_graph_runners.items()}
+        for r in self._cuda_graph_runners.values():
+            r.allow_capture = False
+        try:
+            yield
+        finally:
+            for name, r in self._cuda_graph_runners.items():
+                r.allow_capture = prev[name]
 
     @property
     def rank(self):
@@ -630,12 +645,14 @@ class BasePipeline(nn.Module):
     def warmup(self) -> None:
         """Run warmup inference to trigger torch.compile and CUDA initialization.
 
-        Resolves warmup shapes from user config or model defaults, then runs
-        a short denoising loop with dummy inputs for each shape. This:
-        1. Triggers torch.compile's lazy compilation (first forward trace + codegen)
-        2. Pre-captures CUDA graphs (if enabled)
-        3. Warms up CUDA kernels and allocators
-        4. Populates any lazy caches (e.g., RoPE frequencies)
+        Resolves warmup shapes from user config or model defaults, then runs a
+        short denoising loop with dummy inputs for each shape, triggering
+        torch.compile, CUDA graph capture (if enabled), and autotuner tuning.
+
+        With autotuning enabled, a single rank tunes and captures in one pass.
+        On multiple ranks, tactics are tuned with capture off, merged across
+        ranks at ``autotune()`` exit, then recaptured — so every rank bakes the
+        same tactic into its graphs.
 
         Called automatically by PipelineLoader after model loading and torch.compile.
         OOM is not caught — if a warmup shape OOMs, the server fails fast at startup.
@@ -645,24 +662,61 @@ class BasePipeline(nn.Module):
             logger.info("Warmup disabled (no warmup shapes)")
             return
 
+        shape_list = ", ".join(f"{h}x{w}x{f}" for h, w, f in shapes)
         logger.info(
-            f"Running warmup for {self.__class__.__name__} "
-            f"with {len(shapes)} shapes and {steps} steps..."
+            f"Running warmup for {self.__class__.__name__}: "
+            f"{len(shapes)} shape(s) [{shape_list}], {steps} steps..."
         )
         warmup_start = time.time()
 
+        # Autotuner tuning knobs: cache path from env, plus (multi-rank only) a
+        # world-group communicator that drives the post-tune cross-rank merge.
+        enable_autotune = self.pipeline_config.torch_compile.enable_autotune
+        cache_path = None
+        post_tune_merge_dist = None
+        if enable_autotune:
+            cache_path = os.environ.get("TLLM_AUTOTUNER_CACHE_PATH")
+            if dist.is_initialized() and dist.get_world_size() > 1:
+                amap = self.pipeline_config.visual_gen_mapping.to_autotuner_mapping()
+                post_tune_merge_dist = _VisualGenAutotuneDist(amap)
+
         self._is_warmup = True
-        for height, width, num_frames in shapes:
-            logger.info(f"Warmup: {height}x{width}, {num_frames} frames, {steps} steps")
-            self._run_warmup(height, width, num_frames, steps)
-            torch.cuda.synchronize()
-        self._is_warmup = False
+        try:
+            if not enable_autotune:
+                self._run_warmup_pass(shapes, steps)
+            elif post_tune_merge_dist is None:
+                # Single rank: nothing to merge; tune and capture in one pass.
+                with autotune(cache_path=cache_path, skip_dynamic_tuning_buckets=True):
+                    self._run_warmup_pass(shapes, steps)
+            else:
+                # Multi rank: tune with capture off, merge tactics across ranks
+                # at autotune() exit, then recapture from the merged tactics
+                # (only needed when CUDA graphs are enabled).
+                with (
+                    self.disallow_cuda_graph_capture(),
+                    autotune(
+                        cache_path=cache_path,
+                        skip_dynamic_tuning_buckets=True,
+                        post_tune_merge_dist=post_tune_merge_dist,
+                    ),
+                ):
+                    self._run_warmup_pass(shapes, steps)
+                if self.pipeline_config.cuda_graph.enable:
+                    self._run_warmup_pass(shapes, steps)
+        finally:
+            self._is_warmup = False
 
         self._warmed_up_shapes = set(
             self.warmup_cache_key(h, w, num_frames=f) for h, w, f in shapes
         )
         elapsed = time.time() - warmup_start
         logger.info(f"Warmup completed in {elapsed:.2f}s")
+
+    def _run_warmup_pass(self, shapes, steps) -> None:
+        """Run one warmup pass over all shapes (denoise loop with dummy inputs)."""
+        for height, width, num_frames in shapes:
+            self._run_warmup(height, width, num_frames, steps)
+            torch.cuda.synchronize()
 
     def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
         """Run warmup for a single shape. Subclasses must override.

--- a/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, List, Optional, Union
 import torch
 import torch.distributed as dist
 
-from tensorrt_llm._torch.autotuner import autotune
 from tensorrt_llm._torch.models.modeling_utils import MetaInitMode
 from tensorrt_llm._torch.visual_gen.cute_dsl_kernels.blackwell.video_sparse_attention import (
     CUTE_AVAILABLE,
@@ -313,14 +312,7 @@ class PipelineLoader:
             pipeline._setup_cache_acceleration()
 
         if not skip_warmup:
-            if config.torch_compile.enable_autotune:
-                with autotune(
-                    cache_path=os.environ.get("TLLM_AUTOTUNER_CACHE_PATH"),
-                    skip_dynamic_tuning_buckets=True,
-                ):
-                    pipeline.warmup()
-            else:
-                pipeline.warmup()
+            pipeline.warmup()
             logger.info(f"Warmup completed in {time.time() - t0:.2f}s")
         else:
             logger.info("Warmup skipped (skip_warmup=True)")

--- a/tests/unittest/_torch/misc/test_autotuner.py
+++ b/tests/unittest/_torch/misc/test_autotuner.py
@@ -1,3 +1,4 @@
+import enum
 import itertools
 import json
 import math
@@ -1321,3 +1322,90 @@ def test_trtllm_gen_moe_dummy_topk_local_experts_less_than_topk(
         assert sum(x in shard for x in row) == local_num_experts, (
             f"expected all {local_num_experts} local experts in row {row}")
         assert all(0 <= x < num_experts for x in row), row
+
+
+def test_post_tune_merge_tactics_min_time_and_subset_kept():
+    tuner = autotuner.AutoTuner()
+    tuner.mapping = Mapping(world_size=2, rank=0, tp_size=2)
+
+    r0 = {
+        ("gemm", "X"): (0, ("cutlass", 10), 1.0),
+        ("q", "A"): (0, ("trtllm", ), 1.0)
+    }
+    r1 = {
+        ("gemm", "X"): (0, ("cublaslt", 0), 0.5),
+        ("vae", "B"): (0, ("cutlass", 2), 1.0)
+    }
+
+    class _FakeDist:
+
+        def tp_cp_allgather(self, obj):
+            return [r0, r1]
+
+    tuner._dist = _FakeDist()
+    tuner.profiling_cache.cache = dict(r0)
+    tuner.post_tune_merge_tactics()
+
+    cache = tuner.profiling_cache.cache
+    assert cache[("gemm", "X")] == (0, ("cublaslt", 0), 0.5)
+    assert cache[("q", "A")] == r0[("q", "A")]
+    assert cache[("vae", "B")] == r1[("vae", "B")]
+
+
+def test_post_tune_merge_tactics_single_rank_noop():
+    tuner = autotuner.AutoTuner()
+    tuner.mapping = Mapping(world_size=1, rank=0, tp_size=1)
+    tuner._dist = None
+    original = {("gemm", "X"): (0, ("cutlass", 10), 1.0)}
+    tuner.profiling_cache.cache = dict(original)
+    tuner.post_tune_merge_tactics()
+    assert tuner.profiling_cache.cache == original
+
+
+def test_profiling_cache_enum_tactic_roundtrip(tmp_path):
+    # An enum tactic must survive save -> load: repr("<Enum.X: v>") isn't
+    # ast.literal_eval-parsable, so the cache serializes tactic.value instead.
+    class _Tac(enum.IntEnum):
+        TRTLLM = -1
+
+    key = ("op::x", "Runner", "(1,)")
+    src = autotuner.AutoTuner().profiling_cache
+    src.cache[key] = (0, _Tac.TRTLLM, 1.0)
+    path = str(tmp_path / "cache.json")
+    src.save_cache(path, rank=0)  # must not raise
+
+    dst = autotuner.AutoTuner().profiling_cache
+    dst.load_cache(path, rank=0)
+    assert dst.cache[key][1] == _Tac.TRTLLM  # IntEnum compares equal to -1
+
+
+def test_autotune_post_tune_merge_before_save(tmp_path):
+    # autotune(post_tune_merge_dist=...) must merge across ranks and persist the
+    # merged winner, then restore the singleton's prior distributed state.
+    tuner = AutoTuner.get()
+    tuner.clear_cache()
+    r0 = {("gemm", "X"): (0, ("cutlass", 10), 1.0)}
+    r1 = {("gemm", "X"): (0, ("cublaslt", 0), 0.5)}
+    tuner.profiling_cache.cache = dict(r0)
+
+    class _FakeDist:
+        mapping = Mapping(world_size=2, rank=0, tp_size=2)
+
+        def tp_cp_allgather(self, obj):
+            return [r0, r1]
+
+    prev_mapping, prev_dist = tuner.mapping, tuner._dist
+    path = str(tmp_path / "cache.json")
+    with autotune(cache_path=path, post_tune_merge_dist=_FakeDist()):
+        pass
+
+    # Merged in memory (fastest tactic won) and persisted before the context
+    # exits (the saved file carries the merged winner).
+    assert tuner.profiling_cache.cache[("gemm", "X")] == (0, ("cublaslt", 0),
+                                                          0.5)
+    persisted = autotuner.AutoTuner().profiling_cache
+    persisted.load_cache(path, rank=0)
+    assert persisted.cache[("gemm", "X")][1] == ("cublaslt", 0)
+    # The temporary full-world distributed state was restored.
+    assert tuner.mapping is prev_mapping
+    assert tuner._dist is prev_dist

--- a/tests/unittest/_torch/misc/test_autotuner.py
+++ b/tests/unittest/_torch/misc/test_autotuner.py
@@ -1409,3 +1409,79 @@ def test_autotune_post_tune_merge_before_save(tmp_path):
     # The temporary full-world distributed state was restored.
     assert tuner.mapping is prev_mapping
     assert tuner._dist is prev_dist
+
+
+def _post_tune_merge_worker(world_size):
+    """Run on each MPI rank: seed a distinct cache, then merge for real."""
+    rank = tensorrt_llm.mpi_rank()
+    mapping = Mapping(world_size=world_size,
+                      rank=rank,
+                      tp_size=world_size,
+                      pp_size=1)
+    tuner = AutoTuner.get()
+    tuner.clear_cache()
+    tuner.setup_distributed_state(mapping)
+
+    # Shared key: rank 1's tactic is faster (should win). Plus a rank-unique key.
+    shared = ("gemm", "X")
+    tuner.profiling_cache.cache = {
+        shared: (0, ("cutlass", 10), 1.0) if rank == 0 else
+        (0, ("cublaslt", 0), 0.5),
+        (f"only_rank{rank}", "K"): (0, ("trtllm", ), 1.0),
+    }
+    tuner.post_tune_merge_tactics()
+
+    cache = tuner.profiling_cache.cache
+    return {
+        "shared": cache[shared],
+        "has_r0": ("only_rank0", "K") in cache,
+        "has_r1": ("only_rank1", "K") in cache,
+    }
+
+
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_post_tune_merge_tactics_multi_rank(mpi_pool_executor):
+    # Real 2-rank merge over an actual process group (not a FakeDist): every
+    # rank must converge to the same cache — the min-time winner for the shared
+    # key and both ranks' unique keys kept.
+    world_size = 2
+    results = list(
+        mpi_pool_executor.map(_post_tune_merge_worker,
+                              *zip(*[(world_size, )] * world_size)))
+    assert len(results) == world_size
+    for r in results:
+        assert r["shared"] == (0, ("cublaslt", 0), 0.5)
+        assert r["has_r0"] and r["has_r1"]
+
+
+def _autotune_dist_allgather_worker(world_size):
+    import torch.distributed as dist
+
+    from tensorrt_llm._torch.visual_gen.mapping import _VisualGenAutotuneDist
+    rank = tensorrt_llm.mpi_rank()
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29557")
+    if not dist.is_initialized():
+        dist.init_process_group(backend="gloo",
+                                world_size=world_size,
+                                rank=rank)
+    # VG's real mesh has tp_size=1; the communicator must gather over the whole
+    # world regardless, so the mapping's tp axis is irrelevant to the gather.
+    d = _VisualGenAutotuneDist(
+        Mapping(world_size=world_size, rank=rank, tp_size=world_size))
+    return d.tp_cp_allgather(f"rank{rank}")
+
+
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_visual_gen_autotune_dist_world_allgather(mpi_pool_executor):
+    # _VisualGenAutotuneDist.tp_cp_allgather must gather every rank's object over
+    # the default world group (not the single-rank tp subgroup), and construct
+    # without running TorchDist.__init__.
+    world_size = 2
+    results = list(
+        mpi_pool_executor.map(_autotune_dist_allgather_worker,
+                              *zip(*[(world_size, )] * world_size)))
+    for got in results:
+        assert got == ["rank0", "rank1"]

--- a/tests/unittest/_torch/visual_gen/test_warmup.py
+++ b/tests/unittest/_torch/visual_gen/test_warmup.py
@@ -3,6 +3,7 @@
 
 """Tests for VisualGen warmup configuration, plan resolution, and shape validation."""
 
+import contextlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -104,6 +105,8 @@ class _BaseStubPipeline(BasePipeline):
         self._warmed_up_shapes = set()
         self.pipeline_config = MagicMock()
         self.pipeline_config.compilation = warmup_cfg or CompilationConfig()
+        # warmup() branches on this; keep the stub on the plain (no-autotune) path.
+        self.pipeline_config.torch_compile.enable_autotune = False
 
     def forward(self, *args, **kwargs):
         pass
@@ -285,6 +288,66 @@ class TestWarmupExecution:
         pipe = _make_stub_pipeline(cfg)
         pipe.warmup()
         assert pipe._warmed_up_shapes == {(480, 832, 33)}
+
+
+class TestWarmupPhasing:
+    """warmup() tune/merge/capture phasing: number of warmup passes per config.
+
+    Fully mocked (autotune, communicator, dist, the pass itself) so it exercises
+    the branch logic without a GPU or a real process group.
+    """
+
+    def _count_passes(self, monkeypatch, *, enable_autotune, world_size, cuda_graph_enable):
+        import tensorrt_llm._torch.visual_gen.pipeline as pmod
+
+        pipe = _make_stub_pipeline(CompilationConfig(resolutions=[(480, 832)], num_frames=[33]))
+        pipe.pipeline_config.torch_compile.enable_autotune = enable_autotune
+        pipe.pipeline_config.cuda_graph.enable = cuda_graph_enable
+
+        passes = {"n": 0}
+        monkeypatch.setattr(
+            pipe, "_run_warmup_pass", lambda shapes, steps: passes.__setitem__("n", passes["n"] + 1)
+        )
+        monkeypatch.setattr(pipe, "disallow_cuda_graph_capture", lambda: contextlib.nullcontext())
+        monkeypatch.setattr(pmod, "autotune", lambda **kw: contextlib.nullcontext())
+        monkeypatch.setattr(pmod, "_VisualGenAutotuneDist", lambda amap: object())
+        monkeypatch.setattr(pmod.dist, "is_initialized", lambda: world_size > 1)
+        monkeypatch.setattr(pmod.dist, "get_world_size", lambda: world_size)
+
+        pipe.warmup()
+        return passes["n"]
+
+    def test_no_autotune_one_pass(self, monkeypatch):
+        assert (
+            self._count_passes(
+                monkeypatch, enable_autotune=False, world_size=1, cuda_graph_enable=True
+            )
+            == 1
+        )
+
+    def test_single_rank_one_pass(self, monkeypatch):
+        assert (
+            self._count_passes(
+                monkeypatch, enable_autotune=True, world_size=1, cuda_graph_enable=True
+            )
+            == 1
+        )
+
+    def test_multi_rank_two_pass(self, monkeypatch):
+        assert (
+            self._count_passes(
+                monkeypatch, enable_autotune=True, world_size=2, cuda_graph_enable=True
+            )
+            == 2
+        )
+
+    def test_multi_rank_graph_off_one_pass(self, monkeypatch):
+        assert (
+            self._count_passes(
+                monkeypatch, enable_autotune=True, world_size=2, cuda_graph_enable=False
+            )
+            == 1
+        )
 
 
 class TestRequestValidation:


### PR DESCRIPTION
## Description

Multi-GPU VisualGen (LTX-2, Wan 2.2) DiT output was nondeterministic: a fresh autotuning run produced different frames than a persistent-cache load of the *same* run, and different ranks silently diverged. This PR fixes the three root causes so that a tune-run is byte-identical to a cache-load, and every rank runs the identical kernels.

**1. CUDA graphs were captured while the autotuner was still tuning.** Warmup ran torch.compile + autotune + CUDA-graph capture in one pass, so each rank baked its own *in-flight* tactic choices into the graphs before tactics were finalized. Rank-level `nsys --cuda-graph-trace=node` confirmed this: a rank whose local tactic for a shape was cutlass had no cuBLASLt (`nvjet_*`) kernel in its graph at that shape, whereas every cache-load rank uniformly baked the cache's tactic.

**2. NVFP4 GEMM tactic selection flips between numerically-distinct backends on tiny perf gaps.** The GEMM autotuner picks among cutlass / cuBLASLt / cuda_core by measured time. On several LTX/Wan shapes cutlass and cuBLASLt are within timing noise of each other, so the winner flips per-launch and per-rank; the two backends are numerically distinct (~1e-4/element), so a flip changes the output. (Intra-backend flips are bit-exact, which is how the cross-backend flip was isolated: forcing a single backend is fully deterministic.)

**3. The autotuner's cross-rank tactic sync never engaged for VisualGen (mapping/mesh gap).** The autotuner unifies per-rank tactics through its `Distributed` backend keyed off a `Mapping`. VisualGen's `to_llm_mapping()` reports `tp_size == 1` (its parallelism is on cfg/ulysses), so the autotuner saw a world of 1 and never synced. Even forcing a world-sized mapping is not enough: the autotuner's `tp_cp_allgather` gathers over the mapping's TP process group, and VisualGen's `DeviceMeshTopologyImpl.device_mesh` is a build-once class singleton whose TP axis spans a single rank — so the gather returned only the local cache and the merge was a silent no-op (verified: `gathered=1` on 8 ranks).

**Fix — two-phase warmup + a one-shot world-domain post-tune tactic merge, generic to all VisualGen pipelines** (mirrors the LLM `_run_autotuner_warmup`, which also disables graph capture while tuning and syncs tactics through the autotuner's distributed backend):

- `CUDAGraphRunner.capture_enabled` flag + `BasePipeline.no_cuda_graph_capture()` context manager: warmup forwards run eagerly (no capture) while tuning.
- `AutoTuner.post_tune_merge_tactics()` + `autotune(post_tune_merge_dist=dist)`: a new one-shot collective that all-gathers every rank's whole profiling cache and keeps the fastest tactic per key, run once at the `autotune()` context exit before the cache is saved. Unlike the per-op `distributed_tuning_strategy` sync it runs once and does not require the tuned ops to be invoked symmetrically across ranks, so it is safe for VisualGen's non-SPMD warmup (rank-0-only text encoder, parallel-VAE subsets).
- `VisualGenMapping.to_autotuner_mapping()` + `_VisualGenAutotuneDist`: give the autotuner a world-sized mapping so it treats all ranks as one tuning group, and a torch.distributed communicator whose gather spans the default world group (bypassing the VisualGen device mesh's single-rank TP axis). `autotune()` attaches that mapping up front (for a correct rank) but only wires the communicator at exit, so `_is_distributed()` stays False and per-op sync is skipped while phase-1 tuning runs; the merge then runs once at exit.
- `PipelineLoader`: phase 1 tunes eagerly with capture disabled and passes `post_tune_merge_dist` to `autotune()`, which merges tactics across all ranks and saves the cache at context exit → phase 2 re-runs warmup to capture graphs from the finalized, merged tactics.
- `autotuner._serialize_cache_data`: serialize enum tactics by `.value` so `Fp4QuantTactic` round-trips (otherwise `ast.literal_eval` crashes when loading any cache that contains it).

Trade-off: warmup now runs the pipeline forward twice (tune, then capture), which increases load-time warmup. Scope: this makes a tune-run byte-identical to a persistent-cache load and merges tactics across ranks within a run. Full cross-*launch* determinism (two independent no-cache tuning runs) still requires the persistent autotuner cache to freeze the tactic table, since problem 2's near-tie selection is timing-dependent per launch.

## Deterministic cache workflow

Determinism is gated by the `TLLM_AUTOTUNER_CACHE_PATH` env var. `autotune()` loads the cache when that file already exists (otherwise it tunes), and always re-saves the cross-rank-merged table on context exit — so a build-once-then-load flow reproduces byte-identical output on every run:

```bash
# Build once: the file does not exist yet -> tune, merge across ranks, write the cache.
TLLM_AUTOTUNER_CACHE_PATH=/path/to/vg_cache.json <run VisualGen>

# Every later run: the file exists -> load it, capture from it, reproduce byte-for-byte.
TLLM_AUTOTUNER_CACHE_PATH=/path/to/vg_cache.json <run VisualGen>
```

With this PR the build run itself is already byte-identical to the loads (tune-run == cache-load), so the first, cache-building run is usable output rather than a throwaway. Cross-*launch* determinism across two independent *no-cache* runs still requires this persistent cache, since the tactic table depends on per-launch near-tie timing.

## Test Coverage

Verified byte-identical tune-run vs cache-load output (mp4 md5) on B200 x8:

| Model | Config | tune-run mp4 md5 | cache-load mp4 md5 | graphs captured |
|-------|--------|------------------|--------------------|-----------------|
| LTX-2 | 768x1280x121, 40 steps, cfg2 x ulysses4, mixed backends | `5a8bfb2f` | `5a8bfb2f` (equal) | 16/16 |
| Wan 2.2 A14B | 480x832x81, static NVFP4, two-expert, cfg2 x ulysses4 | `b06b734f` | `b06b734f` (equal) | 32/32 |

Pre-fix baseline on the same LTX config: tune-run vs cache-load mp4 md5 differed on every launch, and three fresh tuning runs produced three different outputs. `AutoTuner.post_tune_merge_tactics` gets unit coverage in `tests/unittest/_torch/misc/test_autotuner.py` (min-time winner + rank-subset keys kept + single-rank no-op); the end-to-end determinism check is multi-GPU + real-checkpoint, so its scripts are attached to TRTLLM-14541 rather than added to CI.

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Ensured nondeterministic multi-GPU VisualGen output is addressed by preventing premature CUDA graph capture during tuning and enabling capture only after cross-rank tactic unification with finalized tactics.
- Implemented two-phase warmup in `visual_gen/pipeline_loader.py`:
  - Phase 1: run warmup under `pipeline.no_cuda_graph_capture()` with tuning graph capture disabled (`skip_dynamic_tuning_buckets=True`) and an optional distributed post-merge hook.
  - Phase 2: rerun warmup after leaving the tuning context so kernels/tactics are consistent across ranks and CUDA graph capture can occur deterministically.
- Added instance-level CUDA graph gating in `visual_gen/cuda_graph_runner.py` (`capture_enabled`) and a pipeline-scoped context manager `BasePipeline.no_cuda_graph_capture()` that snapshots/restores runner state via `finally` to avoid leaking capture settings.
- Made autotune results byte-identical between tune-runs and persistent-cache loads by:
  - Adding `autotune(..., post_tune_merge_dist=...)` and `AutoTuner.post_tune_merge_tactics()` to all-gather per-rank in-memory profiling caches and merge by cache key while keeping the minimum recorded time.
  - Fixing enum-valued tactic cache serialization: `AutoTunerProfilingCache._serialize_cache_data` now serializes `repr(tactic.value)` for `enum.Enum` tactics, matching the existing deserialization path and preventing enum literal round-trip failures.
- Improved distributed tactic synchronization by introducing `VisualGenMapping.to_autotuner_mapping()` (world-sized autotuning group) and `_VisualGenAutotuneDist` (object all-gather via `dist.all_gather_object`) to unify autotuner state across ranks.
- Added state hygiene: the autotune context temporarily re-attaches a distributed-state attachment for independent tuning, then restores the autotuner singleton’s previous distributed mapping/state after post-merge to avoid cross-context contamination.

## QA Engineer Review

### Test changes
`tests/unittest/_torch/misc/test_autotuner.py`
- Added:
  - `test_post_tune_merge_tactics_min_time_and_subset_kept`
  - `test_post_tune_merge_tactics_single_rank_noop`
  - `test_profiling_cache_enum_tactic_roundtrip`
  - `test_autotune_post_tune_merge_before_save`

### Coverage in `tests/integration/test_lists/`
- None of the newly added test functions are referenced under `tests/integration/test_lists/` (no matches found for the test names).

### Verdict
insufficient
<!-- end of auto-generated comment: release notes by coderabbit.ai -->