### PR TITLE
[None][fix] Prepare offloaded KV blocks for disagg transfer

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheEventManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheEventManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,9 +68,10 @@ public:
     void exchangeAttentionDpThread();
 
 private:
-    // Add an event to mEventQueue
+    // Add an event to mEventQueue. Caller must hold mEventQueueMutex.
     void enqueueEvent(executor::KVCacheEvent&& event);
 
+    // Flush pending removed events for a window. Caller must hold mEventQueueMutex.
     void flushRemovedEvents(SizeType32 windowSize);
 
     /// @brief Flag to terminate the worker
@@ -94,7 +95,9 @@ private:
     /// @brief Condition variable to notify worker thread
     std::condition_variable mPendingEmptyCV;
 
-    /// @brief Buffer of events waiting to be added to the eventQueue. Only ever accessed by forward pass thread.
+    /// @brief Protects event production before events are flushed to the worker thread.
+    std::mutex mEventQueueMutex;
+    /// @brief Buffer of events waiting to be added to the eventQueue.
     std::deque<executor::KVCacheEvent> mEventQueue;
 
     /// @brief The maximum size of the deque

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -1376,20 +1376,17 @@ private:
     //! \param sequence Sequence which the free block is allocated for
     //! \param wantPlaceholder If true, return a pre-allocated placeholder block instead of a normal block
     //! \param countAllocationStats If true, update request-allocation counters for the returned block
-    //! \param suppressEvents If true, do not emit cache update/remove events while acquiring the block. This is used
-    //! when transfer preparation borrows a scratch primary block for an already-pinned cache block; the cache ownership
-    //! visible to scheduling has not changed, so update/remove events would incorrectly invalidate reusable prefixes.
     [[nodiscard]] BlockPtr getFreeBlock(GenerationRequest& sequence,
         executor::RetentionPriority = executor::KvCacheRetentionConfig::kDefaultRetentionPriority,
         std::optional<std::chrono::milliseconds> durationMs = std::nullopt,
         executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "",
-        bool wantPlaceholder = false, bool countAllocationStats = true, bool suppressEvents = false);
+        bool wantPlaceholder = false, bool countAllocationStats = true);
 
     [[nodiscard]] BlockPtr getFreeBlock(std::optional<LlmRequest::RequestIdType> requestId,
         executor::RetentionPriority = executor::KvCacheRetentionConfig::kDefaultRetentionPriority,
         std::optional<std::chrono::milliseconds> durationMs = std::nullopt,
         executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "",
-        bool wantPlaceholder = false, bool countAllocationStats = true, bool suppressEvents = false);
+        bool wantPlaceholder = false, bool countAllocationStats = true);
 
     void unpinBlocksByIdNoLock(std::vector<KVCacheBlock::IdType> const& blockIds);
 

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -75,6 +75,7 @@ static constexpr SizeType32 kSWAExtraBlock = 1;
 class KVCacheBlock;
 class BlockManager;
 class KVCacheManager;
+class KvCacheTransferLease;
 class KVCacheTransferManager;
 
 using SizeType32 = tensorrt_llm::runtime::SizeType32;
@@ -1200,6 +1201,12 @@ public:
     void onboardBlock(GenerationRequest& sequence, BlockPtr const& offloadBlock,
         executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "");
 
+    //! \brief Pin block IDs and make sure they are resident in primary memory for cache transfer.
+    //! \return Pair of block IDs that were pinned and whether any onboard copies were issued.
+    [[nodiscard]] std::pair<std::vector<KVCacheBlock::IdType>, bool> pinAndOnboardBlocksById(
+        std::vector<KVCacheBlock::IdType> const& blockIds, LlmRequest::RequestIdType requestId,
+        executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "");
+
     //! \brief Bring block from primary to secondary memory.
     //! \details Does nothing if block is already in secondary memory.
     void offloadBlock(BlockPtr const& block, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
@@ -1216,6 +1223,9 @@ public:
 
     //! \brief Sync internal streams used by transfer manager with buffer manager stream
     void syncTransferManagerWithBufferManager();
+
+    //! \brief Make the buffer manager stream wait for scheduled transfer-manager work.
+    void syncTransferManagerToBufferManager();
 
     //! \brief Perform per-request bookkeeping
     void refreshBlocks();
@@ -1352,11 +1362,20 @@ private:
     //! \brief Find block least likely to be reused, free it if necessary and return.
     //! \param sequence Sequence which the free block is allocated for
     //! \param wantPlaceholder If true, return a pre-allocated placeholder block instead of a normal block
+    //! \param countAllocationStats If true, update request-allocation counters for the returned block
     [[nodiscard]] BlockPtr getFreeBlock(GenerationRequest& sequence,
         executor::RetentionPriority = executor::KvCacheRetentionConfig::kDefaultRetentionPriority,
         std::optional<std::chrono::milliseconds> durationMs = std::nullopt,
         executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "",
-        bool wantPlaceholder = false);
+        bool wantPlaceholder = false, bool countAllocationStats = true);
+
+    [[nodiscard]] BlockPtr getFreeBlock(LlmRequest::RequestIdType requestId,
+        executor::RetentionPriority = executor::KvCacheRetentionConfig::kDefaultRetentionPriority,
+        std::optional<std::chrono::milliseconds> durationMs = std::nullopt,
+        executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "",
+        bool wantPlaceholder = false, bool countAllocationStats = true);
+
+    void unpinBlocksByIdNoLock(std::vector<KVCacheBlock::IdType> const& blockIds);
 
     //! \brief Calls KVCacheBlock::freeLeafBlock to remove block from search tree.
     void freeLeafBlock(BlockPtr const& block);
@@ -1579,6 +1598,15 @@ public:
     void pinBlocks(GenerationRequest& sequence);
 
     void unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds);
+
+    //! \brief Unpin window-qualified block IDs across one or more window managers.
+    void unpinBlocksById(std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> const& blockIdsPerWindow);
+
+    //! \brief Pin block IDs and make sure they are primary-resident for cache transfer formatting.
+    [[nodiscard]] KvCacheTransferLease prepareBlocksForTransfer(
+        std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> const& blockIdsPerWindow,
+        LlmRequest::RequestIdType requestId, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
+        std::string const& directory = "");
 
     void releaseLastBlock(GenerationRequest& sequence, SizeType32 windowSize);
 
@@ -1886,6 +1914,9 @@ public:
     //! \brief Sync internal streams used by transfer manager with buffer manager stream
     void syncTransferManagerWithBufferManager();
 
+    //! \brief Make the buffer manager stream wait for scheduled transfer-manager work.
+    void syncTransferManagerToBufferManager();
+
     //! \brief Perform per-request bookkeeping
     void refreshBlocks();
 
@@ -1982,6 +2013,42 @@ private:
     SizeType32 mIndexerKCacheIndexHeadDim{0};
     bool mIndexerKCacheUseFp4{false};
     std::optional<LinearAttentionMetadata> mLinearAttentionMetadata;
+};
+
+class KvCacheTransferLease
+{
+public:
+    KvCacheTransferLease() = default;
+    KvCacheTransferLease(BlockManager& blockManager,
+        std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> blockIdsPerWindow, bool issuedOnboardCopies);
+    ~KvCacheTransferLease();
+
+    KvCacheTransferLease(KvCacheTransferLease const&) = delete;
+    KvCacheTransferLease& operator=(KvCacheTransferLease const&) = delete;
+    KvCacheTransferLease(KvCacheTransferLease&& other) noexcept;
+    KvCacheTransferLease& operator=(KvCacheTransferLease&& other) noexcept;
+
+    [[nodiscard]] std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> const&
+    blockIdsPerWindow() const noexcept
+    {
+        return mBlockIdsPerWindow;
+    }
+
+    [[nodiscard]] bool issuedOnboardCopies() const noexcept
+    {
+        return mIssuedOnboardCopies;
+    }
+
+    //! \brief Make the buffer-manager stream wait on pending onboard copies before transfer formatting reads them.
+    void syncReadyForFormat();
+
+    //! \brief Release transfer pins before the lease object is destroyed.
+    void release();
+
+private:
+    BlockManager* mBlockManager{nullptr};
+    std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> mBlockIdsPerWindow;
+    bool mIssuedOnboardCopies{false};
 };
 
 struct OffsetTableDimensions
@@ -2245,6 +2312,15 @@ public:
         = 0;
 
     virtual void unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds) = 0;
+
+    //! \brief Pin block IDs and make sure they are primary-resident for cache transfer formatting.
+    [[nodiscard]] virtual KvCacheTransferLease prepareBlocksForTransfer(
+        std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> const& blockIdsPerWindow,
+        LlmRequest::RequestIdType requestId, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
+        std::string const& directory = "")
+    {
+        TLLM_THROW("prepareBlocksForTransfer is not implemented for this KV cache manager.");
+    }
 
     /// @brief Release cached blocks for a token sequence beyond a given prefix length.
     /// @param targetTokens The full token sequence whose cached blocks are walked.
@@ -2601,6 +2677,12 @@ public:
     void pinBlocks(LlmRequest::RequestIdType requestId) override;
 
     void unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds) override;
+
+    //! \brief Pin block IDs and make sure they are primary-resident for cache transfer formatting.
+    [[nodiscard]] KvCacheTransferLease prepareBlocksForTransfer(
+        std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> const& blockIdsPerWindow,
+        LlmRequest::RequestIdType requestId, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
+        std::string const& directory = "") override;
 
     [[nodiscard]] executor::RetentionPriority getPriorityByBlockId(
         KVCacheBlock::IdType blockId, SizeType32 windowSize) const override;

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -1227,6 +1227,9 @@ public:
     //! \brief Make the buffer manager stream wait for scheduled transfer-manager work.
     void syncTransferManagerToBufferManager();
 
+    //! \brief Make a formatter buffer-manager stream wait for scheduled onboard work.
+    void syncOnboardTransferManagerToBufferManager(runtime::BufferManager const& bufferManager);
+
     //! \brief Perform per-request bookkeeping
     void refreshBlocks();
 
@@ -1917,6 +1920,9 @@ public:
     //! \brief Make the buffer manager stream wait for scheduled transfer-manager work.
     void syncTransferManagerToBufferManager();
 
+    //! \brief Make a formatter buffer-manager stream wait for scheduled onboard work.
+    void syncOnboardTransferManagerToBufferManager(runtime::BufferManager const& bufferManager);
+
     //! \brief Perform per-request bookkeeping
     void refreshBlocks();
 
@@ -2039,8 +2045,8 @@ public:
         return mIssuedOnboardCopies;
     }
 
-    //! \brief Make the buffer-manager stream wait on pending onboard copies before transfer formatting reads them.
-    void syncReadyForFormat();
+    //! \brief Make the formatter stream wait on pending onboard copies before transfer formatting reads them.
+    void syncReadyForFormat(runtime::BufferManager const& bufferManager);
 
     //! \brief Release transfer pins before the lease object is destroyed.
     void release();
@@ -2318,9 +2324,7 @@ public:
         std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> const& blockIdsPerWindow,
         LlmRequest::RequestIdType requestId, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
         std::string const& directory = "")
-    {
-        TLLM_THROW("prepareBlocksForTransfer is not implemented for this KV cache manager.");
-    }
+        = 0;
 
     /// @brief Release cached blocks for a token sequence beyond a given prefix length.
     /// @param targetTokens The full token sequence whose cached blocks are walked.

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheTransferManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheTransferManager.h
@@ -19,6 +19,8 @@
 #include "tensorrt_llm/runtime/bufferManager.h"
 #include "tensorrt_llm/runtime/cudaEvent.h"
 
+#include <mutex>
+
 namespace tr = tensorrt_llm::runtime;
 namespace kvc = tensorrt_llm::executor::kv_cache;
 
@@ -68,14 +70,21 @@ public:
     //! \brief Synchronize internal streams with bufferManager stream.
     //! \details The buffer manager uses the same stream as the prefill and decode kernels. This method ensures that the
     //! internal kernels used for offloading and onboarding will wait for prefill and decode kernels before performing
-    //! any block copies. This method must be called before the first call to
-    //! KVCacheManager::addSequenceBatch in every step.
+    //! any block copies. This method must be called before the first call to KVCacheManager::addSequenceBatch in every
+    //! step. This is a stream-ordering operation; it does not reset raw-slot transfer dependencies.
     void syncWithBufferManager();
 
     //! \brief Synchronize bufferManager stream with internal streams. This method ensures that prefill and decode
     //! kernels for next step will wait for offloading and onboarding work that has already been scheduled. This method
-    //! must be called after the last call to KVCacheManager::addSequenceBatch in every step.
+    //! must be called after the last call to KVCacheManager::addSequenceBatch in every step. This is a stream-ordering
+    //! operation; it does not reset raw-slot transfer dependencies.
     void syncTransfers();
+
+    //! \brief Make a target buffer-manager stream wait for already-scheduled onboard copies.
+    //! \details This is used by cache-transfer formatting, whose private stream may differ from the KV manager's
+    //! stream. Unlike syncTransfers(), this is not an iteration-boundary API and does not clear pending-transfer
+    //! bookkeeping.
+    void syncOnboardToBufferManager(tr::BufferManager const& bufferManager);
 
     //! \brief Get transfer stats accumulated since last call, and reset the counters.
     [[nodiscard]] KvCacheTransferStats getAndResetTransferStats();
@@ -117,8 +126,12 @@ private:
     runtime::BufferManager mOnboardManager;
     runtime::BufferManager mOffloadManager;
 
