### PR TITLE
[SCAN-423][feat] Onboard pre-commit and Pulse secret scanning

### DIFF
--- a/.github/workflows/secret-scan-pulse.yml
+++ b/.github/workflows/secret-scan-pulse.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# CI secret-scan enforcement via NVIDIA/security-workflows (Pulse).
+# Runs on Linux nv-gha-runners (Pulse Docker image + OIDC/Vault) — Linux-only by design.
+# The local secret-scan-trufflehog pre-commit hook is cross-platform (Linux/macOS/Windows via Git Bash).
+# Pinned to a reviewed commit SHA; bump when NVIDIA/security-workflows consolidates.
+#
+# TensorRT-LLM uses Blossom CI (not copy-pr-bot), so this scans post-merge on
+# main plus on-demand via workflow_dispatch, rather than copy-pr-bot mirror
+# branches.
+
+name: Secret Scan (Pulse)
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+  cancel-in-progress: true
+
+# Caller must grant at least every permission the reusable workflow declares
+# (a reusable workflow requesting more than the caller allows fails at load time).
+permissions:
+  contents: read
+  id-token: write          # OIDC -> Vault -> nvcr.io image pull
+  security-events: write   # publish redacted SARIF to code scanning
+  actions: read            # reusable workflow declares actions: read (upload-sarif)
+
+jobs:
+  secret-scan:
+    name: Secret Scan
+    # Pulse needs nv-gha-runners + Vault/nvcr vars; skip on forks.
+    if: github.repository == 'NVIDIA/TensorRT-LLM'
+    uses: NVIDIA/security-workflows/.github/workflows/secret-scan-pulse.yml@69032f641c3c34e0c0b46f636b54ed2b101b7aa4
+    with:
+      runs-on: linux-amd64-cpu4
+      # Set failure_policy explicitly so enforcement can't drift with upstream defaults.
+      #   unverified — fail on verified/live secrets (183); warn on unverified (185)  [default]
+      #   strict     — fail on any finding (verified or unverified)
+      #   all        — warn only; never fail the job on findings
+      failure_policy: unverified

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1559,8 +1559,20 @@ static-analysis-files: &static_analysis_files |
 # Global exclude: vendored code + trtllm-gen FMHA artifacts (cubin pointers, export headers, cuda_ptx)
 exclude: '(^triton_kernels/|trtllmGenKernels/fmha/cubin/kernelMetaInfo\.h$|cubin\.cpp$|cubin\.h$|trtllmGenKernels/fmha/trtllmGen_fmha_export/|trtllmGenKernels/fmha/cuda_ptx/)'
 
+ci:
+    # trufflehog is not available in the hosted pre-commit.ci sandbox; the
+    # server-side Pulse workflow is the authoritative secret-scan enforcement.
+    skip: [secret-scan-trufflehog]
+
 default_install_hook_types: [pre-commit, commit-msg]
 repos:
+# Runs first so a leaked credential blocks the commit before any formatter runs.
+# Self-installing: downloads a pinned, checksum-verified trufflehog on first use
+# (no manual install). Skipped on pre-commit.ci; Pulse CI enforces server-side.
+-   repo: https://github.com/NVIDIA/security-workflows
+    rev: v0.2.0
+    hooks:
+    -   id: secret-scan-trufflehog
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,15 @@ If any files were modified by this hook, you will need to stage and commit them 
 > See [CODING_GUIDELINES.md](CODING_GUIDELINES.md#pre-commit-linting-supplemental-rules)
 > for details on the two-group system and how to graduate files.
 
+### Secret Scanning
+
+Two complementary controls prevent accidental credential leakage:
+
+- **Local pre-commit** (`secret-scan-trufflehog`, from `NVIDIA/security-workflows`): catches credentials before commit. Self-installing — no manual setup beyond `pre-commit install`; the hook downloads a pinned, checksum-verified `trufflehog` on first use. On **Windows**, run from a Git Bash / MSYS shell.
+- **Server-side enforcement** (Pulse reusable workflow, pinned by SHA): runs on `main` on NVIDIA Linux runners and blocks on verified secrets.
+
+The local hook is skipped on hosted pre-commit.ci (no `trufflehog` binary there); Pulse remains the authoritative CI enforcement. Never commit a flagged secret; if a real credential is exposed, rotate it immediately.
+
 In addition, please try to keep pull requests (PRs) as concise as possible:
 * Avoid committing commented-out code.
 * Wherever possible, each PR should address a single concern. If there are several otherwise-unrelated things that should be fixed to reach a desired endpoint, our recommendation is to open several PRs and indicate the dependencies in the description. The more complex the changes are in a single PR, the more time it will take to review those changes.


### PR DESCRIPTION
## Description

Onboard NVIDIA secret scanning to TensorRT-LLM using the centrally maintained `NVIDIA/security-workflows` surfaces. Two complementary controls:
- **Local (advisory):** the self-installing `secret-scan-trufflehog` pre-commit hook catches credentials before commit.
- **CI (enforcement):** the Pulse reusable workflow runs a server-side scan that blocks on verified secrets.

Changes:
- `.github/workflows/secret-scan-pulse.yml`: calls the Pulse reusable workflow (pinned by commit SHA) on pushes to `main` and via `workflow_dispatch`; runs on `linux-amd64-cpu4` (nv-gha-runners) with explicit `failure_policy: unverified`. TensorRT-LLM uses Blossom CI (not copy-pr-bot), so scanning is post-merge on `main` plus on-demand.
- `.pre-commit-config.yaml`: adds the self-installing `secret-scan-trufflehog` hook (pinned to `security-workflows` `v0.2.0`) as the first hook; skipped on pre-commit.ci which lacks the `trufflehog` binary.
- `CONTRIBUTING.md`: documents the two-layer secret-scan model.

## Test Coverage

- The reusable Pulse workflow and the pre-commit hook are exercised end-to-end by `NVIDIA/security-workflows` CI (positive/negative cases across all `failure_policy` values).
- In this repo, the Pulse workflow runs on push to `main` and via `workflow_dispatch`; the local hook runs on commit/push. No TensorRT-LLM runtime code paths change.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (N/A — CI/tooling only).
- If PR introduces API changes, an appropriate PR label is added (N/A — no API changes).
- Any new dependencies have been scanned for license and vulnerabilities (TruffleHog is pinned + SHA-256 verified; recorded in `security-workflows` THIRD_PARTY_NOTICES).
- CODEOWNERS updated if ownership changes (N/A).
- Documentation updated as needed (`CONTRIBUTING.md`).
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.