### PR TITLE
[#16792][fix] Preserve Qwen3.5-VL multimodal content order

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3_5.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_5.py
@@ -649,6 +649,7 @@ _QWEN3_5_VL_PLACEHOLDER_METADATA = MultimodalPlaceholderMetadata(
     placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
     placeholders_separator="",
     content_format=ContentFormat.STRING,
+    interleave_placeholders=True,
 )
 
 

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -69,8 +69,10 @@ l0_h100:
   # test must run on Hopper-or-newer GPUs. Peer Qwen3-VL / Qwen3-VL-MoE
   # tests stay on L40s because they're pure attention and don't trigger the GDN kernel.
   - unittest/_torch/modeling/test_modeling_qwen3_5_vl_moe.py::TestQwen3_5MoeVL::test_all
+  - unittest/_torch/modeling/test_modeling_qwen3_5_vl_moe.py::test_qwen35_moe_vl_serving_preserves_content_part_order
   # Dense Qwen3.5-VL is the same hybrid family (sm90+ GDN kernel), so it lands here too.
   - unittest/_torch/modeling/test_modeling_qwen3_5_vl.py::TestQwen3_5VL::test_all
+  - unittest/_torch/modeling/test_modeling_qwen3_5_vl.py::test_qwen35_dense_vl_serving_preserves_content_part_order
   - unittest/disaggregated/test_disagg_utils.py
   - unittest/disaggregated/test_router.py
   - unittest/disaggregated/test_remoteDictionary.py

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl.py
@@ -208,6 +208,7 @@ def test_qwen35_dense_vl_placeholder_metadata_registered() -> None:
     }
     assert metadata.placeholders_separator == ""
     assert metadata.content_format is ContentFormat.STRING
+    assert metadata.interleave_placeholders
 
 
 # --- Layered parity test scaffold -------------------------------------------

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl.py
@@ -27,6 +27,7 @@ from tensorrt_llm._torch.pyexecutor.config_utils import (
 from tensorrt_llm._torch.pyexecutor.model_loader import validate_and_set_mamba_ssm_cache_dtype
 from tensorrt_llm.inputs import ContentFormat
 from tensorrt_llm.inputs.registry import MULTIMODAL_PLACEHOLDER_REGISTRY
+from tensorrt_llm.serve.chat_utils import parse_chat_messages_coroutines
 
 # Dense sibling of test_modeling_qwen3_5_vl_moe.py. The dense Qwen3.5-VL
 # (Qwen/Qwen3.5-27B, arch Qwen3_5ForConditionalGeneration, model_type qwen3_5)
@@ -209,6 +210,39 @@ def test_qwen35_dense_vl_placeholder_metadata_registered() -> None:
     assert metadata.placeholders_separator == ""
     assert metadata.content_format is ContentFormat.STRING
     assert metadata.interleave_placeholders
+
+
+def test_qwen35_dense_vl_serving_preserves_content_part_order() -> None:
+    class _Qwen35Config:
+        model_type = "qwen3_5"
+
+    image_placeholder = MULTIMODAL_PLACEHOLDER_REGISTRY.get_placeholder("qwen3_5", "image")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "before"},
+                {"type": "image_embeds", "image_embeds": {"data": "AAAA"}},
+                {"type": "text", "text": "middle"},
+                {"type": "image_embeds", "image_embeds": {"data": "BBBB"}},
+                {"type": "text", "text": "after"},
+            ],
+        }
+    ]
+
+    conversation, mm_coroutine, placeholder_counts, _ = parse_chat_messages_coroutines(
+        messages, _Qwen35Config(), None
+    )
+
+    try:
+        assert conversation[0]["content"] == (
+            f"before{image_placeholder}middle{image_placeholder}after"
+        )
+        assert placeholder_counts == [{image_placeholder: 2}]
+    finally:
+        mm_coroutine.close()
+        for media in conversation[0]["media"]:
+            media["data"].close()
 
 
 # --- Layered parity test scaffold -------------------------------------------

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl_moe.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl_moe.py
@@ -27,6 +27,7 @@ from tensorrt_llm._torch.pyexecutor.config_utils import (
 from tensorrt_llm._torch.pyexecutor.model_loader import validate_and_set_mamba_ssm_cache_dtype
 from tensorrt_llm.inputs import ContentFormat
 from tensorrt_llm.inputs.registry import MULTIMODAL_PLACEHOLDER_REGISTRY
+from tensorrt_llm.serve.chat_utils import parse_chat_messages_coroutines
 
 
 def _write_qwen35_moe_vl_config(tmp_path: Path) -> Path:
@@ -166,6 +167,39 @@ def test_qwen35_moe_vl_placeholder_metadata_registered() -> None:
     assert metadata.placeholders_separator == ""
     assert metadata.content_format is ContentFormat.STRING
     assert metadata.interleave_placeholders
+
+
+def test_qwen35_moe_vl_serving_preserves_content_part_order() -> None:
+    class _Qwen35MoeConfig:
+        model_type = "qwen3_5_moe"
+
+    image_placeholder = MULTIMODAL_PLACEHOLDER_REGISTRY.get_placeholder("qwen3_5_moe", "image")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "before"},
+                {"type": "image_embeds", "image_embeds": {"data": "AAAA"}},
+                {"type": "text", "text": "middle"},
+                {"type": "image_embeds", "image_embeds": {"data": "BBBB"}},
+                {"type": "text", "text": "after"},
+            ],
+        }
+    ]
+
+    conversation, mm_coroutine, placeholder_counts, _ = parse_chat_messages_coroutines(
+        messages, _Qwen35MoeConfig(), None
+    )
+
+    try:
+        assert conversation[0]["content"] == (
+            f"before{image_placeholder}middle{image_placeholder}after"
+        )
+        assert placeholder_counts == [{image_placeholder: 2}]
+    finally:
+        mm_coroutine.close()
+        for media in conversation[0]["media"]:
+            media["data"].close()
 
 
 # --- Layered parity test scaffold -------------------------------------------

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl_moe.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl_moe.py
@@ -165,6 +165,7 @@ def test_qwen35_moe_vl_placeholder_metadata_registered() -> None:
     }
     assert metadata.placeholders_separator == ""
     assert metadata.content_format is ContentFormat.STRING
