### PR TITLE
[None][fix] Do not synthesize mrope_config for text-only prompts

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -866,18 +866,17 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
 
         # Text-only fast path: skip the multi-modal HF processor (tokenizer
         # output matches it bit-exactly when `images` / `videos` are `None`)
-        # while still populating mrope_config since the LM is M-RoPE.
+        # and emit no multimodal data at all.  M-RoPE positions for a prompt
+        # with no multimodal spans are just the sequential positions broadcast
+        # across the three axes, which PyTorchModelEngine._prepare_tp_inputs
+        # already writes as its text-only default before overwriting multimodal
+        # spans, so an mrope_config here would only recompute that value -- and
+        # by making MultimodalParams.has_content() true it would additionally
+        # open the EPD mRoPE IPC re-registration for context-only requests.
         if not mm_data:
             input_ids = self.tokenizer(text_prompt,
                                        return_tensors="pt").input_ids
-            attention_mask = torch.ones_like(input_ids)
-            mrope_config = self.get_mrope_config(input_ids, None, None,
-                                                 attention_mask, None)
-            return input_ids[0].to(torch.int32).tolist(), {
-                "multimodal_data": {
-                    "mrope_config": mrope_config
-                },
-            }
+            return input_ids[0].to(torch.int32).tolist(), None
 
         processed_inputs = self._preprocess(text_prompt, mm_data,
                                             mm_processor_kwargs)

--- a/tests/unittest/_torch/multimodal/test_qwen2vl_text_only_prompt.py
+++ b/tests/unittest/_torch/multimodal/test_qwen2vl_text_only_prompt.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.models.modeling_qwen2vl import (
+    Qwen2_5VLInputProcessorBase,
+    Qwen2VLInputProcessorBase,
+)
+from tensorrt_llm._torch.models.modeling_qwen3vl import Qwen3VLInputProcessorBase
+
+_PROMPT_TOKEN_IDS = [9001, 17, 42]
+
+
+class _FakeTokenizer:
+    def __init__(self, input_ids):
+        self.input_ids = input_ids
+
+    def __call__(self, prompt, return_tensors=None):
+        assert return_tensors == "pt"
+        return SimpleNamespace(input_ids=torch.tensor([self.input_ids]))
+
+
+def _make_processor(processor_cls):
+    # `_config` / `_processor` / `_dtype` are deliberately left unset: the
+    # text-only branch reads nothing but the tokenizer, so a regression that
+    # falls through into the multimodal branch fails loudly instead of
+    # silently synthesizing multimodal data.
+    processor = object.__new__(processor_cls)
+    processor._tokenizer = _FakeTokenizer(_PROMPT_TOKEN_IDS)
+    return processor
+
+
+@pytest.mark.parametrize(
+    "processor_cls",
+    [
+        pytest.param(Qwen2VLInputProcessorBase, id="qwen2-vl"),
+        pytest.param(Qwen2_5VLInputProcessorBase, id="qwen2.5-vl"),
+        pytest.param(Qwen3VLInputProcessorBase, id="qwen3-vl"),
+    ],
+)
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        {"prompt": "a text prompt"},
+        {"prompt": "a text prompt", "multi_modal_data": None},
+        {"prompt": "a text prompt", "multi_modal_data": {}},
+    ],
+    ids=["absent", "none", "empty"],
+)
+def test_text_only_prompt_returns_no_extra_processed_inputs(processor_cls, inputs):
+    """A prompt with no multimodal data emits no extra processed inputs at all."""
+    processor = _make_processor(processor_cls)
+
+    # Patched on the parametrized class so an inherited *or* overridden
+    # implementation is intercepted (Qwen3-VL overrides `_preprocess`).
+    with (
+        patch.object(processor_cls, "get_mrope_config") as mrope_config,
+        patch.object(processor_cls, "_preprocess") as preprocess,
+    ):
+        token_ids, extra = processor.call_with_text_prompt(inputs, None)
+
+    # `extra is None` is the load-bearing assertion and must not be weakened:
+    # it is what keeps the caller (`BaseLLM._preprocess`, llmapi/llm.py:835)
+    # from building a `MultimodalParams` at all, which in turn keeps a
+    # context-only request out of the mRoPE IPC re-registration at
+    # _torch/pyexecutor/model_engine.py:4057-4068, whose `SharedTensorContainer`
+    # exports are never rebuilt (and so leak) under disaggregated serving.
+    assert extra is None
+    assert token_ids == _PROMPT_TOKEN_IDS
+    # Guards the two ways the fast path (modeling_qwen2vl.py:876-879) can
+    # regress: recomputing a redundant mrope_config, or being deleted outright
+    # so control falls through to `_preprocess` at modeling_qwen2vl.py:881.
+    mrope_config.assert_not_called()
+    preprocess.assert_not_called()
+
+
+def test_multimodal_prompt_still_takes_the_full_path():
+    """Complement check: the fast path did not over-reach past `if not mm_data`.
+
+    This exercises modeling_qwen2vl.py:881-913, which the fix does not touch;
+    it passes before and after, and is here only to pin that the gate at :876
+    is still the sole thing the text-only path skips on.
+    """
+    processor = object.__new__(Qwen2VLInputProcessorBase)
+    processor._tokenizer = _FakeTokenizer(_PROMPT_TOKEN_IDS)
+    # Read by the real `get_rope_index` (modeling_qwen2vl.py:580-583) below.
+    processor._config = SimpleNamespace(
+        image_token_id=151655,
+        video_token_id=151656,
+        vision_start_token_id=151652,
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+    )
+    processed_inputs = {
+        "input_ids": torch.tensor([[1, 2, 3]]),
+        "attention_mask": torch.ones(1, 3, dtype=torch.long),
+    }
+
+    # Only the HF processor is stubbed; `get_mrope_config` runs for real so the
+    # assertions below read computed values rather than a mock's return_value.
+    with patch.object(Qwen2VLInputProcessorBase, "_preprocess", return_value=processed_inputs):
+        token_ids, extra = processor.call_with_text_prompt(
+            {"prompt": "an image prompt", "multi_modal_data": {"image": [object()]}},
+            None,
+        )
+
+    assert token_ids == [1, 2, 3]
+    mrope_config = extra["multimodal_data"]["mrope_config"]
+    assert mrope_config["mrope_position_ids"].shape == (3, 1, 3)
+    assert mrope_config["mrope_position_deltas"].shape == (1, 1)


