### PR TITLE
[None][perf] Fuse MiniMax-M3 prefill projections

### DIFF
--- a/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
+++ b/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,6 +86,21 @@ __device__ __forceinline__ void storeHeadElements(
             reinterpret_cast<__nv_fp8x2_storage_t*>(&out[offsetThread])[i / 2] = packed.__x;
         }
     }
+}
+
+template <int numElemsPerThread>
+__device__ __forceinline__ void storeFp8HeadElements64(
+    __nv_fp8_e4m3* out, int64_t offsetThread, float const (&elements)[numElemsPerThread])
+{
+    static_assert(numElemsPerThread == 4, "MiniMax-M3 FP8 store expects four elements per thread");
+    // Form the final pointer with 64-bit arithmetic before one aligned 32-bit
+    // store. Production coalesced paged-cache offsets can exceed INT32_MAX
+    // FP8 elements even though each individual head row is small.
+    auto* threadOut = out + offsetThread;
+    __nv_fp8x2_e4m3 const low(make_float2(elements[0], elements[1]));
+    __nv_fp8x2_e4m3 const high(make_float2(elements[2], elements[3]));
+    uint32_t const packed = static_cast<uint32_t>(low.__x) | (static_cast<uint32_t>(high.__x) << 16);
+    *reinterpret_cast<uint32_t*>(threadOut) = packed;
 }
 
 // Perform per-head QK Norm and RoPE in a single kernel, reading a BF16 input and
@@ -343,6 +358,279 @@ __global__ void fusedQKNormRopeKernel(
     storeHeadElements<OutT, numElemsPerThread, vecSize>(qkv_out, offsetThread, elements);
 }
 
+namespace
+{
+
+constexpr int kMinimaxM3HeadDim = 128;
+constexpr int kMinimaxM3RotaryDim = 64;
+constexpr int kMinimaxM3PageSize = 128;
+constexpr int kMinimaxM3ElemsPerThread = kMinimaxM3HeadDim / 32;
+
+// MiniMax-M3-only direct-cache specialization for eager pure prefill. The
+// general fused QK-norm/RoPE producer plus the #16755 Triton scatter remains
+// the fallback for decode, mixed batches, BF16 caches, and unsupported layouts.
+__global__ void minimaxM3Fp8QKNormRopeKVInsertKernel(__nv_bfloat16 const* qkvInput, __nv_fp8_e4m3* qOutput,
+    __nv_fp8_e4m3* kvCache, int const* outCacheLoc, int64_t pageStride, int64_t planeStride, int64_t headStride,
+    int64_t tokenStride, int numTokens, int numHeadsQ, int numHeadsK, int numHeadsV, float eps,
+    __nv_bfloat16 const* qWeight, __nv_bfloat16 const* kWeight, float base, int const* positionIds)
+{
+    int const warpsPerBlock = blockDim.x / 32;
+    int const warpId = threadIdx.x / 32;
+    int const laneId = threadIdx.x % 32;
+    int const globalWarp = blockIdx.x * warpsPerBlock + warpId;
+    int const totalHeads = numHeadsQ + numHeadsK + numHeadsV;
+    int const tokenIdx = globalWarp / totalHeads;
+    int const localHead = globalWarp % totalHeads;
+    if (tokenIdx >= numTokens)
+    {
+        return;
+    }
+
+    int const totalQKHeads = numHeadsQ + numHeadsK;
+    bool const isQ = localHead < numHeadsQ;
+    bool const isV = localHead >= totalQKHeads;
+    int const headIdx = isQ ? localHead : (isV ? localHead - totalQKHeads : localHead - numHeadsQ);
+    int const inputOffset = (tokenIdx * totalHeads + localHead) * kMinimaxM3HeadDim + laneId * kMinimaxM3ElemsPerThread;
+
+    float elements[kMinimaxM3ElemsPerThread];
+    float sumSquares = 0.0F;
+    constexpr int kVecSize = kMinimaxM3ElemsPerThread * sizeof(__nv_bfloat16) / 4;
+    using VecT = typename tensorrt_llm::common::packed_as<uint, kVecSize>::type;
+    VecT const packedInput = *reinterpret_cast<VecT const*>(qkvInput + inputOffset);
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i)
+    {
+        float2 const values = __bfloat1622float2(
+            *reinterpret_cast<__nv_bfloat162 const*>(reinterpret_cast<uint const*>(&packedInput) + i));
+        if (!isV)
+        {
+            sumSquares += values.x * values.x;
+            sumSquares += values.y * values.y;
+        }
+        elements[2 * i] = values.x;
+        elements[2 * i + 1] = values.y;
+    }
+
+    __nv_fp8_e4m3* output = qOutput;
+    int64_t outputOffset;
+    if (isQ)
+    {
+        outputOffset = (static_cast<int64_t>(tokenIdx) * numHeadsQ + headIdx) * kMinimaxM3HeadDim
+            + laneId * kMinimaxM3ElemsPerThread;
+    }
+    else
+    {
+        int slot = laneId == 0 ? outCacheLoc[tokenIdx] : 0;
+        slot = __shfl_sync(0xffffffff, slot, 0);
+        int const page = slot >> 7;
+        int const withinPage = slot & (kMinimaxM3PageSize - 1);
+        int const plane = isV ? 1 : 0;
+        output = kvCache;
+        outputOffset = static_cast<int64_t>(page) * pageStride + static_cast<int64_t>(plane) * planeStride
+            + static_cast<int64_t>(headIdx) * headStride + static_cast<int64_t>(withinPage) * tokenStride
+            + laneId * kMinimaxM3ElemsPerThread;
+    }
+
+    // V is copy-cast only.
+    if (isV)
+    {
+        storeFp8HeadElements64<kMinimaxM3ElemsPerThread>(output, outputOffset, elements);
+        return;
+    }
+
+    sumSquares = tensorrt_llm::common::warpReduceSum(sumSquares);
+    float const rmsReciprocal = rsqrtf(sumSquares / static_cast<float>(kMinimaxM3HeadDim) + eps);
+#pragma unroll
+    for (int i = 0; i < kMinimaxM3ElemsPerThread; ++i)
+    {
+        int const dim = laneId * kMinimaxM3ElemsPerThread + i;
+        float const weight = isQ ? __bfloat162float(qWeight[dim]) : __bfloat162float(kWeight[dim]);
+        elements[i] *= rmsReciprocal * (1.0F + weight);
+    }
+
+    // MiniMax-M3 uses NeoX partial RoPE over the first 64 of 128 channels.
+    // Only lanes 0..7 calculate the 32 distinct angles; lanes 8..15 reuse
+    // them for the paired half, while lanes 16..31 bypass RoPE.
+    float pairedElements[kMinimaxM3ElemsPerThread];
+    float cosineValues[kMinimaxM3ElemsPerThread] = {};
+    float sineValues[kMinimaxM3ElemsPerThread] = {};
+    __syncwarp();
+    constexpr int kPairOffset = (kMinimaxM3RotaryDim / 2) / kMinimaxM3ElemsPerThread;
+    int positionId = laneId == 0 ? positionIds[tokenIdx] : 0;
+    positionId = __shfl_sync(0xffffffff, positionId, 0);
+#pragma unroll
+    for (int i = 0; i < kMinimaxM3ElemsPerThread; ++i)
+    {
+        int const dim = laneId * kMinimaxM3ElemsPerThread + i;
+        pairedElements[i] = __shfl_xor_sync(0xffffffff, elements[i], kPairOffset);
+        if (laneId < kPairOffset)
+        {
+            pairedElements[i] = -pairedElements[i];
+        }
+
+        if (laneId < kPairOffset)
+        {
+            int const halfDim = dim;
+            float const frequency = powf(base, -2.0F * halfDim / static_cast<float>(kMinimaxM3RotaryDim));
+            __sincosf(static_cast<float>(positionId) * frequency, &sineValues[i], &cosineValues[i]);
+        }
+        if (laneId < 2 * kPairOffset)
+        {
+            int const sourceLane = laneId % kPairOffset;
+            cosineValues[i] = __shfl_sync(0x0000ffff, cosineValues[i], sourceLane);
+            sineValues[i] = __shfl_sync(0x0000ffff, sineValues[i], sourceLane);
+        }
+    }
+    __syncwarp();
+
+#pragma unroll
+    for (int i = 0; i < kMinimaxM3ElemsPerThread; ++i)
+    {
+        int const dim = laneId * kMinimaxM3ElemsPerThread + i;
+        if (dim < kMinimaxM3RotaryDim)
+        {
+            elements[i] = elements[i] * cosineValues[i] + pairedElements[i] * sineValues[i];
+        }
+    }
+
+    storeFp8HeadElements64<kMinimaxM3ElemsPerThread>(output, outputOffset, elements);
+}
+
+// Horizontal sparse producer for a packed [Q|K|V|index-Q|index-K] row.
+// One warp owns one (token, head slot). All four norm/RoPE branches share the
+// model's precomputed FP32 RoPE table, eliminating per-head powf/sincos work.
+__global__ void minimaxM3Fp8QKVIndexerNormRopeKVInsertKernel(__nv_bfloat16 const* packedInput, __nv_fp8_e4m3* qOutput,
+    __nv_fp8_e4m3* indexQOutput, __nv_fp8_e4m3* kvCache, __nv_fp8_e4m3* indexKCache, int const* outCacheLoc,
+    int64_t kvPageStride, int64_t kvPlaneStride, int64_t kvHeadStride, int64_t kvTokenStride, int64_t indexPageStride,
+    int64_t indexTokenStride, int numTokens, int numHeadsQ, int numHeadsKV, int numHeadsIndex, float eps,
+    __nv_bfloat16 const* qWeight, __nv_bfloat16 const* kWeight, __nv_bfloat16 const* indexQWeight,
+    __nv_bfloat16 const* indexKWeight, float const* rotaryCosSin, int const* positionIds)
+{
+    int const warpsPerBlock = blockDim.x / 32;
+    int const warpId = threadIdx.x / 32;
+    int const laneId = threadIdx.x % 32;
+    int const globalWarp = blockIdx.x * warpsPerBlock + warpId;
+    int const totalHeads = numHeadsQ + 2 * numHeadsKV + numHeadsIndex + 1;
+    int const tokenIdx = globalWarp / totalHeads;
+    int const localHead = globalWarp % totalHeads;
+    if (tokenIdx >= numTokens)
+    {
+        return;
+    }
+
+    int const kBegin = numHeadsQ;
+    int const vBegin = kBegin + numHeadsKV;
+    int const indexQBegin = vBegin + numHeadsKV;
+    int const indexKHead = indexQBegin + numHeadsIndex;
+    bool const isQ = localHead < kBegin;
+    bool const isK = localHead >= kBegin && localHead < vBegin;
+    bool const isV = localHead >= vBegin && localHead < indexQBegin;
+    bool const isIndexQ = localHead >= indexQBegin && localHead < indexKHead;
+    bool const isIndexK = localHead == indexKHead;
+
+    int const inputOffset = (tokenIdx * totalHeads + localHead) * kMinimaxM3HeadDim + laneId * kMinimaxM3ElemsPerThread;
+    constexpr int kVecSize = kMinimaxM3ElemsPerThread * sizeof(__nv_bfloat16) / 4;
+    using VecT = typename tensorrt_llm::common::packed_as<uint, kVecSize>::type;
+    VecT const packed = *reinterpret_cast<VecT const*>(packedInput + inputOffset);
+
+    float elements[kMinimaxM3ElemsPerThread];
+    float sumSquares = 0.0F;
+#pragma unroll
+    for (int pair = 0; pair < kVecSize; ++pair)
+    {
+        float2 const values = __bfloat1622float2(
+            *reinterpret_cast<__nv_bfloat162 const*>(reinterpret_cast<uint const*>(&packed) + pair));
+        elements[2 * pair] = values.x;
+        elements[2 * pair + 1] = values.y;
+        if (!isV)
+        {
+            sumSquares += values.x * values.x + values.y * values.y;
+        }
+    }
+
+    if (!isV)
+    {
+        auto const* normWeight = isQ ? qWeight : (isK ? kWeight : (isIndexQ ? indexQWeight : indexKWeight));
+        sumSquares = tensorrt_llm::common::warpReduceSum(sumSquares);
+        float const rmsReciprocal = rsqrtf(sumSquares / static_cast<float>(kMinimaxM3HeadDim) + eps);
+#pragma unroll
+        for (int i = 0; i < kMinimaxM3ElemsPerThread; ++i)
+        {
+            int const dim = laneId * kMinimaxM3ElemsPerThread + i;
+            elements[i] *= rmsReciprocal * (1.0F + __bfloat162float(normWeight[dim]));
+        }
+
+        __syncwarp();
+        constexpr int kPairOffset = (kMinimaxM3RotaryDim / 2) / kMinimaxM3ElemsPerThread;
+        int positionId = laneId == 0 ? positionIds[tokenIdx] : 0;
+        positionId = __shfl_sync(0xffffffff, positionId, 0);
+        int64_t const ropeRow = static_cast<int64_t>(positionId) * kMinimaxM3RotaryDim;
+#pragma unroll
+        for (int i = 0; i < kMinimaxM3ElemsPerThread; ++i)
+        {
+            int const dim = laneId * kMinimaxM3ElemsPerThread + i;
+            float paired = __shfl_xor_sync(0xffffffff, elements[i], kPairOffset);
+            if (dim < kMinimaxM3RotaryDim)
+            {
+                bool const firstHalf = dim < kMinimaxM3RotaryDim / 2;
+                if (firstHalf)
+                {
+                    paired = -paired;
+                }
+                int const coefficient = firstHalf ? dim : dim - kMinimaxM3RotaryDim / 2;
+                float const cosine = rotaryCosSin[ropeRow + coefficient];
+                float const sine = rotaryCosSin[ropeRow + kMinimaxM3RotaryDim / 2 + coefficient];
+                elements[i] = elements[i] * cosine + paired * sine;
+            }
+        }
+        __syncwarp();
+    }
+
+    if (isQ)
+    {
+        int const head = localHead;
+        int64_t const outputOffset = (static_cast<int64_t>(tokenIdx) * numHeadsQ + head) * kMinimaxM3HeadDim
+            + laneId * kMinimaxM3ElemsPerThread;
+        storeFp8HeadElements64<kMinimaxM3ElemsPerThread>(qOutput, outputOffset, elements);
+        return;
+    }
+    if (isIndexQ)
+    {
+        int const head = localHead - indexQBegin;
+        int64_t const outputOffset = (static_cast<int64_t>(tokenIdx) * numHeadsIndex + head) * kMinimaxM3HeadDim
+            + laneId * kMinimaxM3ElemsPerThread;
+        // Match vLLM's CUDA path: normalized/RoPE FP32 registers convert
+        // directly to saturating E4M3, without an intermediate BF16 round.
+        storeFp8HeadElements64<kMinimaxM3ElemsPerThread>(indexQOutput, outputOffset, elements);
+        return;
+    }
+
+    int slot = laneId == 0 ? outCacheLoc[tokenIdx] : 0;
+    slot = __shfl_sync(0xffffffff, slot, 0);
+    if (slot < 0)
+    {
+        return;
+    }
+    int const page = slot >> 7;
+    int const withinPage = slot & (kMinimaxM3PageSize - 1);
+    if (isIndexK)
+    {
+        int64_t const outputOffset = static_cast<int64_t>(page) * indexPageStride
+            + static_cast<int64_t>(withinPage) * indexTokenStride + laneId * kMinimaxM3ElemsPerThread;
+        storeFp8HeadElements64<kMinimaxM3ElemsPerThread>(indexKCache, outputOffset, elements);
+        return;
+    }
+
+    int const head = isK ? localHead - kBegin : localHead - vBegin;
+    int const plane = isV ? 1 : 0;
+    int64_t const outputOffset = static_cast<int64_t>(page) * kvPageStride + static_cast<int64_t>(plane) * kvPlaneStride
+        + static_cast<int64_t>(head) * kvHeadStride + static_cast<int64_t>(withinPage) * kvTokenStride
+        + laneId * kMinimaxM3ElemsPerThread;
+    storeFp8HeadElements64<kMinimaxM3ElemsPerThread>(kvCache, outputOffset, elements);
+}
+
+} // namespace
+
 // Borrowed from
 // https://github.com/flashinfer-ai/flashinfer/blob/8125d079a43e9a0ba463a4ed1b639cefd084cec9/include/flashinfer/pos_enc.cuh#L568
 #define DISPATCH_INTERLEAVE(interleave, INTERLEAVE, ...)                                                               \
