### PR TITLE
[None][fix] Skip empty aux buffers when registering NIXL memory

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -2354,7 +2354,14 @@ class TransferWorker:
         ptr_num = len(aux_meta.ptrs)
         ptr_descs = []
         for i in range(ptr_num):
+            # An empty aux buffer (draft tokens when max_draft_len == 0) has a null
+            # data_ptr(). NIXL's LIBFABRIC backend rejects a null address and fails the
+            # whole registration; UCX tolerates it. Empty buffers carry no data anyway.
+            if int(aux_meta.ptrs[i]) == 0 or int(aux_meta.size[i]) == 0:
+                continue
             ptr_descs.append((aux_meta.ptrs[i], aux_meta.size[i], 0, f"aux_buffer_ptr_{i}"))
+        if not ptr_descs:
+            return
         reg_memory_desc = RegMemoryDescs("DRAM", ptr_descs)
         self._agent.register_memory(reg_memory_desc)
         logger.debug(f"Registered auxiliary buffer memory with transfer agent: {reg_memory_desc}")

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -75,6 +75,7 @@ l0_a10:
   - unittest/disaggregated/test_peer.py
   - unittest/disaggregated/test_cache_reuse_adapter.py
   - unittest/disaggregated/test_bounce.py
+  - unittest/disaggregated/test_aux_buffer_registration.py
   - unittest/disaggregated/region/test_block.py
   - unittest/disaggregated/test_mamba_transfer.py
   - unittest/tools

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -88,6 +88,7 @@ l0_h100:
   - unittest/disaggregated/test_kv_transfer.py
   - unittest/disaggregated/test_kv_transfer_mp.py
   - unittest/disaggregated/test_transceiver_bounded_polling.py
+  - unittest/disaggregated/test_aux_buffer_registration.py
   - unittest/disaggregated/test_pool_matching.py
   - unittest/disaggregated/test_deepseek_v4_kv_transfer.py
   - unittest/disaggregated/test_minimax_m3_kv_transfer.py

--- a/tests/unittest/disaggregated/test_aux_buffer_registration.py
+++ b/tests/unittest/disaggregated/test_aux_buffer_registration.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Aux-buffer registration must skip empty (null-pointer) buffers.
+
+``torch.empty(n, 0)`` — which is what the draft-token buffer is when
+``max_draft_len == 0`` — has ``data_ptr() == 0``. Handing that null address to
+NIXL fails the whole registration on the LIBFABRIC backend.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+
+from tensorrt_llm._torch.disaggregation.native.auxiliary import AuxBufferMeta
+from tensorrt_llm._torch.disaggregation.native.transfer import TransferWorker
+
+
+def _fake_worker(ptrs, sizes):
+    """Minimal stand-in exposing only what _register_aux_buffer touches."""
+    meta = AuxBufferMeta(ptrs=np.array(ptrs, dtype=np.int64), size=np.array(sizes, dtype=np.int64))
+    return SimpleNamespace(
+        _aux_buffer=SimpleNamespace(meta=meta), _agent=Mock(), _registered_mem=[]
+    )
+
+
+def _registered_descs(worker):
+    worker._agent.register_memory.assert_called_once()
+    return worker._agent.register_memory.call_args[0][0].descs
+
+
+def test_null_pointer_aux_buffer_is_skipped():
+    # Index 1 mirrors the draft-token buffer with max_draft_len == 0.
+    worker = _fake_worker([0x1000, 0, 0x3000, 0x4000], [512, 0, 128, 128])
+
+    TransferWorker._register_aux_buffer(worker)
+
+    descs = _registered_descs(worker)
+    assert [d[0] for d in descs] == [0x1000, 0x3000, 0x4000]
+    assert all(d[1] > 0 for d in descs)
+    assert len(worker._registered_mem) == 1
+
+
+def test_zero_size_aux_buffer_is_skipped():
+    worker = _fake_worker([0x1000, 0x2000], [512, 0])
+
+    TransferWorker._register_aux_buffer(worker)
+
+    assert [d[0] for d in _registered_descs(worker)] == [0x1000]
+
+
+def test_all_buffers_registered_when_none_are_empty():
+    ptrs = [0x1000, 0x2000, 0x3000, 0x4000]
+    worker = _fake_worker(ptrs, [512, 256, 128, 128])
+
+    TransferWorker._register_aux_buffer(worker)
+
+    descs = _registered_descs(worker)
+    assert [d[0] for d in descs] == ptrs
+    # Names stay tied to the original buffer index so peers still match up.
+    assert [d[3] for d in descs] == [f"aux_buffer_ptr_{i}" for i in range(4)]
+
+
+def test_nothing_registered_when_every_buffer_is_empty():
+    worker = _fake_worker([0, 0], [0, 0])
+
+    TransferWorker._register_aux_buffer(worker)
+
+    worker._agent.register_memory.assert_not_called()
+    assert worker._registered_mem == []

