### PR TITLE
[TRTLLM-14798][perf] Fuse Wan DupUp3D output mapping

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
@@ -86,7 +86,26 @@ def dup_up3d(
     factor_s: int,
     first_chunk: bool,
 ) -> torch.Tensor | None:
-    """Write the shuffled output, or return ``None`` when Triton cannot index it."""
+    """Write the shuffled output directly in channels-last-3d format.
+
+    Args:
+        x: Five-dimensional CUDA tensor with shape ``[N, C, T, H, W]``.
+            The output preserves its dtype.
+        output_channels: Number of channels in the shuffled output.
+        repeats: Number of copies of each input channel before shuffling.
+        factor_t: Temporal pixel-shuffle factor.
+        factor_s: Spatial pixel-shuffle factor applied to height and width.
+        first_chunk: Whether to crop the leading ``factor_t - 1`` frames
+            produced by the cache-initializing temporal chunk.
+
+    Returns:
+        The shuffled CUDA tensor, or ``None`` when its size exceeds Triton's
+        signed 32-bit indexing limit and the caller must use the eager path.
+
+    Raises:
+        ValueError: If ``x`` is not a five-dimensional CUDA tensor or the
+            channel and shuffle factors are invalid.
+    """
     if x.dim() != 5:
         raise ValueError(f"DupUp3D expects a five-dimensional tensor, got shape {x.shape}")
     if not x.is_cuda:

--- a/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import math
+
 import torch
 import triton
 import triton.language as tl
@@ -19,6 +21,85 @@ _MAX_TRITON_INDEXED_ELEMENTS = 1 << 31
 def _supports_triton_indexing(output_elements: int) -> bool:
     """Return whether the output fits the kernel's signed 32-bit offsets."""
     return output_elements <= _MAX_TRITON_INDEXED_ELEMENTS
+
+
+def _validate_dup_up3d_contract(
+    x: torch.Tensor,
+    output_channels: int,
+    repeats: int,
+    factor_t: int,
+    factor_s: int,
+) -> None:
+    """Assert invariants supplied by the internal ``DupUp3D`` caller."""
+    assert x.dim() == 5, f"DupUp3D expects NCTHW input, got shape {x.shape}"
+    assert min(output_channels, repeats, factor_t, factor_s) >= 1
+    input_channels = x.shape[1]
+    factor = factor_t * factor_s * factor_s
+    assert input_channels * repeats == output_channels * factor
+
+
+def _dup_up3d_output_shape(
+    x: torch.Tensor,
+    output_channels: int,
+    factor_t: int,
+    factor_s: int,
+    first_chunk: bool,
+) -> tuple[int, int, int, int, int]:
+    batch, _, input_frames, input_height, input_width = x.shape
+    temporal_crop = factor_t - 1 if first_chunk else 0
+    return (
+        batch,
+        output_channels,
+        input_frames * factor_t - temporal_crop,
+        input_height * factor_s,
+        input_width * factor_s,
+    )
+
+
+def can_implement_dup_up3d(
+    x: torch.Tensor,
+    *,
+    output_channels: int,
+    repeats: int,
+    factor_t: int,
+    factor_s: int,
+    first_chunk: bool,
+) -> bool:
+    """Return whether the fused kernel supports this internal invocation.
+
+    Args:
+        x: Logical NCTHW input tensor.
+        output_channels: Number of logical output channels.
+        repeats: Number of channel copies before pixel shuffle.
+        factor_t: Temporal pixel-shuffle factor.
+        factor_s: Height and width pixel-shuffle factor.
+        first_chunk: Whether the cache-initializing temporal crop is required.
+
+    Returns:
+        ``True`` for a non-empty CUDA invocation whose output fits the kernel's
+        signed 32-bit indexing range; otherwise ``False``.
+    """
+    _validate_dup_up3d_contract(x, output_channels, repeats, factor_t, factor_s)
+    if not x.is_cuda or 0 in x.shape:
+        return False
+
+    output_shape = _dup_up3d_output_shape(
+        x,
+        output_channels,
+        factor_t,
+        factor_s,
+        first_chunk,
+    )
+    output_elements = math.prod(output_shape)
+    supported = _supports_triton_indexing(output_elements)
+    if not supported:
+        logger.warning_once(
+            "Fused DupUp3D output has %d elements, exceeding the Triton "
+            "signed 32-bit indexing limit; falling back to the eager implementation.",
+            output_elements,
+            key="wan_dup_up3d_int32_index_fallback",
+        )
+    return supported
 
 
 @triton.jit
@@ -85,12 +166,12 @@ def dup_up3d(
     factor_t: int,
     factor_s: int,
     first_chunk: bool,
-) -> torch.Tensor | None:
-    """Write the shuffled output directly in channels-last-3d format.
+) -> torch.Tensor:
+    """Write the shuffled logical NCTHW output in physical NTHWC order.
 
     Args:
-        x: Five-dimensional CUDA tensor with shape ``[N, C, T, H, W]``.
-            The output preserves its dtype.
+        x: Logical NCTHW CUDA tensor with shape ``[N, C, T, H, W]``. It may
+            have arbitrary non-overlapping strides, and its dtype is preserved.
         output_channels: Number of channels in the shuffled output.
         repeats: Number of copies of each input channel before shuffling.
         factor_t: Temporal pixel-shuffle factor.
