### PR TITLE
[https://nvbugs/6479324][test] Remove waiver for fixed qwen3_5_4b_fp8_stress disaggregated stress test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -226,7 +226,6 @@ full:H100/accuracy/test_llm_api_pytorch_multimodal.py::TestQwen3_5_35B_A3B_VL::t
 full:H100/disaggregated/test_disaggregated.py::test_disaggregated_logprobs_serving[llama-3.1-8b-instruct] SKIP (https://nvbugs/6275959)
 full:H100/disaggregated/test_disaggregated.py::test_disaggregated_mixed_stress_test[req10k-conc512-qwen3_32b_fp8_mixed_stress] SKIP (https://nvbugs/6440089)
 full:H100/disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_32b_fp8_stress] SKIP (https://nvbugs/6312828)
-full:H100/disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_5_4b_fp8_stress] SKIP (https://nvbugs/6479324)
 full:H100/test_e2e.py::test_qwen_e2e_cpprunner_large_new_tokens[DeepSeek-R1-Distill-Qwen-1.5B-DeepSeek-R1-Distill-Qwen-1.5B] SKIP (https://nvbugs/6414760)
 full:H100_PCIe/unittest/llmapi/test_llm_pytorch.py::test_llama_7b_multi_lora_evict_and_reload_lora_gpu_cache SKIP (https://nvbugs/5682551)
 full:H20/accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype[mtp_nextn=2-overlap_scheduler=False] SKIP (https://nvbugs/6345827)


### PR DESCRIPTION
## Description

NVBug 6479324 has been fixed on `main`, so its test waiver is no longer needed. This PR removes the stale waiver entry for:

```
full:H100/disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_5_4b_fp8_stress] SKIP (https://nvbugs/6479324)
```

## Test Coverage

`tests/integration/defs/disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_5_4b_fp8_stress]` is now re-enabled and will run in CI.

## PR Checklist

- [x] PR title follows `[NVBUG][type] description` format
- [x] Only removes a stale waiver; no source behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**

- Removed the stale NVBug 6479324 waiver for the fixed H100 disaggregated `qwen3_5_4b_fp8_stress` test.
- The test-list format and scope are consistent; no source behavior or public APIs changed.
- No duplicate or unintended entries were introduced.

**QA Engineer Review**

- Modified `tests/integration/test_lists/waives.txt`: removed one waived test entry.
- No `test-db/` or `qa/` files were modified.
- Verdict: needs follow-up pending CBTS coverage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->