### PR TITLE
[None][perf] Extend packed MiniMax-M3 producer to mixed and decode batches

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_minimaxm3.py
+++ b/tensorrt_llm/_torch/models/modeling_minimaxm3.py
@@ -1316,7 +1316,12 @@ class MiniMaxM3Attention(Attention):
         position_ids: Optional[torch.Tensor],
         attn_metadata: AttentionMetadata,
     ) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
-        """Run the vLLM-style horizontal sparse producer for pure prefill."""
+        """Run the vLLM-style horizontal producer for every sparse batch.
+
+        The CUDA kernel is token-major and batch-type agnostic: per-token
+        positions and cache slots cover pure prefill, mixed aggregate batches,
+        and CUDA-graph decode.
+        """
         if (
             not self.enable_fused_qkv_index_projection
             or not isinstance(self.attn, MiniMaxM3MsaSparseAttention)
@@ -1324,13 +1329,7 @@ class MiniMaxM3Attention(Attention):
             or self.attn.indexer_kv_dtype != "fp8"
         ):
             return None
-        if (
-            is_torch_compiling()
-            or getattr(attn_metadata, "is_cuda_graph", False)
-            or int(getattr(attn_metadata, "num_generations", 0)) != 0
-            or int(getattr(attn_metadata, "num_contexts", 0)) == 0
-            or int(packed.shape[0]) != int(attn_metadata.num_tokens)
-        ):
+        if is_torch_compiling() or int(packed.shape[0]) != int(attn_metadata.num_tokens):
             return None
         if (
             packed.dtype != torch.bfloat16

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -738,10 +738,10 @@ class MiniMaxM3SparseAttentionConfig(BaseSparseAttentionConfig):
         default=False,
         description=
         "Fuse Q/K/V and index-Q/index-K into one quantized projection. Index-Q "
-        "is sharded with the KV heads and index-K is replicated. This prototype "
-        "currently targets disaggregated prefill workers; leave it disabled on "
-        "decode or mixed workers. The MiniMax-M3-specific path requires the MSA "
-        "implementation.",
+        "is sharded with the KV heads and index-K is replicated. MSA batches "
+        "also use a horizontal norm/RoPE/cache-insertion producer for prefill, "
+        "mixed, and CUDA-graph decode execution. The MiniMax-M3-specific path "
+        "requires the MSA implementation.",
         status="prototype",
     )
     num_attention_heads: Optional[int] = Field(

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_horizontal_producer.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_horizontal_producer.py
@@ -63,6 +63,9 @@ def test_minimax_m3_horizontal_producer_matches_separate_producers(num_tokens):
     slots = (torch.arange(num_tokens, dtype=torch.int32, device="cuda") * 37) % (
         (num_pages - 1) * 128
     )
+    # Keep the parity reference slots valid: the legacy separate main-K/V
+    # producer does not support negative slots. Negative-slot handling is
+    # exercised below using horizontal eager execution versus graph replay.
     rope_cache = _rope_cache(max(256, num_tokens))
 
     main_width = (num_heads_q + 2 * num_kv_heads) * 128
@@ -121,8 +124,9 @@ def test_minimax_m3_horizontal_producer_matches_separate_producers(num_tokens):
         position_ids,
     )
 
-    pages = slots.long() // 128
-    within = slots.long() % 128
+    valid = slots >= 0
+    pages = slots[valid].long() // 128
+    within = slots[valid].long() % 128
     assert torch.equal(q.view(torch.uint8), q_reference.view(torch.uint8))
     # The horizontal producer follows vLLM's CUDA contract and converts its
     # normalized/RoPE FP32 registers directly to E4M3. The existing separate
@@ -144,4 +148,97 @@ def test_minimax_m3_horizontal_producer_matches_separate_producers(num_tokens):
         reference_index_cache[pages, :, within, :].float(),
         rtol=0.13,
         atol=0.05,
