### PR TITLE
[https://nvbugs/6485885][fix] Stop thinking-budget processor re-forcing the reasoning end tag

### DIFF
--- a/tensorrt_llm/llmapi/thinking_budget.py
+++ b/tensorrt_llm/llmapi/thinking_budget.py
@@ -33,6 +33,19 @@ class ThinkingBudgetLogitsProcessor(LogitsProcessor):
         self.thinking_token_budget = budget
         self.reasoning_start_token_ids = list(reasoning_start_token_ids)
         self.reasoning_end_token_ids = list(reasoning_end_token_ids)
+        # Progress through the reasoning end sequence, keyed by (req_id, beam_idx):
+        # 0 = not closing, 1..len-1 = mid-sequence, >= len = fully emitted. A
+        # missing key defaults to 0; the key is popped when the block closes.
+        #
+        # We keep this instead of re-deriving from `token_ids` because the overlap
+        # scheduler runs the processor one step behind the sampled tokens: a stale
+        # view would not show the just-forced end sequence, so re-derivation would
+        # force it again and leak a duplicate end tag (e.g. `</think>`).
+        #
+        # Keys are reclaimed only when a block is seen to close, so entries for
+        # blocks that never close persist for the processor's lifetime -- bounded
+        # per request, but a slow drip if one SamplingParams is shared across many.
+        self._end_progress: dict = {}
 
     def __call__(
         self,
@@ -42,27 +55,40 @@ class ThinkingBudgetLogitsProcessor(LogitsProcessor):
         stream_ptr: Optional[int],
         client_id: Optional[int],
     ) -> None:
-        del req_id, client_id
+        del client_id
         if stream_ptr is None:
-            self._apply(token_ids, logits)
+            self._apply(req_id, token_ids, logits)
             return
         with torch.cuda.stream(torch.cuda.ExternalStream(stream_ptr)):
-            self._apply(token_ids, logits)
+            self._apply(req_id, token_ids, logits)
 
-    def _apply(self, token_ids: List[List[int]], logits: torch.Tensor) -> None:
+    def _apply(self, req_id: int, token_ids: List[List[int]], logits: torch.Tensor) -> None:
         for beam_idx, beam_token_ids in enumerate(token_ids):
-            forced_token = self._forced_token(beam_token_ids)
+            forced_token = self._forced_token((req_id, beam_idx), beam_token_ids)
             if forced_token is not None:
                 self._force_token(logits, beam_idx, len(token_ids), forced_token)
 
-    def _forced_token(self, token_ids: List[int]) -> Optional[int]:
+    def _forced_token(self, key, token_ids: List[int]) -> Optional[int]:
         start_idx = _find_last_sequence_index(token_ids, self.reasoning_start_token_ids)
         if start_idx == -1:
             return None
 
         end_idx = _find_last_sequence_index(token_ids, self.reasoning_end_token_ids)
         if end_idx > start_idx:
+            # Reasoning block closed; reset so a later block is budgeted again.
+            self._end_progress.pop(key, None)
             return None
+
+        # Block still open. If we have already begun forcing the end sequence,
+        # trust recorded progress (see _end_progress) over the lagging token view.
+        progress = self._end_progress.get(key, 0)
+        if progress >= len(self.reasoning_end_token_ids):
+            # Whole end sequence already forced; stop so we don't leak a second tag.
+            return None
+        if progress > 0:
+            # Mid end-sequence: emit the next token and advance (don't restart at 0).
+            self._end_progress[key] = progress + 1
+            return self.reasoning_end_token_ids[progress]
 
         reasoning_start = start_idx + len(self.reasoning_start_token_ids)
         reasoning_token_count = len(token_ids) - reasoning_start
@@ -71,9 +97,11 @@ class ThinkingBudgetLogitsProcessor(LogitsProcessor):
             partial_end_len > 0
             and reasoning_token_count - partial_end_len >= self.thinking_token_budget
         ):
+            self._end_progress[key] = partial_end_len + 1
             return self.reasoning_end_token_ids[partial_end_len]
 
         if reasoning_token_count >= self.thinking_token_budget:
+            self._end_progress[key] = 1
             return self.reasoning_end_token_ids[0]
         return None
 

--- a/tests/unittest/llmapi/test_sampling_params.py
+++ b/tests/unittest/llmapi/test_sampling_params.py
@@ -201,6 +201,66 @@ def test_thinking_budget_logits_processor_ignores_closed_reasoning_block():
     assert torch.equal(logits, torch.zeros(1, 1, 8))
 
 
