### PR TITLE
[None][perf] optimize SM103 NVFP4 grouped GEMM

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -207,6 +207,37 @@ class GroupedGemmInputsHelper:
         )
         return a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles, *others
 
+    def inputs_pre_hook_with_mn_limit(
+            self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
+        """Regenerate grouped GEMM routing metadata, including expert row limits."""
+        a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, \
+            tile_idx_to_mn_limit, num_non_exiting_tiles, *others = inputs
+        num_tokens = self.infer_num_tokens(a.size(0))
+        num_tokens_per_expert = self.generate_num_tokens_per_expert(
+            num_tokens, approx_max_load=True)
+        token_selected_experts = self.generate_token_selected_experts(
+            num_tokens, num_tokens_per_expert).cuda()
+        token_final_scales = torch.ones_like(token_selected_experts,
+                                             dtype=torch.float32)
+        (
+            tile_idx_to_group_idx,
+            tile_idx_to_mn_limit,
+            expanded_idx_to_permuted_idx,
+            permuted_idx_to_expanded_idx,
+            total_num_padded_tokens,
+            num_non_exiting_tiles,
+        ) = torch.ops.trtllm.moe_sort(
+            token_selected_experts=token_selected_experts,
+            token_final_scales=token_final_scales,
+            num_experts=self.num_experts,
+            top_k=self.top_k,
+            local_expert_offset=self.local_expert_offset,
+            local_num_experts=self.num_local_experts,
+            tile_tokens_dim=self.tile_size,
+        )
+        return (a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx,
+                tile_idx_to_mn_limit, num_non_exiting_tiles, *others)
+
     def inputs_pre_hook_finalize_fusion(
             self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
         a, b, a_sf, b_sf, alpha, output, tile_idx_to_group_idx, tile_idx_to_mn_limit, permuted_idx_to_expanded_idx, num_non_exiting_tiles, token_final_scales = inputs
@@ -2214,6 +2245,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 raise ValueError(
                     f"{self.__class__.kernel_class.__name__} supports SM 100 (B200) and SM 103 (B300) only, but got SM {sm_version}"
                 )
+            self.epilogue_tile_n = 64 if sm_version == 103 else None
 
             if self.tile_size not in (128, 256):
                 raise ValueError(
@@ -2229,6 +2261,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 self.tile_size,
                 self.output_dtype,
                 self.scaling_vector_size,
+                self.epilogue_tile_n,
             )
 
         def get_valid_tactics(
@@ -2236,7 +2269,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
             **kwargs,
-        ) -> List[Tuple[int, int]]:
+        ) -> List[tuple]:
             a, b, *_ = inputs
             b_list = b if isinstance(b, (list, tuple)) else [b]
             m, k = a.size(0), a.size(1) * 2
@@ -2248,6 +2281,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             cluster_shape_mn_candidates = [(self.tile_size // 128, 1),
                                            (self.tile_size // 128, 2)]
 
+            sm_version = get_sm_version()
             valid_tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
                     mma_tiler_mn_candidates, cluster_shape_mn_candidates):
@@ -2272,7 +2306,35 @@ if IS_CUTLASS_DSL_AVAILABLE:
                         b_major="k",
                         c_major="n",
                 ):
-                    valid_tactics.append((mma_tiler_mn, cluster_shape_mn))
+                    valid_tactics.append(
+                        (mma_tiler_mn, cluster_shape_mn, False))
+                    if (sm_version == 103 and n %
+                        (mma_tiler_mn[1] * cluster_shape_mn[1]) == 0):
+                        valid_tactics.append(
+                            (mma_tiler_mn, cluster_shape_mn, True))
+                        if (self.tile_size == 256 and m // self.tile_size
+                                == 4 * self.num_local_experts):
+                            valid_tactics.append(
+                                (mma_tiler_mn, cluster_shape_mn, True, True))
+                            # Keep workload-specific scheduling changes behind exact shape
+                            # guards so the already competitive larger-M cases retain their
+                            # existing tactic set and generated kernels.
+                            if (m == 131072 and n == 4608 and k == 6144
+                                    and l == 128
+                                    and self.num_local_experts == 128
+                                    and mma_tiler_mn == (256, 256)
+                                    and cluster_shape_mn == (2, 1)):
+                                valid_tactics.append(
+                                    (mma_tiler_mn, cluster_shape_mn, True, True,
+                                     4))
+                            if (m == 131072 and n == 6144 and k == 2304
+                                    and l == 128
+                                    and self.num_local_experts == 128
+                                    and mma_tiler_mn == (256, 256)
+                                    and cluster_shape_mn == (2, 1)):
+                                valid_tactics.append(
+                                    (mma_tiler_mn, cluster_shape_mn, True, True,
+                                     1, 4, 14))
 
             return valid_tactics
 
@@ -2291,15 +2353,19 @@ if IS_CUTLASS_DSL_AVAILABLE:
                                                      fp4_scale_infer_shape),
                                       ConstraintSpec(
                                           5, 0,
+                                          helper.infer_shape_max_num_tiles),
+                                      ConstraintSpec(
+                                          6, 0,
                                           helper.infer_shape_max_num_tiles)),
-                    inputs_pre_hook=helper.inputs_pre_hook,
+                    inputs_pre_hook=helper.inputs_pre_hook_with_mn_limit,
                     use_cold_l2_cache=True,
                 )
             return self.__class__.tuning_config_cache[key]
 
         def forward(self, inputs: List[torch.Tensor],
                     tactic: Optional[tuple]) -> torch.Tensor:
-            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, num_non_exiting_tiles = inputs
+            a, b, a_sf, b_sf, alpha, tile_idx_to_group_idx, \
+                tile_idx_to_mn_limit, num_non_exiting_tiles = inputs
             assert a.dtype == torch.float4_e2m1fn_x2
             assert a.dim() == 2
             assert b.dtype == torch.float4_e2m1fn_x2
@@ -2326,8 +2392,35 @@ if IS_CUTLASS_DSL_AVAILABLE:
             num_tiles = m // self.tile_size
             assert tile_idx_to_group_idx.dtype == torch.int32
             assert tile_idx_to_group_idx.size() == (num_tiles, )
+            assert tile_idx_to_mn_limit.dtype == torch.int32
+            assert tile_idx_to_mn_limit.size() == (num_tiles, )
             assert num_non_exiting_tiles.dtype == torch.int32
             assert num_non_exiting_tiles.numel() == 1
+
+            direct_store_requested = False
+            predicated_tail_requested = False
+            scheduler_swizzle_size = 1
+            pipeline_stage_config = None
+            if isinstance(tactic, tuple) and len(tactic) == 7:
+                (mma_tiler_mn, cluster_shape_mn, direct_store_requested,
+                 predicated_tail_requested, scheduler_swizzle_size,
+                 num_ab_stage, num_sf_stage) = tactic
+                pipeline_stage_config = (num_ab_stage, num_sf_stage)
+            elif isinstance(tactic, tuple) and len(tactic) == 5:
+                (mma_tiler_mn, cluster_shape_mn, direct_store_requested,
+                 predicated_tail_requested, scheduler_swizzle_size) = tactic
+            elif isinstance(tactic, tuple) and len(tactic) == 4:
+                (mma_tiler_mn, cluster_shape_mn, direct_store_requested,
+                 predicated_tail_requested) = tactic
+            elif isinstance(tactic, tuple) and len(tactic) == 3:
+                mma_tiler_mn, cluster_shape_mn, direct_store_requested = tactic
+            elif isinstance(tactic, tuple) and len(tactic) == 2:
+                mma_tiler_mn, cluster_shape_mn = tactic
+            else:
+                mma_tiler_mn = (self.tile_size, 128)
+                cluster_shape_mn = (self.tile_size // 128, 1)
+            assert mma_tiler_mn[
+                0] == self.tile_size, f"Tactic ({tactic}) is incompatible with tile size ({self.tile_size})"
 
             c = torch.empty(m, n, dtype=self.output_dtype, device=a.device)
 
@@ -2352,40 +2445,118 @@ if IS_CUTLASS_DSL_AVAILABLE:
             tile_idx_to_group_idx_ptr = make_ptr(
                 cutlass.Int32, tile_idx_to_group_idx.data_ptr(),
                 cute.AddressSpace.gmem)
+            tile_idx_to_mn_limit_ptr = make_ptr(cutlass.Int32,
+                                                tile_idx_to_mn_limit.data_ptr(),
+                                                cute.AddressSpace.gmem)
             num_non_exiting_tiles_ptr = make_ptr(
                 cutlass.Int32, num_non_exiting_tiles.data_ptr(),
                 cute.AddressSpace.gmem)
+            use_direct_store = (direct_store_requested
+                                and get_sm_version() == 103
+                                and c.dtype == torch.bfloat16
+                                and c.is_contiguous() and c.stride(1) == 1
+                                and c.data_ptr() % 32 == 0
+                                and c.stride(0) * c.element_size() % 32 == 0
+                                and n %
+                                (mma_tiler_mn[1] * cluster_shape_mn[1]) == 0)
+            use_predicated_tail = (predicated_tail_requested
+                                   and use_direct_store
+                                   and self.tile_size == 256)
+            if not use_direct_store:
+                pipeline_stage_config = None
             c_ptr = make_ptr(cutlass.BFloat16,
                              c.data_ptr(),
                              cute.AddressSpace.gmem,
-                             assumed_align=16)
+                             assumed_align=32 if use_direct_store else 16)
 
             torch_stream = torch.cuda.current_stream()
             stream = cuda.CUstream(torch_stream.cuda_stream)
 
-            if isinstance(tactic, tuple):
-                mma_tiler_mn, cluster_shape_mn = tactic
-            else:
-                mma_tiler_mn = (self.tile_size, 128)
-                cluster_shape_mn = (self.tile_size // 128, 1)
-            assert mma_tiler_mn[
-                0] == self.tile_size, f"Tactic ({tactic}) is incompatible with tile size ({self.tile_size})"
-
-            cache_key = (self.scaling_vector_size, self.tile_size, mma_tiler_mn,
-                         cluster_shape_mn)
+            cache_key = (get_sm_version(), self.scaling_vector_size,
+                         self.tile_size, mma_tiler_mn, cluster_shape_mn,
+                         use_direct_store, use_predicated_tail,
+                         scheduler_swizzle_size, pipeline_stage_config,
+                         self.epilogue_tile_n)
             if cache_key not in self.__class__.kernel_cache:
                 gemm = self.__class__.kernel_class(
                     sf_vec_size=self.scaling_vector_size,
                     mma_tiler_mn=mma_tiler_mn,
                     cluster_shape_mn=cluster_shape_mn,
+                    use_direct_store=use_direct_store,
+                    use_predicated_tail=use_predicated_tail,
+                    scheduler_swizzle_size=scheduler_swizzle_size,
+                    pipeline_stage_config=pipeline_stage_config,
+                    epilogue_tile_n=self.epilogue_tile_n,
                 )
                 # Compute max active clusters on current device
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
                     cluster_shape_mn[0] * cluster_shape_mn[1])
 
