### PR TITLE
[None][feat] Add opt-in JSONL device-time logging to torch AutoTuner

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -318,6 +318,14 @@ def autotune(tune_mode: bool = True,
         autotuner.skip_dynamic_tuning_buckets = old_skip
         if autotune_enabled:
             logger.info("[Autotuner] Autotuning process ends")
+            # Flush any JSONL buckets left open by an exception before their
+            # selection. Only the outermost session flushes (autotune_enabled),
+            # and completed buckets are already popped, so this never
+            # double-writes. Best-effort: never perturb the tuning run.
+            try:
+                autotuner._jsonl_profiler.flush_open_buckets()
+            except Exception:
+                pass
 
         try:
             # Merge tactics across ranks in one collective before the cache is
@@ -888,13 +896,34 @@ def _spec_in_bounds(spec, shapes_list) -> bool:
 class _AutotunerJsonlProfiler:
     """Best-effort structured JSONL sink for autotuner device-time measurements.
 
-    Writes one JSON object per line (JSONL) capturing, for every profiled
-    ``(custom_op, opt_shape, tactic)`` combination, the measured device time in
-    milliseconds — plus one ``selection`` record per ``(custom_op, opt_shape)``
-    naming the winning tactic. The intended consumer is a disaggregated-serving
-    sweep where **each rank of each worker (gen / ctx) emits its own file**, so
-    the identity of the emitting rank and worker role is stamped on every line
-    and the files can be concatenated and grouped with ``cat *.jsonl | jq``.
+    Emits, for every profiled ``(custom_op, opt_shapes)``, **one bucketed
+    ``tuning`` record** (JSONL, one JSON object per line) that carries every
+    profiled tactic's device time, the winning tactic, and the shape / dtype /
+    runner metadata shared across the bucket. One ``meta`` record is written
+    first per file with the emitting rank's identity. The intended consumer is a
+    disaggregated-serving sweep where **each rank of each worker (gen / ctx)
+    emits its own file**; concatenate and group by ``(custom_op, opt_shapes)``.
+
+    Record shape (schema_version 2)::
+
+        {"type":"tuning", "custom_op":str, "opt_shapes":[[int,...],...],
+         "input_dtypes":[str,...],
+         "runners":{"<rid>":{"name":cls,"uid":uid}, ...},
+         "tactics":[[rid, tactic_repr, device_time_ms], ...],  # ok: 3-elem
+                                                               # untimed: [rid,repr,None,"not_measured"]
+         "failed":[[rid, tactic_repr, error], ...],   # omitted if empty;
+                                                      # untimed single-pair fail: +4th elem "not_measured"
+         "input_shapes":[[int,...],...],  # only if != opt_shapes; else omitted
+         "best":[rid, best_tactic_repr, best_device_time_ms] | null,
+         "num_considered":int, "num_failed":int, "cache_key":str|null}
+
+    Records are written in **completion order** (a re-entrant inner op finishes
+    before its outer op), so consumers must group by ``(custom_op, opt_shapes)``
+    and never rely on line order. A ``(custom_op, opt_shapes)`` re-tuned in one
+    session (``exclude_from_cache`` / after ``clear_cache``) yields more than one
+    ``tuning`` record for that key; consumers keep the last (or all). This
+    bucketed layout is ~89% smaller than the earlier one-line-per-tactic format
+    with no loss of per-tactic timings.
 
     Activation is env-gated and entirely opt-in: unless
     ``TLLM_AUTOTUNER_PROFILE_JSONL_DIR`` is set the profiler is a no-op with
@@ -915,9 +944,19 @@ class _AutotunerJsonlProfiler:
     first emitted record, NOT at construction: ``AutoTuner.mapping`` is a
     rank-0 default until ``setup_distributed_state()`` runs, so opening the file
     eagerly would mislabel every rank as rank 0.
+
+    Buffering: per-tactic ``measurement`` rows are accumulated in ``_buckets``
+    keyed on ``(custom_op, opt_shapes)`` and flushed as one ``tuning`` record
+    when the matching ``selection`` arrives (which pops the key, so a re-tune of
+    the same key starts fresh). Any bucket still open at the outermost
+    ``autotune()`` exit — e.g. an exception escaped before selection — is
+    flushed by ``flush_open_buckets()`` with ``best=null`` + ``incomplete=true``.
+    A hard crash between measurement and selection loses that one in-flight
+    bucket (bounded to autotune stack depth); an incomplete bucket has no winner
+    anyway.
     """
 
-    _SCHEMA_VERSION = 1
+    _SCHEMA_VERSION = 2
 
     def __init__(self, tuner: "AutoTuner"):
         self._tuner = tuner
@@ -929,7 +968,9 @@ class _AutotunerJsonlProfiler:
                         or os.getenv("SLURM_JOB_ID", "").strip() or "local")
         self._fh = None
         self._opened = False
-        self._seq = 0
+        # Open buckets keyed on (custom_op, hashable opt_shapes): each holds the
+        # per-tactic rows accumulated since the last selection for that key.
+        self._buckets: Dict[Any, Dict[str, Any]] = {}
         # Identity fields, populated on first emit.
         self._ident: Dict[str, Any] = {}
 
