### PR TITLE
[TRTLLM-14706][fix] Fix SA specdec + CUDA graphs

### DIFF
--- a/docs/source/deployment-guide/deployment-guide-for-kimi-k3-on-trtllm.md
+++ b/docs/source/deployment-guide/deployment-guide-for-kimi-k3-on-trtllm.md
@@ -31,7 +31,7 @@ The checkpoint and the configuration file must live on a shared filesystem visib
 * **CUDA graphs and the overlap scheduler are enabled.** The performance-sweep recipes set `disable_overlap_scheduler: false` and enable CUDA graphs. DEP16 additionally sets `cuda_graph_config.enable_padding: true`.
 * **Chunked prefill is supported and enabled** (`enable_chunked_prefill: true`), so prompts longer than `max_num_tokens` are scheduled across multiple steps.
 * **`kv_cache_config.tokens_per_block` must be `64`** — required by the MLA (576, 512) trtllm-gen generation kernel.
-* **Speculative decoding and disaggregated serving are supported with constraints.** Suffix-automaton speculative decoding is an opt-in for evaluation and requires CUDA graphs and the overlap scheduler disabled with `max_batch_size` ≤ 8; disaggregated serving requires matched DEP16 context and generation servers. See the "Current limitations" section of `examples/kimi_k3/README.md` and `examples/kimi_k3/disagg/README.md` for details.
+* **Speculative decoding and disaggregated serving are supported with constraints.** Suffix-automaton speculative decoding is an opt-in for evaluation and requires the overlap scheduler disabled with `max_batch_size` ≤ 8 (CUDA graphs are supported); disaggregated serving requires matched DEP16 context and generation servers. See the "Current limitations" section of `examples/kimi_k3/README.md` and `examples/kimi_k3/disagg/README.md` for details.
 * **FP8 KV cache is supported** (`kv_cache_config.dtype: fp8`). Enabling it forces the trtllm-gen MLA generation backend, which is accuracy-equivalent to the default cute-dsl backend.
 
 ## Deployment Steps

--- a/examples/kimi_k3/README.md
+++ b/examples/kimi_k3/README.md
@@ -198,11 +198,12 @@ decoding requires the default cache manager, which cannot reuse blocks.
   GSM8K.
 - Speculative decoding:
   - Suffix-automaton (SA) speculative decoding is supported as an opt-in
-    for evaluation (see `eval_extra_llm_options_sa.yaml`). SA requires CUDA
-    graphs disabled (`cuda_graph_config: null`), the overlap scheduler off,
-    and `max_batch_size` ≤ 8. Enabling CUDA graphs together with SA
-    currently degrades output quality. SA speedup is workload-dependent —
-    proportional to n-gram repetition in the generated output.
+    for evaluation (see `eval_extra_llm_options_sa.yaml`). SA requires the
+    overlap scheduler off and `max_batch_size` ≤ 8, and is compatible with
+    CUDA graphs — set the CUDA-graph `max_batch_size` to match (GSM8K with
+    graphs matches the eager baseline for `max_draft_len` 1 and 2). SA
+    speedup is workload-dependent — proportional to n-gram repetition in
+    the generated output.
   - MTP and DFlash speculative decoding are scaffolding only and not yet
     functional; support depends on compatible draft weights.
 - Disaggregated serving works end-to-end within the constraints below; see

--- a/examples/kimi_k3/disagg/README.md
+++ b/examples/kimi_k3/disagg/README.md
@@ -126,11 +126,13 @@ python3 examples/disaggregated/slurm/benchmark/submit.py \
    setup MPI collectives. Not an MPI/pmix or V2 code bug; with
    `UCX_TLS=tcp,self,sm,cuda_copy,cuda_ipc` V2 NIXL passes multi-node
    with no code change.
-2. **SA runs eager.** SA speculative decoding in disagg is validated for
-   accuracy (GSM8K parity with aggregated serving) with CUDA graphs
-   disabled, as configured in `gen_config.yaml`. Do not enable CUDA
-   graphs together with SA: it currently degrades output quality.
-   Start with `gen_config_no_sa.yaml` for the first
+2. **SA ships eager here.** SA speculative decoding in disagg is
+   validated for accuracy (GSM8K parity with aggregated serving) with
+   CUDA graphs disabled, as configured in `gen_config.yaml`. SA with
+   CUDA graphs is functional (the MLA latent-cache append under CUDA
+   graphs handles spec-dec verification), but the disagg SA + graphs
+   perf points have not been re-measured yet, so `gen_config.yaml`
+   keeps graphs off. Start with `gen_config_no_sa.yaml` for the first
    bring-up on a new cluster, then switch to `gen_config.yaml`.
 3. **Matched-DP only.** Keep ctx and gen at identical DEP16 with
    attention-DP on both sides; heterogeneous parallelism with

--- a/examples/kimi_k3/eval_extra_llm_options_sa.yaml
+++ b/examples/kimi_k3/eval_extra_llm_options_sa.yaml
@@ -1,7 +1,8 @@
 enable_attention_dp: true
 moe_expert_parallel_size: 16
 disable_overlap_scheduler: true
