### PR TITLE
[#17027][fix] Realign misaligned int32 index slices in FlashInfer GDN decode

### DIFF
--- a/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
+++ b/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
@@ -283,6 +283,16 @@ def _flashinfer_gdn_decode(
     if b.data_ptr() % 32 != 0:
         b = b.clone(memory_format=torch.contiguous_format)
 
+    # The int32 index tensor may likewise be a slice of a larger buffer
+    # (e.g. the decode half ``state_indices[num_prefills:]`` of a mixed
+    # batch) whose 4*offset storage offset breaks the 32-byte alignment;
+    # ``.int()`` is a no-op for int32 and keeps the misaligned pointer, so
+    # realign with an explicit copy when needed, matching
+    # ``_flashinfer_gdn_verify``.
+    initial_state_indices = initial_state_indices.int()
+    if initial_state_indices.data_ptr() % 32 != 0:
+        initial_state_indices = initial_state_indices.clone()
+
     # Reshape from packed varlen [1, N*T, ...] to batched [N, T, ...].
     q_bat = q.view(N, T_per_seq, q.shape[2], q.shape[3])
     k_bat = k.view(N, T_per_seq, k.shape[2], k.shape[3])
@@ -307,7 +317,7 @@ def _flashinfer_gdn_decode(
         v=v_bat,
         b=b_bat,
         initial_state_source=initial_state_source,
-        initial_state_indices=initial_state_indices.int(),
+        initial_state_indices=initial_state_indices,
         use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
         scale=scale,
         output=output,

--- a/tests/unittest/_torch/modules/mamba/test_flashinfer_gdn_decode.py
+++ b/tests/unittest/_torch/modules/mamba/test_flashinfer_gdn_decode.py
@@ -20,20 +20,25 @@ def _fi_decode_available() -> bool:
         return False
     try:
         from flashinfer.gdn_kernels.gdn_decode_bf16_state import gated_delta_rule  # noqa: F401
-    except Exception:
+    except (ImportError, RuntimeError):
+        # Mirror the guard in fused_sigmoid_gating_recurrent.py (and
+        # FlashInfer's own gdn_kernels/__init__.py): a missing build raises
+        # ImportError, a CuTe/CUTLASS mismatch raises RuntimeError; in both
+        # cases production falls back to Triton, so the FI path is
+        # unavailable and the test must skip.
         return False
     return True
 
 
-skip_unsupported = pytest.mark.skipif(
+SKIP_UNSUPPORTED = pytest.mark.skipif(
     not _fi_decode_available(),
     reason="Requires SM90/SM100/SM103 and a FlashInfer build with "
     "gdn_decode_bf16_state.gated_delta_rule",
 )
 
 
-@skip_unsupported
-def test_fi_decode_misaligned_index_slice():
+@SKIP_UNSUPPORTED
+def test_fi_decode_misaligned_index_slice() -> None:
     """Index slices with a non-32B-aligned storage offset must be realigned.
 
     A caller splitting a mixed batch passes the decode half

--- a/tests/unittest/_torch/modules/mamba/test_flashinfer_gdn_decode.py
+++ b/tests/unittest/_torch/modules/mamba/test_flashinfer_gdn_decode.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Alignment regression test for the GDN standard-decode path: FlashInfer
+``gated_delta_rule`` requires every tensor argument's data pointer to be
+32-byte aligned, and ``_flashinfer_gdn_decode`` must realign int32 index
+slices before dispatch (``.int()`` is a no-op on an already-int32 tensor and
+keeps the misaligned pointer), matching ``_flashinfer_gdn_verify``.
+"""
+
+import pytest
+import torch
+
+
+def _fi_decode_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    from tensorrt_llm._utils import is_flashinfer_gdn_supported_arch
+
+    if not is_flashinfer_gdn_supported_arch():
+        return False
+    try:
+        from flashinfer.gdn_kernels.gdn_decode_bf16_state import gated_delta_rule  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+skip_unsupported = pytest.mark.skipif(
+    not _fi_decode_available(),
+    reason="Requires SM90/SM100/SM103 and a FlashInfer build with "
+    "gdn_decode_bf16_state.gated_delta_rule",
+)
+
+
+@skip_unsupported
+def test_fi_decode_misaligned_index_slice():
+    """Index slices with a non-32B-aligned storage offset must be realigned.
+
+    A caller splitting a mixed batch passes the decode half
+    ``state_indices[num_prefills:]`` — an int32 view whose 4*num_prefills-byte
+    storage offset violates the FI kernel's 32-byte alignment assert
+    (``Misaligned Tensor data on argument`` at runtime) whenever
+    ``num_prefills % 8 != 0``. ``_flashinfer_gdn_decode`` must copy such views
+    before dispatch, exactly like ``_flashinfer_gdn_verify`` already does.
+    """
+    from tensorrt_llm._torch.modules.fla.fused_sigmoid_gating_recurrent import (
+        _flashinfer_gdn_decode,
+    )
+
+    torch.manual_seed(0)
+    dev = "cuda"
+    N, H, HV, K, V = 3, 4, 8, 128, 128
+    # Standard decode: one token per sequence, packed varlen layout.
+    q = (torch.randn(1, N, H, K, device=dev) * 0.1).to(torch.bfloat16)
+    k = (torch.randn(1, N, H, K, device=dev) * 0.1).to(torch.bfloat16)
+    v = (torch.randn(1, N, HV, V, device=dev) * 0.1).to(torch.bfloat16)
+    a = torch.randn(1, N, HV, device=dev) * 0.1
+    b = torch.randn(1, N, HV, device=dev) * 0.1
+    A_log = torch.empty(HV, device=dev).uniform_(1.0, 16.0).log()
+    dt_bias = torch.randn(HV, device=dev) * 0.1
+    state_pool = (torch.randn(N + 1, HV, V, K, device=dev) * 0.1).to(torch.bfloat16)
+    cu_seqlens = torch.arange(N + 1, device=dev, dtype=torch.long)
+
+    # int32 slice with a 4-byte storage offset (mimics the decode half
+    # state_indices[num_prefills:] with num_prefills == 1).
+    idx_buf = torch.arange(N + 1, device=dev, dtype=torch.int32)
+    idx_misaligned = idx_buf[1:]
+    assert idx_misaligned.data_ptr() % 32 != 0
+
+    # The decode kernel updates the state pool in place, so give each call
+    # its own copy and compare the final pools as well as the outputs.
+    pool_mis = state_pool.clone()
+    out_mis = _flashinfer_gdn_decode(
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        q=q,
+        k=k,
+        v=v,
+        b=b,
+        initial_state_source=pool_mis,
+        initial_state_indices=idx_misaligned,
+        scale=K**-0.5,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens,
+    )
+
+    pool_ref = state_pool.clone()
+    out_ref = _flashinfer_gdn_decode(
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        q=q,
+        k=k,
+        v=v,
+        b=b,
+        initial_state_source=pool_ref,
+        initial_state_indices=idx_misaligned.clone(),
+        scale=K**-0.5,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens,
+    )
+
+    torch.testing.assert_close(out_mis.float(), out_ref.float())
+    torch.testing.assert_close(pool_mis.float(), pool_ref.float())


### PR DESCRIPTION
## Description

Fixes #17027.

`_flashinfer_gdn_decode` (`tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py`) passes `initial_state_indices` to the FlashInfer CuTe-DSL kernel through `.int()`, which is a no-op on an already-int32 tensor: it returns the same storage and keeps the data pointer of a sliced view (e.g. the decode half `state_indices[num_prefills:]` of a mixed batch, offset `4 * num_prefills` bytes). The kernel asserts 32-byte data alignment on every tensor argument, so such a view is rejected at runtime:

```
ValueError: Misaligned Tensor data on argument #10 ... expected data alignment=32 bytes
```

`_can_use_flashinfer_gdn_decode` does not check alignment, so this is a hard error with no Triton fallback. The hazard is dormant for the current in-tree callers (they pass zero-offset views) but fires for any caller handing this public dispatch API an offset slice at an element offset not divisible by 8.

The fix mirrors the two guards that already exist for this exact bug class:
- `_flashinfer_gdn_verify` realigns the same argument with a clone-when-misaligned guard (#15975);
- #15194 added the analogous `% 32` guards for the `a`/`b` activation slices in `_flashinfer_gdn_decode` itself, but left the index tensor unguarded.

The clone only happens when the pointer is actually misaligned, so the common aligned case stays zero-copy.

## Test Coverage

- New: `tests/unittest/_torch/modules/mamba/test_flashinfer_gdn_decode.py::test_fi_decode_misaligned_index_slice` — feeds an int32 index slice with a 4-byte storage offset to `_flashinfer_gdn_decode` and checks output and final state pool against an aligned-clone baseline. Without this fix, the call raises the misaligned-tensor `ValueError`. Mirrors the existing `test_fi_mtp_verify_misaligned_index_slice`. Requires SM90/SM100/SM103 + a FlashInfer build with `gdn_kernels.gdn_decode_bf16_state` (skips otherwise), so it needs GPU CI.
- Existing: `tests/unittest/_torch/modules/mamba/test_flashinfer_gdn_verify.py` (verify-path twin) is unaffected.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- `_flashinfer_gdn_decode` converts `initial_state_indices` to `int32`.
- The code clones the tensor only when its pointer is not 32-byte aligned.
- Aligned tensors retain zero-copy behavior.
- The change matches existing alignment handling.
- No configuration or test-list files changed.

## QA Engineer Review

- Added `test_fi_decode_misaligned_index_slice()`.
- The test compares decode outputs and final state pools with an aligned-clone baseline.
- The test is not listed in `tests/integration/test_lists/` for CI or manual QA.
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->