### PR TITLE
[TRTLLM-14571][infra] Enable container-local AutoTuner cache in CI

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1302,6 +1302,13 @@ def getPytestBaseCommandLine(
     extraInternalEnv += " NCCL_DEBUG=INFO"
     // Pass stage name to perf sanity tests for OpenSearch tracking
     extraInternalEnv += " stageName=${stageName}"
+    // Persist the AutoTuner profiling cache to a CONTAINER-LOCAL, volatile path so
+    // that repeated tactic profiling is reused across testcases within one stage.
+    // /tmp lives on the container overlay (srun --no-container-mount-home / fresh
+    // pod), so the cache is never written to the host and vanishes when the stage
+    // container is destroyed. Never point this at a bind-mounted / shared path:
+    // the AutoTuner cache uses fcntl.lockf, which is unreliable over NFS.
+    extraInternalEnv += " TLLM_AUTOTUNER_CACHE_PATH=/tmp/trtllm_autotuner_cache/autotuner_cache.json"
     // CBTS stages put cbts_plugin on PYTHONPATH (via ${VAR:-} for set -u safety) plus the marker/config env vars sitecustomize.py reads in subprocesses.
     if (cbtsMode) {
         def cbtsScriptDir = "${llmSrc}/jenkins/scripts/cbts/coverage_utils"

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -804,10 +804,18 @@ class AutoTunerProfilingCache:
                 continue
             try:
                 tactic = ast.literal_eval(value["tactic"])
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, SyntaxError):
+                # A tactic whose repr is not a Python literal (e.g. an IntEnum
+                # member serialized as "<Fp4QuantTactic.TRTLLM: -1>") cannot be
+                # reconstructed. Skip the entry instead of crashing the load:
+                # the affected op simply misses the cache and is re-profiled.
+                # SyntaxError must be caught here because repr(Enum) parses as
+                # invalid syntax, and a missing `continue` would otherwise reuse
+                # the previous iteration's tactic (silent wrong kernel).
                 logger.warning_once(
-                    f"[AutoTuner] Could not deserialize tactic: {value['tactic']} for cache key {key_str}",
+                    f"[AutoTuner] Could not deserialize tactic: {value['tactic']} for cache key {key_str}; skipping entry.",
                     key=value["tactic"])
+                continue
 
             runner_id = value["runner_id"]
             min_time = value["min_time"]

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -805,13 +805,11 @@ class AutoTunerProfilingCache:
             try:
                 tactic = ast.literal_eval(value["tactic"])
             except (ValueError, TypeError, SyntaxError):
-                # A tactic whose repr is not a Python literal (e.g. an IntEnum
-                # member serialized as "<Fp4QuantTactic.TRTLLM: -1>") cannot be
-                # reconstructed. Skip the entry instead of crashing the load:
-                # the affected op simply misses the cache and is re-profiled.
-                # SyntaxError must be caught here because repr(Enum) parses as
-                # invalid syntax, and a missing `continue` would otherwise reuse
-                # the previous iteration's tactic (silent wrong kernel).
+                # Skip any tactic whose repr is not a Python literal so one bad
+                # entry can't crash the whole load; the op just re-profiles.
+                # (#16782 removes the current enum trigger at the serialize side.)
+                # SyntaxError is caught too; `continue` is required, else the
+                # entry reuses the previous tactic.
                 logger.warning_once(
                     f"[AutoTuner] Could not deserialize tactic: {value['tactic']} for cache key {key_str}; skipping entry.",
                     key=value["tactic"])

--- a/tests/unittest/_torch/misc/test_autotuner.py
+++ b/tests/unittest/_torch/misc/test_autotuner.py
@@ -524,6 +524,67 @@ def test_autotuner_tuning_configs():
     runner_0([x, w], tactic=deserialized_tactic)
 
 
+def test_load_cache_skips_non_literal_tactic():
+    """Regression: a cache entry whose tactic repr is not a Python literal must
+    be skipped on load, never crash the load.
+
+    ``trtllm::tunable_fp4_quantize`` caches an ``Fp4QuantTactic`` IntEnum whose
+    ``repr`` is ``"<Fp4QuantTactic.TRTLLM: -1>"``. ``ast.literal_eval`` rejects
+    that with ``SyntaxError``. Before the fix, ``_deserialize_cache_data`` only
+    caught ``(ValueError, TypeError)`` and had no ``continue``, so the
+    ``SyntaxError`` propagated out of ``load_cache`` and crashed the autotuner
+    warmup. The load must now skip the bad entry (that op re-profiles) while
+    every literal-safe entry in the same file still loads correctly.
+    """
+    import ast
+    import enum
+
+    class _Tactic(enum.IntEnum):
+        TRTLLM = -1
+        FLASHINFER = 1
+
+    poisoned_repr = repr(_Tactic.TRTLLM)  # "<_Tactic.TRTLLM: -1>"
+    # Precondition: this really is the SyntaxError-raising shape we care about.
+    with pytest.raises(SyntaxError):
+        ast.literal_eval(poisoned_repr)
+
+    cache = AutoTuner.get().profiling_cache
+    cache.clear()
+    good_key = "('op_good', 'R', '0', ((1, 128),))"
+    bad_key = "('op_bad', 'R', '0', ((2, 128),))"
+    doc = {
+        "metadata": cache._serialize_metadata(),
+        "shared": {},
+        "rank_0": {
+            good_key: {
+                "runner_id": 0,
+                "tactic": "7",
+                "min_time": 0.001
+            },
+            bad_key: {
+                "runner_id": 1,
+                "tactic": poisoned_repr,
+                "min_time": 0.002
+            },
+        },
+    }
+    temp_dir = tempfile.TemporaryDirectory()
+    cache_path = os.path.join(temp_dir.name, "poisoned_cache.json")
+    with open(cache_path, "w") as f:
+        json.dump(doc, f)
+
+    # Must not raise (previously raised SyntaxError out of load_cache).
+    cache.load_cache(cache_path, rank=0)
+
+    # The literal-safe entry survived with its exact tactic ...
+    good = ("op_good", "R", "0", ((1, 128), ))
+    assert good in cache.cache
+    assert cache.cache[good][1] == 7
+    # ... and the non-literal entry was skipped, not silently mis-decoded.
+    bad = ("op_bad", "R", "0", ((2, 128), ))
+    assert bad not in cache.cache
+
+
 def test_kernel_testing_single_context():
     """Test kernel testing with a single choose_one context"""
     x, w = torch.randn(16, 64), torch.randn(64, 128)

--- a/tests/unittest/_torch/misc/test_autotuner.py
+++ b/tests/unittest/_torch/misc/test_autotuner.py
@@ -525,26 +525,22 @@ def test_autotuner_tuning_configs():
 
 
 def test_load_cache_skips_non_literal_tactic():
-    """Regression: a cache entry whose tactic repr is not a Python literal must
-    be skipped on load, never crash the load.
+    """Regression: a non-literal tactic repr must be skipped on load, not crash it.
 
-    ``trtllm::tunable_fp4_quantize`` caches an ``Fp4QuantTactic`` IntEnum whose
-    ``repr`` is ``"<Fp4QuantTactic.TRTLLM: -1>"``. ``ast.literal_eval`` rejects
-    that with ``SyntaxError``. Before the fix, ``_deserialize_cache_data`` only
-    caught ``(ValueError, TypeError)`` and had no ``continue``, so the
-    ``SyntaxError`` propagated out of ``load_cache`` and crashed the autotuner
-    warmup. The load must now skip the bad entry (that op re-profiles) while
-    every literal-safe entry in the same file still loads correctly.
+    ``_deserialize_cache_data`` reconstructs tactics with ``ast.literal_eval``,
+    which raises ``SyntaxError`` on non-literal reprs (e.g. enum tactic reprs,
+    until #16782 serializes enums by value). It must skip such entries -- once
+    ``SyntaxError`` was uncaught and had no ``continue``, crashing the load.
     """
     import ast
-    import enum
 
-    class _Tactic(enum.IntEnum):
-        TRTLLM = -1
-        FLASHINFER = 1
+    class _NonLiteralTactic:
 
-    poisoned_repr = repr(_Tactic.TRTLLM)  # "<_Tactic.TRTLLM: -1>"
-    # Precondition: this really is the SyntaxError-raising shape we care about.
+        def __repr__(self):
+            return "<_NonLiteralTactic object nvfp4>"
+
+    poisoned_repr = repr(_NonLiteralTactic())  # non-literal object repr
+    # Precondition: confirm this repr really does raise SyntaxError.
     with pytest.raises(SyntaxError):
         ast.literal_eval(poisoned_repr)
 


### PR DESCRIPTION
- Wire TLLM_AUTOTUNER_CACHE_PATH into pytest stages to reuse tactic profiling across testcases via a volatile container-local /tmp path.
- Harden _deserialize_cache_data to skip non-literal tactics (SyntaxError) instead of crashing load_cache, e.g. Fp4QuantTactic IntEnum reprs.
- Add regression test for the skip-on-load behavior.

**The goal is to improve GPU utilization during CI runs.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Dev Engineer Review**

- Updated `jenkins/L0_Test.groovy` to inject `TLLM_AUTOTUNER_CACHE_PATH` into pytest runs, pointing to a container-local volatile `/tmp/trtllm_autotuner_cache/autotuner_cache.json`, with inline rationale to avoid writing to shared/bind-mounted paths due to unreliable locking over NFS.
- Hardened `AutoTunerProfilingCache._deserialize_cache_data` in `tensorrt_llm/_torch/autotuner.py` to also catch `SyntaxError` from `ast.literal_eval` when cached tactic representations are not valid Python literals; it logs once and skips the bad entry instead of failing the entire cache load (preventing reuse of stale/incorrect tactics).
- Regression test added to verify non-literal tactic representations are skipped rather than causing `load_cache` to raise.

**QA Engineer Review**

- Added test: `test_load_cache_skips_non_literal_tactic()` in `tests/unittest/_torch/misc/test_autotuner.py`.
- Test-list coverage: no changes found under `tests/integration/test_lists/`, and the new test is not listed in `test-db/` or `qa/` test lists.
- Verdict: **insufficient**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [X] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
