### PR TITLE
[None][fix] Keep MRoPE delta read slots dense across mixed batches

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -873,18 +873,18 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
 
         # Text-only fast path: skip the multi-modal HF processor (tokenizer
         # output matches it bit-exactly when `images` / `videos` are `None`)
-        # while still populating mrope_config since the LM is M-RoPE.
+        # and emit no multimodal data at all. Without vision spans the M-RoPE
+        # coordinates degenerate to the scalar token positions on all three
+        # axes and the position delta is zero, which is exactly what the model
+        # engine falls back to for a request carrying no `mrope_config`.
+        # Synthesizing them would cost an O(seq_len) (3, 1, N) tensor per
+        # request that the engine then moves to device, and in disaggregated
+        # serving the prefill worker re-registers that tensor as a CUDA IPC
+        # handle no one ever consumes.
         if not mm_data:
             input_ids = self.tokenizer(text_prompt,
                                        return_tensors="pt").input_ids
-            attention_mask = torch.ones_like(input_ids)
-            mrope_config = self.get_mrope_config(input_ids, None, None,
-                                                 attention_mask, None)
-            return input_ids[0].to(torch.int32).tolist(), {
-                "multimodal_data": {
-                    "mrope_config": mrope_config
-                },
-            }
+            return input_ids[0].to(torch.int32).tolist(), None
 
         processed_inputs = self._preprocess(text_prompt, mm_data,
                                             mm_processor_kwargs)
@@ -904,7 +904,8 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
                 "video_grid_thw": processed_inputs.get('video_grid_thw')
             }
 
-        # NOTE: Even on the text-only prompts, we still need 'mrope_position_ids'.
+        # Computed from the fused ids so the vision spans get their per-axis
+        # coordinates; the text-only path above returns before reaching here.
         mrope_config = self.get_mrope_config(
             processed_inputs['input_ids'],
             processed_inputs.get('image_grid_thw', None),
@@ -1874,8 +1875,12 @@ class Qwen2VLModelBase(PreTrainedModel, MultimodalModelMixin):
         multimodal_params = kwargs.get("multimodal_params", [])
         mm_embeds = []
         mrope_config = {}
-        # NOTE: Qwen*-VL series has mrope_config even on the text-only prompts, so we need to separate
-        # the entries that do have multimodal data from those that correspond to text-only prompts.
+        # `multimodal_params` holds one entry per request that carried any
+        # multimodal data, context entries first, followed by the generation
+        # entries that only seed the MRoPE delta cache. The slice bounds the
+        # scan to the context prefix; `_get_requests_with_mm_data` is what
+        # actually selects the entries with encoder input, so this does not
+        # rely on the entries lining up with the context requests.
         if num_context_requests > 0:
             mm_multimodal_params = self._get_requests_with_mm_data(
                 multimodal_params[:num_context_requests])

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -1410,8 +1410,12 @@ class Qwen3VLModelBase(PreTrainedModel, MultimodalModelMixin):
         mrope_config = {}
         deepstack_embeds = []
 
-        # NOTE: Qwen*-VL series has mrope_config even on the text-only prompts,
-        # so we need to separate the mm_multimodal_params from the text-only prompts.
+        # `multimodal_params` holds one entry per request that carried any
+        # multimodal data, context entries first, followed by the generation
+        # entries that only seed the MRoPE delta cache. The slice bounds the
+        # scan to the context prefix; `_get_requests_with_mm_data` is what
+        # actually selects the entries with encoder input, so this does not
+        # rely on the entries lining up with the context requests.
         if num_context_requests > 0:
             mm_multimodal_params, has_raw_image_or_video_data = self._get_requests_with_mm_data(
                 multimodal_params[:num_context_requests]

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3879,8 +3879,14 @@ class PyTorchModelEngine(ModelEngine):
         ]  # (start_idx, end_idx, (3,1,L) mrope_pos_ids) per multimodal request
         mrope_delta_write_seq_slots = []
         mrope_delta_read_seq_slots = []
+        # Whether any generation request in this batch carries real MRoPE
+        # metadata; see the post-loop cleanup below.
+        has_gen_mrope_delta = False
         # Extra model-side cache slot reserved for CUDA graph / warmup dummy
-        # requests, whose outputs are discarded.
+        # requests, whose outputs are discarded, and for generation requests
+        # that carry no MRoPE metadata at all. The cache is zero-initialized and
+        # the write path only ever targets real ``py_seq_slot``s, so this slot
+        # permanently reads back a zero delta.
         mrope_dummy_seq_slot = self.max_num_tokens * self.mapping.pp_size
         num_accepted_draft_tokens = []  # per request
         is_enc_dec = self._is_encoder_decoder_model()
@@ -4032,16 +4038,25 @@ class PyTorchModelEngine(ModelEngine):
                                                 "multimodal_data_device_paths",
                                                 None))
                 if _use_mrope:
