### PR TITLE
[https://nvbugs/6517844][fix] Fall back to DeepEP when NCCL-EP lacks shared memory

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
@@ -38,15 +38,24 @@ from .nvlink_one_sided import NVLinkOneSided
 from .nvlink_two_sided import NVLinkTwoSided
 from .nvlink_two_sided_flashinfer import NVLinkTwoSidedFlashinfer
 
+# Temporary NCCL-EP v0.1.0 limitation. The LL combine kernel derives its
+# warp-group count and dynamic-SMEM requirement here:
+# https://github.com/NVIDIA/nccl/blob/nccl-ep-v0.1.0/contrib/nccl_ep/device/low_latency.cu#L1990-L2025
+# Its v0.1.0 group initialization limits LL execution to 14 warp groups:
+# https://github.com/NVIDIA/nccl/blob/nccl-ep-v0.1.0/contrib/nccl_ep/nccl_ep.cc#L1302-L1314
+# TODO: Remove this compatibility check after upgrading to NCCL-EP v0.2,
+# which removes the v0.1.0 LL-combine launch limitation.
+_NCCL_EP_V0_1_LL_MAX_WARP_GROUPS = 14
+
 
 def _get_nccl_ep_ll_combine_smem_requirement(
     num_slots: int, hidden_size: int, num_device_sms: int
 ) -> int | None:
     """Return the NCCL-EP LL combine dynamic-SMEM requirement in bytes."""
     num_warp_groups = (num_slots + num_device_sms - 1) // num_device_sms
-    num_warps_per_group = 32 // num_warp_groups
-    if num_warps_per_group == 0:
+    if num_warp_groups > _NCCL_EP_V0_1_LL_MAX_WARP_GROUPS:
         return None
+    num_warps_per_group = 32 // num_warp_groups
 
     num_warps = num_warp_groups * num_warps_per_group
     num_meta_bytes = hidden_size // 128 * 4
@@ -444,7 +453,8 @@ class CommunicationFactory:
             )
             if required_smem is None:
                 return (
-                    "NcclEP low-latency combine requires at most 32 expert warp groups, got "
+                    "NcclEP low-latency combine requires at most "
+                    f"{_NCCL_EP_V0_1_LL_MAX_WARP_GROUPS} expert warp groups, got "
                     f"{num_slots=} and {device_properties.multi_processor_count=}."
                 )
             if required_smem > max_dynamic_smem:

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
@@ -39,6 +39,25 @@ from .nvlink_two_sided import NVLinkTwoSided
 from .nvlink_two_sided_flashinfer import NVLinkTwoSidedFlashinfer
 
 
