### PR TITLE
[None][test] Parse KV cache manager V2 size in perf tests

### DIFF
--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -159,6 +159,11 @@ def import_allowed_perf_config():
 
 
 # Regex commands used to parse the metric result for the metric type.
+# V1 reports its allocated capacity, while V2 reports the equivalent device quota.
+KV_CACHE_SIZE_LOG_QUERY = re.compile(
+    r".*(?:Allocated ([\d\.]+) GiB for max tokens in paged KV cache|"
+    r"KV cache manager v2 device quota set to ([\d\.]+)GiB).*")
+
 PERF_METRIC_LOG_QUERIES = {
     PerfMetricType.BUILD_TIME:
     re.compile(r"Engine generation completed in ([\d\.]+) seconds"),
@@ -211,7 +216,7 @@ BENCH_PERF_METRIC_LOG_QUERIES = {
     # tensorrt_llm/_torch/auto_deploy/shim/interface.py), so its post-resize
     # capacity also logs this line (max() below picks that final value).
     PerfMetricType.KV_CACHE_SIZE:
-    re.compile(r".*Allocated ([\d\.]+) GiB for max tokens in paged KV cache.*"),
+    KV_CACHE_SIZE_LOG_QUERY,
     PerfMetricType.PER_USER_OUTPUT_THROUGHPUT:
     re.compile(
         r"Per User Output Throughput \[w\/ ctx\] \(tps\/user\):\s+([\d\.]+)"),
@@ -252,9 +257,9 @@ AGGR_SERVER_PERF_METRIC_LOG_QUERIES = {
     re.compile(r"Median E2EL \(ms\):\s+(-?[\d\.]+)"),
     PerfMetricType.P99_INFERENCE_TIME:
     re.compile(r"P99 E2EL \(ms\):\s+(-?[\d\.]+)"),
-    # Printed by the shared C++ KVCacheManager on server startup, same as trtllm-bench.
+    # Printed by the selected KV cache manager on server startup, same as trtllm-bench.
     PerfMetricType.KV_CACHE_SIZE:
-    re.compile(r".*Allocated ([\d\.]+) GiB for max tokens in paged KV cache.*"),
+    KV_CACHE_SIZE_LOG_QUERY,
 }
 
 # (Relative threshold, Absolute threshold) for all metric types


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `tests/integration/defs/perf/test_perf.py` to add a shared `KV_CACHE_SIZE_LOG_QUERY` regex that can parse both KV cache manager V1 (“Allocated … GiB for max tokens…”) and V2 (“KV cache manager v2 device quota … GiB”) log formats.
- Replaced duplicated inline `re.compile(...)` usage for `PerfMetricType.KV_CACHE_SIZE` in both `BENCH_PERF_METRIC_LOG_QUERIES` and `AGGR_SERVER_PERF_METRIC_LOG_QUERIES` to consistently reference `KV_CACHE_SIZE_LOG_QUERY`.
- No configuration or test-list files were modified (logic change is limited to metrics log parsing).

## QA Engineer Review

- Test code changed: `tests/integration/defs/perf/test_perf.py`
  - Test functions added/modified/removed: none (metrics parsing regex/definitions only).
- No updates were made under `tests/integration/test_lists/` (no CI/manual test coverage mapping affected for this change).
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
