### PR TITLE
[None][fix] Avoid an NCCL window output buffer in the symmetric all-reduce during CUDA graph capture

### DIFF
--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -554,8 +554,28 @@ private:
             inputPtr = windowBuffer0.ptr;
         }
 
+        // Writing the all-reduce result into an NCCL window buffer is not safe
+        // while capturing a CUDA graph: replaying such a graph yields wrong
+        // results (seen on TP=4 GB200 as a non-finite residual and a decode
+        // collapse). A 2x2 ablation showed the output side is solely
+        // responsible -- a window input is harmless. Fall back to a plain
+        // output during capture, as runNCCLAllReduce does; eager calls keep the
+        // full symmetric path.
+        cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
+        bool isCapturing = false;
+        if (cudaStreamIsCapturing(stream, &captureStatus) == cudaSuccess)
+        {
+            isCapturing = (captureStatus != cudaStreamCaptureStatusNone);
+        }
+        else
+        {
+            cudaGetLastError(); // don't leak a sticky error to later calls
+        }
+
         // Use window-backed output buffer
-        auto [normOut, windowBuffer1] = createNCCLWindowTensor(rawComm, input.sizes(), input.scalar_type());
+        auto [normOut, windowBuffer1] = isCapturing
+            ? std::make_pair(torch::Tensor(), tensorrt_llm::common::nccl_util::NCCLWindowBuffer())
+            : createNCCLWindowTensor(rawComm, input.sizes(), input.scalar_type());
         torch::Tensor outputTensor = windowBuffer1.isValid() ? normOut : torch::empty_like(inputTensor);
         void* outputPtr = windowBuffer1.isValid() ? windowBuffer1.ptr : outputTensor.data_ptr();
         if (!windowBuffer1.isValid())

--- a/tests/unittest/_torch/multi_gpu/test_allreduce_cudagraph_window.py
+++ b/tests/unittest/_torch/multi_gpu/test_allreduce_cudagraph_window.py
@@ -1,0 +1,102 @@
+"""NCCL_SYMMETRIC must not write into an NCCL window buffer while capturing.
+
+Replaying a graph that captured such an all-reduce yields wrong results (on
+TP=4 GB200: a non-finite residual at the first global-attention layer and a
+decode collapse). A 2x2 ablation showed the output buffer is solely
+responsible; a window input is harmless.
+
+The test asserts that invariant instead of trying to reproduce the corruption:
+outside the full model the numerical failure does not reproduce, and a
+pointer-stability assertion gives false negatives -- an allocator fix that
+removed all cross-graph aliasing passed it while the model still collapsed.
+"""
+
+import pytest
+import torch
+from mpi4py import MPI
+
+import tensorrt_llm
+from tensorrt_llm._torch.distributed import (AllReduce, AllReduceParams,
+                                             AllReduceStrategy)
+from tensorrt_llm.functional import AllReduceFusionOp
+from tensorrt_llm.mapping import Mapping
+
+HIDDEN = 1024
+TOKENS = 8
+
+
+def _in_window(tensor, group):
+    """True if ``tensor`` is backed by a registered NCCL window buffer."""
+    if not hasattr(torch.ops.trtllm, "is_nccl_window_buffer"):
+        return False
+    return bool(torch.ops.trtllm.is_nccl_window_buffer(tensor, list(group)))
+
+
+def _run(rank, world):
+    torch.cuda.set_device(rank)
+    mapping = Mapping(world_size=world, tp_size=world, rank=rank)
+    ar = AllReduce(mapping=mapping,
+                   strategy=AllReduceStrategy.NCCL_SYMMETRIC,
+                   dtype=torch.bfloat16)
+    group = mapping.tp_group
+    x = torch.randn(TOKENS, HIDDEN, dtype=torch.bfloat16,
+                    device=torch.device("cuda", rank))
+
+    def call(t):
+        return ar(t,
+                  all_reduce_params=AllReduceParams(
+                      fusion_op=AllReduceFusionOp.NONE))
+
+    # Warm up on a side stream: required before an NCCL-involving capture, and
+    # it is what populates the window pool.
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        for _ in range(3):
+            eager_out = call(x)
+    torch.cuda.current_stream().wait_stream(side)
+    torch.cuda.synchronize()
+
+    # Reported, not asserted: a pool miss may legitimately fall back, but the
+    # fix must not disable the window path outside capture.
+    eager_in_window = _in_window(eager_out, group)
+
+    static_in = x.clone()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_out = call(static_in)
+    torch.cuda.synchronize()
+
+    captured_in_window = _in_window(captured_out, group)
+    print(
+        f"[rank {rank}] eager_output_in_window={eager_in_window} "
+        f"captured_output_in_window={captured_in_window}",
+        flush=True)
+
+    assert not captured_in_window, (
+        f"[rank {rank}] the NCCL_SYMMETRIC all-reduce output captured into a "
+        f"CUDA graph is backed by an NCCL window buffer; replaying such a "
+        f"graph yields wrong results")
+
+    static_in.copy_(x)
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.isfinite(captured_out).all(), (
+        f"[rank {rank}] replayed all-reduce produced non-finite values")
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4,
+                    reason="needs 4 GPUs for TP=4")
+def test_nccl_symmetric_output_not_in_window_under_capture():
+    world = tensorrt_llm.mpi_world_size()
+    if world < 2:
+        pytest.skip("needs a multi-rank launch")
+    _run(tensorrt_llm.mpi_rank(), world)
+    MPI.COMM_WORLD.barrier()
+
+
+if __name__ == "__main__":
+    _run(tensorrt_llm.mpi_rank(), tensorrt_llm.mpi_world_size())
+    MPI.COMM_WORLD.barrier()
+    if tensorrt_llm.mpi_rank() == 0:
+        print("NCCL_SYMMETRIC_CUDAGRAPH_WINDOW_TEST_OK", flush=True)


