### PR TITLE
[https://nvbugs/6528742][test] Disable V2 in legacy Mamba test

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -7115,6 +7115,7 @@ class TestNemotronV3Super(LlmapiAccuracyTestHarness):
                     enable_block_reuse=False,
                     mamba_ssm_cache_dtype="float16",
                     free_gpu_memory_fraction=0.5,
+                    use_kv_cache_manager_v2=False,
                 ),
                 max_batch_size=32,
                 tensor_parallel_size=4,


### PR DESCRIPTION
## What changed

- Explicitly set `KvCacheConfig.use_kv_cache_manager_v2=False` in the parameterized Nemotron V3 Super legacy Mamba cache manager test.

## Why

The model defaults can otherwise select `MambaHybridCacheManagerV2`, even when the test sets `TRTLLM_USE_PY_MAMBA=1`. This made the `python_mamba_cache` case stop exercising the intended legacy `MixedMambaHybridCacheManager`.

Pinning V2 off keeps both legacy Python and C++ manager parameterizations on their intended paths.

## Validation

- `pre-commit run --files tests/integration/defs/accuracy/test_llm_api_pytorch.py`
- `pytest tests/unittest/_torch/executor/test_mamba_cache_manager.py -k hybrid_cache_manager_factory_honors_v2_setting` — 4 passed
- B200, 4 GPUs:
  `TestNemotronV3Super::test_fp8_4gpus[attention_dp_on-python_mamba_cache]` — passed
  - MMLU: 85.526 (threshold 83.883)
  - GSM8K: 92.456 (threshold 88.897)
  - Runtime log confirmed `MixedMambaHybridCacheManager`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Dev Engineer Review**

- Updated `test_fp8_4gpus` to explicitly set `KvCacheConfig.use_kv_cache_manager_v2=False`, ensuring the test exercises the intended legacy Mamba cache manager regardless of model defaults or `TRTLLM_USE_PY_MAMBA`.
- The change is minimal, uses a valid existing API field, and does not alter production behavior or public interfaces.
- Validation reported: pre-commit checks, four passing unit tests, and a successful B200 4-GPU run with MMLU and GSM8K scores above thresholds.

**QA Engineer Review**

- Modified test: `test_fp8_4gpus` in `tests/integration/defs/accuracy/test_llm_api_pytorch.py`.
- No test-list changes were identified; coverage should remain associated with its existing test-list entry.
- Verdict: **sufficient**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->