### PR TITLE
[None][fix] Fix Backend's CUDA graph pool handle lifetime

### DIFF
--- a/tensorrt_llm/_torch/compilation/backend.py
+++ b/tensorrt_llm/_torch/compilation/backend.py
@@ -42,8 +42,6 @@ from .remove_copy_pass import remove_copy_for_mutates_args
 
 class Backend:
 
-    _graph_pool_handle: tuple[int, int] = None
-
     # Following classes are used to let weakref ref the stream and eventlist objects.
     class Streams(list):
         pass
@@ -78,8 +76,12 @@ class Backend:
         self.events = Backend.Events()
         inductor_config.enable_auto_functionalized_v2 = False
 
-        if Backend._graph_pool_handle is None:
-            Backend._graph_pool_handle = torch.cuda.graph_pool_handle()
+        # Per-instance pool: the decode CUDA graph runner borrows this handle
+        # (PyTorchModelEngine._cuda_graph_mem_pool), so its lifetime must not
+        # outlive this backend. _release_cuda_graphs() resets every graph that
+        # allocated from the pool, which drops the allocator's use_count for it
+        # to 0.
+        self._graph_pool_handle = torch.cuda.graph_pool_handle()
 
         self.match_count = []
         self.match_count_by_pass = OrderedDict()


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Backend._graph_pool_handle is a class attribute, created once per process and never reset. With torch.compile on, the decode CUDA graph runner uses it, but on engine teardown _release_cuda_graphs() resets the graphs, dropping the pool's use_count to 0, creating danling handle in Backend. If a second engine is built in the same process — e.g. pytest reusing the MPI worker pool across cases — it passes that dead pool id to graph capture and trips use_count > 0 INTERNAL ASSERT FAILED.

Fix: make the handle per-instance, so each engine starts from a fresh pool. Sharing within one engine is unchanged. Verified on 4×H100: the full test_fp8_4gpus sweep in one pytest process now passes, GSM8K accuracy unchanged.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- pytest TestLlama3_1_8BInstruct::test_fp8_4gpus should pass despite reusing same session.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