### PR DESCRIPTION

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

# PR description

## Problem

With `AllReduceStrategy.NCCL_SYMMETRIC`, `runNCCLAllReduceSymmetric` takes its
output buffer from `createNCCLWindowTensor`, i.e. NCCL window-registered memory.
When such an all-reduce is captured into a CUDA graph, replaying that graph
produces wrong results.

Seen on TP=4 GB200 (NVL72) with a 66-layer NVFP4 MoE model on the production
decode path (`cuda_graph` + overlap scheduler): a non-finite residual appears at
the first global-attention layer and decode collapses into a repeated token 0
(`" Paris"` followed by 139× `"!"`). Eager execution of the same model is
unaffected.

The failure is intermittent because the AutoTuner selects the all-reduce tactic
from measured timings, so whether `NCCL_SYMMETRIC` ends up inside a captured
graph varies run to run. At the collapsing configuration the rate was
**114/120 (95%)**.

## Isolation

`runNCCLAllReduceSymmetric` differs from the plain-NCCL path
(`runNCCLAllReduce`) in exactly two places: the input may be copied into a
window buffer, and the output comes from one. Ablating them independently
(the input side via the existing `TLLM_NCCL_MIN_REGISTRATION`) isolates the
output buffer as the sole cause.

n=6 per arm, against a deterministic 20/20 collapse baseline:

| input  | output | collapse |
|--------|--------|----------|
| window | window | 6/6      |
| plain  | window | 6/6      | ← the input side is irrelevant
| window | plain  | 0/6      | ← this fix
| plain  | plain  | 0/6      | ← equals plain NCCL, the control

## What is and isn't established

**Established:** the trigger is a captured all-reduce whose *output* is NCCL
window memory. Why only the output matters is explained by the code: the
`cudaMemcpyAsync` that fills the window *input* is itself captured, so every
replay re-establishes it, whereas nothing re-establishes the output — and the
CUDA graph runner stores graph outputs as weak refs, while PyTorch's graph
private pool does not cover `from_blob` memory.

**Not established:** what exactly goes wrong inside NCCL. The symmetric
all-reduce writes its result with `multimem_st_global` to an address derived
from `(window, offset)` rather than from the local virtual address
(`nccl_device/impl/ptr__funcs.h`, `device/symmetric/all_reduce.cuh`), which
requires every rank to agree on the offset — and `NCCLWindowAllocator` picks by
local best-fit with no cross-rank agreement. That is a plausible mechanism but
it has not been verified here, and it does not explain why a single graph that
uses a window output *and is itself replayed* stays clean (0/8).

## Fix

While `cudaStreamIsCapturing()`, fall back to a plain output tensor, exactly as
`runNCCLAllReduce` does.

* Eager calls are untouched and keep the full symmetric path.
* The window **input** copy is kept in both cases, so the read-side zero-copy
  benefit is retained.
* Measured with `NCCL_DEBUG=INFO`: with a plain output NCCL leaves the symmetric
  path entirely for that collective (`Symmetric` occurrences 5010 → 0, `RING`
  261 → 2682). This also covers the case where the input is already a
  registered window (`TLLM_NCCL_SYMMETRIC_ZERO_COPY`, on by default).

## Verification

All runs below have the capture-time dispatch left completely unguarded, so this
change is the only thing between the model and the bug. A bootstrap assertion
fails the job if any capture guard is present, to rule out a run being silently
protected by something else.

| configuration                              | before      | after   |
|--------------------------------------------|-------------|---------|
| production config, no intervention, 60 runs | 114/120 (95%) | **0/60** |
| same binary, output forced back to a window | —           | 3/3 collapse (control) |
| same binary, fix active                     | —           | **0/3** |
| bucket pinned to `NCCL_SYMMETRIC`           | 20/20       | **0/5** |
| window input + window output                | 6/6         | **0/4** |
| plain input + window output                 | 6/6         | **0/2** |
| minimal two-graph repro (`cg_batch_sizes=[1,8]`) | 9/12   | **0/2** |

The same-binary A/B is the strongest control: both arms are the same build and
differ only by an environment variable, which rules out rebuild side effects or
environment drift.

## Test

`tests/unittest/_torch/multi_gpu/test_allreduce_cudagraph_window.py` asserts the
invariant directly — under capture, the symmetric all-reduce output must not be
backed by a registered NCCL window (`trtllm::is_nccl_window_buffer`) — and
checks the replayed result is finite.

It deliberately does not try to reproduce the corruption. Outside the full model
the numerical failure does not reproduce (0/60 across several standalone harness
designs), and a pointer-stability assertion gives false negatives, as the
rejected aliasing hypothesis above shows. Neither can serve as a regression test.

## Limitations

* **Performance is not measured.** During capture the collective now runs a
  legacy RING/LL kernel instead of the symmetric one. The decode-path cost of
  that has not been quantified and should be before this is relied on for
  throughput-sensitive deployments.
* The mechanism inside NCCL is not identified, so this is a targeted avoidance
  rather than a fix at the true origin. If the multimem-offset hypothesis is
  confirmed, the more complete fix is to make the window buffer selection agree
  across ranks, or to exclude `NCCL_SYMMETRIC` from the tunable tactic set while
  CUDA graphs are in use (which is what upstream already does per-platform for
  GB10, see #12715).
* Upstream `main` at the time of writing has no capture guard on this path, and
  the GB10 workaround is gated on `realSmVersion == 121 && isIntegrated`, so
  GB200 is not covered by it.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