-cuda_graph_config: null
+cuda_graph_config:
+  max_batch_size: 8
 kv_cache_config:
   enable_block_reuse: false
   free_gpu_memory_fraction: 0.6

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1591,7 +1591,9 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             # lists (request ids, seq lens, cached-token counts) are frozen
             # into the graph at capture time and corrupt the cache on replay.
             # The helper falls back to the host-side loop for eager forwards
-            # and q_len > 1 (speculative decoding).
+            # only; under CUDA graphs it scatters device-side for any
+            # uniform q_len (1 for plain decode, 1 + draft_len for padded
+            # spec-dec verification batches).
             append_mla_latent_cache_generation_cuda_graph_safe(
                 metadata,
                 # NOTE: get_buffers / layer_offsets take the GLOBAL layer

--- a/tensorrt_llm/_torch/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/attention_backend/utils.py
@@ -124,26 +124,39 @@ def append_mla_latent_cache_generation_cuda_graph_safe(
     buffers that ``metadata.prepare()`` refreshes every step:
 
     - ``kv_lens_cuda_runtime`` holds each request's total KV length (cached +
-      new), so the new token's position is ``kv_len - 1`` (clamped to 0 so
-      graph-warmup passes with zeroed lengths stay in bounds).
+      new), so the ``q_len`` new tokens sit at positions
+      ``kv_len - q_len .. kv_len - 1`` (clamped to 0 so graph-warmup passes
+      with zeroed lengths stay in bounds).
     - ``kv_cache_block_offsets[pool_idx, slot, 0]`` is the C++
       ``setOffsets``-encoded block table: entries hold
       ``pool_block_index * num_pool_layers * kv_factor`` (+ the K/V field
       index, always 0 for the single-plane MLA cache), so the raw block index
       for the per-layer ``get_buffers`` view is recovered by integer division.
 
