### PR TITLE
[None][perf] Autotune large-M MXFP8 GEMM tactics

### DIFF
--- a/cpp/tensorrt_llm/thop/mxfp8Gemm.cpp
+++ b/cpp/tensorrt_llm/thop/mxfp8Gemm.cpp
@@ -25,6 +25,11 @@
 
 #include <cstdint>
 #include <cuda_fp16.h>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <tuple>
 #include <vector>
 
 namespace tkc = tensorrt_llm::cutlass_extensions;
@@ -39,11 +44,103 @@ namespace torch_ext
 namespace
 {
 
+constexpr int64_t kMxfp8LargeMMin = 6553;
+constexpr int64_t kMxfp8M8kBucket = 8192;
+constexpr int64_t kMxfp8M16kMin = 13106;
+constexpr int64_t kMxfp8M16kBucket = 16384;
+constexpr int64_t kMxfp8M32kMin = 19659;
+constexpr int64_t kMxfp8M32kBucket = 32768;
+constexpr int64_t kMxfp8TacticCacheMiss = -2;
+
+int getMxfp8SmVersion()
+{
+    // PyExecutor binds one GPU architecture per rank.
+    static int const smVersion = tensorrt_llm::common::getSMVersion();
+    return smVersion;
+}
+
+int64_t getMxfp8TuningBucket(int64_t const m)
+{
+    if (m < kMxfp8LargeMMin)
+    {
+        return m;
+    }
+    if (m <= kMxfp8M8kBucket)
+    {
+        return kMxfp8M8kBucket;
+    }
+    if (m >= kMxfp8M16kMin && m <= kMxfp8M16kBucket)
+    {
+        return kMxfp8M16kBucket;
+    }
+    if (m >= kMxfp8M32kMin && m <= kMxfp8M32kBucket)
+    {
+        return kMxfp8M32kBucket;
+    }
+    return m;
+}
+
+using Mxfp8TacticCacheKey = std::tuple<int, at::ScalarType, int64_t, int64_t, int64_t>;
+
+struct Mxfp8TacticCacheEntry
+{
+    tkc::CutlassGemmConfig config;
+    int64_t tactic;
+};
+
+using Mxfp8TacticCache = std::map<Mxfp8TacticCacheKey, Mxfp8TacticCacheEntry>;
+
+Mxfp8TacticCache& getMxfp8TacticCache()
+{
+    static Mxfp8TacticCache cache;
+    return cache;
+}
+
+std::shared_mutex& getMxfp8TacticCacheMutex()
+{
+    static std::shared_mutex mutex;
+    return mutex;
+}
+
+Mxfp8TacticCacheKey makeMxfp8TacticCacheKey(
+    int64_t const m, int64_t const n, int64_t const k, at::ScalarType const outputDtype)
+{
+    return {getMxfp8SmVersion(), outputDtype, getMxfp8TuningBucket(m), n, k};
+}
+
+std::optional<Mxfp8TacticCacheEntry> findMxfp8TacticCacheEntry(
+    int64_t const m, int64_t const n, int64_t const k, at::ScalarType const outputDtype)
+{
+    std::shared_lock<std::shared_mutex> lock(getMxfp8TacticCacheMutex());
+    auto const& cache = getMxfp8TacticCache();
+    auto const iterator = cache.find(makeMxfp8TacticCacheKey(m, n, k, outputDtype));
+    if (iterator == cache.end())
+    {
+        return std::nullopt;
+    }
+    return iterator->second;
+}
+
+void cacheMxfp8Tactic(int64_t const m, int64_t const n, int64_t const k, at::ScalarType const outputDtype,
+    tkc::CutlassGemmConfig const& config, int64_t const tactic)
+{
+    std::unique_lock<std::shared_mutex> lock(getMxfp8TacticCacheMutex());
+    getMxfp8TacticCache().insert_or_assign(
+        makeMxfp8TacticCacheKey(m, n, k, outputDtype), Mxfp8TacticCacheEntry{config, tactic});
+}
+
+void clearMxfp8CachedTactics()
+{
+    std::unique_lock<std::shared_mutex> lock(getMxfp8TacticCacheMutex());
+    getMxfp8TacticCache().clear();
+}
+
 tkc::CutlassGemmConfig getDefaultMxfp8GemmConfig()
 {
     // Reuse the same default tile/cluster as MXFP8xMXFP4 -- the B operand is
     // 2x wider in MXFP8xMXFP8, but the same 4x4 cluster/256x256 tile shape is
-    // a reasonable starting point on B200.
+    // a reasonable Blackwell fallback before startup tuning populates the
+    // native tactic cache.
     return tkc::CutlassGemmConfig(tkc::CutlassTileConfigSM100::CtaShape128x256x256B, tkc::MainloopScheduleType::AUTO,
         tkc::EpilogueScheduleType::AUTO, tkc::ClusterShape::ClusterShape_4x4x1);
 }
@@ -63,25 +160,9 @@ void runMxfp8Gemm(at::Tensor& out, at::Tensor const& act, at::Tensor const& weig
         reinterpret_cast<char*>(workspace.data_ptr()), wsBytes, at::cuda::getCurrentCUDAStream(act.get_device()));
 }
 
