### PR TITLE
[None][perf] fuse Kimi K3 latent up projection and shared add

### DIFF
--- a/cpp/tensorrt_llm/kernels/dsv3MinLatencyKernels/dsv3FusedAGemm.cu
+++ b/cpp/tensorrt_llm/kernels/dsv3MinLatencyKernels/dsv3FusedAGemm.cu
@@ -368,10 +368,12 @@ struct MmaComputer
     static_assert(n_iter_cnt == 1 || n_iter_cnt == 2);
 
     __device__ MmaComputer(bf16_t* gmem_c_local_, uint8_t* gmem_c_mxfp8_local_, uint8_t* gmem_c_sf_local_,
-        bf16_t* smem_a_, bf16_t* smem_b_, uint64_t* smem_barrier_, int warp_idx_, int gemm_n_)
+        bf16_t const* gmem_residual_local_, bf16_t* smem_a_, bf16_t* smem_b_, uint64_t* smem_barrier_, int warp_idx_,
+        int gemm_n_)
         : gmem_c(gmem_c_local_)
         , gmem_c_mxfp8(gmem_c_mxfp8_local_)
         , gmem_c_sf(gmem_c_sf_local_)
+        , gmem_residual(gmem_residual_local_)
         , smem_a(smem_a_)
         , smem_b(smem_b_)
         , smem_barrier(smem_barrier_)
@@ -586,7 +588,14 @@ public:
                     }
                     else
                     {
-                        gmem_c[n_idx * gemm_m + m_idx] = acc_final[reg_idx];
+                        int const output_idx = n_idx * gemm_m + m_idx;
+                        bf16_t output = __float2bfloat16_rn(acc_final[reg_idx]);
+                        if (gmem_residual != nullptr)
+                        {
+                            output = __float2bfloat16_rn(
+                                __bfloat162float(output) + __bfloat162float(gmem_residual[output_idx]));
+                        }
+                        gmem_c[output_idx] = output;
                     }
                 }
             }
@@ -597,6 +606,7 @@ public:
     bf16_t* gmem_c;
     uint8_t* gmem_c_mxfp8;
     uint8_t* gmem_c_sf;
+    bf16_t const* gmem_residual;
     bf16_t* smem_a;
     bf16_t* smem_b;
     uint64_t* smem_barrier;
@@ -618,8 +628,8 @@ public:
 // AB swapped, kernel is k-major, k-major, m-major
 template <bool kQuantizeMxFp8, int batch_size, int gemm_m, int gemm_k, int tile_m, int tile_n, int tile_k,
     int stage_cnt>
-__global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
-    bf16_t* output, uint8_t* output_mxfp8, uint8_t* output_sf, bf16_t const* mat_a, bf16_t const* mat_b, int gemm_n)
+__global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(bf16_t* output, uint8_t* output_mxfp8, uint8_t* output_sf,
+    bf16_t const* mat_a, bf16_t const* mat_b, bf16_t const* residual, int gemm_n)
 {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
     constexpr int load_thread_cnt = 128;
@@ -652,6 +662,7 @@ __global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
     bf16_t* gmem_c_local = output == nullptr ? nullptr : output + cta_n_idx * gemm_m + cta_m_idx;
     uint8_t* gmem_c_mxfp8_local = output_mxfp8 == nullptr ? nullptr : output_mxfp8 + cta_n_idx * gemm_m + cta_m_idx;
     uint8_t* gmem_c_sf_local = output_sf == nullptr ? nullptr : output_sf + cta_n_idx * (gemm_m / 32) + cta_m_idx / 32;
+    bf16_t const* gmem_residual_local = residual == nullptr ? nullptr : residual + cta_n_idx * gemm_m + cta_m_idx;
 
     int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
 
@@ -681,8 +692,8 @@ __global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
     }
     else
     {
-        MmaComputer<kQuantizeMxFp8, gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt> mma_computer(
-            gmem_c_local, gmem_c_mxfp8_local, gmem_c_sf_local, smem_a, smem_b, smem_barrier, warp_idx, gemm_n);
+        MmaComputer<kQuantizeMxFp8, gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt> mma_computer(gmem_c_local,
+            gmem_c_mxfp8_local, gmem_c_sf_local, gmem_residual_local, smem_a, smem_b, smem_barrier, warp_idx, gemm_n);
         mma_computer.prepare();
         mma_computer.issue_mainloop();
         mma_computer.epi();
@@ -691,7 +702,8 @@ __global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
 }
 
 template <typename T, int kHdIn, int kHdOut, int kTileN>
