### PR TITLE
[None][perf] Add CUTEDSL FC2 N-tile tuning override

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -4,6 +4,7 @@
 import functools
 import itertools
 import math
+import os
 from typing import List, Optional, Tuple
 
 import torch
@@ -34,10 +35,25 @@ except ImportError:
 
 # Torch schema parsing rejects ``inf`` as a default value.
 SWIGLU_LIMIT_SCALAR_DISABLED = -1.0
+_CUTEDSL_FC2_N_TILE_SIZE_ENV = "TRTLLM_CUTEDSL_FC2_N_TILE_SIZE"
+_CUTEDSL_FC2_N_TILE_SIZES = (128, 256)
 
 
 def _canonicalize_swiglu_limit_scalar(swiglu_limit_scalar: float) -> float:
     return float("inf") if swiglu_limit_scalar < 0 else swiglu_limit_scalar
+
+
+def _get_cutedsl_fc2_n_tile_size_override() -> Optional[int]:
+    value = os.environ.get(_CUTEDSL_FC2_N_TILE_SIZE_ENV)
+    if value is None:
+        return None
+    valid_values = tuple(
+        str(tile_size) for tile_size in _CUTEDSL_FC2_N_TILE_SIZES)
+    if value not in valid_values:
+        raise ValueError(
+            f"{_CUTEDSL_FC2_N_TILE_SIZE_ENV} must be unset or one of "
+            f"{', '.join(valid_values)}; got {value!r}")
+    return int(value)
 
 
 class GroupedGemmInputsHelper:
@@ -2508,6 +2524,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             assert output_dtype == torch.bfloat16
             self.output_dtype = output_dtype
             self.scaling_vector_size = scaling_vector_size
+            self.fc2_n_tile_size_override = (
+                _get_cutedsl_fc2_n_tile_size_override())
 
             if (sm_version := get_sm_version()) not in (100, 103):
                 raise ValueError(
@@ -2520,7 +2538,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 )
 
         def unique_id(self):
