### PR TITLE
[None][fix] enable static EPLB for the one-model DSpark drafter

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_dspark.py
+++ b/tensorrt_llm/_torch/models/modeling_dspark.py
@@ -79,6 +79,96 @@ from .modeling_deepseekv4 import (
 _DSPARK_MTP_RE = re.compile(r"^mtp\.(\d+)\.(.+)$")
 
 
+def _active_moe_load_balancer():
+    """The engine-wide ``MoeLoadBalancer``, or None when EPLB is not active.
+
+    Non-None exactly inside ``maybe_create_moe_load_balancer(...)`` when EPLB is
+    really enabled for this engine (supported arch, ``moe_ep_size > 1``, no smart
+    router, ``moe_load_balancer`` configured) -- i.e. exactly the condition under
+    which ``MoE._init_load_balancer`` consumes ``model_config.moe_load_balancer``.
+    Gating every DSpark EPLB check on it keeps the non-EPLB path untouched.
+    """
+    from ..modules.fused_moe.moe_load_balancer import get_moe_load_balancer
+
+    return get_moe_load_balancer()
+
+
+def validate_dspark_eplb_layer_base(model_config, draft_config) -> None:
+    """Require the draft's layer namespace to match the target's, under EPLB.
+
+    DSpark stages take ``layer_idx = draft_config.num_hidden_layers + stage_id``
+    and register as extra EPLB layers in the *target* engine's balancer, whose
+    ``initial_global_assignments`` are keyed by target layer index. If the draft
+    checkpoint's config reports a different depth the stages silently land on the
+    wrong keys, so fail fast instead. Only enforced when EPLB is active; a
+    draft-only checkpoint config remains valid without EPLB.
+    """
+    if _active_moe_load_balancer() is None:
+        return
+    target_layers = model_config.pretrained_config.num_hidden_layers
+    draft_layers = draft_config.pretrained_config.num_hidden_layers
+    if target_layers != draft_layers:
+        raise ValueError(
+            "DSpark + EPLB requires the draft checkpoint config to report the "
+            f"same num_hidden_layers as the target (target={target_layers}, "
+            f"draft={draft_layers}). DSpark stage layer indices are derived as "
+            "draft num_hidden_layers + stage_id and must line up with the "
+            "target layer namespace that initial_global_assignments is keyed by."
+        )
+
+
+def validate_dspark_eplb_stage_layers(model_config, base: int, num_stages: int) -> None:
+    """Validate the EPLB config actually covers the DSpark draft stages.
+
+    DSpark registers each stage as an independent EPLB layer at index
+    ``base + stage_id`` (``base = num_hidden_layers``). Two failure modes are
+    caught here, before any DSpark MoE layer is built, so the user gets one
+    actionable error instead of a bare ``KeyError`` from deep inside MoE init:
+
+      1. online EPLB, which DSpark does not support (see below);
+      2. an ``initial_global_assignments`` map generated without DSpark enabled,
+         which therefore lacks the draft stage indices.
+    """
+    if _active_moe_load_balancer() is None:
+        return
+    lb_config = getattr(model_config, "moe_load_balancer", None)
+    if lb_config is None:
+        return
+
+    draft_layers = list(range(base, base + num_stages))
+
+    # DSpark supports STATIC EPLB only. Online EPLB requires every registered MoE
+    # layer to run exactly once per iteration, but the DSpark draft MoE is skipped
+    # on iterations with no generation requests anywhere (context-only batches,
+    # warmup), and the balancer's CPU worker then spins forever in its untimed
+    # waitCpuStage() waiting for a GPU signal that is only emitted from an MoE
+    # forward -- a silent deadlock.
+    if getattr(lb_config, "layer_updates_per_iter", 0) > 0:
+        raise ValueError(
+            "DSpark speculative decoding supports static EPLB only, but "
+            f"layer_updates_per_iter={lb_config.layer_updates_per_iter} requests "
+            "online EPLB. The DSpark draft MoE does not run on iterations without "
+            "generation requests (context-only batches, warmup), which deadlocks "
+            "the MoE load balancer worker. Set layer_updates_per_iter=0 in the "
+            "load balancer config, or disable DSpark."
+        )
+
+    assignments = getattr(lb_config, "initial_global_assignments", None)
+    if not assignments:
+        # No custom placement: the auto-generated assignment covers every layer.
+        return
+    missing = [layer_idx for layer_idx in draft_layers if layer_idx not in assignments]
+    if missing:
+        raise ValueError(
+            f"initial_global_assignments is missing DSpark layer(s) {missing}. "
+            f"The {num_stages} DSpark draft stages register as additional EPLB "
+            f"layers with indices [{base}, {base + num_stages}). Regenerate the "
+            "EPLB config from statistics collected with DSpark enabled (see "
+            "examples/wide_ep/ep_load_balancer/README.md), or omit "
+            "initial_global_assignments to use the auto-generated placement."
+        )
+
+
 def count_dspark_stages(ckpt_dir: str) -> Optional[int]:
     """Count the DSpark draft stages (``mtp.{s}.*``) in a checkpoint index.
 
@@ -297,6 +387,11 @@ class DSparkDraftModel(nn.Module):
         target_layer_ids = getattr(config, "dspark_target_layer_ids", [])
         self.num_capture_layers = len(target_layer_ids)
         base = config.num_hidden_layers
+        # Each DSpark stage becomes an independent EPLB layer at index base + s.
+        # Validate the load-balancer config covers them (and rejects online EPLB)
+        # before building any MoE, so a stale config fails with one actionable
+        # error instead of a bare KeyError from inside MoE._init_load_balancer.
+        validate_dspark_eplb_stage_layers(model_config, base, self.num_stages)
         # Derive a draft-only model_config (a shallow copy so the shared config
         # and the target model are untouched) carrying two draft-specific fixes:
         #
@@ -1141,4 +1236,10 @@ class DSparkForCausalLM(nn.Module):
             self.dspark_model.lm_head = target_model.lm_head
 
 
-__all__ = ["DSparkBlock", "DSparkDraftModel", "DSparkForCausalLM"]
+__all__ = [
+    "DSparkBlock",
+    "DSparkDraftModel",
+    "DSparkForCausalLM",
+    "validate_dspark_eplb_layer_base",
+    "validate_dspark_eplb_stage_layers",
+]

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -1839,6 +1839,36 @@ class MTPDraftModelForCausalLM(DecoderModelForCausalLM[MTPDraftModel,
         )
 
 
+def external_drafter_config_kwargs(model_config, spec_config) -> dict:
+    """`ModelConfig.from_pretrained` kwargs for a one-model external drafter.
+
+    The drafter is a separate checkpoint, so it gets its own `ModelConfig`; the
+    kwargs below are the execution-layout properties it must inherit from the
+    target engine it runs inside.
+
+    `moe_load_balancer` is propagated for DSpark ONLY. DSpark's draft stages are
+    full DeepSeek-V4 blocks sharing the target's expert topology and layer-index
+    namespace (`layer_idx = num_hidden_layers + stage_id`), so they can register
+    into the target's EPLB manager. Other external drafters (PARD, DFlash,
+    draft-target) are independent checkpoints whose expert topology and layer
+    numbering need not match the target's, and whose EPLB configs would therefore
+    be keyed against a different namespace -- do not generalize this without
+    designing a per-drafter EPLB config domain and layer identity first.
+    """
+    kwargs = dict(
+        trust_remote_code=True,
+        attn_backend=model_config.attn_backend,
+        moe_backend=model_config.moe_backend,
+        mapping=model_config.mapping,
+        spec_config=None,  # Avoid recursive spec-dec
+        max_num_tokens=model_config.max_num_tokens,
+        moe_max_num_tokens=model_config.moe_max_num_tokens,
+    )
+    if spec_config.spec_dec_mode.is_dspark():
+        kwargs["moe_load_balancer"] = model_config.moe_load_balancer
+    return kwargs
+
+
 def get_draft_model(model_config, draft_config, lm_head, model):
     """Construct the draft model for the configured speculative-decoding mode
     (EAGLE3 / MTP / PARD / DFlash). The DFlash branch selects the Laguna drafter
