### PR TITLE
[None][perf] Address D2D copies in mixed batches

### DIFF
--- a/3rdparty/patches/msa_strided_paged_kv.patch
+++ b/3rdparty/patches/msa_strided_paged_kv.patch
@@ -1,18 +1,18 @@
 diff --git a/python/fmha_sm100/cute/interface.py b/python/fmha_sm100/cute/interface.py
-index d72b17a..e27a74f 100644
+index d72b17a..e4ad52e 100644
 --- a/python/fmha_sm100/cute/interface.py
 +++ b/python/fmha_sm100/cute/interface.py
 @@ -136,6 +136,32 @@ def _prepare_paged_kv_for_tma(k, v, blk_kv: int):
      return k, v
-
-
+ 
+ 
 +def _prepare_paged_hnd_input(tensor: torch.Tensor, blk_kv: int) -> torch.Tensor:
 +    """Keep TMA-compatible paged HND views strided across physical pages.
 +
-+    The sparse prefill kernel imports the runtime tensor strides through
-+    DLPack. It requires each ``[page_size, head_dim]`` head plane to be packed,
-+    but the outer physical-page stride may include other coalesced cache roles.
-+    Materialize every other layout to preserve the public API's old contract.
++    The sparse prefill kernel imports the runtime tensor strides through DLPack.
++    It requires each [page_size, head_dim] head plane to be packed, but the
++    outer physical-page stride may include other coalesced cache roles.
++    Materialize every other layout so callers can pass any strides.
 +    """
 +    if tensor.ndim != 4 or int(tensor.shape[2]) != int(blk_kv):
 +        return tensor.contiguous()
