### PR TITLE
[https://nvbugs/6510284][fix] Cap gen-only benchmark queue size

### DIFF
--- a/jenkins/scripts/perf/local/submit.py
+++ b/jenkins/scripts/perf/local/submit.py
@@ -324,6 +324,25 @@ def get_benchmark_config(config, benchmark_mode):
     }
 
 
+def get_benchmark_request_queue_size(config, concurrency):
+    """Cap the gen-only fill target to the GEN executor's active capacity."""
+    gen_config = (config.get("worker_config", {}) or {}).get("gen", {}) or {}
+    concurrency = int(concurrency)
+    max_batch_size = int(gen_config.get("max_batch_size", concurrency))
+    enable_attention_dp = gen_config.get("enable_attention_dp", False)
+    tp_size = int(gen_config.get("tensor_parallel_size", 1))
+    max_capacity = max_batch_size * tp_size if enable_attention_dp else max_batch_size
+    queue_size = min(max_capacity, concurrency)
+    if queue_size < concurrency:
+        print(
+            "[WARNING] TLLM_BENCHMARK_REQ_QUEUES_SIZE capped to "
+            f"{queue_size} (max_batch_size={max_batch_size}, tp_size={tp_size}, "
+            f"attention_dp={enable_attention_dp}) instead of concurrency={concurrency}. "
+            "The fill loop cannot reach a target above the GEN executor capacity."
+        )
+    return queue_size
+
+
 def partition_has_gpu_gres(partition):
     """Return True if the Slurm partition reports GPU GRES (e.g. 'gpu:4'), False if null/absent."""
     try:
@@ -835,12 +854,13 @@ def main():
             srun_args_lines.append("--container-env=TRTLLM_DISAGG_BENCHMARK_GEN_ONLY")
         elif "gen_only" in bm_config.get("mode", ""):
             concurrency = bm_config.get("concurrency", 1)
+            queue_size = get_benchmark_request_queue_size(config, concurrency)
             ctx_worker_env_vars = (
                 f"TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP=1 {ctx_worker_env_vars}"
             )
             gen_worker_env_vars = (
                 f"TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP=1 "
-                f"TLLM_BENCHMARK_REQ_QUEUES_SIZE={concurrency} {gen_worker_env_vars}"
+                f"TLLM_BENCHMARK_REQ_QUEUES_SIZE={queue_size} {gen_worker_env_vars}"
             )
 
         if is_gb300:

--- a/jenkins/scripts/perf/submit.py
+++ b/jenkins/scripts/perf/submit.py
@@ -289,6 +289,25 @@ def get_benchmark_config(config):
     }
 
 
+def get_benchmark_request_queue_size(config, concurrency):
+    """Cap the gen-only fill target to the GEN executor's active capacity."""
+    gen_config = (config.get("worker_config", {}) or {}).get("gen", {}) or {}
+    concurrency = int(concurrency)
+    max_batch_size = int(gen_config.get("max_batch_size", concurrency))
+    enable_attention_dp = gen_config.get("enable_attention_dp", False)
+    tp_size = int(gen_config.get("tensor_parallel_size", 1))
+    max_capacity = max_batch_size * tp_size if enable_attention_dp else max_batch_size
+    queue_size = min(max_capacity, concurrency)
+    if queue_size < concurrency:
+        print(
+            "[WARNING] TLLM_BENCHMARK_REQ_QUEUES_SIZE capped to "
+            f"{queue_size} (max_batch_size={max_batch_size}, tp_size={tp_size}, "
+            f"attention_dp={enable_attention_dp}) instead of concurrency={concurrency}. "
+            "The fill loop cannot reach a target above the GEN executor capacity."
+        )
+    return queue_size
+
+
 # --------------------------------------------------------------------------- #
 # pytestCommand splitting
 # --------------------------------------------------------------------------- #
@@ -554,12 +573,13 @@ def main():
             srun_args_lines.append("--container-env=TRTLLM_DISAGG_BENCHMARK_GEN_ONLY")
         elif benchmark_mode == "gen_only":
             concurrency = benchmark_config.get("concurrency", 1)
+            queue_size = get_benchmark_request_queue_size(config, concurrency)
             ctx_worker_env_vars = (
                 f"TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP=1 {ctx_worker_env_vars}"
             )
             gen_worker_env_vars = (
                 f"TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP=1 "
-                f"TLLM_BENCHMARK_REQ_QUEUES_SIZE={concurrency} {gen_worker_env_vars}"
+                f"TLLM_BENCHMARK_REQ_QUEUES_SIZE={queue_size} {gen_worker_env_vars}"
             )
 
         if is_gb300:

--- a/tests/unittest/scripts/test_perf_submit.py
+++ b/tests/unittest/scripts/test_perf_submit.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SUBMIT_PATHS = (
+    REPO_ROOT / "jenkins" / "scripts" / "perf" / "submit.py",
+    REPO_ROOT / "jenkins" / "scripts" / "perf" / "local" / "submit.py",
+)
+DISAGG_CONFIG_DIR = REPO_ROOT / "tests" / "scripts" / "perf-sanity" / "disaggregated"
+
+
+@pytest.fixture(params=SUBMIT_PATHS, ids=("ci", "local"))
+def submit_module(request):
+    spec = importlib.util.spec_from_file_location(
+        f"perf_submit_{request.param.parent.name}", request.param
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("config_name", "expected_queue_size"),
+    (
+        ("gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL", 1),
+        (
+            "gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL",
+            128,
+        ),
+        (
+            "gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL",
+            512,
+        ),
+        (
+            "gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL",
+            4096,
+        ),
+    ),
+)
+def test_gen_only_queue_size_does_not_exceed_executor_capacity(
+    submit_module, config_name, expected_queue_size
+):
+    with open(DISAGG_CONFIG_DIR / f"{config_name}.yaml") as config_file:
+        config = yaml.safe_load(config_file)
+
+    concurrency = config["benchmark"]["concurrency_list"]
+
+    assert (
+        submit_module.get_benchmark_request_queue_size(config, concurrency) == expected_queue_size
+    )
+
+
+def test_gen_only_queue_size_preserves_reachable_concurrency(submit_module):
+    config = {
+        "worker_config": {
+            "gen": {
+                "max_batch_size": 8,
+                "tensor_parallel_size": 4,
+                "enable_attention_dp": True,
+            }
+        }
+    }
+
+    assert submit_module.get_benchmark_request_queue_size(config, 16) == 16