-void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens, cudaStream_t const stream)
+void invokeFusedAGemm(
+    T* output, T const* mat_a, T const* mat_b, T const* residual, int num_tokens, cudaStream_t const stream)
 {
     auto const sm = tensorrt_llm::common::getSMVersion();
     if (sm < 90)
@@ -736,7 +748,7 @@ void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens,
     }
     TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config,
         fused_a_gemm_kernel<false, batch_size, gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt>, output,
-        static_cast<uint8_t*>(nullptr), static_cast<uint8_t*>(nullptr), mat_a, mat_b, gemm_n));
+        static_cast<uint8_t*>(nullptr), static_cast<uint8_t*>(nullptr), mat_a, mat_b, residual, gemm_n));
 }
 
 template <typename T, int kHdIn, int kHdOut, int kTileN>
@@ -786,21 +798,21 @@ void invokeFusedAGemmMxFp8(
     }
     TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config,
         fused_a_gemm_kernel<true, batch_size, gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt>,
-        static_cast<bf16_t*>(nullptr), output, output_sf, mat_a, mat_b, gemm_n));
+        static_cast<bf16_t*>(nullptr), output, output_sf, mat_a, mat_b, static_cast<bf16_t const*>(nullptr), gemm_n));
 }
 
 template void invokeFusedAGemm<__nv_bfloat16, 7168, 2112, 8>(
-    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
 
 template void invokeFusedAGemm<__nv_bfloat16, 7168, 2112, 16>(
-    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
 
 // Kimi K3 latent MoE projections (hidden 7168 <-> MoE latent 3584).
 template void invokeFusedAGemm<__nv_bfloat16, 7168, 3584, 8>(
-    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
 
 template void invokeFusedAGemm<__nv_bfloat16, 7168, 3584, 16>(
-    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
 
 template void invokeFusedAGemmMxFp8<__nv_bfloat16, 7168, 3584, 8>(
     uint8_t*, uint8_t*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
@@ -809,10 +821,10 @@ template void invokeFusedAGemmMxFp8<__nv_bfloat16, 7168, 3584, 16>(
     uint8_t*, uint8_t*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
 
 template void invokeFusedAGemm<__nv_bfloat16, 3584, 7168, 8>(
-    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
 
 template void invokeFusedAGemm<__nv_bfloat16, 3584, 7168, 16>(
-    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
+    __nv_bfloat16*, __nv_bfloat16 const*, __nv_bfloat16 const*, __nv_bfloat16 const*, int num_tokens, cudaStream_t);
 } // namespace kernels::dsv3MinLatencyKernels
 
 TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/dsv3MinLatencyKernels/dsv3FusedAGemm.h
+++ b/cpp/tensorrt_llm/kernels/dsv3MinLatencyKernels/dsv3FusedAGemm.h
@@ -29,7 +29,8 @@ namespace kernels::dsv3MinLatencyKernels
 {
 
 template <typename T, int kHdIn, int kHdOut, int kTileN>
-void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens, cudaStream_t const stream);
+void invokeFusedAGemm(
+    T* output, T const* mat_a, T const* mat_b, T const* residual, int num_tokens, cudaStream_t const stream);
 
 template <typename T, int kHdIn, int kHdOut, int kTileN>
 void invokeFusedAGemmMxFp8(

--- a/cpp/tensorrt_llm/thop/dsv3FusedAGemmOp.cpp
+++ b/cpp/tensorrt_llm/thop/dsv3FusedAGemmOp.cpp
@@ -35,22 +35,25 @@ namespace
 // Supported (hd_in, hd_out) shapes must have explicit invokeFusedAGemm instantiations
 // in dsv3FusedAGemm.cu.
 template <int kHdIn, int kHdOut>
-void runFusedAGemm(th::Tensor& out, th::Tensor const& mat_a, th::Tensor const& mat_b, int num_tokens)
+void runFusedAGemm(
+    th::Tensor& out, th::Tensor const& mat_a, th::Tensor const& mat_b, th::Tensor const* residual, int num_tokens)
 {
     auto stream = at::cuda::getCurrentCUDAStream(mat_a.get_device());
+    auto const* residual_ptr
+        = residual == nullptr ? nullptr : reinterpret_cast<__nv_bfloat16 const*>(residual->data_ptr());
     if (num_tokens <= 8)
     {
         tk::dsv3MinLatencyKernels::invokeFusedAGemm<__nv_bfloat16, kHdIn, kHdOut, 8>(
             reinterpret_cast<__nv_bfloat16*>(out.mutable_data_ptr()),
             reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr()),
-            reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()), num_tokens, stream);
+            reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()), residual_ptr, num_tokens, stream);
     }
     else
     {
         tk::dsv3MinLatencyKernels::invokeFusedAGemm<__nv_bfloat16, kHdIn, kHdOut, 16>(
             reinterpret_cast<__nv_bfloat16*>(out.mutable_data_ptr()),
             reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr()),
-            reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()), num_tokens, stream);
+            reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()), residual_ptr, num_tokens, stream);
     }
 }
 
