### PR TITLE
[TRTLLM-13409][infra] recover completed test results when a stage is interrupted

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2778,7 +2778,7 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
     } finally {
         ensureStageResultNotUploaded(stageName + postTag)
         if (stageIsInterrupted) {
-            echo "Stage is interrupted, skip to upload test result."
+            recoverInterruptedStageResults(stageName, postTag)
         } else {
             // Temporarily disable to reduce the log size
             // sh 'if [ "$(id -u)" -eq 0 ]; then dmesg || true; fi'
@@ -2851,6 +2851,56 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
         """
 
         echo "Finished test stage execution."
+    }
+}
+
+// Publish the test results that pytest had already written to disk before an
+// interrupt (fail-fast abort of a sibling stage, user abort or walltime timeout)
+// reached this stage.
+//
+// The pytest run writes ${stageName}/results.xml incrementally
+// (--periodic-junit), so at interrupt time that file already holds the real
+// pass/fail verdicts of every test that finished. Dropping it loses genuine
+// failures and coverage data from post-mortem triage for no benefit.
+//
+// Deliberately narrow: nothing is *generated* here. No "terminated unexpectedly"
+// testcase is synthesized for the test that was still in flight, and no
+// synthetic stage-fail XML is written. Only files that the normal, uninterrupted
+// code path had already produced are uploaded and reported. This mirrors what
+// uploadResults() (the multi-node SLURM path) already does for interrupted
+// stages, where the interrupt only gates synthetic XML generation and the real
+// results are still uploaded and passed to junit().
+//
+// Everything is best-effort. This runs inside the finally block of an in-flight
+// InterruptedException: an exception escaping here would replace that
+// InterruptedException and turn an aborted stage into a failed one, so the whole
+// body is bounded by a fresh timeout and wrapped in a catch-all.
+def recoverInterruptedStageResults(stageName, postTag)
+{
+    try {
+        timeout(time: 5, unit: 'MINUTES') {
+            def hasResults = sh(
+                script: "ls ${stageName}/results*.xml >/dev/null 2>&1",
+                returnStatus: true
+            ) == 0
+            if (!hasResults) {
+                echo "Stage is interrupted, no completed test result to recover."
+            } else {
+                // Attribute the recovered results to this stage, the same way
+                // finallyRunner() does for the uninterrupted path.
+                sh "cd ${stageName} && sed -i 's/testsuite name=\"pytest\"/testsuite name=\"${stageName}\"/g' results*.xml || true"
+                sh "ls -al ${stageName}/"
+                echo "Stage is interrupted, uploading the test results completed before the interrupt."
+                sh "tar -czvf results-${stageName}${postTag}.tar.gz ${stageName}/"
+                trtllm_utils.uploadArtifacts(
+                    "results-${stageName}${postTag}.tar.gz",
+                    "${UPLOAD_PATH}/test-results/"
+                )
+                junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
+            }
+        }
+    } catch (Exception e) {
+        echo "Stage is interrupted, recovering completed test results failed and was ignored: ${e.getMessage()}"
     }
 }
 


### PR DESCRIPTION
## Summary

When a test stage is interrupted, `cacheErrorAndUploadResult()` skipped the entire result-upload block and discarded `${stageName}/results*.xml`:

```groovy
if (stageIsInterrupted) {
    echo "Stage is interrupted, skip to upload test result."
} else { /* tar + uploadArtifacts + junit */ }
```

Those XMLs are **not** synthetic. The pytest run writes them incrementally (`--periodic-junit`, `--periodic-batch-size=1`), so at interrupt time the file already holds the real pass/fail verdicts of every test that finished. Discarding it loses genuine failures and coverage data from post-mortem triage.

Measured example — build 51002, `GB200-4_GPUs-SBSA-PyTorch-5`:

| time | log line |
|---|---|
| 02:35:12 | `Periodic report generated with 8 tests: .../results.xml` |
| 02:36:05 | interrupt arrives |
| 02:36:47 | `Stage is interrupted, skip to upload test result.` |

Eight completed results thrown away.

This PR replaces the `echo` with `recoverInterruptedStageResults()`, which uploads the tar and calls `junit()` on whatever pytest had already written.

## What this PR deliberately does *not* do

**No synthetic test results are generated on this path.** No "terminated unexpectedly" testcase is synthesized for the test that was still in flight, and no `results-stage.xml` is written. Only files the normal, uninterrupted code path had already produced are uploaded and reported. So:

- `waives.txt` is not bypassed — every recovered testcase went through the normal pytest waive/skip machinery.
- The failure index is not polluted with one synthetic entry per interrupted stage.
- Dead code at the old `:2821-2822` (`if (stageIsInterrupted)` inside the `else` branch, unreachable) is left untouched.

This is also exactly the shape `uploadResults()` (the multi-node SLURM path, `L0_Test.groovy:300`) already ships today: there, `stageIsInterrupted` gates *only* `generateTimeoutTestResultXml()` at `:317-318`, while the real results are still tarred, uploaded, and passed to `junit(allowEmptyResults: true, ...)` at `:405-417`. This PR brings the K8s path in line with the SLURM path; it does not invent a new policy.

## Build-result neutrality

Pre-empting the obvious review concern: **this cannot flip an ABORTED or FAILURE build to UNSTABLE, and cannot flip a SUCCESS build at all.** Three independent arguments, each checkable:

1. **An interrupted stage is never retried.** `runWithK8sInfraRetry` rethrows unconditionally on interruption (`L0_Test.groovy:5057-5059` `catch (InterruptedException e) { // User abort / pipeline timeout -- never retry; throw e }` and `:5069` `if (c instanceof PipelineInterruption) throw e`). So the "an intermediate attempt's failing results leave the build UNSTABLE even though the retry passed" hazard that `suppressTestReporting` exists to guard against structurally cannot apply here — there is no retry after an interrupt.

2. **The interrupt always reaches the top of the flow.** No `catchError` wraps the test stages: `parallel singleGpuJobs` / `parallel dgxJobs` (`:6221`, `:6229`, `:6236`, `:6244`) are unguarded, and `runInDockerOnNodeMultiStage` only swallows `"Failed to kill container"`. So the build ends FAILURE (fail-fast: `parallel` rethrows the sibling's original failure) or ABORTED (user abort / walltime).

3. **`junit()` cannot undo either.** `hudson.model.Result` ordinals are `SUCCESS=0, UNSTABLE=1, FAILURE=2, NOT_BUILT=3, ABORTED=4`, and `Run.setResult` is explicitly `// result can only get worse` — it applies a new result only `if (result == null || r.isWorseThan(result))`, with `isWorseThan` = higher ordinal. A `junit()`-induced `setResult(UNSTABLE)` therefore loses to both the later `setResult(FAILURE)` and `setResult(ABORTED)`.

Belt and braces on top of that:

- The whole recovery body is wrapped in `catch (Exception e) { echo ... }`. It runs in the `finally` of an in-flight `InterruptedException`; an exception escaping it would *replace* that exception and convert an aborted stage into a failed one. The catch-all makes that impossible.
- `junit(allowEmptyResults: true, ...)` — without this, `JUnitResultArchiver` throws when the glob matches nothing, which is precisely the escape described above.
- The body is bounded by a fresh `timeout(time: 5, unit: 'MINUTES')` so recovery can never stall the fail-fast path.

The visible change is that a build's *test report* will now show real failures that used to be silently dropped. The build *result* is unchanged.

## Walltime path — what is proven and what is not

`cacheErrorAndUploadResult` runs inside `runner{}`, which is wrapped in `timeout(time: partitionTimeout - 10, unit: 'MINUTES')` (`:4802`, `:4824`).

- **Proven:** on the fail-fast abort path, `sh` steps still execute in this `finally` after the interrupt — the workspace-cleanup `sh` at the end of the same block ran 42 s after the interrupt in build 51002.
- **Not proven:** the walltime-expiry path. All positive evidence is from fail-fast aborts. Recovery there runs inside an already-expired `timeout`, and Jenkins' `timeout` step hard-kills the body after a grace period once it fires. The nested `timeout(5, MINUTES)` bounds *our* work but does **not** shield it from that outer kill. So on walltime expiry, recovery is best-effort: it may complete, or it may be cut short, in which case behaviour is identical to today (results discarded) — never worse. Reviewers with better knowledge of this deployment's grace-period setting: please sanity-check whether 5 minutes should be lowered.

## Testing

Honest scope: this is Groovy CI infrastructure. There is no meaningful unit test and no way to exercise a mid-stage interrupt locally.

- **Done:** parsed the modified `L0_Test.groovy` with the Groovy 4.0.24 compiler through `Phases.CONVERSION` (full parse + AST build) — passes, with the unmodified `origin/main` file as the baseline control. `SEMANTIC_ANALYSIS` is not reachable offline because the `trtllm.*` shared-library classes live outside this repo.
- **Done:** traced control flow through `cacheErrorAndUploadResult` → `runWithK8sInfraRetry` → `parallel` for the neutrality argument above.
- **Not done:** no live interrupted stage has exercised this code. A `/bot run` on this PR would confirm the pipeline still loads and that uninterrupted stages are unaffected (the `else` branch is byte-identical). It would **not** exercise the new function unless a stage actually gets interrupted.

## Notes for reviewers

`/jenkins` is owned exclusively by @NVIDIA/trt-llm-infra-devs (`.github/CODEOWNERS:70`), so this needs your review. The diff is 51 added lines in one file, one call site changed, and the uninterrupted path is untouched.

Do not run `/bot run` on this yet — validation is sequenced separately.