-    // Track reads and writes for blocks. Note that it is the pool-qualified memory pool index
-    // that identifies the raw memory blocks involved in I/O, not the block Id.
+    // Track last read and write events for raw memory slots. Note that it is the pool-qualified memory pool index that
+    // identifies the raw memory blocks involved in I/O, not the block Id. These maps are cross-thread dependency state:
+    // they survive iteration-boundary syncs because the C++ transceiver sender can schedule transfers outside the main
+    // scheduler thread. The mutex is mutable so const observers can lock it before reading these maps without changing
+    // the logical transfer-manager state.
+    mutable std::mutex mPendingTransfersMutex;
     std::unordered_map<kernels::KVCacheIndex::UnderlyingType, tr::CudaEvent> mPendingReads;
     std::unordered_map<kernels::KVCacheIndex::UnderlyingType, tr::CudaEvent> mPendingWrites;
     // Reference to parent loopback agent

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
@@ -338,7 +338,8 @@ inline BlockIterator BlockRangeForWindow::begin() const
 }
 
 inline KvCacheTransferLease prepareBlockRangeForTransfer(BaseKVCacheManager& cacheManager, BlockRange const& blockRange,
-    std::vector<SizeType32> const& windowSizes, LlmRequest::RequestIdType requestId)
+    std::vector<SizeType32> const& windowSizes, LlmRequest::RequestIdType requestId,
+    runtime::BufferManager const& bufferManager, LlmRequest const* llmRequest = nullptr)
 {
     auto const& allBlockIdsPerWindow = blockRange.getBlockIdsPerWindow();
     std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> blockIdsPerWindow;
@@ -351,10 +352,17 @@ inline KvCacheTransferLease prepareBlockRangeForTransfer(BaseKVCacheManager& cac
         }
     }
 
-    auto const& sequence = cacheManager.getSequence(requestId);
-    auto transferLease = cacheManager.prepareBlocksForTransfer(
-        blockIdsPerWindow, requestId, sequence.getTransferMode(), sequence.getDirectory());
-    transferLease.syncReadyForFormat();
+    auto mode = executor::KvCacheTransferMode::DRAM;
+    std::string directory;
+    if (llmRequest != nullptr)
+    {
+        requestId = llmRequest->mRequestId;
+        auto const& sequence = cacheManager.getSequence(requestId);
+        mode = sequence.getTransferMode();
+        directory = sequence.getDirectory();
+    }
+    auto transferLease = cacheManager.prepareBlocksForTransfer(blockIdsPerWindow, requestId, mode, directory);
+    transferLease.syncReadyForFormat(bufferManager);
     return transferLease;
 }
 

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
@@ -337,4 +337,25 @@ inline BlockIterator BlockRangeForWindow::begin() const
     return {this, 0};
 }
 
+inline KvCacheTransferLease prepareBlockRangeForTransfer(BaseKVCacheManager& cacheManager, BlockRange const& blockRange,
+    std::vector<SizeType32> const& windowSizes, LlmRequest::RequestIdType requestId)
+{
+    auto const& allBlockIdsPerWindow = blockRange.getBlockIdsPerWindow();
+    std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> blockIdsPerWindow;
+    for (auto const windowSize : windowSizes)
+    {
+        auto const it = allBlockIdsPerWindow.find(windowSize);
+        if (it != allBlockIdsPerWindow.end() && !it->second.empty())
+        {
+            blockIdsPerWindow.emplace(windowSize, it->second);
+        }
+    }
+
+    auto const& sequence = cacheManager.getSequence(requestId);
+    auto transferLease = cacheManager.prepareBlocksForTransfer(
+        blockIdsPerWindow, requestId, sequence.getTransferMode(), sequence.getDirectory());
+    transferLease.syncReadyForFormat();
+    return transferLease;
+}
+
 } // namespace tensorrt_llm::batch_manager::kv_cache_manager

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -425,7 +425,8 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         allWindowSizes.size(), numKvPools, numPools,
         llmRequest.has_value() ? std::to_string((*llmRequest)->mRequestId).c_str() : "<request-free>");
 
-    auto transferLease = prepareBlockRangeForTransfer(*mCacheManager, blockRange, kvWindowSizes, llmRequest.mRequestId);
+    auto transferLease = prepareBlockRangeForTransfer(
+        *mCacheManager, blockRange, kvWindowSizes, session.getRequestId(), bufferManager, llmRequest.value_or(nullptr));
 
     bool layerWise = common::getEnvDisaggLayerwise() && numKvPools == 1;
     if (layerWise)

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -425,6 +425,8 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         allWindowSizes.size(), numKvPools, numPools,
         llmRequest.has_value() ? std::to_string((*llmRequest)->mRequestId).c_str() : "<request-free>");
 
+    auto transferLease = prepareBlockRangeForTransfer(*mCacheManager, blockRange, kvWindowSizes, llmRequest.mRequestId);
+
     bool layerWise = common::getEnvDisaggLayerwise() && numKvPools == 1;
     if (layerWise)
     {

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -530,11 +530,11 @@ public:
             {
                 auto session = cancelFlag != nullptr
                     ? TransferSession(std::vector<Connection const*>(allCounterparts.size(), nullptr),
-                        DataContext{tagFromRequestId(requestId), *cancelFlag}, allCounterparts, mSelfState,
+                        DataContext{tagFromRequestId(requestId), *cancelFlag}, requestId, allCounterparts, mSelfState,
                         info.getTransState(), mBufferManager, info.getIndexFromEnd(), info.getLastBlockKey(), nullptr,
                         !common::getEnvKVCacheTimeOutputPath().empty())
                     : TransferSession(std::vector<Connection const*>(allCounterparts.size(), nullptr),
-                        DataContext{tagFromRequestId(requestId), mTerminate}, allCounterparts, mSelfState,
+                        DataContext{tagFromRequestId(requestId), mTerminate}, requestId, allCounterparts, mSelfState,
                         info.getTransState(), mBufferManager, info.getIndexFromEnd(), info.getLastBlockKey(), nullptr,
                         !common::getEnvKVCacheTimeOutputPath().empty());
                 session.setTime(TransferSession::kTimeRequestInfo);
@@ -1380,11 +1380,11 @@ public:
             auto const& resource = getReceiveCacheResource(llmRequest);
             TransferSession session = perRequestCancel != nullptr
                 ? TransferSession(std::move(allConnections),
-                    DataContext{tagFromRequestId(requestId), *perRequestCancel}, std::move(allCounterparts), mSelfState,
-                    contextState, resource->mBufferManager, requestInfo.getIndexFromEnd(),
+                    DataContext{tagFromRequestId(requestId), *perRequestCancel}, requestId, std::move(allCounterparts),
+                    mSelfState, contextState, resource->mBufferManager, requestInfo.getIndexFromEnd(),
                     requestInfo.getLastBlockKey(), &llmRequest, !common::getEnvKVCacheTimeOutputPath().empty())
                 : TransferSession(std::move(allConnections), DataContext{tagFromRequestId(requestId), mTerminate},
-                    std::move(allCounterparts), mSelfState, contextState, resource->mBufferManager,
+                    requestId, std::move(allCounterparts), mSelfState, contextState, resource->mBufferManager,
                     requestInfo.getIndexFromEnd(), requestInfo.getLastBlockKey(), &llmRequest,
                     !common::getEnvKVCacheTimeOutputPath().empty());
             if (!recvHolders.empty())

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
@@ -85,12 +85,14 @@ public:
     };
 
     TransferSession(std::vector<Connection const*> connections, DataContext dataContext,
-        std::vector<SizeType32> counterPartRanks, executor::DataTransceiverState const& selfState,
-        executor::DataTransceiverState otherState, runtime::BufferManager const& bufferManager, int32_t indexFromEnd,
-        BlockKey const& lastBlockKey, LlmRequest const* llmRequest = nullptr, bool recordTiming = false)
+        LlmRequest::RequestIdType requestId, std::vector<SizeType32> counterPartRanks,
+        executor::DataTransceiverState const& selfState, executor::DataTransceiverState otherState,
+        runtime::BufferManager const& bufferManager, int32_t indexFromEnd, BlockKey const& lastBlockKey,
+        LlmRequest const* llmRequest = nullptr, bool recordTiming = false)
         : mConnections(std::move(connections))
         , mCounterPartRanks(std::move(counterPartRanks))
         , mDataContext(std::move(dataContext))
+        , mRequestId(requestId)
         , mSelfState(&selfState)
         , mOtherState(std::move(otherState))
         , mBufferManager(&bufferManager)
@@ -123,6 +125,11 @@ public:
     void recv(size_t idx, void* data, size_t size);
 
     [[nodiscard]] std::optional<LlmRequest const*> getLlmRequest() const;
+
+    [[nodiscard]] LlmRequest::RequestIdType getRequestId() const noexcept
+    {
+        return mRequestId;
+    }
 
     // in CacheSender, the LlmRequest is not available until the sendSync is called
     void setLlmRequest(LlmRequest const& llmRequest);
@@ -170,8 +177,9 @@ public:
 
 private:
     std::vector<Connection const*> mConnections;
-    std::vector<SizeType32> mCounterPartRanks;        // Ranks corresponding to mConnections indices
+    std::vector<SizeType32> mCounterPartRanks; // Ranks corresponding to mConnections indices
     DataContext mDataContext;
+    LlmRequest::RequestIdType mRequestId{0};
     executor::DataTransceiverState const* mSelfState; // stored in CacheReceiver/CacheSender
     executor::DataTransceiverState mOtherState;
     runtime::BufferManager const* mBufferManager;

