### PR TITLE
[None][fix] Keep drafting alive when dynamic draft length hits its floor

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -740,9 +740,12 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_last_draft_tokens = None
         self.py_num_accepted_draft_tokens = 0
         # One-model rejection: set per-iteration by _handle_dynamic_draft_len when
-        # this gen request produced 0 real draft tokens, so _prepare_tp_inputs
-        # one-hots its stale draft_probs slot. Consumed (and cleared) there.
+        # this gen request produced fewer real draft tokens than the runtime draft
+        # length, so _prepare_tp_inputs one-hots the stale suffix of its
+        # draft_probs slot starting at py_onehot_draft_probs_start. Consumed (and
+        # cleared) there.
         self.py_needs_onehot_draft_probs = False
+        self.py_onehot_draft_probs_start = 0
         self.py_num_accepted_draft_tokens_indices = []
         self.py_rewind_draft_token_separate_adjustment = 0
         self.py_per_pos_drafted = [0] * MAX_SPEC_DECODE_POSITIONS

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -10,6 +10,7 @@ import math
 import os
 import weakref
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -1665,12 +1666,18 @@ class PyTorchModelEngine(ModelEngine):
         """Compute graph_bs → draft_len mapping for dynamic draft length feature.
 
         Example: draft_len_schedule = {4:4, 8:2, 32:1}, cuda_graph_batch_sizes = [1,2,3,4,5,6,7,8,16,24,32,64]
+        with min_runtime_draft_len = 1:
         - Batch sizes 1-4:   use draft_len=4 (up to key 4)
         - Batch sizes 5-8:   use draft_len=2 (up to key 8)
         - Batch sizes 9-32:  use draft_len=1 (up to key 32)
-        - Batch sizes 33+:   use draft_len=0 (implicit, speculation disabled)
+        - Batch sizes 33+:   use draft_len=1 (min_runtime_draft_len, implicit)
 
-        Returns: {1:4, 2:4, 3:4, 4:4, 5:2, 6:2, 7:2, 8:2, 16:1, 24:1, 32:1, 64:0}
+        Returns: {1:4, 2:4, 3:4, 4:4, 5:2, 6:2, 7:2, 8:2, 16:1, 24:1, 32:1, 64:1}
+
+        The floor applied here must match the one applied when the runtime draft
+        length is resolved (PyExecutor._handle_dynamic_draft_len); graph lookup is
+        an exact (batch_size, draft_len) match, so a mismatch silently drops those
+        batches to eager execution.
         """
         # Dynamic draft length for CUDA graphs is only supported for one-model path
         if (not self.spec_config or not self.spec_config.draft_len_schedule or
@@ -1679,6 +1686,7 @@ class PyTorchModelEngine(ModelEngine):
 
         schedule = self.spec_config.draft_len_schedule
         schedule_keys = list(schedule.keys())
+        min_draft_len = self.spec_config.min_runtime_draft_len
 
         mapping = {}
         key_idx = 0
@@ -1687,9 +1695,9 @@ class PyTorchModelEngine(ModelEngine):
                     schedule_keys) and schedule_keys[key_idx] < graph_bs:
                 key_idx += 1
             if key_idx < len(schedule_keys):
-                draft_len = schedule[schedule_keys[key_idx]]
+                draft_len = max(schedule[schedule_keys[key_idx]], min_draft_len)
             else:
-                draft_len = 0
+                draft_len = min_draft_len
             mapping[graph_bs] = draft_len
         return mapping
 
@@ -3870,10 +3878,11 @@ class PyTorchModelEngine(ModelEngine):
         draft_tokens = []
         draft_lens = []
         gen_request_seq_slots = []  # per generation request
-        # One-model rejection: slots of gen requests that produced 0 real draft
-        # tokens this step (marked in _handle_dynamic_draft_len); their stale
-        # draft_probs rows are one-hot'd after spec_metadata.prepare().
-        padding_gen_slots = []
+        # One-model rejection: slots of gen requests whose draft_probs rows were
+        # only partly written this step (marked in _handle_dynamic_draft_len),
+        # keyed by the row the stale suffix starts at; those rows are one-hot'd
+        # after spec_metadata.prepare().
+        padding_gen_slots = defaultdict(list)
         multimodal_params_list = []
         mrope_position_ids = [
         ]  # (start_idx, end_idx, (3,1,L) mrope_pos_ids) per multimodal request
@@ -4125,7 +4134,8 @@ class PyTorchModelEngine(ModelEngine):
         for request in extend_requests:
             if getattr(request, "py_needs_onehot_draft_probs", False):
                 if request.py_seq_slot is not None:
-                    padding_gen_slots.append(request.py_seq_slot)
+                    start = getattr(request, "py_onehot_draft_probs_start", 0)
+                    padding_gen_slots[start].append(request.py_seq_slot)
                 request.py_needs_onehot_draft_probs = False  # consume once
             request_ids.append(request.py_request_id)
             request_accepted_path[
@@ -4876,10 +4886,12 @@ class PyTorchModelEngine(ModelEngine):
                 scheduled_requests.all_requests())
             spec_metadata.prepare()
             # One-model rejection: one-hot the stale draft_probs rows of gen
-            # requests that produced no draft tokens this step, so the (possibly
-            # captured) rejection kernel reads a legal placeholder distribution.
-            spec_metadata.write_padding_onehot_draft_probs(
-                padding_gen_slots, self.runtime_draft_len)
+            # requests that produced fewer draft tokens than the runtime draft
+            # length this step, so the (possibly captured) rejection kernel reads
+            # a legal placeholder distribution.
+            for start, slots in padding_gen_slots.items():
+                spec_metadata.write_padding_onehot_draft_probs(
+                    slots, self.runtime_draft_len, start)
             inputs['spec_metadata'] = spec_metadata
 
             if self.enable_attention_dp:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3225,28 +3225,39 @@ class PyExecutor:
             # 1. Resolve runtime draft length from schedule
             runtime_draft_len = get_draft_len_for_batch_size(
                 self.model_engine.spec_config.draft_len_schedule,
-                scheduled_batch.batch_size, self.model_engine.max_draft_len)
+                scheduled_batch.batch_size, self.model_engine.max_draft_len,
+                self.model_engine.spec_config.min_runtime_draft_len)
             # 2. Pad or truncate draft tokens to the resolved length
             DRAFT_BUFFER_PAD = 0  # Buffer sentinel, not PARD mask_token_id.
             rejection_on = getattr(self.model_engine.spec_config,
                                    "use_rejection_sampling", False)
             for request in scheduled_batch.generation_requests:
                 current_num_draft_tokens = len(request.py_draft_tokens)
-                # One-model rejection: a gen request entering with 0 real draft
-                # tokens produced no draft-prob scatter for its slot last iter,
-                # so next iter's rejection kernel would read a stale draft_probs
-                # row. Mark it (pre-pad signal) so _prepare_tp_inputs writes a
-                # one-hot placeholder row after spec_metadata.prepare().
-                request.py_needs_onehot_draft_probs = (
-                    rejection_on and current_num_draft_tokens == 0)
                 if spec_dec_mode.is_pard():
-                    # special case: PARD carries 2K-1 draft tokens per request
+                    # PARD carries 2K-1 draft tokens per request, so its
+                    # logical draft length is not the buffer length.
+                    current_runtime_draft_len = (
+                        (current_num_draft_tokens + 1) //
+                        2 if current_num_draft_tokens > 0 else 0)
+                else:
+                    current_runtime_draft_len = current_num_draft_tokens
+                # One-model rejection: the draft sampler only scattered
+                # draft_probs rows [0, current_runtime_draft_len) for this slot
+                # last iteration, so every row the padding below adds is stale
+                # (or uninitialized) and next iteration's rejection kernel would
+                # read it. Record where the stale suffix starts (pre-pad signal)
+                # so _prepare_tp_inputs can one-hot it after
+                # spec_metadata.prepare(). Both a re-enable from the shortest
+                # draft length and any upward schedule transition land here.
+                onehot_start = min(current_runtime_draft_len, runtime_draft_len)
+                request.py_needs_onehot_draft_probs = (rejection_on
+                                                       and onehot_start
+                                                       < runtime_draft_len)
+                request.py_onehot_draft_probs_start = onehot_start
+                if spec_dec_mode.is_pard():
                     runtime_draft_token_buffer_width = (
                         self.model_engine.spec_config.
                         get_runtime_tokens_per_gen_step(runtime_draft_len) - 1)
-                    current_runtime_draft_len = (
-                        current_num_draft_tokens +
-                        1) // 2 if current_num_draft_tokens > 0 else 0
                     real_draft_tokens = request.py_draft_tokens[:min(
                         current_runtime_draft_len, runtime_draft_len)]
                     real_draft_tokens.extend(

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -368,7 +368,14 @@ class SpeculativeDecodingMode(IntEnum):
         ) or self.is_external_drafter() or self.is_sa()
 
     def support_dynamic_draft_len(self):