@@ -458,6 +746,62 @@ void launchFusedQKNormRopeOut(void const* qkv_in, void* qkv_out, bool out_fp8, b
             factor, low, high, attention_factor, stream, is_qk_norm, use_gemma, use_mrope, mrope_section1,
             mrope_section2);
     }
+}
+
+void launchMinimaxM3Fp8QKNormRopeKVInsert(void const* qkv_input, void* q_output, void* kv_cache,
+    int const* out_cache_loc, int64_t page_stride, int64_t plane_stride, int64_t head_stride, int64_t token_stride,
+    int page_size, int num_tokens, int num_heads_q, int num_heads_k, int num_heads_v, int head_dim, int rotary_dim,
+    float eps, void const* q_weight, void const* k_weight, float base, int const* position_ids, cudaStream_t stream)
+{
+    TLLM_CHECK_WITH_INFO(head_dim == kMinimaxM3HeadDim, "MiniMax-M3 FP8 main Q/K/V producer requires head_dim=128");
+    TLLM_CHECK_WITH_INFO(
+        rotary_dim == kMinimaxM3RotaryDim, "MiniMax-M3 FP8 main Q/K/V producer requires rotary_dim=64");
+    TLLM_CHECK_WITH_INFO(num_heads_q > 0, "MiniMax-M3 FP8 main Q/K/V producer requires query heads");
+    TLLM_CHECK_WITH_INFO(
+        num_heads_k > 0 && num_heads_v > 0, "MiniMax-M3 FP8 main Q/K/V producer requires K and V heads");
+    TLLM_CHECK_WITH_INFO(page_size == kMinimaxM3PageSize, "MiniMax-M3 FP8 main Q/K/V producer requires page_size=128");
+
+    constexpr int kBlockSize = 256;
+    constexpr int kWarpsPerBlock = kBlockSize / 32;
+    int const totalWarps = num_tokens * (num_heads_q + num_heads_k + num_heads_v);
+    int const gridSize = common::divUp(totalWarps, kWarpsPerBlock);
+    minimaxM3Fp8QKNormRopeKVInsertKernel<<<gridSize, kBlockSize, 0, stream>>>(
+        static_cast<__nv_bfloat16 const*>(qkv_input), static_cast<__nv_fp8_e4m3*>(q_output),
+        static_cast<__nv_fp8_e4m3*>(kv_cache), out_cache_loc, page_stride, plane_stride, head_stride, token_stride,
+        num_tokens, num_heads_q, num_heads_k, num_heads_v, eps, static_cast<__nv_bfloat16 const*>(q_weight),
+        static_cast<__nv_bfloat16 const*>(k_weight), base, position_ids);
+    TLLM_CUDA_CHECK(cudaGetLastError());
+}
+
+void launchMinimaxM3Fp8QKVIndexerNormRopeKVInsert(void const* packed_input, void* q_output, void* index_q_output,
+    void* kv_cache, void* index_k_cache, int const* out_cache_loc, int64_t kv_page_stride, int64_t kv_plane_stride,
+    int64_t kv_head_stride, int64_t kv_token_stride, int64_t index_page_stride, int64_t index_token_stride,
+    int page_size, int num_tokens, int num_heads_q, int num_heads_kv, int num_heads_index, int head_dim, int rotary_dim,
+    float eps, void const* q_weight, void const* k_weight, void const* index_q_weight, void const* index_k_weight,
+    float const* rotary_cos_sin, int const* position_ids, cudaStream_t stream)
+{
+    TLLM_CHECK_WITH_INFO(head_dim == kMinimaxM3HeadDim, "MiniMax-M3 horizontal producer requires head_dim=128");
+    TLLM_CHECK_WITH_INFO(rotary_dim == kMinimaxM3RotaryDim, "MiniMax-M3 horizontal producer requires rotary_dim=64");
+    TLLM_CHECK_WITH_INFO(page_size == kMinimaxM3PageSize, "MiniMax-M3 horizontal producer requires page_size=128");
+    TLLM_CHECK_WITH_INFO(num_heads_q > 0 && num_heads_kv > 0 && num_heads_index > 0,
+        "MiniMax-M3 horizontal producer requires Q, KV, and index heads");
+    TLLM_CHECK_WITH_INFO(
+        num_heads_index == num_heads_kv, "MiniMax-M3 horizontal producer requires index heads to equal KV heads");
+
+    constexpr int kBlockSize = 256;
+    constexpr int kWarpsPerBlock = kBlockSize / 32;
+    int const slotsPerToken = num_heads_q + 2 * num_heads_kv + num_heads_index + 1;
+    int const totalWarps = num_tokens * slotsPerToken;
+    int const gridSize = common::divUp(totalWarps, kWarpsPerBlock);
+    minimaxM3Fp8QKVIndexerNormRopeKVInsertKernel<<<gridSize, kBlockSize, 0, stream>>>(
+        static_cast<__nv_bfloat16 const*>(packed_input), static_cast<__nv_fp8_e4m3*>(q_output),
+        static_cast<__nv_fp8_e4m3*>(index_q_output), static_cast<__nv_fp8_e4m3*>(kv_cache),
+        static_cast<__nv_fp8_e4m3*>(index_k_cache), out_cache_loc, kv_page_stride, kv_plane_stride, kv_head_stride,
+        kv_token_stride, index_page_stride, index_token_stride, num_tokens, num_heads_q, num_heads_kv, num_heads_index,
+        eps, static_cast<__nv_bfloat16 const*>(q_weight), static_cast<__nv_bfloat16 const*>(k_weight),
+        static_cast<__nv_bfloat16 const*>(index_q_weight), static_cast<__nv_bfloat16 const*>(index_k_weight),
+        rotary_cos_sin, position_ids);
+    TLLM_CUDA_CHECK(cudaGetLastError());
 }
 } // namespace kernels
 

--- a/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.h
+++ b/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "tensorrt_llm/common/config.h"
+
+#include <cstdint>
 #include <cuda_runtime.h>
 
 TRTLLM_NAMESPACE_BEGIN
@@ -70,6 +72,24 @@ void launchFusedQKNormRopeOut(void const* qkv_in, // BF16 input [num_tokens, tot
     int const rotary_dim, float const eps, void const* q_weight, void const* k_weight, float const base,
     bool const interleave, int const* position_ids, float factor, float low, float high, float attention_factor,
     cudaStream_t stream, bool is_qk_norm, bool use_gemma, bool use_mrope, int mrope_section1, int mrope_section2);
+
+// MiniMax-M3-specific producer for eager pure prefill. It returns contiguous
+// FP8 Q and inserts normalized/RoPE'd FP8 K plus copy-cast FP8 V directly into
+// a paged HND pool [num_pages, 2, num_heads, page_size, head_dim].
+void launchMinimaxM3Fp8QKNormRopeKVInsert(void const* qkv_input, void* q_output, void* kv_cache,
+    int const* out_cache_loc, int64_t page_stride, int64_t plane_stride, int64_t head_stride, int64_t token_stride,
+    int page_size, int num_tokens, int num_heads_q, int num_heads_k, int num_heads_v, int head_dim, int rotary_dim,
+    float eps, void const* q_weight, void const* k_weight, float base, int const* position_ids, cudaStream_t stream);
+
+// MiniMax-M3 sparse producer for the packed [Q|K|V|index-Q|index-K]
+// projection. It uses a precomputed FP32 RoPE table, emits compact FP8 Q and
+// index-Q, and inserts main K/V plus index-K into their paged FP8 HND caches.
+void launchMinimaxM3Fp8QKVIndexerNormRopeKVInsert(void const* packed_input, void* q_output, void* index_q_output,
+    void* kv_cache, void* index_k_cache, int const* out_cache_loc, int64_t kv_page_stride, int64_t kv_plane_stride,
+    int64_t kv_head_stride, int64_t kv_token_stride, int64_t index_page_stride, int64_t index_token_stride,
+    int page_size, int num_tokens, int num_heads_q, int num_heads_kv, int num_heads_index, int head_dim, int rotary_dim,
+    float eps, void const* q_weight, void const* k_weight, void const* index_q_weight, void const* index_k_weight,
+    float const* rotary_cos_sin, int const* position_ids, cudaStream_t stream);
 
 } // namespace kernels
 

--- a/cpp/tensorrt_llm/thop/fusedQKNormRopeOp.cpp
+++ b/cpp/tensorrt_llm/thop/fusedQKNormRopeOp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,37 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/extension.h>
 
