### PR TITLE
[None][fix] Route the ctx branch on the request object that is later completed

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -396,10 +396,14 @@ class OpenAIDisaggregatedService(OpenAIService):
             # arrival->here = pre-ctx wait in the orchestrator/fleet.
             if hooks:
                 hooks.on_ctx_dispatch(request)
-            ctx_server, ctx_server_info = await self._ctx_router.get_next_server(
-                request, req_id=disagg_request_id
-            )
+            # ConversationRouter keys per-request load on id(request), and the
+            # client completes the ctx branch with ctx_req. Route on ctx_req so
+            # registration and release use the same object, as the gen-first
+            # branch above already does.
             ctx_req = self._get_ctx_request(request, disagg_request_id)
+            ctx_server, ctx_server_info = await self._ctx_router.get_next_server(
+                ctx_req, req_id=disagg_request_id
+            )
         gen_req = self._get_gen_request(
             request,
             ctx_response=None,

--- a/tests/unittest/disaggregated/test_openai_disagg_service.py
+++ b/tests/unittest/disaggregated/test_openai_disagg_service.py
@@ -752,3 +752,51 @@ class TestFirstGenLogitsSerializeRoundtrip:
     def test_deserialize_missing_key_raises(self):
         with pytest.raises(ValueError, match="missing required key"):
             _deserialize_first_gen_logits([{"data": "abc", "shape": [1]}])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("schedule_style", ["context_first", "generation_first"])
+async def test_ctx_branch_routes_and_finishes_same_object(schedule_style):
+    """The object routed to the ctx router must be the object later completed.
+
+    ConversationRouter keys ``_num_active_requests`` and ``_server_content_load``
+    on ``id(request)``. The context-first branch used to route on ``request`` but
+    send -- and therefore complete -- ``ctx_req = request.model_copy(...)``, so
+    the release looked up an identity that was never registered and both counters
+    grew without bound. Since they feed ``_select_least_loaded``, placement is
+    then decided against stale load.
+
+    Asserting object identity rather than call order keeps this valid under
+    refactoring: any path that routes one object and completes another fails.
+    """
+    service = _make_service(schedule_style)
+
+    routed = {}
+
+    async def _capture_get_next_server(req, *args, **kwargs):
+        routed["ctx"] = req
+        return ("ctx:8000", None)
+
+    service._ctx_router.get_next_server = AsyncMock(side_effect=_capture_get_next_server)
+    service._gen_router.get_next_server = AsyncMock(return_value=("gen:8000", None))
+
+    sent = {}
+
+    async def _capture_send(req, *args, **kwargs):
+        sent["ctx"] = req
+        raise RuntimeError("stop after ctx dispatch")
+
+    service._ctx_client.send_request = AsyncMock(side_effect=_capture_send)
+
+    request = CompletionRequest(model="model", prompt=[1] * 8, stream=False)
+    try:
+        await service._send_disagg_request(request, None)
+    except Exception:
+        pass  # we only care about which object reached the router vs the client
+
+    assert "ctx" in routed, "ctx router was never consulted"
+    assert "ctx" in sent, "ctx client was never called"
+    assert routed["ctx"] is sent["ctx"], (
+        "ctx branch routed one object and sent/completed another "
+        f"(routed id={id(routed['ctx'])}, sent id={id(sent['ctx'])}); "
+        "router load state keyed on id(request) can never be released")


### PR DESCRIPTION
## Description

`ConversationRouter` keys its per-request state on `id(request)`. It registers via
`_register_request(server, request)` (plus `_add_content_load`) and releases via
`finish_request` → `_unregister_request(request)`. Both explicitly discard `req_id`
(`del req_id`), so on this path **object identity is the key**, not the disagg request id.

The context-first branch of `_send_disagg_request_gen_first` routed on `request`, then
built `ctx_req = request.model_copy(...)` *afterwards* and sent that copy — so
`OpenAIClient._finish_request` completed `ctx_req`. Registration under `id(request)` and
release under `id(ctx_req)` never match, so `_num_active_requests` and
`_server_content_load` are never decremented and grow without bound.

```python
# before — routed on `request`, completed on `ctx_req`
ctx_server, ctx_server_info = await self._ctx_router.get_next_server(
    request, req_id=disagg_request_id)
ctx_req = self._get_ctx_request(request, disagg_request_id)
```

The gen-first branch a few lines above already builds `ctx_req` **before** routing and
routes on it. This change makes the two paths consistent.

## Impact

These counters feed `_select_least_loaded`, so the effect is not cosmetic: once reported
load is wrong, placement is decided against stale load and can concentrate work on a subset
of context servers.

Two invariants are violated:

1. reported outstanding requests can exceed the number actually in flight, even though each
   in-flight request has at most one context branch;
2. the counters do not return to zero after all requests have drained.

## Scope

No behaviour change for routers that key on `req_id` (`KvCacheAwareRouter` via `_route`) —
the same `req_id` is still passed through. The fix only changes which object instance is
handed to the router on the context-first path.

## Test

Adds `test_ctx_branch_routes_and_finishes_same_object`, parameterized over both schedule
styles. It asserts that the object handed to `_ctx_router.get_next_server` **is** the
object handed to `_ctx_client.send_request` — object identity rather than call order, so a
future refactor that reintroduces the mismatch by a different route still fails.

## Test Coverage

`tests/unittest/disaggregated/test_openai_disagg_service.py::test_ctx_branch_routes_and_finishes_same_object`

## PR Checklist

- [x] PR title follows `[JIRA/NVBugs/GitHub-issue/None][fix] Summary` format
- [x] Test cases added for the fix
- [x] Change is limited to the described defect


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**
- Fixed the context-first “need_ctx” branch in `OpenAIDisaggregatedService._send_disagg_request_gen_first` to create `ctx_req = _get_ctx_request(request, disagg_request_id)` before routing, and to call `_ctx_router.get_next_server` with `ctx_req` (matching the object later sent/completed to the ctx client).
- This makes router release/accounting work correctly again for identity-keyed state (`id(request)`-based counters), aligning behavior with the generation-first schedule and leaving `req_id`-keyed routers unaffected.
- Updated inline documentation in the gen-first path to describe the prior routing/sending identity mismatch and its impact on placement decisions.
- No public API/config/test-list changes.

**QA Engineer Review**
- Added regression test `test_ctx_branch_routes_and_finishes_same_object` (async, parametrized over `schedule_style` = `context_first`, `generation_first`) in `tests/unittest/disaggregated/test_openai_disagg_service.py`.
- The test mocks the ctx router and ctx client, captures the exact request object passed to the ctx router (`routed["ctx"]`) and the object passed to the ctx client (`sent["ctx"]`), and asserts object identity: `routed["ctx"] is sent["ctx"]`.
- Coverage in `tests/integration/test_lists/` (test-db/ or qa/) not identified.
- Verdict: **needs follow-up**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->