### PR TITLE
[https://nvbugs/6513132][fix] DSA: rebuild token-to-request map inside the MTP draft loop

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -931,7 +931,13 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
         cu_seq_lens_buf: torch.Tensor,
         req_idx_per_token_buf: torch.Tensor,
     ) -> torch.Tensor:
-        """Compute cu_seq_lens, req_idx_per_token, and token_positions (eager)."""
+        """Compute cu_seq_lens and token_positions (eager).
+
+        ``req_idx_per_token_buf`` must already describe the current seq_lens
+        layout; ``super().on_update_kv_lens()`` rebuilds it via
+        ``build_req_idx_per_token`` before this runs, so it is read here
+        rather than recomputed.
+        """
         device = seq_lens.device
 
         # cu_seq_lens
@@ -939,14 +945,10 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
             torch.cumsum(seq_lens.to(torch.int), dim=0), (1, 0)
         )
 
-        # req_idx_per_token via searchsorted
-        token_idx = torch.arange(num_tokens, dtype=torch.int32, device=device)
-        req_idx = torch.searchsorted(
-            cu_seq_lens_buf[1 : batch_size + 1].to(torch.int32), token_idx, right=True
-        )
-        req_idx_per_token_buf[:num_tokens] = req_idx
+        req_idx = req_idx_per_token_buf[:num_tokens].to(torch.int64)
 
         # token positions
+        token_idx = torch.arange(num_tokens, dtype=torch.int32, device=device)
         base_pos = cached_tokens[req_idx].to(torch.int32)
         offsets = token_idx - cu_seq_lens_buf[req_idx].to(torch.int32)
         return base_pos + offsets

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -933,10 +933,8 @@ class DeepseekV4TrtllmAttentionMetadata(DSAtrtllmAttentionMetadata):
     ) -> torch.Tensor:
         """Compute cu_seq_lens and token_positions (eager).
 
-        ``req_idx_per_token_buf`` must already describe the current seq_lens
-        layout; ``super().on_update_kv_lens()`` rebuilds it via
-        ``build_req_idx_per_token`` before this runs, so it is read here
-        rather than recomputed.
+        req_idx_per_token_buf is read, not recomputed: super().on_update_kv_lens()
+        has already rebuilt it for the current seq_lens.
         """
         device = seq_lens.device
 

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -834,8 +834,17 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
             # Runtime cached lengths after overlap/spec-dec correction.
             start_positions = self.kv_lens_cuda[:self.num_seqs] - seq_lens
 