+#include <tuple>
+
 TRTLLM_NAMESPACE_BEGIN
 
 namespace torch_ext
 {
+
+namespace
+{
+
+void checkMinimaxM3HndKVPool(torch::Tensor const& kvCache, int64_t numHeads, int64_t headDim)
+{
+    TORCH_CHECK(kvCache.is_cuda(), "kv_cache must be a CUDA tensor");
+    TORCH_CHECK(kvCache.scalar_type() == at::ScalarType::Float8_e4m3fn, "kv_cache must use torch.float8_e4m3fn");
+    TORCH_CHECK(kvCache.dim() == 5, "kv_cache must be HND [num_pages, 2, num_heads, page_size, head_dim]");
+    TORCH_CHECK(kvCache.size(0) > 0 && kvCache.size(3) > 0, "kv_cache must have positive num_pages and page_size");
+    TORCH_CHECK(kvCache.size(1) == 2, "kv_cache plane dimension must contain K and V");
+    TORCH_CHECK(kvCache.size(2) == numHeads, "kv_cache num_heads mismatch");
+    TORCH_CHECK(kvCache.size(4) == headDim, "kv_cache head_dim mismatch");
+    TORCH_CHECK(kvCache.stride(4) == 1 && kvCache.stride(3) == headDim,
+        "kv_cache must have contiguous head_dim rows in HND layout");
+    TORCH_CHECK(kvCache.stride(2) == kvCache.size(3) * kvCache.stride(3),
+        "kv_cache must have contiguous [page_size, head_dim] blocks in HND layout");
+    TORCH_CHECK(kvCache.stride(1) >= kvCache.size(2) * kvCache.stride(2), "kv_cache K and V planes must not overlap");
+    TORCH_CHECK(kvCache.stride(0) >= kvCache.size(1) * kvCache.stride(1),
+        "kv_cache page stride must not overlap adjacent HND pages");
+    TORCH_CHECK(kvCache.stride(0) % 4 == 0 && kvCache.stride(1) % 4 == 0,
+        "kv_cache page and plane strides must preserve 32-bit FP8 store alignment");
+}
+
+} // namespace
 
 // Function for fused QK Norm and RoPE
 // This operator applies RMS normalization and RoPE to Q and K tensors in a single CUDA kernel.
@@ -149,6 +176,160 @@ torch::Tensor fused_qk_norm_rope_to_fp8_meta(torch::Tensor const& qkv, int64_t n
     return torch::empty({num_tokens, total_heads * head_dim}, qkv.options().dtype(torch::kFloat8_e4m3fn));
 }
 
+torch::Tensor minimaxM3Fp8QKNormRopeKVInsert(torch::Tensor const& qkv, torch::Tensor& kvCache,
+    torch::Tensor const& outCacheLoc, int64_t numHeadsQ, int64_t numHeadsK, int64_t numHeadsV, int64_t headDim,
+    int64_t rotaryDim, double eps, torch::Tensor const& qWeight, torch::Tensor const& kWeight, double base, bool isNeox,
+    torch::Tensor const& positionIds)
+{
+    constexpr int64_t kHeadDim = 128;
+    constexpr int64_t kRotaryDim = 64;
+    constexpr int64_t kPageSize = 128;
+    TORCH_CHECK(numHeadsQ > 0, "MiniMax-M3 FP8 main Q/K/V producer requires num_heads_q > 0");
+    TORCH_CHECK(numHeadsK > 0 && numHeadsV > 0, "MiniMax-M3 FP8 main Q/K/V producer requires K and V heads");
+    TORCH_CHECK(numHeadsK == numHeadsV, "MiniMax-M3 FP8 main Q/K/V producer requires equal K and V head counts");
+    TORCH_CHECK(headDim == kHeadDim, "MiniMax-M3 FP8 main Q/K/V producer requires head_dim=128");
+    TORCH_CHECK(rotaryDim == kRotaryDim, "MiniMax-M3 FP8 main Q/K/V producer requires rotary_dim=64");
+    TORCH_CHECK(isNeox, "MiniMax-M3 FP8 main Q/K/V producer requires NeoX RoPE");
+    TORCH_CHECK(eps >= 0.0, "MiniMax-M3 FP8 main Q/K/V producer requires eps >= 0");
+    TORCH_CHECK(base > 0.0, "MiniMax-M3 FP8 main Q/K/V producer requires base > 0");
+
+    TORCH_CHECK(qkv.dim() == 2, "QKV tensor must be 2D: [num_tokens, (num_heads_q+num_heads_k+num_heads_v)*head_dim]");
+    TORCH_CHECK(outCacheLoc.dim() == 1, "out_cache_loc must be one-dimensional");
+    TORCH_CHECK(positionIds.dim() == 1, "position_ids must be one-dimensional");
+    TORCH_CHECK(qWeight.dim() == 1 && kWeight.dim() == 1, "Q/K norm weights must be one-dimensional");
+
+    CHECK_INPUT(qkv, torch::kBFloat16);
+    CHECK_INPUT(outCacheLoc, torch::kInt32);
+    CHECK_INPUT(positionIds, torch::kInt32);
+    CHECK_INPUT(qWeight, torch::kBFloat16);
+    CHECK_INPUT(kWeight, torch::kBFloat16);
+    checkMinimaxM3HndKVPool(kvCache, numHeadsK, headDim);
+    TORCH_CHECK(kvCache.size(3) == kPageSize, "MiniMax-M3 FP8 main Q/K/V producer requires page_size=128");
+
+    int64_t const numTokens = qkv.size(0);
+    int64_t const totalHeads = numHeadsQ + numHeadsK + numHeadsV;
+    TORCH_CHECK(qkv.size(1) == totalHeads * headDim,
+        "QKV tensor width must equal (num_heads_q + num_heads_k + num_heads_v) * head_dim");
+    TORCH_CHECK(outCacheLoc.numel() >= numTokens, "out_cache_loc is shorter than num_tokens");
+    TORCH_CHECK(positionIds.numel() == numTokens, "position_ids length must equal num_tokens");
+    TORCH_CHECK(qWeight.numel() == headDim && kWeight.numel() == headDim, "Q/K norm weight width must equal head_dim");
+    TORCH_CHECK(qkv.get_device() == kvCache.get_device() && qkv.get_device() == outCacheLoc.get_device()
+            && qkv.get_device() == positionIds.get_device() && qkv.get_device() == qWeight.get_device()
+            && qkv.get_device() == kWeight.get_device(),
+        "All MiniMax-M3 FP8 main Q/K/V producer tensors must be on the same CUDA device");
+
+    auto qOut = torch::empty({numTokens, numHeadsQ, headDim}, qkv.options().dtype(at::ScalarType::Float8_e4m3fn));
+    if (numTokens == 0)
+    {
+        return qOut;
+    }
+
+    auto stream = at::cuda::getCurrentCUDAStream(qkv.get_device());
+    tensorrt_llm::kernels::launchMinimaxM3Fp8QKNormRopeKVInsert(qkv.data_ptr(), qOut.data_ptr(), kvCache.data_ptr(),
+        outCacheLoc.data_ptr<int>(), kvCache.stride(0), kvCache.stride(1), kvCache.stride(2), kvCache.stride(3),
+        static_cast<int>(kvCache.size(3)), static_cast<int>(numTokens), static_cast<int>(numHeadsQ),
+        static_cast<int>(numHeadsK), static_cast<int>(numHeadsV), static_cast<int>(headDim),
+        static_cast<int>(rotaryDim), static_cast<float>(eps), qWeight.data_ptr(), kWeight.data_ptr(),
+        static_cast<float>(base), positionIds.data_ptr<int>(), stream);
+    return qOut;
+}
+
+torch::Tensor minimaxM3Fp8QKNormRopeKVInsertMeta(torch::Tensor const& qkv, torch::Tensor& /*kvCache*/,
+    torch::Tensor const& /*outCacheLoc*/, int64_t numHeadsQ, int64_t /*numHeadsK*/, int64_t /*numHeadsV*/,
+    int64_t headDim, int64_t /*rotaryDim*/, double /*eps*/, torch::Tensor const& /*qWeight*/,
+    torch::Tensor const& /*kWeight*/, double /*base*/, bool /*isNeox*/, torch::Tensor const& /*positionIds*/)
+{
+    return torch::empty({qkv.size(0), numHeadsQ, headDim}, qkv.options().dtype(at::ScalarType::Float8_e4m3fn));
+}
+
+std::tuple<torch::Tensor, torch::Tensor> minimaxM3Fp8QKVIndexerNormRopeKVInsert(torch::Tensor const& packed,
+    torch::Tensor& kvCache, torch::Tensor& indexKCache, torch::Tensor const& outCacheLoc, int64_t numHeadsQ,
+    int64_t numHeadsKV, int64_t numHeadsIndex, int64_t headDim, int64_t rotaryDim, double eps,
+    torch::Tensor const& qWeight, torch::Tensor const& kWeight, torch::Tensor const& indexQWeight,
+    torch::Tensor const& indexKWeight, torch::Tensor const& rotaryCosSin, torch::Tensor const& positionIds)
+{
+    constexpr int64_t kHeadDim = 128;
+    constexpr int64_t kRotaryDim = 64;
+    constexpr int64_t kPageSize = 128;
+    TORCH_CHECK(numHeadsQ > 0 && numHeadsKV > 0 && numHeadsIndex > 0,
+        "MiniMax-M3 horizontal producer requires Q, KV, and index heads");
+    TORCH_CHECK(numHeadsKV == numHeadsIndex, "MiniMax-M3 horizontal producer requires index heads to equal KV heads");
+    TORCH_CHECK(headDim == kHeadDim, "MiniMax-M3 horizontal producer requires head_dim=128");
+    TORCH_CHECK(rotaryDim == kRotaryDim, "MiniMax-M3 horizontal producer requires rotary_dim=64");
+    TORCH_CHECK(eps >= 0.0, "MiniMax-M3 horizontal producer requires eps >= 0");
+
+    TORCH_CHECK(packed.dim() == 2, "Packed QKV+index tensor must be two-dimensional");
+    TORCH_CHECK(outCacheLoc.dim() == 1, "out_cache_loc must be one-dimensional");
+    TORCH_CHECK(positionIds.dim() == 1, "position_ids must be one-dimensional");
+    CHECK_INPUT(packed, torch::kBFloat16);
+    CHECK_INPUT(outCacheLoc, torch::kInt32);
+    CHECK_INPUT(positionIds, torch::kInt32);
+    CHECK_INPUT(qWeight, torch::kBFloat16);
+    CHECK_INPUT(kWeight, torch::kBFloat16);
+    CHECK_INPUT(indexQWeight, torch::kBFloat16);
+    CHECK_INPUT(indexKWeight, torch::kBFloat16);
+    CHECK_INPUT(rotaryCosSin, torch::kFloat32);
+    checkMinimaxM3HndKVPool(kvCache, numHeadsKV, headDim);
+    TORCH_CHECK(kvCache.size(3) == kPageSize, "MiniMax-M3 horizontal producer requires page_size=128");
+    TORCH_CHECK(indexKCache.is_cuda() && indexKCache.scalar_type() == at::ScalarType::Float8_e4m3fn,
+        "Index-K cache must be CUDA torch.float8_e4m3fn");
+    TORCH_CHECK(indexKCache.dim() == 4 && indexKCache.size(1) == 1 && indexKCache.size(2) == kPageSize
+            && indexKCache.size(3) == kHeadDim,
+        "Index-K cache must be HND [num_pages, 1, 128, 128]");
+    TORCH_CHECK(indexKCache.stride(3) == 1 && indexKCache.stride(2) == kHeadDim,
+        "Index-K cache must have contiguous token rows");
+    TORCH_CHECK(rotaryCosSin.dim() == 3 && rotaryCosSin.size(1) == 2 && rotaryCosSin.size(2) == kRotaryDim / 2,
+        "rotary_cos_sin must be [max_positions, 2, rotary_dim/2]");
+
+    int64_t const numTokens = packed.size(0);
+    int64_t const totalHeads = numHeadsQ + 2 * numHeadsKV + numHeadsIndex + 1;
+    TORCH_CHECK(
+        packed.size(1) == totalHeads * headDim, "Packed tensor width must equal (Q + 2*KV + index-Q + 1) * head_dim");
+    TORCH_CHECK(outCacheLoc.numel() >= numTokens, "out_cache_loc is shorter than num_tokens");
+    TORCH_CHECK(positionIds.numel() == numTokens, "position_ids length must equal num_tokens");
+    TORCH_CHECK(qWeight.numel() == headDim && kWeight.numel() == headDim && indexQWeight.numel() == headDim
+            && indexKWeight.numel() == headDim,
+        "All norm weights must contain head_dim elements");
+    TORCH_CHECK(packed.get_device() == kvCache.get_device() && packed.get_device() == indexKCache.get_device()
+            && packed.get_device() == outCacheLoc.get_device() && packed.get_device() == positionIds.get_device()
+            && packed.get_device() == qWeight.get_device() && packed.get_device() == kWeight.get_device()
+            && packed.get_device() == indexQWeight.get_device() && packed.get_device() == indexKWeight.get_device()
+            && packed.get_device() == rotaryCosSin.get_device(),
+        "All MiniMax-M3 horizontal producer tensors must be on the same CUDA device");
+
+    auto qOut = torch::empty({numTokens, numHeadsQ, headDim}, packed.options().dtype(at::ScalarType::Float8_e4m3fn));
+    auto indexQOut
+        = torch::empty({numTokens, numHeadsIndex, headDim}, packed.options().dtype(at::ScalarType::Float8_e4m3fn));
+    if (numTokens == 0)
+    {
+        return {qOut, indexQOut};
+    }
+
+    auto stream = at::cuda::getCurrentCUDAStream(packed.get_device());
+    tensorrt_llm::kernels::launchMinimaxM3Fp8QKVIndexerNormRopeKVInsert(packed.data_ptr(), qOut.data_ptr(),
+        indexQOut.data_ptr(), kvCache.data_ptr(), indexKCache.data_ptr(), outCacheLoc.data_ptr<int>(),
+        kvCache.stride(0), kvCache.stride(1), kvCache.stride(2), kvCache.stride(3), indexKCache.stride(0),
+        indexKCache.stride(2), static_cast<int>(kvCache.size(3)), static_cast<int>(numTokens),
+        static_cast<int>(numHeadsQ), static_cast<int>(numHeadsKV), static_cast<int>(numHeadsIndex),
+        static_cast<int>(headDim), static_cast<int>(rotaryDim), static_cast<float>(eps), qWeight.data_ptr(),
+        kWeight.data_ptr(), indexQWeight.data_ptr(), indexKWeight.data_ptr(), rotaryCosSin.data_ptr<float>(),
+        positionIds.data_ptr<int>(), stream);
+    return {qOut, indexQOut};
+}
+
+std::tuple<torch::Tensor, torch::Tensor> minimaxM3Fp8QKVIndexerNormRopeKVInsertMeta(torch::Tensor const& packed,
+    torch::Tensor& /*kvCache*/, torch::Tensor& /*indexKCache*/, torch::Tensor const& /*outCacheLoc*/, int64_t numHeadsQ,
+    int64_t /*numHeadsKV*/, int64_t numHeadsIndex, int64_t headDim, int64_t /*rotaryDim*/, double /*eps*/,
+    torch::Tensor const& /*qWeight*/, torch::Tensor const& /*kWeight*/, torch::Tensor const& /*indexQWeight*/,
+    torch::Tensor const& /*indexKWeight*/, torch::Tensor const& /*rotaryCosSin*/, torch::Tensor const& /*positionIds*/)
+{
+    auto options = packed.options().dtype(at::ScalarType::Float8_e4m3fn);
+    return {
+        torch::empty({packed.size(0), numHeadsQ, headDim}, options),
+        torch::empty({packed.size(0), numHeadsIndex, headDim}, options),
+    };
+}
+
 // Register the PyTorch operators
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
@@ -163,6 +344,15 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
         "rotary_dim, float eps, Tensor q_weight, Tensor k_weight, float base, bool is_neox, Tensor position_ids, float "
         "factor, float low, float high, float attention_factor, bool is_qk_norm, bool use_gemma, bool use_mrope, int "
         "mrope_section1, int mrope_section2) -> Tensor");