-        return self.is_mtp_one_model() or self.is_eagle3_one_model(
+        # Vanilla MTP is deliberately excluded: it owns one KV-cache layer per
+        # MTP module, and the draft loop only runs mtp_layers[:runtime_draft_len]
+        # (see MTPWorker.forward). Any runtime draft length below the module
+        # count leaves the remaining modules' KV allocated but never written, so
+        # they attend to uninitialized rows once the draft length rises again.
+        # A minimum draft length of 1 cannot fix that, so vanilla MTP keeps its
+        # static draft length instead.
+        return self.is_eagle3_one_model(
         ) or self.is_mtp_eagle_one_model() or self.is_pard() or self.is_dflash(
         ) or self.is_draft_target_one_model() or self.is_sa()
 
@@ -640,18 +647,25 @@ class SpecMetadata:
                 dtype=torch.float32,
                 device='cuda')
 
-    def write_padding_onehot_draft_probs(self, padding_slot_ids, draft_len):
-        """Write a one-hot draft-prob row (prob 1.0 at draft-vocab token id 0,
-        the placeholder token) into each padding gen request's stable slot row.
+    def write_padding_onehot_draft_probs(self,
+                                         padding_slot_ids,
+                                         draft_len,
+                                         start=0):
+        """Write one-hot draft-prob rows (prob 1.0 at draft-vocab token id 0, the
+        placeholder token) into rows [start, draft_len) of each padding gen
+        request's stable slot row.
 
-        Padding requests are gen requests that entered this iteration with 0 real
-        draft tokens (e.g. a runtime_draft_len K->0->K dynamic-draft-len toggle).
-        Their slot's draft_probs row was never scattered by the draft sampler, so
-        the next iteration's (possibly CUDA-graph-captured) rejection kernel would
-        read a stale/uninitialized distribution. Writing a legal one-hot row makes
-        acceptance reject the placeholder and resample from the target (equivalent
-        to strict acceptance) for those rows. Written eagerly before graph replay
-        into the stable draft_probs buffer, so the replayed kernel reads it.
+        Padding requests are gen requests that entered this iteration with fewer
+        real draft tokens than the runtime draft length, so the draft sampler only
+        scattered rows [0, start) for their slot. That happens whenever the draft
+        length rises between iterations - a K->0->K toggle (start=0), and equally
+        a K->min->K one once scheduled draft lengths are floored. The remaining
+        rows hold a stale/uninitialized distribution that the next iteration's
+        (possibly CUDA-graph-captured) rejection kernel would read. Writing a legal
+        one-hot row makes acceptance reject the placeholder and resample from the
+        target (equivalent to strict acceptance) for those rows. Written eagerly
+        before graph replay into the stable draft_probs buffer, so the replayed
+        kernel reads it.
 
         Idempotent w.r.t. context->gen transitions whose row was already one-hot'd
         by write_context_onehot_draft_probs. The width matches the value already
@@ -659,7 +673,7 @@ class SpecMetadata:
         overwritten here. No-op unless rejection is enabled and slots exist.
         Static shapes -> CUDA-graph safe.
         """
-        if (not padding_slot_ids
+        if (not padding_slot_ids or start >= draft_len
                 or not getattr(self, "use_rejection_sampling", False)
                 or self.draft_probs is None):
             return
@@ -668,8 +682,8 @@ class SpecMetadata:
         slots = torch.tensor(padding_slot_ids,
                              dtype=torch.long,
                              device=self.draft_probs.device)
-        self.draft_probs[slots, :draft_len, :onehot_vocab] = 0.0
-        self.draft_probs[slots, :draft_len, 0] = 1.0
+        self.draft_probs[slots, start:draft_len, :onehot_vocab] = 0.0
+        self.draft_probs[slots, start:draft_len, 0] = 1.0
 
     def prepare(self):
         """
@@ -1137,7 +1151,16 @@ class SpecWorkerBase(nn.Module, ABC):
         draft_model,
     ):
         """
-        Used when speculation is disabled for dynamic draft length (e.g., large batch size).
+        Used when speculation is disabled at runtime, i.e. the acceptance-rate gate
+        has permanently disabled it (PyExecutor.speculation_permanently_disabled).
+
+        Draft lengths resolved from a draft_len_schedule no longer reach 0 - they
+        are floored at DecodingBaseConfig.min_runtime_draft_len - because skipping
+        the draft forward stops the drafter's cross-iteration state from being
+        updated while the target keeps committing tokens, and the drafter then
+        attends to positions that were allocated but never written. That is
+        harmless here only because the acceptance-rate gate never re-enables
+        speculation.
         """
         batch_size = attn_metadata.num_seqs
         num_contexts = attn_metadata.num_contexts

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -577,6 +577,31 @@ def update_spec_config_from_model_config(spec_config, model_config):
     if not spec_config.use_dynamic_tree:
         spec_config.max_total_draft_tokens = spec_config.max_draft_len
 
