### PR TITLE
[NVBUG-6379624][fix] Enable W4A8 checkpoint loading for Gemma4 K=V layers

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/gemma4_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/gemma4_weight_mapper.py
@@ -23,6 +23,10 @@ from tensorrt_llm._torch.modules.linear import W4A16_AWQ_LinearMethod
 _LANG_PREFIX = "model.language_model."
 _MODEL_PREFIX = "model."
 _LAYER_IDX_RE = re.compile(r"layers\.(\d+)$")
+_LAYER_SCALAR_KEY_RE = re.compile(r"^(?:language_model\.)?model\.layers\.(\d+)\.layer_scalar$")
+_K_PROJ_KEY_RE = re.compile(
+    r"^((?:language_model\.)?model\.layers\.(\d+)\.self_attn\.)k_proj(\..+)$"
+)
 
 
 @register_mapper("HF", "Gemma4ForCausalLM")
@@ -273,9 +277,6 @@ class Gemma4HfWeightMapper(HfWeightMapper):
 
     def _handle_buffers_and_kvdup(self, weights: dict) -> dict:
         """Load layer_scalar buffers and duplicate k_proj for k_eq_v layers."""
-        # Determine the layer scalar key pattern and accessor based on
-        # whether any key starts with "language_model." (VLM sub-model
-        # weights after filter_weights) or "model." (text-only).
         # Navigate to decoder layers regardless of model structure
         # (multimodal wrapper has .llm.model.layers, text-only has .model.layers)
         _root = self.model
@@ -289,17 +290,9 @@ class Gemma4HfWeightMapper(HfWeightMapper):
         def get_layer(idx):
             return _layers[idx] if _layers else None
 
-        sample = next(iter(weights), "")
-        if sample.startswith("language_model.model."):
-            scalar_pattern = r"language_model\.model\.layers\.(\d+)\.layer_scalar"
-            key_tmpl = "language_model.model.layers.{}.self_attn.{}_proj.weight"
-        else:
-            scalar_pattern = r"model\.layers\.(\d+)\.layer_scalar"
-            key_tmpl = "model.layers.{}.self_attn.{}_proj.weight"
-
         layer_scalar_keys = [k for k in weights if k.endswith(".layer_scalar")]
         for key in layer_scalar_keys:
-            m = re.match(scalar_pattern, key)
+            m = _LAYER_SCALAR_KEY_RE.match(key)
             if m:
                 layer_idx = int(m.group(1))
                 try:
@@ -312,12 +305,17 @@ class Gemma4HfWeightMapper(HfWeightMapper):
         config = self.model.config
         if getattr(config, "attention_k_eq_v", False):
             layer_types = getattr(config, "layer_types", [])
-            for layer_idx, lt in enumerate(layer_types):
-                if lt == "full_attention":
-                    k_key = key_tmpl.format(layer_idx, "k")
-                    v_key = key_tmpl.format(layer_idx, "v")
-                    if k_key in weights and v_key not in weights:
-                        weights[v_key] = weights[k_key]
+            for k_key, value in list(weights.items()):
+                match = _K_PROJ_KEY_RE.match(k_key)
+                if match is None:
+                    continue
+                layer_idx = int(match.group(2))
+                if layer_idx >= len(layer_types) or layer_types[layer_idx] != "full_attention":
+                    continue
+                suffix = match.group(3)
+                suffix = {".k_scale": ".v_scale", ".k_bias": ".v_bias"}.get(suffix, suffix)
+                v_key = f"{match.group(1)}v_proj{suffix}"
+                weights.setdefault(v_key, value)
 
         # KV shared layers: HF omits k_proj/v_proj for shared layers.
         # The model uses Q-only projection for these layers, so no dummy

--- a/tests/unittest/_torch/modeling/test_modeling_gemma4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma4.py
@@ -22,6 +22,7 @@ import math
 import unittest
 import unittest.mock
 from copy import deepcopy
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import torch
@@ -369,6 +370,91 @@ class TestGemma4ModelInstantiation(unittest.TestCase):
 
 class TestGemma4HfWeightMapper(unittest.TestCase):
     """Tests for Gemma4-specific checkpoint key transformations."""
