### PR TITLE
[https://nvbugs/6529626][fix] Pin mcp<2.0.0 and unwaive the scaffolding tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ jinja2 # required for MinimaxM3 MSA
 plotly
 numexpr
 partial_json_parser
-mcp
+mcp<2.0.0 # 2.0.0 removed mcp.server.fastmcp; scaffolding still uses the 1.x APIs
 apache-tvm-ffi==0.1.6 # used for reduce nvidia-cutlass-dsl host overhead
 torch-c-dlpack-ext==0.1.3 # used for reduce nvidia-cutlass-dsl host overhead, optional package for improved torch tensor calling perf
 flash-attn-4==4.0.0b11

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -182,7 +182,6 @@ full:B300/disaggregated/test_disaggregated.py::test_disaggregated_ctxpp2_genpp2[
 full:B300/test_e2e.py::test_qwen_e2e_cpprunner_large_new_tokens[DeepSeek-R1-Distill-Qwen-1.5B-DeepSeek-R1-Distill-Qwen-1.5B] SKIP (https://nvbugs/6414760)
 full:DGX_B200/accuracy/test_disaggregated_serving.py::TestQwen3NextInstruct::test_auto_dtype[use_py_transceiver=True] SKIP (https://nvbugs/6501837)
 full:DGX_B200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV4ProDSpark::test_gsm8k_dep8_megamoe_deepgemm SKIP (https://nvbugs/6506920)
-full:DGX_H100/unittest/scaffolding SKIP (https://nvbugs/6529626)
 full:DGX_H200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[disable_skip_indexer] SKIP (https://nvbugs/6476233)
 full:DGX_H200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[latency_default] SKIP (https://nvbugs/6476233)
 full:GB200/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_auto_dtype[False-True-True-True] SKIP (https://nvbugs/6525893)


### PR DESCRIPTION
Fixes https://nvbugs/6529626

## What broke

`mcp` was unpinned at `requirements.txt:80`. **mcp 2.0.0**, published **2026-07-28 13:45 UTC**, removed `mcp.server.fastmcp`:

| version | files under `mcp/server/fastmcp/` |
|---|---|
| 1.29.0 | 19 |
| 2.0.0 | **0** |

`tests/unittest/scaffolding/test_mcp_worker.py` imports it at module level, so any image built after that timestamp fails while pytest is *collecting* the file.

## Why one broken import takes out an entire stage

A collection error is not a test failure. pytest reports `Interrupted: 1 error during collection` and exits **2** before running anything:

- the other **seven** files in `tests/unittest/scaffolding` never execute;
- **no JUnit XML is written at all**, because the run dies before `--periodic-junit-xmlpath` is honoured.

That is why this surfaces only as the outer wrapper's `assert passed, "failure reported in unittests"`, with no inner test named anywhere in the archived stage results — the failing import is visible only in the stage's raw `stdout.log`.

It also cannot be waived. `apply_waives` (`tests/integration/defs/test_list_parser.py`) and `apply_waives_ut` (`tests/unittest/conftest.py`) both run inside `pytest_collection_modifyitems` and add skip markers to **collected items**; a module that fails to import produces none. The only waive that works is the directory-level one against the `test_unittests_v2[unittest/scaffolding]` wrapper (#16978), which suppresses all eight files to silence one.

## Why pin rather than skip the test

`tensorrt_llm/scaffolding/worker.py` and `tensorrt_llm/scaffolding/contrib/mcp/mcp_utils.py` both ship against the 1.x API, and `test_mcp_worker.py` is the only CI coverage that exercises `MCPWorker` against the installed `mcp`. Guarding the test with `importorskip` would have dropped that coverage precisely when the dependency took a major version bump — hiding a library-level risk instead of resolving it.

Note the library's own imports (`from mcp import ClientSession`, `from mcp.client.sse import sse_client`) do still resolve under 2.0.0, so this is not an immediate import break in `tensorrt_llm/`; the point is that the 2.x behaviour is unverified, and the pin keeps the shipped code and its coverage on the version they were written against.

Lifting the pin means migrating the library off the 1.x APIs first, not just the test.

## Unwaiving

#16978 waived the whole `unittest/scaffolding` directory as an interim unblock, because the collection error could not be waived at test granularity. With the pin in place that error is gone, so this change removes the waive in the same commit — leaving it would keep all eight scaffolding files skipped indefinitely for a cause that no longer exists.

```diff
-full:DGX_H100/unittest/scaffolding SKIP (https://nvbugs/6529626)
```

This also means the run on this PR is a direct test of the fix: if the pin did not work, `unittest/scaffolding` will fail here rather than being silently skipped.

## Scope

`unittest/scaffolding` runs on **H100 only** — `l0_h100.yml:116` is the sole test-db entry, in a block gated on `orchestrator: mpi`, `stage: pre_merge`. `mcp<2.0.0` resolves to 1.29.0, which ships `mcp/server/fastmcp/` intact. This is the only `mcp` declaration in the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**

- Pinned `mcp` in `requirements.txt` to `mcp<2.0.0` (with an inline note that `mcp==2.0.0` removed `mcp.server.fastmcp`, while the scaffolding code still relies on the 1.x API).
- Change is narrowly scoped to dependency resolution to avoid pytest collection failures caused by the removed import; no other code or behavioral logic was modified.
- The follow-on issue (“migration to standalone `fastmcp`”) is still not addressed, but this unblocks existing MCP-based scaffolding tests.

**QA Engineer Review**

- Updated `tests/integration/test_lists/waives.txt`:
  - Removed the waiver entry for `full:DGX_H100/unittest/scaffolding` (SKIP reference to `nvbugs/6529626`).
- Verdict: needs follow-up (CBTS/coverage status for the scaffolding/test list change wasn’t provided).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->