@@ -38,7 +38,7 @@ index d72b17a..e27a74f 100644
 @@ -736,10 +762,21 @@ def sparse_atten_func(
      max_seqlen_q = int(max_seqlen_q)
      max_seqlen_k = int(max_seqlen_k)
-
+ 
 +    k_input = (
 +        k.contiguous()
 +        if page_table is None
@@ -65,8 +65,8 @@ index 21c777e..c22beef 100644
 +++ b/python/fmha_sm100/cute/test_sparse_atten.py
 @@ -61,6 +61,43 @@ DECODE_DIM = 128
  DECODE_KV_TOKEN_SWEEP = tuple(2**exp for exp in range(3, 21))
-
-
+ 
+ 
 +def test_prepare_paged_hnd_input_keeps_aligned_outer_page_stride() -> None:
 +    pages, roles, heads, page_size, head_dim = 5, 3, 2, 128, 128
 +    pool = torch.empty(
@@ -108,9 +108,9 @@ index 21c777e..c22beef 100644
  def _nvtx_range(message: str):
      torch.cuda.nvtx.range_push(message)
 @@ -1786,6 +1823,74 @@ def test_sparse_page_atten(
-
+ 
      _assert_forward_close(out, out_ref, out_pt.float(), lse, lse_ref)
-
+ 
 +
 +def test_sparse_page_atten_strided_outer_page_matches_packed() -> None:
 +    inputs = _build_paged_inputs(
@@ -182,3 +182,117 @@ index 21c777e..c22beef 100644
  @pytest.mark.parametrize("paged", [False, True])
  @pytest.mark.parametrize("causal", [True])
  @pytest.mark.parametrize("batch", [3])
+diff --git a/python/fmha_sm100/sparse_fmha_adapter.py b/python/fmha_sm100/sparse_fmha_adapter.py
+index 306b416..fd24e7e 100644
+--- a/python/fmha_sm100/sparse_fmha_adapter.py
++++ b/python/fmha_sm100/sparse_fmha_adapter.py
+@@ -228,23 +228,83 @@ def _build_page_table(
+     page_size: int,
+     batch: int,
+ ) -> torch.Tensor:
+-    """Flat kv_indices → page_table [batch, max_pages_per_seq]."""
+-    kv_lens = kv_segment_lens.tolist()
+-    pages_per_batch = [(int(kl) + page_size - 1) // page_size for kl in kv_lens]
+-    max_pages = max(pages_per_batch)
+-    total = batch * max_pages
+-    buf = torch.zeros(total + 4, dtype=torch.int32, device=kv_indices.device)
+-    shift = ((-buf.data_ptr()) % 16) // 4
+-    page_table = buf[shift : shift + total].view(batch, max_pages)
++    """Flat kv_indices → page_table [batch, max_pages_per_seq].
++
++    Each request's pages are a contiguous run of kv_indices, so the padded table
++    is kv_indices[start[b] + col] masked to the request's page count. One gather
++    builds it: a copy per request would dominate host time once the batch is
++    wide.
++    """
++    lens = kv_segment_lens if kv_segment_lens.device.type == "cpu" else kv_segment_lens.cpu()
++    pages = (lens.to(torch.int64) + (page_size - 1)) // page_size
++    max_pages = int(pages.max())
++    starts = torch.cumsum(pages, 0) - pages
++    # Both row descriptors travel in a single host-to-device copy.
++    meta = torch.stack((pages, starts)).to(kv_indices.device, non_blocking=True)
++    pages_dev = meta[0].unsqueeze(1)
++    starts_dev = meta[1].unsqueeze(1)
++
++    col = torch.arange(max_pages, device=kv_indices.device, dtype=torch.int64).unsqueeze(0)
++    mask = col < pages_dev
++    # Padded columns run past the end of a request's run, so clamp the gather
++    # index into range and zero them afterwards.
++    src = (starts_dev + col).clamp_(max=max(kv_indices.numel() - 1, 0))
++    page_table = kv_indices.index_select(0, src.reshape(-1)).to(torch.int32)
++    page_table = page_table.view(batch, max_pages).masked_fill_(~mask, 0)
+     assert page_table.data_ptr() % 16 == 0, (
+-        f"_build_page_table failed to align: buf=0x{buf.data_ptr():x} "
+-        f"shift={shift} page_table=0x{page_table.data_ptr():x}"
++        f"_build_page_table failed to align: page_table=0x{page_table.data_ptr():x}"
++    )
++    return page_table
++
++
++def _version_token(tensor: torch.Tensor):
++    """Version counter for `tensor`, or None if it does not track one.
++
++    Inference tensors have no version counter, so this is None on the serving
++    path and the caller falls back to identity checks alone.
++    """
++    return None if torch.is_inference(tensor) else tensor._version
++
++
++def _page_table_for_plan(
++    plan_info: dict,
++    kv_indices: torch.Tensor,
++    kv_segment_lens: torch.Tensor,
++    page_size: int,
++    batch: int,
++) -> torch.Tensor:
++    """Return this plan's page table, building it at most once per step.
++
++    Every sparse layer of a step runs the same plan over the same kv_indices
++    buffer, so they all build a byte-identical table. Cache it on the plan and
++    reuse it while the inputs look unchanged.
++
++    The cache holds a reference to kv_segment_lens so identity comparison is
++    sound: a live object's id cannot be recycled. A caller that rebuilds its
++    plan or restages these lengths therefore gets a fresh table. Version
++    counters add a content check where tensors track one.
++    """
++    cached = plan_info.get("_page_table_cache")
++    if cached is not None:
++        lens, ptr, numel, versions, geometry, page_table = cached
++        if (
++            lens is kv_segment_lens
++            and ptr == kv_indices.data_ptr()
++            and numel == kv_indices.numel()
++            and geometry == (page_size, batch)
++            and versions
++            == (_version_token(kv_indices), _version_token(kv_segment_lens))
++        ):
++            return page_table
++    page_table = _build_page_table(kv_indices, kv_segment_lens, page_size, batch)
++    plan_info["_page_table_cache"] = (
++        kv_segment_lens,
++        kv_indices.data_ptr(),
++        kv_indices.numel(),
++        (_version_token(kv_indices), _version_token(kv_segment_lens)),
++        (page_size, batch),
++        page_table,
+     )
+-    offset = 0
+-    for b in range(batch):
+-        n = pages_per_batch[b]
+-        page_table[b, :n] = kv_indices[offset : offset + n].to(torch.int32)
+-        offset += n
+     return page_table
+ 
+ 
+@@ -351,8 +411,8 @@ def sparse_fmha(
+     if is_paged:
+ 
+         if kv_indices is not None:
+-            page_table = _build_page_table(
+-                kv_indices, kv_segment_lens, page_size, batch,
++            page_table = _page_table_for_plan(
++                plan_info, kv_indices, kv_segment_lens, page_size, batch,
+             )
+ 
+     # build_k2q_csr(return_schedule=True) builds schedule using hardware SM count internally

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_utils.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_utils.py
@@ -51,27 +51,32 @@ def msa_package_available() -> bool:
     return importlib.util.find_spec("fmha_sm100") is not None
 
 
-# Symbol added by 3rdparty/patches/msa_strided_paged_kv.patch. Its presence in
-# the imported module confirms the downstream MSA patch was applied to the
-# loaded fmha_sm100 sources.
-_MSA_PATCH_MARKER = "_prepare_paged_hnd_input"
+# One symbol per module touched by 3rdparty/patches/msa_strided_paged_kv.patch.
+_MSA_PATCH_MARKERS = (
+    ("fmha_sm100.cute.interface", "_prepare_paged_hnd_input"),
+    ("fmha_sm100.sparse_fmha_adapter", "_page_table_for_plan"),
+)
 
 
 def _require_msa_patch() -> None:
     """Fail fast if the loaded fmha_sm100 is missing the downstream patch.
 
-    The patch avoids paged K/V materialization during prefill and is applied in
-    place on the 3rdparty/MSA submodule by scripts/build_wheel.py. An unpatched
-    copy would silently regress prefill, so raise an actionable error that names
-    the loaded module file.
+    The patch keeps prefill from materializing the paged K/V cache and builds
+    the sparse page table with one gather per step. scripts/build_wheel.py
+    applies it in place on the 3rdparty/MSA submodule. A copy missing either
+    marker would silently regress prefill or per-step host time, so report
+    every absent symbol with the file it was expected in.
     """
-    from fmha_sm100.cute import interface
+    missing = []
+    for module_name, symbol in _MSA_PATCH_MARKERS:
+        module = importlib.import_module(module_name)
+        if not hasattr(module, symbol):
+            missing.append(f"'{symbol}' in '{getattr(module, '__file__', '<unknown>')}'")
 
-    if not hasattr(interface, _MSA_PATCH_MARKER):
+    if missing:
         raise RuntimeError(
             "The imported fmha_sm100 is missing the TensorRT-LLM MSA patch "
-            f"(expected symbol '{_MSA_PATCH_MARKER}' in "
-            f"'{getattr(interface, '__file__', '<unknown>')}'). Rebuild with "
+            f"(expected {', '.join(missing)}). Rebuild with "
             "scripts/build_wheel.py, which applies "
             "3rdparty/patches/msa_strided_paged_kv.patch in place, or apply the "
             "patch to 3rdparty/MSA manually."


### PR DESCRIPTION
## Description

There are two problems:
- `_build_page_table` issues a lot of D2D copies when it sees a mixed batch. These could span ~110us for a batch with 1 context request and 120 decode requests.
- This is called once for every sparse layer though it remains the same across layers in a single forward.

Fixes:
- Vectorize the large number of D2D copies into 1. ~110us -> ~27us per layer.
- Build the table only on the first spare layer in a forward and reuse for the rest. ~110us * 57 per forward -> ~27us per forward.

At TP=4, ISL=8192, OSL=128, c=320, request latency in ms.

Baseline
```
[Latency] P50    : 77856.8572
[Latency] P90    : 92172.6618
[Latency] P95    : 101829.9520
[Latency] P99    : 109621.2746
[Latency] MINIMUM: 33805.4149
[Latency] MAXIMUM: 111413.5935
[Latency] AVERAGE: 73564.0792
```

Vectorization
```
[Latency] P50    : 73897.6915
[Latency] P90    : 88268.8825
[Latency] P95    : 97409.3261
[Latency] P99    : 104814.1584
[Latency] MINIMUM: 32896.9142
[Latency] MAXIMUM: 106521.8771
[Latency] AVERAGE: 70207.9022
```

Vectorization + Hoist
```
[Latency] P50    : 72969.3661
[Latency] P90    : 87000.6669
[Latency] P95    : 96023.0939
[Latency] P99    : 103330.9747
[Latency] MINIMUM: 32364.5672
[Latency] MAXIMUM: 105018.2742
[Latency] AVERAGE: 69344.3009
```

## Test Coverage
```
$ pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=True-eval_mode=default] -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
