### PR TITLE
[https://nvbugs/6503293][fix] Restore whole-node GPU visibility for default packing

### DIFF
--- a/examples/disaggregated/slurm/benchmark/start_worker.sh
+++ b/examples/disaggregated/slurm/benchmark/start_worker.sh
@@ -11,9 +11,16 @@ numa_bind=${5}
 log_dir=${6}
 enable_nsys=${7}
 config_file=${8}
+cuda_devices=${9}
 # CUDA_VISIBLE_DEVICES selection:
 #   - Default packing (no gpu_map file): each node is dedicated to one
-#     worker, so SLURM_LOCALID maps directly to the physical GPU id.
+#     worker, so every rank on the node is given the node's full GPU list
+#     (passed as ${9} by submit.py) and binds to its own device via
+#     mapping.local_rank (= rank % gpus_per_node). Exposing the whole node
+#     is required for intra-node TP custom all-reduce (attention_dp=false /
+#     TEP): its cudaDeviceCanAccessPeer() topology check must be able to see
+#     the peer GPUs. Pinning a single GPU per rank only works for DEP
+#     (attention_dp=true), which has no intra-node TP all-reduce.
 #   - Compact packing (gpu_map file emitted by submit.py): two workers may
 #     share a node and would both see LOCALID=0, so look up the per-worker
 #     gpu_map "<rank> <host> <local_gpu_id>" by SLURM_PROCID. srun
@@ -28,7 +35,7 @@ if [ -f "${gpu_map_file}" ]; then
     fi
     export CUDA_VISIBLE_DEVICES=${gpu_id}
 else
-    export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
+    export CUDA_VISIBLE_DEVICES=${cuda_devices}
 fi
 
 # Clear UCX_TLS for specific clusters

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -622,12 +622,22 @@ def submit_job(config, log_dir, dry_run):
                             hf.write(f"{host}\n")
                             gm.write(f"{rank} {host} {gpu}\n")
                             rank += 1
+                # Compact packing derives CUDA_VISIBLE_DEVICES from gpu_map.
+                cuda_devices = "none"
             else:
                 # Default packing: each node is dedicated to one worker, so
-                # SLURM_LOCALID directly maps to the physical GPU id in
-                # start_worker.sh (no hostfile/gpu_map needed).
+                # every rank on that node is given the node's full GPU list and
+                # binds to its own device via mapping.local_rank
+                # (= rank % gpus_per_node). Exposing the whole node is required
+                # for intra-node TP custom all-reduce (attention_dp=false /
+                # TEP), whose cudaDeviceCanAccessPeer() topology check must see
+                # the peer GPUs; pinning one GPU per rank only works for DEP.
                 node_list = list(allocation["nodes"].keys())
                 num_nodes = len(node_list)
+                # Whole-node ownership means every node carries the same GPU
+                # layout, so the first node's list applies to all ranks.
+                gpu_ids = sorted(list(allocation["nodes"].values())[0])
+                cuda_devices = ','.join(map(str, gpu_ids))
 
             worker_env = build_worker_environment(
                 worker_config=worker_config,
@@ -670,6 +680,7 @@ def submit_job(config, log_dir, dry_run):
                 log_dir,
                 str(profiling_config['nsys_on']).lower(),
                 server_cfg['config_path'],
+                cuda_devices,
                 f"&> {log_dir}/3_output_{server_type}_{server_id}.log &",
             ]
             start_server_cmds.append(" ".join(cmd))


### PR DESCRIPTION
## Description

Commit db347a94847 added compact packing to support non-divisible EP. That work
was designed and validated with **DEP** (`enable_attention_dp=true`) in mind,
where each rank runs independently and there is no intra-node TP all-reduce, so
giving every rank a single GPU is harmless. Along with the new compact path, it
also rewrote the **default (non-compact) packing** path to pin one GPU per rank
(`CUDA_VISIBLE_DEVICES=SLURM_LOCALID`) instead of exposing the node's full GPU
list as before.

That assumption does not hold for **TEP** (`enable_attention_dp=false`), which
performs a per-layer TP all-reduce. The custom all-reduce topology check calls
`cudaDeviceCanAccessPeer()` over the node-local ranks and therefore requires the
peer GPUs to be visible to each rank. With only one visible device the peer
ordinals are invalid, so every generation rank aborts at executor initialization
with

```
CUDA runtime error in cudaDeviceCanAccessPeer(&can_access_peer, first_device_id,
second_device_id): invalid device ordinal (tensorrt_llm/thop/allreduceOp.cpp)
```

before any KV-cache transfer happens. Restricting visibility to one GPU also
collapses the auto-detected `gpus_per_node` to 1.

## Fix

Bring the path that TEP uses back in line with the pre-db347a94847 behaviour,
scoped to **default packing only**: `submit.py` computes the node's full GPU
list again and passes it to `start_worker.sh`, which exports it as
`CUDA_VISIBLE_DEVICES`. Each rank still binds to its own device through
`mapping.local_rank` (= `rank % gpus_per_node`), so this restores GPU visibility
without changing rank-to-device assignment.

The **compact packing** path added for non-divisible EP is left untouched and
keeps deriving `CUDA_VISIBLE_DEVICES` from the per-worker `gpu_map`, so the
non-divisible EP support introduced by db347a94847 is unaffected.

## Test Coverage

Verified on GB200 with `qwen3-235b-fp4` tep4 (tp4 + ep4,
`enable_attention_dp=false`), matching
`gb200_qwen3-235b-fp4_8k1k_con1_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL.yaml`:

- **Before**: all 4 generation ranks crash at executor init with the error above.
- **After**: `gpus_per_node` is detected as 4, the worker serves, and greedy
  (`temperature=0`) generation returns correct output
  ("The capital of France is" -> " Paris"; "12 multiplied by 12?" -> " 144").
- `--dry-run` confirms the compact path still emits its `hostfile`/`gpu_map`
  unchanged, and that the default path now passes `0,1,2,3` to a tep4 gen worker
  while a tp1 ctx worker still gets `0`.

## PR Checklist

- [x] Commit message follows the required format and is DCO signed off
- [x] Test coverage described above
- [ ] CI: these are `examples/` slurm benchmark scripts, which the standard
      pipeline may not exercise -- the GB200 multi-node perf sanity stage is the
      relevant coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Restores full-node GPU visibility for default, non-compact Slurm packing by passing the sorted allocated GPU list from `submit.py` to `start_worker.sh`.
- Preserves rank-to-device assignment through `mapping.local_rank` while allowing TEP topology checks to access valid peer ordinals.
- Keeps compact packing behavior unchanged by continuing to derive visibility from `gpu_map`.
- The new positional argument and `CUDA_VISIBLE_DEVICES` handling are consistent across the submission and worker scripts. No unintended public API or configuration changes were identified.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->