### PR TITLE
[None][perf] prepare_inputs: avoid O(seq_len) get_tokens(0) marshalling on the host

### DIFF
--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -101,6 +101,34 @@ void initBindings(nb::module_& m)
         .def("get_token", &GenLlmReq::getToken, nb::arg("beam"), nb::arg("pos"))
         .def("get_tokens", nb::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getTokens, nb::const_), nb::arg("beam"))
         .def("get_tokens", nb::overload_cast<>(&GenLlmReq::getTokens, nb::const_))
+        // Copies only [begin, end) -> O(end-begin), vs get_tokens(beam) which
+        // marshals the whole O(seq_len) VecTokens into a Python list.
+        .def(
+            "get_tokens_range",
+            [](GenLlmReq const& self, GenLlmReq::SizeType32 beam, GenLlmReq::SizeType32 begin,
+                GenLlmReq::SizeType32 end)
+            {
+                auto const& tokens = self.getTokens(beam);
+                auto const n = static_cast<GenLlmReq::SizeType32>(tokens.size());
+                if (begin < 0)
+                {
+                    begin = 0;
+                }
+                if (begin > n)
+                {
+                    begin = n;
+                }
+                if (end < begin)
+                {
+                    end = begin;
+                }
+                if (end > n)
+                {
+                    end = n;
+                }
+                return GenLlmReq::VecTokens(tokens.begin() + begin, tokens.begin() + end);
+            },
+            nb::arg("beam"), nb::arg("begin"), nb::arg("end"))
         .def("get_last_tokens", nb::overload_cast<GenLlmReq::SizeType32>(&GenLlmReq::getLastTokens), nb::arg("beam"))
         .def("get_last_tokens", nb::overload_cast<>(&GenLlmReq::getLastTokens))
         .def("get_beam_width_by_iter", &GenLlmReq::getBeamWidthByIter, nb::arg("for_next_iteration") = false)

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -204,7 +204,9 @@ class CUDAGraphRunner:
                 num_draft_tokens = self.spec_config.max_draft_len if is_spec_request else 0
                 # First draft
                 if request.py_is_first_draft:
-                    total_seq_len = len(request.get_tokens(0))
+                    # get_num_tokens is O(1); len(get_tokens(0)) marshals the
+                    # whole O(seq_len) VecTokens into a Python list just for len.
+                    total_seq_len = request.get_num_tokens(0)
                 # With overlap scheduler disabled or dummy request or not assigned to a batch,
                 elif not overlap_scheduler_enabled or request.is_dummy or request.py_batch_idx is None:
                     total_seq_len = request.max_beam_num_tokens + num_draft_tokens

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3938,11 +3938,16 @@ class PyTorchModelEngine(ModelEngine):
 
         for request in scheduled_requests.context_requests:
             request_ids.append(request.py_request_id)
-            all_prompt_tokens = request.get_tokens(0)
             draft_lens.append(0)
             begin_compute = request.context_current_position
             end_compute = begin_compute + request.context_chunk_size
-            prompt_tokens = all_prompt_tokens[begin_compute:end_compute]
+            # Fetch only the current chunk. get_tokens(0) marshals the whole
+            # O(seq_len) VecTokens into a Python list of boxed ints; chunked
+            # prefill re-enters this loop for every chunk of the same prompt, so
+            # that is O(L) per chunk = O(L^2/chunk) over the prefill.
+            # get_tokens_range copies only [begin, end) -> O(chunk).
+            prompt_tokens = request.get_tokens_range(0, begin_compute,
+                                                     end_compute)
             position_ids.extend(
                 range(begin_compute, begin_compute + len(prompt_tokens)))
 
@@ -3987,7 +3992,7 @@ class PyTorchModelEngine(ModelEngine):
                 request.py_multimodal_data,
                 begin_compute=past_seen_token_num,
                 end_compute=end_compute,
-                prompt_len=len(all_prompt_tokens),
+                prompt_len=request.get_num_tokens(0),
             )
             mm_data = request.py_multimodal_data or {}
             cumsum = mm_data.get('multimodal_embed_mask_cumsum')
@@ -4209,12 +4214,16 @@ class PyTorchModelEngine(ModelEngine):
 
         for request in first_draft_requests:
             request_ids.append(request.py_request_id)
-            all_prompt_tokens = request.get_tokens(0)
             draft_lens.append(0)
