### PR TITLE
[None][chore] Give MLA model-owned aux streams via aux_stream_dict

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -752,7 +752,8 @@ class DeepseekV3Attention(MLA):
         self,
         model_config: ModelConfig[PretrainedConfig],
         layer_idx: Optional[int] = None,
-        aux_stream: Optional[torch.cuda.Stream] = None,
+        aux_stream_dict: Optional[Dict[AuxStreamType,
+                                       torch.cuda.Stream]] = None,
         mapping_with_cp: Optional[Mapping] = None,
         reduce_output: bool = True,
     ):
@@ -777,7 +778,7 @@ class DeepseekV3Attention(MLA):
                          layer_idx=layer_idx,
                          dtype=config.torch_dtype,
                          config=model_config,
-                         aux_stream=aux_stream,
+                         aux_stream_dict=aux_stream_dict,
                          mapping_with_cp=mapping_with_cp,
                          reduce_output=reduce_output)
         self.kv_a_proj_with_mqa = DeepseekV3Linear(
@@ -801,7 +802,8 @@ class DeepseekV32Attention(MLA):
         self,
         model_config: ModelConfig[PretrainedConfig],
         layer_idx: Optional[int] = None,
-        aux_stream: Optional[torch.cuda.Stream] = None,
+        aux_stream_dict: Optional[Dict[AuxStreamType,
+                                       torch.cuda.Stream]] = None,
         mapping_with_cp: Optional[Mapping] = None,
         reduce_output: bool = True,
     ):
@@ -827,7 +829,7 @@ class DeepseekV32Attention(MLA):
                          layer_idx=layer_idx,
                          dtype=config.torch_dtype,
                          config=model_config,
-                         aux_stream=aux_stream,
+                         aux_stream_dict=aux_stream_dict,
                          mapping_with_cp=mapping_with_cp,
                          reduce_output=reduce_output)
 
@@ -1274,14 +1276,14 @@ class DeepseekV3DecoderLayer(DecoderLayer):
             self.self_attn = DeepseekV32Attention(
                 model_config,
                 layer_idx=layer_idx_for_attention,
-                aux_stream=aux_stream_dict[AuxStreamType.Attention],
+                aux_stream_dict=aux_stream_dict,
                 mapping_with_cp=mapping_with_cp,
                 reduce_output=needs_tp_reduce or needs_cp_reduce)
         else:
             self.self_attn = DeepseekV3Attention(
                 model_config,
                 layer_idx=layer_idx_for_attention,
-                aux_stream=aux_stream_dict[AuxStreamType.Attention],
+                aux_stream_dict=aux_stream_dict,
                 mapping_with_cp=mapping_with_cp,
                 reduce_output=needs_tp_reduce or needs_cp_reduce)
 

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -1316,7 +1316,7 @@ class DeepseekV4Attention(MLA):
         self,
         model_config: ModelConfig[PretrainedConfig],
         layer_idx: Optional[int] = None,
-        aux_stream: Optional[torch.cuda.Stream] = None,
+        aux_stream_dict: Optional[Dict[AuxStreamType, torch.cuda.Stream]] = None,
         mapping_with_cp: Optional[Mapping] = None,
         reduce_output: bool = True,
     ):
@@ -1348,7 +1348,7 @@ class DeepseekV4Attention(MLA):
             layer_idx=layer_idx,
             dtype=config.torch_dtype,
             config=model_config,
-            aux_stream=aux_stream,
+            aux_stream_dict=aux_stream_dict,
             num_groups=config.o_groups,
             o_lora_rank=config.o_lora_rank,
             mapping_with_cp=mapping_with_cp,
@@ -1783,7 +1783,7 @@ class DeepseekV4DecoderLayer(DecoderLayer):
         self.self_attn = DeepseekV4Attention(
             model_config,
             layer_idx=attention_layer_idx,
-            aux_stream=aux_stream_dict[AuxStreamType.Attention],
+            aux_stream_dict=aux_stream_dict,
             reduce_output=not self.enable_attention_dp and self.mapping.tp_size > 1,
         )
 
@@ -2355,6 +2355,9 @@ class DeepseekV4Model(DecoderModel):
         self.vocab_size = config.vocab_size
         self.num_hidden_layers = config.num_hidden_layers
         self.hc_mult = config.hc_mult
