### PR TITLE
[None][fix] Fix Qwen3Next MoE expert-quant probe and GDN verify tensor alignment

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -38,6 +38,7 @@ from tensorrt_llm._torch.modules.mamba.mamba2_metadata import Mamba2Metadata
 from tensorrt_llm._torch.pyexecutor.config_utils import \
     get_qwen3_hybrid_layer_types
 from tensorrt_llm._utils import get_sm_version
+from tensorrt_llm.models.modeling_utils import QuantConfig
 
 from ...logger import logger
 from ..attention_backend import AttentionMetadata
@@ -112,6 +113,32 @@ def _precompute_fused_norm_weights(module: nn.Module) -> None:
 def _eager_fusion_enabled(enable_attention_dp: bool) -> bool:
     return (os.environ.get("TRTLLM_QWEN3_EAGER_FUSION_DISABLED", "0") == "0"
             and not enable_attention_dp)
+
+
+def _experts_excluded_from_quant(model_config: ModelConfig[Qwen3NextConfig],
+                                 layer_idx: Optional[int]) -> bool:
+    """Is this layer's routed-experts module listed in ``exclude_modules``?
+
+    ``exclude_modules`` is applied only after every module is built, but
+    ``create_moe`` has to pick the MoE backend class before that. A backend
+    picked for FP8/NVFP4 weights rejects the experts if they turn out to be
+    bf16, so look the answer up now instead of waiting for that pass.
+    """
+    quant_config = model_config.quant_config
+    if layer_idx is None or not quant_config.exclude_modules:
+        return False
+    candidates = [f"model.layers.{layer_idx}.mlp.experts"]
+    n_hidden_layers = getattr(model_config.pretrained_config,
+                              "num_hidden_layers", None)
+    # One MTP layer has two names: mtp.layers.<i> in the checkpoint and
+    # model.layers.<n_hidden_layers + i> at runtime. Only the Qwen3.5 entry
+    # points rewrite the first into the second, so try both names here.
+    if n_hidden_layers is not None and layer_idx >= n_hidden_layers:
+        candidates.append(
+            f"mtp.layers.{layer_idx - n_hidden_layers}.mlp.experts")
+    return any(
+        quant_config.is_module_excluded_from_quantization(candidate)
+        for candidate in candidates)
 
 
 class Qwen3NextGate(nn.Module):
@@ -213,6 +240,11 @@ class Qwen3NextSparseMoeBlock(nn.Module):
         if quant_config_dict and layer_idx is not None:
             expert_quant_config = quant_config_dict.get(
                 f"model.layers.{layer_idx}.mlp.experts")
+        # Excluded experts end up bf16 whatever the per-layer entry says, so
+        # hand create_moe a bf16 config and let it pick a backend serving bf16.
+        if _experts_excluded_from_quant(model_config, layer_idx):
+            expert_quant_config = QuantConfig(kv_cache_quant_algo=model_config.
+                                              quant_config.kv_cache_quant_algo)
         self.experts = create_moe(
             num_experts=self.num_experts,
             routing_method=self.gate.routing_method,
@@ -766,20 +798,12 @@ class Qwen3NextMTP(Qwen3NextFullAttentionDecoderLayer):
     def __init__(self, model_config: ModelConfig[Qwen3NextConfig],
                  layer_idx: int, aux_stream_dict: Dict[AuxStreamType,
                                                        torch.cuda.Stream]):
-        # Some HF checkpoints (e.g. Qwen3.5 NVFP4) keep the MTP layer entirely
-        # unquantized -- including its MoE experts (no weight_scale tensors).
-        # Most non-CUTLASS MoE backends (TRTLLMGen, CuteDsl, ...) reject
-        # unquantized / kv-cache-only quant_modes at create_weights or
-        # forward time (e.g. "TRTLLMGenFusedMoE doesn't support
-        # fp16/bf16/fp32 MoE", "CuteDslFusedMoE doesn't support quantization
-        # mode [128]" where bit 128 is FP8_KV_CACHE only).  CUTLASS MoE
-        # supports both BF16 and quantized MoE, so when the checkpoint marks
-        # MTP as excluded from quantization, fall back to CUTLASS *only* for
-        # the MTP layer.  Regular layers (0..num_hidden_layers-1) keep the
-        # user-selected backend.
+        # Some HF checkpoints (e.g. Qwen3.5 NVFP4) keep the whole MTP layer in
+        # bf16. Given a bf16 config most backends switch to CUTLASS on their
+        # own; DEEPGEMM and WIDEEP do not, so switch for them here.
         mtp_model_config = model_config
         if (model_config.moe_backend != "CUTLASS"
-                and Qwen3NextMTP._is_mtp_excluded_from_quant(model_config)):
+                and _experts_excluded_from_quant(model_config, layer_idx)):
             original_backend = model_config.moe_backend
             mtp_model_config = copy.copy(model_config)
             mtp_model_config._frozen = False
