### PR TITLE
[None][feat] Enable block reuse for flashinfer

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -437,8 +437,9 @@ def create_py_executor(
         tokens_per_block = 128 if m3_sparse_config.implementation == "msa" else 32
         kv_cache_config.tokens_per_block = tokens_per_block
 
-    if llm_args.attn_backend in ["FLASHINFER", "FLASHINFER_STAR_ATTENTION"]:
-        # Workaround for flashinfer and star attention
+    if llm_args.attn_backend == "FLASHINFER_STAR_ATTENTION":
+        # Star attention still derives its page table from every allocated block,
+        # which is incompatible with blocks allocated ahead for reuse.
         if kv_cache_config.enable_block_reuse:
             logger.warning(
                 f"Disabling block reuse for {llm_args.attn_backend} backend")

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -82,6 +82,20 @@ def _get_default_torch_compile_config(torch_compile):
                               max_num_streams=3) if torch_compile else None
 
 
+def _latest_kv_cache_stats(llm):
+    """Cumulative KV cache stats, warmup-adjusted, from the last iteration.
+
+    Requires the LLM to be built with enable_iter_perf_stats=True; without it
+    the reuse counters are never populated.
+    """
+    entries = [
+        s["kvCacheStats"] for s in llm.get_stats(timeout=5)
+        if s.get("kvCacheStats")
+    ]
+    assert entries, "No kvCacheStats reported; is enable_iter_perf_stats set?"
+    return entries[-1]
+
+
 def _run_multinode_accuracy(model_path,
                             model_name,
                             *,
@@ -176,11 +190,25 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
         with LLM(self.MODEL_PATH,
                  attn_backend=attn_backend,
                  enable_chunked_prefill=True,
-                 max_num_tokens=512) as llm:
+                 max_num_tokens=512,
+                 enable_iter_perf_stats=True) as llm:
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm,
                           sampling_params=(SamplingParams(
                               temperature=0.001) if use_temperature else None))
+
+            # MMLU prepends a fixed 5-shot prefix per subject (~12 blocks at the median), and
+            # iterates subject by subject, so block reuse should be hit heavily here regardless of
+            # attention backend.
+            stats = _latest_kv_cache_stats(llm)
+            # Uncomment for debugging:
+            # print(f"[MMLU] backend={attn_backend} "
+            #       f"reused={stats['reusedBlocks']} "
+            #       f"missed={stats['missedBlocks']} "
+            #       f"hit_rate={stats['cacheHitRate']:.4f}")
+
+            # This should be close to 0.8, but keeping it low out of caution for CI.
+            assert stats["reusedBlocks"] > 0.5
 
     @pytest.mark.skip_less_device_memory(32000)
     def test_dummy_load_format(self):

