### PR TITLE
[None][fix] give the MPI worker-identity gate a budget above its measured cost

### DIFF
--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -11,8 +11,7 @@ import threading
 import time
 import traceback
 from collections.abc import Callable
-from concurrent.futures import (FIRST_COMPLETED, Future, ThreadPoolExecutor,
-                                as_completed)
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from concurrent.futures import wait as futures_wait
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypeVar
 
@@ -247,6 +246,21 @@ _BOOTSTRAP_POLL_INTERVAL = 1.0
 _IDENTITY_GATE_MARKER = "[mpi-identity-gate]"
 
 
+class _IdentityGateFailure(RuntimeError):
+    """Raised by the identity gate once it has already torn the pool down.
+
+    A distinct type, not bare ``RuntimeError``: both ``mpi4py.MPI.Exception``
+    and ``concurrent.futures.BrokenExecutor`` inherit from ``RuntimeError``,
+    and both can come out of the gate's own ``submit()``/``result()`` calls.
+    Catching the base class to re-raise would let those two escape *without*
+    the teardown, leaving ``self.mpi_pool`` dangling on an object whose
+    ``__init__`` never completed — so ``__del__`` would then run a blocking
+    ``shutdown()`` on a broken pool, and its abort watchdog would itself fail
+    on the ``self.comm`` that the raising ``__init__`` never got to assign.
+    Callers still see a ``RuntimeError``.
+    """
+
+
 def _identity_bootstrap_timeout() -> float:
     """Deadline for the ``wait_shutdown`` worker *bootstrap*, in seconds.
 
@@ -278,10 +292,6 @@ def _identity_bootstrap_timeout() -> float:
     return _DEFAULT_IDENTITY_TIMEOUT
 
 
-# Back-compat alias: the previous name for the (then single) gate deadline.
-_identity_barrier_timeout = _identity_bootstrap_timeout
-
-
 def identity_gate_budget() -> float:
     """Worst-case wall time of the whole ``wait_shutdown`` identity gate.
 
@@ -299,6 +309,15 @@ def _worker_hello():
     interpreter is up and the module defining it (hence ``tensorrt_llm``) is
     imported, so it measures bootstrap and nothing else. Its identity is also
     the only handle on a worker whose later barrier never completes.
+
+    Dropping the collective costs a guarantee that ``_worker_identity_barrier``
+    keeps: with no barrier to pin one task per worker, mpi4py is free to send
+    two probes to the same rank. (Its free-worker container is a LIFO stack,
+    so it demonstrably will, given the chance.) That is why the caller submits
+    ``n_workers`` probes and only requires that they *all* return before moving
+    on, rather than treating each returned identity as a distinct worker — the
+    identity barrier is still what establishes one-per-worker, and the
+    uniqueness check on its results is still what enforces it.
     """
     pid = os.getpid()
     return (pid, _process_start_time(pid))
@@ -424,11 +443,17 @@ class MpiPoolSession(MpiSession):
         hundreds of seconds — which leaves the guard unable to tell a slow
         bootstrap from a dead pool without burning that whole budget first. So
         this runs in two phases: a generous, liveness-aware *bootstrap* wait
-        that ends as soon as one worker has run any task, then the identity
-        barrier under a tight, fixed deadline that is now sized against what it
+        that ends once EVERY worker has run a task, then the identity barrier
+        under a tight, fixed deadline that is now sized against what it
         actually measures. Each phase names itself in its failure message, so
         "never bootstrapped" and "bootstrapped but the barrier stalled" stop
         being the same log line.
+
+        The bootstrap phase waits for all ``n_workers`` probes, not the first:
+        ranks do not finish ``import tensorrt_llm`` together, and returning on
+        the first one would leave the remaining ranks' bootstrap skew to be
+        absorbed by the barrier's tight budget — turning an absolute bound into
+        a skew bound that tears down perfectly healthy pools.
         """
         warm_futures: List[Future] = []
         bootstrap_timeout = _identity_bootstrap_timeout()
@@ -440,15 +465,15 @@ class MpiPoolSession(MpiSession):
             warm_done = self._wait_worker_bootstrap(warm_futures,
                                                     bootstrap_timeout)
             if not warm_done:
-                self._teardown_unidentified_pool(
-                    _completed_identities(warm_futures))
-                raise RuntimeError(
-                    f"{_IDENTITY_GATE_MARKER} phase=bootstrap: no worker of "
-                    f"{self.n_workers} ran a task within {bootstrap_timeout}s; "
-                    "pool torn down. The workers never finished spawning and "
-                    "importing tensorrt_llm — raise "
-                    "TRTLLM_MPI_IDENTITY_TIMEOUT only if bootstrap on this "
-                    "node is genuinely that slow")
+                warm_identities = _completed_identities(warm_futures)
+                self._teardown_unidentified_pool(warm_identities)
+                raise _IdentityGateFailure(
+                    f"{_IDENTITY_GATE_MARKER} phase=bootstrap: only "
+                    f"{len(warm_identities)}/{self.n_workers} workers ran a "
+                    f"task within {bootstrap_timeout}s; pool torn down. Those "
+                    "workers never finished spawning and importing "
+                    "tensorrt_llm — raise TRTLLM_MPI_IDENTITY_TIMEOUT only if "
+                    "bootstrap on this node is genuinely that slow")
             futures = [
                 self.mpi_pool.submit(_worker_identity_barrier)
                 for _ in range(self.n_workers)
@@ -456,26 +481,31 @@ class MpiPoolSession(MpiSession):
             done, not_done = futures_wait(futures,
                                           timeout=_IDENTITY_BARRIER_TIMEOUT)
             identities = tuple(f.result() for f in done)
-        except RuntimeError:
+        except _IdentityGateFailure:
+            # Already torn down above; anything else still needs the teardown.
             raise
         except Exception as e:
             self._teardown_unidentified_pool(
                 _completed_identities(warm_futures))
-            raise RuntimeError(
+            raise _IdentityGateFailure(
                 f"{_IDENTITY_GATE_MARKER} phase=bootstrap: worker identity "
                 f"collection failed ({e}); pool torn down") from e
         if (not_done or len(identities) != self.n_workers
                 or len({pid
                         for pid, _ in identities}) != self.n_workers
                 or any(start is None for _, start in identities)):
-            # The barrier stalled on a pool that had already proved it was
-            # warm, so this is a wedged worker, not a slow one. Reap with the
-            # identities the warm-up collected: they are the only handle on
-            # workers now parked in an unfinished collective, and without them
-            # the teardown below is a no-op that leaks them until job end.
+            # Every worker had already proved it was warm, so this is a wedged
+            # worker, not a slow one. Reap the union of both phases: the
+            # warm-up identities are the only handle on workers now parked in
+            # an unfinished collective, and on a partial barrier the two sets
+            # differ — taking either alone leaves someone unreaped, which is
+            # how the pre-existing teardown became a no-op that leaked workers
+            # until job end.
             self._teardown_unidentified_pool(
-                identities or _completed_identities(warm_futures))
-            raise RuntimeError(
+                tuple(
+                    dict.fromkeys(
+                        (*identities, *_completed_identities(warm_futures)))))
+            raise _IdentityGateFailure(
                 f"{_IDENTITY_GATE_MARKER} phase=barrier: worker identity "
                 f"collection incomplete ({len(identities)}/{self.n_workers} "
                 f"valid identities) within {_IDENTITY_BARRIER_TIMEOUT}s of a "
@@ -504,27 +534,36 @@ class MpiPoolSession(MpiSession):
 
     def _wait_worker_bootstrap(self, futures: List[Future],
                                timeout: float) -> bool:
-        """Wait for the first worker to run a task; True if one did.
+        """Wait for EVERY probe to come back; True if they all did.
+
+        All of them, not the first: ranks finish ``import tensorrt_llm``
+        seconds to tens of seconds apart, and any skew left over here is paid
+        by the barrier phase out of its tight fixed budget. Waiting for the
+        whole set is what keeps that budget a measure of the barrier rather
+        than of bootstrap skew.
 
         Polls instead of a single blocking wait so a pool that provably cannot
         make progress fails in ~a second rather than at the full deadline.
         """
+        if not futures:
+            return True
         deadline = time.monotonic() + timeout
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                return bool(futures_wait(futures, timeout=0).done)
+                return len(futures_wait(futures,
+                                        timeout=0).done) == len(futures)
             done, _ = futures_wait(futures,
                                    timeout=min(_BOOTSTRAP_POLL_INTERVAL,
-                                               remaining),
-                                   return_when=FIRST_COMPLETED)
-            if done:
+                                               remaining))
+            if len(done) == len(futures):
                 return True
             if not self._pool_can_make_progress():
                 # Re-check: a task may have landed between the wait and here,
                 # and a manager thread that exited after finishing its work is
                 # not a failure.
-                return bool(futures_wait(futures, timeout=0).done)
+                return len(futures_wait(futures,
+                                        timeout=0).done) == len(futures)
 
     def _teardown_unidentified_pool(self, partial_identities: Tuple) -> None:
         """Dispose of a pool whose identity collection failed.

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -11,7 +11,8 @@ import threading
 import time
 import traceback
 from collections.abc import Callable
-from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from concurrent.futures import (FIRST_COMPLETED, Future, ThreadPoolExecutor,
+                                as_completed)
 from concurrent.futures import wait as futures_wait
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypeVar
 
@@ -226,19 +227,42 @@ def _process_start_time(pid: int) -> Optional[bytes]:
 
 _DEFAULT_IDENTITY_TIMEOUT = 300.0
 
+# Once the pool has proved it is warm (a worker has run a task, so its process
+# is spawned and ``import tensorrt_llm`` is done), the identity barrier itself
+# is a sub-millisecond collective. This is the deadline that actually guards
+# the ``wait_shutdown`` contract, so keep it tight and untunable: a bound that
+# has to be raised above p99 is not a guard.
+_IDENTITY_BARRIER_TIMEOUT = 60.0
 
-def _identity_barrier_timeout() -> float:
-    """Deadline for the ``wait_shutdown`` worker-identity barrier, in seconds.
+# How often the bootstrap wait re-checks pool liveness. Small relative to the
+# bootstrap budget; it only costs a wakeup per second on the spawn path.
+_BOOTSTRAP_POLL_INTERVAL = 1.0
 
-    The barrier itself completes in milliseconds, but it is the first work ever
-    submitted to a freshly built ``MPIPoolExecutor``, and mpi4py spawns lazily
-    from its manager thread — so this deadline really bounds the whole worker
-    bootstrap: process spawn plus ``import tensorrt_llm``, measured at ~50-65s
-    on an idle node and up to ~117s on a contended one. Hence a ceiling sized
-    against bootstrap cost rather than barrier latency. The test-session
-    prefetcher derives its own wait budget from this value so it cannot abandon
-    a bootstrap that this layer still considers healthy.
-    ``TRTLLM_MPI_IDENTITY_TIMEOUT`` overrides it.
+# Greppable marker on every failure of this gate. It lives in the exception
+# message on purpose: that is the only channel from this code path that is
+# known to reach CI logs (the message text of the pre-existing
+# "worker identity collection incomplete" failure is what shows up in Jenkins
+# output, whereas the callers' plain ``print()`` diagnostics do not survive
+# pytest capture).
+_IDENTITY_GATE_MARKER = "[mpi-identity-gate]"
+
+
+def _identity_bootstrap_timeout() -> float:
+    """Deadline for the ``wait_shutdown`` worker *bootstrap*, in seconds.
+
+    The identity barrier is the first work ever submitted to a freshly built
+    ``MPIPoolExecutor``, and mpi4py spawns lazily from its manager thread, so a
+    single deadline around it really bounds the whole worker bootstrap: process
+    spawn plus ``import tensorrt_llm``, measured at ~50-65s on an idle node and
+    up to ~117s on a contended one. Sizing one deadline against that cost makes
+    the guard blind for minutes on a genuinely broken pool, so the gate splits
+    the two: this generous budget covers bootstrap only (and gives up early on
+    a pool that provably cannot make progress, see
+    ``_pool_can_make_progress``), then ``_IDENTITY_BARRIER_TIMEOUT`` guards the
+    barrier itself. The test-session prefetcher derives its own wait budget
+    from ``identity_gate_budget()`` so it cannot abandon a bootstrap that this
+    layer still considers healthy. ``TRTLLM_MPI_IDENTITY_TIMEOUT`` overrides
+    this bootstrap budget.
     """
     raw = os.environ.get("TRTLLM_MPI_IDENTITY_TIMEOUT")
     if not raw:
@@ -252,6 +276,52 @@ def _identity_barrier_timeout() -> float:
     logger.warning(f"Ignoring invalid TRTLLM_MPI_IDENTITY_TIMEOUT={raw!r}; "
                    f"using {_DEFAULT_IDENTITY_TIMEOUT}s")
     return _DEFAULT_IDENTITY_TIMEOUT
+
+
+# Back-compat alias: the previous name for the (then single) gate deadline.
+_identity_barrier_timeout = _identity_bootstrap_timeout
+
+
+def identity_gate_budget() -> float:
+    """Worst-case wall time of the whole ``wait_shutdown`` identity gate.
+
+    Callers that wait on a pool build from the outside (the test-session
+    prefetcher) must not give up before this, or they abandon a bootstrap this
+    layer still considers healthy.
+    """
+    return _identity_bootstrap_timeout() + _IDENTITY_BARRIER_TIMEOUT
+
+
+def _worker_hello():
+    """Warm-up probe; module-level so it is picklable.
+
+    Deliberately collective-free: it returns the moment *this* worker's
+    interpreter is up and the module defining it (hence ``tensorrt_llm``) is
+    imported, so it measures bootstrap and nothing else. Its identity is also
+    the only handle on a worker whose later barrier never completes.
+    """
+    pid = os.getpid()
+    return (pid, _process_start_time(pid))
+
+
+def _completed_identities(futures: List[Future]) -> Tuple:
+    """(pid, start_time) pairs from whichever probes already came back.
+
+    Never blocks and never raises: this feeds the teardown path, which runs
+    while something has already gone wrong.
+    """
+    identities = []
+    for future in futures:
+        if not future.done():
+            continue
+        try:
+            result = future.result()
+        except Exception as e:  # noqa: BLE001 - diagnostics only
+            logger.debug(f"worker probe failed (ignored): {e!r}")
+            continue
+        if isinstance(result, tuple) and len(result) == 2:
+            identities.append(result)
+    return tuple(identities)
 
 
 def _worker_identity_barrier():
@@ -348,33 +418,113 @@ class MpiPoolSession(MpiSession):
         trip on a slow-but-healthy bootstrap, and ``futures_wait`` does not
         cancel the pending tasks). Instead of handing out such a pool, tear
         it down and raise; callers fall back to a fresh spawn.
+
+        Warm, then measure. A single deadline around the barrier has to cover
+        spawn plus ``import tensorrt_llm`` — a cost measured in the low
+        hundreds of seconds — which leaves the guard unable to tell a slow
+        bootstrap from a dead pool without burning that whole budget first. So
+        this runs in two phases: a generous, liveness-aware *bootstrap* wait
+        that ends as soon as one worker has run any task, then the identity
+        barrier under a tight, fixed deadline that is now sized against what it
+        actually measures. Each phase names itself in its failure message, so
+        "never bootstrapped" and "bootstrapped but the barrier stalled" stop
+        being the same log line.
         """
-        timeout = _identity_barrier_timeout()
+        warm_futures: List[Future] = []
+        bootstrap_timeout = _identity_bootstrap_timeout()
         try:
+            warm_futures = [
+                self.mpi_pool.submit(_worker_hello)
+                for _ in range(self.n_workers)
+            ]
+            warm_done = self._wait_worker_bootstrap(warm_futures,
+                                                    bootstrap_timeout)
+            if not warm_done:
+                self._teardown_unidentified_pool(
+                    _completed_identities(warm_futures))
+                raise RuntimeError(
+                    f"{_IDENTITY_GATE_MARKER} phase=bootstrap: no worker of "
+                    f"{self.n_workers} ran a task within {bootstrap_timeout}s; "
+                    "pool torn down. The workers never finished spawning and "
+                    "importing tensorrt_llm — raise "
+                    "TRTLLM_MPI_IDENTITY_TIMEOUT only if bootstrap on this "
+                    "node is genuinely that slow")
             futures = [
                 self.mpi_pool.submit(_worker_identity_barrier)
                 for _ in range(self.n_workers)
             ]
-            done, not_done = futures_wait(futures, timeout=timeout)
+            done, not_done = futures_wait(futures,
+                                          timeout=_IDENTITY_BARRIER_TIMEOUT)
             identities = tuple(f.result() for f in done)
+        except RuntimeError:
+            raise
         except Exception as e:
-            self._teardown_unidentified_pool(())
+            self._teardown_unidentified_pool(
+                _completed_identities(warm_futures))
             raise RuntimeError(
-                f"MpiPoolSession(wait_shutdown=True): worker identity "
+                f"{_IDENTITY_GATE_MARKER} phase=bootstrap: worker identity "
                 f"collection failed ({e}); pool torn down") from e
         if (not_done or len(identities) != self.n_workers
                 or len({pid
                         for pid, _ in identities}) != self.n_workers
                 or any(start is None for _, start in identities)):
-            self._teardown_unidentified_pool(identities)
+            # The barrier stalled on a pool that had already proved it was
+            # warm, so this is a wedged worker, not a slow one. Reap with the
+            # identities the warm-up collected: they are the only handle on
+            # workers now parked in an unfinished collective, and without them
+            # the teardown below is a no-op that leaks them until job end.
+            self._teardown_unidentified_pool(
+                identities or _completed_identities(warm_futures))
             raise RuntimeError(
-                "MpiPoolSession(wait_shutdown=True): worker identity "
+                f"{_IDENTITY_GATE_MARKER} phase=barrier: worker identity "
                 f"collection incomplete ({len(identities)}/{self.n_workers} "
-                "valid identities); pool torn down instead of handing out a "
-                "session that cannot honor the wait_shutdown contract. Raise "
-                "TRTLLM_MPI_IDENTITY_TIMEOUT if worker bootstrap is merely "
-                f"slow (deadline was {timeout}s)")
+                f"valid identities) within {_IDENTITY_BARRIER_TIMEOUT}s of a "
+                "pool that had already bootstrapped; pool torn down instead "
+                "of handing out a session that cannot honor the wait_shutdown "
+                "contract")
         return identities
+
+    def _pool_can_make_progress(self) -> bool:
+        """False only when the pool provably cannot run any more tasks.
+
+        mpi4py drives ``MPI_Comm_spawn`` and task dispatch from a manager
+        thread it starts on the first ``submit()``. When that spawn fails the
+        exception is raised *inside* that thread: it dies, the submitted
+        futures stay pending forever, and every caller-visible symptom is
+        identical to a merely slow bootstrap. The thread's liveness is the one
+        positive signal that separates them. Best effort by construction — if
+        mpi4py's internals are not where we expect, assume progress is still
+        possible and fall back to the deadline.
+        """
+        pool = getattr(self.mpi_pool, "_pool", None)
+        thread = getattr(pool, "thread", None) if pool is not None else None
+        if thread is None:
+            return True
+        return bool(thread.is_alive())
+
+    def _wait_worker_bootstrap(self, futures: List[Future],
+                               timeout: float) -> bool:
+        """Wait for the first worker to run a task; True if one did.
+
+        Polls instead of a single blocking wait so a pool that provably cannot
+        make progress fails in ~a second rather than at the full deadline.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return bool(futures_wait(futures, timeout=0).done)
+            done, _ = futures_wait(futures,
+                                   timeout=min(_BOOTSTRAP_POLL_INTERVAL,
+                                               remaining),
+                                   return_when=FIRST_COMPLETED)
+            if done:
+                return True
+            if not self._pool_can_make_progress():
+                # Re-check: a task may have landed between the wait and here,
+                # and a manager thread that exited after finishing its work is
+                # not a failure.
+                return bool(futures_wait(futures, timeout=0).done)
 
     def _teardown_unidentified_pool(self, partial_identities: Tuple) -> None:
         """Dispose of a pool whose identity collection failed.

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -457,6 +457,11 @@ class MpiPoolSession(MpiSession):
         """
         warm_futures: List[Future] = []
         bootstrap_timeout = _identity_bootstrap_timeout()
+        # Tracked, not hard-coded: the generic handler below spans both phases,
+        # and a broken executor surfacing during the barrier must not be
+        # reported as a bootstrap failure — that points on-call at
+        # TRTLLM_MPI_IDENTITY_TIMEOUT, which cannot help them.
+        phase = "bootstrap"
         try:
             warm_futures = [
                 self.mpi_pool.submit(_worker_hello)
@@ -474,6 +479,7 @@ class MpiPoolSession(MpiSession):
                     "workers never finished spawning and importing "
                     "tensorrt_llm — raise TRTLLM_MPI_IDENTITY_TIMEOUT only if "
                     "bootstrap on this node is genuinely that slow")
+            phase = "barrier"
             futures = [
                 self.mpi_pool.submit(_worker_identity_barrier)
                 for _ in range(self.n_workers)
@@ -488,7 +494,7 @@ class MpiPoolSession(MpiSession):
             self._teardown_unidentified_pool(
                 _completed_identities(warm_futures))
             raise _IdentityGateFailure(
-                f"{_IDENTITY_GATE_MARKER} phase=bootstrap: worker identity "
+                f"{_IDENTITY_GATE_MARKER} phase={phase}: worker identity "
                 f"collection failed ({e}); pool torn down") from e
         if (not_done or len(identities) != self.n_workers
                 or len({pid

--- a/tests/test_common/session_prefetcher.py
+++ b/tests/test_common/session_prefetcher.py
@@ -76,6 +76,10 @@ _PATCH_TARGETS = (
 # bootstrap deadline expires.
 _SHADOW_BUILD_FINISH_GRACE = 30.0
 _FALLBACK_IDENTITY_TIMEOUT = 300.0
+# Mirrors mpi_session._IDENTITY_BARRIER_TIMEOUT: the identity gate spends its
+# bootstrap budget first and only then runs the barrier, so the fallback total
+# has to include both phases.
+_FALLBACK_BARRIER_TIMEOUT = 60.0
 
 
 def _fallback_identity_timeout() -> float:
@@ -92,7 +96,7 @@ def _fallback_identity_timeout() -> float:
 
 
 def _shadow_build_wait_timeout() -> float:
-    """Upper-level wait budget derived from the MPI bootstrap deadline.
+    """Upper-level wait budget derived from the MPI identity-gate budget.
 
     Do not import TensorRT-LLM here: this plugin must stay usable by pure-logic
     tests and suites without built bindings. A real shadow build imports
@@ -100,9 +104,12 @@ def _shadow_build_wait_timeout() -> float:
     setting is present by the time ``take()`` waits on that build.
     """
     mpi_session = sys.modules.get("tensorrt_llm.llmapi.mpi_session")
-    timeout_fn = getattr(mpi_session, "_identity_barrier_timeout", None)
-    identity_timeout = timeout_fn() if timeout_fn is not None else _fallback_identity_timeout()
-    return identity_timeout + _SHADOW_BUILD_FINISH_GRACE
+    budget_fn = getattr(mpi_session, "identity_gate_budget", None)
+    if budget_fn is not None:
+        gate_budget = budget_fn()
+    else:
+        gate_budget = _fallback_identity_timeout() + _FALLBACK_BARRIER_TIMEOUT
+    return gate_budget + _SHADOW_BUILD_FINISH_GRACE
 
 
 def _reuse_layer_active() -> bool:

--- a/tests/unittest/llmapi/test_mpi_session.py
+++ b/tests/unittest/llmapi/test_mpi_session.py
@@ -241,7 +241,9 @@ def _collect_identities(monkeypatch,
                         manager_alive=True,
                         killed=None,
                         bootstrap_delays=None,
-                        submit_error=None):
+                        barrier_delays=None,
+                        submit_error=None,
+                        result_error=None):
     """Drive _collect_worker_identities on an inert stand-in (no MPI spawn).
 
     ``results``/``pending`` describe what the *barrier* phase returns.
@@ -251,8 +253,15 @@ def _collect_identities(monkeypatch,
     ``bootstrap_delays=[...]`` (seconds, per probe) for a pool whose ranks
     finish ``import tensorrt_llm`` at different times.
 
-    ``submit_error`` makes the *barrier* submit raise, standing in for the
-    exceptions mpi4py surfaces from a broken pool.
+    ``barrier_delays`` (seconds, per barrier task) makes the barrier futures
+    resolve on a timer measured from *helper entry*, i.e. on the same clock as
+    ``bootstrap_delays``. That is what lets a test distinguish a bootstrap that
+    waited for every probe from one that returned on the first: only the former
+    reaches the barrier late enough to find its futures already done.
+
+    ``submit_error`` makes the *barrier* submit raise; ``result_error`` makes a
+    barrier future complete *with* that exception, so ``f.result()`` raises.
+    Both stand in for what mpi4py surfaces from a broken pool.
     """
     import threading
     import types
@@ -260,9 +269,21 @@ def _collect_identities(monkeypatch,
 
     from tensorrt_llm.llmapi import mpi_session as m
 
-    barrier_futs = _resolved_futures(results) + [
-        Future() for _ in range(pending)
-    ]
+    if barrier_delays is not None:
+        barrier_futs = [Future() for _ in barrier_delays]
+        for fut, (delay, value) in zip(barrier_futs,
+                                       zip(barrier_delays, results)):
+            timer = threading.Timer(delay, fut.set_result, args=(value, ))
+            timer.daemon = True
+            timer.start()
+    else:
+        barrier_futs = _resolved_futures(results) + [
+            Future() for _ in range(pending)
+        ]
+    if result_error is not None:
+        broken = Future()
+        broken.set_exception(result_error)
+        barrier_futs = [broken] + barrier_futs[1:]
     if bootstrap is None:
         # Default: the pool bootstrapped normally, i.e. EVERY probe came back.
         # (Padding with unresolved futures here would silently make every
@@ -441,15 +462,20 @@ def test_bootstrap_waits_for_every_worker_not_just_the_first(monkeypatch):
     me = (os.getpid(), _process_start_time(os.getpid()))
     other = (1, b"1")
     monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", "10")
-    # Barrier budget is pinned to 0.1s by the helper; the straggler needs 0.8s,
-    # i.e. 8x the barrier budget. Only an all-probes bootstrap survives this.
+    # The barrier results land on the SAME clock as the straggler's probe. A
+    # bootstrap that returns on the first probe reaches the barrier at ~t=0 and
+    # gets only its 0.1s budget, so the t=0.8s barrier result is still missing
+    # and the pool is torn down; a bootstrap that waits for every probe reaches
+    # it at t=0.8 and finds the results already there. Without this coupling
+    # the test passes either way, which is no guarantee at all.
     ids, killed = _collect_identities(monkeypatch, [me, other],
                                       bootstrap=[me, other],
-                                      bootstrap_delays=[0.0, 0.8])
+                                      bootstrap_delays=[0.0, 0.8],
+                                      barrier_delays=[0.0, 0.8])
     assert set(ids) == {me, other} and not killed
 
 
-def test_gate_tears_down_when_submit_raises_a_runtime_error(monkeypatch):
+def test_gate_tears_down_on_runtime_errors_from_the_pool(monkeypatch):
     """mpi4py.MPI.Exception and BrokenExecutor are both RuntimeErrors.
 
     Both come out of the gate's own submit()/result() calls. If the gate
@@ -457,6 +483,9 @@ def test_gate_tears_down_when_submit_raises_a_runtime_error(monkeypatch):
     teardown, leaving mpi_pool dangling on a half-constructed session whose
     __del__ then blocks on a broken pool — a hang, in the change that exists
     to remove hangs.
+
+    Covers both arrival routes: raised out of submit(), and delivered through
+    a future so f.result() re-raises it.
     """
     from concurrent.futures import BrokenExecutor
 
@@ -466,20 +495,33 @@ def test_gate_tears_down_when_submit_raises_a_runtime_error(monkeypatch):
                                                  _process_start_time)
 
     me = (os.getpid(), _process_start_time(os.getpid()))
