### PR TITLE
[https://nvbugs/6507109][infra] Split slow DGX B300 attention unit tests

### DIFF
--- a/tests/integration/test_lists/test-db/l0_dgx_b300.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b300.yml
@@ -15,7 +15,10 @@ l0_dgx_b300:
       stage: post_merge
       backend: pytorch
   tests:
-  - unittest/_torch/attention
+  - unittest/_torch/attention --ignore=unittest/_torch/attention/sparse/test_cute_dsl_fp8_paged_mqa_logits.py --ignore=unittest/_torch/attention/sparse/test_cute_dsl_fp4_paged_mqa_logits.py --ignore=unittest/_torch/attention/sparse/test_cute_dsl_gvr_topk_decode.py
+  - unittest/_torch/attention/sparse/test_cute_dsl_fp8_paged_mqa_logits.py
+  - unittest/_torch/attention/sparse/test_cute_dsl_fp4_paged_mqa_logits.py
+  - unittest/_torch/attention/sparse/test_cute_dsl_gvr_topk_decode.py
   - unittest/_torch/executor
   # ------------- modules (multi-GPU) ---------------
   - unittest/_torch/modules/test_mla_helix.py


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `tests/integration/test_lists/test-db/l0_dgx_b300.yml` to run the attention suite while excluding four slow sparse attention test files for independent CI execution.
- The change is limited to test selection configuration; no code, APIs, dependencies, or production behavior are affected.
- Test paths and ignore entries are consistent with the stated objective, with no apparent scope expansion or duplicate declarations.

## QA Engineer Review

- Modified `tests/integration/test_lists/test-db/l0_dgx_b300.yml`.
- Removed the broad exclusion of `unittest/_torch/attention`.
- Added the attention suite with four explicit sparse attention file exclusions: two FP8/FP4 paged MQA logits tests and two GVR top-k decode tests.
- Verdict: needs follow-up pending CBTS coverage data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Apply the attention test split from #16709 to the DGX B300 post-merge test list. The main attention entry excludes the three slow sparse CuTe DSL files, and each excluded file runs as a separate CI entry.

## Test Coverage

- `pre-commit run --files tests/integration/test_lists/test-db/l0_dgx_b300.yml`
- `python scripts/check_test_list.py --validate`
- `git diff --check`

## PR Checklist

- PR description clearly explains what and why.
- PR follows the TRT-LLM coding guidelines.
- No new code paths, APIs, or dependencies are introduced.
- No CODEOWNERS, documentation, or architecture updates are required.
- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, comment `/bot help`.
