### PR TITLE
[None][test] Enable overlap scheduler in the remaining perf sanity configs

### DIFF
--- a/tests/integration/defs/perf/pytorch_model_config.py
+++ b/tests/integration/defs/perf/pytorch_model_config.py
@@ -129,7 +129,7 @@ def get_model_yaml_config(model_label: str,
                     'free_gpu_memory_fraction': 0.5,
                 },
                 'enable_chunked_prefill': False,
-                'disable_overlap_scheduler': True,
+                'disable_overlap_scheduler': False,
                 'custom_tokenizer': 'deepseek_v4',
                 'speculative_config': {
                     'decoding_type':
@@ -465,7 +465,7 @@ def get_model_yaml_config(model_label: str,
             ],
             'config': {
                 'enable_attention_dp': False,
-                'disable_overlap_scheduler': True,
+                'disable_overlap_scheduler': False,
                 'enable_autotuner': False,
                 'cuda_graph_config': {
                     'enable_padding': True,

--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -1931,8 +1931,9 @@ class PerfSanityTestConfig:
             ctx_config = dict(worker_config.get("ctx", {}))
             # Ignore cache_transceiver_config for ctx_only
             ctx_config.pop("cache_transceiver_config", None)
-            # Disable overlap scheduler for ctx_only
-            ctx_config["disable_overlap_scheduler"] = True
+            # The overlap scheduler setting is taken from the ctx worker config
+            # so that ctx_only measures the same scheduler path the ctx worker
+            # uses in e2e. ServerConfig defaults it to False when unset.
 
             # Create server config for ctx_only (single ServerConfig, not tuple)
             ctx_server_config_data = {

--- a/tests/scripts/perf-sanity/aggregated/dynamo_deepseek_v32_fp4_2_nodes_grace_blackwell.yaml
+++ b/tests/scripts/perf-sanity/aggregated/dynamo_deepseek_v32_fp4_2_nodes_grace_blackwell.yaml
@@ -21,7 +21,7 @@ server_configs:
     attn_backend: "TRTLLM"
     enable_attention_dp: true
     enable_chunked_prefill: true
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     allreduce_strategy: MNNVL
     num_postprocess_workers: 8
     print_iter_log: true

--- a/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -65,7 +65,7 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 1
@@ -94,5 +94,5 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,7 +62,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 3
@@ -90,5 +90,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/b200_deepseek-r1-fp4_8k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -64,7 +64,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 1
@@ -92,5 +92,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -65,7 +65,7 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 1
@@ -93,5 +93,5 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_128k8k_con1_ctx1_pp8_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_128k8k_con1_ctx1_pp8_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,7 +62,7 @@ worker_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 3
@@ -90,5 +90,5 @@ worker_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -64,7 +64,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 3
@@ -92,5 +92,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,7 +62,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 3
@@ -91,5 +91,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -64,7 +64,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 1
@@ -92,5 +92,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -66,7 +66,7 @@ worker_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 3
@@ -104,5 +104,5 @@ worker_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
@@ -71,7 +71,7 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 1
@@ -109,5 +109,5 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -67,7 +67,7 @@ worker_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 3
@@ -104,5 +104,5 @@ worker_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -84,7 +84,7 @@ worker_config:
     max_num_tokens: 8192
     max_seq_len: 121000
     enable_chunked_prefill: true
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     cuda_graph_config:
       enable_padding: true
       max_batch_size: 32

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
@@ -68,7 +68,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 3
@@ -103,5 +103,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,7 +63,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       max_draft_len: 3
@@ -99,5 +99,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
@@ -68,7 +68,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
     nvfp4_gemm_config:
@@ -100,4 +100,4 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -103,6 +103,6 @@ worker_config:
       max_tokens_in_buffer: 9216
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con128_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con128_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -63,7 +63,7 @@ worker_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
   ctx:
@@ -88,4 +88,4 @@ worker_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -63,7 +63,7 @@ worker_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
   ctx:
@@ -88,4 +88,4 @@ worker_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
@@ -67,7 +67,7 @@ worker_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
   ctx:
@@ -92,4 +92,4 @@ worker_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false

--- a/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL.yaml
@@ -67,7 +67,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: Eagle
       max_draft_len: 3
@@ -98,6 +98,6 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml
@@ -65,7 +65,7 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     trust_remote_code: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -92,5 +92,5 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,7 +62,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: Eagle
       max_draft_len: 3
@@ -94,6 +94,6 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_qwen3-235b-fp4_8k1k_con1024_ctx1_tp1_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_qwen3-235b-fp4_8k1k_con1024_ctx1_tp1_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -63,7 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32768
       backend: NIXL
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
   ctx:
@@ -86,4 +86,4 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32768
       backend: NIXL
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false

--- a/tests/scripts/perf-sanity/disaggregated/gb200_qwen3-235b-fp4_8k1k_con1_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_qwen3-235b-fp4_8k1k_con1_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL.yaml
@@ -62,7 +62,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32768
       backend: NIXL
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
   ctx:
@@ -85,4 +85,4 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32768
       backend: NIXL
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false

--- a/tests/scripts/perf-sanity/disaggregated/gb200_qwen3-235b-fp4_8k1k_con64_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_qwen3-235b-fp4_8k1k_con64_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL.yaml
@@ -61,7 +61,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32768
       backend: NIXL
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
   ctx:
@@ -84,4 +84,4 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 32768
       backend: NIXL
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con1_ctx1_pp4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con1_ctx1_pp4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,7 +63,7 @@ worker_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 3
@@ -91,5 +91,5 @@ worker_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL.yaml
@@ -65,7 +65,7 @@ worker_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 1
@@ -92,5 +92,5 @@ worker_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con64_ctx1_pp4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_128k8k_con64_ctx1_pp4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -65,7 +65,7 @@ worker_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 1
@@ -92,5 +92,5 @@ worker_config:
       max_tokens_in_buffer: 131104
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -64,7 +64,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 3
@@ -92,5 +92,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,7 +62,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 3
@@ -91,5 +91,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml
@@ -63,7 +63,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 1
@@ -90,5 +90,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -66,7 +66,7 @@ worker_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 3
@@ -104,5 +104,5 @@ worker_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL.yaml
@@ -71,7 +71,7 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 1
@@ -109,5 +109,5 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -67,7 +67,7 @@ worker_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 3
@@ -104,5 +104,5 @@ worker_config:
       max_tokens_in_buffer: 32832
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL.yaml
@@ -85,7 +85,7 @@ worker_config:
     max_num_tokens: 8192
     max_seq_len: 121000
     enable_chunked_prefill: true
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     cuda_graph_config:
       enable_padding: true
       max_batch_size: 32

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL.yaml
@@ -68,7 +68,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 3
@@ -103,5 +103,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,7 +63,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 3
@@ -99,5 +99,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml
@@ -68,7 +68,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
     nvfp4_gemm_config:
@@ -100,4 +100,4 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL.yaml
@@ -101,5 +101,5 @@ worker_config:
       kv_transfer_timeout_ms: 600000
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL.yaml
@@ -168,5 +168,5 @@ worker_config:
       kv_transfer_timeout_ms: 600000
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL.yaml
@@ -101,5 +101,5 @@ worker_config:
       kv_transfer_timeout_ms: 600000
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -103,5 +103,5 @@ worker_config:
       kv_transfer_timeout_ms: 600000
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con1024_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con1024_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL.yaml
@@ -68,7 +68,7 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 1
@@ -97,5 +97,5 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_transfer_timeout_ms: 600000
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con1_ctx1_dep2_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con1_ctx1_dep2_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -62,7 +62,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 3
@@ -91,5 +91,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml
@@ -64,7 +64,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: MTP
       num_nextn_predict_layers: 3
@@ -92,5 +92,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001

--- a/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL.yaml
@@ -67,7 +67,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: Eagle
       max_draft_len: 3
@@ -98,6 +98,6 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml
@@ -64,7 +64,7 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     trust_remote_code: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -90,5 +90,5 @@ worker_config:
       max_tokens_in_buffer: 16384
       backend: NIXL
       transceiver_runtime: PYTHON
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     trust_remote_code: true

--- a/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb300_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL.yaml
@@ -63,7 +63,7 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_cache_bounce_size_mb: 384
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: &id001
       decoding_type: Eagle
       max_draft_len: 3
@@ -96,6 +96,6 @@ worker_config:
       backend: NIXL
       transceiver_runtime: PYTHON
       kv_cache_bounce_size_mb: 384
-    disable_overlap_scheduler: true
+    disable_overlap_scheduler: false
     speculative_config: *id001
     trust_remote_code: true


### PR DESCRIPTION
## Summary

PR #17390 ("Enable overlap schedule on qa side for disagg perf") re-enabled the overlap scheduler across the disaggregated perf sanity YAMLs. Despite its title it touched **both** trees — 64 files in `tests/scripts/perf/` and **90 files in `tests/scripts/perf-sanity/`** — flipping 278 lines `true` → `false` on ctx and gen alike.

That **supersedes this PR's original diff entirely** (all 48 files it changed are now already `false` on main), so this branch has been reset onto latest main and repurposed to close the four places #17390 missed. Those four sit outside the disagg YAMLs and still force the scheduler off, so the cases they drive keep measuring a runtime path nothing else exercises any more.

## Changes

| File | Site | Why |
|---|---|---|
| `tests/integration/defs/perf/pytorch_model_config.py` | `deepseek_v4_pro_dspark` | Aggregated bench config, still pinned on. |
| `tests/integration/defs/perf/pytorch_model_config.py` | `gpt_oss_120b_eagle3_throughput-bench-pytorch` | Its latency sibling `gpt_oss_120b_eagle3-bench-pytorch` already ran with the scheduler **enabled** — the two variants disagreed. |
| `tests/integration/defs/perf/test_perf_sanity.py` | `ctx_only` mode override | **Prefill side.** The mode overwrote the flag with `True` *after* reading the ctx worker config, silently defeating the ctx entries #17390 had just flipped. |
| `tests/scripts/perf-sanity/aggregated/dynamo_deepseek_v32_fp4_2_nodes_grace_blackwell.yaml` | `disable_overlap_scheduler` | Last file under `tests/scripts/perf-sanity/` still on `true`. |

### On the `ctx_only` override

The override is **removed** rather than set to `False`. Forcing it either way defeats the config file; `ServerConfig` already defaults the flag to `False` when absent (`test_perf_sanity.py:494`), so:

- configs that omit the key — unchanged,
- configs set to `false` (all non-QA disagg configs after #17390) — now actually run with overlap enabled in `ctx_only`,
- a config that deliberately sets `true` — keeps its setting instead of being clobbered.

## Reviewer notes

1. **The Dynamo file is a deliberate replica.** Its header points at an upstream Dynamo recipe. I flipped it because `disable_overlap_scheduler` is a TRT-LLM runtime knob rather than part of the model/accuracy setup being replicated — but if the intent is to track that recipe verbatim, say so and I'll drop this one line.
2. **Stragglers remain on the QA side, out of scope here.** Five configs under `tests/scripts/perf/` still have `ctx: disable_overlap_scheduler: true`. Four of them *were* touched by #17390 (its diff flipped their `gen` but missed their `ctx`); one (`gb200_gpt-oss-120b-fp4_8k1k_con1024_...`) it never touched. Listed for whoever owns the QA tree:
   - `gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL.yaml`
   - `gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml`
   - `gb300_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL.yaml`
   - `gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL.yaml`
   - `gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml`

## Perf impact

These cases will re-baseline in OpenSearch, exactly as the disaggregated cases did after #17390. The affected stages do not gate on perf regression, so no thresholds change.

## Test Coverage

Local functional check on GB300 DeepSeek-V4-Pro disagg perf sanity configs (see comments).

## PR Checklist

- [x] PR title has the format `[JIRA/NVBugs/GitHub issue/None][type] Summary`
- [x] Commit messages are signed off (DCO)
- [x] `pre-commit run` passes on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Updated active performance-sanity configurations to set `disable_overlap_scheduler: false` for context and generation workers.
- Updated the DeepSeek V4 Pro DSpark and GPT-OSS 120B Eagle3 throughput configurations.
- Preserved the 42 unreferenced configurations.
- Removed the forced scheduler override from `ctx_only` parsing. The setting now uses the context worker configuration and defaults to `False` through `ServerConfig`.
- The changes match the recommended runtime setting and existing `LlmArgs` defaults.
- No API or public entity changes were identified.
- No test-list files were modified.
- Configuration values use valid YAML booleans and have no reported scope or consistency issues.

## QA Engineer Review

- Modified test code in `tests/integration/defs/perf/test_perf_sanity.py`.
- Modified performance configuration definitions and YAML files.
- The `ctx_only` configuration parsing logic was modified. No test function was added, removed, or explicitly renamed.
- No corresponding `test-db/` or `qa/` test-list entry was reported.
- Verdict: needs follow-up. Historical OpenSearch performance baselines must be re-established after merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->