### PR TITLE
[https://nvbugs/6424956][fix] Support large FP8 quantization grids

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.cu
@@ -71,8 +71,8 @@ __global__ void fp8_quantize_1x128_packed_kernel_impl(__nv_fp8_e4m3* __restrict_
     int const packed_sf_k_idx = static_cast<int>(blockIdx.x);
     int const warp_id = static_cast<int>(threadIdx.x) >> 5;
     int const lane_id = static_cast<int>(threadIdx.x) & 31;
-    int const mBlockIdx = static_cast<int>(blockIdx.z * gridDim.y + blockIdx.y);
-    int const m_idx = mBlockIdx * WarpsPerBlock + warp_id;
+    int64_t const mBlockIdx = static_cast<int64_t>(blockIdx.z) * gridDim.y + blockIdx.y;
+    int64_t const m_idx = mBlockIdx * WarpsPerBlock + warp_id;
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
     cudaGridDependencySynchronize();

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.cu
@@ -40,6 +40,17 @@ namespace kernels::fp8_blockscale_gemm
 namespace
 {
 
+// CUDA limits grid.y and grid.z to 65535. Distribute row blocks across both
+// dimensions while keeping the total number of launched blocks near mBlocks.
+dim3 makeQuantizeGrid(int numPackedSfK, int mBlocks)
+{
+    constexpr int kMaxGridDimY = 65535;
+    int const gridZ = (mBlocks + kMaxGridDimY - 1) / kMaxGridDimY;
+    int const gridY = (mBlocks + gridZ - 1) / gridZ;
+    return {
+        static_cast<unsigned int>(numPackedSfK), static_cast<unsigned int>(gridY), static_cast<unsigned int>(gridZ)};
+}
+
 __device__ __forceinline__ float reciprocal_approximate_ftz_local(float a)
 {
     float b;
@@ -60,7 +71,8 @@ __global__ void fp8_quantize_1x128_packed_kernel_impl(__nv_fp8_e4m3* __restrict_
     int const packed_sf_k_idx = static_cast<int>(blockIdx.x);
     int const warp_id = static_cast<int>(threadIdx.x) >> 5;
     int const lane_id = static_cast<int>(threadIdx.x) & 31;
-    int const m_idx = static_cast<int>(blockIdx.y) * WarpsPerBlock + warp_id;
+    int const mBlockIdx = static_cast<int>(blockIdx.z * gridDim.y + blockIdx.y);
+    int const m_idx = mBlockIdx * WarpsPerBlock + warp_id;
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
     cudaGridDependencySynchronize();
@@ -239,7 +251,7 @@ void launch_fp8_quantize_1x128_packed_bf16_e4m3(__nv_fp8_e4m3* fp8_output, int32
     // extent of packed_scale_output is written (in-kernel zero for rows past `m`),
     // regardless of how the caller padded the input.
     int const m_blocks = (scale_leading_dim_uint32 + kWarpsPerBlock - 1) / kWarpsPerBlock;
-    dim3 const grid(num_packed_sf_k, m_blocks, 1);
+    dim3 const grid = makeQuantizeGrid(num_packed_sf_k, m_blocks);
     dim3 const block(kWarpsPerBlock * 32, 1, 1);
 
     tensorrt_llm::common::launchWithPdlWhenEnabled("fp8_quantize_1x128_packed_kernel_impl",
@@ -258,7 +270,7 @@ void launch_fp8_quantize_1x128_cutedsl_bf16_e4m3(__nv_fp8_e4m3* fp8_output, uint
     constexpr int kWarpsPerBlock = 4;
     int const num_packed_sf_k = (((k + 127) / 128) + 3) / 4;
     int const m_blocks = (padded_m + kWarpsPerBlock - 1) / kWarpsPerBlock;
-    dim3 const grid(num_packed_sf_k, m_blocks, 1);
+    dim3 const grid = makeQuantizeGrid(num_packed_sf_k, m_blocks);
     dim3 const block(kWarpsPerBlock * 32, 1, 1);
 
     tensorrt_llm::common::launchWithPdlWhenEnabled("fp8_quantize_1x128_cutedsl_kernel_impl",

--- a/tests/unittest/_torch/thop/parallel/test_fp8_quantize.py
+++ b/tests/unittest/_torch/thop/parallel/test_fp8_quantize.py
@@ -397,6 +397,7 @@ def _decode_packed_int32_ue8m0(packed_int32):
     (16, 7168),
     (127, 4096),
     (1024, 7168),
+    pytest.param(262141, 128, id="grid-y-overflow"),
 ])
 def test_fp8_quantize_1x128_packed_ue8m0_matches_legacy(m, k):
     """The fused packed op should produce the same FP8 output and UE8M0


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated FP8 quantization kernel launches to distribute FP8 row blocks across `grid.y` and `grid.z`, preventing failures when `max_num_tokens` pushes `grid.y` beyond CUDA’s 65,535 dimension limit.
- Adjusted kernel indexing to linearize `blockIdx.z` and `blockIdx.y` into the FP8 row-block index (`m_idx`), while preserving the prior mapping behavior for launches within the previous limit (e.g., `grid.z == 1`).
- Added `makeQuantizeGrid(numPackedSfK, mBlocks)` to construct the bounded 3D grid rather than hardcoding `dim3(numPackedSfK, m_blocks, 1)`.
- Preserved existing semantics/mapping for smaller launches; no public API, dependency, or configuration changes were introduced.
- GPU execution remains unverified in CI due to the reported B200 NVLink Fabric state and CUDA error 802; build/registration/binary inspection/pre-commit checks passed.

## QA Engineer Review

- Extended the SM100-only `fp8_quantize_1x128_packed_ue8m0_matches_legacy` parameterization with a boundary case `m=262141, k=128` (`id="grid-y-overflow"`) to exercise the grid-dimension limit fix.
- The boundary regression asserts bit-identical FP8 output and exact packed UE8M0 scale equality between the fused FP8 quant+pack path and the legacy quantize-and-pack path.
- No changes were made to integration test list files (`tests/integration/test_lists/test-db`, `tests/integration/test_lists/qa`, or `tests/integration/test_lists/*.txt`).
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

NVBug 6424956 reports a `cudaLaunchKernelEx` invalid-argument failure when
`max_num_tokens` is 64K. The fused 1x128 FP8 quantization kernels mapped all
row blocks to `grid.y`; after token expansion, an aligned row count of 262144
requires 65536 row blocks, exceeding CUDA's 65535 limit for `grid.y`.

This change distributes row blocks across `grid.y` and `grid.z` and linearizes
the two indices in the kernel. Launches within the existing limit retain
`grid.z == 1` and the same row mapping. A boundary regression case compares
the fused path with the legacy quantize-and-pack path.

There are no API or dependency changes. The expected functional impact is
limited to enabling large FP8 quantization launches that previously failed.
GPU execution remains unverified because the available B200 node's NVLink
Fabric stayed in `In Progress` state and CUDA initialization returned error
802; the PR is therefore submitted as a draft.

Related: NVBug 6424956, TRTLLM-14125.

## Test Coverage

- [x] Built `tensorrt_llm`, `th_common`, and Python bindings for SM100.
- [x] Linked and installed the built libraries into the worktree package.
- [x] Loaded the new `libth_common.so` and confirmed the target op is
      registered and all mapped TensorRT-LLM libraries come from this
      worktree.
- [x] Confirmed the compiled kernel reads `SR_CTAID.Z` with `cuobjdump`.
- [x] Passed all staged-file pre-commit hooks.
- [x] Run
      `test_fp8_quantize.py::test_fp8_quantize_1x128_packed_ue8m0_matches_legacy[grid-y-overflow]`
      on B200. This is blocked by the node-level NVLink Fabric/CUDA error 802
      described above.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