+    # max_concurrency is only translated into a schedule for modes that support
+    # dynamic draft length, so check it separately: a config that already reads
+    # as vanilla MTP (use_mtp_vanilla) never gets a schedule to begin with.
+    from_max_concurrency = (
+        getattr(spec_config, "max_concurrency", None) is not None
+        or getattr(spec_config, "_translated_from_max_concurrency", False))
+    # Vanilla MTP builds one MTP module per draft token, each owning its own
+    # KV-cache layer, and the draft loop only runs mtp_layers[:runtime_draft_len].
+    # Shortening the draft length therefore leaves the trailing modules' KV
+    # allocated but unwritten, and they attend to those rows once the draft
+    # length rises again. The mode opts out of dynamic draft length for that
+    # reason (SpeculativeDecodingMode.support_dynamic_draft_len); say so here,
+    # because the knob is only known to be inert once the checkpoint has
+    # resolved this as vanilla MTP.
+    if (is_vanilla and spec_config.max_draft_len > 1 and
+        (spec_config.draft_len_schedule is not None or from_max_concurrency)):
+        knob = "max_concurrency" if from_max_concurrency else "draft_len_schedule"
+        logger.warning(
+            f"MTP: {knob} is ignored for vanilla MTP with "
+            f"{spec_config.max_draft_len} MTP modules. Reducing the draft "
+            "length below the module count would leave the unused modules' KV "
+            "cache stale and silently degrade the acceptance rate, so "
+            f"speculation stays at max_draft_len={spec_config.max_draft_len}. "
+            "Use MTP-Eagle if you need dynamic draft lengths.")
+
 
 def update_spec_config_from_loaded_model(spec_config, model) -> None:
     """Populate spec config fields from loaded target and draft model configs."""
