### PR TITLE
[TRTLLM-14555][fix] Map offset VAE halo peers to global ranks

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/modules/vae/conv.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/vae/conv.py
@@ -255,6 +255,14 @@ class HaloExchangeConv2dStride2(nn.Module):
         else:
             raise ValueError(f"chunk_dim={chunk_dim} not supported for stride-2")
 
+    def _adj_group(self, index: int) -> dist.ProcessGroup:
+        group = self.adj_groups[index]
+        if group is None:
+            raise RuntimeError(
+                f"Missing VAE adjacent process group {index} for local rank {self.rank}"
+            )
+        return group
+
     def _recv_from_right(self, x: torch.Tensor) -> torch.Tensor:
         """Receive halo context from the right neighbor.
 
@@ -270,24 +278,15 @@ class HaloExchangeConv2dStride2(nn.Module):
         right_context = None
         if self.rank != self.world_size - 1:
             right_context = torch.zeros_like(send_left)
-            right_group = self.adj_groups[self.rank]
-            if right_group is None:
-                raise RuntimeError(
-                    f"Missing VAE adjacent process group {self.rank} for local rank {self.rank}"
-                )
+            right_group = self._adj_group(self.rank)
             right_global_rank = dist.get_global_rank(right_group, 1)
             dist.recv(right_context, src=right_global_rank, group=right_group)
         if self.rank != 0:
-            left_group = self.adj_groups[self.rank - 1]
-            if left_group is None:
-                raise RuntimeError(
-                    f"Missing VAE adjacent process group {self.rank - 1} for local rank {self.rank}"
-                )
+            left_group = self._adj_group(self.rank - 1)
             left_global_rank = dist.get_global_rank(left_group, 0)
             dist.send(send_left, dst=left_global_rank, group=left_group)
 
-        if self.rank != self.world_size - 1:
-            assert right_context is not None
+        if right_context is not None:
             # Match the halo slice's layout to ``x`` so the cat preserves
             # channels-last (see ``_spatial_channels_last_format``).
             mf = _spatial_channels_last_format(x)

--- a/tensorrt_llm/_torch/visual_gen/modules/vae/conv.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/vae/conv.py
@@ -267,13 +267,27 @@ class HaloExchangeConv2dStride2(nn.Module):
         dim = self.chunk_dim
         send_left = torch.narrow(x, dim, 0, self.halo_left).contiguous()
 
+        right_context = None
         if self.rank != self.world_size - 1:
             right_context = torch.zeros_like(send_left)
-            dist.recv(right_context, src=self.rank + 1)
+            right_group = self.adj_groups[self.rank]
+            if right_group is None:
+                raise RuntimeError(
+                    f"Missing VAE adjacent process group {self.rank} for local rank {self.rank}"
+                )
+            right_global_rank = dist.get_global_rank(right_group, 1)
+            dist.recv(right_context, src=right_global_rank, group=right_group)
         if self.rank != 0:
-            dist.send(send_left, dst=self.rank - 1)
+            left_group = self.adj_groups[self.rank - 1]
+            if left_group is None:
+                raise RuntimeError(
+                    f"Missing VAE adjacent process group {self.rank - 1} for local rank {self.rank}"
+                )
+            left_global_rank = dist.get_global_rank(left_group, 0)
+            dist.send(send_left, dst=left_global_rank, group=left_group)
 
         if self.rank != self.world_size - 1:
+            assert right_context is not None
             # Match the halo slice's layout to ``x`` so the cat preserves
             # channels-last (see ``_spatial_channels_last_format``).
             mf = _spatial_channels_last_format(x)

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Multi-GPU tests for parallel convolution wrappers.
 
 Tests HaloExchangeConv (stride-1) and HaloExchangeConv2dStride2 (stride-2)
@@ -196,6 +199,42 @@ def _logic_halo_conv2d_stride2(rank, world_size):
         _gather_and_check(local_out, ref, chunk_dim, world_size, rank)
 
 
+def _logic_halo_conv2d_stride2_offset_group(rank, world_size):
+    """Stride-2 halo works when VAE-local ranks differ from global ranks."""
+    assert world_size == 4
+    vae_ranks = [2, 3]
+    vae_group = dist.new_group(vae_ranks)
+    adjacent_group = dist.new_group(vae_ranks)
+    if rank not in vae_ranks:
+        dist.barrier()
+        return
+
+    local_rank = vae_ranks.index(rank)
+    device = f"cuda:{rank}"
+    conv = nn.Conv2d(96, 96, kernel_size=3, stride=2, padding=0).to(device).float()
+    for parameter in conv.parameters():
+        dist.broadcast(parameter.data, src=vae_ranks[0], group=vae_group)
+
+    x = torch.randn((4, 96, 64, 48), dtype=torch.float32, device=device)
+    dist.broadcast(x, src=vae_ranks[0], group=vae_group)
+    reference = conv(nn.ZeroPad2d((0, 1, 0, 1))(x)).detach()
+    local_x = x.chunk(len(vae_ranks), dim=3)[local_rank]
+    parallel = HaloExchangeConv2dStride2(
+        conv,
+        chunk_dim=3,
+        adj_groups=[adjacent_group],
+        rank=local_rank,
+        world_size=len(vae_ranks),
+        pad_before_conv=(0, 1, 0, 1),
+    )
+    local_output = parallel(local_x).contiguous()
+    gathered = [torch.empty_like(local_output) for _ in vae_ranks]
+    dist.all_gather(gathered, local_output, group=vae_group)
+    output = torch.cat(gathered, dim=3)
+    assert torch.max(torch.abs(output - reference)).item() < 0.01
+    dist.barrier()
+
+
 class TestHaloExchangeConv:
     def test_wan_conv3d_with_cache_2gpu(self):
         _run(2, _logic_halo_conv3d)
@@ -207,6 +246,9 @@ class TestHaloExchangeConv:
 class TestHaloExchangeConv2dStride2:
     def test_conv2d_stride2_2gpu(self):
         _run(2, _logic_halo_conv2d_stride2)
+
+    def test_conv2d_stride2_offset_group_4gpu(self):
+        _run(4, _logic_halo_conv2d_stride2_offset_group)
 
 
 @pytest.mark.skipif(not MODULES_AVAILABLE, reason="Required modules not available")

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_conv.py
@@ -199,7 +199,7 @@ def _logic_halo_conv2d_stride2(rank, world_size):
         _gather_and_check(local_out, ref, chunk_dim, world_size, rank)
 
 
-def _logic_halo_conv2d_stride2_offset_group(rank, world_size):
+def _logic_halo_conv2d_stride2_offset_group(rank: int, world_size: int) -> None:
     """Stride-2 halo works when VAE-local ranks differ from global ranks."""
     assert world_size == 4
     vae_ranks = [2, 3]
@@ -247,7 +247,7 @@ class TestHaloExchangeConv2dStride2:
     def test_conv2d_stride2_2gpu(self):
         _run(2, _logic_halo_conv2d_stride2)
 
-    def test_conv2d_stride2_offset_group_4gpu(self):
+    def test_conv2d_stride2_offset_group_4gpu(self) -> None:
         _run(4, _logic_halo_conv2d_stride2_offset_group)
 
 


### PR DESCRIPTION
@coderabbitai summary

## Description

`HaloExchangeConv2dStride2` stores VAE ranks in subgroup-local rank space, but
its point-to-point halo exchange previously passed those local ranks to
`torch.distributed.send` and `recv` without a process group. PyTorch therefore
interpreted them as global ranks.

This happened to work when the VAE group occupied global ranks starting at
zero. For an offset VAE group such as global ranks `[2, 3]`, however, local VAE
rank 0 attempted to receive from global rank 1 instead of its actual neighbor,
global rank 3. Depending on the surrounding process topology, that can contact
the wrong peer or hang the decode.

This PR:

- selects and validates the adjacent two-rank process group for each halo edge;
- maps the peer's subgroup rank to its global rank with
  `torch.distributed.get_global_rank`; and
- passes the matching process group to `send` and `recv`.

The change is limited to distributed rank addressing. It does not change the
convolution, halo contents, public API, or behavior when local and global ranks
already coincide.

## Test Coverage

- Added
  `TestHaloExchangeConv2dStride2::test_conv2d_stride2_offset_group_4gpu`.
  It runs a two-rank VAE subgroup on global ranks `[2, 3]`, gathers its
  stride-2 halo-convolution output, and compares it with the unsharded
  convolution reference.
- Four-GPU NSC NCCL offset-subgroup parity passed in array job `1554035`
  (task 0).
- Repository pre-commit hooks and `git diff --check` pass.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] Test coverage is included for the new distributed-rank path.
- [x] No public API or dependency changes.
- [x] No CODEOWNERS, documentation, or architecture-diagram changes are needed.