+    m.def(
+        "minimax_m3_fp8_qk_norm_rope_kv_insert(Tensor qkv, Tensor(a!) kv_cache, Tensor out_cache_loc, int "
+        "num_heads_q, int num_heads_k, int num_heads_v, int head_dim, int rotary_dim, float eps, Tensor q_weight, "
+        "Tensor k_weight, float base, bool is_neox, Tensor position_ids) -> Tensor");
+    m.def(
+        "minimax_m3_fp8_qkv_indexer_norm_rope_kv_insert(Tensor packed, Tensor(a!) kv_cache, Tensor(b!) "
+        "index_k_cache, Tensor out_cache_loc, int num_heads_q, int num_heads_kv, int num_heads_index, int head_dim, "
+        "int rotary_dim, float eps, Tensor q_weight, Tensor k_weight, Tensor index_q_weight, Tensor index_k_weight, "
+        "Tensor rotary_cos_sin, Tensor position_ids) -> (Tensor, Tensor)");
 }
 
 // Register the CUDA implementation
@@ -170,12 +360,16 @@ TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 {
     m.impl("fused_qk_norm_rope", &fused_qk_norm_rope);
     m.impl("fused_qk_norm_rope_to_fp8", &fused_qk_norm_rope_to_fp8);
+    m.impl("minimax_m3_fp8_qk_norm_rope_kv_insert", &minimaxM3Fp8QKNormRopeKVInsert);
+    m.impl("minimax_m3_fp8_qkv_indexer_norm_rope_kv_insert", &minimaxM3Fp8QKVIndexerNormRopeKVInsert);
 }
 
 // Register the Meta implementation (shape/dtype inference for torch.compile).
 TORCH_LIBRARY_IMPL(trtllm, Meta, m)
 {
     m.impl("fused_qk_norm_rope_to_fp8", &fused_qk_norm_rope_to_fp8_meta);
+    m.impl("minimax_m3_fp8_qk_norm_rope_kv_insert", &minimaxM3Fp8QKNormRopeKVInsertMeta);
+    m.impl("minimax_m3_fp8_qkv_indexer_norm_rope_kv_insert", &minimaxM3Fp8QKVIndexerNormRopeKVInsertMeta);
 }
 
 } // namespace torch_ext

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/common.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/common.py
@@ -43,6 +43,7 @@ class MiniMaxM3SparseParams(SparseParams):
     disable_index_value: bool = True
     implementation: Literal["triton", "msa"] = "triton"
     indexer_kv_dtype: Literal["bf16", "fp8"] = "bf16"
+    fuse_qkv_index_projection: bool = False
 
     @property
     def indices_block_size(self) -> int:
@@ -62,6 +63,7 @@ class MiniMaxM3SparseMetadataParams(SparseMetadataParams):
     global_num_kv_heads: int = 0
     num_index_heads: int = 4
     topk: int = 16
+    fuse_qkv_index_projection: bool = False
 
     def sharded_head_counts(self, mapping: Optional["Mapping"] = None) -> Tuple[int, int]:
         """Return per-rank (num_q_heads, num_kv_heads) for mapping.
@@ -78,6 +80,13 @@ class MiniMaxM3SparseMetadataParams(SparseMetadataParams):
             return (int(num_heads) + tp_size - 1) // tp_size
 
         return _shard(self.global_num_q_heads), _shard(self.global_num_kv_heads)
+
+    def sharded_index_head_count(self, mapping: Optional["Mapping"] = None) -> int:
+        """Return the index-head count used by this rank's proxy attention."""
+        if not self.fuse_qkv_index_projection:
+            return int(self.num_index_heads)
+        _, num_kv_heads = self.sharded_head_counts(mapping)
+        return num_kv_heads
 
 
 @dataclass(frozen=True)
@@ -149,7 +158,11 @@ class MiniMaxM3SparseConfig:
             num_q_heads=int(num_q_heads),
             num_kv_heads=int(num_kv_heads),
             head_dim=int(head_dim),
-            num_index_heads=int(sparse_params.num_index_heads),
+            num_index_heads=(
+                int(num_kv_heads)
+                if sparse_params.fuse_qkv_index_projection
+                else int(sparse_params.num_index_heads)
+            ),
             sparse_index_dim=int(sparse_params.sparse_index_dim),
             block_size=int(sparse_params.block_size),
             topk=int(sparse_params.topk),

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
@@ -479,14 +479,15 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
         params = self._msa_params
         if params is not None:
             fmha_sm100 = require_msa_module()
+            num_index_heads = params.sharded_index_head_count(self.mapping)
             max_k_tiles = _worst_case_proxy_max_k_tiles(
                 fmha_sm100,
-                num_index_heads=params.num_index_heads,
+                num_index_heads=num_index_heads,
                 kv_cache_manager=kv_cache_manager,
                 max_batch=max_num_sequences,
             )
             self._alloc_msa_proxy_scratch(
-                num_index_heads=params.num_index_heads,
+                num_index_heads=num_index_heads,
                 max_tokens=self._msa_max_decode_tokens(),
                 max_k_tiles=max_k_tiles,
                 capture_graph=capture_graph,
@@ -747,7 +748,7 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
         params = self._msa_params
         if params is None:
             return
-        num_index_heads = params.num_index_heads
+        num_index_heads = params.sharded_index_head_count(self.mapping)
         num_q_heads, num_kv_heads = params.sharded_head_counts(self.mapping)
         topk = params.topk
 
@@ -1162,6 +1163,9 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
         if idx_k is not None and not idx_k_prewritten:
             idx_k_view = idx_k.reshape(num_tokens, 1, config.sparse_index_dim)
             metadata.msa_write_idx_k(self.layer_idx, idx_k_view)
+            # Lightweight metadata implementations may install their cache on
+            # first write, so refresh the handle before the proxy reads it.
+            idx_k_cache = metadata.msa_idx_k_cache(self.layer_idx)
         elif idx_k is None and (
             idx_k_cache.dtype != torch.float8_e4m3fn or idx_q_view.dtype != torch.float8_e4m3fn
         ):
@@ -1236,6 +1240,48 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
         forward_args: "AttentionForwardArgs",
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         return None, None
+
+    def forward_prepopulated_kv(
+        self,
+        q: torch.Tensor,
+        metadata: MiniMaxM3MsaSparseAttentionMetadata,
+        forward_args: "AttentionForwardArgs",
+    ) -> None:
+        """Run MSA after the eager-prefill producer inserted main K/V.
+
+        ``TrtllmAttention.forward`` interprets ``k=None`` as a fused QKV
+        buffer, so it cannot represent compact Q with prewritten paged K/V.
+        Dispatch the same MSA paged-GQA helper directly; the #16755 prewritten
+        marker is consumed there exactly as on its general scatter path.
+        """
+        output = forward_args.output
+        if output is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.forward_prepopulated_kv requires an output buffer."
+            )
+
+        kv_block_indexes = forward_args.topk_indices
+        if kv_block_indexes is not None:
+            plan = metadata.msa_decode_gqa_plan
+            if plan is None:
+                plan = metadata.msa_eager_gqa_plan
+        else:
+            plan = metadata.msa_decode_dense_plan
+            if plan is None:
+                plan = metadata.msa_eager_dense_plan
+
+        from tensorrt_llm._torch.attention_backend.fmha.msa_sparse_gqa import run_msa_paged_gqa
+
+        run_msa_paged_gqa(
+            self,
+            q,
+            None,
+            None,
+            metadata,
+            output,
+            kv_block_indexes=kv_block_indexes,
+            plan=plan,
+        )
 
 
 __all__ = [

--- a/tensorrt_llm/_torch/models/modeling_minimaxm3.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm3.py
@@ -81,6 +81,171 @@ from .modeling_utils import DecoderModel, ModelConfig, filter_weights, register_
 # and flash SDPA does not accept attn_mask.
 _DENSE_SDPA_BACKENDS = [SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]
 
+# Experimental A/B gate for producing compact FP8 Q while inserting main K/V
+# directly into the MSA paged cache during supported eager pure-prefill steps.
+_FUSED_MAIN_KV_WRITE_ENV = "TRTLLM_MINIMAX_M3_FUSED_MAIN_KV_WRITE"
+
+
+class MiniMaxM3QKVIndexerLinear(Linear):
+    """Five-way MiniMax-M3 projection with vLLM-compatible TP sharding.
+
+    Each rank emits ``[Q | K | V | index-Q | index-K]``. Q follows normal
+    attention head sharding, K/V/index-Q follow KV-head sharding (including
+    replication when TP exceeds the KV-head count), and the single index-K
+    head is replicated. The underlying :class:`Linear` remains the standard
+    quantized implementation; only checkpoint packing is model-specific.
+    """
+
+    _SHARD_NAMES = ("q", "k", "v", "index_q", "index_k")
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        head_dim: int,
+        total_num_heads: int,
+        total_num_kv_heads: int,
+        total_num_index_heads: int,
+        index_head_dim: int,
+        dtype: torch.dtype,
+        mapping: Mapping,
+        quant_config: Optional[QuantConfig],
+        skip_create_weights_in_init: bool,
+        force_dynamic_quantization: bool,
+        disable_deep_gemm: bool,
+        use_custom_cublas_mm: bool,
+        use_cute_dsl_blockscaling_mm: bool,
+    ) -> None:
+        if total_num_index_heads != total_num_kv_heads:
+            raise ValueError(
+                "MiniMax-M3 fused QKV+index projection requires index heads "
+                f"({total_num_index_heads}) to equal KV heads ({total_num_kv_heads})."
+            )
+        if index_head_dim != head_dim:
+            raise ValueError(
+                "MiniMax-M3 fused QKV+index projection requires index_head_dim "
+                f"({index_head_dim}) to equal head_dim ({head_dim})."
+            )
+
+        tp_size = int(mapping.tp_size)
+        if total_num_heads % tp_size != 0:
+            raise ValueError(f"Q heads ({total_num_heads}) must be divisible by TP ({tp_size}).")
+        if total_num_kv_heads >= tp_size:
+            if total_num_kv_heads % tp_size != 0:
+                raise ValueError(
+                    f"KV heads ({total_num_kv_heads}) must be divisible by TP ({tp_size})."
+                )
+            local_num_kv_heads = total_num_kv_heads // tp_size
+        else:
+            if tp_size % total_num_kv_heads != 0:
+                raise ValueError(
+                    f"TP ({tp_size}) must be divisible by KV heads "
+                    f"({total_num_kv_heads}) for replication."
+                )
+            local_num_kv_heads = 1
+
+        self.total_num_heads = int(total_num_heads)
+        self.total_num_kv_heads = int(total_num_kv_heads)
+        self.total_num_index_heads = int(total_num_index_heads)
+        self.head_dim = int(head_dim)
+        self.index_head_dim = int(index_head_dim)
+        self.local_num_heads = total_num_heads // tp_size
+        self.local_num_kv_heads = local_num_kv_heads
+        self.local_num_index_heads = local_num_kv_heads
+        self.local_output_sizes = (
+            self.local_num_heads * head_dim,
+            local_num_kv_heads * head_dim,
+            local_num_kv_heads * head_dim,
+            local_num_kv_heads * index_head_dim,
+            index_head_dim,
+        )
+        local_out_features = sum(self.local_output_sizes)
+
+        super().__init__(
+            hidden_size,
+            tp_size * local_out_features,
+            bias=False,
+            dtype=dtype,
+            mapping=mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            quant_config=quant_config,
+            weights_loading_config=WeightsLoadingConfig(weight_mode=WeightMode.FUSED_QKV_LINEAR),
+            reduce_output=False,
+            skip_create_weights_in_init=skip_create_weights_in_init,
+            force_dynamic_quantization=force_dynamic_quantization,
+            disable_deep_gemm=disable_deep_gemm,
+            use_custom_cublas_mm=use_custom_cublas_mm,
+            use_cute_dsl_blockscaling_mm=use_cute_dsl_blockscaling_mm,
+        )
+
+    def _shard_geometry(self, shard_name: str) -> Tuple[int, int]:
+        """Return effective (world size, rank) for one checkpoint shard."""
+        if shard_name == "q":
+            return self.tp_size, self.tp_rank
+        if shard_name == "index_k":
+            return 1, 0
+
+        total_heads = (
+            self.total_num_index_heads if shard_name == "index_q" else self.total_num_kv_heads
+        )
+        if self.tp_size <= total_heads:
+            return self.tp_size, self.tp_rank
+        replicas = self.tp_size // total_heads
+        return total_heads, self.tp_rank // replicas
+
+    def load_five_way_weights(self, shards: Dict[str, Dict]) -> None:
+        """Load five checkpoint projections into this rank's packed MXFP8 matrix."""
+        local_shards: Dict[str, Dict[str, torch.Tensor]] = {}
+        for shard_name in self._SHARD_NAMES:
+            shard = shards[shard_name]
+            if "weight" not in shard:
+                raise KeyError(f"Missing {shard_name} projection weight.")
+            shard_world, shard_rank = self._shard_geometry(shard_name)
+            local = {}
+            for key in ("weight", "weight_scale_inv", "weight_scale", "bias"):
+                if key in shard:
+                    local[key] = load_weight_shard(
+                        shard[key],
+                        shard_world,
+                        shard_rank,
+                        TensorParallelMode.COLUMN,
+                        device=torch.device("cuda"),
+                    )
+            local_shards[shard_name] = local
+
+        combined: Dict[str, torch.Tensor] = {
+            "weight": torch.cat(
+                [local_shards[name]["weight"] for name in self._SHARD_NAMES], dim=0
+            ).contiguous()
+        }
+        for key in ("weight_scale_inv", "weight_scale", "bias"):
+            present = [key in local_shards[name] for name in self._SHARD_NAMES]
+            if any(present):
+                if not all(present):
+                    raise KeyError(f"Incomplete {key} across fused QKV+index shards.")
+                combined[key] = torch.cat(
+                    [local_shards[name][key] for name in self._SHARD_NAMES], dim=0
+                ).contiguous()
+
+        # The checkpoint tensors above are already rank-local and packed.
+        # Temporarily select vanilla loading so Linear copies them without a
+        # second TP split or the three-shard QKV loader.
+        saved_tp_size = self.tp_size
+        saved_tp_rank = self.tp_rank
+        saved_tp_mode = self.tp_mode
+        saved_loading_config = self.weights_loading_config
+        try:
+            self.tp_size = 1
+            self.tp_rank = 0
+            self.tp_mode = None
+            self.weights_loading_config = WeightsLoadingConfig(weight_mode=WeightMode.VANILLA)
+            self.load_weights([combined])
+        finally:
+            self.tp_size = saved_tp_size
+            self.tp_rank = saved_tp_rank
+            self.tp_mode = saved_tp_mode
+            self.weights_loading_config = saved_loading_config
+
 
 # ---------------------------------------------------------------------------
 # Config normalization helpers
