### PR TITLE
[None][doc] Fix broken figures and math rendering in tech blogs 25 and 26

### DIFF
--- a/docs/source/blogs/tech_blog/blog25_Scaling_Video_Generation_Across_NVL72_Rack_with_TensorRT-LLM.md
+++ b/docs/source/blogs/tech_blog/blog25_Scaling_Video_Generation_Across_NVL72_Rack_with_TensorRT-LLM.md
@@ -13,8 +13,8 @@ On Wan 2.2 T2V-A14B (a 5-second 1280×720 video, 40 steps), the `CFG=2 × Ulysse
 The same runtime carries over unchanged to Cosmos3-Super (a 64B Mixture-of-Transformers generating a 189-frame 1280×720 clip), where the identical `CFG=2 × Ulysses=4 × Attention2D 3×3` recipe delivers **~55× on the denoise loop (~33× end-to-end)** on the full GB200 NVL72 rack.
 
 <p align="center">
-  <img src="../media/tech_blog25_nvl72_scaling.png" alt="Wan 2.2 T2V-A14B scaling from one B200 GPU to the 72-GPU GB200 NVL72 recipe: ~53x denoise, ~41x end-to-end" width="49%">
-  <img src="../media/tech_blog25_cosmos3_highlight.png" alt="Cosmos3-Super scaling from one B200 GPU to the full 72-GPU GB200 NVL72 recipe: ~55x denoise, ~33x end-to-end" width="49%">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_nvl72_scaling.png" alt="Wan 2.2 T2V-A14B scaling from one B200 GPU to the 72-GPU GB200 NVL72 recipe: ~53x denoise, ~41x end-to-end" width="49%">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_cosmos3_highlight.png" alt="Cosmos3-Super scaling from one B200 GPU to the full 72-GPU GB200 NVL72 recipe: ~55x denoise, ~33x end-to-end" width="49%">
 </p>
 
 <p align="center"><sub><em>Figure 1. The same VisualGen recipe scaling two models from a single GPU to a full GB200 NVL72 rack. Left: Wan 2.2 T2V-A14B (5-second 1280×720, 40 steps). Right: Cosmos3-Super (189-frame 1280×720, 35 steps) under the identical `CFG=2 × Ulysses=4 × Attention2D 3×3` recipe.</em></sub></p>
@@ -67,11 +67,11 @@ The rest of this post walks through each of these axes first, then shows how the
 
 ## CFG Parallelism
 
-Classifier-Free Guidance evaluates the diffusion transformer twice per denoising step - once with the positive prompt embedding to produce $`\text{noise}_\text{cond}`$, once with the negative prompt embedding to produce $`\text{noise}_\text{uncond}`$ - and combines the two predictions as
+Classifier-Free Guidance evaluates the diffusion transformer twice per denoising step - once with the positive prompt embedding to produce $\text{noise}_\text{cond}$, once with the negative prompt embedding to produce $\text{noise}_\text{uncond}$ - and combines the two predictions as
 
-```math
+$$
 \text{noise} = \text{noise}_\text{uncond} + \text{guidance\_scale} \cdot (\text{noise}_\text{cond} - \text{noise}_\text{uncond})
