### PR TITLE
[https://nvbugs/6210714][test] Unwaive TestQwen3_5_35B_A3B fp8 block reuse test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -98,7 +98,6 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_fp8[latency] SKIP (h
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_fp8[throughput_latency] SKIP (https://nvbugs/6177390)
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_trtllm] SKIP (https://nvbugs/6402009)
 accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[dep4_latency_moe_trtllm-torch_compile=False] SKIP (https://nvbugs/6507110)
-accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8[enable_block_reuse=True] SKIP (https://nvbugs/6210714)
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_397B_A17B::test_nvfp4[tep4_cutedsl] SKIP (https://nvbugs/6255417)
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_397B_A17B::test_nvfp4_4gpus_static_eplb[moe_backend=TRTLLM] SKIP (https://nvbugs/6418830)
 accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_bf16[latency] SKIP (https://nvbugs/6412098)


### PR DESCRIPTION
## Description

Unwaive `accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8[enable_block_reuse=True]`.

The issue tracked by https://nvbugspro.nvidia.com/bug/6210714 is no longer reproducible, so the corresponding SKIP entry is removed from `tests/integration/test_lists/waives.txt`.

## Test Coverage

The unwaived test itself provides the coverage; it now runs in CI again.

## PR Checklist

- [x] PR title follows `[JIRA/NVBUG/None][type] description` format
- [x] Commit is signed off (DCO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Removed the single waiver for `TestQwen3_5_35B_A3B::test_fp8[enable_block_reuse=True]` associated with NVBug 6210714.
- The change is correctly scoped to `tests/integration/test_lists/waives.txt`, with no code or public API changes.
- Test-list format and entry removal are consistent; no duplicate or unintended entries were introduced.

## QA Engineer Review

- No `test-db/` or `qa/` files were modified, and no test functions were changed.
- The previously waived test will run in CI again.
- Verdict: needs follow-up pending CBTS coverage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->