@@ -99,48 +180,28 @@ def dup_up3d(
             produced by the cache-initializing temporal chunk.
 
     Returns:
-        The shuffled CUDA tensor, or ``None`` when its size exceeds Triton's
-        signed 32-bit indexing limit and the caller must use the eager path.
-
-    Raises:
-        ValueError: If ``x`` is not a five-dimensional CUDA tensor or the
-            channel and shuffle factors are invalid.
+        A logical NCTHW tensor stored in PyTorch ``channels_last_3d`` physical
+        order, which corresponds to NTHWC.
     """
-    if x.dim() != 5:
-        raise ValueError(f"DupUp3D expects a five-dimensional tensor, got shape {x.shape}")
-    if not x.is_cuda:
-        raise ValueError("Fused DupUp3D requires a CUDA tensor")
-    if min(output_channels, repeats, factor_t, factor_s) < 1:
-        raise ValueError("DupUp3D channels, repeats, and factors must be positive")
-
-    batch, input_channels, input_frames, input_height, input_width = x.shape
-    factor = factor_t * factor_s * factor_s
-    if input_channels * repeats != output_channels * factor:
-        raise ValueError(
-            "DupUp3D channel mapping is inconsistent: "
-            f"{input_channels=} * {repeats=} != {output_channels=} * {factor=}"
-        )
+    assert can_implement_dup_up3d(
+        x,
+        output_channels=output_channels,
+        repeats=repeats,
+        factor_t=factor_t,
+        factor_s=factor_s,
+        first_chunk=first_chunk,
+    )
 
     temporal_crop = factor_t - 1 if first_chunk else 0
-    output_frames = input_frames * factor_t - temporal_crop
-    output_height = input_height * factor_s
-    output_width = input_width * factor_s
-    output_shape = (
-        batch,
+    output_shape = _dup_up3d_output_shape(
+        x,
         output_channels,
-        output_frames,
-        output_height,
-        output_width,
+        factor_t,
+        factor_s,
+        first_chunk,
     )
-    output_elements = batch * output_channels * output_frames * output_height * output_width
-    if not _supports_triton_indexing(output_elements):
-        logger.warning_once(
-            "Fused DupUp3D output has %d elements, exceeding the Triton "
-            "signed 32-bit indexing limit; falling back to the eager implementation.",
-            output_elements,
-            key="wan_dup_up3d_int32_index_fallback",
-        )
-        return None
+    _, _, output_frames, output_height, output_width = output_shape
+    output_elements = math.prod(output_shape)
 
     output = torch.empty(
         output_shape,

--- a/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
@@ -6,78 +6,72 @@
 from __future__ import annotations
 
 import torch
+import triton
+import triton.language as tl
 
-_KERNEL_CACHE: dict = {}
+_BLOCK_SIZE = 256
+_NUM_WARPS = 8
 
 
-def _build_kernel():
-    if "fn" in _KERNEL_CACHE:
-        return _KERNEL_CACHE["fn"]
+@triton.jit
+def _dup_up3d_kernel(
+    x_ptr,
+    output_ptr,
+    output_elements,
+    output_channels: tl.constexpr,
+    output_frames: tl.constexpr,
+    output_height: tl.constexpr,
+    output_width: tl.constexpr,
+    repeats: tl.constexpr,
+    factor_t: tl.constexpr,
+    factor_s: tl.constexpr,
+    temporal_crop: tl.constexpr,
+    stride_xn: tl.constexpr,
+    stride_xc: tl.constexpr,
+    stride_xt: tl.constexpr,
+    stride_xh: tl.constexpr,
+    stride_xw: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    offsets = tl.program_id(0) * block_size + tl.arange(0, block_size)
+    mask = offsets < output_elements
 
-    import triton
-    import triton.language as tl
+    output_channel = offsets % output_channels
+    logical = offsets // output_channels
+    output_w = logical % output_width
+    logical = logical // output_width
+    output_h = logical % output_height
+    logical = logical // output_height
+    output_t = logical % output_frames
+    batch = logical // output_frames
 
-    @triton.jit
-    def _dup_up3d_kernel(
-        x_ptr,
-        output_ptr,
-        output_elements,
-        output_channels: tl.constexpr,
-        output_frames: tl.constexpr,
-        output_height: tl.constexpr,
-        output_width: tl.constexpr,
-        repeats: tl.constexpr,
-        factor_t: tl.constexpr,
-        factor_s: tl.constexpr,
-        temporal_crop: tl.constexpr,
-        stride_xn: tl.constexpr,
-        stride_xc: tl.constexpr,
-        stride_xt: tl.constexpr,
-        stride_xh: tl.constexpr,
-        stride_xw: tl.constexpr,
-        block_size: tl.constexpr,
-    ):
-        offsets = tl.program_id(0) * block_size + tl.arange(0, block_size)
-        mask = offsets < output_elements
+    full_output_t = output_t + temporal_crop
+    input_t = full_output_t // factor_t
+    factor_t_index = full_output_t % factor_t
+    input_h = output_h // factor_s
+    factor_h_index = output_h % factor_s
+    input_w = output_w // factor_s
+    factor_w_index = output_w % factor_s
 
-        output_channel = offsets % output_channels
-        logical = offsets // output_channels
-        output_w = logical % output_width
-        logical = logical // output_width
-        output_h = logical % output_height
-        logical = logical // output_height
-        output_t = logical % output_frames
-        batch = logical // output_frames
+    repeat_channel = output_channel * factor_t * factor_s * factor_s
+    repeat_channel += (factor_t_index * factor_s + factor_h_index) * factor_s
+    repeat_channel += factor_w_index
+    input_channel = repeat_channel // repeats
 
-        full_output_t = output_t + temporal_crop
-        input_t = full_output_t // factor_t
-        factor_t_index = full_output_t % factor_t
-        input_h = output_h // factor_s
-        factor_h_index = output_h % factor_s
-        input_w = output_w // factor_s
-        factor_w_index = output_w % factor_s
-
-        repeat_channel = output_channel * factor_t * factor_s * factor_s
-        repeat_channel += (factor_t_index * factor_s + factor_h_index) * factor_s
-        repeat_channel += factor_w_index
-        input_channel = repeat_channel // repeats
-
-        input_offset = (
-            batch * stride_xn
-            + input_channel * stride_xc
-            + input_t * stride_xt
-            + input_h * stride_xh
-            + input_w * stride_xw
-        )
-        value = tl.load(x_ptr + input_offset, mask=mask)
-        tl.store(output_ptr + offsets, value, mask=mask)
-
-    _KERNEL_CACHE["fn"] = (triton, _dup_up3d_kernel)
-    return _KERNEL_CACHE["fn"]
+    input_offset = (
+        batch * stride_xn
+        + input_channel * stride_xc
+        + input_t * stride_xt
+        + input_h * stride_xh
+        + input_w * stride_xw
+    )
+    value = tl.load(x_ptr + input_offset, mask=mask)
+    tl.store(output_ptr + offsets, value, mask=mask)
 
 
 def dup_up3d(
     x: torch.Tensor,
+    *,
     output_channels: int,
     repeats: int,
     factor_t: int,
@@ -87,8 +81,19 @@ def dup_up3d(
     """Write repeated-and-shuffled ``x`` directly in final channels-last layout."""
     if x.dim() != 5:
         raise ValueError(f"DupUp3D expects a five-dimensional tensor, got shape {x.shape}")
+    if not x.is_cuda:
+        raise ValueError("Fused DupUp3D requires a CUDA tensor")
+    if min(output_channels, repeats, factor_t, factor_s) < 1:
+        raise ValueError("DupUp3D channels, repeats, and factors must be positive")
 
-    batch, _, input_frames, input_height, input_width = x.shape
+    batch, input_channels, input_frames, input_height, input_width = x.shape
+    factor = factor_t * factor_s * factor_s
+    if input_channels * repeats != output_channels * factor:
+        raise ValueError(
+            "DupUp3D channel mapping is inconsistent: "
+            f"{input_channels=} * {repeats=} != {output_channels=} * {factor=}"
+        )
+
     temporal_crop = factor_t - 1 if first_chunk else 0
     output_frames = input_frames * factor_t - temporal_crop
     output_height = input_height * factor_s
@@ -100,10 +105,8 @@ def dup_up3d(
         memory_format=torch.channels_last_3d,
     )
 
-    triton, kernel = _build_kernel()
     output_elements = output.numel()
-    block_size = 256
-    kernel[(triton.cdiv(output_elements, block_size),)](
+    _dup_up3d_kernel[(triton.cdiv(output_elements, _BLOCK_SIZE),)](
         x,
         output,
         output_elements,
@@ -120,7 +123,7 @@ def dup_up3d(
         stride_xt=x.stride(2),
         stride_xh=x.stride(3),
         stride_xw=x.stride(4),
-        block_size=block_size,
-        num_warps=8,
+        block_size=_BLOCK_SIZE,
+        num_warps=_NUM_WARPS,
     )
     return output

--- a/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fused channel-repeat and pixel-shuffle mapping for Wan ``DupUp3D``."""
+
+from __future__ import annotations
+
+import torch
+
+_KERNEL_CACHE: dict = {}
+
+
+def _build_kernel():
+    if "fn" in _KERNEL_CACHE:
+        return _KERNEL_CACHE["fn"]
+
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _dup_up3d_kernel(
+        x_ptr,
+        output_ptr,
+        output_elements,
+        output_channels: tl.constexpr,
+        output_frames: tl.constexpr,
+        output_height: tl.constexpr,
+        output_width: tl.constexpr,
+        repeats: tl.constexpr,
+        factor_t: tl.constexpr,
+        factor_s: tl.constexpr,
+        temporal_crop: tl.constexpr,
+        stride_xn: tl.constexpr,
+        stride_xc: tl.constexpr,
+        stride_xt: tl.constexpr,
+        stride_xh: tl.constexpr,
+        stride_xw: tl.constexpr,
+        block_size: tl.constexpr,
+    ):
+        offsets = tl.program_id(0) * block_size + tl.arange(0, block_size)
+        mask = offsets < output_elements
+
+        output_channel = offsets % output_channels
+        logical = offsets // output_channels
+        output_w = logical % output_width
+        logical = logical // output_width
+        output_h = logical % output_height
+        logical = logical // output_height
+        output_t = logical % output_frames
+        batch = logical // output_frames
+
+        full_output_t = output_t + temporal_crop
+        input_t = full_output_t // factor_t
+        factor_t_index = full_output_t % factor_t
+        input_h = output_h // factor_s
+        factor_h_index = output_h % factor_s
+        input_w = output_w // factor_s
+        factor_w_index = output_w % factor_s
+
+        repeat_channel = output_channel * factor_t * factor_s * factor_s
+        repeat_channel += (factor_t_index * factor_s + factor_h_index) * factor_s
+        repeat_channel += factor_w_index
+        input_channel = repeat_channel // repeats
+
+        input_offset = (
+            batch * stride_xn
+            + input_channel * stride_xc
+            + input_t * stride_xt
+            + input_h * stride_xh
+            + input_w * stride_xw
+        )
+        value = tl.load(x_ptr + input_offset, mask=mask)
+        tl.store(output_ptr + offsets, value, mask=mask)
+
+    _KERNEL_CACHE["fn"] = (triton, _dup_up3d_kernel)
+    return _KERNEL_CACHE["fn"]
+
+
+def dup_up3d(
+    x: torch.Tensor,
+    output_channels: int,
+    repeats: int,
+    factor_t: int,
+    factor_s: int,
+    first_chunk: bool,
+) -> torch.Tensor:
+    """Write repeated-and-shuffled ``x`` directly in final channels-last layout."""
+    if x.dim() != 5:
+        raise ValueError(f"DupUp3D expects a five-dimensional tensor, got shape {x.shape}")
+
+    batch, _, input_frames, input_height, input_width = x.shape
+    temporal_crop = factor_t - 1 if first_chunk else 0
+    output_frames = input_frames * factor_t - temporal_crop
+    output_height = input_height * factor_s
+    output_width = input_width * factor_s
+    output = torch.empty(
+        (batch, output_channels, output_frames, output_height, output_width),
+        dtype=x.dtype,
+        device=x.device,
+        memory_format=torch.channels_last_3d,
+    )
+
+    triton, kernel = _build_kernel()
+    output_elements = output.numel()
+    block_size = 256
+    kernel[(triton.cdiv(output_elements, block_size),)](
+        x,
+        output,
+        output_elements,
+        output_channels=output_channels,
+        output_frames=output_frames,
+        output_height=output_height,
+        output_width=output_width,
+        repeats=repeats,
+        factor_t=factor_t,
+        factor_s=factor_s,
+        temporal_crop=temporal_crop,
+        stride_xn=x.stride(0),
+        stride_xc=x.stride(1),
+        stride_xt=x.stride(2),
+        stride_xh=x.stride(3),
+        stride_xw=x.stride(4),
+        block_size=block_size,
+        num_warps=8,
+    )
+    return output

--- a/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
@@ -9,8 +9,16 @@ import torch
 import triton
 import triton.language as tl
 
+from tensorrt_llm.logger import logger
+
 _BLOCK_SIZE = 256
 _NUM_WARPS = 8
+_MAX_TRITON_INDEXED_ELEMENTS = 1 << 31
+
+
+def _supports_triton_indexing(output_elements: int) -> bool:
+    """Return whether the output fits the kernel's signed 32-bit offsets."""
+    return output_elements <= _MAX_TRITON_INDEXED_ELEMENTS
 
 
 @triton.jit
@@ -77,8 +85,8 @@ def dup_up3d(
     factor_t: int,
     factor_s: int,
     first_chunk: bool,
-) -> torch.Tensor:
-    """Write repeated-and-shuffled ``x`` directly in final channels-last layout."""
+) -> torch.Tensor | None:
+    """Write the shuffled output, or return ``None`` when Triton cannot index it."""
     if x.dim() != 5:
         raise ValueError(f"DupUp3D expects a five-dimensional tensor, got shape {x.shape}")
     if not x.is_cuda:
@@ -98,14 +106,30 @@ def dup_up3d(
     output_frames = input_frames * factor_t - temporal_crop
     output_height = input_height * factor_s
     output_width = input_width * factor_s
+    output_shape = (
+        batch,
+        output_channels,
+        output_frames,
+        output_height,
+        output_width,
+    )
+    output_elements = batch * output_channels * output_frames * output_height * output_width
+    if not _supports_triton_indexing(output_elements):
+        logger.warning_once(
+            "Fused DupUp3D output has %d elements, exceeding the Triton "
+            "signed 32-bit indexing limit; falling back to the eager implementation.",
+            output_elements,
+            key="wan_dup_up3d_int32_index_fallback",
+        )
+        return None
+
     output = torch.empty(
-        (batch, output_channels, output_frames, output_height, output_width),
+        output_shape,
         dtype=x.dtype,
         device=x.device,
         memory_format=torch.channels_last_3d,
     )
 
-    output_elements = output.numel()
     _dup_up3d_kernel[(triton.cdiv(output_elements, _BLOCK_SIZE),)](
         x,
         output,

--- a/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py
@@ -76,8 +76,8 @@ def can_implement_dup_up3d(
         first_chunk: Whether the cache-initializing temporal crop is required.
 
     Returns:
-        ``True`` for a non-empty CUDA invocation whose output fits the kernel's
-        signed 32-bit indexing range; otherwise ``False``.
+        ``True`` for a non-empty CUDA invocation whose input span and output
+        fit the kernel's signed 32-bit indexing range; otherwise ``False``.
     """
     _validate_dup_up3d_contract(x, output_channels, repeats, factor_t, factor_s)
     if not x.is_cuda or 0 in x.shape:
@@ -91,12 +91,15 @@ def can_implement_dup_up3d(
         first_chunk,
     )
     output_elements = math.prod(output_shape)
-    supported = _supports_triton_indexing(output_elements)
+    input_span_elements = 1 + sum((size - 1) * stride for size, stride in zip(x.shape, x.stride()))
+    supported = _supports_triton_indexing(output_elements) and _supports_triton_indexing(
+        input_span_elements
+    )
     if not supported:
         logger.warning_once(
-            "Fused DupUp3D output has %d elements, exceeding the Triton "
+            f"Fused DupUp3D input span ({input_span_elements} elements) or output size "
+            f"({output_elements} elements) exceeds the Triton "
             "signed 32-bit indexing limit; falling back to the eager implementation.",
-            output_elements,
             key="wan_dup_up3d_int32_index_fallback",
         )
     return supported
@@ -183,14 +186,7 @@ def dup_up3d(
         A logical NCTHW tensor stored in PyTorch ``channels_last_3d`` physical
         order, which corresponds to NTHWC.
     """
-    assert can_implement_dup_up3d(
-        x,
-        output_channels=output_channels,
-        repeats=repeats,
-        factor_t=factor_t,
-        factor_s=factor_s,
-        first_chunk=first_chunk,
-    )
+    _validate_dup_up3d_contract(x, output_channels, repeats, factor_t, factor_s)
 
     temporal_crop = factor_t - 1 if first_chunk else 0
     output_shape = _dup_up3d_output_shape(

--- a/tensorrt_llm/_torch/visual_gen/models/wan/wan_vae.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/wan_vae.py
@@ -263,19 +263,26 @@ class DupUp3D(nn.Module):
         self.repeats = out_channels * self.factor // in_channels
 
     def forward(self, x: torch.Tensor, first_chunk: bool = False) -> torch.Tensor:
+        # The fused Triton implementation is CUDA-only; CPU retains the eager path.
         if x.is_cuda:
-            from .dup_up3d import dup_up3d
+            from .dup_up3d import can_implement_dup_up3d, dup_up3d
 
-            output = dup_up3d(
+            if can_implement_dup_up3d(
                 x,
                 output_channels=self.out_channels,
                 repeats=self.repeats,
                 factor_t=self.factor_t,
                 factor_s=self.factor_s,
                 first_chunk=first_chunk,
-            )
-            if output is not None:
-                return output
+            ):
+                return dup_up3d(
+                    x,
+                    output_channels=self.out_channels,
+                    repeats=self.repeats,
+                    factor_t=self.factor_t,
+                    factor_s=self.factor_s,
+                    first_chunk=first_chunk,
+                )
         x = x if self.repeats == 1 else x.repeat_interleave(self.repeats, dim=1)
         x = x.reshape(
             x.size(0),

--- a/tensorrt_llm/_torch/visual_gen/models/wan/wan_vae.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/wan_vae.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
@@ -35,6 +36,7 @@ from diffusers.models.autoencoders.vae import DecoderOutput, DiagonalGaussianDis
 # kernel size 3, i.e. 2 frames of left context) stays continuous when encode /
 # decode run frame-by-frame.
 CACHE_T = 2
+_FUSED_DUP_UP3D_ENV = "TRTLLM_WAN_VAE_FUSE_DUP_UP3D"
 
 # Default latent normalization statistics, copied verbatim from the diffusers
 # AutoencoderKLWan constructor defaults (the 16-channel Wan2.1 values). They are
@@ -98,6 +100,10 @@ def _to_device_if_needed(x: torch.Tensor, device: torch.device) -> torch.Tensor:
     if x.device == device:
         return x
     return x.to(device)
+
+
+def _fused_dup_up3d_enabled() -> bool:
+    return os.environ.get(_FUSED_DUP_UP3D_ENV, "0").lower() not in ("0", "", "false", "no")
 
 
 def _causal_conv_with_cache(
@@ -261,8 +267,20 @@ class DupUp3D(nn.Module):
         if out_channels * self.factor % in_channels != 0:
             raise ValueError("DupUp3D channel repeat count must divide evenly")
         self.repeats = out_channels * self.factor // in_channels
+        self._fused = _fused_dup_up3d_enabled()
 
     def forward(self, x: torch.Tensor, first_chunk: bool = False) -> torch.Tensor:
+        if self._fused and x.is_cuda:
+            from .dup_up3d import dup_up3d
+
+            return dup_up3d(
+                x,
+                self.out_channels,
+                self.repeats,
+                self.factor_t,
+                self.factor_s,
+                first_chunk,
+            )
         x = x if self.repeats == 1 else x.repeat_interleave(self.repeats, dim=1)
         x = x.reshape(
             x.size(0),

--- a/tensorrt_llm/_torch/visual_gen/models/wan/wan_vae.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/wan_vae.py
@@ -266,7 +266,7 @@ class DupUp3D(nn.Module):
         if x.is_cuda:
             from .dup_up3d import dup_up3d
 
-            return dup_up3d(
+            output = dup_up3d(
                 x,
                 output_channels=self.out_channels,
                 repeats=self.repeats,
@@ -274,6 +274,8 @@ class DupUp3D(nn.Module):
                 factor_s=self.factor_s,
                 first_chunk=first_chunk,
             )
+            if output is not None:
+                return output
         x = x if self.repeats == 1 else x.repeat_interleave(self.repeats, dim=1)
         x = x.reshape(
             x.size(0),

--- a/tensorrt_llm/_torch/visual_gen/models/wan/wan_vae.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/wan_vae.py
@@ -21,7 +21,6 @@
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
@@ -36,7 +35,6 @@ from diffusers.models.autoencoders.vae import DecoderOutput, DiagonalGaussianDis
 # kernel size 3, i.e. 2 frames of left context) stays continuous when encode /
 # decode run frame-by-frame.
 CACHE_T = 2
-_FUSED_DUP_UP3D_ENV = "TRTLLM_WAN_VAE_FUSE_DUP_UP3D"
 
 # Default latent normalization statistics, copied verbatim from the diffusers
 # AutoencoderKLWan constructor defaults (the 16-channel Wan2.1 values). They are
@@ -100,10 +98,6 @@ def _to_device_if_needed(x: torch.Tensor, device: torch.device) -> torch.Tensor:
     if x.device == device:
         return x
     return x.to(device)
-
-
-def _fused_dup_up3d_enabled() -> bool:
-    return os.environ.get(_FUSED_DUP_UP3D_ENV, "0").lower() not in ("0", "", "false", "no")
 
 
 def _causal_conv_with_cache(
@@ -267,19 +261,18 @@ class DupUp3D(nn.Module):
         if out_channels * self.factor % in_channels != 0:
             raise ValueError("DupUp3D channel repeat count must divide evenly")
         self.repeats = out_channels * self.factor // in_channels
-        self._fused = _fused_dup_up3d_enabled()
 
     def forward(self, x: torch.Tensor, first_chunk: bool = False) -> torch.Tensor:
-        if self._fused and x.is_cuda:
+        if x.is_cuda:
             from .dup_up3d import dup_up3d
 
             return dup_up3d(
                 x,
-                self.out_channels,
-                self.repeats,
-                self.factor_t,
-                self.factor_s,
-                first_chunk,
+                output_channels=self.out_channels,
+                repeats=self.repeats,
+                factor_t=self.factor_t,
+                factor_s=self.factor_s,
+                first_chunk=first_chunk,
             )
         x = x if self.repeats == 1 else x.repeat_interleave(self.repeats, dim=1)
         x = x.reshape(

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -220,6 +220,7 @@ l0_b200:
   - unittest/_torch/visual_gen/test_wan22_t2v_pipeline.py
   - unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py
   - unittest/_torch/visual_gen/test_wan_vsa_pipeline.py
+  - unittest/_torch/visual_gen/test_wan_dup_up3d.py
   - unittest/_torch/visual_gen/test_wan_vae.py
   - unittest/_torch/visual_gen/test_wan21_i2v_teacache.py
   - unittest/_torch/visual_gen/test_wan21_t2v_teacache.py

--- a/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
@@ -77,7 +77,7 @@ def test_fused_dup_up3d_empty_input_uses_eager(
     module = DupUp3D(4, 4, factor_t=2, factor_s=2)
     expected = module(x.cpu(), first_chunk=first_chunk).cuda()
 
-    def fail_if_launched(*args, **kwargs):
+    def fail_if_launched(*_args: object, **_kwargs: object) -> None:
         pytest.fail("Empty inputs must bypass the fused DupUp3D kernel")
 
     monkeypatch.setattr(dup_up3d_module, "dup_up3d", fail_if_launched)

--- a/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
@@ -6,6 +6,7 @@
 import pytest
 import torch
 
+from tensorrt_llm._torch.visual_gen.models.wan import dup_up3d as dup_up3d_module
 from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import DupUp3D
 
 
@@ -47,3 +48,32 @@ def test_fused_dup_up3d_matches_eager(
 
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
     assert actual.is_contiguous(memory_format=torch.channels_last_3d)
+
+
+def test_fused_dup_up3d_int32_index_limit() -> None:
+    assert dup_up3d_module._supports_triton_indexing(1 << 31)
+    assert not dup_up3d_module._supports_triton_indexing((1 << 31) + 1)
+
+
+def test_fused_dup_up3d_falls_back_above_index_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required to exercise the fused DupUp3D dispatch")
+
+    x = torch.randn(
+        1,
+        4,
+        2,
+        3,
+        4,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    module = DupUp3D(4, 4, factor_t=2, factor_s=2)
+    expected = module(x.cpu(), first_chunk=True).cuda()
+
+    monkeypatch.setattr(dup_up3d_module, "_MAX_TRITON_INDEXED_ELEMENTS", 0)
+    actual = module(x, first_chunk=True)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
@@ -11,7 +11,7 @@ from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import DupUp3D
 
 
 @pytest.mark.parametrize("first_chunk", [False, True])
-@pytest.mark.parametrize("memory_format", [torch.contiguous_format, torch.channels_last_3d])
+@pytest.mark.parametrize("input_layout", ["contiguous", "channels_last_3d", "strided"])
 @pytest.mark.parametrize(
     ("in_channels", "out_channels", "factor_t"),
     [
@@ -24,7 +24,7 @@ from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import DupUp3D
 )
 def test_fused_dup_up3d_matches_eager(
     first_chunk: bool,
-    memory_format: torch.memory_format,
+    input_layout: str,
     in_channels: int,
     out_channels: int,
     factor_t: int,
@@ -32,15 +32,21 @@ def test_fused_dup_up3d_matches_eager(
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required for the fused DupUp3D kernel")
 
+    input_width = 10 if input_layout == "strided" else 5
     x = torch.randn(
         2,
         in_channels,
         3,
         4,
-        5,
+        input_width,
         device="cuda",
         dtype=torch.bfloat16,
-    ).contiguous(memory_format=memory_format)
+    )
+    if input_layout == "channels_last_3d":
+        x = x.contiguous(memory_format=torch.channels_last_3d)
+    elif input_layout == "strided":
+        x = x[..., ::2]
+        assert not x.is_contiguous()
     module = DupUp3D(in_channels, out_channels, factor_t=factor_t, factor_s=2)
 
     expected = module(x.cpu(), first_chunk=first_chunk).cuda()
@@ -48,6 +54,36 @@ def test_fused_dup_up3d_matches_eager(
 
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
     assert actual.is_contiguous(memory_format=torch.channels_last_3d)
+
+
+@pytest.mark.parametrize(
+    ("shape", "first_chunk"),
+    [
+        ((0, 4, 2, 3, 4), False),
+        ((1, 4, 0, 3, 4), True),
+        ((1, 4, 2, 0, 4), False),
+        ((1, 4, 2, 3, 0), False),
+    ],
+)
+def test_fused_dup_up3d_empty_input_uses_eager(
+    monkeypatch: pytest.MonkeyPatch,
+    shape: tuple[int, ...],
+    first_chunk: bool,
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required to exercise the fused DupUp3D dispatch")
+
+    x = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    module = DupUp3D(4, 4, factor_t=2, factor_s=2)
+    expected = module(x.cpu(), first_chunk=first_chunk).cuda()
+
+    def fail_if_launched(*args, **kwargs):
+        pytest.fail("Empty inputs must bypass the fused DupUp3D kernel")
+
+    monkeypatch.setattr(dup_up3d_module, "dup_up3d", fail_if_launched)
+    actual = module(x, first_chunk=first_chunk)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
 def test_fused_dup_up3d_int32_index_limit() -> None:

--- a/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the fused Wan DupUp3D output mapping."""
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import DupUp3D
+
+
+@pytest.mark.parametrize("first_chunk", [False, True])
+@pytest.mark.parametrize("memory_format", [torch.contiguous_format, torch.channels_last_3d])
+@pytest.mark.parametrize(
+    ("in_channels", "out_channels", "factor_t"),
+    [
+        pytest.param(4, 4, 2, id="temporal-repeat-8"),
+        pytest.param(8, 4, 2, id="temporal-repeat-4"),
+        pytest.param(8, 2, 2, id="temporal-repeat-2"),
+        pytest.param(4, 4, 1, id="spatial-repeat-4"),
+        pytest.param(8, 4, 1, id="spatial-repeat-2"),
+    ],
+)
+def test_fused_dup_up3d_matches_eager(
+    first_chunk: bool,
+    memory_format: torch.memory_format,
+    in_channels: int,
+    out_channels: int,
+    factor_t: int,
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the fused DupUp3D kernel")
+
+    x = torch.randn(
+        2,
+        in_channels,
+        3,
+        4,
+        5,
+        device="cuda",
+        dtype=torch.bfloat16,
+    ).contiguous(memory_format=memory_format)
+    module = DupUp3D(in_channels, out_channels, factor_t=factor_t, factor_s=2)
+
+    expected = module(x.cpu(), first_chunk=first_chunk).cuda()
+    actual = module(x, first_chunk=first_chunk)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual.is_contiguous(memory_format=torch.channels_last_3d)

--- a/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py
@@ -3,6 +3,8 @@
 
 """Unit tests for the fused Wan DupUp3D output mapping."""
 
+from unittest import mock
+
 import pytest
 import torch
 
@@ -18,6 +20,7 @@ from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import DupUp3D
         pytest.param(4, 4, 2, id="temporal-repeat-8"),
         pytest.param(8, 4, 2, id="temporal-repeat-4"),
         pytest.param(8, 2, 2, id="temporal-repeat-2"),
+        pytest.param(32, 4, 2, id="temporal-repeat-1"),
         pytest.param(4, 4, 1, id="spatial-repeat-4"),
         pytest.param(8, 4, 1, id="spatial-repeat-2"),
     ],
@@ -89,6 +92,28 @@ def test_fused_dup_up3d_empty_input_uses_eager(
 def test_fused_dup_up3d_int32_index_limit() -> None:
     assert dup_up3d_module._supports_triton_indexing(1 << 31)
     assert not dup_up3d_module._supports_triton_indexing((1 << 31) + 1)
+
+
+def test_fused_dup_up3d_input_span_limit() -> None:
+    x = mock.Mock(spec=torch.Tensor)
+    x.dim.return_value = 5
+    x.shape = (1, 4, 2, 3, 4)
+    x.stride.return_value = (1, 1 << 30, 12, 4, 1)
+    x.is_cuda = True
+
+    with mock.patch.object(dup_up3d_module.logger, "warning_once") as warning_once:
+        supported = dup_up3d_module.can_implement_dup_up3d(
+            x,
+            output_channels=4,
+            repeats=8,
+            factor_t=2,
+            factor_s=2,
+            first_chunk=False,
+        )
+
+    assert not supported
+    warning_once.assert_called_once()
+    assert "%d" not in warning_once.call_args.args[0]
 
 
 def test_fused_dup_up3d_falls_back_above_index_limit(

--- a/tests/unittest/_torch/visual_gen/test_wan_vae.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_vae.py
@@ -16,40 +16,13 @@ from tensorrt_llm._torch.visual_gen.models.wan.vae_loader import (
     _use_native_wan_vae,
     load_wan_vae,
 )
-from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import DupUp3D, WanVAE, WanVAEConfig
+from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import WanVAE, WanVAEConfig
 
 DEVICE = "cuda"
 # Parity runs in fp32 to check whether our implementation matches diffusers'
 # computation, isolated from bf16 rounding noise that differs by memory layout
 # (our channels_last vs diffusers' contiguous). Production runs the VAE in bf16.
 DTYPE = torch.float32
-
-
-@pytest.mark.parametrize("first_chunk", [False, True])
-def test_fused_dup_up3d_matches_eager(monkeypatch, first_chunk):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA is required for the fused DupUp3D kernel")
-
-    x = torch.randn(
-        2,
-        8,
-        3,
-        4,
-        5,
-        device=DEVICE,
-        dtype=torch.bfloat16,
-    ).contiguous(memory_format=torch.channels_last_3d)
-
-    monkeypatch.delenv("TRTLLM_WAN_VAE_FUSE_DUP_UP3D", raising=False)
-    eager = DupUp3D(8, 4, factor_t=2, factor_s=2)
-    expected = eager(x, first_chunk=first_chunk)
-
-    monkeypatch.setenv("TRTLLM_WAN_VAE_FUSE_DUP_UP3D", "1")
-    fused = DupUp3D(8, 4, factor_t=2, factor_s=2)
-    actual = fused(x, first_chunk=first_chunk)
-
-    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
-    assert actual.is_contiguous(memory_format=torch.channels_last_3d)
 
 
 def _require_checkpoint(model_dir: str, env_var: str) -> Path:

--- a/tests/unittest/_torch/visual_gen/test_wan_vae.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_vae.py
@@ -16,13 +16,40 @@ from tensorrt_llm._torch.visual_gen.models.wan.vae_loader import (
     _use_native_wan_vae,
     load_wan_vae,
 )
-from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import WanVAE, WanVAEConfig
+from tensorrt_llm._torch.visual_gen.models.wan.wan_vae import DupUp3D, WanVAE, WanVAEConfig
 
 DEVICE = "cuda"
 # Parity runs in fp32 to check whether our implementation matches diffusers'
 # computation, isolated from bf16 rounding noise that differs by memory layout
 # (our channels_last vs diffusers' contiguous). Production runs the VAE in bf16.
 DTYPE = torch.float32
+
+
+@pytest.mark.parametrize("first_chunk", [False, True])
+def test_fused_dup_up3d_matches_eager(monkeypatch, first_chunk):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the fused DupUp3D kernel")
+
+    x = torch.randn(
+        2,
+        8,
+        3,
+        4,
+        5,
+        device=DEVICE,
+        dtype=torch.bfloat16,
+    ).contiguous(memory_format=torch.channels_last_3d)
+
+    monkeypatch.delenv("TRTLLM_WAN_VAE_FUSE_DUP_UP3D", raising=False)
+    eager = DupUp3D(8, 4, factor_t=2, factor_s=2)
+    expected = eager(x, first_chunk=first_chunk)
+
+    monkeypatch.setenv("TRTLLM_WAN_VAE_FUSE_DUP_UP3D", "1")
+    fused = DupUp3D(8, 4, factor_t=2, factor_s=2)
+    actual = fused(x, first_chunk=first_chunk)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual.is_contiguous(memory_format=torch.channels_last_3d)
 
 
 def _require_checkpoint(model_dir: str, env_var: str) -> Path:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Implemented a Triton-fused Wan `DupUp3D` output mapping in `tensorrt_llm/_torch/visual_gen/models/wan/dup_up3d.py` that performs channel repetition + temporal/spatial pixel-shuffle and writes directly to a `torch.channels_last_3d` (NTHWC) output using masked `tl.load`/`tl.store`.
- Added `can_implement_dup_up3d(...) -> bool` to validate the internal `DupUp3D` contract, compute the fused output shape (including `first_chunk` temporal cropping), and ensure the fused output element count fits Triton’s signed 32-bit indexing limit (`_MAX_TRITON_INDEXED_ELEMENTS = 1<<31`). For oversized outputs it emits a one-time warning (`key="wan_dup_up3d_int32_index_fallback"`) and returns `False`.
- Updated `dup_up3d(...)` to `assert can_implement_dup_up3d(...)` before allocating/launching, removing any oversized-output `None` return path (now returns `torch.Tensor`).
- Updated `DupUp3D.forward` in `tensorrt_llm/_torch/visual_gen/models/wan/wan_vae.py` to only take the CUDA fused path when `can_implement_dup_up3d(...)` is `True`; otherwise it falls back to the existing eager tensor implementation.
- Indexing/dispatch safety and correctness are handled by: (1) early dispatch rejection for non-CUDA and empty tensors (`0 in x.shape`), and (2) kernel-side masked offset handling (`mask = offsets < output_elements`).

## QA Engineer Review

- Modified tests in `tests/unittest/_torch/visual_gen/test_wan_dup_up3d.py`:
  - `test_fused_dup_up3d_matches_eager` (expanded): parameterized across `input_layout` (`contiguous`, `channels_last_3d`, `strided`), `first_chunk`, and multiple `(in_channels, out_channels, factor_t)` configurations; asserts exact parity vs eager CPU and enforces `channels_last_3d` contiguity.
  - Added `test_fused_dup_up3d_empty_input_uses_eager`: verifies empty CUDA inputs bypass fused `dup_up3d` by monkeypatching the fused entrypoint to fail if launched.
  - `test_fused_dup_up3d_int32_index_limit`: validates `_supports_triton_indexing` at the `(1<<31)` boundary.
  - `test_fused_dup_up3d_falls_back_above_index_limit`: forces non-Triton dispatch by monkeypatching `_MAX_TRITON_INDEXED_ELEMENTS` and checks exact equality with eager CPU.
- CI/coverage registration: updated `tests/integration/test_lists/test-db/l0_b200.yml` to include `unittest/_torch/visual_gen/test_wan_dup_up3d.py`.
- Verdict: sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Jira: [TRTLLM-14798](https://jirasw.nvidia.com/browse/TRTLLM-14798) (Task under epic [TRTLLM-12775](https://jirasw.nvidia.com/browse/TRTLLM-12775))

Wan 2.2's residual upsampling shortcut uses `DupUp3D` to repeat input channels,
reshape and permute them into temporal/spatial pixel-shuffle positions,
materialize the permuted tensor, and optionally crop the first temporal chunk.
The eager path writes large repeated and permuted intermediates even though the
operation only rearranges values.

This PR adds one Triton kernel that maps each element of the final
channels-last output directly to its source input index. It fuses the channel
repeat, temporal/spatial pixel shuffle, final layout, and first-chunk temporal
crop without intermediate tensors.

The implementation:

- supports arbitrary input strides and both row-major and channels-last input;
- preserves the original first-versus-later temporal-chunk behavior;
- writes the final tensor directly as `channels_last_3d`;
- runs automatically for eligible CUDA tensors;
- emits a one-time warning and falls back to the eager implementation when the
  output exceeds the Triton kernel's signed 32-bit indexing range
  (`2^31` elements); and
- retains the eager CPU/non-CUDA fallback.

This is a shared VAE activation kernel, not an FP4 kernel. Native BF16 and FP4
Conv paths feed it the same BF16 activations and execute the same Triton source.

## Performance

Matched four-GPU NSC A/B measurements show gains on both paths:

| VAE path | Eager `DupUp3D` | Fused `DupUp3D` | Saving | Speedup |
|---|---:|---:|---:|---:|
| Native BF16, chunk 4 | 634.365 ms | 598.571 ms | 35.794 ms | 1.060x |
| FP4 campaign baseline | 436.712 ms | 407.400 ms | 29.312 ms | 1.072x |

A later selected-stack FP4 campaign independently measured
`368.843 -> 337.792 ms`, a `31.052 ms` reduction.

## Test Coverage

- Added CUDA bit-exact comparison against the eager implementation for
  row-major, channels-last, and genuinely strided inputs, first/later chunks, temporal/spatial
  factors, and production repeat counts 8, 4, and 2.
- Added exact-boundary coverage for the `2^31` signed-index limit and a forced
  CUDA dispatch test that verifies oversized outputs take the eager fallback.
- The result is required to retain `channels_last_3d`.
- Wan2.2 360p checkpoint decode parity against Diffusers passes with the fused
  path selected automatically.
- NSC array job `1553978` task 4 passed 20 kernel matrix cases and the
  checkpoint parity case.
- NSC job `1560274` passed all 36 focused CUDA tests, including strided
  addressing and empty N/T/H/W eager-dispatch coverage.
- Repository pre-commit hooks and `git diff --check` pass.

## PR Checklist

- [x] The kernel is independent of FP4 and shared by BF16 and FP4 paths.
- [x] CUDA output is bit-exact with the eager mapping.
- [x] Oversized outputs and CPU/non-CUDA inputs retain eager behavior.
- [x] No public API, dependency, CODEOWNERS, or architecture-diagram changes.

## FP4 integration report

This precision-independent optimization composes with the FP4 Wan VAE integration in #17262. The consolidated performance/accuracy report and dependency map are maintained there.