-            begin_compute = len(
-                all_prompt_tokens) - self.original_max_draft_len - 1
+            # Only the length and the last (original_max_draft_len+1) tokens are
+            # needed here; get_num_tokens is O(1) and get_tokens_range copies only
+            # the requested window, whereas get_tokens(0) marshals the whole
+            # O(seq_len) VecTokens into a Python list.
+            _num_tokens = request.get_num_tokens(0)
+            begin_compute = _num_tokens - self.original_max_draft_len - 1
             end_compute = begin_compute + self.original_max_draft_len + 1
-            prompt_tokens = all_prompt_tokens[begin_compute:end_compute]
+            prompt_tokens = request.get_tokens_range(0, begin_compute,
+                                                     end_compute)
             position_ids.extend(
                 range(begin_compute, begin_compute + len(prompt_tokens)))
 


### PR DESCRIPTION
## Summary
`request.get_tokens(0)` marshals the whole C++ `VecTokens` (the entire sequence) into a fresh Python list of boxed ints — **O(seq_len) host work that grows linearly with ISL**. Three call sites in `_prepare_tp_inputs` / `cuda_graph_runner` pay this only to read a length or a small slice, and re-pay it **every iteration**. In chunked prefill the context loop re-marshals the full prompt for every chunk → **O(L²/chunk) per request** over the prefill. Normal decode is already immune (it uses `get_last_tokens(0)`, O(1)); the waste is in the prefill/context path and the MTP first-draft paths.

## Changes
- **New nanobind binding `LlmRequest.get_tokens_range(beam, begin, end)`** — returns only the `[begin, end)` window, so nanobind copies just `(end-begin)` tokens (**O(chunk)**) instead of the whole `VecTokens`. Bounds are clamped.
- **context loop** (`_prepare_tp_inputs`): use `get_tokens_range(0, begin, end)` for the current chunk and `get_num_tokens(0)` (O(1)) for the prompt length, instead of `get_tokens(0)` + slice + `len(...)`.
- **first_draft loop** (MTP): same — `get_num_tokens(0)` for the length, `get_tokens_range` for the last `original_max_draft_len+1` tokens.
- **cuda_graph_runner** first-draft branch: `len(get_tokens(0))` → `get_num_tokens(0)`.

Output is **bit-identical** — `get_tokens_range` returns exactly the same subrange the old `get_tokens(0)[begin:end]` produced.

## Perf — `_prepare_inputs` host time (DSv4-Pro disagg, c3120, matched A/B, nsys, `nvtx_range("_prepare_inputs")`)

**CTX / prefill worker** (non-overlap, host-bound; primary target; iters 400–500, N=80):
| `_prepare_inputs` | p50 | p90 | success |
|---|---:|---:|---:|
| baseline | 27.53 ms | 43.29 ms | — |
| **this PR** | **15.10 ms (−45%)** | **20.43 ms (−53%)** | 100% (3000/3000) |

**GEN / decode worker** (overlap on; only the MTP first-draft path hits `get_tokens(0)`, so only the large-L tail moves; iters 6000–6050, N=50):
| `_prepare_inputs` | mean | p50 | p90 |
|---|---:|---:|---:|
| baseline | 17.84 ms | 13.31 ms | 32.78 ms |
| **this PR** | **13.26 ms (−26%)** | **11.05 ms (−17%)** | **14.64 ms (−55%)** |

Each site drops from O(L) to O(1)/O(chunk); a synthetic microbench (bs128) shows each site flat across ISL after the fix (baseline `get_tokens` ~18 ms/iter at ISL 50K → ~0.05 ms). On CTX the whole `_prepare_inputs` shifts down (it sits on the exposed critical path). On GEN the median iter barely moves (normal decode is already O(1) via `get_last_tokens`) while the tail collapses (−55% p90) — the large-accumulated-length first-draft iters. GPU-timeline analysis on the same GEN capture shows the reduction is *exposed*, not hidden: GEN GPU bubble 25.7% → 20.7% and per-iteration cycle −6.3% with GPU compute unchanged (host win on the local critical path); pooled E2E SSE/throughput stay flat because GEN decode is not this workload's binding constraint. The binding was rebuilt and the new `get_tokens_range` verified present on the C++ `LlmRequest`; the full disagg run served at 100% success (functional parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