-                compiled_gemm = cute.compile(
-                    gemm.wrapper,
+                if use_predicated_tail:
+                    compiled_gemm = cute.compile(
+                        gemm.wrapper_predicated,
+                        a_ptr,
+                        b_ptr,
+                        a_sf_ptr,
+                        b_sf_ptr,
+                        c_ptr,
+                        alpha_ptr,
+                        tile_idx_to_group_idx_ptr,
+                        tile_idx_to_mn_limit_ptr,
+                        num_non_exiting_tiles_ptr,
+                        m,
+                        n,
+                        k,
+                        l,
+                        tile_size=self.tile_size,
+                        scaling_vector_size=self.scaling_vector_size,
+                        max_active_clusters=max_active_clusters,
+                        stream=stream,
+                    )
+                else:
+                    compiled_gemm = cute.compile(
+                        gemm.wrapper,
+                        a_ptr,
+                        b_ptr,
+                        a_sf_ptr,
+                        b_sf_ptr,
+                        c_ptr,
+                        alpha_ptr,
+                        tile_idx_to_group_idx_ptr,
+                        num_non_exiting_tiles_ptr,
+                        m,
+                        n,
+                        k,
+                        l,
+                        tile_size=self.tile_size,
+                        scaling_vector_size=self.scaling_vector_size,
+                        max_active_clusters=max_active_clusters,
+                        stream=stream,
+                    )
+                self.__class__.kernel_cache[cache_key] = compiled_gemm
+            else:
+                compiled_gemm = self.__class__.kernel_cache[cache_key]
+
+            if use_predicated_tail:
+                compiled_gemm(
+                    a_ptr,
+                    b_ptr,
+                    a_sf_ptr,
+                    b_sf_ptr,
+                    c_ptr,
+                    alpha_ptr,
+                    tile_idx_to_group_idx_ptr,
+                    tile_idx_to_mn_limit_ptr,
+                    num_non_exiting_tiles_ptr,
+                    m,
+                    n,
+                    k,
+                    l,
+                    stream=stream,
+                )
+            else:
+                compiled_gemm(
                     a_ptr,
                     b_ptr,
                     a_sf_ptr,
@@ -2398,30 +2569,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     n,
                     k,
                     l,
-                    tile_size=self.tile_size,
-                    scaling_vector_size=self.scaling_vector_size,
-                    max_active_clusters=max_active_clusters,
                     stream=stream,
                 )
-                self.__class__.kernel_cache[cache_key] = compiled_gemm
-            else:
-                compiled_gemm = self.__class__.kernel_cache[cache_key]
-
-            compiled_gemm(
-                a_ptr,
-                b_ptr,
-                a_sf_ptr,
-                b_sf_ptr,
-                c_ptr,
-                alpha_ptr,
-                tile_idx_to_group_idx_ptr,
-                num_non_exiting_tiles_ptr,
-                m,
-                n,
-                k,
-                l,
-                stream=stream,
-            )
             return c
 
     @torch.library.custom_op("trtllm::cute_dsl_nvfp4_grouped_gemm_blackwell",
@@ -2434,6 +2583,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         weight_scale: torch.Tensor,
         alpha: torch.Tensor,
         tile_idx_to_group_idx: torch.Tensor,
+        tile_idx_to_mn_limit: torch.Tensor,
         num_non_exiting_tiles: torch.Tensor,
         num_experts: int,
         top_k: int,
@@ -2450,7 +2600,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             tile_size, output_dtype, scaling_vector_size)
         inputs = [
             input, weight, input_scale, weight_scale, alpha,
-            tile_idx_to_group_idx, num_non_exiting_tiles
+            tile_idx_to_group_idx, tile_idx_to_mn_limit, num_non_exiting_tiles
         ]
 
         _, best_tactic = tuner.choose_one(
@@ -2471,6 +2621,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         weight_scale: torch.Tensor,
         alpha: torch.Tensor,
         tile_idx_to_group_idx: torch.Tensor,
+        tile_idx_to_mn_limit: torch.Tensor,
         num_non_exiting_tiles: torch.Tensor,
         num_experts: int,
         top_k: int,

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Tuple, Type, Union
+from typing import Optional, Tuple, Type, Union
 
 import cuda.bindings.driver as cuda
 import cutlass
@@ -50,7 +50,12 @@ import cutlass.pipeline as pipeline
 import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
-from cutlass.cute.nvgpu import cpasync, tcgen05
+import cutlass.utils.gemm.sm100 as sm100_gemm_utils
+from cutlass.base_dsl.arch import Arch
+from cutlass.cute.nvgpu import OperandMajorMode, cpasync, tcgen05
+from cutlass.cute.nvgpu.common import CacheEvictionPriority
+from cutlass.cutlass_dsl import BaseDSL
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 
 from .utils import (
     TRTLLM_ENABLE_PDL,
@@ -107,6 +112,11 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
         raster_along_m: bool = False,
+        use_direct_store: bool = False,
+        use_predicated_tail: bool = False,
+        scheduler_swizzle_size: int = 1,
+        pipeline_stage_config: Optional[Tuple[int, int]] = None,
+        epilogue_tile_n: Optional[int] = None,
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel.
 
@@ -125,10 +135,58 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         :type cluster_shape_mn: Tuple[int, int]
         :param raster_along_m: If True, raster along M dimension for tile scheduler.
         :type raster_along_m: bool
+        :param use_direct_store: If True, use 256-bit register-to-global stores on SM103 when the
+            BF16 output pointer and row stride satisfy 32-byte alignment. Callers of ``wrapper``
+            must also guarantee that N is divisible by ``mma_tiler_n * cluster_n``; production
+            dispatch checks this requirement and otherwise selects the TMA fallback.
+        :type use_direct_store: bool
+        :param use_predicated_tail: If True, skip direct stores for expert-padding rows on SM103.
+            Callers must use ``wrapper_predicated`` and provide ``tile_idx_to_mn_limit``.
+        :type use_predicated_tail: bool
+        :param scheduler_swizzle_size: Cluster-level scheduler swizzle. Four places the four
+            consecutive M tiles for an expert next to each other before advancing N and therefore
+            requires raster_along_m=False.
+        :type scheduler_swizzle_size: int
+        :param pipeline_stage_config: Optional direct-store SM103 ``(AB, scale-factor)``
+            pipeline stage override. The default derives both stage counts from shared-memory
+            capacity.
+        :type pipeline_stage_config: Optional[Tuple[int, int]]
+        :param epilogue_tile_n: Optional SM103 epilogue tile N dimension. The default uses the
+            CUTLASS heuristic; 64 selects an LDTM.x64 accumulator fragment for the 256x256 MMA.
+        :type epilogue_tile_n: Optional[int]
         """
 
         self.sf_vec_size = sf_vec_size
         self.raster_along_m = raster_along_m
+        self.direct_store_requested = use_direct_store
+        self.predicated_tail_requested = use_predicated_tail
+        self.use_direct_store = False
+        self.use_predicated_tail = False
+        self.num_tile_info_fields = 4
+        if scheduler_swizzle_size not in (1, 4):
+            raise ValueError("scheduler_swizzle_size must be 1 or 4")
+        if scheduler_swizzle_size != 1 and raster_along_m:
+            raise ValueError("scheduler_swizzle_size > 1 requires raster_along_m=False")
+        self.scheduler_swizzle_size = scheduler_swizzle_size
+        if pipeline_stage_config is not None and (
+            len(pipeline_stage_config) != 2
+            or pipeline_stage_config[0] <= 0
+            or pipeline_stage_config[1] <= 0
+        ):
+            raise ValueError("pipeline_stage_config must contain positive AB and SF stage counts")
+        self.pipeline_stage_config = pipeline_stage_config
+        if epilogue_tile_n not in (None, 32, 64):
+            raise ValueError("epilogue_tile_n must be None, 32, or 64")
+        self.epilogue_tile_n_override = epilogue_tile_n
+        self.arch = BaseDSL._get_dsl().get_arch_enum()
+        # SM103's K=96 instruction is available only for NVFP4 and the native
+        # N tiles below. Keep every other configuration on the SM100 path.
+        self.use_3x_mma = (
+            self.arch >= Arch.sm_103
+            and self.arch <= Arch.sm_103f
+            and sf_vec_size == 16
+            and mma_tiler_mn[1] in (128, 256)
+        )
         self.acc_dtype = cutlass.Float32
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
         self.cluster_shape_mn = cluster_shape_mn
@@ -140,24 +198,20 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         self.occupancy = 1
         self.epilog_warp_id = (0, 1, 2, 3)
         self.mma_warp_id = 4
-        self.tma_warp_id = 5
-        self.sched_warp_id = 6
+        self.tma_ab_warp_id = 5
+        self.tma_sf_warp_id = 6 if self.use_3x_mma else 5
+        self.tma_warp_id = self.tma_ab_warp_id
+        self.sched_warp_id = 7 if self.use_3x_mma else 6
         self.threads_per_warp = 32
-        self.threads_per_cta = self.threads_per_warp * len(
-            (
-                *self.epilog_warp_id,
-                self.mma_warp_id,
-                self.tma_warp_id,
-                self.sched_warp_id,
-            )
+        worker_warp_ids = (
+            *self.epilog_warp_id,
+            self.mma_warp_id,
+            self.tma_ab_warp_id,
         )
-        self.threads_wo_sched = self.threads_per_warp * len(
-            (
-                *self.epilog_warp_id,
-                self.mma_warp_id,
-                self.tma_warp_id,
-            )
-        )
+        if self.use_3x_mma:
+            worker_warp_ids = (*worker_warp_ids, self.tma_sf_warp_id)
+        self.threads_per_cta = self.threads_per_warp * len((*worker_warp_ids, self.sched_warp_id))
+        self.threads_wo_sched = self.threads_per_warp * len(worker_warp_ids)
         self.num_regs_uniform_warps = 64
         self.num_regs_sched_warps = 64
         self.num_regs_epilogue_warps = 216
@@ -179,7 +233,9 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
             barrier_id=4,
             num_threads=self.threads_per_warp,
         )
-        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        target_arch = "sm_103" if self.use_3x_mma else "sm_100"
+        self.num_smem_capacity = utils.get_smem_capacity_in_bytes(target_arch)
+        self.sf_buffers_per_tile_k = 4 if self.sf_vec_size == 16 else 2
         # TMEM offset for final accumulator
         self.tmem_final_offset = 384
 
@@ -280,7 +336,6 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
             self.c_layout,
             self.c_dtype,
         )
-
         self.epi_tile_n = cute.size(self.epi_tile[1])
 
         # Setup A/B/C/Scale stage count in shared memory and ACC stage count in tensor memory
@@ -356,8 +411,150 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         # Compute the number of tensor memory allocation columns
         self.num_tmem_alloc_cols = 512
 
+    def _setup_attributes_sm103(self):
+        """Configure the SM103 K=96 MMA, K=768 mainloop, and split AB/SF pipelines."""
+        self.mma_inst_shape_mn = (self.mma_tiler[0], self.mma_tiler[1])
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+        tiled_mma = sm100_utils.sm103_make_blockscaled_trivial_tiled_mma(
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+        tiled_mma_sfb = sm100_utils.sm103_make_blockscaled_trivial_tiled_mma(
+            self.sf_dtype,
+            self.sf_vec_size,
+            tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+        assert cute.size(tiled_mma.shape_mnk, mode=[2]) == 96
+        self.mma_tiler = (*self.mma_inst_shape_mn, 768)
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_layout_vmnk.shape[0]),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_n_sf = cute.round_up(self.cta_tile_shape_mnk[1], 128)
+        self.mma_sf_tiler = (
+            self.cta_tile_shape_mnk[0],
+            self.cta_n_sf,
+            self.cta_tile_shape_mnk[2] // self.sf_buffers_per_tile_k,
+        )
+        self.sf_atom = blockscaled_utils.Sm103BlockScaledBasicChunk(
+            self.sf_vec_size, tiled_mma.op.a_major_mode
+        ).layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+        self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            self.use_2cta_instrs,
+            self.c_layout,
+            self.c_dtype,
+        )
+        if self.epilogue_tile_n_override is not None:
+            self.epi_tile = (self.epi_tile[0], self.epilogue_tile_n_override)
+        (
+            self.num_acc_stage,
+            self.num_ab_stage,
+            self.num_sf_stage,
+            self.num_c_stage,
+        ) = self._compute_stages_sm103(
+            tiled_mma,
+            self.mma_tiler,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.num_smem_capacity,
+            self.occupancy,
+            not self.use_direct_store,
+        )
+        if self.pipeline_stage_config is not None:
+            if not self.use_direct_store:
+                raise ValueError("pipeline_stage_config requires the SM103 direct-store path")
+            self.num_ab_stage, self.num_sf_stage = self.pipeline_stage_config
+        self.num_tile_stage = 2
+        self.a_smem_layout_staged = self.sm103_make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.num_ab_stage,
+        )
+        self.a_smem_layout_staged_tma = self.sm103_make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            3,
+        )
+        self.b_smem_layout_staged = self.sm103_make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged_tma = self.sm103_make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            3,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.sm103_make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_sf_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.sm103_make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_sf_stage,
+        )
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            max(self.num_c_stage, 1),
+        )
+        self.c_smem_storage_elements = (
+            0 if self.use_direct_store else cute.cosize(self.c_smem_layout_staged.outer)
+        )
+        self.epi_tile_n = cute.size(self.epi_tile[1])
+
+        def _sf_tmem_cols(make_tmem_layout, smem_layout_staged):
+            tmem_layout = make_tmem_layout(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(smem_layout_staged, (None, None, None, 0)),
+            )
+            return cute.cosize(cute.recast_layout(32, self.sf_dtype.width, tmem_layout)) & 0xFFFF
+
+        self.num_sfa_tmem_cols = _sf_tmem_cols(
+            blockscaled_utils.make_tmem_layout_sfa, self.sfa_smem_layout_staged
+        )
+        self.num_sfb_tmem_cols = _sf_tmem_cols(
+            blockscaled_utils.make_tmem_layout_sfb, self.sfb_smem_layout_staged
+        )
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.overlapping_accum = self.num_acc_stage == 1
+        self.iter_acc_early_release_in_epilogue = self.num_sf_tmem_cols // self.epi_tile_n
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_103")
+
     @cute.jit
-    def __call__(
+    def _call_sm100(
         self,
         a: cute.Tensor,
         b: cute.Tensor,
@@ -365,6 +562,7 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         sfa: cute.Tensor,
         sfb: cute.Tensor,
         tile_idx_to_group_idx: cute.Tensor,
+        tile_idx_to_mn_limit: cute.Tensor,
         num_non_exiting_tiles: cute.Tensor,
         alpha: cute.Tensor,
         max_active_clusters: cutlass.Constexpr,
@@ -544,6 +742,7 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
             self.cluster_shape_mn,
             max_active_clusters,
             self.raster_along_m,
+            self.scheduler_swizzle_size,
         )
 
         self.buffer_align_bytes = 1024
@@ -631,6 +830,375 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         )
         return
 
+    @cute.jit
+    def _call_sm103(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        sfa: cute.Tensor,
+        sfb: cute.Tensor,
+        tile_idx_to_group_idx: cute.Tensor,
+        tile_idx_to_mn_limit: cute.Tensor,
+        num_non_exiting_tiles: cute.Tensor,
+        alpha: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Build and launch the SM103 3xNVFP4 grouped GEMM specialization."""
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.sf_dtype = sfa.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.c_alignment = c.iterator.max_alignment
+        self.use_direct_store = (
+            self.direct_store_requested
+            and self.c_dtype is cutlass.BFloat16
+            and self.c_layout is utils.LayoutEnum.ROW_MAJOR
+            and self.c_alignment >= 32
+        )
+        self.use_predicated_tail = self.use_direct_store and self.predicated_tail_requested
+        self.num_tile_info_fields = 5 if self.use_predicated_tail else 4
+        if cutlass.const_expr(
+            self.a_dtype is not cutlass.Float4E2M1FN or self.b_dtype is not cutlass.Float4E2M1FN
+        ):
+            raise TypeError("SM103 3x MMA requires Float4E2M1FN A and B")
+        self._setup_attributes_sm103()
+        sfa_layout = cute.tile_to_shape(self.sf_atom, a.shape, (2, 1, 3))
+        sfa = cute.make_tensor(sfa.iterator, sfa_layout)
+        sfb_layout = cute.tile_to_shape(self.sf_atom, b.shape, (2, 1, 3))
+        sfb = cute.make_tensor(sfb.iterator, sfb_layout)
+        tiled_mma = sm100_utils.sm103_make_blockscaled_trivial_tiled_mma(
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+        tiled_mma_sfb = sm100_utils.sm103_make_blockscaled_trivial_tiled_mma(
+            self.sf_dtype,
+            self.sf_vec_size,
+            tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        a_smem_layout_tma = self.adapt_layout_for_tma_ab(self.a_smem_layout_staged_tma)
+        a_uint8 = cute.recast_tensor(a, cutlass.Uint8)
+        tma_atom_a, tma_tensor_a = cpasync.make_tiled_tma_atom(
+            a_op,
+            a_uint8,
+            a_smem_layout_tma,
+            (cute.size(tiled_mma.tv_layout_A[1][0]), 384),
+            self.cluster_shape_mn[1],
+            internal_type=cutlass.Uint8,
+        )
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(self.cluster_shape_mn, tiled_mma.thr_id)
+        b_smem_layout_tma = self.adapt_layout_for_tma_ab(self.b_smem_layout_staged_tma)
+        b_uint8 = cute.recast_tensor(b, cutlass.Uint8)
+        tma_atom_b, tma_tensor_b = cpasync.make_tiled_tma_atom(
+            b_op,
+            b_uint8,
+            b_smem_layout_tma,
+            (cute.size(tiled_mma.tv_layout_B[1][0]), 384),
+            self.cluster_shape_mn[0] // atom_thr_size,
+            internal_type=cutlass.Uint8,
+        )
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cpasync.make_tiled_tma_atom(
+            sfa_op,
+            sfa,
+            self.adapt_layout_for_tma_sf(sfa_smem_layout),
+            (self.mma_sf_tiler[0], self.mma_sf_tiler[2]),
+            self.cluster_shape_mn[1],
+            internal_type=cutlass.Uint8,
+        )
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(self.cluster_shape_mn, tiled_mma.thr_id)
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cpasync.make_tiled_tma_atom(
+            sfb_op,
+            sfb,
+            self.adapt_layout_for_tma_sf(sfb_smem_layout),
+            (self.mma_sf_tiler[1], self.mma_sf_tiler[2]),
+            self.cluster_shape_mn[0] // cute.size(tiled_mma_sfb.thr_id),
+            internal_type=cutlass.Uint8,
+        )
+        tma_atom_c = None
+        tma_tensor_c = None
+        if cutlass.const_expr(not self.use_direct_store):
+            epi_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+            tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                c,
+                epi_smem_layout,
+                self.epi_tile,
+            )
+        a_copy_size = cute.size_in_bytes(
+            cutlass.Uint8,
+            cute.slice_(self.a_smem_layout_staged_tma, (None, None, None, 0)),
+        )
+        b_copy_size = cute.size_in_bytes(
+            cutlass.Uint8,
+            cute.slice_(self.b_smem_layout_staged_tma, (None, None, None, 0)),
+        )
+        sfa_copy_size = cute.size_in_bytes(
+            cutlass.Uint8,
+            cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0)),
+        )
+        sfb_copy_size = cute.size_in_bytes(
+            cutlass.Uint8,
+            cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0)),
+        )
+        self.num_tma_load_bytes_ab = (a_copy_size + b_copy_size) * atom_thr_size
+        self.num_tma_load_bytes_sf = (sfa_copy_size + sfb_copy_size) * atom_thr_size
+        self.tile_sched_params, grid = self._compute_grid(
+            c,
+            self.cta_tile_shape_mnk,
+            self.cluster_shape_mn,
+            max_active_clusters,
+            self.raster_along_m,
+            self.scheduler_swizzle_size,
+        )
+        self.buffer_align_bytes = 1024
+
+        @cute.struct
+        class SharedStorage:
+            sInfo: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Int32,
+                    self.num_tile_info_fields * self.num_tile_stage,
+                ],
+                1,
+            ]
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            sf_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_sf_stage]
+            sf_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_sf_stage]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            tile_info_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_tile_stage * 2]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype,
+                    self.c_smem_storage_elements,
+                ],
+                self.buffer_align_bytes,
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8,
+                    cute.cosize(self.a_smem_layout_staged.outer),
+                ],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8,
+                    cute.cosize(self.b_smem_layout_staged.outer),
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8,
+                    cute.cosize(self.sfa_smem_layout_staged),
+                ],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8,
+                    cute.cosize(self.sfb_smem_layout_staged),
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage_sm103 = SharedStorage
+        kernel_tensor_c = c if self.use_direct_store else tma_tensor_c
+        if self.use_predicated_tail:
+            self._kernel_sm103_predicated(
+                tiled_mma,
+                tma_atom_a,
+                tma_tensor_a,
+                tma_atom_b,
+                tma_tensor_b,
+                tma_atom_sfa,
+                tma_tensor_sfa,
+                tma_atom_sfb,
+                tma_tensor_sfb,
+                tma_atom_c,
+                kernel_tensor_c,
+                tile_idx_to_group_idx,
+                tile_idx_to_mn_limit,
+                num_non_exiting_tiles,
+                alpha,
+                self.cluster_layout_vmnk,
+                self.cluster_layout_sfb_vmnk,
+                self.a_smem_layout_staged,
+                self.b_smem_layout_staged,
+                self.sfa_smem_layout_staged,
+                self.sfb_smem_layout_staged,
+                self.c_smem_layout_staged,
+                self.epi_tile,
+                self.tile_sched_params,
+                epilogue_op,
+            ).launch(
+                grid=grid,
+                block=[self.threads_per_cta, 1, 1],
+                cluster=(*self.cluster_shape_mn, 1),
+                smem=self.shared_storage_sm103.size_in_bytes(),
+                stream=stream,
+                min_blocks_per_mp=1,
+                use_pdl=TRTLLM_ENABLE_PDL,
+            )
+        else:
+            self._kernel_sm103(
+                tiled_mma,
+                tma_atom_a,
+                tma_tensor_a,
+                tma_atom_b,
+                tma_tensor_b,
+                tma_atom_sfa,
+                tma_tensor_sfa,
+                tma_atom_sfb,
+                tma_tensor_sfb,
+                tma_atom_c,
+                kernel_tensor_c,
+                tile_idx_to_group_idx,
+                num_non_exiting_tiles,
+                alpha,
+                self.cluster_layout_vmnk,
+                self.cluster_layout_sfb_vmnk,
+                self.a_smem_layout_staged,
+                self.b_smem_layout_staged,
+                self.sfa_smem_layout_staged,
+                self.sfb_smem_layout_staged,
+                self.c_smem_layout_staged,
+                self.epi_tile,
+                self.tile_sched_params,
+                epilogue_op,
+            ).launch(
+                grid=grid,
+                block=[self.threads_per_cta, 1, 1],
+                cluster=(*self.cluster_shape_mn, 1),
+                smem=self.shared_storage_sm103.size_in_bytes(),
+                stream=stream,
+                min_blocks_per_mp=1,
+                use_pdl=TRTLLM_ENABLE_PDL,
+            )
+        return
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        sfa: cute.Tensor,
+        sfb: cute.Tensor,
+        tile_idx_to_group_idx: cute.Tensor,
+        tile_idx_to_mn_limit: cute.Tensor,
+        num_non_exiting_tiles: cute.Tensor,
+        alpha: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        call_impl = self._call_sm103 if self.use_3x_mma else self._call_sm100
+        return call_impl(
+            a,
+            b,
+            c,
+            sfa,
+            sfb,
+            tile_idx_to_group_idx,
+            tile_idx_to_mn_limit,
+            num_non_exiting_tiles,
+            alpha,
+            max_active_clusters,
+            stream,
+            epilogue_op,
+        )
+
+    @staticmethod
+    def sm103_make_smem_layout_a(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: cute.Tile,
+        num_stages: int,
+    ) -> Union[cute.Layout, cute.ComposedLayout]:
+        is_k_major = tiled_mma.op.a_major_mode == OperandMajorMode.K
+        layout_atom = tcgen05.make_smem_layout_atom(
+            tcgen05.SmemLayoutAtomKind.K_SW128, cutlass.Uint8
+        )
+        stage_shape = (
+            (
+                mma_tiler_mnk[0] // cute.size(tiled_mma.thr_layout_vmnk.shape[0]),
+                16,
+            ),
+            1,
+            8,
+        )
+        return tcgen05.tile_to_mma_shape(
+            layout_atom,
+            cute.append(stage_shape, num_stages),
+            order=((1, 0, 2) if not is_k_major else (0, 1, 2)),
+        )
+
+    @staticmethod
+    def sm103_make_smem_layout_b(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: cute.Tile,
+        num_stages: int,
+    ) -> Union[cute.Layout, cute.ComposedLayout]:
+        is_k_major = tiled_mma.op.b_major_mode == OperandMajorMode.K
+        layout_atom = tcgen05.make_smem_layout_atom(
+            tcgen05.SmemLayoutAtomKind.K_SW128, cutlass.Uint8
+        )
+        stage_shape = (
+            (mma_tiler_mnk[1] // cute.size(tiled_mma.thr_id.shape), 16),
+            1,
+            8,
+        )
+        return tcgen05.tile_to_mma_shape(
+            layout_atom,
+            cute.append(stage_shape, num_stages),
+            order=((1, 0, 2) if not is_k_major else (0, 1, 2)),
+        )
+
+    @staticmethod
+    def append_coalesce_layout(layout: cute.Layout) -> cute.Layout:
+        part1 = cute.coalesce(cute.append(layout[0][0], layout[1]))
+        part2 = cute.coalesce(cute.append(layout[0][1], layout[2]))
+        result = cute.append(part1, part2)
+        result = cute.append(result, layout[3])
+        result = cute.append(result, layout[4])
+        return cute.append(result, layout[5])
+
+    @staticmethod
+    def adapt_layout_for_tma_ab(
+        composed_layout: cute.ComposedLayout,
+    ) -> cute.ComposedLayout:
+        layout = composed_layout.outer
+        part1 = cute.coalesce(cute.append(layout[0][0], layout[1]))
+        part2 = cute.coalesce(cute.append(layout[0][1], layout[2]))
+        result = cute.append(part1, cute.append(part2, layout[3]))
+        return cute.make_composed_layout(composed_layout.inner, composed_layout.offset, result)
+
+    @staticmethod
+    def adapt_layout_for_tma_sf(layout: cute.Layout) -> cute.Layout:
+        part1 = cute.coalesce(cute.append(layout[0][0], layout[1]))
+        part2 = cute.coalesce(cute.append(layout[0][1], layout[2]))
+        return cute.append(
+            cute.group_modes(part1, 0, cute.rank(part1)),
+            part2,
+        )
+
     def mainloop_s2t_copy_and_partition(
         self,
         sSF: cute.Tensor,
@@ -655,13 +1223,25 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         tCsSF_compact = cute.filter_zeros(sSF)
         # (MMA, MMA_MN, MMA_K)
         tCtSF_compact = cute.filter_zeros(tSF)
+        tCtSF_copy = tCtSF_compact
+        if cutlass.const_expr(self.use_3x_mma):
+            tCtSF_copy = cute.make_tensor(
+                tCtSF_compact.iterator,
+                cute.append(
+                    cute.append(
+                        tCtSF_compact[(None, 0, 0)].layout,
+                        cute.make_layout((1)),
+                    ),
+                    cute.make_layout(1),
+                ),
+            )
 
         # Make S2T CopyAtom and tiledCopy
         copy_atom_s2t = cute.make_copy_atom(
             tcgen05.Cp4x32x128bOp(self.cta_group),
             self.sf_dtype,
         )
-        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_copy)
         thr_copy_s2t = tiled_copy_s2t.get_slice(0)
 
         # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
@@ -672,6 +1252,1191 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
 
         return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    @staticmethod
+    def make_desc_and_call_mma(
+        tiled_mma: cute.TiledMma,
+        d: cute.Tensor,
+        sA_cur: cute.Tensor,
+        sA_next: cute.Tensor,
+        sfA: cute.Tensor,
+        sB_cur: cute.Tensor,
+        sB_next: cute.Tensor,
+        sfB: cute.Tensor,
+        c: cute.Tensor,
+    ) -> None:
+        a_desc = tcgen05.make_umma_smem_desc(
+            sA_cur.iterator,
+            sA_cur.layout,
+            "k" if tiled_mma.op.a_major_mode.name == "K" else "mn",
+            next_src=sA_next.iterator,
+        )
+        b_desc = tcgen05.make_umma_smem_desc(
+            sB_cur.iterator,
+            sB_cur.layout,
+            "k" if tiled_mma.op.b_major_mode.name == "K" else "mn",
+            next_src=sB_next.iterator,
+        )
+        view_layout = cute.make_layout(1, stride=0)
+        a_tensor = cute.make_tensor(a_desc, view_layout)
+        b_tensor = cute.make_tensor(b_desc, view_layout)
+        cute.mma_atom_call(tiled_mma, d, [a_tensor, sfA], [b_tensor, sfB], c)
+
+    @cute.kernel
+    def _kernel_sm103(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        tile_idx_to_group_idx: cute.Tensor,
+        num_non_exiting_tiles: cute.Tensor,
+        alpha: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        self._kernel_sm103_impl(
+            tiled_mma,
+            tma_atom_a,
+            mA_mkl,
+            tma_atom_b,
+            mB_nkl,
+            tma_atom_sfa,
+            mSFA_mkl,
+            tma_atom_sfb,
+            mSFB_nkl,
+            tma_atom_c,
+            mC_mnl,
+            tile_idx_to_group_idx,
+            tile_idx_to_group_idx,
+            num_non_exiting_tiles,
+            alpha,
+            cluster_layout_vmnk,
+            cluster_layout_sfb_vmnk,
+            a_smem_layout_staged,
+            b_smem_layout_staged,
+            sfa_smem_layout_staged,
+            sfb_smem_layout_staged,
+            c_smem_layout_staged,
+            epi_tile,
+            tile_sched_params,
+            epilogue_op,
+        )
+
+    @cute.kernel
+    def _kernel_sm103_predicated(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        tile_idx_to_group_idx: cute.Tensor,
+        tile_idx_to_mn_limit: cute.Tensor,
+        num_non_exiting_tiles: cute.Tensor,
+        alpha: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        self._kernel_sm103_impl(
+            tiled_mma,
+            tma_atom_a,
+            mA_mkl,
+            tma_atom_b,
+            mB_nkl,
+            tma_atom_sfa,
+            mSFA_mkl,
+            tma_atom_sfb,
+            mSFB_nkl,
+            tma_atom_c,
+            mC_mnl,
+            tile_idx_to_group_idx,
+            tile_idx_to_mn_limit,
+            num_non_exiting_tiles,
+            alpha,
+            cluster_layout_vmnk,
+            cluster_layout_sfb_vmnk,
+            a_smem_layout_staged,
+            b_smem_layout_staged,
+            sfa_smem_layout_staged,
+            sfb_smem_layout_staged,
+            c_smem_layout_staged,
+            epi_tile,
+            tile_sched_params,
+            epilogue_op,
+        )
+
+    @cute.jit
+    def _kernel_sm103_impl(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        tile_idx_to_group_idx: cute.Tensor,
+        tile_idx_to_mn_limit: cute.Tensor,
+        num_non_exiting_tiles: cute.Tensor,
+        alpha: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        if warp_idx == self.tma_ab_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            if cutlass.const_expr(not self.use_direct_store):
+                cpasync.prefetch_descriptor(tma_atom_c)
+        if warp_idx == self.tma_sf_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+        bidx, _, _ = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage_sm103)
+        # CUTLASS DSL 4.6 derives this from one Warp consumer when multicast
+        # signaling is enabled. Spell it out for compatibility with 4.5.
+        num_tma_consumer_threads = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, num_tma_consumer_threads
+            ),
+            tx_count=self.num_tma_load_bytes_ab,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        sf_producer, sf_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.sf_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_sf_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, num_tma_consumer_threads
+            ),
+            tx_count=self.num_tma_load_bytes_sf,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        num_acc_consumers = len(self.epilog_warp_id) * (2 if use_2cta_instrs else 1)
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, num_acc_consumers),
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+        tile_info_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.tile_info_mbar_ptr.data_ptr(),
+            num_stages=self.num_tile_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_warp),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_wo_sched),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+        )
+        pipeline_init_arrive(
+            cluster_shape_mn=self.cluster_shape_mn,
+            is_relaxed=True,
+        )
+        sC = None
+        if cutlass.const_expr(not self.use_direct_store):
+            sC = storage.sC.get_tensor(
+                c_smem_layout_staged.outer,
+                swizzle=c_smem_layout_staged.inner,
+            )
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer,
+            swizzle=b_smem_layout_staged.inner,
+        )
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+        sInfo = storage.sInfo.get_tensor(
+            cute.make_layout(
+                (self.num_tile_info_fields, self.num_tile_stage),
+                stride=(1, self.num_tile_info_fields),
+            )
+        )
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_sfb_vmnk,
+                block_in_cluster_coord_sfb_vmnk,
+                mcast_mode=1,
+            )
+        ab_tiler = (self.mma_tiler[0], self.mma_tiler[1], 384)
+        gA_mkl = cute.local_tile(
+            mA_mkl,
+            cute.slice_(ab_tiler, (None, 0, None)),
+            (None, None, None),
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl,
+            cute.slice_(ab_tiler, (0, None, None)),
+            (None, None, None),
+        )
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl,
+            cute.slice_(self.mma_sf_tiler, (None, 0, None)),
+            (None, None, None),
+        )
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            cute.slice_(self.mma_sf_tiler, (0, None, None)),
+            (None, None, None),
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl,
+            cute.slice_(self.mma_tiler, (None, None, 0)),
+            (None, None, None),
+        )
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        tCgA_tmp = thr_mma.partition_A(gA_mkl)
+        cta_tCgA = cute.make_tensor(
+            tCgA_tmp.iterator,
+            self.append_coalesce_layout(tCgA_tmp.layout),
+        )
+        tCgA = cute.make_tensor(
+            cta_tCgA.iterator,
+            cute.tiled_divide(
+                cta_tCgA.layout,
+                (cute.size(tiled_mma.tv_layout_A[1][0]), 128),
+            ),
+        )
+        tCgB_tmp = thr_mma.partition_B(gB_nkl)
+        cta_tCgB = cute.make_tensor(
+            tCgB_tmp.iterator,
+            self.append_coalesce_layout(tCgB_tmp.layout),
+        )
+        tCgB = cute.make_tensor(
+            cta_tCgB.iterator,
+            cute.tiled_divide(
+                cta_tCgB.layout,
+                (cute.size(tiled_mma.tv_layout_B[1][0]), 128),
+            ),
+        )
+        tCgSFA = cute.make_tensor(
+            gSFA_mkl.iterator,
+            cute.tiled_divide(
+                gSFA_mkl.layout,
+                (self.mma_sf_tiler[0], self.mma_sf_tiler[2]),
+            ),
+        )
+        tCgSFB = cute.make_tensor(
+            gSFB_nkl.iterator,
+            cute.tiled_divide(
+                gSFB_nkl.layout,
+                (self.mma_sf_tiler[1], self.mma_sf_tiler[2]),
+            ),
+        )
+        tCgC = thr_mma.partition_C(gC_mnl)
+        a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 1),
+        )
+        b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 1),
+        )
+        tAsSFA, tAgSFA = cpasync.tma_partition(
+            tma_atom_sfa,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sSFA, 0, 3),
+            cute.group_modes(tCgSFA, 0, 3),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        sfb_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+        )
+        tBsSFB, tBgSFB = cpasync.tma_partition(
+            tma_atom_sfb,
+            block_in_cluster_coord_sfb_vmnk[1],
+            sfb_cta_layout,
+            cute.group_modes(sSFB, 0, 3),
+            cute.group_modes(tCgSFB, 0, 3),
+        )
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        if cutlass.const_expr(self.overlapping_accum):
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, 2))
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        (self.cta_tile_shape_mnk[1] - self.num_sf_tmem_cols)
+                        * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+        else:
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, self.num_acc_stage))
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+        griddepcontrol_wait()
+
+        if warp_idx == self.sched_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_sched_warps)
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params,
+                cute.arch.block_idx(),
+                cute.arch.grid_dim(),
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+            tile_info_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer,
+                self.num_tile_stage,
+            )
+            num_valid_tiles = num_non_exiting_tiles[0]
+            is_continue = cutlass.Boolean(1)
+            while work_tile.is_valid_tile and is_continue:
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_m = cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape)
+                # Swizzling can pad the scheduler M extent, so guard metadata loads first.
+                if mma_tile_coord_m < num_valid_tiles:
+                    expert_idx = tile_idx_to_group_idx[mma_tile_coord_m]
+                    tile_info_pipeline.producer_acquire(tile_info_producer_state)
+                    with cute.arch.elect_one():
+                        sInfo[(0, tile_info_producer_state.index)] = cur_tile_coord[0]
+                        sInfo[(1, tile_info_producer_state.index)] = cur_tile_coord[1]
+                        sInfo[(2, tile_info_producer_state.index)] = expert_idx
+                        sInfo[(3, tile_info_producer_state.index)] = cutlass.Int32(1)
+                        if cutlass.const_expr(self.use_predicated_tail):
+                            sInfo[(4, tile_info_producer_state.index)] = tile_idx_to_mn_limit[
+                                mma_tile_coord_m
+                            ]
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.sched_sync_barrier.arrive_and_wait()
+                    tile_info_pipeline.producer_commit(tile_info_producer_state)
+                    tile_info_producer_state.advance()
+                elif cutlass.const_expr(
+                    not self.raster_along_m and self.scheduler_swizzle_size == 1
+                ):
+                    is_continue = cutlass.Boolean(0)
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+            tile_info_pipeline.producer_acquire(tile_info_producer_state)
+            with cute.arch.elect_one():
+                sInfo[(0, tile_info_producer_state.index)] = 0
+                sInfo[(1, tile_info_producer_state.index)] = 0
+                sInfo[(2, tile_info_producer_state.index)] = -1
+                sInfo[(3, tile_info_producer_state.index)] = 0
+                if cutlass.const_expr(self.use_predicated_tail):
+                    sInfo[(4, tile_info_producer_state.index)] = 0
+            cute.arch.fence_proxy("async.shared", space="cta")
+            self.sched_sync_barrier.arrive_and_wait()
+            tile_info_pipeline.producer_commit(tile_info_producer_state)
+            tile_info_producer_state.advance()
+            tile_info_pipeline.producer_tail(tile_info_producer_state)
+        if warp_idx == self.tma_ab_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_tile_stage,
+            )
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[3] == 1
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+            while is_valid_tile:
+                mma_tile_coord_mnl = (
+                    tile_info[0] // cute.size(tiled_mma.thr_id.shape),
+                    tile_info[1],
+                    tile_info[2],
+                )
+                tAgA_slice = tAgA[
+                    (
+                        None,
+                        None,
+                        None,
+                        mma_tile_coord_mnl[0],
+                        None,
+                        0,
+                    )
+                ]
+                tBgB_slice = tBgB[
+                    (
+                        None,
+                        None,
+                        None,
+                        mma_tile_coord_mnl[1],
+                        None,
+                        mma_tile_coord_mnl[2],
+                    )
+                ]
+                ab_producer.reset()
+                peek_ab_empty_status = ab_producer.try_acquire()
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    for buffer in cutlass.range(3, unroll_full=True):
+                        ab_empty = ab_producer.acquire_and_advance(peek_ab_empty_status)
+                        cute.copy(
+                            tma_atom_a,
+                            cute.group_modes(
+                                tAgA_slice[(None, None, buffer, k_tile)],
+                                0,
+                                2,
+                            ),
+                            tAsA[(None, ab_empty.index)],
+                            tma_bar_ptr=ab_empty.barrier,
+                            mcast_mask=a_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_b,
+                            cute.group_modes(
+                                tBgB_slice[(None, None, buffer, k_tile)],
+                                0,
+                                2,
+                            ),
+                            tBsB[(None, ab_empty.index)],
+                            tma_bar_ptr=ab_empty.barrier,
+                            mcast_mask=b_full_mcast_mask,
+                        )
+                        peek_ab_empty_status = cutlass.Boolean(1)
+                        if not (k_tile == k_tile_cnt - 1 and buffer == 2):
+                            peek_ab_empty_status = ab_producer.try_acquire()
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[3] == 1
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+            ab_producer.tail()
+        if warp_idx == self.tma_sf_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_tile_stage,
+            )
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[3] == 1
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+            while is_valid_tile:
+                tAgSFA_slice = tAgSFA[(None, tile_info[0], None, 0)]
+                tBgSFB_slice = tBgSFB[(None, tile_info[1], None, tile_info[2])]
+                sf_producer.reset()
+                peek_sf_empty_status = sf_producer.try_acquire()
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    for sf_stage in cutlass.range(
+                        self.sf_buffers_per_tile_k,
+                        unroll_full=True,
+                    ):
+                        sf_empty = sf_producer.acquire_and_advance(peek_sf_empty_status)
+                        sf_k = k_tile * self.sf_buffers_per_tile_k + sf_stage
+                        tAgSFA_compact = cute.filter_zeros(tAgSFA_slice[(None, sf_k)])
+                        tBgSFB_compact = cute.filter_zeros(tBgSFB_slice[(None, sf_k)])
+                        cute.copy(
+                            tma_atom_sfa,
+                            tAgSFA_compact,
+                            tAsSFA[(None, sf_empty.index)],
+                            tma_bar_ptr=sf_empty.barrier,
+                            mcast_mask=sfa_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_sfb,
+                            tBgSFB_compact,
+                            tBsSFB[(None, sf_empty.index)],
+                            tma_bar_ptr=sf_empty.barrier,
+                            mcast_mask=sfb_full_mcast_mask,
+                        )
+                        peek_sf_empty_status = cutlass.Boolean(1)
+                        if not (
+                            k_tile == k_tile_cnt - 1 and sf_stage == self.sf_buffers_per_tile_k - 1
+                        ):
+                            peek_sf_empty_status = sf_producer.try_acquire()
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[3] == 1
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+            sf_producer.tail()
+        if warp_idx == self.mma_warp_id:
+            if cutlass.const_expr(self.epilogue_tile_n_override == 64):
+                cute.arch.setmaxregister_increase(96)
+            else:
+                cute.arch.setmaxregister_increase(88)
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base),
+                dtype=self.sf_dtype,
+            )
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(
+                    sfa_smem_layout_staged,
+                    (None, None, None, 0),
+                ),
+            )
+            mn_basic_block = (32, 4)
+            k_basic_block = (self.sf_vec_size, 1)
+            sfa_iter_shape = (
+                (
+                    (
+                        mn_basic_block,
+                        self.cta_tile_shape_mnk[0] // 128,
+                    ),
+                    k_basic_block,
+                ),
+                1,
+                (self.cta_tile_shape_mnk[2] // 2) // self.sf_vec_size,
+            )
+            sfa_iter_layout = cute.make_layout(sfa_iter_shape)
+            tCtSFA_layout_mma = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                sfa_iter_layout,
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+            tCtSFA_mma = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout_mma)
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr
+                + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
+                + tcgen05.find_tmem_tensor_col_offset(tCtSFA),
+                dtype=self.sf_dtype,
+            )
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(
+                    sfb_smem_layout_staged,
+                    (None, None, None, 0),
+                ),
+            )
+            sfb_iter_shape = (
+                (
+                    (mn_basic_block, self.cta_n_sf // 128),
+                    k_basic_block,
+                ),
+                1,
+                (self.cta_tile_shape_mnk[2] // 2) // self.sf_vec_size,
+            )
+            sfb_iter_layout = cute.make_layout(sfb_iter_shape)
+            tCtSFB_layout_mma = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                sfb_iter_layout,
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+            tCtSFB_mma = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout_mma)
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer,
+                self.num_acc_stage,
+            )
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_tile_stage,
+            )
+            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(4, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[3] == 1
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+            mmas_per_sf_buffer = 8 // self.sf_buffers_per_tile_k
+            sf_stride = 6 if self.sf_vec_size == 16 else 3
+            while is_valid_tile:
+                # The single physical pipeline stage represents two partially
+                # overlapping logical accumulator buffers. The producer writes
+                # the phase opposite to the one currently owned by epilogue.
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+                tCtAcc = tCtAcc_base[(None, 0, 0, acc_stage_index)]
+                if cutlass.const_expr(not self.overlapping_accum):
+                    if is_leader_cta:
+                        acc_pipeline.producer_acquire(acc_producer_state)
+                ab_consumer.reset()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if is_leader_cta:
+                    peek_ab_full_status = ab_consumer.try_wait()
+                sf_consumer.reset()
+                peek_sf_full_status = cutlass.Boolean(1)
+                if is_leader_cta:
+                    peek_sf_full_status = sf_consumer.try_wait()
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                is_first_iteration = True
+                # Each K=768 tile is eight K=96 MMAs. Three circular AB
+                # buffers supply the descriptor sequence 0,3,6,1,4,7,2,5;
+                # four SF buffers are promoted to TMEM before MMA 0/2/4/6.
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    if is_leader_cta:
+                        sf_full = sf_consumer.wait_and_advance(peek_sf_full_status)
+                        sf_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            sf_full.index,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t[sf_stage_coord],
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t[sf_stage_coord],
+                            tCtSFB_compact_s2t,
+                        )
+                        sf_full.release()
+                        peek_sf_full_status = sf_consumer.try_wait()
+                        ab_full0 = ab_consumer.wait_and_advance(peek_ab_full_status)
+                        peek_ab_full_status = ab_consumer.try_wait()
+                        if is_first_iteration:
+                            # Overlap keeps this acquire after the first SF
+                            # promotion so epilogue can finish its TMEM loads.
+                            if cutlass.const_expr(self.overlapping_accum):
+                                acc_pipeline.producer_acquire(acc_producer_state)
+                            is_first_iteration = False
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[(None, 0, 0, ab_full0.index)],
+                            sA[(None, 0, 0, ab_full0.index)],
+                            tCtSFA_mma[(None, 0, 0)],
+                            sB[(None, 0, 0, ab_full0.index)],
+                            sB[(None, 0, 0, ab_full0.index)],
+                            tCtSFB_mma[(None, 0, 0)],
+                            tCtAcc,
+                        )
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                        sf_offset = (1 % mmas_per_sf_buffer) * sf_stride
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[(None, 0, 3, ab_full0.index)],
+                            sA[(None, 0, 0, ab_full0.index)],
+                            tCtSFA_mma[(None, 0, sf_offset)],
+                            sB[(None, 0, 3, ab_full0.index)],
+                            sB[(None, 0, 0, ab_full0.index)],
+                            tCtSFB_mma[(None, 0, sf_offset)],
+                            tCtAcc,
+                        )
+                        sf_full = sf_consumer.wait_and_advance(peek_sf_full_status)
+                        sf_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            sf_full.index,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t[sf_stage_coord],
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t[sf_stage_coord],
+                            tCtSFB_compact_s2t,
+                        )
+                        sf_full.release()
+                        peek_sf_full_status = sf_consumer.try_wait()
+                        ab_full1 = ab_consumer.wait_and_advance(peek_ab_full_status)
+                        peek_ab_full_status = ab_consumer.try_wait()
+                        sf_offset = (2 % mmas_per_sf_buffer) * sf_stride
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[(None, 0, 6, ab_full0.index)],
+                            sA[(None, 0, 0, ab_full1.index)],
+                            tCtSFA_mma[(None, 0, sf_offset)],
+                            sB[(None, 0, 6, ab_full0.index)],
+                            sB[(None, 0, 0, ab_full1.index)],
+                            tCtSFB_mma[(None, 0, sf_offset)],
+                            tCtAcc,
+                        )
+                        ab_full0.release()
+                        sf_offset = (3 % mmas_per_sf_buffer) * sf_stride
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[(None, 0, 1, ab_full1.index)],
+                            sA[(None, 0, 0, ab_full1.index)],
+                            tCtSFA_mma[(None, 0, sf_offset)],
+                            sB[(None, 0, 1, ab_full1.index)],
+                            sB[(None, 0, 0, ab_full1.index)],
+                            tCtSFB_mma[(None, 0, sf_offset)],
+                            tCtAcc,
+                        )
+                        sf_full = sf_consumer.wait_and_advance(peek_sf_full_status)
+                        sf_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            sf_full.index,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t[sf_stage_coord],
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t[sf_stage_coord],
+                            tCtSFB_compact_s2t,
+                        )
+                        sf_full.release()
+                        peek_sf_full_status = sf_consumer.try_wait()
+                        sf_offset = (4 % mmas_per_sf_buffer) * sf_stride
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[(None, 0, 4, ab_full1.index)],
+                            sA[(None, 0, 0, ab_full1.index)],
+                            tCtSFA_mma[(None, 0, sf_offset)],
+                            sB[(None, 0, 4, ab_full1.index)],
+                            sB[(None, 0, 0, ab_full1.index)],
+                            tCtSFB_mma[(None, 0, sf_offset)],
+                            tCtAcc,
+                        )
+                        ab_full2 = ab_consumer.wait_and_advance(peek_ab_full_status)
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        if k_tile + 1 < k_tile_cnt:
+                            peek_ab_full_status = ab_consumer.try_wait()
+                        sf_offset = (5 % mmas_per_sf_buffer) * sf_stride
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[(None, 0, 7, ab_full1.index)],
+                            sA[(None, 0, 0, ab_full2.index)],
+                            tCtSFA_mma[(None, 0, sf_offset)],
+                            sB[(None, 0, 7, ab_full1.index)],
+                            sB[(None, 0, 0, ab_full2.index)],
+                            tCtSFB_mma[(None, 0, sf_offset)],
+                            tCtAcc,
+                        )
+                        sf_full = sf_consumer.wait_and_advance(peek_sf_full_status)
+                        sf_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            sf_full.index,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t[sf_stage_coord],
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t[sf_stage_coord],
+                            tCtSFB_compact_s2t,
+                        )
+                        sf_full.release()
+                        peek_sf_full_status = cutlass.Boolean(1)
+                        if k_tile + 1 < k_tile_cnt:
+                            peek_sf_full_status = sf_consumer.try_wait()
+                        ab_full1.release()
+                        sf_offset = (6 % mmas_per_sf_buffer) * sf_stride
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[(None, 0, 2, ab_full2.index)],
+                            sA[(None, 0, 0, ab_full2.index)],
+                            tCtSFA_mma[(None, 0, sf_offset)],
+                            sB[(None, 0, 2, ab_full2.index)],
+                            sB[(None, 0, 0, ab_full2.index)],
+                            tCtSFB_mma[(None, 0, sf_offset)],
+                            tCtAcc,
+                        )
+                        sf_offset = (7 % mmas_per_sf_buffer) * sf_stride
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[(None, 0, 5, ab_full2.index)],
+                            sA[(None, 0, 0, ab_full2.index)],
+                            tCtSFA_mma[(None, 0, sf_offset)],
+                            sB[(None, 0, 5, ab_full2.index)],
+                            sB[(None, 0, 0, ab_full2.index)],
+                            tCtSFB_mma[(None, 0, sf_offset)],
+                            tCtAcc,
+                        )
+                        ab_full2.release()
+
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(4, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[3] == 1
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        if warp_idx < self.mma_warp_id:
+            if cutlass.const_expr(self.epilogue_tile_n_override == 64):
+                cute.arch.setmaxregister_increase(96)
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            epi_tidx = tidx % 128
+            if cutlass.const_expr(self.use_direct_store):
+                tCtAcc_epilogue = sm100_gemm_utils.transform_partitioned_tensor_layout(tCtAcc_base)
+                tCgC_epilogue = sm100_gemm_utils.transform_partitioned_tensor_layout(tCgC)
+            else:
+                tCtAcc_epilogue = tCtAcc_base
+                tCgC_epilogue = tCgC
+            if cutlass.const_expr(self.use_direct_store):
+                (
+                    tiled_copy_t2r,
+                    tTR_tAcc_base,
+                    tTR_rAcc,
+                ) = sm100_gemm_utils.epilogue_tmem_copy_and_partition(
+                    self,
+                    epi_tidx,
+                    tCtAcc_epilogue,
+                    tCgC_epilogue,
+                    epi_tile,
+                    use_2cta_instrs,
+                )
+            else:
+                (
+                    tiled_copy_t2r,
+                    tTR_tAcc_base,
+                    tTR_rAcc,
+                ) = self.epilog_tmem_copy_and_partition(
+                    epi_tidx,
+                    tCtAcc_epilogue,
+                    tCgC_epilogue,
+                    epi_tile,
+                    use_2cta_instrs,
+                )
+
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            if cutlass.const_expr(self.use_direct_store):
+                (
+                    copy_atom_r2g,
+                    tTR_rC,
+                    tTR_gC_partitioned,
+                ) = self.epilog_gmem_direct_copy_and_partition(
+                    tiled_copy_t2r,
+                    tTR_rC,
+                    epi_tidx,
+                    tCgC_epilogue,
+                    epi_tile,
+                )
+            else:
+                (
+                    tiled_copy_r2s,
+                    tRS_rC,
+                    tRS_sC,
+                ) = self.epilog_smem_copy_and_partition(
+                    tiled_copy_t2r,
+                    tTR_rC,
+                    epi_tidx,
+                    sC,
+                )
+                (
+                    tma_atom_c,
+                    bSG_sC,
+                    bSG_gC_partitioned,
+                ) = self.epilog_gmem_copy_and_partition(
+                    epi_tidx,
+                    tma_atom_c,
+                    tCgC,
+                    epi_tile,
+                    sC,
+                )
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_acc_stage,
+            )
+            if cutlass.const_expr(not self.use_direct_store):
+                c_producer_group = pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread,
+                    32 * len(self.epilog_warp_id),
+                )
+                c_pipeline = pipeline.PipelineTmaStore.create(
+                    num_stages=self.num_c_stage,
+                    producer_group=c_producer_group,
+                )
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_tile_stage,
+            )
+            tile_info = cute.make_rmem_tensor((self.num_tile_info_fields,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(self.num_tile_info_fields, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[3] == 1
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            num_prev_subtiles = cutlass.Int32(0)
+
+            while is_valid_tile:
+                mma_tile_coord_mnl = (
+                    tile_info[0] // cute.size(tiled_mma.thr_id.shape),
+                    tile_info[1],
+                    tile_info[2],
+                )
+                expert_idx = mma_tile_coord_mnl[2]
+                alpha_val = alpha[expert_idx]
+
+                if cutlass.const_expr(self.use_direct_store):
+                    tTR_gC = tTR_gC_partitioned[
+                        (
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            mma_tile_coord_mnl[0],
+                            mma_tile_coord_mnl[1],
+                            0,
+                        )
+                    ]
+                else:
+                    bSG_gC = bSG_gC_partitioned[
+                        (
+                            None,
+                            None,
+                            None,
+                            mma_tile_coord_mnl[0],
+                            mma_tile_coord_mnl[1],
+                            0,
+                        )
+                    ]
+
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_consumer_state.phase
+                    reverse_subtile = (
+                        cutlass.Boolean(True) if acc_stage_index == 0 else cutlass.Boolean(False)
+                    )
+                else:
+                    acc_stage_index = acc_consumer_state.index
+
+                tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_stage_index)]
+                acc_pipeline.consumer_wait(acc_consumer_state)
+
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                if cutlass.const_expr(self.use_direct_store):
+                    tTR_gC = cute.group_modes(tTR_gC, 3, cute.rank(tTR_gC))
+                else:
+                    bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+
+                for subtile_idx in cutlass.range(subtile_cnt):
+                    real_subtile_idx = subtile_idx
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if reverse_subtile:
+                            real_subtile_idx = (
+                                self.cta_tile_shape_mnk[1] // self.epi_tile_n - 1 - subtile_idx
+                            )
+
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                    cute.copy(
+                        tiled_copy_t2r,
+                        tTR_tAcc_mn,
+                        tTR_rAcc,
+                    )
+
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if subtile_idx == self.iter_acc_early_release_in_epilogue:
+                            cute.arch.fence_view_async_tmem_load()
+                            with cute.arch.elect_one():
+                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_consumer_state.advance()
+                    elif cutlass.const_expr(self.use_direct_store):
+                        if subtile_idx == subtile_cnt - 1:
+                            with cute.arch.elect_one():
+                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_consumer_state.advance()
+
+                    if cutlass.const_expr(self.use_direct_store):
+                        acc_vec = tTR_rAcc.load()
+                        acc_vec = epilogue_op((alpha_val * acc_vec).to(self.c_dtype))
+                        tTR_rC.store(acc_vec)
+                        if cutlass.const_expr(self.use_predicated_tail):
+                            if tile_info[0] * self.cta_tile_shape_mnk[0] + epi_tidx < tile_info[4]:
+                                cute.copy(
+                                    copy_atom_r2g,
+                                    tTR_rC,
+                                    tTR_gC[(None, None, None, real_subtile_idx)],
+                                )
+                        else:
+                            cute.copy(
+                                copy_atom_r2g,
+                                tTR_rC,
+                                tTR_gC[(None, None, None, real_subtile_idx)],
+                            )
+                    else:
+                        acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+                        acc_vec = epilogue_op((alpha_val * acc_vec).to(self.c_dtype))
+                        tRS_rC.store(acc_vec)
+
+                        num_prev_subtiles = num_prev_subtiles + 1
+                        c_buffer = num_prev_subtiles % self.num_c_stage
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rC,
+                            tRS_sC[(None, None, None, c_buffer)],
+                        )
+                        cute.arch.fence_proxy(
+                            "async.shared",
+                            space="cta",
+                        )
+                        self.epilog_sync_barrier.arrive_and_wait()
+                        if warp_idx == self.epilog_warp_id[0]:
+                            cute.copy(
+                                tma_atom_c,
+                                bSG_sC[(None, c_buffer)],
+                                bSG_gC[(None, real_subtile_idx)],
+                            )
+                            c_pipeline.producer_commit()
+                            c_pipeline.producer_acquire()
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                if cutlass.const_expr(not self.overlapping_accum and not self.use_direct_store):
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(self.num_tile_info_fields, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[3] == 1
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+
+            tmem.relinquish_alloc_permit()
+            self.epilog_sync_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+            if cutlass.const_expr(not self.use_direct_store):
+                c_pipeline.producer_tail()
+
+        griddepcontrol_launch_dependents()
 
     # GPU device kernel
     @cute.kernel
@@ -706,6 +2471,7 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         """
         GPU device kernel performing the Persistent batched GEMM computation.
         """
+
         warp_idx = cute.arch.warp_idx()
         warp_idx = cute.arch.make_warp_uniform(warp_idx)
 
@@ -1013,10 +2779,11 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
                     cur_tile_coord = work_tile.tile_idx
                     mma_tile_coord_m = cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape)
 
