### PR TITLE
[None][test] Enable gen_only + ctx_only DeepSeek-V4-Pro perf-sanity on GB300

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -5045,11 +5045,6 @@ def launchTestJobs(pipeline, testFilter)
         "GB200-4_GPUs-PyTorch-PerfSanity-Post-Merge-2": ["auto:gb200-x4-split", "l0_gb200_multi_gpus_perf_sanity", 2, 4, 4],
         "GB200-4_GPUs-PyTorch-PerfSanity-Post-Merge-3": ["auto:gb200-x4-split", "l0_gb200_multi_gpus_perf_sanity", 3, 4, 4],
         "GB200-4_GPUs-PyTorch-PerfSanity-Post-Merge-4": ["auto:gb200-x4-split", "l0_gb200_multi_gpus_perf_sanity", 4, 4, 4],
-        // Split bumped 2 -> 3 in the gen_only/ctx_only follow-up: the 4 DeepSeek-V4-Pro
-        // ctx_only tests were added here (8 -> 12 active), and #16540 deferred them due to
-        // a cross-test cleanup OOM cascade on a shared stage (con4301 ctx_only passed in
-        // isolation). A third shard keeps ~4 tests/shard so the heavyweight DSv4-Pro
-        // ctx_only cases get more per-node isolation rather than accumulating with 5 peers.
         "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-1": ["auto:gb300-x4", "l0_gb300_multi_gpus_perf_sanity", 1, 3, 4],
         "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-2": ["auto:gb300-x4", "l0_gb300_multi_gpus_perf_sanity", 2, 3, 4],
         "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-3": ["auto:gb300-x4", "l0_gb300_multi_gpus_perf_sanity", 3, 3, 4],
@@ -5232,10 +5227,6 @@ def launchTestJobs(pipeline, testFilter)
         36,
         9
     )
-    // GB300 DeepSeek-V4-Pro disaggregated (4 shapes: single-user latency +
-    // throughput sweep). Each yaml is registered with two active tests
-    // (gen_only + e2e), so testCount=2 per shape. The gen_only variants were
-    // enabled in a follow-up PR after gen_only runtime characterization.
     // 9 Nodes: ctx1 (1 node, 4 GPUs) + gen4 (2 nodes, 8 GPUs each) = 36 GPUs
     multiNodesSBSAConfigs += buildStageConfigs(
         "GB300-36_GPUs-9_Nodes-PyTorch-Disagg-PerfSanity-CTX1-NODE1-GPU4-GEN4-NODE2-GPU8-Post-Merge",

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -5045,8 +5045,14 @@ def launchTestJobs(pipeline, testFilter)
         "GB200-4_GPUs-PyTorch-PerfSanity-Post-Merge-2": ["auto:gb200-x4-split", "l0_gb200_multi_gpus_perf_sanity", 2, 4, 4],
         "GB200-4_GPUs-PyTorch-PerfSanity-Post-Merge-3": ["auto:gb200-x4-split", "l0_gb200_multi_gpus_perf_sanity", 3, 4, 4],
         "GB200-4_GPUs-PyTorch-PerfSanity-Post-Merge-4": ["auto:gb200-x4-split", "l0_gb200_multi_gpus_perf_sanity", 4, 4, 4],
-        "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-1": ["auto:gb300-x4", "l0_gb300_multi_gpus_perf_sanity", 1, 2, 4],
-        "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-2": ["auto:gb300-x4", "l0_gb300_multi_gpus_perf_sanity", 2, 2, 4],
+        // Split bumped 2 -> 3 in the gen_only/ctx_only follow-up: the 4 DeepSeek-V4-Pro
+        // ctx_only tests were added here (8 -> 12 active), and #16540 deferred them due to
+        // a cross-test cleanup OOM cascade on a shared stage (con4301 ctx_only passed in
+        // isolation). A third shard keeps ~4 tests/shard so the heavyweight DSv4-Pro
+        // ctx_only cases get more per-node isolation rather than accumulating with 5 peers.
+        "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-1": ["auto:gb300-x4", "l0_gb300_multi_gpus_perf_sanity", 1, 3, 4],
+        "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-2": ["auto:gb300-x4", "l0_gb300_multi_gpus_perf_sanity", 2, 3, 4],
+        "GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge-3": ["auto:gb300-x4", "l0_gb300_multi_gpus_perf_sanity", 3, 3, 4],
     ]
     SBSASlurmTestConfigs = cbtsResizeSplits(SBSASlurmTestConfigs)
     fullSet += SBSASlurmTestConfigs.keySet()