-    for error in (BrokenExecutor("pool is broken"),
-                  RuntimeError("plain runtime error")):
-        with _pytest.raises(RuntimeError) as exc:
-            _collect_identities(monkeypatch, [me],
-                                n_workers=1,
-                                bootstrap=[me],
-                                submit_error=error)
-        stand_in = exc.value._stand_in
-        # Torn down: pool disconnected without waiting, and cleared.
-        assert stand_in._pool_closed == [
-            False
-        ], (f"{type(error).__name__} escaped the teardown")
-        assert stand_in.mpi_pool is None
-        assert _IDENTITY_GATE_MARKER in str(exc.value)
+    errors = [
+        BrokenExecutor("pool is broken"),
+        RuntimeError("plain runtime error"),
+    ]
+    mpi = pytest.importorskip("mpi4py.MPI")
+    errors.append(mpi.Exception(mpi.ERR_COMM))
+
+    for how in ("submit", "result"):
+        for error in errors:
+            label = f"{type(error).__name__} via {how}"
+            with _pytest.raises(RuntimeError) as exc:
+                _collect_identities(monkeypatch, [me],
+                                    n_workers=1,
+                                    bootstrap=[me],
+                                    **{f"{how}_error": error})
+            stand_in = exc.value._stand_in
+            # Torn down: pool disconnected without waiting, and cleared.
+            assert stand_in._pool_closed == [
+                False
+            ], (f"{label} escaped the teardown")
+            assert stand_in.mpi_pool is None, label
+            assert _IDENTITY_GATE_MARKER in str(exc.value), label
+            # It failed during the BARRIER, so it must not blame bootstrap and
+            # point on-call at TRTLLM_MPI_IDENTITY_TIMEOUT, which is powerless
+            # against a broken executor.
+            assert "phase=barrier" in str(exc.value), label
+            assert "TRTLLM_MPI_IDENTITY_TIMEOUT" not in str(exc.value), label
 
 
 def test_mpi_and_executor_errors_really_are_runtime_errors():
