### PR TITLE
[None][test] Stabilize scaffolding OpenAI worker tests

### DIFF
--- a/tests/unittest/scaffolding/test_worker.py
+++ b/tests/unittest/scaffolding/test_worker.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pathlib import Path
 
 # isort: off
@@ -55,7 +70,8 @@ def server(model_name: str, backend: str, num_postprocess_workers: int):
     args.extend(["--num_postprocess_workers", f"{num_postprocess_workers}"])
     args.extend(["--kv_cache_free_gpu_memory_fraction", "0.5"])
     remote_server = RemoteOpenAIServer(model_path, args)
-    return remote_server
+    yield remote_server
+    remote_server.terminate()
 
 
 def create_trtoai_worker(model_name, async_client):
@@ -69,13 +85,10 @@ def create_trtoai_worker(model_name, async_client):
 def test_trtoai_worker_generation(default_prompt, model_name, server):
     worker = create_trtoai_worker(model_name, server.get_async_client())
     task = GenerationTask.create_from_prompt(default_prompt)
+    task.max_tokens = 100
     status = asyncio.run(worker.run_task(task))
-    try:
-        assert status == TaskStatus.SUCCESS, "Generation Task is not successful with TRTOpenaiWorker"
-    except AssertionError as e:
-        worker.shutdown()
-        server.__exit__(None, None, None)
-        raise e
+    assert status == TaskStatus.SUCCESS, "Generation Task is not successful with TRTOpenaiWorker"
+    worker.shutdown()
 
 
 @pytest.mark.asyncio(loop_scope="module")

--- a/tests/unittest/scaffolding/test_worker.py
+++ b/tests/unittest/scaffolding/test_worker.py
@@ -84,21 +84,25 @@ def create_trtoai_worker(model_name, async_client):
 @pytest.mark.asyncio(loop_scope="module")
 def test_trtoai_worker_generation(default_prompt, model_name, server):
     worker = create_trtoai_worker(model_name, server.get_async_client())
-    task = GenerationTask.create_from_prompt(default_prompt)
-    task.max_tokens = 100
-    status = asyncio.run(worker.run_task(task))
-    assert status == TaskStatus.SUCCESS, "Generation Task is not successful with TRTOpenaiWorker"
-    worker.shutdown()
+    try:
+        task = GenerationTask.create_from_prompt(default_prompt)
+        task.max_tokens = 100
+        status = asyncio.run(worker.run_task(task))
+        assert status == TaskStatus.SUCCESS, "Generation Task is not successful with TRTOpenaiWorker"
+    finally:
+        worker.shutdown()
 
 
 @pytest.mark.asyncio(loop_scope="module")
 def test_trtoai_worker_chat(default_prompt, model_name, server):
     worker = create_trtoai_worker(model_name, server.get_async_client())
-    task = ChatTask.create_from_messages([UserMessage(default_prompt)])
-    task.max_tokens = 100
-    status = asyncio.run(worker.run_task(task))
-    assert status == TaskStatus.SUCCESS, "Chat Task is not successful with TRTOpenaiWorker"
-    worker.shutdown()
+    try:
+        task = ChatTask.create_from_messages([UserMessage(default_prompt)])
+        task.max_tokens = 100
+        status = asyncio.run(worker.run_task(task))
+        assert status == TaskStatus.SUCCESS, "Chat Task is not successful with TRTOpenaiWorker"
+    finally:
+        worker.shutdown()
 
 
 def create_trtllm_worker(model_path):


### PR DESCRIPTION
## What changed

- Bound the scaffolding OpenAI generation test to 100 output tokens.
- Move the module-scoped server teardown into its pytest fixture.
- Stop an individual test failure from terminating the server shared with the chat test.

## Why

`GenerationTask.create_from_prompt()` leaves `max_tokens` unset. In a recent CI failure, the gpt-oss-20b request was accepted but continued until the OpenAI client's 600-second timeout. The failure handler then terminated the module-scoped server, causing the following chat test to fail against the same dead server.

Bounding the request matches the existing chat test and keeps this test focused on verifying successful worker generation. Fixture-owned teardown preserves pytest fail-fast behavior while preventing cascading failures and ensuring cleanup after the module.

## Impact

Test-only change. Production behavior is unaffected.

## Validation

- `python3 -m py_compile tests/unittest/scaffolding/test_worker.py`
- Formatting, codespell, legacy Ruff, and repository configuration pre-commit hooks passed.
- Test-list duplicate and AST validation checks passed under Python 3.12.

The model-backed test requires the TensorRT-LLM GPU CI environment and was not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added SPDX-2.0 Apache license header to `tests/unittest/scaffolding/test_worker.py`.
- Updated the module-scoped `server` pytest fixture to `yield` the `RemoteOpenAIServer` and always terminate it in fixture teardown (`remote_server.terminate()`).
- Stabilized `TRTOpenaiWorker` scaffolding tests by setting `task.max_tokens = 100` in both:
  - `test_trtoai_worker_generation`
  - `test_trtoai_worker_chat`
  This prevents requests from running until the OpenAI client timeout when `max_tokens` could otherwise be unset.
- Ensured cleanup even on assertion failures by wrapping each TRTOpenaiWorker test in `try/finally` with unconditional `worker.shutdown()`.

## QA Engineer Review

- Modified test functions in `tests/unittest/scaffolding/test_worker.py`:
  - `test_trtoai_worker_generation` (sets `task.max_tokens = 100`; uses `try/finally` to always call `worker.shutdown()`)
  - `test_trtoai_worker_chat` (sets `task.max_tokens = 100`; uses `try/finally` to always call `worker.shutdown()`)
- Coverage in `tests/integration/test_lists/` (test-db/ for CI, qa/ for manual QA): not identified/verified in this review.
- Verdict: needs follow-up (GPU-backed CI required; not run locally).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->