+        # Attention-phase and MoE-phase lanes are sequential within a layer, so the
+        # Mla* roles reuse the Moe* slots. Engram keeps its own: it precomputes
+        # across the layer rather than inside the MoE phase.
         aux_stream_list = [torch.cuda.Stream() for _ in range(5)]
         self.aux_stream_dict = {
             AuxStreamType.Attention: aux_stream_list[0],
@@ -2363,6 +2366,9 @@ class DeepseekV4Model(DecoderModel):
             AuxStreamType.MoeBalancer: aux_stream_list[2],
             AuxStreamType.MoeOutputMemset: aux_stream_list[3],
             AuxStreamType.EngramPrecompute: aux_stream_list[4],
+            AuxStreamType.MlaCompressor: aux_stream_list[1],
+            AuxStreamType.MlaIndexer: aux_stream_list[2],
+            AuxStreamType.MlaIndexerAux: aux_stream_list[3],
         }
 
         self.embed_tokens = Embedding(

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -122,7 +122,8 @@ class Eagle3MLAttention(MLA):
         self,
         model_config: ModelConfig[PretrainedConfig],
         layer_idx: Optional[int] = None,
-        aux_stream: Optional[torch.cuda.Stream] = None,
+        aux_stream_dict: Optional[Dict[AuxStreamType,
+                                       torch.cuda.Stream]] = None,
         next_layer_regular: bool = False,
     ):
         config = model_config.pretrained_config
@@ -152,7 +153,7 @@ class Eagle3MLAttention(MLA):
             layer_idx=layer_idx,
             dtype=config.torch_dtype,
             config=model_config,
-            aux_stream=aux_stream,
+            aux_stream_dict=aux_stream_dict,
         )
 
         # Override the kv_a_proj_with_mqa projection for first layer.
@@ -200,7 +201,7 @@ class Eagle3DecoderLayer(DecoderLayer):
             self.self_attn = Eagle3MLAttention(
                 model_config,
                 layer_idx,
-                aux_stream=aux_stream,
+                aux_stream_dict={AuxStreamType.Attention: aux_stream},
                 next_layer_regular=self._next_layer_regular,
             )
         else:

--- a/tensorrt_llm/_torch/modules/mla.py
+++ b/tensorrt_llm/_torch/modules/mla.py
@@ -17,7 +17,7 @@ import functools
 import math
 import os
 import weakref
-from typing import List, Optional, cast
+from typing import Dict, List, Optional, cast
 
 import torch
 from torch import nn
@@ -49,6 +49,7 @@ from ..attention_backend.utils import create_attention
 from ..distributed import AllReduceParams
 from ..model_config import ModelConfig
 from ..utils import (
+    AuxStreamType,
     Fp4QuantizedTensor,
     compute_swizzled_sf_shape,
     is_torch_compiling,
@@ -422,7 +423,7 @@ class MLA(nn.Module):
         predicted_tokens_per_seq: int,
         max_position_embeddings: int,
         bias: bool,
-        aux_stream: Optional[torch.cuda.Stream] = None,
+        aux_stream_dict: Optional[Dict[AuxStreamType, torch.cuda.Stream]] = None,
         pos_embd_params: Optional[PositionalEmbeddingParams] = None,
         layer_idx: Optional[int] = None,
         dtype: torch.dtype = None,
@@ -448,8 +449,9 @@ class MLA(nn.Module):
             predicted_tokens_per_seq (int): The number of predicted tokens per sequence.
             max_position_embeddings (int): The maximum position embeddings.
             bias (bool): Whether to use bias in the linear layers.
-            aux_stream (Optional[torch.cuda.Stream]): The auxiliary CUDA stream
-                for running operations in two parallel streams.
+            aux_stream_dict (Optional[Dict[AuxStreamType, torch.cuda.Stream]]): Auxiliary
+                CUDA streams by role. The DSv4 lanes are read only when the layer has
+                a DSv4 indexer.
             pos_embd_params (PositionalEmbeddingParams): The positional embedding parameters.
             layer_idx (int): The layer index.
             dtype (torch.dtype): The data type.
@@ -761,16 +763,12 @@ class MLA(nn.Module):
             and sparse_params is not None
             and sparse_params.compress_ratios[layer_idx] == 4
         )
