### PR TITLE
[None][fix] Resolve NVFP4 mixed-precision base layers for the DSpark draft

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_dspark.py
+++ b/tensorrt_llm/_torch/models/modeling_dspark.py
@@ -45,6 +45,7 @@ import torch.nn.functional as F
 from torch import nn
 
 from tensorrt_llm.logger import logger
+from tensorrt_llm.quantization.mode import QuantAlgo
 
 from ..distributed import AllReduceParams
 from ..modules.linear import Linear
@@ -66,6 +67,7 @@ from .modeling_deepseekv4 import (
     DeepseekV4WeightLoader,
     _get_deepseek_v4_routed_moe_scale_name,
     _maybe_view_deepseek_v4_routed_moe_tensor,
+    _normalize_deepseek_v4_nvfp4_mixed_precision_config,
     _rename_deepseek_v4_attn_subkey,
     _rename_deepseek_v4_ffn_subkey,
 )
@@ -497,7 +499,8 @@ class DSparkDraftModel(nn.Module):
         """
         new_sa = cls._draft_sparse_config(model_config, base, num_stages)
         new_qcd = cls._draft_quant_config_dict(model_config, base, num_stages)
-        if new_sa is None and new_qcd is None:
+        new_qc = cls._draft_normalized_quant_config(model_config)
+        if new_sa is None and new_qcd is None and new_qc is None:
             return model_config
         draft_cfg = copy.copy(model_config)
         # ModelConfig is a frozen dataclass; bypass the guard for these fields.
@@ -505,7 +508,35 @@ class DSparkDraftModel(nn.Module):
             object.__setattr__(draft_cfg, "sparse_attention_config", new_sa)
         if new_qcd is not None:
             object.__setattr__(draft_cfg, "quant_config_dict", new_qcd)
+        if new_qc is not None:
+            object.__setattr__(draft_cfg, "quant_config", new_qc)
         return draft_cfg
+
+    @staticmethod
+    def _draft_normalized_quant_config(model_config):
+        """Resolved global ``quant_config`` for NVFP4 DSpark checkpoints, or None.
+
+        NVFP4 DSpark checkpoints declare a global ``MIXED_PRECISION`` quant algo
+        (per-layer NVFP4 routed experts over an FP8 base). The target resolves it
+        in :func:`_normalize_deepseek_v4_nvfp4_mixed_precision_config`
+        (base -> ``FP8_BLOCK_SCALES``); the separately-built draft config needs
+        the same, otherwise the inherited ``DeepseekV4DecoderLayer`` asserts
+        ``"MIXED_PRECISION is ambiguous"`` when it builds the draft stages.
+        Returns the resolved ``quant_config`` to set on the draft copy, or None
+        when nothing changes (e.g. the MXFP4 checkpoint, whose global algo is not
+        ``MIXED_PRECISION``) so the draft config is left byte-identical.
+        """
+        qc = getattr(model_config, "quant_config", None)
+        if qc is None or getattr(qc, "quant_algo", None) != QuantAlgo.MIXED_PRECISION:
+            return None
+        # Reuse the target normalizer on a throwaway shallow copy so we only
+        # extract the resolved global quant_config; the shared ``model_config``
+        # is left untouched (the normalizer rebinds ``.quant_config`` on the copy).
+        probe = copy.copy(model_config)
+        object.__setattr__(probe, "_frozen", False)
+        normalized = _normalize_deepseek_v4_nvfp4_mixed_precision_config(probe)
+        resolved = getattr(normalized, "quant_config", qc)
+        return resolved if resolved is not qc else None
 
     @staticmethod
     def _draft_sparse_config(model_config, base: int, num_stages: int):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `DSparkDraftModel` to normalize global `MIXED_PRECISION` quantization using the target DeepSeek-V4 model’s normalizer.
- Applies the resolved `quant_config` only when normalization changes the configuration, preserving existing behavior for other checkpoints.
- Draft configuration updates remain copy-on-write and consistently handle sparse attention, quantization dictionaries, and quantization configuration.
- No test, configuration, or test-list files were changed.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

NVFP4 DeepSeek-V4 checkpoints declare a global `MIXED_PRECISION` quant algo
(per-layer NVFP4 routed experts over an FP8 base). The target model resolves
this base in `_normalize_deepseek_v4_nvfp4_mixed_precision_config`
(`MIXED_PRECISION` → `FP8_BLOCK_SCALES`; the routed experts stay NVFP4 through
`quant_config_dict`).

The DSpark draft model builds its `ModelConfig` separately
(`get_draft_model` → `DSparkDraftModel._derive_draft_model_config`) and never
went through that normalization, so the inherited `DeepseekV4DecoderLayer` hits
the `MIXED_PRECISION is ambiguous` assertion while building the draft stages and
an NVFP4 DSpark checkpoint fails to load.

This PR extends the same normalization to the draft. `DSparkDraftModel`
now derives the resolved global `quant_config` via a new
`_draft_normalized_quant_config` helper (reusing the target normalizer on a
throwaway shallow copy) and sets it on the draft `ModelConfig`. The path is a
strict no-op for checkpoints whose global algo is not `MIXED_PRECISION`
(e.g. MXFP4) and for checkpoints the target normalizer leaves unchanged, so
those draft configs stay byte-identical.

## Test Coverage

Validated end-to-end on `nvidia/DeepSeek-V4-Pro-nvfp4-DSpark` (TP4/EP4): with
this change the draft model loads and DSpark speculative decoding runs a full
draft-length 1–7 acceptance sweep (GSM8K / HumanEval / MATH500, chat and
thinking) with no acceptance-length regression versus the MXFP4 checkpoint.
Without this change the same run aborts while building the draft stages with
`MIXED_PRECISION is ambiguous`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
