### PR TITLE
[None][fix] Structured Output with DSpark Speculative Drafter

### DIFF
--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -419,9 +419,7 @@ class DSparkWorker(SpecWorkerBase):
         """
         vocab = gen_logits.shape[-1]
         # Lay the block out step-major ([K, batch, vocab]) so each step's slice is
-        # a contiguous [batch, vocab] tensor: torch.ops.trtllm.logits_bitmask
-        # requires contiguous logits, which a [:, k, :] slice of a
-        # [batch, K, vocab] tensor is not.
+        # a contiguous [batch, vocab] tensor.
         if num_contexts > 0:
             full_logits = gen_logits.new_zeros((K, batch_size, vocab))
             full_logits[:, num_contexts:, :] = gen_logits.transpose(0, 1)

--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -434,9 +434,10 @@ class DSparkWorker(SpecWorkerBase):
           drafts context requests (zero placeholder), so context rows are padded
           with zeros; their matcher advance/rollback is a net no-op (mirrors
           MTP's context handling) and their draft_probs rows are overwritten by
-          ``write_context_onehot_draft_probs`` below. Gen-only CUDA-graph batches
-          (``num_contexts == 0``) use ``gen_logits`` directly (static shape,
-          capture-safe).
+          ``write_context_onehot_draft_probs`` below. The block is transposed to
+          step-major ([K, batch, vocab]) so each step's slice is contiguous, as
+          the bitmask kernel requires; shapes are static, so this is
+          CUDA-graph-capture-safe.
         * Sampling reuses ``SpecWorkerBase.sample_draft_tokens``' 2D per-step form
           (the same path MTP uses), so the TP vocab gather and the slot-indexed
           ``draft_probs`` scatter are byte-for-byte the ones verification's
@@ -449,11 +450,15 @@ class DSparkWorker(SpecWorkerBase):
           ``rollback_draft_tokens``, restoring the matcher for next iteration.
         """
         vocab = gen_logits.shape[-1]
+        # Lay the block out step-major ([K, batch, vocab]) so each step's slice is
+        # a contiguous [batch, vocab] tensor: torch.ops.trtllm.logits_bitmask
+        # requires contiguous logits, which a [:, k, :] slice of a
+        # [batch, K, vocab] tensor is not.
         if num_contexts > 0:
-            full_logits = gen_logits.new_zeros((batch_size, K, vocab))
-            full_logits[num_contexts:] = gen_logits
+            full_logits = gen_logits.new_zeros((K, batch_size, vocab))
+            full_logits[:, num_contexts:, :] = gen_logits.transpose(0, 1)
         else:
-            full_logits = gen_logits
+            full_logits = gen_logits.transpose(0, 1).contiguous()
 
         # Step-0 matcher-advance token = each request's last committed token (the
         # bonus for gens), mirroring MTP's draft_inputs['input_ids'][last_tokens_idx].
@@ -465,7 +470,7 @@ class DSparkWorker(SpecWorkerBase):
             # Advance the matcher with the token chosen at position k-1 (bonus at
             # k==0) and apply position-k's bitmask before sampling, as MTP does.
             self.guided_decoder.add_draft_batch(new_tokens, num_accepted_tokens, draft_step=k)
-            step_logits = full_logits[:, k, :]
+            step_logits = full_logits[k]
             self.guided_decoder.execute_draft_batch(step_logits, draft_step=k)
             step_tokens = self.sample_draft_tokens(
                 step_logits, spec_metadata, batch_size, draft_step=k

--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -414,40 +414,8 @@ class DSparkWorker(SpecWorkerBase):
         batch_size: int,
         K: int,
     ):