+    Handles any uniform ``q_len >= 1`` per generation request: plain decode
+    (``q_len == 1``) and speculative-verification batches (``q_len ==
+    1 + draft_len``; the spec workers pad drafts to the static max, so the
+    per-request token count is uniform). This matters for spec-dec under
+    CUDA graphs: the previous ``q_len == 1``-only version silently fell back
+    to the host-side loop for verification batches, whose capture-time write
+    positions (dummy-request block tables) were frozen into the graph — real
+    requests' generation-token latents were never appended on replay,
+    corrupting decode accuracy (Kimi K3 SA GSM8K 88.2 with graphs vs 96.2
+    eager).
+
     Falls back to the host-side loop for eager forwards (numerics identical
-    to the non-graph baseline) and for ``q_len > 1`` generation (speculative
-    decoding), which the single-token scatter below does not handle.
+    to the non-graph baseline) and for ragged generation batches, which
+    cannot occur under CUDA graphs.
     """
     kv_cache_manager = metadata.kv_cache_manager
     num_ctx = metadata.num_contexts
     n_gen = metadata.num_generations
     # Tensor shapes are static under CUDA graphs, so this host-side check is
-    # stable across replays: one latent row per generation request means
-    # q_len == 1 for every one of them.
-    q_len_is_one = latent_cache.shape[0] == n_gen
-    if not metadata.is_cuda_graph or not q_len_is_one:
+    # stable across replays: generation-only graph batches carry a uniform
+    # per-request token count (1 for plain decode, 1 + draft_len for
+    # padded speculative verification).
+    q_len_is_uniform = n_gen > 0 and latent_cache.shape[0] % n_gen == 0
+    if not metadata.is_cuda_graph or not q_len_is_uniform:
         append_mla_latent_cache(
             kv_cache_manager,
             layer_idx,
@@ -170,20 +183,27 @@ def append_mla_latent_cache_generation_cuda_graph_safe(
     kv_factor = kv_cache_manager.kv_factor
     tokens_per_block = kv_cache_manager.tokens_per_block
 
-    # Everything below only reads graph-stable device buffers.
+    # Everything below only reads graph-stable device buffers. ``q_len`` is
+    # derived from static tensor shapes, so it is a stable host constant per
+    # captured graph (1 for plain decode, 1 + draft_len for spec verify).
+    q_len = latent_cache.shape[0] // n_gen
     kv_lens = metadata.kv_lens_cuda_runtime[num_ctx:num_ctx + n_gen]
-    pos = (kv_lens.to(torch.int64) - 1).clamp_(min=0)
+    # ``kv_len`` includes the new tokens, so they occupy positions
+    # ``kv_len - q_len .. kv_len - 1``. pos: [n_gen, q_len].
+    pos = ((kv_lens.to(torch.int64) - q_len).clamp_(min=0).unsqueeze(1) +
+           torch.arange(q_len, dtype=torch.int64, device=kv_lens.device))
     block_slot = pos // tokens_per_block
     block_offset = pos % tokens_per_block
     # [num_pools, max_num_sequences, 2, max_blocks_per_seq]; the two K/V
     # entries are identical for the kv_factor=1 MLA cache, take field 0.
     block_table = metadata.kv_cache_block_offsets[pool_idx,
                                                   num_ctx:num_ctx + n_gen, 0]
-    encoded = block_table.gather(1, block_slot.unsqueeze(1)).squeeze(1)
+    encoded = block_table.gather(1, block_slot)  # [n_gen, q_len]
     # Placeholder entries are negative; clamp so warmup rows stay in bounds.
-    dest_block = encoded.to(torch.int64).clamp_(min=0) // (num_pool_layers *
-                                                           kv_factor)
-    src = latent_cache.to(kv_cache.dtype)
+    dest_block = encoded.to(
+        torch.int64).clamp_(min=0) // (num_pool_layers * kv_factor)
+    src = latent_cache.to(kv_cache.dtype).reshape(n_gen, q_len,
+                                                  latent_cache.shape[-1])
     if kv_layout == "NHD":
         kv_cache[dest_block, 0, block_offset, 0, :] = src
     elif kv_layout == "HND":


### PR DESCRIPTION
## Cherrypick of MR119 from @brnguyen2 

## Problem

SA speculative decoding + CUDA graphs silently corrupts decoded tokens on K3.
Clean A/B (identical DEP16 config: SA md=2, gen mbs 8, overlap + chunked
prefill off, GSM8K full 1319, GB300, wts-final weights):

| run | GSM8K | AL (decoded tok/step) | job |
|---|---|---|---|
| graphs ON, no fix | **88.21** | 1.319 | 2696161 |
| graphs OFF (control) | 96.17 | 1.318 | 2697272 |
| graphs ON, **with this fix** | **96.44** | 1.318 | 2698182 |

AL unchanged in all three → acceptance bookkeeping fine; the loss was in the
decoded tokens themselves.

## Root cause

`append_mla_latent_cache_generation_cuda_graph_safe`
(`tensorrt_llm/_torch/attention_backend/utils.py`) only
handles the `q_len == 1` decode shape on the graph-safe device path:

```python
q_len_is_one = latent_cache.shape[0] == n_gen
if not metadata.is_cuda_graph or not q_len_is_one:
    append_mla_latent_cache(...)   # host-side loop
```

SA verify runs `q_len = 1 + max_draft_len` (= 3 for md=2), so under graph
capture the HOST loop executes — and its write positions (`seq_lens.tolist()`,
`num_cached_tokens_per_seq`, `get_batch_cache_indices(request_ids)`) are the
CAPTURE batch's host values, frozen into the captured copy kernels. On replay,
every step scatters the fresh MLA latents into the capture-time dummy blocks;
the real requests' generation-token MLA KV is never appended, and FMHA attends
over never-written rows. K3 being hybrid (most layers KDA, which is unaffected)
is why the damage is an 8-point accuracy drop rather than gibberish, and why
AL stays flat.

Explains all prior evidence: graphs without spec-dec is clean (q_len=1 device
path), eager+SA is clean (host loop re-executes each step), corruption is
deterministic, and the earlier SA+graphs parity FAILs that were attributed to
harness regime mismatch.

## Fix

Generalize the device-side scatter to any uniform `q_len >= 1`: positions
`kv_len - q_len .. kv_len - 1` per request, per-token block lookup via a
`[n_gen, q_len]` gather on `kv_cache_block_offsets`, one advanced-indexing
scatter — all from graph-stable device buffers. The host loop remains only for
eager (non-graph) forwards. `q_len == 1` reduces exactly to the previous code.

## Validation (original, on tekit)

- CPU parity test vs the host-loop reference (q_len 1/3; fresh, mid-block,
  block-crossing, block-end, batched): ALL PASS
  (`test_append_parity.py`, kept in the investigation workdir).
- GSM8K full with fix: 96.44 (job 2698182).

## Validation on this branch (GB300, full GSM8K 1319, DEP16, mbs 8)

The two items the original MR listed as "not yet run" were completed here
with this branch's SM103 wheel (same harness shape as the A/B above):

- **md=1 spot-check: PASS.** SA `max_draft_len=1` + CUDA graphs
  (`max_batch_size: 8`) scores GSM8K **96.51** (strict and flexible both
  96.51 ± 0.51; job 2744177) — within noise of the eager baseline; no
  graphs-induced corruption at md=1.
- **graphs ON + spec-dec OFF regression check: PASS.** CUDA graphs with
  speculative decoding disabled scores GSM8K **96.55** (strict 96.51 /
  flexible 96.59; job 2744178) — the generalized `q_len == 1` path is
  regression-free vs the ~96.47 reference.
- CPU parity test extended with `q_len=2` (md=1) cases: all 11 cases pass
  (q_len 1/2/3 across fresh, mid-block, block-crossing, block-end, and
  batched layouts).

The second commit updates the docs that still claimed SA requires CUDA
graphs disabled (`examples/kimi_k3/README.md`,
`eval_extra_llm_options_sa.yaml`, disagg README, deployment guide).
`examples/kimi_k3/disagg/gen_config.yaml` intentionally keeps graphs off
until the disagg SA+graphs perf points are re-measured (tracked in the
original tekit MR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
