### PR TITLE
[None][fix] Stop NVLink probe from throwing on out-of-range link indices

### DIFF
--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -365,6 +365,7 @@ class MnnvlMemory:
         link_count = pynvml.NVML_NVLINK_MAX_LINKS
         active_links = 0
         available_links = 0
+        probed_links = link_count
         for link_idx in range(link_count):
             try:
                 if pynvml.nvmlDeviceGetNvLinkCapability(
@@ -376,11 +377,22 @@ class MnnvlMemory:
                         active_links += 1
             except pynvml.NVMLError_NotSupported:
                 continue
-        return (
+            except pynvml.NVMLError_InvalidArgument:
+                # NVML_NVLINK_MAX_LINKS (36) is an upper bound over all architectures;
+                # the driver rejects indices past this GPU's link count (18 on GB200).
+                probed_links = link_idx
+                break
+        supported = (
             active_links == available_links and available_links > 0
             if need_all_up
             else available_links > 0
         )
+        logger.info(
+            f"[MnnvlMemory] dev {dev_id} NVLink: {active_links}/{available_links} links up "
+            f"({probed_links} of {link_count} link indices accepted by the driver), "
+            f"need_all_up={need_all_up}, supported={supported}"
+        )
+        return supported
 
     @staticmethod
     def supports_mnnvl() -> bool:


### PR DESCRIPTION
## Description

`MnnvlMemory.support_nvlink()` walks link indices from `0` to `pynvml.NVML_NVLINK_MAX_LINKS`. `nvidia-ml-py` (pinned to `>=13` in `requirements.txt`) defines that constant as **36**, which is an upper bound across architectures rather than a per-GPU link count. GB200 exposes **18** links, and the driver rejects indices `18..35` with `NVML_ERROR_INVALID_ARGUMENT` — not `NVML_ERROR_NOT_SUPPORTED`. The loop caught only `NVMLError_NotSupported`, so the exception escaped `support_nvlink()` and `supports_mnnvl()` raised instead of returning `True`.

`CommunicationFactory` catches exceptions per strategy, so on a perfectly healthy NVL72 node every MNNVL-backed strategy was rejected with the same opaque message:

```
[TRT-LLM] [I] NVLinkOneSided not available: Invalid Argument
[TRT-LLM] [I] NVLinkTwoSided not available: Invalid Argument
[TRT-LLM] [I] DeepEP not available: Invalid Argument
```

Selection then fell through to `DeepEPLowLatency`, whose NVSHMEM symmetric heap init failed and took the job down several layers away from the actual cause:

```
.../src/host/mem/mem_heap.cpp:1519: non-zero status: 1 cuMemMap failed
.../src/host/mem/mem_heap.cpp:1590: non-zero status: 7 allocate_physical_memory_to_heap failed
[.../src/host/coll/barrier/barrier.cpp:21] cuda failed with an illegal memory access was encountered
```

Reproduced on GB200 (2 nodes x 4 GPUs, DeepSeek-V4 at tp8) — the job aborted with exit code 255 during warmup. The environment where this did *not* reproduce turned out to have an old `pynvml` 11.5.3 package shadowing `nvidia-ml-py`'s module, where the same constant is 18; so the bug is masked purely by which NVML binding wins on `sys.path`, and any environment that honors the repo's own `nvidia-ml-py>=13` pin hits it.

Raw NVML probe on GB200 confirming the boundary:

```
NVML_NVLINK_MAX_LINKS: 36
link 0..17 : cap=1 state=1
link 18..35: NVMLError_InvalidArgument: Invalid Argument
```

### Changes

- Treat `NVMLError_InvalidArgument` as the end of the GPU's link range and stop probing. The rejected range is contiguous — the driver refuses every index at or past the device's link count — so `break` is sufficient and avoids the remaining dead NVML calls. `NVMLError_NotSupported` keeps using `continue`, since that one can legitimately be a hole (link present, capability query unsupported).
- Log the link tally plus the number of indices the driver actually accepted. The previous code was silent both when it succeeded and when it bailed out, which is why this surfaced as an unrelated NVSHMEM allocation failure instead of pointing at the NVML constant. New line on GB200:

```
[MnnvlMemory] dev 0 NVLink: 18/18 links up (18 of 36 link indices accepted by the driver), need_all_up=True, supported=True
```

## Test Coverage

`support_nvlink()` / `supports_mnnvl()` query live NVML state and have no existing unit test; the result is only observable on NVSwitch hardware, so this is covered by the multi-GPU integration tests that select an MNNVL all-to-all path rather than by a new unit test.

Verified manually on GB200 inside the release container, before and after the change:

- before: `supports_mnnvl()` raised `NVMLError_InvalidArgument`, all three MNNVL strategies reported "not available", job died in the NVSHMEM barrier
- after: `supports_mnnvl()` returns `True` and logs `18/18 links up (18 of 36 link indices accepted by the driver)`

Existing coverage that exercises this path on NVSwitch runners: `tests/integration/defs/accuracy/test_llm_api_pytorch.py` MoE all-to-all cases (e.g. `TestDeepSeekV3Lite` / wide-EP variants), which select `NVLinkOneSided` through `CommunicationFactory`.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `MnnvlMemory.support_nvlink()` to stop probing when NVML reports `NVMLError_InvalidArgument`.
- Continues past `NVMLError_NotSupported`.
- Records accepted probe positions with `probed_links`.
- Adds diagnostic logging for link status, probe coverage, `need_all_up`, and the support result.
- No public API, configuration, or test-list changes.
- The change fixes GB200 probing, but may report H100/H200/B200 NVL PCIe SKUs as MNNVL-supported. Add or sequence the `_is_pcie_nvl_sku` guard before merging.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->