@@ -840,56 +864,6 @@ class Qwen3NextMTP(Qwen3NextFullAttentionDecoderLayer):
         # MTP applies shared_head.norm after the base decoder forward, so its
         # MoE-output all-reduce cannot consume next_layer_layernorm.
         self.fusion_config.POST_MOE_FUSION = False
-
-    @staticmethod
-    def _mtp_pattern_covers_experts(tail: str) -> bool:
-        """Does an MTP exclude pattern cover the routed experts?
-
-        ``tail`` is what follows the ``mtp.`` /
-        ``model.layers.<n_hidden_layers>`` prefix.
-        """
-        stripped = tail.strip(".*")
-        if not stripped:
-            # Bare (or wildcarded) layer prefix: covers the whole layer.
-            return True
-        if stripped.startswith("layers."):
-            # "layers.<idx>[.<module>]" -- drop "layers" and the index.
-            parts = stripped.split(".", 2)
-            stripped = parts[2] if len(parts) > 2 else ""
-            if not stripped:
-                return True
-        return "mlp.experts" in stripped
-
-    @staticmethod
-    def _is_mtp_excluded_from_quant(
-            model_config: ModelConfig[Qwen3NextConfig]) -> bool:
-        """Heuristic: did the checkpoint leave the MTP *MoE* unquantized?
-
-        ``apply_quant_config_exclude_modules`` runs *after* this constructor.
-        For Qwen3.5 paths the exclude_modules list has already been
-        translated to ``model.layers.<n_hidden_layers>*`` by
-        ``_normalize_qwen35_exclude_modules`` -- detect that.  Raw HF
-        ``mtp.*`` patterns are also accepted (defensive: if some future
-        weight mapper does not translate them, this still triggers the
-        backend fallback so the MoE path doesn't crash).
-        """
-        qc = getattr(model_config, "quant_config", None)
-        if qc is None or not getattr(qc, "exclude_modules", None):
-            return False
-        n_layers = getattr(model_config.pretrained_config, "num_hidden_layers",
-                           None)
-        target_prefix = (f"model.layers.{n_layers}"
-                         if n_layers is not None else None)
-        for pat in qc.exclude_modules:
-            if pat.startswith("mtp."):
-                tail = pat[len("mtp."):]
-            elif target_prefix is not None and pat.startswith(target_prefix):
-                tail = pat[len(target_prefix):]
-            else:
-                continue
-            if Qwen3NextMTP._mtp_pattern_covers_experts(tail):
-                return True
-        return False
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
+++ b/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
@@ -386,9 +386,17 @@ def _flashinfer_gdn_verify(
     output = (output.view(N, T, HV, V) if output is not None else q.new_empty(
         N, T, HV, V))
     # The FI CuTe-DSL kernel asserts 32-byte data alignment on every tensor
-    # argument. The int32 index tensor may be a slice of a larger buffer
+    # argument. ``a`` starts ``num_v_heads_per_tp`` bf16 elements into the fused
+    # ``in_proj_ba`` output, so it is misaligned when that count is not a
+    # multiple of 16 (e.g. Qwen3.5 TEP16: 128 / 16 = 8) -- see the note in
+    # _flashinfer_gdn_decode for why this clones instead of .contiguous().
+    if a.data_ptr() % 32 != 0:
+        a = a.clone(memory_format=torch.contiguous_format)
+    if b.data_ptr() % 32 != 0:
+        b = b.clone(memory_format=torch.contiguous_format)
+    # The int32 index tensor may likewise be a slice of a larger buffer
     # (e.g. state_indices_d = cache_indices[num_prefills:]) whose 4*offset
-    # storage offset breaks that; .int() is a no-op for int32, so realign
+    # storage offset breaks alignment; .int() is a no-op for int32, so realign
     # with an explicit copy when needed.
     initial_state_indices = initial_state_indices.int()
     if initial_state_indices.data_ptr() % 32 != 0:

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -48,6 +48,7 @@ l0_a10:
   # NOTE: this is a CPU-only test, but we do not have a dedicated job for this (and therefore no
   # test list either).
   - unittest/_torch/models/checkpoints
+  - unittest/_torch/models/test_qwen3_next_moe_quant.py
   - unittest/_torch/weight_sharing
   - unittest/inputs/test_chat_template_dispatch.py
   - unittest/inputs/test_content_format.py

--- a/tests/unittest/_torch/models/test_qwen3_next_moe_quant.py
+++ b/tests/unittest/_torch/models/test_qwen3_next_moe_quant.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unquantized-MoE probe for the Qwen3Next / Qwen3.5 MTP layer."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tensorrt_llm._torch.models.modeling_qwen3_5 import _normalize_qwen35_exclude_modules
+from tensorrt_llm._torch.models.modeling_qwen3_next import _experts_excluded_from_quant
+from tensorrt_llm.models.modeling_utils import QuantConfig
+from tensorrt_llm.quantization.mode import QuantAlgo
+
+NUM_HIDDEN_LAYERS = 40
+# MTP layers are appended after the regular ones (MTPForCausalLM start_layer_idx).
+MTP_LAYER_IDX = NUM_HIDDEN_LAYERS
+
+
+def _model_config(exclude_modules, quant_algo=QuantAlgo.NVFP4):
+    return SimpleNamespace(
+        quant_config=QuantConfig(
+            quant_algo=quant_algo,
+            kv_cache_quant_algo=QuantAlgo.FP8,
+            exclude_modules=exclude_modules,
+        ),
+        pretrained_config=SimpleNamespace(
+            num_hidden_layers=NUM_HIDDEN_LAYERS,
+            num_nextn_predict_layers=1,
+        ),
+    )
+
+
+# All of these cover model.layers.40.mlp.experts under QuantConfig's matcher -- exact name,
+# ancestor walk (a parent entry excludes everything below it), trailing ".*", "re:" regex -- in
+# either the translated TRT-LLM namespace or the raw HF one, so every one must be recognized.
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        f"model.layers.{MTP_LAYER_IDX}",
+        f"model.layers.{MTP_LAYER_IDX}*",
+        f"model.layers.{MTP_LAYER_IDX}.*",
+        f"model.layers.{MTP_LAYER_IDX}.mlp",
+        f"model.layers.{MTP_LAYER_IDX}.mlp*",
+        f"model.layers.{MTP_LAYER_IDX}.mlp.*",
+        f"model.layers.{MTP_LAYER_IDX}.mlp.experts",
+        f"model.layers.{MTP_LAYER_IDX}.mlp.experts*",
+        rf"re:model\.layers\.{MTP_LAYER_IDX}\..*",
+        r"re:.*\.mlp\.experts$",
+        "mtp.layers.0",
+        "mtp.layers.0*",
+        "mtp.layers.0.mlp",
+        "mtp.layers.0.mlp*",
+        "mtp.layers.0.mlp.experts*",
+    ],
+)
+def test_experts_covered_by_exclusion(pattern):
+    model_config = _model_config([pattern, "lm_head"])
+
+    assert _experts_excluded_from_quant(model_config, MTP_LAYER_IDX)
+
+
+# Leaf-level exclusions around the experts (what FP8 block-scale checkpoints emit) leave the
+# experts quantized: forcing the CUTLASS fp8_blockscale GEMM there aborts on Blackwell.
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "mtp.fc",
+        "mtp.norm",
+        "mtp.layers.0.mlp.gate",
+        "mtp.layers.0.mlp.shared_expert_gate",
+        "mtp.layers.0.mlp.shared_expert.down_proj",
+        "mtp.layers.0.self_attn.q_proj",
+        f"model.layers.{MTP_LAYER_IDX}.mlp.gate",
+        f"model.layers.{MTP_LAYER_IDX}.mlp.shared_expert.down_proj",
+        f"model.layers.{MTP_LAYER_IDX - 1}*",
+        "*kv_b_proj*",
+        "*linear_attn.conv1d",
+    ],
+)
+def test_experts_not_covered_by_exclusion(pattern):
+    model_config = _model_config([pattern, "lm_head"])
+
+    assert not _experts_excluded_from_quant(model_config, MTP_LAYER_IDX)
+
+
+# The exclude_modules shapes checkpoints are known to emit, run through the same normalization
+# the Qwen3.5 entry points apply. ``expected`` says whether the routed experts end up bf16.
+@pytest.mark.parametrize(
+    "shape,exclude_modules,quant_algo,expected",
+    [
+        ("whole MTP layer wildcard", ["mtp.layers.0*", "lm_head"], QuantAlgo.NVFP4, True),
+        (
+            "bare mtp subtree plus layer wildcard",
+            ["mtp*", "mtp.layers.0*"],
+            QuantAlgo.MIXED_PRECISION,
+            True,
+        ),
+        (
+            "leaf-level entries only",
+            ["mtp.fc", "mtp.layers.0.mlp.gate", "mtp.layers.0.mlp.shared_expert_gate"],
+            QuantAlgo.FP8_BLOCK_SCALES,
+            False,
+        ),
+        (
+            "leaf-level entries incl. top-level norms",
+            [
+                "mtp.fc",
+                "mtp.norm",
+                "mtp.pre_fc_norm_embedding",
+                "mtp.pre_fc_norm_hidden",
+                "mtp.layers.0.input_layernorm",
+                "mtp.layers.0.mlp.gate",
+            ],
+            QuantAlgo.FP8_BLOCK_SCALES,
+            False,
+        ),
+    ],
+)
+def test_known_exclude_module_shapes(shape, exclude_modules, quant_algo, expected):
+    model_config = _model_config(exclude_modules, quant_algo=quant_algo)
+    _normalize_qwen35_exclude_modules(model_config)
+
+    assert _experts_excluded_from_quant(model_config, MTP_LAYER_IDX) is expected, shape
+
+
+def test_no_exclusions_needs_no_fallback():
+    assert not _experts_excluded_from_quant(_model_config(None), MTP_LAYER_IDX)
+
+
+@pytest.mark.parametrize(
+    "pattern,layer_idx,expected",
+    [
+        # A regular layer's experts get the same treatment as the MTP layer's:
+        # create_moe must see the unquantized config, or it picks a backend the
+        # experts will not have once the exclusion pass runs.
+        ("model.layers.5.mlp.experts", 5, True),
+        ("model.layers.5.mlp", 5, True),
+        ("model.layers.5*", 5, True),
+        ("model.layers.5.mlp.experts", 6, False),
+        # The raw HF mtp.* spelling only applies to layers past the last
+        # regular one, so it must not leak onto a regular layer.
+        ("mtp.layers.0.mlp.experts", 5, False),
+        ("mtp.layers.0.mlp.experts", MTP_LAYER_IDX, True),
+    ],
+)
+def test_regular_layers_are_covered_too(pattern, layer_idx, expected):
+    model_config = _model_config([pattern, "lm_head"])
+
+    assert _experts_excluded_from_quant(model_config, layer_idx) is expected
+
+
+def test_missing_layer_idx_is_a_noop():
+    assert not _experts_excluded_from_quant(_model_config(["model.layers.5*"]), None)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated Qwen3Next MoE quantization exclusion handling by introducing a centralized helper `_experts_excluded_from_quant(model_config, layer_idx)` that checks `quant_config.exclude_modules` against both:
  - the standard runtime routed-experts module path, and
  - the Qwen3 MTP naming variant with the runtime `layer_idx` offset (MTP layer index = `NUM_HIDDEN_LAYERS`).