@@ -1041,10 +1082,6 @@ class _AutotunerJsonlProfiler:
         self._fh.write(json.dumps(record, default=str))
         self._fh.write("\n")
 
-    def _next_seq(self) -> int:
-        self._seq += 1
-        return self._seq
-
     @staticmethod
     def _finite_ms(value: Any) -> Optional[float]:
         """Return a JSON-safe float, or None for inf/nan/non-numeric."""
@@ -1072,13 +1109,48 @@ class _AutotunerJsonlProfiler:
         except Exception:
             return "<unrepr-able>"
 
-    def _base(self, custom_op: str) -> Dict[str, Any]:
+    @staticmethod
+    def _shapes_key(shapes) -> tuple:
+        """Hashable analog of ``_shapes_to_lists`` for use as a bucket key."""
+        out = []
+        for s in shapes:
+            try:
+                out.append(tuple(int(d) for d in s))
+            except Exception:
+                out.append(tuple())
+        return tuple(out)
+
+    def _new_bucket(self, custom_op: str, opt_shapes) -> Dict[str, Any]:
         return {
-            "run_id": self._ident["run_id"],
-            "role": self._ident["role"],
-            "global_rank": self._ident["global_rank"],
             "custom_op": custom_op,
+            "opt_shapes": self._shapes_to_lists(opt_shapes),
+            "input_dtypes": None,
+            "input_shapes": None,
+            "runners": {},
+            "tactics": [],
+            "failed": [],
         }
