### PR TITLE
[None][chore] Address patch application with dangling gitlink

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -28,7 +28,8 @@ from functools import partial
 from multiprocessing import cpu_count
 from pathlib import Path
 from shutil import copy, copytree, rmtree
-from subprocess import DEVNULL, CalledProcessError, check_output, run
+from subprocess import (DEVNULL, PIPE, STDOUT, CalledProcessError, check_output,
+                        run)
 from typing import Optional, Sequence
 
 try:
@@ -87,6 +88,12 @@ def apply_msa_patch(project_dir: Path) -> None:
     tree so every consumer sees the patched fmha_sm100 sources: the runtime
     importer, editable installs, and wheel packaging. Re-running is a no-op, so
     it is safe to call on every build.
+
+    Patching goes through patch(1), as 3rdparty/CMakeLists.txt does for its
+    dependencies, so only a working tree is required. A tree copied without the
+    superproject's .git, as Dockerfile.multi does, keeps a gitlink to a gitdir
+    that is not there, and every git command fails in it. That rules out
+    git apply.
     """
     msa_source_dir = project_dir / "3rdparty" / "MSA"
     msa_package_dir = msa_source_dir / "python" / "fmha_sm100"
@@ -96,36 +103,39 @@ def apply_msa_patch(project_dir: Path) -> None:
             f"MSA sources are missing at {msa_package_dir}; initialize 3rdparty/MSA"
         )
 
-    git_env = os.environ.copy()
-    git_env["GIT_CEILING_DIRECTORIES"] = str(msa_source_dir.parent.resolve())
+    def patch_cmd(*flags: str):
+        # --no-backup-if-mismatch keeps the .orig copy of a hunk applied at an
+        # offset out of the packaged submodule.
+        return [
+            "patch", "-p1", "--batch", "--no-backup-if-mismatch", *flags, "-i",
+            str(msa_patch)
+        ]
 
-    # A clean reverse-apply means the patch is already present, so a forward
-    # apply would fail. Skip in that case.
-    already_applied = run(
-        ["git", "apply", "--reverse", "--check",
-         str(msa_patch)],
+    forward_check = run(
+        patch_cmd("--dry-run", "--forward"),
         cwd=msa_source_dir,
-        env=git_env,
-        stdout=DEVNULL,
-        stderr=DEVNULL,
-    ).returncode == 0
-    if already_applied:
+        stdout=PIPE,
+        stderr=STDOUT,
+        text=True,
+    )
+    if forward_check.returncode != 0:
+        # --forward also refuses an already applied patch, so only a clean
+        # reverse tells that no-op apart from a real conflict. Conflicts must
+        # fail loudly: the runtime asserts on the patched symbols.
+        reverse_applies = run(
+            patch_cmd("--dry-run", "--reverse"),
+            cwd=msa_source_dir,
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+        ).returncode == 0
+        if not reverse_applies:
+            raise RuntimeError(
+                f"Cannot apply {msa_patch} to {msa_source_dir}:\n"
+                f"{forward_check.stdout.strip()}")
         print(f"-- MSA patch already applied at {msa_package_dir}; skipping.")
         return
 
-    # Verify a clean forward apply before mutating the working tree.
-    run(
-        ["git", "apply", "--check", str(msa_patch)],
-        cwd=msa_source_dir,
-        env=git_env,
-        check=True,
-    )
-    run(
-        ["git", "apply", str(msa_patch)],
-        cwd=msa_source_dir,
-        env=git_env,
-        check=True,
-    )
+    run(patch_cmd("--forward"), cwd=msa_source_dir, check=True)
     print(f"-- Applied MSA patch to {msa_package_dir}.")
 
 

--- a/tests/unittest/scripts/test_build_wheel.py
+++ b/tests/unittest/scripts/test_build_wheel.py
@@ -64,6 +64,30 @@ def test_apply_msa_patch_is_idempotent_in_place(tmp_path):
     assert "def _prepare_paged_hnd_input" in patched_interface.read_text()
 
 
+def test_apply_msa_patch_with_dangling_submodule_gitlink(tmp_path):
+    """Patching must work in a copied tree whose gitlink points nowhere."""
+    project_dir = _stage_project(tmp_path)
+    patched_interface = project_dir / "3rdparty" / "MSA" / MSA_INTERFACE
+    (project_dir / "3rdparty" / "MSA" / ".git").write_text(
+        "gitdir: ../../.git/modules/3rdparty/MSA\n"
+    )
+
+    apply_msa_patch(project_dir)
+    assert "def _prepare_paged_hnd_input" in patched_interface.read_text()
+
+    apply_msa_patch(project_dir)
+    assert "def _prepare_paged_hnd_input" in patched_interface.read_text()
+
+
+def test_apply_msa_patch_reports_conflict(tmp_path):
+    """A patch that does not apply must fail, not pass as an applied one."""
+    project_dir = _stage_project(tmp_path)
+    (project_dir / "3rdparty" / "MSA" / MSA_INTERFACE).write_text("unrelated\n")
+
+    with pytest.raises(RuntimeError, match="Cannot apply"):
+        apply_msa_patch(project_dir)
+
+
 def test_apply_msa_patch_requires_initialized_submodule(tmp_path):
     project_dir = tmp_path / "project"
     project_dir.mkdir()


### PR DESCRIPTION
## Description

Following setup fails with existing method of MSA patch application because of dangling gitlink.
```
$ git clone --depth 1 --branch feat/m3_with_msa https://github.com/NVIDIA/TensorRT-LLM.git tensorrt_llm
$ cd tensorrt_llm/
$ git submodule update --init --recursive
$ make -C docker release_build \
   IMAGE_WITH_TAG=trtllm-test:latest.make \
   BUILD_WHEEL_OPTS="--nvtx" \
   CUDA_ARCHS="90-real;100-real;103-real" \
   DOCKER_PROGRESS=plain
```

This MR uses a `patch` command instead of `git apply <patch>`.

## Test Coverage

Verified this fixes the issue.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
