### PR TITLE
[TRTLLM-14808][fix] MNNVL partial-allocation cleanup and warmup compile fix

### DIFF
--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -323,14 +323,14 @@ class MnnvlMemory:
             for rank_ptr in reversed(mapped_rank_ptrs):
                 try:
                     _check_cu_result(cuda.cuMemUnmap(rank_ptr, aligned_size))
-                except Exception as e:
+                except RuntimeError as e:
                     logger.warning("cuMemUnmap failed during error cleanup: %s", e)
             for mem_handle in mem_handles:
                 if mem_handle is None:
                     continue
                 try:
                     _check_cu_result(cuda.cuMemRelease(mem_handle))
-                except Exception as e:
+                except RuntimeError as e:
                     logger.warning("cuMemRelease failed during error cleanup: %s", e)
             if reserved_new_address:
                 try:
@@ -338,7 +338,7 @@ class MnnvlMemory:
                     _check_cu_result(
                         cuda.cuMemAddressFree(device_ptr, comm_size * cls.current_rank_stride)
                     )
-                except Exception as e:
+                except RuntimeError as e:
                     logger.warning("cuMemAddressFree failed during error cleanup: %s", e)
                 else:
                     (

--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -202,7 +202,13 @@ class MnnvlMemory:
         granularity = MnnvlMemory.get_allocation_granularity(dev_id)
         aligned_size = (size + granularity - 1) // granularity * granularity
 
-        if cls.current_mem_offset + aligned_size > cls.current_rank_stride:
+        previous_address_state = (
+            cls.current_start_address,
+            cls.current_rank_stride,
+            cls.current_mem_offset,
+        )
+        reserved_new_address = cls.current_mem_offset + aligned_size > cls.current_rank_stride
+        if reserved_new_address:
             cls.new_mnnvl_memory_address(mapping, aligned_size)
 
         assert cls.current_mem_offset + aligned_size <= cls.current_rank_stride
@@ -292,26 +298,55 @@ class MnnvlMemory:
         madesc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
 
         mem_handles = [None] * comm_size
+        mem_handles[comm_rank] = allocated_mem_handle
+        mapped_rank_ptrs = []
 
-        for i, remote_handle_data in enumerate(all_handles_data):
-            rank_ptr = (
-                cls.current_start_address + cls.current_rank_stride * i + cls.current_mem_offset
-            )
-            if i == comm_rank:
-                # Local memory mapping
-                mem_handles[i] = allocated_mem_handle
-                _check_cu_result(cuda.cuMemMap(rank_ptr, aligned_size, 0, allocated_mem_handle, 0))
-            else:
-                # Fabric memory mapping
-                imported_mem_handle = _check_cu_result(
-                    cuda.cuMemImportFromShareableHandle(
-                        remote_handle_data, allocation_prop.requestedHandleTypes
-                    )
+        try:
+            for i, remote_handle_data in enumerate(all_handles_data):
+                rank_ptr = (
+                    cls.current_start_address + cls.current_rank_stride * i + cls.current_mem_offset
                 )
-                mem_handles[i] = imported_mem_handle
-                _check_cu_result(cuda.cuMemMap(rank_ptr, aligned_size, 0, imported_mem_handle, 0))
+                if i != comm_rank:
+                    # Fabric memory mapping
+                    mem_handles[i] = _check_cu_result(
+                        cuda.cuMemImportFromShareableHandle(
+                            remote_handle_data, allocation_prop.requestedHandleTypes
+                        )
+                    )
 
-            _check_cu_result(cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1))
+                _check_cu_result(cuda.cuMemMap(rank_ptr, aligned_size, 0, mem_handles[i], 0))
+                mapped_rank_ptrs.append(rank_ptr)
+                _check_cu_result(cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1))
+        except Exception:
+            # Clean up partially imported and mapped memory before propagating
+            # the failure to the caller.
+            for rank_ptr in reversed(mapped_rank_ptrs):
+                try:
+                    _check_cu_result(cuda.cuMemUnmap(rank_ptr, aligned_size))
+                except Exception as e:
+                    logger.warning("cuMemUnmap failed during error cleanup: %s", e)
+            for mem_handle in mem_handles:
+                if mem_handle is None:
+                    continue
+                try:
+                    _check_cu_result(cuda.cuMemRelease(mem_handle))
+                except Exception as e:
+                    logger.warning("cuMemRelease failed during error cleanup: %s", e)
+            if reserved_new_address:
+                try:
+                    device_ptr = cuda.CUdeviceptr(cls.current_start_address)
+                    _check_cu_result(
+                        cuda.cuMemAddressFree(device_ptr, comm_size * cls.current_rank_stride)
+                    )
+                except Exception as e:
+                    logger.warning("cuMemAddressFree failed during error cleanup: %s", e)
+                else:
+                    (
+                        cls.current_start_address,
+                        cls.current_rank_stride,
+                        cls.current_mem_offset,
+                    ) = previous_address_state
+            raise
 
         ptr = cls.current_start_address + cls.current_mem_offset
         stride = cls.current_rank_stride

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1483,7 +1483,7 @@ class PyTorchModelEngine(ModelEngine):
 
         model_type = getattr(self.model.model_config.pretrained_config,
                              "model_type", None)
