### PR TITLE
[https://nvbugs/6506918][fix] Reject the incompatible configuration up front in `Linear.__init__` with an…

### DIFF
--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -3306,6 +3306,16 @@ class Linear(nn.Module):
                 f"Invalid tp_mode {self.tp_mode!r}; expected ROW, COLUMN, or None."
             )
 
+        # gather_output requires a uniform NCCL AllGather; uneven column shards
+        # would produce mismatched local buffers and hang the collective. Reject
+        # this configuration up front rather than fail mid-collective.
+        if (gather_output and self.tp_size > 1
+                and self.tp_mode == TensorParallelMode.COLUMN):
+            assert out_features % self.tp_size == 0, (
+                f"gather_output=True is not supported with uneven TP. "
+                f"out_features={out_features} must be divisible by tp_size={self.tp_size}."
+            )
+
         # Init TP sharding either from override or auto generated
         _uneven_tp_unsupported = {QuantAlgo.NVFP4_ARC}
         _quant_algo = quant_config.quant_algo if quant_config else None

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -179,7 +179,6 @@ full:B300/disaggregated/test_disaggregated.py::test_disaggregated_ctxpp2_genpp2[
 full:B300/test_e2e.py::test_qwen_e2e_cpprunner_large_new_tokens[DeepSeek-R1-Distill-Qwen-1.5B-DeepSeek-R1-Distill-Qwen-1.5B] SKIP (https://nvbugs/6414760)
 full:DGX_B200/accuracy/test_disaggregated_serving.py::TestQwen3NextInstruct::test_auto_dtype[use_py_transceiver=True] SKIP (https://nvbugs/6501837)
 full:DGX_B200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV4ProDSpark::test_gsm8k_dep8_megamoe_deepgemm SKIP (https://nvbugs/6506920)
-full:DGX_H100/unittest/_torch/multi_gpu/test_linear.py::test_column_linear[2-unbalanced] SKIP (https://nvbugs/6506918)
 full:DGX_H200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[disable_skip_indexer] SKIP (https://nvbugs/6476233)
 full:DGX_H200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[latency_default] SKIP (https://nvbugs/6476233)
 full:GB200/accuracy/test_dwdp_disaggregated_serving.py::TestDwdpDeepSeekV3Lite::test_dwdp_accuracy SKIP (https://nvbugs/6276923)


### PR DESCRIPTION
## Summary
- **Root cause**: Uneven-TP column-parallel Linear + gather_output=True hangs the NCCL AllGather because per-rank local buffer sizes differ but no `sizes=` argument is passed, and the underlying C++ AllGather with sizes is also broken for this case.
- **Fix**: Reject the incompatible configuration up front in `Linear.__init__` with an `assert out_features % self.tp_size == 0` guard that fires when `gather_output=True and tp_mode==COLUMN and tp_size>1`. This restores the pre-TRTLLM-13117 behavior for exactly the code path that gather_output relies on (uniform NCCL AllGather), matches the test's `pytest.raises(AssertionError)` expectation, and leaves uneven TP working for `gather_output=False` VisualGen use cases. Also remove the corresponding `waives.txt` entry.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6506918


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Added upfront validation in `Linear.__init__` to reject gathered outputs for uneven column-parallel sharding, preventing NCCL AllGather buffer-size mismatches and hangs.
- Preserves uneven tensor parallelism when `gather_output=False`.
- Removed the corresponding waiver entry; the test-list format and scope are consistent.
- No public API declarations were changed.

## QA Engineer Review

- No test code was modified.
- Removed the `test_column_linear[2-unbalanced]` waiver from `tests/integration/test_lists/waives.txt`.
- CBTS coverage data is unavailable, so the verdict is **needs follow-up**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->