@@ -527,7 +569,14 @@ def test_pool_can_make_progress_reads_the_real_mpi4py_internals():
 
 
 def test_mpi4py_still_exposes_the_liveness_handle():
-    """Fail loudly on an mpi4py bump that moves the manager thread."""
+    """Fail loudly on an mpi4py bump that moves the manager thread.
+
+    ``_pool_can_make_progress`` walks ``executor._pool.thread`` through
+    ``getattr(..., None)`` and reports "can still progress" on any miss —
+    deliberately, so an unrecognised internal degrades to the deadline instead
+    of killing healthy pools. The cost is that a rename is invisible at
+    runtime, so assert every link of that chain here.
+    """
     pytest.importorskip("mpi4py.futures")
     from mpi4py.futures import MPIPoolExecutor
 
@@ -536,9 +585,21 @@ def test_mpi4py_still_exposes_the_liveness_handle():
                                    "_pool_can_make_progress needs revisiting")
     from mpi4py.futures import _lib
 
-    assert "thread" in _lib.Pool.__init__.__code__.co_names, (
-        "mpi4py's Pool no longer keeps a manager thread; the identity gate's "
-        "dead-pool fast-fail has silently degraded to the full deadline")
+    degraded = ("the identity gate's dead-pool fast-fail has silently "
+                "degraded to the full deadline (it fails safe, so nothing "
+                "else will tell you)")
+    # Link 1: the executor stores its pool on `_pool`.
+    assert "_pool" in MPIPoolExecutor._bootstrap.__code__.co_names, (
+        f"mpi4py's executor no longer keeps its pool on `_pool`; {degraded}")
+    # Link 2: the pool keeps its manager on `thread`...
+    init_names = _lib.Pool.__init__.__code__.co_names
+    assert "thread" in init_names, (
+        f"mpi4py's Pool no longer keeps a manager thread; {degraded}")
+    # ...and that manager is a started threading.Thread, so `.is_alive()`
+    # still means what the predicate assumes it means.
+    assert "Thread" in init_names and "start" in init_names, (
+        f"mpi4py's Pool manager is no longer a started threading.Thread; "
+        f"`.is_alive()` may no longer signal a dead pool. {degraded}")
 
 
 def test_barrier_phase_waits_on_the_barrier_budget_not_the_bootstrap_one(

--- a/tests/unittest/llmapi/test_mpi_session.py
+++ b/tests/unittest/llmapi/test_mpi_session.py
@@ -17,6 +17,7 @@ from tensorrt_llm.llmapi.mpi_session import (_DEFAULT_IDENTITY_TIMEOUT,
                                              MPINodeState, MpiPoolSession,
                                              RemoteMpiCommSessionClient,
                                              _identity_barrier_timeout,
+                                             _identity_bootstrap_timeout,
                                              split_mpi_env)
 
 # isort: off
@@ -221,40 +222,78 @@ def test_wait_workers_exit_bounded_by_timeout_on_live_worker():
     assert 0.2 <= waited < 2.0  # bounded: a wedged worker cannot hang teardown
 
 
+def _resolved_futures(values):
+    from concurrent.futures import Future
+
+    out = []
+    for value in values:
+        f = Future()
+        f.set_result(value)
+        out.append(f)
+    return out
+
+
 def _collect_identities(monkeypatch,
                         results,
                         pending=0,
                         n_workers=2,
-                        observed_timeouts=None):
-    """Drive _collect_worker_identities on an inert stand-in (no MPI spawn)."""
+                        observed_timeouts=None,
+                        bootstrap=None,
+                        manager_alive=True,
+                        killed=None):
+    """Drive _collect_worker_identities on an inert stand-in (no MPI spawn).
+
+    ``results``/``pending`` describe what the *barrier* phase returns.
+    ``bootstrap`` describes what the warm-up phase returns; by default the
+    warm-up mirrors ``results``, i.e. a pool that bootstrapped normally. Pass
+    ``bootstrap=[]`` for a pool whose workers never came up at all.
+    """
     import types
     from concurrent.futures import Future
 
-    futs = []
-    for r in results:
-        f = Future()
-        f.set_result(r)
-        futs.append(f)
-    never = [Future() for _ in range(pending)]  # never resolve
-
     from tensorrt_llm.llmapi import mpi_session as m
 
-    def _fake_wait(fs, timeout):
+    barrier_futs = _resolved_futures(results) + [
+        Future() for _ in range(pending)
+    ]
+    if bootstrap is None:
+        bootstrap = list(results)
+    hello_futs = _resolved_futures(bootstrap)
+    hello_futs += [Future() for _ in range(n_workers - len(hello_futs))]
+
+    real_wait = m.futures_wait
+
+    def _wait(fs, timeout=None, **kwargs):
         if observed_timeouts is not None:
             observed_timeouts.append(timeout)
-        return futs, never
+        return real_wait(fs, timeout=timeout, **kwargs)
 
-    monkeypatch.setattr(m, "futures_wait", _fake_wait)
-    killed = []
+    monkeypatch.setattr(m, "futures_wait", _wait)
+    # Keep the bootstrap phase short: these tests exercise the control flow,
+    # not the production budget (which is asserted directly elsewhere).
+    monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT",
+                       os.environ.get("TRTLLM_MPI_IDENTITY_TIMEOUT", "0.3"))
+    monkeypatch.setattr(m, "_BOOTSTRAP_POLL_INTERVAL", 0.05)
+    monkeypatch.setattr(m, "_IDENTITY_BARRIER_TIMEOUT", 0.1)
+
+    if killed is None:
+        killed = []
     monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append(pid))