- Applied the exclusion result consistently by:
  - overriding `Qwen3NextSparseMoeBlock`’s per-layer `expert_quant_config` to a `QuantConfig` derived from `model_config.quant_config.kv_cache_quant_algo` when that layer’s experts are excluded, and
  - updating `Qwen3NextMTP.__init__` to choose `moe_backend="CUTLASS"` on a per-`layer_idx` basis when MTP experts are excluded.
- Removed prior `Qwen3NextMTP` private static heuristics used for pattern matching/exclusion decisions (`_mtp_pattern_covers_experts`, `_is_mtp_excluded_from_quant`).
- Fixed FlashInfer GDN verify tensor alignment by cloning bf16-state `a`/`b` into 32-byte-aligned contiguous storage when `data_ptr()` is misaligned (and preserving existing `initial_state_indices` handling with `disable_state_update=True`).

## QA Engineer Review

- Test code added: `tests/unittest/_torch/models/test_qwen3_next_moe_quant.py`
  - Added test functions:
    - `test_experts_covered_by_exclusion(pattern)`
    - `test_experts_not_covered_by_exclusion(pattern)`
    - `test_known_exclude_module_shapes(shape, exclude_modules, quant_algo, expected)`
    - `test_no_exclusions_needs_no_fallback()`
    - `test_regular_layers_are_covered_too(pattern, layer_idx, expected)`
    - `test_missing_layer_idx_is_a_noop()`
- Test list update (CI selection):
  - `tests/integration/test_lists/test-db/l0_a10.yml`: added `unittest/_torch/models/test_qwen3_next_moe_quant.py` under `l0_a10` `pre_merge` / `pytorch`.
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