+
+    def _bucket_record(self, bucket: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the common ``tuning`` record body from an accumulated bucket.
+
+        Caller attaches the selection-derived fields (``best`` /
+        ``num_considered`` / ``num_failed`` / ``cache_key``) or the orphan
+        markers (``best=None`` / ``incomplete=True``).
+        """
+        rec = {
+            "type": "tuning",
+            "custom_op": bucket["custom_op"],
+            "opt_shapes": bucket["opt_shapes"],
+            "input_dtypes": bucket["input_dtypes"],
+            "runners": bucket["runners"],
+            "tactics": bucket["tactics"],
+        }
+        if bucket["input_shapes"] is not None:
+            rec["input_shapes"] = bucket["input_shapes"]
+        if bucket["failed"]:
+            rec["failed"] = bucket["failed"]
+        return rec
 
     # ---- public API ------------------------------------------------------
 
@@ -1096,50 +1168,60 @@ class _AutotunerJsonlProfiler:
         status: str,
         error: Optional[str] = None,
     ) -> None:
-        """Emit one ``measurement`` line for a single profiled tactic."""
+        """Accumulate one profiled tactic into its ``(op, opt_shapes)`` bucket.
+
+        Nothing is written here; the bucket is flushed as a single ``tuning``
+        record when the matching :meth:`record_selection` arrives.
+        """
         if not self.enabled or not self._ensure_open():
             return
         try:
-            sizes = self._tuner._get_input_sizes(input_tensors)
-            dtypes = []
-            for t in input_tensors:
-                dtypes.append(
-                    str(t.dtype).replace("torch.", "") if isinstance(
-                        t, torch.Tensor) else None)
-            record = self._base(custom_op)
-            record.update({
-                "type":
-                "measurement",
-                "runner":
-                runner.__class__.__name__,
-                "runner_id":
-                int(runner_id),
-                "runner_uid":
-                self._safe_uid(runner),
-                "opt_shapes":
-                self._shapes_to_lists(opt_shapes),
-                "input_shapes":
-                self._shapes_to_lists(sizes),
-                "input_dtypes":
-                dtypes,
-                "tactic":
-                tactic if isinstance(tactic, (int, float, str, bool)) else None,
-                "tactic_repr":
-                self._tactic_repr(tactic),
-                "is_fallback":
-                tactic == -1,
-                "device_time_ms":
-                self._finite_ms(device_time_ms),
-                "measured":
-                bool(measured),
-                "status":
-                status,
-                "error":
-                error,
-                "seq":
-                self._next_seq(),
-            })
-            self._write(record)
+            key = (custom_op, self._shapes_key(opt_shapes))
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = self._new_bucket(custom_op, opt_shapes)
+                self._buckets[key] = bucket
+
+            # Shape/dtype are fixed within one _profile_runners call (input
+            # tensors are constant), so record them once per bucket.
+            if bucket["input_dtypes"] is None:
+                dtypes = []
+                for t in input_tensors:
+                    dtypes.append(
+                        str(t.dtype).replace("torch.", "") if isinstance(
+                            t, torch.Tensor) else None)
+                bucket["input_dtypes"] = dtypes
+            if bucket["input_shapes"] is None:
+                input_shapes = self._shapes_to_lists(
+                    self._tuner._get_input_sizes(input_tensors))
+                # Only carry input_shapes when it actually differs from
+                # opt_shapes (the single-pair path); otherwise it is redundant.
+                if input_shapes != bucket["opt_shapes"]:
+                    bucket["input_shapes"] = input_shapes
+
+            rid = int(runner_id)
+            skey = str(rid)
+            if skey not in bucket["runners"]:
+                bucket["runners"][skey] = {
+                    "name": runner.__class__.__name__,
+                    "uid": self._safe_uid(runner),
+                }
+
+            rep = self._tactic_repr(tactic)
+            if status == "failed":
+                # measured==False marks the untimed single-pair failure; the
+                # 4th element preserves that distinction from a timed failure.
+                row = [rid, rep, error]
+                if not measured:
+                    row.append("not_measured")
+                bucket["failed"].append(row)
+            elif status == "ok":
+                bucket["tactics"].append(
+                    [rid, rep, self._finite_ms(device_time_ms)])
+            else:
+                # Untimed single-pair winner: null time + explicit status tag.
+                bucket["tactics"].append(
+                    [rid, rep, self._finite_ms(device_time_ms), status])
         except Exception as e:
             self._disable(e, "record_measurement")
 
@@ -1156,42 +1238,60 @@ class _AutotunerJsonlProfiler:
         num_failed: int,
         cache_key: Any,
     ) -> None:
-        """Emit one ``selection`` line naming the winner for an (op, shape)."""
+        """Finalize the ``(op, opt_shapes)`` bucket into one ``tuning`` record.
+
+        Pops the bucket (so a re-tune of the same key starts fresh) and writes
+        exactly one line combining the accumulated tactics with this winner.
+        """
         if not self.enabled or not self._ensure_open():
             return
         try:
-            record = self._base(custom_op)
-            record.update({
-                "type":
-                "selection",
-                "runner":
-                runner.__class__.__name__ if runner is not None else None,
-                "runner_id":
+            key = (custom_op, self._shapes_key(opt_shapes))
+            bucket = self._buckets.pop(key, None)
+            if bucket is None:
+                # No measurement preceded this selection — only reachable on the
+                # no-valid-tactic path (num_considered may be 0). Emit an empty
+                # bucket so the (op, opt_shapes) is still represented.
+                bucket = self._new_bucket(custom_op, opt_shapes)
+
+            record = self._bucket_record(bucket)
+            record["best"] = ([
                 int(runner_id) if runner_id is not None else None,
-                "runner_uid":
-                self._safe_uid(runner) if runner is not None else None,
-                "opt_shapes":
-                self._shapes_to_lists(opt_shapes),
-                "best_tactic":
-                best_tactic if isinstance(best_tactic,
-                                          (int, float, str, bool)) else None,
-                "best_tactic_repr":
-                self._tactic_repr(best_tactic)
-                if best_tactic is not None else None,
-                "best_device_time_ms":
+                self._tactic_repr(best_tactic),
                 self._finite_ms(best_device_time_ms),
-                "num_tactics_considered":
-                int(num_considered),
-                "num_tactics_failed":
-                int(num_failed),
-                "cache_key":
-                str(cache_key),
-                "seq":
-                self._next_seq(),
-            })
+            ] if best_tactic is not None else None)
+            record["num_considered"] = int(num_considered)
+            record["num_failed"] = int(num_failed)
+            record["cache_key"] = None if cache_key is None else str(cache_key)
             self._write(record)
         except Exception as e:
             self._disable(e, "record_selection")
+
+    def flush_open_buckets(self) -> None:
+        """Flush buckets left open at the outermost ``autotune()`` exit.
+
+        In the normal flow every bucket is popped by :meth:`record_selection`;
+        a bucket survives only if an exception escaped ``_profile_runners``
+        before its selection. Such orphans are written with ``best=null`` and
+        ``incomplete=true`` (the selection-derived counts are unknown). Called
+        once at the end of the outermost tuning session.
+        """
+        if not self.enabled or not self._buckets:
+            # Skip _ensure_open when there is nothing to flush so an all-cache-
+            # hit session never creates a spurious meta-only file.
+            return
+        if not self._ensure_open():
+            return
+        try:
+            for bucket in list(self._buckets.values()):
+                record = self._bucket_record(bucket)
+                record["best"] = None
+                record["incomplete"] = True
+                self._write(record)
+        except Exception as e:
+            self._disable(e, "flush_open_buckets")
+        finally:
+            self._buckets.clear()
 
     def _safe_uid(self, runner: "TunableRunner") -> Optional[str]:
         try:

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -6,7 +6,9 @@ import fcntl
 import inspect
 import itertools
 import json
+import math
 import os
+import socket
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -883,6 +885,321 @@ def _spec_in_bounds(spec, shapes_list) -> bool:
     return True
 
 
+class _AutotunerJsonlProfiler:
+    """Best-effort structured JSONL sink for autotuner device-time measurements.
+
+    Writes one JSON object per line (JSONL) capturing, for every profiled
+    ``(custom_op, opt_shape, tactic)`` combination, the measured device time in
+    milliseconds — plus one ``selection`` record per ``(custom_op, opt_shape)``
+    naming the winning tactic. The intended consumer is a disaggregated-serving
+    sweep where **each rank of each worker (gen / ctx) emits its own file**, so
+    the identity of the emitting rank and worker role is stamped on every line
+    and the files can be concatenated and grouped with ``cat *.jsonl | jq``.
+
+    Activation is env-gated and entirely opt-in: unless
+    ``TLLM_AUTOTUNER_PROFILE_JSONL_DIR`` is set the profiler is a no-op with
+    zero overhead (callers still gate on ``.enabled`` so the record-building
+    work is skipped as well). Every public method is wrapped in a best-effort
+    guard: any failure disables the profiler for the rest of the process rather
+    than perturbing the tuning run it is only observing.
+
+    Env vars:
+        TLLM_AUTOTUNER_PROFILE_JSONL_DIR : output directory (enables the sink).
+        TLLM_AUTOTUNER_PROFILE_ROLE      : worker role tag, e.g. "gen"/"ctx"
+                                           (default "unknown").
+        TLLM_AUTOTUNER_PROFILE_RUN_ID    : correlation id shared by all ranks of
+                                           one run (default: $SLURM_JOB_ID or
+                                           "local").
+
+    Identity (rank / world_size / parallel ranks) is resolved lazily on the
+    first emitted record, NOT at construction: ``AutoTuner.mapping`` is a
+    rank-0 default until ``setup_distributed_state()`` runs, so opening the file
+    eagerly would mislabel every rank as rank 0.
+    """
+
+    _SCHEMA_VERSION = 1
+
+    def __init__(self, tuner: "AutoTuner"):
+        self._tuner = tuner
+        self._dir = os.getenv("TLLM_AUTOTUNER_PROFILE_JSONL_DIR", "").strip()
+        self.enabled = bool(self._dir)
+        self._role = os.getenv("TLLM_AUTOTUNER_PROFILE_ROLE",
+                               "unknown").strip() or "unknown"
+        self._run_id = (os.getenv("TLLM_AUTOTUNER_PROFILE_RUN_ID", "").strip()
+                        or os.getenv("SLURM_JOB_ID", "").strip() or "local")
+        self._fh = None
+        self._opened = False
+        self._seq = 0
+        # Identity fields, populated on first emit.
+        self._ident: Dict[str, Any] = {}
+
+    # ---- internal helpers ------------------------------------------------
+
+    def _disable(self, exc: Exception, where: str) -> None:
+        """Permanently disable the sink after an unexpected failure."""
+        self.enabled = False
+        try:
+            if self._fh is not None:
+                self._fh.close()
+        except Exception:
+            pass
+        self._fh = None
+        logger.warning_once(
+            f"[Autotuner] JSONL profiler disabled after error in {where}: {exc}",
+            key=("autotuner_jsonl_profiler_disabled", ),
+        )
+
+    def _resolve_identity(self) -> Dict[str, Any]:
+        mapping = getattr(self._tuner, "mapping", None)
+
+        def _attr(name, default=0):
+            try:
+                val = getattr(mapping, name)
+                return int(val)
+            except Exception:
+                return default
+
+        try:
+            lib_version = tensorrt_llm.__version__
+        except Exception:
+            lib_version = "unknown"
+
+        device_name, device_capability = "unknown", None
+        try:
+            if torch.cuda.is_available():
+                idx = torch.cuda.current_device()
+                device_name = torch.cuda.get_device_name(idx)
+                cap = torch.cuda.get_device_capability(idx)
+                device_capability = [int(cap[0]), int(cap[1])]
+        except Exception:
+            pass
+
+        return {
+            "run_id":
+            self._run_id,
+            "role":
+            self._role,
+            "global_rank":
+            _attr("rank", 0),
+            "world_size":
+            _attr("world_size", 1),
+            "tp_rank":
+            _attr("tp_rank", 0),
+            "tp_size":
+            _attr("tp_size", 1),
+            "pp_rank":
+            _attr("pp_rank", 0),
+            "pp_size":
+            _attr("pp_size", 1),
+            "cp_rank":
+            _attr("cp_rank", 0),
+            "cp_size":
+            _attr("cp_size", 1),
+            "hostname":
+            socket.gethostname(),
+            "pid":
+            os.getpid(),
+            "device_name":
+            device_name,
+            "device_capability":
+            device_capability,
+            "lib_version":
+            lib_version,
+            "timer_backend":
+            ("globaltimer" if self._tuner._use_global_timer else "cuda_event"),
+            "warmup":
+            int(self._tuner.warmup),
+            "repeat":
+            int(self._tuner.repeat),
+        }
+
+    def _ensure_open(self) -> bool:
+        """Lazily resolve identity and open the per-rank file. Returns enabled."""
+        if self._opened:
+            return self.enabled
+        self._opened = True  # attempt exactly once regardless of outcome
+        try:
+            self._ident = self._resolve_identity()
+            os.makedirs(self._dir, exist_ok=True)
+            rank = self._ident["global_rank"]
+            host = self._ident["hostname"]
+            pid = self._ident["pid"]
+            fname = (f"autotuner.{self._role}.r{rank}.{host}.pid{pid}.jsonl")
+            path = os.path.join(self._dir, fname)
+            # Line-buffered so a crash mid-run still leaves complete records.
+            self._fh = open(path, "a", buffering=1)
+            meta = {"type": "meta", "schema_version": self._SCHEMA_VERSION}
+            meta.update(self._ident)
+            meta["start_ts"] = time.strftime("%Y-%m-%dT%H:%M:%SZ",
+                                             time.gmtime())
+            self._write(meta)
+        except Exception as e:
+            self._disable(e, "_ensure_open")
+        return self.enabled
+
+    def _write(self, record: Dict[str, Any]) -> None:
+        self._fh.write(json.dumps(record, default=str))
+        self._fh.write("\n")
+
+    def _next_seq(self) -> int:
+        self._seq += 1
+        return self._seq
+
+    @staticmethod
+    def _finite_ms(value: Any) -> Optional[float]:
+        """Return a JSON-safe float, or None for inf/nan/non-numeric."""
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            return None
+        if math.isinf(f) or math.isnan(f):
+            return None
+        return f
+
+    @staticmethod
+    def _shapes_to_lists(shapes) -> List[List[int]]:
+        out = []
+        for s in shapes:
+            try:
+                out.append([int(d) for d in s])
+            except Exception:
+                out.append([])
+        return out
+
+    def _tactic_repr(self, tactic: Any) -> str:
+        try:
+            return repr(tactic)
+        except Exception:
+            return "<unrepr-able>"
+
+    def _base(self, custom_op: str) -> Dict[str, Any]:
+        return {
+            "run_id": self._ident["run_id"],
+            "role": self._ident["role"],
+            "global_rank": self._ident["global_rank"],
+            "custom_op": custom_op,
+        }
+
+    # ---- public API ------------------------------------------------------
+
+    def record_measurement(
+        self,
+        *,
+        custom_op: str,
+        runner: "TunableRunner",
+        runner_id: int,
+        opt_shapes,
+        input_tensors: List[torch.Tensor],
+        tactic: Any,
+        device_time_ms: Any,
+        measured: bool,
+        status: str,
+        error: Optional[str] = None,
+    ) -> None:
+        """Emit one ``measurement`` line for a single profiled tactic."""
+        if not self.enabled or not self._ensure_open():
+            return
+        try:
+            sizes = self._tuner._get_input_sizes(input_tensors)
+            dtypes = []
+            for t in input_tensors:
+                dtypes.append(
+                    str(t.dtype).replace("torch.", "") if isinstance(
+                        t, torch.Tensor) else None)
+            record = self._base(custom_op)
+            record.update({
+                "type":
+                "measurement",
+                "runner":
+                runner.__class__.__name__,
+                "runner_id":
+                int(runner_id),
+                "runner_uid":
+                self._safe_uid(runner),
+                "opt_shapes":
+                self._shapes_to_lists(opt_shapes),
+                "input_shapes":
+                self._shapes_to_lists(sizes),
+                "input_dtypes":
+                dtypes,
+                "tactic":
+                tactic if isinstance(tactic, (int, float, str, bool)) else None,
+                "tactic_repr":
+                self._tactic_repr(tactic),
+                "is_fallback":
+                tactic == -1,
+                "device_time_ms":
+                self._finite_ms(device_time_ms),
+                "measured":
+                bool(measured),
+                "status":
+                status,
+                "error":
+                error,
+                "seq":
+                self._next_seq(),
+            })
+            self._write(record)
+        except Exception as e:
+            self._disable(e, "record_measurement")
+
+    def record_selection(
+        self,
+        *,
+        custom_op: str,
+        runner: Optional["TunableRunner"],
+        runner_id: Optional[int],
+        opt_shapes,
+        best_tactic: Any,
+        best_device_time_ms: Any,
+        num_considered: int,
+        num_failed: int,
+        cache_key: Any,
+    ) -> None:
+        """Emit one ``selection`` line naming the winner for an (op, shape)."""
+        if not self.enabled or not self._ensure_open():
+            return
+        try:
+            record = self._base(custom_op)
+            record.update({
+                "type":
+                "selection",
+                "runner":
+                runner.__class__.__name__ if runner is not None else None,
+                "runner_id":
+                int(runner_id) if runner_id is not None else None,
+                "runner_uid":
+                self._safe_uid(runner) if runner is not None else None,
+                "opt_shapes":
+                self._shapes_to_lists(opt_shapes),
+                "best_tactic":
+                best_tactic if isinstance(best_tactic,
+                                          (int, float, str, bool)) else None,
+                "best_tactic_repr":
+                self._tactic_repr(best_tactic)
+                if best_tactic is not None else None,
+                "best_device_time_ms":
+                self._finite_ms(best_device_time_ms),
+                "num_tactics_considered":
+                int(num_considered),
+                "num_tactics_failed":
+                int(num_failed),
+                "cache_key":
+                str(cache_key),
+                "seq":
+                self._next_seq(),
+            })
+            self._write(record)
+        except Exception as e:
+            self._disable(e, "record_selection")
+
+    def _safe_uid(self, runner: "TunableRunner") -> Optional[str]:
+        try:
+            return str(runner.unique_id())
+        except Exception:
+            return None
+
+
 class AutoTuner:
     """AutoTuner for optimizing TensorRT LLM operations.
 
@@ -937,6 +1254,12 @@ class AutoTuner:
         self._dist: Optional[Distributed] = None
         self._has_received_cache: bool = False
         self.mapping: Mapping = Mapping()
+
+        # Optional structured per-(op, shape, tactic) device-time sink. No-op
+        # unless TLLM_AUTOTUNER_PROFILE_JSONL_DIR is set. Identity (rank/role)
+        # is resolved lazily on first emit — see _AutotunerJsonlProfiler — so
+        # constructing it here (before setup_distributed_state) is safe.
+        self._jsonl_profiler = _AutotunerJsonlProfiler(self)
 
     @classmethod
     def get(cls):
@@ -1233,6 +1556,17 @@ class AutoTuner:
         min_time = float('inf')
         has_tuning_failure_occurred = False
         best_runner_id, best_tactic = None, None
+
+        # Structured JSONL device-time logging (no-op unless enabled). Counters
+        # feed the per-(op, shape) `selection` record; `single_pair_winner`
+        # tracks whether the winner came from the untimed shortcut so the
+        # selection reports a null device time rather than the 0.0 sentinel.
+        prof = self._jsonl_profiler
+        opt_shapes_for_emit = profile.get_opt_shapes() if prof.enabled else None
+        num_considered = 0
+        num_failed = 0
+        single_pair_winner = False
+
         # If the inputs_pre_hook is provided, it will be called before profiling.
         if tuning_config.inputs_pre_hook is not None:
             input_tensors = tuning_config.inputs_pre_hook(input_tensors)
@@ -1276,6 +1610,7 @@ class AutoTuner:
             tac = valid_tactics[0]
             if "do_preparation" in runner_arg_names:
                 runner(input_tensors, tactic=-1, do_preparation=True, **kwargs)
+            num_considered += 1
             try:
                 with nvtx_range(f"r{runner_id}, tactic {tac} (single-pair)"):
                     runner(input_tensors, tactic=tac, **kwargs)
@@ -1284,6 +1619,22 @@ class AutoTuner:
                 # distinguish "recorded without profiling" from a real
                 # timing.
                 min_time = 0.0
+                single_pair_winner = True
+                if prof.enabled:
+                    # Untimed shortcut: record the pair but flag it as not
+                    # measured so downstream analysis never mistakes the 0.0
+                    # sentinel for a real device time.
+                    prof.record_measurement(
+                        custom_op=custom_op,
+                        runner=runner,
+                        runner_id=runner_id,
+                        opt_shapes=opt_shapes_for_emit,
+                        input_tensors=input_tensors,
+                        tactic=tac,
+                        device_time_ms=None,
+                        measured=False,
+                        status="not_measured",
+                    )
             except Exception as e:
                 shapes = self._get_input_sizes(input_tensors)
                 logger.warning_once(
@@ -1298,6 +1649,20 @@ class AutoTuner:
                         tuning_config,
                         apply_map_to_tuning_buckets=False))
                 has_tuning_failure_occurred = True