@@ -603,7 +628,9 @@ class SpecDecodingTensor:
 
 
 def get_draft_len_for_batch_size(draft_len_schedule: Dict[int, int],
-                                 batch_size: int, max_draft_len: int) -> int:
+                                 batch_size: int,
+                                 max_draft_len: int,
+                                 min_draft_len: int = 0) -> int:
     """
     Get the appropriate draft length for the given batch size using binary search.
 
@@ -615,13 +642,18 @@ def get_draft_len_for_batch_size(draft_len_schedule: Dict[int, int],
 
     Args:
         draft_len_schedule: Mapping from batch size thresholds to draft lengths.
-                            Example: {4: 4, 8: 2, 32: 1} means:
+                            Example: {4: 4, 8: 2, 32: 1} with min_draft_len=1:
                             - batch size 1-4:   use draft_len=4 (up to key 4)
                             - batch size 5-8:   use draft_len=2 (up to key 8)
                             - batch size 9-32:  use draft_len=1 (up to key 32)
-                            - batch size 33+:   use draft_len=0 (speculation disabled, implicit)
+                            - batch size 33+:   use draft_len=1 (min_draft_len, implicit)
         batch_size: Current batch size.
         max_draft_len: Maximum draft length to use if no schedule is provided.
+        min_draft_len: Floor applied to every scheduled draft length, including the
+                       implicit one above the largest key. Drafting has to keep
+                       running for algorithms whose drafter carries cross-iteration
+                       state, otherwise that state goes stale while the target keeps
+                       committing tokens. See DecodingBaseConfig.min_runtime_draft_len.
 
     Returns:
         The draft length to use for this batch size.
@@ -638,7 +670,8 @@ def get_draft_len_for_batch_size(draft_len_schedule: Dict[int, int],
     idx = bisect_left(schedule_batch_sizes, batch_size)
 
     if idx < len(schedule_batch_sizes):
-        return draft_len_schedule[schedule_batch_sizes[idx]]
+        return max(draft_len_schedule[schedule_batch_sizes[idx]], min_draft_len)
 
-    # batch_size > all batch sizes in draft_len_schedule: speculation disabled (implicit)
-    return 0
+    # batch_size > all batch sizes in draft_len_schedule: speculation drops to the
+    # shortest draft length this algorithm can sustain (implicit).
+    return min_draft_len

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1712,9 +1712,13 @@ class DecodingBaseConfig(StrictBaseModel):
     max_concurrency: Optional[PositiveInt] = Field(
         default=None,
         description=
-        "When specified (>0), speculation will be disabled at batch sizes above this value. Otherwise, "
-        "speculation will always be on. PyTorch backend only. "
-        "Mutually exclusive with max_concurrency since draft_len_schedule implicitly supports max concurrency control."
+        "When specified (>0), speculation is reduced to the shortest draft length the algorithm can "
+        "sustain at batch sizes above this value. Otherwise, speculation will always be on. "
+        "For one-model speculation that shortest length is 1 rather than 0: the drafter carries "
+        "cross-iteration state (draft KV cache, hidden-state pools) that goes stale if drafting stops "
+        "while the target keeps committing tokens. To turn speculation off for good, use "
+        "acceptance_rate_window_size together with acceptance_rate_threshold. PyTorch backend only. "
+        "Mutually exclusive with draft_len_schedule since draft_len_schedule implicitly supports max concurrency control."
     )
 
     draft_len_schedule: Optional[dict[int, int]] = Field(
@@ -1726,7 +1730,9 @@ class DecodingBaseConfig(StrictBaseModel):
         " - Batch sizes 1-4:   use draft_len=4"
         " - Batch sizes 5-8:   use draft_len=2"
         " - Batch sizes 9-32:  use draft_len=1"
-        " - Batch sizes 33+:   use draft_len=0 (implicit, speculation disabled). "
+        " - Batch sizes 33+:   use draft_len=1 (implicit, the shortest sustainable draft length). "
+        "Scheduled draft lengths are floored at min_runtime_draft_len, so speculation is never fully "
+        "disabled mid-flight; see max_concurrency for how to turn it off permanently. "
         "Mutually exclusive with max_concurrency since draft_len_schedule implicitly support max concurrency control."
     )
 
@@ -1896,6 +1902,24 @@ class DecodingBaseConfig(StrictBaseModel):
             SpeculativeDecodingMode as TorchSpeculativeDecodingMode
         return TorchSpeculativeDecodingMode.from_string(
             self.decoding_type.upper())
+
+    @property
+    def min_runtime_draft_len(self) -> int:
+        """Smallest runtime draft length that keeps the drafter's state coherent.
+
+        One-engine speculation carries cross-iteration drafter state (draft KV
+        cache, hidden-state pools, per-request context buffers) that is only
+        written while drafting runs. Letting a ``draft_len_schedule`` drive the
+        runtime draft length to 0 stops those writes while the target keeps
+        committing tokens, so the drafter later attends to positions that were
+        allocated but never written and its acceptance rate silently collapses.
+        Resolved draft lengths are therefore floored at this value.
+
+        Returns 0 for algorithms that carry no such state, which is also the
+        value an algorithm reports once it can refresh its state without
+        producing draft tokens.
+        """
+        return 1 if self.spec_dec_mode.use_one_engine() else 0
 
     @functools.cached_property
     def is_linear_tree(self) -> bool:

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dynamic_spec_decode.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dynamic_spec_decode.py
@@ -19,21 +19,25 @@ def enforce_single_worker(monkeypatch):
 
 
 def test_dynamic_draft_len(enforce_single_worker):
-    def mock_get_draft_len_for_batch_size(draft_len_schedule, batch_size, max_total_draft_tokens):
-        # The draft length for each iter will be 4-4-2-2-0-0-2-2-4-4-2-2-0-0-2-2-...
+    def mock_get_draft_len_for_batch_size(
+        draft_len_schedule, batch_size, max_total_draft_tokens, min_draft_len=0
+    ):
+        # The draft length for each iter will be 4-4-2-2-1-1-2-2-4-4-2-2-1-1-2-2-...
         # which tested:
         # (1) decrease draft length: 4->2,
         # (2) increase draft length: 2->4,
-        # (3) disable and re-enable drafting: 2->0->2.
+        # (3) drop to the shortest sustainable draft length and back: 2->1->2.
+        # Scheduled draft lengths never reach 0: drafting has to keep refreshing
+        # the drafter's cross-iteration state (see min_runtime_draft_len).
         if mock_get_draft_len_for_batch_size.call_count % 8 < 2:
             dynamic_draft_len = 4
         elif mock_get_draft_len_for_batch_size.call_count % 8 < 4:
             dynamic_draft_len = 2
         elif mock_get_draft_len_for_batch_size.call_count % 8 < 6:
-            dynamic_draft_len = 0
+            dynamic_draft_len = 1
         else:
             dynamic_draft_len = 2
-        return dynamic_draft_len
+        return max(dynamic_draft_len, min_draft_len)
 
     # Create a Mock object with the mock function as side_effect
     mock_get_draft_len_for_batch_size = Mock(side_effect=mock_get_draft_len_for_batch_size)

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_min_runtime_draft_len.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_min_runtime_draft_len.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dynamic draft length never drops below the drafter's minimum sustainable length.
+
+One-engine speculation carries cross-iteration drafter state (draft KV cache,
+hidden-state pools, per-request context buffers) that is only refreshed while
+drafting runs. A draft_len_schedule that resolves to 0 stops those updates while
+the target keeps committing tokens, so the drafter later attends to positions
+that were allocated but never written and its acceptance rate silently drops.
+"""
+
+import pytest
+
+from tensorrt_llm._torch.pyexecutor.model_engine import PyTorchModelEngine
+from tensorrt_llm._torch.speculative.interface import SpeculativeDecodingMode
+from tensorrt_llm._torch.speculative.utils import get_draft_len_for_batch_size
+from tensorrt_llm.llmapi.llm_args import (
+    DraftTargetDecodingConfig,
+    Eagle3DecodingConfig,
+    MTPDecodingConfig,
+    NGramDecodingConfig,
+)
+
+SCHEDULE = {4: 4, 8: 2, 32: 1}
+
+
+class _ScheduleOnlyEngine:
+    """Minimal stand-in exposing what the graph mapping reads."""
+
+    def __init__(self, spec_config, cuda_graph_batch_sizes):
+        self.spec_config = spec_config
+        self._cuda_graph_batch_sizes = cuda_graph_batch_sizes
+
+
+class _SpecConfigStub:
+    def __init__(self, schedule, min_runtime_draft_len, supports_dynamic=True):
+        self.draft_len_schedule = schedule
+        self.min_runtime_draft_len = min_runtime_draft_len
+        self.spec_dec_mode = _ModeStub(supports_dynamic)
+
+
+class _ModeStub:
+    def __init__(self, supports_dynamic):
+        self._supports_dynamic = supports_dynamic
+
+    def support_dynamic_draft_len(self):
+        return self._supports_dynamic
+
+
+@pytest.mark.parametrize(
+    "batch_size,expected",
+    [(1, 4), (4, 4), (5, 2), (8, 2), (9, 1), (32, 1)],
+)
+def test_scheduled_draft_lengths_are_unchanged(batch_size, expected):
+    assert get_draft_len_for_batch_size(SCHEDULE, batch_size, 4, 1) == expected
+
+
+@pytest.mark.parametrize("batch_size", [33, 64, 4096])
+def test_implicit_tier_above_largest_key_is_floored(batch_size):
+    """Above the largest key drafting continues at the floor instead of stopping."""
+    assert get_draft_len_for_batch_size(SCHEDULE, batch_size, 4, 1) == 1
+
+
+def test_explicit_zero_tier_is_floored_without_touching_the_schedule():
+    schedule = {4: 4, 8: 0}
+    assert get_draft_len_for_batch_size(schedule, 8, 4, 1) == 1
+    assert schedule == {4: 4, 8: 0}, "the user's schedule must not be rewritten"
+
+
+def test_floor_defaults_to_zero_for_callers_that_do_not_opt_in():
+    """The two-model drafter path keeps its own semantics, including explicit 0."""
+    assert get_draft_len_for_batch_size(SCHEDULE, 33, 4) == 0
+    assert get_draft_len_for_batch_size({4: 4, 8: 0}, 8, 4) == 0
+
+
+def test_no_schedule_uses_max_draft_len():
+    assert get_draft_len_for_batch_size(None, 4096, 4, 1) == 4
+
+
+@pytest.mark.parametrize(
+    "spec_config,expected",
+    [
+        # One-engine: the drafter runs inside the target forward and owns state
+        # that only drafting refreshes.
+        (
+            Eagle3DecodingConfig(
+                max_draft_len=8,
+                speculative_model="/path/to/draft",
+                num_eagle_layers=8,
+            ),
+            1,
+        ),
+        (MTPDecodingConfig(max_draft_len=1), 1),
+        (
+            DraftTargetDecodingConfig(max_draft_len=4, speculative_model="/path/to/draft"),
+            1,
+        ),
+        # Two-model and stateless drafters keep the existing behaviour, including
+        # the ability to turn speculation off through the schedule.
+        (
+            Eagle3DecodingConfig(
+                max_draft_len=8,
+                speculative_model="/path/to/draft",
+                num_eagle_layers=8,
+                eagle3_one_model=False,
+            ),
+            0,
+        ),
+        (NGramDecodingConfig(max_draft_len=4, max_matching_ngram_size=2), 0),
+    ],
+)
+def test_min_runtime_draft_len_is_one_only_for_one_engine_modes(spec_config, expected):
+    assert spec_config.min_runtime_draft_len == expected
+
+
+def test_vanilla_mtp_opts_out_of_dynamic_draft_len():
+    """Vanilla MTP owns one KV-cache layer per module and only runs
+    mtp_layers[:runtime_draft_len], so no floor above 0 keeps every module warm."""
+    assert not SpeculativeDecodingMode.MTP.support_dynamic_draft_len()
+    assert SpeculativeDecodingMode.MTP_EAGLE_ONE_MODEL.support_dynamic_draft_len()
+    for mode in (
+        SpeculativeDecodingMode.EAGLE3_ONE_MODEL,
+        SpeculativeDecodingMode.DFLASH,
+        SpeculativeDecodingMode.PARD,
+        SpeculativeDecodingMode.SA,
+        SpeculativeDecodingMode.DRAFT_TARGET_ONE_MODEL,
+    ):
+        assert mode.support_dynamic_draft_len(), mode
+
+
+@pytest.mark.parametrize(
+    "schedule",
+    [{4: 4, 8: 2, 32: 1}, {50: 4, 200: 3, 350: 2}, {4: 4, 8: 0}, {1: 4}],
+)
+def test_graph_mapping_matches_runtime_resolution(schedule):
+    """A captured graph is looked up by an exact (batch_size, draft_len) match, so a
+    floor applied to one of the two resolution sites and not the other would silently
+    drop those batches to eager execution."""
+    graph_batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 200, 256, 350, 384, 500]
+    max_draft_len = max(schedule.values())
+    engine = _ScheduleOnlyEngine(_SpecConfigStub(schedule, 1), graph_batch_sizes)
+
+    mapping = PyTorchModelEngine._compute_dynamic_draft_len_mapping(engine)
+
+    for batch_size in graph_batch_sizes:
+        assert mapping[batch_size] == get_draft_len_for_batch_size(
+            schedule, batch_size, max_draft_len, 1
+        )
+    assert 0 not in mapping.values(), "no graph may be captured with drafting disabled"
+
+
+def test_graph_mapping_is_inert_when_the_mode_opts_out():
+    engine = _ScheduleOnlyEngine(
+        _SpecConfigStub(SCHEDULE, 1, supports_dynamic=False), [1, 4, 8, 64]
+    )
+    assert PyTorchModelEngine._compute_dynamic_draft_len_mapping(engine) is None


