### PR TITLE
[https://nvbugs/6450333][test] Unwaive DeepSeek V4 Flash auto dtype test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -66,7 +66,6 @@ accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backe
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=2-pp4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=False-torch_compile=False] SKIP (https://nvbugs/6245394)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=2-tp2pp2-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-low_precision_combine=False-torch_compile=False] SKIP (https://nvbugs/6384625)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=2-tp2pp2-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=False-torch_compile=False] SKIP (https://nvbugs/6384625)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype SKIP (https://nvbugs/6450333)
 accuracy/test_llm_api_pytorch.py::TestGLM52::test_nvfp4[tp_size=8-ep_size=8] SKIP (https://nvbugs/6507108)
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_guided_decoding_4gpus[one_model] SKIP (https://nvbugs/5596343)
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_1gpu[v1_kv_cache-True-True-triton-auto] SKIP (https://nvbugs/6026676)


### PR DESCRIPTION
## Description

NVBug 6450333 is not reproducible on the latest `main`, so the waiver for the following test is no longer needed:

```
accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype SKIP (https://nvbugs/6450333)
```

This PR removes only that waiver entry, re-enabling the existing DeepSeek V4 Flash auto-dtype accuracy test in the configured B200 and B300 CI stages. It does not change source or runtime behavior.

## Test Coverage

Validated on 4x B200 from `main` at `b91ffdad9113f1d04adbb685b044f9d64759ab88` after a clean SM100 build-install. The test process loaded the current repository source and rebuilt nanobind module; `LlmRequest.get_tokens_range` was present.

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
LLM_MODELS_ROOT=/home/scratch.trt_llm_data/llm-models \
PYTHONPATH="$PWD:$PWD/tests/integration/defs:$PWD/examples" \
python3 -m pytest -vv -s \
  tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype \
  --timeout=2400
```

Result: `1 passed in 431.42s`.

- MMLU: 89.059 (threshold 85.383)
- GSM8K: 95.451 (threshold 91.907)
- `pre-commit run --files tests/integration/test_lists/waives.txt`: passed

The local validation used B200 hardware; removing the waiver restores coverage for both the B200 and B300 stages where this test is already listed.

## PR Checklist

- [x] PR title follows the `[JIRA/NVBUG][type] description` format
- [x] PR description clearly explains what and why
- [x] Relevant test coverage is included above
- [x] Change is limited to one stale waiver; no API, dependency, CODEOWNERS, documentation, or architecture changes
- [x] DCO sign-off is included

## GitHub Bot Help

To see a list of available CI bot commands, comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Removed the `TestDeepSeekV4Flash::test_auto_dtype` waiver and its NVBug reference from `tests/integration/test_lists/waives.txt`.
- The change is correctly scoped to the intended test-list entry, with no source or runtime behavior changes.
- Waiver format remains valid, with no unintended configuration changes or duplicate entries identified.

## QA Engineer Review

- No `test-db/` or `qa/` files were modified.
- Removed the waiver for `accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype`, re-enabling its configured B200 and B300 CI coverage.
- The test passed on 4x B200 with MMLU 89.059 and GSM8K 95.451.
- Verdict: sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->