### PR TITLE
[None][perf] Explicitly set Kimi K3 router correction bias in FP32

### DIFF
--- a/tensorrt_llm/_torch/modules/kimi_k3_moe/kimi_k3_moe_gate.py
+++ b/tensorrt_llm/_torch/modules/kimi_k3_moe/kimi_k3_moe_gate.py
@@ -29,8 +29,7 @@ from typing import Any, Tuple
 import torch
 from torch import nn
 
-from ..fused_moe.routing import (DeepSeekV3MoeRoutingMethod,
-                                 Deepseekv3RoutingImpl)
+from ..fused_moe.routing import DeepSeekV3MoeRoutingMethod, Deepseekv3RoutingImpl
 
 
 class KimiK3MoEGate(nn.Module):
@@ -89,7 +88,9 @@ class KimiK3MoEGate(nn.Module):
         self.weight = nn.Parameter(
             torch.empty((self.num_experts, self.gating_dim), dtype=weight_dtype)
         )
-        self.e_score_correction_bias = nn.Parameter(torch.empty(self.num_experts))
+        self.e_score_correction_bias = nn.Parameter(
+            torch.empty(self.num_experts, dtype=torch.float32)
+        )
 
         self.softmax_routing_mutation = softmax_routing_mutation
         self.biased_weights_mutation = biased_weights_mutation
@@ -145,8 +146,7 @@ class KimiK3MoEGate(nn.Module):
         parameter mapping identity.
         """
         hidden_2d = hidden_states.reshape(-1, self.gating_dim)
-        if (self.weight.dtype == torch.bfloat16
-                and hidden_2d.dtype == torch.bfloat16):
+        if self.weight.dtype == torch.bfloat16 and hidden_2d.dtype == torch.bfloat16:
             # Single bf16xbf16 -> fp32 GEMM (fp32 accumulate); no input
             # upcast kernel, no fp32 splitK-reduce. K3's 896 experts miss
             # the op's specialized 256-expert kernels and take its cublas
@@ -204,7 +204,7 @@ class KimiK3MoEGate(nn.Module):
             # indices (as ``torch.topk`` yields) and fp32 weights -- so every
             # downstream consumer is byte-for-byte unaffected by the swap.
             topk_weight, topk_idx = self._routing_impl.noaux_tc(
-                logits, self.e_score_correction_bias.float()
+                logits, self.e_score_correction_bias
             )
             return topk_idx.to(torch.int64), topk_weight.to(torch.float32)
 


### PR DESCRIPTION
@coderabbitai summary

## Description

Make the Kimi K3 router correction-bias dtype invariant explicit by allocating
`e_score_correction_bias` as FP32. The checkpoint loader copies into the
destination parameter dtype, so the bias remains FP32 after loading.

Pass the stored parameter directly to the fused `noaux_tc` routing path instead
of requesting a per-call `.float()` conversion. This preserves routing behavior
while ensuring the fused path cannot allocate an upcast tensor when model
construction uses a non-FP32 default dtype.

## Test Coverage

- `pre-commit run --files tensorrt_llm/_torch/modules/kimi_k3_moe/kimi_k3_moe_gate.py`
- `python3 -m py_compile tensorrt_llm/_torch/modules/kimi_k3_moe/kimi_k3_moe_gate.py`
- CUDA unit tests were not run because no remote GPU target was specified.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