### PR DESCRIPTION
# [None][fix] Do not synthesize mrope_config for text-only prompts

## Summary

`Qwen2VLInputProcessorBase.call_with_text_prompt()` has a text-only fast path that
skips the multimodal HF processor but still calls `get_mrope_config()`, reasoning
that "the LM is M-RoPE". For a prompt with no images or video that work is
redundant, and it has an unbounded side effect under disaggregated serving: the
context worker permanently strands one `(3, 1, prompt_len)` int64 tensor **per
scheduled context request**.

On Qwen3.5-397B-A17B over long-context agentic traces this is 24 bytes per prompt
token per scheduling event — 16.6 MiB/s of unrecoverable device memory, and the
context worker exhausts a GB300 in 2,300–3,500 s depending on KV-pool headroom.

## Why it is redundant

`PyTorchModelEngine._prepare_tp_inputs` already establishes the text-only answer
itself:

```python
# Broadcast [N] to [3,1,N]: default for text-only tokens.
self.mrope_position_ids_cuda[:, :, :total_num_tokens].copy_(
    self.position_ids_cuda[:total_num_tokens].view(1, 1, -1).expand(3, 1, -1), ...)
# Overwrite multimodal spans with per-axis MRoPE positions.
for start_idx, end_idx, segment in mrope_position_ids:
    ...
```

The per-axis positions only ever *overwrite multimodal spans*. With no such spans
there is nothing to overwrite, so the synthesized `mrope_config` reproduces a
value the engine has already written.