@@ -1878,9 +1908,11 @@ def get_draft_model(model_config, draft_config, lm_head, model):
         # modeling_speculative). The DSpark draft reuses the target's aux streams.
         # The draft stage count (n_mtp_layers) is not in the HF config, so derive
         # it from the checkpoint's mtp.* namespace.
-        from .modeling_dspark import DSparkForCausalLM, count_dspark_stages
+        from .modeling_dspark import (DSparkForCausalLM, count_dspark_stages,
+                                      validate_dspark_eplb_layer_base)
         num_stages = count_dspark_stages(
             model_config.spec_config.speculative_model)
+        validate_dspark_eplb_layer_base(model_config, draft_config)
         return DSparkForCausalLM(
             draft_config,
             getattr(model, "aux_stream_dict", None),
@@ -1952,13 +1984,8 @@ class SpecDecOneEngineForCausalLM(DecoderModelForCausalLM[TModel, TConfig],
                 elif spec_config.spec_dec_mode.is_external_drafter():
                     self.draft_config = ModelConfig.from_pretrained(
                         model_config.spec_config.speculative_model,
-                        trust_remote_code=True,
-                        attn_backend=model_config.attn_backend,
-                        moe_backend=model_config.moe_backend,
-                        mapping=model_config.mapping,
-                        spec_config=None,  # Avoid recursive spec-dec
-                        max_num_tokens=model_config.max_num_tokens,
-                        moe_max_num_tokens=model_config.moe_max_num_tokens)
+                        **external_drafter_config_kwargs(
+                            model_config, spec_config))
                     self.draft_config.quant_config.kv_cache_quant_algo = \
                         model_config.quant_config.kv_cache_quant_algo
                     self.draft_config.extra_attrs = model_config.extra_attrs

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_eplb_config.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_eplb_config.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""EPLB wiring for the one-model DSpark drafter (CPU-only, no weights).
+
+Covers the three P0 guarantees:
+  1. the target's ``moe_load_balancer`` reaches the DSpark draft config -- and
+     ONLY DSpark's (PARD / DFlash / draft-target must be untouched);
+  2. an ``initial_global_assignments`` map that predates DSpark fails early with
+     every missing stage index listed, not a bare ``KeyError``;
+  3. online EPLB is rejected at config time instead of deadlocking at runtime.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tensorrt_llm._torch.models import modeling_dspark
+from tensorrt_llm._torch.models.modeling_dspark import (
+    validate_dspark_eplb_layer_base,
+    validate_dspark_eplb_stage_layers,
+)
+from tensorrt_llm._torch.models.modeling_speculative import external_drafter_config_kwargs
+from tensorrt_llm._torch.speculative.interface import SpeculativeDecodingMode
+from tensorrt_llm.llmapi.llm_args import MoeLoadBalancerConfig
+
+NUM_HIDDEN_LAYERS = 61
+NUM_STAGES = 3
+NUM_EXPERTS = 384
+# DSpark stages register as EPLB layers 61, 62, 63.
+DSPARK_LAYERS = list(range(NUM_HIDDEN_LAYERS, NUM_HIDDEN_LAYERS + NUM_STAGES))
+
+
+def _assignments(layer_ids):
+    """A structurally valid placement (one permutation of the experts) per layer."""
+    return {layer_id: list(range(NUM_EXPERTS)) for layer_id in layer_ids}
+
+
+def _lb_config(layer_ids=None, layer_updates_per_iter=0):
+    return MoeLoadBalancerConfig(
+        num_slots=NUM_EXPERTS,
+        initial_global_assignments=(_assignments(layer_ids) if layer_ids is not None else None),
+        layer_updates_per_iter=layer_updates_per_iter,
+    )
+
+
+def _model_config(lb_config=None, num_hidden_layers=NUM_HIDDEN_LAYERS):
+    return SimpleNamespace(
+        moe_load_balancer=lb_config,
+        attn_backend="TRTLLM",
+        moe_backend="CUTLASS",
+        mapping=object(),
+        max_num_tokens=8192,
+        moe_max_num_tokens=8192,
+        pretrained_config=SimpleNamespace(num_hidden_layers=num_hidden_layers),
+    )
+
+
+def _spec_config(mode):
+    return SimpleNamespace(spec_dec_mode=mode)
+
+
+@pytest.fixture
+def eplb_active():
+    """Pretend an engine-wide MoeLoadBalancer is live during model construction."""
+    with patch.object(modeling_dspark, "_active_moe_load_balancer", return_value=object()):
+        yield
+
+
+# --------------------------------------------------------------------------
+# 1. config propagation -- DSpark only
+# --------------------------------------------------------------------------
+
+
+def test_dspark_draft_config_inherits_load_balancer():
+    lb_config = _lb_config(DSPARK_LAYERS)
+    kwargs = external_drafter_config_kwargs(
+        _model_config(lb_config), _spec_config(SpeculativeDecodingMode.DSPARK)
+    )
+    # The very same object, so MoeLoadBalancerConfig.setup() done on the target
+    # side is already visible to the draft.
+    assert kwargs["moe_load_balancer"] is lb_config
+
+
+def test_dspark_draft_config_does_not_recurse_into_spec_dec():
+    # Regression guard: propagating moe_load_balancer must not tempt anyone into
+    # also forwarding spec_config, which would recursively build a drafter.
+    kwargs = external_drafter_config_kwargs(
+        _model_config(_lb_config(DSPARK_LAYERS)), _spec_config(SpeculativeDecodingMode.DSPARK)
+    )
+    assert kwargs["spec_config"] is None
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        SpeculativeDecodingMode.PARD,
+        SpeculativeDecodingMode.DFLASH,
+        SpeculativeDecodingMode.DRAFT_TARGET_ONE_MODEL,
+    ],
+    # SpeculativeDecodingMode is an IntEnum, so the default ids would be the raw
+    # numbers -- name the cases so a CI failure says which drafter regressed.
+    ids=["pard", "dflash", "draft_target_one_model"],
+)
+def test_non_dspark_external_drafters_do_not_inherit_load_balancer(mode):
+    # These are independent checkpoints whose expert topology and layer-index
+    # namespace need not match the target's. Keep the DSpark fix from being
+    # silently generalized by a future refactor.
+    kwargs = external_drafter_config_kwargs(
+        _model_config(_lb_config(DSPARK_LAYERS)), _spec_config(mode)
+    )
+    assert "moe_load_balancer" not in kwargs
+
+
+def test_external_drafter_kwargs_are_stable_across_modes():
+    common = external_drafter_config_kwargs(
+        _model_config(_lb_config(DSPARK_LAYERS)), _spec_config(SpeculativeDecodingMode.PARD)
+    )
+    dspark = external_drafter_config_kwargs(
+        _model_config(_lb_config(DSPARK_LAYERS)), _spec_config(SpeculativeDecodingMode.DSPARK)
+    )
+    assert set(dspark) - set(common) == {"moe_load_balancer"}
+
+
+# --------------------------------------------------------------------------
+# 2. stage-layer placement coverage
+# --------------------------------------------------------------------------
+
+
+def test_complete_assignments_accepted(eplb_active):
+    lb_config = _lb_config(list(range(NUM_HIDDEN_LAYERS)) + DSPARK_LAYERS)
+    validate_dspark_eplb_stage_layers(_model_config(lb_config), NUM_HIDDEN_LAYERS, NUM_STAGES)
+
+
+def test_missing_stage_layers_listed_in_one_error(eplb_active):
+    # A config generated back when the drafter was 1-layer MTP: covers layer 61
+    # (the old MTP layer) but not the two extra DSpark stages.
+    lb_config = _lb_config(list(range(NUM_HIDDEN_LAYERS + 1)))
+    with pytest.raises(ValueError) as excinfo:
+        validate_dspark_eplb_stage_layers(_model_config(lb_config), NUM_HIDDEN_LAYERS, NUM_STAGES)
+    message = str(excinfo.value)
+    assert "[62, 63]" in message
+    assert "61" not in message.split("missing DSpark layer(s)")[1].split("]")[0]
+
+
+def test_auto_placement_needs_no_assignments(eplb_active):
+    # initial_global_assignments omitted -> auto-generated placement covers every
+    # registered layer, including the DSpark stages.
+    validate_dspark_eplb_stage_layers(
+        _model_config(_lb_config(None)), NUM_HIDDEN_LAYERS, NUM_STAGES
+    )
+
+
+def test_no_validation_when_eplb_inactive():
+    # Without an active balancer the config is never consumed, so an incomplete
+    # (or online) one must not break the non-EPLB DSpark path.
+    lb_config = _lb_config(list(range(NUM_HIDDEN_LAYERS)), layer_updates_per_iter=4)
+    with patch.object(modeling_dspark, "_active_moe_load_balancer", return_value=None):
+        validate_dspark_eplb_stage_layers(_model_config(lb_config), NUM_HIDDEN_LAYERS, NUM_STAGES)
+
+
+# --------------------------------------------------------------------------
+# 3. online EPLB rejected at config time
+# --------------------------------------------------------------------------
+
+
+def test_online_eplb_rejected(eplb_active):
+    lb_config = _lb_config(list(range(NUM_HIDDEN_LAYERS)) + DSPARK_LAYERS, layer_updates_per_iter=2)
+    with pytest.raises(ValueError, match="static EPLB only"):
+        validate_dspark_eplb_stage_layers(_model_config(lb_config), NUM_HIDDEN_LAYERS, NUM_STAGES)
+
+
+# --------------------------------------------------------------------------
+# 4. draft/target layer namespace must line up
+# --------------------------------------------------------------------------
+
+
+def test_layer_base_mismatch_rejected(eplb_active):
+    with pytest.raises(ValueError, match="num_hidden_layers"):
+        validate_dspark_eplb_layer_base(
+            _model_config(_lb_config(DSPARK_LAYERS)),
+            _model_config(_lb_config(DSPARK_LAYERS), num_hidden_layers=3),
+        )
+
+
+def test_layer_base_match_accepted(eplb_active):
+    validate_dspark_eplb_layer_base(
+        _model_config(_lb_config(DSPARK_LAYERS)), _model_config(_lb_config(DSPARK_LAYERS))
+    )
+
+
+def test_layer_base_not_checked_without_eplb():
+    # A draft-only checkpoint config with its own depth stays valid when EPLB is
+    # off -- the layer namespace only has to line up for EPLB placement keys.
+    with patch.object(modeling_dspark, "_active_moe_load_balancer", return_value=None):
+        validate_dspark_eplb_layer_base(
+            _model_config(None), _model_config(None, num_hidden_layers=3)
+        )


