### PR TITLE
[https://nvbugs/6479324][test] Waive 1 failed test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -228,6 +228,7 @@ full:H100/accuracy/test_llm_api_pytorch_multimodal.py::TestQwen3_5_35B_A3B_VL::t
 full:H100/disaggregated/test_disaggregated.py::test_disaggregated_logprobs_serving[llama-3.1-8b-instruct] SKIP (https://nvbugs/6275959)
 full:H100/disaggregated/test_disaggregated.py::test_disaggregated_mixed_stress_test[req10k-conc512-qwen3_32b_fp8_mixed_stress] SKIP (https://nvbugs/6440089)
 full:H100/disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_32b_fp8_stress] SKIP (https://nvbugs/6312828)
+full:H100/disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_5_4b_fp8_stress] SKIP (https://nvbugs/6479324)
 full:H100/test_e2e.py::test_qwen_e2e_cpprunner_large_new_tokens[DeepSeek-R1-Distill-Qwen-1.5B-DeepSeek-R1-Distill-Qwen-1.5B] SKIP (https://nvbugs/6414760)
 full:H100_PCIe/unittest/llmapi/test_llm_pytorch.py::test_llama_7b_multi_lora_evict_and_reload_lora_gpu_cache SKIP (https://nvbugs/5682551)
 full:H20/accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype[mtp_nextn=2-overlap_scheduler=False] SKIP (https://nvbugs/6345827)


### PR DESCRIPTION
## Description

Reverts #16878. NVBug 6479324 is **not** actually fixed yet, so removing its waiver was premature and re-enables a failing test. This restores the waiver entry:

```
full:H100/disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_5_4b_fp8_stress] SKIP (https://nvbugs/6479324)
```

## Test Coverage

Re-adds the SKIP waiver so `test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_5_4b_fp8_stress]` is skipped again until NVBug 6479324 is genuinely fixed.

## PR Checklist

- [x] PR title follows `[NVBUG][type] description` format
- [x] Pure revert of the waiver removal; no source behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**
- Restores the waiver for the H100 disaggregated stress-test variant due to NVBug 6479324.
- The waiver entry is correctly scoped and introduces no source or public API changes.
- No duplicate or unintended configuration changes were identified.

**QA Engineer Review**
- Test-list-only change: added the affected test to `tests/integration/test_lists/waives.txt`.
- No `test-db/` or `qa/` files were modified.
- Verdict: needs follow-up because CBTS coverage data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->