### PR TITLE
[None][fix] accept NumPy token IDs in executor generate methods

### DIFF
--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -147,7 +147,7 @@ class GenerationExecutor(ABC):
         """Generate output for the given prompt token ids in the asynchronous mode.
         Asynchronous generation accepts single prompt only.
         """
-        assert isinstance(prompt_token_ids[0], int)
+        assert isinstance(prompt_token_ids[0], (int, np.integer))
         assert isinstance(sampling_params, SamplingParams)
 
         self._maybe_initialize_iteration_results()
@@ -194,7 +194,7 @@ class GenerationExecutor(ABC):
         """Generate output for the given prompt token ids in the synchronous mode.
         Synchronous generation accepts either single prompt or batched prompts.
         """
-        unbatched = isinstance(prompt_token_ids[0], int)
+        unbatched = isinstance(prompt_token_ids[0], (int, np.integer))
 
         if unbatched:
             prompt_token_ids = [prompt_token_ids]

--- a/tests/unittest/executor/test_executor_token_inputs.py
+++ b/tests/unittest/executor/test_executor_token_inputs.py
@@ -1,0 +1,60 @@
+# Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from tensorrt_llm.executor.executor import GenerationExecutor
+from tensorrt_llm.executor.request import GenerationRequest
+from tensorrt_llm.executor.result import GenerationResult
+from tensorrt_llm.sampling_params import SamplingParams
+
+
+class _FakeExecutor(GenerationExecutor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.submitted: list[GenerationRequest] = []
+
+    def submit(self, request: GenerationRequest) -> GenerationResult:
+        self.submitted.append(request)
+        return MagicMock()
+
+    def abort_request(self, request_id: int) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.uint32])
+def test_generate_async_accepts_numpy_token_ids(dtype: type[np.integer]) -> None:
+    executor = _FakeExecutor()
+    token_ids = np.array([1, 2, 3], dtype=dtype)
+
+    executor.generate_async(token_ids, SamplingParams(max_tokens=1))
+
+    assert executor.submitted[0].prompt_token_ids == token_ids.tolist()
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.uint32])
+def test_generate_treats_numpy_token_ids_as_unbatched(dtype: type[np.integer]) -> None:
+    executor = _FakeExecutor()
+    token_ids = np.array([1, 2, 3], dtype=dtype)
+
+    result = executor.generate(token_ids, SamplingParams(max_tokens=1))
+
+    assert len(executor.submitted) == 1
+    result.result.assert_called_once_with()


### PR DESCRIPTION
## What changed

- Accept NumPy integer scalars when validating asynchronous token inputs.
- Treat one-dimensional NumPy token arrays as an unbatched synchronous input.
- Add CPU regression tests for `np.int32` and `np.uint32` inputs through both entry points.

## Why

`GenerationRequest` already accepts NumPy arrays, but `GenerationExecutor.generate_async()` checks the first token with `isinstance(token, int)`. NumPy integer scalars do not satisfy that check. The same check in `generate()` consequently misclassifies a one-dimensional NumPy array as a batch.

This is a correctness fix only. It does not change the existing array-to-list normalization or native buffer handling.

Relates to #16910.

## Validation

- `ruff check tests/unittest/executor/test_executor_token_inputs.py`
- `ruff format --check tests/unittest/executor/test_executor_token_inputs.py`
- `python3 -m compileall -q tensorrt_llm/executor/executor.py tests/unittest/executor/test_executor_token_inputs.py`
- `git diff --check`

The focused pytest file could not be collected in the lightweight source checkout because it does not include the TensorRT-LLM development runtime (`torch`, `nvtx`, and compiled bindings). The tests are CPU-only and ready for upstream CI.