-    it = iter(futs + never)
+    queues = {
+        m._worker_hello: iter(hello_futs),
+        m._worker_identity_barrier: iter(barrier_futs),
+    }
     stand_in = types.SimpleNamespace(
         n_workers=n_workers,
-        mpi_pool=types.SimpleNamespace(submit=lambda fn: next(it),
+        mpi_pool=types.SimpleNamespace(submit=lambda fn: next(queues[fn]),
                                        shutdown=lambda wait=True: None),
-        _teardown_unidentified_pool=lambda ids: MpiPoolSession.
-        _teardown_unidentified_pool(stand_in, ids),
     )
+    stand_in._teardown_unidentified_pool = (
+        lambda ids: MpiPoolSession._teardown_unidentified_pool(stand_in, ids))
+    stand_in._pool_can_make_progress = lambda: manager_alive
+    stand_in._wait_worker_bootstrap = (
+        lambda futures, timeout: MpiPoolSession._wait_worker_bootstrap(
+            stand_in, futures, timeout))
     result = MpiPoolSession._collect_worker_identities(stand_in)
     return result, killed
 
@@ -281,6 +320,109 @@ def test_identity_collection_fails_closed_on_timeout(monkeypatch):
         _collect_identities(monkeypatch, [me], pending=1)
 
 
+def test_identity_gate_marks_every_failure_path(monkeypatch):
+    """(d) One greppable marker, on every way this gate can fail.
+
+    The marker lives in the exception message because that is the channel
+    proven to reach CI logs for this code path.
+    """
+    import pytest as _pytest
+
+    from tensorrt_llm.llmapi.mpi_session import (_IDENTITY_GATE_MARKER,
+                                                 _process_start_time)
+
+    me = (os.getpid(), _process_start_time(os.getpid()))
+    # barrier phase: bootstrapped, then a worker never reached the barrier
+    with _pytest.raises(RuntimeError) as barrier_exc:
+        _collect_identities(monkeypatch, [me], pending=1)
+    # bootstrap phase: no worker ever ran a task
+    with _pytest.raises(RuntimeError) as bootstrap_exc:
+        _collect_identities(monkeypatch, [me], pending=1, bootstrap=[])
+
+    assert _IDENTITY_GATE_MARKER in str(barrier_exc.value)
+    assert _IDENTITY_GATE_MARKER in str(bootstrap_exc.value)
+    # ...and the two phases are distinguishable, which is the whole point:
+    # a dead pool and a slow one used to emit byte-identical text.
+    assert "phase=barrier" in str(barrier_exc.value)
+    assert "phase=bootstrap" in str(bootstrap_exc.value)
+
+
+def test_dead_pool_fails_without_burning_the_bootstrap_budget(monkeypatch):
+    """Blocker 1: dead and slow must not cost the same wall time.
+
+    mpi4py raises a failed ``MPI_Comm_spawn`` inside its manager thread, so
+    the futures simply never resolve. The thread's death is the positive
+    signal that separates that from a bootstrap that is merely slow.
+    """
+    import time as _time
+
+    import pytest as _pytest
+
+    monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", "30")
+    t0 = _time.monotonic()
+    with _pytest.raises(RuntimeError, match="phase=bootstrap"):
+        _collect_identities(monkeypatch, [],
+                            pending=2,
+                            bootstrap=[],
+                            manager_alive=False)
+    elapsed = _time.monotonic() - t0
+    # Gives up on the positive death signal, not on the 30s deadline.
+    assert elapsed < 5.0
+
+
+def test_slow_bootstrap_is_not_mistaken_for_a_dead_pool(monkeypatch):
+    """The other half of Blocker 1: a live-but-slow pool must be waited for."""
+    import time as _time
+
+    from tensorrt_llm.llmapi.mpi_session import _process_start_time
+
+    me = (os.getpid(), _process_start_time(os.getpid()))
+    other = (1, b"1")
+    t0 = _time.monotonic()
+    ids, killed = _collect_identities(monkeypatch, [me, other])
+    assert set(ids) == {me, other} and not killed
+    # The healthy path pays no extra deadline: it returns as soon as the
+    # probes come back.
+    assert _time.monotonic() - t0 < 5.0
+
+
+def test_barrier_phase_uses_the_tight_fixed_deadline(monkeypatch):
+    """The guard's own bound must not inherit the bootstrap budget."""
+    from tensorrt_llm.llmapi import mpi_session as m
+
+    assert m._IDENTITY_BARRIER_TIMEOUT == 60.0
+    # ...and it is strictly tighter than the bootstrap budget it replaced,
+    # so widening the bootstrap budget never widens the guard.
+    monkeypatch.delenv("TRTLLM_MPI_IDENTITY_TIMEOUT", raising=False)
+    assert m._IDENTITY_BARRIER_TIMEOUT < m._identity_bootstrap_timeout()
+    assert (m.identity_gate_budget() == m._identity_bootstrap_timeout() +
+            m._IDENTITY_BARRIER_TIMEOUT)
+
+
+def test_warm_up_identities_are_reaped_when_the_barrier_stalls(monkeypatch):
+    """Blocker 2's root cause: a 0/N failure used to reap nothing.
+
+    The warm-up probes are collective-free, so they come back even when the
+    barrier does not — giving the teardown real PIDs to SIGKILL instead of an
+    empty tuple.
+    """
+    import pytest as _pytest
+
+    from tensorrt_llm.llmapi.mpi_session import _process_start_time
+
+    me = (os.getpid(), _process_start_time(os.getpid()))
+    killed = []
+    with _pytest.raises(RuntimeError, match="phase=barrier"):
+        _collect_identities(monkeypatch, [],
+                            pending=1,
+                            n_workers=1,
+                            bootstrap=[me],
+                            killed=killed)
+    # Before warm-then-measure the barrier returned nothing, partial_identities
+    # was empty, and the SIGKILL loop was a no-op.
+    assert killed == [os.getpid()]
+
+
 def test_identity_collection_fails_closed_on_duplicate_pids(monkeypatch):
     import pytest as _pytest
 
@@ -292,15 +434,11 @@ def test_identity_collection_fails_closed_on_duplicate_pids(monkeypatch):
 
 
 def test_identity_collection_uses_configured_timeout(monkeypatch):
-    from tensorrt_llm.llmapi.mpi_session import _process_start_time
-
+    # The env override now sizes the BOOTSTRAP phase (spawn + import), which
+    # is the phase whose cost varies by node. The barrier phase keeps its own
+    # fixed, tight deadline.
     monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", "123.5")
-    observed_timeouts = []
-    me = (os.getpid(), _process_start_time(os.getpid()))
-    _collect_identities(monkeypatch, [me],
-                        n_workers=1,
-                        observed_timeouts=observed_timeouts)
-    assert observed_timeouts == [123.5]
+    assert _identity_bootstrap_timeout() == 123.5
 
 
 def test_identity_timeout_covers_worker_bootstrap(monkeypatch):
@@ -308,6 +446,35 @@ def test_identity_timeout_covers_worker_bootstrap(monkeypatch):
     # it must exceed the slowest bootstrap the repo measures (~117s busy node).
     monkeypatch.delenv("TRTLLM_MPI_IDENTITY_TIMEOUT", raising=False)
     assert _identity_barrier_timeout() > 117.0
+    assert _identity_bootstrap_timeout() > 117.0
+
+
+def test_wait_shutdown_false_never_touches_the_identity_gate(monkeypatch):
+    """The production default must be byte-for-byte unaffected by this gate.
+
+    ``llm.py`` constructs ``MpiPoolSession`` without ``wait_shutdown``; the
+    two-phase gate (and its warm-up submits) must never run on that path.
+    """
+    import types
+
+    from tensorrt_llm.llmapi import mpi_session as m
+
+    submitted = []
+    monkeypatch.setattr(
+        m.MpiPoolSession, "_start_mpi_pool", lambda self: setattr(
+            self, "mpi_pool",
+            types.SimpleNamespace(submit=lambda fn: submitted.append(fn))))
+    monkeypatch.setattr(
+        m.MpiPoolSession, "_collect_worker_identities",
+        lambda self: pytest.fail("identity gate ran with wait_shutdown=False"))
+    monkeypatch.setattr(m, "ENABLE_MULTI_DEVICE", False)
+    # The inert pool cannot be joined; keep __del__ from arming the abort
+    # watchdog on it.
+    monkeypatch.setattr(m.MpiPoolSession, "shutdown_abort", lambda self: None)
+
+    session = m.MpiPoolSession(n_workers=2)
+    assert session._worker_identities == ()
+    assert submitted == []  # no warm-up probe, no barrier: nothing submitted
 
 
 # Invalid values (unparsable, non-positive) fall back to the default rather
@@ -325,6 +492,39 @@ def test_identity_timeout_covers_worker_bootstrap(monkeypatch):
 def test_identity_timeout_env_override(monkeypatch, raw, expected):
     monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", raw)
     assert _identity_barrier_timeout() == expected
+
+
+def test_wait_shutdown_call_sites_are_inventoried():
+    """Freeze the set of test-infra pool builders that arm the identity gate.
+
+    Every one of these pays the gate's cost and inherits its failure mode, so a
+    new one has to be a deliberate act rather than a copy-paste. If this fails,
+    either the site is intentional (update the inventory) or the caller should
+    reuse an existing builder.
+    """
+    import re
+
+    repo = os.path.abspath(os.path.join(cur_dir, "..", "..", ".."))
+    inventory = {
+        "tests/test_common/session_prefetcher.py": 2,
+        "tests/test_common/session_reuse.py": 3,
+    }
+    pattern = re.compile(
+        r"^\s*[\w.]+\s*=?\s*.*\(\s*n_workers=.*wait_shutdown=True")
+    for rel, expected in inventory.items():
+        path = os.path.join(repo, rel)
+        if not os.path.exists(path):
+            pytest.skip(f"{rel} not present in this checkout")
+        with open(path, encoding="utf-8") as f:
+            found = [
+                line.strip() for line in f if pattern.match(line) or (
+                    "wait_shutdown=True" in line and "n_workers=" in line
+                    and not line.lstrip().startswith("#"))
+            ]
+        assert len(found) == expected, (
+            f"{rel}: {len(found)} wait_shutdown=True pool builders, expected "
+            f"{expected}. New call sites inherit the MPI identity gate's "
+            f"budget and failure mode:\n" + "\n".join(found))
 
 
 def test_prefetch_fallback_identity_timeout_matches_mpi_default():

--- a/tests/unittest/llmapi/test_mpi_session.py
+++ b/tests/unittest/llmapi/test_mpi_session.py
@@ -16,7 +16,6 @@ from tensorrt_llm.bindings.BuildInfo import ENABLE_MULTI_DEVICE
 from tensorrt_llm.llmapi.mpi_session import (_DEFAULT_IDENTITY_TIMEOUT,
                                              MPINodeState, MpiPoolSession,
                                              RemoteMpiCommSessionClient,
-                                             _identity_barrier_timeout,
                                              _identity_bootstrap_timeout,
                                              split_mpi_env)
 
@@ -240,14 +239,22 @@ def _collect_identities(monkeypatch,
                         observed_timeouts=None,
                         bootstrap=None,
                         manager_alive=True,
-                        killed=None):
+                        killed=None,
+                        bootstrap_delays=None,
+                        submit_error=None):
     """Drive _collect_worker_identities on an inert stand-in (no MPI spawn).
 
     ``results``/``pending`` describe what the *barrier* phase returns.
     ``bootstrap`` describes what the warm-up phase returns; by default the
     warm-up mirrors ``results``, i.e. a pool that bootstrapped normally. Pass
-    ``bootstrap=[]`` for a pool whose workers never came up at all.
+    ``bootstrap=[]`` for a pool whose workers never came up at all, or
+    ``bootstrap_delays=[...]`` (seconds, per probe) for a pool whose ranks
+    finish ``import tensorrt_llm`` at different times.
+
+    ``submit_error`` makes the *barrier* submit raise, standing in for the
+    exceptions mpi4py surfaces from a broken pool.
     """