+    )
+
+    # Aggregate decode captures this producer in a CUDA graph. The operator
+    # allocates compact Q/index-Q outputs while writing graph-stable paged
+    # caches through a graph-stable slot mapping, so exercise both capture and
+    # replay for decode-sized (1) and larger mixed/prefill token counts.
+    graph_packed = packed.clone()
+    graph_positions = position_ids.clone()
+    graph_slots = slots.clone()
+    graph_main_cache = _main_cache(num_pages, num_kv_heads)
+    graph_index_cache = _index_cache(num_pages)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_q, graph_index_q = torch.ops.trtllm.minimax_m3_fp8_qkv_indexer_norm_rope_kv_insert(
+            graph_packed,
+            graph_main_cache,
+            graph_index_cache,
+            graph_slots,
+            num_heads_q,
+            num_kv_heads,
+            num_index_heads,
+            128,
+            64,
+            1e-5,
+            q_weight,
+            k_weight,
+            index_q_weight,
+            index_k_weight,
+            rope_cache,
+            graph_positions,
+        )
+
+    # Replay with different projection values, nonuniform positions, and new
+    # cache destinations. This proves replay reads the refreshed graph buffers
+    # rather than retaining capture-time values or slots.
+    replay_packed = torch.randn_like(packed)
+    replay_positions = (
+        torch.arange(num_tokens, dtype=torch.int32, device="cuda") * 7 + 3
+    ) % rope_cache.shape[0]
+    replay_slots = (torch.arange(num_tokens, dtype=torch.int32, device="cuda") * 53 + 11) % (
+        (num_pages - 1) * 128
+    )
+    if num_tokens > 1:
+        replay_slots[-1] = -1
+    graph_packed.copy_(replay_packed)
+    graph_positions.copy_(replay_positions)
+    graph_slots.copy_(replay_slots)
+    graph_main_cache.zero_()
+    graph_index_cache.zero_()
+
+    replay_main_cache = _main_cache(num_pages, num_kv_heads)
+    replay_index_cache = _index_cache(num_pages)
+    replay_q, replay_index_q = torch.ops.trtllm.minimax_m3_fp8_qkv_indexer_norm_rope_kv_insert(
+        replay_packed,
+        replay_main_cache,
+        replay_index_cache,
+        replay_slots,
+        num_heads_q,
+        num_kv_heads,
+        num_index_heads,
+        128,
+        64,
+        1e-5,
+        q_weight,
+        k_weight,
+        index_q_weight,
+        index_k_weight,
+        rope_cache,
+        replay_positions,
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    replay_valid = replay_slots >= 0
+    replay_pages = replay_slots[replay_valid].long() // 128
+    replay_within = replay_slots[replay_valid].long() % 128
+    assert torch.equal(graph_q.view(torch.uint8), replay_q.view(torch.uint8))
+    torch.testing.assert_close(
+        graph_index_q.float(),
+        replay_index_q.float(),
+        rtol=0.0,
+        atol=0.0,
+    )
+    assert torch.equal(
+        graph_main_cache[replay_pages, :, :, replay_within, :].view(torch.uint8),
+        replay_main_cache[replay_pages, :, :, replay_within, :].view(torch.uint8),
+    )
+    torch.testing.assert_close(
+        graph_index_cache[replay_pages, :, replay_within, :].float(),
+        replay_index_cache[replay_pages, :, replay_within, :].float(),
+        rtol=0.0,
+        atol=0.0,
     )


### PR DESCRIPTION
@coderabbitai summary

### Prerequisite

- [x] https://github.com/NVIDIA/TensorRT-LLM/pull/16852

## Description

PR #16852 uses one packed MXFP8 `[Q|K|V|index-Q|index-K]` projection for
MiniMax-M3, but restricts its horizontal norm/RoPE/cache-insertion producer to
pure prefill. Aggregate mixed and decode batches therefore split the packed
output and return to the separate main and index producer paths, repeating
intermediate materialization, normalization, RoPE, quantization, and cache
writes on generation steps.

This PR reuses the existing token-major horizontal producer for aggregate
mixed batches and CUDA-graph decode. Per-token positions and cache slots already
describe all three batch types, so the change removes the batch-type and
CUDA-graph restrictions while preserving the existing compile, shape, dtype,
MSA, FP8-cache, RoPE, and layout guards. The packed optimization remains opt-in
through `fuse_qkv_index_projection=False` by default.

An initial matched GB300 aggregate TP8/EP8 attention-DP A/B used exact 8K input,
1K output, concurrency 256, and 2,560 requests. Both variants completed every
request with identical input and output token counts:

| Metric | Pure-prefill producer | All-batches producer | Change |
|---|---:|---:|---:|
| Benchmark duration | 575.10 s | 509.24 s | **-11.45%** |
| Total token throughput | 37,082 tok/s | 41,878 tok/s | **+12.93%** |
| Median TTFT | 604.44 ms | 531.15 ms | **-12.13%** |
| Median TPOT | 64.27 ms | 56.95 ms | **-11.39%** |
| Median E2E latency | 59.38 s | 52.40 s | **-11.76%** |

This aggregate measurement predates #16923, which optimizes the downstream MSA
mixed-batch execution stage and is now part of the target branch. The two
changes operate on different pipeline stages. A matched GB300 disaggregated
TP8/EP8 GEN-only A/B on the current target branch showed no measurable decode
throughput gain, while median TPOT improved by **1.3%**.

## Test Coverage

- Changed-file pre-commit passed for all three files in this PR.
- Focused SM100 CUDA test passed for 1-, 16-, and 129-token shapes:
  - exact main-Q and paged main-K/V parity against the separate producers;
  - FP8 index-Q and index-K parity;
  - strided HND cache layouts; and
  - CUDA-graph capture/replay with refreshed projection values, positions,
    cache destinations, and a padded negative cache slot.
- Full GB300 aggregate TP8/EP8 serving A/B captured the CUDA-graph schedule
  through batch size 256 and completed 2,560/2,560 requests in both variants
  with identical token counts.
- Matched GB300 disaggregated TP8/EP8 GEN-only serving A/B completed
  successfully and showed flat decode throughput with a 1.3% median TPOT
  improvement.
- No C++ or CUDA source changes are introduced by this follow-up; it reuses the
  producer built and validated in #16852.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