--- a/tests/unittest/disaggregated/test_aux_buffer_registration.py
+++ b/tests/unittest/disaggregated/test_aux_buffer_registration.py
@@ -22,6 +22,7 @@ NIXL fails the whole registration on the LIBFABRIC backend.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import List, Sequence, Tuple
 from unittest.mock import Mock
 
 import numpy as np
@@ -30,7 +31,7 @@ from tensorrt_llm._torch.disaggregation.native.auxiliary import AuxBufferMeta
 from tensorrt_llm._torch.disaggregation.native.transfer import TransferWorker
 
 
-def _fake_worker(ptrs, sizes):
+def _fake_worker(ptrs: Sequence[int], sizes: Sequence[int]) -> SimpleNamespace:
     """Minimal stand-in exposing only what _register_aux_buffer touches."""
     meta = AuxBufferMeta(ptrs=np.array(ptrs, dtype=np.int64), size=np.array(sizes, dtype=np.int64))
     return SimpleNamespace(
@@ -38,24 +39,27 @@ def _fake_worker(ptrs, sizes):
     )
 
 
-def _registered_descs(worker):
+def _registered_descs(worker: SimpleNamespace) -> List[Tuple[int, int, int, str]]:
     worker._agent.register_memory.assert_called_once()
     return worker._agent.register_memory.call_args[0][0].descs
 
 
-def test_null_pointer_aux_buffer_is_skipped():
-    # Index 1 mirrors the draft-token buffer with max_draft_len == 0.
-    worker = _fake_worker([0x1000, 0, 0x3000, 0x4000], [512, 0, 128, 128])
+def test_null_pointer_aux_buffer_is_skipped() -> None:
+    # Index 1 mirrors the draft-token buffer with max_draft_len == 0. Its size is
+    # deliberately non-zero so this fails if only zero-sized buffers are filtered.
+    worker = _fake_worker([0x1000, 0, 0x3000, 0x4000], [512, 256, 128, 128])
 
     TransferWorker._register_aux_buffer(worker)
 
     descs = _registered_descs(worker)
     assert [d[0] for d in descs] == [0x1000, 0x3000, 0x4000]
-    assert all(d[1] > 0 for d in descs)
+    # Names keep their original index, so the list is sparse rather than renumbered.
+    assert [d[3] for d in descs] == ["aux_buffer_ptr_0", "aux_buffer_ptr_2", "aux_buffer_ptr_3"]
     assert len(worker._registered_mem) == 1
 
 
-def test_zero_size_aux_buffer_is_skipped():
+def test_zero_size_aux_buffer_is_skipped() -> None:
+    # Mirror image of the case above: a valid pointer with nothing behind it.
     worker = _fake_worker([0x1000, 0x2000], [512, 0])
 
     TransferWorker._register_aux_buffer(worker)
@@ -63,7 +67,7 @@ def test_zero_size_aux_buffer_is_skipped():
     assert [d[0] for d in _registered_descs(worker)] == [0x1000]
 
 
-def test_all_buffers_registered_when_none_are_empty():
+def test_all_buffers_registered_when_none_are_empty() -> None:
     ptrs = [0x1000, 0x2000, 0x3000, 0x4000]
     worker = _fake_worker(ptrs, [512, 256, 128, 128])
 
@@ -75,7 +79,7 @@ def test_all_buffers_registered_when_none_are_empty():
     assert [d[3] for d in descs] == [f"aux_buffer_ptr_{i}" for i in range(4)]
 
 
-def test_nothing_registered_when_every_buffer_is_empty():
+def test_nothing_registered_when_every_buffer_is_empty() -> None:
     worker = _fake_worker([0, 0], [0, 0])
 
     TransferWorker._register_aux_buffer(worker)


### PR DESCRIPTION
## Description