+def _run(processor, token_ids):
+    """Call the processor on a fresh logits row and return it."""
+    logits = torch.zeros(1, 1, 8)
+    processor(0, logits, token_ids, None, None)
+    return logits
+
+
+def test_thinking_budget_logits_processor_does_not_force_end_twice_on_stale_view():
+    """Regression: a stale token view must not re-force the end tag.
+
+    With the overlap scheduler, logits processors run one step
+    behind the sampled tokens, so the call right after forcing the end token
+    sees token_ids WITHOUT it. A stateless processor forces the end token a
+    second time, producing e.g. `</think></think>` — the reasoning parser
+    consumes the first tag and the second leaks into message.content.
+    """
+    processor = ThinkingBudgetLogitsProcessor(
+        thinking_token_budget=2,
+        reasoning_start_token_ids=[1],
+        reasoning_end_token_ids=[2],
+    )
+    stale = [[1, 5, 6]]  # budget spent, forced end not visible yet
+
+    logits = _run(processor, stale)
+    assert logits[0, 0, 2] == 0 and torch.isneginf(logits[0, 0, 3])
+
+    # Next step: the forced end token is still not visible (stale view).
+    assert torch.equal(_run(processor, stale), torch.zeros(1, 1, 8))
+
+    # Once the view catches up (end tag present), progress state resets so a
+    # later reasoning block is budgeted again.
+    assert torch.equal(_run(processor, [[1, 5, 6, 2, 7]]), torch.zeros(1, 1, 8))
+    logits = _run(processor, [[1, 5, 6, 2, 7, 1, 8, 9]])
+    assert logits[0, 0, 2] == 0 and torch.isneginf(logits[0, 0, 3])
+
+
+def test_thinking_budget_logits_processor_continues_end_sequence_on_stale_view():
+    """Multi-token end sequence must continue, not restart, on a stale view.
+
+    Under the overlap scheduler the processor must continue from its
+    recorded progress rather than re-derive from token_ids.
+    """
+    processor = ThinkingBudgetLogitsProcessor(
+        thinking_token_budget=2,
+        reasoning_start_token_ids=[1],
+        reasoning_end_token_ids=[2, 3],
+    )
+    stale = [[1, 5, 6]]
+
+    assert _run(processor, stale)[0, 0, 2] == 0
+
+    # Stale view: forced first end token not visible; must force the SECOND
+    # end token, not the first again.
+    logits = _run(processor, stale)
+    assert logits[0, 0, 3] == 0 and torch.isneginf(logits[0, 0, 2])
+
+    # Sequence complete: no further forcing even while the view is stale.
+    assert torch.equal(_run(processor, stale), torch.zeros(1, 1, 8))
+
+
 def test_add_thinking_budget_logits_processor_uses_reasoning_parser_tokens():
     class FakeTokenizer:
         def encode(self, text, add_special_tokens=False):


### PR DESCRIPTION
With the overlap scheduler, logits processors run one step behind the sampled tokens (request.get_tokens() does not yet include the previous iteration's token). ThinkingBudgetLogitsProcessor was stateless and re-derived its decision from that stale view, so the step right after forcing the reasoning end tag could not see it and forced it again. The raw stream then contained a doubled end tag (e.g. '</think></think>'); the reasoning parser consumes the first and the second leaks into message.content (reproduced 3/3 with nano-v3 + thinking_token_budget on nemotron-nano-3.5; clean with the overlap scheduler disabled).

Track per-(request, beam) progress through the end sequence: continue from recorded progress instead of re-deriving from token_ids, stop once the sequence is complete, and reset when the view shows the block closed so later reasoning blocks are budgeted again. Also fixes multi-token end sequences restarting at the first token under the same lag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Dev Engineer Review

- Updated `ThinkingBudgetLogitsProcessor` to track per-request, per-beam reasoning-end progress, preventing duplicated end tags when the overlap scheduler exposes stale token views.
- Supports multi-token reasoning-end sequences and resets tracking after the reasoning block closes.
- Preserves stream handling while explicitly ignoring `client_id`.
- No public API or configuration changes.

### QA Engineer Review

- Added regression coverage for stale token views and multi-token reasoning-end progress in `tests/unittest/llmapi/test_sampling_params.py`.
- No test-list changes were identified; coverage is not listed in `tests/integration/test_lists/`.
- **Verdict: needs follow-up** for CI/manual test-list coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