-        """Grammar-constrained draft sampling for the guided-decoding path.
-
-        The block backbone already produced all ``K`` positions in one forward
-        (``gen_logits`` = ``[num_gens, K, vocab]``); here we sample them
-        left-to-right, advancing the grammar matcher and applying the
-        per-position bitmask BEFORE each position's sample. This is the DSpark
-        parity for MTP's per-draft-step guided masking (``mtp.py``:
-        ``add_draft_batch`` -> ``execute_draft_batch`` inside the draft loop):
-        without it the unconstrained block drafts make the target-verify matcher
-        break mid-block, later verify positions go unmasked, the target commits
-        an illegal token, and guidance is disabled ("failed to accept last new
-        token"), collapsing acceptance on structured traffic.
-
-        Correctness notes:
-        * ``add_draft_batch``/``execute_draft_batch`` are row-per-request over the
-          FULL batch (contexts first), so we feed full-batch per-step logits and
-          full-batch matcher-advance tokens, exactly as MTP does. DSpark never
-          drafts context requests (zero placeholder), so context rows are padded
-          with zeros; their matcher advance/rollback is a net no-op (mirrors
-          MTP's context handling) and their draft_probs rows are overwritten by
-          ``write_context_onehot_draft_probs`` below. The block is transposed to
-          step-major ([K, batch, vocab]) so each step's slice is contiguous, as
-          the bitmask kernel requires; shapes are static, so this is
-          CUDA-graph-capture-safe.
-        * Sampling reuses ``SpecWorkerBase.sample_draft_tokens``' 2D per-step form
-          (the same path MTP uses), so the TP vocab gather and the slot-indexed
-          ``draft_probs`` scatter are byte-for-byte the ones verification's
-          rejection path reads next iteration; because ``execute_draft_batch``
-          masks the (possibly vocab-sharded) step logits in place first, the
-          scattered proposal distribution is the grammar-constrained one.
-        * ``K == guided_decoder.max_num_draft_tokens`` for DSpark (both derive from
-          ``max_draft_len``; ``block_size == max_draft_len`` is asserted), so the
-          last step ``k == K - 1`` triggers ``execute_draft_batch``'s
-          ``rollback_draft_tokens``, restoring the matcher for next iteration.
+        """
+        Grammar-constrained draft sampling for the guided-decoding path.
         """
         vocab = gen_logits.shape[-1]
         # Lay the block out step-major ([K, batch, vocab]) so each step's slice is
@@ -460,15 +428,11 @@ class DSparkWorker(SpecWorkerBase):
         else:
             full_logits = gen_logits.transpose(0, 1).contiguous()
 
-        # Step-0 matcher-advance token = each request's last committed token (the
-        # bonus for gens), mirroring MTP's draft_inputs['input_ids'][last_tokens_idx].
         gidx = (num_accepted_tokens - 1).clamp(min=0).unsqueeze(1)
         new_tokens = accepted_tokens.gather(1, gidx).squeeze(1).to(torch.int32)
 
         gen_draft_tokens = []
         for k in range(K):
-            # Advance the matcher with the token chosen at position k-1 (bonus at
-            # k==0) and apply position-k's bitmask before sampling, as MTP does.
             self.guided_decoder.add_draft_batch(new_tokens, num_accepted_tokens, draft_step=k)
             step_logits = full_logits[k]
             self.guided_decoder.execute_draft_batch(step_logits, draft_step=k)
@@ -585,11 +549,6 @@ class DSparkWorker(SpecWorkerBase):
             )
             if gen_logits is not None:
                 if self.guided_decoder is not None:
-                    # Guided path: grammar-constrain the drafted block position by
-                    # position (parity with MTP's per-draft-step masking), so the
-                    # proposed drafts are grammar-legal and the target-verify
-                    # matcher never breaks mid-block. Reuses the same TP gather +
-                    # draft_probs scatter as the unguided block sampler below.
                     gen_draft_tokens, gen_vocab = self._sample_draft_tokens_guided(
                         gen_logits,
                         spec_metadata,
@@ -600,17 +559,12 @@ class DSparkWorker(SpecWorkerBase):
                         K,
                     )
                 else:
-                    # SpecWorkerBase samples the draft tokens (greedy argmax, or
-                    # rejection sampling for a non-greedy batch), performs the TP
-                    # gather, and scatters the proposal distribution into draft_probs.
+                    # SpecWorkerBase samples the draft tokens.
                     gen_draft_tokens = self.sample_draft_tokens(
                         gen_logits, spec_metadata, batch_size, num_contexts=num_contexts
                     )
                     # The context one-hot must match the width the gen scatter just
-                    # published to draft_probs, NOT gen_logits.shape[-1]: under TP the
-                    # draft logits are vocab-sharded and sample_draft_tokens gathers
-                    # them to full vocab before scattering, so the pre-gather shard
-                    # width would leave stale columns and corrupt rejection.
+                    # published to draft_probs, NOT gen_logits.shape[-1].
                     gen_vocab = spec_metadata.draft_probs_last_dim
             else:
                 gen_draft_tokens = torch.zeros((num_gens, K), dtype=torch.int32, device="cuda")

--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -440,7 +440,7 @@ class DSparkWorker(SpecWorkerBase):
             gen_draft_tokens.append(step_tokens[num_contexts:])
             new_tokens = step_tokens
         gen_draft_tokens = torch.stack(gen_draft_tokens, dim=1)
-        return gen_draft_tokens, spec_metadata.draft_probs_last_dim
+        return gen_draft_tokens
 
     def _forward_impl(
         self,
@@ -547,7 +547,7 @@ class DSparkWorker(SpecWorkerBase):
             )
             if gen_logits is not None:
                 if self.guided_decoder is not None:
-                    gen_draft_tokens, gen_vocab = self._sample_draft_tokens_guided(
+                    gen_draft_tokens = self._sample_draft_tokens_guided(
                         gen_logits,
                         spec_metadata,
                         accepted_tokens,
@@ -561,9 +561,12 @@ class DSparkWorker(SpecWorkerBase):
                     gen_draft_tokens = self.sample_draft_tokens(
                         gen_logits, spec_metadata, batch_size, num_contexts=num_contexts
                     )
-                    # The context one-hot must match the width the gen scatter just
-                    # published to draft_probs, NOT gen_logits.shape[-1].
-                    gen_vocab = spec_metadata.draft_probs_last_dim
+                # The context one-hot must match the width the gen scatter just
+                # published to draft_probs, NOT gen_logits.shape[-1]: under TP the
+                # draft logits are vocab-sharded and sample_draft_tokens gathers
+                # them to full vocab before scattering, so the pre-gather shard
+                # width would leave stale columns and corrupt rejection.
+                gen_vocab = spec_metadata.draft_probs_last_dim
             else:
                 gen_draft_tokens = torch.zeros((num_gens, K), dtype=torch.int32, device="cuda")
                 gen_vocab = None

--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -426,7 +426,7 @@ class DSparkWorker(SpecWorkerBase):
         else:
             full_logits = gen_logits.transpose(0, 1).contiguous()
 
-        gidx = (num_accepted_tokens - 1).clamp(min=0).unsqueeze(1)
+        gidx = (num_accepted_tokens - 1).clamp(min=0).unsqueeze(1).long()
         new_tokens = accepted_tokens.gather(1, gidx).squeeze(1).to(torch.int32)
 
         gen_draft_tokens = []

--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -404,6 +404,77 @@ class DSparkWorker(SpecWorkerBase):
         )
         return block_logits
 
+    def _sample_draft_tokens_guided(
+        self,
+        gen_logits: torch.Tensor,
+        spec_metadata: "DSparkSpecMetadata",
+        accepted_tokens: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        num_contexts: int,
+        batch_size: int,
+        K: int,
+    ):
+        """Grammar-constrained draft sampling for the guided-decoding path.
+
+        The block backbone already produced all ``K`` positions in one forward
+        (``gen_logits`` = ``[num_gens, K, vocab]``); here we sample them
+        left-to-right, advancing the grammar matcher and applying the
+        per-position bitmask BEFORE each position's sample. This is the DSpark
+        parity for MTP's per-draft-step guided masking (``mtp.py``:
+        ``add_draft_batch`` -> ``execute_draft_batch`` inside the draft loop):
+        without it the unconstrained block drafts make the target-verify matcher
+        break mid-block, later verify positions go unmasked, the target commits
+        an illegal token, and guidance is disabled ("failed to accept last new
+        token"), collapsing acceptance on structured traffic.
+
+        Correctness notes:
+        * ``add_draft_batch``/``execute_draft_batch`` are row-per-request over the
+          FULL batch (contexts first), so we feed full-batch per-step logits and
+          full-batch matcher-advance tokens, exactly as MTP does. DSpark never
+          drafts context requests (zero placeholder), so context rows are padded
+          with zeros; their matcher advance/rollback is a net no-op (mirrors
+          MTP's context handling) and their draft_probs rows are overwritten by
+          ``write_context_onehot_draft_probs`` below. Gen-only CUDA-graph batches
+          (``num_contexts == 0``) use ``gen_logits`` directly (static shape,
+          capture-safe).
+        * Sampling reuses ``SpecWorkerBase.sample_draft_tokens``' 2D per-step form
+          (the same path MTP uses), so the TP vocab gather and the slot-indexed
+          ``draft_probs`` scatter are byte-for-byte the ones verification's
+          rejection path reads next iteration; because ``execute_draft_batch``
+          masks the (possibly vocab-sharded) step logits in place first, the
+          scattered proposal distribution is the grammar-constrained one.
+        * ``K == guided_decoder.max_num_draft_tokens`` for DSpark (both derive from
+          ``max_draft_len``; ``block_size == max_draft_len`` is asserted), so the
+          last step ``k == K - 1`` triggers ``execute_draft_batch``'s
+          ``rollback_draft_tokens``, restoring the matcher for next iteration.
+        """
+        vocab = gen_logits.shape[-1]
+        if num_contexts > 0:
+            full_logits = gen_logits.new_zeros((batch_size, K, vocab))
+            full_logits[num_contexts:] = gen_logits
+        else:
+            full_logits = gen_logits
+
+        # Step-0 matcher-advance token = each request's last committed token (the
+        # bonus for gens), mirroring MTP's draft_inputs['input_ids'][last_tokens_idx].
+        gidx = (num_accepted_tokens - 1).clamp(min=0).unsqueeze(1)
+        new_tokens = accepted_tokens.gather(1, gidx).squeeze(1).to(torch.int32)
+
+        gen_draft_tokens = []
+        for k in range(K):
+            # Advance the matcher with the token chosen at position k-1 (bonus at
+            # k==0) and apply position-k's bitmask before sampling, as MTP does.
+            self.guided_decoder.add_draft_batch(new_tokens, num_accepted_tokens, draft_step=k)
+            step_logits = full_logits[:, k, :]
+            self.guided_decoder.execute_draft_batch(step_logits, draft_step=k)
+            step_tokens = self.sample_draft_tokens(
+                step_logits, spec_metadata, batch_size, draft_step=k
+            )
+            gen_draft_tokens.append(step_tokens[num_contexts:])
+            new_tokens = step_tokens
+        gen_draft_tokens = torch.stack(gen_draft_tokens, dim=1)
+        return gen_draft_tokens, spec_metadata.draft_probs_last_dim
+
     def _forward_impl(
         self,
         input_ids,
@@ -508,18 +579,34 @@ class DSparkWorker(SpecWorkerBase):
                 all_rank_num_tokens=all_rank_draft_tokens,
             )
             if gen_logits is not None:
-                # SpecWorkerBase samples the draft tokens (greedy argmax, or
-                # rejection sampling for a non-greedy batch), performs the TP
-                # gather, and scatters the proposal distribution into draft_probs.
-                gen_draft_tokens = self.sample_draft_tokens(
-                    gen_logits, spec_metadata, batch_size, num_contexts=num_contexts
-                )
-                # The context one-hot must match the width the gen scatter just
-                # published to draft_probs, NOT gen_logits.shape[-1]: under TP the
-                # draft logits are vocab-sharded and sample_draft_tokens gathers
-                # them to full vocab before scattering, so the pre-gather shard
-                # width would leave stale columns and corrupt rejection.
-                gen_vocab = spec_metadata.draft_probs_last_dim
+                if self.guided_decoder is not None:
+                    # Guided path: grammar-constrain the drafted block position by
+                    # position (parity with MTP's per-draft-step masking), so the
+                    # proposed drafts are grammar-legal and the target-verify
+                    # matcher never breaks mid-block. Reuses the same TP gather +
+                    # draft_probs scatter as the unguided block sampler below.
+                    gen_draft_tokens, gen_vocab = self._sample_draft_tokens_guided(
+                        gen_logits,
+                        spec_metadata,
+                        accepted_tokens,
+                        num_accepted_tokens,
+                        num_contexts,
+                        batch_size,
+                        K,
+                    )
+                else:
+                    # SpecWorkerBase samples the draft tokens (greedy argmax, or
+                    # rejection sampling for a non-greedy batch), performs the TP
+                    # gather, and scatters the proposal distribution into draft_probs.
+                    gen_draft_tokens = self.sample_draft_tokens(
+                        gen_logits, spec_metadata, batch_size, num_contexts=num_contexts
+                    )
+                    # The context one-hot must match the width the gen scatter just
+                    # published to draft_probs, NOT gen_logits.shape[-1]: under TP the
+                    # draft logits are vocab-sharded and sample_draft_tokens gathers
+                    # them to full vocab before scattering, so the pre-gather shard
+                    # width would leave stale columns and corrupt rejection.
+                    gen_vocab = spec_metadata.draft_probs_last_dim
             else:
                 gen_draft_tokens = torch.zeros((num_gens, K), dtype=torch.int32, device="cuda")
                 gen_vocab = None

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
@@ -354,3 +354,142 @@ def test_forward_mixed_batch_routes_through_base_entries(monkeypatch):
     # Verified tokens are surfaced unchanged.
     assert torch.equal(out["new_tokens"], accepted)
     assert torch.equal(out["new_tokens_lens"], num_accepted)
+
+
+def test_forward_guided_batch_masks_and_advances_matcher_per_step(monkeypatch):
+    """Guided mixed (context + gen) batch: ``forward`` must walk the K draft
+    positions left-to-right, advancing the grammar matcher
+    (``add_draft_batch``) and masking each position's logits in place
+    (``execute_draft_batch``) BEFORE that position is sampled.
+
+    This is the guided sibling of
+    ``test_forward_mixed_batch_routes_through_base_entries``; it pins the
+    parts static reading can't settle — the step-major contiguous layout the
+    bitmask kernel requires, the zero-padded context rows, the seed token fed
+    to the matcher, and mask-before-sample ordering — with a fake guided
+    decoder (no grammar backend / draft model / MPI).
+    """
+    worker = _make_worker()
+    dm = _fake_draft_model(num_stages=3, window_size=128, head_dim=64)
+
+    K = worker.max_draft_len
+    vocab = 16
+    num_contexts, num_gens = 2, 3
+    batch_size = num_contexts + num_gens
+    BANNED = 3  # grammar forbids this draft-vocab column
+    FULL_VOCAB = 97  # post-TP-gather scatter width (wider than sharded `vocab`)
+
+    meta = _make_metadata(max_num_requests=8)
+    meta.request_ids = [10, 11, 20, 21, 22]  # 2 context + 3 gen
+    meta.prepare()
+
+    attn_metadata = types.SimpleNamespace(
+        num_seqs=batch_size,
+        num_contexts=num_contexts,
+        num_ctx_tokens=0,
+        num_tokens=batch_size,
+    )
+
+    # Acceptance: one accepted token per request (num_accepted == 1), so the
+    # matcher seed is accepted_tokens[:, 0].
+    accepted = torch.arange(batch_size * (K + 1), dtype=torch.int32, device="cuda").reshape(
+        batch_size, K + 1
+    )
+    num_accepted = torch.ones(batch_size, dtype=torch.int32, device="cuda")
+    monkeypatch.setattr(
+        worker, "sample_and_accept_draft_tokens", lambda *a, **k: (accepted, num_accepted)
+    )
+    monkeypatch.setattr(worker, "_seed_context_windows", lambda *a, **k: None)
+
+    gen_logits = torch.randn(num_gens, K, vocab, device="cuda")
+    monkeypatch.setattr(worker, "_draft_gen_block_batched", lambda *a, **k: gen_logits)
+
+    class FakeGuidedDecoder:
+        def __init__(self):
+            self.add_steps = []
+            self.add_tokens = []
+            self.exec_records = []
+
+        def execute(self, logits, d2t=None):
+            # Target-verify masking (``_execute_guided_decoder_if_present`` in
+            # ``_forward_impl``); a no-op here — this test asserts only the
+            # draft-loop behavior, not target-side masking.
+            pass
+
+        def add_draft_batch(self, new_tokens, num_accepted_tokens, draft_step=0):
+            self.add_steps.append(draft_step)
+            self.add_tokens.append(new_tokens.clone())
+
+        def execute_draft_batch(self, logits, draft_step=0):
+            # Record the exact tensor properties the bitmask kernel requires,
+            # BEFORE mutating: contiguous [batch, vocab] with zero-padded
+            # context rows.
+            self.exec_records.append(
+                dict(
+                    step=draft_step,
+                    contiguous=logits.is_contiguous(),
+                    shape=tuple(logits.shape),
+                    ctx_sum=float(logits[:num_contexts].abs().sum()),
+                )
+            )
+            # Simulate the grammar bitmask applied in place before sampling.
+            logits[:, BANNED] = float("-inf")
+
+    guided = FakeGuidedDecoder()
+    worker.guided_decoder = guided
+
+    sampled_per_step = []
+
+    def fake_sample_draft_tokens(gl, sm, bs, *, draft_step):
+        # The sampler must see the already-masked logits (mask-before-sample).
+        assert torch.all(gl[:, BANNED] == float("-inf"))
+        sm.draft_probs_last_dim = FULL_VOCAB  # simulate the full-vocab scatter
+        tokens = gl.argmax(dim=-1).to(torch.int32)
+        sampled_per_step.append(tokens.clone())
+        return tokens
+
+    monkeypatch.setattr(worker, "sample_draft_tokens", fake_sample_draft_tokens)
+
+    onehot_calls = {}
+    monkeypatch.setattr(
+        worker,
+        "write_context_onehot_draft_probs",
+        lambda sm, nc, ng, k, gv: onehot_calls.update(nc=nc, ng=ng, k=k, gv=gv),
+    )
+
+    input_ids = torch.zeros(batch_size, dtype=torch.long, device="cuda")
+    position_ids = torch.zeros(batch_size, dtype=torch.long, device="cuda")
+    hidden = torch.zeros(batch_size, HIDDEN, device="cuda", dtype=torch.bfloat16)
+    logits = torch.zeros(batch_size, vocab, device="cuda")
+
+    out = worker.forward(input_ids, position_ids, hidden, logits, attn_metadata, meta, dm)
+
+    # Matcher advanced once per draft position, in order 0..K-1.
+    assert guided.add_steps == list(range(K))
+    assert [r["step"] for r in guided.exec_records] == list(range(K))
+
+    # Each step's logits were the contiguous [batch, vocab] slice the bitmask
+    # kernel requires, with context rows zero-padded (they carry no draft).
+    for rec in guided.exec_records:
+        assert rec["contiguous"]
+        assert rec["shape"] == (batch_size, vocab)
+        assert rec["ctx_sum"] == 0.0
+
+    # Step 0's matcher seed is the last accepted token (accepted[:, 0], since
+    # num_accepted == 1); each later step is fed the previous step's full-batch
+    # sample.
+    assert torch.equal(guided.add_tokens[0], accepted[:, 0])
+    for k in range(1, K):
+        assert torch.equal(guided.add_tokens[k], sampled_per_step[k - 1])
+
+    # Context rows are one-hot-filled at the scatter width (draft_probs_last_dim),
+    # NOT the sharded gen_logits width.
+    assert onehot_calls == {"nc": num_contexts, "ng": num_gens, "k": K, "gv": FULL_VOCAB}
+
+    # Output excludes context rows and matches the per-step masked samples.
+    nd = out["next_draft_tokens"]
+    assert nd.shape == (batch_size, K)
+    assert torch.all(nd[:num_contexts] == 0)
+    gen_draft = nd[num_contexts:]
+    expected_gen = torch.stack([s[num_contexts:] for s in sampled_per_step], dim=1)
+    assert torch.equal(gen_draft, expected_gen)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

### Description

Ref #15808  
Fix #16967

This PR fixes DSpark speculative decoding structured-output guided decoding by applying xgrammar guidance consistently during draft-token generation, so grammar constraints remain enforced across the full speculative block (and JSON-schema violations like missing required fields are avoided).

Previously, DSpark applied the xgrammar-derived mask only when performing target verification sampling, while the drafter sampled draft tokens without grammar constraints. If a drafted token became grammar-illegal, the matcher/bitmask state could become inconsistent within the block, allowing later verification to proceed without the intended constraints and potentially committing an illegal token (silently disabling guidance).

Now, when `guided_decoder` is present, DSpark generates draft tokens **left-to-right** for each of the `K` draft steps:
- seeds matcher state from each request’s last accepted token
- for each draft position `k`:
  - calls `guided_decoder.add_draft_batch(..., draft_step=k)`
  - calls `guided_decoder.execute_draft_batch(...)` to apply the per-position grammar mask **in-place**
  - samples the drafter token from the masked, guided step logits
- returns only generation-row tokens (excluding context rows)

### Key implementation changes

- Added `_sample_draft_tokens_guided(...)` in `tensorrt_llm/_torch/speculative/dspark.py`:
  - converts provided `gen_logits` into a step-major layout to produce per-step `[batch, vocab]` tensors (with zero-filled context rows when `num_contexts > 0`)
  - seeds matcher using `accepted_tokens` last-accepted token per request
  - iterates `k in 0..K-1`: `add_draft_batch` → `execute_draft_batch` → `sample_draft_tokens`
  - assembles and returns `gen_draft_tokens` as `[num_gens, K]`
- Updated `DSparkWorker._forward_impl(...)` to route draft sampling:
  - guided path: `_sample_draft_tokens_guided(...)`
  - fallback path: existing unguided `sample_draft_tokens(...)`
- Preserved the `gen_vocab`/`draft_probs_last_dim` handling and its tensor-parallel comment to ensure the context one-hot uses the **post-TP scatter width** (`spec_metadata.draft_probs_last_dim`), not the sharded `gen_logits` width.

## Dev Engineer Review

- **Correctness:** Implements guided, per-draft-step left-to-right sampling for DSpark so `guided_decoder` updates/masks the logits *before* the drafter samples at each step, keeping matcher/verification state synchronized across the entire `K` block (directly addressing the guidance-desynchronization failure mode behind JSON-schema violations).
- **Consistency:** Guided decoding now mirrors the guided per-step loop ordering (`add_draft_batch` → `execute_draft_batch` → sampling), reducing the risk of divergence between drafter drafts and matcher/verify logic.
- **TP/shape correctness:** Builds step-major logits and preserves the existing logic around `gen_vocab = spec_metadata.draft_probs_last_dim`, including the comment about matching the context one-hot scatter width under tensor parallelism.
- **Test coverage gaps / risk areas noted in review request:** The new unit test covers mixed context+generation guided drafting behavior, but explicit coverage for “matcher rollback on the final step” and guided decoding with “tensor-parallel rejection-probability storage under CUDA-graph capture” is not confirmed in the added test.

## QA Engineer Review

### Test changes
- **Added:** `test_forward_guided_batch_masks_and_advances_matcher_per_step` in `tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py`
  - Validates guided mixed (context + gen) batching:
    - left-to-right `K` draft step ordering
    - `add_draft_batch` called per draft position
    - `execute_draft_batch` invoked with contiguous `[batch, vocab]` logits per step and zero-summed context rows
    - matcher seeding uses each request’s last accepted token
    - in-place grammar masking occurs **before** sampling (forbidden token set to `-inf`)
    - context one-hot drafting uses scatter “full vocab” width (`draft_probs_last_dim`)
    - assembled `next_draft_tokens` excludes context rows and never proposes the forbidden token

### Coverage in tests/integration/test_lists/
- This specific unittest is **not** referenced in `tests/integration/test_lists/test-db/` or `tests/integration/test_lists/qa/` (only DSpark appears in a performance QA list unrelated to this unit test).

**Verdict:** needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->