@@ -723,6 +888,7 @@ class MiniMaxM3Attention(Attention):
             and quant_config.quant_mode is not None
             and quant_config.quant_mode.has_fp8_kv_cache()
         )
+        self.enable_fused_main_kv_write = os.environ.get(_FUSED_MAIN_KV_WRITE_ENV, "0") == "1"
 
         # Per-head Gemma RMSNorm — one set of weights shared across heads.
         self.q_norm = RMSNorm(
@@ -749,9 +915,16 @@ class MiniMaxM3Attention(Attention):
 
         self.is_sparse_attention_layer = bool(is_sparse_attention_layer)
         self.disable_index_value = bool(disable_index_value)
+        sparse_runtime_cfg = getattr(model_config, "sparse_attention_config", None)
+        self.enable_fused_qkv_index_projection = bool(
+            self.is_sparse_attention_layer
+            and sparse_runtime_cfg is not None
+            and getattr(sparse_runtime_cfg, "fuse_qkv_index_projection", False)
+        )
         if self.is_sparse_attention_layer:
             sparse_cfg = getattr(config, "sparse_attention_config", None) or {}
-            self.sparse_num_index_heads = int(sparse_cfg.get("sparse_num_index_heads", 4))
+            total_num_index_heads = int(sparse_cfg.get("sparse_num_index_heads", 4))
+            self.sparse_num_index_heads = total_num_index_heads
             self.sparse_index_dim = int(sparse_cfg.get("sparse_index_dim", 128))
             self.sparse_block_size = int(sparse_cfg.get("sparse_block_size", 128))
             self.sparse_topk_blocks = int(sparse_cfg.get("sparse_topk_blocks", 16))
@@ -759,25 +932,44 @@ class MiniMaxM3Attention(Attention):
             self.sparse_local_block = int(sparse_cfg.get("sparse_local_block", 1))
             self.sparse_score_type = str(sparse_cfg.get("sparse_score_type", "max"))
 
-            # Index Q and K are both replicated (no head sharding) and project
-            # the same hidden_states, so fuse them into one index_qk_proj GEMM
-            # with output [idx_q | idx_k]. idx_q holds all num_index_heads heads;
-            # idx_k is a single K per token, broadcast across heads when scoring.
+            if self.enable_fused_qkv_index_projection:
+                old_qkv_proj = self.qkv_proj
+                self.qkv_proj = MiniMaxM3QKVIndexerLinear(
+                    hidden_size=config.hidden_size,
+                    head_dim=self.head_dim,
+                    total_num_heads=config.num_attention_heads,
+                    total_num_kv_heads=config.num_key_value_heads,
+                    total_num_index_heads=total_num_index_heads,
+                    index_head_dim=self.sparse_index_dim,
+                    dtype=config.torch_dtype,
+                    mapping=old_qkv_proj.mapping,
+                    quant_config=old_qkv_proj.quant_config,
+                    skip_create_weights_in_init=model_config.skip_create_weights_in_init,
+                    force_dynamic_quantization=old_qkv_proj.force_dynamic_quantization,
+                    disable_deep_gemm=old_qkv_proj.disable_deep_gemm,
+                    use_custom_cublas_mm=old_qkv_proj.use_custom_cublas_mm,
+                    use_cute_dsl_blockscaling_mm=old_qkv_proj.use_cute_dsl_blockscaling_mm,
+                )
+                self.sparse_num_index_heads = self.qkv_proj.local_num_index_heads
+            else:
+                # The compatibility path keeps index Q and K replicated and
+                # emits them from a separate GEMM.
+                self.index_qk_proj = Linear(
+                    config.hidden_size,
+                    total_num_index_heads * self.sparse_index_dim + self.sparse_index_dim,
+                    bias=False,
+                    dtype=config.torch_dtype,
+                    mapping=model_config.mapping,
+                    tensor_parallel_mode=None,
+                    quant_config=None,
+                    weights_loading_config=WeightsLoadingConfig(
+                        weight_mode=WeightMode.FUSED_GATE_UP_LINEAR
+                    ),
+                    skip_create_weights_in_init=model_config.skip_create_weights_in_init,
+                )
+
             self.index_q_size = self.sparse_num_index_heads * self.sparse_index_dim
             self.index_k_size = self.sparse_index_dim
-            self.index_qk_proj = Linear(
-                config.hidden_size,
-                self.index_q_size + self.index_k_size,
-                bias=False,
-                dtype=config.torch_dtype,
-                mapping=model_config.mapping,
-                tensor_parallel_mode=None,
-                quant_config=None,
-                weights_loading_config=WeightsLoadingConfig(
-                    weight_mode=WeightMode.FUSED_GATE_UP_LINEAR
-                ),
-                skip_create_weights_in_init=model_config.skip_create_weights_in_init,
-            )
             # Per-head Gemma RMSNorm of width ``sparse_index_dim``;
             # applied to the projected index Q/K before partial RoPE in
             # the sparse forward path.
@@ -1019,6 +1211,207 @@ class MiniMaxM3Attention(Attention):
             position_ids.reshape(-1).contiguous().to(torch.int32),
         ).flatten(1)
 
