### PR TITLE
[https://nvbugs/6533916][fix] Make sparse attention example runnable

### DIFF
--- a/examples/llm-api/llm_sparse_attention.py
+++ b/examples/llm-api/llm_sparse_attention.py
@@ -33,9 +33,9 @@ python llm_sparse_attention.py \
     --prompt_budget 2048
 ```
 
-When ``--input_file`` is omitted, the example uses a built-in long prompt that
-exceeds the default ``prompt_budget`` and exercises RocketKV's sparse attention
-path.
+When ``--input_file`` is omitted, the example uses a built-in
+needle-in-a-haystack prompt that exceeds the default ``prompt_budget`` and
+exercises the sparse attention path.
 """
 import argparse
 import json
@@ -45,15 +45,53 @@ from tensorrt_llm.llmapi import (CudaGraphConfig, DeepSeekSparseAttentionConfig,
                                  KvCacheConfig, MoeConfig,
                                  RocketSparseAttentionConfig)
 
-_DEFAULT_PROMPT_CONTEXT = (
-    "TensorRT-LLM accelerates large language model inference on NVIDIA GPUs. "
-    "It combines optimized CUDA kernels, quantization, and in-flight batching "
-    "to improve throughput and latency. Efficient KV cache management helps "
-    "serve long contexts while controlling GPU memory use. ")
-DEFAULT_PROMPTS = [
-    _DEFAULT_PROMPT_CONTEXT * 64 +
-    "\nSummarize the main idea of the preceding context in one sentence."
-]
+# The built-in prompt follows a self-contained needle-in-a-haystack layout:
+# 1. Cycle routine expedition log templates to form a deterministic haystack.
+# 2. Replace one numbered log entry with a unique access-code needle.
+# 3. Append a question that asks the model to retrieve the needle.
+# With the default model, 128 entries produce about 2.8K tokens, exceeding the
+# default 2,048-token prompt budget so that sparse attention is exercised.
+_DEFAULT_LOG_TEMPLATES = (
+    "The survey team checked the northern weather station and recorded normal "
+    "temperature and pressure readings.",
+    "Technicians inspected backup batteries, radio transmitters, and emergency "
+    "lighting; all systems passed routine checks.",
+    "Researchers cataloged soil samples, labeled storage containers, and "
+    "updated the expedition inventory.",
+    "The navigation group reviewed trail maps, satellite images, and the next "
+    "day's travel schedule.",
+    "At sunset, the field crew secured scientific instruments and uploaded the "
+    "day's measurements.",
+    "The medical officer reviewed first-aid supplies and confirmed the "
+    "evacuation plan with base camp.",
+    "Engineers calibrated wind sensors and verified timestamps against the "
+    "observatory master clock.",
+    "The logistics team counted food, water, fuel, and spare parts before "
+    "closing the storage area.",
+)
+_DEFAULT_NUM_LOG_ENTRIES = 128
+_DEFAULT_NEEDLE_INDEX = 87
+_DEFAULT_ACCESS_CODE = "314159"
+
+
+def _build_default_prompt():
+    log_entries = []
+    for index in range(_DEFAULT_NUM_LOG_ENTRIES):
+        if index == _DEFAULT_NEEDLE_INDEX:
+            message = (f"The expedition access code is {_DEFAULT_ACCESS_CODE}. "
+                       "Remember this code for the final question.")
+        else:
+            message = _DEFAULT_LOG_TEMPLATES[index %
+                                             len(_DEFAULT_LOG_TEMPLATES)]
+        log_entries.append(f"Log entry {index}: {message}")
+
+    return (
+        "Read the following expedition field log carefully. One entry contains "
+        "an access code that you will need to recall.\n\n" +
+        "\n".join(log_entries) + "\n\nWhat is the expedition access code?")
+
+
+DEFAULT_PROMPTS = [_build_default_prompt()]
 
 
 def read_input(input_file):

--- a/examples/llm-api/llm_sparse_attention.py
+++ b/examples/llm-api/llm_sparse_attention.py
@@ -1,7 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ### :title Sparse Attention
 ### :order 5
 ### :section Customization
-"""
+r"""
 This example demonstrates how to use sparse attention with TensorRT-LLM.
 
 Supported sparse attention algorithms:
@@ -10,8 +24,18 @@ Supported sparse attention algorithms:
 
 Usage:
 ```bash
-python llm_sparse_attention.py --algo ROCKETKV --attention_backend TRTLLM --window_size 32 --kernel_size 63 --prompt_budget 2048
+python llm_sparse_attention.py \
+    --model_path nvidia/Llama-3.1-8B-Instruct-FP8 \
+    --algo ROCKETKV \
+    --attention_backend TRTLLM \
+    --window_size 32 \
+    --kernel_size 63 \
+    --prompt_budget 2048
 ```
+
+When ``--input_file`` is omitted, the example uses a built-in long prompt that
+exceeds the default ``prompt_budget`` and exercises RocketKV's sparse attention
+path.
 """
 import argparse
 import json
@@ -20,6 +44,16 @@ from tensorrt_llm import LLM, SamplingParams
 from tensorrt_llm.llmapi import (CudaGraphConfig, DeepSeekSparseAttentionConfig,
                                  KvCacheConfig, MoeConfig,
                                  RocketSparseAttentionConfig)
+
+_DEFAULT_PROMPT_CONTEXT = (
+    "TensorRT-LLM accelerates large language model inference on NVIDIA GPUs. "
+    "It combines optimized CUDA kernels, quantization, and in-flight batching "
+    "to improve throughput and latency. Efficient KV cache management helps "
+    "serve long contexts while controlling GPU memory use. ")
+DEFAULT_PROMPTS = [
+    _DEFAULT_PROMPT_CONTEXT * 64 +
+    "\nSummarize the main idea of the preceding context in one sentence."
+]
 
 
 def read_input(input_file):
@@ -33,16 +67,16 @@ def read_input(input_file):
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--model_path',
-        type=str,
-        default=
-        "/home/scratch.trt_llm_data_ci/llm-models/llama-3.1-model/Llama-3.1-8B-Instruct"
-    )
+    parser.add_argument('--model_path',
+                        type=str,
+                        default="nvidia/Llama-3.1-8B-Instruct-FP8",
+                        help="The local path or Hugging Face ID of the model.")
     parser.add_argument(
         '--input_file',
         type=str,
-        default="tests/unittest/_torch/multi_gpu/NIAH_simple_data.jsonl")
+        default=None,
+        help="Optional path to a JSONL input file. The built-in "
+        "long prompt is used when omitted.")
 
     # Build config
     parser.add_argument('--algo',
@@ -141,10 +175,18 @@ def parse_arguments():
 
 
 def run_llm(args, sparse_attention_config):
-    data = read_input(args.input_file)
-    num_samples = args.num_samples if args.num_samples is not None else len(
-        data)
-    data = data[:num_samples]
+    if args.input_file is None:
+        prompts = DEFAULT_PROMPTS
+        reference = [None] * len(prompts)
+    else:
+        data = read_input(args.input_file)
+        num_samples = args.num_samples if args.num_samples is not None else len(
+            data)
+        data = data[:num_samples]
+        prompts = [{
+            'prompt': sample['input_context'] + sample['input_query']
+        } for sample in data]
+        reference = [sample['outputs'] for sample in data]
 
     kv_cache_config = KvCacheConfig(
         enable_block_reuse=
@@ -178,13 +220,6 @@ def run_llm(args, sparse_attention_config):
         enable_chunked_prefill=args.enable_chunked_prefill,
     )
 
-    prompts = []
-    reference = []
-    for sample in data:
-        prompts.append(
-            {'prompt': sample['input_context'] + sample['input_query']})
-        reference.append(sample['outputs'])
-
     sampling_params = SamplingParams(add_special_tokens=False,
                                      max_tokens=args.max_new_tokens,
                                      temperature=0.8,
@@ -192,9 +227,10 @@ def run_llm(args, sparse_attention_config):
 
     outputs = llm.generate(prompts, sampling_params)
     for idx, output in enumerate(outputs):
-        print(
-            f'Generated text: {output.outputs[0].text!r}, ref: {reference[idx]}'
-        )
+        result = f'Generated text: {output.outputs[0].text!r}'
+        if reference[idx] is not None:
+            result += f', ref: {reference[idx]}'
+        print(result)
 
 
 def run_RocketKV(args):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated the sparse attention example to use the public `nvidia/Llama-3.1-8B-Instruct-FP8` model by default.
- Made `--input_file` optional and added a deterministic needle-in-a-haystack prompt for zero-input execution.
- Retained JSONL input support for custom long-context workloads.
- Ensured the built-in prompt exceeds the default `prompt_budget=2048` and exercises sparse attention.
- Added an Apache-2.0 SPDX header and expanded usage documentation.
- Scoped changes to one Python example. No public APIs, kernels, runtimes, dependencies, or test files changed.
- Validation included formatting checks, source compilation, CLI-default checks, prompt-content and token-length checks, and mocked validation of both input paths.
- Full GPU inference remains unverified because `libnvinfer.so.10` is unavailable.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

NVBug 6533916 reports that the documented sparse-attention example fails immediately for external users because its model and input defaults point to internal NVIDIA and repository test paths.

This PR replaces the internal model default with the public `nvidia/Llama-3.1-8B-Instruct-FP8` Hugging Face ID and makes `--input_file` optional. Without an input file, the example now builds a deterministic needle-in-a-haystack prompt from numbered expedition logs, hides an access code in one entry, and asks the model to retrieve it. The prompt exceeds the default prompt budget and directly exercises sparse attention. Users can still provide a JSONL file for custom long-context inputs. The change is limited to the example and does not modify public APIs, kernels, dependencies, or runtime behavior outside this script.

Related issue: https://nvbugspro.nvidia.com/bug/6533916

## Test Coverage

- Reproduced the original `FileNotFoundError` from the example's invalid default input path on the latest `main` branch used for this fix.
- `pre-commit run --files examples/llm-api/llm_sparse_attention.py`
- `git diff --check`
- Compiled the modified source with Python and confirmed the loaded module path points to the current working-tree script.
- Validated that the built-in prompt contains 128 log entries and exactly one access-code occurrence.
- Validated with the default model tokenizer that the built-in prompt is 2,842 tokens: greater than `prompt_budget=2048` and less than `max_seq_len=10240`.
- Ran mocked end-to-end validation of both the built-in prompt path and the optional JSONL input path.

Full GPU model inference was not run because the current environment does not provide `libnvinfer.so.10`; the reported failure and this fix occur before model initialization.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
