### PR TITLE
[https://nvbugs/6479863][fix] Use scalar SwiGLU limit for DeepSeek V4 FP8 MoE

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -1517,7 +1517,17 @@ class DeepseekV4MoE(nn.Module):
                 moe_cls in (TRTLLMGenFusedMoE, WideEPMoE)
                 and experts_quant_config.quant_mode.has_nvfp4()
             )
-            if supports_swiglu_limit and not kernel_requires_bias_for_swiglu_limit:
+            # DeepSeek-V4 supplies a uniform scalar limit. The TRTLLM-Gen FP8
+            # path consumes it directly and rejects the redundant tensor.
+            requires_scalar_only_swiglu_limit = (
+                moe_cls is TRTLLMGenFusedMoE
+                and experts_quant_config.quant_mode.has_fp8_block_scales()
+            )
+            if (
+                supports_swiglu_limit
+                and not kernel_requires_bias_for_swiglu_limit
+                and not requires_scalar_only_swiglu_limit
+            ):
                 moe_load_balancer_config = getattr(model_config, "moe_load_balancer", None)
                 num_slots = (
                     moe_load_balancer_config.num_slots


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `DeepseekV4MoE.__init__` so TRTLLM-Gen FP8 block-scale routed experts receive only the scalar `swiglu_limit_scalar`.
- Preserves existing tensor behavior for other MoE backends and quantization formats.
- AUTO backend selection remains unchanged.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

DeepSeek V4 Flash Base FP8 checkpoints define a uniform `swiglu_limit` scalar. The model construction path expanded that scalar into a per-expert tensor while also passing the original scalar to the MoE backend. AUTO correctly selects TRTLLM-Gen on B200/B300, but its FP8 block-scale activation kernel consumes the scalar form and rejects the redundant tensor, causing model initialization to fail.

This change keeps the existing AUTO-to-TRTLLM backend selection and passes only `swiglu_limit_scalar` for TRTLLM-Gen FP8 block-scale routed experts. Other MoE backends and quantization formats retain their existing tensor behavior. There is no backend-selection or expected performance change.

Related NVBug: 6479863.

## Test Coverage

- Existing DeepSeek V4 AUTO MoE backend resolver unit test: 1 passed.
- Real `DeepSeek-V4-Flash-Base` checkpoint configuration validation on B200: loaded from this checkout, detected `FP8_BLOCK_SCALES`, and AUTO resolved to TRTLLM.
- 4x B200 end-to-end `DeepSeek-V4-Flash-Base` TRTLLM initialization and integration accuracy smoke test: 1 passed in 14m35s (MMLU 91.23, GSM8K 100.00). Runtime configuration confirmed `moe_config.backend='TRTLLM'` and executed the TRTLLM FP8 block-scale MoE runner.
- Pre-commit hooks for the changed file and commit-message DCO validation passed.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