-        self.indexer_stream = None
-        self.indexer_aux_stream = None
-        self.compressor_stream = None
-        if self.has_dsv4_indexer and aux_stream is not None:
-            self.indexer_stream = torch.cuda.Stream(device=aux_stream.device)
-            self.indexer_aux_stream = torch.cuda.Stream(device=aux_stream.device)
-            self.compressor_stream = torch.cuda.Stream(device=aux_stream.device)
-        mqa_aux_stream = (
-            self.indexer_aux_stream if self.indexer_aux_stream is not None else aux_stream
-        )
+        aux_stream_dict = aux_stream_dict or {}
+        self.aux_stream = aux_stream_dict.get(AuxStreamType.Attention, None)
+        self.indexer_stream = aux_stream_dict.get(AuxStreamType.MlaIndexer, None)
+        self.indexer_aux_stream = aux_stream_dict.get(AuxStreamType.MlaIndexerAux, None)
+        self.compressor_stream = aux_stream_dict.get(AuxStreamType.MlaCompressor, None)
+        mqa_aux_stream = self.indexer_aux_stream if self.has_dsv4_indexer else self.aux_stream
 
         self.mqa = create_attention(
             config.attn_backend,
@@ -800,7 +798,6 @@ class MLA(nn.Module):
 
         self.softmax_scale = 1.0 / (math.sqrt(self.qk_head_dim) * q_scaling)
 
-        self.aux_stream = aux_stream
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
         self.dsv4_overlap_start_event = torch.cuda.Event()
         self.dsv4_compressor_start_event = torch.cuda.Event()

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -26,6 +26,9 @@ aux_stream_name_list = [
     'MoeOutputMemset',
     'MoeFc2Alpha',
     'EngramPrecompute',
+    'MlaIndexer',
+    'MlaIndexerAux',
+    'MlaCompressor',
 ]
 AuxStreamType = Enum(
     'AuxStreamType',


### PR DESCRIPTION
## Description

`MLA` allocated its three DSv4 side streams (indexer, indexer-aux, compressor) in its own constructor:

```python
if self.has_dsv4_indexer and aux_stream is not None:
    self.indexer_stream = torch.cuda.Stream(device=aux_stream.device)
    self.indexer_aux_stream = torch.cuda.Stream(device=aux_stream.device)
    self.compressor_stream = torch.cuda.Stream(device=aux_stream.device)
```

so every CSA layer got a private set — **90 CUDA streams on DeepSeek-V4-Pro** (30 `compress_ratio == 4` layers x 3). Those streams are never concurrent with each other: layers run sequentially on the caller stream, and each layer gates its own aux work with its own events, so one stream per *role* serves the whole model. The per-layer sets also made stream ids meaningless in a profile — the same logical lane landed on a different id in every layer, so an nsys trace could not be read by lane.

This adds `MlaIndexer` / `MlaIndexerAux` / `MlaCompressor` to `AuxStreamType` (appended, so existing `EventType` ordinals are unchanged) and allocates them once in `DeepseekV4Model`, alongside the MoE lanes. Attention-phase and MoE-phase lanes are sequential within a layer, so the `Mla*` roles share slots with the `Moe*` ones and the pool stays at five streams; `EngramPrecompute` keeps its own, since it precomputes across the layer rather than inside the MoE phase.

`MLA` now takes `aux_stream_dict` instead of a single `aux_stream`, following the convention already used in this codebase: submodules needing one stream keep the plain `aux_stream` argument (`MiniMaxM2MoE`, the llama variants, `moe_load_balancer`), and submodules needing several take the role dict (every `fused_moe` backend, and now `MLA`).

Compatibility:

- `MLA` still reads `AuxStreamType.Attention` for its `q_a`/`kv_a` layernorm lane, so models with an older pool — v3, v3.2, Eagle3 — resolve it unchanged.
- `mqa_aux_stream` stays gated on `has_dsv4_indexer`, so non-CSA layers keep using that same `Attention` lane exactly as before.
- No change to stream assignment or ordering: q still runs on `compressor_stream` after the compressor, the indexer keeps its two lanes, the kv branch stays on the caller stream.

## Test Coverage

No new unit test: this changes where streams are *allocated*, not what runs on them, and the existing attention tests already construct `MLA` both through the model path and directly.

- `tests/unittest/_torch/modules/test_mla_registry.py` — builds `MLA` directly, so it covers the constructor signature change. It caught a real defect during development (a stale local reference in `mqa_aux_stream`) that an import-only check missed.
- `tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_sparse_mla.py` and `test_deepseek_v4_indices_transform.py` — 16 tests, pass.
- `accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Pro::test_gsm8k_full_accuracy` on 2x GB200 (tp8, fp8 KV, MTP1) — passes.

Direct verification of the intended effect, by logging the stream handles at construction: the pool is five distinct streams, and all 62 layers (30 CSA / 32 non-CSA) resolve to the same id-tuple, where previously each CSA layer held its own three. An nsys trace of one GEN rank went from 24 distinct stream ids to 7 — the remainder being the main compute stream, the draft model's lanes, a runtime stream, and CUDA-graph clones of the pooled ones.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.
