### PR TITLE
[https://nvbugs/6262973][perf] Move AllReduce autotuner dispatch to C++

### DIFF
--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -1597,6 +1597,10 @@ namespace
 constexpr std::array<int64_t, 14> kAllReduceTuningBuckets
     = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
 constexpr size_t kAllReduceNumTuningBuckets = kAllReduceTuningBuckets.size();
+constexpr size_t kAllReduceNumInputs = 6;
+
+using AllReduceInputShape = c10::SmallVector<int64_t, 8>;
+using AllReduceInputShapes = std::array<AllReduceInputShape, kAllReduceNumInputs>;
 
 struct AllReduceTacticCacheKey
 {
@@ -1604,12 +1608,12 @@ struct AllReduceTacticCacheKey
     AllReduceFusionOp fusionOp;
     bool inputUsesNcclWindow;
     c10::ScalarType dtype;
-    c10::SmallVector<int64_t, 8> staticInputShape;
+    AllReduceInputShapes staticInputShapes;
 
     bool operator<(AllReduceTacticCacheKey const& other) const
     {
-        return std::tie(group, fusionOp, inputUsesNcclWindow, dtype, staticInputShape)
-            < std::tie(other.group, other.fusionOp, other.inputUsesNcclWindow, other.dtype, other.staticInputShape);
+        return std::tie(group, fusionOp, inputUsesNcclWindow, dtype, staticInputShapes)
+            < std::tie(other.group, other.fusionOp, other.inputUsesNcclWindow, other.dtype, other.staticInputShapes);
     }
 };
 
@@ -1636,8 +1640,7 @@ std::optional<size_t> getAllReduceBucketIndexForTokens(int64_t numTokens)
     // Match Python's last_positive_power_of_2: the largest bucket also
     // represents token counts through the value immediately before its next
     // power of two.
-    if (numTokens < kAllReduceTuningBuckets.front()
-        || numTokens >= 2 * kAllReduceTuningBuckets.back())
+    if (numTokens < kAllReduceTuningBuckets.front() || numTokens >= 2 * kAllReduceTuningBuckets.back())
     {
         return std::nullopt;
     }
@@ -1675,24 +1678,69 @@ std::optional<int64_t> findAllReduceTactic(AllReduceTacticCacheKey const& key, s
     return iterator == cache.tactics.end() ? std::nullopt : iterator->second[*bucketIndex];
 }
 
-AllReduceTacticCacheKey getAllReduceTacticCacheKey(
-    torch::Tensor const& input, torch::List<int64_t> const& group, AllReduceFusionOp fusionOp, bool inputUsesNcclWindow)
+AllReduceInputShapes getAllReduceStaticInputShapes(torch::Tensor const& input,
+    torch::optional<torch::Tensor> const& residual, torch::optional<torch::Tensor> const& normWeight,
+    torch::optional<torch::Tensor> const& scale, torch::optional<torch::Tensor> const& bias,
+    torch::optional<torch::Tensor> const& workspace)
+{
+    AllReduceInputShapes staticInputShapes;
+    staticInputShapes[0].append(input.sizes().begin() + 1, input.sizes().end());
+
+    if (residual.has_value())
+    {
+        TORCH_CHECK(residual->dim() > 0, "AllReduce residual must have at least one dimension");
+        staticInputShapes[1].append(residual->sizes().begin(), residual->sizes().end());
+        // Match the constrained dimension in the Python OptimizationProfile.
+        staticInputShapes[1].front() = -1;
+    }
+    else
+    {
+        staticInputShapes[1].push_back(0);
+    }
+
+    auto const appendOptionalInputShape
+        = [](AllReduceInputShape& shape, torch::optional<torch::Tensor> const& optionalInput)
+    {
+        if (optionalInput.has_value())
+        {
+            shape.append(optionalInput->sizes().begin(), optionalInput->sizes().end());
+        }
+        else
+        {
+            // Match the [0] placeholder used by OptimizationProfile for None.
+            shape.push_back(0);
+        }
+    };
+    appendOptionalInputShape(staticInputShapes[2], normWeight);
+    appendOptionalInputShape(staticInputShapes[3], scale);
+    appendOptionalInputShape(staticInputShapes[4], bias);
+    appendOptionalInputShape(staticInputShapes[5], workspace);
+    return staticInputShapes;
+}
+
+AllReduceTacticCacheKey getAllReduceTacticCacheKey(torch::Tensor const& input,
+    torch::optional<torch::Tensor> const& residual, torch::optional<torch::Tensor> const& normWeight,
+    torch::optional<torch::Tensor> const& scale, torch::optional<torch::Tensor> const& bias,
+    torch::optional<torch::Tensor> const& workspace, torch::List<int64_t> const& group, AllReduceFusionOp fusionOp,
+    bool inputUsesNcclWindow)
 {
     TORCH_CHECK(input.dim() > 0, "AllReduce input must have at least one dimension");
     std::vector<int64_t> groupVector(group.begin(), group.end());
-    c10::SmallVector<int64_t, 8> staticInputShape(input.sizes().begin() + 1, input.sizes().end());
-    return {std::move(groupVector), fusionOp, inputUsesNcclWindow, input.scalar_type(), std::move(staticInputShape)};
+    auto staticInputShapes = getAllReduceStaticInputShapes(input, residual, normWeight, scale, bias, workspace);
+    return {std::move(groupVector), fusionOp, inputUsesNcclWindow, input.scalar_type(), std::move(staticInputShapes)};
 }
 
 } // namespace
 