-        if model_type in ("kimi_k3", "kimi_linear"):
+        if can_run_general_warmup and model_type in ("kimi_k3", "kimi_linear"):
             # Kimi's one-token context takes the NT < 4 FLA fallback and does
             # not compile the optimized single-sequence K123 variant. A
             # non-aligned five-chunk context enters the pure K123 path.

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1481,6 +1481,17 @@ class PyTorchModelEngine(ModelEngine):
         else:
             logger.debug("Skipped TRTLLM-Gen FMHA JIT warmup for Ctx kernels")
 
+        model_type = getattr(self.model.model_config.pretrained_config,
+                             "model_type", None)
+        if model_type in ("kimi_k3", "kimi_linear"):
+            # Kimi's one-token context takes the NT < 4 FLA fallback and does
+            # not compile the optimized single-sequence K123 variant. A
+            # non-aligned five-chunk context enters the pure K123 path.
+            _KIMI_KDA_PREFILL_WARMUP_TOKENS = 257
+            logger.info("Adding Kimi KDA pure-prefill warmup with "
+                        f"{_KIMI_KDA_PREFILL_WARMUP_TOKENS} context tokens")
+            warmup_requests_configs.append((_KIMI_KDA_PREFILL_WARMUP_TOKENS, 0))
+
         for num_tokens, num_gen_requests in warmup_requests_configs:
             warmup_request = self._create_warmup_request(
                 resource_manager,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Tightened MNNVL partial-allocation cleanup during cross-rank handle import/mapping: cleanup now catches only expected `RuntimeError` failures, logs cleanup errors without masking the original exception, and restores the prior address state.
- Added a 257-token pure-prefill warmup for `kimi_k3` / `kimi_linear` models to compile the optimized K123 variant, gated by `can_run_general_warmup`.
- No configuration or public API changes.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Ports commit `46289149ba` from `feat/kimi_k3` to `main` (JIRA: TRTLLM-14808). Two fixes found during Kimi K3 bring-up; this is part of the feat/kimi_k3 -> main staging plan (Wave A).

**1. MNNVL partial-allocation cleanup (`tensorrt_llm/_mnnvl_utils.py`)**

`MnnvlMemory.open_mnnvl_memory` previously leaked resources if the import/map/set-access loop failed partway (e.g. `cuMemImportFromShareableHandle` failing for one remote rank): already-mapped ranges stayed mapped, the local and previously-imported handles were never released, and a freshly reserved VA range was leaked while the class address state pointed at the poisoned range. The loop is now wrapped so that on failure we:
- unmap every range mapped so far (in reverse order),
- release the local allocation handle and all successfully imported handles,
- if a new VA range was reserved for this allocation, free it and roll `current_start_address/current_rank_stride/current_mem_offset` back to the previous state,
- then re-raise the original exception. Cleanup steps are best-effort (logged warnings) so they cannot mask the original error.

**2. Warmup compile fix (`tensorrt_llm/_torch/pyexecutor/model_engine.py`)**

For Kimi KDA models (`model_type` in `kimi_k3`/`kimi_linear`), a one-token context warmup takes the NT < 4 FLA fallback and never compiles the optimized single-sequence K123 torch.compile variant, causing a pathological recompilation at the start of long evaluations. Warmup now adds a 257-token pure-prefill request (non-chunk-aligned, five chunks) that enters the pure K123 path. This hunk is guarded by `model_type` and is inert on `main` until the Kimi K3 model definition lands (later wave of the staging plan).

## Test Coverage

**Multi-node hardware validation** (run after the initial review, closing the gap noted below): two nodes in a single NVLink domain, 8 ranks, FABRIC handle path. Failure was injected into `cuMemImportFromShareableHandle` partway through the import/map loop — after at least one range is already mapped, and after all `allgather` collectives, so ranks stay in step. Each scenario then requires that a *subsequent* allocation still succeeds and that every rank's slice is readable from every other rank.

| Scenario | With this change | Without it (control) |
|---|---|---|
| Failing allocation reserved a new VA range | Exception propagates; address state rolled back to the pre-call values; retry allocates 512 MB; all 8 ranks' data verifies | Address state left pointing at the poisoned range (stride 512 MB, offset 0); retry fails with `CUDA_ERROR_INVALID_VALUE` |
| Failing allocation reused an existing VA range | Exception propagates; address state untouched; retry allocates 128 MB; all 8 ranks' data verifies | Retry fails with `CUDA_ERROR_INVALID_VALUE` — the partial mappings survive and the next `cuMemMap` hits already-mapped addresses |

The control is the pre-change file from this PR's merge base, run on the same hardware in the same job, and it reproduces the leak in both scenarios — so the passing cases are attributable to this change rather than to the environment.

Success path on the same setup: unaligned 4 MB, 30 MB, then 768 MB allocations, with offset bookkeeping asserted after each, `rank_stride == 1 GiB` after the large allocation, and cross-rank reads verified for all three.

Other validation:

- Mock-harness unit test of `MnnvlMemory.open_mnnvl_memory` (cuda driver / MPI comm / torch stubbed, FABRIC handle path, 4 ranks): success path bookkeeping, mid-loop import failure with fresh VA reservation (verifies reverse-order unmap, release of local + imported handles, VA free + address-state rollback), failure on a reused VA range (verifies the range is NOT freed and offset is untouched), and cleanup-failure-does-not-mask-original-error. All 4 pass on this branch; as a control, the 3 failure-path tests fail on unpatched `main`.
- `pre-commit run` (isort, yapf, ruff, ruff-format, codespell, etc.) passes on both files; `py_compile` clean.
- Still not validated here: the Kimi warmup path, which is inert on `main` (no `kimi_k3`/`kimi_linear` model type exists on `main` yet). It was exercised on multi-node hardware during Kimi K3 bring-up on `feat/kimi_k3`.

**Correction to an earlier claim in this description, and a finding worth flagging separately:** I previously wrote that `tests/unittest/_torch/multi_gpu/test_mnnvl_memory.py` covers the success path on MNNVL-capable runners. That is not currently true, for a reason unrelated to this PR. The test builds `Mapping(world_size, rank, gpus_per_node, tp_size=world_size)`, leaving `moe_tp_size` at its `-1` default, which resolves to `world_size`. `MnnvlMemory.get_comm` splits on `(pp_rank * cp_size + cp_rank) * moe_tp_size + moe_tp_rank`, so that color reduces to the global rank and every rank ends up in a singleton communicator; the strided tensor then has one segment and the test raises `IndexError` at line 68 for every rank > 0. I confirmed this on the hardware above — it fails identically with and without this PR's change, before reaching any of the modified code. The file is not referenced by any list under `tests/integration/test_lists/test-db/`, which is consistent with it not being exercised. This PR does not modify it and does not add it to any list; flagging it for whoever owns that test.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

