### PR TITLE
[None][doc] Fix stale script references in ray_orchestrator and disaggregated benchmark examples

### DIFF
--- a/examples/disaggregated/slurm/benchmark/README.md
+++ b/examples/disaggregated/slurm/benchmark/README.md
@@ -14,8 +14,6 @@ The benchmarking process is orchestrated through a combination of Python scripts
    - `start_server.sh`: Starts the disaggregated serving coordinator
    - `wait_server.sh`: Waits for server readiness before benchmarking
    - `run_benchmark.sh` / `run_benchmark_nv_sa.sh`: Execute benchmark workloads
-   - `accuracy_eval.sh`: Runs accuracy evaluation using lm_eval
-   - `gen_server_config.py`: Generates server configuration from worker settings
 
 ## Configuration (config.yaml)
 

--- a/examples/ray_orchestrator/multi_nodes/run_cluster.sh
+++ b/examples/ray_orchestrator/multi_nodes/run_cluster.sh
@@ -9,7 +9,7 @@
 
 # Run inside an already‑active allocated node.
 # To start a Ray cluster across nodes:
-#       >> bash -e launch_ray.sh
+#       >> bash -e run_cluster.sh
 #
 # See multi_nodes/README.md for more details.
 #


### PR DESCRIPTION
Two stale references to files that do not exist in the repo:

**1. `examples/ray_orchestrator/multi_nodes/run_cluster.sh`** — the usage comment says:
```
# To start a Ray cluster across nodes:
#       >> bash -e launch_ray.sh
```
There is no `launch_ray.sh` anywhere in the repo; the script itself is `run_cluster.sh` (and `multi_nodes/README.md` already documents `bash -e run_cluster.sh`). Copy-pasting the comment gives `bash: launch_ray.sh: No such file or directory`. Fixed the comment to `run_cluster.sh`.

**2. `examples/disaggregated/slurm/benchmark/README.md`** — the "Supporting scripts" list includes:
```
- `accuracy_eval.sh`: Runs accuracy evaluation using lm_eval
- `gen_server_config.py`: Generates server configuration from worker settings
```
Neither file exists in that directory (or anywhere in the repo) — the orchestrator runs `lm_eval` directly and writes the server config inline. Removed the two stale bullets; the remaining four listed scripts all exist.

Docs/comment only. Both commits are signed off (DCO).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Corrected the Ray cluster command reference from `launch_ray.sh` to `run_cluster.sh`.
- Removed stale references to `accuracy_eval.sh` and `gen_server_config.py`.
- Changes are documentation/comment-only and introduce no code or API changes.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->