@@ -5227,15 +5233,15 @@ def launchTestJobs(pipeline, testFilter)
         9
     )
     // GB300 DeepSeek-V4-Pro disaggregated (4 shapes: single-user latency +
-    // throughput sweep). Each yaml is registered with one active e2e test, so
-    // testCount=1 per shape. gen_only variants remain in the yamls as
-    // commented-out lines and can be re-enabled in a follow-up PR.
+    // throughput sweep). Each yaml is registered with two active tests
+    // (gen_only + e2e), so testCount=2 per shape. The gen_only variants were
+    // enabled in a follow-up PR after gen_only runtime characterization.
     // 9 Nodes: ctx1 (1 node, 4 GPUs) + gen4 (2 nodes, 8 GPUs each) = 36 GPUs
     multiNodesSBSAConfigs += buildStageConfigs(
         "GB300-36_GPUs-9_Nodes-PyTorch-Disagg-PerfSanity-CTX1-NODE1-GPU4-GEN4-NODE2-GPU8-Post-Merge",
         "auto:gb300-flex",
         "l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen4_node2_gpu8",
-        1,
+        2,
         36,
         9
     )
@@ -5244,7 +5250,7 @@ def launchTestJobs(pipeline, testFilter)
         "GB300-40_GPUs-10_Nodes-PyTorch-Disagg-PerfSanity-CTX6-NODE1-GPU4-GEN1-NODE4-GPU16-Post-Merge",
         "auto:gb300-flex",
         "l0_gb300_multi_nodes_perf_sanity_ctx6_node1_gpu4_gen1_node4_gpu16",
-        1,
+        2,
         40,
         10
     )
@@ -5253,7 +5259,7 @@ def launchTestJobs(pipeline, testFilter)
         "GB300-44_GPUs-11_Nodes-PyTorch-Disagg-PerfSanity-CTX3-NODE1-GPU4-GEN1-NODE8-GPU32-Post-Merge",
         "auto:gb300-flex",
         "l0_gb300_multi_nodes_perf_sanity_ctx3_node1_gpu4_gen1_node8_gpu32",
-        1,
+        2,
         44,
         11
     )
@@ -5262,7 +5268,7 @@ def launchTestJobs(pipeline, testFilter)
         "GB300-56_GPUs-14_Nodes-PyTorch-Disagg-PerfSanity-CTX12-NODE1-GPU4-GEN1-NODE2-GPU8-Post-Merge",
         "auto:gb300-flex",
         "l0_gb300_multi_nodes_perf_sanity_ctx12_node1_gpu4_gen1_node2_gpu8",
-        1,
+        2,
         56,
         14
     )

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_gpus_perf_sanity.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_gpus_perf_sanity.yml
@@ -27,11 +27,7 @@ l0_gb300_multi_gpus_perf_sanity:
   - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
   - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_glm-5-fp4_8k1k_con1024_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL] TIMEOUT (90)
   # deepseek-v4-pro-fp4 8k1k
-  # ctx_only variants are commented out; enable in a follow-up PR after
-  # investigating the CI-side cross-test cleanup that caused an OOM cascade
-  # on stage-2 (the con4301 ctx_only test passed cleanly in isolation on
-  # OCI-AGA, so the shared-stage leak is orthogonal to these configs).
-  # - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
-  # - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL] TIMEOUT (90)
-  # - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL] TIMEOUT (90)
-  # - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL] TIMEOUT (90)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx12_node1_gpu4_gen1_node2_gpu8.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx12_node1_gpu4_gen1_node2_gpu8.yml
@@ -15,7 +15,5 @@ l0_gb300_multi_nodes_perf_sanity_ctx12_node1_gpu4_gen1_node2_gpu8:
       backend: pytorch
   tests:
   # deepseek-v4-pro-fp4 8k1k con4301 (max throughput)
