### PR TITLE
[None][chore] Kimi K3: apply isort/ruff-format pre-commit formatting

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1586,6 +1586,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             assert forward_args.latent_cache is not None
             from .utils import \
                 append_mla_latent_cache_generation_cuda_graph_safe
+
             # The write positions must come from device tensors: the host
             # lists (request ids, seq lens, cached-token counts) are frozen
             # into the graph at capture time and corrupt the cache on replay.

--- a/tensorrt_llm/_torch/modules/kimi_k3_mla/kimi_k3_mla_attention.py
+++ b/tensorrt_llm/_torch/modules/kimi_k3_mla/kimi_k3_mla_attention.py
@@ -213,9 +213,8 @@ def _supports_mla_prefill_direct_output(
     """Whether native generation preprocessing accepts this packed batch."""
     num_generations = rt.metadata.num_generations
     query_len = rt.seq_lens[0]
-    return (
-        query_len * num_generations == num_tokens
-        and all(seq_len == query_len for seq_len in rt.seq_lens)
+    return query_len * num_generations == num_tokens and all(
+        seq_len == query_len for seq_len in rt.seq_lens
     )
 
 
@@ -412,15 +411,16 @@ class KimiK3MLAAttention(nn.Module):
         # hard error here was the severed None kv-scale delivery, not the
         # fp8 cache itself).
         self.has_fp8_kv_cache = bool(
-            quant_config is not None
-            and quant_config.layer_quant_mode.has_fp8_kv_cache())
+            quant_config is not None and quant_config.layer_quant_mode.has_fp8_kv_cache()
+        )
         if self.has_fp8_kv_cache and gen_mla_backend != "trtllm-gen":
             # cute-dsl rejects fp8 KV device scales; trtllm-gen decode is
             # accuracy-equivalent to cute-dsl on K3 (96.59 vs 96.44).
             logger.info(
                 "Kimi K3 MLA: FP8 KV cache requires the trtllm-gen MLA "
                 "generation backend; overriding "
-                f"'{gen_mla_backend}' -> 'trtllm-gen'.")
+                f"'{gen_mla_backend}' -> 'trtllm-gen'."
+            )
             gen_mla_backend = "trtllm-gen"
 
         # Context backend: absorbed MQA path, head_dim = kv_lora +
@@ -505,8 +505,7 @@ class KimiK3MLAAttention(nn.Module):
         # refreshes it). DeepSeek's mla.py pre-materializes the same
         # tensors once for the same reason.
         cache = getattr(self, "_absorb_cache", None)
-        if (cache is not None and w.device.type != "meta"
-                and cache[0] == w.data_ptr()):
+        if cache is not None and w.device.type != "meta" and cache[0] == w.data_ptr():
             return cache[1], cache[2]
         H = self.num_heads
         n = self.qk_nope_head_dim
@@ -784,12 +783,15 @@ class KimiK3MLAAttention(nn.Module):
                 forward_args.quant_q_buffer,
             )
         else:
-            if (getattr(self._backend_ctx, "has_fp8_kv_cache", False)
-                    and rt.metadata.kv_cache_manager is not None):
+            if (
+                getattr(self._backend_ctx, "has_fp8_kv_cache", False)
+                and rt.metadata.kv_cache_manager is not None
+            ):
                 raise NotImplementedError(
                     "Kimi K3 MLA prefill fallback (ragged/mismatched batch) "
                     "does not support FP8 KV cache: the python latent-append "
-                    "helper writes unquantized BF16 rows into the FP8 pool.")
+                    "helper writes unquantized BF16 rows into the FP8 pool."
+                )
             forward_args = AttentionForwardArgs(
                 latent_cache=latent_cache,
                 attention_input_type=AttentionInputType.generation_only,
@@ -831,8 +833,10 @@ class KimiK3MLAAttention(nn.Module):
         legacy python path, whose latent-append helper handles q_len > 1.
         """
         metadata = rt.metadata
-        if (hidden_states.shape[0] == metadata.num_generations
-                and metadata.kv_cache_manager is not None):
+        if (
+            hidden_states.shape[0] == metadata.num_generations
+            and metadata.kv_cache_manager is not None
+        ):
             return self._forward_decode_fused(hidden_states, rt)
         return self._forward_decode_legacy(hidden_states, rt)
 
@@ -871,24 +875,18 @@ class KimiK3MLAAttention(nn.Module):
         q_rot_use, _ = self._maybe_rotate_qk(q_rot, None)
 
         fused_q = hidden_states.new_empty(
-            (num_tokens, self.num_heads,
-             self.kv_lora_rank + self.qk_rope_head_dim))
+            (num_tokens, self.num_heads, self.kv_lora_rank + self.qk_rope_head_dim)
+        )
         # Absorb: [H, T, m] × [H, m, kv] -> [H, T, kv] (m = qk_nope_head_dim),
         # written directly into fused_q's latent slice.
         torch.ops.trtllm.bmm_out(
-            q_nope.transpose(0, 1), k_absorb,
-            fused_q[..., :self.kv_lora_rank].transpose(0, 1))
+            q_nope.transpose(0, 1), k_absorb, fused_q[..., : self.kv_lora_rank].transpose(0, 1)
+        )
 
         num_seqs = metadata.num_seqs
-        cu_q_seqlens = torch.empty(num_seqs + 1,
-                                   dtype=torch.int32,
-                                   device=hidden_states.device)
-        cu_kv_seqlens = torch.empty(num_seqs + 1,
-                                    dtype=torch.int32,
-                                    device=hidden_states.device)
-        fmha_scheduler_counter = torch.empty(1,
-                                             dtype=torch.uint32,
-                                             device=hidden_states.device)
+        cu_q_seqlens = torch.empty(num_seqs + 1, dtype=torch.int32, device=hidden_states.device)
+        cu_kv_seqlens = torch.empty(num_seqs + 1, dtype=torch.int32, device=hidden_states.device)
+        fmha_scheduler_counter = torch.empty(1, dtype=torch.uint32, device=hidden_states.device)
         # FP8 KV cache: the rope-generation op additionally quantizes the
         # appended latent row and fused_q, emitting the FMHA dequant scales
         # and the quantized-Q buffer (same contract as the DeepSeek MLA
@@ -897,18 +895,15 @@ class KimiK3MLAAttention(nn.Module):
         mla_bmm2_scale = None
         quant_q_buffer = None
         if getattr(self._backend_gen, "has_fp8_kv_cache", False):
-            mla_bmm1_scale = torch.empty(2,
-                                         dtype=torch.float32,
-                                         device=hidden_states.device)
-            mla_bmm2_scale = torch.empty(1,
-                                         dtype=torch.float32,
-                                         device=hidden_states.device)
+            mla_bmm1_scale = torch.empty(2, dtype=torch.float32, device=hidden_states.device)
+            mla_bmm2_scale = torch.empty(1, dtype=torch.float32, device=hidden_states.device)
             quant_q_buffer = torch.empty(
                 num_tokens,
                 self.num_heads,
                 self.kv_lora_rank + self.qk_rope_head_dim,
                 dtype=torch.uint8,
-                device=hidden_states.device)
+                device=hidden_states.device,
+            )
         # Identity rope (NoPE): writes q_rot into fused_q's rope tail,
         # appends the latent row to the paged cache, and fills the
         # scheduler buffers — one op, CUDA-graph-safe (the DeepSeek MLA
@@ -946,16 +941,15 @@ class KimiK3MLAAttention(nn.Module):
             forward_args=forward_args,
         )
         # ``attn_absorbed`` shape: ``[num_tokens, num_heads * kv_lora_rank]``.
-        attn_absorbed = attn_absorbed.view(num_tokens, self.num_heads,
-                                           self.kv_lora_rank)
-        attn_out = hidden_states.new_empty(
-            (num_tokens, self.num_heads * self.v_head_dim))
+        attn_absorbed = attn_absorbed.view(num_tokens, self.num_heads, self.kv_lora_rank)
+        attn_out = hidden_states.new_empty((num_tokens, self.num_heads * self.v_head_dim))
         # Un-absorb: [H, T, kv] × [H, kv, v] -> [H, T, v], written directly
         # into the gate/o_proj input buffer.
         torch.ops.trtllm.bmm_out(
-            attn_absorbed.transpose(0, 1), v_absorb.transpose(1, 2),
-            attn_out.view(num_tokens, self.num_heads,
-                          self.v_head_dim).transpose(0, 1))
+            attn_absorbed.transpose(0, 1),
+            v_absorb.transpose(1, 2),
+            attn_out.view(num_tokens, self.num_heads, self.v_head_dim).transpose(0, 1),
+        )
         return self._apply_output_gate_and_o_proj(hidden_states, attn_out)
 
     def _forward_decode_legacy(
@@ -969,13 +963,16 @@ class KimiK3MLAAttention(nn.Module):
         where ``append_mla_latent_cache_generation_cuda_graph_safe`` handles
         the multi-token append.
         """
-        if (getattr(self._backend_gen, "has_fp8_kv_cache", False)
-                and rt.metadata.kv_cache_manager is not None):
+        if (
+            getattr(self._backend_gen, "has_fp8_kv_cache", False)
+            and rt.metadata.kv_cache_manager is not None
+        ):
             raise NotImplementedError(
                 "Kimi K3 MLA legacy decode (speculative-verification, "
                 "q_len > 1) does not support FP8 KV cache: the python "
                 "latent-append helper writes unquantized BF16 rows into "
-                "the FP8 pool.")
+                "the FP8 pool."
+            )
         num_tokens = hidden_states.shape[0]
         q_nope, q_rot = self._project_q_unabsorbed(hidden_states)
         normed_kv, k_pe, latent_cache = self._project_kv_and_latent(hidden_states)
