### PR TITLE
[TRTLLM-13409][test] right-size perf-sanity per-test timeouts to measured runtime

### DIFF
--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -95,6 +95,9 @@ def ensure_bench_serving_repo() -> str:
     return bench_script
 
 
+# Fallback whole-test budget, used only when a config declares no `slurm.timeout`
+# AND the test carries no `TIMEOUT (N)` marker (i.e. local runs). Under CI the
+# effective value is always clamped to the marker -- see marker_bounded_timeout.
 DEFAULT_TIMEOUT = 10800
 # Defaults for the server *ready* wait, separate from the whole-test timeout:
 # a server that is not healthy after this long is not going to be, and failing
@@ -104,6 +107,71 @@ DEFAULT_TIMEOUT = 10800
 # once EVERY ctx/gen worker has finished model load + autotune + warmup.
 AGG_SERVER_READY_TIMEOUT = 1800
 DISAGG_SERVER_READY_TIMEOUT = 3600
+
+# How far ahead of the per-test pytest `TIMEOUT (N)` marker the harness's own
+# waits give up. The marker kill is a SIGALRM from pytest-timeout: it reports
+# "Test terminated unexpectedly" with l_e2e_time_ms = 1000 and no indication of
+# which wait was stuck. Failing HARNESS_TIMEOUT_MARGIN seconds earlier lets the
+# harness raise its own RuntimeError instead, naming the wait that hung and
+# leaving the server-log tails in the CI log -- so a real hang is classifiable
+# rather than an anonymous kill.
+HARNESS_TIMEOUT_MARGIN = 180
+
+
+def marker_bounded_timeout(config_timeout: int, pytest_timeout: Optional[int]) -> int:
+    """Bound a config-declared timeout by this test's own pytest timeout marker.
+
+    ``DEFAULT_TIMEOUT`` (and the per-config ``slurm.timeout``) are provisioned at
+    or above the largest ``TIMEOUT (N)`` marker in the test lists, so on their own
+    they can never fire before pytest kills the process. Clamping to the marker --
+    rather than to a constant, which would false-kill the legitimately long
+    128k8k benchmarks -- makes every harness wait bounded by the same budget CI
+    actually enforces, per test.
+
+    The returned value is not only a wait bound: for disagg it is also passed to
+    ``trtllm-serve disaggregated`` as ``-t``/``-r``, so a smaller marker also
+    shortens the proxy's own request/router timeouts. That cannot cause a
+    failure the marker would not have caused anyway (the proxy bound stays below
+    the wall-clock kill), but it does change the failure *mode*: a stuck request
+    now surfaces as a proxy timeout rather than as the whole test being killed.
+
+    Returns ``config_timeout`` unchanged when no marker is present (local runs,
+    or a test list entry without ``TIMEOUT``).
+    """
+    if not pytest_timeout or pytest_timeout <= 0:
+        return config_timeout
+    # The 60s clamp is a negative guard, not a case that occurs today: it would
+    # only bind for a marker under 4 minutes, and the smallest marker in the
+    # test lists is 30 minutes. It exists so a hand-edited tiny marker degrades
+    # to a short-but-positive bound instead of a negative one.
+    return min(config_timeout, max(60, pytest_timeout - HARNESS_TIMEOUT_MARGIN))
+
+
+def get_pytest_timeout(request) -> Optional[int]:
+    """Seconds from this test's pytest-timeout marker, or None if unmarked.
+
+    The marker is attached from the test-list ``TIMEOUT (N)`` suffix by
+    ``test_list_parser.apply_test_list_markers``; ``N`` is in minutes there and
+    already converted to seconds on the marker.
+
+    Falls back to the global ``--timeout`` / ini value so that a run which sets
+    only the global bound (and no per-test marker) still gets the clamp instead
+    of silently keeping ``DEFAULT_TIMEOUT``.
+    """
+    marker = request.node.get_closest_marker("timeout")
+    value = None
+    if marker is not None:
+        value = marker.args[0] if marker.args else marker.kwargs.get("timeout")
+    if value is None:
+        try:
+            value = request.config.getoption("timeout", None)
+        except ValueError:
+            # pytest-timeout not installed: no bound to inherit.
+            value = None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def server_ready_timeout(default: int, mode: str) -> int:
@@ -1327,6 +1395,14 @@ class DisaggTestCmds(NamedTuple):
 
         The benchmark-done check runs FIRST so a server exiting just after a
         completed benchmark cannot fail an otherwise-passing test.