Verified numerically rather than argued — `get_rope_index()` on text-only input,
across four prompt lengths:

| assertion | result |
|---|---|
| three axes identical | pass |
| equals `arange(L)` broadcast to `[3,1,L]` | pass |
| `mrope_position_deltas == 0` | pass |
| dtype `int64` (24 B/token) | pass |

`deltas == 0` also covers the generation phase: with no `mrope_position_delta`
the engine falls back to `past_seen_token_num`, which is exactly
`past_seen_token_num + 0`.

## Why it leaks

Populating `multimodal_data` makes `MultimodalParams.has_content()` true, which
opens the EPD mRoPE re-registration for context-only requests in
`model_engine.py`:

```python
if (request.is_context_only_request and _use_mrope and
        "mrope_config" in multimodal_params.multimodal_data):
    request.py_result.set_mrope_position(_mrope_position_ids.clone(),
                                         _mrope_position_deltas.clone())
```

`set_mrope_position` wraps both clones in `SharedTensorContainer.from_tensor()`,
i.e. `reduce_tensor()` → `storage._share_cuda_()`, which replaces the storage's
`DataPtr` with a `CudaIPCSentData` owning the original. The block does not return
to the caching allocator when the Python tensor dies; it enters
`CudaIPCSentDataLimbo` and is freed only once a consumer opens and drops the
handle. `shared_tensor.py` states the contract directly:

> Whenever you call reduce_tensor, you must call the corresponding rebuild method
> at consumer process(es), otherwise, the producer process cannot release the
> memory to caching allocator as the inner refcount never reaches zero.

Under `trtllm-serve` disaggregation no consumer can exist: the serve-layer
`DisaggregatedParams` carries no mRoPE handle fields — see the existing
`TODO(TRTLLM-12407)` in `serve/openai_protocol.py`. The handle is dropped at the
orchestrator, so every export is a permanent pin.

## Evidence

CUDA allocator snapshots (`torch.cuda.memory._record_memory_history`) taken 900 s
apart on the context worker, before and after this change. Same image, same
workload, same config.

| | before | after |
|---|---:|---:|
| device growth over the 900 s window | +10,037 MiB | **+10 MiB** |
| live blocks at the `mrope_position_ids` clone | 828 → 4,247 | **0 → 0** |
| live blocks at the `mrope_position_deltas` clone | 828 → 4,247 | **0 → 0** |
| live blocks, whole process | 4,631 → 11,470 | 2,974 → **2,971** |
| steady-state slope | 16.6 MiB/s | ~0 |
| context-worker OOM | yes | no |

The two clone sites accounted for 100% of the process's live-block growth
(+6,838 of +6,839) in exact 1:1 pairing, with block sizes spread over 1,474
distinct values from 0.007 to 6.740 MiB — i.e. 24 bytes × prompt_len, mean
2.44 MiB.

Throughput, prefix-cache hit rate and startup KV-pool sizing are unchanged
(8.33 req/s, 95.6%, 168.20 GiB); the benchmark completed with zero errors.

With the fix the affected configuration also reproduces its pre-regression
baseline. A full 3600 s disaggregated run at the same operating point as a known
good build from before this path started firing — same parallelism, batch sizes,
sequence lengths, KV-pool fraction and client concurrency:

| | known good build | this build + fix |
|---|---:|---:|
| request throughput | 8.17 req/s | 8.13 req/s |
| request error rate | 0.02% | 0.01% |
| requests completed | 29,666 | 29,507 |
| TTFT mean | 2,247 ms | 2,210 ms |
| theoretical prefix cache hit | 95.64% | 95.64% |

Every metric is within run-to-run noise, and the context worker no longer runs
out of memory. Without the fix the same configuration cannot finish the window.

## Scope

This does not close the underlying defect for genuine multimodal traffic: a
request that really carries images over `trtllm-serve` disaggregation would still
export mRoPE handles that nothing can rebuild. That needs the protocol fields
tracked by TRTLLM-12407. This change removes the text-only case, which is the one
that fires on 100% of requests for a text workload.