-                    mrope_config = multimodal_params.multimodal_data[
-                        'mrope_config']
-                    mrope_pos_ids = mrope_config['mrope_position_ids']
-                    ctx_mrope_position_ids = mrope_pos_ids[:, :, begin_compute:
-                                                           begin_compute +
-                                                           len(prompt_tokens)]
-                    # Record as (start_idx, end_idx, (3,1,L) mrope_pos_ids)
-                    mrope_position_ids.append(
-                        (len(position_ids) - len(prompt_tokens),
-                         len(position_ids), ctx_mrope_position_ids))
+                    # A request may carry multimodal content but no MRoPE
+                    # metadata (a text-only prompt whose input processor skips
+                    # ``mrope_config``, or a model that does not consume it).
+                    # Its per-axis positions are just the scalar positions,
+                    # which the (3,1,N) seeding further below already
+                    # broadcasts, so leave that span alone.
+                    mrope_config = multimodal_params.multimodal_data.get(
+                        'mrope_config') or {}
+                    mrope_pos_ids = mrope_config.get('mrope_position_ids')
+                    if mrope_pos_ids is not None:
+                        ctx_mrope_position_ids = mrope_pos_ids[:, :,
+                                                               begin_compute:
+                                                               begin_compute +
+                                                               len(prompt_tokens
+                                                                   )]
+                        # Record as (start_idx, end_idx, (3,1,L) mrope_pos_ids)
+                        mrope_position_ids.append(
+                            (len(position_ids) - len(prompt_tokens),
+                             len(position_ids), ctx_mrope_position_ids))
                     mrope_position_delta = mrope_config.get(
                         'mrope_position_deltas')
                     if mrope_position_delta is not None:
@@ -4352,19 +4367,21 @@ class PyTorchModelEngine(ModelEngine):
                                                    "py_mrope_position_delta",
                                                    None)
                     if mrope_position_delta is None and request.py_multimodal_data:
-                        mrope_config = request.py_multimodal_data[
-                            'mrope_config']
-                        mrope_position_delta = mrope_config[
-                            'mrope_position_deltas']
-                        if mrope_position_delta.device.type == "cpu":
-                            mrope_position_delta = maybe_pin_memory(
-                                mrope_position_delta).to(device='cuda',
-                                                         dtype=torch.int32,
-                                                         non_blocking=True)
-                            mrope_config[
-                                'mrope_position_deltas'] = mrope_position_delta
-                        request.py_mrope_position_delta = mrope_position_delta
+                        mrope_config = request.py_multimodal_data.get(
+                            'mrope_config') or {}
+                        mrope_position_delta = mrope_config.get(
+                            'mrope_position_deltas')
+                        if mrope_position_delta is not None:
+                            if mrope_position_delta.device.type == "cpu":
+                                mrope_position_delta = maybe_pin_memory(
+                                    mrope_position_delta).to(device='cuda',
+                                                             dtype=torch.int32,
+                                                             non_blocking=True)
+                                mrope_config[
+                                    'mrope_position_deltas'] = mrope_position_delta
+                            request.py_mrope_position_delta = mrope_position_delta
                     if mrope_position_delta is not None:
+                        has_gen_mrope_delta = True
                         # NOTE: Expanding position_ids to 3D tensor who is using mrope
                         gen_mrope_position_ids = (past_seen_token_num +
                                                   mrope_position_delta).expand(
@@ -4398,6 +4415,21 @@ class PyTorchModelEngine(ModelEngine):
                                  gen_mrope_position_ids))
                             mrope_delta_read_seq_slots.append(
                                 delta_read_seq_slot)
+                    else:
+                        # No MRoPE metadata for this request (text-only prompt
+                        # on an MRoPE model): its delta is zero by construction,
+                        # so read the reserved zero slot instead of skipping the
+                        # append. The kernel indexes ``mrope_position_deltas``
+                        # by *generation batch index*
+                        # (decoderMaskedMultiheadAttentionTemplate.h), so a list
+                        # that is sparse w.r.t. the generation batch would
+                        # silently shift every later request onto another
+                        # request's delta. No ``mrope_position_ids`` span is
+                        # recorded: the broadcast scalar position is already
+                        # this request's answer on all three axes.
+                        for _ in range(beam_width):
+                            mrope_delta_read_seq_slots.append(
+                                mrope_dummy_seq_slot)
                 # Equivalent to the original `is_generation_admission and
                 # request.py_multimodal_data`. The batch-level flag is checked
                 # first so non-multimodal models pay one LOAD_FAST per request
@@ -4414,6 +4446,14 @@ class PyTorchModelEngine(ModelEngine):
                 # to prevent access errors due to None values
                 if not request.is_cuda_graph_dummy:
                     gen_request_seq_slots.append(request.py_seq_slot)
+
+        if _use_mrope and not has_gen_mrope_delta:
+            # Every generation request in this batch resolved to the zero slot,
+            # so the gathered deltas would be an all-zero vector -- identical to
+            # passing no deltas at all. Dropping the list keeps the steady-state
+            # generation fast path (which requires the mrope lists to be empty)
+            # reachable for text-only batches on MRoPE models.
+            mrope_delta_read_seq_slots.clear()
 
         previous_batch_len = len(previous_batch_indices)
 

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -686,10 +686,154 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
         torch.testing.assert_close(position_ids, expected, atol=0, rtol=0)
         self.assertEqual(result["mrope_delta_write_seq_slots"].cpu().tolist(),
                          [0])
+        # Read slots are dense w.r.t. the generation batch: the padded dummy
+        # has no MRoPE metadata, so it resolves to the reserved zero slot
+        # (max_num_tokens * pp_size) rather than being dropped, which would
+        # shift every later request onto another request's delta.
         self.assertEqual(result["mrope_delta_read_seq_slots"].cpu().tolist(),
-                         [0])
+                         [0, 32])
         self.assertNotIn("multimodal_embedding",
                          multimodal_request.py_multimodal_data)