+                num_failed += 1
+                if prof.enabled:
+                    prof.record_measurement(
+                        custom_op=custom_op,
+                        runner=runner,
+                        runner_id=runner_id,
+                        opt_shapes=opt_shapes_for_emit,
+                        input_tensors=input_tensors,
+                        tactic=tac,
+                        device_time_ms=None,
+                        measured=False,
+                        status="failed",
+                        error=repr(e),
+                    )
         else:
             for runner_id, runner, runner_arg_names, all_valid_tactics in candidates:
                 valid_tactics = self._maybe_parallelize_tactics(
@@ -1313,6 +1678,7 @@ class AutoTuner:
                     )
 
                 for tac in valid_tactics:
+                    num_considered += 1
                     try:
                         with nvtx_range(f"r{runner_id}, tactic {tac}"):
                             time_measured = self._profile_single_kernel(
@@ -1322,6 +1688,18 @@ class AutoTuner:
                                 tuning_config=tuning_config,
                                 use_cuda_graph=tuning_config.use_cuda_graph,
                                 **kwargs,
+                            )
+                        if prof.enabled:
+                            prof.record_measurement(
+                                custom_op=custom_op,
+                                runner=runner,
+                                runner_id=runner_id,
+                                opt_shapes=opt_shapes_for_emit,
+                                input_tensors=input_tensors,
+                                tactic=tac,
+                                device_time_ms=time_measured,
+                                measured=True,
+                                status="ok",
                             )
                     except Exception as e:
                         # Synchronize to clear any pending CUDA errors left by the
