### PR TITLE
[None][feat] Add kimi_k2/glm_5 grouped routing and fused router to bench_moe

### DIFF
--- a/tests/microbenchmarks/bench_moe/mapping.py
+++ b/tests/microbenchmarks/bench_moe/mapping.py
@@ -129,7 +129,7 @@ def _create_routing_method(
             topk_group=topk_group,
             routed_scaling_factor=1.0,
             callable_e_score_correction_bias=lambda: e_score_correction_bias,
-            is_fused=False,
+            is_fused=True,
         )
 
     if routing_method_cls is MiniMaxM2MoeRoutingMethod:

--- a/tests/microbenchmarks/bench_moe/search.py
+++ b/tests/microbenchmarks/bench_moe/search.py
@@ -177,6 +177,19 @@ def is_candidate_valid(
             "use DEP/TEP modes only"
         )
 
+    # MegaMoEDeepGemm does not support TEP: its DeepGEMM fp8_fp4_mega_moe kernel
+    # assumes the MoE input is partitioned across ranks (single rank, or DEP with
+    # ep_size == parallel_size). TEP replicates the input TP-wide, so
+    # MegaMoEDeepGemm.__init__ raises NotImplementedError (enable_attention_dp=False,
+    # parallel_size>1). Prune here so the sweep records status="skipped" instead of a
+    # hard build failure.
+    if config.backend.upper() == "MEGAMOE_DEEPGEMM" and not enable_dp and world_size > 1:
+        return False, (
+            f"MEGAMOE_DEEPGEMM does not support TEP (enable_attention_dp=False, "
+            f"parallel_size={world_size}>1); use DEP with ep_size==parallel_size "
+            "or enable attention-DP"
+        )
+
     # DENSEGEMM DTP: FC2 kernel requires (intermediate_size / moe_tp_size) % 256 == 0.
     # DENSEGEMM __init__ only checks the full intermediate_size, so a model like
     # DeepSeek V3 (intermediate_size=2048, 2048%256=0) passes __init__ but fails

--- a/tests/microbenchmarks/bench_moe/specs.py
+++ b/tests/microbenchmarks/bench_moe/specs.py
@@ -308,6 +308,23 @@ BUILT_IN_MODELS: Dict[str, ModelSpec] = {
         intermediate_size=2048,
         quant_algo="FP8_BLOCK_SCALES",
         routing_method="DEEPSEEK_V3",
+        n_group=1,
+        topk_group=1,
+    ),
+    # GLM-5 (zai-org/GLM-5): 256 routed experts, top-8, sigmoid/noaux_tc
+    # (DeepSeek-V3-style) routing with a single expert group (n_group=1,
+    # topk_group=1). intermediate_size is the per-expert moe_intermediate_size.
+    # quant_algo left None: pass --quant on the CLI (the glm_5 sweep uses NVFP4).
+    "glm_5": ModelSpec(
+        name="glm_5",
+        num_experts=256,
+        top_k=8,
+        hidden_size=6144,
+        intermediate_size=2048,
+        quant_algo=None,
+        routing_method="DEEPSEEK_V3",
+        n_group=1,
+        topk_group=1,
     ),
     # DeepSeek-V4-Pro: 1.6T total / 49B activated. quant_algo intentionally
     # left None: pass --quant on the CLI to pin the mode (the released


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updates `tests/microbenchmarks/bench_moe/mapping.py` to construct `DeepSeekV3MoeRoutingMethod` with `is_fused=True`, enabling the fused DeepSeek-V3 routing path for this benchmark configuration.
- Fixes grouped-routing configuration for Kimi-K2 and adds GLM-5: `tests/microbenchmarks/bench_moe/specs.py` updates `kimi_k2` to `n_group=1/topk_group=1` and adds a new `glm_5` `ModelSpec` with `routing_method="DEEPSEEK_V3"`, `n_group=1/topk_group=1`, and `quant_algo=None`.
- Prevents sweep failures by pruning unsupported MegaMoE-DeepGemm + TEP combinations early: `tests/microbenchmarks/bench_moe/search.py` rejects `MEGAMOE_DEEPGEMM` when `enable_dp` is false (TEP) and `world_size > 1`, recording the candidate as skipped instead of hard-failing during backend initialization.
- Scope is limited to `bench_moe` microbenchmark code/specs; no unrelated config/test-list changes were made.

## QA Engineer Review

- Updated test/benchmark code under `tests/microbenchmarks/bench_moe/`:
  - `mapping.py`: `_create_routing_method` (DeepSeek-V3 routing construction now uses `is_fused=True`).
  - `search.py`: `is_candidate_valid` (adds early prune for `MEGAMOE_DEEPGEMM` + TEP when `enable_dp` is false and `world_size > 1`).
  - `specs.py`: `BUILT_IN_MODELS` registry (adds `glm_5`, updates `kimi_k2` routing grouping to `n_group=1/topk_group=1`).
- No corresponding entries were found in `tests/integration/test_lists/` (e.g., `test-db/`, `qa/`, `waives.txt`) for `bench_moe`/`microbenchmarks/bench_moe`.
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR adds `bench_moe` support for two additional MoE models and fixes a routing
configuration issue for Kimi-K2:

- **`specs.py`**: set `kimi_k2` `n_group=1`/`topk_group=1`. Real Kimi-K2 uses a single
  expert group; the previous multi-group value tripped the TRT-LLM routing kernel
  assertion `topk_group <= 4` and failed the build. Also adds a `glm_5` model spec
  (256 experts, top-8, DeepSeek-V3-style single-group routing).
- **`mapping.py`**: use the fused DeepSeek-V3 routing path (`is_fused=True`) for these specs.
- **`search.py`**: mark the `MEGAMOE_DEEPGEMM` + TEP combination as *skipped* rather than a
  hard build failure. That kernel assumes a partitioned MoE input, whereas TEP replicates
  the tensor TP-wide, so the combination is not valid and should be pruned from the sweep.

The change is scoped entirely to the `bench_moe` benchmarking utility and does not touch
runtime/serving code paths.

## Test Coverage

Validated by running the `bench_moe` sweep locally for `kimi_k2` and `glm_5`:
the previously-failing Kimi-K2 routing build now succeeds, `glm_5` is enumerated and
benchmarked, and `MEGAMOE_DEEPGEMM`+TEP entries are reported as skipped instead of aborting
the sweep.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
