### PR TITLE
[None][fix] Fix mmha generation workspace calculation

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -973,36 +973,41 @@ size_t AttentionOp::getWorkspaceSizeForGeneration(tensorrt_llm::DataType type, i
     }
 
     size_t generation_workspace_size = 0;
-    // The minimum number of sequence length tiles (limited by the shared memory size).
-    int minSeqLenTile
-        = estimate_min_multi_block_count(max_attention_window_size, mMaxSharedMemoryPerBlockOptin - 2048, size);
-    int32_t const maxSeqLenTile
-        = std::max({minSeqLenTile, getMaxNumSeqLenTile(batch_beam), (int) tc::divUp(mMultiProcessorCount, mNumHeads)});
-
-    size_t const partial_out_size = size * batch_beam * mNumHeads * mHeadSize * maxSeqLenTile;
-    size_t const partial_sum_size = sizeof(float) * batch_beam * mNumHeads * maxSeqLenTile;
-    size_t const partial_max_size = sizeof(float) * batch_beam * mNumHeads * maxSeqLenTile;
-    size_t const shift_k_cache_size = (!mPosShiftEnabled || isCrossAttention())
-        ? 0
-        : size * batch_beam * mNumHeads * mHeadSize * max_attention_window_size;
-    size_t const cpMaxPaddedSequenceLength = (batch_beam + mCpSize - 1) / mCpSize * mCpSize;
-    size_t const cpWorkspaceSize
-        = mCpSize == 1 ? 0 : (2 * size * cpMaxPaddedSequenceLength * getHeadSize() * (mNumHeads + 2 * mNumKVHeads));
-
-    AttentionGenerationWorkspaceSizes generationWorkspaceSizes{};
-    generationWorkspaceSizes.cpWorkspace = cpWorkspaceSize;
-    generationWorkspaceSizes.partialOut = partial_out_size;
-    generationWorkspaceSizes.partialSum = partial_sum_size;
-    generationWorkspaceSizes.partialMax = partial_max_size;
-    generationWorkspaceSizes.shiftKCache = shift_k_cache_size;
+    if (!mIsMLAEnabled)
     {
-        auto const cascadeSizes
-            = tensorrt_llm::kernels::mmha::cascade::getCascadeWorkspaceSizes(batch_beam, mNumHeads, mHeadSize);
-        generationWorkspaceSizes.cascadeOut = cascadeSizes.out;
-        generationWorkspaceSizes.cascadeMax = cascadeSizes.mMax;
-        generationWorkspaceSizes.cascadeSum = cascadeSizes.lSum;
+        // MLA generation uses dedicated kernels and does not consume the MMHA generation workspace.
+        // The minimum number of sequence length tiles (limited by the shared memory size).
+        int const minSeqLenTile
+            = estimate_min_multi_block_count(max_attention_window_size, mMaxSharedMemoryPerBlockOptin - 2048, size);
+        int32_t const maxSeqLenTile = std::max({minSeqLenTile, getMaxNumSeqLenTile(batch_beam),
+            static_cast<int>(tc::divUp(mMultiProcessorCount, mNumHeads))});
+
+        size_t const partial_out_size = size * batch_beam * mNumHeads * mHeadSize * maxSeqLenTile;
+        size_t const partial_sum_size = sizeof(float) * batch_beam * mNumHeads * maxSeqLenTile;
+        size_t const partial_max_size = sizeof(float) * batch_beam * mNumHeads * maxSeqLenTile;
+        size_t const shift_k_cache_size = (!mPosShiftEnabled || isCrossAttention())
+            ? 0
+            : size * batch_beam * mNumHeads * mHeadSize * max_attention_window_size;
+        size_t const cpMaxPaddedSequenceLength = (batch_beam + mCpSize - 1) / mCpSize * mCpSize;
+        size_t const cpWorkspaceSize
+            = mCpSize == 1 ? 0 : (2 * size * cpMaxPaddedSequenceLength * getHeadSize() * (mNumHeads + 2 * mNumKVHeads));
+
+        AttentionGenerationWorkspaceSizes generationWorkspaceSizes{};
+        generationWorkspaceSizes.cpWorkspace = cpWorkspaceSize;
+        generationWorkspaceSizes.partialOut = partial_out_size;
+        generationWorkspaceSizes.partialSum = partial_sum_size;
+        generationWorkspaceSizes.partialMax = partial_max_size;
+        generationWorkspaceSizes.shiftKCache = shift_k_cache_size;
+        {
+            auto const cascadeSizes
+                = tensorrt_llm::kernels::mmha::cascade::getCascadeWorkspaceSizes(batch_beam, mNumHeads, mHeadSize);
+            generationWorkspaceSizes.cascadeOut = cascadeSizes.out;
+            generationWorkspaceSizes.cascadeMax = cascadeSizes.mMax;
+            generationWorkspaceSizes.cascadeSum = cascadeSizes.lSum;
+        }
+        generation_workspace_size
+            = AttentionWorkspaceManager::buildGenerationLayout(generationWorkspaceSizes).totalSize;
     }
-    generation_workspace_size = AttentionWorkspaceManager::buildGenerationLayout(generationWorkspaceSizes).totalSize;
 
     size_t xqa_workspace_size = 0;
     if (mEnableXQA)

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -404,7 +404,8 @@ public:
         // is not enough.
         // The attention kernel might split the heads into multiple blocks, so we might need to reserve more semaphores.
         // Use mMultiProcessorCount as the lower-bound to make sure we reserve enough semaphores.
-        op.reserveSemaphoreArray(std::max(op.mNumHeads * max_num_requests, op.getMultiProcessorCount()));
+        int32_t const maxNumSequences = max_num_requests * beam_width;
+        op.reserveSemaphoreArray(std::max(op.mNumHeads * maxNumSequences, op.getMultiProcessorCount()));
     }
 
     int64_t getWorkspaceSize(AttentionOp const& op, int const num_tokens, int const max_attention_window_size,
@@ -412,8 +413,9 @@ public:
     {
         size_t const context_workspace_size = op.getWorkspaceSizeForContext(
             op.mType, max_num_requests, op.mMaxContextLength, 0, num_tokens, ctx_total_kv_len);
+        int32_t const maxNumSequences = max_num_requests * beam_width;
         size_t const generation_workspace_size = op.getWorkspaceSizeForGeneration(
-            op.mType, max_num_requests, max_attention_window_size, num_gen_tokens, max_blocks_per_sequence);
+            op.mType, maxNumSequences, max_attention_window_size, num_gen_tokens, max_blocks_per_sequence);
 
         return std::max(context_workspace_size, generation_workspace_size);
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Fixed MMHA generation workspace sizing to account for `num_requests * beam_size`, including semaphore reservation and workspace estimation.
- Avoided unnecessary MMHA-generation workspace allocation when MLA is enabled.
- Changes are localized and preserve public APIs. No configuration or test-list files were modified.
- Recommend validating decode workspace bounds across beam sizes and MLA/non-MLA paths.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

During review of #16929 I discovered a possible attention decode workspace OOB issue. It's due to passing `num_requests` instead of `num_requests * beam_size` during workspace calculation. The PR fixed this, and also changed calculation of workspace for MLA to avoid allocating unnecessary memory.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