@@ -1354,6 +1732,22 @@ class AutoTuner:
                         # or some runtime error occurs during profiling.
                         time_measured = float('inf')
                         has_tuning_failure_occurred = True
+                        num_failed += 1
+                        if prof.enabled:
+                            # Never serialize inf: a failed tactic is recorded
+                            # with a null device time plus an explicit status.
+                            prof.record_measurement(
+                                custom_op=custom_op,
+                                runner=runner,
+                                runner_id=runner_id,
+                                opt_shapes=opt_shapes_for_emit,
+                                input_tensors=input_tensors,
+                                tactic=tac,
+                                device_time_ms=None,
+                                measured=True,
+                                status="failed",
+                                error=repr(e),
+                            )
                     if time_measured < min_time:
                         min_time = time_measured
                         best_runner_id, best_tactic = runner_id, tac
@@ -1376,6 +1770,23 @@ class AutoTuner:
                                                min_time)
 
             self.stats.tuned_op_profiled_configs[custom_op] += 1
+
+            if prof.enabled:
+                # `min_time` is the 0.0 sentinel for the untimed single-pair
+                # winner; report null there so the selection carries no
+                # spurious device time.
+                prof.record_selection(
+                    custom_op=custom_op,
+                    runner=runners[best_runner_id],
+                    runner_id=best_runner_id,
+                    opt_shapes=opt_shapes_for_emit,
+                    best_tactic=best_tactic,
+                    best_device_time_ms=(None
+                                         if single_pair_winner else min_time),
+                    num_considered=num_considered,
+                    num_failed=num_failed,
+                    cache_key=cache_key,
+                )
         else:
             logger.warning_once(
                 f"[Autotuner] No valid runner/tactic was found for custom_op={custom_op}, input_shapes={profile.get_opt_shapes()}. "
@@ -1384,6 +1795,18 @@ class AutoTuner:
                 f"and should not occurs during the inference stage, or fallback tactic is implemented. Otherwise, the the tuning process will crash.",
                 key=(custom_op, "warning_autotuning_no_valid_tactic"),
             )
