### PR TITLE
[None][fix] Make KV bounce work for MiniMax-M3's multi-pool, replicated-pool cache

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/base/region.py
+++ b/tensorrt_llm/_torch/disaggregation/base/region.py
@@ -106,6 +106,11 @@ class RegionMapperBase(ABC):
     Maps a batch of region descriptors to corresponding destination(s).
     """
 
+    @property
+    def frags_per_block(self) -> int:
+        """Transfer fragments one block expands into; 1 means already coalesced."""
+        return 1
+
     @abstractmethod
     def map(self, src_regions: SpecRegion, dst_regions: SpecRegion) -> SpecRegionPair:
         """

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/config.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/config.py
@@ -23,8 +23,7 @@ from tensorrt_llm import logger
 
 _MIB = 1024 * 1024
 
-# Test/advanced override for the block-count gate below (users only tune the bounce size). Read on
-# the generation side, so set it there; unset uses the default.
+# Test override for the size gate (users only tune the bounce size). Read on the generation side.
 _MIN_BLOCKS_ENV = "TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS"
 
 
@@ -107,7 +106,8 @@ def fit_within_free(
 class Config:
     sizing: Sizing = field(default_factory=FixedSizing)  # how much memory to reserve (pluggable)
     chunk_mb: int = 32  # physical chunk size; a large chunk keeps the write to a single descriptor
-    # skip bounce below this many blocks (roughly 12k tokens at 128 per block); heuristic, tunable
+    # Skip bounce below this many transfer fragments; a whole-slot copy makes one per block, so
+    # for those it is still a block count. Heuristic, tunable.
     min_blocks: int = 96
 
 

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/core.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/core.py
@@ -69,6 +69,8 @@ class TransferContext:
     base_addr: int
     per_writer_bytes: int
     num_writers: int
+    # Set only when writers contribute unequally; None keeps the uniform per_writer_bytes split.
+    writer_sizes: Optional[List[int]] = None
     on_done: Optional[Callable[[bool], None]] = None
 
     # Whether each writer that reported succeeded, keyed by rank; presence means it reported.
@@ -82,7 +84,15 @@ class TransferContext:
 
     def writer_base(self, writer_index: int) -> int:
         """Where this fan-in writer writes in the region."""
-        return self.base_addr + writer_index * self.per_writer_bytes
+        if self.writer_sizes is None:
+            return self.base_addr + writer_index * self.per_writer_bytes
+        return self.base_addr + sum(self.writer_sizes[:writer_index])
+
+    def writer_bytes(self, writer_index: int) -> int:
+        """How many bytes this fan-in writer may write, i.e. its sub-region size."""
+        if self.writer_sizes is None:
+            return self.per_writer_bytes
+        return self.writer_sizes[writer_index]
 
     def _writers_final(self) -> bool:
         return self.settled or self.state in (
@@ -192,12 +202,25 @@ class BounceTransport(ABC):
         """Release a send region after its write completes."""
 
     @abstractmethod
-    def reserve(self, recv_req, num_writers: int = 1, *, timeout: Optional[float] = None) -> bool:
-        """Reserve a region and record its address for the senders. False falls back to per-fragment."""
+    def reserve(
+        self,
+        recv_req,
+        num_writers: int = 1,
+        *,
+        timeout: Optional[float] = None,
+        frags_per_block: Optional[Dict[int, int]] = None,
+        writer_owns_replicated: Optional[List[bool]] = None,
+    ) -> bool:
+        """Reserve a region and record its address for the senders. False falls back to per-fragment.
+
+        ``frags_per_block`` gives, per layer group, how many fragments one block expands into, so
+        the size gate can weigh descriptor pressure instead of block count.
+        ``writer_owns_replicated`` says, per fan-in writer, whether it is the elected sender of the
+        replicated pools, so their bytes are charged to that writer alone."""
 
     @abstractmethod
-    def writer_base(self, rid_slice, writer_index: int) -> Optional[int]:
-        """Where the given fan-in writer writes in the region."""
+    def writer_region(self, rid_slice, writer_index: int) -> Tuple[Optional[int], Optional[int]]:
+        """Where the given fan-in writer writes and how much it may write: (base, bytes)."""
 
     @abstractmethod
     def is_bounced(self, rid_slice) -> bool:

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/gather_scatter.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/gather_scatter.py
@@ -209,19 +209,29 @@ def gather_contiguous(
     )
 
 
-def scatter_contiguous(
-    src_base: int,
-    dst_ptrs: np.ndarray,
-    sizes: np.ndarray,
-    offsets: np.ndarray,
-    *,
-    stream,
-) -> None:
-    """The inverse of gather: scatter each piece of the contiguous buffer back to its destination
-    fragment, asynchronously. The caller syncs before signaling completion."""
-    dst_addrs = np.asarray(dst_ptrs, dtype=np.int64)
-    src_addrs = np.int64(src_base) + np.asarray(offsets, dtype=np.int64)
-    sizes = np.asarray(sizes, dtype=np.int64)
+def scatter_contiguous_multi(regions, *, stream) -> None:
+    """The inverse of gather: scatter each region back to its fragments, asynchronously.
+
+    All regions go in ONE batched copy: the per-stream metadata buffers may only be refilled after
+    a sync, and the caller syncs once at the end. The caller syncs before signaling completion.
+    """
+    dst_parts, src_parts, size_parts = [], [], []
+    for src_base, dst_ptrs, sizes in regions:
+        sizes = np.asarray(sizes, dtype=np.int64)
+        if sizes.size == 0:
+            continue
+        offsets = np.empty(sizes.size, dtype=np.int64)
+        offsets[0] = 0
+        np.cumsum(sizes[:-1], out=offsets[1:])
+        dst_parts.append(np.asarray(dst_ptrs, dtype=np.int64))
+        src_parts.append(np.int64(src_base) + offsets)
+        size_parts.append(sizes)
+    if not size_parts:
+        return
+
+    dst_addrs = dst_parts[0] if len(dst_parts) == 1 else np.concatenate(dst_parts)
+    src_addrs = src_parts[0] if len(src_parts) == 1 else np.concatenate(src_parts)
+    sizes = size_parts[0] if len(size_parts) == 1 else np.concatenate(size_parts)
 
     if _launch_batched_copy(dst_addrs, src_addrs, sizes, stream):
         return

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/impl.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/impl.py
@@ -18,7 +18,7 @@ and runs the side effects that drive each region's state machine. Never imports 
 
 import queue
 import threading
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -39,7 +39,7 @@ from tensorrt_llm._utils import CUASSERT
 from .buffer import SlotAllocator
 from .config import SizingContext, fit_within_free
 from .core import BounceTransport, Disposition, Settlement, TransferContext
-from .gather_scatter import Plan, gather_contiguous, scatter_contiguous
+from .gather_scatter import Plan, gather_contiguous, scatter_contiguous_multi
 
 RidSlice = tuple  # the request id and slice id a region serves
 _MIB = 1024 * 1024
@@ -57,7 +57,12 @@ class VmmBounceTransport(BounceTransport):
 
     @classmethod
     def from_config(
-        cls, agent, cfg, *, device_id: int, block_bytes_per_group: List[int]
+        cls,
+        agent,
+        cfg,
+        *,
+        device_id: int,
+        block_bytes_per_group: Tuple[List[int], List[int]],
     ) -> Optional["VmmBounceTransport"]:
         """Build a transport sized from the config and clamped to free memory, or None if not even one
         chunk fits."""
@@ -93,17 +98,20 @@ class VmmBounceTransport(BounceTransport):
         device_id: int,
         capacity_bytes: int,
         phys_chunk_size: int,
-        block_bytes_per_group: List[int],
+        block_bytes_per_group: Tuple[List[int], List[int]],
         min_blocks: int = 96,
         quarantine_grace_s: float = _QUARANTINE_GRACE_S,
         name: str = "kv_bounce",
     ):
         self._agent = agent
         self._device_id = device_id
-        # The byte size of one cache block, listed for each attention layer group.
-        self._block_bytes_per_group = list(block_bytes_per_group)
-        # Below this many blocks, skip bounce: coalescing only pays off for long context (the default
-        # is roughly twelve thousand tokens; a heuristic, and tunable).
+        # Bytes of one cache block per attention layer group, and the replicated part of that,
+        # which a fan-in sends once from an elected owner rather than splitting.
+        self._block_bytes_per_group, self._replicated_block_bytes_per_group = (
+            list(x) for x in block_bytes_per_group
+        )
+        # Skip bounce below this many fragments: coalescing pays off only once the per-fragment
+        # path would submit many descriptors.
         self._min_blocks = min_blocks
         # how long an orphaned region is held out of reuse; must outlast the worst in-flight write
         self._quarantine_grace_s = quarantine_grace_s
@@ -180,6 +188,16 @@ class VmmBounceTransport(BounceTransport):
         """Reserve a send slot and gather into it, or None on send-region backpressure. Eligibility
         was already decided by the receiver, so the sender only falls back under backpressure."""
         total = int(write_meta.sizes.sum())
+        limit = getattr(write_meta, "bounce_dst_bytes", None)
+        if limit is not None and total > int(limit):
+            # The two sides disagree about the coalesced size; fall back rather than overrun the
+            # neighbouring slot.
+            logger.warning_once(
+                f"[kv-bounce] in-place: gathered {total}B exceeds the {int(limit)}B the receiver "
+                "reserved; falling back to per-fragment (sender/receiver size mismatch)",
+                key="kv-bounce-dst-overrun",
+            )
+            return None
         res = self._send_alloc.reserve(total, timeout=timeout)
         if res is None:
             logger.debug(
@@ -217,35 +235,58 @@ class VmmBounceTransport(BounceTransport):
         return False
 
     def reserve(
-        self, recv_req, num_writers: int = 1, *, timeout: Optional[float] = _RESERVE_TIMEOUT_S
+        self,
+        recv_req,
+        num_writers: int = 1,
+        *,
+        timeout: Optional[float] = _RESERVE_TIMEOUT_S,
+        frags_per_block: Optional[Dict[int, int]] = None,
+        writer_owns_replicated: Optional[List[bool]] = None,
     ) -> bool:
-        """Reserve a region and create its state, recording the address for the senders. Returns
-        False to fall back to the per-fragment path. A fan-in splits the region evenly, so the total
-        must divide across the writers."""
-        nblocks = sum(int(a.size) for a in recv_req.block_ids_per_layer_groups)
-        if nblocks < self._min_blocks:
-            return self._skip_bounce(f"{nblocks} blocks < min {self._min_blocks} (too small)")
-        total = 0
-        for g, block_ids in enumerate(recv_req.block_ids_per_layer_groups):
-            if g >= len(self._block_bytes_per_group):
-                return self._skip_bounce(f"layer group {g} has no known slot size (e.g. mamba)")
-            total += int(block_ids.size) * self._block_bytes_per_group[g]
+        """Reserve a region and record its address for the senders, or return False to fall back
+        to the per-fragment path. A fan-in splits the region, so the sharded bytes must divide
+        evenly between the writers."""
+        blocks = [int(a.size) for a in recv_req.block_ids_per_layer_groups]
+        if len(blocks) > len(self._block_bytes_per_group):
+            g = len(self._block_bytes_per_group)
+            return self._skip_bounce(f"layer group {g} has no known slot size (e.g. mamba)")
+        # Gate on fragments, not blocks: a head-mismatched mapping splits each block per layer and
+        # buffer, so it reaches the gate at a block count a whole-slot copy never would.
+        nfrags = sum(n * (frags_per_block or {}).get(g, 1) for g, n in enumerate(blocks))
+        if nfrags < self._min_blocks:
+            return self._skip_bounce(
+                f"{sum(blocks)} blocks / {nfrags} fragments < min {self._min_blocks} (too small); "
+                "lower TRTLLM_KV_CACHE_BOUNCE_MIN_BLOCKS on the generation side to coalesce anyway",
+                warn_key="kv-bounce-too-small",
+            )
+        total = sum(n * b for n, b in zip(blocks, self._block_bytes_per_group))
         if total <= 0:
             return self._skip_bounce(f"computed transfer size {total} <= 0")
-        if num_writers > 1 and total % num_writers != 0:
-            return self._skip_bounce(
-                f"fan-in {total}B across {num_writers} senders is not an even split "
-                f"({total % num_writers}B remainder); head-mismatch explosion NOT mitigated",
-                warn_key="kv-bounce-uneven-fanin",
-            )
+        writer_sizes: Optional[List[int]] = None
         if num_writers > 1:
-            # Fan-in gives each writer an equal share of the region, which only matches where it
-            # writes when all writers send the same bytes. Equal layer count guarantees that only
-            # when the per-block sizes match, so require that here, else fall back.
+            # Replicated views go out once from an elected owner, so only the rest is divided.
+            repl_total = sum(n * r for n, r in zip(blocks, self._replicated_block_bytes_per_group))
+            shard_total = total - repl_total
+            if shard_total <= 0:
+                # Empty sub-regions all resolve to the same address; fall back, don't alias.
+                return self._skip_bounce(
+                    f"fan-in across {num_writers} senders leaves {shard_total}B to share after "
+                    f"{repl_total}B of replicated views; cannot give each writer its own region",
+                    warn_key="kv-bounce-no-sharded-bytes",
+                )
+            if shard_total % num_writers != 0:
+                return self._skip_bounce(
+                    f"fan-in {shard_total}B across {num_writers} senders is not an even split "
+                    f"({shard_total % num_writers}B remainder); head-mismatch explosion NOT mitigated",
+                    warn_key="kv-bounce-uneven-fanin",
+                )
+            # An equal share only lands where a writer writes when the per-block sizes match.
             present_slot_bytes = {
-                self._block_bytes_per_group[g]
-                for g, block_ids in enumerate(recv_req.block_ids_per_layer_groups)
-                if int(block_ids.size) > 0
+                b - r
+                for n, b, r in zip(
+                    blocks, self._block_bytes_per_group, self._replicated_block_bytes_per_group
+                )
+                if n > 0
             }
             if len(present_slot_bytes) > 1:
                 return self._skip_bounce(
@@ -253,6 +294,22 @@ class VmmBounceTransport(BounceTransport):
                     f"{sorted(present_slot_bytes)}; the equal split would overrun a sub-region",
                     warn_key="kv-bounce-heterogeneous-fanin",
                 )
+            even = shard_total // num_writers
+            if repl_total == 0:
+                writer_sizes = [even] * num_writers
+            else:
+                # One writer carries the replicated bytes, so its sub-region is the larger one;
+                # without a prediction naming exactly one owner, guessing would overrun.
+                owners = [i for i, owns in enumerate(writer_owns_replicated or ()) if owns]
+                if len(writer_owns_replicated or ()) != num_writers or len(owners) != 1:
+                    return self._skip_bounce(
+                        f"fan-in across {num_writers} senders carries {repl_total}B of replicated "
+                        f"pools but the elected owner is {owners or 'unknown'}; cannot size "
+                        "sub-regions",
+                        warn_key="kv-bounce-replicated-fanin",
+                    )
+                writer_sizes = [even] * num_writers
+                writer_sizes[owners[0]] += repl_total
         if total > self._recv_alloc.capacity:  # too big to ever fit, unlike transient backpressure
             return self._skip_bounce(
                 f"transfer {total // _MIB}MiB exceeds the {self._recv_alloc.capacity // _MIB}MiB bounce "
@@ -262,10 +319,15 @@ class VmmBounceTransport(BounceTransport):
         res = self._recv_alloc.reserve(total, timeout=timeout)
         if res is None:
             return self._skip_bounce(
-                f"no recv region space for {total // _MIB}MiB within {timeout}s (backpressure)"
+                f"no recv region space for {total // _MIB}MiB within {timeout}s; the "
+                f"{self._recv_alloc.capacity // _MIB}MiB arena fits "
+                f"{self._recv_alloc.capacity // max(1, total)} concurrent transfer(s), so raise the "
+                "bounce size or lower max_tokens_in_buffer",
+                warn_key="kv-bounce-backpressure",
             )
         slot_id, addr = res
         recv_req.bounce_dst_base = addr
+        recv_req.bounce_dst_bytes = writer_sizes[0] if writer_sizes else total
         with self._reserved_map_lock:
             ctx = TransferContext(
                 rid_slice=(recv_req.unique_rid, recv_req.slice_id),
@@ -273,23 +335,29 @@ class VmmBounceTransport(BounceTransport):
                 base_addr=addr,
                 per_writer_bytes=total // num_writers,
                 num_writers=num_writers,
+                writer_sizes=writer_sizes,
             )
             self._reserved_map[ctx.rid_slice] = ctx  # inactive until the first writer reports
         # Positive marker: all fall-back guards above passed, so this transfer provably takes the
         # coalesced-bounce WRITE path. Logged once (per process) so an e2e test can assert that
         # bounce actually engaged instead of silently falling back to the per-fragment path.
         logger.info_once(
-            f"[kv-bounce] coalesced {nblocks} blocks / {total // _MIB}MiB into one region "
+            f"[kv-bounce] coalesced {sum(blocks)} blocks / {total // _MIB}MiB into one region "
             f"across {num_writers} writer(s)",
             key="kv-bounce-coalesced",
         )
         return True
 
-    def writer_base(self, rid_slice: RidSlice, writer_index: int) -> Optional[int]:
-        """Where the given fan-in writer writes in the region."""
+    def writer_region(self, rid_slice: RidSlice, writer_index: int):
+        """Where a fan-in writer writes and how much it may write: (base, bytes).
+
+        Both under one lock: the size limit is what stops an oversized gather from overrunning a
+        neighbour, so a concurrent cancel must not be able to strip it from a base."""
         with self._reserved_map_lock:
             ctx = self._reserved_map.get(rid_slice)
-            return None if ctx is None else ctx.writer_base(writer_index)
+            if ctx is None:
+                return None, None
+            return ctx.writer_base(writer_index), int(ctx.writer_bytes(writer_index))
 
     def is_bounced(self, rid_slice: RidSlice) -> bool:
         with self._reserved_map_lock:
@@ -392,13 +460,10 @@ class VmmBounceTransport(BounceTransport):
             ctx, descs = item
             ok = True
             try:
-                # Scatter each writer's fragments from its own source, never one global offset, so a
-                # missing or fallback writer cannot shift where the others are read from.
-                for src_base, dst_ptrs, sizes in descs:
-                    p = Plan(dst_ptrs, dst_ptrs, sizes, int(sizes.sum()))
-                    scatter_contiguous(
-                        src_base, p.dst_ptrs, p.sizes, p.offsets, stream=self._scatter_stream
-                    )
+                # Each writer scatters from its own source, so a missing or fallback writer cannot
+                # shift where the others are read from; one batched copy for all of them, because
+                # the per-stream metadata buffers may only be refilled after the sync below.
+                scatter_contiguous_multi(descs, stream=self._scatter_stream)
                 CUASSERT(cudart.cudaStreamSynchronize(self._scatter_stream))
             except Exception as e:
                 # a scatter failure must not kill the worker nor be reported as success
@@ -435,13 +500,11 @@ class NoBounceTransport(BounceTransport):
     def release_send(self, slot_id) -> None:
         pass
 
-    def reserve(
-        self, recv_req, num_writers: int = 1, *, timeout: Optional[float] = _RESERVE_TIMEOUT_S
-    ) -> bool:
+    def reserve(self, recv_req, num_writers: int = 1, **_) -> bool:
         return False
 
-    def writer_base(self, rid_slice, writer_index: int):
-        return None
+    def writer_region(self, rid_slice, writer_index: int):
+        return None, None
 
     def is_bounced(self, rid_slice) -> bool:
         return False
@@ -471,7 +534,10 @@ def create_bounce(agent, cfg, *, device_id: int, page_table) -> BounceTransport:
         return NoBounceTransport()
     try:
         transport = VmmBounceTransport.from_config(
-            agent, cfg, device_id=device_id, block_bytes_per_group=block_bytes_per_group(page_table)
+            agent,
+            cfg,
+            device_id=device_id,
+            block_bytes_per_group=block_bytes_per_group(page_table),
         )
         return transport if transport is not None else NoBounceTransport()
     except (
@@ -525,16 +591,33 @@ def decode_result_tail(message):
     return None, None, None
 
 
-def block_bytes_per_group(page_table) -> list:
-    """Byte size of one cache block for each leading attention layer group, stopping at the first
-    non-attention group."""
-    from tensorrt_llm._torch.disaggregation.resource.page import AttentionLayerGroup
+def block_bytes_per_group(page_table) -> Tuple[List[int], List[int]]:
+    """Bytes in one cache block per leading attention layer group: (total, replicated share).
+
+    The total sums every pool backing a group, deduplicated by index, because the sender coalesces
+    all of them into one write; a group with no pool views falls back to pool 0. The replicated
+    share is measured per VIEW, since one pool can hold views of both classes and charging the
+    whole slot to the replicated class would leave the writers nothing to split."""
+    from tensorrt_llm._torch.disaggregation.resource.page import AttentionLayerGroup, MapperKind
     from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool
 
     assert page_table is not None
-    out: list = []
+    total: List[int] = []
+    replicated: List[int] = []
     for lg_idx, lg in enumerate(page_table.layer_groups):
         if not isinstance(lg, AttentionLayerGroup):
             break
-        out.append(int(get_physical_pool(page_table, lg_idx, 0).slot_bytes))
-    return out
+        views = getattr(lg, "pool_views", ())
+        pool_indices = {int(pv.pool_idx) for pv in views} or {0}
+        total.append(
+            sum(int(get_physical_pool(page_table, lg_idx, pi).slot_bytes) for pi in pool_indices)
+        )
+        replicated.append(
+            sum(
+                int(entry["size"])
+                for pv in views
+                if pv.mapper_kind == MapperKind.REPLICATED
+                for entry in pv.buffer_entries
+            )
+        )
+    return total, replicated

--- a/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
@@ -70,6 +70,11 @@ class IntactMapper(RegionMapperBase):
             )
         self._runs = self._merge_contiguous(src, dst, self_bytes_per_layer)
 
+    @property
+    def frags_per_block(self) -> int:
+        """One fragment per contiguous run of layers; a dedicated K/V pool merges to 1."""
+        return len(self._runs)
+
     @staticmethod
     def _merge_contiguous(
         src: np.ndarray, dst: np.ndarray, bytes_per_layer: int
@@ -256,6 +261,11 @@ class HNDHeadMismatchMapper(RegionMapperBase):
             buffer_bytes=dst_buffer_bytes,
             head_offset=self._dst_head_off,
         )
+
+    @property
+    def frags_per_block(self) -> int:
+        """One fragment per (layer, buffer): the head-mismatch descriptor explosion."""
+        return int(self._src_flat_offsets.size)
 
     @staticmethod
     def _build_flat_offsets(

--- a/tensorrt_llm/_torch/disaggregation/native/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/peer.py
@@ -266,6 +266,17 @@ class PeerRegistrar:
         self._lg_pool_mapping_cache[key] = mapping
         return mapping
 
+    def frags_per_block_per_group(self, peer_ri: RankInfo) -> Dict[int, int]:
+        """Fragments one block expands into, summed over each self layer group's pools.
+
+        Counts pools this rank does not send itself too: the receiver sizes the whole fan-in group.
+        """
+        out: Dict[int, int] = {}
+        for self_key, peer_key in self.get_pool_mapping(peer_ri).items():
+            mapper = self.get_kv_map(peer_ri, self_key, peer_key)
+            out[self_key[0]] = out.get(self_key[0], 0) + int(mapper.frags_per_block)
+        return out
+
     def get_kv_map(
         self,
         peer_ri: RankInfo,
@@ -466,22 +477,52 @@ class PeerRegistrar:
             self_tp_rank_in_dp_group % dup_head_factor
         )
 
-    def _owns_tp_fan_in(self, peer_rank_info: RankInfo) -> bool:
-        """Elect one owner when replicated bytes fan in across TP ranks.
+    @staticmethod
+    def elects_fan_in_owner(
+        *,
+        sender_tp_rank: int,
+        sender_tp_size_per_dp_group: int,
+        receiver_tp_size_per_dp_group: int,
+        receiver_dp_rank: int,
+    ) -> bool:
+        """Whether this sender is the elected owner of replicated bytes for this receiver.
 
-        A peer with fewer TP shards receives identical replicated data from
-        several local ranks. Rotate the elected owner by the destination's
-        DP rank (mirroring ``should_send_kv``'s head-duplication pairing) so
-        that with a multi-DP-group generation side the extra replicated
-        traffic spreads across local ranks instead of always landing on the
-        first rank of each fan-in group.
+        A receiver with fewer TP shards gets identical replicated data from several of the
+        sender's ranks, so exactly one of them must send it. The owner rotates by the
+        destination's DP rank (mirroring ``should_send_kv``'s head-duplication pairing) so
+        that with a multi-DP-group generation side the extra replicated traffic spreads
+        across sender ranks instead of always landing on the first rank of each fan-in group.
+
+        Both sides evaluate it -- the sender to decide what to send, the receiver to size each
+        writer's sub-region -- so it stays one implementation: a mispredicting receiver would
+        under-size the elected writer's slot.
         """
-        ratio = max(
-            1,
-            self._ri.tp_size_per_dp_group // peer_rank_info.tp_size_per_dp_group,
+        ratio = max(1, sender_tp_size_per_dp_group // receiver_tp_size_per_dp_group)
+        return (sender_tp_rank % sender_tp_size_per_dp_group) % ratio == receiver_dp_rank % ratio
+
+    def fan_in_replicated_owners(self, peer_ri: RankInfo, sender_ranks: List[int]) -> List[bool]:
+        """Receiver side: which of these senders will carry the replicated pools.
+
+        Mirrors each sender's own ``should_send_pool``; a rank's TP index is ``rank % tp_size``.
+        """
+        return [
+            self.elects_fan_in_owner(
+                sender_tp_rank=rank % peer_ri.tp_size,
+                sender_tp_size_per_dp_group=peer_ri.tp_size_per_dp_group,
+                receiver_tp_size_per_dp_group=self._ri.tp_size_per_dp_group,
+                receiver_dp_rank=self._ri.dp_rank,
+            )
+            for rank in sender_ranks
+        ]
+
+    def _owns_tp_fan_in(self, peer_rank_info: RankInfo) -> bool:
+        """Elect one owner when replicated bytes fan in across TP ranks (sender side)."""
+        return self.elects_fan_in_owner(
+            sender_tp_rank=self._ri.tp_rank,
+            sender_tp_size_per_dp_group=self._ri.tp_size_per_dp_group,
+            receiver_tp_size_per_dp_group=peer_rank_info.tp_size_per_dp_group,
+            receiver_dp_rank=peer_rank_info.dp_rank,
         )
-        self_tp_rank = self._ri.tp_rank % self._ri.tp_size_per_dp_group
-        return self_tp_rank % ratio == peer_rank_info.dp_rank % ratio
 
     def should_send_pool(
         self,

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -96,6 +96,10 @@ class RecvReqInfo:
     mamba_state_index: Optional[int] = None
     slice_id: Optional[int] = None
     bounce_dst_base: Optional[int] = None
+    # Upper bound on what a sender may write at bounce_dst_base: the receiver's
+    # per-writer sub-region. Lets the sender fail closed instead of overrunning the
+    # slot if the two sides ever disagree about the coalesced size.
+    bounce_dst_bytes: Optional[int] = None
 
     def to_bytes(self) -> bytes:
         return msgpack.packb(
@@ -112,6 +116,7 @@ class RecvReqInfo:
                 "mamba_state_index": self.mamba_state_index,
                 "slice_id": self.slice_id,
                 "bounce_dst_base": self.bounce_dst_base,
+                "bounce_dst_bytes": self.bounce_dst_bytes,
             }
         )
 
@@ -121,7 +126,10 @@ class RecvReqInfo:
         d["block_ids_per_layer_groups"] = [
             np.frombuffer(b, dtype=np.int64).copy() for b in d["block_ids_per_layer_groups"]
         ]
-        return cls(**d)
+        # Drop keys this build does not know: a newer peer's extra field must not raise here and
+        # hang the transfer.
+        known = cls.__dataclass_fields__
+        return cls(**{k: v for k, v in d.items() if k in known})
 
 
 @dataclass
@@ -152,6 +160,7 @@ class WriteMeta:
     is_last_slice: bool = False
     meta_type: WriteMetaType = WriteMetaType.KV
     bounce_dst_base: Optional[int] = None
+    bounce_dst_bytes: Optional[int] = None
 
 
 class MessageType:
@@ -914,6 +923,7 @@ class Sender(SenderBase):
             slice_id=task.slice_id,
             is_last_slice=task._slice.is_last_slice,
             bounce_dst_base=req_info.bounce_dst_base,
+            bounce_dst_bytes=req_info.bounce_dst_bytes,
         )
 
     def _build_aux_write_meta(self, task: AuxSendTask, req_info: RecvReqInfo) -> WriteMeta:
@@ -1549,31 +1559,21 @@ class Receiver(ReceiverBase):
 
     @staticmethod
     def _fanin_bounce_safe(overlap, peer_ri) -> bool:
-        """Whether multi-writer bounce's equal total//num_writers split is valid for this overlap.
-        The split assumes every writer contributes the same size, which holds when:
-          * duplicate_head_factor == 1 -- else some ranks don't send KV (should_send_kv) yet still
-            count in expected_transfers, so the live writers overflow their slots;
-          * the PP layer split is even -- a single PP stage (overlap_pp_size <= 1) is trivially fine;
-            for PP fan-in, every overlapping stage must hold the same number of layers
-            (peer_ri.layer_num_per_pp all-equal) or per-writer sizes differ. If that full per-stage
-            list isn't available (shorter than the fan-in degree), be conservative and fall back.
-        Otherwise fall back to the per-fragment path (correct, just not coalesced).
-        Equal layer count means equal bytes only when the per-block sizes match; reserve() rejects
-        the mismatched case, so this only needs the count to split evenly."""
+        """Whether reserve() can size a multi-writer bounce here; else fall back to the
+        per-fragment path (correct, just not coalesced). It needs duplicate_head_factor == 1 (else
+        some ranks skip KV yet still count in expected_transfers), an even PP layer split, and no
+        replicated pool under a PP fan-in (reserve() sizes those only for a pure-TP fan-in)."""
         if overlap.duplicate_head_factor != 1:
             return False
-        if overlap.overlap_pp_size > 1:
-            lpp = getattr(peer_ri, "layer_num_per_pp", None)
-            if not lpp or len(lpp) < overlap.overlap_pp_size or len(set(lpp)) != 1:
-                return False
-        # Replicated pools (e.g. MiniMax M3 index-key) are sent by one elected
-        # fan-in owner only, so with multiple writers their contributions
-        # differ in size and the equal split is invalid.
-        if len(overlap.ranks) > 1 and peer_ri.page_table is not None:
-            for layer_group in peer_ri.page_table.layer_groups:
-                for pool_view in getattr(layer_group, "pool_views", ()):
-                    if pool_view.mapper_kind == MapperKind.REPLICATED:
-                        return False
+        if overlap.overlap_pp_size <= 1:  # implies a single writer per stage: nothing to split
+            return True
+        lpp = getattr(peer_ri, "layer_num_per_pp", None)
+        if not lpp or len(lpp) < overlap.overlap_pp_size or len(set(lpp)) != 1:
+            return False
+        for layer_group in getattr(peer_ri.page_table, "layer_groups", ()):
+            for pool_view in getattr(layer_group, "pool_views", ()):
+                if pool_view.mapper_kind == MapperKind.REPLICATED:
+                    return False
         return True
 
     def dispatch_task(self, task: KVRecvTask):
@@ -1617,10 +1617,22 @@ class Receiver(ReceiverBase):
         # _fanin_bounce_safe() (TP-by-head / even-PP), and never under ADP broadcast (sender_dp_rank
         # None), where the real writer count exceeds expected_transfers and would overflow the slot.
         topo_overlap = peer_overlap if sender_dp_rank is not None else dp0_overlap
-        allow_bounce = task.expected_transfers == 1 or (
-            sender_dp_rank is not None and self._fanin_bounce_safe(topo_overlap, peer_infos)
+        # Check enabled first: with bounce off, reserve() is a no-op but its arguments would still
+        # build every peer mapper on the receive path.
+        allow_bounce = self._bounce.enabled and (
+            task.expected_transfers == 1
+            or (sender_dp_rank is not None and self._fanin_bounce_safe(topo_overlap, peer_infos))
         )
-        bounced = allow_bounce and self._bounce.reserve(receiver_req, task.expected_transfers)
+        # The gate weighs fragments; the owner list charges replicated bytes to the sender that
+        # actually writes them.
+        bounced = allow_bounce and self._bounce.reserve(
+            receiver_req,
+            task.expected_transfers,
+            frags_per_block=self._registrar.frags_per_block_per_group(peer_infos),
+            writer_owns_replicated=self._registrar.fan_in_replicated_owners(
+                peer_infos, topo_overlap.ranks
+            ),
+        )
         session = self._get_session(task._unique_rid)
         if session is None:
             raise RuntimeError(
@@ -1640,7 +1652,9 @@ class Receiver(ReceiverBase):
             if task._perf_timer is not None:
                 task._perf_timer.record_task_start(rank)
             if fanin_bounce:
-                receiver_req.bounce_dst_base = self._bounce.writer_base(key, i)
+                receiver_req.bounce_dst_base, receiver_req.bounce_dst_bytes = (
+                    self._bounce.writer_region(key, i)
+                )
                 receiver_req_bytes = receiver_req.to_bytes()
             self._request_sender_data(peer_infos.sender_endpoints[rank], receiver_req_bytes)
         return

--- a/tests/unittest/disaggregated/test_bounce.py
+++ b/tests/unittest/disaggregated/test_bounce.py
@@ -224,10 +224,10 @@ def test_fanin_bounce_safe_gate():
     assert safe(ov(1, 4), ri([20])) is False
     # duplicate heads blocks even an otherwise-even PP split
     assert safe(ov(2, 4), ri([20, 20, 20, 20])) is False
-    # replicated views (one elected sender per destination) make multi-writer
-    # contributions unequal -> fall back; single-writer overlap stays safe,
-    # and sharded-only view schemes are unaffected
-    assert safe(ov(1, 1, ranks=(0, 1)), ri([24], pt(MapperKind.REPLICATED))) is False
+    # Replicated views make multi-writer contributions unequal. reserve() sizes the sub-regions
+    # per writer for a pure-TP fan-in; combined with a PP fan-in it still falls back.
+    assert safe(ov(1, 1, ranks=(0, 1)), ri([24], pt(MapperKind.REPLICATED))) is True
+    assert safe(ov(1, 4, ranks=(0, 1)), ri([20, 20, 20, 20], pt(MapperKind.REPLICATED))) is False
     assert safe(ov(1, 1, ranks=(0,)), ri([24], pt(MapperKind.REPLICATED))) is True
     assert safe(ov(1, 1, ranks=(0, 1)), ri([24], pt(MapperKind.NHD))) is True
 
@@ -242,7 +242,7 @@ class TestNoBounce:
         assert nb.enabled is False
         assert nb.reserve(SimpleNamespace()) is False
         assert nb.build_request(SimpleNamespace()) is None
-        assert nb.writer_base(("r", 0), 1) is None
+        assert nb.writer_region(("r", 0), 1) == (None, None)
         assert nb.is_bounced(("r", 0)) is False
         nb.record_result(("r", 0), 1)  # no-op, must not raise
         nb.record_failure(("r", 0), 1)  # no-op, must not raise
@@ -264,7 +264,7 @@ class TestNoBounce:
 
 
 # --------------------------------------------------------------------------- #
-# Transport TP fan-in logic — reserve gate / writer_base / accumulate ordering
+# Transport TP fan-in logic — reserve gate / writer_region / accumulate ordering
 # (GPU allocators, streams and the scatter worker are mocked out)
 # --------------------------------------------------------------------------- #
 class _FakeAlloc:
@@ -301,7 +301,13 @@ class _FakeAlloc:
         return []
 
 
-def _make_transport(monkeypatch, block_bytes_per_group, capacity=1 << 30, min_blocks=1):
+def _make_transport(
+    monkeypatch,
+    block_bytes_per_group,
+    capacity=1 << 30,
+    min_blocks=1,
+    replicated_block_bytes_per_group=None,
+):
     monkeypatch.setattr(btr, "SlotAllocator", _FakeAlloc)
     monkeypatch.setattr(btr.VmmBounceTransport, "_new_stream", lambda self: 0)
     monkeypatch.setattr(
@@ -315,7 +321,10 @@ def _make_transport(monkeypatch, block_bytes_per_group, capacity=1 << 30, min_bl
         device_id=0,
         capacity_bytes=capacity,
         phys_chunk_size=32 * _MIB,
-        block_bytes_per_group=block_bytes_per_group,
+        block_bytes_per_group=(
+            block_bytes_per_group,
+            replicated_block_bytes_per_group or [0] * len(block_bytes_per_group),
+        ),
         min_blocks=min_blocks,
     )
 
@@ -326,6 +335,7 @@ def _recv_req(block_counts, rid=1, slice_id=0):
         unique_rid=rid,
         slice_id=slice_id,
         bounce_dst_base=None,
+        bounce_dst_bytes=None,
     )
 
 
@@ -337,8 +347,9 @@ class TestFanInReserve:
         assert t.reserve(req, num_writers=2) is True
         assert req.bounce_dst_base == 0x100000
         # writer i lands at base + i * (total // num_writers); per_writer = 100.
-        assert t.writer_base((req.unique_rid, req.slice_id), 0) == 0x100000
-        assert t.writer_base((req.unique_rid, req.slice_id), 1) == 0x100000 + 100
+        key = (req.unique_rid, req.slice_id)
+        assert t.writer_region(key, 0) == (0x100000, 100)
+        assert t.writer_region(key, 1) == (0x100000 + 100, 100)
 
     def test_reserve_uneven_fanin_falls_back(self, monkeypatch):
         t = _make_transport(monkeypatch, block_bytes_per_group=[3])
@@ -372,6 +383,23 @@ class TestFanInReserve:
     def test_reserve_too_small_falls_back(self, monkeypatch):
         t = _make_transport(monkeypatch, block_bytes_per_group=[100], min_blocks=96)
         assert t.reserve(_recv_req([4]), num_writers=1) is False  # 4 < 96 blocks
+
+    def test_size_gate_counts_fragments_not_blocks(self, monkeypatch):
+        """Fragments, not blocks, decide the gate.
+
+        64 blocks at 120 fragments each clears the gate; 64 whole-slot blocks do not.
+        """
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100], min_blocks=96)
+        assert t.reserve(_recv_req([64], rid=1), num_writers=1) is False
+        assert (
+            t.reserve(_recv_req([64], rid=2), num_writers=1, frags_per_block={0: 120}) is True
+        )  # 64 * 120 = 7680 fragments
+
+    def test_size_gate_unchanged_for_whole_slot_copies(self, monkeypatch):
+        """One fragment per block makes the fragment gate identical to the old block gate."""
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100], min_blocks=96)
+        assert t.reserve(_recv_req([95], rid=1), num_writers=1, frags_per_block={0: 1}) is False
+        assert t.reserve(_recv_req([96], rid=2), num_writers=1, frags_per_block={0: 1}) is True
 
     def test_reserve_unknown_slot_size_falls_back(self, monkeypatch):
         t = _make_transport(monkeypatch, block_bytes_per_group=[100])  # only 1 group known
@@ -726,3 +754,257 @@ class TestQuarantine:
         a.quarantine(s, grace_s=float("inf"))  # close-only reclaim
         assert a.reclaim_expired() == 0
         assert a.quarantined_bytes == 512
+
+
+@pytest.mark.skipif(not _HAVE_TRANSPORT, reason="bounce.transport import needs CUDA bindings")
+class TestReplicatedFanInSplit:
+    """The replicated pool's elected owner must get the larger sub-region.
+
+    A replicated pool is sent once by one elected owner while the
+    sharded pools split across all writers, so an even split would leave the owner short and
+    its write would run into the next writer's region.
+    """
+
+    # One layer group, 100B/block total, of which 40B live in a replicated pool.
+    GROUP = [100]
+    REPLICATED = [40]
+
+    def test_owner_gets_the_replicated_bytes(self, monkeypatch):
+        t = _make_transport(
+            monkeypatch,
+            block_bytes_per_group=self.GROUP,
+            replicated_block_bytes_per_group=self.REPLICATED,
+        )
+        req = _recv_req([2])  # total 200B: 120B sharded (60B each) + 80B replicated
+        assert t.reserve(req, num_writers=2, writer_owns_replicated=[False, True]) is True
+        key = (req.unique_rid, req.slice_id)
+        assert t.writer_region(key, 0)[1] == 60
+        assert t.writer_region(key, 1)[1] == 60 + 80
+        # Sub-regions tile the reservation without overlap or gap.
+        assert t.writer_region(key, 0)[0] == req.bounce_dst_base
+        assert t.writer_region(key, 1)[0] == req.bounce_dst_base + 60
+
+    def test_owner_first_also_tiles(self, monkeypatch):
+        t = _make_transport(
+            monkeypatch,
+            block_bytes_per_group=self.GROUP,
+            replicated_block_bytes_per_group=self.REPLICATED,
+        )
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=2, writer_owns_replicated=[True, False]) is True
+        key = (req.unique_rid, req.slice_id)
+        assert t.writer_region(key, 0)[1] == 140
+        assert t.writer_region(key, 1)[0] == req.bounce_dst_base + 140
+
+    def test_sub_regions_never_overlap(self, monkeypatch):
+        for owner in range(4):
+            t = _make_transport(
+                monkeypatch,
+                block_bytes_per_group=self.GROUP,
+                replicated_block_bytes_per_group=self.REPLICATED,
+            )
+            req = _recv_req([4])  # 400B: 240B sharded (60B each) + 160B replicated
+            owns = [i == owner for i in range(4)]
+            assert t.reserve(req, num_writers=4, writer_owns_replicated=owns) is True
+            key = (req.unique_rid, req.slice_id)
+            base = req.bounce_dst_base
+            cursor = base
+            for i in range(4):
+                assert t.writer_region(key, i)[0] == cursor, f"owner={owner} writer={i}"
+                cursor += t.writer_region(key, i)[1]
+            assert cursor == base + 400, f"owner={owner}: sub-regions must cover exactly the total"
+
+    def test_unknown_owner_falls_back(self, monkeypatch):
+        """No prediction means no bounce, rather than a guess.
+
+        Without it the receiver cannot say where the extra bytes land, and an even split
+        would overrun.
+        """
+        t = _make_transport(
+            monkeypatch,
+            block_bytes_per_group=self.GROUP,
+            replicated_block_bytes_per_group=self.REPLICATED,
+        )
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=2) is False
+        assert req.bounce_dst_base is None
+
+    def test_ambiguous_owner_falls_back(self, monkeypatch):
+        t = _make_transport(
+            monkeypatch,
+            block_bytes_per_group=self.GROUP,
+            replicated_block_bytes_per_group=self.REPLICATED,
+        )
+        assert (
+            t.reserve(_recv_req([2], rid=1), num_writers=2, writer_owns_replicated=[True, True])
+            is False
+        )
+        assert (
+            t.reserve(_recv_req([2], rid=2), num_writers=2, writer_owns_replicated=[False, False])
+            is False
+        )
+        assert (
+            t.reserve(_recv_req([2], rid=3), num_writers=2, writer_owns_replicated=[True]) is False
+        )
+
+    def test_uneven_sharded_remainder_falls_back(self, monkeypatch):
+        # 1 block: 60B sharded across 3 writers is 20B each (fine); make it indivisible instead.
+        t = _make_transport(
+            monkeypatch, block_bytes_per_group=[100], replicated_block_bytes_per_group=[41]
+        )
+        req = _recv_req([1])  # 59B sharded, not divisible by 2
+        assert t.reserve(req, num_writers=2, writer_owns_replicated=[False, True]) is False
+
+    def test_no_replicated_keeps_even_split(self, monkeypatch):
+        """Models without replicated pools are unaffected: the owner list is ignored."""
+        t = _make_transport(
+            monkeypatch, block_bytes_per_group=[100], replicated_block_bytes_per_group=[0]
+        )
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=2, writer_owns_replicated=[False, True]) is True
+        key = (req.unique_rid, req.slice_id)
+        assert t.writer_region(key, 0)[1] == t.writer_region(key, 1)[1] == 100
+
+    def test_single_writer_ignores_replicated(self, monkeypatch):
+        t = _make_transport(
+            monkeypatch,
+            block_bytes_per_group=self.GROUP,
+            replicated_block_bytes_per_group=self.REPLICATED,
+        )
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=1) is True
+        assert req.bounce_dst_bytes == 200
+
+    def test_shared_pool_replicated_share_falls_back(self, monkeypatch):
+        """Nothing left to share after the replicated bytes means fall back, not empty regions.
+
+        One pool can hold views of both classes, and charging the whole slot to the replicated one
+        leaves every non-owner writer an empty sub-region -- which all alias the same address.
+        """
+        t = _make_transport(
+            monkeypatch, block_bytes_per_group=[100], replicated_block_bytes_per_group=[100]
+        )
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=2, writer_owns_replicated=[False, True]) is False
+        assert req.bounce_dst_base is None
+
+
+@pytest.mark.skipif(not _HAVE_TRANSPORT, reason="bounce.transport import needs CUDA bindings")
+class TestReplicatedBytesAreMeasuredPerView:
+    """The replicated share is a property of the view, not of the pool it lives in.
+
+    It must come from the replicated view's own buffer entries: views of both classes can share
+    one physical pool.
+    """
+
+    @staticmethod
+    def _page_table(shared_pool: bool):
+        from tensorrt_llm._torch.disaggregation.resource.page import (
+            BUFFER_ENTRY_DTYPE,
+            AttentionLayerGroup,
+            MapperKind,
+            PoolView,
+        )
+
+        def view(pool_idx, kind, sizes):
+            entries = np.array(
+                [(i, sum(sizes[:i]), s) for i, s in enumerate(sizes)], dtype=BUFFER_ENTRY_DTYPE
+            )
+            return PoolView(pool_idx=pool_idx, buffer_entries=entries, mapper_kind=kind)
+
+        kv = view(0, MapperKind.NHD, [40, 40])  # 80B of sharded key/value
+        idx = view(0 if shared_pool else 1, MapperKind.REPLICATED, [20])  # 20B of replicated
+        # Shared: one 100B slot holding both. Separate: an 80B slot and a 20B one.
+        pools = (
+            [SimpleNamespace(slot_bytes=100)]
+            if shared_pool
+            else [
+                SimpleNamespace(slot_bytes=80),
+                SimpleNamespace(slot_bytes=20),
+            ]
+        )
+        return SimpleNamespace(
+            layer_groups=[AttentionLayerGroup(pool_group_idx=0, pool_views=[kv, idx])],
+            pool_groups=[SimpleNamespace(pools=pools)],
+        )
+
+    @pytest.mark.parametrize("shared_pool", [True, False])
+    def test_replicated_share_is_the_view_not_the_pool(self, shared_pool):
+        total, replicated = btr.block_bytes_per_group(self._page_table(shared_pool))
+        # The total counts each physical pool once; the replicated share counts only its view, so
+        # sharing a pool with the sharded view must not inflate it.
+        assert total == [100]
+        assert replicated == [20]
+
+
+@pytest.mark.skipif(not _HAVE_TRANSPORT, reason="bounce.transport import needs CUDA bindings")
+class TestMultiWriterScatterIsOneBatch:
+    """A fan-in scatter must issue ONE batched copy, not one per writer.
+
+    The batched-copy metadata buffers are cached per stream and may only be refilled after a
+    sync; the scatter worker syncs once, after all writers. A copy per writer let the second
+    refill them while the first kernel was still reading, which faulted in production.
+    """
+
+    def test_all_writers_go_in_a_single_launch(self, monkeypatch):
+        from tensorrt_llm._torch.disaggregation.native.bounce import gather_scatter as gs
+
+        calls = []
+        monkeypatch.setattr(
+            gs,
+            "_launch_batched_copy",
+            lambda dst, src, sizes, stream: calls.append((dst.copy(), src.copy(), sizes.copy()))
+            or True,
+        )
+        regions = [
+            (1000, np.array([10, 20], dtype=np.int64), np.array([4, 4], dtype=np.int64)),
+            (2000, np.array([30], dtype=np.int64), np.array([8], dtype=np.int64)),
+        ]
+        gs.scatter_contiguous_multi(regions, stream=0)
+
+        assert len(calls) == 1, "one launch for the whole fan-in, else the buffers are reused"
+        dst, src, sizes = calls[0]
+        assert list(dst) == [10, 20, 30]
+        # Each region keeps its own base and its own running offsets.
+        assert list(src) == [1000, 1004, 2000]
+        assert list(sizes) == [4, 4, 8]
+
+    def test_empty_regions_are_skipped(self, monkeypatch):
+        from tensorrt_llm._torch.disaggregation.native.bounce import gather_scatter as gs
+
+        calls = []
+        monkeypatch.setattr(gs, "_launch_batched_copy", lambda *a, **k: calls.append(a) or True)
+        gs.scatter_contiguous_multi(
+            [(1000, np.array([], dtype=np.int64), np.array([], dtype=np.int64))], stream=0
+        )
+        assert calls == []
+
+
+def test_recv_req_info_tolerates_unknown_wire_keys():
+    """An unknown field from a newer peer must be dropped, not raise.
+
+    RecvReqInfo travels from the generation side to the context side; a TypeError here would
+    swallow REQUEST_DATA and hang the transfer instead of degrading.
+    """
+    tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
+    import msgpack
+
+    payload = msgpack.packb(
+        {
+            "sender_req_id": 1,
+            "instance_name": "gen",
+            "instance_rank": 0,
+            "block_ids_per_layer_groups": [np.array([1, 2], dtype=np.int64).tobytes()],
+            "unique_rid": 7,
+            "dst_start_token": None,
+            "aux_slot": None,
+            "mamba_state_index": None,
+            "slice_id": 0,
+            "bounce_dst_base": None,
+            "bounce_dst_bytes": None,
+            "a_field_from_the_future": 123,
+        }
+    )
+    info = tfr.RecvReqInfo.from_bytes(payload)
+    assert info.unique_rid == 7
+    assert not hasattr(info, "a_field_from_the_future")

--- a/tests/unittest/disaggregated/test_peer.py
+++ b/tests/unittest/disaggregated/test_peer.py
@@ -720,6 +720,57 @@ def test_replicated_pool_owner_rotates_by_destination_dp_rank(peer_dp_rank):
     assert ownership.index(True) == peer_dp_rank % 8
 
 
+@pytest.mark.parametrize("sender_tp,receiver_tp_per_dp", [(2, 1), (4, 1), (8, 1), (4, 2), (2, 2)])
+@pytest.mark.parametrize("receiver_dp_rank", [0, 1, 3])
+def test_receiver_predicts_the_same_replicated_owner_as_the_senders(
+    sender_tp, receiver_tp_per_dp, receiver_dp_rank
+):
+    """Receiver and senders must elect the same replicated-pool owner.
+
+    The receiver sizes bounce sub-regions from its own prediction, so a disagreement would hand
+    the elected sender too small a sub-region and its write would run into the next writer's.
+    """
+    page_table = make_page_table(global_layer_ids=[0])
+    page_table.layer_groups[0].pool_views[0].mapper_kind = MapperKind.REPLICATED
+
+    receiver_ri = make_rankinfo(
+        instance_name="gen",
+        tp_size=receiver_tp_per_dp * 8,
+        dp_size=8,
+        dp_rank=receiver_dp_rank,
+        enable_attention_dp=receiver_tp_per_dp == 1,
+        page_table=page_table,
+        layer_num_per_pp=[1],
+    )
+    sender_ri = make_rankinfo(
+        instance_name="ctx",
+        tp_size=sender_tp,
+        page_table=page_table,
+        layer_num_per_pp=[1],
+    )
+
+    # What each sender decides for itself.
+    overlap = PeerOverlap()
+    decided = [
+        _make_peer_registrar(
+            make_rankinfo(
+                instance_name="ctx",
+                tp_size=sender_tp,
+                tp_rank=tp_rank,
+                page_table=page_table,
+                layer_num_per_pp=[1],
+            )
+        ).should_send_pool(overlap, receiver_ri, 0, 0)
+        for tp_rank in range(sender_tp)
+    ]
+    # What the receiver predicts for those same senders.
+    predicted = _make_peer_registrar(receiver_ri).fan_in_replicated_owners(
+        sender_ri, list(range(sender_tp))
+    )
+
+    assert predicted == decided
+
+
 def test_peer_registrar_tpb_divisible_warns_but_compatible():
     # local=16, peer=32: 32 % 16 == 0 → compatible with warning, register succeeds
     self_rankinfo = make_rankinfo(instance_name="local", tokens_per_block=16)


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This pull request introduces several improvements and refactorings to the bounce buffer transport logic, mainly focusing on more accurate handling of region fragmentation, fan-in writers, and transfer sizing. The changes enhance the flexibility and correctness of region reservation, especially for complex cases involving replicated data and non-uniform writer contributions. The update also improves the efficiency of scatter operations by batching them.

**Region Reservation and Sizing Improvements**
* `VmmBounceTransport.reserve` now accepts per-layer-group fragment expansion and explicit ownership of replicated fragments, enabling more precise gating and sizing of coalesced transfers. It computes writer region sizes more accurately, especially when replicated data is involved, and adds robust fallbacks for edge cases. [[1]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L220-R312) [[2]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L265-R360)
* The `TransferContext` class now supports non-uniform writer region sizes via a new `writer_sizes` field and associated logic, allowing for flexible assignment of sub-regions to writers. [[1]](diffhunk://#diff-cf03151ea02e8744577d78b5f8de6b34e2da70f2025a021edcd20904a8a0aad4R72-R73) [[2]](diffhunk://#diff-cf03151ea02e8744577d78b5f8de6b34e2da70f2025a021edcd20904a8a0aad4R87-R95)

**API and Interface Updates**
* The `BounceTransport` interface and its implementations now use a new `writer_region` method (replacing `writer_base`), which returns both the base address and size for each writer's region. [[1]](diffhunk://#diff-cf03151ea02e8744577d78b5f8de6b34e2da70f2025a021edcd20904a8a0aad4L195-R223) [[2]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L265-R360) [[3]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L438-R507)
* The `from_config` and constructor for `VmmBounceTransport` now expect and propagate both per-group block sizes and replicated block sizes, supporting more complex memory layouts. [[1]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L42-R42) [[2]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L96-R114) [[3]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L474-R540)

**Fragmentation and Block Gate Logic**
* The region reservation logic now gates on the number of transfer fragments (not just blocks), making the coalescing heuristic more accurate for cases where blocks are split into multiple fragments. [[1]](diffhunk://#diff-ba40c1c0fad5a3f5d11f7645b69557b07d088ac9db4097b0475f6a9f1355185eL110-R110) [[2]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L220-R312)
* The base region mapper interface adds a `frags_per_block` property, clarifying how many fragments each block expands into for transfer decisions.

**Scatter Operation Optimization**
* The scatter operation is refactored to batch all regions in a single copy operation (`scatter_contiguous_multi`), improving efficiency and reducing per-stream metadata pressure. [[1]](diffhunk://#diff-b75324c18741dc41a0541f1027d2a534b25b119af628f1ac1d9b2a652e3c5c33L212-R234) [[2]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L395-R466) [[3]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L42-R42)

**Other Minor Cleanups**
* Typing and docstring improvements clarify the intent of overrides and parameters throughout the affected modules. [[1]](diffhunk://#diff-3b09827286be096e8c3d16ede01929f4129869f059acbc297a9fe70a6c041433L21-R21) [[2]](diffhunk://#diff-ba40c1c0fad5a3f5d11f7645b69557b07d088ac9db4097b0475f6a9f1355185eL26-R26)

These changes collectively improve the robustness, efficiency, and clarity of the bounce buffer transport system, especially for advanced use cases involving multiple writers and heterogeneous memory layouts.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->