### PR DESCRIPTION
## Description

One-engine speculative decoding carries cross-iteration drafter state: the draft KV cache, MTP's hidden-state and token pools, and the per-request context buffers DFlash keeps. All of it is only refreshed while the draft forward runs.

A `draft_len_schedule` resolves to `0` above its largest batch-size key, and `max_concurrency` is translated into exactly such a schedule, so at high concurrency every one-engine worker took its `skip_drafting` path. Positions kept being allocated for the drafter while nothing wrote them, and once the batch shrank and speculation resumed, the drafter attended to rows that were never initialized. Nothing failed loudly — the acceptance rate silently collapsed for the remainder of every affected request. This behavior was never documented.

This PR floors the draft lengths resolved from a schedule at `DecodingBaseConfig.min_runtime_draft_len` (1 for one-engine algorithms) so drafting keeps refreshing that state.

### Design notes

**The floor is applied where the draft length is read, not in the config.** Both read sites change together — `get_draft_len_for_batch_size` (runtime) and `_compute_dynamic_draft_len_mapping` (CUDA-graph capture) — because graphs are looked up by an exact `(batch_size, draft_len)` match, so a floor applied to only one of them would silently drop exactly the high-concurrency batches to eager execution. The user's `draft_len_schedule` is left exactly as written.

