### PR TITLE
[None][test] Stabilize TRTLLM scaffolding worker test

### DIFF
--- a/tests/unittest/scaffolding/test_worker.py
+++ b/tests/unittest/scaffolding/test_worker.py
@@ -111,10 +111,10 @@ def create_trtllm_worker(model_path):
 
 def test_trtllm_worker_generation(default_prompt, deepseek_distill_7b_path):
     worker = create_trtllm_worker(deepseek_distill_7b_path)
-    task = GenerationTask.create_from_prompt(default_prompt)
-    status = asyncio.run(worker.run_task(task))
     try:
+        task = GenerationTask.create_from_prompt(default_prompt)
+        task.max_tokens = 100
+        status = asyncio.run(worker.run_task(task))
         assert status == TaskStatus.SUCCESS, "Generation Task is not successful with TRTLLMWorker"
-    except AssertionError as e:
+    finally:
         worker.shutdown()
-        raise e


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `test_trtllm_worker_generation` to cap `GenerationTask.max_tokens` at **100**, preventing unbounded generation (especially when `max_tokens` could otherwise be unset) and reducing CI timeout risk.
- Refactored the test flow into a `try`/`finally` so `worker.shutdown()` is **always** executed, ensuring LLM/GPU resources are released on both success and failure paths.
- No public API changes, configuration changes, or scope changes beyond the test’s execution/safety mechanics.

## QA Engineer Review

- Modified test: `test_trtllm_worker_generation` in `tests/unittest/scaffolding/test_worker.py`.
- Test coverage:
  - Covered by existing CI listing: `tests/integration/test_lists/test-db/l0_h100.yml` (includes `unittest/scaffolding`).
- Verdict: sufficient
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Bound `test_trtllm_worker_generation` to 100 generated tokens and always shut down its owned `TRTLLMWorker` in a `finally` block.

`GenerationTask.max_tokens` defaults to `None` and is passed directly to the local worker's sampling parameters. The DeepSeek reasoning model can therefore generate until it emits EOS or reaches a backend limit, making the test vulnerable to long-tail CI timeouts.

The previous cleanup also ran only when the final assertion failed. Successful runs and exceptions raised before that assertion could leave the owned LLM and GPU resources alive, potentially affecting later tests.

The test remains a generation-success smoke test, but now has deterministic work bounds and releases its resources on every exit path.

## Test Coverage

- Existing GPU CI registration: `unittest/scaffolding` in `tests/integration/test_lists/test-db/l0_h100.yml`.
- `git diff --check`
- Python 3.12 `py_compile`
- YAPF 0.43.0 formatting check
- Ruff 0.9.4 legacy lint check

The model-backed test requires the DeepSeek checkpoint and a GPU, so runtime coverage is left to the existing H100 CI stage.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
