### PR TITLE
[TRTLLM-14810][chore] Pre-flight: sync sa_worker.py with main (#16759); require packaging>=24.2

### DIFF
--- a/docs/source/deployment-guide/deployment-guide-for-kimi-k3-on-trtllm.md
+++ b/docs/source/deployment-guide/deployment-guide-for-kimi-k3-on-trtllm.md
@@ -56,13 +56,12 @@ Kimi K3 additionally depends on `fla` and `einops`, installed into the same in-p
 To use the optimized CuTeDSL MLA kernel, install the FlashInfer revision used by the Kimi K3 example into the same in-place environment:
 
 ```bash
-.venv-3.12/bin/python -m pip install -U 'packaging>=24.2'  # required by the FlashInfer source build
 .venv-3.12/bin/python -u -m pip install --force-reinstall --no-deps \
     --no-build-isolation \
     "flashinfer-python[cu13] @ git+https://github.com/PerkzZheng/flashinfer-k3.git@b6cc594918baf76c40c3a6236fd53f0f8fb9d2dc"
 ```
 
-The TensorRT LLM environment already provides FlashInfer's runtime dependencies. The `--no-deps` option prevents `pip` from replacing the pinned PyTorch, Triton, CUDA, and CuTeDSL packages. Install FlashInfer after TensorRT LLM because a later dependency-resolving TensorRT LLM installation can replace this source revision with the currently pinned `flashinfer-python==0.6.14`.
+The `packaging>=24.2` requirement of this source build is already satisfied by `requirements.txt`. The TensorRT LLM environment already provides FlashInfer's runtime dependencies. The `--no-deps` option prevents `pip` from replacing the pinned PyTorch, Triton, CUDA, and CuTeDSL packages. Install FlashInfer after TensorRT LLM because a later dependency-resolving TensorRT LLM installation can replace this source revision with the currently pinned `flashinfer-python==0.6.14`.
 
 For general build-from-source instructions see [https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source.html](https://nvidia.github.io/TensorRT-LLM/latest/installation/build-from-source.html).
 

--- a/examples/kimi_k3/README.md
+++ b/examples/kimi_k3/README.md
@@ -41,13 +41,14 @@ other GPU architectures may be added in a future release.
   revision into the same in-place environment after installing TensorRT-LLM:
 
   ```bash
-  .venv-3.12/bin/python -m pip install -U 'packaging>=24.2'  # required by the FlashInfer source build
   .venv-3.12/bin/python -u -m pip install --force-reinstall --no-deps \
       --no-build-isolation \
       "flashinfer-python[cu13] @ git+https://github.com/PerkzZheng/flashinfer-k3.git@b6cc594918baf76c40c3a6236fd53f0f8fb9d2dc"
   ```
 
-  The TensorRT-LLM environment already provides FlashInfer's runtime
+  The `packaging>=24.2` requirement of this source build is already
+  satisfied by `requirements.txt`. The TensorRT-LLM environment already
+  provides FlashInfer's runtime
   dependencies; `--no-deps` prevents pip from replacing its pinned PyTorch,
   Triton, CUDA, and CuTeDSL packages. Install FlashInfer last: TensorRT-LLM
   currently pins `flashinfer-python==0.6.14`, so a later

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,8 @@ fastapi>=0.120.1,<=0.121.3
 starlette>=0.49.1
 uvicorn
 setuptools<80
+# FlashInfer source builds (--no-build-isolation) need packaging>=24.2 for setuptools license-expression validation
+packaging>=24.2
 ordered-set
 peft>=0.18.1,<0.19.0
 patchelf

--- a/tensorrt_llm/_torch/speculative/sa_worker.py
+++ b/tensorrt_llm/_torch/speculative/sa_worker.py
@@ -188,9 +188,7 @@ class SAWorker(SpecWorkerBase):
         # one-engine workers (dflash/eagle3); no-op for pure-attention
         # models via the isinstance gate.
         num_gens = batch_size - num_contexts
-        if num_gens > 0 and isinstance(
-            attn_metadata.kv_cache_manager, MambaHybridCacheManager
-        ):
+        if num_gens > 0 and isinstance(attn_metadata.kv_cache_manager, MambaHybridCacheManager):
             attn_metadata.kv_cache_manager.update_mamba_states(
                 attn_metadata=attn_metadata,
                 num_accepted_tokens=num_accepted_tokens,


### PR DESCRIPTION
## Description

Pre-flight change to shrink the conflict surface of the upcoming `main` -> `feat/kimi_k3` catch-up merge (TRTLLM-14810). Two independent commits:

1. **Sync `tensorrt_llm/_torch/speculative/sa_worker.py` with `main`.** Main PR #16759 upstreamed this branch's SA in-worker hybrid-state promotion verbatim, so the file contents now match `main` except for one line. Verification of the base-class interface on this branch: `SpecWorkerBase` here does not yet carry main's #16382 exception-safe `forward` wrapper (there is no `_forward_impl` anywhere in `tensorrt_llm/_torch/speculative/` on this branch, and workers are invoked through `nn.Module.__call__` -> `forward`). The method therefore stays named `forward` here; renaming it would leave the worker uncalled. This is the single intentional residual delta vs `main`'s copy of the file — the catch-up merge finishes the rename when it brings in #16382.

2. **Require `packaging>=24.2` in `requirements.txt`** (mirrors #17075: FlashInfer source builds with `--no-build-isolation` need it for setuptools license-expression validation), and drop the now-redundant manual `pip install -U 'packaging>=24.2'` workaround step from `examples/kimi_k3/README.md` and the Kimi K3 deployment guide, replaced by a note that `requirements.txt` already satisfies it.

## Test Coverage

Validated on Blackwell hardware at the tip of this branch with both commits applied (python-only changes validated against prebuilt binaries):

- KDA/SA unit suites: `tests/unittest/_torch/modeling/test_kda_mtp_decode_cute_parity.py`, `test_kimi_kda_fused_verify_parity.py`, `test_kimi_kda_verify_parity.py`, `tests/unittest/_torch/modules/kimi_kda/`, `tests/unittest/_torch/modules/moe/test_kimi_k3_situ_moe.py`, `tests/torch/speculative/test_suffix_automaton.py` — all green.
- SA-vs-baseline logits-parity integration run (4 GPUs, truncated-layer checkpoint, `tests/integration/defs/kimi_k3_sa_harness.py`) — the decisive gate for the sa_worker change; no logits drift.
- End-to-end 16-GPU serving smoke (`examples/kimi_k3/quick_start_kimi_k3.sbatch`), standard and `--enable-block-reuse` variants — all expected-text checks pass.
- Disaggregated-serving suites: `tests/unittest/disaggregated/test_bounce.py`, `tests/unittest/disaggregated/test_kda_mamba_transfer.py`, `tests/unittest/_torch/speculative/hw_agnostic/test_sa.py`, plus the TinyLlama ctx/gen/proxy-vs-aggregated parity smoke (`tests/integration/defs/kimi_k3_disagg_parity.py`) — all pass. Note: the parity smoke was initially blocked by a dependency-artifact incompatibility unrelated to this change (the test environment carried a newer `flashinfer-python` than this branch's `==0.6.14` pin, tripping a kernel-signature mismatch in the attention decode path); rerunning with the pinned version restored it, and the smoke passes with this PR applied.

## PR Checklist

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.
