### PR TITLE
[None][fix] Fix disaggregated draft token accounting

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -222,6 +222,7 @@ public:
             mState = LlmRequestState::kENCODER_INIT;
         }
 
+        adoptContextPhaseDraftTokens();
         initialize(*inputTokens, returnLogProbs, arrivalTime);
     }
 
@@ -290,6 +291,7 @@ public:
         {
             mState = LlmRequestState::kENCODER_INIT;
         }
+        adoptContextPhaseDraftTokens();
         initialize(inputTokens, returnLogProbs);
     }
 
@@ -522,6 +524,7 @@ public:
         default: throw std::runtime_error("Unsupported request type found.");
         }
 
+        adoptContextPhaseDraftTokens();
         initialize(req.getInputTokenIds(), req.getOutputConfig().returnLogProbs);
     }
 
@@ -540,9 +543,29 @@ public:
         return mContextPhaseParams;
     }
 
+    /// @brief Get the number of generation tokens carried by context phase handoff.
+    /// @return Number of first generation tokens plus draft tokens.
+    [[nodiscard]] SizeType32 getNumContextPhaseGenerationTokens() const noexcept
+    {
+        if (!mContextPhaseParams.has_value())
+        {
+            return 0;
+        }
+
+        auto const& contextPhaseParams = mContextPhaseParams.value();
+        auto numTokens = static_cast<SizeType32>(contextPhaseParams.getFirstGenTokens().size());
+        auto const& draftTokens = contextPhaseParams.getDraftTokens();
+        if (draftTokens.has_value())
+        {
+            numTokens += static_cast<SizeType32>(draftTokens->size());
+        }
+        return numTokens;
+    }
+
     void setContextPhaseParams(executor::ContextPhaseParams contextPhaseParams)
     {
         mContextPhaseParams = std::move(contextPhaseParams);
+        adoptContextPhaseDraftTokens();
     }
 
     /// @brief Get the state params of the context
@@ -2253,6 +2276,20 @@ protected:
     std::optional<std::vector<std::tuple<std::string, int>>> mAgentHierarchy{std::nullopt};
 
 private:
+    void adoptContextPhaseDraftTokens()
+    {
+        if (hasDraftTokens() || !mContextPhaseParams.has_value())
+        {
+            return;
+        }
+
+        auto const& draftTokens = mContextPhaseParams.value().getDraftTokens();
+        if (draftTokens.has_value() && !draftTokens->empty())
+        {
+            mDraftTokens = std::make_shared<VecTokens>(*draftTokens);
+        }
+    }
+
     void initialize(
         VecTokens const& inputTokens, bool outputLogProbs, std::optional<TimePoint> arrivalTime = std::nullopt)
     {

--- a/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
+++ b/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
@@ -69,10 +69,8 @@ void copySequenceLengths(RequestVector const& contextRequests, DecoderInputBuffe
     SizeType32 batchIdx{0};
     for (auto const& llmReq : contextRequests)
     {
-        auto const disaggFirstGenTokenSize
-            = llmReq->getContextPhaseParams() ? llmReq->getContextPhaseParams().value().getFirstGenTokens().size() : 0;
         auto const currentSequenceLen
-            = llmReq->mPromptLen + llmReq->getMaxNumGeneratedTokens() + disaggFirstGenTokenSize;
+            = llmReq->mPromptLen + llmReq->getMaxNumGeneratedTokens() + llmReq->getNumContextPhaseGenerationTokens();
         // Get position of the current sequence in the decoder
         auto const seqSlot = llmReq->mSeqSlot.value();
         batchSlotsRange[batchIdx] = seqSlot;

--- a/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -788,6 +788,41 @@ TEST_F(LlmRequestTest, createResultDisaggContextComplete)
         << "contextPhaseParams must be populated for context-only DISAGG_CONTEXT_COMPLETE requests";
     EXPECT_EQ(response->contextPhaseParams->getReqId(), requestId);
     EXPECT_TRUE(response->isSequenceFinal);
+}
+
+TEST_F(LlmRequestTest, generationOnlyRequestAdoptsContextPhaseDraftTokens)
+{
+    VecTokens inputTokens{1, 2, 3, 4, 5};
+    VecTokens firstGenTokens{100};
+    VecTokens draftTokens{101, 102, 103};
+    SizeType32 maxNewTokens{10};
+    texec::IdType requestId{42};
+
+    texec::Request execReq(inputTokens, maxNewTokens);
+    execReq.setRequestType(texec::RequestType::REQUEST_TYPE_GENERATION_ONLY);
+    execReq.setContextPhaseParams(
+        texec::ContextPhaseParams{firstGenTokens, requestId, static_cast<void*>(nullptr), draftTokens});
+    auto const expectedContextPhaseTokens = static_cast<SizeType32>(firstGenTokens.size() + draftTokens.size());
+    auto const expectedDraftTokens = static_cast<SizeType32>(draftTokens.size());
+
+    tb::LlmRequest llmReq(requestId, execReq);
+
+    EXPECT_TRUE(llmReq.isGenerationOnlyRequest());
+    EXPECT_EQ(llmReq.getNumDraftTokens(), expectedDraftTokens);
+    EXPECT_EQ(*llmReq.getDraftTokens(), draftTokens);
+    EXPECT_EQ(llmReq.getNumContextPhaseGenerationTokens(), expectedContextPhaseTokens);
+
+    texec::Request lateExecReq(inputTokens, maxNewTokens);
+    lateExecReq.setRequestType(texec::RequestType::REQUEST_TYPE_GENERATION_ONLY);
+    tb::LlmRequest lateLlmReq(requestId, lateExecReq);
+    EXPECT_EQ(lateLlmReq.getNumDraftTokens(), 0);
+
+    lateLlmReq.setContextPhaseParams(
+        texec::ContextPhaseParams{firstGenTokens, requestId, static_cast<void*>(nullptr), draftTokens});
+
+    EXPECT_EQ(lateLlmReq.getNumDraftTokens(), expectedDraftTokens);
+    EXPECT_EQ(*lateLlmReq.getDraftTokens(), draftTokens);
+    EXPECT_EQ(lateLlmReq.getNumContextPhaseGenerationTokens(), expectedContextPhaseTokens);
 }
 
 INSTANTIATE_TEST_SUITE_P(LlmRequestTest, ParamTest,

--- a/tests/unittest/_torch/executor/test_request_utils.py
+++ b/tests/unittest/_torch/executor/test_request_utils.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Tests for request_utils.py functions.
 
 This module tests:
@@ -17,6 +20,7 @@ from tensorrt_llm._torch.pyexecutor.request_utils import (
     attach_py_objects_to_requests,
     can_process_attention_dp_request,
     derive_attention_dp_per_rank_request_cap,
+    executor_request_to_llm_request,
     get_from_waiting_queue,
     merge_helix_requests,
     merge_requests,
@@ -93,6 +97,40 @@ def test_request_broadcaster_requires_conversation_params_attr():
 
     with pytest.raises(AttributeError):
         RequestBroadcaster._collect_py_objects(None, source_items)
+
+
+def test_executor_request_to_llm_request_adopts_context_phase_draft_tokens() -> None:
+    request_id = 42
+    first_gen_tokens = [100]
+    draft_tokens = [101, 102, 103]
+    context_phase_params = trtllm.ContextPhaseParams(
+        first_gen_tokens,
+        request_id,
+        None,
+        draft_tokens,
+        None,
+        None,
+    )
+    executor_request = trtllm.Request(
+        input_token_ids=[1, 2, 3],
+        max_tokens=10,
+        type=trtllm.RequestType.REQUEST_TYPE_GENERATION_ONLY,
+        context_phase_params=context_phase_params,
+    )
+
+    llm_request = executor_request_to_llm_request(
+        request_id,
+        executor_request,
+        child_req_ids=[],
+        exclude_last_generation_logits=False,
+    )
+
+    assert llm_request.is_generation_only_request()
+    assert llm_request.has_draft_tokens()
+    assert llm_request.num_draft_tokens == len(draft_tokens)
+    assert llm_request.draft_tokens == draft_tokens
+    assert llm_request.py_draft_tokens == draft_tokens
+    assert llm_request.context_phase_params.draft_tokens == draft_tokens
 
 
 def test_merge_helix_requests_with_padding():

--- a/tests/unittest/bindings/test_bindings_ut.py
+++ b/tests/unittest/bindings/test_bindings_ut.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import json
 import pickle
 import tempfile
@@ -415,6 +418,55 @@ def test_llm_request():
     logits = torch.tensor([-5, -6 - 7], dtype=torch.float)
     llm_request.draft_logits = logits
     assert torch.equal(llm_request.draft_logits, logits)
+
+
+def test_generation_only_llm_request_adopts_draft_tokens() -> None:
+    request_id = 42
+    first_gen_tokens = [100]
+    draft_tokens = [101, 102, 103]
+    llm_request_type = _tb.internal.batch_manager.LlmRequestType
+    context_phase_params = _tb.executor.ContextPhaseParams(
+        first_gen_tokens,
+        request_id,
+        None,
+        draft_tokens,
+        None,
+        None,
+    )
+
+    llm_request = _tb.internal.batch_manager.LlmRequest(
+        request_id=request_id,
+        max_new_tokens=10,
+        sampling_config=_tb.SamplingConfig(1),
+        input_tokens=[1, 2, 3],
+        is_streaming=False,
+        llm_request_type=llm_request_type.LLMREQUEST_TYPE_GENERATION_ONLY,
+        context_phase_params=context_phase_params,
+    )
+
+    assert llm_request.is_generation_only_request
+    assert llm_request.has_draft_tokens()
+    assert llm_request.num_draft_tokens == len(draft_tokens)
+    assert llm_request.draft_tokens == draft_tokens
+    assert llm_request.context_phase_params.draft_tokens == draft_tokens
+
+    late_llm_request = _tb.internal.batch_manager.LlmRequest(
+        request_id=request_id,
+        max_new_tokens=10,
+        sampling_config=_tb.SamplingConfig(1),
+        input_tokens=[1, 2, 3],
+        is_streaming=False,
+        llm_request_type=llm_request_type.LLMREQUEST_TYPE_GENERATION_ONLY,
+    )
+
+    assert late_llm_request.draft_tokens is None
+    assert late_llm_request.num_draft_tokens == 0
+
+    late_llm_request.context_phase_params = context_phase_params
+
+    assert late_llm_request.has_draft_tokens()
+    assert late_llm_request.num_draft_tokens == len(draft_tokens)
+    assert late_llm_request.draft_tokens == draft_tokens
 
 
 def test_llm_request_kv_cache_transfer_metric_bindings():


### PR DESCRIPTION
Generation-only requests created from disaggregated context-phase handoff can carry draft tokens alongside first-generation tokens. Adopt those draft tokens into LlmRequest so decoder capacity and Python-visible request state account for every generation token handed off by prefill.

Add C++ and Python unit coverage for constructor-time and late context-phase parameter handoff paths.

Tests added:
- LlmRequestTest.generationOnlyRequestAdoptsContextPhaseDraftTokens
- tests/unittest/_torch/executor/test_request_utils.py::test_executor_request_to_llm_request_adopts_context_phase_draft_tokens
- tests/unittest/bindings/test_bindings_ut.py::test_generation_only_llm_request_adopts_draft_tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `GenericLlmRequest` to adopt context-phase draft tokens during construction and when context-phase parameters are set later.
- Added `getNumContextPhaseGenerationTokens()` and integrated it into decoder sequence-length accounting.
- The implementation and API changes are consistent with the stated draft-token accounting fix. No configuration or test-list changes were identified.
- C++ and Python unit tests cover both constructor-time and late context-phase handoff paths.

## QA Engineer Review

- Added `generationOnlyRequestAdoptsContextPhaseDraftTokens` in `cpp/tests/unit_tests/batch_manager/llmRequestTest.cpp`.
- Added `test_generation_only_llm_request_adopts_draft_tokens` in `tests/unittest/bindings/test_bindings_ut.py`.
- Added coverage in `tests/unittest/_torch/executor/test_request_utils.py` for `executor_request_to_llm_request`.
- No corresponding `tests/integration/test_lists/`, `test-db/`, or `qa/` entries were found for these unit tests, so CI/manual-QA listing coverage is not explicitly recorded.
- **Verdict: needs follow-up**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