+
+    def test_duplicate_full_attention_kv_projection_tensors(self):
+        """Full K=V layers should duplicate all missing k_proj tensors to v_proj."""
+        fields = ("weight", "weight_scale", "input_scale", "weight_scale_2", "pre_quant_scale")
+        for is_vlm in (False, True):
+            with self.subTest(is_vlm=is_vlm):
+                mapper = Gemma4HfWeightMapper()
+                config = SimpleNamespace(
+                    attention_k_eq_v=True,
+                    layer_types=["sliding_attention", "full_attention"],
+                )
+                layer_scalar_buffers = [unittest.mock.Mock(), unittest.mock.Mock()]
+                layers = [
+                    SimpleNamespace(layer_scalar=layer_scalar_buffer)
+                    for layer_scalar_buffer in layer_scalar_buffers
+                ]
+                if is_vlm:
+                    mapper._model = SimpleNamespace(
+                        config=config,
+                        vision_tower=object(),
+                        llm=SimpleNamespace(model=SimpleNamespace(layers=layers)),
+                    )
+                    model_prefix = "language_model.model"
+                else:
+                    mapper._model = SimpleNamespace(
+                        config=config,
+                        model=SimpleNamespace(layers=layers),
+                    )
+                    model_prefix = "model"
+
+                weights = {}
+                if is_vlm:
+                    weights["model.vision_tower.marker"] = object()
+                raw_prefix = "model.language_model"
+                full_k_prefix = f"{model_prefix}.layers.1.self_attn.k_proj."
+                full_v_prefix = f"{model_prefix}.layers.1.self_attn.v_proj."
+                sliding_v_prefix = f"{model_prefix}.layers.0.self_attn.v_proj."
+                for field in fields:
+                    weights[f"{raw_prefix}.layers.1.self_attn.k_proj.{field}"] = object()
+                    weights[f"{raw_prefix}.layers.0.self_attn.k_proj.{field}"] = object()
+
+                explicit_v_input_scale = object()
+                weights[f"{raw_prefix}.layers.1.self_attn.v_proj.input_scale"] = (
+                    explicit_v_input_scale
+                )
+                explicit_v_scale = object()
+                weights[f"{raw_prefix}.layers.1.self_attn.k_proj.k_scale"] = object()
+                weights[f"{raw_prefix}.layers.1.self_attn.k_proj.k_bias"] = object()
+                weights[f"{raw_prefix}.layers.1.self_attn.v_proj.v_scale"] = explicit_v_scale
+                weights[f"{raw_prefix}.layers.1.self_attn.k_norm.weight"] = object()
+                layer_scalar_value = object()
+                weights[f"{raw_prefix}.layers.1.layer_scalar"] = layer_scalar_value
+
+                result = mapper.preprocess_weights(weights)
+
+                self.assertIs(
+                    result[f"{full_v_prefix}input_scale"],
+                    explicit_v_input_scale,
+                )
+                for field in fields:
+                    if field == "input_scale":
+                        continue
+                    self.assertIs(
+                        result[f"{full_v_prefix}{field}"],
+                        result[f"{full_k_prefix}{field}"],
+                    )
+                self.assertIs(result[f"{full_v_prefix}v_scale"], explicit_v_scale)
+                self.assertIs(
+                    result[f"{full_v_prefix}v_bias"],
+                    result[f"{full_k_prefix}k_bias"],
+                )
+                self.assertNotIn(f"{full_v_prefix}k_scale", result)
+                self.assertNotIn(f"{full_v_prefix}k_bias", result)
+                for field in fields:
+                    self.assertNotIn(f"{sliding_v_prefix}{field}", result)
+                self.assertNotIn(
+                    f"{model_prefix}.layers.1.self_attn.v_norm.weight",
+                    result,
+                )
+                layer_scalar_buffers[1].copy_.assert_called_once_with(layer_scalar_value)
+                self.assertNotIn(f"{model_prefix}.layers.1.layer_scalar", result)
+
+                second_result = mapper.preprocess_weights(result)
+                for key, value in result.items():
+                    self.assertIs(second_result[key], value)
 
     def test_remap_modelopt_nvfp4_per_expert_weights(self):
         """ModelOpt's split expert tensors should map to the VANILLA MoE layout."""


