### PR TITLE
[None][fix] Preserve compact Kimi-K3 special tokens

### DIFF
--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -157,6 +157,36 @@ if _MSGSPEC_ENABLED:
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 
 
+def _configure_parser_special_token_decoding(
+        sampling_params: SamplingParams, reasoning_parser_name: Optional[str],
+        tool_parser_name: Optional[str], has_tools: bool) -> None:
+    """Configure detokenization for parsers that consume special tokens."""
+    needs_compact_special_tokens = False
+    if reasoning_parser_name and ReasoningParserFactory.needs_raw_special_tokens(
+            reasoning_parser_name):
+        # Unlike the tool-parser flag below, this applies to every chat
+        # request: reasoning delimiters are special tokens regardless of
+        # whether tools are attached.
+        sampling_params.skip_special_tokens = False
+        needs_compact_special_tokens = reasoning_parser_name.lower(
+        ) == "kimi_k3"
+
+    if tool_parser_name and has_tools:
+        tool_parser_cls = ToolParserFactory.parsers.get(
+            tool_parser_name.lower())
+        if tool_parser_cls and getattr(tool_parser_cls,
+                                       'needs_raw_special_tokens', False):
+            sampling_params.skip_special_tokens = False
+            needs_compact_special_tokens |= tool_parser_name.lower(
+            ) == "kimi_k3"
+
+    if needs_compact_special_tokens:
+        # K3 XTML places ordinary-text tag names directly between special
+        # tokens, for example ``<|open|>tools<|sep|>``. Inserting spaces here
+        # changes the protocol and prevents the K3 parsers from matching it.
+        sampling_params.spaces_between_special_tokens = False
+
+
 def _build_tool_strict_guided_decoding_params(tools, tool_parser_name):
     """Build GuidedDecodingParams with structural tags for tools with strict=True.
 
@@ -1506,18 +1536,12 @@ class OpenAIServer(_VideoRoutesMixin):
                 chat_template_kwargs=request.chat_template_kwargs,
             )
             reasoning_parser_name = self.generator.args.reasoning_parser
-            if reasoning_parser_name and ReasoningParserFactory.needs_raw_special_tokens(
-                    reasoning_parser_name):
-                # Unlike the tool-parser flag below, this applies to every
-                # chat request: the reasoning delimiters are special tokens
-                # regardless of whether tools are attached.
-                sampling_params.skip_special_tokens = False
+            _configure_parser_special_token_decoding(
+                sampling_params,
+                reasoning_parser_name=reasoning_parser_name,
+                tool_parser_name=self.tool_parser,
+                has_tools=bool(request.tools))
             if self.tool_parser and request.tools:
-                tool_parser_cls = ToolParserFactory.parsers.get(
-                    self.tool_parser.lower())
-                if tool_parser_cls and getattr(
-                        tool_parser_cls, 'needs_raw_special_tokens', False):
-                    sampling_params.skip_special_tokens = False
                 # When strict=True on any tool, apply constrained decoding
                 # via structural tags (only if response_format doesn't already
                 # set guided decoding).

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -19,6 +19,7 @@ from typing import NamedTuple
 
 import pytest
 
+from tensorrt_llm.sampling_params import SamplingParams
 from tensorrt_llm.serve.openai_protocol import (ChatCompletionToolsParam,
                                                 FunctionDefinition)
 from tensorrt_llm.serve.tool_parser.base_tool_parser import BaseToolParser
@@ -3787,8 +3788,7 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         assert parser.eot_token == self.EOT
 
     def test_undefined_tool(self, sample_tools, parser, tool_parser_test_cases):
-        """K3 keeps undefined-tool calls (with a warning) at their
-        positional index rather than remapping tool_index to -1."""
+        """Keep undefined-tool calls at their positional index."""
         text = tool_parser_test_cases.undefined_tool
 
         result = parser.detect_and_parse(text, sample_tools)
@@ -3798,8 +3798,7 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         assert result.calls[0].tool_index == 0
 
     def test_supports_structural_tag(self):
-        """XTML bodies are tag-structured text: JSON-schema structural-tag
-        constrained decoding does not apply."""
+        """Reject JSON-schema structural tagging for XTML bodies."""
         parser = KimiK3ToolParser()
         assert parser.supports_structural_tag() is False
         with pytest.raises(NotImplementedError):
@@ -3833,8 +3832,7 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
 
     def test_argument_invalid_json_falls_back_to_raw(self, sample_tools,
                                                      parser):
-        """A declared non-string type whose body is not valid JSON keeps the
-        raw text instead of raising."""
+        """Keep a non-string argument's invalid JSON body as raw text."""
         text = self._section(
             self._call("get_weather", 1,
                        self._argument("count", "number", "not-a-number")))