The draft-token aux buffer is allocated as `torch.empty(max_slot_num, max_draft_len)`, so when
`max_draft_len == 0` (the default with speculative decoding off) it has `numel() == 0` and
**`data_ptr() == 0`**.

`TransferWorker._register_aux_buffer` registered all four aux pointers unconditionally, handing that
null address to NIXL. The LIBFABRIC backend rejects it outright — `libfabric_rail_manager.cpp`
`if (!buffer) { NIXL_ERROR << "Invalid buffer parameter"; }` — which fails the **entire** registration
and aborts transceiver setup:

```
E libfabric_rail_manager.cpp:759] Invalid buffer parameter
E libfabric_backend.cpp:932]      Rail Manager registerMemory failed
E nixl_agent.cpp:545]             registerMem: registration failed
RuntimeError: Assertion failed: status == NIXL_SUCCESS (transferAgent.cpp:702)
  NixlTransferAgent::registerMemory(MemoryDescs const&)
```

That string occurs at exactly one site in NIXL and its only precondition is `buffer != nullptr`, so the
failure is purely the null descriptor — no alignment, size, or memory-type constraint is involved.

Two reasons this went unnoticed:

- **UCX tolerates the null descriptor**, so it only reproduces with `TRTLLM_NIXL_KVCACHE_BACKEND=LIBFABRIC`.
- **The C++ transceiver is unaffected** — its only `registerMemory` call site
  (`agent_utils/connection.cpp`) registers just the `CacheTransBufferManager` staging buffers, never the
  aux buffer. Only the Python transceiver registers aux memory.

This blocks `cache_transceiver_config.transceiver_runtime: PYTHON` + LIBFABRIC entirely, which in turn
blocks EFA for any model pinned to the V2 KV-cache manager.

## Fix

Skip zero-pointer / zero-size buffers, and skip the registration call entirely if nothing is left.
Empty buffers carry no data, so nothing is lost. Descriptor names stay tied to the original buffer
index so peer matching is unchanged.

## Test Coverage

New `tests/unittest/disaggregated/test_aux_buffer_registration.py` (4 cases, no GPU required): null
pointer skipped, zero size skipped, all-non-empty unchanged (including desc names), and nothing
registered when every buffer is empty.

Validated end-to-end on 2 nodes x 2 GPU over AWS EFA (16 rails), NIXL + LIBFABRIC:

| combination | before | after |
|---|---|---|
| NIXL / PYTHON / V1 | `TRANSFER_ERROR` | **PASS, 96.7 GB/s per GPU** |

For reference the C++ transceiver reaches 93.6 GB/s per GPU on the same setup; the Python path is
slightly faster since it is zero-copy and skips the staging-buffer hop.

## PR Checklist

- [x] PR title follows `[JIRA/NVBUG/None][type] Summary`
- [x] Commit is signed off (DCO)
- [x] New tests added
- [x] Change is limited to one concern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `TransferWorker._register_aux_buffer` to skip auxiliary-buffer slots where the aux pointer (`data_ptr()`) is `0` or the aux size is `0`, preventing NIXL/LIBFABRIC registration failures when speculative decoding leaves auxiliary buffers empty.
- Added an early return when all aux slots are empty, so `_agent.register_memory` is not called with no valid `(ptr, size)` descriptors.
- Preserved descriptor-to-buffer index mapping by keeping the original per-slot index in the descriptor name (`aux_buffer_ptr_{i}`) for surviving entries.

## QA Engineer Review

Touched:
- `tests/unittest/disaggregated/test_aux_buffer_registration.py`
- `tests/integration/test_lists/test-db/l0_a10.yml`
- `tests/integration/test_lists/test-db/l0_h100.yml`

Test functions added:
- `test_null_pointer_aux_buffer_is_skipped()`
- `test_zero_size_aux_buffer_is_skipped()`
- `test_all_buffers_registered_when_none_are_empty()`
- `test_nothing_registered_when_every_buffer_is_empty()`

Integration coverage (`test-db/`):
- Added `unittest/disaggregated/test_aux_buffer_registration.py` to:
  - `tests/integration/test_lists/test-db/l0_a10.yml`
  - `tests/integration/test_lists/test-db/l0_h100.yml`

Verdict: needs follow-up
<!-- end of auto-generated comment: release notes by coderabbit.ai -->