+        kv_cache_manager.shutdown()
+
+    def _setup_mrope_engine(self, max_num_tokens: int = 32):
+        """Build a DummyModelEngine that takes the MRoPE path, plus its KV cache
+        manager and attention metadata."""
+        llm_args = TorchLlmArgs(model="dummy")
+        model_engine = DummyModelEngine(llm_args, dtype=torch.half)
+        model_engine.model.model_config.pretrained_config.rope_scaling = {
+            "type": "mrope"
+        }
+
+        mapping = Mapping(world_size=1, tp_size=1, rank=0)
+        kv_cache_config = KvCacheConfig(max_tokens=max_num_tokens)
+        kv_cache_manager = KVCacheManager(
+            kv_cache_config,
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            num_layers=1,
+            num_kv_heads=16,
+            head_dim=16,
+            tokens_per_block=1,
+            max_seq_len=max_num_tokens,
+            max_batch_size=4,
+            mapping=mapping,
+            dtype=tensorrt_llm.bindings.DataType.HALF,
+        )
+        attn_metadata = AttentionMetadata(max_num_requests=4,
+                                          max_num_tokens=max_num_tokens,
+                                          kv_cache_manager=kv_cache_manager)
+        attn_metadata.is_cuda_graph = False
+
+        model_engine.max_num_tokens = max_num_tokens
+        model_engine.input_ids_cuda = torch.zeros(max_num_tokens,
+                                                  dtype=torch.int32,
+                                                  device='cuda')
+        model_engine.position_ids_cuda = torch.zeros(max_num_tokens,
+                                                     dtype=torch.int32,
+                                                     device='cuda')
+        model_engine.mrope_position_ids_cuda = torch.zeros(
+            (3, 1, max_num_tokens), dtype=torch.int32, device='cuda')
+        model_engine.previous_batch_indices_cuda = torch.zeros(
+            max_num_tokens, dtype=torch.int32, device='cuda')
+        return model_engine, kv_cache_manager, attn_metadata
+
+    @staticmethod
+    def _make_mrope_gen_request(num_tokens: int, req_id: int, seq_slot: int,
+                                delta):
+        """Generation request carrying an MRoPE delta when `delta` is not None,
+        and no multimodal data at all otherwise (a text-only prompt)."""
+        request = _create_request(num_tokens, req_id)
+        request.py_prompt_len = num_tokens
+        request.py_batch_idx = None
+        request.py_seq_slot = seq_slot
+        request.sampling_config.beam_width = 1
+        if delta is None:
+            request.py_multimodal_data = {}
+        else:
+            request.py_multimodal_data = {
+                "mrope_config": {
+                    "mrope_position_deltas":
+                    torch.tensor([[delta]], dtype=torch.int32)
+                },
+            }
+        return request
+
+    def test_prepare_tp_inputs_mixed_text_only_keeps_mrope_deltas_dense(
+            self) -> None:
+        """A text-only request between two multimodal ones must not compact the
+        MRoPE delta read slots.
+
+        The attention kernel indexes `mrope_position_deltas` by generation batch
+        index, so a list that skips the text-only request would hand request 2's
+        delta to the text-only request and read out of bounds for request 2.
+        """
+        model_engine, kv_cache_manager, attn_metadata = self._setup_mrope_engine(
+        )
+
+        # (num_tokens, seq_slot, delta); the middle request is text-only.
+        requests = [
+            self._make_mrope_gen_request(4, 1, 0, 10),
+            self._make_mrope_gen_request(5, 2, 1, None),
+            self._make_mrope_gen_request(6, 3, 2, 20),
+        ]
+
+        scheduled_requests = ScheduledRequests()
+        scheduled_requests.context_requests_last_chunk = []
+        scheduled_requests.generation_requests = requests
+
+        result, _ = model_engine._prepare_tp_inputs(
+            scheduled_requests=scheduled_requests,
+            kv_cache_manager=kv_cache_manager,
+            attn_metadata=attn_metadata)
+
+        # One entry per generation request, in batch order. Slot 32 is the
+        # reserved zero slot (max_num_tokens * pp_size) standing in for the
+        # text-only request's zero delta.
+        self.assertEqual(result["mrope_delta_read_seq_slots"].cpu().tolist(),
+                         [0, 32, 2])
+        # Only the two multimodal requests seed the seq-slot delta cache.
+        self.assertEqual(result["mrope_delta_write_seq_slots"].cpu().tolist(),
+                         [0, 2])
+
+        # past_seen_token_num is num_tokens - 1, offset by the request's delta;
+        # the text-only request keeps the plain scalar position on all 3 axes.
+        position_ids = result["position_ids"]
+        self.assertEqual(tuple(position_ids.shape), (3, 1, 3))
+        expected = torch.tensor([[[13, 4, 25]]] * 3,
+                                dtype=torch.int32,
+                                device='cuda')
+        torch.testing.assert_close(position_ids, expected, atol=0, rtol=0)
+        kv_cache_manager.shutdown()
+
+    def test_prepare_tp_inputs_all_text_only_drops_mrope_deltas(self) -> None:
+        """A generation batch with no MRoPE metadata at all emits no delta
+        tensors, so the steady-state generation fast path stays reachable."""
+        model_engine, kv_cache_manager, attn_metadata = self._setup_mrope_engine(
+        )
+
+        scheduled_requests = ScheduledRequests()
+        scheduled_requests.context_requests_last_chunk = []
+        scheduled_requests.generation_requests = [
+            self._make_mrope_gen_request(4, 1, 0, None),
+            self._make_mrope_gen_request(6, 2, 1, None),
+        ]
+
+        result, _ = model_engine._prepare_tp_inputs(
+            scheduled_requests=scheduled_requests,
+            kv_cache_manager=kv_cache_manager,
+            attn_metadata=attn_metadata)
+
+        # An all-zero delta vector is identical to passing no deltas at all.
+        self.assertNotIn("mrope_delta_read_seq_slots", result)
+        self.assertNotIn("mrope_delta_write_seq_slots", result)
+
+        # MRoPE models keep the (3,1,N) layout even with no mrope work.
+        position_ids = result["position_ids"]
+        self.assertEqual(tuple(position_ids.shape), (3, 1, 2))
+        expected = torch.tensor([[[3, 5]]] * 3,
+                                dtype=torch.int32,
+                                device='cuda')
+        torch.testing.assert_close(position_ids, expected, atol=0, rtol=0)
         kv_cache_manager.shutdown()
 
     def test_kv_cache_manager_with_execution_stream(self):