-                    expert_idx = tile_idx_to_group_idx[mma_tile_coord_m]
                     tile_idx = mma_tile_coord_m
 
+                    # Swizzling can pad the scheduler M extent, so guard metadata loads first.
                     if tile_idx < num_valid_tiles:
+                        expert_idx = tile_idx_to_group_idx[mma_tile_coord_m]
                         tile_info_pipeline.producer_acquire(tile_info_producer_state)
                         with cute.arch.elect_one():
                             sInfo[(0, tile_info_producer_state.index)] = cur_tile_coord[0]
@@ -1043,10 +2810,11 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
                     cur_tile_coord = work_tile.tile_idx
                     mma_tile_coord_m = cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape)
 
-                    expert_idx = tile_idx_to_group_idx[mma_tile_coord_m]
                     tile_idx = mma_tile_coord_m
 
+                    # Swizzling can pad the scheduler M extent, so guard metadata loads first.
                     if tile_idx < num_valid_tiles:
+                        expert_idx = tile_idx_to_group_idx[mma_tile_coord_m]
                         tile_info_pipeline.producer_acquire(tile_info_producer_state)
                         with cute.arch.elect_one():
                             sInfo[(0, tile_info_producer_state.index)] = cur_tile_coord[0]
@@ -1065,7 +2833,7 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
                         tile_info_pipeline.producer_commit(tile_info_producer_state)
                         tile_info_producer_state.advance()
 