### PR DESCRIPTION
  ## Description

  Gemma4 full-attention layers may set `attention_k_eq_v=True`. Hugging Face/ModelOpt checkpoints then omit `v_proj` tensors and reuse `k_proj` for V.

  The Gemma4 HF weight mapper previously synthesized only `v_proj.weight`. For W4A8_AWQ checkpoints, the missing V quantization tensors left the fused QKV `weight_scale` width at 18432 while the target expected 20480, causing model
  initialization to fail.

  This PR:

  - Duplicates missing `k_proj` projection tensors to `v_proj` for full-attention K=V layers, including W4A8 quantization metadata.
  - Preserves explicitly exported V tensors.
  - Maps `k_scale`/`k_bias` metadata to `v_scale`/`v_bias`.
  - Supports both text and multimodal checkpoint prefixes without depending on checkpoint dictionary order.
  - Adds regression coverage for text/VLM checkpoints, full/sliding attention, quantization metadata, explicit V values, layer-scalar loading, and idempotence.

  The change is limited to Gemma4 HF checkpoint preprocessing. It does not change public APIs or inference kernels.

  ## Test Coverage

  - Gemma4 weight-mapper regression test:
    ```bash
    pytest -q tests/unittest/_torch/modeling/test_modeling_gemma4.py \
        -k duplicate_full_attention_kv_projection_tensors

  Passed for both text and multimodal checkpoint layouts.

  - Static checks:

    ruff check \
        tensorrt_llm/_torch/models/checkpoints/hf/gemma4_weight_mapper.py \
        tests/unittest/_torch/modeling/test_modeling_gemma4.py

    ruff format --check \
        tensorrt_llm/_torch/models/checkpoints/hf/gemma4_weight_mapper.py \
        tests/unittest/_torch/modeling/test_modeling_gemma4.py

  - B200 end-to-end validation:
      - Exported Gemma4-31B-it using ModelOpt 0.45.0rc1 with W4A8_AWQ and FP8 KV cache.
      - Confirmed the unpatched TRT-LLM 1.3.0rc19 loader reproduces the 20480 vs. 18432 fused-QKV scale mismatch.
      - Confirmed the patched loader loads the full checkpoint, starts trtllm-serve, and successfully serves a completion request.

  - Generic dense W4A8 control:
      - Exported and served TinyLlama using the same W4A8_AWQ + FP8 KV-cache recipe.
      - Confirmed the existing generic W4A8 loader and runtime path remain functional.

  The B200 runs used calib_size=8 as a structural and functional smoke test; no accuracy claim is made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Updated Gemma4 HF checkpoint preprocessing to regex-match `layer_scalar` and `k_proj` keys independently of dictionary order and optional `language_model.` prefixes.
- For full-attention layers with `attention_k_eq_v=True`, missing `v_proj` tensors are derived from K tensors, including W4A8 `k_scale`/`k_bias` metadata mapped to V equivalents.
- Explicit V tensors remain preserved; processing is idempotent and scoped to Gemma4 checkpoint preprocessing without public API or kernel changes.
- Regression coverage includes text/VLM prefixes, full vs. sliding attention, explicit V values, scalar buffers, quantization metadata, and repeated preprocessing.
- No configuration or test-list changes were identified.

## QA Engineer Review

- Added test: `TestGemma4HfWeightMapper.test_duplicate_full_attention_kv_projection_tensors`.
- The test covers both non-VLM and VLM mapper layouts and validates KV duplication, metadata handling, preservation of explicit V tensors, scalar copying, exclusion of sliding-attention V keys, and idempotence.
- No `tests/integration/test_lists/` changes are included, so test-list coverage is not explicitly registered.
- Verdict: needs follow-up to confirm CI/manual QA coverage registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->