-            return (
+            runner_id = (
                 self.num_experts,
                 self.top_k,
                 self.num_local_experts,
@@ -2529,6 +2547,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 self.output_dtype,
                 self.scaling_vector_size,
             )
+            if self.fc2_n_tile_size_override is not None:
+                runner_id += (
+                    "fc2_n_tile_size_override",
+                    self.fc2_n_tile_size_override,
+                )
+            return runner_id
 
         def get_valid_tactics(
             self,
@@ -2542,6 +2566,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             mma_tiler_mn_candidates = [(self.tile_size, 128),
                                        (self.tile_size, 256)]
+            if self.fc2_n_tile_size_override is not None:
+                mma_tiler_mn_candidates = [(self.tile_size,
+                                            self.fc2_n_tile_size_override)]
             cluster_shape_mn_candidates = [(self.tile_size // 128, 1),
                                            (self.tile_size // 128, 2)]
             # raster_along_m=False should be theoretically more performant than raster_along_m=True.

--- a/tests/unittest/_torch/custom_ops/test_cutedsl_fc2_tuning.py
+++ b/tests/unittest/_torch/custom_ops/test_cutedsl_fc2_tuning.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops as cute_dsl_custom_ops
+from tensorrt_llm._torch.autotuner import OptimizationProfile
+from tensorrt_llm._torch.cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
+
+if IS_CUTLASS_DSL_AVAILABLE:
+    from tensorrt_llm._torch.custom_ops.cute_dsl_custom_ops import (
+        Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner,
+    )
+
+
+_CUTEDSL_FC2_N_TILE_SIZE_ENV = "TRTLLM_CUTEDSL_FC2_N_TILE_SIZE"
+
+pytestmark = pytest.mark.skipif(
+    not IS_CUTLASS_DSL_AVAILABLE,
+    reason="Requires CUTLASS DSL",
+)
+
+
+def _make_runner(monkeypatch) -> "Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner":
+    monkeypatch.setattr(cute_dsl_custom_ops, "get_sm_version", lambda: 100)
+    monkeypatch.setattr(
+        Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner,
+        "kernel_class",
+        SimpleNamespace(can_implement=lambda **kwargs: True),
+    )
+    return Sm100BlockScaledContiguousGroupedGemmFinalizeFusionRunner(
+        num_experts=256,
+        top_k=8,
+        num_local_experts=8,
+        local_expert_offset=0,
+        tile_size=128,
+        output_dtype=torch.bfloat16,
+    )
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_n_tiles"),
+    [
+        (None, {128, 256}),
+        ("128", {128}),
+        ("256", {256}),
+    ],
+)
+def test_fc2_n_tile_size_override(monkeypatch, env_value, expected_n_tiles) -> None:
+    if env_value is None:
+        monkeypatch.delenv(_CUTEDSL_FC2_N_TILE_SIZE_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_CUTEDSL_FC2_N_TILE_SIZE_ENV, env_value)
+
+    runner = _make_runner(monkeypatch)
+    inputs = [torch.empty(256, 64), torch.empty(8, 256)]
+
+    tactics = runner.get_valid_tactics(inputs, OptimizationProfile())
+
+    assert {tactic[0][1] for tactic in tactics} == expected_n_tiles
+    if env_value is None:
+        assert "fc2_n_tile_size_override" not in runner.unique_id()
+    else:
+        assert runner.unique_id()[-2:] == (
+            "fc2_n_tile_size_override",
+            int(env_value),
+        )
+
+
+@pytest.mark.parametrize("env_value", ["", "64", "128,256", " 128", "invalid"])
+def test_fc2_n_tile_size_override_rejects_invalid_values(monkeypatch, env_value) -> None:
+    monkeypatch.setenv(_CUTEDSL_FC2_N_TILE_SIZE_ENV, env_value)
+
+    with pytest.raises(ValueError, match=f"{_CUTEDSL_FC2_N_TILE_SIZE_ENV} must be unset"):
+        _make_runner(monkeypatch)


### PR DESCRIPTION
## Description

Small per-expert FC2 GEMMs in WideEP can favor a different N tile size than
larger MoE shapes. The existing CuTeDSL autotuner evaluates N128 and N256
tactics, but it has no way to pin one candidate for controlled tuning and
deployment.

This PR defaults the FC2 finalize-fusion runner to the measured N128 tactic and
keeps a strict `TRTLLM_CUTEDSL_FC2_N_TILE_SIZE` control:

- leaving the variable unset or setting `128` selects the N128 candidate;
- `256` selects the N256 candidate; and
- `0` restores the original autotuning over both candidates.

The active value is included in the runner identity so tuning-cache entries
cannot collide. Invalid values fail fast, and the no-tactic fallback honors
the same selected tile size.

For DeepSeek-R1 FP4 WideEP EP32 decode on B200, N128 improved the
position-balanced MBS32 point by 1.82% and the full-Pareto geometric mean by
1.22%.

## Test Coverage

- Focused unit coverage verifies default N128 selection, the original
  autotuning rollback, both explicit tile sizes, invalid values, fallback
  tactics, and tuning-cache identity.
- The test file is registered in the B200 pre-merge list.
- Changed-file pre-commit and Homebrew Python 3.12 syntax checks pass.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] Follows the TensorRT-LLM coding guidelines.
- [x] Test cases and pre-merge test-list coverage are provided.
- [x] No new dependency, public API, or ownership change is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds the `TRTLLM_CUTEDSL_FC2_N_TILE_SIZE` override for the CuTeDSL FC2 finalize-fusion runner.

- Defaults to tile size `128`.
- Supports tile size `256`.
- Preserves autotuning across both candidates when set to `0`.
- Rejects unsupported values with `ValueError`.
- Caches the environment value after the first lookup.
- Includes the active override in runner identity.
- Applies the override to generated and fallback tactics.
- Adds focused tests and registers them in the B200 pre-merge test list.

## Dev Engineer Review

- The implementation validates the override and captures it during runner initialization.
- Runner identity includes the selected tile size to prevent tuning-cache collisions.
- Generated and fallback tactics honor the selected tile size.
- The default behavior selects tile size `128`.
- The `0` value preserves the existing autotuning candidates.
- The B200 test-list entry targets the intended test path.
- No functional correctness, configuration, or API consistency issue is evident from the available changes.

## QA Engineer Review

Modified test functions:

- `test_fc2_n_tile_size_override`
- `test_fc2_n_tile_size_override_is_cached`
- `test_fc2_n_tile_size_override_rejects_invalid_values`

The tests cover default behavior, explicit tile sizes, autotuning, cache behavior, invalid values, tactic selection, and runner identity.

The test file is registered in `tests/integration/test_lists/test-db/l0_b200.yml` for CI coverage.

**Verdict: sufficient**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->