--- a/cpp/tensorrt_llm/batch_manager/kvCacheEventManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheEventManager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,11 +83,13 @@ KVCacheEventManager::~KVCacheEventManager()
 void KVCacheEventManager::enqueueCreatedEvent(
     std::vector<SizeType32> const& numBlocksPerCacheLevel, SizeType32 windowSize)
 {
+    std::lock_guard<std::mutex> lck(mEventQueueMutex);
     enqueueEvent({mEventId++, tle::KVCacheCreatedData{numBlocksPerCacheLevel}, windowSize, mAttentionDpRank});
 }
 
 void KVCacheEventManager::enqueueStoredEvent(std::vector<BlockPtr> const& blocks, SizeType32 windowSize)
 {
+    std::lock_guard<std::mutex> lck(mEventQueueMutex);
     if (blocks.empty())
     {
         return;
@@ -114,6 +116,7 @@ void KVCacheEventManager::enqueueStoredEvent(std::vector<BlockPtr> const& blocks
 
 void KVCacheEventManager::enqueueRemovedEvent(BlockPtr const& block, SizeType32 windowSize)
 {
+    std::lock_guard<std::mutex> lck(mEventQueueMutex);
     auto& latestRemovedEvent = mLatestRemovedEvents[windowSize];
     if (latestRemovedEvent != std::nullopt)
     {
@@ -140,6 +143,7 @@ void KVCacheEventManager::flushRemovedEvents(SizeType32 windowSize)
 
 void KVCacheEventManager::enqueueUpdatedEvent(tle::KVCacheUpdatedData const& data, SizeType32 windowSize)
 {
+    std::lock_guard<std::mutex> lck(mEventQueueMutex);
     enqueueEvent({mEventId++, data, windowSize, mAttentionDpRank});
 }
 
@@ -167,11 +171,15 @@ std::deque<tle::KVCacheEvent> KVCacheEventManager::getEvents(std::optional<std::
 
 void KVCacheEventManager::flush()
 {
-    for (auto const& [windowSize, latestRemovedEvent] : mLatestRemovedEvents)
+    std::deque<tle::KVCacheEvent> eventQueue;
     {
-        flushRemovedEvents(windowSize);
+        std::lock_guard<std::mutex> lck(mEventQueueMutex);
+        for (auto const& [windowSize, latestRemovedEvent] : mLatestRemovedEvents)
+        {
+            flushRemovedEvents(windowSize);
+        }
+        eventQueue = std::exchange(mEventQueue, {});
     }
-    auto eventQueue = std::exchange(mEventQueue, {});
 
     if (eventQueue.empty())
     {

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1317,16 +1317,15 @@ void WindowBlockManager::releaseSubtree(BlockPtr const& block)
 
 BlockPtr WindowBlockManager::getFreeBlock(GenerationRequest& sequence, executor::RetentionPriority priority,
     std::optional<std::chrono::milliseconds> durationMs, executor::KvCacheTransferMode mode,
-    std::string const& directory, bool wantPlaceholder, bool countAllocationStats, bool suppressEvents)
+    std::string const& directory, bool wantPlaceholder, bool countAllocationStats)
 {
     return getFreeBlock(std::optional<LlmRequest::RequestIdType>{sequence.getRequestId()}, priority, durationMs, mode,
-        directory, wantPlaceholder, countAllocationStats, suppressEvents);
+        directory, wantPlaceholder, countAllocationStats);
 }
 
 BlockPtr WindowBlockManager::getFreeBlock(std::optional<LlmRequest::RequestIdType> requestId,
     executor::RetentionPriority priority, std::optional<std::chrono::milliseconds> durationMs,
-    executor::KvCacheTransferMode mode, std::string const& directory, bool wantPlaceholder, bool countAllocationStats,
-    bool suppressEvents)
+    executor::KvCacheTransferMode mode, std::string const& directory, bool wantPlaceholder, bool countAllocationStats)
 {
     std::lock_guard<std::recursive_mutex> lock(mLookupTree->getMutex());
     // eviction policy get free primary block
@@ -1362,7 +1361,7 @@ BlockPtr WindowBlockManager::getFreeBlock(std::optional<LlmRequest::RequestIdTyp
         // swap linear block offsets (i.e. make block the offload block)
         block->swapMemoryPoolBlockOffset(offloadBlock);
 
-        if (!suppressEvents && mEventManager && blockInRadixTree(block))
+        if (mEventManager && blockInRadixTree(block))
         {
             mEventManager->enqueueUpdatedEvent(
                 tle::KVCacheUpdatedData(block->getHash()).cacheLevelUpdated(kPrimaryLevel, kSecondaryLevel),
@@ -1388,7 +1387,7 @@ BlockPtr WindowBlockManager::getFreeBlock(std::optional<LlmRequest::RequestIdTyp
     // detachFromLookupNode must do the same.
     {
         std::lock_guard<std::recursive_mutex> treeLock(mLookupTree->getMutex());
-        if (!suppressEvents && mEventManager && blockInRadixTree(block))
+        if (mEventManager && blockInRadixTree(block))
         {
             mEventManager->enqueueRemovedEvent(block, mWindowSize);
         }
@@ -1531,15 +1530,19 @@ std::pair<std::vector<KVCacheBlock::IdType>, bool> WindowBlockManager::pinAndOnb
                 BlockPtr scratchPrimaryBlock;
                 try
                 {
-                    // Transfer preparation only needs a scratch primary allocation so the offloaded, already-pinned
-                    // block can be read by the formatter/transceiver. Do not emit eviction-style cache events here:
-                    // the logical cached prefix still belongs to the pinned block, and notifying the scheduler would
-                    // make other components treat the reusable prefix as removed.
+                    // Transfer preparation needs a temporary primary block so the formatter can read an offloaded
+                    // block. Use normal allocation semantics here: if capacity pressure requires moving or evicting
+                    // a cached victim, getFreeBlock emits the corresponding Updated/Removed KV-cache event.
                     scratchPrimaryBlock = getFreeBlock(std::nullopt, block->getPriority(), block->getDurationMs(), mode,
-                        directory, /*wantPlaceholder=*/false, /*countAllocationStats=*/false,
-                        /*suppressEvents=*/true);
+                        directory, /*wantPlaceholder=*/false, /*countAllocationStats=*/false);
                     mTransferManager->onboard(block, scratchPrimaryBlock, mPools, 0, mode, directory);
                     block->swapMemoryPoolBlockOffset(scratchPrimaryBlock);
+                    if (mEventManager && blockInRadixTree(block))
+                    {
+                        mEventManager->enqueueUpdatedEvent(
+                            tle::KVCacheUpdatedData(block->getHash()).cacheLevelUpdated(kSecondaryLevel, kPrimaryLevel),
+                            mWindowSize);
+                    }
                 }
                 catch (...)
                 {

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1450,11 +1450,18 @@ std::pair<std::vector<KVCacheBlock::IdType>, bool> WindowBlockManager::pinAndOnb
     std::lock_guard<std::recursive_mutex> lock(mLookupTree->getMutex());
     try
     {
+        auto getValidBlockById = [this](KVCacheBlock::IdType blockId) -> BlockPtr
+        {
+            if (blockId >= 0 && static_cast<size_t>(blockId) >= mAllBlocksById.size())
+            {
+                return nullptr;
+            }
+            return getBlockById(blockId);
+        };
+
         for (auto const blockId : blockIds)
         {
-            TLLM_CHECK_WITH_INFO(blockId >= 0 && static_cast<size_t>(blockId) < mAllBlocksById.size(),
-                "Block id %d is out of range", blockId);
-            auto block = mAllBlocksById[blockId];
+            auto block = getValidBlockById(blockId);
             TLLM_CHECK_WITH_INFO(block != nullptr && block->getBlockId() != KVCacheBlock::kCachedBlocksRootId,
                 "Block id %d is not a valid cache block", blockId);
 
@@ -1464,26 +1471,37 @@ std::pair<std::vector<KVCacheBlock::IdType>, bool> WindowBlockManager::pinAndOnb
             }
             block->incRefCount();
             pinnedBlockIds.push_back(blockId);
+        }
 
+        for (auto const blockId : pinnedBlockIds)
+        {
+            auto block = getValidBlockById(blockId);
+            TLLM_CHECK_WITH_INFO(block != nullptr && block->getBlockId() != KVCacheBlock::kCachedBlocksRootId,
+                "Block id %d is not a valid cache block", blockId);
             if (!block->isPlaceholder() && !block->isPrimary())
             {
-                auto scratchPrimaryBlock = getFreeBlock(requestId, block->getPriority(), block->getDurationMs(), mode,
-                    directory, /*wantPlaceholder=*/false, /*countAllocationStats=*/false);
-                mTransferManager->onboard(block, scratchPrimaryBlock, mPools, 0, mode, directory);
-                block->swapMemoryPoolBlockOffset(scratchPrimaryBlock);
+                BlockPtr scratchPrimaryBlock;
+                try
+                {
+                    scratchPrimaryBlock = getFreeBlock(requestId, block->getPriority(), block->getDurationMs(), mode,
+                        directory, /*wantPlaceholder=*/false, /*countAllocationStats=*/false);
+                    mTransferManager->onboard(block, scratchPrimaryBlock, mPools, 0, mode, directory);
+                    block->swapMemoryPoolBlockOffset(scratchPrimaryBlock);
+                }
+                catch (...)
+                {
+                    if (scratchPrimaryBlock != nullptr)
+                    {
+                        mEvictionPolicy->releaseBlock(scratchPrimaryBlock);
+                    }
+                    throw;
+                }
                 issuedOnboardCopies = true;
                 // Transfer onboarding can consume primary capacity after startScheduling() snapshots
                 // availability. Keep the scheduler-side view conservative for the current iteration.
                 if (mSchedulingNumFreeBlocks > 0)
                 {
                     --mSchedulingNumFreeBlocks;
-                }
-
-                if (mEventManager && blockInRadixTree(block))
-                {
-                    mEventManager->enqueueUpdatedEvent(
-                        tle::KVCacheUpdatedData(block->getHash()).cacheLevelUpdated(kSecondaryLevel, kPrimaryLevel),
-                        mWindowSize);
                 }
                 mEvictionPolicy->releaseBlock(scratchPrimaryBlock);
             }
@@ -2323,6 +2341,19 @@ void BlockManager::syncTransferManagerToBufferManager()
 void WindowBlockManager::syncTransferManagerToBufferManager()
 {
     mTransferManager->syncTransfers();
+}
+
+void BlockManager::syncOnboardTransferManagerToBufferManager(runtime::BufferManager const& bufferManager)
+{
+    for (auto& [_, manager] : mWindowBlockManagers)
+    {
+        manager.syncOnboardTransferManagerToBufferManager(bufferManager);
+    }
+}
+
+void WindowBlockManager::syncOnboardTransferManagerToBufferManager(runtime::BufferManager const& bufferManager)
+{
+    mTransferManager->syncOnboardToBufferManager(bufferManager);
 }
 
 void BlockManager::refreshBlocks()
@@ -3231,11 +3262,11 @@ KvCacheTransferLease& KvCacheTransferLease::operator=(KvCacheTransferLease&& oth
     return *this;
 }
 
-void KvCacheTransferLease::syncReadyForFormat()
+void KvCacheTransferLease::syncReadyForFormat(runtime::BufferManager const& bufferManager)
 {
     if (mBlockManager != nullptr && mIssuedOnboardCopies)
     {
-        mBlockManager->syncTransferManagerToBufferManager();
+        mBlockManager->syncOnboardTransferManagerToBufferManager(bufferManager);
     }
 }
 
@@ -3276,16 +3307,17 @@ void WindowBlockManager::unpinBlocksByIdNoLock(std::vector<KVCacheBlock::IdType>
 {
     for (auto const& blockId : blockIds)
     {
-        TLLM_CHECK_WITH_INFO(blockId >= 0 && static_cast<size_t>(blockId) < mAllBlocksById.size(),
-            "Block id %d is out of range", blockId);
-        auto block = mAllBlocksById[blockId];
-        if (block && block->getBlockId() != KVCacheBlock::kCachedBlocksRootId)
+        BlockPtr block;
+        if (blockId < 0 || static_cast<size_t>(blockId) < mAllBlocksById.size())
         {
-            block->decRefCount();
-            if (!block->hasRefs())
-            {
-                mEvictionPolicy->releaseBlock(block);
-            }
+            block = getBlockById(blockId);
+        }
+        TLLM_CHECK_WITH_INFO(block != nullptr && block->getBlockId() != KVCacheBlock::kCachedBlocksRootId,
+            "Block id %d is not a valid cache block", blockId);
+        block->decRefCount();
+        if (!block->hasRefs())
+        {
+            mEvictionPolicy->releaseBlock(block);
         }
     }
 }

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -38,6 +38,7 @@
 #include "tensorrt_llm/runtime/worldConfig.h"
 
 #include <algorithm>
+#include <exception>
 #include <limits>
 #include <map>
 #include <optional>
@@ -1276,16 +1277,27 @@ void WindowBlockManager::releaseSubtree(BlockPtr const& block)
 
 BlockPtr WindowBlockManager::getFreeBlock(GenerationRequest& sequence, executor::RetentionPriority priority,
     std::optional<std::chrono::milliseconds> durationMs, executor::KvCacheTransferMode mode,
-    std::string const& directory, bool wantPlaceholder)
+    std::string const& directory, bool wantPlaceholder, bool countAllocationStats)
+{
+    return getFreeBlock(
+        sequence.getRequestId(), priority, durationMs, mode, directory, wantPlaceholder, countAllocationStats);
+}
+
+BlockPtr WindowBlockManager::getFreeBlock(LlmRequest::RequestIdType requestId, executor::RetentionPriority priority,
+    std::optional<std::chrono::milliseconds> durationMs, executor::KvCacheTransferMode mode,
+    std::string const& directory, bool wantPlaceholder, bool countAllocationStats)
 {
     std::lock_guard<std::recursive_mutex> lock(mLookupTree->getMutex());
     // eviction policy get free primary block
     auto [block, canOffload] = mEvictionPolicy->getFreeBlock(kPrimaryLevel, wantPlaceholder);
-    if (block->getUniqueTokens().empty())
+    if (countAllocationStats)
     {
-        ++mAllocNewBlocks;
+        if (block->getUniqueTokens().empty())
+        {
+            ++mAllocNewBlocks;
+        }
+        ++mAllocTotalBlocks;
     }
-    ++mAllocTotalBlocks;
     // Offloading is an option only when these conditions are met:
     // 1. Block contains state (evidenced by presence of tokens)
     // 2. Eviction policy indicated block can be offloaded
@@ -1344,7 +1356,7 @@ BlockPtr WindowBlockManager::getFreeBlock(GenerationRequest& sequence, executor:
     // Claim the block in primary block queue
     mEvictionPolicy->claimBlock(block, priority, durationMs);
     TLLM_LOG_DEBUG("%s::getFreeBlock - Block %d is now acquired by sequence %d", mLogPrefix.c_str(),
-        block->getBlockId(), sequence.getRequestId());
+        block->getBlockId(), requestId);
 
     return block;
 }
@@ -1420,6 +1432,70 @@ void WindowBlockManager::onboardBlock(GenerationRequest& sequence, BlockPtr cons
         mEvictionPolicy->releaseBlock(block); // append block to offload queue
                                               // offloadBlock is now in primary memory pool
     }
+}
+
+std::pair<std::vector<KVCacheBlock::IdType>, bool> WindowBlockManager::pinAndOnboardBlocksById(
+    std::vector<KVCacheBlock::IdType> const& blockIds, LlmRequest::RequestIdType requestId,
+    executor::KvCacheTransferMode mode, std::string const& directory)
+{
+    std::vector<KVCacheBlock::IdType> pinnedBlockIds;
+    pinnedBlockIds.reserve(blockIds.size());
+    bool issuedOnboardCopies{false};
+
+    if (blockIds.empty())
+    {
+        return {std::move(pinnedBlockIds), issuedOnboardCopies};
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(mLookupTree->getMutex());
+    try
+    {
+        for (auto const blockId : blockIds)
+        {
+            TLLM_CHECK_WITH_INFO(blockId >= 0 && static_cast<size_t>(blockId) < mAllBlocksById.size(),
+                "Block id %d is out of range", blockId);
+            auto block = mAllBlocksById[blockId];
+            TLLM_CHECK_WITH_INFO(block != nullptr && block->getBlockId() != KVCacheBlock::kCachedBlocksRootId,
+                "Block id %d is not a valid cache block", blockId);
+
+            if (!block->hasRefs())
+            {
+                mEvictionPolicy->claimBlock(block, block->getPriority(), block->getDurationMs());
+            }
+            block->incRefCount();
+            pinnedBlockIds.push_back(blockId);
+
+            if (!block->isPlaceholder() && !block->isPrimary())
+            {
+                auto scratchPrimaryBlock = getFreeBlock(requestId, block->getPriority(), block->getDurationMs(), mode,
+                    directory, /*wantPlaceholder=*/false, /*countAllocationStats=*/false);
+                mTransferManager->onboard(block, scratchPrimaryBlock, mPools, 0, mode, directory);
+                block->swapMemoryPoolBlockOffset(scratchPrimaryBlock);
+                issuedOnboardCopies = true;
+                // Transfer onboarding can consume primary capacity after startScheduling() snapshots
+                // availability. Keep the scheduler-side view conservative for the current iteration.
+                if (mSchedulingNumFreeBlocks > 0)
+                {
+                    --mSchedulingNumFreeBlocks;
+                }
+
+                if (mEventManager && blockInRadixTree(block))
+                {
+                    mEventManager->enqueueUpdatedEvent(
+                        tle::KVCacheUpdatedData(block->getHash()).cacheLevelUpdated(kSecondaryLevel, kPrimaryLevel),
+                        mWindowSize);
+                }
+                mEvictionPolicy->releaseBlock(scratchPrimaryBlock);
+            }
+        }
+    }
+    catch (...)
+    {
+        unpinBlocksByIdNoLock(pinnedBlockIds);
+        throw;
+    }
+
+    return {std::move(pinnedBlockIds), issuedOnboardCopies};
 }
 
 void BlockManager::offloadBlock(
@@ -2236,6 +2312,19 @@ void WindowBlockManager::syncTransferManagerWithBufferManager()
     mTransferManager->syncWithBufferManager();
 }
 
+void BlockManager::syncTransferManagerToBufferManager()
+{
+    for (auto& [_, manager] : mWindowBlockManagers)
+    {
+        manager.syncTransferManagerToBufferManager();
+    }
+}
+
+void WindowBlockManager::syncTransferManagerToBufferManager()
+{
+    mTransferManager->syncTransfers();
+}
+
 void BlockManager::refreshBlocks()
 {
     for (auto& [_, manager] : mWindowBlockManagers)
@@ -3049,6 +3138,118 @@ void WindowBlockManager::unpinBlock(BlockPtr const& block)
     }
 }
 
+void BlockManager::unpinBlocksById(
+    std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> const& blockIdsPerWindow)
+{
+    for (auto const& [windowSize, blockIds] : blockIdsPerWindow)
+    {
+        mWindowBlockManagers.at(windowSize).unpinBlocksById(blockIds);
+    }
+}
+
+KvCacheTransferLease BlockManager::prepareBlocksForTransfer(
+    std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> const& blockIdsPerWindow,
+    LlmRequest::RequestIdType requestId, executor::KvCacheTransferMode mode, std::string const& directory)
+{
+    std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> pinnedBlockIdsPerWindow;
+    bool issuedOnboardCopies{false};
+
+    try
+    {
+        for (auto const& [windowSize, blockIds] : blockIdsPerWindow)
+        {
+            auto [pinnedBlockIds, windowIssuedOnboardCopies]
+                = mWindowBlockManagers.at(windowSize).pinAndOnboardBlocksById(blockIds, requestId, mode, directory);
+            if (!pinnedBlockIds.empty())
+            {
+                pinnedBlockIdsPerWindow.emplace(windowSize, std::move(pinnedBlockIds));
+            }
+            issuedOnboardCopies = issuedOnboardCopies || windowIssuedOnboardCopies;
+        }
+    }
+    catch (...)
+    {
+        unpinBlocksById(pinnedBlockIdsPerWindow);
+        throw;
+    }
+
+    return KvCacheTransferLease(*this, std::move(pinnedBlockIdsPerWindow), issuedOnboardCopies);
+}
+
+KvCacheTransferLease::KvCacheTransferLease(BlockManager& blockManager,
+    std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> blockIdsPerWindow, bool issuedOnboardCopies)
+    : mBlockManager(&blockManager)
+    , mBlockIdsPerWindow(std::move(blockIdsPerWindow))
+    , mIssuedOnboardCopies(issuedOnboardCopies)
+{
+}
+
+KvCacheTransferLease::~KvCacheTransferLease()
+{
+    try
+    {
+        release();
+    }
+    catch (std::exception const& e)
+    {
+        TLLM_LOG_ERROR("Failed to release KV cache transfer lease: %s", e.what());
+    }
+    catch (...)
+    {
+        TLLM_LOG_ERROR("Failed to release KV cache transfer lease: unknown error");
+    }
+}
+
+KvCacheTransferLease::KvCacheTransferLease(KvCacheTransferLease&& other) noexcept
+    : mBlockManager(std::exchange(other.mBlockManager, nullptr))
+    , mBlockIdsPerWindow(std::move(other.mBlockIdsPerWindow))
+    , mIssuedOnboardCopies(std::exchange(other.mIssuedOnboardCopies, false))
+{
+}
+
+KvCacheTransferLease& KvCacheTransferLease::operator=(KvCacheTransferLease&& other) noexcept
+{
+    if (this != &other)
+    {
+        try
+        {
+            release();
+        }
+        catch (std::exception const& e)
+        {
+            TLLM_LOG_ERROR("Failed to release KV cache transfer lease during move assignment: %s", e.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_ERROR("Failed to release KV cache transfer lease during move assignment: unknown error");
+        }
+
+        mBlockManager = std::exchange(other.mBlockManager, nullptr);
+        mBlockIdsPerWindow = std::move(other.mBlockIdsPerWindow);
+        mIssuedOnboardCopies = std::exchange(other.mIssuedOnboardCopies, false);
+    }
+    return *this;
+}
+
+void KvCacheTransferLease::syncReadyForFormat()
+{
+    if (mBlockManager != nullptr && mIssuedOnboardCopies)
+    {
+        mBlockManager->syncTransferManagerToBufferManager();
+    }
+}
+
+void KvCacheTransferLease::release()
+{
+    if (mBlockManager != nullptr && !mBlockIdsPerWindow.empty())
+    {
+        mBlockManager->unpinBlocksById(mBlockIdsPerWindow);
+        mBlockIdsPerWindow.clear();
+    }
+    mBlockManager = nullptr;
+    mIssuedOnboardCopies = false;
+}
+
 void WindowBlockManager::pinBlocks(GenerationRequest& sequence)
 {
     std::lock_guard<std::recursive_mutex> lock(mLookupTree->getMutex());
@@ -3062,12 +3263,17 @@ void WindowBlockManager::pinBlocks(GenerationRequest& sequence)
 
 void WindowBlockManager::unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds)
 {
-    std::lock_guard<std::recursive_mutex> lock(mLookupTree->getMutex());
     if (blockIds.empty())
     {
         return;
     }
 
+    std::lock_guard<std::recursive_mutex> lock(mLookupTree->getMutex());
+    unpinBlocksByIdNoLock(blockIds);
+}
+
+void WindowBlockManager::unpinBlocksByIdNoLock(std::vector<KVCacheBlock::IdType> const& blockIds)
+{
     for (auto const& blockId : blockIds)
     {
         TLLM_CHECK_WITH_INFO(blockId >= 0 && static_cast<size_t>(blockId) < mAllBlocksById.size(),
@@ -3075,7 +3281,11 @@ void WindowBlockManager::unpinBlocksById(std::vector<KVCacheBlock::IdType> const
         auto block = mAllBlocksById[blockId];
         if (block && block->getBlockId() != KVCacheBlock::kCachedBlocksRootId)
         {
-            unpinBlock(block);
+            block->decRefCount();
+            if (!block->hasRefs())
+            {
+                mEvictionPolicy->releaseBlock(block);
+            }
         }
     }
 }
@@ -4046,6 +4256,13 @@ void KVCacheManager::pinBlocks(RequestIdType requestId)
 void KVCacheManager::unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds)
 {
     mBlockManager.unpinBlocksById(blockIds);
+}
+
+KvCacheTransferLease KVCacheManager::prepareBlocksForTransfer(
+    std::unordered_map<SizeType32, std::vector<KVCacheBlock::IdType>> const& blockIdsPerWindow,
+    LlmRequest::RequestIdType requestId, executor::KvCacheTransferMode mode, std::string const& directory)
+{
+    return mBlockManager.prepareBlocksForTransfer(blockIdsPerWindow, requestId, mode, directory);
 }
 
 tle::RetentionPriority KVCacheManager::getPriorityByBlockId(KVCacheBlock::IdType blockId, SizeType32 windowSize) const

--- a/cpp/tensorrt_llm/batch_manager/kvCacheTransferManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheTransferManager.cpp
@@ -290,14 +290,29 @@ void KVCacheTransferManager::copyBlock(BlockPtr const& src, BlockPtr const& dst,
 // As before, syncTransfers() must be called after the last call to KVCacheManager::addSequenceBatch.
 // Failing to do so will lead to corrupted blocks eventually.
 //
+// The pending-access maps intentionally survive syncTransfers() and syncWithBufferManager(). Those APIs order CUDA
+// streams at iteration boundaries, but the C++ transceiver sender may still schedule offload/onboard work from another
+// thread. Keeping the maps as last-access records preserves raw-slot dependencies across both scheduler and sender
+// threads. A completed event is cheap to wait on, and the maps are bounded by the number of raw KV slots touched by
+// transfers.
+//
 
 void KVCacheTransferManager::onboard(BlockPtr const& offloadedBlock, BlockPtr const& block,
     std::vector<KVCacheBlockPool> const& pools, int numTokensToCopy, executor::KvCacheTransferMode mode,
     std::string const& directory)
 {
+    std::lock_guard<std::mutex> lock(mPendingTransfersMutex);
     auto const offloadedBlockIndex = getPendingTransferIndex(offloadedBlock);
     auto const blockIndex = getPendingTransferIndex(block);
 
+    // Wait for any pending reads before reading from offloadedBlock. Reads from
+    // the same raw slot could be scheduled on different transfer streams; serializing
+    // them lets one last-read event conservatively represent all prior reads.
+    auto offloadedBlockPendingReadItr = mPendingReads.find(offloadedBlockIndex);
+    if (offloadedBlockPendingReadItr != mPendingReads.end())
+    {
+        mOnboardManager.getStream().wait(offloadedBlockPendingReadItr->second);
+    }
     // Wait for any pending writes before reading from offloadedBlock
     auto offloadedBlockPendingWriteItr = mPendingWrites.find(offloadedBlockIndex);
     if (offloadedBlockPendingWriteItr != mPendingWrites.end())
@@ -350,9 +365,18 @@ void KVCacheTransferManager::offload(BlockPtr const& block, BlockPtr const& offl
     std::vector<KVCacheBlockPool> const& pools, int numTokensToCopy, executor::KvCacheTransferMode mode,
     std::string const& directory)
 {
+    std::lock_guard<std::mutex> lock(mPendingTransfersMutex);
     auto const blockIndex = getPendingTransferIndex(block);
     auto const offloadBlockIndex = getPendingTransferIndex(offloadBlock);
 
+    // Wait for any pending reads before reading from block. Reads from the same
+    // raw slot could be scheduled on different transfer streams; serializing them
+    // lets one last-read event conservatively represent all prior reads.
+    auto blockPendingReadItr = mPendingReads.find(blockIndex);
+    if (blockPendingReadItr != mPendingReads.end())
+    {
+        mOffloadManager.getStream().wait(blockPendingReadItr->second);
+    }
     // Wait for any pending writes before reading from block
     auto blockPendingWriteItr = mPendingWrites.find(blockIndex);
     if (blockPendingWriteItr != mPendingWrites.end())
@@ -394,6 +418,7 @@ void KVCacheTransferManager::offload(BlockPtr const& block, BlockPtr const& offl
 
 void KVCacheTransferManager::syncWithBufferManager()
 {
+    std::lock_guard<std::mutex> lock(mPendingTransfersMutex);
     tr::CudaEvent readyForOffloadEvent;
     mBufferManager.getStream().record(readyForOffloadEvent);
     mOffloadManager.getStream().wait(readyForOffloadEvent);
@@ -401,14 +426,11 @@ void KVCacheTransferManager::syncWithBufferManager()
     tr::CudaEvent readyForOnboardEvent;
     mBufferManager.getStream().record(readyForOnboardEvent);
     mOnboardManager.getStream().wait(readyForOnboardEvent);
-
-    // Once we synchronize, clear our list of pending transfers.
-    mPendingReads.clear();
-    mPendingWrites.clear();
 }
 
 void KVCacheTransferManager::syncTransfers()
 {
+    std::lock_guard<std::mutex> lock(mPendingTransfersMutex);
     tr::CudaEvent offloadEvent;
     mOffloadManager.getStream().record(offloadEvent);
     mBufferManager.getStream().wait(offloadEvent);
@@ -416,10 +438,14 @@ void KVCacheTransferManager::syncTransfers()
     tr::CudaEvent onboardEvent;
     mOnboardManager.getStream().record(onboardEvent);
     mBufferManager.getStream().wait(onboardEvent);
+}
 
-    // Once we synchronize, clear our list of pending transfers.
-    mPendingReads.clear();
-    mPendingWrites.clear();
+void KVCacheTransferManager::syncOnboardToBufferManager(tr::BufferManager const& bufferManager)
+{
+    std::lock_guard<std::mutex> lock(mPendingTransfersMutex);
+    tr::CudaEvent onboardEvent;
+    mOnboardManager.getStream().record(onboardEvent);
+    bufferManager.getStream().wait(onboardEvent);
 }
 
 KvCacheTransferStats KVCacheTransferManager::getAndResetTransferStats()

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -167,6 +167,7 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
     auto const& windowSizes = blockRange.getWindowSizes();
     TLLM_CHECK_WITH_INFO(
         static_cast<int>(windowSizes.size()) == numPools, "window sizes should be the same as numPools");
+    auto transferLease = prepareBlockRangeForTransfer(*mCacheManager, blockRange, windowSizes, llmRequest.mRequestId);
 
     for (auto transferIndexerKCache : transferringIndexerKCache)
     {

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -167,7 +167,8 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
     auto const& windowSizes = blockRange.getWindowSizes();
     TLLM_CHECK_WITH_INFO(
         static_cast<int>(windowSizes.size()) == numPools, "window sizes should be the same as numPools");
-    auto transferLease = prepareBlockRangeForTransfer(*mCacheManager, blockRange, windowSizes, llmRequest.mRequestId);
+    auto transferLease = prepareBlockRangeForTransfer(
+        *mCacheManager, blockRange, windowSizes, session.getRequestId(), bufferManager, llmRequest.value_or(nullptr));
 
     for (auto transferIndexerKCache : transferringIndexerKCache)
     {

--- a/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
@@ -85,6 +85,8 @@ void RnnCacheFormatter::format(TransferSession& session)
 
     auto const& blockIdsPerWindow = blockRange.getBlockIdsPerWindow();
     auto const allWindowSizes = blockRange.getWindowSizes();
+    std::vector<SizeType32> rnnWindowSizes;
+    rnnWindowSizes.reserve(allWindowSizes.size());
 
     for (auto const& ws : allWindowSizes)
     {
@@ -92,6 +94,14 @@ void RnnCacheFormatter::format(TransferSession& session)
         {
             continue;
         }
+        rnnWindowSizes.push_back(ws);
+    }
+
+    auto transferLease = kv_cache_manager::prepareBlockRangeForTransfer(
+        *mKvCacheManager, blockRange, rnnWindowSizes, llmRequest.mRequestId);
+
+    for (auto const& ws : rnnWindowSizes)
+    {
         auto it = blockIdsPerWindow.find(ws);
         if (it == blockIdsPerWindow.end() || it->second.empty())
         {

--- a/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
@@ -98,7 +98,7 @@ void RnnCacheFormatter::format(TransferSession& session)
     }
 
     auto transferLease = kv_cache_manager::prepareBlockRangeForTransfer(
-        *mKvCacheManager, blockRange, rnnWindowSizes, llmRequest.mRequestId);
+        *mKvCacheManager, blockRange, rnnWindowSizes, session.getRequestId(), bufferManager, &llmRequest);
 
     for (auto const& ws : rnnWindowSizes)
     {

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -69,7 +69,7 @@ std::optional<tensorrt_llm::runtime::ITensor::UniquePtr> from_torch(std::optiona
 class PyKvCacheManager : public tbk::BaseKVCacheManager
 {
 public:
-    NB_TRAMPOLINE(tbk::BaseKVCacheManager, 39);
+    NB_TRAMPOLINE(tbk::BaseKVCacheManager, 40);
 
     // using BaseKVCacheManager::BaseKVCacheManager; // Inherit constructors
     void allocatePools(bool useUvm = false) override
@@ -261,6 +261,14 @@ public:
     void syncTransferManagerWithBufferManager() override
     {
         NB_OVERRIDE_PURE(syncTransferManagerWithBufferManager);
+    }
+
+    tbk::KvCacheTransferLease prepareBlocksForTransfer(
+        std::unordered_map<SizeType32, std::vector<tbk::KVCacheBlock::IdType>> const&, tb::LlmRequest::RequestIdType,
+        tensorrt_llm::executor::KvCacheTransferMode = tensorrt_llm::executor::KvCacheTransferMode::DRAM,
+        std::string const& = "") override
+    {
+        TLLM_THROW("prepareBlocksForTransfer is not supported by Python KV cache manager overrides.");
     }
 
     void refreshBlocks() override

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -50,6 +50,7 @@
 #include <set>
 #include <sys/types.h>
 #include <thread>
+#include <tuple>
 #include <unistd.h>
 #include <variant>
 
@@ -5124,6 +5125,245 @@ TEST_F(KVCacheManagerTest, DisaggTransferBlockRangePreparationOnboardsOffloadedB
 
     tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*setup.llmRequest);
     (void) kvCacheManager.removeSequence(setup.llmRequest->mRequestId, setup.llmRequest);
+}
+
+namespace
+{
+struct DisaggTransferScratchPressureSetup
+{
+    std::unique_ptr<KVCacheManager> kvCacheManager;
+    std::shared_ptr<LlmRequest> sourceRequest;
+    std::shared_ptr<LlmRequest> consumerRequest2;
+    std::shared_ptr<LlmRequest> consumerRequest3;
+    BlockPtr sourceBlock;
+    KVCacheBlock::IdType sourceBlockId{};
+    BlockPtr victimBlock;
+    size_t victimHash{};
+    SizeType32 maxAttentionWindow{};
+};
+
+DisaggTransferScratchPressureSetup makeDisaggTransferScratchPressureSetup(SizeType32 blocksInSecondaryPool)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr sizePerHead = 16;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimaryPool = 3;
+    auto constexpr maxNumSequences = 8;
+    auto constexpr beamWidth = 1;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const maxAttentionWindow = tokensPerBlock * blocksInPrimaryPool;
+    BlocksPerWindow const blocksPerWindow{{maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}}};
+
+    auto kvCacheManager = std::make_unique<KVCacheManager>(numLayers, numKvHeads, sizePerHead, tokensPerBlock,
+        blocksPerWindow, maxNumSequences, beamWidth, std::vector<BlockManager::SizeType32>{maxAttentionWindow},
+        tensorrt_llm::DataType::kHALF, 0, stream, maxAttentionWindow, maxAttentionWindow, true, CacheType::kSELF,
+        std::nullopt, std::make_unique<tlk::KVCacheEventManager>(1024));
+    kvCacheManager->allocatePools(false);
+    (void) getEvents(*kvCacheManager);
+
+    auto& blockManager = tensorrt_llm::testing::KvCacheManagerTestUtil::mutableBlockManager(*kvCacheManager);
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+
+    auto makeRequest = [&](LlmRequest::RequestIdType requestId, TokenIdType firstToken)
+    {
+        auto inputTokens = std::make_shared<VecTokens>(VecTokens{firstToken, static_cast<TokenIdType>(firstToken + 1),
+            static_cast<TokenIdType>(firstToken + 2), static_cast<TokenIdType>(firstToken + 3)});
+        auto request = std::make_shared<LlmRequest>(requestId, 0, inputTokens, samplingConfig, isStreaming);
+        return std::make_tuple(std::move(request), std::move(inputTokens));
+    };
+
+    auto [victimRequest, victimTokens] = makeRequest(0, 0);
+    victimRequest->setKvCacheRetentionConfig(tle::KvCacheRetentionConfig(
+        std::vector{tle::KvCacheRetentionConfig::TokenRangeRetentionConfig(0, std::nullopt, 90)}, 90));
+    kvCacheManager->addSequenceBatch(
+        {{{0, static_cast<SizeType32>(victimTokens->size()), beamWidth}}}, {std::ref(*victimRequest)});
+    auto const victimBlockId = kvCacheManager->getCacheBlockIds(0, maxAttentionWindow)[0].front();
+    auto victimBlock = blockManager.getBlockById(victimBlockId, maxAttentionWindow);
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*victimRequest);
+    (void) kvCacheManager->removeSequence(0, victimRequest);
+    (void) getEvents(*kvCacheManager);
+
+    TLLM_CHECK(victimBlock != nullptr);
+    TLLM_CHECK(victimBlock->isPrimary());
+    TLLM_CHECK(!victimBlock->isDetached());
+    TLLM_CHECK(!victimBlock->getUniqueTokens().empty());
+    auto const victimHash = victimBlock->getHash();
+
+    auto [sourceRequest, sourceTokens] = makeRequest(1, 100);
+    kvCacheManager->addSequenceBatch(
+        {{{1, static_cast<SizeType32>(sourceTokens->size()), beamWidth}}}, {std::ref(*sourceRequest)});
+    auto const sourceBlockId = kvCacheManager->getCacheBlockIds(1, maxAttentionWindow)[0].front();
+    auto sourceBlock = blockManager.getBlockById(sourceBlockId, maxAttentionWindow);
+    TLLM_CHECK(sourceBlock != nullptr);
+    TLLM_CHECK(sourceBlockId != victimBlockId);
+    blockManager.offloadBlock(sourceBlock, maxAttentionWindow);
+    TLLM_CUDA_CHECK(cudaDeviceSynchronize());
+    TLLM_CHECK(!sourceBlock->isPrimary());
+
+    auto consumePrimaryBlock = [&](LlmRequest::RequestIdType requestId, TokenIdType firstToken)
+    {
+        auto [request, tokens] = makeRequest(requestId, firstToken);
+        kvCacheManager->addSequenceBatch(
+            {{{requestId, static_cast<SizeType32>(tokens->size()), beamWidth}}}, {std::ref(*request)});
+        auto const blockId = kvCacheManager->getCacheBlockIds(requestId, maxAttentionWindow)[0].front();
+        TLLM_CHECK(blockId != victimBlockId);
+        return request;
+    };
+    auto consumerRequest2 = consumePrimaryBlock(2, 200);
+    auto consumerRequest3 = consumePrimaryBlock(3, 300);
+
+    TLLM_CHECK(blockManager.getNumFreeBlocksPerWindowSize().at(maxAttentionWindow) == 1);
+    return {std::move(kvCacheManager), std::move(sourceRequest), std::move(consumerRequest2),
+        std::move(consumerRequest3), sourceBlock, sourceBlockId, victimBlock, victimHash, maxAttentionWindow};
+}
+
+bool hasCacheLevelUpdate(
+    std::deque<tle::KVCacheEvent> const& events, size_t blockHash, SizeType32 oldLevel, SizeType32 newLevel)
+{
+    return std::any_of(events.begin(), events.end(),
+        [blockHash, oldLevel, newLevel](tle::KVCacheEvent const& event)
+        {
+            if (!std::holds_alternative<tle::KVCacheUpdatedData>(event.data))
+            {
+                return false;
+            }
+            auto const& data = std::get<tle::KVCacheUpdatedData>(event.data);
+            return data.blockHash == blockHash && data.cacheLevel.has_value() && data.cacheLevel->oldValue == oldLevel
+                && data.cacheLevel->newValue == newLevel;
+        });
+}
+
+bool hasRemoveEvent(std::deque<tle::KVCacheEvent> const& events, size_t blockHash)
+{
+    return std::any_of(events.begin(), events.end(),
+        [blockHash](tle::KVCacheEvent const& event)
+        {
+            if (!std::holds_alternative<tle::KVCacheRemovedData>(event.data))
+            {
+                return false;
+            }
+            auto const& data = std::get<tle::KVCacheRemovedData>(event.data);
+            return std::find(data.blockHashes.begin(), data.blockHashes.end(), blockHash) != data.blockHashes.end();
+        });
+}
+} // namespace
+
+TEST_F(KVCacheManagerTest, DisaggTransferPreparationPromotesCachedSourceEvent)
+{
+    using namespace tensorrt_llm::batch_manager::kv_cache_manager;
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr sizePerHead = 16;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimaryPool = 2;
+    auto constexpr blocksInSecondaryPool = 1;
+    auto constexpr maxNumSequences = 4;
+    auto constexpr beamWidth = 1;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const maxAttentionWindow = tokensPerBlock * blocksInPrimaryPool;
+    BlocksPerWindow const blocksPerWindow{{maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}}};
+
+    KVCacheManager kvCacheManager(numLayers, numKvHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
+        beamWidth, std::vector<BlockManager::SizeType32>{maxAttentionWindow}, tensorrt_llm::DataType::kHALF, 0, stream,
+        maxAttentionWindow, maxAttentionWindow, true, CacheType::kSELF, std::nullopt,
+        std::make_unique<tlk::KVCacheEventManager>(1024));
+    kvCacheManager.allocatePools(false);
+    (void) getEvents(kvCacheManager);
+
+    LlmRequest::RequestIdType requestId{0};
+    auto inputTokens = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3});
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+    auto llmRequest = std::make_shared<LlmRequest>(requestId, 0, inputTokens, samplingConfig, isStreaming);
+
+    kvCacheManager.addSequenceBatch(
+        {{{requestId, static_cast<SizeType32>(inputTokens->size()), beamWidth}}}, {std::ref(*llmRequest)});
+    auto const sourceBlockId = kvCacheManager.getCacheBlockIds(requestId, maxAttentionWindow)[0].front();
+    auto& blockManager = tensorrt_llm::testing::KvCacheManagerTestUtil::mutableBlockManager(kvCacheManager);
+    auto sourceBlock = blockManager.getBlockById(sourceBlockId, maxAttentionWindow);
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*llmRequest);
+    (void) kvCacheManager.removeSequence(requestId, llmRequest);
+
+    TLLM_CHECK(sourceBlock != nullptr);
+    TLLM_CHECK(sourceBlock->isPrimary());
+    TLLM_CHECK(!sourceBlock->isDetached());
+    auto const sourceHash = sourceBlock->getHash();
+    (void) getEvents(kvCacheManager);
+
+    blockManager.offloadBlock(sourceBlock, maxAttentionWindow);
+    TLLM_CUDA_CHECK(cudaDeviceSynchronize());
+    TLLM_CHECK(!sourceBlock->isPrimary());
+    TLLM_CHECK(!sourceBlock->isDetached());
+    (void) getEvents(kvCacheManager);
+
+    {
+        auto transferLease = kvCacheManager.prepareBlocksForTransfer({{maxAttentionWindow, {sourceBlockId}}});
+        EXPECT_TRUE(transferLease.issuedOnboardCopies());
+        transferLease.syncReadyForFormat(blockManager.getBufferManager(maxAttentionWindow));
+    }
+
+    EXPECT_TRUE(sourceBlock->isPrimary());
+    EXPECT_FALSE(sourceBlock->isDetached());
+    EXPECT_TRUE(blockManager.verifyQueueIntegrity(maxAttentionWindow));
+
+    auto const events = getEvents(kvCacheManager);
+    EXPECT_TRUE(hasCacheLevelUpdate(events, sourceHash, kSecondaryLevel, kPrimaryLevel));
+}
+
+TEST_F(KVCacheManagerTest, DisaggTransferPreparationOffloadsCachedVictimForScratch)
+{
+    auto setup = makeDisaggTransferScratchPressureSetup(/*blocksInSecondaryPool=*/2);
+    auto& kvCacheManager = *setup.kvCacheManager;
+    auto& blockManager = tensorrt_llm::testing::KvCacheManagerTestUtil::mutableBlockManager(kvCacheManager);
+
+    {
+        auto transferLease
+            = kvCacheManager.prepareBlocksForTransfer({{setup.maxAttentionWindow, {setup.sourceBlockId}}});
+        EXPECT_TRUE(transferLease.issuedOnboardCopies());
+        transferLease.syncReadyForFormat(blockManager.getBufferManager(setup.maxAttentionWindow));
+    }
+
+    EXPECT_TRUE(setup.sourceBlock->isPrimary());
+    EXPECT_FALSE(setup.victimBlock->isPrimary());
+    EXPECT_FALSE(setup.victimBlock->isDetached());
+    EXPECT_FALSE(setup.victimBlock->getUniqueTokens().empty());
+    EXPECT_TRUE(blockManager.verifyQueueIntegrity(setup.maxAttentionWindow));
+
+    auto const events = getEvents(kvCacheManager);
+    EXPECT_TRUE(hasCacheLevelUpdate(events, setup.victimHash, kPrimaryLevel, kSecondaryLevel));
+
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.removeSequence(1, std::nullopt)));
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.removeSequence(2, std::nullopt)));
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.removeSequence(3, std::nullopt)));
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), 3);
+}
+
+TEST_F(KVCacheManagerTest, DisaggTransferPreparationEvictsCachedVictimForScratch)
+{
+    auto setup = makeDisaggTransferScratchPressureSetup(/*blocksInSecondaryPool=*/1);
+    auto& kvCacheManager = *setup.kvCacheManager;
+    auto& blockManager = tensorrt_llm::testing::KvCacheManagerTestUtil::mutableBlockManager(kvCacheManager);
+
+    {
+        auto transferLease
+            = kvCacheManager.prepareBlocksForTransfer({{setup.maxAttentionWindow, {setup.sourceBlockId}}});
+        EXPECT_TRUE(transferLease.issuedOnboardCopies());
+        transferLease.syncReadyForFormat(blockManager.getBufferManager(setup.maxAttentionWindow));
+    }
+
+    EXPECT_TRUE(setup.sourceBlock->isPrimary());
+    EXPECT_TRUE(setup.victimBlock->isDetached());
+    EXPECT_TRUE(blockManager.verifyQueueIntegrity(setup.maxAttentionWindow));
+
+    auto const events = getEvents(kvCacheManager);
+    EXPECT_TRUE(hasRemoveEvent(events, setup.victimHash));
+
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.removeSequence(1, std::nullopt)));
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.removeSequence(2, std::nullopt)));
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.removeSequence(3, std::nullopt)));
+    EXPECT_EQ(kvCacheManager.getNumFreeBlocks(), 3);
 }
 
 // Regression test for NVBug 6018647: storeBlocks(pin=true) on a zero-ref block

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -4913,6 +4913,141 @@ TEST_F(KVCacheManagerTest, PinAndUnpinBlocksById)
     EXPECT_EQ(freeAfterUnpin, totalBlocks);
 }
 
