### PR TITLE
[None][test] Stabilize scaffolding LLM tests

### DIFF
--- a/tests/unittest/scaffolding/test_scaffolding.py
+++ b/tests/unittest/scaffolding/test_scaffolding.py
@@ -29,7 +29,8 @@ def create_scaffolding_llm_with_majority_vote_controller(
     trtllm_worker = create_trtllm_worker(deepseek_distill_7b_path)
 
     workers = {}
-    prototype_generation_controller = NativeGenerationController()
+    prototype_generation_controller = NativeGenerationController(
+        sampling_params={"max_tokens": 100})
     workers[NativeGenerationController.WorkerTag.GENERATION] = trtllm_worker
 
     prototype_majority_vote_controller = MajorityVoteController(
@@ -48,23 +49,28 @@ def create_scaffolding_llm_with_majority_vote_controller(
 def test_unbatched_scaffolding_sync(default_prompt, deepseek_distill_7b_path):
     scaffolding_llm = create_scaffolding_llm_with_native_generation_controller(
         deepseek_distill_7b_path)
-    result = scaffolding_llm.generate(default_prompt)
-    assert isinstance(result.outputs[0].text, str) and len(
-        result.outputs[0].text) > 0, "Output should be a non-empty string"
-    scaffolding_llm.shutdown(shutdown_workers=True)
+    try:
+        result = scaffolding_llm.generate(default_prompt)
+        assert isinstance(result.outputs[0].text, str) and len(
+            result.outputs[0].text) > 0, "Output should be a non-empty string"
+    finally:
+        scaffolding_llm.shutdown(shutdown_workers=True)
 
 
 def test_batched_scaffolding_sync(default_prompt, deepseek_distill_7b_path):
     scaffolding_llm = create_scaffolding_llm_with_native_generation_controller(
         deepseek_distill_7b_path)
-    batch_size = 3
-    prompts = [default_prompt] * batch_size
-    results = scaffolding_llm.generate(prompts)
-    assert len(results) == batch_size
-    for result in results:
-        assert isinstance(result.outputs[0].text, str) and len(
-            result.outputs[0].text) > 0, "Output should be a non-empty string"
-    scaffolding_llm.shutdown(shutdown_workers=True)
+    try:
+        batch_size = 3
+        prompts = [default_prompt] * batch_size
+        results = scaffolding_llm.generate(prompts)
+        assert len(results) == batch_size
+        for result in results:
+            assert isinstance(result.outputs[0].text, str) and len(
+                result.outputs[0].text
+            ) > 0, "Output should be a non-empty string"
+    finally:
+        scaffolding_llm.shutdown(shutdown_workers=True)
 
 
 def test_async_scaffolding_generation(default_prompt, deepseek_distill_7b_path):
@@ -72,11 +78,14 @@ def test_async_scaffolding_generation(default_prompt, deepseek_distill_7b_path):
     async def run_async_test():
         scaffolding_llm = create_scaffolding_llm_with_native_generation_controller(
             deepseek_distill_7b_path)
-        future = scaffolding_llm.generate_async(default_prompt)
-        result = await future.aresult()
-        assert isinstance(result.outputs[0].text, str) and len(
-            result.outputs[0].text) > 0, "Output should be a non-empty string"
-        scaffolding_llm.shutdown(shutdown_workers=True)
+        try:
+            future = scaffolding_llm.generate_async(default_prompt)
+            result = await future.aresult()
+            assert isinstance(result.outputs[0].text, str) and len(
+                result.outputs[0].text
+            ) > 0, "Output should be a non-empty string"
+        finally:
+            scaffolding_llm.shutdown(shutdown_workers=True)
 
     import asyncio
     asyncio.run(run_async_test())
@@ -85,7 +94,9 @@ def test_async_scaffolding_generation(default_prompt, deepseek_distill_7b_path):
 def test_majority_vote(default_prompt, deepseek_distill_7b_path):
     scaffolding_llm = create_scaffolding_llm_with_majority_vote_controller(
         deepseek_distill_7b_path, samples_num=3)
-    result = scaffolding_llm.generate(default_prompt)
-    assert isinstance(result.outputs[0].text, str) and len(
-        result.outputs[0].text) > 0, "Output should be a non-empty string"
-    scaffolding_llm.shutdown(shutdown_workers=True)
+    try:
+        result = scaffolding_llm.generate(default_prompt)
+        assert isinstance(result.outputs[0].text, str) and len(
+            result.outputs[0].text) > 0, "Output should be a non-empty string"
+    finally:
+        scaffolding_llm.shutdown(shutdown_workers=True)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Dev Engineer Review**
- Limited DeepSeek majority-vote generations by configuring the `NativeGenerationController` used by `create_scaffolding_llm_with_majority_vote_controller` with `sampling_params={"max_tokens": 100}` to prevent unbounded reasoning in CI.
- Improved test cleanup robustness by wrapping `scaffolding_llm.generate(...)` / `generate_async(...)` calls in `try/finally` blocks across all four tests to always execute `scaffolding_llm.shutdown(shutdown_workers=True)` even if assertions fail or exceptions occur.
- Kept changes localized to `tests/unittest/scaffolding/test_scaffolding.py` with no API/config or test-list changes.

**QA Engineer Review**
- Modified tests (all in `tests/unittest/scaffolding/test_scaffolding.py`):
  - `test_unbatched_scaffolding_sync` (added/ensured `finally` shutdown via `scaffolding_llm.shutdown(shutdown_workers=True)`)
  - `test_batched_scaffolding_sync` (added/ensured `finally` shutdown)
  - `test_async_scaffolding_generation` (inner `run_async_test` now `finally`-shuts down)
  - `test_majority_vote` (added/ensured `finally` shutdown)
- Test-list coverage: not verified (no `test-db/` or `qa/` coverage references provided).
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Stabilize the model-backed scaffolding LLM tests by:

- Limiting each DeepSeek majority-vote generation to 100 tokens.
- Shutting down the `ScaffoldingLlm` and its owned worker in `finally` blocks in all four tests.

The majority-vote controller previously launched three concurrent generations without an output bound. Because `GenerationTask.max_tokens` defaults to `None`, a reasoning response could continue until EOS or a backend limit and create long-tail CI runtimes.

Cleanup also ran only after generation and assertions succeeded. An exception or failed assertion could therefore leave the scaffolding event loop and owned GPU LLM alive, potentially hanging the test process or affecting later tests.

This is a follow-up to #16964.