### PR DESCRIPTION
## Summary

Enable **static** MoE EPLB for the one-model DSpark drafter. With EPLB configured, the
DSpark gen worker currently dies at model init:

```
File ".../models/modeling_dspark.py", line 322, in __init__      <- DSparkDraftModel
File ".../models/modeling_deepseekv4.py", line 1817, in __init__  <- DeepseekV4MoE
File ".../modules/fused_moe/interface.py", line 549, in _init_load_balancer
    assert moe_load_balancer_config is not None
AssertionError
```

The target model is built inside `maybe_create_moe_load_balancer(...)`, so the
engine-wide `MoeLoadBalancer` is live while the DSpark stages are constructed. But
the generic external-drafter branch builds `draft_config` from the speculative
checkpoint without propagating `moe_load_balancer`, so every DSpark stage MoE sees

```
get_moe_load_balancer()               -> active manager
draft_config.moe_load_balancer        -> None
```

`DSparkDraftModel._derive_draft_model_config()` is not the loss point — its shallow
copy preserves whatever it receives; the config is already `None` by then.

## Changes

**1. Propagate `moe_load_balancer` — DSpark only.**
`external_drafter_config_kwargs()` factors out the kwargs the one-model external
drafter inherits, and adds `moe_load_balancer` **only** when
`spec_dec_mode.is_dspark()`. DSpark's stages are full DeepSeek-V4 blocks sharing the
target's expert topology and layer-index namespace (`layer_idx = num_hidden_layers +
stage_id`), so they can register into the target's balancer. PARD / DFlash /
draft-target are independent checkpoints whose topology and layer numbering need not
match the target's, and whose EPLB configs would be keyed against a different
namespace — their kwargs are byte-for-byte unchanged, and a test pins that so a
future refactor cannot silently generalize this.

**2. Validate the EPLB config covers the DSpark stages.**
A config generated before DSpark (or in the 1-layer-MTP era) lacks the stage
indices, which today surfaces as a bare `KeyError: layer_idx 62 not found` from deep
inside MoE init. The new check runs before any DSpark MoE is built and reports every
missing index at once, with the layer-index convention and a pointer to the
regeneration docs.

**3. Reject online EPLB (`layer_updates_per_iter > 0`) at config time.**
DSpark supports static EPLB only. Online EPLB requires every registered MoE layer to
run exactly once per iteration, but the DSpark draft MoE is skipped on iterations
with no generation requests anywhere (context-only batches, warmup). The balancer's
CPU worker then spins forever in its untimed `waitCpuStage()`, waiting for a GPU
signal only an MoE forward emits — a silent deadlock. Failing at startup beats
hanging in production.

Also: when EPLB is active, require the draft config's `num_hidden_layers` to match
the target's, since the stage indices derive from it and must line up with the
namespace `initial_global_assignments` is keyed by.

All three validations are gated on `get_moe_load_balancer()` being non-None — the
exact condition under which `MoE._init_load_balancer` consumes the config — so the
non-EPLB path is untouched.

## Test Coverage

**Unit** — `tests/unittest/_torch/speculative/hw_agnostic/test_dspark_eplb_config.py`,
14 CPU-only cases: propagation, PARD/DFlash/draft-target isolation, `spec_config=None`
preservation, stage-layer coverage, auto-placement, EPLB-inactive no-op, online-EPLB
rejection, layer-base match/mismatch.

**Multi-GPU smoke** (no CI stage covers DSpark + EPLB + real weights, so this was run
by hand):

| Case | Setup | Result |
|---|---|---|
| Missing stage layers | DeepSeek-V4-Pro-DSpark, 8x B200, TP8/EP8, a real deployment EPLB config covering layers 0..61 | `ValueError: initial_global_assignments is missing DSpark layer(s) [62, 63]. ... indices [61, 64).` on all 8 ranks — the old `AssertionError` is gone |
| Full coverage | DeepSeek-V4-Flash-DSpark, 4x B200, TP4/EP4, config covering 0..45 | Model constructs; EPLB registers layers **0..45** = `num_hidden_layers(43) + num_stages(3)`, i.e. the DSpark stages land on **43/44/45** as designed; weight load, `register_weight_slots_after_to_cuda()` and `finalize_model()` all pass |

The full-coverage run stops in `_run_attention_warmup` on a CuTe-DSL codegen error
(`nvgpu.cvt_fptrunc` operand type), so it does not reach token generation. That
failure is **unrelated to this change**: an otherwise identical run with EPLB fully
disabled fails identically.

## Notes for reviewers

- Scope is deliberately DSpark-only; generalizing to other external drafters needs a
  per-drafter EPLB config domain and layer identity design first.
- No user-facing or nested config fields are added, so the LLM args golden manifest
  does not change.
- **Pre-existing issue, out of scope:** any construction-time exception raised after
  `MoeLoadBalancer(...)` exists leaves `MpiPoolSession.shutdown` blocked joining its
  workers forever, while they still hold GPU contexts. Confirmed with a control that
  fails from pre-existing code (`interface.py` assignment-length check) on *target*
  layer 0, with these validators inactive — it hangs identically. Worth a separate
  issue: it turns a fast, clear config error into a wedged node.

## PR Checklist

- [x] PR title follows `[JIRA/NVBUG/None][type] description`
- [x] New unit tests added and passing locally
- [x] Pre-commit hooks pass
- [x] DCO signed off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Adds DSpark-only static EPLB propagation and validation.
- Enforces complete stage-layer assignments and matching draft/target layer counts.
- Preserves behavior when EPLB is inactive.
- No configuration or test-list files were changed.
- CI merge pipelines failed twice and require investigation before retriggering.

## QA Engineer Review

Added 14 CPU-only unit tests covering propagation, drafter isolation, layer coverage, inactive/online EPLB behavior, and layer-count validation.

No corresponding entries were added to `tests/integration/test_lists/test-db/` or `qa/`. Existing DSpark performance entries in `qa/llm_perf_core.yml` do not cover this unit-test file.

**Verdict: needs follow-up**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->