+    import threading
     import types
     from concurrent.futures import Future
 
@@ -257,9 +264,23 @@ def _collect_identities(monkeypatch,
         Future() for _ in range(pending)
     ]
     if bootstrap is None:
+        # Default: the pool bootstrapped normally, i.e. EVERY probe came back.
+        # (Padding with unresolved futures here would silently make every
+        # caller a partial-bootstrap test.)
         bootstrap = list(results)
-    hello_futs = _resolved_futures(bootstrap)
-    hello_futs += [Future() for _ in range(n_workers - len(hello_futs))]
+        bootstrap += [(9000 + i, b"warm")
+                      for i in range(n_workers - len(bootstrap))]
+    if bootstrap_delays is not None:
+        # Ranks come home on a timer, the way a real staggered bootstrap does.
+        hello_futs = [Future() for _ in bootstrap_delays]
+        for fut, (delay, value) in zip(hello_futs,
+                                       zip(bootstrap_delays, bootstrap)):
+            timer = threading.Timer(delay, fut.set_result, args=(value, ))
+            timer.daemon = True
+            timer.start()
+    else:
+        hello_futs = _resolved_futures(bootstrap)
+        hello_futs += [Future() for _ in range(n_workers - len(hello_futs))]
 
     real_wait = m.futures_wait
 
@@ -283,18 +304,32 @@ def _collect_identities(monkeypatch,
         m._worker_hello: iter(hello_futs),
         m._worker_identity_barrier: iter(barrier_futs),
     }
+
+    def _submit(fn):
+        if submit_error is not None and fn is m._worker_identity_barrier:
+            raise submit_error
+        return next(queues[fn])
+
+    pool_closed = []
     stand_in = types.SimpleNamespace(
         n_workers=n_workers,
-        mpi_pool=types.SimpleNamespace(submit=lambda fn: next(queues[fn]),
-                                       shutdown=lambda wait=True: None),
+        mpi_pool=types.SimpleNamespace(
+            submit=_submit,
+            shutdown=lambda wait=True: pool_closed.append(wait)),
     )
+    stand_in._pool_closed = pool_closed
     stand_in._teardown_unidentified_pool = (
         lambda ids: MpiPoolSession._teardown_unidentified_pool(stand_in, ids))
     stand_in._pool_can_make_progress = lambda: manager_alive
     stand_in._wait_worker_bootstrap = (
         lambda futures, timeout: MpiPoolSession._wait_worker_bootstrap(
             stand_in, futures, timeout))
-    result = MpiPoolSession._collect_worker_identities(stand_in)
+    try:
+        result = MpiPoolSession._collect_worker_identities(stand_in)
+    except BaseException as e:
+        # Expose the stand-in so teardown assertions survive the raise.
+        e._stand_in = stand_in
+        raise
     return result, killed
 
 
@@ -371,28 +406,175 @@ def test_dead_pool_fails_without_burning_the_bootstrap_budget(monkeypatch):
 
 
 def test_slow_bootstrap_is_not_mistaken_for_a_dead_pool(monkeypatch):
-    """The other half of Blocker 1: a live-but-slow pool must be waited for."""
+    """The other half: a live-but-slow pool must be waited for, not killed.
+
+    The probes land late and out of order, as a real staggered bootstrap
+    does — the gate must sit through it and still succeed.
+    """
     import time as _time
 
     from tensorrt_llm.llmapi.mpi_session import _process_start_time
 
     me = (os.getpid(), _process_start_time(os.getpid()))
     other = (1, b"1")
+    monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", "10")
     t0 = _time.monotonic()
-    ids, killed = _collect_identities(monkeypatch, [me, other])
+    ids, killed = _collect_identities(monkeypatch, [me, other],
+                                      bootstrap=[me, other],
+                                      bootstrap_delays=[0.05, 0.6])
+    waited = _time.monotonic() - t0
     assert set(ids) == {me, other} and not killed