+
+        ``self.timeout`` is the backstop for the case a process death does not
+        cover (a live-but-wedged server). It is clamped to this test's own
+        ``TIMEOUT (N)`` marker by ``marker_bounded_timeout``, so it fires --
+        with this message and the elapsed time -- shortly before pytest would
+        SIGALRM the process into an unattributable "Test terminated
+        unexpectedly". Before that clamp it defaulted to ``DEFAULT_TIMEOUT``,
+        which is >= every marker in the test lists and so never fired.
         """
         start_time = time.time()
         while True:
@@ -1716,9 +1792,12 @@ def get_config_dir(benchmark_mode: Optional[str]) -> str:
 class PerfSanityTestConfig:
     """Configuration for perf sanity tests."""
 
-    def __init__(self, test_case_name: str, output_dir: str):
+    def __init__(self, test_case_name: str, output_dir: str, pytest_timeout: Optional[int] = None):
         self._output_dir = output_dir
         self._perf_results: Dict[int, List[Dict[str, float]]] = {}
+        # Per-test budget from the test list's `TIMEOUT (N)` marker; every
+        # harness wait is clamped to it (see marker_bounded_timeout).
+        self._pytest_timeout = pytest_timeout
 
         # Initialize server configs
         self.server_configs: List = []
@@ -1864,7 +1943,9 @@ class PerfSanityTestConfig:
         slurm_config = config.get("slurm", {})
         worker_config = config.get("worker_config", {})
 
-        timeout = slurm_config.get("timeout", DEFAULT_TIMEOUT)
+        timeout = marker_bounded_timeout(
+            slurm_config.get("timeout", DEFAULT_TIMEOUT), self._pytest_timeout
+        )
         numa_bind = slurm_config.get("numa_bind", False)
         gpus_per_node = hardware.get("gpus_per_node", 0)
         model_name = metadata.get("model_name", "")
@@ -2056,7 +2137,7 @@ class PerfSanityTestConfig:
         return AggrTestCmds(
             server_cmds=server_cmds,
             client_cmds=client_cmds,
-            timeout=DEFAULT_TIMEOUT,
+            timeout=marker_bounded_timeout(DEFAULT_TIMEOUT, self._pytest_timeout),
             output_dir=output_dir,
             test_output_dir=test_output_dir,
             client_configs=self.server_client_configs,
@@ -2566,9 +2647,11 @@ PERF_SANITY_TEST_CASES = get_aggr_test_cases() + get_disagg_test_cases() + MULTI
 
 
 @pytest.mark.parametrize("perf_sanity_test_case", PERF_SANITY_TEST_CASES)
-def test_e2e(output_dir, perf_sanity_test_case):
+def test_e2e(request, output_dir, perf_sanity_test_case):
     # Create config and parse test case name
-    config = PerfSanityTestConfig(perf_sanity_test_case, output_dir)
+    config = PerfSanityTestConfig(
+        perf_sanity_test_case, output_dir, pytest_timeout=get_pytest_timeout(request)
+    )
 
     # Parse config file to get server_configs and server_client_configs
     config.parse_config_file()

--- a/tests/integration/test_lists/test-db/l0_b200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node1_gpu8.yml
+++ b/tests/integration/test_lists/test-db/l0_b200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node1_gpu8.yml
@@ -14,7 +14,7 @@ l0_b200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node1_gpu8:
       stage: pre_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL] TIMEOUT (120)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL] TIMEOUT (50)
 
 - condition:
     ranges:
@@ -30,8 +30,8 @@ l0_b200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node1_gpu8:
       stage: post_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (120)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL] TIMEOUT (120)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (80)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL] TIMEOUT (30)
   # - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL] TIMEOUT (120)
   # - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-b200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (120)
   # - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-b200_deepseek-r1-fp4_8k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL] TIMEOUT (120)

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu2.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu2.yml
@@ -14,4 +14,4 @@ l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu2:
       stage: post_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL] TIMEOUT (70)

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu4.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu4.yml
@@ -30,8 +30,8 @@ l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu4:
       stage: post_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con128_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con1_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con64_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con128_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL] TIMEOUT (65)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL] TIMEOUT (65)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con1_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL] TIMEOUT (50)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con64_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL] TIMEOUT (65)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL] TIMEOUT (80)

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node2_gpu8.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node2_gpu8.yml
@@ -14,5 +14,5 @@ l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node2_gpu8:
       stage: post_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con1024_ctx1_tp1_gen1_dep8_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con1024_ctx1_tp1_gen1_dep8_eplb0_mtp0_ccb-NIXL] TIMEOUT (35)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb200_qwen3-235b-fp4_8k1k_con1024_ctx1_tp1_gen1_dep8_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node2_gpu8.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node2_gpu8.yml
@@ -14,7 +14,7 @@ l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node2_gpu8:
       stage: post_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (80)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (75)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
   # - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16.yml
@@ -14,7 +14,7 @@ l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16:
       stage: post_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL] TIMEOUT (60)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL] TIMEOUT (90)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb200_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node8_gpu32.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node8_gpu32.yml
@@ -14,9 +14,9 @@ l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node8_gpu32:
       stage: post_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL] TIMEOUT (85)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL] TIMEOUT (90)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL] TIMEOUT (70)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL] TIMEOUT (90)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL] TIMEOUT (90)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL] TIMEOUT (90)

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node2_gpu8_gen1_node2_gpu8.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node2_gpu8_gen1_node2_gpu8.yml
@@ -14,5 +14,5 @@ l0_gb200_multi_nodes_perf_sanity_ctx1_node2_gpu8_gen1_node2_gpu8:
       stage: post_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_128k8k_con1_ctx1_pp8_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (180)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_128k8k_con1_ctx1_pp8_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (75)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node2_gpu8_gen1_node4_gpu16.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_nodes_perf_sanity_ctx1_node2_gpu8_gen1_node4_gpu16.yml
@@ -14,5 +14,5 @@ l0_gb200_multi_nodes_perf_sanity_ctx1_node2_gpu8_gen1_node4_gpu16:
       stage: post_merge
       backend: pytorch
   tests:
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL] TIMEOUT (180)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL] TIMEOUT (140)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL] TIMEOUT (180)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu2_gen1_node2_gpu8.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu2_gen1_node2_gpu8.yml
@@ -32,5 +32,5 @@ l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu2_gen1_node2_gpu8:
       backend: pytorch
   tests:
   # glm-5-fp4
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con1_ctx1_dep2_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con1024_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con1_ctx1_dep2_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (35)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con1024_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL] TIMEOUT (60)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu2_gen1_node8_gpu32.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu2_gen1_node8_gpu32.yml
@@ -15,4 +15,4 @@ l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu2_gen1_node8_gpu32:
       backend: pytorch
   tests:
   # glm-5-fp4
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL] TIMEOUT (40)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node2_gpu8.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node2_gpu8.yml
@@ -15,7 +15,7 @@ l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node2_gpu8:
       backend: pytorch
   tests:
   # kimi-k25-thinking-fp4 8k1k
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (50)
 
 - condition:
     ranges:

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16.yml
@@ -15,8 +15,8 @@ l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16:
       backend: pytorch
   tests:
   # deepseek-r1-fp4 8k1k
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL] TIMEOUT (60)
   # kimi-k25-thinking-fp4 8k1k
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL] TIMEOUT (65)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL] TIMEOUT (90)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL] TIMEOUT (90)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen4_node2_gpu8.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen4_node2_gpu8.yml
@@ -16,4 +16,4 @@ l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen4_node2_gpu8:
   tests:
   # deepseek-v4-pro-fp4 8k1k con8 (single-user latency)
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (120)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (120)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL] TIMEOUT (70)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx3_node1_gpu4_gen1_node8_gpu32.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx3_node1_gpu4_gen1_node8_gpu32.yml
@@ -16,4 +16,4 @@ l0_gb300_multi_nodes_perf_sanity_ctx3_node1_gpu4_gen1_node8_gpu32:
   tests:
   # deepseek-v4-pro-fp4 8k1k con180
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL] TIMEOUT (75)

--- a/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx6_node1_gpu4_gen1_node4_gpu16.yml
+++ b/tests/integration/test_lists/test-db/l0_gb300_multi_nodes_perf_sanity_ctx6_node1_gpu4_gen1_node4_gpu16.yml
@@ -16,4 +16,4 @@ l0_gb300_multi_nodes_perf_sanity_ctx6_node1_gpu4_gen1_node4_gpu16:
   tests:
   # deepseek-v4-pro-fp4 8k1k con666
   - perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)
-  - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL] TIMEOUT (120)
+  - perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL] TIMEOUT (80)


### PR DESCRIPTION
## What

Right-size the pytest `TIMEOUT (N)` markers on disagg perf-sanity benchmarks to their **measured** runtime, and make the harness's own waits bounded by that same marker instead of by a constant that can never fire.

> **v2 (review round 1).** The guard is now computed over the **full available window** rather than a 46-day slice. Under the wide window 10 of the v1 markers fell below the 2.5x guard -- one of them (`gen_only-b200_deepseek-r1_8k1k_con1`) *below its observed max outright*, i.e. it would already have killed a real PASSED run. Details in "Why the window width was the defect" below. Recovery drops 4,461 -> 3,799 GPU-h (85% retained).

## The finding

The `TIMEOUT (N)` marker parsed from the test-list suffix (`tests/integration/defs/conftest.py:1898-1914`, via `tests/integration/defs/test_list_parser.py:666-669`) is the only bound that fires on a hung disagg benchmark. It is provisioned far above the benchmark's own legitimate runtime -- marker-to-p99 ratios up to **11.7x**. A hang burns the whole marker on 8-56 GPUs.

**MEASURED**, OpenSearch `test_info` + `stage_info`, `test_e2e[disagg_upload-*]`, every record the index holds:
- n = **12977** PASSED runs, spanning **114 days** (2026-04-08 .. 2026-07-31). The index has no disagg perf-sanity records before ~2026-04-23 even with no time filter at all, so 114 d *is* the widest window with reliable data -- a "180-day" query returns the same rows.
- n = **715** kills (`s_short_error_msg = "Test terminated unexpectedly"`), each joined to its `stage_info` FAILURE record

Killed-stage wall time tracks the marker roughly 1:1 (the offset is stage setup, not the test). Every killed run reports `l_e2e_time_ms = 1000` -- the harness records **no** usable duration for a marker kill (MEASURED, n=715, 100%). That is the fake-hang mechanism in one number.

## Policy: the marker is a HANG bound, not a perf gate

The perf-sanity harness has its own regression check, and it needs the run to **complete**:
- `tests/integration/defs/perf/perf_regression_utils.py:347-356` -- flags a metric outside `baseline * (1 +/- threshold)`
- thresholds at `:35-36` -- 5% post-merge, 10% pre-merge
- baseline from OpenSearch history (`d_baseline_*`) or computed from history at `:224`
- `check_perf_regression()` at `:417` -- raises `RuntimeError` pre-merge, warns post-merge
- regression metric selection at `test_perf_sanity.py:2322-2337`: gen_only gates on `d_mean_gen_worker_per_iter_device_step_time` (minimize -- slower run = regression); every other mode on token throughput (maximize -- slower run = regression)

A slow-but-completing run **is** reported as a perf regression with numbers attached. Kill it with a tight marker instead and it becomes `Test terminated unexpectedly` / `l_e2e_time_ms = 1000` -- a fake hang that corrupts the hang census and throws away the perf signal.

## Why the window width was the defect

The v1 guard used a 46-day window. Over the full 114 days, 10 of the 27 v1 markers violate the very 2.5x guard they were supposed to satisfy:

| old -> v1 | max (46 d) | **max (full)** | v1 / max_full | corrected |
|---:|---:|---:|---:|---:|
| 120 -> 30 | 8.5 | **31.2** | 0.96x :x: | **80** |
| 90 -> 30 | 8.3 | **26.9** | 1.11x | **80** |
| 90 -> 30 | 4.9 | **25.9** | 1.16x | **65** |
| 90 -> 30 | 7.2 | **25.8** | 1.16x | **65** |
| 90 -> 30 | 4.1 | **25.8** | 1.16x | **65** |
| 90 -> 30 | 7.5 | **19.8** | 1.52x | **50** |
| 90 -> 60 | 23.6 | **37.2** | 1.61x | **90** |
| 180 -> 50 | 19.4 | **28.4** | 1.76x | **75** |
| 90 -> 50 | 18.5 | **24.2** | 2.07x | **70** |
| 90 -> 65 | 25.6 | **29.1** | 2.24x | **75** |

This is **not** a stale-era artifact. The spikes are build-correlated across unrelated benchmarks and different GPU types under `L0_MergeRequest_PR` -- so a single systemic slow build would trip several markers at once and manufacture a *cluster* of simultaneous fake hangs, which is strictly worse than the single-benchmark case. A short window systematically understates `max` precisely for the failure mode the guard exists to prevent.

## Recovery-vs-headroom curve

Burn is the marker-attributable GPU-h in killed runs: `sum over kills of (marker x n_gpus)`. All variants apply a 30 min floor and round up to a 5-min grid.

Today = **24,628 GPU-h / 114 d** (n_kills = 715). `hdrm` = new marker / that benchmark's slowest observed PASSED run, over the full window.

| rule | burn | recovered | % | #changed | min hdrm | chg <2.5x max | chg <1.5x max |
|---|---:|---:|---:|---:|---:|---:|---:|
| `1.5x p99` | 16,454 | 8,174 | 33.2% | 40 | 0.84x | 37 | 26 |
| `1.5x p99` + `2.5x max` | 20,541 | 4,087 | 16.6% | 27 | 2.51x | 0 | 0 |
| `2x p99` | 17,643 | 6,985 | 28.4% | 35 | 0.94x | 32 | 10 |
| `2x p99` + `2.5x max` | 20,541 | 4,087 | 16.6% | 27 | 2.51x | 0 | 0 |
| `3x p99` | 19,625 | 5,003 | 20.3% | 30 | 1.40x | 14 | 1 |
| `3x p99` + `2.5x max` **<- chosen** | 20,829 | 3,799 | 15.4% | 26 | 2.51x | 0 | 0 |
| `4x p99` | 21,471 | 3,157 | 12.8% | 24 | 1.72x | 6 | 0 |
| `4x p99` + `2.5x max` | 21,804 | 2,824 | 11.5% | 21 | 2.51x | 0 | 0 |
| ~~v1: `3x p99` + `2.5x max`, 46-day guard~~ (rejected) | 20,167 | 4,461 | 18.1% | 27 | 0.96x | 10 | 5 |

Reading the table: `1.5x p99` recovers the most (33.2%) and is exactly what the fake-hang argument rules out -- 26 of its 40 changed markers land below 1.5x their own observed max, and the worst sits at **0.84x**, a guaranteed false hang on day one. Once the `2.5x max` guard is applied, `k` stops binding below ~2.5 (the 1.5x and 2x rows are identical): **the observed max, not p99, is the constraint that matters here.** The last row is the rejected v1 rule, shown against the wide window that exposed it.

## Recommendation

    new_marker = max(30 min, ceil5(3 x p99), ceil5(2.5 x observed_max_PASSED))

with both `p99` and `max` taken over the **full available window**.

- **3x p99** -- absorbs a 3x slowdown, i.e. 30-60x the 5-10% regression threshold, so any regression large enough to matter is reported rather than killed.
- **2.5x observed max** guard -- p99 at n=100-600 sits close to the max and misses the real tail. It binds on 14 of the 26 changes.
- **30 min floor** -- small p99 x any multiplier produces absurd bounds. It binds on 1 benchmark.
- **Never raises a marker.** Where the guard wants more than the current value the marker is left alone (see "Not changed").
- **Recovers 3,799 GPU-h / 114 d (15.4%)** across 26 markers, with **no reduced marker below 2.51x** its slowest healthy run.

## Thin samples -- excluded, not re-provisioned

Active benchmarks with fewer than 10 PASSED runs keep their markers; their "p99" would be 1-4 observations:

| n PASSED | marker | benchmark |
|---:|---:|---|
| 0 | 90 | `sagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL` |
| 0 | 90 | `sagg_upload-gen_only-gb200_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL` |
| 0 | 120 | `sagg_upload-gen_only-gb300_kimi-k25-thinking-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb416_mtp3_ccb-NIXL` |
| 1 | 120 | `sagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL` |
| 1 | 120 | `sagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL` |
| 1 | 120 | `sagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL` |
| 2 | 120 | `sagg_upload-gen_only-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL` |
| 3 | 90 | `sagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL` |
| 4 | 180 | `sagg_upload-e2e-gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL` |

`n = 0` rows are active list entries with no PASSED run at all in the window (they only ever failed) -- those need triage, not re-provisioning, and are out of scope.

## Per-benchmark changes (26)

`bind` = which term of the formula set the value.

| old | new | n | p99 | max | 3xp99 | 2.5xmax | bind | new/max | kills | GPUs | GPU-h | benchmark |
|---:|---:|---:|---:|---:|---:|---:|:--|---:|---:|---:|---:|---|
| 90 | **40** | 114 | 12.1 | 12.3 | 36.3 | 30.8 | `3xp99` | 3.25x | 27 | 36 | 810 | `sagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con512_ctx1_dep2_gen1_dep32_eplb0_mtp3_ccb-NIXL` |
| 120 | **50** | 89 | 16.3 | 16.8 | 48.8 | 42.1 | `3xp99` | 2.97x | 31 | 16 | 579 | `sagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con1536_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL` |
| 180 | **75** | 213 | 19.3 | 28.4 | 57.8 | 71.0 | `2.5xmax` | 2.64x | 13 | 16 | 364 | `sagg_upload-gen_only-gb200_deepseek-r1-fp4_128k8k_con1_ctx1_pp8_gen1_tep8_eplb0_mtp3_ccb-NIXL` |
| 90 | **65** | 143 | 15.1 | 24.4 | 45.2 | 60.9 | `2.5xmax` | 2.67x | 26 | 20 | 217 | `sagg_upload-gen_only-gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL` |
| 90 | **50** | 519 | 8.7 | 18.6 | 26.1 | 46.6 | `2.5xmax` | 2.68x | 23 | 12 | 184 | `sagg_upload-gen_only-gb300_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL` |
| 90 | **60** | 221 | 14.2 | 23.9 | 42.7 | 59.7 | `2.5xmax` | 2.51x | 18 | 20 | 180 | `sagg_upload-gen_only-gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL` |
| 120 | **30** | 170 | 9.6 | 10.3 | 28.8 | 25.7 | floor | 2.92x | 7 | 16 | 168 | `sagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con256_ctx1_dep4_gen1_dep8_eplb0_mtp1_ccb-NIXL` |
| 180 | **140** | 136 | 46.7 | 48.2 | 140.0 | 120.5 | `3xp99` | 2.90x | 10 | 24 | 160 | `sagg_upload-gen_only-gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL` |
| 90 | **60** | 60 | 19.3 | 19.5 | 57.8 | 48.7 | `3xp99` | 3.08x | 25 | 12 | 150 | `sagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con1024_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL` |
| 120 | **80** | 154 | 20.1 | 31.2 | 60.2 | 78.0 | `2.5xmax` | 2.56x | 14 | 16 | 149 | `sagg_upload-gen_only-b200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL` |
| 90 | **35** | 244 | 10.3 | 11.9 | 30.8 | 29.6 | `3xp99` | 2.95x | 12 | 12 | 132 | `sagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con1024_ctx1_tp1_gen1_dep8_eplb0_mtp0_ccb-NIXL` |
| 90 | **70** | 108 | 15.2 | 27.8 | 45.5 | 69.5 | `2.5xmax` | 2.52x | 11 | 36 | 132 | `sagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL` |
| 90 | **50** | 220 | 15.2 | 19.8 | 45.7 | 49.5 | `2.5xmax` | 2.53x | 20 | 8 | 107 | `sagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con1_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL` |
| 90 | **35** | 77 | 11.5 | 11.5 | 34.6 | 28.9 | `3xp99` | 3.03x | 9 | 12 | 99 | `sagg_upload-gen_only-gb300_glm-5-fp4_8k1k_con1_ctx1_dep2_gen1_tep8_eplb0_mtp3_ccb-NIXL` |
| 90 | **60** | 174 | 16.6 | 22.4 | 49.7 | 56.1 | `2.5xmax` | 2.67x | 9 | 20 | 90 | `sagg_upload-gen_only-gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL` |
| 90 | **65** | 203 | 20.5 | 25.8 | 61.4 | 64.5 | `2.5xmax` | 2.52x | 19 | 8 | 63 | `sagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL` |
| 90 | **65** | 182 | 19.5 | 25.8 | 58.6 | 64.6 | `2.5xmax` | 2.51x | 16 | 8 | 53 | `sagg_upload-gen_only-gb200_qwen3-235b-fp4_8k1k_con64_ctx1_tp1_gen1_tep4_eplb0_mtp0_ccb-NIXL` |
| 90 | **65** | 228 | 20.5 | 25.9 | 61.4 | 64.9 | `2.5xmax` | 2.51x | 13 | 8 | 43 | `sagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con128_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL` |
| 90 | **75** | 196 | 21.3 | 29.1 | 63.9 | 72.7 | `2.5xmax` | 2.58x | 13 | 12 | 39 | `sagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL` |
| 90 | **70** | 248 | 22.7 | 24.2 | 68.0 | 60.4 | `3xp99` | 2.90x | 12 | 8 | 32 | `sagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL` |
| 90 | **85** | 210 | 13.4 | 32.1 | 40.1 | 80.2 | `2.5xmax` | 2.65x | 8 | 36 | 24 | `sagg_upload-gen_only-gb200_deepseek-r1-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL` |
| 90 | **80** | 213 | 26.6 | 28.6 | 79.9 | 71.5 | `3xp99` | 2.80x | 11 | 12 | 22 | `sagg_upload-gen_only-gb200_deepseek-r1-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL` |
| 90 | **80** | 200 | 26.5 | 26.9 | 79.4 | 67.3 | `3xp99` | 2.97x | 1 | 8 | 1 | `sagg_upload-gen_only-gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL` |
| 120 | **70** | 23 | 22.9 | 22.9 | 68.6 | 57.2 | `3xp99` | 3.06x | 0 | 36 | 0 | `sagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con8_ctx1_dep4_gen4_tep8_eplb0_mtp3_ccb-NIXL` |
| 120 | **75** | 23 | 24.8 | 25.1 | 74.3 | 62.7 | `3xp99` | 2.99x | 0 | 44 | 0 | `sagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con180_ctx3_dep4_gen1_dep32_eplb384_mtp3_ccb-NIXL` |
| 120 | **80** | 27 | 26.2 | 26.5 | 78.7 | 66.3 | `3xp99` | 3.02x | 0 | 40 | 0 | `sagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con666_ctx6_dep4_gen1_dep16_eplb384_mtp3_ccb-NIXL` |

Total: **3,799 GPU-h / 114 d**.

## `DEFAULT_TIMEOUT` / `wait_for_benchmark_ready`

`DEFAULT_TIMEOUT = 10800` (`test_perf_sanity.py:98`) equals the largest marker (180 min) and exceeds the other two, so `self.timeout` -- the backstop in `wait_for_benchmark_ready`, `wait_for_gen_log_sentinels`, `_wait_for_config_file` and the hostname wait -- could never fire before pytest killed the process.

Rather than clamp to a constant (3600 would false-kill the legitimate 144-minute `128k8k` benchmark), the test's **own** marker is now plumbed through:

- `get_pytest_timeout(request)` reads the `pytest.mark.timeout` that `test_list_parser.py:669` attached from the `TIMEOUT (N)` suffix, falling back to the global `--timeout` / ini value so a run that sets only the global bound still gets the clamp
- `marker_bounded_timeout(config_timeout, pytest_timeout)` returns `min(config_timeout, marker - 180 s)`, and returns `config_timeout` unchanged when there is no bound at all (local runs)
- applied at both sites that set `self.timeout`: the disagg path (`slurm.timeout` / `DEFAULT_TIMEOUT`) and the aggr path (`AggrTestCmds(timeout=...)`)

Effect: a genuinely wedged server now trips the harness's own `RuntimeError` -- which names the wait and carries the elapsed time and server-log tails -- ~3 min before pytest SIGALRMs the process into an unattributable `Test terminated unexpectedly`.

Note the value also reaches `trtllm-serve disaggregated` as `-t`/`-r` (`:2163-2166`), so a smaller marker also shortens the proxy's request/router timeouts. It cannot cause a failure the marker would not have caused anyway, but it changes the failure *mode*; documented on the helper.

Extends the clamp pattern established by ST-9(a) at `test_perf_sanity.py:1512-1516`.

## Not changed

- **14 markers are already below 2.5x their own observed max** and were left alone -- loosening markers is the opposite of this PR's purpose, and each needs its own judgement. They are the benchmarks most at risk of a fake hang *today*. Worst first:

| marker/max | marker | max | n | benchmark | location |
|---:|---:|---:|---:|---|---|
| **1.09x** | 90 | 82.8 | 137 | `sagg_upload-e2e-gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL` | `l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node8_gpu32.yml:23` |
| **1.25x** | 180 | 144.0 | 66 | `sagg_upload-e2e-gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL` | `l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node2_gpu8.yml:36` |
| **1.36x** | 90 | 66.2 | 186 | `sagg_upload-e2e-gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL` | `l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node8_gpu32.yml:24` |
| **1.50x** | 90 | 60.0 | 70 | `sagg_upload-e2e-gb200_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL` | `l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16.yml:20` |
| **1.59x** | 90 | 56.5 | 257 | `sagg_upload-e2e-gb300_glm-5-fp4_8k1k_con1024_ctx1_dep2_gen1_dep8_eplb256_mtp1_ccb-NIXL` | `l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu2_gen1_node2_gpu8.yml:18` |
| **1.73x** | 90 | 52.0 | 163 | `sagg_upload-e2e-gb200_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL` | `l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16.yml:19` |
| **1.99x** | 180 | 90.7 | 155 | `sagg_upload-gen_only-gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL` | `l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node2_gpu8.yml:35` |
| **2.09x** | 90 | 43.1 | 226 | `sagg_upload-e2e-gb300_deepseek-r1-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp1_ccb-NIXL` | `l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16.yml:21` |
| **2.12x** | 90 | 42.5 | 95 | `sagg_upload-e2e-gb300_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL` | `l0_gb300_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node4_gpu16.yml:22` |
| **2.21x** | 90 | 40.7 | 108 | `sagg_upload-gen_only-gb200_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL` | `l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node2_gpu8.yml:19` |
| **2.23x** | 90 | 40.4 | 139 | `sagg_upload-e2e-gb200_qwen3-235b-fp4_8k1k_con1024_ctx1_tp1_gen1_dep8_eplb0_mtp0_ccb-NIXL` | `l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node2_gpu8.yml:18` |
| **2.32x** | 90 | 38.7 | 84 | `sagg_upload-gen_only-gb200_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep32_eplb256_mtp3_ccb-NIXL` | `l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu4_gen1_node8_gpu32.yml:20` |
| **2.42x** | 90 | 37.2 | 631 | `sagg_upload-e2e-gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL` | `l0_gb200_multi_nodes_perf_sanity_ctx1_node1_gpu1_gen1_node1_gpu4.yml:17` |
| **2.47x** | 120 | 48.5 | 28 | `sagg_upload-e2e-gb300_deepseek-v4-pro-fp4_8k1k_con4301_ctx12_dep4_gen1_dep8_eplb384_mtp1_ccb-NIXL` | `l0_gb300_multi_nodes_perf_sanity_ctx12_node1_gpu4_gen1_node2_gpu8.yml:19` |

  The worst, **`e2e-gb200_deepseek-v32-fp4_32k4k_con2048` at 1.09x** (marker 90, observed max 82.8, n=137), is one bad build away from a permanent fake hang and is worth raising in a follow-up. `e2e-gb200_gpt-oss-120b_8k1k_con1024` (2.42x) is in this set, which is why the formula leaves it at 90 rather than raising it to 95.

- **aggr / `ctx_only` / visual-gen markers.** Same over-provisioning likely applies; this measurement covers `disagg_upload-*` only. Follow-up.
- **Commented-out test-list entries** keep their old markers.
- **CI check for `marker > k x p99`.** Deliberately left as a follow-up -- it needs an OpenSearch round-trip at lint time, which does not belong in this PR.

## Reproducibility note on `3 x p99`

OpenSearch `percentiles` is a **TDigest estimator**, not an exact quantile, so the `3 x p99` term is **not bit-reproducible across pulls**. An independent re-derivation of this table landed one 5-minute grid step away on six markers (`gpt-oss con4`/`con128`, `qwen3 con64`, `v4-pro con180`, `deepseek-r1_8k1k_con1`, `128k8k_con128`) purely from p99 estimate drift.

The `2.5 x max_observed` guard is **exact and reproducible**, and it is the term that enforces the policy bar. Every marker in this PR is >= 2.51x its observed max regardless of which p99 estimate is used. A small p99 disagreement on re-derivation is estimator noise, not a discrepancy.

## Test Coverage

No new test. The change is per-test-list timeout values plus two pure helpers, both exercised directly over the marker set in use ({None, 30, ..., 180} min) and over the fallback/malformed/absent-plugin paths of `get_pytest_timeout`.

## PR Checklist

- [x] PR title uses the `[JIRA][type] summary` format
- [x] Commit is DCO signed (`git commit -s`)
- [x] Pre-commit hooks pass

