### PR TITLE
[None][infra] Place CodeRabbit summary in the walkthrough instead of the PR description

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,6 +22,10 @@ reviews:
   auto_title_placeholder: '@coderabbitai title'
   auto_title_instructions: 'Format: "[<category>] <title>". Category must be one of: fix, feat, doc, infra, style, refactor, perf, test, chore, revert. Enclose the category in square brackets. Title should be concise (<= 60 chars). Example: "[feat] Add logit_bias support".'
   commit_status: false
+  # Post the high-level summary in the walkthrough comment instead of writing it
+  # into the PR description, so author-written description text is never replaced
+  # or pushed down by generated content.
+  high_level_summary_in_walkthrough: true
   high_level_summary_instructions: |
     Always produce two review sections in the summary:
 


### PR DESCRIPTION
> **Draft / discussion starter.** Opening this as a draft to get agreement on the behavior change before it lands. Not requesting CI.

## Description

One-line change to `.coderabbit.yaml`: set `reviews.high_level_summary_in_walkthrough: true` so CodeRabbit's high-level summary is posted in its walkthrough comment instead of being written into the PR description.

### Current behavior

CodeRabbit writes its high-level summary into the **PR description**:

- If the description contains the `high_level_summary_placeholder` (default `@coderabbitai summary`), CodeRabbit replaces that placeholder with the generated summary. Our `.github/pull_request_template.md` puts `@coderabbitai summary` on the very first line, so every PR opened from the template gets this substitution.
- If the placeholder is absent, CodeRabbit appends the summary to the description.

Documented in the [CodeRabbit configuration reference](https://docs.coderabbit.ai/reference/configuration):

- `high_level_summary` (boolean, default `true`) — "Generate a high-level summary of the changes in the PR description or walkthrough."
- `high_level_summary_placeholder` (string, default `"@coderabbitai summary"`) — "Placeholder in the PR description that CodeRabbit replaces with the high-level summary."
- `high_level_summary_instructions` — "By default, CodeRabbit generates release notes **in the description**. ... Note: Use `high_level_summary_in_walkthrough` to place the summary in the walkthrough instead of the description."
- `high_level_summary_in_walkthrough` (boolean, default `false`) — "Include the high-level summary in the walkthrough comment."

The net effect is that the PR description is a surface that generated content writes to, and it is rewritten on subsequent updates.

### Why it matters

Authors routinely put load-bearing, non-obvious context in the PR description — things a generated diff summary cannot reconstruct because they are not visible in the diff. Common examples:

- "This code path is inert until <dependency> lands" / "feature is off by default, wired up in a follow-up."
- Known limitations and deliberate scope cuts ("does not handle X yet, tracked separately").
- Test-evidence caveats ("validated on <hardware> only", "perf numbers from a single run, not a full sweep").
- Explicit reviewer instructions ("please look closely at the locking in file Y").

When the description is regenerated or when generated content is inserted above it, these notes can be replaced or pushed far enough down that reviewers do not read them. That is a correctness risk for review, not just a cosmetic one: a reviewer who misses "this is inert until X lands" reviews the change under the wrong assumptions.

### Proposed change

```yaml
reviews:
  high_level_summary_in_walkthrough: true
```

- The PR description stays exactly as the author wrote it.
- The summary — including the full **Dev Engineer Review** and **QA Engineer Review** sections configured in `high_level_summary_instructions` — still gets generated and posted, just in the walkthrough comment.
- `high_level_summary_instructions` is intentionally left untouched. This PR is about *where* the summary lands, not *what* it contains.
- Our config already has `collapse_walkthrough: false`, so the walkthrough renders expanded rather than hidden behind a disclosure triangle.

## Trade-offs and open questions for reviewers

These are the reasons this is a draft rather than a merge request. Input welcome on all of them.

1. **The description no longer carries a generated overview at a glance.** Anyone who skims the description to understand a PR would need to scroll to the walkthrough comment. For large PRs from authors who write thin descriptions, this is a real loss. Counter-argument: a thin author description is itself signal, and the template's checklist already asks for "PR description clearly explains what and why."

2. **The PR template needs a companion edit.** `.github/pull_request_template.md` currently opens with a literal `@coderabbitai summary` line. With this change, that placeholder would no longer be substituted, so the string would sit unreplaced at the top of every PR description. I deliberately did **not** change the template in this PR so the behavior question can be decided first — but if we take this change, the template line should be removed (or replaced with a short "CodeRabbit's summary is posted in the walkthrough comment below" note) in the same PR before merge. Please say which you prefer and I will fold it in.

3. **Repo-wide behavior change.** This affects every contributor and every PR, including external contributors who may be used to the current behavior from the template. It is trivially revertible (one boolean), but it is not opt-in per PR.

4. **`auto_title_placeholder` is out of scope.** The config also sets `auto_title_placeholder: '@coderabbitai title'`, which lets authors opt into a generated *title*. That is opt-in per PR (you have to type the token into the title) and does not overwrite author-written prose, so I am not proposing to change it here.

5. **The alternative is to do nothing** and rely on convention: ask authors to put durable notes in a PR comment rather than the description, or to keep them below the summary placeholder. That costs nothing to implement but depends on every author remembering, and comments get buried by review activity too.

## Test Coverage

No code change; this is a CI/review-tooling configuration change with no automated test surface. Verification performed:

- `high_level_summary_in_walkthrough` confirmed present as a `boolean` with default `false` under `reviews` in the schema pinned by this file (`https://coderabbit.ai/integrations/schema.v2.json`), and in the public configuration reference linked above.
- The edited `.coderabbit.yaml` parses as YAML and validates against that pinned schema.
- `pre-commit run --files .coderabbit.yaml` passes.
- Behavior in practice will be observable on this PR itself: if the change were active, the summary would appear in the walkthrough comment and this description would remain untouched. Note that CodeRabbit reads `.coderabbit.yaml` from the base branch, so this PR will still exhibit the current behavior.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
