### PR TITLE
[None][fix] Pin kimiK3AttnRes to the sm_100 family

### DIFF
--- a/cpp/tensorrt_llm/kernels/kimiK3AttnRes/CMakeLists.txt
+++ b/cpp/tensorrt_llm/kernels/kimiK3AttnRes/CMakeLists.txt
@@ -15,6 +15,15 @@
 
 add_library(kimi_k3_attn_res_src OBJECT attnResFwd.cu)
 
+# The kernel is warp-specialized for the SM100 (datacenter Blackwell) family and
+# uses tcgen05/TMEM PTX instructions that ptxas rejects for other architectures
+# (e.g. sm_120f), so pin the target to the sm_100 family instead of inheriting
+# the global architecture list. On builds without any sm_100-family architecture
+# the target still compiles (the tcgen05 code paths are guarded by
+# __CUDA_ARCH__), and the Torch-op bridge rejects unsupported devices at
+# runtime.
+set_cuda_architectures(kimi_k3_attn_res_src 100f)
+
 set_property(TARGET kimi_k3_attn_res_src PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET kimi_k3_attn_res_src PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS
                                                   ON)

--- a/cpp/tensorrt_llm/thop/attnResOp.cpp
+++ b/cpp/tensorrt_llm/thop/attnResOp.cpp
@@ -33,7 +33,7 @@ namespace torch_ext
 namespace
 {
 
-bool is_sm100_or_later()
+bool is_sm100_family()
 {
     int dev = 0;
     cudaGetDevice(&dev);
@@ -44,7 +44,10 @@ bool is_sm100_or_later()
     }
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, dev);
-    bool const ok = prop.major >= 10;
+    // The kernel binary is compiled for the sm_100 family only (it relies on
+    // tcgen05/TMEM, which later architectures such as sm_120 do not support),
+    // so require compute capability major == 10 rather than >= 10.
+    bool const ok = prop.major == 10;
     if (dev >= 0 && dev < 64)
     {
         cached_state[dev] = ok ? 2 : 1;
@@ -54,7 +57,7 @@ bool is_sm100_or_later()
 
 void check_attn_res_contract(int N, int T, int B, int H)
 {
-    TORCH_CHECK(is_sm100_or_later(), "attn_res_fwd requires sm_100 (Blackwell) or later");
+    TORCH_CHECK(is_sm100_family(), "attn_res_fwd requires an sm_100-family (datacenter Blackwell) GPU");
     TORCH_CHECK(B == 1, "attn_res_fwd: unsupported B=", B, " (only B=1 is supported)");
     TORCH_CHECK(N >= 1 && N <= 12, "attn_res_fwd: unsupported N=", N, " (must be in [1, 12])");
     TORCH_CHECK(T >= 1 && T <= 16384, "attn_res_fwd: unsupported T=", T, " (must be in [1, 16384])");
@@ -62,8 +65,8 @@ void check_attn_res_contract(int N, int T, int B, int H)
         " (must be a multiple of 1024 in [4096, 8192])");
 }
 
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> attn_res_fwd(at::Tensor layer_residual,
-    at::Tensor block_residual, at::Tensor res_weight, at::Tensor rms_weight, double rms_eps)
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> attn_res_fwd(
+    at::Tensor layer_residual, at::Tensor block_residual, at::Tensor res_weight, at::Tensor rms_weight, double rms_eps)
 {
     TORCH_CHECK(layer_residual.dim() == 3, "attn_res_fwd: layer_residual must be [T, B, H]");
     TORCH_CHECK(block_residual.dim() == 4, "attn_res_fwd: block_residual must be [K, T, B, H]");
@@ -96,8 +99,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> attn_res_fwd(at::Tens
     auto logits = at::empty({N, T, B}, float_options);
 
     kernels::kimiK3AttnRes::AttnResFwdParams params{};
-    params.blockResidual
-        = N > 1 ? reinterpret_cast<__nv_bfloat16 const*>(block_residual.const_data_ptr()) : nullptr;
+    params.blockResidual = N > 1 ? reinterpret_cast<__nv_bfloat16 const*>(block_residual.const_data_ptr()) : nullptr;
     params.layerResidual = reinterpret_cast<__nv_bfloat16 const*>(layer_residual.const_data_ptr());
     params.resWeight = reinterpret_cast<__nv_bfloat16 const*>(res_weight.const_data_ptr());
     params.rmsWeight = reinterpret_cast<__nv_bfloat16 const*>(rms_weight.const_data_ptr());


### PR DESCRIPTION
@coderabbitai summary

## Description

The x86_64 wheel build fails for any build whose CUDA architecture list includes `sm_120f`:

```
ptxas ... error : Instruction 'tcgen05.st' not supported on .target 'sm_120f'
ptxas ... error : Feature '.32x32b' not supported on .target 'sm_120f'
```

`cpp/tensorrt_llm/kernels/kimiK3AttnRes/attnResFwd.cu` is warp-specialized for the sm_100 (datacenter Blackwell) family and uses `tcgen05`/TMEM PTX. Its code paths are guarded with `__CUDA_ARCH__ >= 1000`, which also admits sm_120 (`__CUDA_ARCH__ == 1200`), so those instructions are emitted for an architecture that does not support them. Because the object target inherited the global architecture list rather than declaring its own, every build containing sm_120f hit this. Architectures below sm_100 were unaffected: the guards exclude the tcgen05 paths entirely, so the helpers are never emitted.

This blocks the build for all pull requests targeting `feat/kimi_k3`.

Two changes:

1. `cpp/tensorrt_llm/kernels/kimiK3AttnRes/CMakeLists.txt` — pin the object target with `set_cuda_architectures(kimi_k3_attn_res_src 100f)`, the same mechanism other architecture-specific kernel targets use (for example `fp4_gemm_src`, `marlin_src`). On a build with no sm_100-family architecture the helper falls back to its placeholder path, which is safe here because the guards already exclude the tcgen05 code.
2. `cpp/tensorrt_llm/thop/attnResOp.cpp` — the kernel binary now exists only for the sm_100 family, so the capability check requires compute capability major `== 10` rather than `>= 10`. An sm_120 device now gets a clear `TORCH_CHECK` message instead of a missing-kernel-image launch failure. The helper is renamed `is_sm100_family()` to match its meaning.

## Test Coverage

Compiled `attnResFwd.cu` directly with CUDA 13.2 across an architecture matrix, before and after the change:

| Architecture | Result | Notes |
|---|---|---|
| `sm_80` | compiles | tcgen05 paths excluded by the existing guards |
| `sm_90` | compiles | as above |
| `sm_100f` | compiles | the family this kernel targets, and the one now pinned |
| `sm_120f` | fails (`tcgen05.st` / `.32x32b` rejected) | reproduces the reported build failure; this architecture is no longer requested for the target after the change |

The compile matrix was run on an aarch64 host; device-side PTX generation and `ptxas` validation are independent of the host architecture, so this reproduces the failure seen in x86_64 builds. The CI build on this PR exercises the full x86_64 wheel path.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.
