### PR TITLE
[None][perf] Fast-path the MiniMax-M3 MSA plan_kernel

### DIFF
--- a/3rdparty/patches/msa_planner_greedy_fastpaths.patch
+++ b/3rdparty/patches/msa_planner_greedy_fastpaths.patch
@@ -1,0 +1,311 @@
+--- a/python/fmha_sm100/csrc/include/plan.cuh
++++ b/python/fmha_sm100/csrc/include/plan.cuh
+@@ -263,19 +263,226 @@
+   __syncthreads();
+   int max_qo_tiles = _max_qo_tiles;
+ 
++  // ==========================================================================
++  // Fast path 1 (uniform cost): uniform tile_cost => the greedy is EXACTLY round-robin.
++  //
++  // With every work item costing the same C, the bucket costs stay balanced:
++  // after T tasks, buckets 0..(T%N-1) hold ceil(T/N) and the rest floor(T/N).
++  // The rank order (cost asc, index asc) is therefore the cyclic sequence
++  // starting at m = T%N, so the next batch_count tasks land on buckets
++  // m, m+1, ... (mod N). By induction, global task t -> bucket (t % N), and
++  // bucket i's k-th task is t = i + k*N. Every output below is a closed form
++  // of that, so this is bit-identical to the two greedy passes it replaces.
++  //
++  // Guarded to max_qo_tiles==1 && actual_splits==1 && num_heads<=num_buckets so
++  // the row enumeration collapses to r = b and t = b*num_heads + h.
++  // ==========================================================================
++  __shared__ int _work_offsets[MAX_SMS + 1];
++  __shared__ int _uni_min, _uni_max;
++  if (tid == 0) { _uni_min = 0x7fffffff; _uni_max = 0; }
++  __syncthreads();
++  bool _uniform_ok = (max_qo_tiles == 1) && (num_kv_splits <= 1) && (num_heads > 0) &&
++               (num_heads <= num_buckets) && (batch_size > 0);
++  if (_uniform_ok) {
++    int lmin = 0x7fffffff, lmax = 0;
++    for (int b = tid; b < batch_size; b += static_cast<int>(blockDim.x)) {
++      int ki = 0;
++      if (ceil_div(qo_lens[b], qo_tile_size) > 0)
++        ki = compute_kv_iters(b, 0, qo_lens, kv_lens, qo_offsets,
++                              qo_tile_size, kv_tile_size, causal, pack_factor);
++      if (ki < lmin) lmin = ki;
++      if (ki > lmax) lmax = ki;
++    }
++    atomicMin(&_uni_min, lmin);
++    atomicMax(&_uni_max, lmax);
++  }
++  __syncthreads();
++  if (_uniform_ok && _uni_min == _uni_max && _uni_min > 0) {
++    const int ki = _uni_min;
++    const int C = static_cast<int>(kPerIterOverhead * ki + kTileGlobalOverhead);
++    const int N = num_buckets;
++    const int T = batch_size * num_heads;
++    const int q = T / N;
++    const int rr = T - q * N;
++    if (tid < N) {
++      int cnt = q + (tid < rr ? 1 : 0);
++      int off = tid * q + (tid < rr ? tid : rr);
++      s.sm_task_count[tid] = static_cast<int16_t>(cnt);
++      s.sm_cost[tid] = static_cast<int>(kSMGlobalOverhead) + C * cnt;
++      packed_work_range[tid] = pack_work_range(off, off + cnt);
++    }
++    for (int t = tid; t < T; t += static_cast<int>(blockDim.x)) {
++      int i = t % N;
++      int k = t / N;
++      int pos = i * q + (i < rr ? i : rr) + k;
++      int b = t / num_heads;
++      int h = t - b * num_heads;
++      packed_work_info[pos] = pack_work_info(0, h, b);
++      if (kv_tile_begin_indices) kv_tile_begin_indices[pos] = 0;
++      if (kv_tile_end_indices) kv_tile_end_indices[pos] = ki;
++      if (kv_split_indices) kv_split_indices[pos] = 0;
++    }
++    if (num_kv_splits_per_row && qo_segment_offsets) {
++      for (int b = tid; b < batch_size; b += static_cast<int>(blockDim.x)) {
++        int seg_off = qo_segment_offsets[b];
++        int qo_len = qo_lens[b];
++        int row_end = (qo_tile_size < qo_len) ? qo_tile_size : qo_len;
++        for (int rw = 0; rw < row_end; rw++)
++          num_kv_splits_per_row[seg_off + rw] = 1;
++      }
++    }
++    __syncthreads();
++    return static_cast<int>(kSMGlobalOverhead) + C * (q + (rr > 0 ? 1 : 0));
++  }
++
++  // ==========================================================================
++  // Fast path 2 (single head): num_heads == 1  =>  batch_count == 1  =>  each round needs only
++  // the ARGMIN bucket, not every bucket's rank. rank==0 means "cheapest, ties to
++  // lowest index", which is exactly min(pack_cost_idx(cost,idx)) -- so
++  // find_min_cost_sm (warp-shuffle reduction) is an EXACT substitute for the
++  // O(num_buckets) per-thread rank scan. Costs may vary per row here.
++  //
++  // Pass 2's scan is removed entirely: pass 1 memoises each row's destination
++  // bucket and its index within that bucket, so the output write becomes a
++  // parallel scatter. Bit-identical: same assignment, same order, same offsets.
++  // Scratch reuses the unsplit_* arrays, which only the adaptive path uses.
++  // ==========================================================================
++  if (max_qo_tiles == 1 && num_kv_splits <= 1 && num_heads == 1 &&
++      batch_size > 0 && batch_size <= MAX_UNSPLIT) {
++    for (int b = tid; b < batch_size; b += static_cast<int>(blockDim.x)) {
++      int ki = 0;
++      if (ceil_div(qo_lens[b], qo_tile_size) > 0)
++        ki = compute_kv_iters(b, 0, qo_lens, kv_lens, qo_offsets,
++                              qo_tile_size, kv_tile_size, causal, pack_factor);
++      s.unsplit_kv_iters[b] = static_cast<int16_t>(ki > 0 ? ki : 0);
++      s.unsplit_qo_tile[b] = -1;
++    }
++    if (tid < num_buckets) {
++      s.sm_cost[tid] = kSMGlobalOverhead;
++      s.sm_task_count[tid] = 0;
++    }
++    __syncthreads();
++
++    for (int b = 0; b < batch_size; b++) {
++      int ki = s.unsplit_kv_iters[b];
++      if (ki <= 0) continue;  // uniform across the block: no divergent barrier
++      int tile_cost = static_cast<int>(kPerIterOverhead * ki + kTileGlobalOverhead);
++      int win = find_min_cost_sm(s, num_buckets);
++      if (tid == win) {
++        s.unsplit_qo_tile[b] = static_cast<int16_t>(win);
++        s.unsplit_batch[b] = s.sm_task_count[win];
++        s.sm_cost[win] += tile_cost;
++        s.sm_task_count[win]++;
++      }
++      __syncthreads();
++    }
++
++    int _mx = find_max_cost_sm(s, num_buckets);
++    int _max_cost = s.sm_cost[_mx];
++    if (tid == 0) {
++      int pos = 0;
++      for (int sm = 0; sm < num_buckets; sm++) {
++        _work_offsets[sm] = pos;
++        pos += s.sm_task_count[sm];
++      }
++      _work_offsets[num_buckets] = pos;
++    }
++    __syncthreads();
++
++    for (int b = tid; b < batch_size; b += static_cast<int>(blockDim.x)) {
++      int d = s.unsplit_qo_tile[b];
++      if (d < 0) continue;
++      int pos = _work_offsets[d] + s.unsplit_batch[b];
++      packed_work_info[pos] = pack_work_info(0, 0, b);
++      if (kv_tile_begin_indices) kv_tile_begin_indices[pos] = 0;
++      if (kv_tile_end_indices) kv_tile_end_indices[pos] = s.unsplit_kv_iters[b];
++      if (kv_split_indices) kv_split_indices[pos] = 0;
++    }
++    if (num_kv_splits_per_row && qo_segment_offsets) {
++      for (int b = tid; b < batch_size; b += static_cast<int>(blockDim.x)) {
++        if (s.unsplit_kv_iters[b] <= 0) continue;
++        int seg_off = qo_segment_offsets[b];
++        int qo_len = qo_lens[b];
++        int row_end = (qo_tile_size < qo_len) ? qo_tile_size : qo_len;
++        for (int rw = 0; rw < row_end; rw++)
++          num_kv_splits_per_row[seg_off + rw] = 1;
++      }
++    }
++    __syncthreads();
++    if (tid < num_buckets)
++      packed_work_range[tid] = pack_work_range(
++          _work_offsets[tid], _work_offsets[tid] + s.sm_task_count[tid]);
++    __syncthreads();
++    return _max_cost;
++  }
++
+   if (tid < num_buckets) {
+     s.sm_cost[tid] = kSMGlobalOverhead;
+     s.sm_task_count[tid] = 0;
+   }
+   __syncthreads();
+ 
++  // ==========================================================================
++  // Fast path 3 (row compaction): compact the ACTIVE (qt,b) rows once, then let the existing
++  // greedy walk that list instead of the full rectangle.
++  //
++  // On a production mixed step (1 ctx of ~7373 tok + 255 decode rows) the
++  // rectangle is M = max_qo_tiles*batch = 29*256 = 7424 pairs but only R = 284
++  // do work -- 96% are skipped, and each skip costs a global load of qo_lens[b]
++  // plus an IDIV, executed by all 256 threads, in BOTH passes. Measured: 2939 us
++  // with the rectangle vs 1160 us at the same R without it (61% of the kernel).
++  //
++  // Emission order (qt desc, b asc) and every per-row value are unchanged, so
++  // the greedy sees an identical sequence => bit-identical output.
++  // ==========================================================================
++  __shared__ int _num_rows;
++  __shared__ int _rows_compacted;
++  if (tid == 0) { _num_rows = 0; _rows_compacted = (num_kv_splits <= 1 && batch_size > 0 &&
++                                       max_qo_tiles > 0 && max_qo_tiles <= 32767 &&
++                                       batch_size <= 32767) ? 1 : 0; }
++  __syncthreads();
++  if (_rows_compacted) {
++    for (int qt = max_qo_tiles - 1; qt >= 0; qt--) {
++      for (int base = 0; base < batch_size; base += static_cast<int>(blockDim.x)) {
++        int b = base + tid;
++        int ki = 0;
++        if (b < batch_size && qt < ceil_div(qo_lens[b], qo_tile_size))
++          ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
++                                qo_tile_size, kv_tile_size, causal, pack_factor);
++        int act = (ki > 0) ? 1 : 0;
++        int off = 0, agg = 0;
++        int row0 = _num_rows;
++        __syncthreads();
++        cub::BlockScan<int, MAX_SMS>(s.scan_temp).ExclusiveSum(act, off, agg);
++        __syncthreads();
++        if (act && row0 + off < MAX_UNSPLIT) {
++          int q = row0 + off;
++          s.unsplit_qo_tile[q]  = static_cast<int16_t>(qt);
++          s.unsplit_batch[q]    = static_cast<int16_t>(b);
++          s.unsplit_kv_iters[q] = static_cast<int16_t>(ki);
++        }
++        __syncthreads();
++        if (tid == 0) _num_rows = row0 + agg;
++        __syncthreads();
++      }
++    }
++    if (tid == 0 && _num_rows > MAX_UNSPLIT) _rows_compacted = 0;   // overflow -> use the rectangle
++    __syncthreads();
++  }
++
+   // Pass 1: batch-assign heads in reverse QO tile order
+-  for (int qt = max_qo_tiles - 1; qt >= 0; qt--) {
+-    for (int b = 0; b < batch_size; b++) {
+-      if (qt >= ceil_div(qo_lens[b], qo_tile_size)) continue;
+-      int total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
+-                                       qo_tile_size, kv_tile_size, causal, pack_factor);
+-      if (total_ki <= 0) continue;
++  for (int row = 0; row < (_rows_compacted ? _num_rows : max_qo_tiles * batch_size); row++) {
++    {
++      int qt, b, total_ki;
++      if (_rows_compacted) {
++        qt = s.unsplit_qo_tile[row]; b = s.unsplit_batch[row]; total_ki = s.unsplit_kv_iters[row];
++      } else {
++        qt = max_qo_tiles - 1 - (row / batch_size); b = row % batch_size;
++        if (qt >= ceil_div(qo_lens[b], qo_tile_size)) continue;
++        total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
++                                    qo_tile_size, kv_tile_size, causal, pack_factor);
++        if (total_ki <= 0) continue;
++      }
+       int actual_splits = (num_kv_splits <= 1) ? 1
+           : ::min(num_kv_splits, ::max(1, total_ki / MIN_ITERS_PER_SPLIT));
+       for (int sp = 0; sp < actual_splits; sp++) {
+@@ -315,7 +522,6 @@
+   int max_cost = s.sm_cost[max_sm];
+ 
+   // Compute work_indptr, reset for pass 2
+-  __shared__ int _work_offsets[MAX_SMS + 1];
+   if (threadIdx.x == 0) {
+     int pos = 0;
+     for (int sm = 0; sm < num_buckets; sm++) {
+@@ -332,12 +538,18 @@
+   if (tid < num_buckets) s.sm_cost[tid] = kSMGlobalOverhead;
+   __syncthreads();
+ 
+-  for (int qt = max_qo_tiles - 1; qt >= 0; qt--) {
+-    for (int b = 0; b < batch_size; b++) {
+-      if (qt >= ceil_div(qo_lens[b], qo_tile_size)) continue;
+-      int total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
+-                                       qo_tile_size, kv_tile_size, causal, pack_factor);
+-      if (total_ki <= 0) continue;
++  for (int row = 0; row < (_rows_compacted ? _num_rows : max_qo_tiles * batch_size); row++) {
++    {
++      int qt, b, total_ki;
++      if (_rows_compacted) {
++        qt = s.unsplit_qo_tile[row]; b = s.unsplit_batch[row]; total_ki = s.unsplit_kv_iters[row];
++      } else {
++        qt = max_qo_tiles - 1 - (row / batch_size); b = row % batch_size;
++        if (qt >= ceil_div(qo_lens[b], qo_tile_size)) continue;
++        total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
++                                    qo_tile_size, kv_tile_size, causal, pack_factor);
++        if (total_ki <= 0) continue;
++      }
+       int actual_splits = (num_kv_splits <= 1) ? 1
+           : ::min(num_kv_splits, ::max(1, total_ki / MIN_ITERS_PER_SPLIT));
+       if (threadIdx.x == 0 && num_kv_splits_per_row && qo_segment_offsets) {
+--- a/python/fmha_sm100/jit.py
++++ b/python/fmha_sm100/jit.py
+@@ -11,6 +11,7 @@
+ 
+ import itertools
+ import fcntl
++import hashlib
+ import logging
+ import os
+ import shutil
+@@ -395,9 +396,22 @@
+ _plan_lock = threading.Lock()
+ 
+ 
++def _plan_sources_tag() -> str:
++    """Content hash of the plan kernel sources.
++
++    The plan cache directory is keyed on it so a source change (for example a
++    refreshed downstream patch) recompiles instead of silently reusing a stale
++    fmha_sm100_plan.so built from older sources.
++    """
++    plan_cu = _FMHA_VARLEN_DIR / "fmha_sm100_plan.cu"
++    plan_cuh = _FMHA_VARLEN_DIR / "include" / "plan.cuh"
++    digest = hashlib.sha256(plan_cu.read_bytes() + plan_cuh.read_bytes())
++    return digest.hexdigest()[:12]
++
++
+ def _do_compile_plan():
+     """Generate and compile plan kernel. No TVM loading."""
+-    cache_dir = CACHE_BASE / "plan"
++    cache_dir = CACHE_BASE / f"plan-{_plan_sources_tag()}"
+     so_path = cache_dir / "fmha_sm100_plan.so"
+ 
+     if so_path.exists():
+@@ -459,7 +473,7 @@
+     try:
+         _do_compile_plan()
+         import tvm_ffi
+-        so_path = CACHE_BASE / "plan" / "fmha_sm100_plan.so"
++        so_path = CACHE_BASE / f"plan-{_plan_sources_tag()}" / "fmha_sm100_plan.so"
+         return tvm_ffi.load_module(str(so_path))
+     finally:
+         _release_file_lock(lock_fd)

--- a/3rdparty/patches/msa_planner_greedy_fastpaths.patch
+++ b/3rdparty/patches/msa_planner_greedy_fastpaths.patch
@@ -1,6 +1,21 @@
 --- a/python/fmha_sm100/csrc/include/plan.cuh
 +++ b/python/fmha_sm100/csrc/include/plan.cuh
-@@ -263,19 +263,226 @@
+@@ -56,9 +56,12 @@
+   int8_t  unsplit_head[MAX_UNSPLIT];
+   int16_t unsplit_batch[MAX_UNSPLIT];
+   int16_t unsplit_kv_iters[MAX_UNSPLIT];
+-  int     unsplit_sub_counter[MAX_UNSPLIT];
++  union {
++    int unsplit_sub_counter[MAX_UNSPLIT];  // adaptive planner
++    int direct_kv_iters[MAX_UNSPLIT];      // direct planner fast paths
++  };
+   int     num_unsplit;
+-
++
+   uint     warp_scratch[8];  // for block reduce
+   typename cub::BlockScan<int, MAX_SMS>::TempStorage scan_temp;
+ };
+@@ -263,19 +266,253 @@
    __syncthreads();
    int max_qo_tiles = _max_qo_tiles;
  
@@ -86,16 +101,38 @@
 +  // Pass 2's scan is removed entirely: pass 1 memoises each row's destination
 +  // bucket and its index within that bucket, so the output write becomes a
 +  // parallel scatter. Bit-identical: same assignment, same order, same offsets.
-+  // Scratch reuses the unsplit_* arrays, which only the adaptive path uses.
++  // Scratch reuses the full-int direct side of PlanSharedState's zero-size
++  // adaptive/direct union.  The block-uniform guard below proves list
++  // scheduling cannot reach the 24-bit reduction sentinel.  If the proof
++  // fails, every thread skips this block before PlanSharedState is mutated and
++  // falls through to the stock full-width direct planner below.
 +  // ==========================================================================
-+  if (max_qo_tiles == 1 && num_kv_splits <= 1 && num_heads == 1 &&
-+      batch_size > 0 && batch_size <= MAX_UNSPLIT) {
++  const bool _fp2_shape_ok = max_qo_tiles == 1 && num_kv_splits <= 1 &&
++      num_heads == 1 && num_buckets > 0 && batch_size > 0 &&
++      batch_size <= MAX_UNSPLIT;
++  bool _fp2_cost_fits = false;
++  if (_fp2_shape_ok) {
++    // Before any of B tasks is assigned, the cheapest bucket is at most
++    // base + floor((B - 1) * P / N), where P bounds one task.  Adding P gives
++    // a safe upper bound for every active bucket.  The stock 32-bit reducer
++    // reserves cost 0x7fffff for inactive lanes, so active costs must end at
++    // or below 0x7ffffe.
++    const int64_t _max_tile_cost =
++        static_cast<int64_t>(kPerIterOverhead) * _uni_max +
++        static_cast<int64_t>(kTileGlobalOverhead);
++    const int64_t _max_bucket_cost_bound =
++        static_cast<int64_t>(kSMGlobalOverhead) +
++        (static_cast<int64_t>(batch_size - 1) * _max_tile_cost) / num_buckets +
++        _max_tile_cost;
++    _fp2_cost_fits = _max_bucket_cost_bound <= 0x7ffffe;
++  }
++  if (_fp2_shape_ok && _fp2_cost_fits) {
 +    for (int b = tid; b < batch_size; b += static_cast<int>(blockDim.x)) {
 +      int ki = 0;
 +      if (ceil_div(qo_lens[b], qo_tile_size) > 0)
 +        ki = compute_kv_iters(b, 0, qo_lens, kv_lens, qo_offsets,
 +                              qo_tile_size, kv_tile_size, causal, pack_factor);
-+      s.unsplit_kv_iters[b] = static_cast<int16_t>(ki > 0 ? ki : 0);
++      s.direct_kv_iters[b] = ki > 0 ? ki : 0;
 +      s.unsplit_qo_tile[b] = -1;
 +    }
 +    if (tid < num_buckets) {
@@ -105,7 +142,7 @@
 +    __syncthreads();
 +
 +    for (int b = 0; b < batch_size; b++) {
-+      int ki = s.unsplit_kv_iters[b];
++      int ki = s.direct_kv_iters[b];
 +      if (ki <= 0) continue;  // uniform across the block: no divergent barrier
 +      int tile_cost = static_cast<int>(kPerIterOverhead * ki + kTileGlobalOverhead);
 +      int win = find_min_cost_sm(s, num_buckets);
@@ -136,12 +173,12 @@
 +      int pos = _work_offsets[d] + s.unsplit_batch[b];
 +      packed_work_info[pos] = pack_work_info(0, 0, b);
 +      if (kv_tile_begin_indices) kv_tile_begin_indices[pos] = 0;
-+      if (kv_tile_end_indices) kv_tile_end_indices[pos] = s.unsplit_kv_iters[b];
++      if (kv_tile_end_indices) kv_tile_end_indices[pos] = s.direct_kv_iters[b];
 +      if (kv_split_indices) kv_split_indices[pos] = 0;
 +    }
 +    if (num_kv_splits_per_row && qo_segment_offsets) {
 +      for (int b = tid; b < batch_size; b += static_cast<int>(blockDim.x)) {
-+        if (s.unsplit_kv_iters[b] <= 0) continue;
++        if (s.direct_kv_iters[b] <= 0) continue;
 +        int seg_off = qo_segment_offsets[b];
 +        int qo_len = qo_lens[b];
 +        int row_end = (qo_tile_size < qo_len) ? qo_tile_size : qo_len;
@@ -200,7 +237,7 @@
 +          int q = row0 + off;
 +          s.unsplit_qo_tile[q]  = static_cast<int16_t>(qt);
 +          s.unsplit_batch[q]    = static_cast<int16_t>(b);
-+          s.unsplit_kv_iters[q] = static_cast<int16_t>(ki);
++          s.direct_kv_iters[q]  = ki;
 +        }
 +        __syncthreads();
 +        if (tid == 0) _num_rows = row0 + agg;
@@ -211,6 +248,10 @@
 +    __syncthreads();
 +  }
 +
++  const int64_t _num_direct_rows = _rows_compacted
++      ? static_cast<int64_t>(_num_rows)
++      : static_cast<int64_t>(max_qo_tiles) * static_cast<int64_t>(batch_size);
++
    // Pass 1: batch-assign heads in reverse QO tile order
 -  for (int qt = max_qo_tiles - 1; qt >= 0; qt--) {
 -    for (int b = 0; b < batch_size; b++) {
@@ -218,13 +259,14 @@
 -      int total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
 -                                       qo_tile_size, kv_tile_size, causal, pack_factor);
 -      if (total_ki <= 0) continue;
-+  for (int row = 0; row < (_rows_compacted ? _num_rows : max_qo_tiles * batch_size); row++) {
++  for (int64_t row = 0; row < _num_direct_rows; row++) {
 +    {
 +      int qt, b, total_ki;
 +      if (_rows_compacted) {
-+        qt = s.unsplit_qo_tile[row]; b = s.unsplit_batch[row]; total_ki = s.unsplit_kv_iters[row];
++        qt = s.unsplit_qo_tile[row]; b = s.unsplit_batch[row]; total_ki = s.direct_kv_iters[row];
 +      } else {
-+        qt = max_qo_tiles - 1 - (row / batch_size); b = row % batch_size;
++        qt = max_qo_tiles - 1 - static_cast<int>(row / batch_size);
++        b = static_cast<int>(row % batch_size);
 +        if (qt >= ceil_div(qo_lens[b], qo_tile_size)) continue;
 +        total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
 +                                    qo_tile_size, kv_tile_size, causal, pack_factor);
@@ -233,7 +275,7 @@
        int actual_splits = (num_kv_splits <= 1) ? 1
            : ::min(num_kv_splits, ::max(1, total_ki / MIN_ITERS_PER_SPLIT));
        for (int sp = 0; sp < actual_splits; sp++) {
-@@ -315,7 +522,6 @@
+@@ -315,7 +552,6 @@
    int max_cost = s.sm_cost[max_sm];
  
    // Compute work_indptr, reset for pass 2
@@ -241,7 +283,7 @@
    if (threadIdx.x == 0) {
      int pos = 0;
      for (int sm = 0; sm < num_buckets; sm++) {
-@@ -332,12 +538,18 @@
+@@ -332,12 +568,19 @@
    if (tid < num_buckets) s.sm_cost[tid] = kSMGlobalOverhead;
    __syncthreads();
  
@@ -251,13 +293,14 @@
 -      int total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
 -                                       qo_tile_size, kv_tile_size, causal, pack_factor);
 -      if (total_ki <= 0) continue;
-+  for (int row = 0; row < (_rows_compacted ? _num_rows : max_qo_tiles * batch_size); row++) {
++  for (int64_t row = 0; row < _num_direct_rows; row++) {
 +    {
 +      int qt, b, total_ki;
 +      if (_rows_compacted) {
-+        qt = s.unsplit_qo_tile[row]; b = s.unsplit_batch[row]; total_ki = s.unsplit_kv_iters[row];
++        qt = s.unsplit_qo_tile[row]; b = s.unsplit_batch[row]; total_ki = s.direct_kv_iters[row];
 +      } else {
-+        qt = max_qo_tiles - 1 - (row / batch_size); b = row % batch_size;
++        qt = max_qo_tiles - 1 - static_cast<int>(row / batch_size);
++        b = static_cast<int>(row % batch_size);
 +        if (qt >= ceil_div(qo_lens[b], qo_tile_size)) continue;
 +        total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
 +                                    qo_tile_size, kv_tile_size, causal, pack_factor);

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -82,12 +82,13 @@ def get_build_dir(build_dir, build_type):
 
 
 def apply_msa_patch(project_dir: Path) -> None:
-    """Apply TensorRT-LLM's downstream MSA patch in place, idempotently.
+    """Apply TensorRT-LLM's downstream MSA patches in place, idempotently.
 
-    The patch is applied directly to the pinned 3rdparty/MSA submodule working
-    tree so every consumer sees the patched fmha_sm100 sources: the runtime
-    importer, editable installs, and wheel packaging. Re-running is a no-op, so
-    it is safe to call on every build.
+    Every 3rdparty/patches/msa_*.patch is applied, in sorted order, directly to
+    the pinned 3rdparty/MSA submodule working tree so every consumer sees the
+    patched fmha_sm100 sources: the runtime importer, editable installs, and
+    wheel packaging. Re-running is a no-op, so it is safe to call on every
+    build.
 
     Patching goes through patch(1), as 3rdparty/CMakeLists.txt does for its
     dependencies, so only a working tree is required. A tree copied without the
@@ -97,11 +98,19 @@ def apply_msa_patch(project_dir: Path) -> None:
     """
     msa_source_dir = project_dir / "3rdparty" / "MSA"
     msa_package_dir = msa_source_dir / "python" / "fmha_sm100"
-    msa_patch = project_dir / "3rdparty" / "patches" / "msa_strided_paged_kv.patch"
+    msa_patches = sorted(
+        (project_dir / "3rdparty" / "patches").glob("msa_*.patch"))
     if not msa_package_dir.is_dir():
         raise FileNotFoundError(
             f"MSA sources are missing at {msa_package_dir}; initialize 3rdparty/MSA"
         )
+
+    for msa_patch in msa_patches:
+        _apply_one_msa_patch(msa_source_dir, msa_package_dir, msa_patch)
+
+
+def _apply_one_msa_patch(msa_source_dir: Path, msa_package_dir: Path,
+                         msa_patch: Path) -> None:
 
     def patch_cmd(*flags: str):
         # --no-backup-if-mismatch keeps the .orig copy of a hunk applied at an
@@ -132,11 +141,13 @@ def apply_msa_patch(project_dir: Path) -> None:
             raise RuntimeError(
                 f"Cannot apply {msa_patch} to {msa_source_dir}:\n"
                 f"{forward_check.stdout.strip()}")
-        print(f"-- MSA patch already applied at {msa_package_dir}; skipping.")
+        print(
+            f"-- {msa_patch.name} already applied at {msa_package_dir}; skipping."
+        )
         return
 
     run(patch_cmd("--forward"), cwd=msa_source_dir, check=True)
-    print(f"-- Applied MSA patch to {msa_package_dir}.")
+    print(f"-- Applied {msa_patch.name} to {msa_package_dir}.")
 
 
 def clear_folder(folder_path):

--- a/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_plan_fastpaths.py
+++ b/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_plan_fastpaths.py
@@ -13,7 +13,6 @@ skip unless the patched MSA package and an SM100 CUDA runtime are available.
 
 from __future__ import annotations
 
-import random
 from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
@@ -21,12 +20,10 @@ from types import ModuleType
 import pytest
 import torch
 
-
 _PER_ITER_COST = 43
 _TILE_COST = 110
 _SM_COST = 165
 _LEGACY_PACKED_COST_SENTINEL = 0x7FFFFF
-_LEGACY_PACKED_COST_MAX = 0xFFFFFF
 
 
 @lru_cache(maxsize=1)
@@ -157,63 +154,7 @@ def _run_gpu_plan(
 
     ranges = [int(value) for value in plan["packed_work_range"].cpu().tolist()]
     total_work = (ranges[-1] >> 32) & 0xFFFFFFFF
-    work_info = [
-        int(value)
-        for value in plan["packed_work_info"][:total_work].cpu().tolist()
-    ]
-    return ranges, work_info
-
-
-def _run_raw_gpu_plan(
-    qo_lens: list[int],
-    kv_lens: list[int],
-    num_heads: int,
-    num_buckets: int,
-) -> tuple[list[int], list[int]]:
-    """Call the JIT wrapper directly so tests can activate all 256 lanes.
-
-    The public API caps ``num_buckets`` to the physical SM count.  The planner
-    itself is one 256-thread block, so using 256 logical buckets is valid and
-    ensures that neither reduction stage contains an inactive lane.
-    """
-
-    msa_api = _load_patched_msa_api()
-    device = torch.device("cuda", torch.cuda.current_device())
-    batch_size = len(qo_lens)
-    qo_lens_t = torch.tensor(qo_lens, dtype=torch.int32, device=device)
-    kv_lens_t = torch.tensor(kv_lens, dtype=torch.int32, device=device)
-    qo_offsets_t = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
-    packed_work_range = torch.empty(num_buckets, dtype=torch.int64, device=device)
-    packed_work_info = torch.empty(batch_size * num_heads, dtype=torch.int64, device=device)
-
-    msa_api._call_plan(
-        qo_offsets_t,
-        qo_lens_t,
-        kv_lens_t,
-        packed_work_range,
-        packed_work_info,
-        128,  # qo_tile_size
-        256,  # kv_tile_size
-        num_heads,
-        num_buckets,
-        False,  # causal
-        None,  # qo_offset
-        1,  # num_kv_splits
-        None,  # kv_tile_begin_indices
-        None,  # kv_tile_end_indices
-        None,  # kv_split_indices
-        0,  # chunk_size
-        None,  # out_max_sm_cost
-        None,  # num_kv_splits_per_row
-        None,  # workspace_lse
-        0,  # lse_total_size
-        1,  # pack_factor
-    )
-    torch.cuda.synchronize()
-
-    ranges = [int(value) for value in packed_work_range.cpu().tolist()]
-    total_work = (ranges[-1] >> 32) & 0xFFFFFFFF
-    work_info = [int(value) for value in packed_work_info[:total_work].cpu().tolist()]
+    work_info = [int(value) for value in plan["packed_work_info"][:total_work].cpu().tolist()]
     return ranges, work_info
 
 
@@ -224,110 +165,45 @@ def _assert_matches_stock(
     num_buckets: int,
 ) -> None:
     qo_offsets = [0] * len(qo_lens)
-    expected = _stock_direct_greedy(
-        qo_lens, kv_lens, num_heads, num_buckets, False, qo_offsets
-    )
+    expected = _stock_direct_greedy(qo_lens, kv_lens, num_heads, num_buckets, False, qo_offsets)
     actual = _run_gpu_plan(qo_lens, kv_lens, num_heads, num_buckets)
     assert actual == expected
 
 
-@pytest.mark.parametrize("kv_iters_boundary", [32767, 32768])
-@pytest.mark.parametrize("seed", [1, 17, 314159])
-def test_single_head_fast_path_matches_stock_at_int16_boundary(
-    kv_iters_boundary: int, seed: int
-) -> None:
-    """Fast path 2 must preserve kv_iters on both sides of the int16 limit."""
+def test_single_head_fast_path_preserves_full_width_kv_iters() -> None:
+    """Fast path 2 must not narrow a 32,768-iteration row to int16."""
 
-    rng = random.Random(seed)
-    batch_size = rng.randint(3, 8)
-    kv_iters = [rng.randint(1, 1024) for _ in range(batch_size)]
-    kv_iters[rng.randrange(batch_size)] = kv_iters_boundary
-
-    # qo_tile_size=128 => kv_tile_size=256.  Variation prevents the uniform
-    # fast path from intercepting this single-head scenario.
-    qo_lens = [1] * batch_size
+    # qo_tile_size=128 => kv_tile_size=256. Variation prevents fast path 1
+    # from intercepting this single-head scenario.
+    qo_lens = [1, 1, 1, 1]
+    kv_iters = [7, 32768, 31, 1024]
     kv_lens = [iters * 256 for iters in kv_iters]
     _assert_matches_stock(qo_lens, kv_lens, num_heads=1, num_buckets=8)
 
 
-@pytest.mark.parametrize("kv_iters_boundary", [32767, 32768])
-@pytest.mark.parametrize("seed", [2, 23, 271828])
-def test_row_compaction_fast_path_matches_stock_at_int16_boundary(
-    kv_iters_boundary: int, seed: int
-) -> None:
-    """Fast path 3 must preserve kv_iters on both sides of the int16 limit."""
+def test_row_compaction_fast_path_preserves_full_width_kv_iters() -> None:
+    """Fast path 3 must not narrow a 32,768-iteration row to int16."""
 
-    rng = random.Random(seed)
-    batch_size = rng.randint(3, 7)
-    boundary_batch = rng.randrange(batch_size)
-    qo_lens = [rng.randint(1, 256) for _ in range(batch_size)]
-    qo_lens[boundary_batch] = 257  # max_qo_tiles=2: excludes fast paths 1 and 2
-    kv_iters = [rng.randint(1, 1024) for _ in range(batch_size)]
-    kv_iters[boundary_batch] = kv_iters_boundary
-
-    # max(qo_lens)>128 => kv_tile_size=128.
+    # max_qo_tiles=2 excludes fast paths 1 and 2. max(qo_lens)>128 selects a
+    # 128-token KV tile, making the second request cross the int16 boundary.
+    qo_lens = [1, 257, 129, 33]
+    kv_iters = [3, 32768, 17, 5]
     kv_lens = [iters * 128 for iters in kv_iters]
     _assert_matches_stock(qo_lens, kv_lens, num_heads=2, num_buckets=8)
 
 
-@pytest.mark.parametrize("cross_boundary", [False, True])
-def test_single_head_fast_path_matches_stock_at_inactive_lane_sentinel(
-    cross_boundary: bool,
-) -> None:
-    """An inactive reduction lane must not beat a full-width active cost."""
+def test_single_head_fast_path_falls_back_before_packed_cost_sentinel() -> None:
+    """Fast path 2 must not let an inactive lane beat an active bucket."""
 
     # This varied prefix lands exactly one below the legacy inactive sentinel.
     # Appending two rows makes a subsequent find-min observe a cost above it.
     kv_iters = [21670] * 8 + [21697]
-    accumulated_cost = _SM_COST + sum(
-        _PER_ITER_COST * iters + _TILE_COST for iters in kv_iters
-    )
+    accumulated_cost = _SM_COST + sum(_PER_ITER_COST * iters + _TILE_COST for iters in kv_iters)
     assert accumulated_cost == _LEGACY_PACKED_COST_SENTINEL - 1
-    if cross_boundary:
-        kv_iters += [1, 2]
+    # The first light row crosses the sentinel. The following row forces
+    # another argmin, which was incorrect when costs were packed into 24 bits.
+    kv_iters += [1, 2]
 
     qo_lens = [1] * len(kv_iters)
     kv_lens = [iters * 256 for iters in kv_iters]
     _assert_matches_stock(qo_lens, kv_lens, num_heads=1, num_buckets=1)
-
-
-def test_single_head_fast_path_matches_stock_across_24bit_cost_wrap() -> None:
-    """Full-width ordering survives 0xffffff with no inactive lanes involved."""
-
-    num_buckets = 256
-    heavy_kv_iters = 32767
-    heavy_tile_cost = _PER_ITER_COST * heavy_kv_iters + _TILE_COST
-
-    # Eleven complete rounds leave every bucket below 0xffffff.  Another 128
-    # heavy rows push buckets [0, 128) above it, while [128, 256) stay below.
-    # The final light row must therefore go to bucket 128.  A 24-bit shift
-    # wraps the expensive buckets and incorrectly chooses bucket 0 instead.
-    low_cost = _SM_COST + 11 * heavy_tile_cost
-    high_cost = low_cost + heavy_tile_cost
-    assert low_cost < _LEGACY_PACKED_COST_MAX < high_cost
-    assert (high_cost & _LEGACY_PACKED_COST_MAX) < low_cost
-
-    kv_iters = [heavy_kv_iters] * (11 * num_buckets + 128) + [1]
-    qo_lens = [1] * len(kv_iters)
-    kv_lens = [iters * 256 for iters in kv_iters]
-    qo_offsets = [0] * len(kv_iters)
-
-    expected = _stock_direct_greedy(
-        qo_lens,
-        kv_lens,
-        num_heads=1,
-        num_buckets=num_buckets,
-        causal=False,
-        qo_offsets=qo_offsets,
-    )
-    actual = _run_raw_gpu_plan(
-        qo_lens, kv_lens, num_heads=1, num_buckets=num_buckets
-    )
-    assert actual == expected
-
-    # The last row uniquely identifies the decision made after the split cost
-    # state.  Confirm that the stock oracle assigned it to bucket 128.
-    last_batch = len(kv_iters) - 1
-    bucket_start = expected[0][128] & 0xFFFFFFFF
-    bucket_end = (expected[0][128] >> 32) & 0xFFFFFFFF
-    assert last_batch in expected[1][bucket_start:bucket_end]

--- a/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_plan_fastpaths.py
+++ b/tests/unittest/_torch/attention/sparse/test_minimax_m3_msa_plan_fastpaths.py
@@ -1,0 +1,333 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Differential boundary tests for the MSA direct-greedy planner fast paths.
+
+The oracle is a CPU translation of the pre-fast-path ``direct_greedy``
+algorithm, with full-width integer cost ordering.  Comparing packed planner
+output, rather than only coverage, catches changes in tie-breaking, per-SM
+ordering, and dropped work.
+
+Only the planner runs: an 8M-token KV cache is not allocated.  The GPU tests
+skip unless the patched MSA package and an SM100 CUDA runtime are available.
+"""
+
+from __future__ import annotations
+
+import random
+from functools import lru_cache
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import torch
+
+
+_PER_ITER_COST = 43
+_TILE_COST = 110
+_SM_COST = 165
+_LEGACY_PACKED_COST_SENTINEL = 0x7FFFFF
+_LEGACY_PACKED_COST_MAX = 0xFFFFFF
+
+
+@lru_cache(maxsize=1)
+def _load_patched_msa_api() -> ModuleType:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the MSA planner")
+    if torch.cuda.get_device_capability()[0] != 10:
+        pytest.skip("the MSA planner requires an SM100 (Blackwell) GPU")
+
+    try:
+        import fmha_sm100.api as msa_api
+    except (ImportError, OSError) as error:
+        pytest.skip(f"fmha_sm100 (MSA) is unavailable: {error}")
+
+    plan_source = Path(msa_api.__file__).parent / "csrc" / "include" / "plan.cuh"
+    if not plan_source.is_file():
+        pytest.skip("installed MSA package does not contain the planner source")
+    if "Fast path 2 (single head)" not in plan_source.read_text():
+        pytest.skip("installed MSA package does not contain the planner fast paths")
+    return msa_api
+
+
+def _ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def _compute_kv_iters(
+    batch: int,
+    qo_tile: int,
+    qo_lens: list[int],
+    kv_lens: list[int],
+    qo_offsets: list[int],
+    qo_tile_size: int,
+    kv_tile_size: int,
+    causal: bool,
+) -> int:
+    kv_len = kv_lens[batch]
+    if not causal:
+        return _ceil_div(kv_len, kv_tile_size)
+    q_end = (qo_tile + 1) * qo_tile_size
+    effective_kv = min(q_end + qo_offsets[batch], kv_len)
+    return 0 if effective_kv <= 0 else _ceil_div(effective_kv, kv_tile_size)
+
+
+def _stock_direct_greedy(
+    qo_lens: list[int],
+    kv_lens: list[int],
+    num_heads: int,
+    num_buckets: int,
+    causal: bool,
+    qo_offsets: list[int],
+) -> tuple[list[int], list[int]]:
+    """Return the packed ranges/work-info emitted by stock direct_greedy."""
+
+    qo_tile_size = 128 if max(qo_lens) <= 128 else 256
+    kv_tile_size = 256 if qo_tile_size == 128 else 128
+    max_qo_tiles = max(_ceil_div(qo_len, qo_tile_size) for qo_len in qo_lens)
+
+    costs = [_SM_COST] * num_buckets
+    tasks: list[list[tuple[int, int, int]]] = [[] for _ in range(num_buckets)]
+
+    # Stock row order and rank-based assignment.  All cases use one KV split,
+    # so each active row has exactly one KV piece.
+    for qo_tile in range(max_qo_tiles - 1, -1, -1):
+        for batch, qo_len in enumerate(qo_lens):
+            if qo_tile >= _ceil_div(qo_len, qo_tile_size):
+                continue
+            kv_iters = _compute_kv_iters(
+                batch,
+                qo_tile,
+                qo_lens,
+                kv_lens,
+                qo_offsets,
+                qo_tile_size,
+                kv_tile_size,
+                causal,
+            )
+            if kv_iters <= 0:
+                continue
+
+            tile_cost = _PER_ITER_COST * kv_iters + _TILE_COST
+            head_offset = 0
+            while head_offset < num_heads:
+                batch_count = min(num_heads - head_offset, num_buckets)
+                ranked_buckets = sorted(
+                    range(num_buckets), key=lambda bucket: (costs[bucket], bucket)
+                )
+                for rank, bucket in enumerate(ranked_buckets[:batch_count]):
+                    costs[bucket] += tile_cost
+                    tasks[bucket].append((qo_tile, head_offset + rank, batch))
+                head_offset += batch_count
+
+    ranges: list[int] = []
+    work_info: list[int] = []
+    start = 0
+    for bucket_tasks in tasks:
+        end = start + len(bucket_tasks)
+        ranges.append((end << 32) | start)
+        for qo_tile, head, batch in bucket_tasks:
+            work_info.append((qo_tile << 32) | (head << 16) | batch)
+        start = end
+    return ranges, work_info
+
+
+def _run_gpu_plan(
+    qo_lens: list[int],
+    kv_lens: list[int],
+    num_heads: int,
+    num_buckets: int,
+    causal: bool = False,
+) -> tuple[list[int], list[int]]:
+    plan_fn = _load_patched_msa_api()._fmha_sm100_plan
+    qo_lens_t = torch.tensor(qo_lens, dtype=torch.int32)
+    kv_lens_t = torch.tensor(kv_lens, dtype=torch.int32)
+    qo_offsets_t = torch.zeros(len(qo_lens), dtype=torch.int32)
+
+    plan = plan_fn(
+        qo_lens_t,
+        kv_lens_t,
+        num_heads,
+        num_kv_heads=-1,  # pack_factor=1: direct_greedy sees num_heads unchanged
+        qo_offset=qo_offsets_t,
+        num_kv_splits=1,
+        usable_SM_count=num_buckets,
+        causal=causal,
+    )
+    torch.cuda.synchronize()
+
+    ranges = [int(value) for value in plan["packed_work_range"].cpu().tolist()]
+    total_work = (ranges[-1] >> 32) & 0xFFFFFFFF
+    work_info = [
+        int(value)
+        for value in plan["packed_work_info"][:total_work].cpu().tolist()
+    ]
+    return ranges, work_info
+
+
+def _run_raw_gpu_plan(
+    qo_lens: list[int],
+    kv_lens: list[int],
+    num_heads: int,
+    num_buckets: int,
+) -> tuple[list[int], list[int]]:
+    """Call the JIT wrapper directly so tests can activate all 256 lanes.
+
+    The public API caps ``num_buckets`` to the physical SM count.  The planner
+    itself is one 256-thread block, so using 256 logical buckets is valid and
+    ensures that neither reduction stage contains an inactive lane.
+    """
+
+    msa_api = _load_patched_msa_api()
+    device = torch.device("cuda", torch.cuda.current_device())
+    batch_size = len(qo_lens)
+    qo_lens_t = torch.tensor(qo_lens, dtype=torch.int32, device=device)
+    kv_lens_t = torch.tensor(kv_lens, dtype=torch.int32, device=device)
+    qo_offsets_t = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+    packed_work_range = torch.empty(num_buckets, dtype=torch.int64, device=device)
+    packed_work_info = torch.empty(batch_size * num_heads, dtype=torch.int64, device=device)
+
+    msa_api._call_plan(
+        qo_offsets_t,
+        qo_lens_t,
+        kv_lens_t,
+        packed_work_range,
+        packed_work_info,
+        128,  # qo_tile_size
+        256,  # kv_tile_size
+        num_heads,
+        num_buckets,
+        False,  # causal
+        None,  # qo_offset
+        1,  # num_kv_splits
+        None,  # kv_tile_begin_indices
+        None,  # kv_tile_end_indices
+        None,  # kv_split_indices
+        0,  # chunk_size
+        None,  # out_max_sm_cost
+        None,  # num_kv_splits_per_row
+        None,  # workspace_lse
+        0,  # lse_total_size
+        1,  # pack_factor
+    )
+    torch.cuda.synchronize()
+
+    ranges = [int(value) for value in packed_work_range.cpu().tolist()]
+    total_work = (ranges[-1] >> 32) & 0xFFFFFFFF
+    work_info = [int(value) for value in packed_work_info[:total_work].cpu().tolist()]
+    return ranges, work_info
+
+
+def _assert_matches_stock(
+    qo_lens: list[int],
+    kv_lens: list[int],
+    num_heads: int,
+    num_buckets: int,
+) -> None:
+    qo_offsets = [0] * len(qo_lens)
+    expected = _stock_direct_greedy(
+        qo_lens, kv_lens, num_heads, num_buckets, False, qo_offsets
+    )
+    actual = _run_gpu_plan(qo_lens, kv_lens, num_heads, num_buckets)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("kv_iters_boundary", [32767, 32768])
+@pytest.mark.parametrize("seed", [1, 17, 314159])
+def test_single_head_fast_path_matches_stock_at_int16_boundary(
+    kv_iters_boundary: int, seed: int
+) -> None:
+    """Fast path 2 must preserve kv_iters on both sides of the int16 limit."""
+
+    rng = random.Random(seed)
+    batch_size = rng.randint(3, 8)
+    kv_iters = [rng.randint(1, 1024) for _ in range(batch_size)]
+    kv_iters[rng.randrange(batch_size)] = kv_iters_boundary
+
+    # qo_tile_size=128 => kv_tile_size=256.  Variation prevents the uniform
+    # fast path from intercepting this single-head scenario.
+    qo_lens = [1] * batch_size
+    kv_lens = [iters * 256 for iters in kv_iters]
+    _assert_matches_stock(qo_lens, kv_lens, num_heads=1, num_buckets=8)
+
+
+@pytest.mark.parametrize("kv_iters_boundary", [32767, 32768])
+@pytest.mark.parametrize("seed", [2, 23, 271828])
+def test_row_compaction_fast_path_matches_stock_at_int16_boundary(
+    kv_iters_boundary: int, seed: int
+) -> None:
+    """Fast path 3 must preserve kv_iters on both sides of the int16 limit."""
+
+    rng = random.Random(seed)
+    batch_size = rng.randint(3, 7)
+    boundary_batch = rng.randrange(batch_size)
+    qo_lens = [rng.randint(1, 256) for _ in range(batch_size)]
+    qo_lens[boundary_batch] = 257  # max_qo_tiles=2: excludes fast paths 1 and 2
+    kv_iters = [rng.randint(1, 1024) for _ in range(batch_size)]
+    kv_iters[boundary_batch] = kv_iters_boundary
+
+    # max(qo_lens)>128 => kv_tile_size=128.
+    kv_lens = [iters * 128 for iters in kv_iters]
+    _assert_matches_stock(qo_lens, kv_lens, num_heads=2, num_buckets=8)
+
+
+@pytest.mark.parametrize("cross_boundary", [False, True])
+def test_single_head_fast_path_matches_stock_at_inactive_lane_sentinel(
+    cross_boundary: bool,
+) -> None:
+    """An inactive reduction lane must not beat a full-width active cost."""
+
+    # This varied prefix lands exactly one below the legacy inactive sentinel.
+    # Appending two rows makes a subsequent find-min observe a cost above it.
+    kv_iters = [21670] * 8 + [21697]
+    accumulated_cost = _SM_COST + sum(
+        _PER_ITER_COST * iters + _TILE_COST for iters in kv_iters
+    )
+    assert accumulated_cost == _LEGACY_PACKED_COST_SENTINEL - 1
+    if cross_boundary:
+        kv_iters += [1, 2]
+
+    qo_lens = [1] * len(kv_iters)
+    kv_lens = [iters * 256 for iters in kv_iters]
+    _assert_matches_stock(qo_lens, kv_lens, num_heads=1, num_buckets=1)
+
+
+def test_single_head_fast_path_matches_stock_across_24bit_cost_wrap() -> None:
+    """Full-width ordering survives 0xffffff with no inactive lanes involved."""
+
+    num_buckets = 256
+    heavy_kv_iters = 32767
+    heavy_tile_cost = _PER_ITER_COST * heavy_kv_iters + _TILE_COST
+
+    # Eleven complete rounds leave every bucket below 0xffffff.  Another 128
+    # heavy rows push buckets [0, 128) above it, while [128, 256) stay below.
+    # The final light row must therefore go to bucket 128.  A 24-bit shift
+    # wraps the expensive buckets and incorrectly chooses bucket 0 instead.
+    low_cost = _SM_COST + 11 * heavy_tile_cost
+    high_cost = low_cost + heavy_tile_cost
+    assert low_cost < _LEGACY_PACKED_COST_MAX < high_cost
+    assert (high_cost & _LEGACY_PACKED_COST_MAX) < low_cost
+
+    kv_iters = [heavy_kv_iters] * (11 * num_buckets + 128) + [1]
+    qo_lens = [1] * len(kv_iters)
+    kv_lens = [iters * 256 for iters in kv_iters]
+    qo_offsets = [0] * len(kv_iters)
+
+    expected = _stock_direct_greedy(
+        qo_lens,
+        kv_lens,
+        num_heads=1,
+        num_buckets=num_buckets,
+        causal=False,
+        qo_offsets=qo_offsets,
+    )
+    actual = _run_raw_gpu_plan(
+        qo_lens, kv_lens, num_heads=1, num_buckets=num_buckets
+    )
+    assert actual == expected
+
+    # The last row uniquely identifies the decision made after the split cost
+    # state.  Confirm that the stock oracle assigned it to bucket 128.
+    last_batch = len(kv_iters) - 1
+    bucket_start = expected[0][128] & 0xFFFFFFFF
+    bucket_end = (expected[0][128] >> 32) & 0xFFFFFFFF
+    assert last_batch in expected[1][bucket_start:bucket_end]

--- a/tests/unittest/scripts/test_build_wheel.py
+++ b/tests/unittest/scripts/test_build_wheel.py
@@ -23,6 +23,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SCRIPT_PATH = REPO_ROOT / "scripts" / "build_wheel.py"
 MSA_INTERFACE = Path("python/fmha_sm100/cute/interface.py")
+MSA_PLAN = Path("python/fmha_sm100/csrc/include/plan.cuh")
 MSA_PATCH = Path("3rdparty/patches/msa_strided_paged_kv.patch")
 
 _SPEC = importlib.util.spec_from_file_location("build_wheel", SCRIPT_PATH)
@@ -47,7 +48,8 @@ def _stage_project(tmp_path: Path) -> Path:
     shutil.copytree(
         source_msa, project_dir / "3rdparty" / "MSA", ignore=shutil.ignore_patterns(".git")
     )
-    shutil.copy(REPO_ROOT / MSA_PATCH, project_dir / MSA_PATCH)
+    for patch in sorted((REPO_ROOT / "3rdparty" / "patches").glob("msa_*.patch")):
+        shutil.copy(patch, project_dir / "3rdparty" / "patches" / patch.name)
     return project_dir
 
 
@@ -62,6 +64,22 @@ def test_apply_msa_patch_is_idempotent_in_place(tmp_path):
     # raise, leaving the patched content in place.
     apply_msa_patch(project_dir)
     assert "def _prepare_paged_hnd_input" in patched_interface.read_text()
+
+
+def test_apply_msa_patch_applies_every_msa_patch(tmp_path):
+    """All msa_*.patch files apply, not just the first.
+
+    The planner fast paths land in plan.cuh while the strided-paged-kv change
+    lands in interface.py.
+    """
+    project_dir = _stage_project(tmp_path)
+    patched_plan = project_dir / "3rdparty" / "MSA" / MSA_PLAN
+
+    apply_msa_patch(project_dir)
+    assert "Fast path 1 (uniform cost)" in patched_plan.read_text()
+
+    apply_msa_patch(project_dir)
+    assert "Fast path 1 (uniform cost)" in patched_plan.read_text()
 
 
 def test_apply_msa_patch_with_dangling_submodule_gitlink(tmp_path):

--- a/tests/unittest/scripts/test_build_wheel.py
+++ b/tests/unittest/scripts/test_build_wheel.py
@@ -76,7 +76,13 @@ def test_apply_msa_patch_applies_every_msa_patch(tmp_path):
     patched_plan = project_dir / "3rdparty" / "MSA" / MSA_PLAN
 
     apply_msa_patch(project_dir)
-    assert "Fast path 1 (uniform cost)" in patched_plan.read_text()
+    plan_source = patched_plan.read_text()
+    assert "Fast path 1 (uniform cost)" in plan_source
+    assert "int direct_kv_iters[MAX_UNSPLIT]" in plan_source
+    assert "uint pack_cost_idx" in plan_source
+    assert "uint64_t pack_cost_idx" not in plan_source
+    assert "_max_bucket_cost_bound <= 0x7ffffe" in plan_source
+    assert "const int64_t _num_direct_rows" in plan_source
 
     apply_msa_patch(project_dir)
     assert "Fast path 1 (uniform cost)" in patched_plan.read_text()


### PR DESCRIPTION
## Summary

This PR provides three fast path to planner. Under **conc=4096**, it is able to **save~93% overhead in planner** and **have ~4.9% gain in tok/s/user while maintaining tok/s/GPU**. It also shows gains for conc=64, 256, 1024.

There will be less gain after #17171 get merged. This is because 
- Pure decode: #17171 skips MSA planning entirely, so fast paths 1 and 2 become redundant there.
- Mixed/prefill: MSA still handles the context prefix, so fast paths 3 remains valid.

<img width="2410" height="398" alt="image" src="https://github.com/user-attachments/assets/559716f7-4468-4161-9738-5da8519bc265" />


### Fast path 1 — uniform cost ⇒ closed form (sparse/GQA decode, 94×)

  When every task has the same cost, the greedy assignment is deterministic round-robin: task t → SM (t % N). We replace both greedy passes with parallel closed-form calculations. A min == max reduction guards the path; non-uniform cases use the original algorithm.

  Gain: 1080 → 11.7 µs at batch 256 (94×; 113× at batch 2048).

  ### Fast path 2 — single head ⇒ warp argmin + cached scatter (dense/proxy decode, 11×)

  With num_heads == 1, each round assigns only one task, so the full per-thread rank scan is unnecessary. We use the existing warp-shuffle argmin, preserving the lowest-index tie-break, and cache pass-1 placements so pass 2 becomes a parallel scatter.

  Gain: 1075 → 101 µs at batch 256 (11×).

  ### Fast path 3 — active-row compaction (prefill/mixed, 2.8×)

  Mixed steps scan the full max_qo_tiles × batch rectangle twice, although most entries are inactive—96% at concurrency 256. We compact active rows once with cub::BlockScan, preserving stock order, then run both passes over the dense list. Oversized cases fall back to the original path.

  Gain: 2939 → 1062 µs per mixed call (2.8×).

  Delivered as a downstream MSA patch. apply_msa_patch now applies all msa_*.patch files in sorted order using the existing patch mechanism.