### PR DESCRIPTION
## What

- Cap `TLLM_BENCHMARK_REQ_QUEUES_SIZE` to the GEN executor's maximum active-request capacity in both Jenkins CI and local SLURM submitters.
- Use `max_batch_size * tensor_parallel_size` for attention-DP GEN workers and `max_batch_size` otherwise.
- Emit a warning when requested concurrency is above the reachable fill target.
- Add regression coverage for all four affected DeepSeek-V4-Pro FP4 8k1k gen-only configurations.

## Why

`TLLM_BENCHMARK_REQ_QUEUES_SIZE` is used here as a gen-only benchmark fill target. The benchmark fill gate withholds the first decode forward until the executor has fetched and admitted at least that many requests.

Fetched requests occupy the executor's active-request capacity: `max_batch_size * tensor_parallel_size` with attention DP, or `max_batch_size` otherwise. If the fill target is above that capacity, the executor needs a forward pass to complete requests and free slots, but the gate prohibits that forward until the unreachable target is met. This creates the `iter=0` livelock.

This invariant applies only to the disaggregated gen-only benchmark path when `TLLM_BENCHMARK_REQ_QUEUES_SIZE` enables the fill gate. Regular production serving does not enable this gate; its pending queue may safely exceed active capacity and is drained incrementally as requests complete. The `ctx_only` and `e2e` benchmark modes are also unaffected.

For the four NVBUG 6510284 cases, this changes the unreachable targets as follows:

| concurrency | reachable fill target |
| ---: | ---: |
| 8 | 1 |
| 180 | 128 |
| 666 | 512 |
| 4301 | 4096 |

## Timeline

- #5398 introduced the gen-only fill gate. The uncapped `concurrency` assignment appeared in #6995 and entered the Jenkins multi-node disaggregated path in #9138.
- #13065 capped the example submitter only; the Jenkins CI/local copies remained uncapped through the #14438 submitter unification.
- #16540 added the DeepSeek-V4-Pro configurations with `gen_only` disabled; #16795 enabled those tests and exposed the latent capacity mismatch.

## Recommended general fix

This PR intentionally keeps the implementation scoped to restoring the four blocked NVBUG 6510284 tests. The submitters derive a reachable fill target from the configuration values available before launch.

As a follow-up, the safety clamp should move into `PyExecutor`, after the runtime has derived its authoritative admission ceiling, including attention-DP and other runtime constraints. Launchers would continue to pass the requested benchmark concurrency unchanged, while the executor would use an effective target such as:

```python
total_max = (
    tp_size * max_num_active_requests
    if enable_attention_dp
    else max_num_active_requests
)
fill_target = min(requested_fill_target, total_max)
```

The executor should log both requested and effective targets when it clamps. This would provide one authoritative implementation for Jenkins, local SLURM, examples, and custom launchers. A fully general multi-GEN solution may also need an explicit per-worker benchmark-round target or end-of-burst signal, because global concurrency does not guarantee equal request distribution across GEN workers.

That broader cleanup is intentionally deferred so this PR can first close the immediate test gap.

## Verification

- [Targeted pipeline #50194](https://nv/trt-llm-cicd/job/main/job/L0_MergeRequest_PR/50194/) completed with `SUCCESS` on commit `b93ef24` (4 passed, 0 failed, 0 skipped); all four selected GB300 stages and Slurm jobs completed successfully.
- The selected `Post-Merge-1` shards exercised the four corresponding `disagg_upload-e2e` cases. Because these stage definitions use two pytest splits, the affected `disagg_upload-gen_only` cases are assigned to the `Post-Merge-2` shards and were not executed by this targeted run.
- [Full CI was requested](https://github.com/NVIDIA/TensorRT-LLM/pull/16915#issuecomment-5098760492); validation of the four `gen_only` cases remains pending the shard-2 results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Added executor-capacity clamping for `TLLM_BENCHMARK_REQ_QUEUES_SIZE` in Jenkins and local SLURM GEN-only submitters.
- Capacity is correctly derived as `max_batch_size * tensor_parallel_size` for attention-DP workers and `max_batch_size` otherwise.
- Warnings are emitted when requested concurrency exceeds reachable capacity, preventing the reported `iter=0` livelock without affecting production, `ctx_only`, or `e2e` paths.
- Added regression coverage for DeepSeek-V4-Pro FP4 gen-only configurations and reachable-concurrency behavior.
- No configuration or test-list changes were identified.

## QA Engineer Review

- Added:
  - `test_gen_only_queue_size_does_not_exceed_executor_capacity`
  - `test_gen_only_queue_size_preserves_reachable_concurrency`
- Tests cover both `submit.py` implementations and validate configured disaggregated benchmark scenarios.
- These test functions are not registered in `tests/integration/test_lists/` (`test-db/` or `qa/`).
- Verdict: needs follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->