**`min_runtime_draft_len` is a two-valued property on the config.** It answers one question: the smallest draft length that keeps this algorithm's cross-iteration state coherent. It lives on the config rather than the worker because the graph mapping is computed before any worker exists.

**Explicit `0` values in a schedule are floored rather than rejected**, so existing configs keep loading. The new `min_draft_len` argument defaults to `0`, so the two-model drafter path — where an explicit `0` tier is a legitimate off-switch with its own per-request protection — is unchanged.

**`skip_drafting` and the per-worker `runtime_draft_len == 0` branches are kept.** They remain reachable through the acceptance-rate gate, which disables speculation permanently and never re-enables, so no state can go stale behind it.

**Vanilla MTP opts out of dynamic draft length entirely.** It builds one MTP module per draft token, each owning its own KV-cache layer, and only runs `mtp_layers[:runtime_draft_len]`, so *any* draft length below the module count strands the trailing modules — a floor of 1 cannot fix it. It now keeps its static draft length, with a warning at load time naming whichever knob was ignored (the module count is only known once the checkpoint has resolved).

**One rejection-sampling fix is included because the floor creates the exposure.** `write_padding_onehot_draft_probs` previously one-hot'd stale `draft_probs` rows only for gen requests entering with exactly zero draft tokens. With a floor those requests arrive holding a shorter draft instead of an empty one, so the stale suffix `[start, draft_len)` is one-hot'd instead of the whole row. This also covers upward transitions between two non-zero draft lengths, which were already uncovered.

