### PR TITLE
[None][perf] Fuse index-q/index-k projections in MinimaxM3

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_minimaxm3.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm3.py
@@ -52,7 +52,14 @@ from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.fused_moe import MiniMaxM3MoeRoutingMethod, create_moe
 from ..modules.gated_mlp import GatedMLP
-from ..modules.linear import Linear, TensorParallelMode, copy_weight, load_weight_shard
+from ..modules.linear import (
+    Linear,
+    TensorParallelMode,
+    WeightMode,
+    WeightsLoadingConfig,
+    copy_weight,
+    load_weight_shard,
+)
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
 from ..utils import (
@@ -64,7 +71,13 @@ from ..utils import (
 )
 from .checkpoints.base_weight_mapper import BaseWeightMapper
 from .checkpoints.hf.minimaxm3_weight_mapper import MINIMAX_M3_PARAMS_MAP, MiniMaxM3HfWeightMapper
-from .modeling_utils import DecoderModel, DecoderModelForCausalLM, ModelConfig, register_auto_model
+from .modeling_utils import (
+    DecoderModel,
+    DecoderModelForCausalLM,
+    ModelConfig,
+    filter_weights,
+    register_auto_model,
+)
 
 # Dense layers use SDPA with non-contiguous Q/K/V and a bool attn_mask.
 # Limit backends to memory-efficient and math; cuDNN SDPA fails for this layout,
@@ -645,12 +658,10 @@ class MiniMaxM3Attention(Attention):
 
     Both branches share the same dense GQA scaffolding (``qkv_proj`` +
     ``o_proj`` + per-head Gemma Q/K norm + partial RoPE). Sparse layers
-    additionally carry the MiniMax index branch (``index_q_proj``,
-    ``index_k_proj`` and their per-head norms). The index value/output
-    branch is omitted because the M3 checkpoint sets
-    ``sparse_disable_index_value=True`` on every sparse layer; if a
-    future config variant flips that flag the gate will catch the
-    unmapped keys.
+    additionally carry the MiniMax index branch: a fused index_qk_proj that
+    outputs [idx_q | idx_k], plus per-head index norms. The index value and
+    output branch is omitted because the M3 checkpoint sets
+    sparse_disable_index_value=True on every sparse layer.
     """
 
     def __init__(
@@ -717,33 +728,23 @@ class MiniMaxM3Attention(Attention):
             self.sparse_local_block = int(sparse_cfg.get("sparse_local_block", 1))
             self.sparse_score_type = str(sparse_cfg.get("sparse_score_type", "max"))
 
-            # index_q_proj is **replicated** across TP ranks. The sparse
-            # forward reshapes idx_q to
-            # ``[num_tokens, sparse_num_index_heads, sparse_index_dim]``,
-            # which requires the rank-local idx_q to carry all heads.
-            index_q_total = self.sparse_num_index_heads * self.sparse_index_dim
-            self.index_q_proj = Linear(
+            # Index Q and K are both replicated and project the same
+            # hidden_states, so fuse them into one GEMM with output
+            # [idx_q | idx_k]. idx_q holds all index heads; idx_k is a single K
+            # per token, broadcast across heads when scoring.
+            self.index_q_size = self.sparse_num_index_heads * self.sparse_index_dim
+            self.index_k_size = self.sparse_index_dim
+            self.index_qk_proj = Linear(
                 config.hidden_size,
-                index_q_total,
+                self.index_q_size + self.index_k_size,
                 bias=False,
                 dtype=config.torch_dtype,
                 mapping=model_config.mapping,
                 tensor_parallel_mode=None,
                 quant_config=None,
-                skip_create_weights_in_init=model_config.skip_create_weights_in_init,
-            )
-            # index_k_proj is also replicated across TP ranks and
-            # outputs ``sparse_index_dim`` channels — a single K per
-            # token (not per-head), broadcast across index heads when
-            # scoring blocks.
-            self.index_k_proj = Linear(
-                config.hidden_size,
-                self.sparse_index_dim,
-                bias=False,
-                dtype=config.torch_dtype,
-                mapping=model_config.mapping,
-                tensor_parallel_mode=None,
-                quant_config=None,
+                weights_loading_config=WeightsLoadingConfig(
+                    weight_mode=WeightMode.FUSED_GATE_UP_LINEAR
+                ),
                 skip_create_weights_in_init=model_config.skip_create_weights_in_init,
             )
             # Per-head Gemma RMSNorm of width ``sparse_index_dim``;
@@ -1194,8 +1195,8 @@ class MiniMaxM3Attention(Attention):
         # 1. Projections.
         qkv = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        idx_q = self.index_q_proj(hidden_states)
-        idx_k = self.index_k_proj(hidden_states)
+        idx_qk = self.index_qk_proj(hidden_states)
+        idx_q, idx_k = idx_qk.split([self.index_q_size, self.index_k_size], dim=-1)
 
         # 2. Per-head Gemma RMSNorm on both branches.
         q, k = self.apply_qk_norm(q, k)
@@ -1473,6 +1474,33 @@ class MiniMaxM3Model(DecoderModel):
         return hidden_states
 
 
+def _load_index_qk_proj_weights(model: nn.Module, weights) -> None:
+    """Fuse checkpoint index_q_proj and index_k_proj into index_qk_proj.
+
+    The shared weight loader fuses only qkv_proj and gate_up_proj by name, so
+    load the sibling checkpoint tensors into each fused index module through the
+    FUSED_GATE_UP_LINEAR row-concatenation path and mark the sources consumed.
+    """
+    for name, module in model.named_modules():
+        if name.split(".")[-1] != "index_qk_proj":
+            continue
+        parent = name.rsplit(".", 1)[0]
+        q_weights = filter_weights(f"{parent}.index_q_proj", weights)
+        k_weights = filter_weights(f"{parent}.index_k_proj", weights)
+        # Missing sources make Linear.load_weights assert rather than leave
+        # the fused module silently uninitialized.
+        module.load_weights(weights=[q_weights, k_weights])
+        if hasattr(weights, "mark_consumed"):
+            weights.mark_consumed(f"{parent}.index_q_proj")
+            weights.mark_consumed(f"{parent}.index_k_proj")
+        else:
+            for key in list(weights.keys()):
+                if key.startswith(f"{parent}.index_q_proj.") or key.startswith(
+                    f"{parent}.index_k_proj."
+                ):
+                    del weights[key]
+
+
 @register_auto_model("MiniMaxM3SparseForCausalLM")
 class MiniMaxM3ForCausalLM(DecoderModelForCausalLM[MiniMaxM3Model, PretrainedConfig]):
     """Text-only M3 model."""
@@ -1495,6 +1523,9 @@ class MiniMaxM3ForCausalLM(DecoderModelForCausalLM[MiniMaxM3Model, PretrainedCon
         params_map: Optional[Dict[str, str]] = None,
         allow_partial_loading: bool = False,
     ) -> None:
+        # The generic loader has no rule for this fusion. The VL subclass routes
+        # its text weights through here, so both paths are covered.
+        _load_index_qk_proj_weights(self, weights)
         if weight_mapper is None:
             weight_mapper = MiniMaxM3HfWeightMapper()
         weight_mapper.init_model_and_config(self, self.model_config)

--- a/tests/unittest/_torch/models/test_minimax_m3.py
+++ b/tests/unittest/_torch/models/test_minimax_m3.py
@@ -279,17 +279,11 @@ def test_get_moe_layer_ids_length_mismatch_raises():
 #    ``use_gemma=True`` and ``hidden_size=head_dim``; the
 #    :meth:`apply_qk_norm` reshape matches an independent hand-written
 #    reference.
-#  * Sparse index branch: ``index_q_proj`` is column-parallel and
-#    projects to ``num_index_heads * sparse_index_dim``;
-#    ``index_k_proj`` is **replicated** (tp_mode is None) and projects
-#    to **only** ``sparse_index_dim`` (single K per token, broadcast
-#    across all index heads for block-selection scoring) — this is the
-#    SGLang reference contract, confirmed by the M3 checkpoint shape
-#    ``(sparse_index_dim, hidden_size)``.
+#  * Sparse index branch: fused replicated (tp_mode None) index_qk_proj with
+#    output [idx_q | idx_k] = num_index_heads * sparse_index_dim + sparse_index_dim
+#    (idx_k is one K per token).
 #  * Dense layers do not expose any index branch attributes (negative
 #    control).
-#  * Real M3 checkpoint shape for ``index_k_proj.weight`` is
-#    ``(sparse_index_dim, hidden_size)`` = ``(128, 6144)``.
 
 
 def _make_attention_test_config():
@@ -404,6 +398,7 @@ def test_minimax_m3_attention_dense_construction_matches_config():
     for name in (
         "index_q_proj",
         "index_k_proj",
+        "index_qk_proj",
         "index_q_norm",
         "index_k_norm",
     ):
@@ -481,18 +476,13 @@ def test_minimax_m3_attention_apply_qk_norm_matches_reference():
 @pytest.mark.gpu
 @pytest.mark.skipif(not _has_cuda(), reason="MiniMax-M3 attention construction needs CUDA")
 def test_minimax_m3_attention_sparse_construction_matches_config():
-    """Sparse layer adds index branch with the SGLang-correct shapes.
+    """Sparse layer adds the index branch with the fused index projection.
 
-    Verifies the **bug fix** from the iter-4 work:
-      * ``index_q_proj`` is column-parallel and projects to
-        ``num_index_heads * sparse_index_dim``.
-      * ``index_k_proj`` is replicated (``tp_mode is None``) and projects
-        to **only** ``sparse_index_dim`` — a single replicated K per
-        token, *not* per-head. This matches SGLang's ``ReplicatedLinear``
-        and the M3 checkpoint's ``index_k_proj.weight`` shape
-        ``(sparse_index_dim, hidden_size)``.
-      * ``index_q_norm`` / ``index_k_norm`` are per-head Gemma RMSNorm
-        of width ``sparse_index_dim``.
+    * index_qk_proj is replicated (tp_mode None), out =
+      num_index_heads * sparse_index_dim (idx_q) + sparse_index_dim (idx_k),
+      where idx_k is one K per token (SGLang ReplicatedLinear contract).
+    * index_q_norm / index_k_norm are per-head Gemma RMSNorm of width
+      sparse_index_dim.
     """
     text_cfg, model_cfg = _make_attention_test_config()
     sparse_cfg = text_cfg.sparse_attention_config
@@ -509,33 +499,19 @@ def test_minimax_m3_attention_sparse_construction_matches_config():
     assert attn.is_sparse_attention_layer is True
     assert attn.disable_index_value is True
 
-    # index_q_proj: per-head Q for the index branch. As of iter-15 this
-    # is **replicated** (tp_mode=None) across TP ranks, not
-    # column-parallel: the sparse forward consumes ``idx_q`` reshaped to
-    # ``[num_tokens, num_index_heads, sparse_index_dim]`` and a
-    # column-parallel split would slice the head dimension (breaking the
-    # reshape at any ``tp_size > num_index_heads`` geometry, including
-    # the TP=8 configuration the real-checkpoint smoke test now uses).
-    # The replicated weight is small (~3 MiB BF16) so the per-rank
-    # memory cost is negligible.
-    assert attn.index_q_proj.in_features == hidden
-    assert attn.index_q_proj.out_features == num_index_heads * sparse_index_dim
-    assert attn.index_q_proj.tp_mode is None, (
-        f"index_q_proj must be replicated (tp_mode=None) so the sparse "
-        f"forward's `idx_q.view(num_tokens, num_index_heads, sparse_index_dim)` "
-        f"reshape is well-defined at any TP geometry, got "
-        f"{attn.index_q_proj.tp_mode!r}"
+    # Replication keeps the idx_q -> [num_tokens, num_index_heads,
+    # sparse_index_dim] reshape valid at any TP geometry, whereas a
+    # column-parallel split would slice the head dimension.
+    assert attn.index_q_size == num_index_heads * sparse_index_dim
+    assert attn.index_k_size == sparse_index_dim
+    assert attn.index_qk_proj.in_features == hidden
+    assert attn.index_qk_proj.out_features == num_index_heads * sparse_index_dim + sparse_index_dim
+    assert attn.index_qk_proj.tp_mode is None, (
+        f"index_qk_proj must be replicated, got {attn.index_qk_proj.tp_mode!r}"
     )
-
-    # index_k_proj: REPLICATED, only sparse_index_dim outputs.
-    assert attn.index_k_proj.in_features == hidden
-    assert attn.index_k_proj.out_features == sparse_index_dim, (
-        f"index_k_proj.out_features must be sparse_index_dim={sparse_index_dim}, "
-        f"got {attn.index_k_proj.out_features} (regression of the iter-4 fix)"
-    )
-    assert attn.index_k_proj.tp_mode is None, (
-        f"index_k_proj must be replicated (tp_mode=None), got {attn.index_k_proj.tp_mode!r}"
-    )
+    # Only the fused projection exists.
+    assert not hasattr(attn, "index_q_proj")
+    assert not hasattr(attn, "index_k_proj")
 
     # Per-head Gemma RMSNorm of width sparse_index_dim.
     assert attn.index_q_norm.use_gemma is True
@@ -628,17 +604,10 @@ def test_minimax_m3_attention_dense_apply_index_qk_norm_raises():
 def test_minimax_m3_attention_real_config_index_branch_shapes():
     """Real M3 config → sparse-layer index branch has the checkpoint's shapes.
 
-    Asserts the iter-4 fix in numbers:
-      * ``index_q_proj.out_features == 512`` (= 4 * 128
-        = ``num_index_heads * sparse_index_dim``).
-      * ``index_k_proj.out_features == 128`` (= ``sparse_index_dim``)
-        and ``tp_mode is None`` (replicated). The real
-        ``index_k_proj.weight`` in the checkpoint has shape
-        ``(128, 6144)``; a regression to the old
-        ``num_index_heads * sparse_index_dim`` (512) would break weight
-        loading at runtime.
-      * ``index_q_norm.weight.shape == (128,)`` and
-        ``index_k_norm.weight.shape == (128,)``.
+    Asserts the fused index projection in numbers:
+      * index_qk_proj.out_features == 640 (4 * 128 + 128), replicated. Source
+        weights (512, 6144) + (128, 6144) merge into (640, 6144) at load time.
+      * index_q_norm / index_k_norm weights have shape (128,).
     """
     pytest.importorskip("transformers")
     cfg = AutoConfig.from_pretrained(_checkpoint_path(), trust_remote_code=True)
@@ -671,22 +640,13 @@ def test_minimax_m3_attention_real_config_index_branch_shapes():
     assert num_index_heads == 4
     assert sparse_index_dim == 128
 
-    # index_q_proj: 4 * 128 = 512 out, replicated (tp_mode=None) as of
-    # iter-15. The downstream sparse forward reshapes ``idx_q`` to
-    # ``[num_tokens, num_index_heads, sparse_index_dim]``; a
-    # column-parallel split would slice the head dimension and break
-    # that reshape at any ``tp_size > num_index_heads`` geometry
-    # (including TP=8 used by the real-checkpoint smoke test). The
-    # replicated weight is ~3 MiB BF16 — the per-rank memory cost is
-    # negligible.
-    assert attn.index_q_proj.in_features == int(text_cfg.hidden_size)
-    assert attn.index_q_proj.out_features == num_index_heads * sparse_index_dim
-    assert attn.index_q_proj.tp_mode is None
-
-    # index_k_proj: 128 out (NOT 512), replicated.
-    assert attn.index_k_proj.in_features == int(text_cfg.hidden_size)
-    assert attn.index_k_proj.out_features == sparse_index_dim
-    assert attn.index_k_proj.tp_mode is None
+    assert attn.index_q_size == num_index_heads * sparse_index_dim
+    assert attn.index_k_size == sparse_index_dim
+    assert attn.index_qk_proj.in_features == int(text_cfg.hidden_size)
+    assert attn.index_qk_proj.out_features == num_index_heads * sparse_index_dim + sparse_index_dim
+    assert attn.index_qk_proj.tp_mode is None
+    assert not hasattr(attn, "index_q_proj")
+    assert not hasattr(attn, "index_k_proj")
 
     # Per-head Gemma index norms: width sparse_index_dim.
     assert tuple(attn.index_q_norm.weight.shape) == (sparse_index_dim,)


### PR DESCRIPTION
## Description

This MR fuses index-q / index-k projections in Minimax M3.

## Test Coverage
```
$ pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=True] -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Fuses MiniMax-M3 index-Q and index-K projections into a single `index_qk_proj`, reducing projection execution from two calls to one.
- Adds checkpoint weight fusion through `_load_index_qk_proj_weights` and updates sparse attention to split the fused output into `idx_q` and `idx_k`.
- Updates documentation and preserves dense-attention behavior by ensuring only sparse attention exposes the fused projection.
- No configuration or test-list files were modified.
- Implementation is consistent with the stated performance optimization and checkpoint layout.

## QA Engineer Review

- Updated MiniMax-M3 construction and checkpoint configuration tests to validate:
  - Fused `index_qk_proj` dimensions and replication.
  - Absence of separate `index_q_proj` and `index_k_proj` modules in sparse attention.
  - Absence of the fused projection in dense attention.
- No test functions were added or removed; existing assertions and documentation were updated.
- No `tests/integration/test_lists/` coverage changes were included, so CI/manual QA coverage mapping is unavailable.
- Verdict: **needs follow-up**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->