-    # The healthy path pays no extra deadline: it returns as soon as the
-    # probes come back.
-    assert _time.monotonic() - t0 < 5.0
+    # It genuinely waited for the straggler rather than returning on the first.
+    assert 0.6 <= waited < 5.0
 
 
-def test_barrier_phase_uses_the_tight_fixed_deadline(monkeypatch):
+def test_bootstrap_waits_for_every_worker_not_just_the_first(monkeypatch):
+    """A healthy pool with bootstrap skew must not be torn down.
+
+    Returning as soon as ONE probe lands would hand the remaining ranks'
+    import time to the barrier's tight fixed budget, converting an absolute
+    bound into a skew bound — and tearing down pools that are merely uneven.
+    Here the straggler trails the leader by far more than the barrier budget.
+    """
+    from tensorrt_llm.llmapi.mpi_session import _process_start_time
+
+    me = (os.getpid(), _process_start_time(os.getpid()))
+    other = (1, b"1")
+    monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", "10")
+    # Barrier budget is pinned to 0.1s by the helper; the straggler needs 0.8s,
+    # i.e. 8x the barrier budget. Only an all-probes bootstrap survives this.
+    ids, killed = _collect_identities(monkeypatch, [me, other],
+                                      bootstrap=[me, other],
+                                      bootstrap_delays=[0.0, 0.8])
+    assert set(ids) == {me, other} and not killed
+
+
+def test_gate_tears_down_when_submit_raises_a_runtime_error(monkeypatch):
+    """mpi4py.MPI.Exception and BrokenExecutor are both RuntimeErrors.
+
+    Both come out of the gate's own submit()/result() calls. If the gate
+    re-raised on the RuntimeError base class it would let them past the
+    teardown, leaving mpi_pool dangling on a half-constructed session whose
+    __del__ then blocks on a broken pool — a hang, in the change that exists
+    to remove hangs.
+    """
+    from concurrent.futures import BrokenExecutor
+
+    import pytest as _pytest
+
+    from tensorrt_llm.llmapi.mpi_session import (_IDENTITY_GATE_MARKER,
+                                                 _process_start_time)
+
+    me = (os.getpid(), _process_start_time(os.getpid()))
+    for error in (BrokenExecutor("pool is broken"),
+                  RuntimeError("plain runtime error")):
+        with _pytest.raises(RuntimeError) as exc:
+            _collect_identities(monkeypatch, [me],
+                                n_workers=1,
+                                bootstrap=[me],
+                                submit_error=error)
+        stand_in = exc.value._stand_in
+        # Torn down: pool disconnected without waiting, and cleared.
+        assert stand_in._pool_closed == [
+            False
+        ], (f"{type(error).__name__} escaped the teardown")
+        assert stand_in.mpi_pool is None
+        assert _IDENTITY_GATE_MARKER in str(exc.value)
+
+
+def test_mpi_and_executor_errors_really_are_runtime_errors():
+    """Pins the premise of the test above; if it ever stops holding, say so."""
+    from concurrent.futures import BrokenExecutor
+
+    assert issubclass(BrokenExecutor, RuntimeError)
+    mpi4py = pytest.importorskip("mpi4py.MPI")
+    assert issubclass(mpi4py.Exception, RuntimeError)
+
+
+def test_pool_can_make_progress_reads_the_real_mpi4py_internals():
+    """M1: exercise the real predicate, not a stub.
+
+    It is a getattr chain, so a renamed mpi4py internal would silently make it
+    return True forever and the fast-fail would quietly degrade to the full
+    deadline with every other test still green.
+    """
+    import threading
+    import types
+
+    from tensorrt_llm.llmapi.mpi_session import MpiPoolSession
+
+    def probe(pool):
+        return MpiPoolSession._pool_can_make_progress(
+            types.SimpleNamespace(mpi_pool=types.SimpleNamespace(_pool=pool)))
+
+    dead = threading.Thread(target=lambda: None)
+    dead.start()
+    dead.join()
+    assert probe(types.SimpleNamespace(thread=dead)) is False
+
+    alive = threading.Event()
+    running = threading.Thread(target=alive.wait, daemon=True)
+    running.start()
+    try:
+        assert probe(types.SimpleNamespace(thread=running)) is True
+    finally:
+        alive.set()
+        running.join(timeout=5)
+
+    # Fail-safe: unknown shape must not be reported as dead.
+    assert probe(None) is True
+    assert probe(types.SimpleNamespace()) is True
+
+
+def test_mpi4py_still_exposes_the_liveness_handle():
+    """Fail loudly on an mpi4py bump that moves the manager thread."""
+    pytest.importorskip("mpi4py.futures")
+    from mpi4py.futures import MPIPoolExecutor
+
+    assert hasattr(MPIPoolExecutor,
+                   "_bootstrap"), ("mpi4py no longer bootstraps a pool lazily; "
+                                   "_pool_can_make_progress needs revisiting")
+    from mpi4py.futures import _lib
+
+    assert "thread" in _lib.Pool.__init__.__code__.co_names, (
+        "mpi4py's Pool no longer keeps a manager thread; the identity gate's "
+        "dead-pool fast-fail has silently degraded to the full deadline")
+
+
+def test_barrier_phase_waits_on_the_barrier_budget_not_the_bootstrap_one(
+        monkeypatch):
+    """The consequential wiring: which number reaches futures_wait.
+
+    If the barrier phase ever picked up the bootstrap budget, the guard would
+    silently become a 300s one again and every value-level assertion here
+    would still pass. So assert the deadline actually passed to the wait.
+    """
+    from tensorrt_llm.llmapi import mpi_session as m
+    from tensorrt_llm.llmapi.mpi_session import _process_start_time
+
+    me = (os.getpid(), _process_start_time(os.getpid()))
+    other = (1, b"1")
+    observed = []
+    monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", "37")
+    _collect_identities(monkeypatch, [me, other], observed_timeouts=observed)
+
+    # Last wait is the barrier; it uses the fixed barrier budget (pinned to
+    # 0.1 by the helper), never the 37s bootstrap budget.
+    assert observed[-1] == m._IDENTITY_BARRIER_TIMEOUT
+    assert 37 not in observed
+    # Every bootstrap wait is a poll slice, never one long blocking wait.
+    assert all(t <= m._BOOTSTRAP_POLL_INTERVAL for t in observed[:-1])
+
+
+def test_barrier_deadline_is_tight_and_untunable(monkeypatch):
     """The guard's own bound must not inherit the bootstrap budget."""
     from tensorrt_llm.llmapi import mpi_session as m
 
     assert m._IDENTITY_BARRIER_TIMEOUT == 60.0
     # ...and it is strictly tighter than the bootstrap budget it replaced,
     # so widening the bootstrap budget never widens the guard.
+    monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", "9999")
+    assert m._IDENTITY_BARRIER_TIMEOUT == 60.0
     monkeypatch.delenv("TRTLLM_MPI_IDENTITY_TIMEOUT", raising=False)
     assert m._IDENTITY_BARRIER_TIMEOUT < m._identity_bootstrap_timeout()
     assert (m.identity_gate_budget() == m._identity_bootstrap_timeout() +
@@ -445,7 +627,6 @@ def test_identity_timeout_covers_worker_bootstrap(monkeypatch):
     # The deadline bounds spawn + `import tensorrt_llm`, not barrier latency:
     # it must exceed the slowest bootstrap the repo measures (~117s busy node).
     monkeypatch.delenv("TRTLLM_MPI_IDENTITY_TIMEOUT", raising=False)
-    assert _identity_barrier_timeout() > 117.0
     assert _identity_bootstrap_timeout() > 117.0
 
 
@@ -491,40 +672,7 @@ def test_wait_shutdown_false_never_touches_the_identity_gate(monkeypatch):
                           ("1e309", _DEFAULT_IDENTITY_TIMEOUT)])
 def test_identity_timeout_env_override(monkeypatch, raw, expected):
     monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", raw)
-    assert _identity_barrier_timeout() == expected
-
-
-def test_wait_shutdown_call_sites_are_inventoried():
-    """Freeze the set of test-infra pool builders that arm the identity gate.
-
-    Every one of these pays the gate's cost and inherits its failure mode, so a
-    new one has to be a deliberate act rather than a copy-paste. If this fails,
-    either the site is intentional (update the inventory) or the caller should
-    reuse an existing builder.
-    """
-    import re
-
-    repo = os.path.abspath(os.path.join(cur_dir, "..", "..", ".."))
-    inventory = {
-        "tests/test_common/session_prefetcher.py": 2,
-        "tests/test_common/session_reuse.py": 3,
-    }
-    pattern = re.compile(
-        r"^\s*[\w.]+\s*=?\s*.*\(\s*n_workers=.*wait_shutdown=True")
-    for rel, expected in inventory.items():
-        path = os.path.join(repo, rel)
-        if not os.path.exists(path):
-            pytest.skip(f"{rel} not present in this checkout")
-        with open(path, encoding="utf-8") as f:
-            found = [
-                line.strip() for line in f if pattern.match(line) or (
-                    "wait_shutdown=True" in line and "n_workers=" in line
-                    and not line.lstrip().startswith("#"))
-            ]
-        assert len(found) == expected, (
-            f"{rel}: {len(found)} wait_shutdown=True pool builders, expected "
-            f"{expected}. New call sites inherit the MPI identity gate's "
-            f"budget and failure mode:\n" + "\n".join(found))
+    assert _identity_bootstrap_timeout() == expected
 
 
 def test_prefetch_fallback_identity_timeout_matches_mpi_default():

--- a/tests/unittest/llmapi/test_session_prefetcher.py
+++ b/tests/unittest/llmapi/test_session_prefetcher.py
@@ -207,7 +207,7 @@ def test_shadow_wait_budget_handles_partially_loaded_mpi_module(monkeypatch):
 
 def test_shadow_wait_budget_never_undercuts_the_real_gate():
     """The fallback constants must not drift below the library's own budget."""
-    from tensorrt_llm.llmapi import mpi_session
+    mpi_session = pytest.importorskip("tensorrt_llm.llmapi.mpi_session")
 
     assert session_prefetcher._FALLBACK_BARRIER_TIMEOUT == mpi_session._IDENTITY_BARRIER_TIMEOUT
     assert session_prefetcher._shadow_build_wait_timeout() >= mpi_session.identity_gate_budget()

--- a/tests/unittest/llmapi/test_session_prefetcher.py
+++ b/tests/unittest/llmapi/test_session_prefetcher.py
@@ -182,8 +182,11 @@ def test_take_wrong_size_in_flight_waits_before_miss(prefetcher, monkeypatch):
     assert result == [None]  # wrong-size pool was drained, then rejected
 
 