@@ -1021,9 +1018,9 @@ class KimiK3MLAAttention(nn.Module):
         # Multi-token generation batches (spec-dec verify: SA, DFlash) go
         # through the trtllm-gen backend, which supports q_len_per_req > 1.
         num_gens = rt.metadata.num_generations
-        backend = (self._backend_gen
-                   if num_gens > 0 and num_tokens == num_gens
-                   else self._backend_ctx)
+        backend = (
+            self._backend_gen if num_gens > 0 and num_tokens == num_gens else self._backend_ctx
+        )
         attn_absorbed = backend.forward(
             q_fused_flat, None, None, rt.metadata, forward_args=forward_args
         )

--- a/tensorrt_llm/serve/tool_parser/kimi_k3_tool_parser.py
+++ b/tensorrt_llm/serve/tool_parser/kimi_k3_tool_parser.py
@@ -26,6 +26,7 @@ every other type. The section arrives after the response body, so streaming
 buffers the section and emits complete calls once ``<|close|>tools<|sep|>``
 is seen.
 """
+
 import json
 import re
 from typing import Any, Dict, List
@@ -42,10 +43,7 @@ def _unescape_attr(value: str) -> str:
 
 
 def _parse_attrs(header: str) -> Dict[str, str]:
-    return {
-        key: _unescape_attr(value)
-        for key, value in re.findall(r'(\w+)="([^"]*)"', header)
-    }
+    return {key: _unescape_attr(value) for key, value in re.findall(r'(\w+)="([^"]*)"', header)}
 
 
 class KimiK3ToolParser(BaseToolParser):
@@ -55,22 +53,29 @@ class KimiK3ToolParser(BaseToolParser):
 
     def __init__(self):
         super().__init__()
-        self.bot_token = "<|open|>tools<|sep|>"
-        self.eot_token = "<|close|>tools<|sep|>"
+        self.bot_token = "<|open|>tools<|sep|>"  # nosec B105
+        self.eot_token = "<|close|>tools<|sep|>"  # nosec B105
         # Structural leftovers that may trail the tools section when the
         # reasoning parser is not in front of this parser.
         self._trailing_structural = re.compile(
-            r"(?:<\|close\|>message<\|sep\|>|<\|end_of_msg\|>)+\s*$")
+            r"(?:<\|close\|>message<\|sep\|>|<\|end_of_msg\|>)+\s*$"
+        )
 
         self._call_regex = re.compile(
             r"<\|open\|>call(?P<attrs>[^<]*?)<\|sep\|>"
-            r"(?P<body>.*?)<\|close\|>call<\|sep\|>", re.DOTALL)
+            r"(?P<body>.*?)<\|close\|>call<\|sep\|>",
+            re.DOTALL,
+        )
         self._argument_regex = re.compile(
             r"<\|open\|>argument(?P<attrs>[^<]*?)<\|sep\|>"
-            r"(?P<value>.*?)<\|close\|>argument<\|sep\|>", re.DOTALL)
+            r"(?P<value>.*?)<\|close\|>argument<\|sep\|>",
+            re.DOTALL,
+        )
         self._json_regex = re.compile(
             r"<\|open\|>json(?P<attrs>[^<]*?)<\|sep\|>"
-            r"(?P<value>.*?)<\|close\|>json<\|sep\|>", re.DOTALL)
+            r"(?P<value>.*?)<\|close\|>json<\|sep\|>",
+            re.DOTALL,
+        )
 
     def has_tool_call(self, text: str) -> bool:
         return self.bot_token in text
@@ -83,8 +88,8 @@ class KimiK3ToolParser(BaseToolParser):
 
     def structure_info(self) -> _GetInfoFunc:
         raise NotImplementedError(
-            "kimi_k3 XTML tool calls do not support structural-tag "
-            "constrained decoding")
+            "kimi_k3 XTML tool calls do not support structural-tag constrained decoding"
+        )
 
     @staticmethod
     def _coerce_value(value: str, value_type: str) -> Any:
@@ -95,12 +100,13 @@ class KimiK3ToolParser(BaseToolParser):
         except json.JSONDecodeError:
             logger.warning(
                 "kimi_k3 tool parser: argument declared type=%s but body is "
-                "not valid JSON; keeping raw text", value_type)
+                "not valid JSON; keeping raw text",
+                value_type,
+            )
             return value
 
     def _parse_call_arguments(self, body: str) -> str:
-        """Reconstruct the OpenAI ``function.arguments`` JSON string from a
-        call body."""
+        """Reconstruct the OpenAI ``function.arguments`` JSON string from a call body."""
         json_match = self._json_regex.search(body)
         if json_match is not None:
             raw = json_match.group("value").strip()
@@ -108,8 +114,8 @@ class KimiK3ToolParser(BaseToolParser):
                 return json.dumps(json.loads(raw), ensure_ascii=False)
             except json.JSONDecodeError:
                 logger.warning(
-                    "kimi_k3 tool parser: json block is not valid JSON; "
-                    "passing raw text through")
+                    "kimi_k3 tool parser: json block is not valid JSON; passing raw text through"
+                )
                 return raw
         arguments: Dict[str, Any] = {}
         for match in self._argument_regex.finditer(body):
@@ -117,12 +123,10 @@ class KimiK3ToolParser(BaseToolParser):
             key = attrs.get("key")
             if key is None:
                 continue
-            arguments[key] = self._coerce_value(match.group("value"),
-                                                attrs.get("type", "string"))
+            arguments[key] = self._coerce_value(match.group("value"), attrs.get("type", "string"))
         return json.dumps(arguments, ensure_ascii=False)
 
-    def _parse_tools_section(self, section: str,
-                             tools: List[Tool]) -> List[ToolCallItem]:
+    def _parse_tools_section(self, section: str, tools: List[Tool]) -> List[ToolCallItem]:
         tool_indices = self._get_tool_indices(tools)
         calls: List[ToolCallItem] = []
         for position, match in enumerate(self._call_regex.finditer(section)):
@@ -130,28 +134,26 @@ class KimiK3ToolParser(BaseToolParser):
             name = attrs.get("tool")
             if not name:
                 logger.warning(
-                    "kimi_k3 tool parser: call without tool attribute: %s",
-                    match.group("attrs"))
+                    "kimi_k3 tool parser: call without tool attribute: %s", match.group("attrs")
+                )
                 continue
             if name not in tool_indices:
-                logger.warning(
-                    "Model attempted to call undefined function: %s", name)
+                logger.warning("Model attempted to call undefined function: %s", name)
             calls.append(
                 ToolCallItem(
                     tool_index=position,
                     name=name,
                     parameters=self._parse_call_arguments(match.group("body")),
-                ))
+                )
+            )
         return calls
 
-    def detect_and_parse(self, text: str,
-                         tools: List[Tool]) -> StreamingParseResult:
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         bot_idx = text.find(self.bot_token)
         if bot_idx == -1:
-            return StreamingParseResult(
-                normal_text=self._trailing_structural.sub("", text))
+            return StreamingParseResult(normal_text=self._trailing_structural.sub("", text))
         normal_text = text[:bot_idx]
-        section = text[bot_idx + len(self.bot_token):]
+        section = text[bot_idx + len(self.bot_token) :]
         eot_idx = section.find(self.eot_token)
         if eot_idx != -1:
             section = section[:eot_idx]
@@ -162,14 +164,15 @@ class KimiK3ToolParser(BaseToolParser):
                 arguments = json.loads(call.parameters)
             except json.JSONDecodeError:
                 arguments = call.parameters
-            self.prev_tool_call_arr.append({
-                "name": call.name,
-                "arguments": arguments,
-            })
+            self.prev_tool_call_arr.append(
+                {
+                    "name": call.name,
+                    "arguments": arguments,
+                }
+            )
         return StreamingParseResult(normal_text=normal_text, calls=calls)
 
-    def parse_streaming_increment(self, new_text: str,
-                                  tools: List[Tool]) -> StreamingParseResult:
+    def parse_streaming_increment(self, new_text: str, tools: List[Tool]) -> StreamingParseResult:
         self._buffer += new_text
         bot_idx = self._buffer.find(self.bot_token)
         if bot_idx == -1:
@@ -193,6 +196,6 @@ class KimiK3ToolParser(BaseToolParser):
         # Anything after the section (normally empty) is re-examined on the
         # next increment rather than dropped.
         self._buffer = self._buffer[section_end:]
-        return StreamingParseResult(normal_text=normal_text +
-                                    result.normal_text,
-                                    calls=result.calls)
+        return StreamingParseResult(
+            normal_text=normal_text + result.normal_text, calls=result.calls
+        )


### PR DESCRIPTION
Follow-up to #16916, which was merged while its Pre-commit Check was red: the check formats every file a PR touches, and the two files carried pre-existing style divergence from before the branch went through GitHub pre-commit.

Formatting-only (`isort` blank line in `trtllm.py`; `ruff-format` line re-wraps in `kimi_k3_mla_attention.py`) — no functional change, no retest needed. Pre-commit passes locally on all touched files.