### PR TITLE
[None][perf] Reduce DeepEP NVFP4 transport overhead

### DIFF
--- a/3rdparty/patches/deep_ep_intranode_combine_fix.patch
+++ b/3rdparty/patches/deep_ep_intranode_combine_fix.patch
@@ -2,9 +2,7 @@ diff --git a/csrc/deep_ep.cpp b/csrc/deep_ep.cpp
 index 7cb3372..123f723 100644
 --- a/csrc/deep_ep.cpp
 +++ b/csrc/deep_ep.cpp
-@@ -1378,6 +1378,90 @@ Buffer::low_latency_dispatch_fp4(const torch::Tensor& x, const torch::Tensor& x_
- #endif
- }
+@@ -1380,2 +1380,86 @@ Buffer::low_latency_dispatch_fp4(const torch::Tensor& x, const torch::Tensor& x_
  
 +std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
 +Buffer::low_latency_dispatch_bf16_to_fp4(const torch::Tensor& x, const torch::Tensor& global_scale,
@@ -91,23 +89,15 @@ index 7cb3372..123f723 100644
 +}
 +
  std::tuple<torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
- Buffer::low_latency_combine_low_precision(int precision, const torch::Tensor& x, const std::optional<torch::Tensor>& global_scale,
-                             const torch::Tensor& topk_idx, const torch::Tensor& topk_weights,
-@@ -1611,6 +1695,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-         .def("low_latency_dispatch", &deep_ep::Buffer::low_latency_dispatch)
-         .def("low_latency_combine", &deep_ep::Buffer::low_latency_combine)
+@@ -1613,2 +1697,3 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
          .def("low_latency_dispatch_fp4", &deep_ep::Buffer::low_latency_dispatch_fp4)
 +        .def("low_latency_dispatch_bf16_to_fp4", &deep_ep::Buffer::low_latency_dispatch_bf16_to_fp4)
          .def("low_latency_combine_low_precision", &deep_ep::Buffer::low_latency_combine_low_precision)
-         .def("get_next_low_latency_combine_buffer", &deep_ep::Buffer::get_next_low_latency_combine_buffer);
- 
 diff --git a/csrc/deep_ep.hpp b/csrc/deep_ep.hpp
 index 7377b72..6b73565 100644
 --- a/csrc/deep_ep.hpp
 +++ b/csrc/deep_ep.hpp
-@@ -155,6 +155,13 @@ public:
-                         const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
-                         int num_max_dispatch_tokens_per_rank, int num_experts,
+@@ -157,2 +157,9 @@ public:
                          bool async, bool return_recv_hook);
 +
 +    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
@@ -117,15 +107,11 @@ index 7377b72..6b73565 100644
 +                        int num_max_dispatch_tokens_per_rank, int num_experts,
 +                        bool async, bool return_recv_hook);
      std::tuple<torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
