### PR TITLE
[None][fix] Fix nemotron-h quant and loading config

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/nemotron_h_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/nemotron_h_weight_mapper.py
@@ -1,6 +1,8 @@
 import re
+from typing import Optional
 
 import torch
+from torch import nn
 
 import tensorrt_llm.logger as logger
 from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import \
@@ -42,10 +44,14 @@ class NemotronHHfWeightMapper(HfWeightMapper):
             w = torch.concat(w).contiguous()
             return w
 
-        is_nvfp4 = self.config.quant_config.quant_algo == "NVFP4"
         n_groups = config.n_groups
         d_state = config.ssm_state_size
         nheads = config.mamba_num_heads
+        # Full in_proj out_features = concat([z, x, B, C, dt]). Only its
+        # per-output-row block scale spans this dim 0 and takes the same
+        # structured split as the weight; per-tensor scalars (weight_scale_2,
+        # input_scale) do not and are left alone.
+        d_in_proj = 2 * d_inner + 2 * n_groups * d_state + nheads
 
         new_weights = {}
         for name, _ in weights.items():
@@ -71,10 +77,8 @@ class NemotronHHfWeightMapper(HfWeightMapper):
             if "A_log" in key:
                 key = key.replace("A_log", "A")
 
-            if ("mixer.in_proj" in key
-                    or "mixer.out_proj" in key) and "_scale" in key:
-                # Special handing for nvfp4 Mamba2 mixer in_proj.weight_scale.
-                if is_nvfp4 and "in_proj.weight_scale_2" not in key and "in_proj.weight_scale" in key:
+            if "mixer.in_proj" in key and "_scale" in key:
+                if self._num_rows(weights[name]) == d_in_proj:
                     new_weights[key] = _split_mamba2_mixer_in_proj(
                         weights[name])
                 else:
@@ -188,3 +192,41 @@ class NemotronHHfWeightMapper(HfWeightMapper):
                 new_weights[key] = weights[name]
 
         return new_weights
+
+    @staticmethod
+    def _num_rows(tensor) -> Optional[int]:
+        """Size of dim 0 (the output-channel axis), or None for a scalar.
+
+        Works for materialized tensors and lazy safetensors slices. A weight
+        scale that shares this axis with the weight (NVFP4 / MXFP8 / FP8 block
+        scale, FP8 rowwise) is per-output-channel and must undergo the same TP
+        transform as the weight; a per-tensor scalar scale has no such axis.
+        """
+        shape = tensor.get_shape() if hasattr(tensor,
+                                              "get_shape") else tensor.shape
+        return shape[0] if shape else None
+
+    def _duplicate_kv_weights(self, module: nn.Module, new_name: str,
+                              weights: dict):
+        # Override of the base NVFP4-only rule: NemotronH attention may be
+        # FP8/MXFP8 (MIXED_PRECISION checkpoints), so duplicate ANY
+        # per-output-channel weight_scale (one that shares dim 0 with the
+        # weight) alongside the replicated kv weight, not just the NVFP4 case.
+        if new_name not in ('k_proj', 'v_proj'):
+            return weights
+
+        num_kv_heads = self._num_kv_heads
+        duplicated_keys = ["weight", "bias"]
+        weight, scale = weights.get("weight"), weights.get("weight_scale")
+        if (weight is not None and scale is not None
+                and self._num_rows(scale) == self._num_rows(weight)):
+            duplicated_keys.append("weight_scale")
+
+        return {
+            k:
+            self._duplicate_kv(weight=v[:],
+                               num_kv_heads=num_kv_heads,
+                               tensor_parallel_size=self._tp_size)
+            if k in duplicated_keys else v
+            for k, v in weights.items()
+        }

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -378,6 +378,72 @@ class DecoderModelForCausalLM(nn.Module,
                               Generic[TModel, TConfig],
                               metaclass=PostInitCaller):
 
