### PR TITLE
[None][feat] Multimodal encoder cache: per-item partial hits

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -711,7 +711,6 @@ class Mistral3VLM(MultimodalModelMixin, PreTrainedModel):
     """
 
     supports_encoder_cache = True
-    supports_granular_encoder_cache = True
 
     def __init__(
         self,
@@ -862,31 +861,6 @@ class Mistral3VLM(MultimodalModelMixin, PreTrainedModel):
     ) -> torch.Tensor:
         mm_embeds = self._vision_forward(list(multimodal_params))
         return mm_embeds[0]
-
-    def slice_multimodal_data_items(
-        self,
-        param: MultimodalParams,
-        item_indices: Sequence[int],
-    ) -> MultimodalParams:
-        # One item == one image. `pixel_values` is `[B, C, H, W]` with B parallel to
-        # `image_sizes` (a Python list of `[h, w]`), so both are sliced along the item axis.
-        src_image = param.multimodal_data["image"]
-        indices = list(item_indices)
-        sliced_image = {
-            **src_image,
-            "pixel_values": src_image["pixel_values"][indices],
-            "image_sizes": [src_image["image_sizes"][i] for i in indices],
-        }
-        new_multimodal_data = {**param.multimodal_data, "image": sliced_image}
-
-        # Shallow-copy `multimodal_input` so the mixin's metadata slice can rewrite
-        # `multimodal_hashes` on the residual without mutating the source.
-        residual_input = (copy.copy(param.multimodal_input)
-                          if param.multimodal_input is not None else None)
-        return MultimodalParams(
-            multimodal_data=new_multimodal_data,
-            multimodal_input=residual_input,
-        )
 
     def get_language_model_forward_kwargs(
         self,

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -711,6 +711,7 @@ class Mistral3VLM(MultimodalModelMixin, PreTrainedModel):
     """
 
     supports_encoder_cache = True
+    supports_granular_encoder_cache = True
 
     def __init__(
         self,
@@ -861,6 +862,31 @@ class Mistral3VLM(MultimodalModelMixin, PreTrainedModel):
     ) -> torch.Tensor:
         mm_embeds = self._vision_forward(list(multimodal_params))
         return mm_embeds[0]
+
+    def slice_multimodal_data_items(
+        self,
+        param: MultimodalParams,
+        item_indices: Sequence[int],
+    ) -> MultimodalParams:
+        # One item == one image. `pixel_values` is `[B, C, H, W]` with B parallel to
+        # `image_sizes` (a Python list of `[h, w]`), so both are sliced along the item axis.
+        src_image = param.multimodal_data["image"]
+        indices = list(item_indices)
+        sliced_image = {
+            **src_image,
+            "pixel_values": src_image["pixel_values"][indices],
+            "image_sizes": [src_image["image_sizes"][i] for i in indices],
+        }
+        new_multimodal_data = {**param.multimodal_data, "image": sliced_image}
+
+        # Shallow-copy `multimodal_input` so the mixin's metadata slice can rewrite
+        # `multimodal_hashes` on the residual without mutating the source.
+        residual_input = (copy.copy(param.multimodal_input)
+                          if param.multimodal_input is not None else None)
+        return MultimodalParams(
+            multimodal_data=new_multimodal_data,
+            multimodal_input=residual_input,
+        )
 
     def get_language_model_forward_kwargs(
         self,

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -503,9 +503,21 @@ class MultimodalModelMixin:
         ):
             # Stacked layout: dim-0 select from `pixel_values` and list-index `image_sizes`.
             n_items = modality_data["pixel_values"].shape[0]
