### PR TITLE
[None][fix] Preserve HF checkpoint fallback errors

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -328,8 +328,7 @@ class HfWeightLoader(BaseWeightLoader):
                                       weights_only=True,
                                       map_location='cpu',
                                       mmap=False)
-        finally:
-            return part_weights
+        return part_weights
 
     def _prefetch_one_file(self, file_name):
         if os.path.exists(file_name):

--- a/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
@@ -107,6 +107,23 @@ def test_load_weights_ignores_consolidated_ckpt_when_sharded_ckpt_exists(
     assert set(loaded_weight_files) == expected_safetensor_filenames
 
 
+def test_bin_loader_propagates_fallback_error():
+    loader = HfWeightLoader()
+    with (
+        mock.patch(
+            "tensorrt_llm._torch.models.checkpoints.hf.weight_loader.torch.load",
+            side_effect=[OSError("mmap failed"), MyError("fallback failed")],
+        ) as torch_load,
+        pytest.raises(MyError, match="fallback failed"),
+    ):
+        loader._load_bin_or_path_file("model.bin")
+
+    assert torch_load.call_args_list == [
+        mock.call("model.bin", weights_only=True, map_location="cpu", mmap=True),
+        mock.call("model.bin", weights_only=True, map_location="cpu", mmap=False),
+    ]
+
+
 def test_weight_cache_reuses_raw_weights_with_fresh_consumable_wrapper(tmp_path, monkeypatch):
     monkeypatch.setenv("TRTLLM_HF_WEIGHT_CACHE", "1")
 


### PR DESCRIPTION
## Description

The HF bin/PTH loader retries without mmap when the initial load fails. Its return currently sits in a `finally` block, so if the fallback also fails, Python replaces the loader exception with an `UnboundLocalError`.

Move the return after the retry block. Successful loads and the mmap fallback are unchanged, while fallback failures now propagate their original exception.

This restores the behavior from before bin checkpoint loading was parallelized.

## Test Coverage

- Added a unit test that forces both mmap attempts to fail, verifies the retry order, and checks that the fallback exception is preserved.
- `pre-commit run --files tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py`
- `python3 -Werror::SyntaxWarning -m py_compile tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py`

## PR Checklist

- [x] Reviewed the pull request checklist as applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Moved the return outside the `finally` block so fallback-load exceptions propagate unchanged.
- Preserves successful loads and mmap retry behavior without API or performance changes.
- No configuration or test-list changes.

## QA Engineer Review

- Added `test_bin_loader_propagates_fallback_error`.
- Verifies mmap-first loading, non-mmap fallback, call order, arguments, and fallback exception propagation.
- No corresponding `test-db/` or `qa/` coverage entry was identified.
- Verdict: insufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->