### PR TITLE
[https://nvbugs/6481375][test] Unwaive passing DSV3-Lite tests

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -185,8 +185,6 @@ full:GB200/accuracy/test_dwdp_disaggregated_serving.py::TestDwdpDeepSeekV3Lite::
 full:GB200/accuracy/test_dwdp_disaggregated_serving.py::TestDwdpDeepSeekV3Lite::test_dwdp_accuracy_contention_opt SKIP (https://nvbugs/6276923)
 full:GB200/accuracy/test_dwdp_disaggregated_serving.py::TestDwdpDeepSeekV3Lite::test_dwdp_accuracy_mode_b_overlap SKIP (https://nvbugs/6276923)
 full:GB200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False-enable_chunked_prefill=False-v2_kv_cache=False] SKIP (https://nvbugs/6525896)
-full:GB200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=True-enable_chunked_prefill=True-v2_kv_cache=False] SKIP (https://nvbugs/6400067)
-full:GB200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=True-enable_chunked_prefill=True-v2_kv_cache=True] SKIP (https://nvbugs/6400067)
 full:GB200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_cute_dsl_bf16_gemm[cuda_graph=True] SKIP (https://nvbugs/6525897)
 full:GB200/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_cute_dsl_nvfp4_4gpus[tp4-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=True] SKIP (https://nvbugs/6474888)
 full:GB200/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_mxfp8[use_msa=False] SKIP (https://nvbugs/6479471)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -1,4 +1,3 @@
-accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_first[noadp-mtp0] SKIP (https://nvbugs/6481375)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=2] SKIP (https://nvbugs/6427411)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=1-ctx_pp=4] SKIP (https://nvbugs/6428069)
 accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ctx_pp_gen_tp_asymmetric[GSM8K-gen_tp=2-ctx_pp=2] SKIP (https://nvbugs/6427411)


### PR DESCRIPTION
## Description

Unwaive DSV3-Lite tests tracked by NVBug 6481375 and NVBug 6400067 after the underlying failures were fixed.

- Re-enable disaggregated gen-first coverage.
- Re-enable BF16 MTP coverage with both legacy and V2 KV cache.

## Test Coverage

- DSV3-Lite disaggregated gen-first test: passed.
- DSV3-Lite BF16 MTP tests with both KV cache modes: passed.
- Related KV cache V2 unit tests and pre-commit checks: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Removed three obsolete skip entries from `tests/integration/test_lists/waives.txt`.
- The changes target one `TestDeepSeekV3Lite::test_gen_first` case and two GB200 `TestDeepSeekV3Lite::test_bfloat16` cases.
- The change has no API, performance, or error-handling impact.
- The waiver scope is limited to the intended DSV3-Lite tests.
- The waiver-file format and bug-reference consistency are preserved.
- No duplicate or unrelated waiver changes were identified.

## QA Engineer Review

- No `test-db/` or `qa/` files were modified.
- Removed one gen-first waiver and two GB200 BF16 waivers from `tests/integration/test_lists/waives.txt`.
- The related tests are re-enabled for CI coverage.
- Listed tests, KV cache V2 unit tests, pre-commit checks, and CI pipelines passed.
- Verdict: sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->