## Test coverage

`tests/unittest/_torch/multimodal/test_qwen2vl_text_only_prompt.py` (new).

`test_text_only_prompt_returns_no_extra_processed_inputs` asserts that
`call_with_text_prompt` returns `extra_processed_inputs is None` and that
`get_mrope_config` and `_preprocess` are both never called. It is parametrized
over the three falsy shapes of `multi_modal_data` (key absent / `None` / `{}`)
and over the three processor classes that inherit this fast path
(`Qwen2VLInputProcessorBase`, `Qwen2_5VLInputProcessorBase`,
`Qwen3VLInputProcessorBase`), so a subclass reintroducing the export is caught
too.

`test_multimodal_prompt_still_takes_the_full_path` is the complement: with
non-empty `multi_modal_data` the full path still runs and still emits
`mrope_config`, so the fast path cannot be widened into the multimodal case.
It passes both before and after this change and is not the regression guard.

Both are CPU-only and need no model weights or network; the processor is built
with `object.__new__` plus a fake tokenizer, the same technique the neighbouring
`test_qwen3vl_disagg_prompt.py` already uses. The file needs no test-list entry
because `tests/integration/test_lists/test-db/l0_h100.yml` collects
`unittest/_torch/multimodal` as a directory.

Against a revert of this PR's diff, both guard assertions in the first test fail,
in all nine parametrizations.

Accuracy has not been re-measured on non-disaggregated text-only inference for
other Qwen-VL models sharing this processor; happy to run whatever the reviewers
consider sufficient.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `tensorrt_llm/_torch/models/modeling_qwen2vl.py` (`Qwen2VLInputProcessorBase.call_with_text_prompt()`): for the text-only fast path (`multi_modal_data` empty/falsy), the implementation now **avoids computing/synthesizing `mrope_config`** and does not return it via `extra["multimodal_data"]`. It directly tokenizes the prompt and returns only `input_ids` with no processed multimodal inputs produced.
- Maintains correctness/performance rationale: prevents disaggregated-serving CUDA IPC/context-only retention triggered by synthesized mRoPE state; aligned with `PyTorchModelEngine._prepare_tp_inputs`, which already supplies default 3-axis M-RoPE position IDs for text-only inputs.
- Preserves multimodal behavior: when multimodal inputs are present, the function continues through the full multimodal preprocessing path and `extra["multimodal_data"]["mrope_config"]` is still produced.
- Scope note: change is intentionally for text-only/context-only requests; broader multimodal protocol requirements remain tracked separately (e.g., TRTLLM-12407).

## QA Engineer Review

- Added unit tests in `tests/unittest/_torch/multimodal/test_qwen2vl_text_only_prompt.py`:
  - New helpers: `_FakeTokenizer`, `_make_processor(processor_cls)`
  - New tests:
    - `test_text_only_prompt_returns_no_extra_processed_inputs(processor_cls, inputs)` covering text-only handling across `Qwen2VLInputProcessorBase`, `Qwen2_5VLInputProcessorBase`, `Qwen3VLInputProcessorBase` with falsy `multi_modal_data` (`missing`, `None`, `{}`), asserting:
      - `extra is None`
      - returned `token_ids` match expected prompt token IDs
      - `get_mrope_config` and `_preprocess` are **not** called
    - `test_multimodal_prompt_still_takes_the_full_path()` verifying that non-empty multimodal inputs still run the full preprocessing path and produce `extra["multimodal_data"]["mrope_config"]` (including expected `mrope_position_ids` / `mrope_position_deltas` tensor shapes).
- Integration/manual test list coverage:
  - Searched `tests/integration/test_lists` for `test_qwen2vl_text_only_prompt` / `qwen2vl_text_only_prompt`; no matching entries found (no test-list updates).
- Verdict: needs follow-up
<!-- end of auto-generated comment: release notes by coderabbit.ai -->