-```
+$$
 
 The two evaluations share weights, timestep, and shape, so they are perfectly parallelisable across two disjoint GPU groups. CFG parallelism exploits this by setting `cfg_size = 2`: the conditional stream runs on one half of the mesh and the unconditional stream on the other half. Each half runs its full DiT forward end to end with no cross-stream communication; only the two scalar noise tensors meet at the combine step.
 
@@ -91,7 +91,7 @@ That near-linear scaling makes CFG the cheapest scaling axis available, and the 
 The key insight behind Ulysses ([arXiv:2309.14509](https://arxiv.org/abs/2309.14509)) is that outside the attention operation, activations are already sharded across GPUs along the sequence axis — each rank holds $[B, S/P, H, D]$ (`P` is the sequence-parallel degree), and FFN, norms, and modulation all run locally on that shard with no communication. The problem is that standard attention is inherently global: a query at position $i$ needs to see all keys and values across the full sequence length. Ulysses solves this by swapping the sharding axis just for the attention operation. A pair of all-to-alls converts $[B, S/P, H, D] \rightarrow [B, S, H/P, D]$ before attention and back again after, so each rank sees the full sequence but only a $1/P$ slice of heads. The FFN and everything else never touch a collective (unless composed with an FFN-sharding scheme like TP, which adds its own).
 
 <p align="center">
-  <img src="../media/tech_blog25_ulysses_dataflow.png" alt="Ulysses sequence parallelism data layout: a pair of all-to-alls transposes a frame-sharded layout into a head-sharded layout for attention, then back" width="1080">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_ulysses_dataflow.png" alt="Ulysses sequence parallelism data layout: a pair of all-to-alls transposes a frame-sharded layout into a head-sharded layout for attention, then back" width="1080">
 </p>
 
 <p align="center"><sub><em>Figure 2. Ulysses keeps every stage except attention sequence-sharded - each rank owns a slice of the video frames (all heads), so QKV projection, norms, and the MLP run locally with no collective. A pair of all-to-alls transposes the layout to head-sharded (each rank owns all frames but a 1/P slice of heads) just for the full-sequence attention, then transposes back for the MLP.</em></sub></p>
@@ -107,12 +107,12 @@ The stacked QKV buffer produced by the all-to-all is a single contiguous allocat
 
 **Communication cost.** Ulysses parallelism involves **only two all-to-all communications per layer, regardless of sequence length**. For a sequence length $N$ and $P$ GPUs, each GPU sends a data chunk of size $O(N/P^2)$ to each of the other $P-1$ GPUs. This leads to a communication cost of $O(N/P)$.
 
-**Limitation.** Ulysses sequence parallelism is constrained by the model’s attention head count: the Ulysses degree $P$ must not exceed the head count `num_heads` and must evenly divide `num_heads`; to use all GPUs in an NVL72 system uniformly, $P$ must also divide 72. For Wan2.2‑T2V‑A14B with $`\text{num\_heads} = 40`$, this constraint makes $P = 8$ the largest feasible Ulysses degree on NVL72.
+**Limitation.** Ulysses sequence parallelism is constrained by the model’s attention head count: the Ulysses degree $P$ must not exceed the head count `num_heads` and must evenly divide `num_heads`; to use all GPUs in an NVL72 system uniformly, $P$ must also divide 72. For Wan2.2‑T2V‑A14B with $\text{num\_heads} = 40$, this constraint makes $P = 8$ the largest feasible Ulysses degree on NVL72.
 
 ### Toward Async Ulysses: Overlapping Communication and Computation
 
 <p align="center">
-  <img src="../media/tech_blog25_async_ulysses.png" alt="Async Ulysses V-to-Q-to-K pipeline: each tensor's all-to-all runs on the Copy Engines and overlaps the next tensor's projection compute" width="1080">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_async_ulysses.png" alt="Async Ulysses V-to-Q-to-K pipeline: each tensor's all-to-all runs on the Copy Engines and overlaps the next tensor's projection compute" width="1080">
 </p>
 
 <p align="center"><sub><em>Figure 3. Async Ulysses moves the Q/K/V all-to-all onto the GPU's Copy Engines on a separate stream and pipelines it V→Q→K, so each tensor's cross-rank transfer overlaps the next tensor's projection compute (V's transfer hides under Q's compute, Q's under K's), hiding the collective latency behind useful work.</em></sub></p>
@@ -170,28 +170,28 @@ Rank r holds Q_r (fixed) and K/V block for step i
 
 **Overlapping communication and compute.** The K/V exchange for the next block is posted with non-blocking point-to-point (`batch_isend_irecv`) *before* the current block's FA4 kernel runs, so the neighbor transfer overlaps with attention compute. Even ranks send-then-recv and odd ranks recv-then-send to avoid deadlock; the final ring step skips the exchange entirely.
 
-**Communication cost.** Ring pays $P-1$ neighbor exchanges per attention layer, and communication volume scales as $O(N)$ in sequence length $N$ — more sequential steps than Ulysses. Each ring step also runs a partial FA4 pass plus an online-softmax merge, so attention work grows with ring degree $P$, not just communication. The upside is flexibility: **no head-count ceiling**, a simple 1D topology, and straightforward composition with Ulysses on the same mesh ($`\text{cp\_size} \times \text{ulysses\_size}`$). P2P can overlap with compute, which keeps Ring competitive at small $P$ and short sequences. For production video lengths, though, we **generally prefer Attention2D** (detailed in the next section) for the context-parallel axis, owing to its lower communication cost – $O(N/\sqrt{P})$ versus $O(N)$ for Ring attention.
+**Communication cost.** Ring pays $P-1$ neighbor exchanges per attention layer, and communication volume scales as $O(N)$ in sequence length $N$ — more sequential steps than Ulysses. Each ring step also runs a partial FA4 pass plus an online-softmax merge, so attention work grows with ring degree $P$, not just communication. The upside is flexibility: **no head-count ceiling**, a simple 1D topology, and straightforward composition with Ulysses on the same mesh ($\text{cp\_size} \times \text{ulysses\_size}$). P2P can overlap with compute, which keeps Ring competitive at small $P$ and short sequences. For production video lengths, though, we **generally prefer Attention2D** (detailed in the next section) for the context-parallel axis, owing to its lower communication cost – $O(N/\sqrt{P})$ versus $O(N)$ for Ring attention.
 
 ### 2. Attention2D Parallelism
 
-Attention2D parallelism ([arXiv:2503.15758](https://arxiv.org/abs/2503.15758)) treats the $P$ context-parallel GPUs as a logical 2D grid of $`\text{row\_size} \times \text{col\_size}`$ workers. It is our preferred **context-parallel strategy** once Ulysses has consumed the head-divisible fraction of the mesh and more GPUs remain. Like Ring, it shards the spatiotemporal sequence with **no head-count ceiling** — any $`\text{row\_size} \times \text{col\_size}`$ grid is valid regardless of how many attention heads the DiT has. It also **generalizes 1D context parallelism** - setting $`\text{col\_size}=1`$ reduces to the no-merge scheme (all-gather K/V), while setting $`\text{row\_size}=1`$ reduces to the merge scheme (all-gather Q). - and **scales the CP degree better**, gathering only $S/\sqrt{P}$ per axis ($O(N/\sqrt{P})$ communication) on a symmetric grid, which suits long-sequence DiT inference. The runtime adapts the original Attention2D design from causal LLM training to **full bidirectional** DiT inference.
+Attention2D parallelism ([arXiv:2503.15758](https://arxiv.org/abs/2503.15758)) treats the $P$ context-parallel GPUs as a logical 2D grid of $\text{row\_size} \times \text{col\_size}$ workers. It is our preferred **context-parallel strategy** once Ulysses has consumed the head-divisible fraction of the mesh and more GPUs remain. Like Ring, it shards the spatiotemporal sequence with **no head-count ceiling** — any $\text{row\_size} \times \text{col\_size}$ grid is valid regardless of how many attention heads the DiT has. It also **generalizes 1D context parallelism** - setting $\text{col\_size}=1$ reduces to the no-merge scheme (all-gather K/V), while setting $\text{row\_size}=1$ reduces to the merge scheme (all-gather Q). - and **scales the CP degree better**, gathering only $S/\sqrt{P}$ per axis ($O(N/\sqrt{P})$ communication) on a symmetric grid, which suits long-sequence DiT inference. The runtime adapts the original Attention2D design from causal LLM training to **full bidirectional** DiT inference.
 
-**Gather phase: Q along rows and K/V along columns.** Ranks form a $`\text{row\_size} \times \text{col\_size}`$ grid ($`P = \text{row\_size} \times \text{col\_size}`$). Each rank starts with a $1/P$ shard of all three tensors — $Q_i, K_i, V_i$, each $[B, S/P, H, D]$. Attention2D then runs two all-gathers on the two independent grid axes:
+**Gather phase: Q along rows and K/V along columns.** Ranks form a $\text{row\_size} \times \text{col\_size}$ grid ($P = \text{row\_size} \times \text{col\_size}$). Each rank starts with a $1/P$ shard of all three tensors — $Q_i, K_i, V_i$, each $[B, S/P, H, D]$. Attention2D then runs two all-gathers on the two independent grid axes:
 
-- **Q gather** over the **row group** (`row_process_group`): the `col_size` ranks that share a row. Concatenates their $Q_i$ → every member holds $`[B, S/\text{row\_size}, H, D]`$. K/V are untouched.  
-- **K/V gather** over the **column group** (`col_process_group`): the `row_size` ranks that share a column, fused into a single collective. Concatenates their $`K_i / V_i`$ → every member holds $`[B, S/\text{col\_size}, H, D]`$. Q is untouched.
+- **Q gather** over the **row group** (`row_process_group`): the `col_size` ranks that share a row. Concatenates their $Q_i$ → every member holds $[B, S/\text{row\_size}, H, D]$. K/V are untouched.  
+- **K/V gather** over the **column group** (`col_process_group`): the `row_size` ranks that share a column, fused into a single collective. Concatenates their $K_i / V_i$ → every member holds $[B, S/\text{col\_size}, H, D]$. Q is untouched.
 
-So **Q expands by `col_size`** (a row holds `col_size` ranks → $`S/\text{row\_size}`$) and **K/V expand by `row_size`** (a column holds `row_size` ranks → $`S/\text{col\_size}`$); on a symmetric $\sqrt{P} \times \sqrt{P}$ mesh both land at $S/\sqrt{P}$. The picture below uses a $2 \times 3$ grid (`row_size=2, col_size=3`, $P=6$), with $S$ split into shards $0..5$:
+So **Q expands by `col_size`** (a row holds `col_size` ranks → $S/\text{row\_size}$) and **K/V expand by `row_size`** (a column holds `row_size` ranks → $S/\text{col\_size}$); on a symmetric $\sqrt{P} \times \sqrt{P}$ mesh both land at $S/\sqrt{P}$. The picture below uses a $2 \times 3$ grid (`row_size=2, col_size=3`, $P=6$), with $S$ split into shards $0..5$:
 
 <p align="center">
-  <img src="../media/tech_blog25_attention2d.png" alt="Attention2D per-rank data flow on a 2x3 grid: gather Q over the row group, K/V over the column group, one attention pass per rank produces a partial output, then an all-to-all over the row group exchanges partials and a local flash_attn_combine reduction merges them" width="1080">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_attention2d.png" alt="Attention2D per-rank data flow on a 2x3 grid: gather Q over the row group, K/V over the column group, one attention pass per rank produces a partial output, then an all-to-all over the row group exchanges partials and a local flash_attn_combine reduction merges them" width="1080">
 </p>
 
 <p align="center"><sub><em>Figure 4. Attention2D data flow traced for rank0 on a 2x3 grid (`row_size=2, col_size=3`, P=6). Each rank starts with a 1/P shard; ① an all-gather over the `row_process_group` collects Q, ② an all-gather over the `col_process_group` collects K/V, giving each rank the [B, S/row, H, D] queries x [B, S/col, H, D] keys it attends in one pass to produce a single partial output (with its LSE). The row group's ranks share the same Q but attend over disjoint K/V slices, so ③ an `all_to_all` over the `row_process_group` exchanges those partials, then a local `flash_attn_combine` reduction merges them into the final [B, S/P, H, D] shard.</em></sub></p>
 
 Members of a **row (Q) group** end up with identical Q but **disjoint** K/V slices; members of a **column (K/V) group** share identical K/V but hold different Q.
 
-**Local Attention.** The inner backend ([`Attention2DAttention`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py)) runs attention with LSE returning a partial output $`[B, S/\text{row\_size}, H, D]`$ and a log-sum-exp (LSE) statistic $`[B, H, S/\text{row\_size}]`$. The LSE records the softmax normalizer for that partial pass.
+**Local Attention.** The inner backend ([`Attention2DAttention`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py)) runs attention with LSE returning a partial output $[B, S/\text{row\_size}, H, D]$ and a log-sum-exp (LSE) statistic $[B, H, S/\text{row\_size}]$. The LSE records the softmax normalizer for that partial pass.
 
 **Merge phase.** The `col_size` ranks that share the same Q each attended over a **disjoint slice of K/V** (above: ranks `0`, `1`, `2` all hold queries `{0,1,2}` but keys `{0,3}`, `{1,4}`, `{2,5}` respectively). Their FA4 outputs are partial results for the **same query positions** over **complementary key spans**, so they must be combined **within that row group** to recover the full softmax. For `col_size = 3`, the partial results are spread across 3 GPUs. These are combined into the final output as follows: 
 
@@ -212,10 +212,10 @@ Members of a **row (Q) group** end up with identical Q but **disjoint** K/V slic
 | **Communication cost** | $O(N)$ | $O(N / \sqrt{P})$ |
 | **Scaling** | No scaling: communication cost remains constant as $P$ increases | Efficient scaling: communication cost decreases as $O(1 / \sqrt{P})$ as $P$ increases |
 
-**Communication cost.** Across the full layer, Attention2D runs three collective phases: Q all-gather (row), K/V all-gather (column), and output+LSE all-to-all (row). On a symmetric mesh ($`\text{row\_size} \approx \text{col\_size} \approx \sqrt{P}`$), moved volume scales as $O(N / \sqrt{P})$ in sequence length $N$, compared to $O(N)$ for Ring — the same head-count freedom, but better communication scaling and one attention pass instead of $P$.
+**Communication cost.** Across the full layer, Attention2D runs three collective phases: Q all-gather (row), K/V all-gather (column), and output+LSE all-to-all (row). On a symmetric mesh ($\text{row\_size} \approx \text{col\_size} \approx \sqrt{P}$), moved volume scales as $O(N / \sqrt{P})$ in sequence length $N$, compared to $O(N)$ for Ring — the same head-count freedom, but better communication scaling and one attention pass instead of $P$.
 
 <p align="center">
-  <img src="../media/tech_blog25_a2d_vs_ring.png" alt="Bar chart of denoise-loop latency for Attention2D vs Ring at 32 GPU (UL=8, CP=2), 64 GPU (UL=8, CP=4), and 72 GPU (UL=4, CP=9); Ring is +3%, +13%, and +83% slower respectively" width="820">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_a2d_vs_ring.png" alt="Bar chart of denoise-loop latency for Attention2D vs Ring at 32 GPU (UL=8, CP=2), 64 GPU (UL=8, CP=4), and 72 GPU (UL=4, CP=9); Ring is +3%, +13%, and +83% slower respectively" width="820">
 </p>
 
 <p align="center"><sub><em>Figure 5. Denoise-loop latency for Attention2D vs Ring on GB200 NVL72 (Wan 2.2 T2V-A14B, 5-second 1280×720 video, 40 steps). `cfg=2` is fixed. Attention2D scales favorably with increasing context-parallel degree — its communication cost reduces as O(1 / sqrt{P}) while Ring Attention's remains flat at O(1), for a fixed sequence length N  — yielding progressively larger latency gaps of +3% at CP=2, +13% at CP=4, and +83% at CP=9. Ring Attention suffers a sharp latency regression at 72 GPUs: to evenly divide the 36 available GPUs per cfg replica, the Ulysses parallelism degree (UL) must be reduced from 8 to 4, which increases communication volume along the CP axis. This amplifies Ring Attention's latency, as its communication volume scales as O(N). Attention2D is far less sensitive to the increased communication volume because it scales as O(N / sqrt{P}), allowing the higher parallelism degree to offset the additional volume.</em></sub></p>
@@ -227,7 +227,7 @@ After the DiT denoising loop finishes, a single latent tensor still has to be tu
 **Spatial sharding.** Unlike the DiT - which shards the *token sequence* - the VAE is a convolutional UNet-style stack that operates on a `(B, C, T, H, W)` video tensor, so the natural axis to split is **image space**. `parallel_vae_split_dim` selects height or width, and the latent (decode) or video (encode) tensor is chunked along that dimension across the `parallel_vae_size` ranks. Each rank owns a $1/P$ spatial slice and decodes it locally; a single all-gather at the end reconstructs the full frame:
 
 <p align="center">
-  <img src="../media/tech_blog25_parallel_vae.png" alt="Parallel VAE: route the final latent to the parallel_vae_size VAE-group ranks while the rest idle, split image space along W into 1/P slices, decode each slice locally, all-gather into the full video, and use halo exchange so boundary convolutions stay correct" width="1080">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_parallel_vae.png" alt="Parallel VAE: route the final latent to the parallel_vae_size VAE-group ranks while the rest idle, split image space along W into 1/P slices, decode each slice locally, all-gather into the full video, and use halo exchange so boundary convolutions stay correct" width="1080">
 </p>
 
 <p align="center"><sub><em>Figure 6. Parallel VAE decode. The full latent is split along an image-space axis (`W` here) into 1/P slices across the `parallel_vae_size` VAE-group ranks (the rest idle); each rank decodes its slice locally — boundary convolutions exchange only a thin k-1 "halo" with their neighbors (edge ranks zero-pad), and attention blocks gather the full split dimension — then a final all-gather reconstructs the full video.</em></sub></p>
@@ -322,7 +322,7 @@ The headline result is summarized in [Figure 1](#scaling-video-generation-across
 Sweeping the best recipe at every width on GB200 NVL72 shows the DiT denoise loop scaling almost linearly across the full rack:
 
 <p align="center">
-  <img src="../media/tech_blog25_scaling_lines.png" alt="WAN 2.2 T2V-A14B DiT denoise-loop latency vs ideal linear scaling on GB200 NVL72, from 1 to 72 GPUs, with per-point parallel efficiency" width="1080">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_scaling_lines.png" alt="WAN 2.2 T2V-A14B DiT denoise-loop latency vs ideal linear scaling on GB200 NVL72, from 1 to 72 GPUs, with per-point parallel efficiency" width="1080">
 </p>
 
 <p align="center"><sub><em>Figure 7. DiT denoise-loop scaling on GB200 NVL72 (best config at each width, GB200 1-GPU baseline). The loop tracks ideal linear scaling closely - ~49× at 72 GPUs - because CFG and sequence parallelism shard the transformer almost perfectly.</em></sub></p>
@@ -371,7 +371,7 @@ The headline result is summarized on the right of [Figure 1](#scaling-video-gene
 Sweeping the best recipe at every width gives the same near-linear denoise-loop scaling as Wan:
 
 <p align="center">
-  <img src="../media/tech_blog25_cosmos3_scaling_lines.png" alt="Cosmos3-Super DiT denoise-loop latency vs ideal linear scaling on GB200 NVL72, with per-point parallel efficiency" width="1080">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_cosmos3_scaling_lines.png" alt="Cosmos3-Super DiT denoise-loop latency vs ideal linear scaling on GB200 NVL72, with per-point parallel efficiency" width="1080">
 </p>
 
 <p align="center"><sub><em>Figure 8. Cosmos3-Super DiT denoise-loop scaling on GB200 NVL72 (best config at each width, GB200 1-GPU baseline). The loop tracks ideal linear scaling closely - ~49× at 72 GPUs - because CFG and sequence parallelism shard the transformer almost perfectly.</em></sub></p>

--- a/docs/source/blogs/tech_blog/blog25_Scaling_Video_Generation_Across_NVL72_Rack_with_TensorRT-LLM.md
+++ b/docs/source/blogs/tech_blog/blog25_Scaling_Video_Generation_Across_NVL72_Rack_with_TensorRT-LLM.md
@@ -67,10 +67,10 @@ The rest of this post walks through each of these axes first, then shows how the
 
 ## CFG Parallelism
 
-Classifier-Free Guidance evaluates the diffusion transformer twice per denoising step - once with the positive prompt embedding to produce $\text{noise}_\text{cond}$, once with the negative prompt embedding to produce $\text{noise}_\text{uncond}$ - and combines the two predictions as
+Classifier-Free Guidance evaluates the diffusion transformer twice per denoising step - once with the positive prompt embedding to produce the conditional noise prediction, once with the negative prompt embedding to produce the unconditional one - and combines the two predictions as
 
 $$
-\text{noise} = \text{noise}_\text{uncond} + \text{guidance\_scale} \cdot (\text{noise}_\text{cond} - \text{noise}_\text{uncond})
+\text{noise} = \text{noise}_\text{uncond} + \text{guidance scale} \cdot (\text{noise}_\text{cond} - \text{noise}_\text{uncond})
 $$
 
 The two evaluations share weights, timestep, and shape, so they are perfectly parallelisable across two disjoint GPU groups. CFG parallelism exploits this by setting `cfg_size = 2`: the conditional stream runs on one half of the mesh and the unconditional stream on the other half. Each half runs its full DiT forward end to end with no cross-stream communication; only the two scalar noise tensors meet at the combine step.
@@ -107,7 +107,7 @@ The stacked QKV buffer produced by the all-to-all is a single contiguous allocat
 
 **Communication cost.** Ulysses parallelism involves **only two all-to-all communications per layer, regardless of sequence length**. For a sequence length $N$ and $P$ GPUs, each GPU sends a data chunk of size $O(N/P^2)$ to each of the other $P-1$ GPUs. This leads to a communication cost of $O(N/P)$.
 
-**Limitation.** Ulysses sequence parallelism is constrained by the model’s attention head count: the Ulysses degree $P$ must not exceed the head count `num_heads` and must evenly divide `num_heads`; to use all GPUs in an NVL72 system uniformly, $P$ must also divide 72. For Wan2.2‑T2V‑A14B with $\text{num\_heads} = 40$, this constraint makes $P = 8$ the largest feasible Ulysses degree on NVL72.
+**Limitation.** Ulysses sequence parallelism is constrained by the model’s attention head count: the Ulysses degree $P$ must not exceed the head count `num_heads` and must evenly divide `num_heads`; to use all GPUs in an NVL72 system uniformly, $P$ must also divide 72. For Wan2.2‑T2V‑A14B with $\text{num heads} = 40$, this constraint makes $P = 8$ the largest feasible Ulysses degree on NVL72.
 
 ### Toward Async Ulysses: Overlapping Communication and Computation
 
@@ -170,18 +170,18 @@ Rank r holds Q_r (fixed) and K/V block for step i
 
 **Overlapping communication and compute.** The K/V exchange for the next block is posted with non-blocking point-to-point (`batch_isend_irecv`) *before* the current block's FA4 kernel runs, so the neighbor transfer overlaps with attention compute. Even ranks send-then-recv and odd ranks recv-then-send to avoid deadlock; the final ring step skips the exchange entirely.
 
-**Communication cost.** Ring pays $P-1$ neighbor exchanges per attention layer, and communication volume scales as $O(N)$ in sequence length $N$ — more sequential steps than Ulysses. Each ring step also runs a partial FA4 pass plus an online-softmax merge, so attention work grows with ring degree $P$, not just communication. The upside is flexibility: **no head-count ceiling**, a simple 1D topology, and straightforward composition with Ulysses on the same mesh ($\text{cp\_size} \times \text{ulysses\_size}$). P2P can overlap with compute, which keeps Ring competitive at small $P$ and short sequences. For production video lengths, though, we **generally prefer Attention2D** (detailed in the next section) for the context-parallel axis, owing to its lower communication cost – $O(N/\sqrt{P})$ versus $O(N)$ for Ring attention.
+**Communication cost.** Ring pays $P-1$ neighbor exchanges per attention layer, and communication volume scales as $O(N)$ in sequence length $N$ — more sequential steps than Ulysses. Each ring step also runs a partial FA4 pass plus an online-softmax merge, so attention work grows with ring degree $P$, not just communication. The upside is flexibility: **no head-count ceiling**, a simple 1D topology, and straightforward composition with Ulysses on the same mesh ($\text{cp size} \times \text{ulysses size}$). P2P can overlap with compute, which keeps Ring competitive at small $P$ and short sequences. For production video lengths, though, we **generally prefer Attention2D** (detailed in the next section) for the context-parallel axis, owing to its lower communication cost – $O(N/\sqrt{P})$ versus $O(N)$ for Ring attention.
 
 ### 2. Attention2D Parallelism
 
-Attention2D parallelism ([arXiv:2503.15758](https://arxiv.org/abs/2503.15758)) treats the $P$ context-parallel GPUs as a logical 2D grid of $\text{row\_size} \times \text{col\_size}$ workers. It is our preferred **context-parallel strategy** once Ulysses has consumed the head-divisible fraction of the mesh and more GPUs remain. Like Ring, it shards the spatiotemporal sequence with **no head-count ceiling** — any $\text{row\_size} \times \text{col\_size}$ grid is valid regardless of how many attention heads the DiT has. It also **generalizes 1D context parallelism** - setting $\text{col\_size}=1$ reduces to the no-merge scheme (all-gather K/V), while setting $\text{row\_size}=1$ reduces to the merge scheme (all-gather Q). - and **scales the CP degree better**, gathering only $S/\sqrt{P}$ per axis ($O(N/\sqrt{P})$ communication) on a symmetric grid, which suits long-sequence DiT inference. The runtime adapts the original Attention2D design from causal LLM training to **full bidirectional** DiT inference.
+Attention2D parallelism ([arXiv:2503.15758](https://arxiv.org/abs/2503.15758)) treats the $P$ context-parallel GPUs as a logical 2D grid of $\text{row size} \times \text{col size}$ workers. It is our preferred **context-parallel strategy** once Ulysses has consumed the head-divisible fraction of the mesh and more GPUs remain. Like Ring, it shards the spatiotemporal sequence with **no head-count ceiling** — any $\text{row size} \times \text{col size}$ grid is valid regardless of how many attention heads the DiT has. It also **generalizes 1D context parallelism** - setting $\text{col size}=1$ reduces to the no-merge scheme (all-gather K/V), while setting $\text{row size}=1$ reduces to the merge scheme (all-gather Q). - and **scales the CP degree better**, gathering only $S/\sqrt{P}$ per axis ($O(N/\sqrt{P})$ communication) on a symmetric grid, which suits long-sequence DiT inference. The runtime adapts the original Attention2D design from causal LLM training to **full bidirectional** DiT inference.
 
-**Gather phase: Q along rows and K/V along columns.** Ranks form a $\text{row\_size} \times \text{col\_size}$ grid ($P = \text{row\_size} \times \text{col\_size}$). Each rank starts with a $1/P$ shard of all three tensors — $Q_i, K_i, V_i$, each $[B, S/P, H, D]$. Attention2D then runs two all-gathers on the two independent grid axes:
+**Gather phase: Q along rows and K/V along columns.** Ranks form a $\text{row size} \times \text{col size}$ grid ($P = \text{row size} \times \text{col size}$). Each rank starts with a $1/P$ shard of all three tensors — $Q_i, K_i, V_i$, each $[B, S/P, H, D]$. Attention2D then runs two all-gathers on the two independent grid axes:
 
-- **Q gather** over the **row group** (`row_process_group`): the `col_size` ranks that share a row. Concatenates their $Q_i$ → every member holds $[B, S/\text{row\_size}, H, D]$. K/V are untouched.  
-- **K/V gather** over the **column group** (`col_process_group`): the `row_size` ranks that share a column, fused into a single collective. Concatenates their $K_i / V_i$ → every member holds $[B, S/\text{col\_size}, H, D]$. Q is untouched.
+- **Q gather** over the **row group** (`row_process_group`): the `col_size` ranks that share a row. Concatenates their $Q_i$ → every member holds $[B, S/\text{row size}, H, D]$. K/V are untouched.  
+- **K/V gather** over the **column group** (`col_process_group`): the `row_size` ranks that share a column, fused into a single collective. Concatenates their $K_i / V_i$ → every member holds $[B, S/\text{col size}, H, D]$. Q is untouched.
 
-So **Q expands by `col_size`** (a row holds `col_size` ranks → $S/\text{row\_size}$) and **K/V expand by `row_size`** (a column holds `row_size` ranks → $S/\text{col\_size}$); on a symmetric $\sqrt{P} \times \sqrt{P}$ mesh both land at $S/\sqrt{P}$. The picture below uses a $2 \times 3$ grid (`row_size=2, col_size=3`, $P=6$), with $S$ split into shards $0..5$:
+So **Q expands by `col_size`** (a row holds `col_size` ranks → $S/\text{row size}$) and **K/V expand by `row_size`** (a column holds `row_size` ranks → $S/\text{col size}$); on a symmetric $\sqrt{P} \times \sqrt{P}$ mesh both land at $S/\sqrt{P}$. The picture below uses a $2 \times 3$ grid (`row_size=2, col_size=3`, $P=6$), with $S$ split into shards $0..5$:
 
 <p align="center">
   <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_attention2d.png" alt="Attention2D per-rank data flow on a 2x3 grid: gather Q over the row group, K/V over the column group, one attention pass per rank produces a partial output, then an all-to-all over the row group exchanges partials and a local flash_attn_combine reduction merges them" width="1080">
@@ -191,7 +191,7 @@ So **Q expands by `col_size`** (a row holds `col_size` ranks → $S/\text{row\_s
 
 Members of a **row (Q) group** end up with identical Q but **disjoint** K/V slices; members of a **column (K/V) group** share identical K/V but hold different Q.
 
-**Local Attention.** The inner backend ([`Attention2DAttention`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py)) runs attention with LSE returning a partial output $[B, S/\text{row\_size}, H, D]$ and a log-sum-exp (LSE) statistic $[B, H, S/\text{row\_size}]$. The LSE records the softmax normalizer for that partial pass.
+**Local Attention.** The inner backend ([`Attention2DAttention`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py)) runs attention with LSE returning a partial output $[B, S/\text{row size}, H, D]$ and a log-sum-exp (LSE) statistic $[B, H, S/\text{row size}]$. The LSE records the softmax normalizer for that partial pass.
 
 **Merge phase.** The `col_size` ranks that share the same Q each attended over a **disjoint slice of K/V** (above: ranks `0`, `1`, `2` all hold queries `{0,1,2}` but keys `{0,3}`, `{1,4}`, `{2,5}` respectively). Their FA4 outputs are partial results for the **same query positions** over **complementary key spans**, so they must be combined **within that row group** to recover the full softmax. For `col_size = 3`, the partial results are spread across 3 GPUs. These are combined into the final output as follows: 
 
@@ -212,7 +212,7 @@ Members of a **row (Q) group** end up with identical Q but **disjoint** K/V slic
 | **Communication cost** | $O(N)$ | $O(N / \sqrt{P})$ |
 | **Scaling** | No scaling: communication cost remains constant as $P$ increases | Efficient scaling: communication cost decreases as $O(1 / \sqrt{P})$ as $P$ increases |
 
-**Communication cost.** Across the full layer, Attention2D runs three collective phases: Q all-gather (row), K/V all-gather (column), and output+LSE all-to-all (row). On a symmetric mesh ($\text{row\_size} \approx \text{col\_size} \approx \sqrt{P}$), moved volume scales as $O(N / \sqrt{P})$ in sequence length $N$, compared to $O(N)$ for Ring — the same head-count freedom, but better communication scaling and one attention pass instead of $P$.
+**Communication cost.** Across the full layer, Attention2D runs three collective phases: Q all-gather (row), K/V all-gather (column), and output+LSE all-to-all (row). On a symmetric mesh ($\text{row size} \approx \text{col size} \approx \sqrt{P}$), moved volume scales as $O(N / \sqrt{P})$ in sequence length $N$, compared to $O(N)$ for Ring — the same head-count freedom, but better communication scaling and one attention pass instead of $P$.
 
 <p align="center">
   <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog25_a2d_vs_ring.png" alt="Bar chart of denoise-loop latency for Attention2D vs Ring at 32 GPU (UL=8, CP=2), 64 GPU (UL=8, CP=4), and 72 GPU (UL=4, CP=9); Ring is +3%, +13%, and +83% slower respectively" width="820">

--- a/docs/source/blogs/tech_blog/blog26_DeepSeek_V4_on_NVIDIA_Blackwell_Model_Specific_and_Agentic_Workload_Optimizations_in_TensorRT-LLM.md
+++ b/docs/source/blogs/tech_blog/blog26_DeepSeek_V4_on_NVIDIA_Blackwell_Model_Specific_and_Agentic_Workload_Optimizations_in_TensorRT-LLM.md
@@ -93,7 +93,7 @@ DeepSeek-V4's largest architectural change is its attention. DeepSeek-V3.2 intro
 
 <div align="center">
 <figure>
-  <img src="../media/tech_blog26_deepseek_v4_hybrid_attention.png" width="100%" alt="DeepSeek-V4 hybrid attention architecture. Panel a shows SWA attending over the latest 128 raw tokens. Panel b shows CSA combining the sliding window with 4× compressed KV entries selected by an Indexer and Top-K stage. Panel c shows HCA combining the sliding window with all 128× compressed KV entries without an Indexer.">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog26_deepseek_v4_hybrid_attention.png" width="100%" alt="DeepSeek-V4 hybrid attention architecture. Panel a shows SWA attending over the latest 128 raw tokens. Panel b shows CSA combining the sliding window with 4× compressed KV entries selected by an Indexer and Top-K stage. Panel c shows HCA combining the sliding window with all 128× compressed KV entries without an Indexer.">
 </figure>
 </div>
 <p align="center"><sub><em>Figure 1. DeepSeek-V4 hybrid attention. (a) SWA attends densely within the 128-token sliding window. (b) CSA augments that window with Top-K entries selected from the 4× compressed history. (c) HCA attends to the window and the complete 128× compressed history without an Indexer.</em></sub></p>
@@ -116,7 +116,7 @@ TensorRT LLM implements the Compressor as a fused `wkv_gate` projection plus ded
 
 <div align="center">
 <figure>
-  <img src="../media/tech_blog26_deepseek_v4_mhc_moe.png" width="100%" alt="DeepSeek-V4 mHC architecture and MoE routing. Panel a shows the repeated transformer stack with mHC pre- and post-mappings around the attention and MoE blocks, followed by the HC head and language-model head. Panel b shows hash routing through a token-ID embedding table and learned routing through Sqrt-Softplus scores, correction bias, and Top-K expert selection.">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog26_deepseek_v4_mhc_moe.png" width="100%" alt="DeepSeek-V4 mHC architecture and MoE routing. Panel a shows the repeated transformer stack with mHC pre- and post-mappings around the attention and MoE blocks, followed by the HC head and language-model head. Panel b shows hash routing through a token-ID embedding table and learned routing through Sqrt-Softplus scores, correction bias, and Top-K expert selection.">
 </figure>
 </div>
 <p align="center"><sub><em>Figure 2. DeepSeek-V4 components beyond attention. (a) mHC wraps the attention and MoE sublayers with pre- and post-mappings, then uses an HC head to collapse the expanded residual stream before the language-model head. (b) The MoE router supports checkpoint-defined hash routing in the first three layers (left) and learned Sqrt-Softplus scoring with correction bias and Top-6 selection in later layers (right).</em></sub></p>
@@ -262,7 +262,7 @@ After the major kernels are optimized, runtime overhead shifts to the boundaries
 
 <div align="center">
 <figure>
-  <img src="../media/tech_blog26_dsv4_scratch_swa.png" width="100%" alt="SWA scratch reuse during long-context prefill. Scratch-eligible KV blocks produced by the current prefill chunk and falling outside the final retained window reuse the same physical storage across SWA layers, while blocks inside the sliding window remain in the normal KV cache.">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog26_dsv4_scratch_swa.png" width="100%" alt="SWA scratch reuse during long-context prefill. Scratch-eligible KV blocks produced by the current prefill chunk and falling outside the final retained window reuse the same physical storage across SWA layers, while blocks inside the sliding window remain in the normal KV cache.">
 </figure>
 </div>
 <p align="center"><sub><em>Figure 3. SWA scratch reuse during long-context prefill. Scratch-eligible blocks from the current prefill chunk reuse the same physical storage across SWA layers, while the final sliding-window state remains in the normal KV cache.</em></sub></p>
@@ -337,7 +337,7 @@ The following figure summarizes the closed-loop request path for aggregated and 
 
 <div align="center">
 <figure>
-  <img src="../media/tech_blog26_agentperf_closed_loop_workflow.svg" width="100%" alt="AA-AgentPerf closed-loop workflow. A simulated agent sends the next recorded turn with its accumulated conversation. The inference deployment routes the request, reuses matching KV blocks, prefills the uncached suffix, and streams the generated response. In disaggregated serving, the generation side retrieves the KV cache using context metadata. The client drains the complete response, simulates tool time when needed, advances the trajectory, and sends the next turn only after the current cycle completes.">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog26_agentperf_closed_loop_workflow.svg" width="100%" alt="AA-AgentPerf closed-loop workflow. A simulated agent sends the next recorded turn with its accumulated conversation. The inference deployment routes the request, reuses matching KV blocks, prefills the uncached suffix, and streams the generated response. In disaggregated serving, the generation side retrieves the KV cache using context metadata. The client drains the complete response, simulates tool time when needed, advances the trajectory, and sends the next turn only after the current cycle completes.">
 </figure>
 </div>
 <p align="center"><sub><em>Figure 5. AA-AgentPerf closed-loop request workflow. Repeated conversation prefixes can be reused through the KV cache. Aggregated serving performs prefill and generation on the same worker. In disaggregated serving, context metadata allows the generation worker to retrieve the KV cache and continue decoding. Tool time is simulated by the client and consumes no LLM compute.</em></sub></p>
@@ -369,7 +369,7 @@ The DeepSeek-V3.2 study showed the central routing tradeoff: affinity without lo
 
 <div align="center">
 <figure>
-  <img src="../media/tech_blog26_two_level_routing.svg" width="100%" alt="Two-level routing for context locality in disaggregated serving. The front-end orchestrator first selects a context server, then the selected server's attention data-parallel router selects a rank. At each level, the router can use either conversation-aware affinity or KV-cache-aware scoring. Full conversation-prefix reuse requires both decisions to return to the context server and rank that own the corresponding KV blocks. The selected context rank transfers the KV cache to a generation server for decoding.">
+  <img src="https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/tech_blog26_two_level_routing.svg" width="100%" alt="Two-level routing for context locality in disaggregated serving. The front-end orchestrator first selects a context server, then the selected server's attention data-parallel router selects a rank. At each level, the router can use either conversation-aware affinity or KV-cache-aware scoring. Full conversation-prefix reuse requires both decisions to return to the context server and rank that own the corresponding KV blocks. The selected context rank transfers the KV cache to a generation server for decoding.">
 </figure>
 </div>
 <p align="center"><sub><em>Figure 6. Two-level routing for context locality in disaggregated serving. The front-end orchestrator first selects a CTX server, and that server's ADP router then selects a rank. Conversation-aware routing uses explicit conversation affinity, while KV-cache-aware routing infers placement from reusable prefix blocks and load. Full conversation-prefix reuse requires both decisions to return the request to the CTX server and ADP rank that hold the corresponding KV blocks.</em></sub></p>


### PR DESCRIPTION
## Description

Two published tech-blog posts use GitHub-flavored-markdown constructs that the Sphinx/MyST docs pipeline does not render, so on the docs site their figures 404 (and, for blog25, the LaTeX shows as raw source). This PR fixes both, matching the conventions already used by the other tech blogs.

**[blog25 — Scaling Video Generation Across NVL72 (VisualGen)](https://nvidia.github.io/TensorRT-LLM/blogs/tech_blog/blog25_Scaling_Video_Generation_Across_NVL72_Rack_with_TensorRT-LLM.html)**
- **Figures (9):** switch the raw `<img src="../media/...">` tags from relative paths to absolute `https://github.com/NVIDIA/TensorRT-LLM/raw/main/docs/source/blogs/media/...` URLs. Sphinx only copies media referenced through markdown image syntax; media referenced only from raw `<img>` tags is not copied into the build, so the relative paths resolve to nonexistent files.
- **Display math (1):** convert the GitHub ` ```math ` fenced block to a `$$...$$` block. MyST `dollarmath` does not recognize ` ```math ` and renders it as a literal code block.
- **Inline math (18):** convert the GitHub `$`...`$` dollar-backtick spans to plain `$...$`. MyST parses the backticks as an inline code span and leaves the surrounding `$` as literal text, so the expression never renders as math.