-  # gen_only variant is commented out; enable in a follow-up PR after gen_only
-  # runtime characterization on the target CI cluster.
-  # - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL] TIMEOUT (120)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL] TIMEOUT (120)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL] TIMEOUT (120)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen4_node2_gpu8.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen4_node2_gpu8.yml
@@ -15,7 +15,5 @@ l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen4_node2_gpu8:
       backend: pytorch
   tests:
   # deepseek-v4-pro-fp4 8k1k con8 (single-user latency)
-  # gen_only variant is commented out; enable in a follow-up PR after gen_only
-  # runtime characterization on the target CI cluster.
-  # - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (120)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (120)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (120)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx3_node1_gpu4_gen1_node8_gpu32.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx3_node1_gpu4_gen1_node8_gpu32.yml
@@ -15,7 +15,5 @@ l0_gb300_multi_nodes_perf_sanity_ctx3_node1_gpu4_gen1_node8_gpu32:
       backend: pytorch
   tests:
   # deepseek-v4-pro-fp4 8k1k con180
-  # gen_only variant is commented out; enable in a follow-up PR after gen_only
-  # runtime characterization on the target CI cluster.
-  # - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx6_node1_gpu4_gen1_node4_gpu16.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx6_node1_gpu4_gen1_node4_gpu16.yml
@@ -15,7 +15,5 @@ l0_gb300_multi_nodes_perf_sanity_ctx6_node1_gpu4_gen1_node4_gpu16:
       backend: pytorch
   tests:
   # deepseek-v4-pro-fp4 8k1k con666
-  # gen_only variant is commented out; enable in a follow-up PR after gen_only
-  # runtime characterization on the target CI cluster.
-  # - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)


### PR DESCRIPTION
## Summary

Follow-up to #16540. That PR added the four **DeepSeek-V4-Pro (FP4, 1.6T MoE)** disaggregated perf-sanity shapes on GB300 (con8 / con180 / con666 / con4301) but registered only the **e2e** variant of each — the `gen_only` and `ctx_only` variants were left commented out in the test-db yamls:

- `gen_only` — deferred pending gen_only runtime characterization on the target CI cluster.
- `ctx_only` — deferred behind a shared-stage OOM-cascade investigation (the con4301 ctx_only case passed cleanly *in isolation* on OCI-AGA, so the leak was judged orthogonal to these configs).

This PR enables both remaining modes so all three test modes (`aggr_upload-ctx_only-*`, `disagg_upload-gen_only-*`, `disagg_upload-e2e-*`) run for every shape.

## Why this needs no config/model changes

The four disagg config yamls, the `deepseek_v4_pro_fp4 → DeepSeek-V4-Pro` model registration, the role-specific `ctx_worker_env_var` / `gen_worker_env_var` handling, and the in-repo MoE load-balancer yamls all landed in #16540 and are **unchanged here**. `parse_test_string()` derives `benchmark_mode` from the test-ID prefix and resolves the **same** on-disk config for all three modes (only the launched worker fleet differs), so enabling gen_only/ctx_only is purely a test-list registration change.

## Changes

