### PR TITLE
[TRTLLM-13948][feat] Set DeepSeekV3 to use Python KV-cache transceiver V2 by default

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1897,25 +1897,14 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
     def get_preferred_transceiver_runtime(cls,
                                           pretrained_config: Any = None
                                           ) -> Optional[Literal["PYTHON"]]:
-        """GLM-5 family checkpoints default to the Python (v2) KV-cache transceiver.
+        """``DeepseekV3ForCausalLM``, ``DeepseekV32ForCausalLM``, and ``GlmMoeDsaForCausalLM`` all prefer the Python (v2) KV-cache transceiver.
 
-        This implementation class is shared by DeepSeek-V3/V3.2 and the GLM-5 family — both
-        GLM-5 and GLM-5.2 declare ``GlmMoeDsaForCausalLM`` / ``glm_moe_dsa`` — so the preference
-        is differentiated per checkpoint: only GLM checkpoints opt into the Python transceiver.
-        The MLA backbone transfers a large latent KV, which the Python transceiver handles better
-        in disaggregated serving. This is only adopted when the user leaves
-        ``cache_transceiver_config.transceiver_runtime`` at 'auto' and the effective backend is
-        NIXL; otherwise the C++ transceiver is used.
+        All three use MLA attention (``DeepseekV3Attention`` and ``DeepseekV32Attention`` both
+        extend ``MLA``), which transfers a large latent KV that the Python transceiver handles
+        better in disaggregated serving. Applied only when ``transceiver_runtime`` is 'auto'
+        and the backend is NIXL.
         """
-        if pretrained_config is None:
-            return None
-        architectures = getattr(pretrained_config, 'architectures', None) or []
-        # model_type is checked as a fallback: it is 'glm_moe_dsa' on GLM
-        # checkpoints until __init__ rewrites it to 'deepseek_v32'.
-        if ("GlmMoeDsaForCausalLM" in architectures or getattr(
-                pretrained_config, 'model_type', None) == 'glm_moe_dsa'):
-            return "PYTHON"
-        return None
+        return "PYTHON"
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
         self.mapping_with_cp = None

--- a/tests/scripts/perf-sanity/disaggregated/Untitled
+++ b/tests/scripts/perf-sanity/disaggregated/Untitled
@@ -1,1 +1,0 @@
-gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml

--- a/tests/scripts/perf-sanity/disaggregated/Untitled
+++ b/tests/scripts/perf-sanity/disaggregated/Untitled
@@ -1,0 +1,1 @@
+gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -64,6 +64,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: CPP
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -91,6 +92,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: CPP
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,6 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: CPP
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -90,5 +91,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: CPP
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -75,6 +75,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: CPP
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: &id001
@@ -102,6 +103,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
+      transceiver_runtime: CPP
       kv_transfer_timeout_ms: 600000
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -74,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: CPP
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: MTP
@@ -101,5 +102,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
+      transceiver_runtime: CPP
     disable_overlap_scheduler: true
     speculative_config: *id001

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -3775,21 +3775,22 @@ class TestDeepseekTransceiverPreference:
         (["DeepseekV3ForCausalLM"], "deepseek_v3"),
         (["DeepseekV32ForCausalLM"], "deepseek_v32"),
     ])
-    def test_preference_per_architecture(self, architectures, model_type):
+    def test_preference_per_architecture(self, architectures: list[str],
+                                         model_type: str) -> None:
         from tensorrt_llm._torch.models.modeling_deepseekv3 import \
             DeepseekV3ForCausalLM
         cfg = self._pretrained_config(architectures, model_type)
         assert DeepseekV3ForCausalLM.get_preferred_transceiver_runtime(
             cfg) == "PYTHON"
 
-    def test_prefers_python_without_config(self):
+    def test_prefers_python_without_config(self) -> None:
         """Preference is unconditional without a pretrained config."""
         from tensorrt_llm._torch.models.modeling_deepseekv3 import \
             DeepseekV3ForCausalLM
         assert DeepseekV3ForCausalLM.get_preferred_transceiver_runtime(
         ) == "PYTHON"
 
-    def test_deepseek_resolves_auto_to_python_on_nixl(self):
+    def test_deepseek_resolves_auto_to_python_on_nixl(self) -> None:
         """DeepseekV3ForCausalLM on NIXL adopts the Python transceiver from 'auto'."""
         from tensorrt_llm._torch.models.modeling_deepseekv3 import \
             DeepseekV3ForCausalLM

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -3760,13 +3760,8 @@ class TestTransceiverRuntimeAutoResolution:
             backend="UCX")._resolve_default_backend() == ("UCX", None)
 
 
-class TestGlm5TransceiverPreference:
-    """GLM-5 defaults to the Python KV-cache transceiver in disagg.
-
-    DeepseekV3ForCausalLM is shared by DeepSeek-V3/V3.2 and GLM-5
-    (GlmMoeDsaForCausalLM); the preference must apply to GLM checkpoints
-    only.
-    """
+class TestDeepseekTransceiverPreference:
+    """DeepseekV3ForCausalLM, DeepseekV32ForCausalLM, and GlmMoeDsaForCausalLM all prefer the Python KV-cache transceiver."""
 
     @staticmethod
     def _pretrained_config(architectures, model_type):
@@ -3775,43 +3770,33 @@ class TestGlm5TransceiverPreference:
         cfg.model_type = model_type
         return cfg
 
-    @pytest.mark.parametrize(
-        "architectures,model_type,expected",
-        [
-            (["GlmMoeDsaForCausalLM"], "glm_moe_dsa", "PYTHON"),
-            (["DeepseekV3ForCausalLM"], "deepseek_v3", None),
-            (["DeepseekV32ForCausalLM"], "deepseek_v32", None),
-            # Each predicate in isolation: the architecture match and the
-            # model_type fallback must each suffice on their own.
-            (["GlmMoeDsaForCausalLM"], "deepseek_v32", "PYTHON"),
-            (["DeepseekV32ForCausalLM"], "glm_moe_dsa", "PYTHON"),
-        ])
-    def test_preference_per_architecture(self, architectures, model_type,
-                                         expected):
+    @pytest.mark.parametrize("architectures,model_type", [
+        (["GlmMoeDsaForCausalLM"], "glm_moe_dsa"),
+        (["DeepseekV3ForCausalLM"], "deepseek_v3"),
+        (["DeepseekV32ForCausalLM"], "deepseek_v32"),
+    ])
+    def test_preference_per_architecture(self, architectures, model_type):
         from tensorrt_llm._torch.models.modeling_deepseekv3 import \
             DeepseekV3ForCausalLM
         cfg = self._pretrained_config(architectures, model_type)
         assert DeepseekV3ForCausalLM.get_preferred_transceiver_runtime(
-            cfg) == expected
+            cfg) == "PYTHON"
 
-    def test_no_config_defers_to_cpp(self):
-        """Without a pretrained config the class defers to the C++ default."""
+    def test_prefers_python_without_config(self):
+        """Preference is unconditional without a pretrained config."""
         from tensorrt_llm._torch.models.modeling_deepseekv3 import \
             DeepseekV3ForCausalLM
-        assert DeepseekV3ForCausalLM.get_preferred_transceiver_runtime() is None
+        assert DeepseekV3ForCausalLM.get_preferred_transceiver_runtime(
+        ) == "PYTHON"
 
-    def test_glm5_resolves_auto_to_python_on_nixl(self):
-        """GLM-5 on NIXL adopts the Python transceiver from 'auto'.
-
-        End-to-end through _resolve_transceiver_runtime_auto with the real
-        model class and a GLM pretrained config.
-        """
+    def test_deepseek_resolves_auto_to_python_on_nixl(self):
+        """DeepseekV3ForCausalLM on NIXL adopts the Python transceiver from 'auto'."""
         from tensorrt_llm._torch.models.modeling_deepseekv3 import \
             DeepseekV3ForCausalLM
         args = TorchLlmArgs(
             model="/tmp/dummy_model",
             cache_transceiver_config=CacheTransceiverConfig(backend="NIXL"),
         )
-        cfg = self._pretrained_config(["GlmMoeDsaForCausalLM"], "glm_moe_dsa")
+        cfg = self._pretrained_config(["DeepseekV3ForCausalLM"], "deepseek_v3")
         _resolve_transceiver_runtime_auto(args, DeepseekV3ForCausalLM, cfg)
         assert args.cache_transceiver_config.transceiver_runtime == "PYTHON"


### PR DESCRIPTION

## Description

Built on top of https://github.com/NVIDIA/TensorRT-LLM/pull/16344/ and https://github.com/NVIDIA/TensorRT-LLM/pull/16669 (per-model transceiver runtime auto selection): opt DeepSeekV3.2/R1/V3-Lite into the Python KV-cache transceiver by default.

DeepseekV32ForCausalLM and DeepseekV3ForCausalLM now overrides get_preferred_transceiver_runtime() to return "PYTHON". Disaggregated deployments that leave transceiver_runtime at its default auto (backend NIXL/DEFAULT) use the Python transceiver (KvCacheTransceiverV2) out of the box. Explicit user settings always take precedence, and incompatible backends fall back to the C++ transceiver per the https://github.com/NVIDIA/TensorRT-LLM/pull/16164 resolution semantics. No effect on non-disaggregated deployments.

Additionally set the below configs to use the CPP Transceiver while PR https://github.com/NVIDIA/TensorRT-LLM/pull/16834/ addresses the perf regression observed during migration of the transceiver from CPP to PYTHON. 
```
gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
```

## Test Coverage

- Updates the test class `TestGlm5TransceiverPreference` to `TestDeepseekTransceiverPreference`
- Updates the following tests: `test_preference_per_architecture`
- Replaces the following tests: `test_no_config_defers_to_cpp` -> `test_prefers_python_without_config` and `test_glm5_resolves_auto_to_python_on_nixl` -> `test_deepseek_resolves_auto_to_python_on_nixl`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- DeepSeek V3, V3.2, and GLM MoE DSA now consistently prefer the Python KV-cache transceiver under automatic runtime selection.
- Explicit runtime settings remain respected, while incompatible backends can fall back appropriately; non-disaggregated deployments are unaffected.
- Updated unit tests cover supported architectures, missing configuration, and DeepSeek-on-NIXL resolution.
- Four DeepSeek R1 disaggregated benchmark configurations explicitly select `transceiver_runtime: CPP` for both context and generation workers, preserving the intended performance baseline.
- No apparent API, error-handling, or configuration consistency issues were identified.

## QA Engineer Review

- Modified test code: transceiver preference tests in `tests/unittest/llmapi/test_llm_args.py`; the suite was renamed/reworked from GLM-5-focused coverage to DeepSeek/GLM coverage.
- Updated coverage includes:
  - Python runtime preference for supported DeepSeek V3, DeepSeek V3.2, and GLM architectures.
  - Python preference when no pretrained configuration is provided.
  - Automatic DeepSeek-on-NIXL runtime resolution.
- No `tests/integration/test_lists/`, `test-db/`, or `qa/` files were modified, so CI/manual test-list coverage is not represented.
- Reported affected unit tests passed; remaining CI failures were unrelated to this PR.

**Verdict: needs follow-up** — test-list coverage data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->