### PR TITLE
[#17021][fix] DeepSeek-V4: merge request tools into the existing system message

### DIFF
--- a/tensorrt_llm/tokenizer/deepseek_v4/tokenizer.py
+++ b/tensorrt_llm/tokenizer/deepseek_v4/tokenizer.py
@@ -439,7 +439,16 @@ class DeepseekV4Tokenizer(TransformersTokenizer):
         conversation = kwargs.get("conversation", messages)
         messages = list(conversation)
         if tools:
-            messages.insert(0, {"role": "system", "tools": tools})
+            # The reference encoding attaches tools to the *existing* system
+            # message: a system turn renders as ``content + "\n\n" + tools``.
+            # Inserting a separate system message at index 0 instead emits the
+            # tool schemas first and the caller's system prompt after them, with
+            # no separator. Merge when there is a leading system message, and
+            # only insert a synthetic one when there is not.
+            if messages and messages[0].get("role") == "system":
+                messages[0] = {**messages[0], "tools": tools}
+            else:
+                messages.insert(0, {"role": "system", "tools": tools})
 
         rendered = _encode_messages(
             messages=messages,

--- a/tests/unittest/llmapi/test_deepseek_v4_tokenizer.py
+++ b/tests/unittest/llmapi/test_deepseek_v4_tokenizer.py
@@ -353,6 +353,74 @@ def test_deepseek_v4_chat_template_uses_v4_tool_prompt_from_request_tools():
     assert prompt.endswith("<｜User｜>Weather?<｜Assistant｜></think>")
 
 
+def test_deepseek_v4_chat_template_keeps_system_prompt_before_request_tools():
+    tokenizer = DeepseekV4Tokenizer(_DummyTokenizer())
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+
+    prompt = tokenizer.apply_chat_template(
+        [
+            {
+                "role": "system",
+                "content": "SYSTEM_PROMPT_HERE",
+            },
+            {
+                "role": "user",
+                "content": "Weather?",
+            },
+        ],
+        tools=tools,
+        tokenize=False,
+    )
+
+    # The reference encoding renders the system content, then the tool block.
+    assert prompt.startswith("<｜begin▁of▁sentence｜>SYSTEM_PROMPT_HERE\n\n## Tools")
+    assert prompt.count("SYSTEM_PROMPT_HERE") == 1
+    assert prompt.endswith("<｜User｜>Weather?<｜Assistant｜></think>")
+
+
+def test_deepseek_v4_chat_template_inserts_system_message_for_tools_without_system():
+    tokenizer = DeepseekV4Tokenizer(_DummyTokenizer())
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+
+    prompt = tokenizer.apply_chat_template(
+        [
+            {
+                "role": "developer",
+                "content": "DEV",
+            },
+            {
+                "role": "user",
+                "content": "Weather?",
+            },
+        ],
+        tools=tools,
+        tokenize=False,
+    )
+
+    # No leading system message, so the synthetic one is still inserted and the
+    # developer turn keeps rendering after the tool block, as before.
+    assert prompt.startswith("<｜begin▁of▁sentence｜>\n\n## Tools")
+    assert prompt.endswith("<｜User｜>DEV<｜User｜>Weather?<｜Assistant｜></think>")
+
+
 def test_deepseek_v4_chat_template_renders_tool_call_history():
     tokenizer = DeepseekV4Tokenizer(_DummyTokenizer())
     messages = [


### PR DESCRIPTION
## Description

`DeepseekV4Tokenizer.apply_chat_template` handles the OpenAI `tools` argument by always inserting a **synthetic** `{"role": "system", "tools": tools}` message at index 0 (`tokenizer.py:441-442`).

The DeepSeek-V4 reference format instead attaches tools to the *existing* system message — the renderer's `system` branch (`tokenizer.py:307-312`) emits `content` and then `"\n\n" + render_tools(tools)`. With a synthetic message, index 0 has empty content and renders as `"" + "\n\n" + <tools>`, and the caller's real system message renders separately at index 1, i.e. **after** the tool schemas, glued to the trailing newline of the tool block, with a stray `\n\n` right after BOS.

Comparing the same conversation (system prompt + one tool + one user turn) against `encoding/encoding_dsv4.py`, the reference implementation shipped inside the DeepSeek-V4-Flash checkpoint:

```
reference:  <BOS>SYSTEM_PROMPT_HERE\n\n## Tools\n...invoke tool calls.\n<｜User｜>Q<｜Assistant｜><think>
TRT-LLM:    <BOS>\n\n## Tools\n...invoke tool calls.\nSYSTEM_PROMPT_HERE<｜User｜>Q<｜Assistant｜><think>
```

Both strings are 1108 chars with an identical character multiset — a pure transposition. The system prompt moves from offset 21 to offset 1061.

**Scope.** This is the normal serving path: `openai_server.py` builds `tool_dicts` and passes them to `async_apply_chat_template(tools=...)` → `inputs/utils.py:658-663` → `tokenizer.apply_chat_template(messages, tools=tools)`. Every `/v1/chat/completions` request carrying both a system message and tools is affected. Not affected: no system message, `developer` role instead of `system`, or tools attached directly to a message dict rather than passed as the `tools` argument.

That last case is why the checkpoint's own gold vector `test_output_1.txt` passes today — it attaches tools to `messages[0]` and never exercises the `tools=` argument path.

### The change

Merge into a leading system message when one exists; keep inserting a synthetic message when one does not.

| case | before | after |
|---|---|---|
| system + tools | mismatch | matches reference |
| no system + tools | matches | matches (no regression) |
| developer + tools | matches | matches (no regression) |

Reported as #17021.

### For the record

The rest of the port is exact. All 4 shipped gold vectors (`tests/test_output_{1..4}.txt`) reproduce byte-for-byte, and a 36-case sweep of `{basic, multiturn, no-system} x {chat, thinking} x {None, high, max} x drop_thinking{T,F}` is byte-identical to the reference. This ordering bug was the only divergence found.

## Test Coverage

`tests/unittest/llmapi/test_deepseek_v4_tokenizer.py`, two new cases — the existing gold vectors do not cover the `tools=` argument path at all:

- `test_deepseek_v4_chat_template_keeps_system_prompt_before_request_tools` — the regression test. Verified to **fail on `main` and pass with this patch**.
- `test_deepseek_v4_chat_template_inserts_system_message_for_tools_without_system` — guards the insert path (no leading system message) against regression. Passes both before and after.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.