--- a/tests/unittest/_torch/multimodal/test_qwen2vl_text_only_prompt.py
+++ b/tests/unittest/_torch/multimodal/test_qwen2vl_text_only_prompt.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Text-only prompts on the Qwen VL input processors carry no MRoPE metadata.
+
+Without vision spans the M-RoPE coordinates degenerate to the scalar token
+positions and the position delta is zero, so the processor emits no
+`multimodal_data` at all and the model engine falls back to broadcasting the
+scalar positions. Synthesizing an (3, 1, N) `mrope_position_ids` tensor per
+request instead costs an O(seq_len) device allocation, and in disaggregated
+serving the prefill worker re-registers it as a CUDA IPC handle no one reads.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.models.modeling_qwen2vl import (
+    Qwen2_5VLInputProcessorBase,
+    Qwen2VLInputProcessorBase,
+)
+from tensorrt_llm._torch.models.modeling_qwen3vl import Qwen3VLInputProcessorBase
+
+_TOKEN_IDS = [151644, 872, 198, 9707, 151645]
+
+PROCESSOR_CLASSES = [
+    Qwen2VLInputProcessorBase,
+    Qwen2_5VLInputProcessorBase,
+    Qwen3VLInputProcessorBase,
+]
+
+
+class _FakeTokenizer:
+    def __call__(self, prompt, return_tensors=None):
+        assert prompt == "text prompt"
+        assert return_tensors == "pt"
+        return SimpleNamespace(input_ids=torch.tensor([_TOKEN_IDS]))
+
+
+def _make_processor(processor_cls):
+    processor = object.__new__(processor_cls)
+    processor._tokenizer = _FakeTokenizer()
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("get_mrope_config must not run for a text-only prompt")
+
+    processor.get_mrope_config = _fail
+    return processor
+
+
+@pytest.mark.parametrize("processor_cls", PROCESSOR_CLASSES)
+@pytest.mark.parametrize("mm_data", [None, {}], ids=["mm_data_none", "mm_data_empty"])
+def test_text_only_prompt_emits_no_multimodal_data(processor_cls, mm_data):
+    processor = _make_processor(processor_cls)
+
+    token_ids, extra = processor.call_with_text_prompt(
+        {"prompt": "text prompt", "multi_modal_data": mm_data},
+        sampling_params=None,
+    )
+
+    assert token_ids == _TOKEN_IDS
+    assert extra is None
+
+
+@pytest.mark.parametrize("processor_cls", PROCESSOR_CLASSES)
+def test_text_only_prompt_without_multi_modal_data_key(processor_cls):
+    """`multi_modal_data` absent entirely takes the same path."""
+    processor = _make_processor(processor_cls)
+
+    token_ids, extra = processor.call_with_text_prompt(
+        {"prompt": "text prompt"},
+        sampling_params=None,
+    )
+
+    assert token_ids == _TOKEN_IDS
+    assert extra is None


