### PR TITLE
[https://nvbugs/6240584][fix] Qwen3ToolParser: bare-JSON fallback for reasoning-preceded tool calls

### DIFF
--- a/tensorrt_llm/serve/tool_parser/qwen3_tool_parser.py
+++ b/tensorrt_llm/serve/tool_parser/qwen3_tool_parser.py
@@ -52,6 +52,16 @@ class Qwen3ToolParser(BaseToolParser):
         idx = text.find(self.bot_token)
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
+            # Some Qwen3 chat templates (e.g. Qwen3.6 FP8 with thinking enabled)
+            # emit tool calls as bare JSON without a <tool_call> wrapper. Try to
+            # recover those before dropping the text into normal_text.
+            try:
+                parsed = json.loads(text.strip())
+                calls = self.parse_base_json(parsed, tools)
+                if calls:
+                    return StreamingParseResult(normal_text="", calls=calls)
+            except (json.JSONDecodeError, AttributeError):
+                pass
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
         # Find all <tool_call>\n...\n</tool_call> blocks

--- a/tensorrt_llm/serve/tool_parser/qwen3_tool_parser.py
+++ b/tensorrt_llm/serve/tool_parser/qwen3_tool_parser.py
@@ -7,11 +7,12 @@ from tensorrt_llm.logger import logger
 
 from ..openai_protocol import ChatCompletionToolsParam as Tool
 from .base_tool_parser import BaseToolParser
-from .core_types import StreamingParseResult, StructureInfo, _GetInfoFunc
+from .core_types import (StreamingParseResult, StructureInfo, ToolCallItem,
+                         _GetInfoFunc)
 
 
 class Qwen3ToolParser(BaseToolParser):
-    """
+    r"""
     Detector for Qwen 2.5 and Qwen 3 model function call format.
 
     Format Structure:
@@ -23,8 +24,20 @@ class Qwen3ToolParser(BaseToolParser):
     - Tool Call Tags: `<tool_call>` and `</tool_call>` wrap each individual call
     - Function Call Object: JSON object with "name" and "arguments" fields
 
+    Some Qwen3 chat templates (notably Qwen3.6 FP8 served with
+    `--reasoning_parser qwen3_5 --tool_parser qwen3`) emit tool calls as bare
+    JSON objects without the `<tool_call>...</tool_call>` wrapper once the
+    reasoning parser strips the `</think>` block. Both `detect_and_parse` and
+    `parse_streaming_increment` fall back to a bare-JSON parse in that case
+    (see NVBug 6240584).
+
     Reference: https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct?chat_template=default
     """
+
+    # Streaming decision state for the bare-JSON fallback path.
+    _STREAM_MODE_UNDECIDED = "undecided"
+    _STREAM_MODE_WRAPPED = "wrapped"
+    _STREAM_MODE_BARE_JSON = "bare_json"
 
     def __init__(self):
         """
@@ -35,9 +48,18 @@ class Qwen3ToolParser(BaseToolParser):
         self.eot_token = "\n</tool_call>"  # nosec B105
         self.tool_call_separator = "\n"
         self._normal_text_buffer = ""  # Buffer for handling partial end tokens
+        # Bare-JSON streaming fallback state (see NVBug 6240584).
+        self._bare_json_buffer = ""
+        self._stream_mode = self._STREAM_MODE_UNDECIDED
 
     def has_tool_call(self, text: str) -> bool:
-        """Check if the text contains a Qwen 3 format tool call."""
+        """Check if the text contains a Qwen 3 format tool call.
+
+        Note: intentionally strict — this only checks for the `<tool_call>`
+        wrapper. Existing callers rely on it as a wrapped-form gate. The
+        bare-JSON fallback lives inside `detect_and_parse` /
+        `parse_streaming_increment` and does not go through this method.
+        """
         return self.bot_token in text
 
     def detect_and_parse(self, text: str,
@@ -53,15 +75,18 @@ class Qwen3ToolParser(BaseToolParser):
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
             # Some Qwen3 chat templates (e.g. Qwen3.6 FP8 with thinking enabled)
-            # emit tool calls as bare JSON without a <tool_call> wrapper. Try to
-            # recover those before dropping the text into normal_text.
+            # emit tool calls as bare JSON without a <tool_call> wrapper. Try
+            # to recover those before dropping the text into normal_text. Use
+            # an explicit type guard to avoid relying on AttributeError to
+            # catch scalar JSON like "42" or null.
             try:
                 parsed = json.loads(text.strip())
+            except json.JSONDecodeError:
+                return StreamingParseResult(normal_text=normal_text, calls=[])
+            if isinstance(parsed, (dict, list)):
                 calls = self.parse_base_json(parsed, tools)
                 if calls:
                     return StreamingParseResult(normal_text="", calls=calls)
-            except (json.JSONDecodeError, AttributeError):
-                pass
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
         # Find all <tool_call>\n...\n</tool_call> blocks
@@ -81,13 +106,107 @@ class Qwen3ToolParser(BaseToolParser):
 
     def parse_streaming_increment(self, new_text: str,
                                   tools: List[Tool]) -> StreamingParseResult:
-        """
+        r"""
         Streaming incremental parsing for Qwen 3 tool calls.
-        Uses base class implementation with buffering to handle partial end tokens.
+
+        Handles two shapes:
+        - Wrapped: `<tool_call>\n{...}\n</tool_call>` — delegates to the base
+          class implementation, which streams the name first and then the
+          arguments incrementally. Applies the same partial-end-token
+          scrubbing as before.
+        - Bare JSON (NVBug 6240584): when the stream never contains
+          `<tool_call>` but the accumulated buffer is a complete JSON object
+          matching `{"name": ..., "arguments"/"parameters": ...}`, parse it
+          via `parse_base_json` and emit the calls in the same
+          name-first-then-arguments pattern used by the base class.
+
+        The parser picks a mode once and stays in it for the remainder of the
+        stream. Modes:
+          - undecided: buffer input; peek to decide.
+          - wrapped:   route everything through the base implementation.
+          - bare_json: bare-JSON tool call already emitted; drop trailing text.
         """
+        if self._stream_mode == self._STREAM_MODE_WRAPPED:
+            return self._wrapped_streaming(new_text, tools)
+        if self._stream_mode == self._STREAM_MODE_BARE_JSON:
+            # Tool call already emitted; ignore any trailing text.
+            return StreamingParseResult()
+
+        # Undecided: buffer and decide.
+        self._bare_json_buffer += new_text
+        accumulated = self._bare_json_buffer
+
+        if self.bot_token in accumulated:
+            # Wrapped form: replay the accumulated buffer through the base
+            # streaming path.
+            self._stream_mode = self._STREAM_MODE_WRAPPED
+            replay = accumulated
+            self._bare_json_buffer = ""
+            return self._wrapped_streaming(replay, tools)
+
+        if self._ends_with_partial_token(accumulated, self.bot_token):
+            # Could still resolve into a wrapped form — keep buffering.
+            return StreamingParseResult()
+
+        stripped = accumulated.lstrip()
+        if not stripped:
+            # Only whitespace so far — keep buffering.
+            return StreamingParseResult()
+
+        if stripped[0] not in "{[":
+            # Not JSON-like at all — flush as normal text via wrapped path.
+            self._stream_mode = self._STREAM_MODE_WRAPPED
+            replay = accumulated
+            self._bare_json_buffer = ""
+            return self._wrapped_streaming(replay, tools)
+
+        # Leading `{` or `[` — could be a bare JSON tool call, or partial.
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            # Not yet complete — buffer more.
+            return StreamingParseResult()
+
+        if isinstance(parsed, (dict, list)):
+            calls = self.parse_base_json(parsed, tools)
+            if calls:
+                streaming_calls: List[ToolCallItem] = []
+                for i, call_item in enumerate(calls):
+                    # Emit name first with empty parameters, then the full
+                    # arguments — mirrors the base class streaming pattern.
+                    streaming_calls.append(
+                        ToolCallItem(
+                            tool_index=i,
+                            name=call_item.name,
+                            parameters="",
+                        ))
+                    if call_item.parameters:
+                        streaming_calls.append(
+                            ToolCallItem(
+                                tool_index=i,
+                                parameters=call_item.parameters,
+                            ))
+                self._stream_mode = self._STREAM_MODE_BARE_JSON
+                self._bare_json_buffer = ""
+                # Best-effort bookkeeping for callers that inspect these.
+                self.current_tool_id = max(0, len(calls) - 1)
+                self.current_tool_name_sent = True
+                return StreamingParseResult(normal_text="",
+                                            calls=streaming_calls)
+
+        # Parsed as JSON but not a tool call — flush as normal text via
+        # wrapped path.
+        self._stream_mode = self._STREAM_MODE_WRAPPED
+        replay = accumulated
+        self._bare_json_buffer = ""
+        return self._wrapped_streaming(replay, tools)
+
+    def _wrapped_streaming(self, new_text: str,
+                           tools: List[Tool]) -> StreamingParseResult:
+        """Wrapped-form streaming: base implementation + partial-end-token scrubbing."""
         result = super().parse_streaming_increment(new_text, tools)
 
-        # Handle partial end tokens that are streamed character by character
+        # Handle partial end tokens that are streamed character by character.
         if result.normal_text:
             self._normal_text_buffer += result.normal_text
 

--- a/tensorrt_llm/serve/tool_parser/qwen3_tool_parser.py
+++ b/tensorrt_llm/serve/tool_parser/qwen3_tool_parser.py
@@ -79,13 +79,21 @@ class Qwen3ToolParser(BaseToolParser):
             # to recover those before dropping the text into normal_text. Use
             # an explicit type guard to avoid relying on AttributeError to
             # catch scalar JSON like "42" or null.
+            #
+            # Use `raw_decode` (not `json.loads`) so a valid leading JSON
+            # object followed by trailing content is still recognized as a
+            # tool call — `json.loads` would raise `Extra data` and drop the
+            # entire text into normal_text (see NVBug 6240584 review).
+            stripped = text.strip()
             try:
-                parsed = json.loads(text.strip())
+                parsed, _end = json.JSONDecoder().raw_decode(stripped)
             except json.JSONDecodeError:
                 return StreamingParseResult(normal_text=normal_text, calls=[])
             if isinstance(parsed, (dict, list)):
                 calls = self.parse_base_json(parsed, tools)
                 if calls:
+                    # Match the wrapped-form convention: text outside the tool
+                    # call is not surfaced as normal_text.
                     return StreamingParseResult(normal_text="", calls=calls)
             return StreamingParseResult(normal_text=normal_text, calls=[])
 
@@ -161,8 +169,12 @@ class Qwen3ToolParser(BaseToolParser):
             return self._wrapped_streaming(replay, tools)
 
         # Leading `{` or `[` — could be a bare JSON tool call, or partial.
+        # Use `raw_decode` (not `json.loads`) so a complete JSON prefix
+        # followed by trailing text is emitted immediately. `json.loads`
+        # would raise `Extra data` and keep buffering forever (NVBug 6240584
+        # follow-up review).
         try:
-            parsed = json.loads(stripped)
+            parsed, _end = json.JSONDecoder().raw_decode(stripped)
         except json.JSONDecodeError:
             # Not yet complete — buffer more.
             return StreamingParseResult()
@@ -189,8 +201,20 @@ class Qwen3ToolParser(BaseToolParser):
                 self._stream_mode = self._STREAM_MODE_BARE_JSON
                 self._bare_json_buffer = ""
                 # Best-effort bookkeeping for callers that inspect these.
+                # NOTE: This intentionally diverges from `BaseToolParser`,
+                # which increments `current_tool_id` past the last completed
+                # tool. The bare-JSON path emits all calls in a single batch
+                # and never falls back to wrapped streaming afterwards, so
+                # we leave `current_tool_id` at the last emitted index and
+                # `current_tool_name_sent = True` as best-effort state for
+                # any downstream inspection.
                 self.current_tool_id = max(0, len(calls) - 1)
                 self.current_tool_name_sent = True
+                # Any content after the parsed JSON value is trailing text
+                # (e.g. prose after the tool call). Drop it: `_STREAM_MODE_BARE_JSON`
+                # already suppresses subsequent chunks, and surfacing this
+                # tail as `normal_text` would flip `finish_reason` back to
+                # `stop`.
                 return StreamingParseResult(normal_text="",
                                             calls=streaming_calls)
 

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -797,6 +797,158 @@ class TestQwen3ToolParser(BaseToolParserTestClass):
         assert result.calls[0].name == "get_weather"
         assert json.loads(result.calls[0].parameters) == {"location": "Tokyo"}
 
+    # ------------------------------------------------------------------
+    # NVBug 6240584: bare-JSON fallback in detect_and_parse
+    #
+    # Some Qwen3 chat templates (notably Qwen3.6 FP8 with
+    # `--reasoning_parser qwen3_5 --tool_parser qwen3`) emit tool calls
+    # as bare JSON, without a `<tool_call>...</tool_call>` wrapper, once
+    # the reasoning parser strips the `</think>` block. The parser must
+    # recover those before dropping the text into `normal_text`.
+    # ------------------------------------------------------------------
+
+    def test_detect_and_parse_bare_json_dict(self, sample_tools, parser):
+        """Bare JSON dict without <tool_call> wrapper is parsed as a tool call."""
+        text = '{"name":"get_weather","arguments":{"location":"Paris"}}'
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert result.normal_text == ""
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_weather"
+        assert json.loads(result.calls[0].parameters) == {"location": "Paris"}
+
+    def test_detect_and_parse_bare_json_list(self, sample_tools, parser):
+        """Bare JSON list of tool calls without wrapper is parsed."""
+        text = '[{"name":"get_weather","arguments":{"location":"Paris"}}]'
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert result.normal_text == ""
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_weather"
+        assert json.loads(result.calls[0].parameters) == {"location": "Paris"}
+
+    def test_detect_and_parse_bare_json_parameters_key(self, sample_tools,
+                                                       parser):
+        """Bare JSON with `parameters` (instead of `arguments`) is still parsed."""
+        text = '{"name":"get_weather","parameters":{"location":"Paris"}}'
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_weather"
+        assert json.loads(result.calls[0].parameters) == {"location": "Paris"}
+
+    def test_detect_and_parse_non_json_text_falls_through(
+            self, sample_tools, parser):
+        """Plain non-JSON text passes through as normal_text with no calls."""
+        text = "Hello world"
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert result.normal_text == "Hello world"
+        assert result.calls == []
+
+    def test_detect_and_parse_bare_json_scalar_falls_through(
+            self, sample_tools, parser):
+        """A JSON scalar (e.g. `"42"`) must fall through cleanly, not crash.
+
+        This exercises the explicit `isinstance(parsed, (dict, list))` guard —
+        `parse_base_json` would raise `AttributeError` on a bare int, so the
+        guard prevents relying on exception catching for scalar JSON.
+        """
+        text = "42"
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert result.calls == []
+        # No crash is the important part.
+
+    def test_detect_and_parse_malformed_bare_json_falls_through(
+            self, sample_tools, parser):
+        """Malformed JSON without <tool_call> wrapper falls through cleanly."""
+        text = '{"name": "get_weather", "arguments": MALFORMED}'
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert result.calls == []
+        assert result.normal_text == text
+
+    # ------------------------------------------------------------------
+    # NVBug 6240584: bare-JSON fallback in parse_streaming_increment
+    #
+    # The streaming path must also recover bare-JSON tool calls when the
+    # `<tool_call>` wrapper never appears. Without this, streaming clients
+    # receive the JSON as `delta.content` with `finish_reason="stop"`.
+    # ------------------------------------------------------------------
+
+    def test_streaming_bare_json_one_chunk(self, sample_tools, parser):
+        """A complete bare-JSON tool call arriving in a single chunk emits calls."""
+        result = parser.parse_streaming_increment(
+            '{"name":"get_weather","arguments":{"city":"Paris"}}', sample_tools)
+
+        names = [c.name for c in result.calls if c.name]
+        assert "get_weather" in names
+        params = "".join(c.parameters for c in result.calls if c.parameters)
+        assert "Paris" in params
+        assert result.normal_text == ""
+
+    def test_streaming_bare_json_split_across_chunks(self, sample_tools,
+                                                     parser):
+        """Bare-JSON tool call split across multiple chunks parses on completion."""
+        r1 = parser.parse_streaming_increment('{"name":"get_', sample_tools)
+        r2 = parser.parse_streaming_increment('weather","arguments":',
+                                              sample_tools)
+        r3 = parser.parse_streaming_increment('{"city":"Paris"}}', sample_tools)
+
+        all_calls = list(r1.calls) + list(r2.calls) + list(r3.calls)
+        names = [c.name for c in all_calls if c.name]
+        assert "get_weather" in names
+        params = "".join(c.parameters for c in all_calls if c.parameters)
+        assert "Paris" in params
+
+    def test_streaming_bare_json_does_not_leak_content(self, sample_tools,
+                                                       parser):
+        """After a bare-JSON tool call is emitted, trailing text is not leaked.
+
+        This must be the case even for subsequent empty/whitespace chunks:
+        leaking any normal_text would flip `finish_reason` back to `stop`.
+        """
+        r1 = parser.parse_streaming_increment(
+            '{"name":"get_weather","arguments":{"city":"Paris"}}', sample_tools)
+        # Any subsequent chunks must not emit normal_text either.
+        r2 = parser.parse_streaming_increment("", sample_tools)
+
+        assert r1.normal_text == ""
+        assert r2.normal_text == ""
+
+    def test_streaming_non_json_text_flushed_as_normal(self, sample_tools,
+                                                       parser):
+        """Non-JSON text without a wrapper is flushed to normal_text."""
+        result = parser.parse_streaming_increment("Hello world", sample_tools)
+
+        assert result.normal_text == "Hello world"
+        assert result.calls == []
+
+    def test_streaming_wrapped_form_unregressed(self, sample_tools, parser):
+        """The pre-existing wrapped-form streaming path continues to work."""
+        # Send bot token.
+        parser.parse_streaming_increment("<tool_call>\n", sample_tools)
+
+        # Partial JSON with name -> emits name with empty params.
+        r_name = parser.parse_streaming_increment('{"name":"get_weather"',
+                                                  sample_tools)
+        assert len(r_name.calls) == 1
+        assert r_name.calls[0].name == "get_weather"
+        assert r_name.calls[0].parameters == ""
+
+        # Complete the JSON and the wrapper.
+        r_args = parser.parse_streaming_increment(
+            ',"arguments":{"location":"SF"}}\n</tool_call>', sample_tools)
+        assert len(r_args.calls) == 1
+        assert json.loads(r_args.calls[0].parameters) == {"location": "SF"}
+
 
 class TestQwen3CoderToolParser(BaseToolParserTestClass):
     """Test suite for Qwen3CoderToolParser class."""
@@ -2690,6 +2842,62 @@ class TestPoolsideV1ToolParserFactory:
 
 class TestToolParserIntegration:
     """Integration tests for tool parsers."""
+
+    def test_qwen3_5_reasoning_plus_qwen3_tool_parser_bare_json_pipeline(
+            self, sample_tools):
+        """NVBug 6240584: end-to-end reasoning + tool parser pipeline.
+
+        Reproduces the exact scenario from the bug report: the model emits
+        `<think>...</think>` followed by a bare JSON tool call (no
+        `<tool_call>` wrapper). The `qwen3_5` reasoning parser strips the
+        thinking block, then the `qwen3` tool parser must recover the tool
+        call so `args.has_tool_call[0]` is True and downstream logic sets
+        `finish_reason="tool_calls"` (see chat_response_post_processor).
+        """
+        from tensorrt_llm.serve.openai_protocol import ChatCompletionRequest
+        from tensorrt_llm.serve.postprocess_handlers import (
+            ChatPostprocArgs, apply_reasoning_parser, apply_tool_parser)
+
+        # Bug-report input: reasoning block + bare JSON tool call.
+        text = ('<think>Reasoning here.</think>\n'
+                '{"name":"get_weather","arguments":{"city":"Paris"}}')
+
+        # Build a minimal request so we can construct ChatPostprocArgs.
+        req = ChatCompletionRequest(
+            model="Qwen/Qwen3.6-27B-FP8",
+            messages=[{
+                "role": "user",
+                "content": "What is the weather in Paris?"
+            }],
+            tools=sample_tools,
+        )
+        args = ChatPostprocArgs.from_request(req)
+        args.reasoning_parser = "qwen3_5"
+        args.tool_parser = "qwen3"
+
+        # Non-streaming path.
+        content, reasoning_content = apply_reasoning_parser(args,
+                                                            output_index=0,
+                                                            text=text,
+                                                            streaming=False)
+        assert reasoning_content == "Reasoning here."
+        # The reasoning parser strips `<think>...</think>` — the remaining
+        # content is the bare JSON, possibly with a leading newline.
+        assert '"name":"get_weather"' in content
+
+        normal_text, calls = apply_tool_parser(args,
+                                               output_index=0,
+                                               text=content,
+                                               streaming=False)
+
+        assert len(calls) == 1
+        assert calls[0].name == "get_weather"
+        assert json.loads(calls[0].parameters) == {"city": "Paris"}
+        # Downstream (chat_response_post_processor) checks this flag to flip
+        # finish_reason from "stop" to "tool_calls".
+        assert args.has_tool_call.get(0) is True
+        # And no bare JSON leaks into the visible content.
+        assert normal_text == ""
 
     def test_end_to_end_single_tool(self, sample_tools):
         """Test end-to-end parsing of a single tool call."""

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -875,6 +875,25 @@ class TestQwen3ToolParser(BaseToolParserTestClass):
         assert result.calls == []
         assert result.normal_text == text
 
+    def test_detect_and_parse_bare_json_with_trailing_content(
+            self, sample_tools, parser):
+        """Bare JSON followed by trailing non-whitespace text is still parsed.
+
+        NVBug 6240584 review follow-up: `json.loads(text.strip())` raises
+        `json.JSONDecodeError: Extra data` on `'{...} trailing text'`, which
+        used to drop the valid tool call into `normal_text`. The parser now
+        uses `raw_decode` to consume only the leading JSON value and must
+        recover the tool call regardless of what follows.
+        """
+        text = ('{"name":"get_weather","arguments":{"city":"Paris"}}\n'
+                'Extra text after the tool call.')
+
+        result = parser.detect_and_parse(text, sample_tools)
+
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "get_weather"
+        assert json.loads(result.calls[0].parameters) == {"city": "Paris"}
+
     # ------------------------------------------------------------------
     # NVBug 6240584: bare-JSON fallback in parse_streaming_increment
     #
@@ -930,6 +949,50 @@ class TestQwen3ToolParser(BaseToolParserTestClass):
 
         assert result.normal_text == "Hello world"
         assert result.calls == []
+
+    def test_streaming_bare_json_with_trailing_content(self, sample_tools,
+                                                       parser):
+        """Bare-JSON tool call plus trailing text: emit calls, don't buffer.
+
+        NVBug 6240584 review follow-up: previously the streaming path called
+        `json.loads(stripped)`, which fails with `Extra data` when the
+        buffered content is `'{...} trailing text'`. The parser would then
+        keep buffering forever and never emit the tool call. With
+        `raw_decode`, the tool call must be emitted at the JSON boundary
+        and the trailing text must be dropped (bare-JSON mode already
+        suppresses subsequent chunks).
+        """
+        result = parser.parse_streaming_increment(
+            '{"name":"get_weather","arguments":{"city":"Paris"}}\n'
+            'Extra text after the tool call.', sample_tools)
+
+        names = [c.name for c in result.calls if c.name]
+        assert "get_weather" in names
+        params = "".join(c.parameters for c in result.calls if c.parameters)
+        assert "Paris" in params
+        # Trailing text must NOT be surfaced as normal_text — it would flip
+        # finish_reason back to "stop".
+        assert result.normal_text == ""
+
+    def test_streaming_bare_json_trailing_content_split_chunk(
+            self, sample_tools, parser):
+        """Same as above but the trailing text arrives in a later chunk.
+
+        This exercises the state machine: chunk 1 completes the JSON (parser
+        must emit calls now, not wait for more input), chunk 2 arrives after
+        the parser is already in `_STREAM_MODE_BARE_JSON` and must be
+        suppressed.
+        """
+        r1 = parser.parse_streaming_increment(
+            '{"name":"get_weather","arguments":{"city":"Paris"}}', sample_tools)
+        r2 = parser.parse_streaming_increment('\nExtra text.', sample_tools)
+
+        names = [c.name for c in r1.calls if c.name]
+        assert "get_weather" in names
+        assert r1.normal_text == ""
+        # Trailing chunk is fully suppressed.
+        assert r2.calls == []
+        assert r2.normal_text == ""
 
     def test_streaming_wrapped_form_unregressed(self, sample_tools, parser):
         """The pre-existing wrapped-form streaming path continues to work."""
@@ -2904,6 +2967,91 @@ class TestToolParserIntegration:
         assert args.has_tool_call.get(0) is True
         # And no bare JSON leaks into the visible content.
         assert normal_text == ""
+
+    def test_qwen3_5_reasoning_plus_qwen3_tool_parser_bare_json_streaming(
+            self, sample_tools):
+        r"""NVBug 6240584: streaming variant of reasoning+tool parser pipeline.
+
+        The bug most commonly reproduces on streamed chat completions —
+        the model emits tokens one at a time and the OpenAI server relies
+        on the tool parser to flip `finish_reason` to `tool_calls` before
+        the stream ends. Feed the same reasoning + bare-JSON payload
+        through `apply_reasoning_parser` / `apply_tool_parser` with
+        `streaming=True` in small chunks and assert:
+          - `args.has_tool_call[0]` is True at end-of-stream,
+          - the accumulated tool-call name/arguments are correct,
+          - the bare JSON never leaks into visible content.
+        """
+        from tensorrt_llm.serve.openai_protocol import ChatCompletionRequest
+        from tensorrt_llm.serve.postprocess_handlers import (
+            ChatPostprocArgs, apply_reasoning_parser, apply_tool_parser)
+
+        text = ('Reasoning here.</think>\n'
+                '{"name":"get_weather","arguments":{"city":"Paris"}}')
+
+        # Chunk the input to force the streaming state machines to buffer
+        # across boundaries. The split intentionally lands inside both the
+        # `</think>` tag and the JSON payload.
+        chunks = [
+            'Reasoning ',
+            'here.</thi',
+            'nk>\n{"name":"get_',
+            'weather","arguments":',
+            '{"city":"Pa',
+            'ris"}}',
+        ]
+
+        req = ChatCompletionRequest(
+            model="Qwen/Qwen3.6-27B-FP8",
+            messages=[{
+                "role": "user",
+                "content": "What is the weather in Paris?"
+            }],
+            tools=sample_tools,
+        )
+        args = ChatPostprocArgs.from_request(req)
+        args.reasoning_parser = "qwen3_5"
+        args.tool_parser = "qwen3"
+
+        accumulated_content = ""
+        accumulated_normal_text = ""
+        collected_calls = []
+
+        for chunk in chunks:
+            content, _reasoning = apply_reasoning_parser(args,
+                                                         output_index=0,
+                                                         text=chunk,
+                                                         streaming=True)
+            accumulated_content += content
+            if not content:
+                continue
+            normal_text, calls = apply_tool_parser(args,
+                                                   output_index=0,
+                                                   text=content,
+                                                   streaming=True)
+            if normal_text:
+                accumulated_normal_text += normal_text
+            collected_calls.extend(calls)
+
+        # The reasoning parser must have stripped everything through the
+        # `</think>` tag; the bare JSON survives into content.
+        assert '"name":"get_weather"' in accumulated_content
+
+        # The tool parser must have flipped `has_tool_call` before the
+        # stream ended — this is the exact condition
+        # `chat_response_post_processor` uses to set
+        # `finish_reason="tool_calls"`.
+        assert args.has_tool_call.get(0) is True
+
+        # We must have received the tool name and its arguments (potentially
+        # across multiple streaming increments).
+        names = [c.name for c in collected_calls if c.name]
+        assert names == ["get_weather"]
+        params = "".join(c.parameters for c in collected_calls if c.parameters)
+        assert json.loads(params) == {"city": "Paris"}
+
+        # And no visible content is leaked from the bare-JSON payload.
+        assert accumulated_normal_text == ""
 
     def test_end_to_end_single_tool(self, sample_tools):
         """Test end-to-end parsing of a single tool call."""

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -2845,21 +2845,27 @@ class TestToolParserIntegration:
 
     def test_qwen3_5_reasoning_plus_qwen3_tool_parser_bare_json_pipeline(
             self, sample_tools):
-        """NVBug 6240584: end-to-end reasoning + tool parser pipeline.
+        r"""NVBug 6240584: end-to-end reasoning + tool parser pipeline.
 
-        Reproduces the exact scenario from the bug report: the model emits
-        `<think>...</think>` followed by a bare JSON tool call (no
-        `<tool_call>` wrapper). The `qwen3_5` reasoning parser strips the
-        thinking block, then the `qwen3` tool parser must recover the tool
-        call so `args.has_tool_call[0]` is True and downstream logic sets
+        Reproduces the exact scenario from the bug report: the Qwen3.6 FP8
+        chat template pre-injects `<think>\n` into the assistant prompt
+        prefix, so the model output starts *inside* the reasoning block
+        with no opening `<think>` tag. Content up to `</think>` is the
+        reasoning, and what follows is a bare JSON tool call (no
+        `<tool_call>` wrapper). The `qwen3_5` reasoning parser (registered
+        with `reasoning_at_start=True`) strips the thinking block, then
+        the `qwen3` tool parser must recover the tool call so
+        `args.has_tool_call[0]` is True and downstream logic sets
         `finish_reason="tool_calls"` (see chat_response_post_processor).
         """
         from tensorrt_llm.serve.openai_protocol import ChatCompletionRequest
         from tensorrt_llm.serve.postprocess_handlers import (
             ChatPostprocArgs, apply_reasoning_parser, apply_tool_parser)
 
-        # Bug-report input: reasoning block + bare JSON tool call.
-        text = ('<think>Reasoning here.</think>\n'
+        # Bug-report input: reasoning content (no leading `<think>` — the
+        # chat template already injected it into the prompt prefix) followed
+        # by a bare JSON tool call.
+        text = ('Reasoning here.</think>\n'
                 '{"name":"get_weather","arguments":{"city":"Paris"}}')
 
         # Build a minimal request so we can construct ChatPostprocArgs.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `Qwen3ToolParser` to support reasoning-preceded Qwen3 tool-call streams emitted as **bare JSON** (no `<tool_call>...</tool_call>` wrapper), keyed to NVBug 6240584.
- Implemented **mode-based persistent streaming state** in `parse_streaming_increment`:
  - “undecided” buffers and decides between wrapped vs bare-JSON by detecting `<tool_call>` or leading `{`/`[`.
  - “bare_json” parses the first complete leading JSON value, emits tool calls, then **suppresses trailing text** for the remainder of the stream.
  - “wrapped” routes to the existing wrapped-form streaming implementation.
- Fixed non-streaming bare-JSON recovery in `detect_and_parse`:
  - Uses `json.JSONDecoder().raw_decode(...)` so a valid leading JSON object/array can be recovered even when **trailing content** follows (avoids `Extra data`).
  - Only accepts bare-JSON results shaped as `dict`/`list`; otherwise safely falls back to `normal_text` with no tool calls.
- Ensured tool-call emission semantics for bare JSON match wrapped streaming expectations (emits **tool name first with empty parameters**, then the full parameters payload).
- Added/adjusted safeguards for edge cases: scalar/malformed JSON fallback behavior and unregressed wrapped streaming behavior.

## QA Engineer Review

Test-code changes were made in `tests/unittest/llmapi/apps/test_tool_parsers.py`.

### Added/updated test functions (related to NVBug 6240584 / bare-JSON recovery)

- `test_detect_and_parse_bare_json_dict`
- `test_detect_and_parse_bare_json_list`
- `test_detect_and_parse_bare_json_parameters_key`
- `test_detect_and_parse_non_json_text_falls_through`
- `test_detect_and_parse_bare_json_scalar_falls_through`
- `test_detect_and_parse_malformed_bare_json_falls_through`
- `test_detect_and_parse_bare_json_with_trailing_content`
- `test_streaming_bare_json_one_chunk`
- `test_streaming_bare_json_split_across_chunks`
- `test_streaming_bare_json_does_not_leak_content`
- `test_streaming_non_json_text_flushed_as_normal`
- `test_streaming_bare_json_with_trailing_content`
- `test_streaming_bare_json_trailing_content_split_chunk`
- `test_streaming_wrapped_form_unregressed`
- `test_qwen3_5_reasoning_plus_qwen3_tool_parser_bare_json_pipeline`
- `test_qwen3_5_reasoning_plus_qwen3_tool_parser_bare_json_streaming`

### Coverage registration (test lists)
- No changes were made to `tests/integration/test_lists/`, `test-db/`, `qa/`, or `waives.txt`.

**Verdict: needs follow-up.**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
