### PR TITLE
[None][infra] add pst2154 to Blossom CI allowlist

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -277,6 +277,7 @@ jobs:
         "PerkzZheng",
         "poweiw",
         "pranav-nvidia",
+        "pst2154",
         "qiangxu1996",
         "qiaoxj07",
         "QiJune",


### PR DESCRIPTION
## Description

Add `pst2154` to the Blossom CI authorization list so PR CI pipelines can be triggered directly with `/bot run`.

## Test Coverage

- `pre-commit run --files .github/workflows/blossom-ci.yml`
- `git diff --check`

## PR Checklist

- [x] Reviewed the checklist; this is a one-line CI authorization update with no API, dependency, ownership, documentation, or architecture changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `pst2154` to the Blossom CI authorization allowlist, enabling their `/bot run` and related workflow commands.

## Dev Engineer Review

- Correctly scopes the change to the workflow allowlist.
- No exported APIs, performance concerns, or error-handling changes.
- Configuration syntax and formatting validation passed.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->