+    def _fused_fp8_main_qk_norm_rope_kv_insert(
+        self,
+        qkv: torch.Tensor,
+        position_ids: Optional[torch.Tensor],
+        attn_metadata: AttentionMetadata,
+    ) -> Optional[torch.Tensor]:
+        """Produce compact FP8 Q and insert main K/V into their final cache.
+
+        This path is intentionally narrower than the #16755 fused Triton
+        scatter. Unsupported decode, mixed, CUDA-graph, BF16-cache, or layout
+        cases return ``None`` and retain that general producer-plus-scatter
+        path unchanged. Sparse index-K remains owned by the existing FP8 index
+        producer and is not handled by this main-QKV kernel.
+        """
+        if not self.enable_fused_main_kv_write or not self._emit_fp8_main_qkv():
+            return None
+        if (
+            is_torch_compiling()
+            or getattr(attn_metadata, "is_cuda_graph", False)
+            or int(getattr(attn_metadata, "num_generations", 0)) != 0
+            or int(getattr(attn_metadata, "num_contexts", 0)) == 0
+            or int(qkv.shape[0]) != int(attn_metadata.num_tokens)
+        ):
+            return None
+        if (
+            qkv.dtype != torch.bfloat16
+            or position_ids is None
+            or self.head_dim != 128
+            or not self.use_gemma_norm
+            or self.pos_embd_params is None
+            or not self.pos_embd_params.is_neox
+            or self.rotary_emb is None
+            or self.pos_embd_params.rope is None
+            or int(self.pos_embd_params.rope.dim) != 64
+            or self.q_norm.weight.dtype != torch.bfloat16
+            or self.k_norm.weight.dtype != torch.bfloat16
+        ):
+            return None
+        # Sparse layers must leave index-K ownership with the #16742 direct
+        # FP8 producer. Do not create a second write path for BF16 index-K.
+        if self.is_sparse_attention_layer and self.attn.indexer_kv_dtype != "fp8":
+            return None
+
+        kv_cache_manager = getattr(attn_metadata, "kv_cache_manager", None)
+        if kv_cache_manager is None:
+            return None
+        buffers = kv_cache_manager.get_buffers(self.layer_idx, kv_layout="HND")
+        if buffers is None:
+            return None
+        expected_head_stride = 128 * 128
+        supported_hnd = (
+            buffers.is_cuda
+            and buffers.dtype == torch.float8_e4m3fn
+            and buffers.dim() == 5
+            and int(buffers.shape[0]) > 0
+            and tuple(buffers.shape[1:]) == (2, self.num_key_value_heads, 128, 128)
+            and buffers.stride(4) == 1
+            and buffers.stride(3) == 128
+            and buffers.stride(2) == expected_head_stride
+            and buffers.stride(1) >= self.num_key_value_heads * expected_head_stride
+            and buffers.stride(0) >= 2 * buffers.stride(1)
+            and buffers.stride(0) % 4 == 0
+            and buffers.stride(1) % 4 == 0
+        )
+        out_cache_loc = getattr(attn_metadata, "msa_out_cache_loc", None)
+        num_tokens = int(qkv.shape[0])
+        if (
+            not supported_hnd
+            or out_cache_loc is None
+            or not out_cache_loc.is_cuda
+            or out_cache_loc.dtype != torch.int32
+            or out_cache_loc.dim() != 1
+            or not out_cache_loc.is_contiguous()
+            or out_cache_loc.numel() < num_tokens
+        ):
+            return None
+
+        q = torch.ops.trtllm.minimax_m3_fp8_qk_norm_rope_kv_insert(
+            qkv.contiguous(),
+            buffers,
+            out_cache_loc[:num_tokens],
+            self.num_heads,
+            self.num_key_value_heads,
+            self.num_key_value_heads,
+            self.head_dim,
+            64,
+            self.q_norm.variance_epsilon,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            self.pos_embd_params.rope.theta,
+            True,
+            position_ids.reshape(-1).contiguous().to(torch.int32),
+        ).flatten(1)
+        # #16755 consumes this marker in run_msa_paged_gqa. It also lets the
+        # model core distinguish the direct producer from the general path and
+        # skip only this layer's fused Triton K/V scatter.
+        attn_metadata._msa_prewritten_layer = self.attn.layer_idx
+        return q
+
+    def _fused_fp8_qkv_indexer_norm_rope_kv_insert(
+        self,
+        packed: torch.Tensor,
+        position_ids: Optional[torch.Tensor],
+        attn_metadata: AttentionMetadata,
+    ) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+        """Run the vLLM-style horizontal sparse producer for pure prefill."""
+        if (
+            not self.enable_fused_qkv_index_projection
+            or not isinstance(self.attn, MiniMaxM3MsaSparseAttention)
+            or not self._emit_fp8_main_qkv()
+            or self.attn.indexer_kv_dtype != "fp8"
+        ):
+            return None
+        if (
+            is_torch_compiling()
+            or getattr(attn_metadata, "is_cuda_graph", False)
+            or int(getattr(attn_metadata, "num_generations", 0)) != 0
+            or int(getattr(attn_metadata, "num_contexts", 0)) == 0
+            or int(packed.shape[0]) != int(attn_metadata.num_tokens)
+        ):
+            return None
+        if (
+            packed.dtype != torch.bfloat16
+            or position_ids is None
+            or self.head_dim != 128
+            or self.sparse_index_dim != 128
+            or self.sparse_num_index_heads != self.num_key_value_heads
+            or not self.use_gemma_norm
+            or self.pos_embd_params is None
+            or not self.pos_embd_params.is_neox
+            or self.rotary_emb is None
+            or self.pos_embd_params.rope is None
+            or int(self.pos_embd_params.rope.dim) != 64
+        ):
+            return None
+
+        kv_cache_manager = getattr(attn_metadata, "kv_cache_manager", None)
+        if kv_cache_manager is None:
+            return None
+        buffers = kv_cache_manager.get_buffers(self.layer_idx, kv_layout="HND")
+        index_k_cache = attn_metadata.msa_idx_k_cache(self.layer_idx)
+        out_cache_loc = getattr(attn_metadata, "msa_out_cache_loc", None)
+        num_tokens = int(packed.shape[0])
+        supported_main_cache = (
+            buffers is not None
+            and buffers.is_cuda
+            and buffers.dtype == torch.float8_e4m3fn
+            and buffers.dim() == 5
+            and tuple(buffers.shape[1:]) == (2, self.num_key_value_heads, 128, 128)
+            and buffers.stride(4) == 1
+            and buffers.stride(3) == 128
+        )
+        supported_index_cache = (
+            index_k_cache.is_cuda
+            and index_k_cache.dtype == torch.float8_e4m3fn
+            and index_k_cache.dim() == 4
+            and tuple(index_k_cache.shape[1:]) == (1, 128, 128)
+            and index_k_cache.stride(3) == 1
+            and index_k_cache.stride(2) == 128
+        )
+        rotary_cos_sin = self.rotary_emb.rotary_cos_sin
+        supported_rope_cache = (
+            rotary_cos_sin.is_cuda
+            and rotary_cos_sin.dtype == torch.float32
+            and rotary_cos_sin.is_contiguous()
+            and rotary_cos_sin.dim() == 3
+            and tuple(rotary_cos_sin.shape[1:]) == (2, 32)
+        )
+        if (
+            not supported_main_cache
+            or not supported_index_cache
+            or not supported_rope_cache
+            or out_cache_loc is None
+            or not out_cache_loc.is_cuda
+            or out_cache_loc.dtype != torch.int32
+            or not out_cache_loc.is_contiguous()
+            or out_cache_loc.numel() < num_tokens
+        ):
+            return None
+
+        q, index_q = torch.ops.trtllm.minimax_m3_fp8_qkv_indexer_norm_rope_kv_insert(
+            packed.contiguous(),
+            buffers,
+            index_k_cache,
+            out_cache_loc[:num_tokens],
+            self.num_heads,
+            self.num_key_value_heads,
+            self.sparse_num_index_heads,
+            self.head_dim,
+            64,
+            self.q_norm.variance_epsilon,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            self.index_q_norm.weight,
+            self.index_k_norm.weight,
+            rotary_cos_sin,
+            position_ids.reshape(-1).contiguous().to(torch.int32),
+        )
+        attn_metadata._msa_prewritten_layer = self.attn.layer_idx
+        return q.flatten(1), index_q.flatten(1)
+
     def _expect_fused_qk_norm_rope(self, position_ids: Optional[torch.Tensor]) -> bool:
         """Whether the fused path must run rather than fall back.
 
@@ -1179,30 +1572,34 @@ class MiniMaxM3Attention(Attention):
         # Per-head Gemma RMSNorm and partial RoPE on Q/K. The bf16 fast
         # path fuses both into one kernel over the fused qkv; otherwise fall
         # back to separate norm and RoPE.
-        fused_qkv = self._fused_qk_norm_rope(
-            qkv,
-            position_ids,
-            num_heads_q=self.num_heads,
-            num_heads_k=self.num_key_value_heads,
-            num_heads_v=self.num_key_value_heads,
-            head_dim=self.head_dim,
-            q_norm=self.q_norm,
-            k_norm=self.k_norm,
-            out_fp8=self._emit_fp8_main_qkv(),
-        )
-        if fused_qkv is not None:
-            q, k, v = self._split_main_qkv(fused_qkv)
+        fused_q = self._fused_fp8_main_qk_norm_rope_kv_insert(qkv, position_ids, attn_metadata)
+        if fused_q is not None:
+            q, k, v = fused_q, None, None
         else:
-            assert not self._expect_fused_qk_norm_rope(position_ids), (
-                f"MiniMax-M3 dense attention (layer {self.layer_idx}) expected the "
-                f"fused QK-norm+RoPE kernel (bf16 activations, head_dim="
-                f"{self.head_dim}) but fell back to the separate path; qkv dtype "
-                f"is {qkv.dtype} (expected {self.attn_activation_dtype})."
+            fused_qkv = self._fused_qk_norm_rope(
+                qkv,
+                position_ids,
+                num_heads_q=self.num_heads,
+                num_heads_k=self.num_key_value_heads,
+                num_heads_v=self.num_key_value_heads,
+                head_dim=self.head_dim,
+                q_norm=self.q_norm,
+                k_norm=self.k_norm,
+                out_fp8=self._emit_fp8_main_qkv(),
             )
-            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-            q, k = self.apply_qk_norm(q, k)
-            if self.rotary_emb is not None and position_ids is not None:
-                q, k = self.rotary_emb(position_ids, [q, k])
+            if fused_qkv is not None:
+                q, k, v = self._split_main_qkv(fused_qkv)
+            else:
+                assert not self._expect_fused_qk_norm_rope(position_ids), (
+                    f"MiniMax-M3 dense attention (layer {self.layer_idx}) expected the "
+                    f"fused QK-norm+RoPE kernel (bf16 activations, head_dim="
+                    f"{self.head_dim}) but fell back to the separate path; qkv dtype "
+                    f"is {qkv.dtype} (expected {self.attn_activation_dtype})."
+                )
+                q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+                q, k = self.apply_qk_norm(q, k)
+                if self.rotary_emb is not None and position_ids is not None:
+                    q, k = self.rotary_emb(position_ids, [q, k])
 
         # Keep token-wise projections and the output projection visible to
         # torch.compile. Only the metadata/cache-dependent attention core is
@@ -1416,8 +1813,8 @@ class MiniMaxM3Attention(Attention):
     def _forward_attention_core(
         self,
         q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
         idx_q: Optional[torch.Tensor],
         idx_k: Optional[torch.Tensor],
         attn_metadata: AttentionMetadata,
@@ -1445,8 +1842,8 @@ class MiniMaxM3Attention(Attention):
     def _dispatch_attention_backend(
         self,
         q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
         idx_q: Optional[torch.Tensor],
         idx_k: Optional[torch.Tensor],
         attn_metadata: AttentionMetadata,
@@ -1465,6 +1862,7 @@ class MiniMaxM3Attention(Attention):
         """
         if isinstance(self.attn, MiniMaxM3MsaSparseAttention):
             return self._msa_attention_core(q, k, v, idx_q, idx_k, attn_metadata, output)
+        assert k is not None and v is not None
         if self.is_sparse_attention_layer:
             assert idx_q is not None and idx_k is not None
             return self._triton_sparse_attention_core(q, k, v, idx_q, idx_k, attn_metadata, output)
