### PR TITLE
[https://nvbugs/6501394][fix] Amend the attempt 0 commit to also delete the single waives.txt line…

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -352,7 +352,6 @@ unittest/_torch/modules/moe/test_moe_backend.py::test_moe_backend[act=Relu2-e60_
 unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_single_gpu -k "TRTLLM" SKIP (https://nvbugs/6464169)
 unittest/_torch/modules/tests_lora_modules/test_nemotron_h_lora_sanity.py::TestNemotronHLoRA::test_lora_pp2_sanity SKIP (https://nvbugs/6428124)
 unittest/_torch/multi_gpu/test_linear.py::test_row_linear[2-balanced] SKIP (https://nvbugs/6507113)
-unittest/_torch/multi_gpu/test_linear.py::test_row_linear[2-unbalanced] SKIP (https://nvbugs/6501394)
 unittest/_torch/multi_gpu/test_linear.py::test_row_linear_norm_fusion[2-hidden:16-seqlen:2] SKIP (https://nvbugs/6501404)
 unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py -m "part0" SKIP (https://nvbugs/6490036)
 unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py -m "part1" SKIP (https://nvbugs/6490036)

--- a/tests/unittest/_torch/multi_gpu/test_linear.py
+++ b/tests/unittest/_torch/multi_gpu/test_linear.py
@@ -311,13 +311,8 @@ def test_row_linear(hidden_size, mpi_pool_executor):
         run_single_rank,
         *zip(*[(tensor_parallel_size, row_linear_forward, x, [l0_weight],
                 hidden_size, dtype)] * 2))
-    if hidden_size % 2 != 0:
-        with pytest.raises(AssertionError):
-            for r in results:
-                assert r is True
-    else:
-        for r in results:
-            assert r is True
+    for r in results:
+        assert r is True
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2,


### PR DESCRIPTION
## Summary
- **Root cause**: PR #14875 (Uneven TP Linear) made ROW-parallel Linear correctly handle hidden_size % tp_size != 0, so the accuracy assert in row_linear_forward no longer fails for hidden_size=15 and the stale `pytest.raises(AssertionError)` guard triggers "DID NOT RAISE"; the test's waiver in waives.txt (line 355) still skips it in CI.
- **Fix**: Amend the attempt 0 commit to also delete the single waives.txt line `unittest/_torch/multi_gpu/test_linear.py::test_row_linear[2-unbalanced] SKIP (https://nvbugs/6501394)`; leave adjacent lines (6507113, 6501404) untouched — they are different NVBugs.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6501394


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Removed the obsolete NVBug 6501394 waiver for `test_row_linear[2-unbalanced]`.
- Updated `test_row_linear` to assert successful execution for odd hidden sizes unconditionally.
- Changes are consistent with the underlying Linear fix; waiver formatting and adjacent entries remain intact.
- No API, performance, or error-handling regressions identified.

## QA Engineer Review

- Modified test: `test_row_linear` in `tests/unittest/_torch/multi_gpu/test_linear.py`.
- The test is not represented by a corresponding `test-db/` or `qa/` entry; only its waiver entry was removed from `waives.txt`.
- **Verdict: insufficient**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->