### PR TITLE
[None][fix] Fix Qwen3.5 weight-load memory growth and MTP CUTLASS fallback

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
@@ -70,6 +70,30 @@ class ConsumableWeightsDict:
         with self._lock:
             self._weights.update(other)
 
+    def clear(self) -> None:
+        """Drop every remaining reference.
+
+        Use once a downstream dict owns the tensors: a derived dict aliases the
+        source tensors it did not rewrite, so consuming it frees nothing while
+        this dict still holds them.
+        """
+        with self._lock:
+            self._weights.clear()
+
+    def mark_consumed_keys(self, keys) -> int:
+        """Delete an exact set of keys to free memory.
+
+        Use instead of :meth:`mark_consumed` when a module consumed specific
+        tensors rather than a whole ``name.*`` subtree.
+        """
+        deleted = 0
+        with self._lock:
+            for key in keys:
+                if key in self._weights:
+                    del self._weights[key]
+                    deleted += 1
+        return deleted
+
     def mark_consumed(self, prefix: str) -> int:
         """
         Delete all keys starting with the given prefix to free memory.

--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import torch
 from torch import nn
 
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import ConsumableWeightsDict
 from tensorrt_llm._torch.models.checkpoints.hf.qwen3_next_weight_mapper import (
     Qwen3NextHfWeightMapper,
 )
@@ -556,6 +557,7 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         return remapped_weights
 
     def preprocess_weights(self, weights: dict) -> dict:
+        is_consumable = isinstance(weights, ConsumableWeightsDict)
         quant_algo = self.config.quant_config.quant_algo
 
         normalized_weights = self._normalize_weight_names(weights)
@@ -584,4 +586,7 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         if not getattr(self.config.pretrained_config, "num_experts", 0):
             packed_weights = self._remap_dense_mlp_weights(packed_weights)
 
-        return super().preprocess_weights(packed_weights)
+        processed_weights = super().preprocess_weights(packed_weights)
+        if is_consumable and not isinstance(processed_weights, ConsumableWeightsDict):
+            return ConsumableWeightsDict(processed_weights)
+        return processed_weights

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -842,9 +842,28 @@ class Qwen3NextMTP(Qwen3NextFullAttentionDecoderLayer):
         self.fusion_config.POST_MOE_FUSION = False
 
     @staticmethod
+    def _mtp_pattern_covers_experts(tail: str) -> bool:
+        """Does an MTP exclude pattern cover the routed experts?
+
+        ``tail`` is what follows the ``mtp.`` /
+        ``model.layers.<n_hidden_layers>`` prefix.
+        """
+        stripped = tail.strip(".*")
+        if not stripped:
+            # Bare (or wildcarded) layer prefix: covers the whole layer.
+            return True
+        if stripped.startswith("layers."):
+            # "layers.<idx>[.<module>]" -- drop "layers" and the index.
+            parts = stripped.split(".", 2)
+            stripped = parts[2] if len(parts) > 2 else ""
+            if not stripped:
+                return True
+        return "mlp.experts" in stripped
+
+    @staticmethod
     def _is_mtp_excluded_from_quant(
             model_config: ModelConfig[Qwen3NextConfig]) -> bool:
-        """Heuristic: did the checkpoint mark MTP as excluded from quantization?
+        """Heuristic: did the checkpoint leave the MTP *MoE* unquantized?
 
         ``apply_quant_config_exclude_modules`` runs *after* this constructor.
         For Qwen3.5 paths the exclude_modules list has already been
@@ -863,8 +882,12 @@ class Qwen3NextMTP(Qwen3NextFullAttentionDecoderLayer):
                          if n_layers is not None else None)
         for pat in qc.exclude_modules:
             if pat.startswith("mtp."):
-                return True
-            if target_prefix is not None and pat.startswith(target_prefix):
+                tail = pat[len("mtp."):]
+            elif target_prefix is not None and pat.startswith(target_prefix):
+                tail = pat[len(target_prefix):]
+            else:
+                continue
+            if Qwen3NextMTP._mtp_pattern_covers_experts(tail):
                 return True
         return False
 
@@ -1061,6 +1084,12 @@ class Qwen3NextForCausalLM(SpecDecOneEngineForCausalLM[Qwen3NextModel,
                      params_map: Optional[Dict[str, str]] = None,
                      allow_partial_loading: bool = False):
         new_weights = weight_mapper.preprocess_weights(weights)
+        # `new_weights` aliases the source tensors for every key
+        # `preprocess_weights` did not rewrite -- the routed experts, i.e. most
+        # of a MoE checkpoint. Holding `weights` too would pin them, so
+        # consuming `new_weights` during the load would free nothing.
+        if hasattr(weights, "clear"):
+            weights.clear()
         super().load_weights(
             new_weights,
             weight_mapper=weight_mapper,

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -1184,16 +1184,28 @@ def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],
                             module.load_weights(
                                 weights=[module_weights],
                                 allow_partial_loading=allow_partial_loading)
+                        loaded_own_params = None
                     else:
+                        loaded_own_params = []
                         for n, p in module.named_parameters(recurse=False):
                             if not allow_partial_loading:
                                 assert n in module_weights
                             if n in module_weights:
                                 p.data.copy_(module_weights[n][:])
+                                loaded_own_params.append(n)
 
-                    # Mark consumed weights
+                    # Only a module handed the full `name.*` subtree may
+                    # consume it wholesale. Otherwise just its own
+                    # `recurse=False` params were loaded, and since
+                    # `named_modules()` is pre-order, consuming the subtree
+                    # would drop weights its descendants have not loaded yet --
+                    # they would silently keep uninitialized weights.
                     if hasattr(weights, 'mark_consumed'):
-                        weights.mark_consumed(name)
+                        if loaded_own_params is None:
+                            weights.mark_consumed(name)
+                        elif loaded_own_params:
+                            weights.mark_consumed_keys(
+                                f'{name}.{n}' for n in loaded_own_params)
 
     if os.environ.get("TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL",
                       "False") in ["True", "true", "1", "yes", "y"]:
@@ -1285,6 +1297,8 @@ def _load_weights_impl_v2(model: Union[nn.Module, DecoderModelForCausalLM],
                             module_name,
                             module_weights,
                             allow_partial_loading=allow_partial_loading)
+                        # Handed the full subtree, like the `load_weights` case.
+                        loaded_own_params = None
                     elif hasattr(module, 'load_weights'):
                         if "linear_attn.conv1d" in name:
                             module_weights['weight'] = module_weights[
@@ -1297,7 +1311,9 @@ def _load_weights_impl_v2(model: Union[nn.Module, DecoderModelForCausalLM],
                             module.load_weights(
                                 weights=[module_weights],
                                 allow_partial_loading=allow_partial_loading)
+                        loaded_own_params = None
                     else:
+                        loaded_own_params = []
                         for n, p in module.named_parameters(recurse=False):
                             weight_mapper.handle_manual_copy(
                                 module_name,
@@ -1305,10 +1321,16 @@ def _load_weights_impl_v2(model: Union[nn.Module, DecoderModelForCausalLM],
                                 n,
                                 p,
                                 allow_partial_loading=allow_partial_loading)
+                            loaded_own_params.append(n)
 
-                    # Mark consumed weights
+                    # Consume precisely what was loaded; see the matching
+                    # comment in `_load_weights_impl`.
                     if hasattr(weights, 'mark_consumed'):
-                        weights.mark_consumed(name)
+                        if loaded_own_params is None:
+                            weights.mark_consumed(name)
+                        elif loaded_own_params:
+                            weights.mark_consumed_keys(
+                                f'{name}.{n}' for n in loaded_own_params)
 
     if os.environ.get("TRT_LLM_DISABLE_LOAD_WEIGHTS_IN_PARALLEL",
                       "False") in ["True", "true", "1", "yes", "y"]:


### PR DESCRIPTION
Weights were never released during load, so host RSS grew for the whole load and OOM-killed ranks packed onto one node. Three causes: preprocess_weights dropped the ConsumableWeightsDict wrapper, making mark_consumed a no-op; mark_consumed(name) then over-consumed the whole subtree, leaving descendant modules uninitialized (garbage output); and the source dict pinned the tensors the derived dict aliases. Peak host RSS per rank: ~212 -> ~133 GiB.

Also narrow Qwen3NextMTP's unquantized-MoE probe to exclusions that actually cover the routed experts; checkpoints keeping them in FP8 block scales were forced onto the SM90-only CUTLASS fp8_blockscale GEMM and aborted on Blackwell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Preserves `ConsumableWeightsDict` through Qwen3.5 weight preprocessing, preventing premature loss of consumable-memory behavior.
- Extends `ConsumableWeightsDict` with thread-safe helpers: `clear()` (drop remaining underlying references under lock) and `mark_consumed_keys(keys) -> int` (consume only explicitly provided exact keys under lock).
- Improves weight-loading correctness by tracking and consuming only the parameter keys actually copied/loaded per module:
  - Avoids broad subtree consumption after the manual-copy path.
  - Uses a sentinel to indicate full-subtree coverage when a module’s own `load_weights` handles the load.
- Prevents lingering references to potentially aliased/routed-expert tensors by clearing the original `weights` object after `weight_mapper.preprocess_weights` returns.
- Refines Qwen3NextMTP MTP `exclude_modules` matching so routed experts (`mlp.experts`) are correctly considered covered by exclusions, avoiding unsupported CUTLASS FP8 block-scale GEMM fallback on Blackwell.
- No configuration changes identified in the provided diff summary; test handling changes are limited to loader logic.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