+    @staticmethod
+    def _checkpoint_has_lm_head_scale(config: ModelConfig[TConfig]) -> bool:
+        """Whether the checkpoint stores a quantized lm_head (a weight scale).
+
+        Used to decide lm_head quantization for homogeneous checkpoints, which
+        carry no explicit per-layer quant entry. Reads only the safetensors
+        header for ``lm_head.weight_scale`` (no weight load).
+        """
+        checkpoint_dir = getattr(config.pretrained_config, "_name_or_path",
+                                 None)
+        if not checkpoint_dir or not os.path.isdir(checkpoint_dir):
+            return False
+        return ModelConfig._get_safetensors_header_for_tensor(
+            checkpoint_dir, "lm_head.weight_scale") is not None
+
+    @staticmethod
+    def _resolve_lm_head_quant_config(
+            config: ModelConfig[TConfig]) -> Optional[QuantConfig]:
+        """Resolve the quant config for lm_head, or None to keep it unquantized.
+
+        lm_head is quantized only when the checkpoint actually stores a
+        quantized lm_head: MIXED_PRECISION checkpoints carry an explicit
+        per-layer entry in ``quant_config_dict``; homogeneous checkpoints have
+        no per-layer entry, so we additionally require the checkpoint to carry
+        an ``lm_head`` weight scale. (A bf16 lm_head is commonly left OUT of
+        ``exclude_modules``, so "not excluded" alone must NOT imply quantized —
+        otherwise a homogeneous checkpoint with a bf16 lm_head would be built
+        quantized and fail / change its logits.) Several further cases force it
+        back to unquantized.
+        """
+        if config.quant_config_dict is not None:
+            quant_config = config.quant_config_dict.get("lm_head")
+        elif (config.quant_config is not None
+              and config.quant_config.quant_algo is not None and
+              DecoderModelForCausalLM._checkpoint_has_lm_head_scale(config)):
+            quant_config = config.quant_config
+        else:
+            quant_config = None
+        if quant_config is None:
+            return None
+
+        # exclude_modules always wins (an FP16 lm_head is listed there).
+        if (config.quant_config is not None
+                and config.quant_config.is_module_excluded_from_quantization(
+                    "lm_head")):
+            return None
+
+        # Tied embeddings replace lm_head.weight with the dense bf16 embedding
+        # weight, which would silently clash with a quantized (packed) weight.
+        if getattr(config.pretrained_config, 'tie_word_embeddings', False):
+            logger.info("Ignoring lm_head quant entry: tie_word_embeddings "
+                        "shares the dense embedding weight, so lm_head stays "
+                        "unquantized")
+            return None
+
+        # lm_head TP in ADP slices the dense weight at forward time for the
+        # spec-decoding head (see LMHead.forward), which is incompatible with
+        # quantized (packed) weights — LMHead rejects that at construction.
+        if (config.mapping.enable_attention_dp
+                and config.mapping.enable_lm_head_tp_in_adp):
+            logger.info("Ignoring lm_head quant entry: lm_head TP in ADP "
+                        "slices the dense weight, so lm_head stays unquantized")
+            return None
+
+        return quant_config
+
     def __init__(self, model: TModel, *, config: ModelConfig[TConfig],
                  hidden_size: int, vocab_size: int):
         super().__init__()