-                    else:
+                    elif cutlass.const_expr(self.scheduler_swizzle_size == 1):
                         is_continue = cutlass.Boolean(0)
 
                     tile_sched.advance_to_next_work()
@@ -1817,6 +3585,39 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         tRS_rC = tiled_copy_r2s.retile(tTR_rC)
         return tiled_copy_r2s, tRS_rC, tRS_sC
 
+    def epilog_gmem_direct_copy_and_partition(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rC: cute.Tensor,
+        tidx: cutlass.Int32,
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+    ) -> Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]:
+        """Partition a 256-bit register-to-global epilogue store."""
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        gC_mnl_epi = cute.flat_divide(gC_mnl, epi_tile)
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        mcl_c = cute.max_common_layout(
+            tTR_rC.layout,
+            tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].layout,
+        )
+        num_bits_per_copy = min(
+            self.c_alignment * 8,
+            cute.size(mcl_c) * self.c_dtype.width,
+            256,
+        )
+        if num_bits_per_copy != 256:
+            raise ValueError(
+                f"Direct BF16 output requires a 256-bit common layout, got {num_bits_per_copy}"
+            )
+        copy_atom_r2g = cute.make_copy_atom(
+            cute.nvgpu.CopyR2GOp(),
+            self.c_dtype,
+            num_bits_per_copy=num_bits_per_copy,
+            l1c_evict_priority=CacheEvictionPriority.NO_ALLOCATE,
+        )
+        return copy_atom_r2g, tTR_rC, tTR_gC
+
     def epilog_gmem_copy_and_partition(
         self,
         tidx: cutlass.Int32,
@@ -1986,12 +3787,82 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         return num_acc_stage, num_ab_stage, num_c_stage, num_tile_stage
 
     @staticmethod
+    def _compute_stages_sm103(
+        tiled_mma: cute.TiledMma,
+        mma_tiler: Tuple[int, int, int],
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        smem_capacity: int,
+        occupancy: int,
+        use_tma_store: bool,
+    ) -> Tuple[int, int, int, int]:
+        num_acc_stage = 1 if mma_tiler[1] == 256 else 2
+        num_c_stage = 2 if use_tma_store else 0
+        a_layout = Sm100BlockScaledContiguousGroupedGemmKernel.sm103_make_smem_layout_a(
+            tiled_mma,
+            mma_tiler,
+            1,
+        )
+        b_layout = Sm100BlockScaledContiguousGroupedGemmKernel.sm103_make_smem_layout_b(
+            tiled_mma,
+            mma_tiler,
+            1,
+        )
+        sfa_layout = blockscaled_utils.sm103_make_smem_layout_sfa(
+            tiled_mma,
+            mma_tiler,
+            sf_vec_size,
+            1,
+        )
+        sfb_layout = blockscaled_utils.sm103_make_smem_layout_sfb(
+            tiled_mma,
+            mma_tiler,
+            sf_vec_size,
+            1,
+        )
+        c_layout_stage = sm100_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            1,
+        )
+        ab_bytes_per_stage = cute.size_in_bytes(cutlass.Uint8, a_layout) + cute.size_in_bytes(
+            cutlass.Uint8, b_layout
+        )
+        sf_bytes_per_stage = cute.size_in_bytes(sf_dtype, sfa_layout) + cute.size_in_bytes(
+            sf_dtype, sfb_layout
+        )
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_layout_stage)
+        c_bytes = c_bytes_per_stage * num_c_stage
+        mbar_helpers_bytes = 1024
+        num_ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + sf_bytes_per_stage + c_bytes)
+        ) // ab_bytes_per_stage
+        num_sf_stage = (
+            smem_capacity
+            - occupancy * ab_bytes_per_stage * num_ab_stage
+            - occupancy * (mbar_helpers_bytes + c_bytes)
+        ) // (occupancy * sf_bytes_per_stage)
+        if use_tma_store:
+            num_c_stage += (
+                smem_capacity
+                - occupancy * ab_bytes_per_stage * num_ab_stage
+                - occupancy * sf_bytes_per_stage * num_sf_stage
+                - occupancy * (mbar_helpers_bytes + c_bytes)
+            ) // (occupancy * c_bytes_per_stage)
+        return num_acc_stage, num_ab_stage, num_sf_stage, num_c_stage
+
+    @staticmethod
     def _compute_grid(
         c: cute.Tensor,
         cta_tile_shape_mnk: Tuple[int, int, int],
         cluster_shape_mn: Tuple[int, int],
         max_active_clusters: cutlass.Constexpr,
         raster_along_m: bool = False,
+        swizzle_size: int = 1,
     ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
         """Use persistent tile scheduler to compute the grid size for the output tensor C.
 
@@ -2017,7 +3888,10 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         cluster_shape_mnl = (*cluster_shape_mn, 1)
 
         tile_sched_params = utils.PersistentTileSchedulerParams(
-            num_ctas_mnl, cluster_shape_mnl, raster_along_m=raster_along_m
+            num_ctas_mnl,
+            cluster_shape_mnl,
+            swizzle_size=swizzle_size,
+            raster_along_m=raster_along_m,
         )
         grid = utils.StaticPersistentTileScheduler.get_grid_shape(
             tile_sched_params, max_active_clusters
@@ -2330,6 +4204,11 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
         stream: cuda.CUstream,
         epilogue_op: cutlass.Constexpr = lambda x: x,
     ):
+        if cutlass.const_expr(self.use_3x_mma and self.direct_store_requested):
+            n = cute.assume(
+                n,
+                divby=self.mma_tiler[1] * self.cluster_shape_mn[1],
+            )
         scale_k = k // scaling_vector_size
         num_tiles = m // tile_size
         a = cute.make_tensor(a_ptr, layout=cute.make_ordered_layout((m, k, 1), order=(1, 0, 2)))
@@ -2361,6 +4240,93 @@ class Sm100BlockScaledContiguousGroupedGemmKernel:
             a_sf,
             b_sf,
             tile_idx_to_group_idx,
+            tile_idx_to_group_idx,
+            num_non_exiting_tiles,
+            alpha,
+            max_active_clusters=max_active_clusters,
+            stream=stream,
+            epilogue_op=epilogue_op,
+        )
+
+    @cute.jit
+    def wrapper_predicated(
+        self,
+        a_ptr: cute.Pointer,
+        b_ptr: cute.Pointer,
+        a_sf_ptr: cute.Pointer,
+        b_sf_ptr: cute.Pointer,
+        c_ptr: cute.Pointer,
+        alpha_ptr: cute.Pointer,
+        tile_idx_to_group_idx_ptr: cute.Pointer,
+        tile_idx_to_mn_limit_ptr: cute.Pointer,
+        num_non_exiting_tiles_ptr: cute.Pointer,
+        m: cutlass.Int64,
+        n: cutlass.Int64,
+        k: cutlass.Int64,
+        l: cutlass.Int64,  # noqa: E741
+        tile_size: cutlass.Constexpr,
+        scaling_vector_size: cutlass.Constexpr,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Launch the grouped GEMM with per-tile expert row limits."""
+        if cutlass.const_expr(not self.predicated_tail_requested):
+            raise ValueError("wrapper_predicated requires use_predicated_tail=True")
+        if cutlass.const_expr(self.use_3x_mma and self.direct_store_requested):
+            n = cute.assume(
+                n,
+                divby=self.mma_tiler[1] * self.cluster_shape_mn[1],
+            )
+        scale_k = k // scaling_vector_size
+        num_tiles = m // tile_size
+        a = cute.make_tensor(
+            a_ptr,
+            layout=cute.make_ordered_layout((m, k, 1), order=(1, 0, 2)),
+        )
+        b = cute.make_tensor(
+            b_ptr,
+            layout=cute.make_ordered_layout((n, k, l), order=(1, 0, 2)),
+        )
+        a_sf = cute.make_tensor(
+            a_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, m // 128, 4, scale_k // 4, 1),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+        b_sf = cute.make_tensor(
+            b_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, n // 128, 4, scale_k // 4, l),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+        c = cute.make_tensor(
+            c_ptr,
+            layout=cute.make_ordered_layout((m, n, 1), order=(1, 0, 2)),
+        )
+        alpha = cute.make_tensor(alpha_ptr, layout=cute.make_layout((l,)))
+        tile_idx_to_group_idx = cute.make_tensor(
+            tile_idx_to_group_idx_ptr,
+            layout=cute.make_layout((num_tiles,)),
+        )
+        tile_idx_to_mn_limit = cute.make_tensor(
+            tile_idx_to_mn_limit_ptr,
+            layout=cute.make_layout((num_tiles,)),
+        )
+        num_non_exiting_tiles = cute.make_tensor(
+            num_non_exiting_tiles_ptr,
+            layout=cute.make_layout((1,)),
+        )
+        return self(
+            a,
+            b,
+            c,
+            a_sf,
+            b_sf,
+            tile_idx_to_group_idx,
+            tile_idx_to_mn_limit,
             num_non_exiting_tiles,
             alpha,
             max_active_clusters=max_active_clusters,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
@@ -695,6 +695,7 @@ class CuteDslFusedMoE(CutlassFusedMoE):
                 weight_scale=weight_view.fc2_weight_scale.view(torch.uint8),
                 alpha=weight_view.fc2_global_scale,
                 tile_idx_to_group_idx=tile_idx_to_expert_idx,
+                tile_idx_to_mn_limit=tile_idx_to_mn_limit,
                 num_non_exiting_tiles=num_non_exiting_tiles,
                 num_experts=self.num_slots,
                 top_k=effective_top_k,

--- a/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm.py
+++ b/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without
@@ -42,7 +42,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Tuple, Type
+from typing import Optional, Tuple, Type
 
 import cutlass
 import cutlass.cute as cute
@@ -235,6 +235,7 @@ def create_tensors(
     mma_tiler_mn,
     permuted_m=None,
     swap_ab=False,
+    use_direct_store=False,
 ):
     """Create tensors for contiguous grouped GEMM.
 
@@ -275,8 +276,12 @@ def create_tensors(
     b_tensor, b_torch_gpu = cutlass_torch.cute_tensor_like(
         b_torch_cpu, ab_dtype, is_dynamic_layout=True, assumed_align=16
     )
+    c_assumed_align = 32 if use_direct_store else 16
     c_tensor, c_torch_gpu = cutlass_torch.cute_tensor_like(
-        c_torch_cpu, c_dtype, is_dynamic_layout=True, assumed_align=16
+        c_torch_cpu,
+        c_dtype,
+        is_dynamic_layout=True,
+        assumed_align=c_assumed_align,
     )
 
     # Mark tensor with element divisibility for 16B alignment
@@ -293,7 +298,7 @@ def create_tensors(
     c_tensor.mark_compact_shape_dynamic(
         mode=1 if cd_major == "n" else 0,
         stride_order=(2, 0, 1) if cd_major == "n" else (2, 1, 0),
-        divisibility=32 if ab_dtype == cutlass.Float4E2M1FN else 16,
+        divisibility=(n if use_direct_store else (32 if ab_dtype == cutlass.Float4E2M1FN else 16)),
     )
 
     tile_idx_to_expert_idx = from_dlpack(_tile_idx_to_expert_idx).mark_layout_dynamic()
@@ -346,6 +351,8 @@ def run(
     permuted_m: int = None,
     use_cupti: bool = False,
     raster_along_m: bool = False,
+    use_direct_store: bool = False,
+    epilogue_tile_n: Optional[int] = None,
     **kwargs,
 ):
     """Prepare A/B/C tensors, launch GPU kernel, and reference checking."""
@@ -368,9 +375,20 @@ def run(
     print(f"Skip reference checking: {skip_ref_check}")
     print(f"Use CUPTI: {'True' if use_cupti else 'False'}")
     print(f"Raster along M: {raster_along_m}")
+    print(f"Epilogue tile N: {epilogue_tile_n or 'auto'}")
 
     # Unpack parameters
     n, k, l = nkl  # noqa: E741
+    direct_store_requested = use_direct_store
+    use_direct_store = (
+        direct_store_requested
+        and c_dtype is cutlass.BFloat16
+        and c_major == "n"
+        and n % (mma_tiler_mn[1] * cluster_shape_mn[1]) == 0
+    )
+    print(f"Use direct store: {use_direct_store}")
+    if direct_store_requested and not use_direct_store:
+        print("Direct store requirements are not met; using the TMA store fallback")
 
     if not torch.cuda.is_available():
         raise RuntimeError("GPU is required to run this example!")
@@ -433,13 +451,18 @@ def run(
         sf_vec_size,
         mma_tiler_mn,
         permuted_m,
+        use_direct_store=use_direct_store,
     )
+    # This runner uses the non-predicated path, which does not consume row limits.
+    tile_idx_to_mn_limit = tile_idx_to_expert_idx
     # Configure gemm kernel
     gemm = Sm100BlockScaledContiguousGroupedGemmKernel(
         sf_vec_size,
         mma_tiler_mn,
         cluster_shape_mn,
         raster_along_m=raster_along_m,
+        use_direct_store=use_direct_store,
+        epilogue_tile_n=epilogue_tile_n,
     )
 
     # Compute max active clusters on current device
@@ -458,6 +481,7 @@ def run(
         sfa_tensor,
         sfb_tensor,
         tile_idx_to_expert_idx,
+        tile_idx_to_mn_limit,
         num_non_exiting_tiles,
         alpha,
         max_active_clusters,
@@ -474,6 +498,7 @@ def run(
             sfa_tensor,
             sfb_tensor,
             tile_idx_to_expert_idx,
+            tile_idx_to_mn_limit,
             num_non_exiting_tiles,
             alpha,
             current_stream,
@@ -576,7 +601,9 @@ def run(
             sf_vec_size,
             mma_tiler_mn,  # cta_tile_m
             permuted_m,
+            use_direct_store=use_direct_store,
         )
+        tile_idx_to_mn_limit = tile_idx_to_expert_idx
         return cute.testing.JitArguments(
             a_tensor,
             b_tensor,
@@ -584,6 +611,7 @@ def run(
             sfa_tensor,
             sfb_tensor,
             tile_idx_to_expert_idx,
+            tile_idx_to_mn_limit,
             num_non_exiting_tiles,
             alpha,
             current_stream,
@@ -797,6 +825,19 @@ if __name__ == "__main__":
         default=False,
         help="Raster along M dimension for tile scheduler",
     )
+    parser.add_argument(
+        "--use_direct_store",
+        action="store_true",
+        default=False,
+        help="Use the aligned SM103 BF16 256-bit register-to-global epilogue.",
+    )
+    parser.add_argument(
+        "--epilogue_tile_n",
+        type=int,
+        choices=(32, 64),
+        default=None,
+        help="Override the SM103 epilogue tile N dimension.",
+    )
     args = parser.parse_args()
 
     # Process arguments to generate nkl and group_m_list
@@ -835,6 +876,8 @@ if __name__ == "__main__":
         args.permuted_m,
         args.use_cupti,
         args.raster_along_m,
+        args.use_direct_store,
+        args.epilogue_tile_n,
     )
     print("exec_time: ", exec_time)
     print("PASS")

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from utils.util import check_accuracy
@@ -445,14 +448,25 @@ def test_nvfp4_grouped_gemm_blackwell(num_tokens: int, top_k: int, ep_size: int,
 
     num_non_exiting_tiles = torch.tensor([num_valid_tiles], dtype=torch.int32, device="cuda")
     tile_idx_to_group_idx = torch.empty(max_num_tiles, dtype=torch.int32)
+    tile_idx_to_mn_limit = torch.empty(max_num_tiles, dtype=torch.int32)
+    valid_row_mask = torch.zeros(max_num_permuted_tokens, dtype=torch.bool)
     # Note: Fill -2e9 for invalid tiles.
     tile_idx_to_group_idx.fill_(-2e9)
+    tile_idx_to_mn_limit.fill_(-2e9)
     tile_idx = 0
+    permuted_row = 0
     for expert_idx in range(num_local_experts):
+        expert_m = num_tokens_per_expert[expert_idx].item()
+        expert_m_limit = permuted_row + expert_m
+        valid_row_mask[permuted_row:expert_m_limit] = True
         for i in range(num_tiles_per_expert[expert_idx].item()):
             tile_idx_to_group_idx[tile_idx] = expert_idx
+            tile_idx_to_mn_limit[tile_idx] = expert_m_limit
             tile_idx += 1
+        permuted_row += num_tiles_per_expert[expert_idx].item() * tile_size
     tile_idx_to_group_idx = tile_idx_to_group_idx.cuda()
+    tile_idx_to_mn_limit = tile_idx_to_mn_limit.cuda()
+    valid_row_mask = valid_row_mask.cuda()
 
     a = torch.randint(
         -5, 5, (max_num_permuted_tokens, hidden_size), dtype=torch.int32, device="cuda"
@@ -481,6 +495,7 @@ def test_nvfp4_grouped_gemm_blackwell(num_tokens: int, top_k: int, ep_size: int,
         b_sf,
         alpha,
         tile_idx_to_group_idx,
+        tile_idx_to_mn_limit,
         num_non_exiting_tiles,
         num_experts=num_experts,
         top_k=top_k,
@@ -502,7 +517,7 @@ def test_nvfp4_grouped_gemm_blackwell(num_tokens: int, top_k: int, ep_size: int,
         output_dtype=torch.bfloat16,
         scaling_vector_size=sf_vec_size,
     )
-    torch.testing.assert_close(c[:num_valid_permuted_tokens], c_ref[:num_valid_permuted_tokens])
+    torch.testing.assert_close(c[valid_row_mask], c_ref[valid_row_mask])
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
 ### Modifications

  1. Added an SM103-native NVFP4 mainloop using K=96 3x-NVFP4 MMA instructions and a K=768 mainloop tile.
  2. Split A/B and scale-factor transfers into independent producer warps and pipelines, and added aligned BF16 direct stores plus padding-aware predicated tail stores.
  3. Integrated SM103 tactics into the grouped-GEMM and MoE paths, including row-limit metadata, autotuning candidates, runtime guards, and compilation cache keys.
  4. Updated the standalone runner and fused-MoE tests to cover direct stores, row limits, alignment requirements, fallback behavior, and valid-token comparisons.

  ### Performance

  B300/SM103, E=128, uniform expert splits, 10 warmups, 30 CUDA-event measurements:
| Projection | M | K | N | Baseline | Optimized | Speedup |
|---|---|---|---|---|---|---|
| Gate/up | 111600 | 6144 | 4608 | 1.227 ms | 1.096 ms | 11.94% |
| Gate/up | 219600 | 6144 | 4608 | 2.047 ms | 1.800 ms | 13.72% |
| Gate/up | 327600 | 6144 | 4608 | 2.844 ms | 2.516 ms | 13.06% |
| Gate/up | 370800 | 6144 | 4608 | 3.430 ms | 2.987 ms | 14.83% |
| Gate/up | 392400 | 6144 | 4608 | 3.418 ms | 2.989 ms | 14.36% |
| Gate/up | 414000 | 6144 | 4608 | 3.670 ms | 3.225 ms | 13.78% |
| Down | 111600 | 2304 | 6144 | 0.768 ms | 0.685 ms | 12.06% |
| Down | 219600 | 2304 | 6144 | 1.208 ms | 1.119 ms | 7.97% |
| Down | 327600 | 2304 | 6144 | 1.655 ms | 1.543 ms | 7.21% |
| Down | 370800 | 2304 | 6144 | 1.945 ms | 1.814 ms | 7.19% |
| Down | 392400 | 2304 | 6144 | 1.946 ms | 1.808 ms | 7.60% |
| Down | 414000 | 2304 | 6144 | 2.109 ms | 1.963 ms | 7.47% |

  Geometric-mean throughput improvement:

  - Gate/up: 13.61%
  - Down: 8.23%
  - Overall: 10.89%
  - TMA-only path: 7.77%

  These are standalone grouped-GEMM kernel results and exclude routing, quantization, dispatch, and end-to-end MoE overhead.

### Acknowledgement
We would like to thank Baole (baole.abl@alibaba-inc.com), Jiayi Ren (renjiayi@alibaba-inc.com), and Xiangmin Guo (guoxiangmin.gxm@alibaba-inc.com) from Alibaba for testing NVFP4 Grouped GEMM and helping identify the performance issue.