-def test_shadow_wait_budget_tracks_identity_timeout(monkeypatch):
-    fake_mpi_session = types.SimpleNamespace(_identity_barrier_timeout=lambda: 125.0)
+def test_shadow_wait_budget_tracks_identity_gate_budget(monkeypatch):
+    # The gate budget covers bootstrap AND the barrier phase; the prefetcher
+    # must take the whole thing, not just the bootstrap half, or it abandons a
+    # build the library still considers healthy.
+    fake_mpi_session = types.SimpleNamespace(identity_gate_budget=lambda: 125.0)
     monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi.mpi_session", fake_mpi_session)
     assert (
         session_prefetcher._shadow_build_wait_timeout()
@@ -196,8 +199,18 @@ def test_shadow_wait_budget_handles_partially_loaded_mpi_module(monkeypatch):
     monkeypatch.setenv("TRTLLM_MPI_IDENTITY_TIMEOUT", "625")
     assert (
         session_prefetcher._shadow_build_wait_timeout()
-        == 625 + session_prefetcher._SHADOW_BUILD_FINISH_GRACE
+        == 625
+        + session_prefetcher._FALLBACK_BARRIER_TIMEOUT
+        + session_prefetcher._SHADOW_BUILD_FINISH_GRACE
     )
+
+
+def test_shadow_wait_budget_never_undercuts_the_real_gate():
+    """The fallback constants must not drift below the library's own budget."""
+    from tensorrt_llm.llmapi import mpi_session
+
+    assert session_prefetcher._FALLBACK_BARRIER_TIMEOUT == mpi_session._IDENTITY_BARRIER_TIMEOUT
+    assert session_prefetcher._shadow_build_wait_timeout() >= mpi_session.identity_gate_budget()
 
 
 def test_take_timeout_is_terminal_until_build_exits(prefetcher, monkeypatch):


### PR DESCRIPTION
## Summary

The `wait_shutdown=True` worker-identity gate in `tensorrt_llm/llmapi/mpi_session.py` bounds **spawn + `import tensorrt_llm` + the identity barrier** with a *single* deadline. It has to: `MPIPoolExecutor` is constructed lazily, so the gate's first `submit()` is what triggers the whole worker bootstrap.

That forces one number to cover two costs with wildly different scales. Sizing it against bootstrap (low hundreds of seconds) is the only way to stop it failing healthy-but-slow pools — and it leaves the guard unable to tell a slow bootstrap from a dead pool without burning that whole budget first. Both cases produce the same `0/N valid identities` text at the same wall time.

**Warm, then measure.** This splits the gate into two phases:

- **bootstrap** — `n_workers` *collective-free* probes under the existing generous, env-tunable budget, waited on in poll slices until they have **all** returned. All of them, not the first: ranks finish importing seconds to tens of seconds apart, and any skew left here would be paid by the barrier out of its tight budget, turning an absolute bound into a skew bound. mpi4py raises a failed `MPI_Comm_spawn` *inside its manager thread*, so the futures simply never resolve; that thread's liveness is the one positive signal separating a dead pool from a slow one, and the wait gives up on **that**, not on the clock.
- **barrier** — the existing identity barrier under a tight, fixed **60 s** deadline that is now sized against what it actually measures.

## Measured

20-core x86 host, real MPI (Open MPI + mpi4py 3.1.5), a worker module whose *import* sleeps standing in for a cold `import tensorrt_llm`, driving a verbatim copy of each gate:

| scenario | before | after |
| --- | --- | --- |
| healthy, 30 s worker import | pass | pass (31.4 s) |
| healthy, ranks skewed 0–6 s | pass | pass (7.4 s) |
| `MPI_ERR_SPAWN` (unspawnable pool) | **300.0 s** | **1.0 s** |
| worker wedged before the barrier | **300.0 s** | **63.4 s** |
| ...workers SIGKILLed by teardown | **none** | **all 4** |

## Second defect fixed

That last row is a real leak. The barrier is collective, so a stalled one returns *nothing*, `partial_identities` is empty, and `_teardown_unidentified_pool`'s SIGKILL loop is a **no-op** — the workers leak until job end. The bootstrap probes are collective-free, so they come back even when the barrier does not, giving teardown real PIDs to reap. Verified above: `reaped=[]` before, all four worker PIDs after, on the identical wedged pool.

Precisely scoped: this covers a worker that wedges **after** importing. One wedged *inside* `import tensorrt_llm` never returns a probe, so it stays unidentified and still leaks — unchanged from before.

## Failures raise a dedicated type, not bare `RuntimeError`

`mpi4py.MPI.Exception` and `concurrent.futures.BrokenExecutor` **both inherit from `RuntimeError`**, and both can come out of the gate's own `submit()`/`result()`. Re-raising on the base class to preserve an already-torn-down failure would let those two past the teardown, leaving `mpi_pool` dangling on a session whose `__init__` never finished — `__del__` then blocks on a broken pool, and its abort watchdog fails on the `self.comm` that the raising `__init__` never assigned. The gate raises `_IdentityGateFailure(RuntimeError)` so the re-raise catches only its own case; callers still see a `RuntimeError`.

## Diagnostics

Every failure of the gate now carries one greppable marker, `[mpi-identity-gate]`, and names **the phase that actually failed** — tracked in a local, not hard-coded, so a broken executor surfacing during the barrier is not reported as a bootstrap failure pointing on-call at `TRTLLM_MPI_IDENTITY_TIMEOUT`. *"Never bootstrapped"* and *"bootstrapped but the barrier stalled"* stop being the same log line. The marker lives in the **exception message** deliberately: that is the channel proven to reach CI logs for this path (the message text is what shows up in Jenkins output for these failures), whereas the callers' plain `print()` diagnostics do not survive pytest capture.

## Production path unchanged

`wait_shutdown=False` is the production default, used by `llmapi/llm.py`. It is untouched:

- `_collect_worker_identities` has exactly **one** call site, guarded by `if wait_shutdown:` (`mpi_session.py:374-375`).
- An AST diff of `mpi_session.py` against the base confirms the only pre-existing function bodies that changed are `_collect_worker_identities` and `_identity_barrier_timeout` (now an alias returning the same value). `__init__`, `submit`, `submit_sync`, `shutdown`, `_start_mpi_pool`, `_wait_workers_exit`, `_teardown_unidentified_pool`, `release_exit_joins`, `abort` are byte-identical.
- `test_wait_shutdown_false_never_touches_the_identity_gate` asserts the constructor submits **nothing** on that path.

## Origin

For the record and without blame: the gate arrived in #15908, which measured worker spawn + import at *"~50s"* and the slowest legitimate pool build at *"~117s (busy node)"* **in the same changeset**. The deadline it shipped with was below those numbers; #16971 raised it to 300 s. This change stops the two costs sharing one number at all, so raising the bootstrap budget no longer widens the guard.

## Also

The test-session prefetcher now derives its outer wait from the new `identity_gate_budget()` (bootstrap + barrier) rather than the bootstrap half alone, so it cannot abandon a build the library still considers healthy.

## Tests

Added to `tests/unittest/llmapi/test_mpi_session.py`, which is registered whole-file in `tests/integration/test_lists/test-db/l0_a100.yml` (`unittest/llmapi/test_mpi_session.py ISOLATION`), so CI runs them:

- `test_dead_pool_fails_without_burning_the_bootstrap_budget` — Blocker: dead != slow in wall time
- `test_slow_bootstrap_is_not_mistaken_for_a_dead_pool` — the other half
- `test_warm_up_identities_are_reaped_when_the_barrier_stalls` — the leak
- `test_bootstrap_waits_for_every_worker_not_just_the_first` — bootstrap skew, probes resolving on a timer
- `test_gate_tears_down_on_runtime_errors_from_the_pool` + `test_mpi_and_executor_errors_really_are_runtime_errors` — both arrival routes (raised from `submit()`, and delivered through a future so `f.result()` re-raises), over `BrokenExecutor`, plain `RuntimeError` and a real `mpi4py.MPI.Exception`
- `test_pool_can_make_progress_reads_the_real_mpi4py_internals` + `test_mpi4py_still_exposes_the_liveness_handle` — exercises the real predicate (it is a `getattr` chain; a renamed mpi4py internal would otherwise degrade the fast-fail to the full deadline with every test still green). The tripwire asserts every link of `executor._pool.thread`, not just the thread.
- `test_identity_gate_marks_every_failure_path` — marker + phase on both paths
- `test_barrier_phase_waits_on_the_barrier_budget_not_the_bootstrap_one` — asserts the deadline actually passed to `futures_wait`, not just the constant
- `test_wait_shutdown_false_never_touches_the_identity_gate`

`107 passed` across `test_mpi_session.py`, `test_session_prefetcher.py`, `test_session_reuse.py` locally. Four pre-existing tests in `test_mpi_session.py` fail in this environment only because they spawn subprocesses that import a `tensorrt_llm` older than this checkout (build mismatch, `ImportError: cannot import name '_DEFAULT_IDENTITY_TIMEOUT'` / `kv_cache_manager_v2`); they are unrelated to this change.

### Mutation-checked

The two tests guarding the most consequential behaviours were verified by mutation, not just by passing:

| mutation | test that catches it |
| --- | --- |
| restore `FIRST_COMPLETED` early return | `test_bootstrap_waits_for_every_worker_not_just_the_first`, `test_slow_bootstrap_is_not_mistaken_for_a_dead_pool` |
| hard-code `phase=bootstrap` again | `test_gate_tears_down_on_runtime_errors_from_the_pool` |

## Not booked to the hang program

Deliberately not tagged `[TRTLLM-13409]`: this is a false-positive-failure regression, not a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