--- a/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
@@ -210,6 +210,7 @@ def _run_create_py_executor(
     *,
     sm_version,
     kv_cache_quant_algo,
+    attn_backend="TRTLLM",
     cache_transceiver_config=None,
     enable_flash_mla=False,
     model_max_seq_len=128,
@@ -227,6 +228,7 @@ def _run_create_py_executor(
         monkeypatch: pytest fixture for mocking.
         sm_version: CUDA SM version to simulate (e.g., 89, 90).
         kv_cache_quant_algo: Quantization algorithm to use (e.g., NO_QUANT, INT8).
+        attn_backend: Attention backend to configure.
         cache_transceiver_config: Optional transceiver configuration to mutate.
         enable_flash_mla: Whether to emulate the FlashMLA block-size override.
         model_max_seq_len: Effective sequence length reported by the model engine.
@@ -239,6 +241,7 @@ def _run_create_py_executor(
         runtime_chunked_prefill_flag) from created executor.
     """
     llm_args = _make_llm_args()
+    llm_args.attn_backend = attn_backend
     llm_args.cache_transceiver_config = cache_transceiver_config
     llm_args.enable_chunked_prefill = enable_chunked_prefill
     fake_mapping = SimpleNamespace(
@@ -384,6 +387,32 @@ def test_mla_supported_configuration_preserves_cache_reuse(monkeypatch, sm_versi
 
     assert kv_cache_reuse is True
     assert runtime_cache_reuse is True
+
+
+def test_flashinfer_preserves_cache_reuse(monkeypatch):
+    """Verify the FlashInfer backend preserves requested cache reuse."""
+    kv_cache_reuse, runtime_cache_reuse, _ = _run_create_py_executor(
+        monkeypatch,
+        sm_version=100,
+        kv_cache_quant_algo=QuantAlgo.NO_QUANT,
+        attn_backend="FLASHINFER",
+    )
+
+    assert kv_cache_reuse is True
+    assert runtime_cache_reuse is True
+
+
+def test_flashinfer_star_attention_disables_cache_reuse(monkeypatch):
+    """Verify Star Attention retains its cache-reuse compatibility guard."""
+    kv_cache_reuse, runtime_cache_reuse, _ = _run_create_py_executor(
+        monkeypatch,
+        sm_version=100,
+        kv_cache_quant_algo=QuantAlgo.NO_QUANT,
+        attn_backend="FLASHINFER_STAR_ATTENTION",
+    )
+
+    assert kv_cache_reuse is False
+    assert runtime_cache_reuse is False
 
 
 def test_default_transceiver_buffer_rounds_up_to_tokens_per_block(monkeypatch):

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import json
 import pathlib
@@ -247,6 +250,34 @@ def test_llm_perf_metrics():
         assert perf_metrics.first_iter is not None
         assert perf_metrics.iter - perf_metrics.first_iter == sampling_params.max_tokens - 1
         assert perf_metrics.last_iter == perf_metrics.iter
+
+
+@skip_ray
+@pytest.mark.part3
+@pytest.mark.parametrize("attn_backend", ["TRTLLM", "FLASHINFER"])
+def test_llm_prefix_cache_reuse(attn_backend):
+    model_path = get_model_path("llama-models-v2/TinyLlama-1.1B-Chat-v1.0")
+    prompt = "The future of AI is " * 20
+    sampling_params = SamplingParams(temperature=0,
+                                     max_tokens=5,
+                                     return_perf_metrics=True)
+
+    with LLM(
+            model=model_path,
+            attn_backend=attn_backend,
+            kv_cache_config=KvCacheConfig(enable_block_reuse=True),
+            cuda_graph_config=None,
+    ) as llm:
+        cold_output = llm.generate(prompt, sampling_params).outputs[0]
+        warm_output = llm.generate(prompt, sampling_params).outputs[0]
+
+    cold_metrics = cold_output.request_perf_metrics
+    warm_metrics = warm_output.request_perf_metrics
+    assert cold_metrics is not None
+    assert warm_metrics is not None
+    assert cold_metrics.kv_cache_metrics.num_reused_blocks == 0
+    assert warm_metrics.kv_cache_metrics.num_reused_blocks > 0
+    assert cold_output.token_ids == warm_output.token_ids
 
 
 @skip_ray


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Regular `FLASHINFER` now allows block reuse.
- `FLASHINFER_STAR_ATTENTION` still disables block reuse.
- Unit tests cover both backend behaviors.
- KV-cache statistics are enabled for `test_chunked_prefill`.
- The `reusedBlocks > 0.5` assertion can affect TRTLLM pre-merge tests.
- The reported changes do not confirm removal or explanation of the unrelated Gemma4 configuration change.
- Both L0 pipeline runs failed. Investigate and fix the failures before rerunning CI.
- No test-list changes are reported.

## QA Engineer Review

Test functions added or modified:

- `_latest_kv_cache_stats`
- `test_chunked_prefill`
- `test_flashinfer_preserves_cache_reuse`
- `test_flashinfer_star_attention_disables_cache_reuse`
- `test_llm_prefix_cache_reuse`

Coverage includes:

- FlashInfer block reuse.
- FlashInfer Star Attention block-reuse disabling.
- TRTLLM and FlashInfer prefix-cache reuse.
- Chunked-prefill cache reuse.

The summary does not show corresponding `test-db/` or `qa/` entries. FlashInfer chunked-prefill MMLU coverage remains post-merge. Existing pre-merge prefix-cache coverage does not include partial non-page-aligned reuse, chunked prefill, or CUDA graphs.

**Verdict: needs follow-up.**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Removes outdated guard for block reuse with the FLASHINFER
attention backend.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