@@ -100,15 +103,15 @@ th::Tensor dsv3_fused_a_gemm_op(th::Tensor const& mat_a, th::Tensor const& mat_b
 
     if (dtype_ok && hd_in == 7168 && hd_out == 2112) // DeepSeek-V3 fused q_a/kv_a proj
     {
-        runFusedAGemm<7168, 2112>(out, mat_a, mat_b, num_tokens);
+        runFusedAGemm<7168, 2112>(out, mat_a, mat_b, nullptr, num_tokens);
     }
     else if (dtype_ok && hd_in == 7168 && hd_out == 3584) // Kimi K3 latent MoE down proj
     {
-        runFusedAGemm<7168, 3584>(out, mat_a, mat_b, num_tokens);
+        runFusedAGemm<7168, 3584>(out, mat_a, mat_b, nullptr, num_tokens);
     }
     else if (dtype_ok && hd_in == 3584 && hd_out == 7168) // Kimi K3 latent MoE up proj
     {
-        runFusedAGemm<3584, 7168>(out, mat_a, mat_b, num_tokens);
+        runFusedAGemm<3584, 7168>(out, mat_a, mat_b, nullptr, num_tokens);
     }
     else // fallback to cublas, can be slow
     {
@@ -148,6 +151,46 @@ std::tuple<th::Tensor, th::Tensor> dsv3_fused_a_gemm_mxfp8_op(th::Tensor const& 
     return {out, out_sf};
 }
 
+th::Tensor dsv3_fused_a_gemm_add_op(th::Tensor const& mat_a, th::Tensor const& mat_b, th::Tensor const& residual)
+{
+    TORCH_CHECK(mat_a.dim() == 2 && mat_b.dim() == 2 && residual.dim() == 2, "inputs must be rank-2 tensors");
+    TORCH_CHECK(mat_a.is_cuda() && mat_b.is_cuda() && residual.is_cuda(), "inputs must be CUDA tensors");
+    TORCH_CHECK(mat_a.get_device() == mat_b.get_device() && mat_a.get_device() == residual.get_device(),
+        "inputs must be on the same CUDA device");
+    TORCH_CHECK(mat_a.scalar_type() == torch::kBFloat16 && mat_b.scalar_type() == torch::kBFloat16
+            && residual.scalar_type() == torch::kBFloat16,
+        "dsv3_fused_a_gemm_add_op requires BF16 inputs");
+    TORCH_CHECK(
+        mat_a.strides()[0] == mat_a.sizes()[1] && mat_a.strides()[1] == 1, "mat_a must be contiguous row-major");
+    TORCH_CHECK(
+        mat_b.strides()[0] == 1 && mat_b.strides()[1] == mat_b.sizes()[0], "mat_b must be contiguous column-major");
+    TORCH_CHECK(residual.is_contiguous(), "residual must be contiguous");
+
+    int const num_tokens = mat_a.sizes()[0];
+    int const hd_in = mat_a.sizes()[1];
+    TORCH_CHECK(mat_b.sizes()[0] == hd_in, "mat_a and mat_b reduction dimensions must match");
+    int const hd_out = mat_b.sizes()[1];
+    std::vector<int64_t> output_size = {num_tokens, hd_out};
+    TORCH_CHECK(residual.sizes() == output_size, "residual shape must match GEMM output");
+
+    th::Tensor out = th::empty(output_size, mat_a.options());
+    auto const sm = tensorrt_llm::common::getSMVersion();
+    bool const fused_layout_ok = reinterpret_cast<uintptr_t>(mat_a.const_data_ptr()) % sizeof(float4) == 0
+        && reinterpret_cast<uintptr_t>(mat_b.const_data_ptr()) % sizeof(float4) == 0;
+    bool const use_fused_kernel
+        = num_tokens >= 1 && num_tokens <= 16 && hd_in == 3584 && hd_out == 7168 && sm >= 90 && fused_layout_ok;
+    if (use_fused_kernel)
+    {
+        runFusedAGemm<3584, 7168>(out, mat_a, mat_b, &residual, num_tokens);
+    }
+    else
+    {
+        cublas_mm_out(mat_a, mat_b, std::nullopt, out);
+        out.add_(residual);
+    }
+    return out;
+}
+
 } // namespace torch_ext
 
 TRTLLM_NAMESPACE_END
@@ -156,10 +199,12 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def("dsv3_fused_a_gemm_op(Tensor mat_a, Tensor mat_b, Tensor? bias, ScalarType? out_dtype) -> (Tensor out)");
     m.def("dsv3_fused_a_gemm_mxfp8_op(Tensor mat_a, Tensor mat_b) -> (Tensor out, Tensor out_sf)");
+    m.def("dsv3_fused_a_gemm_add_op(Tensor mat_a, Tensor mat_b, Tensor residual) -> (Tensor out)");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 {
     m.impl("dsv3_fused_a_gemm_op", &tensorrt_llm::torch_ext::dsv3_fused_a_gemm_op);
     m.impl("dsv3_fused_a_gemm_mxfp8_op", &tensorrt_llm::torch_ext::dsv3_fused_a_gemm_mxfp8_op);
+    m.impl("dsv3_fused_a_gemm_add_op", &tensorrt_llm::torch_ext::dsv3_fused_a_gemm_add_op);
 }

--- a/tensorrt_llm/_torch/compilation/multi_stream/auto_multi_stream.py
+++ b/tensorrt_llm/_torch/compilation/multi_stream/auto_multi_stream.py
@@ -53,6 +53,7 @@ def estimate_time(node: Node) -> int:
         torch.ops.trtllm.cublas_mm.default,
         torch.ops.trtllm.dsv3_router_gemm_op.default,
         torch.ops.trtllm.dsv3_fused_a_gemm_op.default,
+        torch.ops.trtllm.dsv3_fused_a_gemm_add_op.default,
         torch.ops.trtllm.fp4_gemm.default,
         torch.ops.trtllm.fp4_bmm.default,
         torch.ops.trtllm.fp8_block_scaling_gemm.default,

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -240,6 +240,12 @@ def _register_fake():
         scale = mat_a.new_empty((shape[0], shape[-1] // 32), dtype=torch.uint8)
         return output, scale
 
+    @torch.library.register_fake("trtllm::dsv3_fused_a_gemm_add_op")
+    def _(mat_a, mat_b, residual):
+        shape = list(mat_a.shape)
+        shape[-1] = mat_b.shape[-1]
+        return mat_a.new_empty(shape)
+
     @torch.library.register_fake("trtllm::fp4_gemm")
     def _(
         mat1: torch.Tensor,

--- a/tensorrt_llm/_torch/models/modeling_kimi_linear.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_linear.py
@@ -142,6 +142,11 @@ def _read_fused_finalize_ar_rms_max_tokens() -> int:
 
 _K3_FUSED_MOE_FINALIZE_AR_RMS_MAX_TOKENS = _read_fused_finalize_ar_rms_max_tokens()
 
+# Experimental decode-only fusion of the latent up projection with the shared
+# expert add. This keeps the up-projection weight in BF16 instead of applying
+# the default FP8 weight-read conversion, so it is opt-in pending B200 data.
+_K3_FUSED_LATENT_UP_ADD = os.environ.get("TLLM_K3_ENABLE_FUSED_LATENT_UP_ADD", "0") == "1"
+
 _KDA_INDEXED_STATE_POOL_ENABLED = os.environ.get("TLLM_KDA_ENABLE_INDEXED_STATE_POOL", "1") == "1"
 
 # Routed-expert MoE TP/EP split overrides (read per model init, not import).
@@ -443,7 +448,9 @@ class _Fp8BlockScaleWeightReadLinear(nn.Module):
 
 
 def _convert_moe_mlps_to_fp8_weight_read(
-    model: nn.Module, include_fused_gate_up: bool = True
+    model: nn.Module,
+    include_fused_gate_up: bool = True,
+    include_routed_up: bool = True,
 ) -> int:
     """Swap the replicated MoE-layer MLP projections to an FP8 weight read.
 
@@ -487,8 +494,9 @@ def _convert_moe_mlps_to_fp8_weight_read(
             )
             for attr in shared_attrs:
                 _swap(shared, attr)
-        for attr in ("routed_expert_down_proj", "routed_expert_up_proj"):
-            _swap(moe, attr)
+        _swap(moe, "routed_expert_down_proj")
+        if include_routed_up:
+            _swap(moe, "routed_expert_up_proj")
 
     # Return the freed BF16 blocks to the driver so the raw (non-caching-
     # allocator) allocations made during executor creation succeed on the
@@ -852,6 +860,13 @@ class KimiK3MoERuntime(nn.Module):
         """``hidden_states``: ``[num_tokens, hidden_size]`` bf16."""
         identity = hidden_states
         router_logits = self.gate.compute_logits(hidden_states)
+        fuse_up_add = (
+            _K3_FUSED_LATENT_UP_ADD
+            and not _K3_DISABLE_MIN_LATENCY_LATENT_PROJ
+            and isinstance(self.routed_expert_up_proj, nn.Linear)
+            and hidden_states.dim() == 2
+            and 1 <= hidden_states.shape[0] <= 16
+        )
 
         def _routed_output():
             # Latent down/up projections via the min-latency fused GEMM op:
@@ -917,6 +932,8 @@ class KimiK3MoERuntime(nn.Module):
                 if self.routed_experts.comm is None and moe_all_reduce is not None:
                     y = moe_all_reduce(y)
                 y = self.routed_expert_norm(y)
+            if fuse_up_add:
+                return y
             if _K3_DISABLE_MIN_LATENCY_LATENT_PROJ or not isinstance(
                 self.routed_expert_up_proj, nn.Linear
             ):
@@ -940,6 +957,16 @@ class KimiK3MoERuntime(nn.Module):
             self.aux_stream,
             disable_on_compile=True,
         )
+        if fuse_up_add:
+            # This starts after the MoE backend has returned its combined
+            # latent output. MegaMoE owns/finalizes combine internally, so
+            # neither MegaMoE combine nor RMSNorm is fused here; only the BF16
+            # 3584->7168 up projection and shared-expert add are fused.
+            return torch.ops.trtllm.dsv3_fused_a_gemm_add_op(
+                routed_out,
+                self.routed_expert_up_proj.weight.t(),
+                shared_out.contiguous(),
+            )
         return routed_out + shared_out
 
 
@@ -2704,6 +2731,7 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel, Any]):
                     _KIMI_K3_FP8_WEIGHT_READ_GATE_UP_ENV, gate_up_default
                 )
                 != "0",
+                include_routed_up=not _K3_FUSED_LATENT_UP_ADD,
             )
             logger.info(
                 f"Kimi K3: reading {n_fp8} MoE-layer MLP projections "

--- a/tests/unittest/_torch/modules/moe/test_kimi_k3_situ_moe.py
+++ b/tests/unittest/_torch/modules/moe/test_kimi_k3_situ_moe.py
@@ -414,6 +414,36 @@ def test_fused_forward_without_weights_raises():
 
 
 # ---------------------------------------------------------------------------
+# Latent-tail weight-read selection (CPU-only).
+# ---------------------------------------------------------------------------
+
+
+def test_fp8_conversion_can_preserve_routed_up(monkeypatch):
+    from tensorrt_llm._torch.models.modeling_kimi_linear import (
+        _convert_moe_mlps_to_fp8_weight_read,
+        _Fp8BlockScaleWeightReadLinear,
+    )
+
+    moe = SimpleNamespace(
+        shared_experts=None,
+        routed_expert_down_proj=torch.nn.Linear(8, 4, bias=False),
+        routed_expert_up_proj=torch.nn.Linear(4, 8, bias=False),
+    )
+    model = SimpleNamespace(layers=[SimpleNamespace(block_sparse_moe=moe)])
+    monkeypatch.setattr(
+        _Fp8BlockScaleWeightReadLinear,
+        "from_linear",
+        classmethod(lambda cls, linear: torch.nn.Identity()),
+    )
+
+    count = _convert_moe_mlps_to_fp8_weight_read(model, include_routed_up=False)
+
+    assert count == 1
+    assert isinstance(moe.routed_expert_down_proj, torch.nn.Identity)
+    assert isinstance(moe.routed_expert_up_proj, torch.nn.Linear)
+
+
+# ---------------------------------------------------------------------------
 # Routed MoE TP/EP split selection (CPU-only).
 # ---------------------------------------------------------------------------
 
@@ -496,14 +526,16 @@ def _make_packed_expert_bank(num_experts, intermediate, hidden, seed=101):
 
     bank = []
     for _ in range(num_experts):
-        bank.append({
-            "w1": nibbles(intermediate, hidden // 2),
-            "w1_sf": scales(intermediate, hidden // 32),
-            "w3": nibbles(intermediate, hidden // 2),
-            "w3_sf": scales(intermediate, hidden // 32),
-            "w2": nibbles(hidden, intermediate // 2),
-            "w2_sf": scales(hidden, intermediate // 32),
-        })
+        bank.append(
+            {
+                "w1": nibbles(intermediate, hidden // 2),
+                "w1_sf": scales(intermediate, hidden // 32),
+                "w3": nibbles(intermediate, hidden // 2),
+                "w3_sf": scales(intermediate, hidden // 32),
+                "w2": nibbles(hidden, intermediate // 2),
+                "w2_sf": scales(hidden, intermediate // 32),
+            }
+        )
     return bank
 
 
@@ -521,12 +553,11 @@ def _make_test_gate(num_experts=_TP_EXPERTS, seed=71):
     gate = KimiK3MoEGate(cfg)
     gen = torch.Generator().manual_seed(seed)
     with torch.no_grad():
-        gate.weight.copy_(
-            torch.randn(gate.weight.shape, generator=gen,
-                        dtype=torch.float32) * 0.05)
+        gate.weight.copy_(torch.randn(gate.weight.shape, generator=gen, dtype=torch.float32) * 0.05)
         gate.e_score_correction_bias.copy_(
-            torch.randn(gate.e_score_correction_bias.shape, generator=gen,
-                        dtype=torch.float32) * 0.1)
+            torch.randn(gate.e_score_correction_bias.shape, generator=gen, dtype=torch.float32)
+            * 0.1
+        )
     return gate.cuda()
 
 
@@ -626,23 +657,24 @@ def test_tp_shard_loader_matches_manual_slice(tp_size):
         rows = slice(tp_rank * ipp, (tp_rank + 1) * ipp)
         cols_packed = slice(tp_rank * (ipp // 2), (tp_rank + 1) * (ipp // 2))
         cols_sf = slice(tp_rank * (ipp // 32), (tp_rank + 1) * (ipp // 32))
-        manual_bank = [{
-            "w1": e["w1"][rows].contiguous(),
-            "w1_sf": e["w1_sf"][rows].contiguous(),
-            "w3": e["w3"][rows].contiguous(),
-            "w3_sf": e["w3_sf"][rows].contiguous(),
-            "w2": e["w2"][:, cols_packed].contiguous(),
-            "w2_sf": e["w2_sf"][:, cols_sf].contiguous(),
-        } for e in bank]
+        manual_bank = [
+            {
+                "w1": e["w1"][rows].contiguous(),
+                "w1_sf": e["w1_sf"][rows].contiguous(),
+                "w3": e["w3"][rows].contiguous(),
+                "w3_sf": e["w3_sf"][rows].contiguous(),
+                "w2": e["w2"][:, cols_packed].contiguous(),
+                "w2_sf": e["w2_sf"][:, cols_sf].contiguous(),
+            }
+            for e in bank
+        ]
         via_manual = _make_routed_moe(ipp, gate, num_experts=num_experts)
         _load_bank(via_manual, manual_bank)
 
-        for name in ("w3_w1_weight", "w2_weight", "w3_w1_weight_scale",
-                     "w2_weight_scale"):
+        for name in ("w3_w1_weight", "w2_weight", "w3_w1_weight_scale", "w2_weight_scale"):
             a = getattr(via_shard.backend, name).data
             b = getattr(via_manual.backend, name).data
-            assert torch.equal(a, b), (
-                f"{name} mismatch for tp_size={tp_size} tp_rank={tp_rank}")
+            assert torch.equal(a, b), f"{name} mismatch for tp_size={tp_size} tp_rank={tp_rank}"
 
 
 @situ_supported
@@ -663,14 +695,12 @@ def test_tp8_sharded_forward_matches_whole_expert(num_tokens):
     _load_bank(whole, bank)
 
     torch.manual_seed(3)
-    x = torch.randn(
-        num_tokens, _TP_HIDDEN, dtype=torch.bfloat16, device="cuda") * 0.5
+    x = torch.randn(num_tokens, _TP_HIDDEN, dtype=torch.bfloat16, device="cuda") * 0.5
     router_logits = gate.compute_logits(x)
 
     out_whole = whole.forward(x, router_logits, all_rank_num_tokens=None)
 
-    partial_sum = torch.zeros(num_tokens, _TP_HIDDEN, dtype=torch.float32,
-                              device="cuda")
+    partial_sum = torch.zeros(num_tokens, _TP_HIDDEN, dtype=torch.float32, device="cuda")
     for tp_rank in range(tp_size):
         shard = _make_routed_moe(ipp, gate)
         _load_bank(shard, bank, tp_size=tp_size, tp_rank=tp_rank)
@@ -679,5 +709,4 @@ def test_tp8_sharded_forward_matches_whole_expert(num_tokens):
         del shard
         torch.cuda.empty_cache()
 
-    check_accuracy(partial_sum.to(torch.bfloat16), out_whole,
-                   atol=0.08, rtol=0.08, percent=0.98)
+    check_accuracy(partial_sum.to(torch.bfloat16), out_whole, atol=0.08, rtol=0.08, percent=0.98)

--- a/tests/unittest/_torch/thop/parallel/test_dsv3_fused_a_gemm.py
+++ b/tests/unittest/_torch/thop/parallel/test_dsv3_fused_a_gemm.py
@@ -109,3 +109,22 @@ def test_fused_a_gemm_mxfp8_rejects_misaligned_storage(operand):
 
     with pytest.raises(RuntimeError, match=message):
         torch.ops.trtllm.dsv3_fused_a_gemm_mxfp8_op(input, weight.t())
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 9, 16])
+def test_fused_a_gemm_add_run(num_tokens):
+    torch.manual_seed(31)
+    torch.cuda.manual_seed(31)
+
+    device = torch.device("cuda")
+    input = torch.randn(num_tokens, 3584, dtype=torch.bfloat16, device=device)
+    weight = torch.randn(7168, 3584, dtype=torch.bfloat16, device=device)
+    residual = torch.randn(num_tokens,
+                           7168,
+                           dtype=torch.bfloat16,
+                           device=device)
+
+    output = torch.ops.trtllm.dsv3_fused_a_gemm_add_op(input, weight.t(),
+                                                       residual)
+    output_ref = torch.matmul(input, weight.t()) + residual
+    assert torch.allclose(output, output_ref, rtol=0.1, atol=0.1)


### PR DESCRIPTION
## What changed

- Rebase onto the current `feat/kimi_k3` baseline after #17088.
- Unify the dsv3 A-GEMM epilogue for BF16 output, #17088 MXFP8 output, and BF16 output plus residual.
- Expose the residual variant as `dsv3_fused_a_gemm_add_op`.
- Add opt-in `TLLM_K3_ENABLE_FUSED_LATENT_UP_ADD=1` for the 3584-to-7168 up projection plus shared-expert add at M <= 16.
- Preserve #17088 fused latent-down quantization and fused finalize/AllReduce/RMSNorm wiring.
- Keep routed-up weights in BF16 only when this experiment is enabled.

## Scope and MegaMoE limitation

This PR does not fuse MegaMoE combine or latent RMSNorm. MegaMoE owns/finalizes combine internally, and RMSNorm must run after the combined latent result. This epilogue begins after the MoE backend and RMSNorm; it fuses only BF16 latent up projection and shared-expert add. A deferred-finalize/output contract for MegaMoE is separate work.

The default FP8 routed-up path is not fused. B200 latency and memory-bandwidth measurements are required before considering default-on.

## Validation

- All repository pre-commit hooks passed on rebased commit `e5a1cb04ee`.
- Built `th_common` in `tensorrt_llm-devel-jonasl` on `umbriel-b200-027` for SM90, SM100, and SM103.
- `dsv3FusedAGemm.cu.o` and `dsv3FusedAGemmOp.cpp.o` compiled successfully.
- Full B200 test: `test_dsv3_fused_a_gemm.py` — **18 passed**.
  - Existing BF16 output passed.
  - #17088 MXFP8 parity/validation passed.
  - New BF16+residual parity passed for M=1,8,9,16.

## Remaining performance validation

- Compare decode latency with and without the opt-in.
- Measure TRTLLM MoE and a stacked MegaMoE branch.
- This PR intentionally does not claim MegaMoE combine/RMSNorm fusion.