| File | Change |
|------|--------|
| `l0_gb300_multi_gpus_perf_sanity.yml` | Uncomment the 4 `aggr_upload-ctx_only-*` DeepSeek-V4-Pro entries (8 → 12 active ctx_only tests) |
| `l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen4_node2_gpu8.yml` (con8) | Uncomment the `gen_only` entry (now 1 gen_only + 1 e2e) |
| `l0_gb300_multi_nodes_perf_sanity_ctx6_node1_gpu4_gen1_node4_gpu16.yml` (con666) | Uncomment the `gen_only` entry |
| `l0_gb300_multi_nodes_perf_sanity_ctx3_node1_gpu4_gen1_node8_gpu32.yml` (con180) | Uncomment the `gen_only` entry |
| `l0_gb300_multi_nodes_perf_sanity_ctx12_node1_gpu4_gen1_node2_gpu8.yml` (con4301) | Uncomment the `gen_only` entry |
| `jenkins/L0_Test.groovy` | `GB300-4_GPUs` PerfSanity-Post-Merge split **2 → 3** (keeps ~4 tests/shard for the heavier ctx_only set, giving the DSv4-Pro cases more per-node isolation given the #16540 shared-stage OOM note); the 4 GB300 DeepSeek-V4-Pro multi_nodes Disagg stages `testCount` **1 → 2** (gen_only + e2e) |

## Validation

- All 5 edited test-db yamls parse as valid YAML; each `multi_nodes` file holds exactly 1 `gen_only` + 1 `e2e` entry, matching `testCount=2`.
- All 12 registered DeepSeek-V4-Pro test IDs resolve to an existing config file under `tests/scripts/perf-sanity/disaggregated/`.
- `multi_gpus` ctx_only count (12) vs split (3) → ~4 tests/shard.

## Test plan

- [x] gen_only + ctx_only local functional runs on GB300 (aws-cmh)
- [x] CI post-merge stages green (gen_only/ctx_only)

> Note (carried from #16540): `slurm_install.sh` still hard-codes `--cuda_architectures '100-real'` (GB200); GB300 source builds need `103-real`. Not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Enabled four DeepSeek-V4-Pro FP4 `ctx_only` tests in `l0_gb300_multi_gpus_perf_sanity.yml` (the previously commented entries are now active; `TIMEOUT (90)` preserved).
- Enabled one DeepSeek-V4-Pro FP4 disaggregated `gen_only` test per GB300 multi-node PerfSanity config (4 total) across:
  - `...ctx12_node1_gpu4_gen1_node2_gpu8.yml`
  - `...ctx1_node1_gpu4_gen4_node2_gpu8.yml`
  - `...ctx3_node1_gpu4_gen1_node8_gpu32.yml`
  - `...ctx6_node1_gpu4_gen1_node4_gpu16.yml`
  - (each `TIMEOUT (120)` preserved; `gen_only` now active alongside existing `e2e`).
- Updated `jenkins/L0_Test.groovy` for `GB300-4_GPUs-PyTorch-PerfSanity-Post-Merge` by increasing the GB300 4-GPU split from **2 → 3** and adding the missing split variant **`...-3`** (with `...-1`, `...-2`, `...-3` now present).
- Updated DeepSeek-V4-Pro FP4 disaggregated multi-node PerfSanity post-merge stage generation so the relevant Disagg stage `testCount` values are increased from **1 → 2**, matching the intent that each stage shape now runs two active tests (`gen_only` + `e2e`).
- Changes are scoped to test scheduling/coverage and are consistent with related configs; no model registration/worker environment/MoE load-balancer changes were made.
- Validation: edited YAML entries parse correctly and the enabled test IDs resolve to existing configs; multi-GPU distribution and sharding behavior matched expectations (~four tests per shard).

## QA Engineer Review

Modified test-list files:

- `tests/integration/test_lists/test-db/l0_gb300_multi_gpus_perf_sanity.yml`
  - Enabled 4 `aggr_upload-ctx_only-gb300_deepseek-v4-pro-fp4_8k1k` `perf/test_perf_sanity.py::test_e2e[...]` entries (timeouts retained).
- `tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx12_node1_gpu4_gen1_node2_gpu8.yml`
  - Enabled 1 `disagg_upload-gen_only...` `perf/test_perf_sanity.py::test_e2e[...]` entry (timeout retained).
- `tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen4_node2_gpu8.yml`
  - Enabled 1 `disagg_upload-gen_only...` `perf/test_perf_sanity.py::test_e2e[...]` entry (timeout retained).
- `tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx3_node1_gpu4_gen1_node8_gpu32.yml`
  - Enabled 1 `disagg_upload-gen_only...` `perf/test_perf_sanity.py::test_e2e[...]` entry (timeout retained).
- `tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx6_node1_gpu4_gen1_node4_gpu16.yml`
  - Enabled 1 `disagg_upload-gen_only...` `perf/test_perf_sanity.py::test_e2e[...]` entry (timeout retained).

Verdict: **needs follow-up** — CBTS coverage data isn’t provided, but local GB300 functional runs and CI post-merge stages were reported passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->