### PR TITLE
[None][fix] Kimi K3: restore fp8 KV-cache scale delivery in MLA generation; enable fp8 KV cache

### DIFF
--- a/docs/source/deployment-guide/deployment-guide-for-kimi-k3-on-trtllm.md
+++ b/docs/source/deployment-guide/deployment-guide-for-kimi-k3-on-trtllm.md
@@ -32,7 +32,7 @@ The checkpoint and the configuration file must live on a shared filesystem visib
 * **Chunked prefill is supported and enabled** (`enable_chunked_prefill: true`), so prompts longer than `max_num_tokens` are scheduled across multiple steps.
 * **`kv_cache_config.tokens_per_block` must be `64`** — required by the MLA (576, 512) trtllm-gen generation kernel.
 * **Speculative decoding and disaggregated serving are supported with constraints.** Suffix-automaton speculative decoding is an opt-in for evaluation and requires CUDA graphs and the overlap scheduler disabled with `max_batch_size` ≤ 8; disaggregated serving requires matched DEP16 context and generation servers. See the "Current limitations" section of `examples/kimi_k3/README.md` and `examples/kimi_k3/disagg/README.md` for details.
-* **FP8 KV cache is not supported** due to a known accuracy issue; a fix is in progress.
+* **FP8 KV cache is supported** (`kv_cache_config.dtype: fp8`). Enabling it forces the trtllm-gen MLA generation backend, which is accuracy-equivalent to the default cute-dsl backend.
 
 ## Deployment Steps
 

--- a/examples/kimi_k3/README.md
+++ b/examples/kimi_k3/README.md
@@ -192,9 +192,10 @@ decoding requires the default cache manager, which cannot reuse blocks.
 ## Current limitations
 
 - Pipeline parallelism is not supported.
-- FP8 KV cache has a known accuracy issue and is rejected at engine setup;
-  a fix is in progress. Setting `KIMI_K3_ALLOW_INACCURATE_MLA_GEN=1`
-  bypasses the check for performance experiments only.
+- FP8 KV cache (`kv_cache_config.dtype: fp8`) is supported and forces the
+  trtllm-gen MLA generation backend (the default cute-dsl backend does not
+  accept fp8 KV device scales); accuracy matches the bf16 KV baseline on
+  GSM8K.
 - Speculative decoding:
   - Suffix-automaton (SA) speculative decoding is supported as an opt-in
     for evaluation (see `eval_extra_llm_options_sa.yaml`). SA requires CUDA

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -2048,8 +2048,13 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             metadata.kv_cache_block_offsets,
             metadata.kv_cache_manager.kv_cache_pool_pointers,
             metadata.kv_cache_manager.kv_cache_pool_mapping,
-            None,  # kv_scale_orig_quant
-            None,  # kv_scale_quant_orig
+            # Layer fp8-KV scales (default-1.0 buffers from the ctor).
+            # Passing None here cost ~22 GSM8K points on K3 fp8-KV
+            # (74.45 -> 96.89 with the buffers passed): the
+            # kernel's scale delivery must not be severed even when the
+            # scale is the trivial 1.0.
+            self.kv_scale_orig_quant,
+            self.kv_scale_quant_orig,
             out_scale,
             metadata.block_ids_per_seq,
             helix_tensor_params,

--- a/tensorrt_llm/_torch/modules/kimi_k3_mla/kimi_k3_mla_attention.py
+++ b/tensorrt_llm/_torch/modules/kimi_k3_mla/kimi_k3_mla_attention.py
@@ -406,33 +406,22 @@ class KimiK3MLAAttention(nn.Module):
         )
 
         gen_mla_backend = os.environ.get("TLLM_K3_MLA_GEN_BACKEND", "cute-dsl")
-        # FP8 KV cache is accuracy-broken on K3: GSM8K 74.45 vs 96.44 with
-        # bf16 KV on the same build, with partial scores decaying through the
-        # run — consistent with fp8 latent-cache error compounding over
-        # generation length. The decode backend is NOT the cause: bf16 +
-        # trtllm-gen decode scores 96.59, so the deficit is the fp8 cache
-        # numerics themselves. Fail fast until that is fixed.
+        # FP8 KV cache is accuracy-validated on K3 with the kv-scale
+        # plumbing fix in ``TrtllmAttention.mla_rope_generation``: GSM8K
+        # 96.89 vs 96.44 bf16 control (the pre-fix 74.45 that motivated a
+        # hard error here was the severed None kv-scale delivery, not the
+        # fp8 cache itself).
         self.has_fp8_kv_cache = bool(
             quant_config is not None
             and quant_config.layer_quant_mode.has_fp8_kv_cache())