@@ -3846,19 +3844,15 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         }
 
     def test_attribute_unescaping(self, sample_tools, parser):
-        """Attribute values arrive &amp;/&quot;-escaped (encoding_k3
-        `_escape_attr_value`) and must be unescaped."""
+        """Unescape encoded XTML attribute values."""
         text = self._section(
             self._call(
                 "get_weather", 1,
-                self._argument("say &quot;hi&quot; &amp; bye", "string",
-                               "v")))
+                self._argument("say &quot;hi&quot; &amp; bye", "string", "v")))
 
         result = parser.detect_and_parse(text, sample_tools)
 
-        assert json.loads(result.calls[0].parameters) == {
-            'say "hi" & bye': "v"
-        }
+        assert json.loads(result.calls[0].parameters) == {'say "hi" & bye': "v"}
 
     def test_empty_arguments(self, sample_tools, parser):
         """A call with no argument tags yields an empty JSON object."""
@@ -3870,8 +3864,7 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         assert result.calls[0].parameters == "{}"
 
     def test_trailing_structural_markup_stripped(self, sample_tools, parser):
-        """Without a tools section, trailing XTML message terminators are
-        stripped from normal_text (standalone use, no reasoning parser)."""
+        """Strip trailing XTML terminators from standalone normal text."""
         text = "The answer is 4.<|close|>message<|sep|><|end_of_msg|>"
 
         result = parser.detect_and_parse(text, sample_tools)
@@ -3881,9 +3874,7 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
 
     def test_streaming_buffers_section_until_complete(self, sample_tools,
                                                       parser):
-        """Streaming flushes response text immediately but holds the tools
-        section until <|close|>tools<|sep|> arrives, then emits complete
-        calls."""
+        """Buffer an incomplete tools section while streaming response text."""
         result = parser.parse_streaming_increment("Checking. ", sample_tools)
         assert result.normal_text == "Checking. "
         assert result.calls == []
@@ -3909,10 +3900,8 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         assert result.calls[0].name == "get_weather"
         assert json.loads(result.calls[0].parameters) == {"location": "NYC"}
 
-    def test_composes_with_kimi_k3_reasoning_parser(self, sample_tools,
-                                                    parser):
-        """Serving chains the kimi_k3 reasoning parser (which passes the
-        tools section through into content verbatim) into this parser."""
+    def test_composes_with_kimi_k3_reasoning_parser(self, sample_tools, parser):
+        """Parse tools passed through the Kimi-K3 reasoning parser."""
         from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
 
         completion = (
@@ -3932,3 +3921,48 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         assert len(stage2.calls) == 1
         assert stage2.calls[0].name == "get_weather"
         assert json.loads(stage2.calls[0].parameters) == {"location": "NYC"}
+
+
+class TestConfigureParserSpecialTokenDecoding:
+    """Test parser-specific detokenization settings in the OpenAI server."""
+
+    @staticmethod
+    def _configure(reasoning_parser_name: str | None = None,
+                   tool_parser_name: str | None = None,
+                   has_tools: bool = False) -> SamplingParams:
+        from tensorrt_llm.serve.openai_server import \
+            _configure_parser_special_token_decoding
+
+        sampling_params = SamplingParams()
+        _configure_parser_special_token_decoding(
+            sampling_params,
+            reasoning_parser_name=reasoning_parser_name,
+            tool_parser_name=tool_parser_name,
+            has_tools=has_tools)
+        return sampling_params
+
+    def test_kimi_k3_reasoning_parser_preserves_compact_xtml(self) -> None:
+        sampling_params = self._configure(reasoning_parser_name="kimi_k3")
+
+        assert sampling_params.skip_special_tokens is False
+        assert sampling_params.spaces_between_special_tokens is False
+
+    def test_kimi_k3_tool_parser_preserves_compact_xtml(self) -> None:
+        sampling_params = self._configure(tool_parser_name="KIMI_K3",
+                                          has_tools=True)
+
+        assert sampling_params.skip_special_tokens is False
+        assert sampling_params.spaces_between_special_tokens is False
+
+    def test_tool_parser_does_not_apply_without_tools(self) -> None:
+        sampling_params = self._configure(tool_parser_name="kimi_k3")
+
+        assert sampling_params.skip_special_tokens is True
+        assert sampling_params.spaces_between_special_tokens is True
+
+    def test_other_raw_token_parser_keeps_spacing_contract(self) -> None:
+        sampling_params = self._configure(tool_parser_name="deepseek_v32",
+                                          has_tools=True)
+
+        assert sampling_params.skip_special_tokens is False
+        assert sampling_params.spaces_between_special_tokens is True

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -3788,7 +3788,11 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         assert parser.eot_token == self.EOT
 
     def test_undefined_tool(self, sample_tools, parser, tool_parser_test_cases):
-        """Keep undefined-tool calls at their positional index."""
+        """Keep undefined-tool calls at their positional index.
+
+        K3 warns about undefined tools rather than remapping ``tool_index`` to
+        ``-1``.
+        """
         text = tool_parser_test_cases.undefined_tool
 
         result = parser.detect_and_parse(text, sample_tools)
@@ -3798,7 +3802,11 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         assert result.calls[0].tool_index == 0
 
     def test_supports_structural_tag(self):
-        """Reject JSON-schema structural tagging for XTML bodies."""
+        """Reject JSON-schema structural tagging for XTML bodies.
+
+        XTML bodies already use tag-structured text, so JSON-schema
+        structural-tag constrained decoding does not apply.
+        """
         parser = KimiK3ToolParser()
         assert parser.supports_structural_tag() is False
         with pytest.raises(NotImplementedError):
@@ -3832,7 +3840,10 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
 
     def test_argument_invalid_json_falls_back_to_raw(self, sample_tools,
                                                      parser):
-        """Keep a non-string argument's invalid JSON body as raw text."""
+        """Keep a non-string argument's invalid JSON body as raw text.
+
+        Invalid JSON should fall back to its original text instead of raising.
+        """
         text = self._section(
             self._call("get_weather", 1,
                        self._argument("count", "number", "not-a-number")))
@@ -3844,7 +3855,10 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         }
 
     def test_attribute_unescaping(self, sample_tools, parser):