+def _get_nccl_ep_ll_combine_smem_requirement(
+    num_slots: int, hidden_size: int, num_device_sms: int
+) -> int | None:
+    """Return the NCCL-EP LL combine dynamic-SMEM requirement in bytes."""
+    num_warp_groups = (num_slots + num_device_sms - 1) // num_device_sms
+    num_warps_per_group = 32 // num_warp_groups
+    if num_warps_per_group == 0:
+        return None
+
+    num_warps = num_warp_groups * num_warps_per_group
+    num_meta_bytes = hidden_size // 128 * 4
+    num_send_tma_bytes = 32 * 16 * 4 + 16
+    smem_send_size = num_warps * (3 * num_send_tma_bytes + num_meta_bytes)
+
+    num_recv_tma_bytes = 16 + hidden_size * 2
+    smem_recv_size = 2 * (3 * num_recv_tma_bytes + hidden_size * 2 + 3 * num_meta_bytes * 3)
+    return max(smem_send_size, smem_recv_size)
+
+
 class CommunicationFactory:
     """
     Factory for creating MoE communication methods
@@ -413,4 +432,25 @@ class CommunicationFactory:
             )
         if top_k <= 0 or top_k > num_slots:
             return f"NcclEP requires 0 < top_k <= num_slots, got {top_k=}, {num_slots=}."
+        if torch.cuda.is_available():
+            device_properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+            required_smem = _get_nccl_ep_ll_combine_smem_requirement(
+                num_slots, hidden_size, device_properties.multi_processor_count
+            )
+            max_dynamic_smem = getattr(
+                device_properties,
+                "shared_memory_per_block_optin",
+                device_properties.shared_memory_per_block,
+            )
+            if required_smem is None:
+                return (
+                    "NcclEP low-latency combine requires at most 32 expert warp groups, got "
+                    f"{num_slots=} and {device_properties.multi_processor_count=}."
+                )
+            if required_smem > max_dynamic_smem:
+                return (
+                    "NcclEP low-latency combine requires "
+                    f"{required_smem} bytes of dynamic shared memory, but the current device "
+                    f"supports only {max_dynamic_smem} bytes."
+                )
         return None

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -47,6 +47,7 @@ l0_a10:
   - unittest/_torch/modules/dwdp/test_dwdp_manager.py
   - unittest/_torch/modules/dwdp/test_dwdp_mapping.py
   - unittest/_torch/modules/dwdp/test_dwdp_peer_ranges.py
+  - unittest/_torch/modules/moe/test_communication_factory.py
   # NOTE: this is a CPU-only test, but we do not have a dedicated job for this (and therefore no
   # test list either).
   - unittest/_torch/models/checkpoints

--- a/tests/unittest/_torch/modules/moe/test_communication_factory.py
+++ b/tests/unittest/_torch/modules/moe/test_communication_factory.py
@@ -91,6 +91,11 @@ class _FakeNcclEP:
         self.top_k = top_k
 
 
+class _FakeDeepEP:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+
 @pytest.mark.parametrize(
     ("act_dtype", "moe_max_num_tokens", "match"),
     [
@@ -112,6 +117,45 @@ def test_forced_nccl_ep_validates_preconditions(
             num_slots=32,
             top_k=8,
             expert_size_per_partition=16,
+            payload_in_workspace=False,
+            alltoall_result_do_sum=True,
+            use_flashinfer=False,
+            hidden_size=4096,
+        )
+
+
+def test_forced_nccl_ep_rejects_more_than_32_warp_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_config = _make_model_config()
+    assert (
+        communication_factory._get_nccl_ep_ll_combine_smem_requirement(
+            num_slots=33,
+            hidden_size=4096,
+            num_device_sms=1,
+        )
+        is None
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda _: SimpleNamespace(
+            multi_processor_count=1,
+            shared_memory_per_block_optin=102400,
+            shared_memory_per_block=102400,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="at most 32 expert warp groups"):
+        communication_factory.CommunicationFactory._create_forced_method(
+            "NCCL_EP",
+            model_config,
+            num_experts=34,
+            num_slots=33,
+            top_k=8,
+            expert_size_per_partition=17,
             payload_in_workspace=False,
             alltoall_result_do_sum=True,
             use_flashinfer=False,
@@ -227,6 +271,53 @@ def test_auto_selection_skips_nccl_ep_for_quantized_moe(
     )
 
     assert isinstance(strategy, AllGatherReduceScatter)
+
+
+def test_nccl_ep_ll_combine_smem_requirement() -> None:
+    assert (
+        communication_factory._get_nccl_ep_ll_combine_smem_requirement(
+            num_slots=72,
+            hidden_size=2560,
+            num_device_sms=72,
+        )
+        == 200704
+    )
+
+
+def test_auto_selection_skips_nccl_ep_when_ll_combine_exceeds_dynamic_smem(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model_config = _make_model_config()
+    monkeypatch.setattr(communication_factory, "NVLinkOneSided", _strategy_unavailable)
+    monkeypatch.setattr(communication_factory, "NVLinkTwoSided", _strategy_unavailable)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda _: SimpleNamespace(
+            multi_processor_count=72,
+            shared_memory_per_block_optin=102400,
+            shared_memory_per_block=102400,
+        ),
+    )
+    monkeypatch.setattr(
+        communication_factory,
+        "NcclEP",
+        lambda *args, **kwargs: pytest.fail("NcclEP should not be constructed"),
+    )
+    monkeypatch.setattr(communication_factory, "DeepEP", _FakeDeepEP)
+
+    strategy = communication_factory.CommunicationFactory.create_strategy(
+        model_config,
+        num_experts=72,
+        num_slots=72,
+        top_k=6,
+        expert_size_per_partition=18,
+        hidden_size=2560,
+    )
+
+    assert isinstance(strategy, _FakeDeepEP)
 
 
 def test_auto_selection_falls_back_when_nccl_probe_runtime_fails(

--- a/tests/unittest/_torch/modules/moe/test_communication_factory.py
+++ b/tests/unittest/_torch/modules/moe/test_communication_factory.py
@@ -124,13 +124,13 @@ def test_forced_nccl_ep_validates_preconditions(
         )
 
 
-def test_forced_nccl_ep_rejects_more_than_32_warp_groups(
+def test_forced_nccl_ep_rejects_more_than_14_warp_groups(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     model_config = _make_model_config()
     assert (
         communication_factory._get_nccl_ep_ll_combine_smem_requirement(
-            num_slots=33,
+            num_slots=15,
             hidden_size=4096,
             num_device_sms=1,
         )
@@ -148,14 +148,14 @@ def test_forced_nccl_ep_rejects_more_than_32_warp_groups(
         ),
     )
 
-    with pytest.raises(ValueError, match="at most 32 expert warp groups"):
+    with pytest.raises(ValueError, match="at most 14 expert warp groups"):
         communication_factory.CommunicationFactory._create_forced_method(
             "NCCL_EP",
             model_config,
-            num_experts=34,
-            num_slots=33,
+            num_experts=16,
+            num_slots=15,
             top_k=8,
-            expert_size_per_partition=17,
+            expert_size_per_partition=8,
             payload_in_workspace=False,
             alltoall_result_do_sum=True,
             use_flashinfer=False,

--- a/tests/unittest/_torch/modules/moe/test_communication_factory.py
+++ b/tests/unittest/_torch/modules/moe/test_communication_factory.py
@@ -167,6 +167,17 @@ def test_forced_nccl_ep_allows_missing_moe_max_num_tokens(
     monkeypatch: pytest.MonkeyPatch,
 ):
     model_config = _make_model_config(torch.bfloat16, None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda _: SimpleNamespace(
+            multi_processor_count=72,
+            shared_memory_per_block_optin=232448,
+            shared_memory_per_block=102400,
+        ),
+    )
     monkeypatch.setattr(communication_factory, "NcclEP", _FakeNcclEP)
 
     strategy = communication_factory.CommunicationFactory._create_forced_method(
@@ -195,6 +206,17 @@ def test_auto_selection_uses_nccl_ep_with_missing_moe_max_num_tokens(
     monkeypatch.setattr(communication_factory, "NVLinkOneSided", _strategy_unavailable)
     monkeypatch.setattr(communication_factory, "NVLinkTwoSided", _strategy_unavailable)
     monkeypatch.setenv("TRTLLM_CAN_USE_DEEP_EP", "0")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda _: SimpleNamespace(
+            multi_processor_count=72,
+            shared_memory_per_block_optin=232448,
+            shared_memory_per_block=102400,
+        ),
+    )
     monkeypatch.setattr(communication_factory, "NcclEP", _FakeNcclEP)
 
     strategy = communication_factory.CommunicationFactory.create_strategy(

--- a/tests/unittest/_torch/modules/moe/test_communication_factory.py
+++ b/tests/unittest/_torch/modules/moe/test_communication_factory.py
@@ -284,6 +284,47 @@ def test_nccl_ep_ll_combine_smem_requirement() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "device_properties",
+    [
+        SimpleNamespace(
+            multi_processor_count=72,
+            shared_memory_per_block_optin=200704,
+            shared_memory_per_block=102400,
+        ),
+        SimpleNamespace(
+            multi_processor_count=72,
+            shared_memory_per_block=200704,
+        ),
+    ],
+    ids=["optin_shared_memory", "legacy_shared_memory"],
+)
+def test_forced_nccl_ep_accepts_supported_ll_combine_dynamic_smem(
+    monkeypatch: pytest.MonkeyPatch,
+    device_properties: SimpleNamespace,
+) -> None:
+    model_config = _make_model_config()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _: device_properties)
+    monkeypatch.setattr(communication_factory, "NcclEP", _FakeNcclEP)
+
+    strategy = communication_factory.CommunicationFactory._create_forced_method(
+        "NCCL_EP",
+        model_config,
+        num_experts=72,
+        num_slots=72,
+        top_k=6,
+        expert_size_per_partition=18,
+        payload_in_workspace=False,
+        alltoall_result_do_sum=True,
+        use_flashinfer=False,
+        hidden_size=2560,
+    )
+
+    assert isinstance(strategy, _FakeNcclEP)
+
+
 def test_auto_selection_skips_nccl_ep_when_ll_combine_exceeds_dynamic_smem(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added a NCCL-EP low-latency “LL combine” dynamic shared-memory (SMEM) preflight during MoE communication-strategy selection to fix NVBug 6517844 on RTX Pro 6000D.
- Implemented a helper that computes the required `ll_combine` dynamic SMEM (bytes) from MoE slot count, hidden size, and GPU SM (multi-processor) count, returning `None` when the derived warp-group configuration is invalid.
- Extended `_get_nccl_ep_unavailable_reason` (when CUDA is available) to:
  - Probe current CUDA device properties.
  - Estimate `required_smem` and compare it to the device’s maximum supported dynamic SMEM via `shared_memory_per_block_optin` (falling back to `shared_memory_per_block`).
  - Return specific unavailability reasons for invalid derived configuration vs. capacity-exceeded cases; otherwise treat NCCL-EP as available.
- Updated selection behavior:
  - Automatic selection skips NCCL-EP and falls back to DeepEP when the LL combine SMEM requirement exceeds device dynamic SMEM capacity.
  - Forced `NCCL_EP` selection validates the configuration, rejecting invalid/oversubscribed cases (including the “at most 32 expert warp groups” constraint) with a `ValueError`.
- Added unit coverage for SMEM calculation and both auto-selection fallback and forced-selection rejection/acceptance paths.
- Formatting/linting/codespell/repo checks passed; focused pytest was not run locally because pytest was unavailable.

## QA Engineer Review

Tests touched: `tests/unittest/_torch/modules/moe/test_communication_factory.py`

- Added/extended coverage for:
  - `_get_nccl_ep_ll_combine_smem_requirement` returning the expected SMEM value for a known input.
  - Forced NCCL-EP rejection when expert warp groups exceed 32.
  - Forced NCCL-EP acceptance when device dynamic shared-memory is sufficient (parameterized across opt-in vs legacy shared-memory properties).
  - Automatic selection skipping NCCL-EP and falling back to DeepEP when the LL combine SMEM requirement exceeds device capacity.
- Added a `_FakeDeepEP` stub to detect DeepEP selection without instantiating the real DeepEP implementation.

Test-list coverage mapping:
- `tests/integration/test_lists/test-db/l0_a10.yml`: added `unittest/_torch/modules/moe/test_communication_factory.py` to the pre-merge A10 (ubuntu) PyTorch test list.

Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

  ## Description

  Fixes NVBug 6517844 on RTX Pro 6000D.

  NCCL-EP low-latency combine can require more opt-in dynamic shared memory than the device supports. Previously, this was detected only during NCCL-EP kernel setup, aborting the worker.

  Preflight the NCCL-EP low-latency combine shared-memory requirement during communication-strategy selection. When unsupported, automatic selection skips NCCL-EP and falls back to DeepEP. A forced `NCCL_EP` selection reports a clear validation error.

  The affected EP4 DeepSeek-V3-Lite test remains active in the RTX Pro 6000D L0 test list and has no waiver.

  ## Test Coverage

  - Added unit coverage for the NCCL-EP LL combine shared-memory calculation (72 slots, hidden size 2560 → 200,704 bytes).
  - Added unit coverage that verifies automatic selection bypasses NCCL-EP and chooses DeepEP when dynamic shared memory is insufficient.
  - Pre-commit formatting, ruff, codespell, and relevant repository checks passed.
  - Focused pytest was not run locally because the host Python environment lacks pytest.

  ## PR Checklist

  - [x] PR description clearly explains what and why.
  - [x] PR follows TRT-LLM coding guidelines.
  - [x] Test cases are provided for the new code path.
  - [x] No API change.
  - [x] No new dependencies.
  - [x] CODEOWNERS update not needed.
  - [x] Documentation update not needed.
  - [x] TAVA architecture diagram update not needed.
  - [x] Reviewers will be assigned appropriately.