### PR TITLE
[https://nvbugs/6523785][fix] Added `Backend.get_graph_pool_handle()` / `retire_graph_pool_handle()` and…

### DIFF
--- a/tensorrt_llm/_torch/compilation/backend.py
+++ b/tensorrt_llm/_torch/compilation/backend.py
@@ -78,9 +78,6 @@ class Backend:
         self.events = Backend.Events()
         inductor_config.enable_auto_functionalized_v2 = False
 
-        if Backend._graph_pool_handle is None:
-            Backend._graph_pool_handle = torch.cuda.graph_pool_handle()
-
         self.match_count = []
         self.match_count_by_pass = OrderedDict()
 
@@ -111,6 +108,23 @@ class Backend:
                 PatternMatcherPass("add_norm_fallback", MATCHER_SUBSYSTEM))
             register_add_norm(custom_passes[-1])
         return custom_passes
+
+    @classmethod
+    def get_graph_pool_handle(cls) -> tuple[int, int]:
+        """Return the pool handle shared by every graph runner in this process."""
+        if cls._graph_pool_handle is None:
+            cls._graph_pool_handle = torch.cuda.graph_pool_handle()
+        return cls._graph_pool_handle
+
+    @classmethod
+    def retire_graph_pool_handle(cls) -> None:
+        """Drop the cached handle once its graphs have been reset.
+
+        A private pool cannot outlive its graphs: CUDACachingAllocator asserts
+        on any attempt to incref a pool whose use_count already dropped to
+        zero, so the next caller has to allocate a fresh handle.
+        """
+        cls._graph_pool_handle = None
 
     def bypass_optimization(self):
         self.no_optimization = True
@@ -179,7 +193,7 @@ class Backend:
                 self.enable_inductor,
                 self.input_num_tokens,
                 self.capture_num_tokens,
-                self._graph_pool_handle,
+                self.get_graph_pool_handle(),
                 self.num_streams,
             )
             self._piecewise_runners.update(runners)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -650,7 +650,8 @@ class PyTorchModelEngine(ModelEngine):
         self.encoder_attn_metadata = None
         self.spec_metadata = None
         self.iter_states = {}
-        self._cuda_graph_mem_pool = self._torch_compile_backend._graph_pool_handle if self._torch_compile_enabled else None
+        self._cuda_graph_mem_pool = (Backend.get_graph_pool_handle()
+                                     if self._torch_compile_enabled else None)
 
         self._cuda_graph_padding_enabled = cuda_graph_padding_enabled
 
@@ -2746,6 +2747,11 @@ class PyTorchModelEngine(ModelEngine):
         if hasattr(self, 'encoder_cuda_graph_runner'
                    ) and self.encoder_cuda_graph_runner is not None:
             self.encoder_cuda_graph_runner.clear()
+        # The graphs reset above were captured into Backend's process-wide pool,
+        # so a later engine in this process (e.g. a second LLM sharing the
+        # worker) must not reuse that now-dead handle.
+        Backend.retire_graph_pool_handle()
+        self._cuda_graph_mem_pool = None
 
     def get_max_num_sequences(self) -> int:
         """


### PR DESCRIPTION
## Summary
- **Root cause**: `Backend._graph_pool_handle` is a process-wide class attribute that was kept after `_release_cuda_graphs()` reset every graph captured into that private pool, so a second `LLM` in the same reused MPI worker got a retired handle whose `use_count` was already 0, tripping `CUDACachingAllocator`'s `ensureExistsAndIncrefPool` assert.
- **Fix**: Added `Backend.get_graph_pool_handle()` / `retire_graph_pool_handle()` and retire the shared handle (plus the engine's cached copy) in `_release_cuda_graphs()`, so the next capture lazily allocates a fresh pool.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6523785


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `Backend` to manage the process-wide CUDA graph pool handle via two new lifecycle APIs: `Backend.get_graph_pool_handle()` for lazy creation and `Backend.retire_graph_pool_handle()` for clearing the cached handle after graph teardown.
- Adjusted `Backend.optimize()`’s `piecewise_cuda_graph` path to pass `self.get_graph_pool_handle()` into `piecewise_optimizer` (instead of using a pre-initialized cached field).
- Updated `PyTorchModelEngine.__init__` to initialize `_cuda_graph_mem_pool` from `Backend.get_graph_pool_handle()` when torch.compile is enabled, and updated `PyTorchModelEngine._release_cuda_graphs()` to retire the shared pool handle (`Backend.retire_graph_pool_handle()`) and set `_cuda_graph_mem_pool` to `None` after clearing runners.
- Ensures graphs reset in one engine/worker sequence cannot accidentally reuse a now-dead CUDA graph pool handle in later engines within the same process.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->