### PR TITLE
[None][perf] Remove disaggregated transfer admission and idle-progress collectives

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3414,6 +3414,13 @@ class PyExecutor:
     def _apply_disagg_transfer_admission(
         self, fitting_disagg_gen_init_requests: List[LlmRequest]
     ) -> Tuple[List[LlmRequest], bool]:
+        # Disabled: the controller deferred gen-init requests to bound the
+        # number of in-flight KV transfer blocks. Its FCFS deferral bursts
+        # admissions and was measured costing ~18% of GEN GPU-idle time. With
+        # the idle check above also removed there is no transfer budget left to
+        # wait on, so admit every fitting request and never report "blocked".
+        return fitting_disagg_gen_init_requests, False
+
         # gen_only_no_context has no CTX worker and does not transfer data.
         # Real synchronous gen_only transfers still honor the budget to bound
         # the number of blocking transfers started in one executor iteration.
@@ -3506,6 +3513,23 @@ class PyExecutor:
             fitting_disagg_gen_init_requests: List[LlmRequest],
             wait_for_disagg_gen_transfer_progress: bool,
             all_gen_first: bool) -> None:
+        # Disabled: this ran two collectives on every executor iteration --
+        # _sync_disagg_gen_status_entry (WORLD-scoped) and
+        # _sync_disagg_ctx_status_entry (TP/CP) -- purely to vote on whether any
+        # rank should enter a blocking transfer-status wait. Instrumented on a
+        # GLM-5.2 disagg GEN worker they were 3,995 ms of the method's 4,012 ms
+        # over 3,000 calls, i.e. 99% of its cost was the votes themselves. An
+        # NVTX capture of the CTX put the WORLD allreduce at 19.4% of context
+        # wall-clock (18 calls, 211 ms mean) because it spans every rank in the
+        # deployment, so each call waits on the slowest participant anywhere.
+        #
+        # Removal is safe because transfer completion is still reaped at the
+        # other call sites in the executor loop; only the ones inside this
+        # method are dropped. Both replacements are rank-uniform and contain no
+        # collectives, so ranks cannot diverge -- the deadlock the voting
+        # guarded against cannot arise once nothing here is conditional.
+        return
+
         local_need_check = (num_fitting_reqs == 0
                             and not fitting_disagg_gen_init_requests)
 

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -20,7 +20,6 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
-from tensorrt_llm._torch.distributed.communicator import ReduceOp
 from tensorrt_llm._torch.pyexecutor.executor_request_queue import (
     SHUTDOWN_REQUEST_ID,
     RequestQueueItem,
@@ -508,7 +507,7 @@ class TestDisaggTransferAdmissionController:
         assert result.admitted_requests == [request]
         assert result.admitted_transfer_blocks == 3
 
-    def test_apply_reverts_deferred_v2_allocations(self):
+    def test_apply_bypasses_transfer_admission_controller(self):
         executor = object.__new__(PyExecutor)
         executor.kv_cache_transceiver = Mock()
         executor._is_kv_manager_v2 = True
@@ -523,9 +522,9 @@ class TestDisaggTransferAdmissionController:
             executor, [candidate]
         )
 
-        assert admitted == []
-        assert wait_for_progress
-        executor._revert_ctx_alloc.assert_called_once_with([candidate])
+        assert admitted == [candidate]
+        assert not wait_for_progress
+        executor._revert_ctx_alloc.assert_not_called()
 
     def test_apply_missing_controller_preserves_candidates(self):
         executor = object.__new__(PyExecutor)
@@ -540,7 +539,7 @@ class TestDisaggTransferAdmissionController:
         assert admitted == [candidate]
         assert not wait_for_progress
 
-    def test_apply_missing_v2_flag_defaults_to_non_v2(self):
+    def test_apply_bypasses_controller_without_v2_flag(self):
         executor = object.__new__(PyExecutor)
         executor.kv_cache_transceiver = Mock()
         executor._revert_ctx_alloc = Mock()
@@ -554,11 +553,11 @@ class TestDisaggTransferAdmissionController:
             executor, [candidate]
         )
 
-        assert admitted == []
-        assert wait_for_progress
+        assert admitted == [candidate]
+        assert not wait_for_progress
         executor._revert_ctx_alloc.assert_not_called()
 
-    def test_sync_mode_retains_transfer_budget(self, monkeypatch):
+    def test_sync_mode_bypasses_transfer_budget(self, monkeypatch):
         monkeypatch.setenv("TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP", "1")
         executor = object.__new__(PyExecutor)
         executor.kv_cache_transceiver = Mock()
@@ -577,9 +576,9 @@ class TestDisaggTransferAdmissionController:
             executor, candidates
         )
 
-        assert admitted == [candidates[0]]
+        assert admitted == candidates
         assert not wait_for_progress
-        executor._revert_ctx_alloc.assert_called_once_with([candidates[1]])
+        executor._revert_ctx_alloc.assert_not_called()
 
     def test_gen_only_no_context_bypasses_transfer_budget(self, monkeypatch):
         monkeypatch.setenv("TRTLLM_DISAGG_BENCHMARK_GEN_ONLY", "1")
@@ -634,7 +633,7 @@ class TestDisaggTransferIdleProgress:
 
         executor._check_disagg_gen_cache_transfer_status.assert_not_called()
 
