### PR TITLE
[https://nvbugs/6503293][fix] Restore whole-node GPU visibility for default packing

### DIFF
--- a/examples/disaggregated/slurm/benchmark/start_worker.sh
+++ b/examples/disaggregated/slurm/benchmark/start_worker.sh
@@ -11,9 +11,16 @@ numa_bind=${5}
 log_dir=${6}
 enable_nsys=${7}
 config_file=${8}
+cuda_devices=${9}
 # CUDA_VISIBLE_DEVICES selection:
 #   - Default packing (no gpu_map file): each node is dedicated to one
-#     worker, so SLURM_LOCALID maps directly to the physical GPU id.
+#     worker, so every rank on the node is given the node's full GPU list
+#     (passed as ${9} by submit.py) and binds to its own device via
+#     mapping.local_rank (= rank % gpus_per_node). Exposing the whole node
+#     is required for intra-node TP custom all-reduce (attention_dp=false /
+#     TEP): its cudaDeviceCanAccessPeer() topology check must be able to see
+#     the peer GPUs. Pinning a single GPU per rank only works for DEP
+#     (attention_dp=true), which has no intra-node TP all-reduce.
 #   - Compact packing (gpu_map file emitted by submit.py): two workers may
 #     share a node and would both see LOCALID=0, so look up the per-worker
 #     gpu_map "<rank> <host> <local_gpu_id>" by SLURM_PROCID. srun
@@ -28,7 +35,7 @@ if [ -f "${gpu_map_file}" ]; then
     fi
     export CUDA_VISIBLE_DEVICES=${gpu_id}
 else
-    export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
+    export CUDA_VISIBLE_DEVICES=${cuda_devices}
 fi
 
 # Clear UCX_TLS for specific clusters

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -622,12 +622,22 @@ def submit_job(config, log_dir, dry_run):
                             hf.write(f"{host}\n")
                             gm.write(f"{rank} {host} {gpu}\n")
                             rank += 1
+                # Compact packing derives CUDA_VISIBLE_DEVICES from gpu_map.
+                cuda_devices = "none"
             else:
                 # Default packing: each node is dedicated to one worker, so
-                # SLURM_LOCALID directly maps to the physical GPU id in
-                # start_worker.sh (no hostfile/gpu_map needed).
+                # every rank on that node is given the node's full GPU list and
+                # binds to its own device via mapping.local_rank
+                # (= rank % gpus_per_node). Exposing the whole node is required
+                # for intra-node TP custom all-reduce (attention_dp=false /
+                # TEP), whose cudaDeviceCanAccessPeer() topology check must see
+                # the peer GPUs; pinning one GPU per rank only works for DEP.
                 node_list = list(allocation["nodes"].keys())
                 num_nodes = len(node_list)
+                # Whole-node ownership means every node carries the same GPU
+                # layout, so the first node's list applies to all ranks.
+                gpu_ids = sorted(list(allocation["nodes"].values())[0])
+                cuda_devices = ','.join(map(str, gpu_ids))
 
             worker_env = build_worker_environment(
                 worker_config=worker_config,
@@ -670,6 +680,7 @@ def submit_job(config, log_dir, dry_run):
                 log_dir,
                 str(profiling_config['nsys_on']).lower(),
                 server_cfg['config_path'],
+                cuda_devices,
                 f"&> {log_dir}/3_output_{server_type}_{server_id}.log &",
             ]
             start_server_cmds.append(" ".join(cmd))


### PR DESCRIPTION
This pull request updates the logic for setting `CUDA_VISIBLE_DEVICES` in the Slurm-based benchmarking scripts to better support both default and compact GPU packing modes. The main improvement is that, in default packing mode, each worker is now exposed to the node’s full list of GPUs, which is necessary for certain intra-node communication patterns. The change also ensures that the appropriate GPU list is passed from `submit.py` to `start_worker.sh`.

**GPU device visibility and environment variable handling:**

* In `start_worker.sh`, the script now accepts a `cuda_devices` argument and sets `CUDA_VISIBLE_DEVICES` to this value in default packing mode, rather than just using `SLURM_LOCALID`. This exposes the full node GPU list to each worker, which is required for intra-node tensor parallelism with custom all-reduce operations. [[1]](diffhunk://#diff-63781663b6716da31a57931f971017676550b48571c17666ed073e0049b3efefR14-R23) [[2]](diffhunk://#diff-63781663b6716da31a57931f971017676550b48571c17666ed073e0049b3efefL31-R38)

**Job submission and argument propagation:**

* In `submit.py`, the script constructs the correct `cuda_devices` string (a comma-separated list of GPU IDs) for default packing and passes it as an argument to `start_worker.sh`. In compact packing mode, it sets `cuda_devices` to `"none"` as the GPU mapping is handled differently. [[1]](diffhunk://#diff-5d3b19315c58328c8265b96adf687be5e070a3bc3c6e95c7dddd93edd454a3e2R625-R640) [[2]](diffhunk://#diff-5d3b19315c58328c8265b96adf687be5e070a3bc3c6e95c7dddd93edd454a3e2R683)

**Documentation and code comments:**

* Updated and clarified comments in both scripts to explain the rationale for exposing all GPUs per node in default packing and the requirements for different parallelism strategies. [[1]](diffhunk://#diff-63781663b6716da31a57931f971017676550b48571c17666ed073e0049b3efefR14-R23) [[2]](diffhunk://#diff-5d3b19315c58328c8265b96adf687be5e070a3bc3c6e95c7dddd93edd454a3e2R625-R640)

These changes improve the flexibility and correctness of GPU assignment in multi-GPU, multi-node training scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Restores full-node `CUDA_VISIBLE_DEVICES` visibility for default GPU packing, enabling intra-node tensor parallelism and custom all-reduce topology checks.
- Preserves compact packing behavior by passing `"none"` and retaining the existing GPU-map-based assignment.
- The new positional argument is consistently passed from `submit.py` to `start_worker.sh`, with rank-to-device binding still handled through `mapping.local_rank`.
- No configuration, test-list, or test-code changes were made.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->