### User-visible behavior change

`max_concurrency` now means "reduce speculation to the shortest sustainable draft length above this batch size" rather than "turn speculation off". `acceptance_rate_window_size` together with `acceptance_rate_threshold` remains the way to disable speculation for good. Nothing in-tree depends on the previous hard-off behavior for one-engine modes (no docs page, no config in `examples/configs/database/`, no deployment guide; the AUTO heuristic uses NGram, which is unaffected).

For reference, this is consistent with how other frameworks handle the same trade-off: vLLM V1's Dynamic SD and SGLang's adaptive speculative decoding both allow a draft length of 0 and both keep the drafter running at 0 to preserve its KV cache. vLLM V0, which skipped the drafter instead, had to disable speculation permanently per request as a result.

## Test Coverage

New, hardware-agnostic (`tests/unittest/_torch/speculative/hw_agnostic/test_min_runtime_draft_len.py`, in a directory already registered in `l0_h100.yml`):

- scheduled draft lengths are unchanged; the implicit tier above the largest key is floored
- an explicit `0` tier is floored without rewriting the caller's schedule
- the floor defaults to `0`, preserving the two-model path's semantics
- `min_runtime_draft_len` is 1 only for one-engine modes
- vanilla MTP opts out of dynamic draft length while MTP-Eagle and the other one-engine modes do not
- **the CUDA-graph mapping and the runtime resolution agree for every graph batch size across four schedule shapes, and no graph is captured with drafting disabled**

Updated: `test_dynamic_spec_decode.py` — the mocked resolver gains the new argument, and its draft-length cycle becomes `4-4-2-2-1-1-2-2` (the `2 -> 0 -> 2` phase becomes `2 -> 1 -> 2`, matching the new semantics).

Behavior shift to be aware of in existing integration tests: the dynamic-draft-length tests whose `max_batch_size` exceeds their largest schedule key (e.g. `{50: 4, 200: 3, 350: 2}` with `max_batch_size=500`) now run at draft length 1 instead of 0 in that band. They assert accuracy, which is invariant to acceptance-rate changes, so they should be unaffected.

## Open items before this leaves draft

- [ ] Full unit/integration run. The change was verified by proving the two resolution sites agree across schedule shapes, but the suite has not been executed against a build of this branch.
- [ ] Measure throughput at a batch just above the cutoff (floor 0 vs 1). This is the main cost of the PR and is currently modeled, not measured.
- [ ] Confirm the DeepSeek-V3-Lite checkpoint reports `num_nextn_predict_layers == 1`. If it is greater, the vanilla-MTP opt-out silently disables the schedule in `test_mtp_dynamic_draft_len`, `test_mtp_sa_dynamic_draft_len` and `test_mtp_eagle_dynamic_draft_len` — they would still pass, since they assert accuracy only.
- [ ] An acceptance-rate/length regression test across a `K -> floor -> K` transition with a mid-run prefill. No existing test can observe this bug class: the dynamic-draft-length tests do reach the implicit tier but assert accuracy, which speculation preserves by construction.

## Deliberately out of scope

Each of these is pre-existing and unrelated to the floor:

- DSpark combined with the acceptance-rate gate: DSpark has no `runtime_draft_len == 0` path and uses a static `max_draft_len`, but the gate zeroes `runtime_draft_len` without checking `support_dynamic_draft_len()`.
- Attention-DP: `runtime_draft_len` is resolved from the rank-local batch size with no cross-rank consensus, so ranks can run different numbers of draft forwards.
- The one-model (`bisect_left`, implicit tier above the largest key) and two-model (`bisect_right`, clamped) lookups interpret the same `draft_len_schedule` differently.

## Follow-up

Keep-warm — running the drafter during the off band so speculation can be switched fully off again — is the natural sequel, per algorithm. Recommended order on measured cost: MTP (N=1) first, then DFlash, then Eagle3 bundled with a KV-only draft-KV write, since a full-forward warm on a multi-head-attention draft head reads a large fraction of the target's KV traffic at long context.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] PR follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of my knowledge.
- [x] Test cases are provided for new code paths.
- [ ] API label: the `max_concurrency` / `draft_len_schedule` semantic change above needs a maintainer call on `api-compatible` vs `api-breaking`. No field is added, removed or retyped, so `api_stability` references and the `llm_args` golden manifest are unaffected, but the meaning of an accepted value changes.
- [x] No new dependencies.
- [x] No ownership changes.
- [x] Field descriptions updated; no separate docs page describes this behavior.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