+            if prof.enabled:
+                prof.record_selection(
+                    custom_op=custom_op,
+                    runner=None,
+                    runner_id=None,
+                    opt_shapes=opt_shapes_for_emit,
+                    best_tactic=None,
+                    best_device_time_ms=None,
+                    num_considered=num_considered,
+                    num_failed=num_failed,
+                    cache_key=None,
+                )
 
         return best_runner_id, best_tactic, min_time, has_tuning_failure_occurred
 

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -904,7 +904,7 @@ class _AutotunerJsonlProfiler:
     disaggregated-serving sweep where **each rank of each worker (gen / ctx)
     emits its own file**; concatenate and group by ``(custom_op, opt_shapes)``.
 
-    Record shape (schema_version 2)::
+    Record shape::
 
         {"type":"tuning", "custom_op":str, "opt_shapes":[[int,...],...],
          "input_dtypes":[str,...],
@@ -921,9 +921,7 @@ class _AutotunerJsonlProfiler:
     before its outer op), so consumers must group by ``(custom_op, opt_shapes)``
     and never rely on line order. A ``(custom_op, opt_shapes)`` re-tuned in one
     session (``exclude_from_cache`` / after ``clear_cache``) yields more than one
-    ``tuning`` record for that key; consumers keep the last (or all). This
-    bucketed layout is ~89% smaller than the earlier one-line-per-tactic format
-    with no loss of per-tactic timings.
+    ``tuning`` record for that key; consumers keep the last (or all).
 
     Activation is env-gated and entirely opt-in: unless
     ``TLLM_AUTOTUNER_PROFILE_JSONL_DIR`` is set the profiler is a no-op with