@@ -387,39 +453,9 @@ class DecoderModelForCausalLM(nn.Module,
         self.pp_size = config.mapping.pp_size
         self.has_custom_lm_head = False
 
-        # Per-layer quant entry for lm_head (e.g. ModelOpt MIXED_PRECISION
-        # checkpoints that quantize lm_head to NVFP4). Model-specific
-        # config normalizers opt in by keeping/synthesizing this entry;
-        # exclude_modules still wins. Applies to both the attention-DP
-        # (replicated) and TP lm_head below.
-        lm_head_quant_config = None
-        if config.quant_config_dict is not None:
-            lm_head_quant_config = config.quant_config_dict.get("lm_head")
-            if (lm_head_quant_config is not None
-                    and config.quant_config is not None and config.quant_config.
-                    is_module_excluded_from_quantization("lm_head")):
-                lm_head_quant_config = None
-            if (lm_head_quant_config is not None and getattr(
-                    config.pretrained_config, 'tie_word_embeddings', False)):
-                # Tied embeddings replace lm_head.weight with the dense
-                # bf16 embedding weight below, which would silently clash
-                # with a quantized (packed) weight and its quant method.
-                logger.info(
-                    "Ignoring lm_head quant entry: tie_word_embeddings "
-                    "shares the dense embedding weight, so lm_head stays "
-                    "unquantized")
-                lm_head_quant_config = None
-            if (lm_head_quant_config is not None
-                    and config.mapping.enable_attention_dp
-                    and config.mapping.enable_lm_head_tp_in_adp):
-                # lm_head TP in ADP slices the dense weight at forward time
-                # for the spec-decoding head (see LMHead.forward), which is
-                # incompatible with quantized (packed) weights — LMHead
-                # rejects that combination at construction.
-                logger.info(
-                    "Ignoring lm_head quant entry: lm_head TP in ADP "
-                    "slices the dense weight, so lm_head stays unquantized")
-                lm_head_quant_config = None
+        # Quant config for lm_head (applies to both the attention-DP replicated
+        # and TP lm_head below); None keeps it unquantized.
+        lm_head_quant_config = self._resolve_lm_head_quant_config(config)
 
         if config.mapping.enable_attention_dp and not config.mapping.enable_lm_head_tp_in_adp:
             self.lm_head = LMHead(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- **Nemotron-H (Mamba2) weight mapping**
  - Updated `NemotronHHfWeightMapper.preprocess_weights` to split `mixer.in_proj.*_scale` **structurally** using an expected `d_in_proj` dim-0 row-count heuristic (via new `_num_rows`) rather than checking `quant_algo == "NVFP4"` / relying on string-based NVFP4 detection.
  - Ensures only **per-output-channel** block scales that share dim-0 with the `in_proj` weights get split; per-tensor scalar scales remain unchanged.
  - Added KV duplication override `_duplicate_kv_weights` so that for replicated `k_proj`/`v_proj` weights, companion `weight_scale` tensors are duplicated when they share the same dim-0 row count as the weight (generalizing beyond NVFP4-only assumptions).
- **lm_head quantization resolution**
  - Added `_checkpoint_has_lm_head_scale` (header check for `lm_head.weight_scale`) and `_resolve_lm_head_quant_config` in `DecoderModelForCausalLM` to centralize/guard when `lm_head` should be quantized.
  - `lm_head` quantization is now derived from `quant_config_dict["lm_head"]` when present; otherwise for homogeneous checkpoints it uses `config.quant_config` **only if** the checkpoint actually contains `lm_head.weight_scale`.
  - Preserved existing guards forcing `lm_head` back to unquantized when `exclude_modules` excludes `lm_head`, `tie_word_embeddings` is enabled, or `enable_attention_dp` + `enable_lm_head_tp_in_adp` makes quantized/packed weights incompatible.
- **Other touched correctness-adjacent areas**
  - Updated Mistral processor references in unit tests (`Mistral3InputProcessor` → `MistralHFInputProcessor`).
  - Adjusted multi-GPU linear tests to remove the “odd hidden_size must raise” expectation.
  - Tweaked microbenchmark MoE routing flags/search pruning and added a GLM-5 model spec.

## QA Engineer Review

### Test-list changes (CI / QA routing)

- **`tests/integration/test_lists/qa/llm_perf_core.yml`**
  - Reduced reqs for `qwen3_30b_a3b-bench-pytorch-bfloat16-maxnt` from `reqs:256` → `reqs:64`.
  - Removed/added several `llama_v3.3_nemotron_super_49b` performance test entries to reflect timeout/interconnect constraints (notably moving a previously present `input_output_len:8000,1000` set and adding it back under a different block with accompanying comments).
- **`tests/integration/test_lists/waives.txt`**
  - Removed SKIPs for:
    - `accuracy/test_llm_api_pytorch.py::TestMistralLarge3_675B` `test_fp8[latency_moe_deepgemm]` and `test_nvfp4_4gpus[...]` cases.
    - `full:DGX_H100/.../test_linear.py::test_column_linear[2-unbalanced]`.
    - `unittest/_torch/modeling -k "modeling_qwen"` and `.../test_modeling_qwen3_5_vl.py::test_qwen35_dense_vl_resolves_mamba_ssm_cache_dtype`.
    - `unittest/_torch/multi_gpu/test_linear.py::test_row_linear[2-unbalanced]`.

**Verdict:** needs follow-up (test-list coverage data / CBTS linkage for the associated changes is not provided here).

### Test code changes

- **`tests/unittest/_torch/modeling/test_modeling_mistral.py`**
  - Modified `test_processor_get_num_tokens_per_image` to use `MistralHFInputProcessor`.
  - Modified `_make_dummy_processor` usage to construct `MistralHFInputProcessor` directly (affecting the dummy-input contract for downstream assertions in `test_mistral_attention_swa_layer_types`).
- **`tests/unittest/_torch/multi_gpu/test_linear.py`**
  - Modified `test_column_linear` and `test_row_linear` to remove conditional failure expectations for odd `hidden_size`; now asserts all results are `True`.

**Coverage in `tests/integration/test_lists/`:** not determinable from provided context (no mapping from these unit tests to specific CI lists included here).

**Verdict:** needs follow-up
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