@@ -1474,8 +1872,8 @@ class MiniMaxM3Attention(Attention):
     def _msa_attention_core(
         self,
         q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
         idx_q: Optional[torch.Tensor],
         idx_k: Optional[torch.Tensor],
         attn_metadata: AttentionMetadata,
@@ -1487,29 +1885,36 @@ class MiniMaxM3Attention(Attention):
         inherited FMHA forward; this layer selects the top-k blocks (sparse
         only) and builds the ``forward_args`` the FMHA reads.
         """
+        prewritten_main_kv = k is None or v is None
+        assert (k is None) == (v is None)
+        if prewritten_main_kv:
+            assert attn_metadata._msa_prewritten_layer == self.attn.layer_idx
+
         if self.is_sparse_attention_layer:
             assert idx_q is not None
-            # One launch writes this layer's K/V and, on the bf16 path, index-K,
-            # ahead of the proxy pass that reads the index-K cache. On the FP8
-            # indexer path idx_k is None because the fused producer already
-            # inserted FP8 index-K into the side cache; the fused write then
-            # stores K/V only.
-            attn_metadata.msa_write_layer_caches(self.attn.layer_idx, k, v, idx_k)
+            if not prewritten_main_kv:
+                # General #16755 path: one Triton launch writes this layer's
+                # K/V and, on the BF16 path, index-K.
+                attn_metadata.msa_write_layer_caches(self.attn.layer_idx, k, v, idx_k)
             # Publish the selected blocks so the FMHA runs the sparse path.
-            # idx_k_prewritten marks that index-K is already in the cache (via
-            # the fused write above on bf16, or the FP8 producer when idx_k is
-            # None), so run_indexer must not write it again.
             kv_block_indexes = self.attn.run_indexer(
-                idx_q, idx_k, attn_metadata, idx_k_prewritten=True
+                idx_q,
+                idx_k,
+                attn_metadata,
+                idx_k_prewritten=(not prewritten_main_kv or idx_k is None),
             )
             forward_args = AttentionForwardArgs(output=output, topk_indices=kv_block_indexes)
         else:
             assert idx_q is None and idx_k is None
-            # Dense layers get the same fused K/V write.
-            attn_metadata.msa_write_layer_caches(self.attn.layer_idx, k, v)
+            if not prewritten_main_kv:
+                # Dense layers retain the same general #16755 K/V scatter.
+                attn_metadata.msa_write_layer_caches(self.attn.layer_idx, k, v)
             # No top-k selection means the FMHA attends the full page table.
             forward_args = AttentionForwardArgs(output=output)
-        self.attn.forward(q, k, v, attn_metadata, forward_args=forward_args)
+        if prewritten_main_kv:
+            self.attn.forward_prepopulated_kv(q, attn_metadata, forward_args)
+        else:
+            self.attn.forward(q, k, v, attn_metadata, forward_args=forward_args)
         return output
 
     def _sparse_forward(
@@ -1567,8 +1972,27 @@ class MiniMaxM3Attention(Attention):
         # only hidden_states and write disjoint outputs, so each runs its
         # projection, norm, and RoPE concurrently on the aux stream when
         # multi-stream is enabled, joining before the attention core.
+        packed_qkv = None
+        packed_idx_qk = None
+        if self.enable_fused_qkv_index_projection:
+            packed = self.qkv_proj(hidden_states)
+            horizontal = self._fused_fp8_qkv_indexer_norm_rope_kv_insert(
+                packed, position_ids, attn_metadata
+            )
+            if horizontal is not None:
+                q, idx_q = horizontal
+                o = self._forward_attention_core(q, None, None, idx_q, None, attn_metadata)
+                return self.o_proj(o, all_reduce_params=all_reduce_params)
+            main_size = self.q_size + 2 * self.kv_size
+            packed_qkv, packed_idx_qk = packed.split(
+                [main_size, self.index_q_size + self.index_k_size], dim=-1
+            )
+
         def _main_norm_rope():
-            qkv = self.qkv_proj(hidden_states)
+            qkv = packed_qkv if packed_qkv is not None else self.qkv_proj(hidden_states)
+            fused_q = self._fused_fp8_main_qk_norm_rope_kv_insert(qkv, position_ids, attn_metadata)
+            if fused_q is not None:
+                return fused_q, None, None
             fused_qkv = self._fused_qk_norm_rope(
                 qkv,
                 position_ids,
@@ -1595,7 +2019,9 @@ class MiniMaxM3Attention(Attention):
             return q, k, v
 
         def _index_norm_rope():
-            idx_qk = self.index_qk_proj(hidden_states)
+            idx_qk = (
+                packed_idx_qk if packed_idx_qk is not None else self.index_qk_proj(hidden_states)
+            )
             fp8_idx_q = self._fused_fp8_index_qk_norm_rope(idx_qk, position_ids, attn_metadata)
             if fp8_idx_q is not None:
                 # Index-K was inserted directly into the paged side cache.
@@ -2123,6 +2549,32 @@ def _load_index_qk_proj_weights(model: nn.Module, weights) -> None:
                     del weights[key]
 
 
+def _load_qkv_index_proj_weights(model: nn.Module, weights) -> List[str]:
+    """Pack five checkpoint shards and return generic-loader module skips."""
+    checkpoint_names = ("q_proj", "k_proj", "v_proj", "index_q_proj", "index_k_proj")
+    shard_names = MiniMaxM3QKVIndexerLinear._SHARD_NAMES
+    loaded_modules = []
+    for name, module in model.named_modules():
+        if not isinstance(module, MiniMaxM3QKVIndexerLinear):
+            continue
+        parent = name.rsplit(".", 1)[0]
+        shards = {
+            shard_name: filter_weights(f"{parent}.{checkpoint_name}", weights)
+            for shard_name, checkpoint_name in zip(shard_names, checkpoint_names)
+        }
+        module.load_five_way_weights(shards)
+        loaded_modules.append(name)
+        for checkpoint_name in checkpoint_names:
+            prefix = f"{parent}.{checkpoint_name}"
+            if hasattr(weights, "mark_consumed"):
+                weights.mark_consumed(prefix)
+            else:
+                for key in list(weights.keys()):
+                    if key.startswith(f"{prefix}."):
+                        del weights[key]
+    return loaded_modules
+
+
 # Layer-boundary RMSNorms whose Gemma (1 + weight) scaling is folded into the
 # stored weight at load time so the runtime norm is a plain RMSNorm (see
 # MiniMaxM3DecoderLayer.__init__ / MiniMaxM3Model.__init__). These are exactly
@@ -2177,8 +2629,10 @@ class MiniMaxM3ForCausalLM(SpecDecOneEngineForCausalLM[MiniMaxM3Model, Pretraine
         params_map: Optional[Dict[str, str]] = None,
         allow_partial_loading: bool = False,
     ) -> None:
-        # Fuse index_q/index_k into each index_qk_proj module (also covers
-        # the VL path, which routes text weights through here).
+        # The opt-in vLLM-style path packs all five projections with
+        # MiniMax-specific TP sharding. The compatibility path fuses only the
+        # replicated index Q/K pair.
+        packed_projection_modules = _load_qkv_index_proj_weights(self, weights)
         _load_index_qk_proj_weights(self, weights)
         # Fold Gemma (1 + weight) into the layer-boundary RMSNorm weights so the
         # runtime norms can be plain (non-Gemma) and drive the fused
@@ -2188,6 +2642,11 @@ class MiniMaxM3ForCausalLM(SpecDecOneEngineForCausalLM[MiniMaxM3Model, Pretraine
             weights = _fold_gemma_boundary_norm_weights(weights)
         if weight_mapper is None:
             weight_mapper = MiniMaxM3HfWeightMapper()
+        # These five-way modules were loaded above with model-specific
+        # Q/K/V/index-Q/index-K sharding. The generic HF mapper only knows
+        # three-way Q/K/V fusion; after the source keys are marked consumed it
+        # would still invoke that callback with three empty dictionaries.
+        weight_mapper.add_skip_modules(packed_projection_modules)
         weight_mapper.init_model_and_config(self, self.model_config)
         merged_params_map = {**MINIMAX_M3_PARAMS_MAP, **(params_map or {})}
         super().load_weights(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -736,6 +736,16 @@ class MiniMaxM3SparseAttentionConfig(BaseSparseAttentionConfig):
         "by the MSA implementation.",
         status="prototype",
     )
+    fuse_qkv_index_projection: bool = Field(
+        default=False,
+        description=
+        "Fuse Q/K/V and index-Q/index-K into one quantized projection. Index-Q "
+        "is sharded with the KV heads and index-K is replicated. This prototype "
+        "currently targets disaggregated prefill workers; leave it disabled on "
+        "decode or mixed workers. The MiniMax-M3-specific path requires the MSA "
+        "implementation.",
+        status="prototype",
+    )
     num_attention_heads: Optional[int] = Field(
         default=None,
         description=
@@ -770,6 +780,10 @@ class MiniMaxM3SparseAttentionConfig(BaseSparseAttentionConfig):
         if self.indexer_kv_dtype == "fp8" and not self.sparse_disable_index_value:
             raise ValueError("MiniMax-M3 indexer_kv_dtype='fp8' requires "
                              "sparse_disable_index_value=True.")
+        if self.fuse_qkv_index_projection and self.implementation != "msa":
+            raise ValueError(
+                "MiniMax-M3 fuse_qkv_index_projection=True currently requires "
+                "the 'msa' implementation.")
         return self
 
     def supports_backend(self, backend: str) -> bool:
@@ -793,6 +807,7 @@ class MiniMaxM3SparseAttentionConfig(BaseSparseAttentionConfig):
             disable_index_value=self.sparse_disable_index_value,
             implementation=self.implementation,
             indexer_kv_dtype=self.indexer_kv_dtype,
+            fuse_qkv_index_projection=self.fuse_qkv_index_projection,
         )
 
     def to_sparse_metadata_params(self, **kwargs):
@@ -822,6 +837,7 @@ class MiniMaxM3SparseAttentionConfig(BaseSparseAttentionConfig):
             global_num_kv_heads=num_kv_heads,
             num_index_heads=self.sparse_num_index_heads,
             topk=self.sparse_topk_blocks,
+            fuse_qkv_index_projection=self.fuse_qkv_index_projection,
         )
 
 

--- a/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_backend.py
+++ b/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_backend.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
 from tensorrt_llm._torch.attention_backend.sparse.minimax_m3 import MiniMaxM3MsaSparseAttention
 from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.common import write_kv_slots
 from tensorrt_llm._torch.attention_backend.sparse.minimax_m3.msa_scatter import (
@@ -54,6 +55,81 @@ def test_msa_fp8_indexer_config_is_explicit_and_lowered():
             indexer_kv_dtype="fp8",
             sparse_disable_index_value=False,
         )
+
+
+def test_fused_qkv_index_projection_is_explicit_and_shards_index_heads():
+    cfg = MiniMaxM3SparseAttentionConfig(
+        implementation="msa",
+        fuse_qkv_index_projection=True,
+    )
+    sparse_params = cfg.to_sparse_params()
+    metadata_params = cfg.to_sparse_metadata_params(
+        pretrained_config=SimpleNamespace(num_attention_heads=64, num_key_value_heads=4)
+    )
+    mapping = SimpleNamespace(tp_size=2, enable_attention_dp=False)
+
+    assert sparse_params.fuse_qkv_index_projection is True
+    assert metadata_params.sharded_head_counts(mapping) == (32, 2)
+    assert metadata_params.sharded_index_head_count(mapping) == 2
+
+    compatibility = MiniMaxM3SparseAttentionConfig(implementation="msa").to_sparse_metadata_params(
+        pretrained_config=SimpleNamespace(num_attention_heads=64, num_key_value_heads=4)
+    )
+    assert compatibility.sharded_index_head_count(mapping) == 4
+
+    with pytest.raises(ValueError, match=r"requires the 'msa' implementation"):
+        MiniMaxM3SparseAttentionConfig(
+            implementation="triton",
+            fuse_qkv_index_projection=True,
+        )
+
+
+def test_prepopulated_kv_dispatches_compact_q_and_consumes_marker(monkeypatch):
+    from tensorrt_llm._torch.attention_backend.fmha import msa_sparse_gqa
+
+    attention = MiniMaxM3MsaSparseAttention.__new__(MiniMaxM3MsaSparseAttention)
+    q = torch.empty(3, 8 * 128)
+    output = torch.empty_like(q)
+    topk = torch.zeros(3, 1, 16, dtype=torch.int32)
+    eager_plan = object()
+
+    class FakeMetadata:
+        msa_decode_gqa_plan = None
+        msa_eager_gqa_plan = eager_plan
+        msa_decode_dense_plan = None
+        msa_eager_dense_plan = object()
+        _msa_prewritten_layer = 7
+
+    captured = {}
+
+    def fake_run(attn, q_arg, k, v, metadata, output_arg, **kwargs):
+        captured.update(
+            attn=attn,
+            q=q_arg,
+            k=k,
+            v=v,
+            metadata=metadata,
+            output=output_arg,
+            kwargs=kwargs,
+        )
+        metadata._msa_prewritten_layer = None
+
+    monkeypatch.setattr(msa_sparse_gqa, "run_msa_paged_gqa", fake_run)
+    metadata = FakeMetadata()
+    attention.forward_prepopulated_kv(
+        q,
+        metadata,
+        AttentionForwardArgs(output=output, topk_indices=topk),
+    )
+
+    assert captured["attn"] is attention
+    assert captured["q"] is q
+    assert captured["k"] is None and captured["v"] is None
+    assert captured["metadata"] is metadata
+    assert captured["output"] is output
+    assert captured["kwargs"]["kv_block_indexes"] is topk
+    assert captured["kwargs"]["plan"] is eager_plan
+    assert metadata._msa_prewritten_layer is None
 
 
 def test_msa_metadata_rejects_undersized_max_score_buffer():
@@ -225,6 +301,8 @@ def test_msa_fp8_cache_converts_live_index_query_before_scoring():
         msa_qo_lens_cpu = torch.ones(2, dtype=torch.int32)
         msa_kv_lens_cpu = torch.full((2,), 128, dtype=torch.int32)
         msa_qo_offset_cpu = torch.full((2,), 127, dtype=torch.int32)
+        num_contexts = 0
+        num_generations = 2
 
         def __init__(self):
             self.cache = torch.empty(2, 1, 128, 128, dtype=torch.float8_e4m3fn, device="cuda")

--- a/tests/unittest/_torch/models/test_minimax_m3.py
+++ b/tests/unittest/_torch/models/test_minimax_m3.py
@@ -37,7 +37,9 @@ from tensorrt_llm._torch.models.checkpoints.hf.minimaxm3_weight_mapper import (
 )
 from tensorrt_llm._torch.models.modeling_minimaxm3 import (
     MiniMaxM3Attention,
+    MiniMaxM3QKVIndexerLinear,
     _build_swiglu_oai_dense_mlp,
+    _load_qkv_index_proj_weights,
     _minimax_m3_swiglu_oai,
     _strip_language_model_prefix,
     _wrap_dict_as_config,
@@ -409,6 +411,28 @@ def test_minimax_m3_attention_dense_construction_matches_config():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not _has_cuda(), reason="MiniMax-M3 attention construction needs CUDA")
+def test_minimax_m3_fused_main_kv_write_is_opt_in(monkeypatch):
+    _, model_cfg = _make_attention_test_config()
+
+    monkeypatch.delenv("TRTLLM_MINIMAX_M3_FUSED_MAIN_KV_WRITE", raising=False)
+    baseline = MiniMaxM3Attention(
+        model_config=model_cfg,
+        layer_idx=0,
+        is_sparse_attention_layer=False,
+    )
+    assert baseline.enable_fused_main_kv_write is False
+
+    monkeypatch.setenv("TRTLLM_MINIMAX_M3_FUSED_MAIN_KV_WRITE", "1")
+    candidate = MiniMaxM3Attention(
+        model_config=model_cfg,
+        layer_idx=0,
+        is_sparse_attention_layer=False,
+    )
+    assert candidate.enable_fused_main_kv_write is True
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not _has_cuda(), reason="MiniMax-M3 attention construction needs CUDA")
 def test_minimax_m3_attention_partial_rope_dim_is_rotary_dim():
     """Partial RoPE rotates only ``rotary_dim`` of ``head_dim`` channels."""
     text_cfg, model_cfg = _make_attention_test_config()
@@ -534,6 +558,56 @@ def test_minimax_m3_attention_sparse_construction_matches_config():
         assert "attn_metadata" in msg or "kv_cache_manager" in msg, msg
     else:  # pragma: no cover
         raise AssertionError("sparse forward must raise RuntimeError when attn_metadata is None")
+
+
+def test_minimax_m3_five_way_projection_shard_geometry():
+    module = SimpleNamespace(
+        tp_size=2,
+        tp_rank=1,
+        total_num_kv_heads=4,
+        total_num_index_heads=4,
+    )
+    shard_geometry = MiniMaxM3QKVIndexerLinear._shard_geometry
+    assert shard_geometry(module, "q") == (2, 1)
+    assert shard_geometry(module, "k") == (2, 1)
+    assert shard_geometry(module, "v") == (2, 1)
+    assert shard_geometry(module, "index_q") == (2, 1)
+    assert shard_geometry(module, "index_k") == (1, 0)
+
+    # At TP8, each of four KV/index-Q heads is replicated on two ranks.
+    module.tp_size = 8
+    module.tp_rank = 5
+    assert shard_geometry(module, "k") == (4, 2)
+    assert shard_geometry(module, "index_q") == (4, 2)
+    assert shard_geometry(module, "index_k") == (1, 0)
+
+
+def test_minimax_m3_five_way_loader_returns_exact_generic_skip():
+    projection = object.__new__(MiniMaxM3QKVIndexerLinear)
+    nn.Module.__init__(projection)
+    captured = {}
+    projection.load_five_way_weights = lambda shards: captured.update(shards)
+
+    model = nn.Module()
+    model.sparse = nn.Module()
+    model.sparse.qkv_proj = projection
+    weights = {
+        f"sparse.{name}_proj.weight": torch.empty(1)
+        for name in ("q", "k", "v", "index_q", "index_k")
+    }
+
+    loaded_modules = _load_qkv_index_proj_weights(model, weights)
+
+    assert loaded_modules == ["sparse.qkv_proj"]
+    assert set(captured) == {"q", "k", "v", "index_q", "index_k"}
+    assert all(set(shard) == {"weight"} for shard in captured.values())
+    assert weights == {}
+
+    mapper = MiniMaxM3HfWeightMapper()
+    mapper.add_skip_modules(loaded_modules)
+    mapper._model = SimpleNamespace(config=SimpleNamespace(tie_word_embeddings=False))
+    assert mapper.should_skip_module("sparse.qkv_proj")
+    assert not mapper.should_skip_module("dense.qkv_proj")
 
 
 @pytest.mark.gpu

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_horizontal_producer.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_horizontal_producer.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def _rope_cache(max_positions, rotary_dim=64, base=5_000_000.0):
+    positions = torch.arange(max_positions, dtype=torch.float32, device="cuda")
+    inverse_frequency = 1.0 / (
+        base ** (torch.arange(0, rotary_dim, 2, dtype=torch.float32, device="cuda") / rotary_dim)
+    )
+    frequency = torch.outer(positions, inverse_frequency)
+    return torch.stack((frequency.cos(), frequency.sin()), dim=1).contiguous()
+
+
+def _main_cache(num_pages, num_kv_heads, stride_scale=3):
+    backing = torch.zeros(
+        num_pages * stride_scale,
+        2,
+        num_kv_heads,
+        128,
+        128,
+        dtype=torch.float8_e4m3fn,
+        device="cuda",
+    )
+    return backing[::stride_scale]
+
+
+def _index_cache(num_pages, stride_scale=5):
+    backing = torch.zeros(
+        num_pages * stride_scale,
+        1,
+        128,
+        128,
+        dtype=torch.float8_e4m3fn,
+        device="cuda",
+    )
+    return backing[::stride_scale]
+
+
+@pytest.mark.parametrize("num_tokens", [1, 16, 129])
+def test_minimax_m3_horizontal_producer_matches_separate_producers(num_tokens):
+    torch.manual_seed(1234)
+    num_heads_q = 8
+    num_kv_heads = 2
+    num_index_heads = num_kv_heads
+    num_pages = max(4, (num_tokens + 127) // 128 + 2)
+    total_heads = num_heads_q + 2 * num_kv_heads + num_index_heads + 1
+    packed = torch.randn(
+        num_tokens,
+        total_heads * 128,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    q_weight = torch.randn(128, dtype=torch.bfloat16, device="cuda")
+    k_weight = torch.randn(128, dtype=torch.bfloat16, device="cuda")
+    index_q_weight = torch.randn(128, dtype=torch.bfloat16, device="cuda")
+    index_k_weight = torch.randn(128, dtype=torch.bfloat16, device="cuda")
+    position_ids = torch.arange(num_tokens, dtype=torch.int32, device="cuda")
+    slots = (torch.arange(num_tokens, dtype=torch.int32, device="cuda") * 37) % (
+        (num_pages - 1) * 128
+    )
+    rope_cache = _rope_cache(max(256, num_tokens))
+
+    main_width = (num_heads_q + 2 * num_kv_heads) * 128
+    main_input = packed[:, :main_width].contiguous()
+    index_input = packed[:, main_width:].contiguous()
+    reference_main_cache = _main_cache(num_pages, num_kv_heads)
+    reference_index_cache = _index_cache(num_pages)
+    q_reference = torch.ops.trtllm.minimax_m3_fp8_qk_norm_rope_kv_insert(
+        main_input,
+        reference_main_cache,
+        slots,
+        num_heads_q,
+        num_kv_heads,
+        num_kv_heads,
+        128,
+        64,
+        1e-5,
+        q_weight,
+        k_weight,
+        5_000_000.0,
+        True,
+        position_ids,
+    )
+    index_q_reference = torch.ops.trtllm.minimax_m3_fp8_indexer_qk_norm_rope(
+        index_input,
+        reference_index_cache,
+        slots,
+        num_index_heads,
+        128,
+        64,
+        1e-5,
+        index_q_weight,
+        index_k_weight,
+        5_000_000.0,
+        position_ids,
+    )
+
+    main_cache = _main_cache(num_pages, num_kv_heads)
+    index_cache = _index_cache(num_pages)
+    q, index_q = torch.ops.trtllm.minimax_m3_fp8_qkv_indexer_norm_rope_kv_insert(
+        packed,
+        main_cache,
+        index_cache,
+        slots,
+        num_heads_q,
+        num_kv_heads,
+        num_index_heads,
+        128,
+        64,
+        1e-5,
+        q_weight,
+        k_weight,
+        index_q_weight,
+        index_k_weight,
+        rope_cache,
+        position_ids,
+    )
+
+    pages = slots.long() // 128
+    within = slots.long() % 128
+    assert torch.equal(q.view(torch.uint8), q_reference.view(torch.uint8))
+    # The horizontal producer follows vLLM's CUDA contract and converts its
+    # normalized/RoPE FP32 registers directly to E4M3. The existing separate
+    # TRT-LLM index producer first materializes BF16, so compare within one FP8
+    # ULP rather than requiring byte identity across the different rounding
+    # orders. Main Q/K/V retain byte-exact parity above and below.
+    torch.testing.assert_close(
+        index_q.float(),
+        index_q_reference.float(),
+        rtol=0.13,
+        atol=0.05,
+    )
+    assert torch.equal(
+        main_cache[pages, :, :, within, :].view(torch.uint8),
+        reference_main_cache[pages, :, :, within, :].view(torch.uint8),
+    )
+    torch.testing.assert_close(
+        index_cache[pages, :, within, :].float(),
+        reference_index_cache[pages, :, within, :].float(),
+        rtol=0.13,
+        atol=0.05,
+    )

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_main_kv_insert.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_main_kv_insert.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def _reference(qkv, num_heads_q, num_kv_heads, q_weight, k_weight, position_ids):
+    output = torch.ops.trtllm.fused_qk_norm_rope_to_fp8(
+        qkv,
+        num_heads_q,
+        num_kv_heads,
+        num_kv_heads,
+        128,
+        64,
+        1e-5,
+        q_weight,
+        k_weight,
+        5_000_000.0,
+        True,
+        position_ids,
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+        True,
+        True,
+        False,
+        0,
+        0,
+    )
+    return output.view(qkv.shape[0], num_heads_q + 2 * num_kv_heads, 128).split(
+        [num_heads_q, num_kv_heads, num_kv_heads], dim=1
+    )
+
+
+def _strided_kv_cache(num_pages, num_kv_heads, page_size=128, stride_scale=3):
+    backing = torch.zeros(
+        num_pages * stride_scale,
+        2,
+        num_kv_heads,
+        page_size,
+        128,
+        dtype=torch.float8_e4m3fn,
+        device="cuda",
+    )
+    return backing[::stride_scale]
+
+
+def _inputs(num_tokens, num_heads_q, num_kv_heads):
+    qkv = torch.randn(
+        num_tokens,
+        (num_heads_q + 2 * num_kv_heads) * 128,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    q_weight = torch.randn(128, dtype=torch.bfloat16, device="cuda")
+    k_weight = torch.randn(128, dtype=torch.bfloat16, device="cuda")
+    position_ids = torch.arange(num_tokens, dtype=torch.int32, device="cuda") + 8192
+    return qkv, q_weight, k_weight, position_ids
+
+
+def _run(qkv, kv_cache, slots, q_weight, k_weight, position_ids, num_heads_q, num_kv_heads):
+    return torch.ops.trtllm.minimax_m3_fp8_qk_norm_rope_kv_insert(
+        qkv,
+        kv_cache,
+        slots,
+        num_heads_q,
+        num_kv_heads,
+        num_kv_heads,
+        128,
+        64,
+        1e-5,
+        q_weight,
+        k_weight,
+        5_000_000.0,
+        True,
+        position_ids,
+    )
+
+
+@pytest.mark.parametrize(("num_heads_q", "num_kv_heads"), [(8, 1), (8, 8), (64, 4)])
+@pytest.mark.parametrize("num_tokens", [1, 16, 129])
+def test_minimax_m3_fp8_main_kv_insert_matches_materialize_then_scatter(
+    num_tokens, num_heads_q, num_kv_heads
+):
+    torch.manual_seed(1234)
+    page_size = 128
+    num_pages = max(4, (num_tokens + page_size - 1) // page_size + 2)
+    qkv, q_weight, k_weight, position_ids = _inputs(num_tokens, num_heads_q, num_kv_heads)
+    slots = (torch.arange(num_tokens, dtype=torch.int32, device="cuda") * 37) % (
+        (num_pages - 1) * page_size
+    )
+    kv_cache = _strided_kv_cache(num_pages, num_kv_heads, page_size)
+    guard_page = kv_cache[-1].clone()
+
+    q_out = _run(
+        qkv,
+        kv_cache,
+        slots,
+        q_weight,
+        k_weight,
+        position_ids,
+        num_heads_q,
+        num_kv_heads,
+    )
+    q_ref, k_ref, v_ref = _reference(
+        qkv, num_heads_q, num_kv_heads, q_weight, k_weight, position_ids
+    )
+    pages = slots.long() // page_size
+    within = slots.long() % page_size
+
+    assert torch.equal(q_out.view(torch.uint8), q_ref.contiguous().view(torch.uint8))
+    assert torch.equal(
+        kv_cache[:, 0][pages, :, within, :].view(torch.uint8),
+        k_ref.contiguous().view(torch.uint8),
+    )
+    assert torch.equal(
+        kv_cache[:, 1][pages, :, within, :].view(torch.uint8),
+        v_ref.contiguous().view(torch.uint8),
+    )
+    assert torch.equal(kv_cache[-1].view(torch.uint8), guard_page.view(torch.uint8))
+
+
+def test_minimax_m3_fp8_main_kv_insert_uses_64bit_cache_offsets():
+    """Exercise a real paged-cache address beyond INT32_MAX elements.
+
+    The smallest contiguous HND pool whose page-65536 K row starts at
+    2**31 FP8 elements is about 2 GiB. The former implicit int conversion in
+    the store helper wrapped this address negative; this test writes and reads
+    that real allocation so arithmetic-only tests cannot mask the bug.
+    """
+    required_bytes = (65537 * 2 * 128 * 128) + (1 << 30)
+    free_bytes, _ = torch.cuda.mem_get_info()
+    if free_bytes < required_bytes:
+        pytest.skip("64-bit cache-offset test requires about 3 GiB free GPU memory")
+
+    torch.manual_seed(4321)
+    page = 65536
+    kv_cache = torch.empty(
+        page + 1,
+        2,
+        1,
+        128,
+        128,
+        dtype=torch.float8_e4m3fn,
+        device="cuda",
+    )
+    qkv, q_weight, k_weight, position_ids = _inputs(1, 8, 1)
+    slots = torch.tensor([page * 128], dtype=torch.int32, device="cuda")
+
+    q_out = _run(qkv, kv_cache, slots, q_weight, k_weight, position_ids, 8, 1)
+    q_ref, k_ref, v_ref = _reference(qkv, 8, 1, q_weight, k_weight, position_ids)
+    torch.cuda.synchronize()
+
+    assert torch.equal(q_out.view(torch.uint8), q_ref.contiguous().view(torch.uint8))
+    assert torch.equal(
+        kv_cache[page, 0, :, 0, :].view(torch.uint8),
+        k_ref[0].contiguous().view(torch.uint8),
+    )
+    assert torch.equal(
+        kv_cache[page, 1, :, 0, :].view(torch.uint8),
+        v_ref[0].contiguous().view(torch.uint8),
+    )


### PR DESCRIPTION
@coderabbitai summary

### Prerequisite

- [x] https://github.com/NVIDIA/TensorRT-LLM/pull/16818

## Description

MiniMax-M3 currently projects main Q/K/V and index-Q/index-K separately, then
runs separate normalization, RoPE, quantization, and paged-cache insertion
steps. For long-context prefill, those extra projections and producer launches
are visible in both the critical path and the Nsight Systems trace.

This PR adds an opt-in MiniMax-M3 prefill path that:

- packs Q, K, V, index-Q, and index-K into one MXFP8 projection with the
  MiniMax-M3 TP sharding and replication geometry;
- consumes the packed BF16 output in one horizontal CUDA producer that applies
  Q/K/index-Q/index-K normalization and RoPE, converts the outputs to FP8, and
  directly inserts main K/V plus index-K into their paged caches; and
- returns compact main Q and index-Q tensors to the attention and selector
  paths, avoiding intermediate producer tensors and cache-write launches.

The prototype is disabled by default through
`fuse_qkv_index_projection=False`. It currently targets pure disaggregated
prefill workers. Decode remains disabled based on its separate evaluation and
is outside the performance scope reported here; mixed workers remain
unsupported and unvalidated. Unsupported prefill geometry, dtype, and layout
combinations retain the compatibility path.

The completed matched GB300 NVL72 2P8D prefill-isolation A/B used TP2/EP2
attention-DP on the 2-GPU CTX worker, TP8/EP8 attention-DP on the 8-GPU GEN
worker, concurrency 256, exact 8K input, and configured 1-token output. The
baseline was Slurm job `2490293`; the candidate was `2490294`, with the packed
option enabled only on CTX and disabled on GEN in both runs. Both completed
2,560/2,560 requests:

| Metric | Baseline | Packed prefill | Change |
|---|---:|---:|---:|
| Total token throughput | 53,912 tok/s | 58,417 tok/s | **+8.36%** |
| Mean TTFT | 36.96 s | 34.12 s | **-7.69%** |
| Median TTFT | 38.79 s | 35.82 s | **-7.65%** |
| Benchmark duration | 389.1 s | 359.1 s | **-7.71%** |

The client JSON recorded two output tokens per request despite the configured
`random_osl=1`; this was identical for both variants and does not affect the
relative A/B comparison. The result isolates the prefill benefit; decode
remains disabled and outside the reported A/B scope.

## Test Coverage

- Changed-file pre-commit: passed on all 18 files in the stacked diff.
- Lyris GB300 full and incremental builds: Slurm 2487662, 2487962, and
  2488228 passed.
- Expanded CUDA/Python test job 2488282 passed:
  - horizontal producer numerical tests: 3/3;
  - MiniMax-M3 model tests: 10/10;
  - MSA/index tests: 4/4; and
  - five-way loader geometry and selective-skip tests: 2/2.
- Native checkpoint packing matched exactly for TP2 ranks 0-1 and TP8 ranks
  0-7, including weights, scales, sharding, and replication.
- Real TP4/EP4 attention-DP checkpoint loading completed on all four ranks
  (2090/2090 modules per rank).
- Packaged SQSH smoke job 2488338 passed.
- Full TP4/EP4 MMLU (4096 samples) and GSM8K (1319 samples) registered accuracy
  gates passed in Slurm job 2488379 with the fused projection enabled.
- Matched GB300 NVL72 2P8D prefill-isolation jobs 2490293 and 2490294 completed
  2,560/2,560 requests with exact 8K input and concurrency 256. Enabling the
  packed projection only on CTX improved total token throughput by 8.36% and
  mean TTFT by 7.69%.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
