### PR TITLE
[None][perf] Fused SwiGLU-OAI

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -2041,7 +2041,9 @@ def _(a, b, a_scale, b_scale, tune_max_num_tokens=4096):
 def silu_and_mul(x: torch.Tensor,
                  scale: Optional[torch.Tensor] = None,
                  dtype: Optional[torch.dtype] = None,
-                 swiglu_limit: Optional[float] = None) -> torch.Tensor:
+                 swiglu_limit: Optional[float] = None,
+                 swiglu_alpha: Optional[float] = None,
+                 swiglu_beta: Optional[float] = None) -> torch.Tensor:
     b, n = x.shape
 
     assert n % 2 == 0
@@ -2061,6 +2063,8 @@ def silu_and_mul(x: torch.Tensor,
         x_stride=x.stride(0),
         d=d,
         swiglu_limit=swiglu_limit or 0.0,
+        swiglu_alpha=swiglu_alpha if swiglu_alpha is not None else 1.0,
+        swiglu_beta=swiglu_beta if swiglu_beta is not None else 0.0,
         BLOCK_SIZE=1024,
         HAS_O_SCALE=scale is not None,
         HAS_SWIGLU_LIMIT=swiglu_limit is not None and swiglu_limit > 0.0,
@@ -2075,6 +2079,8 @@ def _(
     scale: Optional[torch.Tensor] = None,
     dtype: Optional[torch.dtype] = None,
     swiglu_limit: Optional[float] = None,
+    swiglu_alpha: Optional[float] = None,
+    swiglu_beta: Optional[float] = None,
 ) -> torch.Tensor:
     b, n = x.shape
 

--- a/tensorrt_llm/_torch/models/modeling_minimaxm3.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm3.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import copy
 import dataclasses
-from functools import partial
 from typing import Any, Dict, List, Optional, Tuple
 from typing import Mapping as TMapping
 
@@ -246,11 +245,18 @@ def _build_swiglu_oai_dense_mlp(
     # MoE composition) carries its own reduction unless ADP collapses
     # TP to 1.
     reduce_output = False if is_shared_expert else (not enable_adp)
+    # SwiGLU-OAI is plain SwiGLU with an alpha gain and an (up + 1) offset, so
+    # the fused silu_and_mul kernel runs it in one launch with an optional fp8
+    # epilogue. Mirrors the routed-expert SwigluBias path; the math lives in
+    # _minimax_m3_swiglu_oai.
     return GatedMLP(
         hidden_size=config.hidden_size,
         intermediate_size=intermediate_size,
         bias=False,
-        activation=partial(_minimax_m3_swiglu_oai, alpha=swiglu_alpha, limit=swiglu_limit),
+        activation=torch.nn.functional.silu,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_beta=1.0,
+        swiglu_limit=swiglu_limit,
         dtype=config.torch_dtype,
         config=model_config,
         overridden_tp_size=1 if enable_adp else None,
@@ -629,7 +635,7 @@ def minimax_m3_attn_custom_op_inplace(
     """Run MiniMax-M3 cache and attention work behind a compile boundary."""
     attn_metadata, attn_layer = _extract_minimax_m3_attention_extra_attrs(layer_idx)
     num_tokens = attn_metadata.num_tokens
-    attn_layer._attention_core(
+    attn_layer._dispatch_attention_backend(
         q[:num_tokens],
         k[:num_tokens],
         v[:num_tokens],
@@ -914,7 +920,7 @@ class MiniMaxM3Attention(Attention):
         o = self._forward_attention_core(q, k, v, None, None, attn_metadata)
         return self.o_proj(o)
 
-    def _dense_attention_core(
+    def _sdpa_dense_attention_core(
         self,
         q: torch.Tensor,
         k: torch.Tensor,
@@ -922,7 +928,7 @@ class MiniMaxM3Attention(Attention):
         attn_metadata: AttentionMetadata,
         output: torch.Tensor,
     ) -> torch.Tensor:
-        """Run dense cache updates and attention into ``output``."""
+        """Run dense cache updates and attention into ``output`` (SDPA path)."""
         kv_cache_manager = getattr(attn_metadata, "kv_cache_manager", None)
         if kv_cache_manager is None:
             raise RuntimeError(
@@ -1111,10 +1117,10 @@ class MiniMaxM3Attention(Attention):
                 output,
             )
         else:
-            self._attention_core(q, k, v, idx_q, idx_k, attn_metadata, output)
+            self._dispatch_attention_backend(q, k, v, idx_q, idx_k, attn_metadata, output)
         return output
 
-    def _attention_core(
+    def _dispatch_attention_backend(
         self,
         q: torch.Tensor,
         k: torch.Tensor,
@@ -1124,27 +1130,51 @@ class MiniMaxM3Attention(Attention):
         attn_metadata: AttentionMetadata,
         output: torch.Tensor,
     ) -> torch.Tensor:
-        # The MSA backend runs the sparse GQA or dense paged GQA through its
-        # inherited forward; this layer selects the top-k blocks (sparse only)
-        # and builds the forward_args the FMHA reads.
+        """Route the attention core to the configured backend.
+
+        self.attn is either a :class:`MiniMaxM3MsaSparseAttention`, which
+        handles both dense and sparse layers, or a
+        :class:`MiniMaxM3SparseRuntimeBackend` (Triton).
+
+        * MSA → :meth:`_msa_attention_core`
+        * Triton sparse → :meth:`_triton_sparse_attention_core`
+        * SDPA dense → :meth:`_sdpa_dense_attention_core`
+        """
         if isinstance(self.attn, MiniMaxM3MsaSparseAttention):
-            if self.is_sparse_attention_layer:
-                assert idx_q is not None and idx_k is not None
-                # Publish the selected blocks so the FMHA runs the sparse path.
-                kv_block_indexes = self.attn.run_indexer(idx_q, idx_k, attn_metadata)
-                forward_args = AttentionForwardArgs(output=output, topk_indices=kv_block_indexes)
-            else:
-                assert idx_q is None and idx_k is None
-                # No top-k selection means the FMHA attends the full page table.
-                forward_args = AttentionForwardArgs(output=output)
-            self.attn.forward(q, k, v, attn_metadata, forward_args=forward_args)
-            return output
+            return self._msa_attention_core(q, k, v, idx_q, idx_k, attn_metadata, output)
+        if self.is_sparse_attention_layer:
+            assert idx_q is not None and idx_k is not None
+            return self._triton_sparse_attention_core(q, k, v, idx_q, idx_k, attn_metadata, output)
+        assert idx_q is None and idx_k is None
+        return self._sdpa_dense_attention_core(q, k, v, attn_metadata, output)
+
+    def _msa_attention_core(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        idx_q: Optional[torch.Tensor],
+        idx_k: Optional[torch.Tensor],
+        attn_metadata: AttentionMetadata,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run the MSA backend (:class:`MiniMaxM3MsaSparseAttention`).
+
+        The backend runs the sparse GQA or dense paged GQA through its inherited
+        FMHA forward; this layer selects the top-k blocks (sparse only) and
+        builds the forward_args the FMHA reads.
+        """
+        if self.is_sparse_attention_layer:
+            assert idx_q is not None and idx_k is not None
+            # Publish the selected blocks so the FMHA runs the sparse path.
+            kv_block_indexes = self.attn.run_indexer(idx_q, idx_k, attn_metadata)
+            forward_args = AttentionForwardArgs(output=output, topk_indices=kv_block_indexes)
         else:
-            if self.is_sparse_attention_layer:
-                assert idx_q is not None and idx_k is not None
-                return self._sparse_attention_core(q, k, v, idx_q, idx_k, attn_metadata, output)
             assert idx_q is None and idx_k is None
-            return self._dense_attention_core(q, k, v, attn_metadata, output)
+            # No top-k selection means the FMHA attends the full page table.
+            forward_args = AttentionForwardArgs(output=output)
+        self.attn.forward(q, k, v, attn_metadata, forward_args=forward_args)
+        return output
 
     def _sparse_forward(
         self,
@@ -1211,7 +1241,7 @@ class MiniMaxM3Attention(Attention):
         o = self._forward_attention_core(q, k, v, idx_q, idx_k, attn_metadata)
         return self.o_proj(o)
 
-    def _sparse_attention_core(
+    def _triton_sparse_attention_core(
         self,
         q: torch.Tensor,
         k: torch.Tensor,

--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -35,6 +35,8 @@ class GatedMLP(nn.Module):
         use_custom_cublas_mm: bool = False,
         is_shared_expert: bool = False,
         swiglu_limit: Optional[float] = None,
+        swiglu_alpha: Optional[float] = None,
+        swiglu_beta: Optional[float] = None,
     ):
 
         super().__init__()
@@ -45,6 +47,12 @@ class GatedMLP(nn.Module):
         self.use_cute_dsl_blockscaling_mm = use_cute_dsl_blockscaling_mm
         self.swiglu_limit = float(
             swiglu_limit) if swiglu_limit is not None else None
+        # SwiGLU-OAI shape parameters, left None for plain SwiGLU, where the
+        # kernel defaults to alpha=1.0 and beta=0.0.
+        self.swiglu_alpha = float(
+            swiglu_alpha) if swiglu_alpha is not None else None
+        self.swiglu_beta = float(
+            swiglu_beta) if swiglu_beta is not None else None
 
         config = config or ModelConfig()
         use_cute_dsl_bf16_gemm = getattr(config, "use_cute_dsl_bf16_gemm",
@@ -167,14 +175,22 @@ class GatedMLP(nn.Module):
                     logger.warning(
                         f"GatedMLP._apply_activation: LoRA path active; forcing non-FP8 activation dtype bf16/fp16, layer_idx={self.layer_idx}"
                     )
-                    return swiglu(x, swiglu_limit=self.swiglu_limit)
+                    return swiglu(x,
+                                  swiglu_limit=self.swiglu_limit,
+                                  swiglu_alpha=self.swiglu_alpha,
+                                  swiglu_beta=self.swiglu_beta)
                 else:
                     return swiglu(x,
                                   quant_scale=self.down_proj.input_scale,
                                   quant_type=torch.float8_e4m3fn,
-                                  swiglu_limit=self.swiglu_limit)
+                                  swiglu_limit=self.swiglu_limit,
+                                  swiglu_alpha=self.swiglu_alpha,
+                                  swiglu_beta=self.swiglu_beta)
             else:
-                return swiglu(x, swiglu_limit=self.swiglu_limit)
+                return swiglu(x,
+                              swiglu_limit=self.swiglu_limit,
+                              swiglu_alpha=self.swiglu_alpha,
+                              swiglu_beta=self.swiglu_beta)
         elif callable(self.activation):
             return self.activation(x)
         elif self.activation is None:
@@ -184,17 +200,26 @@ class GatedMLP(nn.Module):
                 f"Activation {self.activation} not yet implemented for fused GatedMLP"
             )
 
+    def _is_plain_swiglu(self):
+        """True when the SwiGLU has no alpha gain or (up + beta) offset.
+
+        The fused CuteDSL GEMM+SwiGLU epilogue implements plain silu(gate) * up
+        only; a swigluoai-style alpha/beta must use the Triton swiglu kernel.
+        """
+        return ((self.swiglu_alpha is None or self.swiglu_alpha == 1.0)
+                and (self.swiglu_beta is None or self.swiglu_beta == 0.0))
+
     def _can_fuse_gate_up_swiglu(self):
         """Check if fused GEMM + SwiGLU path is available.
 
         Returns True when all conditions are met:
         - CuteDSL blockscaling mode is enabled (implies Blackwell + CuteDSL)
-        - Activation is SwiGLU (F.silu)
+        - Activation is plain SwiGLU (F.silu), see _is_plain_swiglu
         - gate_up_proj uses NVFP4 quantization
         - gate_up_proj has no bias (bias not supported in fused kernel)
         """
         return (self.use_cute_dsl_blockscaling_mm and self.activation == F.silu
-                and self.gate_up_proj.has_nvfp4
+                and self._is_plain_swiglu() and self.gate_up_proj.has_nvfp4
                 and not self.gate_up_proj.has_bias)
 
     def _can_fuse_gate_up_swiglu_fp4out(self):

--- a/tensorrt_llm/_torch/modules/swiglu.py
+++ b/tensorrt_llm/_torch/modules/swiglu.py
@@ -27,7 +27,8 @@ def scale_and_clamp(x, scale, dtype):
 
 @triton.jit
 def silu_and_mul_kernel(o_ptr, o_stride, o_scale_ptr, x_ptr, x_stride, d,
-                        swiglu_limit: tl.constexpr, BLOCK_SIZE: tl.constexpr,
+                        swiglu_limit: tl.constexpr, swiglu_alpha: tl.constexpr,
+                        swiglu_beta: tl.constexpr, BLOCK_SIZE: tl.constexpr,
                         HAS_O_SCALE: tl.constexpr,
                         HAS_SWIGLU_LIMIT: tl.constexpr) -> None:
     i = tl.program_id(axis=0).to(tl.int64)
@@ -43,10 +44,15 @@ def silu_and_mul_kernel(o_ptr, o_stride, o_scale_ptr, x_ptr, x_stride, d,
     b = tl.load(x_row_ptr + offsets + d, mask=mask).to(tl.float32)
 
     if HAS_SWIGLU_LIMIT:
+        # Gate clamp is upper-side only, up clamp is symmetric, as both plain
+        # SwiGLU-with-limit and the SGLang swigluoai activation require.
         a = tl.minimum(a, swiglu_limit)
         b = tl.clamp(b, -swiglu_limit, swiglu_limit)
 
-    result = tl.sigmoid(a) * a * b
+    # swiglu_alpha=1.0, swiglu_beta=0.0 recovers plain silu_and_mul;
+    # swiglu_alpha=1.702, swiglu_beta=1.0 is the swigluoai shape (alpha gain
+    # inside the sigmoid, (up + 1) offset).
+    result = a * tl.sigmoid(swiglu_alpha * a) * (b + swiglu_beta)
 
     if HAS_O_SCALE:
         o_scale = tl.load(o_scale_ptr)
@@ -58,7 +64,9 @@ def silu_and_mul_kernel(o_ptr, o_stride, o_scale_ptr, x_ptr, x_stride, d,
 def swiglu(x,
            quant_scale: Optional[torch.Tensor] = None,
            quant_type=None,
-           swiglu_limit: Optional[float] = None):
+           swiglu_limit: Optional[float] = None,
+           swiglu_alpha: Optional[float] = None,
+           swiglu_beta: Optional[float] = None):
     if quant_scale is not None:
         assert quant_type is not None
         return torch.ops.trtllm.silu_and_mul(
@@ -66,6 +74,11 @@ def swiglu(x,
             scale=quant_scale,
             dtype=quant_type,
             swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
         )
 
-    return torch.ops.trtllm.silu_and_mul(x, swiglu_limit=swiglu_limit)
+    return torch.ops.trtllm.silu_and_mul(x,
+                                         swiglu_limit=swiglu_limit,
+                                         swiglu_alpha=swiglu_alpha,
+                                         swiglu_beta=swiglu_beta)

--- a/tests/unittest/_torch/models/test_minimax_m3.py
+++ b/tests/unittest/_torch/models/test_minimax_m3.py
@@ -38,6 +38,7 @@ from tensorrt_llm._torch.models.checkpoints.hf.minimaxm3_weight_mapper import (
 from tensorrt_llm._torch.models.modeling_minimaxm3 import (
     MiniMaxM3Attention,
     _build_swiglu_oai_dense_mlp,
+    _minimax_m3_swiglu_oai,
     _strip_language_model_prefix,
     _wrap_dict_as_config,
     get_moe_layer_ids,
@@ -978,3 +979,44 @@ def test_minimax_m3_swiglu_oai_dense_mlp_under_adp_is_replicated():
         "ADP down_proj must skip the cross-rank all-reduce; otherwise it "
         "mixes outputs across independent rank-local token sets"
     )
+
+
+# ---------------------------------------------------------------------------
+# Fused SwiGLU-OAI numeric equivalence
+# ---------------------------------------------------------------------------
+#
+# The dense MLP and MoE shared expert express swigluoai as plain SwiGLU with
+# (alpha, beta, limit) so it routes through the fused silu_and_mul kernel.
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not _has_cuda(), reason="fused silu_and_mul Triton kernel requires CUDA")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_minimax_m3_swiglu_oai_fused_matches_reference(dtype):
+    """Fused silu_and_mul with (alpha, beta, limit) matches the eager reference.
+
+    Also checks that alpha=1 and beta=0 recover plain SwiGLU.
+    """
+    from tensorrt_llm._torch.modules.swiglu import swiglu
+
+    torch.manual_seed(0)
+    alpha, limit = 1.702, 7.0
+    # Wide range so both clamp branches (gate upper, up symmetric) are hit.
+    gate_up = torch.randn(64, 2 * 128, device="cuda", dtype=dtype) * 6.0
+
+    ref = _minimax_m3_swiglu_oai(gate_up, alpha=alpha, limit=limit)
+    fused = swiglu(gate_up, swiglu_alpha=alpha, swiglu_beta=1.0, swiglu_limit=limit)
+
+    assert fused.shape == ref.shape
+    assert fused.dtype == gate_up.dtype
+    # fp32 accumulation inside the kernel; loose tol for bf16 rounding.
+    atol = 2e-2 if dtype == torch.bfloat16 else 1e-4
+    torch.testing.assert_close(fused.float(), ref.float(), atol=atol, rtol=1e-2)
+
+    # alpha=1 / beta=0 reduces to plain SwiGLU: silu(gate_clamped) * up_clamped.
+    gate, up = gate_up.chunk(2, dim=-1)
+    gate_c = gate.clamp(max=limit)
+    up_c = up.clamp(min=-limit, max=limit)
+    plain_ref = torch.nn.functional.silu(gate_c) * up_c
+    plain = swiglu(gate_up, swiglu_limit=limit)
+    torch.testing.assert_close(plain.float(), plain_ref.float(), atol=atol, rtol=1e-2)


### PR DESCRIPTION
## Description

This MR enables fusion of activation in dense MLP and shared router modules for MinimaxM3. It doesn't happen automatically because of the activation type. This MR takes care of that.

## Test Coverage
```
$ pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=True] -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Added parameterized SwiGLU support to the custom op, Triton kernel, and `GatedMLP`.
- Updated fusion checks to restrict fused gate/up SwiGLU to compatible plain-SwiGLU parameters.
- Refactored MiniMax-M3 attention dispatch across MSA, Triton sparse, and SDPA dense backends.
- Added fused MiniMax-M3 dense MLP construction and NVFP4/MSA accuracy coverage.
- No configuration or test-list changes were identified.

## QA Engineer Review

- Added `test_minimax_m3_swiglu_oai_fused_matches_reference`, covering bfloat16 and float32 fused-vs-reference results and plain SwiGLU equivalence.
- The test is not listed in the discovered `test-db/` or `qa/` integration test lists.
- Existing MiniMax-M3 NVFP4 with `use_msa=True` coverage is present in `test-db/l0_dgx_b200.yml` and `qa/llm_function_core.txt`.

**Verdict: needs follow-up**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->