### PR TITLE
[https://nvbugs/6523880][fix] Restored the `legacy-files.txt` entry and regenerated the three derived…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -488,6 +488,7 @@ common-files: &common_files |
         tests/integration/defs/accuracy/accuracy_core.py |
         tests/integration/defs/accuracy/scripts/collect_evaluated_accuracies.py |
         tests/integration/defs/accuracy/scripts/compute_theta_and_thresholds.py |
+        tests/integration/defs/accuracy/test_cli_flow.py |
         tests/integration/defs/accuracy/test_disaggregated_serving.py |
         tests/integration/defs/accuracy/test_llm_api_autodeploy.py |
         tests/integration/defs/accuracy/test_llm_api_pytorch.py |
@@ -1258,6 +1259,7 @@ legacy-files: &legacy_files |
         tests/integration/defs/accuracy/accuracy_core.py |
         tests/integration/defs/accuracy/scripts/collect_evaluated_accuracies.py |
         tests/integration/defs/accuracy/scripts/compute_theta_and_thresholds.py |
+        tests/integration/defs/accuracy/test_cli_flow.py |
         tests/integration/defs/accuracy/test_disaggregated_serving.py |
         tests/integration/defs/accuracy/test_llm_api_autodeploy.py |
         tests/integration/defs/accuracy/test_llm_api_pytorch.py |

--- a/legacy-files.txt
+++ b/legacy-files.txt
@@ -480,6 +480,7 @@ tests/integration/defs/accuracy/__init__.py
 tests/integration/defs/accuracy/accuracy_core.py
 tests/integration/defs/accuracy/scripts/collect_evaluated_accuracies.py
 tests/integration/defs/accuracy/scripts/compute_theta_and_thresholds.py
+tests/integration/defs/accuracy/test_cli_flow.py
 tests/integration/defs/accuracy/test_disaggregated_serving.py
 tests/integration/defs/accuracy/test_llm_api_autodeploy.py
 tests/integration/defs/accuracy/test_llm_api_pytorch.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -537,6 +537,7 @@ exclude = [
     "tests/integration/defs/accuracy/accuracy_core.py",
     "tests/integration/defs/accuracy/scripts/collect_evaluated_accuracies.py",
     "tests/integration/defs/accuracy/scripts/compute_theta_and_thresholds.py",
+    "tests/integration/defs/accuracy/test_cli_flow.py",
     "tests/integration/defs/accuracy/test_disaggregated_serving.py",
     "tests/integration/defs/accuracy/test_llm_api_autodeploy.py",
     "tests/integration/defs/accuracy/test_llm_api_pytorch.py",

--- a/ruff-legacy.toml
+++ b/ruff-legacy.toml
@@ -497,6 +497,7 @@ include = [
     "tests/integration/defs/accuracy/accuracy_core.py",
     "tests/integration/defs/accuracy/scripts/collect_evaluated_accuracies.py",
     "tests/integration/defs/accuracy/scripts/compute_theta_and_thresholds.py",
+    "tests/integration/defs/accuracy/test_cli_flow.py",
     "tests/integration/defs/accuracy/test_disaggregated_serving.py",
     "tests/integration/defs/accuracy/test_llm_api_autodeploy.py",
     "tests/integration/defs/accuracy/test_llm_api_pytorch.py",

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -241,21 +241,25 @@ class MpiPoolSession(MpiSession):
                  n_workers: int,
                  wait_shutdown: bool = False,
                  env_overrides: Optional[Dict[str, str]] = None):
-        """Args:
-        n_workers: number of MPI workers to spawn.
-        wait_shutdown: when True, ``shutdown()`` blocks until the spawned
-            worker processes have actually exited. ``MPIPoolExecutor.shutdown``
-            returns at disconnect, but a worker's GPU memory is only released
-            when its process exits; callers that start new GPU work right
-            after ``shutdown()`` (e.g. CI test infrastructure handing a
-            pre-spawned pool to the next test) race that release and can OOM.
-            Off by default: production teardown does not need the barrier and
-            keeps its current latency.
-        env_overrides: extra environment variables to set in the WORKERS at
-            spawn, on top of the TRTLLM*/TLLM* variables forwarded from the
-            parent. The parent process environment is never touched — this
-            replaces the racy "set os.environ around the spawn, then restore"
-            pattern for callers that spawn pools from background threads.
+        """Spawn a pool of MPI worker processes.
+
+        Args:
+            n_workers: number of MPI workers to spawn.
+            wait_shutdown: when True, ``shutdown()`` blocks until the spawned
+                worker processes have actually exited.
+                ``MPIPoolExecutor.shutdown`` returns at disconnect, but a
+                worker's GPU memory is only released when its process exits;
+                callers that start new GPU work right after ``shutdown()``
+                (e.g. CI test infrastructure handing a pre-spawned pool to the
+                next test) race that release and can OOM. Off by default:
+                production teardown does not need the barrier and keeps its
+                current latency.
+            env_overrides: extra environment variables to set in the WORKERS at
+                spawn, on top of the TRTLLM*/TLLM* variables forwarded from the
+                parent. The parent process environment is never touched — this
+                replaces the racy "set os.environ around the spawn, then
+                restore" pattern for callers that spawn pools from background
+                threads.
         """
         self.n_workers = n_workers
         self._wait_shutdown = wait_shutdown


### PR DESCRIPTION
## Summary
- **Root cause**: PR #16612 removed `test_cli_flow.py` from `legacy-files.txt` while the file still exists, silently promoting it from Group B to Group A (full `ruff check`/`format`) which it never conformed to; independently PR #15908 added a second `D205` to `MpiPoolSession.__init__` past its ratchet baseline of 1.
- **Fix**: Restored the `legacy-files.txt` entry and regenerated the three derived configs via `scripts/legacy_utils.py gen-configs` (no hand edits); rewrote the `__init__` docstring with a summary line, blank line, and Google-style `Args:` block inside yapf's 80-col limit — no baseline loosened, no rule disabled.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6523880


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**
- Restored `tests/integration/defs/accuracy/test_cli_flow.py` to the legacy classification and regenerated all related Ruff/pre-commit configuration entries consistently.
- Reworked `MpiPoolSession.__init__` documentation into a compliant Google-style `Args:` section, clarifying shutdown and environment override behavior without changing executable logic or API signatures.
- Configuration paths and formatting exclusions are consistent; no duplicates or unintended scope changes identified.

**QA Engineer Review**
- No test code or test-list files were modified; only the classification of an existing integration test was restored.
- No test functions were added, modified, or removed.
- Verdict: sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->