+            miss_sizes = [modality_data["image_sizes"][i] for i in indices]
+            miss_pixel = modality_data["pixel_values"][indices]
+            # `pixel_values` was padded to the request-wide max H/W by the input
+            # processor. After keeping only the miss subset, crop the trailing H/W back
+            # down to that subset's own max true size -- otherwise a downstream re-batch
+            # step (e.g. Mistral 3's `batch_pixel_values`) that pads to
+            # `max(residual.image_sizes)` would compute a negative pad amount whenever
+            # the omitted items were the largest in the original request.
+            if miss_sizes and miss_pixel.dim() >= 4:
+                max_h = max(int(s[0]) for s in miss_sizes)
+                max_w = max(int(s[1]) for s in miss_sizes)
+                miss_pixel = miss_pixel[..., :max_h, :max_w]
             sliced = {
-                "pixel_values": modality_data["pixel_values"][indices],
-                "image_sizes": [modality_data["image_sizes"][i] for i in indices],
+                "pixel_values": miss_pixel,
+                "image_sizes": miss_sizes,
             }
         else:
             raise NotImplementedError(

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import copy
 import itertools
 from dataclasses import dataclass
 from typing import (
@@ -319,22 +320,14 @@ class MultimodalModelMixin:
 
     * For the time being, the persistent multimodal encoder cache stores per-item embeddings for
       single-modality `MultimodalParams` objects. Mixed-modality objects bypass the cache.
-    * Per-item cache reuse is all-or-nothing by default. Models can opt into partial reuse by
-      implementing `slice_multimodal_data_items` and setting
-      `supports_granular_encoder_cache = True`; miss items are re-encoded and interleaved with
-      cached items in original per-item order.
+    * A partially cached `MultimodalParams` is handled by encoding only its miss items
+      and interleaving cached items back in original per-item order. The default
+      `build_multimodal_encoder_input` handles stacked-on-dim-0 and packed-with-grid-thw
+      layouts; models with other layouts override that method.
     """
 
     supports_encoder_cache: ClassVar[bool] = False
     """Whether the model's production forward path uses the persistent encoder cache."""
-
-    supports_granular_encoder_cache: ClassVar[bool] = False
-    """Whether the mixin may reuse a partial cache hit for this model.
-
-    When True, a partially cached `MultimodalParams` is handled by encoding only its miss
-    items and interleaving cached items back in per-item order. Requires the model to
-    implement `slice_multimodal_data_items`.
-    """
 
     model_config: ModelConfig
     _multimodal_encoder_cache: Optional[TensorLRUCache] = None
@@ -451,7 +444,7 @@ class MultimodalModelMixin:
         # them as extra embeds without changing the base flow.
         return active_embeddings, ()
 
-    def slice_multimodal_data_items(
+    def build_multimodal_encoder_input(
         self,
         param: MultimodalParams,
         item_indices: Sequence[int],
@@ -459,12 +452,72 @@ class MultimodalModelMixin:
         """Return a `MultimodalParams` whose raw modality inputs contain only
         `item_indices` from `param`, in that order.
 
-        Only the model knows how to slice its own modality tensors (`pixel_values`,
-        `image_grid_thw`, packed audio features, ...). The parallel per-item metadata
+        Default handles two common single-modality layouts:
+
+        - Stacked on dim 0 (Mistral 3 / Pixtral / LLaVA-family): `pixel_values`
+          `[B, C, H, W]` with a parallel `image_sizes` list; both sliced by item.
+        - Packed with `*_grid_thw` offsets (Qwen2-VL family): `pixel_values`
+          `[total_patches, feat]` + `image_grid_thw` `[B, 3]`; prefix-summed patch
+          counts locate each item's slice, and `image_grid_thw` is sliced in parallel.
+
+        Models with a different layout (e.g. mixed-modality per param, custom packed
+        formats) override this method. The parallel per-item metadata
         (`multimodal_embedding_lengths`, `multimodal_hashes`) is re-sliced by the mixin
-        after this returns, so implementations should focus on modality data only.
+        after this returns, so overrides need only handle modality data.
         """
-        raise NotImplementedError
+        modality = self._encoder_cache_modality(param)
+        if modality is None:
+            raise NotImplementedError(
+                "Default `build_multimodal_encoder_input` only supports single-modality "
+                "params. Override for other layouts."
+            )
+        modality_data = param.multimodal_data[modality]
+        if not isinstance(modality_data, dict):
+            raise TypeError(
+                f"multimodal_data[{modality!r}] must be a dict, got {type(modality_data).__name__}"
+            )
+
+        indices = list(item_indices)
+        grid_key = {"image": "image_grid_thw", "video": "video_grid_thw"}.get(modality)
+        pixel_key = {"image": "pixel_values", "video": "pixel_values_videos"}.get(modality)
+
+        if grid_key and pixel_key and grid_key in modality_data and pixel_key in modality_data:
+            # Packed layout: prefix-sum patch counts to locate each item's slab, then
+            # concat the requested subset in item-index order.
+            grids = modality_data[grid_key]
+            patch_counts = [int(c) for c in torch.prod(grids, dim=1).tolist()]
+            per_item = torch.split(modality_data[pixel_key], patch_counts, dim=0)
+            sliced = {
+                **modality_data,
+                pixel_key: torch.cat([per_item[i] for i in indices], dim=0),
+                grid_key: grids[indices],
+            }
+        elif (
+            modality == "image"
+            and "pixel_values" in modality_data
+            and "image_sizes" in modality_data
+        ):
+            # Stacked layout: dim-0 select from `pixel_values` and list-index `image_sizes`.
+            sliced = {
+                **modality_data,
+                "pixel_values": modality_data["pixel_values"][indices],
+                "image_sizes": [modality_data["image_sizes"][i] for i in indices],
+            }
+        else:
+            raise NotImplementedError(
+                f"Default `build_multimodal_encoder_input` cannot slice {modality} layout "
+                f"with fields {sorted(modality_data)}; override this method."
+            )
+
+        # Shallow-copy `multimodal_input` so `_apply_metadata_slice` can rewrite
+        # `multimodal_hashes` on the residual without mutating the source.
+        residual_input = (
+            copy.copy(param.multimodal_input) if param.multimodal_input is not None else None
+        )
+        return MultimodalParams(
+            multimodal_data={**param.multimodal_data, modality: sliced},
+            multimodal_input=residual_input,
+        )
 
     # A future optional mixin-owned forward can build on the same template method.
     def prepare_multimodal_inputs(
@@ -546,19 +599,16 @@ class MultimodalModelMixin:
                     # The forward that attached this request-local embedding already populated the
                     # persistent cache.
                     continue
-                partition = self._partition_encoder_cache(param, encoder_cache)
+                partition = self.partition_encoder_cache(param, encoder_cache)
                 if partition is None or partition.is_full_miss:
                     cache_misses.append(param)
                     continue
                 if partition.is_full_hit:
-                    param.multimodal_data["multimodal_embedding"] = self._assemble_full_embedding(
+                    param.multimodal_data["multimodal_embedding"] = self.assemble_full_embedding(
                         partition.hits, len(partition.keys)
                     )
                     continue
-                if self.supports_granular_encoder_cache:
-                    partial_hits.append((param, partition))
-                else:
-                    cache_misses.append(param)
+                partial_hits.append((param, partition))
 
         if partial_hits:
             # `encoder_cache` is non-None here because partitions are only produced when the cache
@@ -719,7 +769,7 @@ class MultimodalModelMixin:
         ]
 
     @classmethod
-    def _partition_encoder_cache(
+    def partition_encoder_cache(
         cls,
         param: MultimodalParams,
         encoder_cache: TensorLRUCache,
@@ -756,7 +806,7 @@ class MultimodalModelMixin:
         return EncoderCachePartition(hits=hits, miss_indices=miss_indices, keys=keys)
 
     @staticmethod
-    def _assemble_full_embedding(
+    def assemble_full_embedding(
         item_tensors: Dict[int, torch.Tensor],
         total_items: int,
     ) -> torch.Tensor:
@@ -776,7 +826,7 @@ class MultimodalModelMixin:
     ) -> None:
         """Overwrite `residual`'s per-item metadata to match the sliced items.
 
-        Models slice raw modality tensors in `slice_multimodal_data_items`; the mixin owns
+        Models slice raw modality tensors in `build_multimodal_encoder_input`; the mixin owns
         the parallel per-item metadata slice so every model gets it identically.
         """
         source_lengths = source.multimodal_data["multimodal_embedding_lengths"]
@@ -799,7 +849,7 @@ class MultimodalModelMixin:
         cached.
         """
         for param, partition in partials:
-            residual = self.slice_multimodal_data_items(param, partition.miss_indices)
+            residual = self.build_multimodal_encoder_input(param, partition.miss_indices)
             self._apply_metadata_slice(residual, param, partition.miss_indices)
 
             residual_output = self.encode_multimodal_inputs([residual])
@@ -812,7 +862,7 @@ class MultimodalModelMixin:
             by_item: Dict[int, torch.Tensor] = dict(partition.hits)
             for miss_idx, tensor in zip(partition.miss_indices, miss_tensors, strict=True):
                 by_item[miss_idx] = tensor
-            param.multimodal_data["multimodal_embedding"] = self._assemble_full_embedding(
+            param.multimodal_data["multimodal_embedding"] = self.assemble_full_embedding(
                 by_item, len(partition.keys)
             )
 

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -287,6 +287,28 @@ class PreparedLlmInputs:
     extra_embeds: Sequence[torch.Tensor] = ()
 
 
+@dataclass(frozen=True)
+class EncoderCachePartition:
+    """Per-item cache partition for a single `MultimodalParams`.
+
+    `hits` maps item index to its cached embedding row-block; `miss_indices` lists item
+    indices that still require encoder work; `keys` is aligned to item order so miss
+    embeddings can be written back after they are computed.
+    """
+
+    hits: Dict[int, torch.Tensor]
+    miss_indices: list[int]
+    keys: list[Hashable]
+
+    @property
+    def is_full_hit(self) -> bool:
+        return bool(self.keys) and not self.miss_indices
+
+    @property
+    def is_full_miss(self) -> bool:
+        return bool(self.keys) and not self.hits
+
+
 class MultimodalModelMixin:
     """Template-method mixin for PyTorch multimodal causal LM models.
 
@@ -296,14 +318,23 @@ class MultimodalModelMixin:
     Current limitations:
 
     * For the time being, the persistent multimodal encoder cache stores per-item embeddings for
-      single-modality `MultimodalParams` objects.
-    * Cache reuse is all-or-nothing for each `MultimodalParams` object: every item in that object
-      hit the cache before cached embeddings are reused. Mixed-modality `MultimodalParams` objects
-      bypass the persistent cache.
+      single-modality `MultimodalParams` objects. Mixed-modality objects bypass the cache.
+    * Per-item cache reuse is all-or-nothing by default. Models can opt into partial reuse by
+      implementing `slice_multimodal_data_items` and setting
+      `supports_granular_encoder_cache = True`; miss items are re-encoded and interleaved with
+      cached items in original per-item order.
     """
 
     supports_encoder_cache: ClassVar[bool] = False
     """Whether the model's production forward path uses the persistent encoder cache."""
+
+    supports_granular_encoder_cache: ClassVar[bool] = False
+    """Whether the mixin may reuse a partial cache hit for this model.
+
+    When True, a partially cached `MultimodalParams` is handled by encoding only its miss
+    items and interleaving cached items back in per-item order. Requires the model to
+    implement `slice_multimodal_data_items`.
+    """
 
     model_config: ModelConfig
     _multimodal_encoder_cache: Optional[TensorLRUCache] = None
@@ -420,6 +451,21 @@ class MultimodalModelMixin:
         # them as extra embeds without changing the base flow.
         return active_embeddings, ()
 
+    def slice_multimodal_data_items(
+        self,
+        param: MultimodalParams,
+        item_indices: Sequence[int],
+    ) -> MultimodalParams:
+        """Return a `MultimodalParams` whose raw modality inputs contain only
+        `item_indices` from `param`, in that order.
+
+        Only the model knows how to slice its own modality tensors (`pixel_values`,
+        `image_grid_thw`, packed audio features, ...). The parallel per-item metadata
+        (`multimodal_embedding_lengths`, `multimodal_hashes`) is re-sliced by the mixin
+        after this returns, so implementations should focus on modality data only.
+        """
+        raise NotImplementedError
+
     # A future optional mixin-owned forward can build on the same template method.
     def prepare_multimodal_inputs(
         self,
@@ -492,15 +538,32 @@ class MultimodalModelMixin:
         the single tensor contract for both encoded and cached-only paths.
         """
         encoder_cache = self._get_multimodal_encoder_cache()
-        cache_misses = []
+        cache_misses: list[MultimodalParams] = []
+        partial_hits: list[tuple[MultimodalParams, EncoderCachePartition]] = []
         if encoder_cache is not None:
             for param in multimodal_params:
                 if param.multimodal_data.get("multimodal_embedding") is not None:
                     # The forward that attached this request-local embedding already populated the
                     # persistent cache.
                     continue
-                if not self._attach_encoder_cache_hit(param, encoder_cache):
+                partition = self._partition_encoder_cache(param, encoder_cache)
+                if partition is None or partition.is_full_miss:
                     cache_misses.append(param)
+                    continue
+                if partition.is_full_hit:
+                    param.multimodal_data["multimodal_embedding"] = self._assemble_full_embedding(
+                        partition.hits, len(partition.keys)
+                    )
+                    continue
+                if self.supports_granular_encoder_cache:
+                    partial_hits.append((param, partition))
+                else:
+                    cache_misses.append(param)
+
+        if partial_hits:
+            # `encoder_cache` is non-None here because partitions are only produced when the cache
+            # exists.
+            self._encode_with_partial_cache(partial_hits, encoder_cache)
 
         embeddings = get_multimodal_embeddings(
             encoder_forward_fn=self.encode_multimodal_inputs,
@@ -656,47 +719,118 @@ class MultimodalModelMixin:
         ]
 
     @classmethod
-    def _attach_encoder_cache_hit(
+    def _partition_encoder_cache(
         cls,
         param: MultimodalParams,
         encoder_cache: TensorLRUCache,
-    ) -> bool:
-        """Attach a full persistent-cache hit and report whether one was found."""
+    ) -> Optional[EncoderCachePartition]:
+        """Look up every item of `param` and return the per-item partition.
+
+        Returns `None` when the param is not cacheable (mixed modality, missing metadata,
+        request-local embedding already attached); the caller treats that as a full miss.
+        """
         if param.multimodal_data.get("multimodal_embedding") is not None:
             logger.debug(
                 f"{_MM_ENCODER_CACHE_LOG_NAME}: request-local multimodal embedding present; "
                 "skipping persistent cache lookup"
             )
-            return False
+            return None
 
         keys = cls._encoder_cache_keys(param)
         if not keys:
-            return False
+            return None
 
-        cached_embeddings = []
-        for key in keys:
-            cached_embedding = encoder_cache.get(key)
-            if cached_embedding is None:
-                # TODO(TRTLLM-13996): allow re-computing only the uncached items.
-                # `get_multimodal_embeddings` treats a param as either fully cached or uncached.
-                # Attaching partial hits would make the later concatenated tensor ambiguous because
-                # there is no placeholder for missing item rows inside `multimodal_embedding`.
-                logger.debug(
-                    f"{_MM_ENCODER_CACHE_LOG_NAME}: cache miss; hit_items={len(cached_embeddings)},"
-                    f" total_items={len(keys)}."
-                )
-                return False
-            cached_embeddings.append(cached_embedding)
+        hits: Dict[int, torch.Tensor] = {}
+        miss_indices: list[int] = []
+        for i, key in enumerate(keys):
+            cached = encoder_cache.get(key)
+            if cached is None:
+                miss_indices.append(i)
+            else:
+                hits[i] = cached
 
-        if len(cached_embeddings) == 1:
-            param.multimodal_data["multimodal_embedding"] = cached_embeddings[0]
-        else:
-            param.multimodal_data["multimodal_embedding"] = torch.cat(cached_embeddings, dim=0)
         logger.debug(
-            f"{_MM_ENCODER_CACHE_LOG_NAME}: full cache hit for {len(keys)} item entries, "
-            f"rows={param.multimodal_data['multimodal_embedding'].shape[0]}."
+            f"{_MM_ENCODER_CACHE_LOG_NAME}: partition hit_items={len(hits)}, "
+            f"miss_items={len(miss_indices)}, total_items={len(keys)}."
         )
-        return True
+        return EncoderCachePartition(hits=hits, miss_indices=miss_indices, keys=keys)
+
+    @staticmethod
+    def _assemble_full_embedding(
+        item_tensors: Dict[int, torch.Tensor],
+        total_items: int,
+    ) -> torch.Tensor:
+        """Concatenate per-item embedding tensors in item-index order.
+
+        `item_tensors` must contain every index in `[0, total_items)`.
+        """
+        if total_items == 1:
+            return item_tensors[0]
+        return torch.cat([item_tensors[i] for i in range(total_items)], dim=0)
+
+    @staticmethod
+    def _apply_metadata_slice(
+        residual: MultimodalParams,
+        source: MultimodalParams,
+        item_indices: Sequence[int],
+    ) -> None:
+        """Overwrite `residual`'s per-item metadata to match the sliced items.
+
+        Models slice raw modality tensors in `slice_multimodal_data_items`; the mixin owns
+        the parallel per-item metadata slice so every model gets it identically.
+        """
+        source_lengths = source.multimodal_data["multimodal_embedding_lengths"]
+        residual.multimodal_data["multimodal_embedding_lengths"] = [
+            source_lengths[i] for i in item_indices
+        ]
+        if residual.multimodal_input is not None and source.multimodal_input is not None:
+            source_hashes = source.multimodal_input.multimodal_hashes
+            residual.multimodal_input.multimodal_hashes = [source_hashes[i] for i in item_indices]
+
+    def _encode_with_partial_cache(
+        self,
+        partials: Sequence[tuple[MultimodalParams, EncoderCachePartition]],
+        encoder_cache: TensorLRUCache,
+    ) -> None:
+        """Encode only the miss items of each partial-hit param and stitch results.
+
+        After this returns, each param's `multimodal_embedding` has the same shape as a
+        full encoder run so downstream `get_multimodal_embeddings` treats it as fully
+        cached.
+        """
+        for param, partition in partials:
+            residual = self.slice_multimodal_data_items(param, partition.miss_indices)
+            self._apply_metadata_slice(residual, param, partition.miss_indices)
+
+            residual_output = self.encode_multimodal_inputs([residual])
+            miss_lengths = [
+                param.multimodal_data["multimodal_embedding_lengths"][i]
+                for i in partition.miss_indices
+            ]
+            miss_tensors = torch.split(residual_output, miss_lengths, dim=0)
+
+            by_item: Dict[int, torch.Tensor] = dict(partition.hits)
+            for miss_idx, tensor in zip(partition.miss_indices, miss_tensors, strict=True):
+                by_item[miss_idx] = tensor
+            param.multimodal_data["multimodal_embedding"] = self._assemble_full_embedding(
+                by_item, len(partition.keys)
+            )
+
+            inserted = 0
+            rejected = 0
+            for miss_idx, tensor in zip(partition.miss_indices, miss_tensors, strict=True):
+                if encoder_cache.put(partition.keys[miss_idx], tensor):
+                    inserted += 1
+                else:
+                    rejected += 1
+            logger.debug(
+                f"{_MM_ENCODER_CACHE_LOG_NAME}: partial-hit encode "
+                f"total_items={len(partition.keys)} "
+                f"hit_items={len(partition.hits)} "
+                f"encoded_items={len(partition.miss_indices)} "
+                f"cache_writes_inserted={inserted} "
+                f"cache_writes_rejected={rejected}"
+            )
 
     @classmethod
     def _write_encoder_cache_entries(

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -452,22 +452,27 @@ class MultimodalModelMixin:
         """Return a `MultimodalParams` whose raw modality inputs contain only
         `item_indices` from `param`, in that order.
 
-        Default handles two common single-modality layouts:
+        Default handles three common single-modality layouts:
 
-        - Stacked on dim 0 (Mistral 3 / Pixtral / LLaVA-family): `pixel_values`
+        - Image, stacked on dim 0 (Mistral 3 / Pixtral / LLaVA-family): `pixel_values`
           `[B, C, H, W]` with a parallel `image_sizes` list; both sliced by item.
-        - Packed with `*_grid_thw` offsets (Qwen2-VL family): `pixel_values`
-          `[total_patches, feat]` + `image_grid_thw` `[B, 3]`; prefix-summed patch
-          counts locate each item's slice, and `image_grid_thw` is sliced in parallel.
+        - Image / video, packed with `*_grid_thw` offsets (Qwen2-VL family):
+          `pixel_values` `[total_patches, feat]` + `image_grid_thw` `[B, 3]`;
+          prefix-summed patch counts locate each item's slice, and `image_grid_thw`
+          is sliced in parallel.
+        - Audio, stacked on dim 0 (Whisper / Qwen2-Audio / Gemma4 audio):
+          `input_features` `[B, mel_bins, T]` sliced by item.
 
         Any additional sibling field in the modality dict whose first-axis length equals
         the item count is also sliced -- covers per-item metadata such as
-        `second_per_grid_ts` on Qwen2.5-VL video without model-specific code.
+        `second_per_grid_ts` (Qwen2.5-VL video) or `input_features_mask` /
+        `feature_attention_mask` (audio) without model-specific code.
 
         Models with a different layout (e.g. mixed-modality per param, custom packed
-        formats) override this method. The parallel per-item metadata
-        (`multimodal_embedding_lengths`, `multimodal_hashes`) is re-sliced by the mixin
-        after this returns, so overrides need only handle modality data.
+        formats) should override this method. The parallel per-item metadata
+        (`multimodal_embedding_lengths`, `multimodal_hashes`) is model-agnostic and is
+        re-sliced by the mixin after this returns, so overrides need only handle the
+        modality-specific raw data.
         """
         modality = self._encoder_cache_modality(param)
         if modality is None:
@@ -485,7 +490,11 @@ class MultimodalModelMixin:
         grid_key = {"image": "image_grid_thw", "video": "video_grid_thw"}.get(modality)
         pixel_key = {"image": "pixel_values", "video": "pixel_values_videos"}.get(modality)
 
-        if grid_key and pixel_key and grid_key in modality_data and pixel_key in modality_data:
+        if (
+            (grid_key and pixel_key)
+            and (grid_key in modality_data)
+            and (pixel_key in modality_data)
+        ):
             # Packed layout: prefix-sum patch counts to locate each item's slab, then
             # concat the requested subset in item-index order.
             grids = modality_data[grid_key]
@@ -518,6 +527,14 @@ class MultimodalModelMixin:
             sliced = {
                 "pixel_values": miss_pixel,
                 "image_sizes": miss_sizes,
+            }
+        elif modality == "audio" and "input_features" in modality_data:
+            # Stacked layout: `input_features [B, mel_bins, T]` sliced on dim 0.
+            # Per-item masks (`input_features_mask`, `feature_attention_mask`, ...)
+            # are handled by the sibling-slice pass below.
+            n_items = modality_data["input_features"].shape[0]
+            sliced = {
+                "input_features": modality_data["input_features"][indices],
             }
         else:
             raise NotImplementedError(
@@ -826,7 +843,8 @@ class MultimodalModelMixin:
         """Look up every item of `param` and return the per-item partition.
 
         Returns `None` when the param is not cacheable (mixed modality, missing metadata,
-        request-local embedding already attached); the caller treats that as a full miss.
+        request-local embedding already attached); the caller should treat that as a
+        full miss.
         """
         if param.multimodal_data.get("multimodal_embedding") is not None:
             logger.debug(
@@ -859,13 +877,30 @@ class MultimodalModelMixin:
         item_tensors: Dict[int, torch.Tensor],
         total_items: int,
     ) -> torch.Tensor:
-        """Concatenate per-item embedding tensors in item-index order.
+        """Copy per-item embedding tensors into a single contiguous buffer in
+        item-index order.
 
-        `item_tensors` must contain every index in `[0, total_items)`.
+        `item_tensors` must contain every index in `[0, total_items)`. Sizes the
+        buffer from the item row counts and `copy_`s each item into its row range:
+        one predictable allocation of the exact final size, with no `torch.cat`
+        temporary competing with the sources for peak memory.
         """
         if total_items == 1:
             return item_tensors[0]
-        return torch.cat([item_tensors[i] for i in range(total_items)], dim=0)
+        first = item_tensors[0]
+        total_rows = sum(item_tensors[i].shape[0] for i in range(total_items))
+        buffer = torch.empty(
+            (total_rows, *first.shape[1:]),
+            dtype=first.dtype,
+            device=first.device,
+        )
+        offset = 0
+        for i in range(total_items):
+            item = item_tensors[i]
+            rows = item.shape[0]
+            buffer[offset : offset + rows].copy_(item)
+            offset += rows
+        return buffer
 
     @staticmethod
     def _apply_metadata_slice(
@@ -893,28 +928,47 @@ class MultimodalModelMixin:
     ) -> None:
         """Encode only the miss items of each partial-hit param and stitch results.
 
-        After this returns, each param's `multimodal_embedding` has the same shape as a
-        full encoder run so downstream `get_multimodal_embeddings` treats it as fully
-        cached.
+        Miss residuals from all partial-hit params in the batch are encoded in a
+        single call and the concatenated output is split back per param, mirroring
+        how `get_multimodal_embeddings` batches full-miss params. After this returns,
+        each param's `multimodal_embedding` has the same shape as a full encoder run
+        so downstream `get_multimodal_embeddings` treats it as fully cached.
         """
-        for param, partition in partials:
-            # Cross-iter prefetch may have staged this request's raw MM tensors on the
-            # aux stream. If its own encoder call then raised, the request reaches this
-            # iteration with an `encoder_event` but no `multimodal_embedding`; slicing
-            # those tensors on the main stream before the event would race the aux-stream
-            # H2D copy. Mirror the wait `get_multimodal_embeddings` does downstream.
+        if not partials:
+            return
+
+        # Cross-iter prefetch may have staged some params' raw MM tensors on the aux
+        # stream. If a prefetch encoder call then raised, the request reaches this
+        # iteration with an `encoder_event` but no `multimodal_embedding`; slicing
+        # those tensors on the main stream before the event would race the aux-stream
+        # H2D copy. Wait per param up front, before any raw-tensor read.
+        for param, _ in partials:
             if param.encoder_event is not None:
                 torch.cuda.current_stream().wait_event(param.encoder_event)
 
+        # Build every residual, then run one batched encoder call over the whole set.
+        residuals: list[MultimodalParams] = []
+        per_param_miss_lengths: list[list[int]] = []
+        for param, partition in partials:
             residual = self.build_multimodal_encoder_input(param, partition.miss_indices)
             self._apply_metadata_slice(residual, param, partition.miss_indices)
+            residuals.append(residual)
+            per_param_miss_lengths.append(
+                [
+                    param.multimodal_data["multimodal_embedding_lengths"][i]
+                    for i in partition.miss_indices
+                ]
+            )
 
-            residual_output = self.encode_multimodal_inputs([residual])
-            miss_lengths = [
-                param.multimodal_data["multimodal_embedding_lengths"][i]
-                for i in partition.miss_indices
-            ]
-            miss_tensors = torch.split(residual_output, miss_lengths, dim=0)
+        batched_output = self.encode_multimodal_inputs(residuals)
+        per_param_slabs = torch.split(
+            batched_output, [sum(lengths) for lengths in per_param_miss_lengths], dim=0
+        )
+
+        for (param, partition), slab, miss_lengths in zip(
+            partials, per_param_slabs, per_param_miss_lengths, strict=True
+        ):
+            miss_tensors = torch.split(slab, miss_lengths, dim=0)
 
             by_item: Dict[int, torch.Tensor] = dict(partition.hits)
             for miss_idx, tensor in zip(partition.miss_indices, miss_tensors, strict=True):

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -460,6 +460,10 @@ class MultimodalModelMixin:
           `[total_patches, feat]` + `image_grid_thw` `[B, 3]`; prefix-summed patch
           counts locate each item's slice, and `image_grid_thw` is sliced in parallel.
 
+        Any additional sibling field in the modality dict whose first-axis length equals
+        the item count is also sliced -- covers per-item metadata such as
+        `second_per_grid_ts` on Qwen2.5-VL video without model-specific code.
+
         Models with a different layout (e.g. mixed-modality per param, custom packed
         formats) override this method. The parallel per-item metadata
         (`multimodal_embedding_lengths`, `multimodal_hashes`) is re-sliced by the mixin
@@ -485,10 +489,10 @@ class MultimodalModelMixin:
             # Packed layout: prefix-sum patch counts to locate each item's slab, then
             # concat the requested subset in item-index order.
             grids = modality_data[grid_key]
+            n_items = grids.shape[0]
             patch_counts = [int(c) for c in torch.prod(grids, dim=1).tolist()]
             per_item = torch.split(modality_data[pixel_key], patch_counts, dim=0)
             sliced = {
-                **modality_data,
                 pixel_key: torch.cat([per_item[i] for i in indices], dim=0),
                 grid_key: grids[indices],
             }
@@ -498,8 +502,8 @@ class MultimodalModelMixin:
             and "image_sizes" in modality_data
         ):
             # Stacked layout: dim-0 select from `pixel_values` and list-index `image_sizes`.
+            n_items = modality_data["pixel_values"].shape[0]
             sliced = {
-                **modality_data,
                 "pixel_values": modality_data["pixel_values"][indices],
                 "image_sizes": [modality_data["image_sizes"][i] for i in indices],
             }
@@ -508,6 +512,15 @@ class MultimodalModelMixin:
                 f"Default `build_multimodal_encoder_input` cannot slice {modality} layout "
                 f"with fields {sorted(modality_data)}; override this method."
             )
+
+        # Sibling per-item fields (e.g. `second_per_grid_ts` on Qwen2.5-VL video)
+        # must be sliced alongside the load-bearing keys above, or the residual
+        # carries a shape-mismatched encoder input.
+        sliced = {
+            **modality_data,
+            **sliced,
+            **self._slice_per_item_sibling_fields(modality_data, n_items, indices, sliced.keys()),
+        }
 
         # Shallow-copy `multimodal_input` so `_apply_metadata_slice` can rewrite
         # `multimodal_hashes` on the residual without mutating the source.
@@ -518,6 +531,30 @@ class MultimodalModelMixin:
             multimodal_data={**param.multimodal_data, modality: sliced},
             multimodal_input=residual_input,
         )
+
+    @staticmethod
+    def _slice_per_item_sibling_fields(
+        modality_data: Dict[str, Any],
+        n_items: int,
+        item_indices: Sequence[int],
+        already_sliced: Iterable[str],
+    ) -> Dict[str, Any]:
+        """Slice modality-dict siblings whose first axis is parallel to items.
+
+        Anything with `shape[0] == n_items` (tensor) or `len == n_items` (list) is
+        assumed to be per-item metadata and sliced by `item_indices`. Fields already
+        handled by the caller (`already_sliced`) and everything else pass through.
+        """
+        skip = set(already_sliced)
+        sliced: Dict[str, Any] = {}
+        for key, value in modality_data.items():
+            if key in skip:
+                continue
+            if isinstance(value, torch.Tensor) and value.dim() > 0 and value.shape[0] == n_items:
+                sliced[key] = value[item_indices]
+            elif isinstance(value, list) and len(value) == n_items:
+                sliced[key] = [value[i] for i in item_indices]
+        return sliced
 
     # A future optional mixin-owned forward can build on the same template method.
     def prepare_multimodal_inputs(
@@ -849,6 +886,14 @@ class MultimodalModelMixin:
         cached.
         """
         for param, partition in partials:
+            # Cross-iter prefetch may have staged this request's raw MM tensors on the
+            # aux stream. If its own encoder call then raised, the request reaches this
+            # iteration with an `encoder_event` but no `multimodal_embedding`; slicing
+            # those tensors on the main stream before the event would race the aux-stream
+            # H2D copy. Mirror the wait `get_multimodal_embeddings` does downstream.
+            if param.encoder_event is not None:
+                torch.cuda.current_stream().wait_event(param.encoder_event)
+
             residual = self.build_multimodal_encoder_input(param, partition.miss_indices)
             self._apply_metadata_slice(residual, param, partition.miss_indices)
 

--- a/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
@@ -146,10 +146,13 @@ def make_keyed_multimodal_param(
     n_items = len(embedding_lengths)
 
     # Pattern-A image data so the mixin's default `build_multimodal_encoder_input` can
-    # slice this param (dim-0 `pixel_values` parallel to a per-item `image_sizes` list).
+    # slice this param (dim-0 `pixel_values [B, C, H, W]` parallel to a per-item
+    # `image_sizes` list).
     mm_data = {
         "image": {
-            "pixel_values": torch.arange(n_items * 3, dtype=torch.float32).reshape(n_items, 3),
+            "pixel_values": torch.arange(n_items * 3 * 2 * 2, dtype=torch.float32).reshape(
+                n_items, 3, 2, 2
+            ),
             "image_sizes": [[2, 2]] * n_items,
         },
         "multimodal_embedding_lengths": embedding_lengths,
@@ -596,6 +599,38 @@ def test_build_multimodal_encoder_input_slices_packed_grid_thw():
     torch.testing.assert_close(residual_image["second_per_grid_ts"], per_item_meta[[2, 0]])
     assert residual_image["per_item_list"] == ["c", "a"]
     torch.testing.assert_close(residual_image["per_request_scalar"], torch.tensor(42.0))
+
+
+def test_build_multimodal_encoder_input_stacked_crops_padding_to_miss_max_size():
+    # `pixel_values` is padded to request-wide 5x5 but item 0's true size is (3, 4)
+    # and item 1's is (5, 5). Slicing to just item 0 must crop `pixel_values` down to
+    # (3, 4) so Mistral 3's `batch_pixel_values` (which re-pads to
+    # `max(image_sizes)`) doesn't apply a negative pad amount.
+    pixels = torch.arange(2 * 3 * 5 * 5, dtype=torch.float32).reshape(2, 3, 5, 5)
+    param = MultimodalParams(
+        multimodal_input=MultimodalInput(
+            multimodal_hashes=[[i] * 8 for i in range(2)],
+            multimodal_positions=[0, 0],
+            multimodal_lengths=[1, 1],
+        ),
+        multimodal_data={
+            "image": {
+                "pixel_values": pixels,
+                "image_sizes": [[3, 4], [5, 5]],
+            },
+            "multimodal_embedding_lengths": [1, 1],
+            "mm_processor_kwargs_hash": "kw",
+        },
+    )
+    model = DummyMultimodalModel(make_embedding(hidden_size=1), torch.tensor([0]))
+
+    residual = model.build_multimodal_encoder_input(param, [0])
+
+    residual_image = residual.multimodal_data["image"]
+    assert residual_image["image_sizes"] == [[3, 4]]
+    assert residual_image["pixel_values"].shape == (1, 3, 3, 4)
+    # Cropped tensor preserves item 0's top-left (H=0..3, W=0..4) window.
+    torch.testing.assert_close(residual_image["pixel_values"], pixels[0:1, :, :3, :4])
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
@@ -101,9 +101,14 @@ class CountingEncoderMultimodalModel(DummyMultimodalModel):
 
     def encode_multimodal_inputs(self, multimodal_params, **encoder_kwargs) -> torch.Tensor:
         self.encode_calls += 1
-        total_rows = sum(
-            param.multimodal_runtime.total_embeds_in_request for param in multimodal_params
-        )
+        total_rows = 0
+        for param in multimodal_params:
+            # Residuals built by the partial-cache path carry `multimodal_embedding_lengths`
+            # but no `multimodal_runtime`; fall through to the metadata in that case.
+            if param.multimodal_runtime is not None:
+                total_rows += param.multimodal_runtime.total_embeds_in_request
+            else:
+                total_rows += sum(param.multimodal_data["multimodal_embedding_lengths"])
         return torch.full(
             (total_rows, self.embedding.embedding_dim),
             float(self.encode_calls),
@@ -138,9 +143,15 @@ def make_keyed_multimodal_param(
         item_hashes = [[1, 2, 3, 4, 5, 6, 7, 8]]
     if embedding_lengths is None:
         embedding_lengths = [2]
+    n_items = len(embedding_lengths)
 
+    # Pattern-A image data so the mixin's default `build_multimodal_encoder_input` can
+    # slice this param (dim-0 `pixel_values` parallel to a per-item `image_sizes` list).
     mm_data = {
-        "image": {"pixel_values": torch.empty(1)},
+        "image": {
+            "pixel_values": torch.arange(n_items * 3, dtype=torch.float32).reshape(n_items, 3),
+            "image_sizes": [[2, 2]] * n_items,
+        },
         "multimodal_embedding_lengths": embedding_lengths,
         "mm_processor_kwargs_hash": kwargs_hash,
     }
@@ -372,7 +383,7 @@ def test_encoder_cache_mixed_attached_and_uncached_requests():
     assert len(cache) == 1
 
 
-def test_encoder_cache_partial_hit_logs_and_uses_encoder():
+def test_encoder_cache_partial_hit_encodes_miss_and_interleaves():
     model = CountingEncoderMultimodalModel(
         make_embedding(hidden_size=4),
         torch.tensor([7]),
@@ -391,11 +402,17 @@ def test_encoder_cache_partial_hit_logs_and_uses_encoder():
     with patch("tensorrt_llm._torch.models.modeling_multimodal_mixin.logger.debug") as debug:
         embeddings = model._get_or_encode_multimodal_embeddings([partial])
 
-    messages = [" ".join(map(str, call.args)) for call in debug.call_args_list]
+    # Encoder ran twice: once for the initial miss item, once for the residual containing
+    # only the second request's novel item. Assembled tensor puts the cached hit before
+    # the freshly encoded miss in item-index order.
     assert model.encode_calls == 2
-    assert embeddings.shape == (4, 4)
+    torch.testing.assert_close(embeddings[:2], torch.full((2, 4), 1.0))
+    torch.testing.assert_close(embeddings[2:], torch.full((2, 4), 2.0))
+    assert len(model._multimodal_encoder_cache) == 2
+    messages = [" ".join(map(str, call.args)) for call in debug.call_args_list]
     assert any(
-        "mm_encoder_cache: cache miss; hit_items=1, total_items=2" in msg for msg in messages
+        "mm_encoder_cache: partial-hit encode total_items=2 hit_items=1 encoded_items=1" in msg
+        for msg in messages
     )
 
 
@@ -495,3 +512,92 @@ def test_request_local_multimodal_embedding_wins_over_encoder_cache():
     torch.testing.assert_close(embeddings, local_embedding)
     put.assert_not_called()
     assert cache.stats().replacements == 0
+
+
+def test_partition_encoder_cache_dispatches_by_hit_outcome():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    seeded = make_keyed_multimodal_param(item_hashes=[[1] * 8, [2] * 8], embedding_lengths=[2, 2])
+    model._get_or_encode_multimodal_embeddings([seeded])
+    cache = model._multimodal_encoder_cache
+
+    full_hit = make_keyed_multimodal_param(item_hashes=[[1] * 8, [2] * 8], embedding_lengths=[2, 2])
+    part = model.partition_encoder_cache(full_hit, cache)
+    assert part.is_full_hit and not part.is_full_miss and part.miss_indices == []
+
+    full_miss = make_keyed_multimodal_param(
+        item_hashes=[[8] * 8, [9] * 8], embedding_lengths=[2, 2]
+    )
+    part = model.partition_encoder_cache(full_miss, cache)
+    assert part.is_full_miss and not part.is_full_hit and part.hits == {}
+
+    partial = make_keyed_multimodal_param(item_hashes=[[1] * 8, [3] * 8], embedding_lengths=[2, 2])
+    part = model.partition_encoder_cache(partial, cache)
+    assert not part.is_full_hit and not part.is_full_miss
+    assert list(part.hits) == [0] and part.miss_indices == [1]
+
+
+def test_assemble_full_embedding_preserves_item_order():
+    per_item = {
+        0: torch.tensor([[0.0]]),
+        1: torch.tensor([[1.0], [1.5]]),
+        2: torch.tensor([[2.0]]),
+    }
+    torch.testing.assert_close(
+        MultimodalModelMixin.assemble_full_embedding(per_item, 3),
+        torch.tensor([[0.0], [1.0], [1.5], [2.0]]),
+    )
+    # Single-item fast path returns the item tensor without an extra copy.
+    single = per_item[1]
+    assert MultimodalModelMixin.assemble_full_embedding({0: single}, 1) is single
+
+
+def test_build_multimodal_encoder_input_slices_packed_grid_thw():
+    # Qwen-VL-style layout: `pixel_values` is a single packed tensor sized by the
+    # cumulative patch counts declared in `image_grid_thw`.
+    grids = torch.tensor([[1, 1, 2], [1, 1, 3], [1, 1, 1]])  # 2 + 3 + 1 patches
+    pixels = torch.arange(12, dtype=torch.float32).reshape(6, 2)
+    param = MultimodalParams(
+        multimodal_input=MultimodalInput(
+            multimodal_hashes=[[i] * 8 for i in range(3)],
+            multimodal_positions=[0, 0, 0],
+            multimodal_lengths=[2, 3, 1],
+        ),
+        multimodal_data={
+            "image": {"pixel_values": pixels, "image_grid_thw": grids},
+            "multimodal_embedding_lengths": [2, 3, 1],
+            "mm_processor_kwargs_hash": "kw",
+        },
+    )
+    model = DummyMultimodalModel(make_embedding(hidden_size=1), torch.tensor([0]))
+
+    residual = model.build_multimodal_encoder_input(param, [2, 0])
+
+    # Item 2 spans rows [5], item 0 spans rows [0, 1]; residual concatenates them in
+    # the requested item order.
+    torch.testing.assert_close(
+        residual.multimodal_data["image"]["pixel_values"],
+        torch.cat([pixels[5:6], pixels[0:2]], dim=0),
+    )
+    torch.testing.assert_close(residual.multimodal_data["image"]["image_grid_thw"], grids[[2, 0]])
+
+
+@pytest.mark.parametrize(
+    "mm_data, expected_match",
+    [
+        # `_encoder_cache_modality` returns None -> single-modality guard fires.
+        ({}, "only supports single-modality"),
+        # Modality present but layout is neither pattern A (image_sizes) nor pattern B
+        # (grid_thw); default has nothing to dispatch on.
+        ({"image": {"pixel_values": torch.zeros(2)}}, "cannot slice image layout"),
+    ],
+    ids=["no_modality", "unhandled_layout"],
+)
+def test_build_multimodal_encoder_input_unhandled_layout_raises(mm_data, expected_match):
+    param = MultimodalParams(multimodal_data=mm_data)
+    model = DummyMultimodalModel(make_embedding(hidden_size=1), torch.tensor([0]))
+    with pytest.raises(NotImplementedError, match=expected_match):
+        model.build_multimodal_encoder_input(param, [0])

--- a/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
@@ -557,9 +557,13 @@ def test_assemble_full_embedding_preserves_item_order():
 
 def test_build_multimodal_encoder_input_slices_packed_grid_thw():
     # Qwen-VL-style layout: `pixel_values` is a single packed tensor sized by the
-    # cumulative patch counts declared in `image_grid_thw`.
+    # cumulative patch counts declared in `image_grid_thw`. `second_per_grid_ts`
+    # stands in for any per-item sibling field (e.g. Qwen2.5-VL video timing) that
+    # must stay in sync with the sliced items; `per_request_scalar` stands in for
+    # non-per-item siblings that must pass through unchanged.
     grids = torch.tensor([[1, 1, 2], [1, 1, 3], [1, 1, 1]])  # 2 + 3 + 1 patches
     pixels = torch.arange(12, dtype=torch.float32).reshape(6, 2)
+    per_item_meta = torch.tensor([0.1, 0.2, 0.3])
     param = MultimodalParams(
         multimodal_input=MultimodalInput(
             multimodal_hashes=[[i] * 8 for i in range(3)],
@@ -567,7 +571,13 @@ def test_build_multimodal_encoder_input_slices_packed_grid_thw():
             multimodal_lengths=[2, 3, 1],
         ),
         multimodal_data={
-            "image": {"pixel_values": pixels, "image_grid_thw": grids},
+            "image": {
+                "pixel_values": pixels,
+                "image_grid_thw": grids,
+                "second_per_grid_ts": per_item_meta,
+                "per_item_list": ["a", "b", "c"],
+                "per_request_scalar": torch.tensor(42.0),
+            },
             "multimodal_embedding_lengths": [2, 3, 1],
             "mm_processor_kwargs_hash": "kw",
         },
@@ -577,12 +587,15 @@ def test_build_multimodal_encoder_input_slices_packed_grid_thw():
     residual = model.build_multimodal_encoder_input(param, [2, 0])
 
     # Item 2 spans rows [5], item 0 spans rows [0, 1]; residual concatenates them in
-    # the requested item order.
+    # the requested item order and slices every parallel sibling the same way.
+    residual_image = residual.multimodal_data["image"]
     torch.testing.assert_close(
-        residual.multimodal_data["image"]["pixel_values"],
-        torch.cat([pixels[5:6], pixels[0:2]], dim=0),
+        residual_image["pixel_values"], torch.cat([pixels[5:6], pixels[0:2]], dim=0)
     )
-    torch.testing.assert_close(residual.multimodal_data["image"]["image_grid_thw"], grids[[2, 0]])
+    torch.testing.assert_close(residual_image["image_grid_thw"], grids[[2, 0]])
+    torch.testing.assert_close(residual_image["second_per_grid_ts"], per_item_meta[[2, 0]])
+    assert residual_image["per_item_list"] == ["c", "a"]
+    torch.testing.assert_close(residual_image["per_request_scalar"], torch.tensor(42.0))
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
@@ -419,6 +419,32 @@ def test_encoder_cache_partial_hit_encodes_miss_and_interleaves():
     )
 
 
+def test_encoder_cache_partial_hit_batches_encoder_across_partial_params():
+    # Two partial-hit params in the same batch must share a single encoder call so
+    # launch overhead scales with iterations, not with partial-hit count.
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    shared = [1, 1, 1, 1, 1, 1, 1, 1]
+    seed = make_keyed_multimodal_param(item_hashes=[shared, [2] * 8], embedding_lengths=[2, 2])
+    partial_a = make_keyed_multimodal_param(item_hashes=[shared, [3] * 8], embedding_lengths=[2, 2])
+    partial_b = make_keyed_multimodal_param(
+        item_hashes=[[2] * 8, [4] * 8], embedding_lengths=[2, 2]
+    )
+
+    model._get_or_encode_multimodal_embeddings([seed])
+    encode_calls_before = model.encode_calls
+    model._get_or_encode_multimodal_embeddings([partial_a, partial_b])
+
+    # Single batched encoder call for both partial residuals.
+    assert model.encode_calls == encode_calls_before + 1
+    # Both new miss items (`[3]*8` and `[4]*8`) written to cache alongside the two
+    # already-cached seed items.
+    assert len(model._multimodal_encoder_cache) == 4
+
+
 def test_encoder_cache_logs_rejected_oversized_write():
     model = CountingEncoderMultimodalModel(
         make_embedding(hidden_size=4),
@@ -633,6 +659,38 @@ def test_build_multimodal_encoder_input_stacked_crops_padding_to_miss_max_size()
     torch.testing.assert_close(residual_image["pixel_values"], pixels[0:1, :, :3, :4])
 
 
+def test_build_multimodal_encoder_input_slices_audio_input_features():
+    # Whisper / Qwen2-Audio / Gemma4-audio layout: `input_features [B, mel, T]`
+    # stacked on dim 0, with an optional per-item mask that sibling-slices
+    # automatically. Two clips: item 0 and item 1 -- slice to [1, 0] to also
+    # confirm item order is preserved.
+    features = torch.arange(2 * 4 * 3, dtype=torch.float32).reshape(2, 4, 3)
+    mask = torch.tensor([[1, 1, 0], [1, 1, 1]])
+    param = MultimodalParams(
+        multimodal_input=MultimodalInput(
+            multimodal_hashes=[[i] * 8 for i in range(2)],
+            multimodal_positions=[0, 0],
+            multimodal_lengths=[1, 1],
+        ),
+        multimodal_data={
+            "audio": {
+                "input_features": features,
+                "input_features_mask": mask,
+            },
+            "multimodal_embedding_lengths": [1, 1],
+            "mm_processor_kwargs_hash": "kw",
+        },
+    )
+    model = DummyMultimodalModel(make_embedding(hidden_size=1), torch.tensor([0]))
+
+    residual = model.build_multimodal_encoder_input(param, [1, 0])
+
+    residual_audio = residual.multimodal_data["audio"]
+    torch.testing.assert_close(residual_audio["input_features"], features[[1, 0]])
+    # Per-item mask is caught by the generic sibling-slice pass.
+    torch.testing.assert_close(residual_audio["input_features_mask"], mask[[1, 0]])
+
+
 @pytest.mark.parametrize(
     "mm_data, expected_match",
     [
@@ -641,8 +699,10 @@ def test_build_multimodal_encoder_input_stacked_crops_padding_to_miss_max_size()
         # Modality present but layout is neither pattern A (image_sizes) nor pattern B
         # (grid_thw); default has nothing to dispatch on.
         ({"image": {"pixel_values": torch.zeros(2)}}, "cannot slice image layout"),
+        # Audio modality but no `input_features`; default falls through.
+        ({"audio": {"nonsense": torch.zeros(2)}}, "cannot slice audio layout"),
     ],
-    ids=["no_modality", "unhandled_layout"],
+    ids=["no_modality", "unhandled_image_layout", "unhandled_audio_layout"],
 )
 def test_build_multimodal_encoder_input_unhandled_layout_raises(mm_data, expected_match):
     param = MultimodalParams(multimodal_data=mm_data)


### PR DESCRIPTION
# Description

Persistent multimodal encoder cache is currently all-or-nothing per `MultimodalParams`: if any item of a request misses the cache, every item is re-encoded.

Add an opt-in per-item partial-hit path to `MultimodalModelMixin`:

- `EncoderCachePartition` records the per-item cache lookup result (hits / miss indices / keys).
- `partition_encoder_cache` (public classmethod) replaces the old private `_attach_encoder_cache_hit` and records every item lookup rather than bailing on first miss.
- `_encode_with_partial_cache` encodes only the miss items via a residual `MultimodalParams`, then interleaves cached and freshly encoded rows in original per-item order so downstream `get_multimodal_embeddings` treats the param as fully cached.
- `_apply_metadata_slice` re-slices `multimodal_embedding_lengths` and `multimodal_hashes` on the residual so every model gets the parallel per-item metadata slice identically.
- Models opt in with `supports_encoder_cache = True`. The mixin's default `build_multimodal_encoder_input` covers three common single-modality layouts (stacked-on-dim-0 images, packed-with-grid-thw images/videos, stacked-on-dim-0 audio) so most models need no per-model slicing code; models with a custom layout override the hook. Existing non-cache models continue unchanged.

Mistral 3 (Mistral-Small-3.1-24B) opts in via `supports_encoder_cache = True`; the mixin default handles its Pattern A image layout, so the model's net delta is a single flag flip.

## Perf

Real trtllm-serve run against `mistralai/Mistral-Small-3.1-24B-Instruct-2503` on 1x H200 (BF16, TP=1, KV block reuse **off**, `encoder_cache_max_bytes=2GiB`).

**Scenario A -- single-param partial hit** (N=100 items of 512x512 images; the partial-hit request shares 99 items with the seed and adds 1 novel):

| config | seed [100 fresh] | partial-hit [99 shared + 1 novel] | delta |
|---|---:|---:|---:|
| baseline (rc22 all-or-nothing) | 6039 ms | 5632 ms | -407 ms (-6.7%) |
| **granular (this PR)**         | 6066 ms | **5263 ms** | **-803 ms (-13.2%)** |

Direct partial-hit comparison: granular is **369 ms faster** than the baseline, matching the encoder cost of 99 Pixtral + projector passes granular skips.

**Scenario B -- cross-request batching** (K=4 concurrent partial-hit requests, each 99 shared + 1 unique novel): with server-side instrumentation, 2 of the 4 concurrent requests landed in a shared context iteration and were encoded in a single batched `encode_multimodal_inputs` call, confirming the batched partial-hit path is reachable end-to-end. Correctness of the batching path is unit-tested by `test_encoder_cache_partial_hit_batches_encoder_across_partial_params`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Introduces opt-in per-item persistent multimodal encoder cache reuse:
  - Adds `EncoderCachePartition` (hit/miss indices + aligned cache keys) and mixin APIs `partition_encoder_cache(...)` and `assemble_full_embedding(...)`.
  - Refactors `_get_or_encode_multimodal_embeddings` to partition each `MultimodalParams` into full-hit, full-miss, and partial-hit flows:
    - Full-hit attaches cached embeddings immediately.
    - Full-miss uses the standard encoder path.
    - Partial-hit encodes only miss items using residual `MultimodalParams`, stitches cached-hit + newly encoded miss rows back into original item order, attaches full embeddings, and writes only newly encoded miss items back to the persistent `TensorLRUCache` (with tracking for inserted vs rejected writes).
  - Removes the previous all-or-nothing granular-cache hit helper (`_attach_encoder_cache_hit`).
- Updates `build_multimodal_encoder_input(param, item_indices)` to slice multimodal tensors for supported single-modality layouts (stacked-on-dim-0 and packed `*_grid_thw`), and slices residual multimodal metadata consistently:
  - Uses a shallow copy of `param.multimodal_input` so residual metadata can be rewritten after slicing.
  - Slices per-item sibling metadata fields alongside the main modality slice via `_slice_per_item_sibling_fields`.
- Onboards opted-in models by overriding slicing behavior for residual inputs:
  - `Mistral 3` slices `pixel_values` and `image_sizes` to match the new per-item residual cache path.
- Follow-up fix/test-input alignment:
  - Crops residual stacked `pixel_values` to the maximum true dimensions of miss items to prevent negative padding.
  - Updates test input generation to use 4-D `pixel_values` matching real Pattern-A processor output.

## QA Engineer Review

- Test code changed: `tests/unittest/_torch/multimodal/test_multimodal_mixin.py`
  - Updated `CountingEncoderMultimodalModel.encode_multimodal_inputs` row-count logic to use `multimodal_runtime.total_embeds_in_request` when available, otherwise derive via `multimodal_embedding_lengths` (to cover residual/partial-cache paths).
  - Updated `make_keyed_multimodal_param` to build per-item “image” payloads with `pixel_values` shaped per item and `image_sizes` aligned to item count from `embedding_lengths`.
  - Renamed/adjusted partial-hit test to validate miss-encoded vs cached-hit embedding interleaving in correct item-index order and a more specific partial-hit debug log message.
  - Added/expanded coverage for:
    - cache partition dispatch (`partition_encoder_cache`)
    - full embedding assembly order preservation (`assemble_full_embedding_preserves_item_order`)
    - encoder input slicing for packed `image_grid_thw`
    - stacked-crop padding/cropping to miss max size
    - unhandled multimodal layouts raising `NotImplementedError` with expected message substrings
- Integration/CBTS coverage tracking: not verifiable from the provided context.
- Verdict: needs follow-up
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
