### PR TITLE
[https://nvbugs/6163690][fix] Use PreTrainedTokenizerFast in trtllm-bench prepare_dataset to avoid NemotronH config parsing error

### DIFF
--- a/tensorrt_llm/bench/dataset/prepare_dataset.py
+++ b/tensorrt_llm/bench/dataset/prepare_dataset.py
@@ -17,7 +17,7 @@ from typing import Optional, Tuple
 
 import click
 from pydantic import BaseModel, model_validator
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
 from tensorrt_llm.bench.dataset.prepare_real_data import real_dataset
 from tensorrt_llm.bench.dataset.prepare_synthetic_data import token_norm_dist, token_unif_dist
@@ -35,9 +35,18 @@ class RootArgs(BaseModel):
     @model_validator(mode="after")
     def validate_tokenizer(self):
         try:
-            tokenizer = AutoTokenizer.from_pretrained(
-                self.tokenizer, padding_side="left", trust_remote_code=self.trust_remote_code
-            )
+            # PreTrainedTokenizerFast loads directly from tokenizer.json without
+            # invoking AutoConfig, avoiding model-config parsing bugs (e.g.
+            # NemotronHConfig._pattern_to_list KeyError for hybrid models).
+            # Fall back to AutoTokenizer for models that lack a fast tokenizer.
+            try:
+                tokenizer = PreTrainedTokenizerFast.from_pretrained(
+                    self.tokenizer, padding_side="left"
+                )
+            except Exception:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    self.tokenizer, padding_side="left", trust_remote_code=self.trust_remote_code
+                )
         except EnvironmentError as e:
             raise ValueError(
                 "Cannot find a tokenizer from the given string because of "

--- a/tensorrt_llm/bench/dataset/prepare_dataset.py
+++ b/tensorrt_llm/bench/dataset/prepare_dataset.py
@@ -43,7 +43,7 @@ class RootArgs(BaseModel):
                 tokenizer = PreTrainedTokenizerFast.from_pretrained(
                     self.tokenizer, padding_side="left"
                 )
-            except Exception:
+            except (OSError, ValueError):
                 tokenizer = AutoTokenizer.from_pretrained(
                     self.tokenizer, padding_side="left", trust_remote_code=self.trust_remote_code
                 )


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

### Problem

trtllm-bench prepare-dataset (and the legacy `benchmarks/cpp/prepare_dataset.py`) fails with KeyError: '-' when the model is NVIDIA-Nemotron-Nano-9B-v2-NVFP4:

```  
File ".../transformers/models/nemotron_h/configuration_nemotron_h.py", line 271, in _pattern_to_list
    return [pattern_mapping[char] for char in pattern]
KeyError: '-'
```
  
### Root cause 
  
`AutoTokenizer.from_pretrained` calls `AutoConfig.from_pretrained` internally to resolve the tokenizer class. This instantiates the built-in `NemotronHConfig` (added in transformers 5.5.3), whose `_pattern_to_list` maps M→mamba, E→moe, *→attention but is missing '-': 'mlp'. The NVFP4 model's `config.json` has `hybrid_override_pattern: M-M-M-MM-M-M-M*-...` where - encodes MLP layers, causing the KeyError.
  
This was not hit before because:
 - rc13 shipped transformers 4.57.3 where `nemotron_h` was not yet a built-in type
 - rc15's test ran with a pre-generated --dataset file, so tokenizer loading was never triggered
  
The upstream fix is in huggingface/transformers PR #44763 (merged 2026-04-22, first in transformers v5.10.1). TRTLLM currently ships transformers 5.5.4 and cannot upgrade to 5.10.1 without accuracy regressions in GPT-OSS tests (chat template changes, `torch_dtype` deprecation).
  
### Fix 
  
`prepare_dataset.py` only uses the tokenizer to encode text for synthetic dataset generation — it never needs model config. `PreTrainedTokenizerFast.from_pretrained` loads directly from tokenizer.json without invoking AutoConfig, bypassing the broken config parsing entirely.
  
  The NVFP4 model ships a complete `tokenizer.json`, so the fast tokenizer loads correctly (131072-vocab, verified on rc19). An AutoTokenizer fallback is kept for models that do not provide a fast tokenizer.
  
## Testing
  
  - Verified `PreTrainedTokenizerFast.from_pretrained` succeeds on rc19 with NVIDIA-Nemotron-Nano-9B-v2-NVFP4 (131072-vocab, tokenizes correctly)
  - `AutoTokenizer` fallback path is exercised by any model without tokenizer.json
  - No change to the throughput command path (uses pre-generated dataset, never calls prepare_dataset)


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
