### PR TITLE
[https://nvbugs/6507955][fix] use net_max_seq_len for request admisson instead of inflated one

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -1009,7 +1009,7 @@ def create_py_executor(
             kv_connector_manager=kv_connector_manager
             if not estimating_kv_cache else None,
             resource_governor_queue=resource_governor_queue,
-            max_seq_len=max_seq_len,
+            max_seq_len=net_max_seq_len,
             max_batch_size=max_batch_size,
             max_beam_width=max_beam_width,
             max_num_tokens=max_num_tokens,
@@ -1084,7 +1084,7 @@ def create_py_executor(
                 garbage_collection_gen0_threshold,
                 kv_connector_manager=kv_connector_manager,
                 resource_governor_queue=resource_governor_queue,
-                max_seq_len=max_seq_len,
+                max_seq_len=net_max_seq_len,
                 max_batch_size=max_batch_size,
                 max_beam_width=max_beam_width,
                 max_num_tokens=max_num_tokens,

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -17,7 +17,8 @@ from tensorrt_llm import LLM
 from tensorrt_llm.bindings import executor as tllm
 from tensorrt_llm.executor import GenerationResultBase, RequestError
 from tensorrt_llm.llmapi import (KvCacheConfig, KvCacheRetentionConfig,
-                                 LookaheadDecodingConfig, RequestOutput)
+                                 LookaheadDecodingConfig, RequestOutput,
+                                 SADecodingConfig)
 from tensorrt_llm.llmapi.llm_args import DynamicBatchConfig, SchedulerConfig
 from tensorrt_llm.llmapi.llm_utils import _ParallelConfig
 from tensorrt_llm.llmapi.tokenizer import (TokenizerBase, TransformersTokenizer,
@@ -1104,6 +1105,38 @@ def _test_llm_capture_request_error(pytorch_backend: bool, tp_size: int = 1):
     # Both backends now consistently raise RequestError for max_num_tokens validation
     with pytest.raises(RequestError):
         llm.generate(prompt)
+
+
+def test_oversized_prompt_rejected_with_inflated_max_seq_len():
+    """Oversized prompt is rejected gracefully when max_seq_len is inflated internally.
+
+    With speculative decoding, KV cache max_seq_len is inflated to reserve space
+    for draft tokens. Admission control must use the net (user-configured) limit,
+    not the inflated value. Otherwise oversized prompts crash the event loop.
+    """
+    max_seq_len = 256
+
+    llm = LLM(
+        model=llama_model_path,
+        max_seq_len=max_seq_len,
+        max_batch_size=1,
+        max_num_tokens=max_seq_len,
+        kv_cache_config=KvCacheConfig(enable_block_reuse=False),
+        speculative_config=SADecodingConfig(max_draft_len=4),
+        disable_overlap_scheduler=True,
+    )
+
+    # Prompt that fills the entire net budget -> 0 tokens left for output -> rejected
+    oversized_prompt_ids = [1] * (max_seq_len + 1)
+    with pytest.raises(RequestError):
+        llm.generate([oversized_prompt_ids],
+                     sampling_params=SamplingParams(max_tokens=1))
+
+    # Executor must still be alive
+    result = llm.generate(["Hello"],
+                          sampling_params=SamplingParams(max_tokens=5))
+    assert len(result) == 1
+    assert len(result[0].outputs[0].text) > 0
 
 
 def test_llm_shutdown_executor():

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -1120,7 +1120,7 @@ def test_oversized_prompt_rejected_with_inflated_max_seq_len():
         model=llama_model_path,
         max_seq_len=max_seq_len,
         max_batch_size=1,
-        max_num_tokens=max_seq_len,
+        max_num_tokens=(max_seq_len + 32),
         kv_cache_config=KvCacheConfig(enable_block_reuse=False),
         speculative_config=SADecodingConfig(max_draft_len=4),
         disable_overlap_scheduler=True,


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/TensorRT-LLM/issues/16826
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `tensorrt_llm/_torch/pyexecutor/py_executor_creator.py` so both `create_py_executor_instance(...)` construction paths use `max_seq_len=net_max_seq_len` (instead of the internally inflated `max_seq_len` used for speculative-decoding KV-cache planning).
- Keeps request admission bounded by the user-configured “net” limit, preventing oversized prompts from being admitted based on speculative-decoding/KV-cache inflation and thereby avoiding executor/server failure modes (e.g., KV-cache overflow and worker thread termination).
- Change is minimal and limited to argument wiring (`max_seq_len` value) in the two executor creation/re-creation call sites; control flow and other parameters are unchanged.

## QA Engineer Review

- **Tests touched:** `tests/unittest/llmapi/test_llm.py`
  - Added `test_oversized_prompt_rejected_with_inflated_max_seq_len()`
    - Verifies that when speculative decoding inflates internal KV-cache `max_seq_len`, an oversized prompt is rejected with `RequestError`.
    - Verifies the executor remains alive by issuing a follow-up successful generation.
  - Updated imports to include `SADecodingConfig` from `tensorrt_llm.llmapi`.
- **Coverage in `tests/integration/test_lists/` (test-db/ or qa/):** not found for the added test name.
- **Verdict:** needs follow-up
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