**[blog26 — DeepSeek-V4 on NVIDIA Blackwell](https://nvidia.github.io/TensorRT-LLM/blogs/tech_blog/blog26_DeepSeek_V4_on_NVIDIA_Blackwell_Model_Specific_and_Agentic_Workload_Optimizations_in_TensorRT-LLM.html)**
- **Figures (5):** same raw-`<img>` fix — point the five relative-path figures (3 PNG + 2 SVG) at the absolute raw URLs. The one figure already embedded with markdown `![](..)` syntax is copied correctly by Sphinx and is left unchanged.

Plain `$...$` / `$$...$$` and absolute image URLs render on both the MyST docs site (`dollarmath` + `amsmath` are enabled in `docs/source/conf.py`) and GitHub, so there is no regression on either viewer.

## Test Coverage

Docs-only change; no runtime code touched. Verified by building both blog pages locally with Sphinx + `myst-parser` using the same MyST config as `docs/source/conf.py`. After the change: all 14 figures resolve (9 blog25 + 5 blog26; the markdown-embedded blog26 figure is still copied to `_images/`), blog25's fenced block renders as a MathJax display equation, and all 94 inline/display math spans render (previously the tokens carried stray backticks). All figure URLs return HTTP 200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Replaced nine blog25 and five blog26 relative image paths with absolute GitHub raw URLs.
- Updated display and inline math to MyST-compatible syntax.
- Preserved the blog content and technical results.
- No configuration, API, or public entity changes.
- Local validation confirmed figure resolution, math rendering, and HTTP 200 responses.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->