### PR TITLE
[https://nvbugs/6030763][fix] Gate native KV-transfer peer endpoints behind an allowlist

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/native/peer_allowlist.py
+++ b/tensorrt_llm/_torch/disaggregation/native/peer_allowlist.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Allowlist for the peer endpoints that the native KV-transfer path dials.
+
+Peer endpoints arrive from data a worker does not control -- ``ctx_info_endpoint``
+on an incoming request, and ``sender_endpoints`` / ``self_endpoint`` /
+``peer_endpoint`` inside peer replies -- and are connected to verbatim. When an
+allowlist is configured, only endpoints whose host is a known peer are dialed.
+
+Matching is on host only, since transfer endpoints bind an ephemeral port.
+Disabled by default; a configured-but-unparsable value raises rather than
+degrading to "allow everything".
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import re
+import socket
+from typing import Iterable, List, Optional, Sequence, Set
+
+from tensorrt_llm import logger
+
+ALLOWED_PEER_HOSTS_ENV = "TRTLLM_KV_TRANSFER_ALLOWED_PEER_HOSTS"
+
+# Underscores are permitted because Kubernetes service names use them.
+_HOSTNAME_RE = re.compile(
+    r"^[a-z0-9_]([a-z0-9_-]*[a-z0-9_])?(\.[a-z0-9_]([a-z0-9_-]*[a-z0-9_])?)*$"
+)
+
+# Not urlparse: libzmq reads "tcp://<source>;<destination>" as "bind <source>,
+# connect <destination>" while urlparse reports only <source>, so a permissive
+# parse would allow "tcp://<allowed>:0;<attacker>:9999" and then dial <attacker>.
+# \Z rather than $, which also matches before a trailing newline.
+_ENDPOINT_RE = re.compile(r"\Atcp://(?P<host>\[[0-9A-Fa-f:.]+\]|[A-Za-z0-9._-]+):(?:\*|\d{1,5})\Z")
+
+
+class PeerEndpointNotAllowedError(ValueError):
+    """Raised when a peer endpoint's host is not in the configured allowlist."""
+
+
+def _normalize_host(host: str) -> str:
+    host = host.strip().lower()
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+    if len(host) > 1 and host.endswith("."):
+        host = host[:-1]
+    return host
+
+
+def _as_network(entry: str) -> Optional[ipaddress._BaseNetwork]:
+    try:
+        # strict=True keeps a mistyped "10.0.3.12/0" from widening to 0.0.0.0/0.
+        return ipaddress.ip_network(entry, strict=True)
+    except ValueError:
+        return None
+
+
+def _resolve(name: str) -> List[str]:
+    try:
+        infos = socket.getaddrinfo(name, None, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, UnicodeError, ValueError, OSError):
+        logger.warning(
+            f"Could not resolve {ALLOWED_PEER_HOSTS_ENV} entry {name!r}; it will "
+            "only match endpoints that carry the name literally"
+        )
+        return []
+    return sorted({info[4][0] for info in infos})
+
+
+class PeerEndpointAllowlist:
+    def __init__(self, entries: Iterable[str]):
+        self._names: Set[str] = set()
+        self._networks: List[ipaddress._BaseNetwork] = []
+        provided = [entry for entry in map(_normalize_host, entries) if entry]
+        rejected: List[str] = []
+        for entry in provided:
+            network = _as_network(entry)
+            if network is not None:
+                self._networks.append(network)
+                continue
+            if not _HOSTNAME_RE.match(entry):
+                rejected.append(entry)
+                continue
+            # A hostname only matches an IP-based endpoint once resolved.
+            self._names.add(entry)
+            for address in _resolve(entry):
+                resolved = _as_network(_normalize_host(address))
+                if resolved is not None:
+                    self._networks.append(resolved)
+        if rejected:
+            raise ValueError(
+                f"{ALLOWED_PEER_HOSTS_ENV} contains entries that are neither a "
+                f"hostname, an IP address, nor a CIDR block: {rejected}"
+            )
+        self._enabled = bool(provided)
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def allows(self, endpoint: Optional[str]) -> bool:
+        if not self._enabled:
+            return True
+        if not endpoint:
+            return False
+        match = _ENDPOINT_RE.match(endpoint)
+        if match is None:
+            return False
+        host = _normalize_host(match.group("host"))
+        if not host:
+            return False
+        if host in self._names:
+            return True
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError:
+            return False
+        if address.version == 6 and address.ipv4_mapped is not None:
+            address = address.ipv4_mapped
+        return any(address in network for network in self._networks)
+
+    def check(self, endpoint: Optional[str]) -> None:
+        if not self.allows(endpoint):
+            raise PeerEndpointNotAllowedError(
+                f"Refusing to connect to peer endpoint {endpoint!r}: host is not "
+                f"in {ALLOWED_PEER_HOSTS_ENV}"
+            )
+
+
+def _configured_entries() -> Sequence[str]:
+    return os.getenv(ALLOWED_PEER_HOSTS_ENV, "").split(",")
+
+
+_allowlist: Optional[PeerEndpointAllowlist] = None
+_allowlist_error: Optional[ValueError] = None
+
+
+def get_peer_endpoint_allowlist() -> PeerEndpointAllowlist:
+    global _allowlist, _allowlist_error
+    # Failures are cached too, so the dial path never re-parses or re-resolves.
+    if _allowlist_error is not None:
+        raise _allowlist_error
+    if _allowlist is None:
+        try:
+            allowlist = PeerEndpointAllowlist(_configured_entries())
+        except ValueError as error:
+            _allowlist_error = error
+            raise
+        if allowlist.enabled:
+            logger.info(f"KV transfer peer endpoint allowlist enabled via {ALLOWED_PEER_HOSTS_ENV}")
+        _allowlist = allowlist
+    return _allowlist
+
+
+def reset_peer_endpoint_allowlist() -> None:
+    global _allowlist, _allowlist_error
+    _allowlist = None
+    _allowlist_error = None
+
+
+def check_peer_endpoint(endpoint: Optional[str]) -> None:
+    get_peer_endpoint_allowlist().check(endpoint)

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -58,6 +58,10 @@ from tensorrt_llm._torch.disaggregation.native.auxiliary import AuxBuffer
 from tensorrt_llm._torch.disaggregation.native.messenger import ZMQMessenger, decode_message
 from tensorrt_llm._torch.disaggregation.native.mixers.ssm.peer import MambaPolicy
 from tensorrt_llm._torch.disaggregation.native.peer import PeerRegistrar
+from tensorrt_llm._torch.disaggregation.native.peer_allowlist import (
+    check_peer_endpoint,
+    get_peer_endpoint_allowlist,
+)
 from tensorrt_llm._torch.disaggregation.native.perf_logger import PerfTimer, perf_log_manager
 from tensorrt_llm._torch.disaggregation.native.rank_info import RankInfo
 from tensorrt_llm._torch.disaggregation.native.utils import get_local_ip
@@ -422,6 +426,7 @@ class Sender(SenderBase):
         access to the same ZMQ socket."""
         if endpoint is None:
             raise ValueError("Sender: peer endpoint is None; peer may not have registered yet")
+        check_peer_endpoint(endpoint)
         dealers = getattr(self._thread_local, "dealers", None)
         if dealers is None:
             dealers = {}
@@ -1088,6 +1093,7 @@ class Sender(SenderBase):
     def _get_or_connect_dealer(self, endpoint: Optional[str]):
         if endpoint is None:
             raise ValueError("Sender: peer endpoint is None; peer may not have registered yet")
+        check_peer_endpoint(endpoint)
         if endpoint not in self._dealers:
             self._dealers[endpoint] = ZMQMessenger(mode="DEALER", endpoint=endpoint)
         return self._dealers[endpoint]
@@ -1659,6 +1665,7 @@ class Receiver(ReceiverBase):
     def _get_or_connect_dealer(self, endpoint: Optional[str]):
         if endpoint is None:
             raise ValueError("Receiver: peer endpoint is None; peer may not have registered yet")
+        check_peer_endpoint(endpoint)
         if endpoint not in self._dealers:
             self._dealers[endpoint] = ZMQMessenger(mode="DEALER", endpoint=endpoint)
         return self._dealers[endpoint]
@@ -1666,6 +1673,7 @@ class Receiver(ReceiverBase):
     def _get_sender_info(self, params: DisaggregatedParams) -> RankInfo:
         info_endpoint = self._extract_info_endpoint(params)
         if self._should_register_peer(params):
+            check_peer_endpoint(info_endpoint)
             logger.info(f"Registering peer in first request to endpoint '{info_endpoint}'")
             messenger = ZMQMessenger(mode="DEALER", endpoint=info_endpoint)
             try:
@@ -2246,6 +2254,8 @@ class TransferWorkerConfig:
 
 class TransferWorker:
     def __init__(self, config: TransferWorkerConfig):
+        # Surface a bad allowlist configuration at startup, not mid-transfer.
+        get_peer_endpoint_allowlist()
         self._config = config
         kvm = config.kv_cache_manager
         self._aux_buffer = _make_aux_buffer(

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -70,6 +70,7 @@ l0_a10:
   - unittest/disaggregated/test_remoteDictionary.py
   - unittest/disaggregated/test_agent_multi_backends.py
   - unittest/disaggregated/test_messenger.py
+  - unittest/disaggregated/test_peer_endpoint_allowlist.py
   - unittest/disaggregated/test_disagg_cluster_manager_worker.py
   - unittest/disaggregated/test_cluster_storage.py
   - unittest/disaggregated/test_extractor.py

--- a/tests/unittest/disaggregated/test_peer_endpoint_allowlist.py
+++ b/tests/unittest/disaggregated/test_peer_endpoint_allowlist.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from tensorrt_llm._torch.disaggregation.native.peer_allowlist import (
+    ALLOWED_PEER_HOSTS_ENV,
+    PeerEndpointAllowlist,
+    PeerEndpointNotAllowedError,
+    check_peer_endpoint,
+    get_peer_endpoint_allowlist,
+    reset_peer_endpoint_allowlist,
+)
+
+ATTACKER = "tcp://10.13.37.99:31337"
+PEER = "tcp://10.0.3.12:29010"
+
+
+@pytest.fixture(autouse=True)
+def _reset_allowlist():
+    reset_peer_endpoint_allowlist()
+    yield
+    reset_peer_endpoint_allowlist()
+
+
+def test_unconfigured_allowlist_allows_everything():
+    allowlist = PeerEndpointAllowlist([])
+
+    assert not allowlist.enabled
+    assert allowlist.allows(ATTACKER)
+    allowlist.check(ATTACKER)
+
+
+def test_configured_allowlist_rejects_unknown_host():
+    allowlist = PeerEndpointAllowlist(["10.0.3.12"])
+
+    assert allowlist.enabled
+    assert allowlist.allows(PEER)
+    assert not allowlist.allows(ATTACKER)
+    with pytest.raises(PeerEndpointNotAllowedError, match="Refusing to connect"):
+        allowlist.check(ATTACKER)
+
+
+def test_port_is_not_part_of_the_match():
+    allowlist = PeerEndpointAllowlist(["10.0.3.12"])
+
+    assert allowlist.allows("tcp://10.0.3.12:1")
+    assert allowlist.allows("tcp://10.0.3.12:65535")
+
+
+def test_cidr_entry_matches_contained_addresses():
+    allowlist = PeerEndpointAllowlist(["10.0.3.0/24"])
+
+    assert allowlist.allows("tcp://10.0.3.1:29010")
+    assert allowlist.allows("tcp://10.0.3.254:29010")
+    assert not allowlist.allows("tcp://10.0.4.1:29010")
+
+
+def test_loopback_and_cloud_metadata_are_rejected():
+    allowlist = PeerEndpointAllowlist(["10.0.3.0/24"])
+
+    for endpoint in (
+        "tcp://127.0.0.1:22",
+        "tcp://127.0.0.1:8080",
+        "tcp://169.254.169.254:80",
+        "tcp://172.17.0.1:2375",
+    ):
+        assert not allowlist.allows(endpoint), endpoint
+
+
+def test_ipv6_entry_and_endpoint():
+    allowlist = PeerEndpointAllowlist(["fd00::/8"])
+
+    assert allowlist.allows("tcp://[fd00::1]:29010")
+    assert not allowlist.allows("tcp://[fe80::1]:29010")
+
+
+def test_hostname_entry_matches_literal_host():
+    allowlist = PeerEndpointAllowlist(["ctx-worker-0"])
+
+    assert allowlist.allows("tcp://ctx-worker-0:29010")
+    assert allowlist.allows("tcp://CTX-Worker-0:29010")
+    assert not allowlist.allows("tcp://ctx-worker-1:29010")
+
+
+def test_localhost_entry_resolves_to_its_addresses():
+    allowlist = PeerEndpointAllowlist(["localhost"])
+
+    assert allowlist.allows("tcp://127.0.0.1:29010")
+
+
+def test_non_tcp_transports_are_rejected():
+    allowlist = PeerEndpointAllowlist(["10.0.3.12"])
+
+    for endpoint in (
+        "ipc:///var/run/docker.sock",
+        "inproc://kv",
+        "pgm://10.13.37.99:9999",
+        "udp://10.13.37.99:9999",
+    ):
+        assert not allowlist.allows(endpoint), endpoint
+
+
+def test_malformed_and_empty_endpoints_are_rejected_when_enabled():
+    allowlist = PeerEndpointAllowlist(["10.0.3.12"])
+
+    for endpoint in (None, "", "tcp://", "tcp://:29010", "not-an-endpoint"):
+        assert not allowlist.allows(endpoint), endpoint
+
+
+def test_blank_entries_do_not_enable_the_allowlist():
+    assert not PeerEndpointAllowlist(["", "  ", "\t"]).enabled
+
+
+def test_unparsable_entry_raises_instead_of_failing_open():
+    for entries in (["10.0.3.12/0"], ["not a host!"], ["10.0.3.12", "bogus!!"]):
+        with pytest.raises(ValueError, match=ALLOWED_PEER_HOSTS_ENV):
+            PeerEndpointAllowlist(entries)
+
+
+def test_mistyped_prefix_is_not_widened_to_everything():
+    with pytest.raises(ValueError):
+        PeerEndpointAllowlist(["10.0.3.12/0"])
+
+
+def test_trailing_dot_is_normalized_on_both_sides():
+    assert PeerEndpointAllowlist(["10.0.3.12."]).allows("tcp://10.0.3.12:29010")
+    assert PeerEndpointAllowlist(["10.0.3.12"]).allows("tcp://10.0.3.12.:29010")
+    assert PeerEndpointAllowlist(["ctx-worker-0"]).allows("tcp://ctx-worker-0.:29010")
+
+
+def test_underscore_hostname_is_accepted():
+    allowlist = PeerEndpointAllowlist(["kv_svc.ns"])
+
+    assert allowlist.enabled
+    assert allowlist.allows("tcp://kv_svc.ns:29010")
+
+
+def test_ipv4_mapped_ipv6_is_unwrapped_before_matching():
+    allowlist = PeerEndpointAllowlist(["10.0.3.0/24"])
+
+    assert allowlist.allows("tcp://[::ffff:10.0.3.12]:29010")
+    assert not allowlist.allows("tcp://[::ffff:127.0.0.1]:22")
+
+
+def test_userinfo_cannot_spoof_an_allowed_host():
+    allowlist = PeerEndpointAllowlist(["10.0.3.12"])
+
+    assert not allowlist.allows("tcp://10.0.3.12@10.13.37.99:31337")
+    assert not allowlist.allows("tcp://user:10.0.3.12@10.13.37.99:31337")
+
+
+def test_obfuscated_ipv4_forms_do_not_match():
+    allowlist = PeerEndpointAllowlist(["127.0.0.0/8"])
+
+    for endpoint in ("tcp://0177.0.0.1:22", "tcp://2130706433:22", "tcp://0x7f.0.0.1:22"):
+        assert not allowlist.allows(endpoint), endpoint
+
+
+def test_uppercase_scheme_is_rejected():
+    assert not PeerEndpointAllowlist(["10.0.3.12"]).allows("TCP://10.13.37.99:31337")
+
+
+def test_zmq_source_destination_syntax_cannot_smuggle_a_host():
+    # libzmq dials the half after ";"; a source-only parse would allow these.
+    allowlist = PeerEndpointAllowlist(["10.0.3.0/24", "127.0.0.0/8"])
+
+    for endpoint in (
+        "tcp://10.0.3.12:0;10.13.37.99:31337",
+        "tcp://127.0.0.1:0;10.13.37.99:31337",
+        "tcp://127.0.0.1:0;evil.example.com:80",
+        "tcp://0.0.0.0:0;10.13.37.99:31337",
+        "tcp://lo:0;10.13.37.99:31337",
+        "tcp://[::1]:0;10.13.37.99:31337",
+    ):
+        assert not allowlist.allows(endpoint), endpoint
+
+
+def test_only_a_bare_tcp_host_port_endpoint_is_accepted():
+    allowlist = PeerEndpointAllowlist(["10.0.3.12"])
+
+    assert allowlist.allows("tcp://10.0.3.12:29010")
+    assert allowlist.allows("tcp://10.0.3.12:*")
+    for endpoint in (
+        "tcp://10.0.3.12:29010/path",
+        "tcp://10.0.3.12:29010?x=1",
+        "tcp://10.0.3.12:29010#frag",
+        "tcp://10.0.3.12:29010 ",
+        "tcp://10.0.3.12:29010\n",
+        "tcp://10.0.3.12%00.evil.com:9999",
+        "tcp://10.0.3.12:999999",
+        "tcp://10.0.3.12",
+    ):
+        assert not allowlist.allows(endpoint), repr(endpoint)
+
+
+def test_bad_configuration_is_cached_and_not_reparsed(monkeypatch):
+    monkeypatch.setenv(ALLOWED_PEER_HOSTS_ENV, "10.0.3.12, bogus!!")
+
+    with pytest.raises(ValueError, match=ALLOWED_PEER_HOSTS_ENV) as first:
+        get_peer_endpoint_allowlist()
+    with pytest.raises(ValueError) as second:
+        check_peer_endpoint(PEER)
+
+    assert first.value is second.value
+
+
+def test_env_var_drives_the_process_wide_allowlist(monkeypatch):
+    monkeypatch.setenv(ALLOWED_PEER_HOSTS_ENV, "10.0.3.12, 10.0.4.0/24")
+
+    assert get_peer_endpoint_allowlist().enabled
+    check_peer_endpoint(PEER)
+    check_peer_endpoint("tcp://10.0.4.7:29010")
+    with pytest.raises(PeerEndpointNotAllowedError):
+        check_peer_endpoint(ATTACKER)
+
+
+def test_check_peer_endpoint_is_a_no_op_without_env_var(monkeypatch):
+    monkeypatch.delenv(ALLOWED_PEER_HOSTS_ENV, raising=False)
+
+    assert not get_peer_endpoint_allowlist().enabled
+    check_peer_endpoint(ATTACKER)
+
+
+def test_rejection_is_a_value_error_subclass():
+    assert issubclass(PeerEndpointNotAllowedError, ValueError)
+
+
+try:
+    from tensorrt_llm._torch.disaggregation.native import transfer
+except ImportError:
+    transfer = None
+
+requires_transfer = pytest.mark.skipif(
+    transfer is None, reason="requires built tensorrt_llm bindings"
+)
+
+
+class _StubMessenger:
+    def __init__(self, mode, endpoint=None):
+        self.mode = mode
+        self.endpoint = endpoint
+
+    def send(self, _):
+        raise AssertionError("peer should not be contacted in this test")
+
+
+@pytest.fixture
+def stub_messenger(monkeypatch):
+    monkeypatch.setattr(transfer, "ZMQMessenger", _StubMessenger)
+
+
+@pytest.fixture
+def allowlisted_peer(monkeypatch):
+    monkeypatch.setenv(ALLOWED_PEER_HOSTS_ENV, "10.0.3.12")
+
+
+def _bare(cls):
+    return object.__new__(cls)
+
+
+@requires_transfer
+def test_receiver_dealer_refuses_endpoint_outside_allowlist(allowlisted_peer):
+    receiver = _bare(transfer.Receiver)
+    receiver._dealers = {}
+
+    with pytest.raises(PeerEndpointNotAllowedError):
+        receiver._get_or_connect_dealer(ATTACKER)
+    assert receiver._dealers == {}
+
+
+@requires_transfer
+def test_receiver_dealer_connects_to_allowlisted_peer(allowlisted_peer, stub_messenger):
+    receiver = _bare(transfer.Receiver)
+    receiver._dealers = {}
+
+    assert receiver._get_or_connect_dealer(PEER).endpoint == PEER
+
+
+@requires_transfer
+def test_sender_dealer_refuses_endpoint_outside_allowlist(allowlisted_peer):
+    sender = _bare(transfer.Sender)
+    sender._dealers = {}
+
+    with pytest.raises(PeerEndpointNotAllowedError):
+        sender._get_or_connect_dealer(ATTACKER)
+    assert sender._dealers == {}
+
+
+@requires_transfer
+def test_sender_thread_dealer_refuses_endpoint_outside_allowlist(allowlisted_peer):
+    import threading
+
+    sender = _bare(transfer.Sender)
+    sender._thread_local = threading.local()
+
+    with pytest.raises(PeerEndpointNotAllowedError):
+        sender._get_or_connect_thread_dealer(ATTACKER)
+
+
+@requires_transfer
+def test_sender_info_refuses_request_supplied_endpoint(allowlisted_peer):
+    from tensorrt_llm.disaggregated_params import DisaggregatedParams
+
+    receiver = _bare(transfer.Receiver)
+    receiver._sender_ep_instance_map = {}
+
+    with pytest.raises(PeerEndpointNotAllowedError):
+        receiver._get_sender_info(DisaggregatedParams(ctx_info_endpoint=ATTACKER))
+
+
+@requires_transfer
+def test_hooks_are_inert_without_allowlist(monkeypatch, stub_messenger):
+    monkeypatch.delenv(ALLOWED_PEER_HOSTS_ENV, raising=False)
+    receiver = _bare(transfer.Receiver)
+    receiver._dealers = {}
+
+    assert receiver._get_or_connect_dealer(ATTACKER).endpoint == ATTACKER


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This pull request introduces a peer endpoint allowlist for the native key-value (KV) transfer path in `tensorrt_llm`, enabling security controls over which peer endpoints may be dialed. The allowlist is configured via the `TRTLLM_KV_TRANSFER_ALLOWED_PEER_HOSTS` environment variable and is enforced in all code paths that connect to peer endpoints. The change includes robust validation, normalization, and matching logic, as well as comprehensive unit tests to ensure correct behavior and prevent security bypasses.

The most important changes are:

**Security: Peer Endpoint Allowlist Implementation**
* Added `peer_allowlist.py`, which implements a configurable allowlist for peer endpoints, matching on host (including hostnames, IPs, and CIDR blocks), with strict parsing and normalization to prevent bypasses. The allowlist is disabled by default and raises on invalid configuration. (`tensorrt_llm/_torch/disaggregation/native/peer_allowlist.py`)
* Integrated allowlist enforcement in all peer connection code paths by invoking `check_peer_endpoint` before connecting to any peer endpoint in `transfer.py`. This ensures only allowlisted endpoints can be dialed. (`tensorrt_llm/_torch/disaggregation/native/transfer.py`) [[1]](diffhunk://#diff-337dabe32d190384907e8c1330d67ed73ff63f41fbf0c1a347ff9f2ad18d4590R61-R64) [[2]](diffhunk://#diff-337dabe32d190384907e8c1330d67ed73ff63f41fbf0c1a347ff9f2ad18d4590R429) [[3]](diffhunk://#diff-337dabe32d190384907e8c1330d67ed73ff63f41fbf0c1a347ff9f2ad18d4590R1096) [[4]](diffhunk://#diff-337dabe32d190384907e8c1330d67ed73ff63f41fbf0c1a347ff9f2ad18d4590R1668-R1676)
* The allowlist is parsed and validated at `TransferWorker` startup, surfacing configuration errors early rather than at first connection. (`tensorrt_llm/_torch/disaggregation/native/transfer.py`)

**Testing: Comprehensive Coverage**
* Added a new unit test suite for the allowlist, covering matching logic, configuration error handling, environment variable integration, and all connection hooks. The tests ensure that only valid endpoints are allowed and that the allowlist cannot be bypassed. (`tests/unittest/disaggregated/test_peer_endpoint_allowlist.py`)
* Registered the new test suite in the integration test list. (`tests/integration/test_lists/test-db/l0_a10.yml`)

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