-     low_latency_combine_low_precision(int precision, const torch::Tensor& x, const std::optional<torch::Tensor>& global_scale,
-                                 const torch::Tensor& topk_idx, const torch::Tensor& topk_weights,
 diff --git a/csrc/kernels/extension_api.cuh b/csrc/kernels/extension_api.cuh
 index af13a4b..223c92b 100644
 --- a/csrc/kernels/extension_api.cuh
 +++ b/csrc/kernels/extension_api.cuh
-@@ -21,6 +21,17 @@ namespace extensions {
-         int num_topk, int num_experts, int rank, int num_ranks,
-         void* workspace, int num_device_sms,
+@@ -23,2 +23,13 @@ namespace extensions {
          cudaStream_t stream, int phases);
 +    void dispatch_bf16_to_fp4(void* packed_recv_x, void* packed_recv_x_scales,
 +        int* packed_recv_src_info, int64_t* packed_recv_layout_range,
@@ -139,57 +125,42 @@ index af13a4b..223c92b 100644
 +        void* workspace, int num_device_sms,
 +        cudaStream_t stream, int phases);
      void low_precision_combine(int precision, void* combined_x,
-         void* rdma_recv_x, int* rdma_recv_flag, void* rdma_send_x,
-         const void* x, const float* global_scale_per_token,
-@@ -33,4 +44,4 @@ namespace extensions {
-         void* workspace, int num_device_sms,
-         cudaStream_t stream, int phases);
+@@ -35,2 +46,2 @@ namespace extensions {
  }
 -}
 \ No newline at end of file
 +}
 diff --git a/csrc/kernels/extension_kernels.cu b/csrc/kernels/extension_kernels.cu
-index 7867f60..c3e1e2f 100644
+index 7867f60..6ba5465 100644
 --- a/csrc/kernels/extension_kernels.cu
 +++ b/csrc/kernels/extension_kernels.cu
-@@ -261,14 +261,15 @@ switch (hidden) { \
-     default: EP_HOST_ASSERT(false && "Unsupported hidden"); \
- } while (false)
+@@ -1 +1,3 @@
++#include <cstdlib>
++
+ #include "configs.cuh"
+@@ -263,3 +265,3 @@ switch (hidden) { \
  
 -template <int kHidden>
 +template <int kHidden, bool kQuantizeBf16Input = false>
  __global__ __launch_bounds__(1024, 1) void
- dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
-             int* packed_recv_src_info, int64_t* packed_recv_layout_range,
-             int* packed_recv_count,
-             int* cumulative_local_expert_recv_stats,
+@@ -270,3 +272,4 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
              void* rdma_recv_x, int* rdma_recv_count, void* rdma_x,
 -            const void* x, const void* x_scales, const int* topk_idx,
 +            const void* x, const void* x_scales, const float* global_scale,
 +            const int* topk_idx,
              int* atomic_counter_per_expert, int* atomic_finish_counter_per_expert,
-             int* next_clean, int num_next_clean_int,
-             int num_tokens, int num_max_dispatch_tokens_per_rank,
-@@ -287,6 +288,7 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
- 
-     constexpr size_t kHiddenBytes = kHidden / 2;
+@@ -289,2 +292,5 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
      constexpr size_t kHiddenVecAccessNum = kHiddenBytes / sizeof(int4);
 +    constexpr size_t kHiddenBf16VecAccessNum = kHidden / (sizeof(int4) / sizeof(nv_bfloat16));
++    EP_STATIC_ASSERT(kHiddenBf16VecAccessNum % 32 == 0,
++            "BF16-to-NVFP4 lane-pair quantization requires complete warps");
      constexpr size_t kScalesBytes = kHidden / 16;
-     constexpr size_t kScalesVecAccessNum = kScalesBytes / sizeof(int4);
- 
-@@ -308,8 +310,6 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
-         const auto num_threads = (num_warps - 1) * 32;
- 
+@@ -310,4 +316,2 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
          for (int token_idx = sm_id; token_idx < num_tokens; token_idx += num_sms) {
 -            const auto x_int4 = reinterpret_cast<const int4*>(x) + token_idx * kHiddenVecAccessNum;
 -            const auto x_scales_int4  = reinterpret_cast<const int4*>(x_scales) + token_idx * kScalesVecAccessNum;
              const auto rdma_x_src_idx = reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(rdma_x) + token_idx * kNumBytesPerMsg);
-             const auto rdma_x_vec = reinterpret_cast<int4*>(reinterpret_cast<uint8_t*>(rdma_x_src_idx) + sizeof(int4));
-             const auto rdma_x_scales = reinterpret_cast<int4*>(reinterpret_cast<uint8_t*>(rdma_x_vec) + kHiddenBytes);
-@@ -318,15 +318,32 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
-             auto dst_expert_idx = warp_id < num_topk ? static_cast<int>(__ldg(topk_idx + token_idx * num_topk + warp_id)) : -1;
-             thread_id == 0 ? (*rdma_x_src_idx = token_idx) : 0;
+@@ -320,11 +324,31 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
  
 -            #pragma unroll
 -            for (int i = thread_id; i < kHiddenVecAccessNum; i += num_threads) {
@@ -207,10 +178,13 @@ index 7867f60..c3e1e2f 100644
 +                auto rdma_x_fp8_scales = reinterpret_cast<uint8_t*>(rdma_x_scales);
 +#pragma unroll
 +                for (int i = thread_id; i < kHiddenBf16VecAccessNum; i += num_threads) {
++                    // Adjacent lanes each own eight BF16 values. The helper
++                    // exchanges lane-pair maxima so both halves use one
++                    // 16-value NVFP4 block scale; the even lane stores it.
 +                    auto [e2m1_vec, fp8_scale_val] =
 +                        quantize_bf16_to_nvfp4(__ldg(x_bf16_int4 + i), global_scale_val);
 +                    rdma_x_fp4[i] = e2m1_vec;
-+                    if (i % 2 == 0)
++                    if (lane_id % 2 == 0)
 +                        rdma_x_fp8_scales[i / 2] = fp8_scale_val;
 +                }
 +            } else {
@@ -227,20 +201,12 @@ index 7867f60..c3e1e2f 100644
 +                    rdma_x_scales[i] = *reinterpret_cast<int4*>(&int4_value);
 +                }
              }
-             asm volatile("bar.sync 1, %0;" :: "r"(num_threads));
- 
-@@ -526,7 +543,7 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
-                 packed_recv_count, \
-                 cumulative_local_expert_recv_stats, \
+@@ -528,3 +552,3 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
                  rdma_recv_x, rdma_recv_count, rdma_x, \
 -                x, x_scales, topk_idx, \
 +                x, x_scales, nullptr, topk_idx, \
                  atomic_counter_per_expert, atomic_finish_counter_per_expert, \
-                 next_clean, num_next_clean_int, \
-                 num_tokens, num_max_dispatch_tokens_per_rank, \
-@@ -539,6 +556,53 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
- #undef DISPATCH_LAUNCH_CASE
- }
+@@ -541,2 +565,49 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
  
 +void dispatch_bf16_to_fp4(void* packed_recv_x, void* packed_recv_x_scales,
 +                int* packed_recv_src_info, int64_t* packed_recv_layout_range,
@@ -290,19 +256,20 @@ index 7867f60..c3e1e2f 100644
 +}
 +
  enum class LowPrecisionType : int {
-     FP8 = 0,
-     NVFP4 = 1
-@@ -658,7 +722,29 @@ low_precision_combine(void* combined_x,
-             float global_scale_val = 0.f;
-             if constexpr (LowPrecisionTypeTraits<kPrecision>::kUseGlobalScale) {
+@@ -584,2 +655,2 @@ struct LowPrecisionTypeTraits<LowPrecisionType::FP8> {
+-template <LowPrecisionType kPrecision, int kHidden, int kNumMaxTopk>
++template <LowPrecisionType kPrecision, int kHidden, int kNumMaxTopk, bool kStageRecvMetadata>
+ __global__ __launch_bounds__(1024, 1) void
+@@ -660,3 +731,26 @@ low_precision_combine(void* combined_x,
                  auto rdma_send_x_global_scale_vec = reinterpret_cast<float*>(rdma_send_x_current_expert + token_idx * kNumBytesPerSlot + kHiddenCommBytes + kScalesBytes);
 -                global_scale_val = __ldg(global_scale_per_token + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank + token_idx);
 +                if (global_scale_per_token != nullptr) {
 +                    global_scale_val = __ldg(global_scale_per_token + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank + token_idx);
 +                } else {
-+                    // Match calculate_nvfp4_global_scale exactly, but compute the
-+                    // per-token reduction in the combine warp to avoid a separate
-+                    // kernel launch and intermediate scale tensor.
++                    // Reproduce calculate_nvfp4_global_scale for finite BF16
++                    // inputs. Its getMaxAbs helper performs a block reduction
++                    // before thread 0 stores 448 * 6 / amax; this warp owns the
++                    // same complete token reduction.
 +                    float per_token_max_abs_val = 0.f;
 +                    const auto x_int4 = local_x + token_idx * kHiddenBf16VecAccessNum;
 +                    for (int i = lane_id; i < kHiddenBf16VecAccessNum; i += 32) {
@@ -321,19 +288,101 @@ index 7867f60..c3e1e2f 100644
 +                    global_scale_val = 448.f * 6.f / per_token_max_abs_val;
 +                }
                  rdma_send_x_global_scale_vec[0] = global_scale_val;
-             }
-             const auto x_int4 = local_x + token_idx * kHiddenBf16VecAccessNum;
-@@ -785,7 +871,6 @@ void low_precision_combine(int precision,void* combined_x,
- auto combine_func = low_precision_combine<LowPrecisionType::FP8, hidden, kNumMaxTopk>; \
- if(precision != 0) { \
-     combine_func = low_precision_combine<LowPrecisionType::NVFP4, hidden, kNumMaxTopk>; \
--    EP_HOST_ASSERT(global_scale_per_token != nullptr); \
- } else { \
-     EP_HOST_ASSERT(global_scale_per_token == nullptr); \
- } \
-@@ -808,4 +893,4 @@ LAUNCH_KERNEL(&cfg, combine_func, \
+@@ -718,2 +812,62 @@ low_precision_combine(void* combined_x,
+     cg::this_grid().sync();
++    if constexpr (kStageRecvMetadata) {
++        __shared__ int staged_topk_idx[kNumMaxTopk];
++        __shared__ float staged_topk_weights[kNumMaxTopk];
++        __shared__ float staged_global_scales[kNumMaxTopk];
++
++        for (int token_idx = sm_id; token_idx < num_combined_tokens; token_idx += num_sms) {
++            if (thread_id < num_topk) {
++                auto expert_idx = static_cast<int>(__ldg(topk_idx + token_idx * num_topk + thread_id));
++                staged_topk_idx[thread_id] = expert_idx;
++                staged_topk_weights[thread_id] = __ldg(topk_weights + token_idx * num_topk + thread_id);
++                if constexpr (LowPrecisionTypeTraits<kPrecision>::kUseGlobalScale) {
++                    if (expert_idx >= 0) {
++                        auto rdma_x_buffer = reinterpret_cast<uint8_t*>(rdma_recv_x) +
++                                (expert_idx * num_max_dispatch_tokens_per_rank + token_idx) * kNumBytesPerSlot;
++                        auto rdma_x_scales_buffer = rdma_x_buffer + kHiddenCommBytes;
++                        auto rdma_global_scale_ptr = reinterpret_cast<float*>(rdma_x_scales_buffer + kScalesBytes);
++                        staged_global_scales[thread_id] = __ldg(rdma_global_scale_ptr);
++                    }
++                }
++            }
++            __syncthreads();
++
++            for(auto vec_id = thread_id; vec_id < kHiddenBf16VecAccessNum; vec_id += num_threads) {
++                float combined_values[kBF16ElemsNumPerVecAccess] = {0.f};
++                #pragma unroll
++                for (int i = 0; i < num_topk; ++ i) if (staged_topk_idx[i] >= 0) {
++                    auto rdma_x_buffer = reinterpret_cast<uint8_t*>(rdma_recv_x) +
++                            (staged_topk_idx[i] * num_max_dispatch_tokens_per_rank + token_idx) * kNumBytesPerSlot;
++                    auto rdma_x_scales_buffer = rdma_x_buffer + kHiddenCommBytes;
++
++                    float global_scale_val = 0.f;
++                    if constexpr (LowPrecisionTypeTraits<kPrecision>::kUseGlobalScale) {
++                        global_scale_val = staged_global_scales[i];
++                    }
++                    auto x_vec = ld_nc_global(reinterpret_cast<CommVecType*>(rdma_x_buffer) + vec_id);
++                    auto x_scale = ld_nc_global(reinterpret_cast<ScaleType*>(rdma_x_scales_buffer) + vec_id / kThreadsPerScale);
++                    float x_fp32[kBF16ElemsNumPerVecAccess];
++                    LowPrecisionTypeTraits<kPrecision>::dequantize(x_vec, global_scale_val, x_scale, x_fp32, staged_topk_weights[i]);
++                    #pragma unroll
++                    for (int j = 0; j < kBF16ElemsNumPerVecAccess; ++ j) {
++                        combined_values[j] += x_fp32[j];
++                    }
++                }
++
++                int4 combined_vec_bf16;
++                #pragma unroll
++                for (int j = 0; j < kBF16ElemsNumPerVecAccess; ++ j)
++                    reinterpret_cast<nv_bfloat16*>(&combined_vec_bf16)[j] = static_cast<nv_bfloat16>(combined_values[j]);
++                (reinterpret_cast<int4*>(combined_x) + token_idx * kHiddenBf16VecAccessNum)[vec_id] = combined_vec_bf16;
++            }
++
++            // Prevent the next token from replacing CTA-shared metadata while
++            // another thread is still consuming the current token's values.
++            // token_idx is CTA-uniform, so every thread reaches the conditional
++            // barrier on the same iterations.
++            if (token_idx + num_sms < num_combined_tokens) {
++                __syncthreads();
++            }
++        }
++    } else {
+     for (int token_idx = sm_id; token_idx < num_combined_tokens; token_idx += num_sms) {
+@@ -756,2 +910,13 @@ low_precision_combine(void* combined_x,
+     }
++    }
++}
++
++static bool low_precision_combine_recv_metadata_staging_enabled() {
++    static bool const enabled = []() {
++        auto const value = std::getenv("TRTLLM_DEEP_EP_LP_COMBINE_RECV_METADATA_STAGING");
++        EP_HOST_ASSERT(value == nullptr or
++                ((value[0] == '0' or value[0] == '1') and value[1] == '\0'));
++        return value != nullptr and value[0] == '1';
++    }();
++    return enabled;
  }
- #undef SWITCH_HIDDEN_FOR_EXTENSION_KERNELS
+@@ -776,2 +941,3 @@ void low_precision_combine(int precision,void* combined_x,
+     const auto num_warps = num_warp_groups * num_warps_per_group;
++    const auto stage_recv_metadata = low_precision_combine_recv_metadata_staging_enabled();
+     const auto num_sms = ceil_div(num_experts, num_warp_groups);
+@@ -784,6 +950,9 @@ void low_precision_combine(int precision,void* combined_x,
+ #define COMBINE_LAUNCH_CASE(hidden) { \
+-auto combine_func = low_precision_combine<LowPrecisionType::FP8, hidden, kNumMaxTopk>; \
++auto combine_func = stage_recv_metadata ? \
++        low_precision_combine<LowPrecisionType::FP8, hidden, kNumMaxTopk, true> : \
++        low_precision_combine<LowPrecisionType::FP8, hidden, kNumMaxTopk, false>; \
+ if(precision != 0) { \
+-    combine_func = low_precision_combine<LowPrecisionType::NVFP4, hidden, kNumMaxTopk>; \
+-    EP_HOST_ASSERT(global_scale_per_token != nullptr); \
++    combine_func = stage_recv_metadata ? \
++            low_precision_combine<LowPrecisionType::NVFP4, hidden, kNumMaxTopk, true> : \
++            low_precision_combine<LowPrecisionType::NVFP4, hidden, kNumMaxTopk, false>; \
+ } else { \
+@@ -810,2 +979,2 @@ LAUNCH_KERNEL(&cfg, combine_func, \
  }
 -}
 \ No newline at end of file
@@ -342,9 +391,7 @@ diff --git a/csrc/kernels/intranode.cu b/csrc/kernels/intranode.cu
 index ee9ca67..0031c07 100644
 --- a/csrc/kernels/intranode.cu
 +++ b/csrc/kernels/intranode.cu
-@@ -844,9 +844,15 @@ combine(dtype_t* recv_x, float* recv_topk_weights,
- 
- #ifndef DISABLE_SM90_FEATURES
+@@ -846,5 +846,11 @@ combine(dtype_t* recv_x, float* recv_topk_weights,
                      // Wait TMA arrival
 +                    // hidden_int4 is not always divisible by a warp. The final tile can have
 +                    // only a subset of lanes active, so synchronize only participating lanes.
@@ -357,31 +404,21 @@ index ee9ca67..0031c07 100644
 -                    __syncwarp();
 +                    __syncwarp(sync_mask);
  
-                     // Write into TMA buffer
-                     auto tma_stage_idx = (i / 32) % kNumStages;
-@@ -854,13 +860,13 @@ combine(dtype_t* recv_x, float* recv_topk_weights,
- 
-                     // Issue TMA
+@@ -856,3 +862,3 @@ combine(dtype_t* recv_x, float* recv_topk_weights,
                      tma_store_fence();
 -                    __syncwarp();
 +                    __syncwarp(sync_mask);
                      if (lane_id == 0) {
-                         auto tma_bytes = min(32, hidden_int4 - i) * static_cast<int>(sizeof(int4));
-                         tma_store_1d(reinterpret_cast<int4*>(tma_buffer) + tma_stage_idx * 32,
-                                      recv_int4 + token_idx * hidden_int4 + i, tma_bytes, false);
+@@ -862,3 +868,3 @@ combine(dtype_t* recv_x, float* recv_topk_weights,
                      }
 -                    __syncwarp();
 +                    __syncwarp(sync_mask);
  #else
-                     recv_int4[token_idx * hidden_int4 + i] = out_int4;
- #endif
 diff --git a/deep_ep/buffer.py b/deep_ep/buffer.py
 index bdc1181..79170ac 100644
 --- a/deep_ep/buffer.py
 +++ b/deep_ep/buffer.py
-@@ -643,6 +643,35 @@ class Buffer:
-                              cumulative_local_expert_recv_stats)
-         return packed_recv_x, packed_recv_x_scales, packed_recv_count, handle, \
+@@ -645,2 +645,31 @@ class Buffer:
              EventOverlap(event, tensors_to_record if async_finish else None), hook
 +
 +    # noinspection PyTypeChecker
@@ -413,30 +450,60 @@ index bdc1181..79170ac 100644
 +        return packed_recv_x, packed_recv_x_scales, packed_recv_count, handle, \
 +            EventOverlap(event, tensors_to_record if async_finish else None), hook
      
-     # noinspection PyTypeChecker
-     def low_latency_combine_low_precision(self, precision: str, x: torch.Tensor, global_scale: torch.Tensor, 
 diff --git a/tests/test_low_latency_fp4.py b/tests/test_low_latency_fp4.py
-index a455091..3a8484a 100644
+index a455091..9eb8b9d 100644
 --- a/tests/test_low_latency_fp4.py
 +++ b/tests/test_low_latency_fp4.py
-@@ -88,6 +88,20 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+@@ -96,3 +96,15 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+     x_global_scales = (448 * 6) / x.abs().max(dim=-1, keepdim=True).values.to(torch.float32)
+-    combined_x, event, hook = buffer.low_latency_combine_low_precision(1, x, x_global_scales, topk_idx[rank], topk_weights, handle)
++    combined_x, event, hook = buffer.low_latency_combine_low_precision(
++        "nvfp4", x, x_global_scales, topk_idx[rank], topk_weights, handle)
++
++    # Omitting the materialized per-token scales selects the fused dynamic
++    # reduction. Re-dispatch because a low-latency handle is single-use.
++    x_dynamic, recv_count_dynamic, dynamic_handle, event, hook = \
++        buffer.low_latency_dispatch(
++            tokens_bf16[rank], topk_idx[rank], num_tokens, num_experts, use_fp8=False)
++    assert torch.equal(recv_count_dynamic, recv_count)
++    combined_x_dynamic, event, hook = buffer.low_latency_combine_low_precision(
++        "nvfp4", x_dynamic, None, topk_idx[rank], topk_weights, dynamic_handle)
++    assert torch.equal(combined_x_dynamic, combined_x)
++
+     tokens_bf16_reconstructed = deep_ep.Buffer.dequantize_nvfp4_to_bf16(tokens_packed_fp4[rank], global_scales[rank], scales_fp8[rank])
+@@ -105,2 +117,3 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+     assert torch.allclose(combined_x, combined_x_ref, atol=1e-1)
++    assert torch.allclose(combined_x_dynamic, combined_x_ref, atol=1e-1)
+     print(f'[rank {rank}] LL Combine FP4 accuracy verify pass', flush=True)
+@@ -111,3 +124,4 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+         combined_x, event, hook = \
+-            buffer.low_latency_combine_low_precision(1, x, x_global_scales, topk_idx[rank], topk_weights, handle)
++            buffer.low_latency_combine_low_precision(
++                "nvfp4", x, x_global_scales, topk_idx[rank], topk_weights, handle)
      
-     verify_dispatch_fp4(packed_recv_x, packed_recv_scales, real_recv_count, tokens_packed_fp4, scales_fp8, topk_idx, num_tokens, num_experts, num_ranks, rank, hidden)
- 
-+    # The fused entry point must produce the same message payload as the
-+    # materialized-FP4 path for one exact static global scale.
+@@ -124,2 +138,21 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+                         barrier_comm_profiling=True, suppress_kineto_output=True)
++
++    # Leave the existing dispatch/combine protocol above unchanged. Exercise
++    # the fused entry point last and compare its message payload against
++    # materialized FP4 produced with one exact static global scale.
 +    static_global_scale = torch.tensor(0.75, dtype=torch.float32, device='cuda')
 +    static_global_scales = static_global_scale.expand(num_ranks, num_tokens, 1).contiguous()
 +    static_tokens_packed_fp4, static_scales_fp8 = \
 +        deep_ep.Buffer.quantize_bf16_to_nvfp4(tokens_bf16, static_global_scales)
-+    fused_recv_x, fused_recv_scales, fused_recv_count, _, _, _ = \
++    fused_recv_x, fused_recv_scales, fused_recv_count, fused_handle, _, _ = \
 +        buffer.low_latency_dispatch_bf16_to_fp4(
 +            tokens_bf16[rank], static_global_scale, topk_idx[rank], num_tokens, num_experts)
++    assert fused_recv_x.shape == packed_recv_x.shape
++    assert fused_recv_scales.shape == packed_recv_scales.shape
++    assert fused_handle[3] == handle[3] == hidden
 +    verify_dispatch_fp4(
 +        fused_recv_x, fused_recv_scales, fused_recv_count,
 +        static_tokens_packed_fp4, static_scales_fp8, topk_idx,
 +        num_tokens, num_experts, num_ranks, rank, hidden)
 +
-     x, recv_count, handle, event, hook = buffer.low_latency_dispatch(tokens_bf16[rank], topk_idx[rank], num_tokens, num_experts, use_fp8=False)
-     assert torch.equal(recv_count, real_recv_count)
+     print(f'[rank {rank}] LL Dispatch FP4 bandwidth: {comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us, | '
+@@ -127,3 +160,2 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
      
+-
+ # noinspection PyUnboundLocalVariable

--- a/3rdparty/patches/deep_ep_intranode_combine_fix.patch
+++ b/3rdparty/patches/deep_ep_intranode_combine_fix.patch
@@ -1,5 +1,5 @@
 diff --git a/csrc/deep_ep.cpp b/csrc/deep_ep.cpp
-index 7cb3372..123f723 100644
+index 7cb3372..9ff05d4 100644
 --- a/csrc/deep_ep.cpp
 +++ b/csrc/deep_ep.cpp
 @@ -1380,2 +1380,86 @@ Buffer::low_latency_dispatch_fp4(const torch::Tensor& x, const torch::Tensor& x_
@@ -89,12 +89,23 @@ index 7cb3372..123f723 100644
 +}
 +
  std::tuple<torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
-@@ -1613,2 +1697,3 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+@@ -1386,3 +1470,4 @@ Buffer::low_latency_combine_low_precision(int precision, const torch::Tensor& x,
+                             bool async, bool return_recv_hook,
+-                            const std::optional<torch::Tensor>& out) {
++                            const std::optional<torch::Tensor>& out,
++                            bool stage_recv_metadata) {
+ #ifndef DISABLE_NVSHMEM
+@@ -1454,3 +1539,3 @@ Buffer::low_latency_combine_low_precision(int precision, const torch::Tensor& x,
+                               num_experts, rank, num_ranks,
+-                              workspace, num_device_sms,
++                              workspace, num_device_sms, stage_recv_metadata,
+                               launch_stream, phases);
+@@ -1613,2 +1698,3 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
          .def("low_latency_dispatch_fp4", &deep_ep::Buffer::low_latency_dispatch_fp4)
 +        .def("low_latency_dispatch_bf16_to_fp4", &deep_ep::Buffer::low_latency_dispatch_bf16_to_fp4)
          .def("low_latency_combine_low_precision", &deep_ep::Buffer::low_latency_combine_low_precision)
 diff --git a/csrc/deep_ep.hpp b/csrc/deep_ep.hpp
-index 7377b72..6b73565 100644
+index 7377b72..70b765d 100644
 --- a/csrc/deep_ep.hpp
 +++ b/csrc/deep_ep.hpp
 @@ -157,2 +157,9 @@ public:
@@ -107,8 +118,14 @@ index 7377b72..6b73565 100644
 +                        int num_max_dispatch_tokens_per_rank, int num_experts,
 +                        bool async, bool return_recv_hook);
      std::tuple<torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
+@@ -163,3 +170,4 @@ public:
+                                 bool async, bool return_recv_hook,
+-                                const std::optional<torch::Tensor>& out);
++                                const std::optional<torch::Tensor>& out,
++                                bool stage_recv_metadata);
+ 
 diff --git a/csrc/kernels/extension_api.cuh b/csrc/kernels/extension_api.cuh
-index af13a4b..223c92b 100644
+index af13a4b..dddce33 100644
 --- a/csrc/kernels/extension_api.cuh
 +++ b/csrc/kernels/extension_api.cuh
 @@ -23,2 +23,13 @@ namespace extensions {
@@ -125,42 +142,42 @@ index af13a4b..223c92b 100644
 +        void* workspace, int num_device_sms,
 +        cudaStream_t stream, int phases);
      void low_precision_combine(int precision, void* combined_x,
-@@ -35,2 +46,2 @@ namespace extensions {
+@@ -32,5 +43,5 @@ namespace extensions {
+         int num_experts, int rank, int num_ranks,
+-        void* workspace, int num_device_sms,
++        void* workspace, int num_device_sms, bool stage_recv_metadata,
+         cudaStream_t stream, int phases);
  }
 -}
 \ No newline at end of file
 +}
 diff --git a/csrc/kernels/extension_kernels.cu b/csrc/kernels/extension_kernels.cu
-index 7867f60..6ba5465 100644
+index 7867f60..38a4aa2 100644
 --- a/csrc/kernels/extension_kernels.cu
 +++ b/csrc/kernels/extension_kernels.cu
-@@ -1 +1,3 @@
-+#include <cstdlib>
-+
- #include "configs.cuh"
-@@ -263,3 +265,3 @@ switch (hidden) { \
+@@ -263,3 +263,3 @@ switch (hidden) { \
  
 -template <int kHidden>
 +template <int kHidden, bool kQuantizeBf16Input = false>
  __global__ __launch_bounds__(1024, 1) void
-@@ -270,3 +272,4 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
+@@ -270,3 +270,4 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
              void* rdma_recv_x, int* rdma_recv_count, void* rdma_x,
 -            const void* x, const void* x_scales, const int* topk_idx,
 +            const void* x, const void* x_scales, const float* global_scale,
 +            const int* topk_idx,
              int* atomic_counter_per_expert, int* atomic_finish_counter_per_expert,
-@@ -289,2 +292,5 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
+@@ -289,2 +290,5 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
      constexpr size_t kHiddenVecAccessNum = kHiddenBytes / sizeof(int4);
 +    constexpr size_t kHiddenBf16VecAccessNum = kHidden / (sizeof(int4) / sizeof(nv_bfloat16));
 +    EP_STATIC_ASSERT(kHiddenBf16VecAccessNum % 32 == 0,
 +            "BF16-to-NVFP4 lane-pair quantization requires complete warps");
      constexpr size_t kScalesBytes = kHidden / 16;
-@@ -310,4 +316,2 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
+@@ -310,4 +314,2 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
          for (int token_idx = sm_id; token_idx < num_tokens; token_idx += num_sms) {
 -            const auto x_int4 = reinterpret_cast<const int4*>(x) + token_idx * kHiddenVecAccessNum;
 -            const auto x_scales_int4  = reinterpret_cast<const int4*>(x_scales) + token_idx * kScalesVecAccessNum;
              const auto rdma_x_src_idx = reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(rdma_x) + token_idx * kNumBytesPerMsg);
-@@ -320,11 +324,31 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
+@@ -320,11 +322,31 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
  
 -            #pragma unroll
 -            for (int i = thread_id; i < kHiddenVecAccessNum; i += num_threads) {
@@ -201,12 +218,12 @@ index 7867f60..6ba5465 100644
 +                    rdma_x_scales[i] = *reinterpret_cast<int4*>(&int4_value);
 +                }
              }
-@@ -528,3 +552,3 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
+@@ -528,3 +550,3 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
                  rdma_recv_x, rdma_recv_count, rdma_x, \
 -                x, x_scales, topk_idx, \
 +                x, x_scales, nullptr, topk_idx, \
                  atomic_counter_per_expert, atomic_finish_counter_per_expert, \
-@@ -541,2 +565,49 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
+@@ -541,2 +563,49 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
  
 +void dispatch_bf16_to_fp4(void* packed_recv_x, void* packed_recv_x_scales,
 +                int* packed_recv_src_info, int64_t* packed_recv_layout_range,
@@ -256,20 +273,24 @@ index 7867f60..6ba5465 100644
 +}
 +
  enum class LowPrecisionType : int {
-@@ -584,2 +655,2 @@ struct LowPrecisionTypeTraits<LowPrecisionType::FP8> {
+@@ -581,5 +650,3 @@ struct LowPrecisionTypeTraits<LowPrecisionType::FP8> {
+ };
+-
+-
 -template <LowPrecisionType kPrecision, int kHidden, int kNumMaxTopk>
 +template <LowPrecisionType kPrecision, int kHidden, int kNumMaxTopk, bool kStageRecvMetadata>
  __global__ __launch_bounds__(1024, 1) void
-@@ -660,3 +731,26 @@ low_precision_combine(void* combined_x,
+@@ -660,3 +727,29 @@ low_precision_combine(void* combined_x,
                  auto rdma_send_x_global_scale_vec = reinterpret_cast<float*>(rdma_send_x_current_expert + token_idx * kNumBytesPerSlot + kHiddenCommBytes + kScalesBytes);
 -                global_scale_val = __ldg(global_scale_per_token + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank + token_idx);
 +                if (global_scale_per_token != nullptr) {
 +                    global_scale_val = __ldg(global_scale_per_token + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank + token_idx);
 +                } else {
 +                    // Reproduce calculate_nvfp4_global_scale for finite BF16
-+                    // inputs. Its getMaxAbs helper performs a block reduction
-+                    // before thread 0 stores 448 * 6 / amax; this warp owns the
-+                    // same complete token reduction.
++                    // inputs. Its getMaxAbs helper performs a block reduction,
++                    // and its division is compiled as a rounded reciprocal
++                    // followed by a rounded multiply. This warp performs the
++                    // same complete token reduction and arithmetic sequence.
 +                    float per_token_max_abs_val = 0.f;
 +                    const auto x_int4 = local_x + token_idx * kHiddenBf16VecAccessNum;
 +                    for (int i = lane_id; i < kHiddenBf16VecAccessNum; i += 32) {
@@ -285,10 +306,12 @@ index 7867f60..6ba5465 100644
 +                        per_token_max_abs_val,
 +                        __shfl_xor_sync(0xffffffff, per_token_max_abs_val, 16));
 +                    per_token_max_abs_val = half_warp_reduce_max(per_token_max_abs_val);
-+                    global_scale_val = 448.f * 6.f / per_token_max_abs_val;
++                    constexpr float kNvfp4GlobalScaleNumerator = 448.f * 6.f;
++                    global_scale_val = __fmul_rn(
++                        kNvfp4GlobalScaleNumerator, __frcp_rn(per_token_max_abs_val));
 +                }
                  rdma_send_x_global_scale_vec[0] = global_scale_val;
-@@ -718,2 +812,62 @@ low_precision_combine(void* combined_x,
+@@ -718,2 +811,62 @@ low_precision_combine(void* combined_x,
      cg::this_grid().sync();
 +    if constexpr (kStageRecvMetadata) {
 +        __shared__ int staged_topk_idx[kNumMaxTopk];
@@ -351,25 +374,16 @@ index 7867f60..6ba5465 100644
 +        }
 +    } else {
      for (int token_idx = sm_id; token_idx < num_combined_tokens; token_idx += num_sms) {
-@@ -756,2 +910,13 @@ low_precision_combine(void* combined_x,
+@@ -756,2 +909,3 @@ low_precision_combine(void* combined_x,
      }
 +    }
-+}
-+
-+static bool low_precision_combine_recv_metadata_staging_enabled() {
-+    static bool const enabled = []() {
-+        auto const value = std::getenv("TRTLLM_DEEP_EP_LP_COMBINE_RECV_METADATA_STAGING");
-+        EP_HOST_ASSERT(value == nullptr or
-+                ((value[0] == '0' or value[0] == '1') and value[1] == '\0'));
-+        return value != nullptr and value[0] == '1';
-+    }();
-+    return enabled;
  }
-@@ -776,2 +941,3 @@ void low_precision_combine(int precision,void* combined_x,
-     const auto num_warps = num_warp_groups * num_warps_per_group;
-+    const auto stage_recv_metadata = low_precision_combine_recv_metadata_staging_enabled();
-     const auto num_sms = ceil_div(num_experts, num_warp_groups);
-@@ -784,6 +950,9 @@ void low_precision_combine(int precision,void* combined_x,
+@@ -767,3 +921,3 @@ void low_precision_combine(int precision,void* combined_x,
+             int num_experts, int rank, int num_ranks,
+-            void* workspace, int num_device_sms,
++            void* workspace, int num_device_sms, bool stage_recv_metadata,
+             cudaStream_t stream, int phases) {
+@@ -784,6 +938,9 @@ void low_precision_combine(int precision,void* combined_x,
  #define COMBINE_LAUNCH_CASE(hidden) { \
 -auto combine_func = low_precision_combine<LowPrecisionType::FP8, hidden, kNumMaxTopk>; \
 +auto combine_func = stage_recv_metadata ? \
@@ -382,7 +396,7 @@ index 7867f60..6ba5465 100644
 +            low_precision_combine<LowPrecisionType::NVFP4, hidden, kNumMaxTopk, true> : \
 +            low_precision_combine<LowPrecisionType::NVFP4, hidden, kNumMaxTopk, false>; \
  } else { \
-@@ -810,2 +979,2 @@ LAUNCH_KERNEL(&cfg, combine_func, \
+@@ -810,2 +967,2 @@ LAUNCH_KERNEL(&cfg, combine_func, \
  }
 -}
 \ No newline at end of file
@@ -415,7 +429,7 @@ index ee9ca67..0031c07 100644
 +                    __syncwarp(sync_mask);
  #else
 diff --git a/deep_ep/buffer.py b/deep_ep/buffer.py
-index bdc1181..79170ac 100644
+index bdc1181..681dca9 100644
 --- a/deep_ep/buffer.py
 +++ b/deep_ep/buffer.py
 @@ -645,2 +645,31 @@ class Buffer:
@@ -450,11 +464,23 @@ index bdc1181..79170ac 100644
 +        return packed_recv_x, packed_recv_x_scales, packed_recv_count, handle, \
 +            EventOverlap(event, tensors_to_record if async_finish else None), hook
      
+@@ -650,3 +679,4 @@ class Buffer:
+                             handle: tuple, async_finish: bool = False,
+-                            return_recv_hook: bool = False, out: Optional[torch.Tensor] = None) -> \
++                            return_recv_hook: bool = False, out: Optional[torch.Tensor] = None,
++                            stage_recv_metadata: bool = False) -> \
+             Tuple[torch.Tensor, EventOverlap, Callable]:
+@@ -666,3 +696,4 @@ class Buffer:
+                                                                        num_max_dispatch_tokens_per_rank, num_experts,
+-                                                                       async_finish, return_recv_hook, out)
++                                                                       async_finish, return_recv_hook, out,
++                                                                       stage_recv_metadata)
+         tensors_to_record = (x, global_scale, topk_idx, topk_weights, src_info, layout_range, combined_x)
 diff --git a/tests/test_low_latency_fp4.py b/tests/test_low_latency_fp4.py
-index a455091..9eb8b9d 100644
+index a455091..e64a1b2 100644
 --- a/tests/test_low_latency_fp4.py
 +++ b/tests/test_low_latency_fp4.py
-@@ -96,3 +96,15 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+@@ -96,3 +96,26 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
      x_global_scales = (448 * 6) / x.abs().max(dim=-1, keepdim=True).values.to(torch.float32)
 -    combined_x, event, hook = buffer.low_latency_combine_low_precision(1, x, x_global_scales, topk_idx[rank], topk_weights, handle)
 +    combined_x, event, hook = buffer.low_latency_combine_low_precision(
@@ -470,18 +496,30 @@ index a455091..9eb8b9d 100644
 +        "nvfp4", x_dynamic, None, topk_idx[rank], topk_weights, dynamic_handle)
 +    assert torch.equal(combined_x_dynamic, combined_x)
 +
++    # Exercise the CTA-shared receive-metadata path with another fresh handle.
++    # Its output must be bit-identical to the legacy register-metadata path.
++    x_staged, recv_count_staged, staged_handle, event, hook = \
++        buffer.low_latency_dispatch(
++            tokens_bf16[rank], topk_idx[rank], num_tokens, num_experts, use_fp8=False)
++    assert torch.equal(recv_count_staged, recv_count)
++    combined_x_staged, event, hook = buffer.low_latency_combine_low_precision(
++        "nvfp4", x_staged, None, topk_idx[rank], topk_weights, staged_handle,
++        stage_recv_metadata=True)
++    assert torch.equal(combined_x_staged, combined_x_dynamic)
++
      tokens_bf16_reconstructed = deep_ep.Buffer.dequantize_nvfp4_to_bf16(tokens_packed_fp4[rank], global_scales[rank], scales_fp8[rank])
-@@ -105,2 +117,3 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+@@ -105,2 +128,4 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
      assert torch.allclose(combined_x, combined_x_ref, atol=1e-1)
 +    assert torch.allclose(combined_x_dynamic, combined_x_ref, atol=1e-1)
++    assert torch.allclose(combined_x_staged, combined_x_ref, atol=1e-1)
      print(f'[rank {rank}] LL Combine FP4 accuracy verify pass', flush=True)
-@@ -111,3 +124,4 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+@@ -111,3 +136,4 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
          combined_x, event, hook = \
 -            buffer.low_latency_combine_low_precision(1, x, x_global_scales, topk_idx[rank], topk_weights, handle)
 +            buffer.low_latency_combine_low_precision(
 +                "nvfp4", x, x_global_scales, topk_idx[rank], topk_weights, handle)
      
-@@ -124,2 +138,21 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+@@ -124,2 +150,21 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
                          barrier_comm_profiling=True, suppress_kineto_output=True)
 +
 +    # Leave the existing dispatch/combine protocol above unchanged. Exercise
@@ -503,7 +541,7 @@ index a455091..9eb8b9d 100644
 +        num_tokens, num_experts, num_ranks, rank, hidden)
 +
      print(f'[rank {rank}] LL Dispatch FP4 bandwidth: {comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us, | '
-@@ -127,3 +160,2 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+@@ -127,3 +172,2 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
      
 -
  # noinspection PyUnboundLocalVariable

--- a/3rdparty/patches/deep_ep_intranode_combine_fix.patch
+++ b/3rdparty/patches/deep_ep_intranode_combine_fix.patch
@@ -33,3 +33,47 @@
  #else
                      recv_int4[token_idx * hidden_int4 + i] = out_int4;
  #endif
+
+--- a/csrc/kernels/extension_kernels.cu
++++ b/csrc/kernels/extension_kernels.cu
+@@ -658,8 +658,30 @@ low_precision_combine(void* combined_x,
+             float global_scale_val = 0.f;
+             if constexpr (LowPrecisionTypeTraits<kPrecision>::kUseGlobalScale) {
+                 auto rdma_send_x_global_scale_vec = reinterpret_cast<float*>(rdma_send_x_current_expert + token_idx * kNumBytesPerSlot + kHiddenCommBytes + kScalesBytes);
+-                global_scale_val = __ldg(global_scale_per_token + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank + token_idx);
+-                rdma_send_x_global_scale_vec[0] = global_scale_val;
++                if (global_scale_per_token != nullptr) {
++                    global_scale_val = __ldg(global_scale_per_token + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank + token_idx);
++                } else {
++                    // Match calculate_nvfp4_global_scale exactly, but compute the
++                    // per-token reduction in the combine warp to avoid a separate
++                    // kernel launch and intermediate scale tensor.
++                    float per_token_max_abs_val = 0.f;
++                    const auto x_int4 = local_x + token_idx * kHiddenBf16VecAccessNum;
++                    for (int i = lane_id; i < kHiddenBf16VecAccessNum; i += 32) {
++                        const auto int4_value = __ldg(x_int4 + i);
++                        const auto bf16_values = reinterpret_cast<const nv_bfloat16*>(&int4_value);
++#pragma unroll
++                        for (int j = 0; j < kBF16ElemsNumPerVecAccess; ++j) {
++                            per_token_max_abs_val = fmaxf(
++                                per_token_max_abs_val, fabsf(static_cast<float>(bf16_values[j])));
++                        }
++                    }
++                    per_token_max_abs_val = fmaxf(
++                        per_token_max_abs_val,
++                        __shfl_xor_sync(0xffffffff, per_token_max_abs_val, 16));
++                    per_token_max_abs_val = half_warp_reduce_max(per_token_max_abs_val);
++                    global_scale_val = 448.f * 6.f / per_token_max_abs_val;
++                }
++                rdma_send_x_global_scale_vec[0] = global_scale_val;
+             }
+             const auto x_int4 = local_x + token_idx * kHiddenBf16VecAccessNum;
+             for(int i = lane_id; i < kHiddenBf16VecAccessNum; i += 32) {
+@@ -785,7 +807,6 @@ void low_precision_combine(int precision,void* combined_x,
+ auto combine_func = low_precision_combine<LowPrecisionType::FP8, hidden, kNumMaxTopk>; \
+ if(precision != 0) { \
+     combine_func = low_precision_combine<LowPrecisionType::NVFP4, hidden, kNumMaxTopk>; \
+-    EP_HOST_ASSERT(global_scale_per_token != nullptr); \
+ } else { \
+     EP_HOST_ASSERT(global_scale_per_token == nullptr); \
+ } \

--- a/3rdparty/patches/deep_ep_intranode_combine_fix.patch
+++ b/3rdparty/patches/deep_ep_intranode_combine_fix.patch
@@ -1,47 +1,302 @@
---- a/csrc/kernels/intranode.cu
-+++ b/csrc/kernels/intranode.cu
-@@ -844,9 +844,15 @@
-
- #ifndef DISABLE_SM90_FEATURES
-                     // Wait TMA arrival
-+                    // hidden_int4 is not always divisible by a warp. The final tile can have
-+                    // only a subset of lanes active, so synchronize only participating lanes.
-+                    auto const tile_start = i - lane_id;
-+                    auto const active_lanes = min(32, hidden_int4 - tile_start);
-+                    auto const sync_mask = active_lanes == 32 ? 0xffffffffu : ((1u << active_lanes) - 1u);
-+
-                     if (lane_id == 0)
-                         tma_store_wait<kNumStages - 1>();
--                    __syncwarp();
-+                    __syncwarp(sync_mask);
-
-                     // Write into TMA buffer
-                     auto tma_stage_idx = (i / 32) % kNumStages;
-@@ -854,13 +860,13 @@
-
-                     // Issue TMA
-                     tma_store_fence();
--                    __syncwarp();
-+                    __syncwarp(sync_mask);
-                     if (lane_id == 0) {
-                         auto tma_bytes = min(32, hidden_int4 - i) * static_cast<int>(sizeof(int4));
-                         tma_store_1d(reinterpret_cast<int4*>(tma_buffer) + tma_stage_idx * 32,
-                                      recv_int4 + token_idx * hidden_int4 + i, tma_bytes, false);
-                     }
--                    __syncwarp();
-+                    __syncwarp(sync_mask);
- #else
-                     recv_int4[token_idx * hidden_int4 + i] = out_int4;
+diff --git a/csrc/deep_ep.cpp b/csrc/deep_ep.cpp
+index 7cb3372..123f723 100644
+--- a/csrc/deep_ep.cpp
++++ b/csrc/deep_ep.cpp
+@@ -1378,6 +1378,90 @@ Buffer::low_latency_dispatch_fp4(const torch::Tensor& x, const torch::Tensor& x_
  #endif
-
+ }
+ 
++std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
++Buffer::low_latency_dispatch_bf16_to_fp4(const torch::Tensor& x, const torch::Tensor& global_scale,
++                    const torch::Tensor& topk_idx,
++                    const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
++                    int num_max_dispatch_tokens_per_rank, int num_experts,
++                    bool async, bool return_recv_hook) {
++#ifndef DISABLE_NVSHMEM
++    EP_HOST_ASSERT(low_latency_mode);
++
++    // This experimental entry point keeps the FP4 receive ABI but materializes
++    // the FP4 payload and block scales directly in the dispatch send phase.
++    EP_HOST_ASSERT(x.dim() == 2 and x.is_contiguous() and x.scalar_type() == torch::kBFloat16);
++    EP_HOST_ASSERT(x.size(1) % 32 == 0);
++    EP_HOST_ASSERT(global_scale.is_contiguous() and global_scale.scalar_type() == torch::kFloat32);
++    EP_HOST_ASSERT(global_scale.numel() == 1);
++    EP_HOST_ASSERT(topk_idx.dim() == 2 and topk_idx.is_contiguous());
++    EP_HOST_ASSERT(x.size(0) == topk_idx.size(0) and x.size(0) <= num_max_dispatch_tokens_per_rank);
++    EP_HOST_ASSERT(topk_idx.scalar_type() == torch::kInt32);
++    EP_HOST_ASSERT(num_experts % num_ranks == 0);
++    if (cumulative_local_expert_recv_stats.has_value()) {
++        EP_HOST_ASSERT(cumulative_local_expert_recv_stats->scalar_type() == torch::kInt);
++        EP_HOST_ASSERT(cumulative_local_expert_recv_stats->dim() == 1 and cumulative_local_expert_recv_stats->is_contiguous());
++        EP_HOST_ASSERT(cumulative_local_expert_recv_stats->size(0) == num_experts / num_ranks);
++    }
++
++    auto num_tokens = static_cast<int>(x.size(0)), hidden = static_cast<int>(x.size(1));
++    auto num_scales = hidden / 16, num_topk = static_cast<int>(topk_idx.size(1));
++    auto num_local_experts = num_experts / num_ranks;
++
++    LowLatencyLayout layout(rdma_buffer_ptr, num_max_dispatch_tokens_per_rank, hidden, num_ranks, num_experts);
++    EP_HOST_ASSERT(layout.total_bytes <= num_rdma_bytes);
++    auto buffer = layout.buffers[low_latency_buffer_idx];
++    auto next_buffer = layout.buffers[low_latency_buffer_idx ^= 1];
++
++    auto compute_stream = at::cuda::getCurrentCUDAStream();
++    auto launch_stream = return_recv_hook ? compute_stream : comm_stream;
++    EP_HOST_ASSERT(not (async and return_recv_hook));
++    if (not return_recv_hook)
++        stream_wait(launch_stream, compute_stream);
++
++    auto packed_recv_x = torch::empty({num_local_experts, num_ranks * num_max_dispatch_tokens_per_rank, hidden / 2},
++                                        x.options().dtype(torch::kByte));
++    auto packed_recv_src_info = torch::empty({num_local_experts, num_ranks * num_max_dispatch_tokens_per_rank}, torch::dtype(torch::kInt32).device(torch::kCUDA));
++    auto packed_recv_layout_range = torch::empty({num_local_experts, num_ranks}, torch::dtype(torch::kInt64).device(torch::kCUDA));
++    auto packed_recv_count = torch::empty({num_local_experts}, torch::dtype(torch::kInt32).device(torch::kCUDA));
++    auto packed_recv_x_scales = torch::empty({num_local_experts, num_ranks * num_max_dispatch_tokens_per_rank, num_scales},
++                                        torch::dtype(torch::kByte).device(torch::kCUDA));
++    EP_HOST_ASSERT((num_ranks * num_max_dispatch_tokens_per_rank) % 4 == 0 and "TMA requires the number of tokens to be multiple of 4");
++
++    auto next_clean_meta = next_buffer.clean_meta();
++    auto launcher = [=](int phases) {
++        extensions::dispatch_bf16_to_fp4(packed_recv_x.data_ptr(), packed_recv_x_scales.data_ptr(),
++                                packed_recv_src_info.data_ptr<int>(), packed_recv_layout_range.data_ptr<int64_t>(),
++                                packed_recv_count.data_ptr<int>(),
++                                cumulative_local_expert_recv_stats.has_value() ? cumulative_local_expert_recv_stats->data_ptr<int>() : nullptr,
++                                buffer.dispatch_rdma_recv_data_buffer, buffer.dispatch_rdma_recv_count_buffer,
++                                buffer.dispatch_rdma_send_buffer,
++                                x.data_ptr(), global_scale.data_ptr<float>(), topk_idx.data_ptr<int>(),
++                                next_clean_meta.first, next_clean_meta.second,
++                                num_tokens, hidden, num_max_dispatch_tokens_per_rank,
++                                num_topk, num_experts, rank, num_ranks,
++                                workspace, num_device_sms,
++                                launch_stream, phases);
++    };
++    launcher(return_recv_hook ? LOW_LATENCY_SEND_PHASE : (LOW_LATENCY_SEND_PHASE | LOW_LATENCY_RECV_PHASE));
++
++    std::optional<EventHandle> event;
++    if (async) {
++        event = EventHandle(launch_stream);
++    } else if (not return_recv_hook) {
++        stream_wait(compute_stream, launch_stream);
++    }
++
++    std::optional<std::function<void()>> recv_hook = std::nullopt;
++    if (return_recv_hook)
++        recv_hook = [=]() { launcher(LOW_LATENCY_RECV_PHASE); };
++
++    return {packed_recv_x, packed_recv_x_scales, packed_recv_count, packed_recv_src_info, packed_recv_layout_range, event, recv_hook};
++#else
++    EP_HOST_ASSERT(false and "NVSHMEM is disabled during compilation");
++    return {};
++#endif
++}
++
+ std::tuple<torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
+ Buffer::low_latency_combine_low_precision(int precision, const torch::Tensor& x, const std::optional<torch::Tensor>& global_scale,
+                             const torch::Tensor& topk_idx, const torch::Tensor& topk_weights,
+@@ -1611,6 +1695,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+         .def("low_latency_dispatch", &deep_ep::Buffer::low_latency_dispatch)
+         .def("low_latency_combine", &deep_ep::Buffer::low_latency_combine)
+         .def("low_latency_dispatch_fp4", &deep_ep::Buffer::low_latency_dispatch_fp4)
++        .def("low_latency_dispatch_bf16_to_fp4", &deep_ep::Buffer::low_latency_dispatch_bf16_to_fp4)
+         .def("low_latency_combine_low_precision", &deep_ep::Buffer::low_latency_combine_low_precision)
+         .def("get_next_low_latency_combine_buffer", &deep_ep::Buffer::get_next_low_latency_combine_buffer);
+ 
+diff --git a/csrc/deep_ep.hpp b/csrc/deep_ep.hpp
+index 7377b72..6b73565 100644
+--- a/csrc/deep_ep.hpp
++++ b/csrc/deep_ep.hpp
+@@ -155,6 +155,13 @@ public:
+                         const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
+                         int num_max_dispatch_tokens_per_rank, int num_experts,
+                         bool async, bool return_recv_hook);
++
++    std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
++    low_latency_dispatch_bf16_to_fp4(const torch::Tensor& x, const torch::Tensor& global_scale,
++                        const torch::Tensor& topk_idx,
++                        const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
++                        int num_max_dispatch_tokens_per_rank, int num_experts,
++                        bool async, bool return_recv_hook);
+     std::tuple<torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
+     low_latency_combine_low_precision(int precision, const torch::Tensor& x, const std::optional<torch::Tensor>& global_scale,
+                                 const torch::Tensor& topk_idx, const torch::Tensor& topk_weights,
+diff --git a/csrc/kernels/extension_api.cuh b/csrc/kernels/extension_api.cuh
+index af13a4b..223c92b 100644
+--- a/csrc/kernels/extension_api.cuh
++++ b/csrc/kernels/extension_api.cuh
+@@ -21,6 +21,17 @@ namespace extensions {
+         int num_topk, int num_experts, int rank, int num_ranks,
+         void* workspace, int num_device_sms,
+         cudaStream_t stream, int phases);
++    void dispatch_bf16_to_fp4(void* packed_recv_x, void* packed_recv_x_scales,
++        int* packed_recv_src_info, int64_t* packed_recv_layout_range,
++        int* packed_recv_count,
++        int* cumulative_local_expert_recv_stats,
++        void* rdma_recv_x, int* rdma_recv_count, void* rdma_x,
++        const void* x, const float* global_scale, const int* topk_idx,
++        int* next_clean, int num_next_clean_int,
++        int num_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
++        int num_topk, int num_experts, int rank, int num_ranks,
++        void* workspace, int num_device_sms,
++        cudaStream_t stream, int phases);
+     void low_precision_combine(int precision, void* combined_x,
+         void* rdma_recv_x, int* rdma_recv_flag, void* rdma_send_x,
+         const void* x, const float* global_scale_per_token,
+@@ -33,4 +44,4 @@ namespace extensions {
+         void* workspace, int num_device_sms,
+         cudaStream_t stream, int phases);
+ }
+-}
+\ No newline at end of file
++}
+diff --git a/csrc/kernels/extension_kernels.cu b/csrc/kernels/extension_kernels.cu
+index 7867f60..c3e1e2f 100644
 --- a/csrc/kernels/extension_kernels.cu
 +++ b/csrc/kernels/extension_kernels.cu
-@@ -658,8 +658,30 @@ low_precision_combine(void* combined_x,
+@@ -261,14 +261,15 @@ switch (hidden) { \
+     default: EP_HOST_ASSERT(false && "Unsupported hidden"); \
+ } while (false)
+ 
+-template <int kHidden>
++template <int kHidden, bool kQuantizeBf16Input = false>
+ __global__ __launch_bounds__(1024, 1) void
+ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
+             int* packed_recv_src_info, int64_t* packed_recv_layout_range,
+             int* packed_recv_count,
+             int* cumulative_local_expert_recv_stats,
+             void* rdma_recv_x, int* rdma_recv_count, void* rdma_x,
+-            const void* x, const void* x_scales, const int* topk_idx,
++            const void* x, const void* x_scales, const float* global_scale,
++            const int* topk_idx,
+             int* atomic_counter_per_expert, int* atomic_finish_counter_per_expert,
+             int* next_clean, int num_next_clean_int,
+             int num_tokens, int num_max_dispatch_tokens_per_rank,
+@@ -287,6 +288,7 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
+ 
+     constexpr size_t kHiddenBytes = kHidden / 2;
+     constexpr size_t kHiddenVecAccessNum = kHiddenBytes / sizeof(int4);
++    constexpr size_t kHiddenBf16VecAccessNum = kHidden / (sizeof(int4) / sizeof(nv_bfloat16));
+     constexpr size_t kScalesBytes = kHidden / 16;
+     constexpr size_t kScalesVecAccessNum = kScalesBytes / sizeof(int4);
+ 
+@@ -308,8 +310,6 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
+         const auto num_threads = (num_warps - 1) * 32;
+ 
+         for (int token_idx = sm_id; token_idx < num_tokens; token_idx += num_sms) {
+-            const auto x_int4 = reinterpret_cast<const int4*>(x) + token_idx * kHiddenVecAccessNum;
+-            const auto x_scales_int4  = reinterpret_cast<const int4*>(x_scales) + token_idx * kScalesVecAccessNum;
+             const auto rdma_x_src_idx = reinterpret_cast<int*>(reinterpret_cast<uint8_t*>(rdma_x) + token_idx * kNumBytesPerMsg);
+             const auto rdma_x_vec = reinterpret_cast<int4*>(reinterpret_cast<uint8_t*>(rdma_x_src_idx) + sizeof(int4));
+             const auto rdma_x_scales = reinterpret_cast<int4*>(reinterpret_cast<uint8_t*>(rdma_x_vec) + kHiddenBytes);
+@@ -318,15 +318,32 @@ dispatch_fp4(void* packed_recv_x, void* packed_recv_x_scales,
+             auto dst_expert_idx = warp_id < num_topk ? static_cast<int>(__ldg(topk_idx + token_idx * num_topk + warp_id)) : -1;
+             thread_id == 0 ? (*rdma_x_src_idx = token_idx) : 0;
+ 
+-            #pragma unroll
+-            for (int i = thread_id; i < kHiddenVecAccessNum; i += num_threads) {
+-                auto int4_value = __ldg(x_int4 + i);
+-                rdma_x_vec[i] = *reinterpret_cast<int4*>(&int4_value);
+-            }
+-            #pragma unroll
+-            for (int i = thread_id; i < kScalesVecAccessNum; i += num_threads) {
+-                auto int4_value = __ldg(x_scales_int4  + i);
+-                rdma_x_scales[i] = *reinterpret_cast<int4*>(&int4_value);
++            if constexpr (kQuantizeBf16Input) {
++                const auto x_bf16_int4 = reinterpret_cast<const int4*>(x) + token_idx * kHiddenBf16VecAccessNum;
++                const auto global_scale_val = __ldg(global_scale);
++                auto rdma_x_fp4 = reinterpret_cast<uint32_t*>(rdma_x_vec);
++                auto rdma_x_fp8_scales = reinterpret_cast<uint8_t*>(rdma_x_scales);
++#pragma unroll
++                for (int i = thread_id; i < kHiddenBf16VecAccessNum; i += num_threads) {
++                    auto [e2m1_vec, fp8_scale_val] =
++                        quantize_bf16_to_nvfp4(__ldg(x_bf16_int4 + i), global_scale_val);
++                    rdma_x_fp4[i] = e2m1_vec;
++                    if (i % 2 == 0)
++                        rdma_x_fp8_scales[i / 2] = fp8_scale_val;
++                }
++            } else {
++                const auto x_int4 = reinterpret_cast<const int4*>(x) + token_idx * kHiddenVecAccessNum;
++                const auto x_scales_int4  = reinterpret_cast<const int4*>(x_scales) + token_idx * kScalesVecAccessNum;
++#pragma unroll
++                for (int i = thread_id; i < kHiddenVecAccessNum; i += num_threads) {
++                    auto int4_value = __ldg(x_int4 + i);
++                    rdma_x_vec[i] = *reinterpret_cast<int4*>(&int4_value);
++                }
++#pragma unroll
++                for (int i = thread_id; i < kScalesVecAccessNum; i += num_threads) {
++                    auto int4_value = __ldg(x_scales_int4  + i);
++                    rdma_x_scales[i] = *reinterpret_cast<int4*>(&int4_value);
++                }
+             }
+             asm volatile("bar.sync 1, %0;" :: "r"(num_threads));
+ 
+@@ -526,7 +543,7 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
+                 packed_recv_count, \
+                 cumulative_local_expert_recv_stats, \
+                 rdma_recv_x, rdma_recv_count, rdma_x, \
+-                x, x_scales, topk_idx, \
++                x, x_scales, nullptr, topk_idx, \
+                 atomic_counter_per_expert, atomic_finish_counter_per_expert, \
+                 next_clean, num_next_clean_int, \
+                 num_tokens, num_max_dispatch_tokens_per_rank, \
+@@ -539,6 +556,53 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
+ #undef DISPATCH_LAUNCH_CASE
+ }
+ 
++void dispatch_bf16_to_fp4(void* packed_recv_x, void* packed_recv_x_scales,
++                int* packed_recv_src_info, int64_t* packed_recv_layout_range,
++                int* packed_recv_count,
++                int* cumulative_local_expert_recv_stats,
++                void* rdma_recv_x, int* rdma_recv_count, void* rdma_x,
++                const void* x, const float* global_scale, const int* topk_idx,
++                int* next_clean, int num_next_clean_int,
++                int num_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
++                int num_topk, int num_experts, int rank, int num_ranks,
++                void* workspace, int num_device_sms,
++                cudaStream_t stream, int phases) {
++    constexpr int kNumMaxTopK = 9;
++    const int num_warp_groups = ceil_div(num_experts, num_device_sms);
++    const int num_warps_per_group = 32 / num_warp_groups;
++    EP_HOST_ASSERT(num_warp_groups > 0 and num_warps_per_group > 0);
++    EP_HOST_ASSERT(kNumMaxTopK + 1 <= num_warp_groups * num_warps_per_group);
++
++    const auto num_warps = num_warp_groups * num_warps_per_group;
++    const auto num_sms = ceil_div(num_experts, num_warp_groups);
++    EP_HOST_ASSERT(num_topk <= kNumMaxTopK);
++    EP_HOST_ASSERT(global_scale != nullptr);
++
++    auto atomic_counter_per_expert = reinterpret_cast<int*>(workspace);
++    auto atomic_finish_counter_per_expert = atomic_counter_per_expert + num_experts;
++    EP_HOST_ASSERT(num_experts * sizeof(int) * 2 <= NUM_WORKSPACE_BYTES);
++
++#define DISPATCH_BF16_TO_FP4_LAUNCH_CASE(hidden) { \
++auto dispatch_func = dispatch_fp4<hidden, true>; \
++LAUNCH_KERNEL(&cfg, dispatch_func, \
++                packed_recv_x, packed_recv_x_scales, \
++                packed_recv_src_info, packed_recv_layout_range, \
++                packed_recv_count, \
++                cumulative_local_expert_recv_stats, \
++                rdma_recv_x, rdma_recv_count, rdma_x, \
++                x, nullptr, global_scale, topk_idx, \
++                atomic_counter_per_expert, atomic_finish_counter_per_expert, \
++                next_clean, num_next_clean_int, \
++                num_tokens, num_max_dispatch_tokens_per_rank, \
++                num_topk, num_experts, rank, num_ranks, \
++                num_warp_groups, num_warps_per_group, \
++                phases); } break
++
++    SETUP_LAUNCH_CONFIG(num_sms, num_warps * 32, stream);
++    SWITCH_HIDDEN_FOR_EXTENSION_KERNELS(DISPATCH_BF16_TO_FP4_LAUNCH_CASE);
++#undef DISPATCH_BF16_TO_FP4_LAUNCH_CASE
++}
++
+ enum class LowPrecisionType : int {
+     FP8 = 0,
+     NVFP4 = 1
+@@ -658,7 +722,29 @@ low_precision_combine(void* combined_x,
              float global_scale_val = 0.f;
              if constexpr (LowPrecisionTypeTraits<kPrecision>::kUseGlobalScale) {
                  auto rdma_send_x_global_scale_vec = reinterpret_cast<float*>(rdma_send_x_current_expert + token_idx * kNumBytesPerSlot + kHiddenCommBytes + kScalesBytes);
 -                global_scale_val = __ldg(global_scale_per_token + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank + token_idx);
--                rdma_send_x_global_scale_vec[0] = global_scale_val;
 +                if (global_scale_per_token != nullptr) {
 +                    global_scale_val = __ldg(global_scale_per_token + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank + token_idx);
 +                } else {
@@ -65,11 +320,10 @@
 +                    per_token_max_abs_val = half_warp_reduce_max(per_token_max_abs_val);
 +                    global_scale_val = 448.f * 6.f / per_token_max_abs_val;
 +                }
-+                rdma_send_x_global_scale_vec[0] = global_scale_val;
+                 rdma_send_x_global_scale_vec[0] = global_scale_val;
              }
              const auto x_int4 = local_x + token_idx * kHiddenBf16VecAccessNum;
-             for(int i = lane_id; i < kHiddenBf16VecAccessNum; i += 32) {
-@@ -785,7 +807,6 @@ void low_precision_combine(int precision,void* combined_x,
+@@ -785,7 +871,6 @@ void low_precision_combine(int precision,void* combined_x,
  auto combine_func = low_precision_combine<LowPrecisionType::FP8, hidden, kNumMaxTopk>; \
  if(precision != 0) { \
      combine_func = low_precision_combine<LowPrecisionType::NVFP4, hidden, kNumMaxTopk>; \
@@ -77,3 +331,112 @@
  } else { \
      EP_HOST_ASSERT(global_scale_per_token == nullptr); \
  } \
+@@ -808,4 +893,4 @@ LAUNCH_KERNEL(&cfg, combine_func, \
+ }
+ #undef SWITCH_HIDDEN_FOR_EXTENSION_KERNELS
+ }
+-}
+\ No newline at end of file
++}
+diff --git a/csrc/kernels/intranode.cu b/csrc/kernels/intranode.cu
+index ee9ca67..0031c07 100644
+--- a/csrc/kernels/intranode.cu
++++ b/csrc/kernels/intranode.cu
+@@ -844,9 +844,15 @@ combine(dtype_t* recv_x, float* recv_topk_weights,
+ 
+ #ifndef DISABLE_SM90_FEATURES
+                     // Wait TMA arrival
++                    // hidden_int4 is not always divisible by a warp. The final tile can have
++                    // only a subset of lanes active, so synchronize only participating lanes.
++                    auto const tile_start = i - lane_id;
++                    auto const active_lanes = min(32, hidden_int4 - tile_start);
++                    auto const sync_mask = active_lanes == 32 ? 0xffffffffu : ((1u << active_lanes) - 1u);
++
+                     if (lane_id == 0)
+                         tma_store_wait<kNumStages - 1>();
+-                    __syncwarp();
++                    __syncwarp(sync_mask);
+ 
+                     // Write into TMA buffer
+                     auto tma_stage_idx = (i / 32) % kNumStages;
+@@ -854,13 +860,13 @@ combine(dtype_t* recv_x, float* recv_topk_weights,
+ 
+                     // Issue TMA
+                     tma_store_fence();
+-                    __syncwarp();
++                    __syncwarp(sync_mask);
+                     if (lane_id == 0) {
+                         auto tma_bytes = min(32, hidden_int4 - i) * static_cast<int>(sizeof(int4));
+                         tma_store_1d(reinterpret_cast<int4*>(tma_buffer) + tma_stage_idx * 32,
+                                      recv_int4 + token_idx * hidden_int4 + i, tma_bytes, false);
+                     }
+-                    __syncwarp();
++                    __syncwarp(sync_mask);
+ #else
+                     recv_int4[token_idx * hidden_int4 + i] = out_int4;
+ #endif
+diff --git a/deep_ep/buffer.py b/deep_ep/buffer.py
+index bdc1181..79170ac 100644
+--- a/deep_ep/buffer.py
++++ b/deep_ep/buffer.py
+@@ -643,6 +643,35 @@ class Buffer:
+                              cumulative_local_expert_recv_stats)
+         return packed_recv_x, packed_recv_x_scales, packed_recv_count, handle, \
+             EventOverlap(event, tensors_to_record if async_finish else None), hook
++
++    # noinspection PyTypeChecker
++    def low_latency_dispatch_bf16_to_fp4(self, x: torch.Tensor, global_scale: torch.Tensor,
++                                         topk_idx: torch.Tensor,
++                                         num_max_dispatch_tokens_per_rank: int,
++                                         num_experts: int,
++                                         cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
++                                         async_finish: bool = False,
++                                         return_recv_hook: bool = False) -> \
++            Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Tuple, EventOverlap, Callable]:
++        """Dispatch contiguous BF16 while packing NVFP4 in the send phase.
++
++        This is an experimental opt-in equivalent of ``low_latency_dispatch_fp4``.
++        It accepts a single FP32 global scale and returns the same packed receive
++        tensors and combine handle as the materialized-FP4 entry point.
++        """
++        packed_recv_x, packed_recv_x_scales, packed_recv_count, packed_recv_src_info, packed_recv_layout_range, event, hook = \
++            self.runtime.low_latency_dispatch_bf16_to_fp4(
++                x, global_scale, topk_idx, cumulative_local_expert_recv_stats,
++                num_max_dispatch_tokens_per_rank, num_experts,
++                async_finish, return_recv_hook)
++        handle = (packed_recv_src_info, packed_recv_layout_range,
++                  num_max_dispatch_tokens_per_rank, x.size(1), num_experts)
++        tensors_to_record = (x, global_scale, topk_idx,
++                             packed_recv_x, packed_recv_x_scales, packed_recv_count,
++                             packed_recv_src_info, packed_recv_layout_range,
++                             cumulative_local_expert_recv_stats)
++        return packed_recv_x, packed_recv_x_scales, packed_recv_count, handle, \
++            EventOverlap(event, tensors_to_record if async_finish else None), hook
+     
+     # noinspection PyTypeChecker
+     def low_latency_combine_low_precision(self, precision: str, x: torch.Tensor, global_scale: torch.Tensor, 
+diff --git a/tests/test_low_latency_fp4.py b/tests/test_low_latency_fp4.py
+index a455091..3a8484a 100644
+--- a/tests/test_low_latency_fp4.py
++++ b/tests/test_low_latency_fp4.py
+@@ -88,6 +88,20 @@ def test_all2all(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
+     
+     verify_dispatch_fp4(packed_recv_x, packed_recv_scales, real_recv_count, tokens_packed_fp4, scales_fp8, topk_idx, num_tokens, num_experts, num_ranks, rank, hidden)
+ 
++    # The fused entry point must produce the same message payload as the
++    # materialized-FP4 path for one exact static global scale.
++    static_global_scale = torch.tensor(0.75, dtype=torch.float32, device='cuda')
++    static_global_scales = static_global_scale.expand(num_ranks, num_tokens, 1).contiguous()
++    static_tokens_packed_fp4, static_scales_fp8 = \
++        deep_ep.Buffer.quantize_bf16_to_nvfp4(tokens_bf16, static_global_scales)
++    fused_recv_x, fused_recv_scales, fused_recv_count, _, _, _ = \
++        buffer.low_latency_dispatch_bf16_to_fp4(
++            tokens_bf16[rank], static_global_scale, topk_idx[rank], num_tokens, num_experts)
++    verify_dispatch_fp4(
++        fused_recv_x, fused_recv_scales, fused_recv_count,
++        static_tokens_packed_fp4, static_scales_fp8, topk_idx,
++        num_tokens, num_experts, num_ranks, rank, hidden)
++
+     x, recv_count, handle, event, hook = buffer.low_latency_dispatch(tokens_bf16[rank], topk_idx[rank], num_tokens, num_experts, use_fp8=False)
+     assert torch.equal(recv_count, real_recv_count)
+     

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep_low_latency.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep_low_latency.py
@@ -32,6 +32,8 @@ from tensorrt_llm.models.modeling_utils import QuantConfig
 
 from .base import Communication
 
+_NVFP4_FUSED_OUTPUT_SCALE_ENV = "TRTLLM_DEEP_EP_NVFP4_FUSED_OUTPUT_SCALE"
+
 
 class DeepEPLowLatency(Communication):
     """
@@ -79,6 +81,18 @@ class DeepEPLowLatency(Communication):
         self.use_low_precision_combine = (
             use_low_precision_combine and self.supports_low_precision_combine()
         )
+        fused_output_scale_value = os.environ.get(_NVFP4_FUSED_OUTPUT_SCALE_ENV)
+        if fused_output_scale_value not in (None, "0", "1"):
+            raise ValueError(
+                f"{_NVFP4_FUSED_OUTPUT_SCALE_ENV} must be 0 or 1, got {fused_output_scale_value!r}"
+            )
+        self._fuse_nvfp4_output_scale = fused_output_scale_value == "1"
+        if self._fuse_nvfp4_output_scale and (
+            not self.use_low_precision_combine or not self._has_nvfp4()
+        ):
+            raise ValueError(
+                f"{_NVFP4_FUSED_OUTPUT_SCALE_ENV} requires low-precision NVFP4 combine"
+            )
         # Read from environment variable, same as wideEP
         self.enable_postquant_alltoall = (
             os.environ.get("TRTLLM_MOE_POST_QUANT_ALLTOALLV", "1") == "1"
@@ -335,9 +349,14 @@ class DeepEPLowLatency(Communication):
         if self.use_low_precision_combine:
             if self._has_nvfp4():
                 precision = "nvfp4"
-                global_scales = torch.ops.trtllm.calculate_nvfp4_global_scale(
-                    final_hidden_states, recv_expert_count
-                )
+                if self._fuse_nvfp4_output_scale:
+                    # A missing scale tensor selects DeepEP's exact in-kernel
+                    # dynamic per-token reduction in low-precision combine.
+                    global_scales = None
+                else:
+                    global_scales = torch.ops.trtllm.calculate_nvfp4_global_scale(
+                        final_hidden_states, recv_expert_count
+                    )
             else:
                 precision = "fp8"
                 global_scales = None

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep_low_latency.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep_low_latency.py
@@ -34,6 +34,14 @@ from .base import Communication
 
 _NVFP4_FUSED_OUTPUT_SCALE_ENV = "TRTLLM_DEEP_EP_NVFP4_FUSED_OUTPUT_SCALE"
 _NVFP4_FUSED_BF16_DISPATCH_ENV = "TRTLLM_DEEP_EP_NVFP4_FUSED_BF16_DISPATCH"
+_LOW_PRECISION_COMBINE_STAGE_METADATA_ENV = "TRTLLM_DEEP_EP_LP_COMBINE_RECV_METADATA_STAGING"
+
+
+def _read_binary_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value not in (None, "0", "1"):
+        raise ValueError(f"{name} must be 0 or 1, got {value!r}")
+    return value == "1"
 
 
 class DeepEPLowLatency(Communication):
@@ -82,19 +90,11 @@ class DeepEPLowLatency(Communication):
         self.use_low_precision_combine = (
             use_low_precision_combine and self.supports_low_precision_combine()
         )
-        fused_output_scale_value = os.environ.get(_NVFP4_FUSED_OUTPUT_SCALE_ENV)
-        if fused_output_scale_value not in (None, "0", "1"):
-            raise ValueError(
-                f"{_NVFP4_FUSED_OUTPUT_SCALE_ENV} must be 0 or 1, got {fused_output_scale_value!r}"
-            )
-        self._fuse_nvfp4_output_scale = fused_output_scale_value == "1"
-        fused_bf16_dispatch_value = os.environ.get(_NVFP4_FUSED_BF16_DISPATCH_ENV)
-        if fused_bf16_dispatch_value not in (None, "0", "1"):
-            raise ValueError(
-                f"{_NVFP4_FUSED_BF16_DISPATCH_ENV} must be 0 or 1, "
-                f"got {fused_bf16_dispatch_value!r}"
-            )
-        self._fuse_nvfp4_bf16_dispatch = fused_bf16_dispatch_value == "1"
+        self._fuse_nvfp4_output_scale = _read_binary_env(_NVFP4_FUSED_OUTPUT_SCALE_ENV)
+        self._fuse_nvfp4_bf16_dispatch = _read_binary_env(_NVFP4_FUSED_BF16_DISPATCH_ENV)
+        self._stage_low_precision_combine_metadata = _read_binary_env(
+            _LOW_PRECISION_COMBINE_STAGE_METADATA_ENV
+        )
         if self._fuse_nvfp4_output_scale and (
             not self.use_low_precision_combine or not self._has_nvfp4()
         ):
@@ -414,6 +414,7 @@ class DeepEPLowLatency(Communication):
                 deep_ep_topk_idx,
                 deep_ep_topk_weights,
                 deep_ep_handle,
+                stage_recv_metadata=self._stage_low_precision_combine_metadata,
             )
         else:
             final_hidden_states = self.deep_ep_buffer.low_latency_combine(

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep_low_latency.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/deep_ep_low_latency.py
@@ -33,6 +33,7 @@ from tensorrt_llm.models.modeling_utils import QuantConfig
 from .base import Communication
 
 _NVFP4_FUSED_OUTPUT_SCALE_ENV = "TRTLLM_DEEP_EP_NVFP4_FUSED_OUTPUT_SCALE"
+_NVFP4_FUSED_BF16_DISPATCH_ENV = "TRTLLM_DEEP_EP_NVFP4_FUSED_BF16_DISPATCH"
 
 
 class DeepEPLowLatency(Communication):
@@ -87,6 +88,13 @@ class DeepEPLowLatency(Communication):
                 f"{_NVFP4_FUSED_OUTPUT_SCALE_ENV} must be 0 or 1, got {fused_output_scale_value!r}"
             )
         self._fuse_nvfp4_output_scale = fused_output_scale_value == "1"
+        fused_bf16_dispatch_value = os.environ.get(_NVFP4_FUSED_BF16_DISPATCH_ENV)
+        if fused_bf16_dispatch_value not in (None, "0", "1"):
+            raise ValueError(
+                f"{_NVFP4_FUSED_BF16_DISPATCH_ENV} must be 0 or 1, "
+                f"got {fused_bf16_dispatch_value!r}"
+            )
+        self._fuse_nvfp4_bf16_dispatch = fused_bf16_dispatch_value == "1"
         if self._fuse_nvfp4_output_scale and (
             not self.use_low_precision_combine or not self._has_nvfp4()
         ):
@@ -154,6 +162,26 @@ class DeepEPLowLatency(Communication):
             return (self.hidden_size // 2) in self.SUPPORTED_HIDDEN_SIZES
         return False
 
+    def should_fuse_bf16_nvfp4_dispatch(
+        self, hidden_states: torch.Tensor, global_scale: Optional[torch.Tensor]
+    ) -> bool:
+        """Return whether dispatch can absorb this call's NVFP4 quantization."""
+        return (
+            getattr(self, "_fuse_nvfp4_bf16_dispatch", False)
+            and self._has_nvfp4()
+            and self.supports_post_quant_dispatch()
+            and isinstance(hidden_states, torch.Tensor)
+            and hidden_states.dtype == torch.bfloat16
+            and hidden_states.dim() == 2
+            and hidden_states.is_contiguous()
+            and hidden_states.shape[1] == self.hidden_size
+            and isinstance(global_scale, torch.Tensor)
+            and global_scale.dtype == torch.float32
+            and global_scale.numel() == 1
+            and global_scale.is_contiguous()
+            and global_scale.device == hidden_states.device
+        )
+
     def supports_low_precision_combine(self) -> bool:
         """
         DeepEP Low Latency supports low-precision combine for: fp8_qdq, nvfp4, w4afp8
@@ -190,6 +218,8 @@ class DeepEPLowLatency(Communication):
         all_rank_num_tokens: List[int],
         use_dp_padding: Optional[bool] = None,
         pre_quant_scale: Optional[torch.Tensor] = None,
+        fuse_bf16_nvfp4_quantization: bool = False,
+        nvfp4_input_scale: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor, Optional[torch.Tensor]]:
         """
@@ -241,39 +271,55 @@ class DeepEPLowLatency(Communication):
                 hidden_states = hidden_states.view(torch.float8_e4m3fn)
 
             elif self._has_nvfp4():
-                token_num = hidden_states.shape[0]
-                # For nvfp4, hidden_states.shape[1] is the quantized dimension (hidden_size // 2)
-                # We need to calculate the original hidden_size
-                # note: we use uint8 to store 2 fp4 values
-                hidden_size = hidden_states.shape[1] * 2
-
-                # Pre-dispatch assertions
-                assert (
-                    hidden_states.dtype == torch.uint8
-                    and hidden_states_sf is not None
-                    and hidden_states_sf.dtype == torch.uint8
-                )
-                assert hidden_size % 32 == 0, (
-                    "HiddenSize should be divisible by 32 in nvfp4 postquant alltoall"
-                )
-                assert (
-                    hidden_states_sf.shape[0] == token_num
-                    and hidden_states_sf.shape[1] == hidden_size // 16
-                )
-                assert (
-                    hidden_states.shape[0] == token_num
-                    and hidden_states.shape[1] == hidden_size // 2
-                )
-
-                hidden_states, hidden_states_sf, recv_expert_count, deep_ep_handle = (
-                    self.deep_ep_buffer.low_latency_dispatch_fp4(
-                        hidden_states,
-                        hidden_states_sf,
-                        deep_ep_topk_idx,
-                        all_rank_max_num_tokens,
-                        self.num_slots,
+                if fuse_bf16_nvfp4_quantization:
+                    if nvfp4_input_scale is None or not self.should_fuse_bf16_nvfp4_dispatch(
+                        hidden_states, nvfp4_input_scale
+                    ):
+                        raise ValueError(
+                            "Fused BF16-to-NVFP4 dispatch requires contiguous BF16 input, "
+                            "one FP32 input scale, and supported NVFP4 post-quant DeepEP"
+                        )
+                    hidden_size = hidden_states.shape[1]
+                    assert hidden_states_sf is None
+                    hidden_states, hidden_states_sf, recv_expert_count, deep_ep_handle = (
+                        self.deep_ep_buffer.low_latency_dispatch_bf16_to_fp4(
+                            hidden_states,
+                            nvfp4_input_scale,
+                            deep_ep_topk_idx,
+                            all_rank_max_num_tokens,
+                            self.num_slots,
+                        )
                     )
-                )
+                else:
+                    token_num = hidden_states.shape[0]
+                    # uint8 stores two FP4 values, so recover the original width.
+                    hidden_size = hidden_states.shape[1] * 2
+                    assert (
+                        hidden_states.dtype == torch.uint8
+                        and hidden_states_sf is not None
+                        and hidden_states_sf.dtype == torch.uint8
+                    )
+                    assert hidden_size % 32 == 0, (
+                        "HiddenSize should be divisible by 32 in nvfp4 postquant alltoall"
+                    )
+                    assert (
+                        hidden_states_sf.shape[0] == token_num
+                        and hidden_states_sf.shape[1] == hidden_size // 16
+                    )
+                    assert (
+                        hidden_states.shape[0] == token_num
+                        and hidden_states.shape[1] == hidden_size // 2
+                    )
+
+                    hidden_states, hidden_states_sf, recv_expert_count, deep_ep_handle = (
+                        self.deep_ep_buffer.low_latency_dispatch_fp4(
+                            hidden_states,
+                            hidden_states_sf,
+                            deep_ep_topk_idx,
+                            all_rank_max_num_tokens,
+                            self.num_slots,
+                        )
+                    )
 
                 # Post-dispatch assertions
                 assert hidden_states.dtype == torch.uint8 and hidden_states_sf.dtype == torch.uint8

--- a/tensorrt_llm/_torch/modules/fused_moe/deep_ep_utils.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/deep_ep_utils.py
@@ -199,18 +199,22 @@ class VariableLengthLowLatencyBuffer:
 
         return recv_hidden_states, recv_scales, recv_expert_count, handle
 
-    def low_latency_combine_low_precision(self, precision: str,
+    def low_latency_combine_low_precision(self,
+                                          precision: str,
                                           hidden_states: torch.Tensor,
                                           global_scales: Optional[torch.Tensor],
                                           topk_idx: torch.Tensor,
                                           topk_weights: torch.Tensor,
-                                          handle: Tuple):
+                                          handle: Tuple,
+                                          stage_recv_metadata: bool = False):
         """
             Arguments:
                 precision: the precision of the low-precision kernel, "fp8" for FP8, "nvfp4" for NVFP4.
         """
         combined_hidden_states, event, hook = \
-            self.buffer.low_latency_combine_low_precision(precision, hidden_states, global_scales, topk_idx, topk_weights, handle)
+            self.buffer.low_latency_combine_low_precision(
+                precision, hidden_states, global_scales, topk_idx, topk_weights,
+                handle, stage_recv_metadata=stage_recv_metadata)
         assert event.event is None
         assert hook is None
 

--- a/tensorrt_llm/_torch/modules/fused_moe/deep_ep_utils.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/deep_ep_utils.py
@@ -182,6 +182,23 @@ class VariableLengthLowLatencyBuffer:
 
         return recv_hidden_states, recv_scales, recv_expert_count, handle
 
+    def low_latency_dispatch_bf16_to_fp4(self, hidden_states: torch.Tensor,
+                                         global_scale: torch.Tensor,
+                                         topk_idx: torch.Tensor,
+                                         num_max_dispatch_tokens_per_rank: int,
+                                         num_experts: int):
+        """Pack BF16 to NVFP4 in the DeepEP dispatch send phase."""
+        assert num_experts == self.num_experts
+
+        recv_hidden_states, recv_scales, recv_expert_count, handle, event, hook = \
+            self.buffer.low_latency_dispatch_bf16_to_fp4(
+                hidden_states, global_scale, topk_idx,
+                num_max_dispatch_tokens_per_rank, num_experts)
+        assert event.event is None
+        assert hook is None
+
+        return recv_hidden_states, recv_scales, recv_expert_count, handle
+
     def low_latency_combine_low_precision(self, precision: str,
                                           hidden_states: torch.Tensor,
                                           global_scales: Optional[torch.Tensor],

--- a/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
@@ -486,12 +486,25 @@ class ExternalCommMoEScheduler(MoEScheduler):
                 moe.dummy_allreduce()
 
             dispatch_kwargs = dict(eplb_dispatch_kwargs)
+            fuse_bf16_nvfp4_dispatch = False
             if isinstance(moe.comm, DeepEP) and isinstance(moe.backend, TRTLLMGenFusedMoE):
                 dispatch_kwargs["enable_sanitize_expert_ids"] = True
+            if isinstance(moe.comm, DeepEPLowLatency) and moe.backend.__class__ == CuteDslFusedMoE:
+                nvfp4_input_scale = getattr(moe.backend, "fc31_input_scale", None)
+                fuse_bf16_nvfp4_dispatch = (
+                    nvfp4_input_scale is not None
+                    and moe.comm.should_fuse_bf16_nvfp4_dispatch(x, nvfp4_input_scale)
+                )
+                if fuse_bf16_nvfp4_dispatch:
+                    dispatch_kwargs["fuse_bf16_nvfp4_quantization"] = True
+                    dispatch_kwargs["nvfp4_input_scale"] = nvfp4_input_scale
 
             if supports_post_quant:
                 # Quantize -> Dispatch
-                x, x_sf = moe.backend.quantize_input(x)
+                if fuse_bf16_nvfp4_dispatch:
+                    x_sf = None
+                else:
+                    x, x_sf = moe.backend.quantize_input(x)
 
                 # W4AFP8 + DeepEPLowLatency needs pre_quant_scale_1; other strategies
                 # absorb the kwarg via **kwargs so unconditional passing is safe.

--- a/tests/unittest/_torch/modules/moe/test_deep_ep_bf16_fp4_dispatch.py
+++ b/tests/unittest/_torch/modules/moe/test_deep_ep_bf16_fp4_dispatch.py
@@ -56,5 +56,11 @@ def test_deep_ep_nvfp4_pack_matches_trtllm_bitwise(num_tokens: int, case: str):
         static_scale.expand(num_tokens, 1).contiguous(),
     )
 
-    assert torch.equal(reference_values.view(torch.uint8), deep_ep_values)
-    assert torch.equal(reference_scales.view(torch.uint8), deep_ep_scales.view(torch.uint8))
+    assert torch.equal(
+        reference_values.view(torch.uint8).reshape(-1),
+        deep_ep_values.view(torch.uint8).reshape(-1),
+    )
+    assert torch.equal(
+        reference_scales.view(torch.uint8).reshape(-1),
+        deep_ep_scales.view(torch.uint8).reshape(-1),
+    )

--- a/tests/unittest/_torch/modules/moe/test_deep_ep_bf16_fp4_dispatch.py
+++ b/tests/unittest/_torch/modules/moe/test_deep_ep_bf16_fp4_dispatch.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.modules.fused_moe.deep_ep_utils import deep_ep_installed
+from tensorrt_llm._utils import get_sm_version
+
+_SM_VERSION = get_sm_version() if torch.cuda.is_available() else 0
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA"),
+    pytest.mark.skipif(not deep_ep_installed, reason="requires DeepEP"),
+    pytest.mark.skipif(_SM_VERSION not in (100, 103), reason="requires SM100/SM103"),
+]
+
+
+def _make_bf16_input(case: str, num_tokens: int, hidden_size: int) -> torch.Tensor:
+    if case == "zeros":
+        return torch.zeros(num_tokens, hidden_size, dtype=torch.bfloat16, device="cuda")
+    if case == "finite_extremes":
+        finfo = torch.finfo(torch.bfloat16)
+        pattern = torch.tensor(
+            [finfo.min, -448.0, -6.0, -0.5, 0.0, 0.5, 6.0, 448.0, finfo.max],
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        num_elements = num_tokens * hidden_size
+        repeat_count = (num_elements + pattern.numel() - 1) // pattern.numel()
+        return pattern.repeat(repeat_count)[:num_elements].view(num_tokens, hidden_size)
+
+    generator = torch.Generator(device="cuda").manual_seed(20260722 + num_tokens)
+    return (
+        torch.randn(
+            num_tokens, hidden_size, dtype=torch.bfloat16, device="cuda", generator=generator
+        )
+        * 32
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 8, 16, 32])
+@pytest.mark.parametrize("case", ["zeros", "finite_extremes", "random"])
+def test_deep_ep_nvfp4_pack_matches_trtllm_bitwise(num_tokens: int, case: str):
+    from tensorrt_llm.deep_ep.buffer import Buffer
+
+    hidden_size = 4096
+    bf16_input = _make_bf16_input(case, num_tokens, hidden_size)
+    static_scale = torch.tensor(0.75, dtype=torch.float32, device="cuda")
+
+    reference_values, reference_scales = torch.ops.trtllm.fp4_quantize(
+        bf16_input, static_scale, 16, False, False
+    )
+    deep_ep_values, deep_ep_scales = Buffer.quantize_bf16_to_nvfp4(
+        bf16_input,
+        static_scale.expand(num_tokens, 1).contiguous(),
+    )
+
+    assert torch.equal(reference_values.view(torch.uint8), deep_ep_values)
+    assert torch.equal(reference_scales.view(torch.uint8), deep_ep_scales.view(torch.uint8))

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -59,10 +59,12 @@ from tensorrt_llm._torch.modules.fused_moe import (
 )
 from tensorrt_llm._torch.modules.fused_moe.communication.deep_ep_low_latency import DeepEPLowLatency
 from tensorrt_llm._torch.modules.fused_moe.create_moe import create_moe_backend, get_moe_cls
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_cute_dsl import CuteDslFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_marlin import MarlinFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.interface import MoE, MoEWeightLoadingMode
 from tensorrt_llm._torch.modules.fused_moe.mega_moe import MegaMoECuteDsl, MegaMoEDeepGemm
+from tensorrt_llm._torch.modules.fused_moe.moe_scheduler import ExternalCommMoEScheduler
 from tensorrt_llm._torch.modules.fused_moe.quantization import (
     FusedMoEMethodBase,
     NVFP4MarlinFusedMoEMethod,
@@ -125,6 +127,89 @@ def test_deep_ep_nvfp4_fused_output_scale_skips_standalone_scale_op(monkeypatch)
     assert call_args[3] is topk_idx
     assert call_args[4] is topk_weights
     assert call_args[5] is deep_ep_handle
+
+
+def test_scheduler_fuses_cutedsl_bf16_quantization_into_deep_ep_dispatch(monkeypatch):
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.modules.fused_moe.moe_scheduler.get_calibrator",
+        lambda: SimpleNamespace(maybe_collect_or_replay_slots=lambda _num_slots, slots: slots),
+    )
+    x = torch.empty(4, 8, dtype=torch.bfloat16)
+    selected_slots = torch.zeros(4, 1, dtype=torch.int32)
+    final_scales = torch.ones(4, 1, dtype=torch.float32)
+    input_scale = torch.tensor(0.75, dtype=torch.float32)
+
+    comm = DeepEPLowLatency.__new__(DeepEPLowLatency)
+    comm.supports_post_quant_dispatch = MagicMock(return_value=True)
+    comm.should_fuse_bf16_nvfp4_dispatch = MagicMock(return_value=True)
+    comm.dispatch = MagicMock(return_value=(x, None, selected_slots, final_scales))
+    comm.combine = MagicMock(side_effect=lambda output, **_kwargs: output)
+
+    backend = CuteDslFusedMoE.__new__(CuteDslFusedMoE)
+    backend._weights_created = True
+    backend.fc31_input_scale = input_scale
+    backend._supports_load_balancer = MagicMock(return_value=False)
+    backend.quantize_input = MagicMock(
+        side_effect=AssertionError("standalone NVFP4 quantization must not run")
+    )
+    backend.run_moe = MagicMock(return_value=x)
+
+    moe = SimpleNamespace(
+        backend=backend,
+        comm=comm,
+        routing_method=SimpleNamespace(requires_separated_routing=False),
+        apply_router_weight_on_input=False,
+        layer_load_balancer=None,
+        layer_idx=0,
+        num_slots=1,
+        enable_dummy_allreduce=False,
+        enable_alltoall=False,
+        _using_load_balancer=MagicMock(return_value=False),
+        _load_balancer_start_wait_gpu_stage=MagicMock(),
+        _load_balancer_start_set_cpu_stage=MagicMock(),
+        _load_balancer_done_set_cpu_stage=MagicMock(),
+    )
+    scheduler = ExternalCommMoEScheduler.__new__(ExternalCommMoEScheduler)
+    scheduler.moe = moe
+
+    scheduler._forward_chunk_impl(
+        x,
+        torch.empty(4, 1),
+        torch.bfloat16,
+        [4],
+        False,
+        True,
+        True,
+    )
+
+    backend.quantize_input.assert_not_called()
+    dispatch_kwargs = comm.dispatch.call_args.kwargs
+    assert dispatch_kwargs["hidden_states"] is x
+    assert dispatch_kwargs["hidden_states_sf"] is None
+    assert dispatch_kwargs["fuse_bf16_nvfp4_quantization"] is True
+    assert dispatch_kwargs["nvfp4_input_scale"] is input_scale
+
+
+def test_deep_ep_bf16_nvfp4_fusion_gate_falls_back_for_unsupported_input():
+    comm = DeepEPLowLatency.__new__(DeepEPLowLatency)
+    comm._fuse_nvfp4_bf16_dispatch = True
+    comm.enable_postquant_alltoall = True
+    comm.hidden_size = 8
+    comm.SUPPORTED_HIDDEN_SIZES_EXTENSION = frozenset({8})
+    comm.quant_config = SimpleNamespace(
+        layer_quant_mode=SimpleNamespace(
+            has_nvfp4=lambda: True,
+            has_fp8_qdq=lambda: False,
+        )
+    )
+    scale = torch.tensor(0.75, dtype=torch.float32)
+
+    assert comm.should_fuse_bf16_nvfp4_dispatch(torch.empty(4, 8, dtype=torch.bfloat16), scale)
+    assert not comm.should_fuse_bf16_nvfp4_dispatch(torch.empty(4, 8, dtype=torch.float32), scale)
+    assert not comm.should_fuse_bf16_nvfp4_dispatch(torch.empty(4, 16, dtype=torch.bfloat16), scale)
+    assert not comm.should_fuse_bf16_nvfp4_dispatch(
+        torch.empty(4, 8, dtype=torch.bfloat16), torch.ones(2, dtype=torch.float32)
+    )
 
 
 def _ensure_single_proc_dist_for_megamoe(backend_type: MoeBackendType, rank: int) -> None:

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -57,6 +57,7 @@ from tensorrt_llm._torch.modules.fused_moe import (
     DeepSeekV3MoeRoutingMethod,
     RenormalizeMoeRoutingMethod,
 )
+from tensorrt_llm._torch.modules.fused_moe.communication.deep_ep_low_latency import DeepEPLowLatency
 from tensorrt_llm._torch.modules.fused_moe.create_moe import create_moe_backend, get_moe_cls
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_marlin import MarlinFusedMoE
@@ -79,6 +80,51 @@ _MEGAMOE_BACKEND_TYPES = {
     MoeBackendType.MEGAMOE_DEEPGEMM,
     MoeBackendType.MEGAMOE_CUTEDSL,
 }
+
+
+def test_deep_ep_nvfp4_fused_output_scale_skips_standalone_scale_op(monkeypatch):
+    calculate_global_scale = MagicMock(
+        side_effect=AssertionError("standalone NVFP4 output-scale op must not run")
+    )
+    monkeypatch.setattr(
+        torch.ops.trtllm,
+        "calculate_nvfp4_global_scale",
+        calculate_global_scale,
+    )
+
+    combined_output = torch.empty(2, 4, dtype=torch.bfloat16)
+    combine_low_precision = MagicMock(return_value=combined_output)
+    comm = DeepEPLowLatency.__new__(DeepEPLowLatency)
+    comm.mapping = SimpleNamespace(moe_ep_size=2)
+    comm.expert_size_per_partition = 2
+    comm.hidden_size = 4
+    comm.use_low_precision_combine = True
+    comm._fuse_nvfp4_output_scale = True
+    comm.quant_config = SimpleNamespace(layer_quant_mode=SimpleNamespace(has_nvfp4=lambda: True))
+    comm.deep_ep_buffer = SimpleNamespace(low_latency_combine_low_precision=combine_low_precision)
+    recv_expert_count = torch.tensor([2, 0], dtype=torch.int32)
+    topk_idx = torch.zeros(2, 1, dtype=torch.int32)
+    topk_weights = torch.ones(2, 1, dtype=torch.float32)
+    deep_ep_handle = object()
+    comm._dispatch_state = {
+        "deep_ep_handle": deep_ep_handle,
+        "deep_ep_topk_idx": topk_idx,
+        "deep_ep_topk_weights": topk_weights,
+        "recv_expert_count": recv_expert_count,
+    }
+
+    final_hidden_states = torch.randn(8, 4, dtype=torch.bfloat16)
+    output = comm.combine(final_hidden_states, all_rank_max_num_tokens=2)
+
+    assert output is combined_output
+    calculate_global_scale.assert_not_called()
+    call_args = combine_low_precision.call_args.args
+    assert call_args[0] == "nvfp4"
+    assert call_args[1].shape == (2, 4, 4)
+    assert call_args[2] is None
+    assert call_args[3] is topk_idx
+    assert call_args[4] is topk_weights
+    assert call_args[5] is deep_ep_handle
 
 
 def _ensure_single_proc_dist_for_megamoe(backend_type: MoeBackendType, rank: int) -> None:

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -57,7 +57,10 @@ from tensorrt_llm._torch.modules.fused_moe import (
     DeepSeekV3MoeRoutingMethod,
     RenormalizeMoeRoutingMethod,
 )
-from tensorrt_llm._torch.modules.fused_moe.communication.deep_ep_low_latency import DeepEPLowLatency
+from tensorrt_llm._torch.modules.fused_moe.communication.deep_ep_low_latency import (
+    DeepEPLowLatency,
+    _read_binary_env,
+)
 from tensorrt_llm._torch.modules.fused_moe.create_moe import create_moe_backend, get_moe_cls
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_cute_dsl import CuteDslFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
@@ -84,6 +87,23 @@ _MEGAMOE_BACKEND_TYPES = {
 }
 
 
+@pytest.mark.parametrize(("value", "expected"), [(None, False), ("0", False), ("1", True)])
+def test_deep_ep_binary_env(monkeypatch, value, expected):
+    name = "TRTLLM_TEST_DEEP_EP_BINARY_ENV"
+    if value is None:
+        monkeypatch.delenv(name, raising=False)
+    else:
+        monkeypatch.setenv(name, value)
+    assert _read_binary_env(name) is expected
+
+
+def test_deep_ep_binary_env_rejects_invalid_value(monkeypatch):
+    name = "TRTLLM_TEST_DEEP_EP_BINARY_ENV"
+    monkeypatch.setenv(name, "true")
+    with pytest.raises(ValueError, match=rf"{name} must be 0 or 1"):
+        _read_binary_env(name)
+
+
 def test_deep_ep_nvfp4_fused_output_scale_skips_standalone_scale_op(monkeypatch):
     calculate_global_scale = MagicMock(
         side_effect=AssertionError("standalone NVFP4 output-scale op must not run")
@@ -102,6 +122,7 @@ def test_deep_ep_nvfp4_fused_output_scale_skips_standalone_scale_op(monkeypatch)
     comm.hidden_size = 4
     comm.use_low_precision_combine = True
     comm._fuse_nvfp4_output_scale = True
+    comm._stage_low_precision_combine_metadata = True
     comm.quant_config = SimpleNamespace(layer_quant_mode=SimpleNamespace(has_nvfp4=lambda: True))
     comm.deep_ep_buffer = SimpleNamespace(low_latency_combine_low_precision=combine_low_precision)
     recv_expert_count = torch.tensor([2, 0], dtype=torch.int32)
@@ -127,6 +148,7 @@ def test_deep_ep_nvfp4_fused_output_scale_skips_standalone_scale_op(monkeypatch)
     assert call_args[3] is topk_idx
     assert call_args[4] is topk_weights
     assert call_args[5] is deep_ep_handle
+    assert combine_low_precision.call_args.kwargs["stage_recv_metadata"] is True
 
 
 def test_scheduler_fuses_cutedsl_bf16_quantization_into_deep_ep_dispatch(monkeypatch):
@@ -157,7 +179,11 @@ def test_scheduler_fuses_cutedsl_bf16_quantization_into_deep_ep_dispatch(monkeyp
     moe = SimpleNamespace(
         backend=backend,
         comm=comm,
-        routing_method=SimpleNamespace(requires_separated_routing=False),
+        routing_method=SimpleNamespace(
+            requires_separated_routing=False,
+            experts_per_token=1,
+            apply=MagicMock(return_value=(selected_slots, final_scales)),
+        ),
         apply_router_weight_on_input=False,
         layer_load_balancer=None,
         layer_idx=0,

--- a/tests/unittest/_torch/moe/test_deep_ep_bf16_fp4_dispatch.py
+++ b/tests/unittest/_torch/moe/test_deep_ep_bf16_fp4_dispatch.py
@@ -1,16 +1,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import pickle
+import sys
 from types import SimpleNamespace
 
+import cloudpickle
 import pytest
 import torch
+from mpi4py import MPI
 
 import tensorrt_llm as tllm
 from tensorrt_llm._torch.moe.fused_moe.communication.deep_ep_low_latency import DeepEPLowLatency
 from tensorrt_llm._torch.moe.fused_moe.deep_ep_utils import deep_ep_installed
 from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.mapping import Mapping
+
+cloudpickle.register_pickle_by_value(sys.modules[__name__])
+MPI.pickle.__init__(
+    cloudpickle.dumps,
+    cloudpickle.loads,
+    pickle.HIGHEST_PROTOCOL,
+)
 
 _SM_VERSION = get_sm_version() if torch.cuda.is_available() else 0
 

--- a/tests/unittest/others/test_deep_ep_recv_metadata_staging_patch.py
+++ b/tests/unittest/others/test_deep_ep_recv_metadata_staging_patch.py
@@ -43,7 +43,11 @@ def test_deep_ep_recv_metadata_staging_patch_contract() -> None:
     # Keep the accepted b2 send-side dynamic-scale fusion in the combined patch.
     assert "if (global_scale_per_token != nullptr)" in source
     assert "getMaxAbs helper performs a block reduction" in source
-    assert "global_scale_val = 448.f * 6.f / per_token_max_abs_val;" in source
+    assert "rounded reciprocal" in source
+    assert "constexpr float kNvfp4GlobalScaleNumerator = 448.f * 6.f;" in source
+    assert "global_scale_val = __fmul_rn(" in source
+    assert "kNvfp4GlobalScaleNumerator, __frcp_rn(per_token_max_abs_val));" in source
+    assert "div.rn.f32" not in source
 
     # The fused dispatch helper shares one 16-value scale across adjacent
     # eight-BF16 lane payloads. Supported widths must keep every pair active.
@@ -51,12 +55,12 @@ def test_deep_ep_recv_metadata_staging_patch_contract() -> None:
     assert "exchanges lane-pair maxima" in source
     assert "if (lane_id % 2 == 0)" in source
 
-    assert source.count(env_name) == 1
-    assert "static bool low_precision_combine_recv_metadata_staging_enabled()" in source
-    assert "static bool const enabled = []()" in source
-    assert "value == nullptr or" in source
-    assert "(value[0] == '0' or value[0] == '1') and value[1] == '\\0'" in source
-    assert "return value != nullptr and value[0] == '1';" in source
+    assert env_name not in source
+    assert "bool stage_recv_metadata" in source
+    assert "stage_recv_metadata: bool = False" in source
+    assert "async_finish, return_recv_hook, out," in source
+    assert "stage_recv_metadata)" in source
+    assert "getenv" not in source
 
     assert "int kNumMaxTopk, bool kStageRecvMetadata" in source
     for precision in ("FP8", "NVFP4"):

--- a/tests/unittest/others/test_deep_ep_recv_metadata_staging_patch.py
+++ b/tests/unittest/others/test_deep_ep_recv_metadata_staging_patch.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+_PATCH = (
+    Path(__file__).resolve().parents[3]
+    / "3rdparty"
+    / "patches"
+    / "deep_ep_intranode_combine_fix.patch"
+)
+
+
+def _added_source(patch: str) -> str:
+    return "\n".join(
+        line[1:]
+        for line in patch.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    )
+
+
+def test_deep_ep_recv_metadata_staging_patch_contract() -> None:
+    patch = _PATCH.read_text()
+    source = _added_source(patch)
+    env_name = "TRTLLM_DEEP_EP_LP_COMBINE_RECV_METADATA_STAGING"
+    extension_diff = (
+        "diff --git a/csrc/kernels/extension_kernels.cu b/csrc/kernels/extension_kernels.cu"
+    )
+    assert patch.count(extension_diff) == 1
+    receive_delta = patch.rsplit(extension_diff, maxsplit=1)[1]
+
+    # Keep the accepted b2 send-side dynamic-scale fusion in the combined patch.
+    assert "if (global_scale_per_token != nullptr)" in source
+    assert "getMaxAbs helper performs a block reduction" in source
+    assert "global_scale_val = 448.f * 6.f / per_token_max_abs_val;" in source
+
+    # The fused dispatch helper shares one 16-value scale across adjacent
+    # eight-BF16 lane payloads. Supported widths must keep every pair active.
+    assert "kHiddenBf16VecAccessNum % 32 == 0" in source
+    assert "exchanges lane-pair maxima" in source
+    assert "if (lane_id % 2 == 0)" in source
+
+    assert source.count(env_name) == 1
+    assert "static bool low_precision_combine_recv_metadata_staging_enabled()" in source
+    assert "static bool const enabled = []()" in source
+    assert "value == nullptr or" in source
+    assert "(value[0] == '0' or value[0] == '1') and value[1] == '\\0'" in source
+    assert "return value != nullptr and value[0] == '1';" in source
+
+    assert "int kNumMaxTopk, bool kStageRecvMetadata" in source
+    for precision in ("FP8", "NVFP4"):
+        for enabled in ("true", "false"):
+            specialization = (
+                f"low_precision_combine<LowPrecisionType::{precision}, "
+                f"hidden, kNumMaxTopk, {enabled}>"
+            )
+            assert specialization in source
+
+    staged = source.split("if constexpr (kStageRecvMetadata) {", maxsplit=1)[1]
+    staged = staged.split("    } else {", maxsplit=1)[0]
+    assert "__shared__ int staged_topk_idx[kNumMaxTopk];" in staged
+    assert "__shared__ float staged_topk_weights[kNumMaxTopk];" in staged
+    assert "__shared__ float staged_global_scales[kNumMaxTopk];" in staged
+    assert "if (thread_id < num_topk)" in staged
+    assert "if (expert_idx >= 0)" in staged
+    assert staged.count("__syncthreads();") == 2
+    assert "if (token_idx + num_sms < num_combined_tokens)" in staged
+    assert "global_scale_val = staged_global_scales[i];" in staged
+    assert "token_idx is CTA-uniform" in staged
+    assert "__shfl" not in staged
+
+    # The integrated patch only wraps the byte-for-byte original receive loop
+    # in `else`; it must not delete or regenerate that loop.
+    assert "+    } else {" in receive_delta
+    assert "-    for (int token_idx = sm_id;" not in receive_delta
+    assert "-        int reg_topk_idx[kNumMaxTopk];" not in receive_delta
+    assert "-        float reg_topk_weights[kNumMaxTopk];" not in receive_delta


### PR DESCRIPTION
## Description

DeepEP NVFP4 WideEP launches separate GPU work to calculate dynamic output
scales and materialize BF16-to-NVFP4 dispatch inputs, while combine repeatedly
reads the same receive metadata from global memory.

This PR adds three independent optimizations for the PyTorch DeepEP low-latency
path. Each applicable fast path is enabled by default, and setting its existing
environment knob to `0` restores the original path:

- `TRTLLM_DEEP_EP_NVFP4_FUSED_OUTPUT_SCALE=0` restores the standalone NVFP4
  output-scale calculation before combine.
- `TRTLLM_DEEP_EP_NVFP4_FUSED_BF16_DISPATCH=0` restores materialized
  BF16-to-NVFP4 quantization before dispatch.
- `TRTLLM_DEEP_EP_LP_COMBINE_RECV_METADATA_STAGING=0` restores direct receive
  metadata reads during low-precision combine.

Fused BF16 dispatch requires an explicit backend capability. Only the exact
static-scale CuTeDSL contract uses it; dynamic-scale, AWQ, padded-hidden,
subclass, and other backends fail closed and retain their normal
`quantize_input()` processing. The optimizations remain separate commits for
bisection while sharing one vendored DeepEP patch.

On the validated B200 EP32 GEN-only WideEP workload, the three changes measured
approximately 2.80%, 0.69% isolated (up to 1.62% stacked), and 0.42–0.46%
step-time improvements, respectively.

## Test Coverage

- Changed-file pre-commit, Python syntax, patch application, and DCO checks
  pass.
- Environment parsing, default-on selection, explicit `0` rollback, and every
  fail-closed backend condition have focused unit coverage.
- B200 BF16-to-NVFP4 packed values and scales are bit-identical to the
  materialized reference across zero, finite-extreme, and seeded-random cases.
- Focused multi-rank DeepEP coverage exercises the real fused dispatch, dynamic
  output scaling, staged combine, zero-amax handling, and numeric outputs.
- The GPU numeric and scheduler/backend tests are explicitly registered in the
  B200 pre-merge test list.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] Follows the TensorRT-LLM coding guidelines.
- [x] Test cases and pre-merge test-list coverage are provided.
- [x] No new dependency or public API is introduced.
- [x] Current-head GPU/runtime validation is covered by pre-merge CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added three enabled-by-default optimizations:
  - Fused NVFP4 output-scale calculation in combine.
  - Fused BF16-to-NVFP4 quantization in dispatch packing.
  - Staged combine receive metadata.
- Preserved existing processing for unsupported and dynamic-scale backends.
- Added validated environment controls and fallback behavior.
- Extended DeepEP C++ APIs, bindings, Python communication paths, scheduler logic, and CuTeDSL capability checks.
- Added partial-warp synchronization fixes for intranode TMA operations.
- Updated low-latency API annotations and documentation.
- Test-list changes use targeted DeepEP coverage and add B200 numeric-reference coverage.
- No correctness or configuration issues were identified from the supplied changes.

## QA Engineer Review

### Test changes

- Added `test_deep_ep_fused_transport_paths_match_numeric_references`.
  - Covered by `tests/integration/test_lists/test-db/l0_dgx_b200.yml`.
- Updated `test_deep_ep_nvfp4_pack_matches_trtllm_bitwise`.
- Updated:
  - `test_deep_ep_nvfp4_optimization_defaults`
  - `test_deep_ep_binary_env`
  - `test_deep_ep_binary_env_rejects_invalid_value`
  - `test_deep_ep_nvfp4_fused_output_scale_skips_standalone_scale_op`
  - `test_scheduler_fuses_cutedsl_bf16_quantization_into_deep_ep_dispatch`
  - `test_unvalidated_backend_cannot_bypass_quantize_input_for_deep_ep_dispatch`
  - `test_deep_ep_bf16_nvfp4_fusion_gate_falls_back_for_unsupported_input`
- `l0_b200.yml` selects targeted NVFP4 dispatch coverage, adds unsupported-layer coverage, and removes the receive-metadata staging patch test.
- `l0_dgx_b200.yml` adds the fused transport numeric-reference test.
- The test-list changes have targeted scope and valid intended coverage.

**Verdict: sufficient**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->