### PR TITLE
[TRTLLM-13409][infra] surface Slurm job output when a multi-GPU stage fails

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -247,6 +247,114 @@ def echoRemoteLogTail(def pipeline, Map remote, String remotePath, int lines = 2
     }
 }
 
+// Bytes of the SLURM job output log kept for post-mortem when a multi-node
+// stage does not finish cleanly. Hang and crash signatures sit at the *end* of
+// the log, so a tail is the right shape; 4 MiB covers the last minutes of every
+// rank's output on the stages this runs on, and it lands compressed in the
+// results tarball rather than in the console log.
+SLURM_JOB_LOG_TAIL_BYTES = 4 * 1024 * 1024
+// Lines of the same log echoed into the Jenkins console. The console copy is
+// the fallback for the case where the tracker script's live `tail -f` was
+// killed (walltime kill, aborted stage) before the failure was printed.
+SLURM_JOB_LOG_ECHO_LINES = 500
+// Redaction applied to the job output log before it is written to disk.
+//
+// The batch script runs under `set -x` and there is no separate `#SBATCH
+// --error`, so xtrace lands in the job output log; the per-rank logs also open
+// with slurm_run.sh's `env | sort`. Jenkins credential masking is a console
+// filter only -- it does not touch archived artifacts -- so the scrub has to
+// happen before the bytes reach ${stageName}/.
+//
+// Anchored at ^, with optional xtrace depth (`+ `, `++ `, ...) and an optional
+// `export ` / `declare -x ` prefix, so only an assignment at the start of a line
+// is rewritten. Matching mid-line would truncate genuine diagnostics -- e.g.
+// `[TRT-LLM] [E] Assertion failed: KEY=missing in map (...)` -- which is exactly
+// the evidence this collection exists to preserve. The value side runs to end of
+// line because a secret can contain whitespace.
+//
+// Must stay byte-identical to DUMP_REDACT_RE in
+// jenkins/scripts/perf/disaggregated/slurm_launch_draft.sh (that copy runs on the
+// cluster, where this constant is not reachable).
+SLURM_LOG_REDACT_CMD = "sed -E 's/^(\\++ )?(export |declare -x )?(HF_TOKEN|S3_SECRET_KEY|[A-Za-z0-9_]*(TOKEN|SECRET|PASSWORD|PASSWD|PSW|KEY))=.*/\\1\\2\\3=***REDACTED***/'"
+
+// Copy a bounded tail of the SLURM job output log into ${stageName}/ and echo a
+// shorter tail into the console log. Returns true if a non-empty log was
+// retrieved.
+//
+// Why this is needed: pytest runs with --timeout-method=thread, which
+// os._exit()s without writing a report, so on a hang the only record of what
+// the ranks did is this log on the cluster -- and cleanUpSlurmResources()
+// `rm -rf`s the job workspace holding it moments after this returns. The
+// perf launch scripts' own failure text ("See slurm-<jobid>.out") points at
+// exactly this file. Landing it in ${stageName}/ is deliberate: that directory
+// is already tarred and uploaded to Artifactory by the caller, so no new
+// artifact path is invented.
+//
+// Best-effort by construction. It runs from a finally block on a stage that has
+// already failed or been interrupted, so it must never throw: a failure here
+// would replace the real failure. The remote read gets its own fresh timeout
+// because the enclosing stage timeout may already have expired (a walltime kill
+// is the common case), and everything is wrapped in a catch-all.
+def collectSlurmJobLog(def pipeline, Map remote, String remoteLogPath, String stageName) {
+    def localLog = "${stageName}/slurm-job-output.log"
+    def collected = false
+    try {
+        timeout(time: 5, unit: 'MINUTES') {
+            // `tail -c` bounds the transfer at the source; the redirection is
+            // local, so no shell quoting has to survive the remote login shell.
+            // Routed through Utils.exec, matching the returnStatus idiom the
+            // other remote calls in this function already use.
+            def tailCmd = Utils.sshUserCmd(remote, "\"tail -c ${SLURM_JOB_LOG_TAIL_BYTES} -- ${remoteLogPath}\"")
+            // Redact on the way in, so no unredacted copy ever exists on disk.
+            // The console echo below reads this same scrubbed file, which covers
+            // that leg too -- uploadResults() runs from the outer finally, i.e.
+            // outside the withCredentials binding, so console masking would not
+            // apply there either.
+            //
+            // Note the returned status is `sed`'s, not `ssh`'s, because this is a
+            // pipeline. That is why it is discarded and `test -s` below is the
+            // success signal instead: a failed ssh still leaves sed exiting 0,
+            // but it leaves the file empty, which `test -s` correctly rejects.
+            Utils.exec(pipeline, script: "${tailCmd} | ${SLURM_LOG_REDACT_CMD} > ${localLog}", returnStatus: true, numRetries: 1)
+            collected = pipeline.sh(script: "test -s ${localLog}", returnStatus: true) == 0
+            if (collected) {
+                pipeline.echo("Collected SLURM job output log tail (<= ${SLURM_JOB_LOG_TAIL_BYTES} bytes) into ${localLog}.")
+                pipeline.echo("===== Last ${SLURM_JOB_LOG_ECHO_LINES} lines of ${remoteLogPath} =====")
+                pipeline.sh(script: "tail -n ${SLURM_JOB_LOG_ECHO_LINES} -- ${localLog} || true")
+                pipeline.echo("===== End of SLURM job output log =====")
+            } else {
+                pipeline.sh(script: "rm -f ${localLog}", returnStatus: true)
+            }
+        }
+    } catch (Exception e) {
+        pipeline.echo("Ignorable warning: could not collect ${remoteLogPath} from ${remote.host}: ${e.message}")
+    }
+    if (!collected) {
+        // The archive copy did not make it; still try to get the evidence into
+        // the console log, which is the surface triage actually reads. Needs its
+        // own catch, because this function's contract is that it never throws.
+        // Redacted the same way as the archived copy: this echo happens outside
+        // the withCredentials binding, so Jenkins console masking does not cover
+        // it. Deliberately not echoRemoteLogTail() -- that helper does not
+        // redact, and its first statement is a pipeline.echo outside its own try.
+        try {
+            def tailOut = Utils.exec(
+                pipeline,
+                script: Utils.sshUserCmd(remote, "\"tail -n ${SLURM_JOB_LOG_ECHO_LINES} -- ${remoteLogPath}\"") +
+                    " | ${SLURM_LOG_REDACT_CMD}",
+                returnStdout: true,
+                numRetries: 1,
+            )?.trim()
+            pipeline.echo("===== Last ${SLURM_JOB_LOG_ECHO_LINES} lines of ${remoteLogPath} (redacted) =====")
+            pipeline.echo(tailOut ?: "[no log content retrieved]")
+            pipeline.echo("===== End of SLURM job output log =====")
+        } catch (Exception e) {
+            pipeline.echo("Ignorable warning: could not echo ${remoteLogPath}: ${e.message}")
+        }
+    }
+    return collected
+}
+
 // Scrape the SLURM job output log for a device / driver / interconnect fault
 // signature and return the matched signature itself, or "" for no match.
 //
