### PR TITLE
[None][perf] Deduplicate plan builds for MinimaxM3 in eager mode

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/fmha/msa_sparse_gqa.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/msa_sparse_gqa.py
@@ -217,11 +217,14 @@ class MsaSparseGqaFmha(Fmha):
         # dense layers leave the indices None and attend the full page table
         # with the dense plan.
         kv_block_indexes = forward_args.sparse_prediction.sparse_attn_indices
-        plan = (
-            metadata.msa_decode_gqa_plan
-            if kv_block_indexes is not None
-            else metadata.msa_decode_dense_plan
-        )
+        if kv_block_indexes is not None:
+            plan = metadata.msa_decode_gqa_plan
+            if plan is None:
+                plan = getattr(metadata, "msa_eager_gqa_plan", None)
+        else:
+            plan = metadata.msa_decode_dense_plan
+            if plan is None:
+                plan = getattr(metadata, "msa_eager_dense_plan", None)
         run_msa_paged_gqa(
             self.attn,
             q,

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
@@ -218,8 +218,9 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
     Length inputs to fmha_sm100_plan (msa_qo_lens_cpu, msa_kv_lens_cpu,
     msa_qo_offset_cpu) are host properties of the base seq_lens/kv_lens,
     read only while building plans in prepare() (outside capture), so they
-    need no graph-stable storage. Plans are built in _build_decode_plans and
-    are absent for prefill/mixed batches, which run eagerly.
+    need no graph-stable storage. Plans are built in _build_step_plans:
+    pure-decode batches use the graph-safe owners (msa_decode_*_plan) while
+    prefill/mixed batches keep plain eager tuples (msa_eager_*_plan).
     """
 
     # Graph-stable buffers; consumers slice to the live count at the call
@@ -241,6 +242,12 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
     _msa_proxy_plan: Optional["_MsaGraphSafePlan"] = None
     _msa_gqa_plan: Optional["_MsaGraphSafePlan"] = None
     _msa_dense_plan: Optional["_MsaGraphSafePlan"] = None
+    # Eager (prefill/mixed) plans, plain tuples with no graph-stable buffers
+    # since prefill runs eagerly and is never CUDA-graph captured. Built once
+    # per step in prepare() and reused by every layer.
+    _msa_eager_proxy_plan: Optional[tuple] = None
+    _msa_eager_gqa_plan: Optional[tuple] = None
+    _msa_eager_dense_plan: Optional[tuple] = None
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -292,6 +299,43 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
         """Dense GQA plan tuple, shared by dense layers 0 to 2."""
         plan = self._msa_dense_plan
         return plan.plan if plan is not None else None
+
+    @property
+    def msa_eager_proxy_plan(self) -> Optional[tuple]:
+        """Prebuilt indexer proxy plan for the eager (prefill/mixed) path."""
+        return self._msa_eager_proxy_plan
+
+    @property
+    def msa_eager_gqa_plan(self) -> Optional[tuple]:
+        """Prebuilt sparse GQA plan for the eager (prefill/mixed) path."""
+        return self._msa_eager_gqa_plan
+
+    @property
+    def msa_eager_dense_plan(self) -> Optional[tuple]:
+        """Prebuilt dense GQA plan for the eager (prefill/mixed) path."""
+        return self._msa_eager_dense_plan
+
+    def _msa_main_kv_is_fp8(self) -> bool:
+        """Whether the main paged K/V cache is stored as FP8 E4M3.
+
+        The eager GQA and dense plans must pass use_fp8_kvcache so the inline
+        sparse-prefill path selects the FP8 AOT kernels; it is a no-op for the
+        decode planner. Mirrors the k_paged.dtype check in run_msa_paged_gqa.
+        """
+        kv_cache_manager = self.kv_cache_manager
+        if kv_cache_manager is None:
+            return False
+        try:
+            buffers = kv_cache_manager.get_buffers(0, kv_layout="HND")
+        except TypeError:
+            buffers = kv_cache_manager.get_buffers(0)
+        except Exception:
+            return False
+
+        try:
+            return buffers[:, 0].dtype == torch.float8_e4m3fn
+        except Exception:
+            return False
 
     def _create_msa_buffers(self) -> None:
         """Allocate the CUDA-graph-stable MSA device buffers.
@@ -423,26 +467,33 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
     def prepare(self) -> None:
         super().prepare()
         self._build_msa_fields()
-        self._build_decode_plans()
+        self._build_step_plans()
 
-    def _build_decode_plans(self) -> None:
-        """Build the graph-safe decode plans and buffers for this step.
+    def _build_step_plans(self) -> None:
+        """Build the three layer-invariant fmha_sm100 plans once per step.
 
-        Runs in prepare(), outside CUDA graph capture. The plans are
-        layer-invariant for MiniMax-M3, so they are built once per step from
-        the shared sparse geometry, mirrored into CUDA-graph-stable buffers,
-        and reused by every layer. Mirrors FlashInfer's plan() split.
-        Prefill/mixed batches leave the plans cleared and run eagerly.
+        Runs in prepare(), outside CUDA graph capture. The proxy, GQA, and
+        dense plans depend only on the per-step sparse geometry (qo/kv lengths,
+        head counts, topk, page size), never on the layer, so they are built
+        once here and reused by every layer:
+
+        * Pure-decode batches mirror the plans into the CUDA-graph-stable
+          _MsaGraphSafePlan buffers (surfaced by msa_decode_*_plan), because
+          decode is captured and the plan worklists must keep a fixed address
+          across replays.
+        * Prefill, chunked-prefill, and mixed batches run eagerly (never
+          captured), so the plans are stored as plain tuples (msa_eager_*_plan)
+          that every sparse and dense layer reuses.
         """
-        # Drop any plan tuples from the previous step; the msa_decode_*_plan
-        # properties then report None until they are rebuilt below.
+        # Drop any plan tuples from the previous step; the msa_decode_*_plan and
+        # msa_eager_*_plan properties then report None until rebuilt below.
         for plan in (self._msa_proxy_plan, self._msa_gqa_plan, self._msa_dense_plan):
             if plan is not None:
                 plan.reset()
+        self._msa_eager_proxy_plan = None
+        self._msa_eager_gqa_plan = None
+        self._msa_eager_dense_plan = None
         if not self._msa_fields_ready:
-            return
-        # A decode batch is pure generation (no context requests).
-        if int(self.num_contexts or 0) > 0:
             return
         # Geometry is captured in __post_init__; skip when it is unavailable.
         params = self._msa_params
@@ -463,6 +514,14 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
         page_size = int(self.kv_cache_manager.tokens_per_block)
         capture_graph = self.is_cuda_graph
         max_batch = int(self.max_num_sequences)
+        # A decode batch is pure generation (no context requests). Only that
+        # path is CUDA-graph captured and uses the graph-stable plan buffers.
+        is_decode = int(self.num_contexts or 0) == 0
+        # The main-attention GQA and dense plans need use_fp8_kvcache so the
+        # eager (inline sparse-prefill) kernel selection matches an FP8 paged
+        # cache; it is a no-op for the decode planner. The proxy runs over the
+        # bf16 index-K cache, so it never needs the flag.
+        use_fp8 = self._msa_main_kv_is_fp8()
 
         # Proxy plan: MQA (num_kv_heads=1) max-score pass over the index
         # branch; output_maxscore feeds the indexer's top-k block selection.
@@ -488,6 +547,7 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
             kv_block_num=topk,
             num_kv_splits=1,
             causal=True,
+            use_fp8_kvcache=use_fp8,
         )
         # Dense-layer plan: no kv_block_num, so it attends the full page table.
         dense_plan = fmha_sm100.fmha_sm100_plan(
@@ -499,7 +559,17 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
             page_size=page_size,
             num_kv_splits=1,
             causal=True,
+            use_fp8_kvcache=use_fp8,
         )
+
+        if not is_decode:
+            # Prefill and mixed batches run eagerly, so keep the plain plan
+            # tuples and leave the graph-safe owners reset. The indexer computes
+            # its own per-query valid-block count on the eager path.
+            self._msa_eager_proxy_plan = proxy_plan
+            self._msa_eager_gqa_plan = gqa_plan
+            self._msa_eager_dense_plan = dense_plan
+            return
 
         required_max_k_tiles = int(proxy_plan[3]["max_k_tiles"])
         self._ensure_msa_decode_scratch_buffers(
@@ -722,8 +792,8 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
 
         The model layer runs this before forward and threads the result through
         forward_args.topk_indices. Returns [total_q, num_kv_heads, topk].
-        Decode uses the prebuilt graph-safe proxy plan; prefill plans
-        eagerly.
+        Decode uses the prebuilt graph-safe proxy plan; prefill and mixed
+        batches use the prebuilt eager proxy plan.
         """
         config = self.m3_config
         idx_sm_scale = idx_sm_scale if idx_sm_scale is not None else config.sparse_index_dim**-0.5
@@ -734,9 +804,13 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
         metadata.msa_write_idx_k(self.layer_idx, idx_k_view)
         idx_k_cache = metadata.msa_idx_k_cache(self.layer_idx)
 
-        # One selection path: decode passes the prebuilt graph-safe proxy
-        # plan plus the proxy scratch shaped to the live query count; prefill
-        # leaves them None and the proxy plan is built inline.
+        # One selection path: decode passes the prebuilt graph-safe proxy plan
+        # plus the proxy scratch shaped to the live query count. Prefill and
+        # mixed batches pass the prebuilt eager proxy plan and let the kernel
+        # allocate the score buffer and the indexer compute the per-query
+        # valid-block count. Only when neither is present (for example a
+        # standalone test that skips prepare) does select_blocks build the proxy
+        # plan inline.
         proxy_plan = metadata.msa_decode_proxy_plan
         if proxy_plan is not None:
             # proxy_plan is (has_mixed, split, batch, decode_dict, prefill);
@@ -747,6 +821,7 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
             )
             n_valid_blocks = metadata.msa_n_valid_blocks[:num_tokens]
         else:
+            proxy_plan = metadata.msa_eager_proxy_plan
             max_score = None
             n_valid_blocks = None
         return self.indexer.select_blocks(

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
@@ -248,6 +248,15 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
     _msa_eager_proxy_plan: Optional[tuple] = None
     _msa_eager_gqa_plan: Optional[tuple] = None
     _msa_eager_dense_plan: Optional[tuple] = None
+    # Eager (prefill/mixed) per-token valid-block count. It is layer-invariant
+    # (a function of qo/kv lengths and page size), so it is computed on the host
+    # and staged to the device once per step via a non-blocking copy_, then
+    # reused by every sparse layer's indexer. _msa_eager_all_blocks_empty caches
+    # the host-side empty-selection result so the indexer can short-circuit without
+    # a device read. _msa_eager_n_valid_buf is the persistent backing store for the view.
+    _msa_eager_n_valid_buf: Optional[torch.Tensor] = None
+    _msa_eager_n_valid_blocks: Optional[torch.Tensor] = None
+    _msa_eager_all_blocks_empty: bool = False
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -314,6 +323,17 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
     def msa_eager_dense_plan(self) -> Optional[tuple]:
         """Prebuilt dense GQA plan for the eager (prefill/mixed) path."""
         return self._msa_eager_dense_plan
+
+    @property
+    def msa_eager_n_valid_blocks(self) -> Optional[torch.Tensor]:
+        """Device int32 valid-block count for the eager path, or None if no eager
+        step was prepared (a decode step or a structural test)."""
+        return self._msa_eager_n_valid_blocks
+
+    @property
+    def msa_eager_all_blocks_empty(self) -> bool:
+        """Whether the eager step has no valid KV blocks for any query token."""
+        return self._msa_eager_all_blocks_empty
 
     def _msa_main_kv_is_fp8(self) -> bool:
         """Whether the main paged K/V cache is stored as FP8 E4M3.
@@ -464,6 +484,20 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
             capture_graph=capture_graph,
         )
 
+    def _ensure_eager_n_valid_buffer(self, total_q: int, device: torch.device) -> torch.Tensor:
+        """Return a persistent device int32 buffer for the eager valid-block count.
+
+        The eager path is never CUDA-graph captured, so a plain device tensor,
+        grown on demand and reused across steps, is sufficient. It is sized to
+        the worst-case per-step query-token count.
+        """
+        buf = self._msa_eager_n_valid_buf
+        if buf is None or buf.numel() < total_q or buf.device != device:
+            cap = max(int(total_q), int(getattr(self, "max_num_tokens", 0) or 0), 1)
+            buf = torch.empty(cap, dtype=torch.int32, device=device)
+            self._msa_eager_n_valid_buf = buf
+        return buf
+
     def prepare(self) -> None:
         super().prepare()
         self._build_msa_fields()
@@ -493,6 +527,8 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
         self._msa_eager_proxy_plan = None
         self._msa_eager_gqa_plan = None
         self._msa_eager_dense_plan = None
+        self._msa_eager_n_valid_blocks = None
+        self._msa_eager_all_blocks_empty = False
         if not self._msa_fields_ready:
             return
         # Geometry is captured in __post_init__; skip when it is unavailable.
@@ -564,11 +600,22 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
 
         if not is_decode:
             # Prefill and mixed batches run eagerly, so keep the plain plan
-            # tuples and leave the graph-safe owners reset. The indexer computes
-            # its own per-query valid-block count on the eager path.
+            # tuples and leave the graph-safe owners reset.
             self._msa_eager_proxy_plan = proxy_plan
             self._msa_eager_gqa_plan = gqa_plan
             self._msa_eager_dense_plan = dense_plan
+            # Stage the valid-block count to the device once for the whole step
+            # (see _msa_eager_n_valid_blocks). The empty-selection check runs
+            # here on the host, so run_indexer can short-circuit cheaply.
+            n_valid_host = per_token_valid_blocks(
+                qo_lens_cpu, kv_lens_cpu, qo_offset_cpu, causal=True, block_size=page_size
+            )
+            total_q = int(n_valid_host.shape[0])
+            self._msa_eager_all_blocks_empty = total_q == 0 or int(n_valid_host.max().item()) <= 0
+            if total_q > 0:
+                dev_buf = self._ensure_eager_n_valid_buffer(total_q, device)
+                dev_buf[:total_q].copy_(n_valid_host.to(torch.int32), non_blocking=True)
+                self._msa_eager_n_valid_blocks = dev_buf[:total_q]
             return
 
         required_max_k_tiles = int(proxy_plan[3]["max_k_tiles"])
@@ -804,13 +851,11 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
         metadata.msa_write_idx_k(self.layer_idx, idx_k_view)
         idx_k_cache = metadata.msa_idx_k_cache(self.layer_idx)
 
-        # One selection path: decode passes the prebuilt graph-safe proxy plan
-        # plus the proxy scratch shaped to the live query count. Prefill and
-        # mixed batches pass the prebuilt eager proxy plan and let the kernel
-        # allocate the score buffer and the indexer compute the per-query
-        # valid-block count. Only when neither is present (for example a
-        # standalone test that skips prepare) does select_blocks build the proxy
-        # plan inline.
+        # One selection path. Decode passes the graph-safe proxy plan plus the
+        # proxy scratch shaped to the live query count. Prefill and mixed batches
+        # pass the eager proxy plan and the device-staged valid-block count. When
+        # neither is present (a standalone test that skips prepare) select_blocks
+        # plans inline and computes the valid-block count itself.
         proxy_plan = metadata.msa_decode_proxy_plan
         if proxy_plan is not None:
             # proxy_plan is (has_mixed, split, batch, decode_dict, prefill);
@@ -823,7 +868,17 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
         else:
             proxy_plan = metadata.msa_eager_proxy_plan
             max_score = None
-            n_valid_blocks = None
+            # The empty case was resolved on the host, so short-circuit here.
+            if metadata.msa_eager_all_blocks_empty:
+                return torch.full(
+                    (num_tokens, config.num_kv_heads, MSA_REQUIRED_TOPK),
+                    -1,
+                    dtype=torch.int32,
+                    device=idx_q.device,
+                )
+            n_valid_blocks = metadata.msa_eager_n_valid_blocks
+            if n_valid_blocks is not None:
+                n_valid_blocks = n_valid_blocks[:num_tokens]
         return self.indexer.select_blocks(
             idx_q_view,
             idx_k_cache,

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_backend.py
@@ -32,6 +32,7 @@ import torch
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
 from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttention, TrtllmAttentionMetadata
+from tensorrt_llm.bindings import DataType
 
 from .common import (
     MiniMaxM3SparseConfig,
@@ -251,12 +252,10 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
     # Eager (prefill/mixed) per-token valid-block count. It is layer-invariant
     # (a function of qo/kv lengths and page size), so it is computed on the host
     # and staged to the device once per step via a non-blocking copy_, then
-    # reused by every sparse layer's indexer. _msa_eager_all_blocks_empty caches
-    # the host-side empty-selection result so the indexer can short-circuit without
-    # a device read. _msa_eager_n_valid_buf is the persistent backing store for the view.
+    # reused by every sparse layer's indexer. _msa_eager_n_valid_buf is the
+    # persistent backing store for the view.
     _msa_eager_n_valid_buf: Optional[torch.Tensor] = None
     _msa_eager_n_valid_blocks: Optional[torch.Tensor] = None
-    _msa_eager_all_blocks_empty: bool = False
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -330,11 +329,6 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
         step was prepared (a decode step or a structural test)."""
         return self._msa_eager_n_valid_blocks
 
-    @property
-    def msa_eager_all_blocks_empty(self) -> bool:
-        """Whether the eager step has no valid KV blocks for any query token."""
-        return self._msa_eager_all_blocks_empty
-
     def _msa_main_kv_is_fp8(self) -> bool:
         """Whether the main paged K/V cache is stored as FP8 E4M3.
 
@@ -343,19 +337,7 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
         decode planner. Mirrors the k_paged.dtype check in run_msa_paged_gqa.
         """
         kv_cache_manager = self.kv_cache_manager
-        if kv_cache_manager is None:
-            return False
-        try:
-            buffers = kv_cache_manager.get_buffers(0, kv_layout="HND")
-        except TypeError:
-            buffers = kv_cache_manager.get_buffers(0)
-        except Exception:
-            return False
-
-        try:
-            return buffers[:, 0].dtype == torch.float8_e4m3fn
-        except Exception:
-            return False
+        return kv_cache_manager is not None and kv_cache_manager.dtype == DataType.FP8
 
     def _create_msa_buffers(self) -> None:
         """Allocate the CUDA-graph-stable MSA device buffers.
@@ -528,7 +510,6 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
         self._msa_eager_gqa_plan = None
         self._msa_eager_dense_plan = None
         self._msa_eager_n_valid_blocks = None
-        self._msa_eager_all_blocks_empty = False
         if not self._msa_fields_ready:
             return
         # Geometry is captured in __post_init__; skip when it is unavailable.
@@ -605,13 +586,11 @@ class MiniMaxM3MsaSparseAttentionMetadata(TrtllmAttentionMetadata):
             self._msa_eager_gqa_plan = gqa_plan
             self._msa_eager_dense_plan = dense_plan
             # Stage the valid-block count to the device once for the whole step
-            # (see _msa_eager_n_valid_blocks). The empty-selection check runs
-            # here on the host, so run_indexer can short-circuit cheaply.
+            # (see _msa_eager_n_valid_blocks).
             n_valid_host = per_token_valid_blocks(
                 qo_lens_cpu, kv_lens_cpu, qo_offset_cpu, causal=True, block_size=page_size
             )
             total_q = int(n_valid_host.shape[0])
-            self._msa_eager_all_blocks_empty = total_q == 0 or int(n_valid_host.max().item()) <= 0
             if total_q > 0:
                 dev_buf = self._ensure_eager_n_valid_buffer(total_q, device)
                 dev_buf[:total_q].copy_(n_valid_host.to(torch.int32), non_blocking=True)
@@ -868,14 +847,6 @@ class MiniMaxM3MsaSparseAttention(TrtllmAttention):
         else:
             proxy_plan = metadata.msa_eager_proxy_plan
             max_score = None
-            # The empty case was resolved on the host, so short-circuit here.
-            if metadata.msa_eager_all_blocks_empty:
-                return torch.full(
-                    (num_tokens, config.num_kv_heads, MSA_REQUIRED_TOPK),
-                    -1,
-                    dtype=torch.int32,
-                    device=idx_q.device,
-                )
             n_valid_blocks = metadata.msa_eager_n_valid_blocks
             if n_valid_blocks is not None:
                 n_valid_blocks = n_valid_blocks[:num_tokens]

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_indexer.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_indexer.py
@@ -134,13 +134,11 @@ class MsaIndexer:
     ) -> torch.Tensor:
         """Return [total_q, num_kv_heads, topk] selected block indices.
 
-        Plan/run split, mirroring the sparse GQA. When `proxy_plan` is None
-        (prefill and focused tests) the proxy plan is built inline and the
-        per-query valid-block count is derived here; when provided (CUDA-graph
-        decode) the proxy runs from the prebuilt plan into the preallocated
-        `max_score` buffer with a precomputed `n_valid_blocks`, so there is
-        no host sync inside the captured region. The same top-k selection serves
-        both, and generation is the one-query-token-per-request special case.
+        Plan/run split, mirroring the sparse GQA. Both production paths pass a
+        prebuilt `proxy_plan` and a precomputed device `n_valid_blocks` (decode
+        from the graph-safe scratch, eager from the step-level device buffer);
+        decode additionally runs into the preallocated `max_score` buffer inside
+        the captured region.
         """
         config = self.config
 
@@ -168,6 +166,7 @@ class MsaIndexer:
                 max_score=max_score,
                 sm_scale=idx_sm_scale,
             )
+
         max_score_kv = _group_max_reduce(max_score, config)
 
         if n_valid_blocks is None:
@@ -178,8 +177,8 @@ class MsaIndexer:
                 causal=True,
                 block_size=int(idx_k_paged.shape[2]),
             )
-            # The empty-selection guard uses a host sync, so it only runs on the
-            # eager path; a decode batch always has valid blocks.
+            # Empty-selection guard. n_valid_blocks is a host tensor on
+            # this path, so the .item() read does not sync the device.
             if n_valid_blocks.numel() == 0 or int(n_valid_blocks.max().item()) <= 0:
                 return torch.full(
                     (idx_q.shape[0], config.num_kv_heads, MSA_REQUIRED_TOPK),

--- a/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_indexer.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/minimax_m3/msa_indexer.py
@@ -177,15 +177,6 @@ class MsaIndexer:
                 causal=True,
                 block_size=int(idx_k_paged.shape[2]),
             )
-            # Empty-selection guard. n_valid_blocks is a host tensor on
-            # this path, so the .item() read does not sync the device.
-            if n_valid_blocks.numel() == 0 or int(n_valid_blocks.max().item()) <= 0:
-                return torch.full(
-                    (idx_q.shape[0], config.num_kv_heads, MSA_REQUIRED_TOPK),
-                    -1,
-                    dtype=torch.int32,
-                    device=idx_q.device,
-                )
         return select_blocks_from_maxscore(
             max_score_kv,
             topk=MSA_REQUIRED_TOPK,


### PR DESCRIPTION
## Description

Given MSA plans are layer-invariant, this MR hoists the plan builds so that they are called only once per forward step.

Also, there is an H2D copy in `select_blocks_from_maxscore` which turned out to be blocking.
```
nvb = n_valid_blocks.to(device=device, dtype=torch.long)
```

This MR creates the tensor on device once per step so that such copy is no longer needed. Above line remains unchanged as issue is fixed at the source (tensor created on device instead of host).

## Test Coverage
```
$ pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_nvfp4[use_msa=True-eval_mode=default] -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Hoists reusable MSA plans and valid-block metadata to reduce per-layer planning and host-to-device synchronization.
- Adds eager fallbacks for unavailable decode plans.
- Uses the cache manager’s declared dtype for FP8 KV-cache detection.
- Removes the redundant empty-selection guard because valid-block guarantees and `-1` handling cover invalid selections.
- No configuration or test-list changes identified.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->