-} // namespace
-
-// MXFP8 (e4m3 + UE8M0 1x32 block scales) x MXFP8 (e4m3 + UE8M0 1x32 block
-// scales) GEMM on Blackwell sm_100/103.
-//
-// Operands (matching the CUTLASS block-scaled tensor-op convention):
-//   act:          [M, K] Float8_e4m3fn, row-major.
-//   actScale:     1D uint8 (UE8M0), swizzled layout produced by
-//                 torch.ops.trtllm.mxfp8_quantize(input, swizzedLayout=True).
-//   weight:       [N, K] Float8_e4m3fn, expected to be column-major in memory.
-//                 The caller is responsible for ensuring the weight tensor is
-//                 contiguous in the column-major sense that CUTLASS expects.
-//   weightScale:  1D uint8 (UE8M0), swizzled layout produced by
-//                 torch.ops.trtllm.block_scale_interleave(scale).
-//   globalScale:  [1] float -- alpha multiplier baked into the epilogue.
-//                 For pure MXFP8xMXFP8 this is usually [1.0].
-//   out_dtype:    fp16 / bf16 / fp32 output element type.
-at::Tensor mxfp8_mxfp8_gemm(at::Tensor const& act, at::Tensor const& actScale, at::Tensor const& weight,
-    at::Tensor const& weightScale, at::Tensor const& globalScale, std::optional<c10::ScalarType> out_dtype)
+at::Tensor mxfp8Mxfp8GemmImpl(at::Tensor const& act, at::Tensor const& actScale, at::Tensor const& weight,
+    at::Tensor const& weightScale, at::Tensor const& globalScale, std::optional<c10::ScalarType> outDtype,
+    tkc::CutlassGemmConfig const* gemmConfig, bool const useTacticCache)
 {
     CHECK_INPUT(act, torch::kFloat8_e4m3fn);
     CHECK_INPUT(weight, torch::kFloat8_e4m3fn);
@@ -105,14 +186,17 @@ at::Tensor mxfp8_mxfp8_gemm(at::Tensor const& act, at::Tensor const& actScale, a
     constexpr int kAlignmentN = 32;
     TORCH_CHECK(n % kAlignmentN == 0, "N (", n, ") must be divisible by ", kAlignmentN);
 
-    auto chosen_dtype = out_dtype.value_or(torch::kBFloat16);
-    TORCH_CHECK(chosen_dtype == torch::kFloat || chosen_dtype == torch::kHalf || chosen_dtype == torch::kBFloat16,
+    auto const chosenDtype = outDtype.value_or(torch::kBFloat16);
+    TORCH_CHECK(chosenDtype == torch::kFloat || chosenDtype == torch::kHalf || chosenDtype == torch::kBFloat16,
         "out_dtype must be one of fp16/bf16/fp32 (default bf16).");
 
-    at::Tensor out = at::detail::empty_cuda({m, n}, chosen_dtype, act.device(), std::nullopt);
+    at::Tensor out = at::detail::empty_cuda({m, n}, chosenDtype, act.device(), std::nullopt);
 
-    auto const config = getDefaultMxfp8GemmConfig();
-    switch (chosen_dtype)
+    auto const cachedEntry = useTacticCache ? findMxfp8TacticCacheEntry(m, n, k, chosenDtype) : std::nullopt;
+    auto const config = gemmConfig != nullptr
+        ? *gemmConfig
+        : (cachedEntry.has_value() ? cachedEntry->config : getDefaultMxfp8GemmConfig());
+    switch (chosenDtype)
     {
     case at::ScalarType::Half:
         runMxfp8Gemm<half>(out, act, weight, actScale, weightScale, globalScale, m, n, k, config);
@@ -132,12 +216,96 @@ at::Tensor mxfp8_mxfp8_gemm(at::Tensor const& act, at::Tensor const& actScale, a
     return out;
 }
 
+} // namespace
+
+// MXFP8 (e4m3 + UE8M0 1x32 block scales) x MXFP8 (e4m3 + UE8M0 1x32 block
+// scales) GEMM on Blackwell sm_100/103.
+//
+// Operands (matching the CUTLASS block-scaled tensor-op convention):
+//   act:          [M, K] Float8_e4m3fn, row-major.
+//   actScale:     1D uint8 (UE8M0), swizzled layout produced by
+//                 torch.ops.trtllm.mxfp8_quantize(input, swizzedLayout=True).
+//   weight:       [N, K] Float8_e4m3fn, expected to be column-major in memory.
+//                 The caller is responsible for ensuring the weight tensor is
+//                 contiguous in the column-major sense that CUTLASS expects.
+//   weightScale:  1D uint8 (UE8M0), swizzled layout produced by
+//                 torch.ops.trtllm.block_scale_interleave(scale).
+//   globalScale:  [1] float -- alpha multiplier baked into the epilogue.
+//                 For pure MXFP8xMXFP8 this is usually [1.0].
+//   out_dtype:    fp16 / bf16 / fp32 output element type.
+at::Tensor mxfp8_mxfp8_gemm(at::Tensor const& act, at::Tensor const& actScale, at::Tensor const& weight,
+    at::Tensor const& weightScale, at::Tensor const& globalScale, std::optional<c10::ScalarType> outDtype)
+{
+    return mxfp8Mxfp8GemmImpl(act, actScale, weight, weightScale, globalScale, outDtype, /*gemmConfig=*/nullptr,
+        /*useTacticCache=*/true);
+}
+
+class MXFP8GemmRunner : public torch::CustomClassHolder
+{
+public:
+    explicit MXFP8GemmRunner(at::ScalarType outputDtype)
+        : mOutputDtype(outputDtype)
+    {
+        TORCH_CHECK(outputDtype == torch::kFloat || outputDtype == torch::kHalf || outputDtype == torch::kBFloat16,
+            "output_dtype must be one of fp16/bf16/fp32.");
+        mConfigs = CutlassFp4GemmRunner<half, FP4GemmType::W8A8_MXFP8_MXFP8>{}.getConfigs();
+    }
+
+    at::Tensor runGemm(at::Tensor const& act, at::Tensor const& actScale, at::Tensor const& weight,
+        at::Tensor const& weightScale, at::Tensor const& globalScale, int64_t configIdx) const
+    {
+        auto const config = configIdx == -1 ? getDefaultMxfp8GemmConfig() : getConfig(configIdx);
+        return mxfp8Mxfp8GemmImpl(
+            act, actScale, weight, weightScale, globalScale, mOutputDtype, &config, /*useTacticCache=*/false);
+    }
+
+    void registerTactic(int64_t const m, int64_t const n, int64_t const k, int64_t const configIdx) const
+    {
+        tkc::CutlassGemmConfig const config = configIdx == -1 ? getDefaultMxfp8GemmConfig() : getConfig(configIdx);
+        cacheMxfp8Tactic(m, n, k, mOutputDtype, config, configIdx);
+    }
+
+    int64_t getCachedTactic(int64_t const m, int64_t const n, int64_t const k) const
+    {
+        auto const entry = findMxfp8TacticCacheEntry(m, n, k, mOutputDtype);
+        return entry.has_value() ? entry->tactic : kMxfp8TacticCacheMiss;
+    }
+
+    void clearTacticCache() const
+    {
+        clearMxfp8CachedTactics();
+    }
+
+    int64_t getNumConfigs() const
+    {
+        return static_cast<int64_t>(mConfigs.size());
+    }
+
+private:
+    tkc::CutlassGemmConfig const& getConfig(int64_t const configIdx) const
+    {
+        TORCH_CHECK(configIdx >= 0 && configIdx < getNumConfigs());
+        return mConfigs.at(configIdx);
+    }
+
+    at::ScalarType mOutputDtype;
+    std::vector<tkc::CutlassGemmConfig> mConfigs;
+};
+
 } // namespace torch_ext
 
 TRTLLM_NAMESPACE_END
 
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
+    m.class_<tensorrt_llm::torch_ext::MXFP8GemmRunner>("MXFP8GemmRunner")
+        .def(torch::init<at::ScalarType>())
+        .def("run_gemm", &tensorrt_llm::torch_ext::MXFP8GemmRunner::runGemm)
+        .def("get_num_configs", &tensorrt_llm::torch_ext::MXFP8GemmRunner::getNumConfigs)
+        .def("register_tactic", &tensorrt_llm::torch_ext::MXFP8GemmRunner::registerTactic)
+        .def("get_cached_tactic", &tensorrt_llm::torch_ext::MXFP8GemmRunner::getCachedTactic)
+        .def("clear_tactic_cache", &tensorrt_llm::torch_ext::MXFP8GemmRunner::clearTacticCache);
+
     m.def(
         "mxfp8_mxfp8_gemm(Tensor act, Tensor actScale, Tensor weight, Tensor weightScale, "
         "Tensor globalScale, ScalarType? out_dtype=None) -> Tensor");

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -552,6 +552,124 @@ def _(
     return act.new_empty((act.size(0), weight.size(0)), dtype=output_dtype)
 
 
+_MXFP8_LARGE_M_BUCKETS = (8192, 16384, 32768)
+_MXFP8_LARGE_M_BANDS = ((6553, 8192), (13106, 16384), (19659, 32768))
+_MXFP8_AUTOTUNED_OP = "trtllm::mxfp8_mxfp8_gemm_autotuned::gemm"
+
+
+def _map_to_mxfp8_large_m_bucket(num_tokens: int) -> int:
+    for (lower_bound, upper_bound), bucket in zip(_MXFP8_LARGE_M_BANDS,
+                                                  _MXFP8_LARGE_M_BUCKETS):
+        if lower_bound <= num_tokens <= upper_bound:
+            return bucket
+    return num_tokens
+
+
+def _get_mxfp8_large_m_tuning_buckets(max_num_tokens: int) -> tuple[int, ...]:
+    mapped_max = _map_to_mxfp8_large_m_bucket(max_num_tokens)
+    return tuple(bucket for bucket in _MXFP8_LARGE_M_BUCKETS
+                 if bucket <= mapped_max)
+
+
+def _mxfp8_scale_infer_shape(input_shapes: List[List[int]]) -> int:
+    _, scale_shape = fp4_utils.get_fp4_shape(input_shapes[0], sf_vec_size=32)
+    return scale_shape
+
+
+class MXFP8GemmRunner(TunableRunner):
+    runner_dict = dict()
+    tuning_config = TuningConfig(dynamic_tensor_specs=(DynamicTensorSpec(
+        0, 0, _get_mxfp8_large_m_tuning_buckets,
+        _map_to_mxfp8_large_m_bucket), ),
+                                 constraint_specs=(ConstraintSpec(
+                                     1, 0, _mxfp8_scale_infer_shape), ),
+                                 use_cuda_graph=False)
+
+    def __init__(self, output_dtype: torch.dtype):
+        self.output_dtype = output_dtype
+        self.sm_version = get_sm_version()
+        instance_key = (output_dtype, self.sm_version)
+        if instance_key not in MXFP8GemmRunner.runner_dict:
+            MXFP8GemmRunner.runner_dict[
+                instance_key] = torch.classes.trtllm.MXFP8GemmRunner(
+                    output_dtype)
+        self.mxfp8_gemm_runner = MXFP8GemmRunner.runner_dict[instance_key]
+
+    def unique_id(self):
+        return (self.output_dtype, self.sm_version)
+
+    def get_valid_tactics(self, inputs: List[torch.Tensor],
+                          profile: OptimizationProfile, **kwargs) -> List[int]:
+        return [-1, *range(self.mxfp8_gemm_runner.get_num_configs())]
+
+    def sync_tactic_cache(self, tuner: AutoTuner) -> None:
+        runner_name = self.__class__.__name__
+        unique_id = str(self.unique_id())
+        cache = tuner.profiling_cache.get_specific_custom_op(
+            _MXFP8_AUTOTUNED_OP)
+        for cache_key, (_runner_id, tactic, _min_time) in cache.items():
+            _, cached_runner_name, cached_unique_id, profile = cache_key
+            if cached_runner_name != runner_name or cached_unique_id != unique_id:
+                continue
+            m, k = profile[0]
+            n, weight_k = profile[2]
+            if k != weight_k:
+                raise ValueError(
+                    f"MXFP8 autotuner cache has mismatched K dimensions: "
+                    f"activation K={k}, weight K={weight_k}")
+            self.mxfp8_gemm_runner.register_tactic(m, n, k, tactic)
+
+    def forward(
+        self,
+        inputs: List[torch.Tensor],
+        tactic: int = -1,
+    ) -> torch.Tensor:
+        act, act_scale, weight, weight_scale, global_scale = inputs
+        return self.mxfp8_gemm_runner.run_gemm(
+            act,
+            act_scale,
+            weight,
+            weight_scale,
+            global_scale,
+            tactic,
+        )
+
+
+@torch.library.custom_op("trtllm::mxfp8_mxfp8_gemm_autotuned", mutates_args=())
+def mxfp8_mxfp8_gemm_autotuned(
+    act: torch.Tensor,
+    act_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    tuner = AutoTuner.get()
+    runner = MXFP8GemmRunner(output_dtype)
+    inputs = [act, act_scale, weight, weight_scale, global_scale]
+    _, best_tactic = tuner.choose_one(
+        _MXFP8_AUTOTUNED_OP,
+        [runner],
+        MXFP8GemmRunner.tuning_config,
+        inputs,
+    )
+    if tuner.is_tuning_mode:
+        runner.sync_tactic_cache(tuner)
+    return runner(inputs=inputs, tactic=best_tactic)
+
+
+@mxfp8_mxfp8_gemm_autotuned.register_fake
+def _(
+    act: torch.Tensor,
+    act_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    return act.new_empty((act.size(0), weight.size(0)), dtype=output_dtype)
+
+
 class FP4GemmRunner(TunableRunner):
     runner_dict = dict()
     tuning_config = TuningConfig(dynamic_tensor_specs=(DynamicTensorSpec(

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -3004,6 +3004,10 @@ class MXFP8LinearMethod(LinearMethodBase):
     ``TRTLLM_MXFP8_GEMM_BACKEND`` can explicitly select ``trtllm``,
     ``flashinfer``, or ``auto``. The reference layout is 2D [O,K/32]; both
     compiled backends consume the same 1D padded swizzled scale layout.
+    When the TensorRT-LLM autotuner is enabled, the native backend profiles
+    its compiled tactics during startup. Learned tactics are registered in
+    the native op so serving avoids the Python autotuner lookup; the generic
+    CUTLASS configuration remains the cache-miss fallback.
     """
     BLOCK_SIZE = 32
     # Swizzled-SF layout padding (matches W4A8MXFP4FP8: rows->128, cols/SFblock->4).
@@ -3014,6 +3018,8 @@ class MXFP8LinearMethod(LinearMethodBase):
         super().__init__()
         self.use_cutlass = _mxfp8_cutlass_op_available()
         self.backend = os.environ.get("TRTLLM_MXFP8_GEMM_BACKEND", "trtllm")
+        self.use_native_autotuner = True
+        self._native_autotuned = False
         if self.backend not in ("trtllm", "flashinfer", "auto"):
             raise ValueError("TRTLLM_MXFP8_GEMM_BACKEND must be 'trtllm', "
                              f"'flashinfer', or 'auto', got {self.backend!r}")
@@ -3032,6 +3038,11 @@ class MXFP8LinearMethod(LinearMethodBase):
     @property
     def needs_flashinfer_autotune(self) -> bool:
         return self.uses_flashinfer and self._flashinfer_mxfp8 is not None
+
+    @property
+    def needs_native_autotune(self) -> bool:
+        return (self.use_native_autotuner and not self._native_autotuned
+                and self.use_cutlass and self.backend == "trtllm")
 
     def _load_flashinfer(self, *, required: bool) -> bool:
         if not self.use_cutlass:
@@ -3066,6 +3077,13 @@ class MXFP8LinearMethod(LinearMethodBase):
 
     def mark_flashinfer_autotuned(self) -> None:
         self._flashinfer_autotuned = True
+
+    def mark_native_autotuned(self) -> None:
+        self._native_autotuned = True
+
+    def disable_native_autotune(self) -> None:
+        self.use_native_autotuner = False
+        self._native_autotuned = False
 
     def disable_flashinfer_auto(self) -> None:
         if self.backend == "auto":
@@ -3138,7 +3156,10 @@ class MXFP8LinearMethod(LinearMethodBase):
                 global_scale = torch.ones([1],
                                           dtype=torch.float32,
                                           device=input.device)
-                output = torch.ops.trtllm.mxfp8_mxfp8_gemm(
+                gemm = (torch.ops.trtllm.mxfp8_mxfp8_gemm_autotuned
+                        if self.needs_native_autotune else
+                        torch.ops.trtllm.mxfp8_mxfp8_gemm)
+                output = gemm(
                     act_e4m3,
                     act_sf,
                     module.weight,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1317,6 +1317,7 @@ class PyTorchModelEngine(ModelEngine):
                 getattr(module, "_use_flashinfer_mxfp8_decode_graph_default",
                         False) for module in self.model.modules()))
         flashinfer_mxfp8_methods = []
+        native_mxfp8_methods = []
         for module in self.model.modules():
             quant_method = getattr(module, "quant_method", None)
             if not isinstance(quant_method, MXFP8LinearMethod):
@@ -1325,7 +1326,12 @@ class PyTorchModelEngine(ModelEngine):
                 quant_method.enable_flashinfer_auto()
             if quant_method.needs_flashinfer_autotune:
                 flashinfer_mxfp8_methods.append(quant_method)
+            if enable_trtllm_autotuner and quant_method.needs_native_autotune:
+                native_mxfp8_methods.append(quant_method)
+            elif not enable_trtllm_autotuner:
+                quant_method.disable_native_autotune()
         enable_flashinfer_mxfp8_autotuner = bool(flashinfer_mxfp8_methods)
+        enable_native_mxfp8_autotuner = bool(native_mxfp8_methods)
 
         if not enable_trtllm_autotuner and not enable_flashinfer_mxfp8_autotuner:
             return
@@ -1333,6 +1339,7 @@ class PyTorchModelEngine(ModelEngine):
             AutoTuner.get().setup_distributed_state(self.mapping, self.dist)
         logger.info(
             f"Running autotuner warmup (TRT-LLM={enable_trtllm_autotuner}, "
+            f"native MXFP8={enable_native_mxfp8_autotuner}, "
             f"FlashInfer MXFP8={enable_flashinfer_mxfp8_autotuner})...")
         kv_cache_manager = resource_manager.get_resource_manager(
             self.kv_cache_manager_key)
@@ -1402,6 +1409,15 @@ class PyTorchModelEngine(ModelEngine):
                 logger.warning(
                     "FlashInfer MXFP8 autotuning could not run; using the native "
                     "TensorRT-LLM GEMM backend.")
+
+        if enable_native_mxfp8_autotuner:
+            if ran_forward:
+                for method in native_mxfp8_methods:
+                    method.mark_native_autotuned()
+            else:
+                logger.warning(
+                    "Native MXFP8 autotuning had no runnable warmup batch; "
+                    "leaving tuning pending for a later warmup.")
 
         if enable_trtllm_autotuner:
             logger.info(

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
@@ -291,6 +291,113 @@ class TestWarmupCleanup(unittest.TestCase):
         self.assertTrue(method._flashinfer_autotuned)
         flashinfer_autotuner_module.autotune.assert_called_once_with()
 
+    def test_native_mxfp8_retries_after_missing_warmup_batch(self):
+        """MXFP8 tuning remains pending until a warmup forward can run."""
+        calls = []
+
+        @contextlib.contextmanager
+        def trtllm_autotune(**kwargs):
+            self.assertIsNone(kwargs["cache_path"])
+            calls.append("autotune_enter")
+            yield
+            calls.append("autotune_exit")
+
+        tuner = SimpleNamespace(
+            setup_distributed_state=Mock(),
+            cache_pp_recv=Mock(),
+            cache_pp_send=Mock(),
+            clean_pp_flag=Mock(),
+            profiling_cache={},
+            print_profiling_cache=Mock(),
+        )
+
+        with patch(
+            "tensorrt_llm._torch.modules.linear._mxfp8_cutlass_op_available",
+            return_value=True,
+        ):
+            method = MXFP8LinearMethod()
+            self.assertTrue(method.needs_native_autotune)
+
+            engine = SimpleNamespace(
+                llm_args=SimpleNamespace(enable_autotuner=True),
+                cuda_graph_runner=SimpleNamespace(enabled=False),
+                model=SimpleNamespace(modules=lambda: [SimpleNamespace(quant_method=method)]),
+                kv_cache_manager_key="kv_cache",
+                max_num_tokens=16,
+                batch_size=16,
+                max_seq_len=2,
+                original_max_draft_len=0,
+                mapping=SimpleNamespace(tp_size=1),
+                dist=object(),
+                is_draft_model=False,
+                no_cuda_graph=lambda: contextlib.nullcontext(),
+                _create_warmup_request=Mock(return_value=object()),
+                _release_batch_context=Mock(
+                    side_effect=[
+                        contextlib.nullcontext(None),
+                        contextlib.nullcontext(object()),
+                    ]
+                ),
+                _assert_all_tp_ranks_have_warmup_batch=Mock(),
+                forward=Mock(side_effect=lambda *args, **kwargs: calls.append("forward")),
+            )
+            kv_cache_manager = SimpleNamespace(get_num_available_tokens=lambda **kwargs: 16)
+            resource_manager = SimpleNamespace(
+                get_resource_manager=lambda key: (kv_cache_manager if key == "kv_cache" else None)
+            )
+
+            with (
+                patch(
+                    "tensorrt_llm._torch.pyexecutor.model_engine.AutoTuner.get",
+                    return_value=tuner,
+                ),
+                patch(
+                    "tensorrt_llm._torch.pyexecutor.model_engine.autotune",
+                    side_effect=trtllm_autotune,
+                ),
+                patch("torch.cuda.synchronize"),
+                patch("torch.cuda.empty_cache"),
+                patch("tensorrt_llm._torch.pyexecutor.model_engine.clear_memory_buffers"),
+            ):
+                PyTorchModelEngine._run_autotuner_warmup(engine, resource_manager)
+                self.assertEqual(calls, ["autotune_enter", "autotune_exit"])
+                self.assertFalse(method._native_autotuned)
+                self.assertTrue(method.needs_native_autotune)
+
+                PyTorchModelEngine._run_autotuner_warmup(engine, resource_manager)
+
+        self.assertEqual(
+            calls,
+            [
+                "autotune_enter",
+                "autotune_exit",
+                "autotune_enter",
+                "forward",
+                "autotune_exit",
+            ],
+        )
+        self.assertTrue(method._native_autotuned)
+        self.assertFalse(method.needs_native_autotune)
+        self.assertEqual(tuner.setup_distributed_state.call_count, 2)
+        tuner.setup_distributed_state.assert_called_with(engine.mapping, engine.dist)
+
+    def test_native_mxfp8_respects_disabled_global_autotuner(self):
+        with patch(
+            "tensorrt_llm._torch.modules.linear._mxfp8_cutlass_op_available",
+            return_value=True,
+        ):
+            method = MXFP8LinearMethod()
+            engine = SimpleNamespace(
+                llm_args=SimpleNamespace(enable_autotuner=False),
+                cuda_graph_runner=SimpleNamespace(enabled=False),
+                model=SimpleNamespace(modules=lambda: [SimpleNamespace(quant_method=method)]),
+            )
+
+            PyTorchModelEngine._run_autotuner_warmup(engine, Mock())
+
+        self.assertFalse(method.use_native_autotuner)
+        self.assertFalse(method.needs_native_autotune)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest/_torch/modules/test_mxfp8_linear.py
+++ b/tests/unittest/_torch/modules/test_mxfp8_linear.py
@@ -21,6 +21,12 @@ import pytest
 import torch
 
 import tensorrt_llm._torch.modules.linear as linear_module
+from tensorrt_llm._torch.autotuner import AutoTuner
+from tensorrt_llm._torch.custom_ops.torch_custom_ops import (
+    MXFP8GemmRunner,
+    _get_mxfp8_large_m_tuning_buckets,
+    _map_to_mxfp8_large_m_bucket,
+)
 from tensorrt_llm._torch.modules.linear import (
     Linear,
     MXFP8LinearMethod,
@@ -62,6 +68,7 @@ def test_mxfp8_dispatch_returns_mxfp8_method(monkeypatch):
     method = get_quant_method(qc)
     assert isinstance(method, MXFP8LinearMethod)
     assert method.backend == "trtllm"
+    assert method.use_native_autotuner
 
 
 def _mock_mxfp8_ops(monkeypatch):
@@ -70,9 +77,23 @@ def _mock_mxfp8_ops(monkeypatch):
     quantize = Mock(return_value=(quantized, activation_scale))
     native_output = torch.empty((2, 3), dtype=torch.bfloat16)
     native_gemm = Mock(return_value=native_output)
-    fake_trtllm_ops = SimpleNamespace(mxfp8_quantize=quantize, mxfp8_mxfp8_gemm=native_gemm)
+    autotuned_output = torch.empty((2, 3), dtype=torch.bfloat16)
+    autotuned_gemm = Mock(return_value=autotuned_output)
+    fake_trtllm_ops = SimpleNamespace(
+        mxfp8_quantize=quantize,
+        mxfp8_mxfp8_gemm=native_gemm,
+        mxfp8_mxfp8_gemm_autotuned=autotuned_gemm,
+    )
     monkeypatch.setattr(linear_module.torch, "ops", SimpleNamespace(trtllm=fake_trtllm_ops))
-    return quantized, activation_scale, quantize, native_gemm, native_output
+    return (
+        quantized,
+        activation_scale,
+        quantize,
+        native_gemm,
+        native_output,
+        autotuned_gemm,
+        autotuned_output,
+    )
 
 
 def test_mxfp8_flashinfer_call_contract(monkeypatch):
@@ -83,7 +104,7 @@ def test_mxfp8_flashinfer_call_contract(monkeypatch):
     expected = torch.empty((2, 3), dtype=torch.bfloat16)
     mm_mxfp8 = Mock(return_value=expected)
     monkeypatch.setitem(sys.modules, "flashinfer", SimpleNamespace(mm_mxfp8=mm_mxfp8))
-    quantized, activation_scale, quantize, _, _ = _mock_mxfp8_ops(monkeypatch)
+    quantized, activation_scale, quantize, _, _, _, _ = _mock_mxfp8_ops(monkeypatch)
 
     weight = torch.empty((3, 4), dtype=torch.float8_e4m3fn)
     weight_scale = torch.empty(512, dtype=torch.uint8)
@@ -116,7 +137,7 @@ def test_mxfp8_auto_keeps_eager_native_and_captures_flashinfer(monkeypatch):
     flashinfer_output = torch.empty((2, 3), dtype=torch.bfloat16)
     mm_mxfp8 = Mock(return_value=flashinfer_output)
     monkeypatch.setitem(sys.modules, "flashinfer", SimpleNamespace(mm_mxfp8=mm_mxfp8))
-    _, _, _, native_gemm, native_output = _mock_mxfp8_ops(monkeypatch)
+    _, _, _, native_gemm, native_output, _, _ = _mock_mxfp8_ops(monkeypatch)
 
     module = SimpleNamespace(
         weight=torch.empty((3, 4), dtype=torch.float8_e4m3fn),
@@ -139,6 +160,117 @@ def test_mxfp8_auto_keeps_eager_native_and_captures_flashinfer(monkeypatch):
     # Leaving the decode-capture scope restores the eager/native path.
     assert method.apply(module, activation, bias=None) is native_output
     assert native_gemm.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "num_tokens,expected",
+    [
+        (1, 1),
+        (6552, 6552),
+        (6553, 8192),
+        (8192, 8192),
+        (8193, 8193),
+        (13105, 13105),
+        (13106, 16384),
+        (16384, 16384),
+        (16385, 16385),
+        (19658, 19658),
+        (19659, 32768),
+        (32768, 32768),
+        (32769, 32769),
+    ],
+)
+def test_mxfp8_large_m_bucket_mapping(num_tokens, expected):
+    assert _map_to_mxfp8_large_m_bucket(num_tokens) == expected
+
+
+@pytest.mark.parametrize(
+    "max_num_tokens,expected",
+    [
+        (4096, ()),
+        (6599, (8192,)),
+        (14906, (8192, 16384)),
+        (29765, (8192, 16384, 32768)),
+    ],
+)
+def test_mxfp8_large_m_tuning_buckets(max_num_tokens, expected):
+    assert _get_mxfp8_large_m_tuning_buckets(max_num_tokens) == expected
+
+
+def test_mxfp8_large_m_cache_profile_maps_act_and_constrains_scale():
+    AutoTuner._find_nearest_profile.cache_clear()
+    input_shapes = (
+        torch.Size((6599, 6144)),
+        torch.Size((1277952,)),
+        torch.Size((9216, 6144)),
+        torch.Size((1769472,)),
+        torch.Size((1,)),
+    )
+    profile = AutoTuner._find_nearest_profile(
+        input_shapes,
+        MXFP8GemmRunner.tuning_config.dynamic_tensor_specs,
+        MXFP8GemmRunner.tuning_config.constraint_specs,
+    )
+    assert profile == (
+        (8192, 6144),
+        (-1,),
+        (9216, 6144),
+        (1769472,),
+        (1,),
+    )
+
+
+def test_mxfp8_native_autotuner_dispatch(monkeypatch):
+    monkeypatch.setattr(linear_module, "_mxfp8_cutlass_op_available", lambda: True)
+    _, _, _, native_gemm, native_output, autotuned_gemm, autotuned_output = _mock_mxfp8_ops(
+        monkeypatch
+    )
+
+    module = SimpleNamespace(
+        weight=torch.empty((3, 4), dtype=torch.float8_e4m3fn),
+        weight_scale=torch.empty(512, dtype=torch.uint8),
+        dtype=torch.bfloat16,
+    )
+    activation = torch.randn((2, 4), dtype=torch.bfloat16)
+
+    method = MXFP8LinearMethod()
+    assert method.use_native_autotuner
+    assert method.needs_native_autotune
+    assert method.apply(module, activation, bias=None) is autotuned_output
+    autotuned_gemm.assert_called_once()
+    native_gemm.assert_not_called()
+
+    method.mark_native_autotuned()
+    assert not method.needs_native_autotune
+    assert method.apply(module, activation, bias=None) is native_output
+    autotuned_gemm.assert_called_once()
+    native_gemm.assert_called_once()
+
+
+def test_mxfp8_native_autotuner_syncs_profiles():
+    runner = object.__new__(MXFP8GemmRunner)
+    runner.output_dtype = torch.bfloat16
+    runner.sm_version = 100
+    runner.mxfp8_gemm_runner = Mock()
+    profile = (
+        (8192, 6144),
+        (-1,),
+        (9216, 6144),
+        (1769472,),
+        (1,),
+    )
+    cache_key = (
+        "trtllm::mxfp8_mxfp8_gemm_autotuned::gemm",
+        "MXFP8GemmRunner",
+        str(runner.unique_id()),
+        profile,
+    )
+    profiling_cache = Mock()
+    profiling_cache.get_specific_custom_op.return_value = {cache_key: (0, 17, 0.25)}
+
+    runner.sync_tactic_cache(SimpleNamespace(profiling_cache=profiling_cache))
+
+    runner.mxfp8_gemm_runner.register_tactic.assert_called_once_with(8192, 9216, 6144, 17)
 
 
 def test_mxfp8_rejects_unknown_backend(monkeypatch):

--- a/tests/unittest/_torch/thop/parallel/test_mxfp8_mxfp8_gemm.py
+++ b/tests/unittest/_torch/thop/parallel/test_mxfp8_mxfp8_gemm.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import torch.nn.functional as F
+from utils.util import getSMVersion
+
+import tensorrt_llm._torch.custom_ops.torch_custom_ops  # noqa: F401
+
+
+@pytest.mark.skipif(
+    getSMVersion() not in (100, 103),
+    reason="MXFP8 GEMM is supported on SM100 and SM103 only. Current SM is %d." % getSMVersion(),
+)
+@pytest.mark.parametrize(
+    "m,n,k",
+    [
+        (6599, 9216, 6144),
+        (6599, 6144, 3072),
+        (14906, 6144, 8192),
+        (14906, 6144, 6144),
+        (29765, 24576, 6144),
+        (29765, 6144, 12288),
+        (8193, 9216, 6144),
+    ],
+)
+def test_mxfp8_mxfp8_gemm_large_m(m: int, n: int, k: int):
+    """The generic fallback agrees with BF16 GEMM for representative shapes."""
+    torch.manual_seed(42)
+    mat_a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    mat_b = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+
+    fp8_a, a_block_sf = torch.ops.trtllm.mxfp8_quantize(mat_a, True)
+    fp8_b, b_block_sf = torch.ops.trtllm.mxfp8_quantize(mat_b, True)
+    global_scale = torch.ones((1,), device="cuda", dtype=torch.float32)
+
+    output = torch.ops.trtllm.mxfp8_mxfp8_gemm(
+        fp8_a,
+        a_block_sf,
+        fp8_b,
+        b_block_sf,
+        global_scale,
+        torch.bfloat16,
+    )
+    output_ref = mat_a @ mat_b.t()
+
+    assert F.cosine_similarity(output.flatten(), output_ref.flatten(), dim=0).item() > 0.98
+
+
+@pytest.mark.skipif(
+    getSMVersion() not in (100, 103),
+    reason="MXFP8 tactic runner requires SM100 or SM103. Current SM is %d." % getSMVersion(),
+)
+def test_mxfp8_mxfp8_runner_tactics():
+    """Every exposed tactic and the generic fallback produce aligned output."""
+    torch.manual_seed(42)
+    m, n, k = 128, 256, 512
+    mat_a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    mat_b = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    fp8_a, a_block_sf = torch.ops.trtllm.mxfp8_quantize(mat_a, True)
+    fp8_b, b_block_sf = torch.ops.trtllm.mxfp8_quantize(mat_b, True)
+    global_scale = torch.ones((1,), device="cuda", dtype=torch.float32)
+    output_ref = mat_a @ mat_b.t()
+
+    runner = torch.classes.trtllm.MXFP8GemmRunner(torch.bfloat16)
+    expected_tactics = 20 if getSMVersion() == 100 else 10
+    assert runner.get_num_configs() == expected_tactics
+
+    for tactic in [-1, *range(expected_tactics)]:
+        output = runner.run_gemm(
+            fp8_a,
+            a_block_sf,
+            fp8_b,
+            b_block_sf,
+            global_scale,
+            tactic,
+        )
+        similarity = F.cosine_similarity(output.flatten(), output_ref.flatten(), dim=0)
+        assert similarity.item() > 0.98
+
+
+@pytest.mark.skipif(
+    getSMVersion() not in (100, 103),
+    reason="MXFP8 tactic cache requires SM100 or SM103. Current SM is %d." % getSMVersion(),
+)
+def test_mxfp8_mxfp8_native_tactic_cache():
+    """The direct op uses cached tactics and preserves the generic fallback."""
+    torch.manual_seed(42)
+    m, n, k = 128, 256, 512
+    mat_a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    mat_b = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+    fp8_a, a_block_sf = torch.ops.trtllm.mxfp8_quantize(mat_a, True)
+    fp8_b, b_block_sf = torch.ops.trtllm.mxfp8_quantize(mat_b, True)
+    global_scale = torch.ones((1,), device="cuda", dtype=torch.float32)
+    runner = torch.classes.trtllm.MXFP8GemmRunner(torch.bfloat16)
+
+    try:
+        runner.clear_tactic_cache()
+        assert runner.get_cached_tactic(m, n, k) == -2
+
+        runner.register_tactic(m, n, k, 0)
+        assert runner.get_cached_tactic(m, n, k) == 0
+        cached_output = torch.ops.trtllm.mxfp8_mxfp8_gemm(
+            fp8_a,
+            a_block_sf,
+            fp8_b,
+            b_block_sf,
+            global_scale,
+            torch.bfloat16,
+        )
+        explicit_output = runner.run_gemm(
+            fp8_a,
+            a_block_sf,
+            fp8_b,
+            b_block_sf,
+            global_scale,
+            0,
+        )
+        torch.testing.assert_close(cached_output, explicit_output, rtol=0, atol=0)
+
+        runner.register_tactic(m, n, k, -1)
+        assert runner.get_cached_tactic(m, n, k) == -1
+        cached_fallback_output = torch.ops.trtllm.mxfp8_mxfp8_gemm(
+            fp8_a,
+            a_block_sf,
+            fp8_b,
+            b_block_sf,
+            global_scale,
+            torch.bfloat16,
+        )
+        explicit_fallback_output = runner.run_gemm(
+            fp8_a,
+            a_block_sf,
+            fp8_b,
+            b_block_sf,
+            global_scale,
+            -1,
+        )
+        torch.testing.assert_close(cached_fallback_output, explicit_fallback_output, rtol=0, atol=0)
+    finally:
+        runner.clear_tactic_cache()


### PR DESCRIPTION
@coderabbitai summary

## Description

The native MXFP8 x MXFP8 GEMM path currently uses one fixed CUTLASS
configuration for every shape. This change profiles the compiled MXFP8
CUTLASS portfolio during the standard TensorRT-LLM startup autotuner and
registers the selected configurations in a process-local C++ cache keyed by
GPU architecture, output dtype, packed-M bucket, N, and K.

Steady-state serving dispatches directly through the native cache without a
Python lookup. Disabling the autotuner or missing the cache retains the
existing generic CUTLASS fallback. This adds no dependency or model-specific
dispatch table.

### Serving results

The table compares the autotuner against the original untuned/default path.
All measurements use MiniMax-M3 disaggregated 2P8D c256 serving with random
8K input and 1K output requests, a 32K CTX `max_num_tokens` cap, and 2,560
requests. Only the CTX image changed; GEN, disaggregator, workload, and
configuration remained fixed. Both arms completed exactly 18,964,292 input
and 2,361,479 output tokens.

| GPU | Total-token throughput | Median TTFT | Median TPOT | Median E2EL |
|---|---:|---:|---:|---:|
| GB300 / SM103 | **+3.92%** | **-8.00%** | **-0.98%** | **-3.94%** |

Positive throughput and negative latency values are improvements.

## Test Coverage

- Exact amended commit `971660629d2bad319150a1317ff34d97ea80dc97`
  compiled for SM100 in Lyris job `2487622` (`0:0`). Wheel SHA-256:
  `8247b61116e072c961f52fbd327aecebe6292aaa05830f72a63b36e575896d47`.
- Installed-wheel and native cache validation job `2487793` completed `0:0`;
  the full MXFP8 warmup test file passed `6/6`.
- Candidate SQSH packaging job `2487910` and independent saved-image cache
  smoke `2487920` completed `0:0`.
- Direct GB300 default-versus-autotuned E2E serving: control `2487974`,
  candidate `2487975`.
- Both candidates completed a 32K warmup with native MXFP8 autotuning enabled,
  populated 33 autotuner cache entries on each rank, and had no post-warmup
  MXFP8 cache misses.
- Python 3.12 syntax and changed-file `isort`, YAPF, clang-format, codespell,
  Ruff, and Ruff-format checks pass.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