@@ -297,7 +405,12 @@ def scrapeSlurmLogForDeviceFault(def pipeline, Map remote, String remoteLogPath)
 // `postTag` uniquifies the uploaded tar filename, the Artifactory guard key and
 // the locally-staged result XMLs when the same stageName is uploaded more than
 // once in a build (e.g. SLURM infra-failure retries). First attempt passes "".
-def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String nodeName, String stageName, Boolean stageIsInterrupted, String postTag="", boolean suppressTestReporting=false) {
+//
+// `slurmJobLogPath` / `stageFailed` drive the post-mortem log collection: when
+// the stage did not finish cleanly, a bounded tail of the SLURM job output log
+// is pulled back before the job workspace is deleted. Callers that have no such
+// log (or that only ever run on the success path) can leave them at defaults.
+def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String nodeName, String stageName, Boolean stageIsInterrupted, String postTag="", boolean suppressTestReporting=false, String slurmJobLogPath="", boolean stageFailed=false) {
     CloudManager.withSlurmSshCredentialRemotes(pipeline, clusterName, cluster) { remotes ->
         // Pin one reachable frontend for the whole collect: every download targets
         // the same node workspace (/home/svc_tensorrt/bloom/scripts/${nodeName}),
@@ -307,6 +420,7 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
         def hasTimeoutTest = false
         def downloadResultSucceed = false
         def downloadPerfResultSucceed = false
+        def gotSlurmJobLog = false
 
         pipeline.stage('Submit Test Result') {
             sh "mkdir -p ${stageName}"
@@ -381,8 +495,23 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
                 }
             }
 
-            echo "hasTimeoutTest: ${hasTimeoutTest}, downloadResultSucceed: ${downloadResultSucceed}, downloadPerfResultSucceed: ${downloadPerfResultSucceed}"
-            if (hasTimeoutTest || downloadResultSucceed || downloadPerfResultSucceed) {
+            // Post-mortem evidence for a stage that did not finish cleanly. Must
+            // stay inside this stage: the caller deletes the job workspace that
+            // holds the log right after uploadResults() returns. Restricted to
+            // the failure path so a green run's console log is untouched.
+            //
+            // Scope, precisely: this collects whatever the job had already
+            // written. On a Jenkins-side abort it runs *before*
+            // cleanUpSlurmResources() issues the scancel, so the dump that
+            // scancel's SIGTERM triggers on the cluster is NOT in what we fetch.
+            // Reordering to collect after the scancel is not an option -- the
+            // same cleanup deletes the job workspace.
+            if (slurmJobLogPath && (stageFailed || stageIsInterrupted)) {
+                gotSlurmJobLog = collectSlurmJobLog(pipeline, remote, slurmJobLogPath, stageName)
+            }
+
+            echo "hasTimeoutTest: ${hasTimeoutTest}, downloadResultSucceed: ${downloadResultSucceed}, downloadPerfResultSucceed: ${downloadPerfResultSucceed}, gotSlurmJobLog: ${gotSlurmJobLog}"
+            if (hasTimeoutTest || downloadResultSucceed || downloadPerfResultSucceed || gotSlurmJobLog) {
                 // On retry attempts, rename freshly-downloaded result XMLs so that
                 // (a) the tar for this attempt is distinguishable from prior attempts
                 //     already uploaded to Artifactory, and
@@ -1456,6 +1585,9 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
     String customSuffix = "${env.BUILD_TAG}-${UUID.randomUUID().toString().replaceAll("-", "").substring(0, 6)}".toLowerCase()
     def jobUID = "${cluster.host}-multi_node_test-${customSuffix}"
     def jobWorkspace = "/home/svc_tensorrt/bloom/scripts/${jobUID}"
+    // Declared out here (not inside the frontend-failover closure) so the finally
+    // block can still name it when collecting post-mortem logs.
+    def slurmJobLogPath = "${jobWorkspace}/job-output.log"
     def disaggMultiNodeMode = stageName.contains("Disagg-PerfSanity")
     def aggMultiNodeMode = !disaggMultiNodeMode && nodeCount > 1 && stageName.contains("PerfSanity")
 
@@ -1488,7 +1620,6 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
             def scriptBashUtilsPathNode = "${jobWorkspace}/${jobUID}-bash_utils.sh"
             def testListPathNode = "${jobWorkspace}/${testList}.txt"
             def waivesListPathNode = "${jobWorkspace}/waives.txt"
-            def slurmJobLogPath = "${jobWorkspace}/job-output.log"
             def scriptLaunchPathLocal = Utils.createTempLocation(pipeline, "./slurm_launch.sh")
             def scriptLaunchPathNode = "${jobWorkspace}/${jobUID}-slurm_launch.sh"
             def scriptSubmitPathLocal = Utils.createTempLocation(pipeline, "./slurm_submit.sh")
@@ -1816,7 +1947,14 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                     export resourcePathNode=$resourcePathNode
                     export pytestCommand="$pytestCommand"
                     export coverageConfigFile="$coverageConfigFile"
+                    # Secrets must not be traced: xtrace goes to stderr, there is no
+                    # separate #SBATCH --error, so anything traced here lands in the
+                    # job output log that is streamed to the console and archived.
+                    # S3_SECRET_KEY was already fenced; HF_TOKEN and the credential
+                    # exports below need the same treatment.
+                    set +x
                     export HF_TOKEN=$HF_TOKEN
+                    set -x
                     if [ -f "${s3SecretKeyPathNode}" ]; then
                         set +x
                         export S3_SECRET_KEY="\$(cat "${s3SecretKeyPathNode}")"
@@ -1824,7 +1962,9 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                     fi
                     export NVIDIA_IMEX_CHANNELS=\${NVIDIA_IMEX_CHANNELS:-0}
                     export NVIDIA_VISIBLE_DEVICES=\${NVIDIA_VISIBLE_DEVICES:-\$(seq -s, 0 \$((\$(nvidia-smi --query-gpu=count -i 0 --format=csv,noheader)-1)))}
+                    set +x
                     ${envExportStatements}
+                    set -x
 
                     echo "Env NVIDIA_IMEX_CHANNELS: \$NVIDIA_IMEX_CHANNELS"
                     echo "Env NVIDIA_VISIBLE_DEVICES: \$NVIDIA_VISIBLE_DEVICES"
@@ -2154,7 +2294,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
             // failure classifies as UserFailure -> not suppressed -> reported.
             boolean suppressTestReporting = (caughtStageError != null && retryContext != null) &&
                 retryContextAllowsRetry(null, retryContext, caughtStageError, false)
-            uploadResults(pipeline, cluster, partition.clusterName, jobUID, stageName, stageIsInterrupted, postTag, suppressTestReporting)
+            uploadResults(pipeline, cluster, partition.clusterName, jobUID, stageName, stageIsInterrupted, postTag, suppressTestReporting, slurmJobLogPath, caughtStageError != null)
         } finally {
             stage("Clean Up Slurm Resource") {
                 // Workaround to handle the interruption during clean up SLURM resources

--- a/jenkins/scripts/perf/disaggregated/slurm_launch_draft.sh
+++ b/jenkins/scripts/perf/disaggregated/slurm_launch_draft.sh
@@ -1,6 +1,112 @@
 
+# Bounded dump of the per-role worker logs into this batch script's stdout,
+# i.e. into the file `#SBATCH --output` points at (the "slurm-<jobid>.out" the
+# failure messages below refer to).
+#
+# Every ctx/gen/disagg-server srun redirects its output to a file under
+# $testOutputDir, so the rank-level [TRT-LLM] output never reaches the batch
+# stdout that the Jenkins tracker tails live. When the benchmark then fails or
+# the job is killed, that evidence stays on the cluster and is deleted with the
+# job workspace, leaving the Jenkins stage log with no record of what the ranks
+# were actually doing. Emitting the tails here is what makes such a run
+# diagnosable.
+#
+# Deliberately bounded: at most DUMP_MAX_FILES logs, DUMP_TAIL_LINES lines each,
+# and at most DUMP_MAX_INVOCATIONS times per job (<= 3200 lines total). A hang or
+# crash signature is at the end of a rank log, so the tail is the part worth
+# shipping. The invocation cap is 2 rather than 1 on purpose: an early SIGTERM
+# can dump near-empty role logs, and collapsing to a single dump would then
+# permanently suppress the informative one that cleanup_on_failure would emit.
+#
+# The tails are scrubbed: slurm_run.sh runs `env | sort`, so every role log opens
+# with a full environment dump. Without this, dumping them into the batch stdout
+# would push those values into a file that is streamed to the Jenkins console and
+# archived. Kept in sync with SLURM_LOG_REDACT_CMD in jenkins/L0_Test.groovy.
+#
+# Best-effort by construction: this only ever runs on a path that is already
+# failing, so every step is guarded and the function always returns 0. It must
+# not change the exit code that brought us here.
+DUMP_TAIL_LINES=${DUMP_TAIL_LINES:-100}
+DUMP_MAX_FILES=${DUMP_MAX_FILES:-16}
+DUMP_MAX_INVOCATIONS=${DUMP_MAX_INVOCATIONS:-2}
+# Anchored at ^ (with optional xtrace depth and export/declare prefix) so only an
+# assignment at the start of a line is rewritten -- matching mid-line would
+# truncate genuine diagnostics such as
+#   [TRT-LLM] [E] Assertion failed: KEY=missing in map (kvCacheManager.cpp:812)
+# Must stay byte-identical to SLURM_LOG_REDACT_CMD's regex in jenkins/L0_Test.groovy.
+DUMP_REDACT_RE='s/^(\++ )?(export |declare -x )?(HF_TOKEN|S3_SECRET_KEY|[A-Za-z0-9_]*(TOKEN|SECRET|PASSWORD|PASSWD|PSW|KEY))=.*/\1\2\3=***REDACTED***/'
+# Intentionally global: the invocation counter has to survive across calls.
+dumped_role_logs=0
+
+dump_role_logs() {
+    # The launch script runs under `set -x`; the dump is unreadable with the
+    # trace interleaved, so suppress it here and restore the caller's setting.
+    local xtraceWasOn=0
+    local count
+    local roleLog
+    case "$-" in
+        *x*) xtraceWasOn=1 ;;
+    esac
+    { set +x; } 2>/dev/null
+
+    if [ "$dumped_role_logs" -ge "$DUMP_MAX_INVOCATIONS" ]; then
+        if [ "$xtraceWasOn" -eq 1 ]; then set -x; fi
+        return 0
+    fi
+    dumped_role_logs=$((dumped_role_logs + 1))
+
+    echo "===== Per-role log tails (reason: ${1:-unspecified}) ====="
+    if [ -z "${testOutputDir:-}" ] || [ ! -d "${testOutputDir:-}" ]; then
+        echo "No per-role logs to dump (testOutputDir='${testOutputDir:-}')"
+    else
+        count=0
+        for roleLog in "${testOutputDir}"/*.log; do
+            [ -f "$roleLog" ] || continue
+            count=$((count + 1))
+            if [ "$count" -gt "$DUMP_MAX_FILES" ]; then
+                echo "===== More logs in ${testOutputDir} not dumped (cap ${DUMP_MAX_FILES}) ====="
+                break
+            fi
+            echo "===== Last ${DUMP_TAIL_LINES} lines of ${roleLog} (redacted) ====="
+            tail -n "$DUMP_TAIL_LINES" -- "$roleLog" 2>/dev/null | sed -E "$DUMP_REDACT_RE" || true
+        done
+        if [ "$count" -eq 0 ]; then
+            echo "No *.log files found under ${testOutputDir}"
+        fi
+    fi
+    echo "===== End of per-role log tails ====="
+
+    if [ "$xtraceWasOn" -eq 1 ]; then set -x; fi
+    return 0
+}
+
+# A walltime kill (SLURM job state TIMEOUT) sends SIGTERM to this batch script
+# before SIGKILL. Two things happen because of this trap, both measured:
+#
+#  1. Without any TERM handler, bash's default disposition kills the batch shell
+#     immediately, so cleanup_on_failure never runs and nothing is dumped at all.
+#     Installing a handler is what keeps the shell alive long enough to react.
+#  2. bash defers a trap until the running foreground command returns, so the
+#     benchmark srun below is started in the background and waited on: `wait` is
+#     interruptible, so the dump happens at once rather than whenever srun
+#     finally reaps.
+#
+# The dump has to finish inside SLURM's KillWait grace (default 30s, not
+# overridden anywhere under jenkins/) before SIGKILL. Measured at 47ms against
+# 16 x 20MB role logs (313MB total) -- `tail -n` seeks from the end, so log size
+# is nearly irrelevant. That is ~600x headroom; the dump is not the constraint,
+# and the background/`wait` form above removed the thing that was.
+#
+# No `#SBATCH --signal` is set to widen the window further, because the directive
+# lives in the shared script prefix, which also feeds the aggregated and plain
+# single-srun branches -- neither installs a TERM handler, so an early SIGTERM
+# would kill those jobs outright.
+trap 'dump_role_logs "SIGTERM (walltime kill or scancel)" || true' TERM
+
 cleanup_on_failure() {
     echo "Error: $1"
+    # Capture the worker evidence *before* scancel tears the allocation down.
+    dump_role_logs "$1" || true
     scancel ${SLURM_JOB_ID}
     exit 1
 }
@@ -119,12 +225,26 @@ sleep 5  # Wait for pyxis container namespace initialization to avoid race condi
 echo "Starting benchmark..."
 export DISAGG_SERVING_TYPE="BENCHMARK"
 export pytestCommand="$pytestCommandBenchmark"
-if ! srun "${srunArgs[@]}" --kill-on-bad-exit=1 --overlap \
+# Backgrounded and waited on rather than run in the foreground so the TERM trap
+# above can fire while the benchmark is still running (bash defers traps until a
+# foreground command returns). `wait` returns >128 when a trapped signal
+# interrupts it and the child is still alive, so resume waiting in that case --
+# otherwise a SIGTERM would make this look like a benchmark failure and scancel a
+# job that had not actually failed.
+srun "${srunArgs[@]}" --kill-on-bad-exit=1 --overlap \
     -N 1 \
     --ntasks=1 \
     --ntasks-per-node=1 \
-    $runScript; then
-    cleanup_on_failure "Benchmark failed. See slurm-${SLURM_JOB_ID}.out"
+    $runScript &
+benchmarkPid=$!
+benchmarkRc=0
+wait "$benchmarkPid" || benchmarkRc=$?
+while [ "$benchmarkRc" -gt 128 ] && kill -0 "$benchmarkPid" 2>/dev/null; do
+    benchmarkRc=0
+    wait "$benchmarkPid" || benchmarkRc=$?
+done
+if [ "$benchmarkRc" -ne 0 ]; then
+    cleanup_on_failure "Benchmark failed (exit ${benchmarkRc}). See slurm-${SLURM_JOB_ID}.out"
 fi
 
 echo "Disagg server and benchmark completed successfully"


### PR DESCRIPTION
## Summary by CodeRabbit

* **New Features**
  * Multi-node Slurm test stages that fail or are interrupted now surface the Slurm job output log in the Jenkins console log and archive a bounded tail of it with the stage's test results.
  * Disaggregated PerfSanity jobs now print a bounded tail of each per-role worker log before the allocation is cancelled, so rank-level output survives a failed or timed-out run.

---

## Description

Multi-node Slurm stages that time out leave **no readable evidence anywhere in Jenkins**.

The chain today:

1. pytest runs with `--timeout-method=thread`, which `os._exit()`s the process without producing a report.
2. `jenkins/scripts/generate_timeout_xml.py` then emits a contentless `Test terminated unexpectedly` placeholder — that placeholder is all that reaches OpenSearch, with `l_e2e_time_ms = 0`.
3. The real evidence — the pytest trace and the per-rank `[TRT-LLM]` output — is on the cluster in the job workspace, which `cleanUpSlurmResources()` `rm -rf`s moments later.

For the disaggregated PerfSanity stages it is worse still: every ctx / gen / disagg-server `srun` redirects its output to a file under `$testOutputDir`, so rank output never reaches the batch stdout that the Jenkins tracker `tail -f`s. The launch script's own failure message is literally `Benchmark failed. See slurm-<jobid>.out` — a file no reader in Jenkins can reach.

This PR gets that output to a reader. Two additions, both on the failure path only, both bounded.

### 1. `jenkins/scripts/perf/disaggregated/slurm_launch_draft.sh`

A `dump_role_logs()` helper emits a bounded tail of the per-role worker logs into the batch script's stdout — i.e. into the file `#SBATCH --output` points at, which the tracker is already streaming into the Jenkins console log.

It is called from two places:

* `cleanup_on_failure()`, **before** `scancel`, so the evidence is out before the allocation goes away. This is the path the observed `pytest --timeout=3600` kill takes.
* a `trap ... TERM`, so a walltime kill (Slurm job state `TIMEOUT`, SIGTERM before SIGKILL) is covered too.

### 2. `jenkins/L0_Test.groovy`

`collectSlurmJobLog()` pulls a bounded tail of the Slurm job output log back and (a) writes it to `${stageName}/slurm-job-output.log` and (b) echoes the last 500 lines into the console log.

It is hooked into `uploadResults()` rather than anywhere else, for three reasons:

* `uploadResults()` already runs on a **pinned, reachable login node** with a working file-retrieval path (`unfinished_test.txt`, `results*.xml`, the perf folders and the CBTS archive all come back through it). No new transport is invented.
* It is **already ordered before** `cleanUpSlurmResources()`, which deletes the job workspace holding the log. Anywhere later and the file is gone.
* `${stageName}/` is already `tar -czvf`'d and pushed to Artifactory by the same function, so the archived copy needs no new artifact path.

## Answers to the two questions this will get in review

### Log volume

| Where | Limit | Why |
|---|---|---|
| Per-role dump into batch stdout | at most **16 files x 100 lines**, **once per job** (`dumped_role_logs` guard) | A hang or crash signature is at the *end* of a rank log. 16 covers `numCtxServers + numGenServers + 1` with headroom on the largest configured stage; the once-per-job guard means the `TERM` trap and `cleanup_on_failure` firing together still produce one dump. Worst case ~1600 lines, and only on a failing job. |
| Archived tail | **4 MiB** (`tail -c`, bounded at the source) | Covers the last minutes of every rank's output; gzips into the results tarball that is already being uploaded. |
| Console echo | **500 lines** | Enough for the failing command, the traceback and the tail of the per-role dump. |

Nothing is emitted on a clean run: the Groovy side is gated on `stageFailed || stageIsInterrupted`, and the shell side only runs from `cleanup_on_failure` / the `TERM` trap.

### Failure-path safety

This code runs when something has *already* gone wrong, so it must not be able to make things worse.

* **Shell.** `dump_role_logs()` always `return 0`, every `tail` is `|| true`, both call sites are `|| true`, and `${testOutputDir:-}` is `set -u`-safe. `cleanup_on_failure` still ends in the same `scancel` / `exit 1`. Verified locally that a simulated `cleanup_on_failure` still exits with the original code, and that a missing / unset / empty `$testOutputDir` produces a one-line note instead of an error under `set -xEeuo pipefail` with the ERR trap installed.
* **Groovy.** `collectSlurmJobLog()` cannot throw: the body is inside `try { ... } catch (Exception e) { echo }`, all shell calls use `returnStatus: true`, and it returns a boolean. It runs from a `finally` block, where an escaping exception would replace the real failure.
* **Enclosing timeout.** On the Slurm path the enclosing stage timeout may already have expired on a walltime kill, so the remote read is wrapped in its own fresh `timeout(time: 5, unit: 'MINUTES')`. If Jenkins is already interrupting the thread, the catch-all swallows it and the original failure still propagates — same shape as the existing CBTS coverage pull a few lines above.
* **No new reporting behaviour.** `junit()` remains gated on `hasTimeoutTest || downloadResultSucceed`; only the tar/upload branch gained `|| gotSlurmJobLog`, so a stage that previously uploaded nothing now uploads the log instead of nothing.

## Review round 1 — what changed

**B1 (blocking, secrets in archived artifacts) — fixed, two layers.**
Reproduced the leak on `main`'s form: `+ export HF_TOKEN=hf_SECRETTOKEN123` / `+ export OPEN_SEARCH_DB_CREDENTIALS_PSW=SUPERSECRETPW` appear in the traced output, and there is no `#SBATCH --error`, so xtrace lands in the archived job output log.
* *Root cause* — `export HF_TOKEN` and `${envExportStatements}` in `scriptLaunchPrefix` are now fenced with `set +x`/`set -x`, mirroring the `S3_SECRET_KEY` fence that already sat three lines below. Verified: leak gone, xtrace still active afterwards, variables still exported correctly. **This bug exists on `main` today, independently of this PR.**
* *Defence in depth* — both the archived tail and the console echo pass through `SLURM_LOG_REDACT_CMD`; the fallback echo is redacted too (it no longer calls `echoRemoteLogTail`, which does not redact). `dump_role_logs` also scrubs the tails it emits, which closes the `slurm_run.sh:76 env | sort` amplifier.
* Verified on a realistic sample containing xtrace `export`, bare xtrace assignment, `env|sort` output and a quoted value with spaces: all redacted; `NCCL_DEBUG=INFO`, `TOKENIZERS_PARALLELISM=true`, `HF_TOKEN_PATH=/tmp/tok`, `[TRT-LLM]` and `srun: error` lines all preserved.

**M2 (TERM trap deferral) — fixed, but not the way suggested; please read.**
Two things measured:
1. The reviewer is right that bash defers the trap: SIGTERM at t+2 s with a foreground `srun`, trap ran at t+20 s.
2. But *without* any TERM handler the batch shell dies at t+2 s (`rc=143`) and `cleanup_on_failure` never runs at all. So the trap is not redundant — it is what keeps the shell alive to react.

Fix applied: the benchmark `srun` is backgrounded and waited on, so the trap fires immediately (measured t+2 s instead of t+20 s). `wait` returning >128 with the child still alive resumes the wait, so a SIGTERM cannot be misread as a benchmark failure.

`#SBATCH --signal=B:TERM@120` was **deliberately not added**: the directive lives in the shared `scriptLaunchPrefix`, and the *aggregated* launch script installs no TERM handler — an early SIGTERM would kill those jobs 120 s before their walltime. Remaining window: the dump must finish inside SLURM's `KillWait` grace (default 30 s, not overridden anywhere under `jenkins/`). **Measured at 47 ms** against 16 x 20 MB role logs (320 MB total; `tail -n` seeks from the end, so log size is nearly irrelevant), reproducible across runs. That is ~600x headroom -- the dump is not the constraint, and the background/`wait` change removed the thing that was.

**Minors / nits** — fallback echo moved inside its own `catch`; the abort-path ordering claim corrected (on a Jenkins abort the collection runs *before* `cleanUpSlurmResources`' `scancel`, so the dump that scancel triggers is not in what we fetch, and reordering is impossible because the same cleanup deletes the workspace); `count` / `roleLog` made `local` (verified caller globals survive); the once-guard raised to two invocations so an early near-empty SIGTERM dump cannot suppress the informative `cleanup_on_failure` one.

**Known, not fixed here:** `jenkins/scripts/slurm_run.sh:76` runs `env | sort` inside the container, so every per-role log still *contains* secrets on disk, and the pre-existing wholesale perf-folder `scp` already archives those files today. This PR stops making it worse but does not fix it. Worth its own PR.

---

## Review round 2 — what changed

* **Redaction regex anchored.** The previous form was unanchored, so it truncated *any* line containing an uppercase `…KEY=` / `…TOKEN=` / etc. to end of line — including genuine diagnostics like `[TRT-LLM] [E] Assertion failed: KEY=missing in map (kvCacheManager.cpp:812)`, exactly the evidence this PR exists to preserve. Now anchored at `^` with optional xtrace depth (`+ `, `++ `, `+++ `) and an optional `export ` / `declare -x ` prefix, which also covers nested-xtrace and `declare -x` forms the old one only caught by accident. Re-verified: all 10 secret forms still redacted, the `KEY=missing` diagnostic preserved verbatim, and the two copies of the regex confirmed byte-identical by an automated comparison.
* **`returnStatus` semantics documented.** With a shell pipeline the returned status is `sed`'s, not `ssh`'s. Harmless here — a failed ssh leaves an empty file and `test -s` rejects it — but that is load-bearing and non-obvious, so it is now stated in the code.

### Known gaps, deliberately not fixed here
* The redaction regex is duplicated between `L0_Test.groovy` and `slurm_launch_draft.sh` (the shell copy runs on the cluster, where the Groovy constant is unreachable). Sync is enforced only by a comment on each side naming the other.
* `echoRemoteLogTail` (`L0_Test.groovy:233`) still exists and is still called **unredacted** from the K8s-agent path. Different log file, pre-existing, out of scope here — flagged so nobody assumes this PR's redaction covers it.
* `jenkins/scripts/slurm_run.sh:76` runs `env | sort` inside the container, so per-role logs still contain secrets *on disk*, and the pre-existing wholesale perf-folder `scp` already archives those files today. This PR stops making it worse but does not fix it.

---

## Test Coverage

Honest scope:

* **Exercised locally** — redaction on a realistic mixed sample (leak scan clean, diagnostic lines preserved); the `set +x` fence (leak reproduced before, absent after, exports still set); the background-`wait` benchmark form in three scenarios (SIGTERM mid-run then clean success -> dump fires immediately, `rc=0`, **no** self-cancel; benchmark `rc=3` -> `cleanup_on_failure` + `scancel` + `exit 1`; clean success -> no dump, no scancel); and the shell logic, against a fake `$testOutputDir`, under the same `set -xEeuo pipefail` + ERR trap the launch prefix installs: normal dump ordering (dump strictly before `scancel`), exit code preserved, the 16-file cap, the once-per-job guard, empty / missing / unset `$testOutputDir`, filenames containing spaces, `xtrace` suppressed during the dump and restored afterwards, and a real `SIGTERM` delivered mid-`srun` firing the trap.
* **Not exercised** — the Groovy half. It needs a real multi-node Slurm stage failing on a Jenkins agent; there is no local harness for `Utils.sshUserCmd` / `timeout` / `uploadResults`. A CI run on a green multi-node stage would demonstrate only that nothing regressed (the new code is skipped entirely); demonstrating the collection itself requires a stage that actually fails or times out.

## PR Checklist

- [x] PR title has one of the prefixes `[fix]`, `[feat]`, `[doc]`, `[infra]`, `[chore]`.
- [x] PR description explains the reason and the fix.
- [x] Test cases are provided for new code paths — see the honest scope above; the shell path is exercised locally, the Groovy path is not locally testable.
- [x] The PR is not a duplicate.
- [x] Commits are signed off (DCO).

---

<!-- markdownlint-disable-next-line MD033 -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)