-            # Reuse request-per-token mapping prepared in metadata.prepare().
-            # This avoids repeat_interleave in graph-capture mode.
+            # Rebuild the token->request map from the current seq_lens: the map
+            # built in prepare() describes the target forward's layout, but the
+            # draft loop rewrites seq_lens to one token per request. Equivalent to
+            # prepare()'s repeat_interleave whenever seq_lens is unchanged.
+            cu_seq_lens = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
+            token_idx = torch.arange(self.num_tokens,
+                                     device=seq_lens.device,
+                                     dtype=torch.int32)
+            self.req_idx_per_token[:self.num_tokens] = torch.searchsorted(
+                cu_seq_lens, token_idx,
+                right=True).to(self.req_idx_per_token.dtype)
             req_indices = self.req_idx_per_token[:self.num_tokens].to(
                 dtype=torch.int64)
             seq_starts = torch.cumsum(

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -265,16 +265,10 @@ def _pick_dsl_expand(
 
 def build_req_idx_per_token(seq_lens: torch.Tensor,
                             num_tokens: int) -> torch.Tensor:
-    """Map each token of the flattened batch to the request it belongs to.
+    """Map each flattened-batch token to its request index.
 
-    Token ``t`` belongs to the first request whose cumulative token end
-    exceeds ``t``; ``right=True`` makes duplicated cumsum boundaries skip
-    zero-length rows, so the result matches ``torch.repeat_interleave(
-    arange(num_seqs), seq_lens)`` for every layout (see the unit test).
-
-    Device-side, fixed-shape counterpart of the host build in
-    ``prepare_for_indices_conversion()`` — usable between draft-loop
-    iterations and inside CUDA-graph capture, where a host round-trip is not.
+    Capture-safe device counterpart of prepare_for_indices_conversion()'s
+    host repeat_interleave; right=True keeps zero-length rows equivalent.
     """
     cu_seq_lens = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
     token_idx = torch.arange(num_tokens,
@@ -849,12 +843,8 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         # boundary so a "shared" layer never reuses a stale top-k.
         self.shared_topk_indices = None
 
-        # Rebuild the token->request map from the current seq_lens: the map
-        # built in prepare() describes the target forward's layout, but the
-        # draft loop rewrites seq_lens to one token per request. Equivalent to
-        # prepare()'s repeat_interleave whenever seq_lens is unchanged.
-        # Unconditional (no kv_cache_manager guard) so subclasses such as
-        # DeepSeek-V4 can reuse the rebuilt buffer instead of recomputing it.
+        # prepare()'s map is stale once the draft loop rewrites seq_lens.
+        # Unconditional so subclasses (DeepSeek-V4) can reuse the buffer.
         if self.num_tokens > 0:
             self.req_idx_per_token[:self.num_tokens] = build_req_idx_per_token(
                 self.seq_lens_cuda[:self.num_seqs],

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -263,6 +263,26 @@ def _pick_dsl_expand(
     return factor, eff
 
 
+def build_req_idx_per_token(seq_lens: torch.Tensor,
+                            num_tokens: int) -> torch.Tensor:
+    """Map each token of the flattened batch to the request it belongs to.
+
+    Token ``t`` belongs to the first request whose cumulative token end
+    exceeds ``t``; ``right=True`` makes duplicated cumsum boundaries skip
+    zero-length rows, so the result matches ``torch.repeat_interleave(
+    arange(num_seqs), seq_lens)`` for every layout (see the unit test).
+
+    Device-side, fixed-shape counterpart of the host build in
+    ``prepare_for_indices_conversion()`` — usable between draft-loop
+    iterations and inside CUDA-graph capture, where a host round-trip is not.
+    """
+    cu_seq_lens = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
+    token_idx = torch.arange(num_tokens,
+                             device=seq_lens.device,
+                             dtype=torch.int32)
+    return torch.searchsorted(cu_seq_lens, token_idx, right=True)
+
+
 def _compute_slot_mappings(
     global_positions: torch.Tensor,
     block_offsets: torch.Tensor,
@@ -829,22 +849,22 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         # boundary so a "shared" layer never reuses a stale top-k.
         self.shared_topk_indices = None
 
+        # Rebuild the token->request map from the current seq_lens: the map
+        # built in prepare() describes the target forward's layout, but the
+        # draft loop rewrites seq_lens to one token per request. Equivalent to
+        # prepare()'s repeat_interleave whenever seq_lens is unchanged.
+        # Unconditional (no kv_cache_manager guard) so subclasses such as
+        # DeepSeek-V4 can reuse the rebuilt buffer instead of recomputing it.
+        if self.num_tokens > 0:
+            self.req_idx_per_token[:self.num_tokens] = build_req_idx_per_token(
+                self.seq_lens_cuda[:self.num_seqs],
+                self.num_tokens).to(self.req_idx_per_token.dtype)
+
         if self.kv_cache_manager is not None and self.num_tokens > 0:
             seq_lens = self.seq_lens_cuda[:self.num_seqs]
             # Runtime cached lengths after overlap/spec-dec correction.
             start_positions = self.kv_lens_cuda[:self.num_seqs] - seq_lens
 
-            # Rebuild the token->request map from the current seq_lens: the map
-            # built in prepare() describes the target forward's layout, but the
-            # draft loop rewrites seq_lens to one token per request. Equivalent to
-            # prepare()'s repeat_interleave whenever seq_lens is unchanged.
-            cu_seq_lens = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
-            token_idx = torch.arange(self.num_tokens,
-                                     device=seq_lens.device,
-                                     dtype=torch.int32)
-            self.req_idx_per_token[:self.num_tokens] = torch.searchsorted(
-                cu_seq_lens, token_idx,
-                right=True).to(self.req_idx_per_token.dtype)
             req_indices = self.req_idx_per_token[:self.num_tokens].to(
                 dtype=torch.int64)
             seq_starts = torch.cumsum(

--- a/tests/unittest/_torch/attention/sparse/dsa/test_req_idx_per_token.py
+++ b/tests/unittest/_torch/attention/sparse/dsa/test_req_idx_per_token.py
@@ -15,16 +15,11 @@
 """
 Tests for the token->request map used by DSAtrtllmAttentionMetadata.
 
-Two invariants, one test each:
-
-1. build_req_idx_per_token (device searchsorted) must equal
-   prepare_for_indices_conversion()'s host repeat_interleave for every batch
-   layout, so the two builders cannot drift.
-2. on_update_kv_lens() must rebuild the map for the CURRENT seq_lens. The MTP
-   draft loop rewrites seq_lens to one token per request without re-running
-   prepare(); reusing prepare()'s map misattributes every draft token to
-   request 0, corrupting indexer K-writes and top-k reads through the wrong
-   block table (https://nvbugs/6513132, https://nvbugs/6513093).
+1. build_req_idx_per_token must match the host repeat_interleave build for
+   every layout, so the device and host builders cannot drift.
+2. on_update_kv_lens() must rebuild the map after the MTP draft loop rewrites
+   seq_lens, or every draft token is misattributed to request 0
+   (https://nvbugs/6513132, https://nvbugs/6513093).
 """
 
 from unittest.mock import Mock
@@ -70,12 +65,7 @@ def test_matches_host_repeat_interleave(seq_lens, device):
 
 
 def test_on_update_kv_lens_rebuilds_stale_map():
-    """The draft-loop transition: the regression this PR fixes.
-
-    Bare-instance construction (object.__new__ + backing fields) mirrors
-    test_dsa_indexer.py; kv_cache_manager=None and num_generations=0 confine
-    on_update_kv_lens() to the map rebuild under test.
-    """
+    """on_update_kv_lens() must replace prepare()'s stale map (fails pre-fix)."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     device = "cuda"
@@ -85,14 +75,12 @@ def test_on_update_kv_lens_rebuilds_stale_map():
     md = object.__new__(DSAtrtllmAttentionMetadata)
     md.kv_cache_manager = None
     md._num_generations = 0
-    # Collaborators invoked at the end of on_update_kv_lens(); unrelated to
-    # the map rebuild under test (same stubbing style as test_dsa_indexer.py).
+    # Stub collaborators unrelated to the map rebuild (test_dsa_indexer.py style).
     md.kv_lens_cuda = torch.tensor([100, 200, 300], dtype=torch.int32, device=device)
     md._compute_kv_lens_row_reorder = Mock()
     md.prepare_dense_topk_indices = Mock()
 
-    # prepare() state for the target forward: 1 + max_draft_len tokens per
-    # request, map built host-side via repeat_interleave.
+    # prepare()-time state: target forward, 1 + max_draft_len tokens/request.
     target_seq_lens = torch.full((num_requests,), 1 + max_draft_len, dtype=torch.int32)
     md._seq_lens = target_seq_lens
     md._seq_lens_cuda = target_seq_lens.to(device)
@@ -100,9 +88,7 @@ def test_on_update_kv_lens_rebuilds_stale_map():
     md.req_idx_per_token = torch.empty(md._num_tokens, dtype=torch.int32, device=device)
     md.req_idx_per_token[:] = _host_reference(md._seq_lens_cuda)
 
-    # The draft loop rewrites seq_lens to one token per request (what
-    # _preprocess_inputs does between draft iterations) without re-running
-    # prepare(). The stale prefix misattributes every token to request 0.
+    # Draft loop: one token per request; the stale prefix reads [0, 0, 0].
     draft_seq_lens = torch.ones(num_requests, dtype=torch.int32)
     md._seq_lens = draft_seq_lens
     md._seq_lens_cuda = draft_seq_lens.to(device)


### PR DESCRIPTION
## The problem (for both GLM5.2 and DSV3.2):
**(1) MTP acceptance rate has regression when batch size is large**: https://nvbugspro.nvidia.com/bug/6513093 
**(2) There is a gap of AL between TRTLLM and vLLM**:https://nvbugspro.nvidia.com/bug/6513132

The root cause is the stale token→request map in DSA.py. req_idx_per_token is initially built from the target forward layout, where each request contributes max_draft_len + 1 tokens. During the one-model draft loop, the layout changes to one token per request, but on_update_kv_lens() recomputes seq_starts while reusing the old map (the map is stale). This corrupts sparse-index reads through the wrong request’s block table and also corrupts Indexer-K writes into the wrong request’s KV pages.

## Fix
Rebuild the map from the current `seq_lens` with a device-side `searchsorted`. 

Deepseek v4 doesn't have such acceptance rate regression as `DeepseekV4TrtllmAttentionMetadata` already rebuilt this map in its own `on_update_kv_lens()` override, so this is a port of existing behaviour to the base class, not new logic.

## NVBugs fixed by this PR
https://nvbugspro.nvidia.com/bug/6513132, https://nvbugspro.nvidia.com/bug/6513093 

---

## Results — before / after

All A/B pairs are the same image and harness, differing **only** by this change.
### GLM-5.2 NVFP4 — offline `trtllm-bench`, 1×GB200 tp4/ep4 + ADP, MTP k=7, greedy

| concurrency | per-rank batch | AL before | AL after | Δ |
|---:|---:|---:|---:|---:|
| 8 | 2 | 3.500 | **3.943** | +12.6% |
| 64 | 16 | 2.789 | **3.909** | +40.2% |

### DeepSeek-V3.2 NVFP4 — the second affected model, same harness, k=7 greedy

| concurrency | per-rank batch | AL before | AL after | Δ |
|---:|---:|---:|---:|---:|
| 8 | 2 | 2.5397 | **2.6379** | +3.9% |
| 64 | 16 | 2.3994 | **2.6587** | +10.8% |
| 128 | 32 | 2.3795 | **2.6769** | +12.5% |

Slope c8 → c128: **−6.3% → +1.5%** (flat). Same qualitative signature on an independent model.

The above proves that **(1) MTP acceptance rate has regression when batch size is large** is fixed.

### GLM-5.2 — depth sweep at c8, against a same-session vLLM reference

| k | before | after | vLLM | gap before | gap after |
|---:|---:|---:|---:|---:|---:|
| 1 | 1.8429 | 1.8504 | 1.849 | 0.006 | −0.001 |
| 4 | 3.0132 | 3.2547 | 3.362 | 0.349 | 0.107 |
| 7 | 3.3178 | 3.7032 | 3.789 | 0.471 | 0.086 |

The above proves that **(2)There is a gap of AL between TRTLLM and vLLM**  is fixed.

### GPQA-Diamond, 198 questions — accuracy is unaffected, as the mechanism requires

GB300 1p1d disagg, c128, MTP k=7, T=1 + rejection sampling, `max_seq_len 400000`:

| | before | after |
|---|---:|---:|
| symbolic_correct | 85.354% | 85.859% |
| no_answer | 5.556% | 3.030% |
| avg generated tokens | 57,171 | 55,662 |
| **generation wall-clock** | **5,117 s** | **3,322 s** (−35%) |

---

## What models get fixed

| architecture | models | metadata class | affected? |
|---|---|---|---|
| `DeepseekV32ForCausalLM` | DeepSeek-V3.2 / V3.2-Exp | `DSAtrtllmAttentionMetadata` (patched) | **yes**, when `max_draft_len ≥ 2` |
| `GlmMoeDsaForCausalLM` | GLM-5, GLM-5.2 | same (patched) | **yes**, same condition |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added `build_req_idx_per_token()` in `dsa.py`.
- Rebuilds the token-to-request map from current sequence lengths with device-side `torch.searchsorted`.
- Supports zero-length requests and CUDA graph execution.
- Updates `on_update_kv_lens()` to refresh the map before slot mapping.
- Updates DeepSeek-V4 position computation to use the refreshed buffer.
- No configuration or test-list changes.
- The change prevents stale request mappings during one-model MTP draft loops and avoids incorrect sparse-index and KV-page accesses.

## QA Engineer Review

- Added tests for device-side request-index construction across CPU and CUDA layouts.
- Added coverage for zero-length requests.
- Added a CUDA regression test for rebuilding stale request mappings after draft-loop sequence lengths change.
- No matching entries were found in `tests/integration/test_lists`, `test-db`, or `qa`.
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->