+TEST_F(KVCacheManagerTest, DisaggTransferBlockIndexLookupOnboardsOffloadedBlocks)
+{
+    using namespace tensorrt_llm::batch_manager::kv_cache_manager;
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr sizePerHead = 16;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimaryPool = 4;
+    auto constexpr blocksInSecondaryPool = 2;
+    auto constexpr maxNumSequences = 8;
+    auto const stream = std::make_shared<tr::CudaStream>();
+
+    auto constexpr beamWidth = 1;
+    auto const maxAttentionWindow = tokensPerBlock * blocksInPrimaryPool;
+
+    BlocksPerWindow const blocksPerWindow{{maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}}};
+
+    KVCacheManager kvCacheManager(numLayers, numKvHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
+        beamWidth, std::vector<BlockManager::SizeType32>{maxAttentionWindow}, tensorrt_llm::DataType::kHALF, 0, stream,
+        maxAttentionWindow, maxAttentionWindow, true);
+    kvCacheManager.allocatePools(false);
+
+    LlmRequest::RequestIdType requestId{0};
+    auto inputTokens = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7});
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+    auto llmRequest = std::make_shared<LlmRequest>(requestId, 0, inputTokens, samplingConfig, isStreaming);
+
+    kvCacheManager.addSequenceBatch(
+        {{{requestId, static_cast<SizeType32>(inputTokens->size()), beamWidth}}}, {std::ref(*llmRequest)});
+
+    auto const& allBlockIds = kvCacheManager.getCacheBlockIds(requestId, maxAttentionWindow)[0];
+    ASSERT_FALSE(allBlockIds.empty());
+    auto const offloadedBlockId = allBlockIds.front();
+
+    auto& blockManager = const_cast<BlockManager&>(kvCacheManager.getBlockManager());
+    auto block = blockManager.getBlockById(offloadedBlockId, maxAttentionWindow);
+    ASSERT_NE(block, nullptr);
+    ASSERT_TRUE(block->isPrimary());
+
+    blockManager.offloadBlock(block, maxAttentionWindow);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    ASSERT_FALSE(block->isPrimary());
+
+    auto const freeBlocksBeforeTransfer = blockManager.getNumFreeBlocksPerWindowSize().at(maxAttentionWindow);
+    ASSERT_GT(freeBlocksBeforeTransfer, 0);
+    auto const allocTotalBeforeTransfer = kvCacheManager.getNumAllocTotalBlocks();
+    auto const allocNewBeforeTransfer = kvCacheManager.getNumAllocNewBlocks();
+    kvCacheManager.startScheduling();
+    ASSERT_TRUE(blockManager.schedulingHasFreeBlocks(freeBlocksBeforeTransfer, maxAttentionWindow));
+
+    {
+        auto transferLease
+            = kvCacheManager.prepareBlocksForTransfer({{maxAttentionWindow, {offloadedBlockId}}}, requestId);
+        EXPECT_TRUE(transferLease.issuedOnboardCopies());
+        transferLease.syncReadyForFormat();
+        ASSERT_TRUE(block->isPrimary());
+        EXPECT_EQ(kvCacheManager.getNumAllocTotalBlocks(), allocTotalBeforeTransfer);
+        EXPECT_EQ(kvCacheManager.getNumAllocNewBlocks(), allocNewBeforeTransfer);
+        EXPECT_TRUE(blockManager.schedulingHasFreeBlocks(freeBlocksBeforeTransfer - 1, maxAttentionWindow));
+        EXPECT_FALSE(blockManager.schedulingHasFreeBlocks(freeBlocksBeforeTransfer, maxAttentionWindow));
+
+        EXPECT_NO_THROW({
+            auto const indices
+                = kvCacheManager.getMemoryPoolBlockIndicesByBlockIds({offloadedBlockId}, maxAttentionWindow);
+            EXPECT_EQ(indices.size(), 1);
+        });
+    }
+
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*llmRequest);
+    (void) kvCacheManager.removeSequence(requestId, llmRequest);
+}
+
+TEST_F(KVCacheManagerTest, DisaggTransferBlockRangePreparationOnboardsOffloadedBlocks)
+{
+    using namespace tensorrt_llm::batch_manager::kv_cache_manager;
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr sizePerHead = 16;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimaryPool = 4;
+    auto constexpr blocksInSecondaryPool = 2;
+    auto constexpr maxNumSequences = 8;
+    auto const stream = std::make_shared<tr::CudaStream>();
+
+    auto constexpr beamWidth = 1;
+    auto const maxAttentionWindow = tokensPerBlock * blocksInPrimaryPool;
+
+    BlocksPerWindow const blocksPerWindow{{maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}}};
+
+    KVCacheManager kvCacheManager(numLayers, numKvHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
+        beamWidth, std::vector<BlockManager::SizeType32>{maxAttentionWindow}, tensorrt_llm::DataType::kHALF, 0, stream,
+        maxAttentionWindow, maxAttentionWindow, true);
+    kvCacheManager.allocatePools(false);
+
+    LlmRequest::RequestIdType requestId{0};
+    auto inputTokens = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7});
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+    auto llmRequest = std::make_shared<LlmRequest>(requestId, 0, inputTokens, samplingConfig, isStreaming);
+
+    kvCacheManager.addSequenceBatch(
+        {{{requestId, static_cast<SizeType32>(inputTokens->size()), beamWidth}}}, {std::ref(*llmRequest)});
+
+    auto const& allBlockIds = kvCacheManager.getCacheBlockIds(requestId, maxAttentionWindow)[0];
+    ASSERT_FALSE(allBlockIds.empty());
+    auto const offloadedBlockId = allBlockIds.front();
+
+    auto& blockManager = const_cast<BlockManager&>(kvCacheManager.getBlockManager());
+    auto block = blockManager.getBlockById(offloadedBlockId, maxAttentionWindow);
+    ASSERT_NE(block, nullptr);
+    ASSERT_TRUE(block->isPrimary());
+
+    blockManager.offloadBlock(block, maxAttentionWindow);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    ASSERT_FALSE(block->isPrimary());
+
+    auto blockRange = BlockRange::fromAllBlockIds(kvCacheManager, requestId);
+    {
+        auto transferLease = prepareBlockRangeForTransfer(kvCacheManager, blockRange, {maxAttentionWindow}, requestId);
+        EXPECT_TRUE(transferLease.issuedOnboardCopies());
+        ASSERT_TRUE(block->isPrimary());
+
+        auto blockRangeForWindow = blockRange.getBlockRangeForWindow(maxAttentionWindow);
+        EXPECT_NO_THROW({
+            auto it = blockRangeForWindow.begin();
+            tr::ITensor::SharedPtr const blockTensor = it;
+            EXPECT_NE(blockTensor, nullptr);
+        });
+    }
+
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*llmRequest);
+    (void) kvCacheManager.removeSequence(requestId, llmRequest);
+}
+
 // Regression test for NVBug 6018647: storeBlocks(pin=true) on a zero-ref block
 // that sits in the eviction free queue must call claimBlock() before incRefCount().
 // Without the fix, unpinBlocksById inserts the block into the free queue a second

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -47,6 +47,7 @@
 #include <fcntl.h>
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <sys/types.h>
 #include <thread>
