### PR TITLE
[None][fix] Drop stale benchmarks copies from Dockerfile.multi

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -106,7 +106,6 @@ RUN --mount=type=bind,source=docker/common,target=/opt/docker/common \
 
 FROM ${DEVEL_IMAGE} AS wheel
 WORKDIR /src/tensorrt_llm
-COPY benchmarks benchmarks
 COPY cpp cpp
 COPY docker docker
 COPY scripts scripts
@@ -136,7 +135,6 @@ RUN --mount=type=bind,source=README.md,target=/mnt/ctx/README.md \
     --mount=type=bind,source=cpp/include,target=/mnt/ctx/include \
     --mount=type=bind,source=examples,target=/mnt/ctx/examples \
     --mount=type=bind,from=wheel,source=/src/tensorrt_llm/build,target=/mnt/wheel \
-    --mount=type=bind,from=wheel,source=/src/tensorrt_llm/benchmarks,target=/mnt/benchmarks \
     # Copy build context files
     cp /mnt/ctx/README.md ./ && \
     cp -r /mnt/ctx/docs ./docs && \
@@ -145,7 +143,6 @@ RUN --mount=type=bind,source=README.md,target=/mnt/ctx/README.md \
     chmod -R a+w examples && \
     # Copy wheel stage outputs
     cp /mnt/wheel/tensorrt_llm*.whl ./ && \
-    cp -r /mnt/benchmarks ./benchmarks && \
     # Create a symlink to installed package libraries
     ln -sv $(python3 -c 'import site; print(f"{site.getsitepackages()[0]}/tensorrt_llm/libs")') lib && \
     test -f lib/libtensorrt_llm.so && \


### PR DESCRIPTION
## Description

`docker/Dockerfile.multi` still copies the `benchmarks/` directory, which was
deleted from the repository by #16612
([TRTLLM-14474][chore] Remove legacy python relics and refresh docs after the
backend removal, commit `3c07ada3c5`). That PR did not update the Dockerfile, so
**every build of the `wheel` or `release` target on `main` has been broken since
Jul 24**:

```
Dockerfile.multi:109
 107 |     FROM ${DEVEL_IMAGE} AS wheel
 108 |     WORKDIR /src/tensorrt_llm
 109 | >>> COPY benchmarks benchmarks
ERROR: failed to solve: failed to compute cache key: "/benchmarks": not found
```

## Why CI did not catch this

Pre-merge CI builds the wheel inside an already-built devel container
(`buildWheelInContainer` in `jenkins/Build.groovy`) rather than going through the
`wheel`/`release` stages of `Dockerfile.multi`, so it never evaluates the failing
`COPY`. The breakage only surfaces on paths that build the release image from the
Dockerfile, e.g. `make -C docker release_build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Removed stale `benchmarks/` references from `wheel` and `release` stages in `docker/Dockerfile.multi` (no remaining `benchmarks` references in the current Dockerfile).
- Prevents Docker builds from failing after the `benchmarks/` directory deletion.
- Changes are scoped to Docker image assembly and do not introduce API/runtime behavior changes.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->