### PR TITLE
[None][perf] Skip DeepGEMM clean_logits in DSA indexer prefill on custom top-k path

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -2308,16 +2308,27 @@ class Indexer(nn.Module):
 
         return k_fp8, k_scale
 
-    def _call_mqa_logits(self, q_fp8: torch.Tensor, k_fp8: torch.Tensor,
-                         k_scale: torch.Tensor, weights: torch.Tensor,
-                         cu_seqlen_ks: torch.Tensor, cu_seqlen_ke: torch.Tensor,
-                         q_scale: Optional[torch.Tensor]) -> torch.Tensor:
+    def _call_mqa_logits(self,
+                         q_fp8: torch.Tensor,
+                         k_fp8: torch.Tensor,
+                         k_scale: torch.Tensor,
+                         weights: torch.Tensor,
+                         cu_seqlen_ks: torch.Tensor,
+                         cu_seqlen_ke: torch.Tensor,
+                         q_scale: Optional[torch.Tensor],
+                         clean_logits: bool = True) -> torch.Tensor:
         """Dispatch fp8_mqa_logits vs fp8_fp4_mqa_logits based on use_fp4.
 
         For FP4 the gather output keeps the legacy float8_e4m3fn dtype for
         API compatibility; reinterpret the bytes as the int8 / int32 layout
         the DeepGEMM kernel expects. The scale tensor is collapsed to 1D for
         the kv side and 2D for the q side per the kernel's asserts.
+
+        clean_logits=False skips DeepGEMM's smxx_clean_logits pass that fills
+        everything outside each row's [ks, ke) window with -inf. Safe only
+        when the consumer never reads outside that window (the custom
+        indexer_topk_prefill kernel); the torch topk fallback scans the full
+        padded row and needs the fill.
         """
         if self.use_fp4:
             k_fp4_bytes = k_fp8.view(torch.int8)
@@ -2331,9 +2342,13 @@ class Indexer(nn.Module):
                 weights,
                 cu_seqlen_ks,
                 cu_seqlen_ke,
+                clean_logits=clean_logits,
             )
-        return fp8_mqa_logits(q_fp8, (k_fp8, k_scale.reshape(-1)), weights,
-                              cu_seqlen_ks, cu_seqlen_ke)
+        return fp8_mqa_logits(q_fp8, (k_fp8, k_scale.reshape(-1)),
+                              weights,
+                              cu_seqlen_ks,
+                              cu_seqlen_ke,
+                              clean_logits=clean_logits)
 
     def _call_paged_mqa_logits(self, q_decode: torch.Tensor,
                                k_cache: torch.Tensor,
@@ -2478,6 +2493,7 @@ class Indexer(nn.Module):
                             chunk.cu_seqlen_ks[c0:c1],
                             chunk.cu_seqlen_ke[c0:c1],
                             tile_q_scale,
+                            clean_logits=not use_custom_topk,
                         )
                         if use_custom_topk:
                             torch.ops.trtllm.indexer_topk_prefill(
@@ -2533,6 +2549,7 @@ class Indexer(nn.Module):
                     cu_seqlen_ks,
                     cu_seqlen_ke,
                     ctx_q_scale,
+                    clean_logits=not use_custom_topk,
                 )
                 if use_custom_topk:
                     torch.ops.trtllm.indexer_topk_prefill(


### PR DESCRIPTION
## Description

### Background

The DeepGEMM MQA-logits kernels used by the DeepSeek-V3.2/V4 DSA indexer (`fp8_mqa_logits` / `fp8_fp4_mqa_logits`) default `clean_logits=true`. After computing the logits they launch an extra `smxx_clean_logits` kernel that fills every element outside each row's causal window `[ks, ke)` with `-inf`. The logits buffer is `torch.empty` with a padded, 1024-byte-aligned row stride, so this fill exists to stop consumers that scan the **full padded row** from selecting uninitialized garbage into the top-k.

The default prefill path (`use_custom_topk=True`) does **not** scan the full row. It uses the custom `indexer_topk_prefill` kernel (`cpp/tensorrt_llm/kernels/indexerTopK.cu`), whose `topKPerRowPrefill` reads strictly `[rowStart, rowEnd) == [ks, ke)` per row (`rowStart = rowStarts[rowIdx]`, `rowEnd = rowEnds[rowIdx]`, and every load in `topKPerRowJob` / `processHistogramStep` is bounded by that window). The padding outside the window is never read, so the `-inf` fill is pure waste on this path.

Only the torch-fallback path (`use_custom_topk=False`), which runs `logits.topk` over the full padded row, actually needs the fill.

### Solution

Plumb a `clean_logits` flag through `Indexer._call_mqa_logits` and pass `clean_logits=not use_custom_topk` at both prefill call sites (the chunked-prefill tile loop and the single-pass fallback). Production runs (custom top-k, the default; no caller overrides it) skip the clean kernel; the torch fallback keeps the fill and stays correct. Decode is unaffected — the paged variants already default `clean_logits=false`.

### Impact

- **Correctness**: neutral. The custom top-k kernel never reads outside `[ks, ke)`, so skipping the fill cannot change its output.
- **Performance**: removes one memory-bandwidth-bound kernel per indexer layer per prefill chunk. The win is small (the kernel is tiny and PDL-overlapped), so this is best viewed as dead-work removal rather than a headline speedup.

### Validation

Rubin, DeepSeek-V4-Pro, DEP8 (TP8/EP8 attention-DP) MTP3, 8k-in/1k-out, aggregated ctx-only `trtllm-bench`, nsys on rank 0:

| kernel (rank-0 GPU kern_sum) | baseline (clean on) | this PR (clean off) |
|---|---|---|
| `smxx_clean_logits` | 5.96 ms × 210, 0.11% GPU time | **absent** |
| `fp8_fp4_mqa_logits` | 19.45 ms × 210 | 19.48 ms × 210 |
| `topKPerRowPrefill` | 32.18 + 19.46 ms | 32.08 + 19.50 ms |

The MQA-logits and top-k kernels are byte-identical across the two runs, i.e. top-k output is unchanged. End-to-end throughput is flat within run-to-run noise.

## Test Coverage

Existing indexer top-k tests in `tests/unittest/_torch/attention/sparse/` compare against a reference implementation and pass on both flag states, so no new tests are added:

```
pytest tests/unittest/_torch/attention/sparse/ -k indexer
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