@@ -72,17 +73,20 @@ class KVCacheTransferManagerTestAccess
 public:
     [[nodiscard]] static std::size_t pendingReadCount(tbk::KVCacheTransferManager const& transferManager)
     {
+        std::lock_guard<std::mutex> lock(transferManager.mPendingTransfersMutex);
         return transferManager.mPendingReads.size();
     }
 
     [[nodiscard]] static std::size_t pendingWriteCount(tbk::KVCacheTransferManager const& transferManager)
     {
+        std::lock_guard<std::mutex> lock(transferManager.mPendingTransfersMutex);
         return transferManager.mPendingWrites.size();
     }
 
     [[nodiscard]] static bool hasPendingReadForBlock(
         tbk::KVCacheTransferManager const& transferManager, tbk::BlockPtr const& block)
     {
+        std::lock_guard<std::mutex> lock(transferManager.mPendingTransfersMutex);
         return transferManager.mPendingReads.find(tbk::KVCacheTransferManager::getPendingTransferIndex(block))
             != transferManager.mPendingReads.end();
     }
@@ -90,6 +94,7 @@ public:
     [[nodiscard]] static bool hasPendingWriteForBlock(
         tbk::KVCacheTransferManager const& transferManager, tbk::BlockPtr const& block)
     {
+        std::lock_guard<std::mutex> lock(transferManager.mPendingTransfersMutex);
         return transferManager.mPendingWrites.find(tbk::KVCacheTransferManager::getPendingTransferIndex(block))
             != transferManager.mPendingWrites.end();
     }