-void registerAllReduceTactic(
-    torch::Tensor const& input, torch::List<int64_t> const& group, int64_t fusionOp, int64_t bucket, int64_t tactic)
+void registerAllReduceTactic(torch::Tensor const& input, torch::optional<torch::Tensor> const& residual,
+    torch::optional<torch::Tensor> const& normWeight, torch::optional<torch::Tensor> const& scale,
+    torch::optional<torch::Tensor> const& bias, torch::optional<torch::Tensor> const& workspace,
+    torch::List<int64_t> const& group, int64_t fusionOp, int64_t bucket, int64_t tactic)
 {
     auto const bucketIndex = getAllReduceBucketIndex(bucket);
     TORCH_CHECK(bucketIndex.has_value(), "Invalid AllReduce autotuner bucket: ", bucket);
-    insertAllReduceTactic(getAllReduceTacticCacheKey(
-                              input, group, static_cast<AllReduceFusionOp>(fusionOp), isNCCLWindowBuffer(input, group)),
+    insertAllReduceTactic(getAllReduceTacticCacheKey(input, residual, normWeight, scale, bias, workspace, group,
+                              static_cast<AllReduceFusionOp>(fusionOp), isNCCLWindowBuffer(input, group)),
         *bucketIndex, tactic);
 }
 
@@ -1746,7 +1794,8 @@ std::vector<torch::Tensor> autotunedAllreduce(torch::Tensor const& input,
     torch::optional<torch::Tensor> workspace, torch::List<int64_t> const& group, int64_t const, int64_t const fusionOp,
     double const eps, bool const triggerCompletionAtEnd)
 {
-    auto key = getAllReduceTacticCacheKey(input, group, static_cast<AllReduceFusionOp>(fusionOp), false);
+    auto key = getAllReduceTacticCacheKey(
+        input, residual, normWeight, scale, bias, workspace, group, static_cast<AllReduceFusionOp>(fusionOp), false);
     auto const bucketIndex = getAllReduceBucketIndexForTokens(input.size(0));
     auto const defaultTactic = findAllReduceTactic(key, bucketIndex);
     key.inputUsesNcclWindow = true;
@@ -2292,7 +2341,9 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
         "int op,"
         "float eps,"
         "bool trigger_completion_at_end) -> Tensor[]");
-    m.def("register_allreduce_tactic(Tensor input, int[] group, int op, int bucket, int tactic) -> ()");
+    m.def(
+        "register_allreduce_tactic(Tensor input, Tensor? residual, Tensor? norm_weight, Tensor? scale, Tensor? bias, "
+        "Tensor? workspace, int[] group, int op, int bucket, int tactic) -> ()");
     m.def("validate_allreduce_tuning_buckets(int[] buckets) -> ()");
     m.def("clear_allreduce_tactic_cache() -> ()");
     m.def(

--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -1633,7 +1633,11 @@ std::optional<size_t> getAllReduceBucketIndex(int64_t bucket)
 
 std::optional<size_t> getAllReduceBucketIndexForTokens(int64_t numTokens)
 {
-    if (numTokens < kAllReduceTuningBuckets.front() || numTokens > kAllReduceTuningBuckets.back())
+    // Match Python's last_positive_power_of_2: the largest bucket also
+    // represents token counts through the value immediately before its next
+    // power of two.
+    if (numTokens < kAllReduceTuningBuckets.front()
+        || numTokens >= 2 * kAllReduceTuningBuckets.back())
     {
         return std::nullopt;
     }

--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -56,10 +56,19 @@
 #include <nvml.h>
 #include <torch/extension.h>
 
+#include <c10/util/SmallVector.h>
+
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <tuple>
 #include <unordered_set>
 
 using tensorrt_llm::kernels::AllReduceFusionOp;
@@ -1582,6 +1591,127 @@ bool isNCCLWindowBuffer(torch::Tensor const& input, torch::List<int64_t> const& 
 #endif
 }
 
+namespace
+{
+
+constexpr std::array<int64_t, 14> kAllReduceTuningBuckets
+    = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192};
+constexpr size_t kAllReduceNumTuningBuckets = kAllReduceTuningBuckets.size();
+
+struct AllReduceTacticCacheKey
+{
+    std::vector<int64_t> group;
+    AllReduceFusionOp fusionOp;
+    bool inputUsesNcclWindow;
+    c10::ScalarType dtype;
+    c10::SmallVector<int64_t, 8> staticInputShape;
+
+    bool operator<(AllReduceTacticCacheKey const& other) const
+    {
+        return std::tie(group, fusionOp, inputUsesNcclWindow, dtype, staticInputShape)
+            < std::tie(other.group, other.fusionOp, other.inputUsesNcclWindow, other.dtype, other.staticInputShape);
+    }
+};
+
+using AllReduceTacticBuckets = std::array<std::optional<int64_t>, kAllReduceNumTuningBuckets>;
+
+struct AllReduceTacticCache
+{
+    mutable std::shared_mutex mutex;
+    std::map<AllReduceTacticCacheKey, AllReduceTacticBuckets> tactics;
+};
+
+std::optional<size_t> getAllReduceBucketIndex(int64_t bucket)
+{
+    auto const iterator = std::lower_bound(kAllReduceTuningBuckets.begin(), kAllReduceTuningBuckets.end(), bucket);
+    if (iterator == kAllReduceTuningBuckets.end() || *iterator != bucket)
+    {
+        return std::nullopt;
+    }
+    return static_cast<size_t>(iterator - kAllReduceTuningBuckets.begin());
+}
+
+std::optional<size_t> getAllReduceBucketIndexForTokens(int64_t numTokens)
+{
+    if (numTokens < kAllReduceTuningBuckets.front() || numTokens > kAllReduceTuningBuckets.back())
+    {
+        return std::nullopt;
+    }
+
+    // Use the largest tuned bucket that does not exceed the token count.
+    auto const firstLargerBucket
+        = std::upper_bound(kAllReduceTuningBuckets.begin(), kAllReduceTuningBuckets.end(), numTokens);
+    return static_cast<size_t>(firstLargerBucket - kAllReduceTuningBuckets.begin() - 1);
+}
+
+AllReduceTacticCache& getAllReduceTacticCache()
+{
+    static AllReduceTacticCache cache;
+    return cache;
+}
+
+void insertAllReduceTactic(AllReduceTacticCacheKey key, size_t bucketIndex, int64_t tactic)
+{
+    TORCH_INTERNAL_ASSERT(bucketIndex < kAllReduceNumTuningBuckets);
+    auto& cache = getAllReduceTacticCache();
+    std::unique_lock lock(cache.mutex);
+    cache.tactics[std::move(key)][bucketIndex] = tactic;
+}
+
+std::optional<int64_t> findAllReduceTactic(AllReduceTacticCacheKey const& key, std::optional<size_t> bucketIndex)
+{
+    if (!bucketIndex.has_value())
+    {
+        return std::nullopt;
+    }
+
+    auto const& cache = getAllReduceTacticCache();
+    std::shared_lock lock(cache.mutex);
+    auto const iterator = cache.tactics.find(key);
+    return iterator == cache.tactics.end() ? std::nullopt : iterator->second[*bucketIndex];
+}
+
+AllReduceTacticCacheKey getAllReduceTacticCacheKey(
+    torch::Tensor const& input, torch::List<int64_t> const& group, AllReduceFusionOp fusionOp, bool inputUsesNcclWindow)
+{
+    TORCH_CHECK(input.dim() > 0, "AllReduce input must have at least one dimension");
+    std::vector<int64_t> groupVector(group.begin(), group.end());
+    c10::SmallVector<int64_t, 8> staticInputShape(input.sizes().begin() + 1, input.sizes().end());
+    return {std::move(groupVector), fusionOp, inputUsesNcclWindow, input.scalar_type(), std::move(staticInputShape)};
+}
+
+} // namespace
+
+void registerAllReduceTactic(
+    torch::Tensor const& input, torch::List<int64_t> const& group, int64_t fusionOp, int64_t bucket, int64_t tactic)
+{
+    auto const bucketIndex = getAllReduceBucketIndex(bucket);
+    TORCH_CHECK(bucketIndex.has_value(), "Invalid AllReduce autotuner bucket: ", bucket);
+    insertAllReduceTactic(getAllReduceTacticCacheKey(
+                              input, group, static_cast<AllReduceFusionOp>(fusionOp), isNCCLWindowBuffer(input, group)),
+        *bucketIndex, tactic);
+}
+
+void validateAllReduceTuningBuckets(torch::List<int64_t> const& buckets)
+{
+    TORCH_CHECK(buckets.size() == kAllReduceNumTuningBuckets, "AllReduce autotuner bucket mismatch: Python provided ",
+        buckets.size(), " buckets, but C++ expects ", kAllReduceNumTuningBuckets,
+        ". Rebuild TensorRT-LLM so the Python and C++ sources match.");
+    for (size_t index = 0; index < kAllReduceNumTuningBuckets; ++index)
+    {
+        TORCH_CHECK(buckets[index] == kAllReduceTuningBuckets[index], "AllReduce autotuner bucket mismatch at index ",
+            index, ": Python provided ", buckets[index], ", but C++ expects ", kAllReduceTuningBuckets[index],
+            ". Rebuild TensorRT-LLM so the Python and C++ sources match.");
+    }
+}
+
+void clearAllReduceTacticCache()
+{
+    auto& cache = getAllReduceTacticCache();
+    std::unique_lock lock(cache.mutex);
+    cache.tactics.clear();
+}
+
 std::vector<torch::Tensor> allreduce_raw(torch::Tensor const& input, torch::optional<torch::Tensor> const& residual,
     torch::optional<torch::Tensor> const& norm_weight, torch::optional<torch::Tensor> const& scale,
     torch::optional<torch::Tensor> const& bias, torch::optional<torch::Tensor> workspace,
@@ -1604,6 +1734,39 @@ std::vector<torch::Tensor> allreduce_raw(torch::Tensor const& input, torch::opti
 #else
     return {input};
 #endif // ENABLE_MULTI_DEVICE
+}
+
+std::vector<torch::Tensor> autotunedAllreduce(torch::Tensor const& input,
+    torch::optional<torch::Tensor> const& residual, torch::optional<torch::Tensor> const& normWeight,
+    torch::optional<torch::Tensor> const& scale, torch::optional<torch::Tensor> const& bias,
+    torch::optional<torch::Tensor> workspace, torch::List<int64_t> const& group, int64_t const, int64_t const fusionOp,
+    double const eps, bool const triggerCompletionAtEnd)
+{
+    auto key = getAllReduceTacticCacheKey(input, group, static_cast<AllReduceFusionOp>(fusionOp), false);
+    auto const bucketIndex = getAllReduceBucketIndexForTokens(input.size(0));
+    auto const defaultTactic = findAllReduceTactic(key, bucketIndex);
+    key.inputUsesNcclWindow = true;
+    auto const windowTactic = findAllReduceTactic(key, bucketIndex);
+
+    int64_t tactic;
+    if (!defaultTactic.has_value() && !windowTactic.has_value())
+    {
+        tactic = static_cast<int64_t>(AllReduceStrategyType::NCCL_SYMMETRIC);
+    }
+    else if (!defaultTactic.has_value())
+    {
+        tactic = *windowTactic;
+    }
+    else if (!windowTactic.has_value())
+    {
+        tactic = *defaultTactic;
+    }
+    else
+    {
+        tactic = isNCCLWindowBuffer(input, group) ? *windowTactic : *defaultTactic;
+    }
+    return allreduce_raw(
+        input, residual, normWeight, scale, bias, workspace, group, tactic, fusionOp, eps, triggerCompletionAtEnd);
 }
 
 std::vector<torch::Tensor> allreduce_pg(torch::Tensor const& input, torch::optional<torch::Tensor> const& residual,
@@ -2113,6 +2276,22 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
         "float eps,"
         "bool trigger_completion_at_end) -> Tensor[]");
     m.def(
+        "autotuned_allreduce("
+        "Tensor input,"
+        "Tensor? residual,"
+        "Tensor? norm_weight,"
+        "Tensor? scale,"
+        "Tensor? bias,"
+        "Tensor? workspace,"
+        "int[] group,"
+        "int strategy,"
+        "int op,"
+        "float eps,"
+        "bool trigger_completion_at_end) -> Tensor[]");
+    m.def("register_allreduce_tactic(Tensor input, int[] group, int op, int bucket, int tactic) -> ()");
+    m.def("validate_allreduce_tuning_buckets(int[] buckets) -> ()");
+    m.def("clear_allreduce_tactic_cache() -> ()");
+    m.def(
         "allreduce_pg("
         "Tensor input,"
         "Tensor? residual,"
@@ -2180,6 +2359,8 @@ TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 {
     m.impl("mnnvl_fusion_allreduce", &tensorrt_llm::torch_ext::mnnvlFusionAllReduce);
     m.impl("allreduce", &tensorrt_llm::torch_ext::allreduce_raw);
+    m.impl("autotuned_allreduce", &tensorrt_llm::torch_ext::autotunedAllreduce);
+    m.impl("register_allreduce_tactic", &tensorrt_llm::torch_ext::registerAllReduceTactic);
     m.impl("allreduce_pg", &tensorrt_llm::torch_ext::allreduce_pg);
     m.impl("moe_allreduce", &tensorrt_llm::torch_ext::moe_allreduce);
     m.impl("moe_finalize_allreduce", &tensorrt_llm::torch_ext::moe_finalize_allreduce);
@@ -2187,6 +2368,12 @@ TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
     m.impl("is_nccl_window_buffer", &tensorrt_llm::torch_ext::isNCCLWindowBuffer);
     m.impl("minimax_allreduce_rms", &tensorrt_llm::torch_ext::minimax_allreduce_rms);
     m.impl("minimax_allreduce_rms_qk", &tensorrt_llm::torch_ext::minimax_allreduce_rms_qk);
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CompositeExplicitAutograd, m)
+{
+    m.impl("validate_allreduce_tuning_buckets", &tensorrt_llm::torch_ext::validateAllReduceTuningBuckets);
+    m.impl("clear_allreduce_tactic_cache", &tensorrt_llm::torch_ext::clearAllReduceTacticCache);
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CPU, m)

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -304,6 +304,10 @@ def autotune(tune_mode: bool = True,
     old_skip = autotuner.skip_dynamic_tuning_buckets
     autotuner.is_tuning_mode = tune_required
     autotuner.skip_dynamic_tuning_buckets = skip_dynamic_tuning_buckets
+    # Avoid making compiled AllReduce paths initialize or inspect AutoTuner.
+    from tensorrt_llm._torch.distributed.ops import \
+        set_allreduce_autotuner_tuning_mode
+    set_allreduce_autotuner_tuning_mode(tune_required)
     autotune_enabled = tune_required and not old_mode
 
     if autotune_enabled:
@@ -314,6 +318,7 @@ def autotune(tune_mode: bool = True,
     finally:
         autotuner.is_tuning_mode = old_mode
         autotuner.skip_dynamic_tuning_buckets = old_skip
+        set_allreduce_autotuner_tuning_mode(old_mode)
         if autotune_enabled:
             logger.info("[Autotuner] Autotuning process ends")
 

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -288,7 +288,11 @@ def autotune(tune_mode: bool = True,
     # record the old tuning mode
     old_mode = autotuner.is_tuning_mode
     old_skip = autotuner.skip_dynamic_tuning_buckets
+    from tensorrt_llm._torch.distributed import ops as distributed_ops
+    old_allreduce_tuning_mode = (
+        distributed_ops._ALLREDUCE_AUTOTUNER_TUNING_MODE)
     autotuner.is_tuning_mode = tune_required
+    distributed_ops._ALLREDUCE_AUTOTUNER_TUNING_MODE = tune_required
     autotuner.skip_dynamic_tuning_buckets = skip_dynamic_tuning_buckets
     autotune_enabled = tune_required and not old_mode
 
@@ -299,6 +303,8 @@ def autotune(tune_mode: bool = True,
         yield
     finally:
         autotuner.is_tuning_mode = old_mode
+        distributed_ops._ALLREDUCE_AUTOTUNER_TUNING_MODE = (
+            old_allreduce_tuning_mode)
         autotuner.skip_dynamic_tuning_buckets = old_skip
         if autotune_enabled:
             logger.info("[Autotuner] Autotuning process ends")
@@ -1742,6 +1748,8 @@ class AutoTuner:
     def clear_cache(self) -> None:
         """Clear the profiling cache."""
         self.profiling_cache.clear()
+        if hasattr(torch.ops.trtllm, "clear_allreduce_tactic_cache"):
+            torch.ops.trtllm.clear_allreduce_tactic_cache()
 
     def reset_statistics(self) -> None:
         """Reset all statistics counters."""

--- a/tensorrt_llm/_torch/compilation/patterns/ar_residual_norm.py
+++ b/tensorrt_llm/_torch/compilation/patterns/ar_residual_norm.py
@@ -939,15 +939,16 @@ def register_ub_patterns(custom_passes: List[PatternMatcherPass],
 
 def register_ar_fusions(custom_passes: List[PatternMatcherPass],
                         mapping: Mapping, enable_ub: bool):
-    register_ar_residual_norm(custom_passes[-1], mapping,
-                              torch.ops.trtllm.allreduce)
-    register_ar_residual_norm(custom_passes[-1], mapping,
-                              torch.ops.trtllm.tunable_allreduce)
+    allreduce_funcs = [
+        torch.ops.trtllm.allreduce,
+        torch.ops.trtllm.tunable_allreduce,
+        torch.ops.trtllm.autotuned_allreduce,
+    ]
+    for allreduce_func in allreduce_funcs:
+        register_ar_residual_norm(custom_passes[-1], mapping, allreduce_func)
 
     _append_named_pass(custom_passes, "ar_residual_norm_quant")
-    for allreduce_func in [
-            torch.ops.trtllm.allreduce, torch.ops.trtllm.tunable_allreduce
-    ]:
+    for allreduce_func in allreduce_funcs:
         register_ar_residual_norm_fp8_quant(custom_passes[-1], mapping,
                                             allreduce_func)
         register_ar_residual_norm_fp4_quant(custom_passes[-1], mapping,
@@ -961,6 +962,5 @@ def register_ar_fusions(custom_passes: List[PatternMatcherPass],
                                                     allreduce_func)
 
     if enable_ub:
-        register_ub_patterns(custom_passes, mapping, torch.ops.trtllm.allreduce)
-        register_ub_patterns(custom_passes, mapping,
-                             torch.ops.trtllm.tunable_allreduce)
+        for allreduce_func in allreduce_funcs:
+            register_ub_patterns(custom_passes, mapping, allreduce_func)

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -77,8 +77,18 @@ def _register_fake():
                          group, strategy, op, eps, trigger_completion_at_end)
 
     @torch.library.register_fake("trtllm::register_allreduce_tactic")
-    def _(input: torch.Tensor, group: List[int], op: int, bucket: int,
-          tactic: int) -> None:
+    def _(
+        input: torch.Tensor,
+        residual: Optional[torch.Tensor],
+        norm_weight: Optional[torch.Tensor],
+        scale: Optional[torch.Tensor],
+        bias: Optional[torch.Tensor],
+        workspace: Optional[torch.Tensor],
+        group: List[int],
+        op: int,
+        bucket: int,
+        tactic: int,
+    ) -> None:
         return None
 
     @torch.library.register_fake("trtllm::validate_allreduce_tuning_buckets")

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -59,6 +59,36 @@ def _register_fake():
         else:
             return [torch.empty_like(input)]
 
+    @torch.library.register_fake("trtllm::autotuned_allreduce")
+    def _(
+        input: torch.Tensor,
+        residual: Optional[torch.Tensor],
+        norm_weight: Optional[torch.Tensor],
+        scale: Optional[torch.Tensor],
+        bias: Optional[torch.Tensor],
+        workspace: Optional[torch.Tensor],
+        group: List[int],
+        strategy: int,
+        op: int,
+        eps: float,
+        trigger_completion_at_end: bool,
+    ) -> List[torch.Tensor]:
+        return allreduce(input, residual, norm_weight, scale, bias, workspace,
+                         group, strategy, op, eps, trigger_completion_at_end)
+
+    @torch.library.register_fake("trtllm::register_allreduce_tactic")
+    def _(input: torch.Tensor, group: List[int], op: int, bucket: int,
+          tactic: int) -> None:
+        return None
+
+    @torch.library.register_fake("trtllm::validate_allreduce_tuning_buckets")
+    def _(buckets: List[int]) -> None:
+        return None
+
+    @torch.library.register_fake("trtllm::clear_allreduce_tactic_cache")
+    def _() -> None:
+        return None
+
     @torch.library.register_fake("trtllm::allreduce_pg")
     def _(
         input: torch.Tensor,

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -2092,6 +2092,8 @@ class AllReduceRunner(TunableRunner):
     _prealloc_max_num_tokens: ClassVar[Optional[int]] = None
     _prealloc_hidden_size: ClassVar[Optional[int]] = None
     _prealloc_dtype: ClassVar[Optional[torch.dtype]] = None
+    # Keep these buckets synchronized with kAllReduceTuningBuckets in
+    # cpp/tensorrt_llm/thop/allreduceOp.cpp.
     tuning_config = TuningConfig(
         dynamic_tensor_specs=(DynamicTensorSpec(
             0, 0, get_last_power_of_2_num_tokens_buckets(8192),
@@ -2104,6 +2106,7 @@ class AllReduceRunner(TunableRunner):
         self,
         tp_size: int,
         group: List[int],
+        input_dtype: torch.dtype,
         op: int,
         eps: float,
         trigger_completion_at_end: bool,
@@ -2112,13 +2115,16 @@ class AllReduceRunner(TunableRunner):
         self.tp_size = tp_size
         self.op = op
         self.group = group
+        self.input_dtype = input_dtype
         self.eps = eps
         self.trigger_completion_at_end = trigger_completion_at_end
         self.input_uses_nccl_window = input_uses_nccl_window
 
-    def unique_id(self):
+    def unique_id(self) -> Tuple[int, Tuple[int, ...], torch.dtype, int, bool]:
         return (
             self.tp_size,
+            tuple(self.group),
+            self.input_dtype,
             self.op,
             self.input_uses_nccl_window,
         )
@@ -2203,6 +2209,44 @@ class AllReduceRunner(TunableRunner):
             valid_strategies.append(AllReduceStrategy.TWOSHOT.value)
 
         return valid_strategies
+
+    def _register_native_tactics(self, input: torch.Tensor) -> None:
+        custom_op = "trtllm::tunable_allreduce::allreduce"
+        runner_key = (custom_op, self.__class__.__name__, str(self.unique_id()))
+        tuning_buckets = self.tuning_config.dynamic_tensor_specs[
+            0].gen_tuning_buckets
+        # Avoid a module-import cycle during custom-op registration.
+        from tensorrt_llm._torch.distributed.ops import \
+            disable_native_allreduce_autotuner
+
+        if not hasattr(torch.ops.trtllm, "validate_allreduce_tuning_buckets"):
+            disable_native_allreduce_autotuner(
+                "native extension does not expose bucket validation")
+            return
+        try:
+            torch.ops.trtllm.validate_allreduce_tuning_buckets(tuning_buckets)
+        except RuntimeError as error:
+            if "AllReduce autotuner bucket mismatch" not in str(error):
+                raise
+            disable_native_allreduce_autotuner(str(error))
+            return
+        cache = AutoTuner.get().profiling_cache.cache
+        static_input_shape = tuple(input.shape[1:])
+        for cache_key, (_, tactic, _) in cache.items():
+            if cache_key[:3] != runner_key:
+                continue
+            profile = cache_key[3]
+            if not profile or not profile[0]:
+                continue
+            input_shape = profile[0]
+            if tuple(input_shape[1:]) != static_input_shape:
+                continue
+            bucket = int(input_shape[0])
+            if bucket not in tuning_buckets:
+                continue
+            torch.ops.trtllm.register_allreduce_tactic(input, self.group,
+                                                       self.op, bucket,
+                                                       int(tactic))
 
     def forward(
         self,
@@ -2297,6 +2341,7 @@ def tunable_allreduce(
     allreduce_runner = AllReduceRunner(
         len(group),
         group,
+        input.dtype,
         op,
         eps,
         trigger_completion_at_end,
@@ -2335,6 +2380,7 @@ def tunable_allreduce(
         tuning_config,
         [input, residual, norm_weight, scale, bias, workspace],
     )
+    allreduce_runner._register_native_tactics(input)
 
     return allreduce_runner(
         [input, residual, norm_weight, scale, bias, workspace],

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -2210,7 +2210,8 @@ class AllReduceRunner(TunableRunner):
 
         return valid_strategies
 
-    def _register_native_tactics(self, input: torch.Tensor) -> None:
+    def _register_native_tactics(self, inputs: List[torch.Tensor]) -> None:
+        input, residual, norm_weight, scale, bias, workspace = inputs
         custom_op = "trtllm::tunable_allreduce::allreduce"
         runner_key = (custom_op, self.__class__.__name__, str(self.unique_id()))
         tuning_buckets = self.tuning_config.dynamic_tensor_specs[
@@ -2231,20 +2232,30 @@ class AllReduceRunner(TunableRunner):
             disable_native_allreduce_autotuner(str(error))
             return
         cache = AutoTuner.get().profiling_cache.cache
-        static_input_shape = tuple(input.shape[1:])
+        static_input_shapes = tuple(
+            (tuple(tensor.shape[1:]) if index == 0 else (
+                -1, *tensor.shape[1:]) if index == 1 else tuple(tensor.shape)
+             ) if isinstance(tensor, torch.Tensor) else (0, )
+            for index, tensor in enumerate(inputs))
         for cache_key, (_, tactic, _) in cache.items():
             if cache_key[:3] != runner_key:
                 continue
             profile = cache_key[3]
-            if not profile or not profile[0]:
+            if not profile or len(profile) != len(inputs) or not profile[0]:
                 continue
             input_shape = profile[0]
-            if tuple(input_shape[1:]) != static_input_shape:
+            profile_static_input_shapes = (
+                tuple(input_shape[1:]),
+                *(tuple(shape) for shape in profile[1:]),
+            )
+            if profile_static_input_shapes != static_input_shapes:
                 continue
             bucket = int(input_shape[0])
             if bucket not in tuning_buckets:
                 continue
-            torch.ops.trtllm.register_allreduce_tactic(input, self.group,
+            torch.ops.trtllm.register_allreduce_tactic(input, residual,
+                                                       norm_weight, scale, bias,
+                                                       workspace, self.group,
                                                        self.op, bucket,
                                                        int(tactic))
 
@@ -2380,7 +2391,8 @@ def tunable_allreduce(
         tuning_config,
         [input, residual, norm_weight, scale, bias, workspace],
     )
-    allreduce_runner._register_native_tactics(input)
+    allreduce_runner._register_native_tactics(
+        [input, residual, norm_weight, scale, bias, workspace])
 
     return allreduce_runner(
         [input, residual, norm_weight, scale, bias, workspace],

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -34,6 +34,22 @@ _MNNVL_ONE_SHOT_THRESHOLD_BYTES = 64 * 1024 * 8 * 2
 
 _thread_local = threading.local()
 
+# Mirrored by the autotune context so Dynamo can guard this branch without
+# tracing the stateful AutoTuner singleton.
+_ALLREDUCE_AUTOTUNER_TUNING_MODE = False
+# Disabled only after the Python/C++ native-tactic contract cannot be honored.
+_ALLREDUCE_NATIVE_AUTOTUNER_ENABLED = True
+
+
+def disable_native_allreduce_autotuner(reason: str) -> None:
+    """Use the Python AllReduce autotuner after a native compatibility failure."""
+    global _ALLREDUCE_NATIVE_AUTOTUNER_ENABLED
+    if _ALLREDUCE_NATIVE_AUTOTUNER_ENABLED:
+        _ALLREDUCE_NATIVE_AUTOTUNER_ENABLED = False
+        logger.warning(
+            "Disabling native AllReduce autotuner (%s); falling back to the Python autotuner.",
+            reason)
+
 
 def get_allreduce_workspace(mapping: Mapping) -> torch.LongTensor:
     if not hasattr(_thread_local, f'allreduce_workspaces_{mapping.pp_rank}'):
@@ -898,20 +914,38 @@ class AllReduce(nn.Module):
             "TLLM_DISABLE_ALLREDUCE_AUTOTUNE", "0") == "1"
 
         if allreduce_strategy == AllReduceStrategy.AUTO and not disable_allreduce_autotune and not self._disable_mpi:
-            output = torch.ops.trtllm.tunable_allreduce(
-                input=input,
-                residual=all_reduce_params.residual,
-                norm_weight=all_reduce_params.norm_weight,
-                scale=all_reduce_params.scale,
-                bias=all_reduce_params.bias,
-                workspace=self.workspace,
-                group=self.mapping.tp_group,
-                strategy=allreduce_strategy,
-                op=all_reduce_params.fusion_op,
-                eps=all_reduce_params.eps,
-                trigger_completion_at_end=all_reduce_params.
-                trigger_completion_at_end,
-            )
+            # Use native lookup after tuning unless its Python/C++ contract
+            # failed; then retain the existing Python cache and selection path.
+            if _ALLREDUCE_AUTOTUNER_TUNING_MODE or not _ALLREDUCE_NATIVE_AUTOTUNER_ENABLED:
+                output = torch.ops.trtllm.tunable_allreduce(
+                    input=input,
+                    residual=all_reduce_params.residual,
+                    norm_weight=all_reduce_params.norm_weight,
+                    scale=all_reduce_params.scale,
+                    bias=all_reduce_params.bias,
+                    workspace=self.workspace,
+                    group=self.mapping.tp_group,
+                    strategy=allreduce_strategy,
+                    op=all_reduce_params.fusion_op,
+                    eps=all_reduce_params.eps,
+                    trigger_completion_at_end=all_reduce_params.
+                    trigger_completion_at_end,
+                )
+            else:
+                output = torch.ops.trtllm.autotuned_allreduce(
+                    input=input,
+                    residual=all_reduce_params.residual,
+                    norm_weight=all_reduce_params.norm_weight,
+                    scale=all_reduce_params.scale,
+                    bias=all_reduce_params.bias,
+                    workspace=self.workspace,
+                    group=self.mapping.tp_group,
+                    strategy=allreduce_strategy,
+                    op=all_reduce_params.fusion_op,
+                    eps=all_reduce_params.eps,
+                    trigger_completion_at_end=all_reduce_params.
+                    trigger_completion_at_end,
+                )
         else:
             output = self.all_reduce_op(
                 input=input,

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -34,6 +34,10 @@ _MNNVL_ONE_SHOT_THRESHOLD_BYTES = 64 * 1024 * 8 * 2
 
 _thread_local = threading.local()
 
+# Mirrored by the autotune context so Dynamo can guard this branch without
+# tracing the stateful AutoTuner singleton.
+_ALLREDUCE_AUTOTUNER_TUNING_MODE = False
+
 # Disabled only after the Python/C++ native-tactic contract cannot be honored.
 _ALLREDUCE_NATIVE_AUTOTUNER_ENABLED = True
 
@@ -46,6 +50,12 @@ def disable_native_allreduce_autotuner(reason: str) -> None:
         logger.warning(
             "Disabling native AllReduce autotuner (%s); falling back to the Python autotuner.",
             reason)
+
+
+def set_allreduce_autotuner_tuning_mode(is_tuning_mode: bool) -> None:
+    """Set the Dynamo-safe AllReduce autotuner mode mirror."""
+    global _ALLREDUCE_AUTOTUNER_TUNING_MODE
+    _ALLREDUCE_AUTOTUNER_TUNING_MODE = is_tuning_mode
 
 
 def get_allreduce_workspace(mapping: Mapping) -> torch.LongTensor:
@@ -913,10 +923,7 @@ class AllReduce(nn.Module):
         if allreduce_strategy == AllReduceStrategy.AUTO and not disable_allreduce_autotune and not self._disable_mpi:
             # Use native lookup after tuning unless its Python/C++ contract
             # failed; then retain the existing Python cache and selection path.
-            # Import lazily because AutoTuner imports the distributed package.
-            from tensorrt_llm._torch.autotuner import AutoTuner
-            is_tuning_mode = AutoTuner.get().is_tuning_mode
-            if is_tuning_mode or not _ALLREDUCE_NATIVE_AUTOTUNER_ENABLED:
+            if _ALLREDUCE_AUTOTUNER_TUNING_MODE or not _ALLREDUCE_NATIVE_AUTOTUNER_ENABLED:
                 output = torch.ops.trtllm.tunable_allreduce(
                     input=input,
                     residual=all_reduce_params.residual,

--- a/tests/unittest/_torch/multi_gpu/test_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_allreduce.py
@@ -133,6 +133,7 @@ def run_allreduce_op(
         rank=tensor_parallel_rank,
     )
 
+    AutoTuner.get().clear_cache()
     AutoTuner.get().setup_distributed_state(mapping)
     linear = Linear(
         in_features=hidden_size,
@@ -261,16 +262,20 @@ def run_allreduce_op(
 
     # trigger autotune
     with autotune():
-        calc_output = calc_func(xs[tensor_parallel_rank], residual)
+        tuning_output = calc_func(xs[tensor_parallel_rank], residual)
 
+    native_output = calc_func(xs[tensor_parallel_rank], residual)
     ref_output = ref_func(xs[tensor_parallel_rank], residual)
 
-    for calc_output_tensor, ref_output_tensor in zip(calc_output, ref_output):
-        check_accuracy(calc_output_tensor,
-                       ref_output_tensor,
-                       atol=0.05,
-                       rtol=0.15,
-                       percent=0.99)
+    for calc_output in (tuning_output, native_output):
+        assert len(calc_output) == len(ref_output)
+        for calc_output_tensor, ref_output_tensor in zip(
+                calc_output, ref_output):
+            check_accuracy(calc_output_tensor,
+                           ref_output_tensor,
+                           atol=0.05,
+                           rtol=0.15,
+                           percent=0.99)
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2,

--- a/tests/unittest/_torch/multi_gpu/test_user_buffers.py
+++ b/tests/unittest/_torch/multi_gpu/test_user_buffers.py
@@ -38,7 +38,7 @@ def _assert_match_counts(backend, expected_match_count_by_pass):
     # - "<pass_name>" for passes that are registered once
     # - "<pass_name>:<allreduce_variant>" for UB passes that are registered
     #   per allreduce backend, where <allreduce_variant> is "allreduce" or
-    #   "tunable_allreduce"
+    #   "tunable_allreduce" or "autotuned_allreduce"
     assert dict(backend.match_count_by_pass) == expected_match_count_by_pass
 
 
@@ -509,10 +509,14 @@ def run_single_rank_ar_rms_norm_fp8_live_scale_compile(tensor_parallel_size, a,
                 "ub_prologue:allreduce": 0,
                 "ub_finalize:allreduce": 0,
                 "insert_copy_for_graph_output:allreduce": 0,
-                "ub_convert_supported_ar_to_ub:tunable_allreduce": 1,
-                "ub_prologue:tunable_allreduce": 1,
+                "ub_convert_supported_ar_to_ub:tunable_allreduce": 0,
+                "ub_prologue:tunable_allreduce": 0,
                 "ub_finalize:tunable_allreduce": 0,
                 "insert_copy_for_graph_output:tunable_allreduce": 0,
+                "ub_convert_supported_ar_to_ub:autotuned_allreduce": 1,
+                "ub_prologue:autotuned_allreduce": 1,
+                "ub_finalize:autotuned_allreduce": 0,
+                "insert_copy_for_graph_output:autotuned_allreduce": 0,
                 "add_norm_fallback": 0,
             })
 
@@ -563,6 +567,10 @@ def run_single_rank_backend_passes_are_per_instance(tensor_parallel_size):
                 "ub_prologue:tunable_allreduce",
                 "ub_finalize:tunable_allreduce",
                 "insert_copy_for_graph_output:tunable_allreduce",
+                "ub_convert_supported_ar_to_ub:autotuned_allreduce",
+                "ub_prologue:autotuned_allreduce",
+                "ub_finalize:autotuned_allreduce",
+                "insert_copy_for_graph_output:autotuned_allreduce",
                 "add_norm_fallback",
             ]
 
@@ -624,10 +632,14 @@ def run_single_rank_ub_pass(
                 "ub_prologue:allreduce": 0,
                 "ub_finalize:allreduce": 0,
                 "insert_copy_for_graph_output:allreduce": 0,
-                "ub_convert_supported_ar_to_ub:tunable_allreduce": 3,
-                "ub_prologue:tunable_allreduce": 3,
-                "ub_finalize:tunable_allreduce": 2,
-                "insert_copy_for_graph_output:tunable_allreduce": 1,
+                "ub_convert_supported_ar_to_ub:tunable_allreduce": 0,
+                "ub_prologue:tunable_allreduce": 0,
+                "ub_finalize:tunable_allreduce": 0,
+                "insert_copy_for_graph_output:tunable_allreduce": 0,
+                "ub_convert_supported_ar_to_ub:autotuned_allreduce": 3,
+                "ub_prologue:autotuned_allreduce": 3,
+                "ub_finalize:autotuned_allreduce": 2,
+                "insert_copy_for_graph_output:autotuned_allreduce": 1,
                 "add_norm_fallback": 0,
             })
         torch.cuda.synchronize()
@@ -972,10 +984,14 @@ def run_single_rank_ub_mm_add_pass(tensor_parallel_size, num_tokens,
                 "ub_prologue:allreduce": 0,
                 "ub_finalize:allreduce": 0,
                 "insert_copy_for_graph_output:allreduce": 0,
-                "ub_convert_supported_ar_to_ub:tunable_allreduce": 3,
-                "ub_prologue:tunable_allreduce": 3,
-                "ub_finalize:tunable_allreduce": 1,
-                "insert_copy_for_graph_output:tunable_allreduce": 1,
+                "ub_convert_supported_ar_to_ub:tunable_allreduce": 0,
+                "ub_prologue:tunable_allreduce": 0,
+                "ub_finalize:tunable_allreduce": 0,
+                "insert_copy_for_graph_output:tunable_allreduce": 0,
+                "ub_convert_supported_ar_to_ub:autotuned_allreduce": 3,
+                "ub_prologue:autotuned_allreduce": 3,
+                "ub_finalize:autotuned_allreduce": 1,
+                "insert_copy_for_graph_output:autotuned_allreduce": 1,
                 "add_norm_fallback": 0,
             })
         torch.cuda.synchronize()
@@ -1223,10 +1239,14 @@ def run_single_rank_ub_pass_fp4(
                 "ub_prologue:allreduce": 0,
                 "ub_finalize:allreduce": 0,
                 "insert_copy_for_graph_output:allreduce": 0,
-                "ub_convert_supported_ar_to_ub:tunable_allreduce": 3,
-                "ub_prologue:tunable_allreduce": 3,
-                "ub_finalize:tunable_allreduce": 2,
-                "insert_copy_for_graph_output:tunable_allreduce": 1,
+                "ub_convert_supported_ar_to_ub:tunable_allreduce": 0,
+                "ub_prologue:tunable_allreduce": 0,
+                "ub_finalize:tunable_allreduce": 0,
+                "insert_copy_for_graph_output:tunable_allreduce": 0,
+                "ub_convert_supported_ar_to_ub:autotuned_allreduce": 3,
+                "ub_prologue:autotuned_allreduce": 3,
+                "ub_finalize:autotuned_allreduce": 2,
+                "insert_copy_for_graph_output:autotuned_allreduce": 1,
                 "add_norm_fallback": 0,
             })
         torch.cuda.synchronize()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Dev Engineer Review**

- Moved hot-path AllReduce autotuner bucket lookup and tactic dispatch from Python into C++ by introducing `autotuned_allreduce` in `cpp/tensorrt_llm/thop/allreduceOp.cpp`.
- Implemented a thread-safe native all-reduce autotuning tactic cache (14 fixed token “bucket” cutoffs). The cache key includes:
  - tensor group, fusion op id
  - NCCL-window-buffer vs non-window mode
  - input scalar dtype
  - static input shape excluding `size(0)`
  Each bucket stores an optional selected tactic.
- Added native contract/control ops in `cpp/tensorrt_llm/thop/allreduceOp.cpp`:
  - `register_allreduce_tactic`
  - `validate_allreduce_tuning_buckets`
  - `clear_allreduce_tactic_cache`
  with CUDA registrations for `autotuned_allreduce` / `register_allreduce_tactic`, and `CompositeExplicitAutograd` registrations for the validate/clear ops.
- Enforced runtime bucket contract alignment between Python and C++:
  - Python validates bucket definitions and (when native validation is available) registers matching native tactics.
  - C++ performs deterministic tactic selection from cached entries; when definitions mismatch, it logs once and falls back to the existing Python autotuner.
- Updated Python orchestration and operator dispatch:
  - `tensorrt_llm/_torch/autotuner.py`: coordinates a shared distributed tuning-mode flag during tuning and restores it on exit; clears the native allreduce tactic cache in `AutoTuner.clear_cache()` when available.
  - `tensorrt_llm/_torch/distributed/ops.py`: introduced `disable_native_allreduce_autotuner(reason)` (disable once + warn) and updated AUTO dispatch to choose `tunable_allreduce` vs `autotuned_allreduce` based on Dynamo tuning-mode and the disable flag.
  - `tensorrt_llm/_torch/compilation/patterns/ar_residual_norm.py`: consolidated AR fusion registration to iterate over `torch.ops.trtllm.allreduce`, `torch.ops.trtllm.tunable_allreduce`, and `torch.ops.trtllm.autotuned_allreduce` (including UB-enabled path).
- Updated custom op integration:
  - `tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py`: added fake/meta plumbing for `trtllm::autotuned_allreduce` and no-op meta implementations for the native tactic cache/control ops.
  - `tensorrt_llm/_torch/custom_ops/torch_custom_ops.py`: extended `AllReduceRunner` identity with `input.dtype` and added native tactic pre-registration:
    - validates expected native buckets via `torch.ops.trtllm.validate_allreduce_tuning_buckets` (when available)
    - registers cached tactics for validated bucket indices via `torch.ops.trtllm.register_allreduce_tactic`
    - updated `tunable_allreduce` to construct the runner with `input.dtype` and register native tactics before selecting/using the `best_tactic`.

**QA Engineer Review**

Modified tests (test code):
- `tests/unittest/_torch/multi_gpu/test_allreduce.py`
  - Updated `run_allreduce_op` to clear the `AutoTuner` cache before distributed setup.
  - Changed verification to compare both:
    - output computed within the `autotune()` context (tuning-context output)
    - output computed after the context (native output)
    against their corresponding references.
- `tests/unittest/_torch/multi_gpu/test_user_buffers.py`
  - Updated UB-related expectation maps and backend pass-list assertions so UB pass generation is associated with `autotuned_allreduce` instead of `tunable_allreduce`.

Test-list / CI coverage:
- No `tests/integration/test_lists/`, `test-db/`, `qa/`, or `waives.txt` changes are indicated in the provided context.
- Verdict: **needs follow-up**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Move the hot-path AllReduce autotuner lookup and tactic dispatch from Python to C++.

Python remains responsible for tuning and registering tactics. The C++ cache performs runtime bucket lookup and dispatch, avoiding Python work during inference. The Python and C++ bucket definitions are validated at runtime; a mismatch logs once and safely falls back to the existing Python autotuner.

This benefits small, CPU-overhead-sensitive models while preserving the existing behavior when native dispatch is unavailable.

 ## Test Coverage

- Focused native AllReduce unit coverage: `42 passed, 6 deselected`.
- File-scoped pre-commit checks passed, including clang-format and Python linting.
- Ran fixed-clock baseline/native performance validation on the AllReduce workload.
- Existing user-buffer numerical sensitivity was checked previously against baseline and is not introduced by this change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