@@ -956,7 +954,7 @@ class _AutotunerJsonlProfiler:
     anyway.
     """
 
-    _SCHEMA_VERSION = 2
+    _SCHEMA_VERSION = 1
 
     def __init__(self, tuner: "AutoTuner"):
         self._tuner = tuner


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added an opt-in JSONL autotuner profiling sink for torch backend `AutoTuner`, enabled via `TLLM_AUTOTUNER_PROFILE_JSONL_DIR` (disabled by default).
- Emits **bucketed** per-`(custom_op, opt_shapes)` “tuning” records to a **per-rank** file, including a `meta` header and per-tactic observations buffered by `(custom_op, opt_shapes)` for re-entrant tuning.
- Instruments `_profile_runners` to record: considered/failed tactics, untimed single-tactic shortcut outcomes (`not_measured` semantics), timed tactic device times, and failures (with captured `error=repr(e)`).
- Supports resolution of distributed identity lazily; converts failed or non-finite timing values to JSON-safe representations, and **permanently disables** the sink for the remainder of the process on unexpected internal errors.
- Ensures exception safety by flushing any open buckets as incomplete records on outermost `autotune()` exit (`best=null` and `incomplete=true`), and preserves the selected winner/tactic fields in the final record (including `null` best for no valid runner/tactic).
- No public Python API signature changes and no non-code/config updates were identified.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Adds **opt-in** structured JSONL logging of autotuner device times to the torch backend `AutoTuner`. Today the autotuner already logs per-tactic device time at DEBUG level and dumps its cache once after warmup, but there is no machine-readable per-`(kernel, shape)` record, and single-tactic ops are never timed at all. This makes it hard to analyze tactic-selection device time across ranks — especially in disaggregated serving, where each rank of the gen/ctx workers tunes independently.

When `TLLM_AUTOTUNER_PROFILE_JSONL_DIR` is set, each rank of each worker writes its own JSONL file:

```
autotuner.{role}.r{global_rank}.{host}.pid{pid}.jsonl
```

so a disagg sweep produces one file per rank that can be concatenated and grouped with `cat *.jsonl | jq`.

### Format

One JSON object per line. The **first** line is a `meta` record; every following line is a `tuning` record.

- **`meta`** (once, first line): schema version, run id, rank/tp/pp/cp identity, hostname/pid, device name + capability, timer backend, warmup/repeat.
- **`tuning`** (one per `(custom_op, opt_shapes)`): collapses **all tactics profiled for that op at that tuning shape** into a single record — the shared `opt_shapes` / `input_dtypes` / `runners` metadata, every profiled tactic with its measured `device_time_ms`, the winning tactic (`best`), `num_considered` / `num_failed`, and the profiling-cache `cache_key`.

```jsonc
{"type":"tuning","custom_op":"trtllm::nvfp4_gemm::gemm",
 "opt_shapes":[[1,8192],[7168,8192], ...],
 "input_dtypes":["uint8","uint8", ...],
 "runners":{"0":{"name":"NVFP4GemmUnifiedRunner","uid":"(0, torch.bfloat16, ...)"}},
 "tactics":[[0,"('cuda_core', 0)",0.04702],[0,"('cutlass', 11)",0.02101], ...],
 "best":[0,"('cutlass', 11)",0.02101],
 "num_considered":9,"num_failed":0,"cache_key":"(...)"}
```

Row / field conventions:

- `tactics` rows are `[runner_id, tactic_repr, device_time_ms]`; an untimed single-tactic winner is `[runner_id, tactic_repr, null, "not_measured"]`.
- `failed` (omitted when empty) holds `[runner_id, tactic_repr, error]` rows (`+ "not_measured"` 4th element for an untimed failure).
- `input_shapes` is present **only** when the runtime shapes differ from `opt_shapes`.
- `incomplete: true` marks a record flushed at session end because an exception escaped before selection (then `best` is `null`).

**Consumer contract:** records are written in *completion* order and the AutoTuner is **re-entrant** (an inner op tuned inside an outer op's profiling is written first), so consumers must **group by `(custom_op, opt_shapes)` and never rely on line order**. A key re-tuned in one session (`exclude_from_cache` / after `clear_cache`) yields more than one `tuning` record for that key; keep the last (or all).

Env vars (all optional):

| Var | Default | Purpose |
|---|---|---|
| `TLLM_AUTOTUNER_PROFILE_JSONL_DIR` | *(unset)* | Output dir. **Enables the sink.** Unset ⇒ no-op, zero overhead. |
| `TLLM_AUTOTUNER_PROFILE_ROLE` | `unknown` | Worker role tag, e.g. `gen` / `ctx`. |
| `TLLM_AUTOTUNER_PROFILE_RUN_ID` | `$SLURM_JOB_ID` or `local` | Correlation id shared by all ranks of one run. |

Design notes:

- Records are built in `_profile_runners`, **not** `_profile_single_kernel`, so the untimed single-pair shortcut is covered and that method's signature/return type are unchanged (it is called directly and monkeypatched by existing tests).
- Per-tactic rows are **buffered** per `(custom_op, opt_shapes)` and flushed as one `tuning` record when the matching selection arrives (which pops the key, so a re-tune of the same key starts a fresh bucket).
- Identity is resolved **lazily on first emit**: `AutoTuner.mapping` is a rank-0 default until `setup_distributed_state()` runs, so an eager file-open would mislabel every rank as rank 0.
- `inf`/`nan` are **never** serialized: failed tactics record `device_time_ms=null`; the untimed single-tactic winner records the `not_measured` tag.
- The sink is **best-effort**: any internal error self-disables it for the rest of the process so it can never perturb the tuning run it only observes.

Example reader:

```bash
# real per-tactic device times across all ranks
cat *.jsonl | jq -rc 'select(.type=="tuning") as $r | $r.tactics[]
  | [$r.custom_op,($r.opt_shapes|tostring),.[0],.[1],.[2]] | @tsv'
# winning tactic per (op, shape)
cat *.jsonl | jq -rc 'select(.type=="tuning" and .best!=null)
  | [.custom_op,(.opt_shapes|tostring),.best[1],.best[2]] | @tsv'
```

## Test Coverage

No new automated test is added: the feature is a pure-additive, env-gated observer that is entirely inert unless `TLLM_AUTOTUNER_PROFILE_JSONL_DIR` is set, and the existing autotuner suite (`tests/unittest/_torch/misc/test_autotuner.py`) exercises the modified `_profile_runners` paths with the sink disabled. In particular `test_single_pair_shortcut` — which monkeypatches `_profile_single_kernel` and asserts it is skipped for single-pair ops and called per-tactic otherwise — continues to hold because emission is gated on `profiler.enabled` and `_profile_single_kernel` is unchanged. The bucketing / serialization logic (filename shape, group-by-`(custom_op, opt_shapes)`, re-entrant ordering, inf/nan→null, untimed `not_measured`, no-winner selection, orphan flush) was validated out-of-band by replaying a real disagg GB200 capture through the sink and reconstructing the per-tactic set with zero loss.

## PR Checklist

- This change adds new optional env vars but no API changes to public Python signatures; it is `api-compatible`.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
