### PR TITLE
[https://nvbugs/6533919][fix] Report unknown stages on stderr with `difflib` near-miss hints, distinguish…

### DIFF
--- a/docs/source/developer-guide/ci-overview.md
+++ b/docs/source/developer-guide/ci-overview.md
@@ -22,7 +22,7 @@ Pull requests do not start testing by themselves. Developers trigger the CI by c
 Integration tests are listed under `tests/integration/test_lists/test-db/`. Most YAML files are named after the GPU or configuration they run on (for example `l0_a100.yml`). Some files, like `l0_sanity_check.yml`, use wildcards and can run on multiple hardware types. Entries contain conditions and a list of tests. Two important terms in each entry are:
 
 - `stage`: either `pre_merge` or `post_merge`.
-- `backend`: `pytorch`, `tensorrt` or `triton`.
+- `backend`: for example `pytorch`, `autodeploy`, `cpp` or `fmha`. Grep the YAML files for `backend:` to see the values currently in use.
 
 Example from `l0_a30.yml`:
 
@@ -43,16 +43,18 @@ Unit tests live under `tests/unittest/` and run during the merge-request pipelin
 `jenkins/L0_Test.groovy` maps stage names to these YAML files.  For A100 the mapping includes:
 
 ```groovy
-    "A100X-Triton-[Post-Merge]-1": ["a100x", "l0_a100", 1, 2],
-    "A100X-Triton-[Post-Merge]-2": ["a100x", "l0_a100", 2, 2],
+    "A100X-PyTorch-1": ["a100x", "l0_a100", 1, 1],
+    "A100X-PyTorch-Post-Merge-1": ["a100x", "l0_a100", 1, 1],
 ```
 
 The array elements are: GPU type, YAML file (without extension), shard index, and total number of shards. Only tests with `stage: post_merge` from that YAML file are selected when a `Post-Merge` stage runs.
 
+Stage names are unbracketed, with `Post-Merge` embedded directly in the name. Copy the name exactly as it appears in the Groovy map for both `--stages` below and `--stage-list`: a name without a `*` wildcard is matched exactly, so a stale spelling such as `A100X-Triton-[Post-Merge]-1` silently selects nothing.
+
 ## Finding the stage for a test
 
 1. Locate the test in the appropriate YAML file under `tests/integration/test_lists/test-db/` and note its `stage` and `backend` values.
-2. Search `jenkins/L0_Test.groovy` for a stage whose YAML file matches (for example `l0_a100`) and whose name contains `[Post-Merge]` if the YAML entry uses `stage: post_merge`.
+2. Search `jenkins/L0_Test.groovy` for a stage whose YAML file matches (for example `l0_a100`) and whose name contains `Post-Merge` if the YAML entry uses `stage: post_merge`.
 3. The resulting stage name(s) are what you pass to Jenkins via the `stage_list` parameter when triggering a job.
 
 ### Using `test_to_stage_mapping.py`
@@ -63,7 +65,7 @@ Manually searching YAML and Groovy files can be tedious.  The helper script
 ```bash
 python scripts/test_to_stage_mapping.py --tests "unittest/_torch/sampler/test_beam_search.py"
 python scripts/test_to_stage_mapping.py --tests test_beam_search
-python scripts/test_to_stage_mapping.py --stages A100X-Triton-Post-Merge-1
+python scripts/test_to_stage_mapping.py --stages A100X-PyTorch-Post-Merge-1
 python scripts/test_to_stage_mapping.py --test-list my_tests.txt
 python scripts/test_to_stage_mapping.py --test-list my_tests.yml
 ```
@@ -80,7 +82,7 @@ tests in a newline‑separated text file or a YAML list and supply it with
 To run the same tests on your pull request, comment:
 
 ```bash
-/bot run --stage-list "A100X-Triton-[Post-Merge]-1,A100X-Triton-[Post-Merge]-2"
+/bot run --stage-list "A100X-PyTorch-Post-Merge-1"
 ```
 
 This executes the same tests that run post-merge for this hardware/backend.

--- a/docs/source/developer-guide/ci-overview.md
+++ b/docs/source/developer-guide/ci-overview.md
@@ -49,7 +49,7 @@ Unit tests live under `tests/unittest/` and run during the merge-request pipelin
 
 The array elements are: GPU type, YAML file (without extension), shard index, and total number of shards. Only tests with `stage: post_merge` from that YAML file are selected when a `Post-Merge` stage runs.
 
-Stage names are unbracketed, with `Post-Merge` embedded directly in the name. Copy the name exactly as it appears in the Groovy map for both `--stages` below and `--stage-list`: a name without a `*` wildcard is matched exactly, so a stale spelling such as `A100X-Triton-[Post-Merge]-1` silently selects nothing.
+Stage names are unbracketed, with `Post-Merge` embedded directly in the name. Copy the name exactly as it appears in the Groovy map. Jenkins `stage_list` matches names without a `*` wildcard exactly, so a stale spelling such as `A100X-Triton-[Post-Merge]-1` silently selects nothing. The mapping script's `--stages` option is stricter: it reports unknown names and near-match suggestions on stderr.
 
 ## Finding the stage for a test
 

--- a/scripts/test_to_stage_mapping.py
+++ b/scripts/test_to_stage_mapping.py
@@ -13,7 +13,10 @@ Example usage::
        "unittest/_torch/sampler/test_beam_search.py"
    python scripts/test_to_stage_mapping.py --tests test_beam_search
    python scripts/test_to_stage_mapping.py --stages \\
-       A100X-Triton-Post-Merge-1
+       A100X-PyTorch-Post-Merge-1
+
+Stage names passed to ``--stages`` must exactly match a key of the stage map in
+``jenkins/L0_Test.groovy``. Unrecognized names are reported on stderr.
 
 Tests can also be provided via ``--test-list`` pointing to either a plain text
 file or a YAML list file. Quote individual test names on the command line so
@@ -21,8 +24,10 @@ the shell does not interpret ``[`` and ``]`` characters.
 """
 
 import argparse
+import difflib
 import os
 import re
+import sys
 from collections import defaultdict
 from glob import glob
 from typing import List
@@ -189,6 +194,10 @@ class StageQuery:
                     result.add(s)
         return sorted(result)
 
+    def suggest_stages(self, stage):
+        """Return live stage names spelled similarly to an unknown one."""
+        return difflib.get_close_matches(stage, self.stage_to_yaml)
+
     def stages_to_tests(self, stages):
         result = set()
         for s in stages:
@@ -261,9 +270,18 @@ def main():
         for s in stages:
             print(s)
     else:
+        unknown = [s for s in args.stages if s not in query.stage_to_yaml]
+        for s in unknown:
+            sys.stderr.write(f'unknown stage: {s}\n')
+            for hint in query.suggest_stages(s):
+                sys.stderr.write(f'  did you mean: {hint}\n')
         tests = query.stages_to_tests(args.stages)
         for t in tests:
             print(t)
+        # Distinguish a stage that legitimately runs no tests from a stage name
+        # that does not exist, instead of both printing nothing at all.
+        if not tests and not unknown:
+            sys.stderr.write(f'no tests mapped to: {", ".join(args.stages)}\n')
 
 
 if __name__ == '__main__':

--- a/scripts/test_to_stage_mapping.py
+++ b/scripts/test_to_stage_mapping.py
@@ -16,7 +16,8 @@ Example usage::
        A100X-PyTorch-Post-Merge-1
 
 Stage names passed to ``--stages`` must exactly match a key of the stage map in
-``jenkins/L0_Test.groovy``. Unrecognized names are reported on stderr.
+``jenkins/L0_Test.groovy``. Unrecognized names, and known names that map to no
+tests, are reported on stderr.
 
 Tests can also be provided via ``--test-list`` pointing to either a plain text
 file or a YAML list file. Quote individual test names on the command line so
@@ -275,13 +276,18 @@ def main():
             sys.stderr.write(f'unknown stage: {s}\n')
             for hint in query.suggest_stages(s):
                 sys.stderr.write(f'  did you mean: {hint}\n')
+        # Report each known-but-empty stage on its own, so it stays visible when
+        # another requested stage does contribute tests, instead of printing
+        # nothing at all for it.
+        empty = [
+            s for s in args.stages
+            if s not in unknown and not query.stages_to_tests([s])
+        ]
         tests = query.stages_to_tests(args.stages)
         for t in tests:
             print(t)
-        # Distinguish a stage that legitimately runs no tests from a stage name
-        # that does not exist, instead of both printing nothing at all.
-        if not tests and not unknown:
-            sys.stderr.write(f'no tests mapped to: {", ".join(args.stages)}\n')
+        if empty:
+            sys.stderr.write(f'no tests mapped to: {", ".join(empty)}\n')
 
 
 if __name__ == '__main__':

--- a/tests/unittest/tools/test_test_to_stage_mapping.py
+++ b/tests/unittest/tools/test_test_to_stage_mapping.py
@@ -1,5 +1,6 @@
 import os
 import random
+import re
 import subprocess
 import sys
 from collections import defaultdict
@@ -107,6 +108,55 @@ def test_s3_stdout_echo_requires_explicit_opt_in():
         context = lines[max(0, idx - 3):idx]
         assert any('if (ENABLE_UPLOAD_TEST_RESULTS)' in line
                    for line in context)
+
+
+def test_documented_stage_examples_are_live(stage_query):
+    """Documented --stages examples must name stages that still exist in CI."""
+    sources = [
+        os.path.join(REPO_ROOT, 'docs', 'source', 'developer-guide',
+                     'ci-overview.md'),
+        os.path.join(SCRIPTS_DIR, 'test_to_stage_mapping.py'),
+    ]
+
+    checked = 0
+    for path in sources:
+        with open(path, 'r') as f:
+            text = f.read()
+
+        # Unwrap backslash continuations so wrapped commands read as one line,
+        # then take the stage names each documented invocation passes.
+        unwrapped = re.sub(r'\\+\s*\n\s*', ' ', text)
+        for example in re.findall(r'test_to_stage_mapping\.py.*?--stages(.*)',
+                                  unwrapped):
+            # Brackets are matched, not skipped, so a stale ``[Post-Merge]``
+            # spelling fails here instead of slipping through as two tokens.
+            for name in re.findall(r'[\w\[\].-]+', example):
+                if name.startswith('-'):
+                    break  # start of the next option, not a stage name
+                why = (f'{os.path.basename(path)} documents --stages {name}, '
+                       'which ')
+                assert name in stage_query.stage_to_yaml, \
+                    why + f'is not a stage in {os.path.basename(GROOVY)}'
+                assert stage_query.stages_to_tests([name]), \
+                    why + 'maps to no tests'
+                checked += 1
+
+    assert checked, 'Found no documented --stages examples to validate'
+
+
+def test_unknown_stage_reports_a_diagnostic(stage_query):
+    """An unresolvable stage name must not be silently swallowed."""
+    bogus = 'A100X-Triton-Post-Merge-1'
+    assert bogus not in stage_query.stage_to_yaml
+    assert 'A100X-PyTorch-Post-Merge-1' in stage_query.suggest_stages(bogus), \
+        f"Expected the live A100X stage to be suggested for '{bogus}'"
+
+    script = os.path.join(SCRIPTS_DIR, 'test_to_stage_mapping.py')
+    proc = subprocess.run([sys.executable, script, '--stages', bogus],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE)
+    assert not proc.stdout.strip(), 'Unknown stage should map to no tests'
+    assert f'unknown stage: {bogus}' in proc.stderr.decode()
 
 
 @pytest.mark.skip(reason="https://nvbugs/5547275")

--- a/tests/unittest/tools/test_test_to_stage_mapping.py
+++ b/tests/unittest/tools/test_test_to_stage_mapping.py
@@ -159,6 +159,33 @@ def test_unknown_stage_reports_a_diagnostic(stage_query):
     assert f'unknown stage: {bogus}' in proc.stderr.decode()
 
 
+def test_known_stage_without_tests_is_reported(tmp_path):
+    """A known stage that runs no tests stays visible alongside other stages."""
+    # No live stage is currently empty, so build a minimal repo whose
+    # ``empty`` stage maps to a YAML holding only post_merge tests.
+    (tmp_path / 'jenkins').mkdir()
+    (tmp_path / 'jenkins' / 'L0_Test.groovy').write_text(
+        '"Filled-PyTorch-1": ["x", "l0_filled", 1, 1],\n'
+        '"Empty-PyTorch-1": ["x", "l0_empty", 1, 1],\n')
+    db_dir = tmp_path / 'tests' / 'integration' / 'test_lists' / 'test-db'
+    db_dir.mkdir(parents=True)
+    for name, stage in (('l0_filled', 'pre_merge'), ('l0_empty', 'post_merge')):
+        (db_dir / f'{name}.yml').write_text(
+            f'version: 0.0.1\n{name}:\n- condition:\n    terms:\n'
+            f'      stage: {stage}\n      backend: pytorch\n'
+            f'  tests:\n  - unittest/{name}.py\n')
+
+    script = os.path.join(SCRIPTS_DIR, 'test_to_stage_mapping.py')
+    proc = subprocess.run([
+        sys.executable, script, '--repo-root',
+        str(tmp_path), '--stages', 'Empty-PyTorch-1', 'Filled-PyTorch-1'
+    ],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE)
+    assert proc.stdout.decode().split() == ['unittest/l0_filled.py']
+    assert 'no tests mapped to: Empty-PyTorch-1' in proc.stderr.decode()
+
+
 @pytest.mark.skip(reason="https://nvbugs/5547275")
 @pytest.mark.parametrize("direction",
                          ["test_to_stage", "stage_to_test", "roundtrip"])


### PR DESCRIPTION
## Summary
- **Root cause**: An unresolvable `--stages` name is dropped by `stages_to_tests()`, so `main()` iterates an empty set and exits 0 with zero bytes; the documented example named `A100X-Triton-Post-Merge-1`, deleted from `jenkins/L0_Test.groovy`.
- **Fix**: Report unknown stages on stderr with `difflib` near-miss hints, distinguish them from known-but-empty, keep exit 0; repoint the doc/docstring at the live stage and fix the page's other stale CI facts; add two GPU-free guards.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6533919


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Dev Engineer Review**

- Reports unknown `--stages` names to stderr with `difflib` suggestions.
- Distinguishes unknown stages from known stages with no tests.
- Preserves exit status 0.
- Adds GPU-free guards for both mapping directions.
- Updates CI documentation, stage names, backend values, Groovy examples, and stale CI details.
- Changes appear focused and consistent. No test-list changes are identified.

**QA Engineer Review**

- Added `test_documented_stage_examples_are_live`.
- Added `test_unknown_stage_reports_a_diagnostic`.
- Added `test_known_stage_without_tests_is_reported`.
- No corresponding `tests/integration/test_lists/` coverage is reported.
- Verdict: **insufficient**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->