-    def test_polls_generation_transfer_when_admission_blocked(self):
+    def test_does_not_poll_generation_transfer_when_admission_blocked(self):
         executor = object.__new__(PyExecutor)
         executor.dist = Mock(tp_size=1)
         executor._check_disagg_gen_cache_transfer_status = Mock()
@@ -648,10 +647,10 @@ class TestDisaggTransferIdleProgress:
             all_gen_first=False,
         )
 
-        executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(1)
+        executor._check_disagg_gen_cache_transfer_status.assert_not_called()
         executor._check_disagg_ctx_cache_transfer_status.assert_not_called()
 
-    def test_peer_rank_enters_bounded_progress_poll(self):
+    def test_peer_rank_does_not_enter_bounded_progress_poll(self):
         executor = object.__new__(PyExecutor)
         executor.dist = Mock(tp_size=1, cp_size=4, world_size=4)
         executor.dist.allreduce.return_value = 1
@@ -666,11 +665,11 @@ class TestDisaggTransferIdleProgress:
             all_gen_first=False,
         )
 
-        executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(1)
+        executor._check_disagg_gen_cache_transfer_status.assert_not_called()
         executor._check_disagg_ctx_cache_transfer_status.assert_not_called()
-        executor.dist.allreduce.assert_called_once_with(0, op=ReduceOp.MAX)
+        executor.dist.allreduce.assert_not_called()
 
-    def test_falls_back_to_context_transfer_when_not_generation_blocked(self):
+    def test_does_not_fall_back_to_context_transfer(self):
         executor = object.__new__(PyExecutor)
         executor.dist = Mock(tp_size=1)
         executor._check_disagg_gen_cache_transfer_status = Mock()
@@ -684,7 +683,7 @@ class TestDisaggTransferIdleProgress:
             all_gen_first=False,
         )
 
-        executor._check_disagg_ctx_cache_transfer_status.assert_called_once_with(1)
+        executor._check_disagg_ctx_cache_transfer_status.assert_not_called()
         executor._check_disagg_gen_cache_transfer_status.assert_not_called()
 
     def test_sync_benchmark_skips_idle_transfer_collectives(self, monkeypatch):
@@ -811,7 +810,7 @@ class TestDisaggTransferIdleProgress:
             charge_budget=False,
         )
 
-    def test_peer_cp_rank_enters_context_progress_poll(self):
+    def test_peer_cp_rank_does_not_enter_context_progress_poll(self):
         executor = object.__new__(PyExecutor)
         executor.dist = Mock(tp_size=1, cp_size=4, world_size=4)
         executor.dist.allreduce.return_value = 0
@@ -827,9 +826,10 @@ class TestDisaggTransferIdleProgress:
             all_gen_first=False,
         )
 
-        executor._check_disagg_ctx_cache_transfer_status.assert_called_once_with(0)
+        executor._check_disagg_ctx_cache_transfer_status.assert_not_called()
         executor._check_disagg_gen_cache_transfer_status.assert_not_called()
-        executor.dist.tp_cp_allgather.assert_called_once_with(0)
+        executor.dist.allreduce.assert_not_called()
+        executor.dist.tp_cp_allgather.assert_not_called()
 
 
 @pytest.mark.usefixtures("_clear_disagg_transfer_mode_env")


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

At high concurrency, MiniMax-M3 disaggregated serving is sensitive to two
executor-side control paths: the transfer-admission controller defers fitting
GEN-init requests based on `max_tokens_in_buffer`, while the idle-progress
path performs WORLD and TP/CP votes on every executor iteration before
polling transfer status. The admission behavior required a large transfer
buffer workaround to avoid a substantial c4096 throughput loss.

This change carries Iman Tabrizian's transfer-admission experiment onto the
MiniMax-M3 feature branch:

- `_apply_disagg_transfer_admission` admits every fitting request and no
  longer reports that admission is blocked;
- `_check_disagg_transfer_progress_when_idle` returns without the per-iteration
  WORLD and TP/CP collectives or blocking status poll;
- transfer completion continues to be reaped at the other executor-loop call
  sites; and
- the existing executor tests now assert the disabled admission and
  idle-progress behavior.

The original experiment measured a 1.4% regression on a separate GLM-5.2
disaggregated topology when applied alone. This PR therefore targets
`feat/m3_with_msa` based on the MiniMax-M3 result below and should not be
interpreted as a general disaggregated-serving optimization.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- MiniMax-M3 disaggregated E2E on 16 B300 GPUs: 4 CTX replicas at TP2/EP2
  with attention DP, 2 GEN replicas at TP4/EP4, concurrency 4096, and 40,960
  random 8K-input/1K-output requests:

  | Configuration | Pareto X (output tok/s/user) | Pareto Y (tok/s/GPU) | Median TTFT |
  |---|---:|---:|---:|
  | Baseline, 8K transfer-admission budget | 10.359 | 4,749.1 | 340.324 s |
  | Baseline, 128K workaround | 18.077 | 12,304.4 | 116.739 s |
  | This change, 8K budget | **18.356** | **12,497.3** | **113.701 s** |

  With this change the configured 8K budget is bypassed, so the 128K
  workaround is no longer required.
- Changed-file pre-commit checks passed for
  `py_executor.py` and `test_py_executor.py`.
- Both changed Python files pass local syntax compilation. Focused pytest was
  not run locally because the available environment does not provide the CUDA
  Python runtime required to collect `test_py_executor.py`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