-        """Unescape encoded XTML attribute values."""
+        """Unescape encoded XTML attribute values.
+
+        K3 attributes arrive escaped by ``encoding_k3._escape_attr_value``.
+        """
         text = self._section(
             self._call(
                 "get_weather", 1,
@@ -3864,7 +3878,10 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         assert result.calls[0].parameters == "{}"
 
     def test_trailing_structural_markup_stripped(self, sample_tools, parser):
-        """Strip trailing XTML terminators from standalone normal text."""
+        """Strip trailing XTML terminators from standalone normal text.
+
+        This covers parsing without a tools section or reasoning parser.
+        """
         text = "The answer is 4.<|close|>message<|sep|><|end_of_msg|>"
 
         result = parser.detect_and_parse(text, sample_tools)
@@ -3874,7 +3891,11 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
 
     def test_streaming_buffers_section_until_complete(self, sample_tools,
                                                       parser):
-        """Buffer an incomplete tools section while streaming response text."""
+        """Buffer an incomplete tools section while streaming response text.
+
+        Response text is emitted immediately, but calls wait for the closing
+        ``<|close|>tools<|sep|>`` marker.
+        """
         result = parser.parse_streaming_increment("Checking. ", sample_tools)
         assert result.normal_text == "Checking. "
         assert result.calls == []
@@ -3901,7 +3922,11 @@ class TestKimiK3ToolParser(BaseToolParserTestClass):
         assert json.loads(result.calls[0].parameters) == {"location": "NYC"}
 
     def test_composes_with_kimi_k3_reasoning_parser(self, sample_tools, parser):
-        """Parse tools passed through the Kimi-K3 reasoning parser."""
+        """Parse tools passed through the Kimi-K3 reasoning parser.
+
+        The reasoning parser preserves the tools section verbatim for this
+        parser.
+        """
         from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
 
         completion = (


### PR DESCRIPTION
[None][fix] Preserve compact Kimi-K3 special tokens

Root cause:
Kimi-K3 emits compact control syntax such as:
`<|open|>tools<|sep|>`
The server already set:
`sampling_params.skip_special_tokens = False`
That preserved the control tokens, but detokenization still inserted spaces:
`<|open|> tools <|sep|>`
The Kimi-K3 parser expects the checkpoint’s compact XTML grammar, so it did not recognize the spaced form. Consequently, XTML leaked into ordinary text and no OpenAI tool_calls object was produced.

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
