### PR TITLE
[#17020][fix] DeepSeek-V4: honor thinking_budget in apply_chat_template

### DIFF
--- a/tensorrt_llm/tokenizer/deepseek_v4/tokenizer.py
+++ b/tensorrt_llm/tokenizer/deepseek_v4/tokenizer.py
@@ -428,9 +428,27 @@ class DeepseekV4Tokenizer(TransformersTokenizer):
         )
         return cls(tokenizer)
 
+    @staticmethod
+    def _resolve_thinking(kwargs: dict[str, Any]) -> bool:
+        """Decide whether to open a ``<think>`` block for this request.
+
+        ``thinking`` / ``enable_thinking`` are the native keys and win whenever
+        the caller passes either of them. Otherwise fall back to
+        ``thinking_budget``, the key used by the Jinja chat templates of other
+        models and the documented default of ``trtllm-eval aime25``/``aime26``
+        (a positive budget means "think", ``0`` disables thinking). DeepSeek-V4
+        ships no Jinja template, so without this the key would be silently
+        dropped and the request would run in non-thinking chat mode.
+        """
+        if "thinking" in kwargs or "enable_thinking" in kwargs:
+            return bool(kwargs.get("thinking", False) or kwargs.get("enable_thinking", False))
+
+        thinking_budget = kwargs.get("thinking_budget")
+        return thinking_budget is not None and int(thinking_budget) > 0
+
     def apply_chat_template(self, messages, tools=None, **kwargs):
         tokenize = kwargs.get("tokenize", False)
-        thinking = kwargs.get("thinking", False) or kwargs.get("enable_thinking", False)
+        thinking = self._resolve_thinking(kwargs)
         thinking_mode = "thinking" if thinking else "chat"
         reasoning_effort = kwargs.get("reasoning_effort")
         if reasoning_effort not in ("max", "high"):

--- a/tests/unittest/llmapi/test_deepseek_v4_tokenizer.py
+++ b/tests/unittest/llmapi/test_deepseek_v4_tokenizer.py
@@ -103,6 +103,58 @@ def test_deepseek_v4_chat_template_supports_thinking_alias():
     assert prompt == ("<｜begin▁of▁sentence｜><｜User｜>hello<｜Assistant｜><think>")
 
 
+def test_deepseek_v4_chat_template_supports_thinking_budget():
+    tokenizer = DeepseekV4Tokenizer(_DummyTokenizer())
+
+    prompt = tokenizer.apply_chat_template(
+        [
+            {
+                "role": "user",
+                "content": "hello",
+            }
+        ],
+        tokenize=False,
+        thinking_budget=32768,
+    )
+
+    assert prompt == ("<｜begin▁of▁sentence｜><｜User｜>hello<｜Assistant｜><think>")
+
+
+def test_deepseek_v4_chat_template_thinking_budget_zero_disables_thinking():
+    tokenizer = DeepseekV4Tokenizer(_DummyTokenizer())
+
+    prompt = tokenizer.apply_chat_template(
+        [
+            {
+                "role": "user",
+                "content": "hello",
+            }
+        ],
+        tokenize=False,
+        thinking_budget=0,
+    )
+
+    assert prompt == ("<｜begin▁of▁sentence｜><｜User｜>hello<｜Assistant｜></think>")
+
+
+def test_deepseek_v4_chat_template_native_thinking_key_wins_over_budget():
+    tokenizer = DeepseekV4Tokenizer(_DummyTokenizer())
+
+    prompt = tokenizer.apply_chat_template(
+        [
+            {
+                "role": "user",
+                "content": "hello",
+            }
+        ],
+        tokenize=False,
+        thinking=False,
+        thinking_budget=32768,
+    )
+
+    assert prompt == ("<｜begin▁of▁sentence｜><｜User｜>hello<｜Assistant｜></think>")
+
+
 def test_deepseek_v4_chat_template_matches_vllm_add_generation_prompt_behavior():
     tokenizer = DeepseekV4Tokenizer(_DummyTokenizer())
 


### PR DESCRIPTION
## Description

`DeepseekV4Tokenizer.apply_chat_template` reads only `thinking` / `enable_thinking`. Every kwarg is fetched with `kwargs.get`, so an unrecognized key is silently dropped — and `thinking_budget` is exactly such a key.

That matters because `trtllm-eval aime25` and `aime26` default `--chat_template_kwargs` to `{"thinking_budget": 32768}` (`lm_eval.py:1513` / `:1630`). DeepSeek-V4 ships **no Jinja chat template** — the checkpoint has no `chat_template` in `tokenizer_config.json` — so the hand-written renderer at `tokenizer/deepseek_v4/tokenizer.py` is the only thing that could honor the key. Today it does not, `thinking` falls back to `False`, and the prompt ends `<｜Assistant｜></think>` with the reasoning block pre-closed. The default output is byte-identical to explicitly passing `{"thinking": false}`.

Nothing in the logs or the results indicates this happened. The run completes successfully and reports a plausible-looking score.

Measured on DeepSeek-V4-Flash, AIME 2025, 4xGB300, TP4/EP4, greedy, everything else identical:

| `--chat_template_kwargs` | `exact_match` | |
|---|---|---|
| `'{"thinking_budget": 32768}'` (current default) | 43.33 (13/30) | ±9.20 |
| `'{"thinking": true}'` | 86.67 (26/30) | ±6.31 |

This is genuine capability loss rather than a scoring artifact: 29/30 non-thinking responses did contain a `\boxed{}`, and 15 of the 17 failures boxed a confidently wrong value.

### The change

Thinking resolution moves into one helper. `thinking` / `enable_thinking` win whenever the caller passes either, so **behavior is unchanged for every caller using the native keys**. Only when neither is present does `thinking_budget` decide: a positive budget means "think", `0` disables it. That is the semantic the CLI help text already documents ("set to 0 to disable thinking").

Reported as #17020. The companion suggestion in that issue — warning on unrecognized `chat_template_kwargs` keys — is deliberately left out of this PR to keep it to a single concern; happy to follow up if wanted.

## Test Coverage

`tests/unittest/llmapi/test_deepseek_v4_tokenizer.py`, three new cases:

- `test_deepseek_v4_chat_template_supports_thinking_budget` — a positive budget opens `<think>`
- `test_deepseek_v4_chat_template_thinking_budget_zero_disables_thinking` — `0` keeps the block pre-closed
- `test_deepseek_v4_chat_template_native_thinking_key_wins_over_budget` — explicit `thinking=False` beats a positive budget, pinning the precedence rule

The existing cases in that file cover the unchanged `thinking` / `enable_thinking` / `reasoning_effort` paths.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.