@@ -4968,7 +4973,7 @@ TEST_F(KVCacheManagerTest, DisaggTransferBlockIndexLookupOnboardsOffloadedBlocks
         auto transferLease
             = kvCacheManager.prepareBlocksForTransfer({{maxAttentionWindow, {offloadedBlockId}}}, requestId);
         EXPECT_TRUE(transferLease.issuedOnboardCopies());
-        transferLease.syncReadyForFormat();
+        transferLease.syncReadyForFormat(blockManager.getBufferManager(maxAttentionWindow));
         ASSERT_TRUE(block->isPrimary());
         EXPECT_EQ(kvCacheManager.getNumAllocTotalBlocks(), allocTotalBeforeTransfer);
         EXPECT_EQ(kvCacheManager.getNumAllocNewBlocks(), allocNewBeforeTransfer);
@@ -5032,7 +5037,8 @@ TEST_F(KVCacheManagerTest, DisaggTransferBlockRangePreparationOnboardsOffloadedB
 
     auto blockRange = BlockRange::fromAllBlockIds(kvCacheManager, requestId);
     {
-        auto transferLease = prepareBlockRangeForTransfer(kvCacheManager, blockRange, {maxAttentionWindow}, requestId);
+        auto transferLease = prepareBlockRangeForTransfer(kvCacheManager, blockRange, {maxAttentionWindow}, requestId,
+            blockManager.getBufferManager(maxAttentionWindow), llmRequest.get());
         EXPECT_TRUE(transferLease.issuedOnboardCopies());
         ASSERT_TRUE(block->isPrimary());
 
@@ -5325,6 +5331,14 @@ TEST_F(KVCacheManagerTest, KVCacheTransferManagerPendingTransfersDistinguishPrim
 
     transferManager.syncTransfers();
     bufferManager.getStream().synchronize();
+
+    EXPECT_EQ(KVCacheTransferManagerTestAccess::pendingReadCount(transferManager), 2);
+    EXPECT_EQ(KVCacheTransferManagerTestAccess::pendingWriteCount(transferManager), 2);
+
+    transferManager.syncWithBufferManager();
+
+    EXPECT_EQ(KVCacheTransferManagerTestAccess::pendingReadCount(transferManager), 2);
+    EXPECT_EQ(KVCacheTransferManagerTestAccess::pendingWriteCount(transferManager), 2);
 }
 
 TEST_P(KVCacheManagerTest, DISABLED_KVCacheManagerSinkTokenLengthTest)

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp1_gentp1_gptoss_host_offload.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp1_gentp1_gptoss_host_offload.yaml
@@ -28,7 +28,7 @@ context_servers:
   enable_iter_perf_stats: true
   cache_transceiver_config:
     backend: NIXL
-    transceiver_runtime: PYTHON
+    transceiver_runtime: CPP
     max_tokens_in_buffer: 4096
 generation_servers:
   num_instances: 1
@@ -53,5 +53,5 @@ generation_servers:
   enable_iter_perf_stats: true
   cache_transceiver_config:
     backend: NIXL
-    transceiver_runtime: PYTHON
+    transceiver_runtime: CPP
     max_tokens_in_buffer: 4096

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp1_gentp1_gptoss_host_offload.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp1_gentp1_gptoss_host_offload.yaml
@@ -1,0 +1,57 @@
+model: gpt_oss/gpt-oss-120b
+hostname: localhost
+backend: pytorch
+context_servers:
+  num_instances: 1
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  max_num_tokens: 4096
+  max_seq_len: 2048
+  max_batch_size: 16
+  trust_remote_code: true
+  enable_chunked_prefill: true
+  kv_cache_config:
+    free_gpu_memory_fraction: 0.4
+    enable_block_reuse: true
+    enable_partial_reuse: true
+    max_tokens: 1024
+    tokens_per_block: 64
+    host_cache_size: 4294967296
+    secondary_offload_min_priority: 0
+    event_buffer_max_size: 1024
+    dtype: fp8
+  disable_overlap_scheduler: true
+  moe_config:
+    backend: TRTLLM
+  cuda_graph_config: null
+  print_iter_log: true
+  enable_iter_perf_stats: true
+  cache_transceiver_config:
+    backend: NIXL
+    transceiver_runtime: PYTHON
+    max_tokens_in_buffer: 4096
+generation_servers:
+  num_instances: 1
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  max_num_tokens: 4096
+  max_seq_len: 2048
+  max_batch_size: 16
+  trust_remote_code: true
+  enable_chunked_prefill: true
+  kv_cache_config:
+    enable_block_reuse: true
+    enable_partial_reuse: true
+    free_gpu_memory_fraction: 0.8
+    tokens_per_block: 64
+    dtype: fp8
+  disable_overlap_scheduler: true
+  moe_config:
+    backend: TRTLLM
+  cuda_graph_config: null
+  print_iter_log: true
+  enable_iter_perf_stats: true
+  cache_transceiver_config:
+    backend: NIXL
+    transceiver_runtime: PYTHON
+    max_tokens_in_buffer: 4096

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -1504,7 +1504,7 @@ def test_disaggregated_overlap_transceiver_runtime_python_bounce(
                            assert_gen_log_contains="[kv-bounce] coalesced")
 
 
-def _verify_python_transceiver_under_host_offload(
+def _verify_transceiver_under_host_offload(
         server_url: str,
         model: str,
         *,
@@ -1512,14 +1512,14 @@ def _verify_python_transceiver_under_host_offload(
         prompt_repeats: int = 4,
         replay_count: int = 5,
         require_stable_output: bool = True) -> None:
-    """End-to-end check: Python transceiver + ctx-side host offload.
+    """End-to-end check: disagg transceiver + ctx-side host offload.
 
-    The fix translates logical block IDs to primary-pool slot indices in
-    `_CacheReuseAdapterV1.get_block_ids` before they reach the disagg
-    sender. Without that translation, once host offload moves blocks
-    around, the sender computes pool pointers from stale block IDs and
-    either reads garbage memory or aborts. This test stresses that path
-    end-to-end:
+    The caller chooses the transceiver runtime in its disagg config. The
+    Python runtime exercises the Python reuse adapter, while the C++ runtime
+    exercises the C++ cache formatter and KV-cache manager preparation path.
+    In both cases, once host offload moves blocks around, the transceiver must
+    read from current primary-pool slots rather than stale logical block IDs.
+    This workload stresses that path end-to-end:
 
       1. Send several distinct prompts to fill the (deliberately small)
          ctx primary pool, committing each to the reuse radix tree.
@@ -1644,7 +1644,7 @@ def test_disaggregated_python_transceiver_host_offload(
 ) -> None:  # noqa: ARG001 - used only for the parametrize label
     """E2E regression for block_id -> primary-slot translation in the Python disagg cache transceiver.
 
-    See `_verify_python_transceiver_under_host_offload` for what this
+    See `_verify_transceiver_under_host_offload` for what this
     test proves. The setup pairs the Python transceiver runtime with a
     ctx-side `host_cache_size` and a deliberately tight primary pool so
     that prefix reuse is forced through an offload+onboard cycle before
@@ -1660,7 +1660,7 @@ def test_disaggregated_python_transceiver_host_offload(
     env["UCX_TLS"] = get_ucx_tls()
 
     def post_client_test(server_url: str) -> None:
-        _verify_python_transceiver_under_host_offload(
+        _verify_transceiver_under_host_offload(
             server_url, "TinyLlama/TinyLlama-1.1B-Chat-v1.0")
 
     run_disaggregated_test(disaggregated_example_root,
@@ -2922,24 +2922,22 @@ def test_disaggregated_gpt_oss_120b_host_offload(
     env["TIKTOKEN_ENCODINGS_BASE"] = tiktoken_vocab
 
     def post_client_test(server_url: str) -> None:
-        _verify_python_transceiver_under_host_offload(
-            server_url,
-            model_path,
-            max_tokens=8,
-            prompt_repeats=2,
-            replay_count=2,
-            require_stable_output=False)
+        _verify_transceiver_under_host_offload(server_url,
+                                               model_path,
+                                               max_tokens=8,
+                                               prompt_repeats=2,
+                                               replay_count=2,
+                                               require_stable_output=False)
         _assert_context_kv_offload_stats(server_url)
 
-    run_disaggregated_test(
-        disaggregated_example_root,
-        "gpt_oss_120b_host_offload",
-        num_iters=1,
-        env=env,
-        model_path=model_dir,
-        cwd=llm_venv.get_working_directory(),
-        post_client_test=post_client_test,
-        assert_ctx_log_contains=("primary blocks=16, secondary blocks=1820"))
+    run_disaggregated_test(disaggregated_example_root,
+                           "gpt_oss_120b_host_offload",
+                           num_iters=1,
+                           env=env,
+                           model_path=model_dir,
+                           cwd=llm_venv.get_working_directory(),
+                           post_client_test=post_client_test,
+                           assert_ctx_log_contains="primary blocks=16")
 
 
 @skip_pre_hopper

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -24,7 +24,7 @@ import tempfile
 import time
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Literal, Optional, TypeAlias
 
 import aiohttp
 import numpy as np
@@ -35,6 +35,7 @@ from defs.common import (parse_gsm8k_output, resolve_llm_model_path,
                          wait_for_server)
 from defs.conftest import (get_sm_version, llm_models_root, skip_arm,
                            skip_no_hopper, skip_pre_blackwell, skip_pre_hopper)
+from defs.local_venv import PythonVenvRunnerImpl
 from defs.trt_test_alternative import check_call, check_output, print_info
 from disagg_test_utils import (ProcessWrapper, run_ctx_worker,
                                run_disagg_server, run_gen_worker, terminate,
@@ -44,6 +45,9 @@ from test_common.perf_metrics_utils import (get_timing_metrics,
 
 from tensorrt_llm._utils import mpi_disabled
 from tensorrt_llm.logger import logger
+
+WorkerRole: TypeAlias = Literal["context_servers", "generation_servers"]
+KVCacheOffloadSummary: TypeAlias = dict[str, int]
 
 
 @dataclass
@@ -337,6 +341,8 @@ def get_test_config(test_desc, example_dir, test_root):
         f"{test_configs_root}/disagg_config_ctxtp4_gentp4_deepseek_r1_v2_fp4_tllm_mtp.yaml",
         "gpt_oss_120b_trtllm_stress":
         f"{test_configs_root}/disagg_config_ctxtp2_gentp2_gptoss_tllm.yaml",
+        "gpt_oss_120b_host_offload":
+        f"{test_configs_root}/disagg_config_ctxtp1_gentp1_gptoss_host_offload.yaml",
         "gpt_oss_120b_eagle_triton_stress":
         f"{test_configs_root}/disagg_config_ctxtp2_gentp2_gptoss_eagle_triton.yaml",
         "gpt_oss_120b_eagle_trtllm_stress":
@@ -905,22 +911,188 @@ def setup_disagg_cluster(
     return config, ctx_workers, gen_workers, disagg_server, server_port, work_dir
 
 
-def run_disaggregated_test(example_dir,
-                           test_desc,
-                           num_iters=5,
-                           env=None,
-                           prompt_file="prompts.json",
-                           extra_endpoints_test=None,
-                           model_path=None,
-                           cwd=None,
-                           disagg_schedule_style=None,
-                           post_client_test=None,
-                           assert_gen_log_contains=None):
+def _assert_worker_logs_contain(workers: list[ProcessWrapper], marker: str,
+                                role: str) -> None:
+    logs: list[str] = []
+    for worker in workers:
+        if worker.log_path and os.path.exists(worker.log_path):
+            with open(worker.log_path, 'r', errors='replace') as f:
+                logs.append(f.read())
+    assert any(marker in log for log in logs), (
+        f"expected marker {marker!r} in a {role} worker log, "
+        f"but none of {len(logs)} log(s) contained it")
+
+
+def _worker_urls_from_cluster_info(server_url: str,
+                                   role: WorkerRole) -> list[str]:
+    import requests as http_requests
+
+    response = http_requests.get(f"{server_url}/cluster_info", timeout=10)
+    assert response.status_code == 200, (
+        f"cluster_info fetch failed with {response.status_code}: "
+        f"{response.text}")
+    info = response.json()
+    current_workers = info.get("current_workers") or {}
+    assert isinstance(
+        current_workers,
+        dict), (f"cluster_info current_workers is not a dict: {info}")
+    workers = current_workers.get(role) or []
+    assert isinstance(workers,
+                      list), (f"cluster_info {role} is not a list: {info}")
+
+    worker_urls: list[str] = []
+    for worker in workers:
+        assert isinstance(
+            worker,
+            dict), (f"cluster_info {role} entry is not a dict: {worker}")
+        host = worker.get("host")
+        port = worker.get("port")
+        assert isinstance(
+            host,
+            str), (f"cluster_info {role} worker host is not a str: {worker}")
+        assert isinstance(port, int) and port > 0, (
+            f"cluster_info {role} worker port is not positive: {worker}")
+        if host in {"0.0.0.0", "::", ""}:  # nosec B104
+            host = "localhost"
+        worker_urls.append(f"http://{host}:{port}")
+
+    assert worker_urls, f"cluster_info contained no {role}: {info}"
+    return worker_urls
+
+
+def _iteration_kv_stat_groups(
+        iteration_stats: dict[str, Any]) -> list[dict[str, Any]]:
+    for key in ("kvCacheIterationStatsByPoolGroup", "kvCacheIterationStats"):
+        grouped_stats = iteration_stats.get(key)
+        if not isinstance(grouped_stats, dict):
+            continue
+        stat_groups = [
+            stat_group for stat_group in grouped_stats.values()
+            if isinstance(stat_group, dict)
+        ]
+        if stat_groups:
+            return stat_groups
+    return []
+
+
+def _get_int_stat(stat_group: dict[str, Any], key: str) -> int:
+    value = stat_group.get(key, 0)
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+    return 0
+
+
+def _summarize_kv_offload_stats(
+        iteration_stats: list[dict[str, Any]]) -> KVCacheOffloadSummary:
+    summary: KVCacheOffloadSummary = {
+        "iterations_with_kv_stats": 0,
+        "primary_max_blocks": 0,
+        "secondary_max_blocks": 0,
+        "secondary_peak_used_blocks": 0,
+        "iter_offload_blocks": 0,
+        "iter_offload_bytes": 0,
+        "iter_onboard_blocks": 0,
+        "iter_onboard_bytes": 0,
+    }
+
+    for iteration_stat in iteration_stats:
+        stat_groups = _iteration_kv_stat_groups(iteration_stat)
+        if not stat_groups:
+            continue
+        summary["iterations_with_kv_stats"] += 1
+        for stat_group in stat_groups:
+            summary["primary_max_blocks"] = max(
+                summary["primary_max_blocks"],
+                _get_int_stat(stat_group, "primaryMaxNumBlocks"))
+            summary["secondary_max_blocks"] = max(
+                summary["secondary_max_blocks"],
+                _get_int_stat(stat_group, "secondaryMaxNumBlocks"))
+            summary["secondary_peak_used_blocks"] = max(
+                summary["secondary_peak_used_blocks"],
+                _get_int_stat(stat_group, "secondaryUsedNumBlocks"),
+                _get_int_stat(stat_group, "secondaryPeakUsedNumBlocks"))
+            summary["iter_offload_blocks"] += _get_int_stat(
+                stat_group, "iterOffloadBlocks")
+            summary["iter_offload_bytes"] += _get_int_stat(
+                stat_group, "iterOffloadBytes")
+            summary["iter_onboard_blocks"] += _get_int_stat(
+                stat_group, "iterOnboardBlocks")
+            summary["iter_onboard_bytes"] += _get_int_stat(
+                stat_group, "iterOnboardBytes")
+
+    return summary
+
+
+def _assert_context_kv_offload_stats(server_url: str,
+                                     timeout_s: float = 60.0) -> None:
+    import requests as http_requests
+
+    worker_urls = _worker_urls_from_cluster_info(server_url, "context_servers")
+    deadline = time.monotonic() + timeout_s
+    collected_stats: list[dict[str, Any]] = []
+    last_error = ""
+
+    while time.monotonic() < deadline:
+        for worker_url in worker_urls:
+            try:
+                response = http_requests.get(f"{worker_url}/metrics",
+                                             timeout=10)
+                if response.status_code != 200:
+                    last_error = (f"{worker_url}/metrics returned "
+                                  f"{response.status_code}: {response.text}")
+                    continue
+                metrics = response.json()
+            except http_requests.RequestException as e:
+                last_error = f"{worker_url}/metrics failed: {e}"
+                continue
+            except ValueError as e:
+                last_error = f"{worker_url}/metrics JSON decode failed: {e}"
+                continue
+
+            if not isinstance(metrics, list):
+                last_error = (
+                    f"{worker_url}/metrics returned non-list JSON: {metrics}")
+                continue
+            collected_stats.extend(metric for metric in metrics
+                                   if isinstance(metric, dict))
+
+        summary = _summarize_kv_offload_stats(collected_stats)
+        print(
+            "[host_offload_e2e] context_kv_offload_stats="
+            f"{json.dumps(summary, sort_keys=True)}",
+            flush=True)
+        if (summary["secondary_max_blocks"] > 0
+                and summary["iter_offload_blocks"] > 0
+                and summary["iter_offload_bytes"] > 0):
+            return
+        time.sleep(1)
+
+    raise AssertionError(
+        "expected context worker metrics to prove host offload during "
+        "disaggregated KV transfer; "
+        f"summary={summary}, last_error={last_error!r}")
+
+
+def run_disaggregated_test(
+        example_dir: str,
+        test_desc: str,
+        num_iters: int = 5,
+        env: Optional[dict[str, str]] = None,
+        prompt_file: str = "prompts.json",
+        extra_endpoints_test: Optional[Callable[[str], None]] = None,
+        model_path: Optional[str] = None,
+        cwd: Optional[str] = None,
+        disagg_schedule_style: Optional[str] = None,
+        post_client_test: Optional[Callable[[str], None]] = None,
+        assert_gen_log_contains: Optional[str] = None,
+        assert_ctx_log_contains: Optional[str] = None) -> None:
     """Run disaggregated test using service discovery instead of MPI.
 
-    If assert_gen_log_contains is set, the generation-worker logs are captured and, after the
-    client tests, at least one of them must contain that substring (used to prove the KV-cache
-    bounce path actually engaged instead of silently falling back to the per-fragment path).
+    If a log assertion is set, worker logs are captured and checked after the
+    client tests. This is used for paths that must prove a configured transport
+    or memory tier was actually enabled, not only that requests succeeded.
     """
     if mpi_disabled():
         pytest.skip(
@@ -932,10 +1104,12 @@ def run_disaggregated_test(example_dir,
 
     config_file = get_test_config(test_desc, example_dir,
                                   os.path.dirname(__file__))
+    save_log = (assert_gen_log_contains is not None
+                or assert_ctx_log_contains is not None)
     config, ctx_workers, gen_workers, disagg_server, server_port, work_dir = \
         setup_disagg_cluster(config_file, model_name=model_path, env=run_env, cwd=cwd,
                              schedule_style=disagg_schedule_style,
-                             save_log=assert_gen_log_contains is not None)
+                             save_log=save_log)
 
     server_host = config.get("hostname", "localhost")
 
@@ -972,17 +1146,11 @@ def run_disaggregated_test(example_dir,
         if post_client_test is not None:
             post_client_test(server_url)
         if assert_gen_log_contains is not None:
-            # Fail loudly if the marker is absent: the transfer silently fell back to the
-            # per-fragment path, so the bounce path we meant to exercise never ran.
-            logs = []
-            for w in gen_workers:
-                if w.log_path and os.path.exists(w.log_path):
-                    with open(w.log_path, 'r', errors='replace') as f:
-                        logs.append(f.read())
-            assert any(assert_gen_log_contains in log for log in logs), (
-                f"expected marker {assert_gen_log_contains!r} in a generation-worker log, "
-                f"but none of {len(logs)} log(s) contained it (bounce did not engage)"
-            )
+            _assert_worker_logs_contain(gen_workers, assert_gen_log_contains,
+                                        "generation")
+        if assert_ctx_log_contains is not None:
+            _assert_worker_logs_contain(ctx_workers, assert_ctx_log_contains,
+                                        "context")
     finally:
         terminate(*ctx_workers, *gen_workers, disagg_server)
         shutil.rmtree(work_dir, ignore_errors=True)
@@ -1336,7 +1504,14 @@ def test_disaggregated_overlap_transceiver_runtime_python_bounce(
                            assert_gen_log_contains="[kv-bounce] coalesced")
 
 
-def _verify_python_transceiver_under_host_offload(server_url: str, model: str):
+def _verify_python_transceiver_under_host_offload(
+        server_url: str,
+        model: str,
+        *,
+        max_tokens: int = 16,
+        prompt_repeats: int = 4,
+        replay_count: int = 5,
+        require_stable_output: bool = True) -> None:
     """End-to-end check: Python transceiver + ctx-side host offload.
 
     The fix translates logical block IDs to primary-pool slot indices in
@@ -1355,23 +1530,17 @@ def _verify_python_transceiver_under_host_offload(server_url: str, model: str):
          succeeds; without it, the sender either crashes on a primary
          assertion or returns nonsense tokens.
 
-    Assertions are deliberately content-agnostic (TinyLlama outputs vary
-    run-to-run): we check that responses are non-empty, the server stays
-    up across the eviction/onboard cycle, and `cached_tokens > 0` on
-    repeats so we know reuse actually fired.
+    The caller's config must make the context primary pool smaller than
+    the concurrent replay working set and must provide a host cache. The
+    assertions are otherwise model-agnostic: responses must be non-empty,
+    the server must stay up across the eviction/onboard cycle, and
+    `cached_tokens > 0` on repeats proves prefix reuse actually fired.
     """
     timeout = aiohttp.ClientTimeout(total=180)
-    max_tokens = 16
-    # Workload sizing: ctx-side primary pool = max_tokens(1024) /
-    # tokens_per_block(64) = 16 blocks. Each prompt below tokenizes to
-    # ~200 tokens ≈ 4 KV blocks. We send 6 distinct prompts → ~24 blocks
-    # of primary demand > 16-block primary pool, forcing eviction of an
-    # earlier prefix to host. Replaying earlier prompts (Pass 2) then
-    # forces onboard from host back to primary, and onboard typically
-    # places the block in a *different* primary slot than its block_id.
-    # That divergence is exactly what the disagg pointer-arithmetic fix
-    # has to handle — without the fix, the sender computes
-    # `base + block_id * slot_bytes` and reads the wrong primary slot.
+    # Workload sizing is controlled jointly by the test config's primary
+    # KV capacity and `prompt_repeats`. Concurrent replays hold several
+    # reused prefixes at once, so a tight primary pool with a host cache
+    # forces host offload and later onboard before disagg transfer.
     _filler = (
         "This is filler context describing computer systems, distributed "
         "inference, KV cache management, host memory offload policies, "
@@ -1386,11 +1555,12 @@ def _verify_python_transceiver_under_host_offload(server_url: str, model: str):
         "radix prefix tree block reuse",
     ]
     distinct_prompts = [
-        f"Topic: {topic}. {_filler * 4} Now answer briefly:"
+        f"Topic: {topic}. {_filler * prompt_repeats} Now answer briefly:"
         for topic in _topics
     ]
 
-    async def send(session, prompt):
+    async def send(session: aiohttp.ClientSession,
+                   prompt: str) -> dict[str, Any]:
         payload = {
             "model": model,
             "prompt": prompt,
@@ -1406,7 +1576,7 @@ def _verify_python_transceiver_under_host_offload(server_url: str, model: str):
                 f"{await resp.text()}")
             return await resp.json()
 
-    def assert_sane(resp, label):
+    def assert_sane(resp: dict[str, Any], label: str) -> str:
         choices = resp.get("choices") or []
         assert choices, f"{label}: response missing 'choices': {resp}"
         text = choices[0].get("text") or ""
@@ -1417,7 +1587,7 @@ def _verify_python_transceiver_under_host_offload(server_url: str, model: str):
             f"got {usage.get('completion_tokens')}")
         return text
 
-    async def drive():
+    async def drive() -> None:
         async with aiohttp.ClientSession() as session:
             # Pass 1: prime the radix tree with each distinct prompt and
             # capture the deterministic output (temperature=0).
@@ -1433,7 +1603,7 @@ def _verify_python_transceiver_under_host_offload(server_url: str, model: str):
             # interleaving and onboard-to-different-slot for replayed
             # prompts. Strict serial sends (Pass 1 above) typically alloc
             # back to original slots and miss the bug.
-            for replay in range(5):
+            for replay in range(replay_count):
                 results = await asyncio.gather(
                     *[send(session, p) for p in distinct_prompts])
                 for idx, resp in enumerate(results):
@@ -1445,31 +1615,33 @@ def _verify_python_transceiver_under_host_offload(server_url: str, model: str):
                     print(f"[host_offload_e2e] replay={replay} prompt={idx} "
                           f"prompt_tokens={usage.get('prompt_tokens')} "
                           f"cached_tokens={cached}")
-                    # Reuse must hit — otherwise we never exercise onboard
+                    # Reuse must hit; otherwise we never exercise onboard
                     # back from host, which is the path the fix protects.
                     assert cached > 0, (
                         f"replay={replay} prompt={idx}: expected reuse "
                         f"hit (cached_tokens > 0), got usage={usage}")
-                    # Primary regression check: deterministic decoding +
-                    # correct KV must reproduce Pass 1's output bit-for-bit.
-                    assert text == first_texts[idx], (
-                        f"replay={replay} prompt={idx}: output diverged "
-                        f"from Pass 1, indicating wrong KV was read after "
-                        f"offload/onboard.\n"
-                        f"  pass1: {first_texts[idx]!r}\n"
-                        f"  replay: {text!r}")
+                    if require_stable_output:
+                        # Primary regression check: deterministic decoding
+                        # with correct KV must reproduce Pass 1's output.
+                        assert text == first_texts[idx], (
+                            f"replay={replay} prompt={idx}: output diverged "
+                            f"from Pass 1, indicating wrong KV was read after "
+                            f"offload/onboard.\n"
+                            f"  pass1: {first_texts[idx]!r}\n"
+                            f"  replay: {text!r}")
 
     asyncio.run(drive())
 
 
 # Plain parametrize (not the `llama_model_root` indirect fixture) so the
 # test ID picks up the `[TinyLlama-1.1B-Chat-v1.0]` suffix that matches
-# the other disagg tests, without forcing LLM_MODELS_ROOT / NFS access —
+# the other disagg tests, without forcing LLM_MODELS_ROOT / NFS access -
 # trtllm-serve resolves the HuggingFace id directly.
 @pytest.mark.parametrize("llama_model_root", ["TinyLlama-1.1B-Chat-v1.0"])
 def test_disaggregated_python_transceiver_host_offload(
-        disaggregated_test_root, llm_venv, disaggregated_example_root,
-        llama_model_root):  # noqa: ARG001 — used only for the parametrize label
+    disaggregated_test_root: str, llm_venv: PythonVenvRunnerImpl,
+    disaggregated_example_root: str, llama_model_root: str
+) -> None:  # noqa: ARG001 - used only for the parametrize label
     """E2E regression for block_id -> primary-slot translation in the Python disagg cache transceiver.
 
     See `_verify_python_transceiver_under_host_offload` for what this
@@ -1487,7 +1659,7 @@ def test_disaggregated_python_transceiver_host_offload(
     env = llm_venv._new_env.copy()
     env["UCX_TLS"] = get_ucx_tls()
 
-    def post_client_test(server_url: str):
+    def post_client_test(server_url: str) -> None:
         _verify_python_transceiver_under_host_offload(
             server_url, "TinyLlama/TinyLlama-1.1B-Chat-v1.0")
 
@@ -2732,6 +2904,42 @@ def test_disaggregated_gpt_oss_120b_harmony(disaggregated_test_root,
                            env=env,
                            model_path=model_dir,
                            cwd=llm_venv.get_working_directory())
+
+
+@skip_pre_blackwell
+@pytest.mark.skip_less_device(2)
+@pytest.mark.parametrize("model_path", ['gpt_oss/gpt-oss-120b'])
+def test_disaggregated_gpt_oss_120b_host_offload(
+        disaggregated_test_root: str, disaggregated_example_root: str,
+        llm_venv: PythonVenvRunnerImpl, model_path: str) -> None:
+    model_dir = f"{llm_models_root()}/{model_path}"
+    setup_model_symlink(llm_venv, model_dir, model_path)
+
+    env = llm_venv._new_env.copy()
+    tiktoken_vocab = os.path.join(llm_models_root(), "datasets",
+                                  "tiktoken_vocab")
+    env["TIKTOKEN_RS_CACHE_DIR"] = tiktoken_vocab
+    env["TIKTOKEN_ENCODINGS_BASE"] = tiktoken_vocab
+
+    def post_client_test(server_url: str) -> None:
+        _verify_python_transceiver_under_host_offload(
+            server_url,
+            model_path,
+            max_tokens=8,
+            prompt_repeats=2,
+            replay_count=2,
+            require_stable_output=False)
+        _assert_context_kv_offload_stats(server_url)
+
+    run_disaggregated_test(
+        disaggregated_example_root,
+        "gpt_oss_120b_host_offload",
+        num_iters=1,
+        env=env,
+        model_path=model_dir,
+        cwd=llm_venv.get_working_directory(),
+        post_client_test=post_client_test,
+        assert_ctx_log_contains=("primary blocks=16, secondary blocks=1820"))
 
 
 @skip_pre_hopper

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -50,6 +50,7 @@ l0_dgx_b200:
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_ucx[DeepSeek-V3-Lite-fp8]
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_nixl[DeepSeek-V3-Lite-fp8]
   - disaggregated/test_disaggregated.py::test_disaggregated_gpt_oss_120b_harmony[gpt_oss/gpt-oss-120b]
+  - disaggregated/test_disaggregated.py::test_disaggregated_gpt_oss_120b_host_offload[gpt_oss/gpt-oss-120b] TIMEOUT (90)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[latency_adp_lmtp_tp4]
   - accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=True] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_4gpus[pp4-mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False] TIMEOUT (60)


### PR DESCRIPTION
Disaggregated KV-cache transfer can format block ids that are no longer resident in the primary KV pool after host offload. Formatting those ids directly can read stale primary slots during prefill-to-decode transfer.

Add a transfer lease that pins requested block ids, onboards offloaded blocks into primary memory before cache formatting, and releases those pins after formatting. Keep transfer-prep onboarding out of request allocation stats. Add unit coverage for offloaded-block lookup and range preparation, plus GPT-OSS TP1 disagg host-offload coverage that asserts nonzero context-worker offload iteration stats.

Tests:
- KVCacheManagerTest.DisaggTransferBlockIndexLookupOnboardsOffloadedBlocks
- KVCacheManagerTest.DisaggTransferBlockRangePreparationOnboardsOffloadedBlocks
- disaggregated/test_disaggregated.py::test_disaggregated_python_transceiver_host_offload[TinyLlama-1.1B-Chat-v1.0]
- disaggregated/test_disaggregated.py::test_disaggregated_gpt_oss_120b_host_offload[gpt_oss/gpt-oss-120b]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added RAII-based `KvCacheTransferLease` support for disaggregated KV-cache transfers.
- Transfer preparation now pins requested blocks and onboards offloaded blocks into primary memory before cache formatting.
- Added stream synchronization to ensure onboarded data is ready for host-visible reads.
- Suppressed request allocation statistics and scheduler cache events for transfer-preparation allocations.
- Updated standard, MLA, and recurrent cache formatters.
- Added Python binding support with an explicit unsupported-operation error.
- No configuration or test-list changes were identified.
- Review focus: validate API consistency, rollback behavior, synchronization ordering, and release of all transfer pins.

## QA Engineer Review

- Added unit coverage for offloaded-block lookup, individual block preparation, full `BlockRange` preparation, allocation-state preservation, memory-pool lookup, and window-scoped iteration.
- Added parameterized cache-transceiver coverage for transfers involving offloaded blocks and secondary pools.
- No `tests/integration/test_lists/`, `test-db/`, `qa/`, or `waives.txt` changes were identified. CI coverage mapping was not provided.
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
