### PR TITLE
[None][feat] Add UBX Caliper all-to-all for Ulysses sequence parallelism

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
@@ -20,6 +20,8 @@ backend — compose around a real backend (VANILLA/TRTLLM/FA4/CUTEDSL).
 
 """
 
+import logging
+import os
 from typing import TYPE_CHECKING, Callable, ClassVar, Dict, Optional
 
 import torch
@@ -33,6 +35,8 @@ from tensorrt_llm._torch.distributed import all_to_all_4d, all_to_all_5d
 
 from ...attention_backend.interface import PredefinedAttentionMask
 from .interface import AttentionBackend, AttentionTensorLayout
+
+logger = logging.getLogger(__name__)
 
 _flash_attn_combine_import_error = None
 try:
@@ -118,6 +122,22 @@ class UlyssesAttention(AttentionBackend):
         # side stream so V/Q/K pushes FIFO together without intermediate
         # barrier kernels.
         self._pending_barriers: int = 0
+
+        # Prefer UBX (caliper) > NCCL for all-to-all when available.
+        # UBX Lamport wins by 1.3–1.5x in CUDA graph mode (≥64KB payloads).
+        # Async path uses TRTLLM CE ops and is not eligible for UBX.
+        self._ub_a2a = None
+        if not async_ulysses and os.environ.get("TRTLLM_FORCE_NCCL_ALLREDUCE", "0") == "0":
+            from ..ubx_alltoall import UBXAllToAll, _ubx_available
+
+            device = None
+            if torch.cuda.is_available():
+                device = torch.device("cuda", torch.cuda.current_device())
+            if _ubx_available(process_group, device):
+                self._ub_a2a = UBXAllToAll(process_group)
+            else:
+                logger.info("UBX all-to-all unavailable on at least one rank; using NCCL")
+
         if async_ulysses:
             device = torch.cuda.current_device()
             if device not in UlyssesAttention._side_stream_by_device:
@@ -125,6 +145,38 @@ class UlyssesAttention(AttentionBackend):
             self._async_side_stream = UlyssesAttention._side_stream_by_device[device]
             if process_group is not None:
                 self._pg_boxed = process_group.boxed()
+
+    def _all_to_all_4d(
+        self,
+        tensor: torch.Tensor,
+        scatter_dim: int,
+        gather_dim: int,
+    ) -> torch.Tensor:
+        """Run the selected 4D all-to-all implementation."""
+        if self._ub_a2a is not None:
+            return self._ub_a2a(tensor, scatter_dim=scatter_dim, gather_dim=gather_dim)
+        return all_to_all_4d(
+            tensor,
+            scatter_dim=scatter_dim,
+            gather_dim=gather_dim,
+            process_group=self.process_group,
+        )
+
+    def _all_to_all_5d(
+        self,
+        tensor: torch.Tensor,
+        scatter_dim: int,
+        gather_dim: int,
+    ) -> torch.Tensor:
+        """Run the selected 5D all-to-all implementation."""
+        if self._ub_a2a is not None:
+            return self._ub_a2a(tensor, scatter_dim=scatter_dim, gather_dim=gather_dim)
+        return all_to_all_5d(
+            tensor,
+            scatter_dim=scatter_dim,
+            gather_dim=gather_dim,
+            process_group=self.process_group,
+        )
 
     def forward(
         self,
@@ -168,18 +220,14 @@ class UlyssesAttention(AttentionBackend):
 
         batch_size = q.shape[0]
         qkv = torch.stack([q, k, v], dim=2)
-        qkv = all_to_all_5d(qkv, scatter_dim=3, gather_dim=1, process_group=self.process_group)
+        qkv = self._all_to_all_5d(qkv, scatter_dim=3, gather_dim=1)
 
         B, seq_len, _, Hp, D = qkv.shape
 
         if gate_compress is not None:
-            gate_compress = all_to_all_4d(
-                gate_compress, scatter_dim=2, gather_dim=1, process_group=self.process_group
-            )
+            gate_compress = self._all_to_all_4d(gate_compress, scatter_dim=2, gather_dim=1)
         if gate_fine is not None:
-            gate_fine = all_to_all_4d(
-                gate_fine, scatter_dim=2, gather_dim=1, process_group=self.process_group
-            )
+            gate_fine = self._all_to_all_4d(gate_fine, scatter_dim=2, gather_dim=1)
 
         # Caller passed pre-A2A (sharded) seq_len; the inner backend
         # reshapes by it, so hand it the post-A2A length instead.
@@ -208,17 +256,13 @@ class UlyssesAttention(AttentionBackend):
         gate_fine = kwargs.pop("gate_fine", None)
 
         batch_size = q.shape[0]
-        q = all_to_all_4d(q, scatter_dim=2, gather_dim=1, process_group=self.process_group)
-        k = all_to_all_4d(k, scatter_dim=2, gather_dim=1, process_group=self.process_group)
-        v = all_to_all_4d(v, scatter_dim=2, gather_dim=1, process_group=self.process_group)
+        q = self._all_to_all_4d(q, scatter_dim=2, gather_dim=1)
+        k = self._all_to_all_4d(k, scatter_dim=2, gather_dim=1)
+        v = self._all_to_all_4d(v, scatter_dim=2, gather_dim=1)
         if gate_compress is not None:
-            gate_compress = all_to_all_4d(
-                gate_compress, scatter_dim=2, gather_dim=1, process_group=self.process_group
-            )
+            gate_compress = self._all_to_all_4d(gate_compress, scatter_dim=2, gather_dim=1)
         if gate_fine is not None:
-            gate_fine = all_to_all_4d(
-                gate_fine, scatter_dim=2, gather_dim=1, process_group=self.process_group
-            )
+            gate_fine = self._all_to_all_4d(gate_fine, scatter_dim=2, gather_dim=1)
 
         seq_len_full = q.shape[1]
         kv_seq_len_full = k.shape[1]
@@ -383,9 +427,7 @@ class UlyssesAttention(AttentionBackend):
                 )
             output = output.contiguous()
 
-        output = all_to_all_4d(
-            output, scatter_dim=1, gather_dim=2, process_group=self.process_group
-        )
+        output = self._all_to_all_4d(output, scatter_dim=1, gather_dim=2)
         return output
 
     @property

--- a/tensorrt_llm/_torch/visual_gen/ubx_alltoall.py
+++ b/tensorrt_llm/_torch/visual_gen/ubx_alltoall.py
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""UBX (Caliper) all-to-all for Ulysses sequence parallelism.
+
+``UBXAllToAll`` wraps Caliper's ``SymmAllocator`` to provide a zero-copy,
+CUDA-graph-safe all-to-all that replaces the NCCL-backed ``all_to_all_4d`` /
+``all_to_all_5d`` calls in ``UlyssesAttention``.
+
+UBX Lamport wins by 1.3–1.5x over NCCL in CUDA graph mode (>=64KB payloads).
+Falls back to NCCL before UBX starts when Caliper is unavailable or symmetric
+pool setup fails on any rank. In-flight UBX collective failures propagate
+rather than locally switching one rank to NCCL.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import ClassVar, Protocol
+
+import torch
+import torch.distributed as dist
+
+logger = logging.getLogger(__name__)
+
+_PoolCacheKey = tuple[torch.Size, torch.dtype]
+_SharedPoolKey = tuple[int, int]
+
+
+class _SymmAllocator(Protocol):
+    """Minimal Caliper allocator protocol used by UBXAllToAll."""
+
+    def create_tensor(self, shape: torch.Size, dtype: torch.dtype) -> torch.Tensor | None:
+        """Create a persistent symmetric tensor from the allocator pool."""
+        ...
+
+    def alltoall_auto(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Run UBX all-to-all on a symmetric tensor."""
+        ...
+
+
+@dataclass
+class _PoolState:
+    """Shared UBX state for one CUDA device and process group."""
+
+    allocator: _SymmAllocator | None = None
+    init_err: BaseException | None = None
+    pool_cache: dict[_PoolCacheKey, torch.Tensor] = field(default_factory=dict)
+    ready_pool_keys: set[_PoolCacheKey] = field(default_factory=set)
+
+
+def _sync_ready(local_ready: bool, device: torch.device, process_group: dist.ProcessGroup) -> bool:
+    """Return True only when every rank reports ready."""
+    ready = torch.tensor([int(local_ready)], device=device, dtype=torch.int32)
+    dist.all_reduce(ready, op=dist.ReduceOp.MIN, group=process_group)
+    return bool(ready.item())
+
+
+def _ubx_available(
+    process_group: dist.ProcessGroup | None = None,
+    device: torch.device | None = None,
+) -> bool:
+    """Return True if Caliper UBX is importable on every participating rank."""
+    try:
+        import ubx.allocator  # noqa: F401
+
+        local_available = True
+    except (ImportError, OSError, RuntimeError):
+        local_available = False
+
+    if process_group is None and dist.is_available() and dist.is_initialized():
+        process_group = dist.group.WORLD
+
+    if process_group is None or device is None or device.type != "cuda":
+        return local_available
+    if dist.get_world_size(group=process_group) == 1:
+        return local_available
+    return _sync_ready(local_available, device, process_group)
+
+
+def _shared_pool_key(device: torch.device, process_group: dist.ProcessGroup) -> _SharedPoolKey:
+    """Build the process-local shared-pool key."""
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    return device_index, id(process_group)
+
+
+def _create_allocator(
+    pool_bytes: int,
+    device: torch.device,
+    process_group: dist.ProcessGroup,
+) -> _SymmAllocator:
+    """Create Caliper's allocator behind a typed protocol boundary."""
+    from ubx.allocator import SymmAllocator
+
+    return SymmAllocator(pool_bytes, device, process_group)
+
+
+class UBXAllToAll:
+    """UBX-backed all-to-all for Ulysses using Caliper's SymmAllocator.
+
+    UBX Lamport wins by 1.3-1.5x over NCCL in CUDA graph mode (>=64KB
+    payloads). It falls back to ``all_to_all_4d`` / ``all_to_all_5d`` only
+    before entering UBX, after a process-group-wide readiness check.
+
+    CUDA graph safe: ``pool_in`` tensors are cached persistently per
+    ``(shape, dtype)`` key so no Python-level alloc/free occurs inside the
+    captured region.  ``pool_out`` is a Lamport rolling buffer owned by
+    ``alltoall_auto`` — never freed.
+
+    Supports 4D tensors ``[B, S, H, D]`` and 5D tensors ``[B, S, Q, H, D]``
+    (stacked QKV).  ``scatter_dim`` and ``gather_dim`` follow the same
+    semantics as ``all_to_all_4d`` / ``all_to_all_5d``.
+    """
+
+    _POOL_MB = 2048  # symmetric pool per rank (MB)
+    _shared_pools: ClassVar[dict[_SharedPoolKey, _PoolState]] = {}
+
+    def __init__(self, process_group: dist.ProcessGroup) -> None:
+        """Create a wrapper that lazily binds shared UBX state."""
+        self._pg = process_group
+        self._allocator: _SymmAllocator | None = None
+        self._init_err: BaseException | None = None
+        self._state: _PoolState | None = None
+        # (flat_shape, dtype) -> persistent SymmTensor; never freed so CUDA
+        # graphs can capture copy_ without the address being reallocated.
+        self._pool_cache: dict[_PoolCacheKey, torch.Tensor] = {}
+
+    def _bind_state(self, device: torch.device, process_group: dist.ProcessGroup) -> _PoolState:
+        """Bind wrapper-local fields to the shared state for this device/group."""
+        key = _shared_pool_key(device, process_group)
+        state = self._shared_pools.get(key)
+        if state is None:
+            state = _PoolState()
+            self._shared_pools[key] = state
+        self._sync_from_state(state)
+        return state
+
+    def _sync_from_state(self, state: _PoolState) -> None:
+        """Refresh wrapper-local aliases for the shared allocator and cache."""
+        self._state = state
+        self._allocator = state.allocator
+        self._init_err = state.init_err
+        self._pool_cache = state.pool_cache
+
+    def _disable_state(self, state: _PoolState, init_err: BaseException) -> None:
+        """Disable UBX and release references to symmetric pool objects."""
+        state.init_err = init_err
+        state.pool_cache.clear()
+        state.ready_pool_keys.clear()
+        state.allocator = None
+        self._sync_from_state(state)
+
+    def _try_init(self, device: torch.device, process_group: dist.ProcessGroup) -> bool:
+        """Initialize the shared allocator only when every rank can do so."""
+        if device.type != "cuda":
+            return False
+
+        state = self._bind_state(device, process_group)
+        if state.init_err is not None:
+            self._sync_from_state(state)
+            return False
+        if state.allocator is not None:
+            return True
+
+        local_err: BaseException | None = None
+        try:
+            pool_bytes = self._POOL_MB * 1024 * 1024
+            state.allocator = _create_allocator(pool_bytes, device, process_group)
+        except (ImportError, MemoryError, OSError, RuntimeError) as exc:
+            local_err = exc
+
+        if not _sync_ready(state.allocator is not None, device, process_group):
+            self._disable_state(
+                state,
+                local_err
+                or RuntimeError("UBXAllToAll disabled because a peer failed initialization"),
+            )
+            logger.warning(
+                "UBXAllToAll: init failed on at least one rank, falling back to NCCL: %s",
+                state.init_err,
+            )
+            return False
+
+        self._sync_from_state(state)
+        logger.info("UBXAllToAll: shared SymmAllocator ready")
+        return True
+
+    def _nccl_fallback(
+        self,
+        tensor: torch.Tensor,
+        scatter_dim: int,
+        gather_dim: int,
+        process_group: dist.ProcessGroup,
+    ) -> torch.Tensor:
+        """Run the existing NCCL-backed all-to-all implementation."""
+        from tensorrt_llm._torch.distributed import all_to_all_4d, all_to_all_5d
+
+        if tensor.ndim == 5:
+            return all_to_all_5d(
+                tensor,
+                scatter_dim=scatter_dim,
+                gather_dim=gather_dim,
+                process_group=process_group,
+            )
+        return all_to_all_4d(
+            tensor,
+            scatter_dim=scatter_dim,
+            gather_dim=gather_dim,
+            process_group=process_group,
+        )
+
+    def __call__(
+        self,
+        tensor: torch.Tensor,
+        scatter_dim: int,
+        gather_dim: int,
+        process_group: dist.ProcessGroup | None = None,
+    ) -> torch.Tensor:
+        """Run UBX all-to-all when collectively ready, otherwise use NCCL."""
+        pg = process_group or self._pg
+        world_size = dist.get_world_size(pg)
+        if world_size == 1:
+            return tensor
+        if not self._try_init(tensor.device, pg):
+            return self._nccl_fallback(tensor, scatter_dim, gather_dim, pg)
+
+        output = self._ubx_all_to_all(tensor, scatter_dim, gather_dim, pg, world_size)
+        if output is None:
+            return self._nccl_fallback(tensor, scatter_dim, gather_dim, pg)
+        return output
+
+    def _get_pool_in(
+        self,
+        flat: torch.Tensor,
+        device: torch.device,
+        process_group: dist.ProcessGroup,
+    ) -> torch.Tensor | None:
+        """Return a shared input pool tensor after collective readiness."""
+        state = self._state
+        alloc = self._allocator
+        if state is None or alloc is None:
+            raise RuntimeError("UBXAllToAll allocator is not initialized")
+
+        key = (flat.shape, flat.dtype)
+        pool_in = state.pool_cache.get(key)
+        local_err: BaseException | None = None
+        if pool_in is None:
+            try:
+                pool_in = alloc.create_tensor(flat.shape, flat.dtype)
+            except (MemoryError, OSError, RuntimeError) as exc:
+                local_err = exc
+            if pool_in is not None:
+                state.pool_cache[key] = pool_in
+
+        if key not in state.ready_pool_keys:
+            if not _sync_ready(pool_in is not None, device, process_group):
+                self._disable_state(
+                    state,
+                    local_err
+                    or RuntimeError("UBXAllToAll disabled because a peer failed pool allocation"),
+                )
+                logger.warning(
+                    "UBXAllToAll: pool allocation failed on at least one rank, "
+                    "falling back to NCCL: %s",
+                    state.init_err,
+                )
+                return None
+            state.ready_pool_keys.add(key)
+
+        self._sync_from_state(state)
+        if pool_in is None:
+            raise RuntimeError("UBXAllToAll pool key is marked ready without a local tensor")
+        return pool_in
+
+    def _ubx_all_to_all(
+        self,
+        tensor: torch.Tensor,
+        scatter_dim: int,
+        gather_dim: int,
+        process_group: dist.ProcessGroup,
+        world_size: int,
+    ) -> torch.Tensor | None:
+        """Transform tensor layout, call UBX, and restore the requested layout."""
+        alloc = self._allocator
+        if alloc is None:
+            raise RuntimeError("UBXAllToAll allocator is not initialized")
+        t = tensor.contiguous()
+        ndim = t.ndim
+        if ndim == 4:
+            batch, seq, heads, head_dim = t.shape
+            if scatter_dim == 2:
+                # [B, S/P, H, D] → scatter heads → [P, B, S/P, H/P, D]
+                inp = t.view(batch, seq, world_size, heads // world_size, head_dim)
+                inp = inp.permute(2, 0, 1, 3, 4).contiguous()
+            else:
+                # [B, S, H/P, D] → scatter seq → [P, B, S/P, H/P, D]
+                inp = t.view(batch, world_size, seq // world_size, heads, head_dim)
+                inp = inp.permute(1, 0, 2, 3, 4).contiguous()
+        elif ndim == 5:
+            batch, seq, qkv, heads, head_dim = t.shape
+            if scatter_dim == 3:
+                # [B, S/P, 3, H, D] → scatter heads → [P, B, S/P, 3, H/P, D]
+                inp = t.view(batch, seq, qkv, world_size, heads // world_size, head_dim)
+                inp = inp.permute(3, 0, 1, 2, 4, 5).contiguous()
+            else:
+                # [B, S, 3, H/P, D] → scatter seq → [P, B, S/P, 3, H/P, D]
+                inp = t.view(batch, world_size, seq // world_size, qkv, heads, head_dim)
+                inp = inp.permute(1, 0, 2, 3, 4, 5).contiguous()
+        else:
+            raise ValueError(f"UBXAllToAll: unsupported ndim={ndim}")
+
+        flat = inp.flatten()
+
+        # pool_in cached permanently; no alloc/free in hot path after warmup.
+        pool_in = self._get_pool_in(flat, tensor.device, process_group)
+        if pool_in is None:
+            return None
+        pool_in.copy_(flat)
+
+        pool_out = alloc.alltoall_auto(pool_in)
+        out_flat = pool_out.clone()  # copy to regular (non-symmetric) memory
+
+        out_t = out_flat.view_as(inp)
+
+        if ndim == 4:
+            if gather_dim == 1:
+                # [P, B, S/P, H/P, D] → [B, S, H/P, D]
+                out = out_t.permute(1, 0, 2, 3, 4).contiguous()
+                out = out.view(batch, seq * world_size, heads // world_size, head_dim)
+            else:
+                # [P, B, S/P, H/P, D] → [B, S/P, H, D]
+                out = out_t.permute(1, 2, 0, 3, 4).contiguous()
+                out = out.view(batch, seq // world_size, heads * world_size, head_dim)
+        else:
+            if gather_dim == 1:
+                # [P, B, S/P, 3, H/P, D] → [B, S, 3, H/P, D]
+                out = out_t.permute(1, 0, 2, 3, 4, 5).contiguous()
+                out = out.view(batch, seq * world_size, qkv, heads // world_size, head_dim)
+            else:
+                # [P, B, S/P, 3, H/P, D] → [B, S/P, 3, H, D]
+                out = out_t.permute(1, 2, 3, 0, 4, 5).contiguous()
+                out = out.view(batch, seq // world_size, qkv, heads * world_size, head_dim)
+
+        return out

--- a/tests/unittest/_torch/visual_gen/test_ubx_alltoall.py
+++ b/tests/unittest/_torch/visual_gen/test_ubx_alltoall.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for VisualGen UBX all-to-all helpers."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+
+def _load_ubx_alltoall_module():
+    """Load the helper module without importing the full tensorrt_llm package."""
+    module_path = (
+        Path(__file__).resolve().parents[4]
+        / "tensorrt_llm"
+        / "_torch"
+        / "visual_gen"
+        / "ubx_alltoall.py"
+    )
+    spec = importlib.util.spec_from_file_location("ubx_alltoall_under_test", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ubx_alltoall = _load_ubx_alltoall_module()
+
+
+class _FailingAllocator:
+    def create_tensor(self, shape, dtype):
+        return None
+
+
+def test_ubx_available_resolves_none_to_default_group(monkeypatch):
+    world_group = object()
+    seen = {}
+
+    def fake_get_world_size(*, group):
+        seen["get_world_size_group"] = group
+        return 2
+
+    def fake_sync_ready(local_ready, device, process_group):
+        seen["sync_ready_args"] = (local_ready, device, process_group)
+        return local_ready
+
+    fake_dist = SimpleNamespace(
+        group=SimpleNamespace(WORLD=world_group),
+        get_world_size=fake_get_world_size,
+        is_available=lambda: True,
+        is_initialized=lambda: True,
+    )
+    monkeypatch.setattr(ubx_alltoall, "dist", fake_dist)
+    monkeypatch.setattr(ubx_alltoall, "_sync_ready", fake_sync_ready)
+
+    assert not ubx_alltoall._ubx_available(process_group=None, device=torch.device("cuda", 0))
+    assert seen["get_world_size_group"] is world_group
+    assert seen["sync_ready_args"][2] is world_group
+
+
+def test_pool_allocation_failure_releases_cached_state(monkeypatch):
+    wrapper = ubx_alltoall.UBXAllToAll(process_group=object())
+    state = ubx_alltoall._PoolState(allocator=_FailingAllocator())
+    ready_key = (torch.Size([2]), torch.float32)
+    state.pool_cache[ready_key] = torch.empty(2)
+    state.ready_pool_keys.add(ready_key)
+    wrapper._sync_from_state(state)
+
+    monkeypatch.setattr(
+        ubx_alltoall, "_sync_ready", lambda local_ready, device, process_group: local_ready
+    )
+
+    assert wrapper._get_pool_in(torch.empty(1), torch.device("cuda", 0), object()) is None
+    assert state.allocator is None
+    assert state.pool_cache == {}
+    assert state.ready_pool_keys == set()
+    assert wrapper._allocator is None
+    assert wrapper._pool_cache == {}


### PR DESCRIPTION
This PR copies #15285 because I do not have write permission to the original PR branch.

## Summary

- Adds `tensorrt_llm/_torch/visual_gen/ubx_alltoall.py` with `UBXAllToAll` backed by Caliper's `SymmAllocator`.
- Wires `UBXAllToAll` into `UlyssesAttention` (`_forward_fused`, `_forward_unfused`, `_output_a2a`) as a transparent drop-in for `all_to_all_4d` / `all_to_all_5d`.
- Shares the 2 GiB symmetric allocator and persistent input pool cache across attention wrappers, keyed by CUDA device and process group.
- Falls back to NCCL only before UBX starts, after process-group-wide availability, allocator, and per-shape pool readiness checks. In-flight UBX collective failures propagate instead of locally switching one rank to NCCL.
- Async Ulysses path (`async_ulysses=True`) is excluded — it uses TRTLLM CE ops that are already optimal.

## Motivation

VisualGen's `CUDAGraphRunner` captures the full transformer block into a CUDA graph. In that mode, UBX Lamport polling outperforms NCCL AllToAll significantly — and the gap widens with GPU count:

**4× B200 NVSwitch, CUDA graph mode:**

| Size | NCCL | UBX | Speedup |
|------|------|-----|---------|
| 64 KB | 20.8 µs | 19.1 µs | 1.09× |
| 256 KB | 27.0 µs | 20.0 µs | 1.35× |
| 512 KB | 28.1 µs | 19.2 µs | 1.46× |
| 1 MB | 29.6 µs | 20.5 µs | 1.44× |

**8× B200 NVSwitch, CUDA graph mode:**

| Size | NCCL | UBX | Speedup |
|------|------|-----|---------|
| 64 KB | 56.0 µs | 22.4 µs | **2.5×** |
| 256 KB | 190.3 µs | 23.1 µs | **8.2×** |
| 512 KB | 107.7 µs | 23.4 µs | **4.6×** |
| 1 MB | 132.1 µs | 30.5 µs | **4.3×** |

## Design

**Shared pool**: `UBXAllToAll` instances share allocator/cache state per `(CUDA device, process group)`, so multi-layer Ulysses wrappers reuse one 2 GiB symmetric pool instead of reserving one pool per layer.

**Collective readiness**: UBX/NCCL selection is synchronized across the process group for import availability, allocator initialization, and per-shape `pool_in` allocation before any rank enters `alltoall_auto`.

**CUDA graph safety**: `pool_in` SymmTensors are cached permanently per `(shape, dtype)` key — no alloc/free inside the captured region. `pool_out` is a Lamport rolling buffer owned by `alltoall_auto` and is never freed.

**5D stacked QKV**: `UBXAllToAll` handles both 4D `[B, S, H, D]` and 5D `[B, S, 3, H, D]` tensors, matching the `_forward_fused` path.

**Failure behavior**: Caliper availability/setup/pool-allocation failures coordinate NCCL fallback before UBX starts. In-flight UBX collective failures are not locally converted to NCCL fallback, avoiding split-rank deadlocks.

## Test plan

- [x] 7/7 correctness tests pass: 4D fwd (B=1,2), 4D bwd, 5D fwd — verified on 8× B200.
- [x] `torchrun --nproc-per-node=8 tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_attention.py`
- [x] `TRTLLM_FORCE_NCCL_ALLREDUCE=1` path passes (pure NCCL fallback).
- [x] Async Ulysses (`async_ulysses=True`) unaffected — `_ub_a2a` is `None` in that path.
- [x] `python3 -m compileall -q tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py tensorrt_llm/_torch/visual_gen/ubx_alltoall.py`
- [x] `git diff --check nvidia/main..HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)