-        if self.has_fp8_kv_cache:
-            if os.environ.get("KIMI_K3_ALLOW_INACCURATE_MLA_GEN",
-                              "0") != "1":
-                raise ValueError(
-                    "Kimi K3: FP8 KV cache (kv_cache_config.dtype='fp8') "
-                    "currently degrades accuracy severely (GSM8K 74.5 vs "
-                    "96.4 with bf16 KV). Use a non-FP8 KV cache "
-                    "(kv_cache_config.dtype 'auto'/'bfloat16'), or set "
-                    "KIMI_K3_ALLOW_INACCURATE_MLA_GEN=1 for perf-only "
-                    "experiments.")
-            if gen_mla_backend != "trtllm-gen":
-                # cute-dsl rejects fp8 KV device scales; trtllm-gen decode
-                # is accuracy-equivalent to cute-dsl on K3 (96.59 vs 96.44).
-                logger.info(
-                    "Kimi K3 MLA: FP8 KV cache requires the trtllm-gen MLA "
-                    "generation backend; overriding "
-                    f"'{gen_mla_backend}' -> 'trtllm-gen'.")
-                gen_mla_backend = "trtllm-gen"
+        if self.has_fp8_kv_cache and gen_mla_backend != "trtllm-gen":
+            # cute-dsl rejects fp8 KV device scales; trtllm-gen decode is
+            # accuracy-equivalent to cute-dsl on K3 (96.59 vs 96.44).
+            logger.info(
+                "Kimi K3 MLA: FP8 KV cache requires the trtllm-gen MLA "
+                "generation backend; overriding "
+                f"'{gen_mla_backend}' -> 'trtllm-gen'.")
+            gen_mla_backend = "trtllm-gen"
 
         # Context backend: absorbed MQA path, head_dim = kv_lora +
         # qk_rope, num_kv_heads=1. Called by ``forward_prefill`` with


### PR DESCRIPTION
### What

Fixes a ~22-point GSM8K accuracy deficit with fp8 KV cache on Kimi K3 and lifts the build-time gate that rejected `kv_cache_config.dtype: fp8`.

Root cause: `TrtllmAttention.mla_rope_generation` passed `None` for `kv_scale_orig_quant` / `kv_scale_quant_orig`, severing kv-scale delivery to the rope/quantization kernel. Passing the constructor's default-1.0 scale buffers instead fully restores accuracy — two functional lines.

With that fix:
- The K3 fp8-KV build-time `ValueError` (and its `KIMI_K3_ALLOW_INACCURATE_MLA_GEN` escape hatch) is removed.
- The cute-dsl → trtllm-gen generation-backend auto-override under fp8 KV stays: cute-dsl rejects fp8 KV device scales, and trtllm-gen decode is accuracy-equivalent (96.59 vs 96.44 on bf16).
- `examples/kimi_k3/README.md` and the Kimi K3 deployment guide are updated to state fp8 KV cache support.

### Evidence (DEP16 GSM8K, strict-match)

| arm | score |
|---|---:|
| bf16 KV control | 96.44 |
| fp8 KV, `None` scales (pre-fix) | 74.45 (partials decay 92→74 with generation length) |
| **fp8 KV, scale buffers @ 1.0 (this fix)** | **96.89** |
| fp8 KV, scale buffers @ 4.0 | 96.74 (value-insensitive — delivery is what matters) |
| fp8 KV, generation capped 96 tok | 96.59 vs bf16-capped 95.83 — prefill leg exonerated |

### Notes

- The `None`s predate Kimi K3 (DeepSeek's fp8-KV routes through the C++ `mlaGeneration` consumer at `tokens_per_block=32`; K3 at `tokens_per_block=64` is the first real user of the flashinfer trtllm-gen fp8 MLA generation leg, which is how this stayed latent).
- Follow-up (not this PR): per-checkpoint kv-scale calibration is now deliverable end-to-end; Q currently shares the KV scale buffer (`dsv3RopeOp.cpp` `quant_scale_q = quant_scale_kv`).

## Test plan

All run on this branch (`d14543b44b`) on GB300 NVL, Kimi K3 final weights, 2026-07-27.

- [x] **Unit tests** (1 node, 4 GPU) — all pass:
  ```
  pytest tests/unittest/_torch/modeling/test_kda_mtp_decode_cute_parity.py
  pytest tests/unittest/_torch/modeling/test_kimi_kda_fused_verify_parity.py
  pytest tests/unittest/_torch/modeling/test_kimi_kda_verify_parity.py
  pytest tests/unittest/_torch/modules/kimi_kda/
  pytest tests/unittest/_torch/modules/moe/test_kimi_k3_situ_moe.py
  pytest tests/torch/speculative/test_suffix_automaton.py
  ```
- [x] **Speculative-decoding logits parity** (4 GPU, truncated 4-layer checkpoint) — baseline dump + suffix-automaton logits-parity comparison via `tests/integration/defs/test_kimi_k3_specdec.py` harness (`KIMI_K3_SPEC_MODE=off` reference vs `KIMI_K3_SPEC_MODE=sa KIMI_K3_SPEC_PARITY=logits`, 48 prompts): no drift.
- [x] **GSM8K, bf16 KV control** (16 GPU DEP16, `examples/kimi_k3/run_gsm8k_kimi_k3.sbatch`) — strict-match **96.66**: no regression from passing the scale buffers on the bf16 path.
- [x] **GSM8K, fp8 KV** (same recipe + `kv_cache_config.dtype: fp8`) — strict-match **96.66** / flexible-extract 96.74, matching the bf16 control (pre-fix: 74.45). Engine setup proceeds with no override env var (gate removed), and the log shows the cute-dsl → trtllm-gen generation-backend auto-override firing. Running partial scores stayed ~96 throughout — no generation-length decay, the pre-fix failure signature.
