### PR TITLE
[None][fix] Bind explicit DP rank for new conversations

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -857,6 +857,42 @@ class ConversationAwareADPRouter(ADPRouter):
         while len(self._conv_to_rank) > self._max_sessions:
             self._conv_to_rank.popitem(last=False)
 
+    def _assign_new_conversation_explicit_dp_ranks(
+        self,
+        requests: List["RequestQueueItem"],
+        all_ranks_new_requests: Dict[int, List["RequestQueueItem"]],
+        all_ranks_num_active_requests: List[int],
+        max_num_active_requests: int,
+    ) -> List["RequestQueueItem"]:
+        """Place explicit first turns and establish their affinity binding.
+
+        Once a conversation is bound, its recorded rank takes precedence over
+        later explicit rank hints. Requests whose explicit target is full remain
+        eligible for the normal affinity/load-balanced path below.
+        """
+        remaining: List["RequestQueueItem"] = []
+        for req_item in requests:
+            conv_id = self._conversation_id(req_item)
+            if conv_id is not None and conv_id in self._conv_to_rank:
+                remaining.append(req_item)
+                continue
+
+            scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
+            target_dp_rank = (
+                scheduling_params.attention_dp_rank if scheduling_params is not None else None
+            )
+            if (
+                target_dp_rank is not None
+                and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
+            ):
+                all_ranks_num_active_requests[target_dp_rank] += 1
+                all_ranks_new_requests[target_dp_rank].append(req_item)
+                if conv_id is not None:
+                    self._record_target_rank(conv_id, target_dp_rank)
+            else:
+                remaining.append(req_item)
+        return remaining
+
     def route_requests(
         self,
         all_rank_states: list[RankState],
@@ -877,8 +913,9 @@ class ConversationAwareADPRouter(ADPRouter):
 
         sorted_requests = sorted(new_requests, key=get_relax_value)
 
-        # 1) Honour an explicit attention_dp_rank first (strict placement).
-        remaining_unscheduled = self._assign_explicit_dp_ranks(
+        # 1) Honour an explicit attention_dp_rank for a new conversation and
+        #    record that placement. Existing conversations keep their binding.
+        remaining_unscheduled = self._assign_new_conversation_explicit_dp_ranks(
             sorted_requests,
             all_ranks_new_requests,
             all_ranks_num_active_requests,

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
 
 HeapVal = namedtuple("HeapVal", ["num_tokens", "num_requests", "rank", "request_list"])
 
+# Capability consumed by external orchestrators that optionally select the
+# initial DP rank. Builds without this marker may honor an explicit first-turn
+# rank without recording it as the conversation's persistent affinity binding.
+SUPPORTS_EXPLICIT_DP_RANK_CONVERSATION_BINDING = True
+
 
 def _num_input_tokens(request) -> int:
     """Token count via the cheap num_input_tokens accessor (avoids materializing

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -35,11 +35,6 @@ if TYPE_CHECKING:
 
 HeapVal = namedtuple("HeapVal", ["num_tokens", "num_requests", "rank", "request_list"])
 
-# Capability consumed by external orchestrators that optionally select the
-# initial DP rank. Builds without this marker may honor an explicit first-turn
-# rank without recording it as the conversation's persistent affinity binding.
-SUPPORTS_EXPLICIT_DP_RANK_CONVERSATION_BINDING = True
-
 
 def _num_input_tokens(request) -> int:
     """Token count via the cheap num_input_tokens accessor (avoids materializing

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -1207,11 +1207,23 @@ class TestConversationAwareADPRouter:
         assert len(router._conv_to_rank) == 2
         assert set(router._conv_to_rank) == {"c3", "c4"}
 
-    def test_explicit_target_dp_rank_respected(self):
+    def test_explicit_target_dp_rank_establishes_binding(self):
         router = self._router(tp_size=4)
-        item = _make_conv_request_item(1, "A", target_dp_rank=2, attention_dp_relax=False)
-        pos = self._route(router, self._states(4), [item])
-        assert pos[1] == 2
+        first = _make_conv_request_item(1, "A", target_dp_rank=2, attention_dp_relax=False)
+        assert self._route(router, self._states(4), [first])[1] == 2
+        assert router._conv_to_rank["A"] == 2
+
+        second = _make_conv_request_item(2, "A")
+        assert self._route(router, self._states(4), [second])[2] == 2
+
+    def test_existing_binding_wins_over_later_explicit_target(self):
+        router = self._router(tp_size=4)
+        first = _make_conv_request_item(1, "A", target_dp_rank=2, attention_dp_relax=False)
+        self._route(router, self._states(4), [first])
+
+        second = _make_conv_request_item(2, "A", target_dp_rank=1, attention_dp_relax=False)
+        assert self._route(router, self._states(4), [second])[2] == 2
+        assert router._conv_to_rank["A"] == 2
 
     def test_sticky_overflow_keeps_mapping(self):
         """When the home rank is saturated at the HARD cap (max_num_active_requests),


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Fixed `ConversationAwareADPRouter` explicit first-turn handling so that when a new conversation provides an explicit `attention_dp_rank`, the conversation→DP-rank affinity binding is recorded (only if the hinted rank has capacity) and then reused on subsequent turns.
- Refactored explicit conversation-first-turn placement:
  - Introduced `_assign_new_conversation_explicit_dp_ranks` and updated `route_requests()` to call it.
  - Conversations already present in `_conv_to_rank` are skipped during explicit placement, so later conflicting explicit `attention_dp_rank` hints cannot override an existing binding.
  - If the hinted `attention_dp_rank` is at capacity, the request is returned for normal affinity/load-balanced routing and is not bound.
  - Requests without a `conversation_id` keep the existing explicit-placement/fallback behavior but are not recorded into the conversation affinity map.
- Updated internal routing step comments to reflect conversation-aware affinity precedence.
- No public API changes or new dependencies introduced. (Note: the previous explicit-rank capability marker referenced in the old summary is not present in the current code.)

## QA Engineer Review

- Updated unit coverage in `tests/unittest/_torch/executor/test_adp_router.py` under `TestConversationAwareADPRouter`:
  - `test_explicit_target_dp_rank_establishes_binding`: verifies an explicit `target_dp_rank`/`attention_dp_rank` for a new conversation creates and records a conversation→rank binding, and subsequent turns reuse it when later requests omit the explicit target.
  - `test_existing_binding_wins_over_later_explicit_target`: verifies a later request with a conflicting explicit target does not override the already-recorded conversation binding.
  - `test_no_conversation_id_falls_back_and_is_not_recorded`: verifies conversation-less requests are routed without being recorded in `_conv_to_rank`.
- No changes to `tests/integration/test_lists/` were identified.
- Verdict: needs follow-up (no CI/manual test-list mapping/coverage data available for these unit tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

`ConversationAwareADPRouter` currently honors an explicit
`attention_dp_rank` before applying conversation-affinity routing. This places
the first request on the requested rank but does not record the resulting
`conversation_id -> DP rank` binding. Subsequent requests in the same
conversation can therefore be routed to a different DP rank.

This change makes explicit placement establish the conversation binding:

- A new conversation with an explicit `attention_dp_rank` is routed to that
  rank and records the affinity binding.
- Subsequent requests use the recorded binding, even if a later request
  supplies a conflicting explicit rank.
- If the explicit target rank is full, the request falls back to the existing
  conversation-affinity and load-balancing path.
- Requests without a conversation ID retain the existing explicit-placement
  behavior.

This enables external orchestrators such as Dynamo to select the initial DP
rank while allowing TensorRT-LLM to preserve that placement for later turns.

Context:
https://github.com/ai-dynamo/dynamo/pull/11609#discussion_r3573334150

There are no public API changes or new dependencies.

## Test Coverage

Added unit coverage for:

- Establishing a conversation binding from an explicit first-turn DP rank.
- Reusing the recorded rank for subsequent turns.
- Preserving an existing binding when a later request supplies a conflicting
  explicit rank.

Local validation completed:

- `pre-commit run --files ...`
- `ruff check`
- `ruff format --check`
- `python3 -m compileall`
- `git diff --check`
- Targeted behavior validation covering first placement, repeated requests,
  conflicting later hints, and requests without conversation IDs.

The full pytest suite could not be collected in the local host environment
because its optional `mpi4py` and `nvtx` dependencies are unavailable. The
added tests should be exercised by the TensorRT-LLM CI pipeline.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