+    assert metadata.interleave_placeholders
 
 
 # --- Layered parity test scaffold -------------------------------------------


### PR DESCRIPTION
## Description

Qwen3.5-VL uses string chat content, but its registration did not opt into the serving path that preserves ordered OpenAI content parts. Requests containing alternating text and images therefore bulk-prepended all vision placeholders, changing prompt tokenization and multimodal positions.

Enable the existing interleaved-placeholder path for the shared dense and MoE metadata. Requests without ordered content parts keep the existing BEFORE_TEXT fallback.

This addresses the placeholder-ordering part of #16792. The separate residual generation parity case described there remains out of scope.

## Test Coverage

- Extended the dense and MoE placeholder-registration tests to cover the interleaving contract.
- pre-commit run --files tensorrt_llm/_torch/models/modeling_qwen3_5.py tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl.py tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl_moe.py
- python3 -m compileall -q tensorrt_llm/_torch/models/modeling_qwen3_5.py tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl.py tests/unittest/_torch/modeling/test_modeling_qwen3_5_vl_moe.py

## PR Checklist

- [x] Reviewed the checklist in the pull request template as applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Enables interleaved placeholder registration for shared Qwen3.5-VL dense and MoE metadata.
- Preserves the order of text and image content parts.
- Retains the existing `BEFORE_TEXT` fallback for requests without ordered content parts.
- No apparent API, performance, error-handling, or regression concerns.
- Adds H100 pre-merge coverage for dense and MoE content-part ordering.
- Residual generation parity remains out of scope.

## QA Engineer Review

- Added `test_qwen35_dense_vl_serving_preserves_content_part_order`.
- Added the corresponding serving-order test for `qwen3_5_moe`.
- Updated metadata tests to verify `interleave_placeholders=True`.
- Added dense and MoE content-part ordering entries to `tests/integration/test_lists/test-db/l0_h100.yml`.
- **Verdict: sufficient** — the new test functions have CI coverage in `test-db/l0_h100.yml`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->