### PR DESCRIPTION
  ## Description

  `_prepare_tp_inputs` appended to `mrope_delta_read_seq_slots` only for
  generation requests carrying MRoPE metadata, compacting the delta vector
  whenever a request without it shared the batch. The attention kernel indexes
  `mrope_position_deltas` by *generation batch index*
  (`decoderMaskedMultiheadAttentionTemplate.h`), so every later request read
  another request's delta and the tail read out of bounds — silent corruption,
  no shape check anywhere. `cuda_graph_runner` already sizes its static slot
  buffer as `batch_size * max_beam_width`, so dense was the assumed contract.

  Reachable on `main` today via CUDA graph padding (dummy requests have no MRoPE
  metadata); dummy outputs are discarded so it went unnoticed. It hits real
  traffic as soon as an input processor stops synthesizing `mrope_config` for
  text-only prompts.

  Commit 1: requests without MRoPE metadata resolve to the reserved zero slot
  instead of being dropped — their delta is zero by construction, and that slot
  always reads back zero. If no generation request has MRoPE metadata the list is
  dropped entirely, keeping the steady-state generation fast path reachable.

  Commit 2: with the runtime no longer requiring it, the text-only fast path stops
  synthesizing MRoPE metadata, saving an O(seq_len) `(3, 1, N)` tensor plus H2D
  per request — and in disagg a CUDA IPC handle nothing consumes.

  Text-only observation raised in #16874; this lands the runtime fix it depends on.

  ## Test Coverage

  - `test_pytorch_model_engine.py`: 2 new tests (dense slots in a mixed batch;
    all-text-only batch drops the deltas) + `test_prepare_tp_inputs_with_partial_mrope_segments`
    updated — the padded dummy now yields `[0, 32]` instead of `[0]`.
  - `test_qwen2vl_text_only_prompt.py` (new): 9 cases across the three Qwen VL
    processors, `multi_modal_data` absent / `None` / empty.

  Local Qwen2.5-VL-7B: interleaving text-only with image requests fails with
  `cudaErrorIllegalAddress` without the runtime fix, matches the multimodal-only
  baseline with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**
- Corrects dense MRoPE delta-slot indexing for mixed multimodal and text-only generation batches.
- Avoids generating unnecessary MRoPE metadata, coordinate tensors, device transfers, and CUDA IPC handles for text-only prompts.
- Uses optional metadata access safely and preserves the text-only scalar-position fallback.
- No configuration, public API, or test-list changes identified.

**QA Engineer Review**
- Added:
  - `test_prepare_tp_inputs_mixed_text_only_keeps_mrope_deltas_dense`
  - `test_prepare_tp_inputs_all_text_only_drops_mrope_deltas`
  - `test_text_only_prompt_emits_no_multimodal_data`
  - `test_text_only_prompt_without_multi_modal_data_key`
- Modified partial-segment MRoPE expectations.
- These tests are not referenced in `tests/integration/test_lists/` test-db or QA lists.
- **Verdict: insufficient** — CI/manual test-list coverage should be added or confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->