### PR TITLE
[TRTLLM-13409][fix] kill a wedged disagg KV transfer instead of spinning to the harness timeout

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/hang_detector.py
+++ b/tensorrt_llm/_torch/pyexecutor/hang_detector.py
@@ -101,6 +101,7 @@ class HangDetector:
         self.active = False
         self._detected = False
         self._status_providers: list[Callable[[], str]] = []
+        self._rearm_suppressor: Optional[Callable[[], bool]] = None
 
     def start(self):
         """Enable hang detection."""
@@ -118,6 +119,42 @@ class HangDetector:
         """Register a nonblocking callable that returns status to dump on hang detection."""
         with self.lock:
             self._status_providers.append(provider)
+
+    def set_rearm_suppressor(self, suppressor: Optional[Callable[[], bool]]) -> None:
+        """Install a predicate that freezes the detection deadline while it holds.
+
+        The executor loop re-arms the watchdog once per iteration, so a loop
+        that spins with nothing to do hides a hang for as long as it spins.
+        While ``suppressor`` returns True the pending detection is left to run
+        down instead of being pushed forward by ``checkpoint()``/``pause()``.
+
+        This can only ever make the detector fire *sooner*, never later: an
+        already-pending detection is never cancelled by the suppressed path,
+        and when nothing is armed yet the normal arming path still runs (see
+        ``_suppress_rearm``). Callers must supply a cheap, nonblocking
+        predicate -- it runs on the executor thread on every checkpoint.
+        """
+        self._rearm_suppressor = suppressor
+
+    def is_armed(self) -> bool:
+        """Whether a hang detection is currently pending."""
+        return self.task is not None and not self.task.done()
+
+    def _suppress_rearm(self) -> bool:
+        """Whether the pending detection must be left alone rather than reset.
+
+        Never suppresses while unarmed, so the detector cannot be disabled by
+        this path -- only prevented from having its deadline pushed forward.
+        """
+        if self._rearm_suppressor is None or not self.is_armed():
+            return False
+        try:
+            return bool(self._rearm_suppressor())
+        except Exception as error:  # noqa: BLE001 - isolate the caller's predicate
+            _best_effort_log_error(
+                f"HangDetector: re-arm suppressor failed with {type(error).__name__}: {error}"
+            )
+            return False
 
     async def _detect_hang(self) -> None:
         await asyncio.sleep(self.timeout)
@@ -154,6 +191,8 @@ class HangDetector:
 
     def checkpoint(self):
         """Reset hang detection timer."""
+        if self._suppress_rearm():
+            return
         self.cancel_task()
         if self.active:
             self.task = asyncio.run_coroutine_threadsafe(self._detect_hang(), self.loop)
@@ -167,6 +206,13 @@ class HangDetector:
     @contextmanager
     def pause(self):
         """Pause hang detection in scope."""
+        if self._suppress_rearm():
+            # A deadline has already been missed. Keep the pending detection
+            # running so a blocking call in this scope cannot hide the hang,
+            # and so the suppressed checkpoint at the top of the executor loop
+            # is not undone by this context manager re-arming on exit.
+            yield
+            return
         try:
             self.cancel_task()
             yield

--- a/tensorrt_llm/_torch/pyexecutor/hang_detector.py
+++ b/tensorrt_llm/_torch/pyexecutor/hang_detector.py
@@ -134,7 +134,8 @@ class HangDetector:
         ``_suppress_rearm``). Callers must supply a cheap, nonblocking
         predicate -- it runs on the executor thread on every checkpoint.
         """
-        self._rearm_suppressor = suppressor
+        with self.lock:
+            self._rearm_suppressor = suppressor
 
     def is_armed(self) -> bool:
         """Whether a hang detection is currently pending."""
@@ -146,10 +147,12 @@ class HangDetector:
         Never suppresses while unarmed, so the detector cannot be disabled by
         this path -- only prevented from having its deadline pushed forward.
         """
-        if self._rearm_suppressor is None or not self.is_armed():
+        with self.lock:
+            suppressor = self._rearm_suppressor
+        if suppressor is None or not self.is_armed():
             return False
         try:
-            return bool(self._rearm_suppressor())
+            return bool(suppressor())
         except Exception as error:  # noqa: BLE001 - isolate the caller's predicate
             _best_effort_log_error(
                 f"HangDetector: re-arm suppressor failed with {type(error).__name__}: {error}"
@@ -222,6 +225,10 @@ class HangDetector:
     def stop(self):
         """Stop hang detection."""
         self.active = False
+        # Drop the suppressor with the rest of the detector state so a stopped
+        # detector cannot keep calling back into a torn-down executor.
+        with self.lock:
+            self._rearm_suppressor = None
         self.cancel_task()
         if self.loop is not None:
             # Cancel all pending tasks before stopping the loop

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -918,11 +918,14 @@ class PyExecutor:
         self.gather_all_responses = False
 
         self.kv_cache_transceiver = kv_cache_transceiver
+        # Initialised unconditionally: an AttributeError raised from the
+        # suppressor would be swallowed by HangDetector._suppress_rearm and
+        # would silently disable the wedged-transfer kill.
+        self._wedged_kv_transfer_iter = -1
+        self._wedged_kv_transfer_result = False
         if kv_cache_transceiver is not None:
             self.hang_detector.register_status_provider(
                 kv_cache_transceiver.get_status_dump)
-            self._wedged_kv_transfer_iter = -1
-            self._wedged_kv_transfer_result = False
             self.hang_detector.set_rearm_suppressor(
                 self._is_wedged_on_timed_out_kv_transfer)
         cache_transceiver_config = getattr(self.llm_args,
@@ -5686,14 +5689,24 @@ class PyExecutor:
 
         The truer signal would be "cancellation was attempted and refused" --
         the ``if not is_cancelled: continue`` branch of
-        ``_check_disagg_ctx_cache_transfer_status``.  It is deliberately not
-        used: that function is reached only from the ``executed_batch is not
-        None`` path, so on a drained PP CTX loop -- exactly the case this fix
-        targets -- cancellation is never attempted and the refusal would never
-        be recorded.  Keying on it would make the fix silently inert on the
-        server that actually hangs.  Elapsed time is the best signal available
-        without also driving cancellation from the empty pass, which would put
-        a C++ cancellation request on every drained iteration.
+        ``_check_disagg_ctx_cache_transfer_status``.  That branch **is
+        reachable** on a drained CTX server: ``_executor_loop_pp`` calls
+        ``_check_disagg_transfer_progress_when_idle`` every iteration, ungated
+        by ``executed_batch_num``, and it reaches
+        ``_check_disagg_ctx_cache_transfer_status`` whenever
+        ``num_fitting_reqs == 0`` and no gen-init request fits -- true exactly
+        when drained.  On ``main`` that call is a no-op only because the loop
+        above it does ``if not request.py_kv_transfer_timed_out: continue`` and
+        the flag is never set, which is the very defect the empty pass fixes.
+        Once the flag is set, cancellation is attempted every iteration and the
+        refusal genuinely occurs.
+
+        It is not used here only because the refusal is **not recorded**:
+        ``_disagg_timed_out_ctx_cancelled_ids`` tracks successful cancellations
+        under in-flight-cancel mode, and nothing tracks refusals.  Adding a
+        refusal set is small but introduces new mutable state on a live disagg
+        path, so it is deliberately left as a follow-up; elapsed time is the
+        v1 proxy.  See the PR description for the follow-up items.
         """
         timeout_ms = self.kv_cache_transceiver.kv_transfer_timeout_ms
         if timeout_ms is None:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -921,6 +921,8 @@ class PyExecutor:
         if kv_cache_transceiver is not None:
             self.hang_detector.register_status_provider(
                 kv_cache_transceiver.get_status_dump)
+            self.hang_detector.set_rearm_suppressor(
+                self._is_wedged_on_timed_out_kv_transfer)
         cache_transceiver_config = getattr(self.llm_args,
                                            "cache_transceiver_config", None)
         max_tokens_in_buffer = getattr(cache_transceiver_config,
@@ -2823,6 +2825,25 @@ class PyExecutor:
 
                 # Stage 3.3: Handle executed batches.
                 handle_executed_batches(executed_batch_num)
+
+                # Once the pipeline drains, executed_batch_num is 0 and the
+                # loop above stops calling _handle_executed_batch entirely --
+                # taking out its ungated tail (the KV-transfer timeout check
+                # and the synced-collective drains) along with it. A disagg
+                # KV transfer wedged at that point would then never be flagged
+                # and this loop would spin until the harness timeout. Make one
+                # empty pass so the tail runs every iteration, mirroring the
+                # loop-body drains in _executor_loop_overlap.
+                #
+                # Rank symmetry: executed_batch_num is the ring-broadcast
+                # consensus value and is identical on every rank, so this
+                # branch is taken by all ranks or by none. Combined with
+                # handle_executed_batches (which calls _handle_executed_batch
+                # exactly executed_batch_num times on every rank) the tail runs
+                # max(executed_batch_num, 1) times per iteration everywhere,
+                # keeping the collectives inside it in lockstep.
+                if executed_batch_num == 0:
+                    self._handle_executed_batch(None)
 
                 # Stage 4: March forward in microbatch slots
                 microbatch_id = (microbatch_id + 1) % self.num_micro_batches
@@ -5602,6 +5623,46 @@ class PyExecutor:
         self._handle_errors(error_msg,
                             requests=error_requests,
                             charge_budget=False)
+
+    def _is_wedged_on_timed_out_kv_transfer(self) -> bool:
+        """Whether this loop is idling behind a KV transfer that blew its deadline.
+
+        Installed as the hang detector's re-arm suppressor. Two conditions,
+        both required:
+
+        * nothing was scheduled on the last iteration, and
+        * some request is flagged ``py_kv_transfer_timed_out``.
+
+        The flag is deliberately the only transfer-side signal used here. It is
+        set solely by ``_check_kv_transfer_timeout``, and only after
+        ``elapsed > kv_transfer_timeout_ms`` -- i.e. after the deadline the
+        operator declared has already been missed -- so there is no legitimate
+        state beyond it. Keying on elapsed time or on schedulability instead
+        would re-admit false positives that this loop must tolerate: a genuine
+        128k-context transfer running for minutes, attention-DP dummy padding,
+        and PP microbatch drain all leave the loop idle without anything being
+        wrong.
+
+        When both hold, the executor is in the disagg livelock: it spins with
+        an empty batch at sub-millisecond period -- re-arming the watchdog
+        thousands of times a second -- while a wedged transfer holds a request
+        the transceiver refuses to cancel. Freezing the watchdog deadline turns
+        that into a hard kill one hang-detection timeout later instead of a run
+        to the harness timeout.
+        """
+        if self.num_scheduled_requests != 0:
+            return False
+        if self.kv_cache_transceiver is None:
+            return False
+        transfer_manager = getattr(self, "async_transfer_manager", None)
+        if transfer_manager is not None:
+            for request in transfer_manager.requests_in_transfer().values():
+                if request.py_kv_transfer_timed_out:
+                    return True
+        for request in self.active_requests:
+            if request.py_kv_transfer_timed_out:
+                return True
+        return False
 
     @nvtx_range("_check_kv_transfer_timeout")
     def _check_kv_transfer_timeout(self):

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -921,6 +921,8 @@ class PyExecutor:
         if kv_cache_transceiver is not None:
             self.hang_detector.register_status_provider(
                 kv_cache_transceiver.get_status_dump)
+            self._wedged_kv_transfer_iter = -1
+            self._wedged_kv_transfer_result = False
             self.hang_detector.set_rearm_suppressor(
                 self._is_wedged_on_timed_out_kv_transfer)
         cache_transceiver_config = getattr(self.llm_args,
@@ -2798,20 +2800,7 @@ class PyExecutor:
                                 )
                     return executed_batch_num
 
-                def handle_executed_batches(executed_batch_num: int):
-                    if self.dist.rank != 0:
-                        dequeue_counter = 0
-                        while dequeue_counter < executed_batch_num:
-                            with nvtx_range("get_executed_batch"):
-                                executed_batch = self.executed_batch_response_queue.get(
-                                )
-                            self._handle_executed_batch(executed_batch)
-                            dequeue_counter += 1
-                    else:
-                        for executed_batch in executed_batches:
-                            self._handle_executed_batch(executed_batch)
-                    self.unhandled_batch_counter -= executed_batch_num
-
+                executed_batches = []
                 executed_batch_num = 0
 
                 # Stage 3.1: The first rank determines the number of executed batches.
@@ -2824,26 +2813,8 @@ class PyExecutor:
                     executed_batch_num)
 
                 # Stage 3.3: Handle executed batches.
-                handle_executed_batches(executed_batch_num)
-
-                # Once the pipeline drains, executed_batch_num is 0 and the
-                # loop above stops calling _handle_executed_batch entirely --
-                # taking out its ungated tail (the KV-transfer timeout check
-                # and the synced-collective drains) along with it. A disagg
-                # KV transfer wedged at that point would then never be flagged
-                # and this loop would spin until the harness timeout. Make one
-                # empty pass so the tail runs every iteration, mirroring the
-                # loop-body drains in _executor_loop_overlap.
-                #
-                # Rank symmetry: executed_batch_num is the ring-broadcast
-                # consensus value and is identical on every rank, so this
-                # branch is taken by all ranks or by none. Combined with
-                # handle_executed_batches (which calls _handle_executed_batch
-                # exactly executed_batch_num times on every rank) the tail runs
-                # max(executed_batch_num, 1) times per iteration everywhere,
-                # keeping the collectives inside it in lockstep.
-                if executed_batch_num == 0:
-                    self._handle_executed_batch(None)
+                self._dispatch_executed_batches(executed_batch_num,
+                                                executed_batches)
 
                 # Stage 4: March forward in microbatch slots
                 microbatch_id = (microbatch_id + 1) % self.num_micro_batches
@@ -3138,6 +3109,49 @@ class PyExecutor:
                     dest=self.dist.next_pp_rank,
                     tag=tag,
                 )
+
+    def _dispatch_executed_batches(self, executed_batch_num: int,
+                                   executed_batches: List[BatchStatePP]):
+        """Run ``_handle_executed_batch`` once per executed batch, plus one
+        empty pass when the pipeline has drained.
+
+        ``executed_batch_num`` is the ring-broadcast consensus value from
+        ``ring_broadcast_executed_batch_num`` and is therefore identical on
+        every rank.  Both rank roles below run exactly ``executed_batch_num``
+        iterations, so the number of ``_handle_executed_batch`` calls -- and
+        with it the ``tp_allgather`` collectives in its tail -- is a pure
+        function of that consensus value and stays in lockstep across ranks.
+
+        The empty pass exists because once the pipeline drains
+        ``executed_batch_num`` is 0 and the loops below stop calling
+        ``_handle_executed_batch`` entirely, taking out its ungated tail (the
+        KV-transfer timeout check and the synced-collective drains) along with
+        it.  A disagg KV transfer wedged at that point would then never be
+        flagged and ``_executor_loop_pp`` would spin until the harness timeout.
+        This mirrors the loop-body drains in ``_executor_loop_overlap``.
+
+        The pass is confined to disagg runs.  ``_handle_kv_transfer_timeouts_synced``
+        gates only on attention-DP, so without the transceiver conjunct every
+        ADP+PP job -- disagg or not -- would take a ``tp_allgather`` on each
+        drained iteration where ``main`` took none, and drained iterations are a
+        recurring steady state whenever ``pp_async_broadcast_sample_state`` is on.
+        ``kv_cache_transceiver`` is built from rank-uniform ``LlmArgs``, so
+        adding it to the guard keeps the branch rank-symmetric.
+        """
+        if self.dist.rank != 0:
+            dequeue_counter = 0
+            while dequeue_counter < executed_batch_num:
+                with nvtx_range("get_executed_batch"):
+                    executed_batch = self.executed_batch_response_queue.get()
+                self._handle_executed_batch(executed_batch)
+                dequeue_counter += 1
+        else:
+            for executed_batch in executed_batches:
+                self._handle_executed_batch(executed_batch)
+        self.unhandled_batch_counter -= executed_batch_num
+
+        if executed_batch_num == 0 and self.kv_cache_transceiver is not None:
+            self._handle_executed_batch(None)
 
     def _handle_executed_batch(self, executed_batch: Optional[BatchStatePP]):
         finished_requests = []
@@ -5625,42 +5639,82 @@ class PyExecutor:
                             charge_budget=False)
 
     def _is_wedged_on_timed_out_kv_transfer(self) -> bool:
-        """Whether this loop is idling behind a KV transfer that blew its deadline.
+        """Whether this loop is idling behind a KV transfer that has given up.
 
-        Installed as the hang detector's re-arm suppressor. Two conditions,
-        both required:
+        Installed as the hang detector's re-arm suppressor.  Requires an empty
+        batch *and* a transfer that is past the give-up threshold defined in
+        ``_compute_wedged_on_timed_out_kv_transfer``.
 
-        * nothing was scheduled on the last iteration, and
-        * some request is flagged ``py_kv_transfer_timed_out``.
-
-        The flag is deliberately the only transfer-side signal used here. It is
-        set solely by ``_check_kv_transfer_timeout``, and only after
-        ``elapsed > kv_transfer_timeout_ms`` -- i.e. after the deadline the
-        operator declared has already been missed -- so there is no legitimate
-        state beyond it. Keying on elapsed time or on schedulability instead
-        would re-admit false positives that this loop must tolerate: a genuine
-        128k-context transfer running for minutes, attention-DP dummy padding,
-        and PP microbatch drain all leave the loop idle without anything being
-        wrong.
-
-        When both hold, the executor is in the disagg livelock: it spins with
-        an empty batch at sub-millisecond period -- re-arming the watchdog
-        thousands of times a second -- while a wedged transfer holds a request
-        the transceiver refuses to cancel. Freezing the watchdog deadline turns
-        that into a hard kill one hang-detection timeout later instead of a run
-        to the harness timeout.
+        The predicate is consulted several times per iteration -- on every
+        ``checkpoint()`` and every ``pause()``, and ``RequestBroadcaster``
+        pauses once per iteration on top of the loop-top checkpoint -- while
+        the request walks below touch C++-backed bindings.  The empty-batch
+        test short-circuits a busy loop cheaply, but a CTX server idling
+        between batches reaches the walks, so the result is memoised per
+        executor iteration.  One-iteration granularity is far finer than the
+        hang-detection timeout being decided.
         """
         if self.num_scheduled_requests != 0:
             return False
         if self.kv_cache_transceiver is None:
             return False
-        transfer_manager = getattr(self, "async_transfer_manager", None)
-        if transfer_manager is not None:
-            for request in transfer_manager.requests_in_transfer().values():
-                if request.py_kv_transfer_timed_out:
-                    return True
+        if self._wedged_kv_transfer_iter != self.iter_counter:
+            self._wedged_kv_transfer_iter = self.iter_counter
+            self._wedged_kv_transfer_result = (
+                self._compute_wedged_on_timed_out_kv_transfer())
+        return self._wedged_kv_transfer_result
+
+    def _compute_wedged_on_timed_out_kv_transfer(self) -> bool:
+        """Whether some transfer is past the point where it can still succeed.
+
+        ``py_kv_transfer_timed_out`` alone is *not* a safe trigger, despite
+        being named like one.  ``kv_transfer_timeout_ms`` defaults to 60s and
+        is a *start-trying-to-cancel* threshold, not a *give-up* threshold: on
+        ``main`` a transfer that blows it but that the transceiver refuses to
+        cancel is left alone and allowed to complete
+        (``_check_disagg_ctx_cache_transfer_status`` does ``continue``).
+        Suppressing on the flag alone would hard-kill every rank -- via
+        ``MPI_Abort``, taking the healthy generation side and every other
+        in-flight request with it -- for a transfer that was merely slow.  A
+        legitimate 128k-context transfer can run past 60s.
+
+        So the trigger is the flag *plus* a further ``hang_detection_timeout``
+        of grace.  A transfer still has the whole grace window to complete
+        normally, and only a transfer that has burned
+        ``kv_transfer_timeout_ms + hang_detection_timeout`` without finishing
+        or being cancellable is treated as wedged.
+
+        The truer signal would be "cancellation was attempted and refused" --
+        the ``if not is_cancelled: continue`` branch of
+        ``_check_disagg_ctx_cache_transfer_status``.  It is deliberately not
+        used: that function is reached only from the ``executed_batch is not
+        None`` path, so on a drained PP CTX loop -- exactly the case this fix
+        targets -- cancellation is never attempted and the refusal would never
+        be recorded.  Keying on it would make the fix silently inert on the
+        server that actually hangs.  Elapsed time is the best signal available
+        without also driving cancellation from the empty pass, which would put
+        a C++ cancellation request on every drained iteration.
+        """
+        timeout_ms = self.kv_cache_transceiver.kv_transfer_timeout_ms
+        if timeout_ms is None:
+            return False
+        give_up_ms = timeout_ms + self.hang_detector.timeout * 1000
+        now = time.monotonic()
+
+        def is_past_give_up(request: LlmRequest) -> bool:
+            if not request.py_kv_transfer_timed_out:
+                return False
+            start_time = request.py_kv_transfer_start_time
+            if start_time is None:
+                return False
+            return (now - start_time) * 1000 > give_up_ms
+
+        for request in self.async_transfer_manager.requests_in_transfer(
+        ).values():
+            if is_past_give_up(request):
+                return True
         for request in self.active_requests:
-            if request.py_kv_transfer_timed_out:
+            if is_past_give_up(request):
                 return True
         return False
 

--- a/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
+++ b/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
@@ -752,6 +752,13 @@ def test_uncancellable_ctx_transfer_keeps_the_timeout_flag_set():
     the transfer is already active, so ``_check_disagg_ctx_cache_transfer_status``
     ``continue``s without ever clearing the flag. That stickiness is what makes
     the watchdog predicate stable rather than flapping.
+
+    Also pins that cancellation *is* attempted once the flag is set. On a
+    drained CTX server this function is still reached every iteration, via
+    ``_check_disagg_transfer_progress_when_idle``, so the refusal genuinely
+    occurs -- it is simply never recorded anywhere. Recording it is the
+    follow-up that would replace the elapsed-time proxy in the watchdog
+    predicate with direct proof of a wedge.
     """
     request = _make_ctx_only_request()
     request.py_kv_transfer_start_time = 1.0
@@ -768,9 +775,12 @@ def test_uncancellable_ctx_transfer_keeps_the_timeout_flag_set():
 
     PyExecutor._check_disagg_ctx_cache_transfer_status(executor, 0)
 
+    executor.kv_cache_transceiver.cancel_request.assert_called_once_with(request)
     executor._end_transfer_and_maybe_terminate.assert_not_called()
     assert request.py_kv_transfer_timed_out is True
     assert request.py_kv_transfer_start_time == 1.0
+    # The refusal happened but left no trace to key a predicate on.
+    assert executor._disagg_timed_out_ctx_cancelled_ids == set()
 
 
 def _make_empty_pass_executor():

--- a/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
+++ b/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
@@ -679,3 +679,243 @@ def test_flag_unset_skips_cpp_poison_query():
 
     assert not BindKvCacheTransceiver.has_poisoned_transfer_buffer(transceiver)
     transceiver.impl.has_poisoned_transfer_buffer.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Wedged disagg KV transfer: detection must reach the PP loop, and a missed
+# transfer deadline must stop the executor loop from re-arming the watchdog.
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx_only_request(request_id=11):
+    return SimpleNamespace(
+        py_request_id=request_id,
+        is_context_only_request=True,
+        is_context_finished=True,
+        is_finished_due_to_length=False,
+        is_finished_due_to_cancellation=False,
+        is_disagg_generation_transmission_in_progress=False,
+        py_kv_transfer_start_time=None,
+        py_kv_transfer_timed_out=False,
+    )
+
+
+def _make_ctx_transfer_executor(request, timeout_ms=0):
+    executor = object.__new__(PyExecutor)
+    executor.kv_cache_transceiver = Mock()
+    executor.kv_cache_transceiver.kv_transfer_timeout_ms = timeout_ms
+    executor.kv_cache_manager = Mock()
+    executor.kv_connector_manager = None
+    executor.active_requests = []
+    executor.async_transfer_manager = Mock()
+    executor.async_transfer_manager.requests_in_transfer.return_value = {
+        request.py_request_id: request
+    }
+    executor._check_disagg_ctx_cache_transfer_status = Mock()
+    executor._is_disagg_inflight_cancel_active = Mock(return_value=False)
+    return executor
+
+
+def test_ctx_transfer_clock_is_armed_before_the_pp_loop_can_drain():
+    """The CTX-side timeout clock is armed on the iteration the context finishes.
+
+    ``py_kv_transfer_start_time`` is stamped by ``_send_kv_async``, which the PP
+    loop only reaches via ``_handle_executed_batch``. That is the same gate that
+    stops running once the pipeline drains -- but a request can only *enter*
+    transfer by being executed, so the stamp necessarily lands while the gate is
+    still open. The loop goes empty strictly afterwards, with the clock already
+    running. Without this, ``py_kv_transfer_timed_out`` could never be set on
+    CTX and the fix would have nothing to key on.
+    """
+    request = _make_ctx_only_request()
+    executor = _make_ctx_transfer_executor(request)
+
+    PyExecutor._send_kv_async(executor, [request])
+
+    executor.async_transfer_manager.start_transfer.assert_called_once_with(request)
+    executor.kv_cache_transceiver.respond_and_send_async.assert_called_once_with(request)
+    assert request.py_kv_transfer_start_time is not None, (
+        "the CTX transfer clock must be armed while the batch gate is still open"
+    )
+
+    # The loop is now empty; the clock keeps running and the deadline is missed.
+    PyExecutor._check_kv_transfer_timeout(executor)
+
+    assert request.py_kv_transfer_timed_out is True
+
+
+def test_uncancellable_ctx_transfer_keeps_the_timeout_flag_set():
+    """The release path dead-ends, so the flag stays set for the wedged request.
+
+    ``cancel_request`` returns False whenever in-flight cancellation is off and
+    the transfer is already active, so ``_check_disagg_ctx_cache_transfer_status``
+    ``continue``s without ever clearing the flag. That stickiness is what makes
+    the watchdog predicate stable rather than flapping.
+    """
+    request = _make_ctx_only_request()
+    request.py_kv_transfer_start_time = 1.0
+    request.py_kv_transfer_timed_out = True
+    request.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
+    executor = _make_ctx_transfer_executor(request)
+    executor.kv_cache_transceiver.check_context_transfer_status.return_value = ([], [])
+    executor.kv_cache_transceiver.cancel_request.return_value = False
+    executor.kv_cache_transceiver.supports_inflight_request_cancellation.return_value = True
+    executor._disagg_timed_out_ctx_cancelled_ids = set()
+    executor._disagg_inflight_cancel_unsupported_logged = False
+    executor._end_transfer_and_maybe_terminate = Mock()
+    executor._check_cache_transfer_errors = Mock()
+
+    PyExecutor._check_disagg_ctx_cache_transfer_status(executor, 0)
+
+    executor._end_transfer_and_maybe_terminate.assert_not_called()
+    assert request.py_kv_transfer_timed_out is True
+    assert request.py_kv_transfer_start_time == 1.0
+
+
+def _make_empty_pass_executor():
+    executor = object.__new__(PyExecutor)
+    executor.kv_cache_transceiver = Mock()
+    executor.async_transfer_manager = Mock()
+    executor.async_transfer_manager.has_any_inflight_requests.return_value = True
+    executor._check_kv_transfer_timeout = Mock()
+    executor._disagg_pp_termination_handler = None
+    executor.enable_iter_perf_stats = True
+    executor._handle_kv_transfer_timeouts_synced = Mock()
+    executor._flush_iter_stats_synced = Mock()
+    executor._commit_kv_cache_stats = Mock()
+    executor._process_iter_stats = Mock()
+    return executor
+
+
+def test_empty_pass_runs_the_timeout_check_the_pp_loop_used_to_skip():
+    """``_handle_executed_batch(None)`` runs exactly the ungated tail.
+
+    This is the call the drained PP loop now makes once per iteration. It must
+    reach ``_check_kv_transfer_timeout`` -- which is what never happened before,
+    because ``handle_executed_batches`` iterates ``executed_batch_num`` times and
+    that is 0 once nothing is queued.
+    """
+    executor = _make_empty_pass_executor()
+
+    PyExecutor._handle_executed_batch(executor, None)
+
+    executor._check_kv_transfer_timeout.assert_called_once_with()
+    executor._handle_kv_transfer_timeouts_synced.assert_called_once_with()
+    executor._flush_iter_stats_synced.assert_called_once_with()
+    # Nothing batch-gated may run: there is no batch.
+    executor._commit_kv_cache_stats.assert_not_called()
+    executor._process_iter_stats.assert_not_called()
+
+
+def _executed_batch_empty_pass_guards():
+    """Return the guard expressions of the empty-pass calls in _executor_loop_pp."""
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(PyExecutor._executor_loop_pp)))
+    guards = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        for inner in ast.walk(node):
+            if (
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Attribute)
+                and inner.func.attr == "_handle_executed_batch"
+                and len(inner.args) == 1
+                and isinstance(inner.args[0], ast.Constant)
+                and inner.args[0].value is None
+            ):
+                guards.append(node.test)
+    return guards
+
+
+def test_pp_loop_makes_one_empty_pass_when_the_pipeline_is_drained():
+    """The drained PP loop must still make a single pass through the tail."""
+    guards = _executed_batch_empty_pass_guards()
+
+    assert len(guards) == 1, (
+        "expected exactly one guarded _handle_executed_batch(None) empty pass in "
+        f"_executor_loop_pp, found {len(guards)}"
+    )
+
+
+def test_empty_pass_is_guarded_only_by_the_broadcast_consensus_value():
+    """Rank symmetry: the guard may depend on nothing rank-local.
+
+    ``executed_batch_num`` is the ring-broadcast consensus value and is identical
+    on every rank, so guarding on it alone means the empty pass -- and the
+    ``tp_allgather`` collectives inside the tail -- is taken by all ranks or by
+    none. Any rank-local term here (``self.dist.rank``, ``executed_batches``,
+    ``unhandled_batch_counter``, ...) would desync the collectives and deadlock
+    every PP job, disagg or not.
+    """
+    import ast
+
+    (guard,) = _executed_batch_empty_pass_guards()
+
+    names = {node.id for node in ast.walk(guard) if isinstance(node, ast.Name)}
+    attributes = {node.attr for node in ast.walk(guard) if isinstance(node, ast.Attribute)}
+
+    assert names == {"executed_batch_num"}, f"guard reads rank-local names: {names}"
+    assert not attributes, f"guard reads rank-local attributes: {attributes}"
+
+
+def _make_watchdog_executor(num_scheduled_requests=0, in_transfer=(), active=()):
+    executor = object.__new__(PyExecutor)
+    executor.num_scheduled_requests = num_scheduled_requests
+    executor.kv_cache_transceiver = Mock()
+    executor.active_requests = list(active)
+    executor.async_transfer_manager = Mock()
+    executor.async_transfer_manager.requests_in_transfer.return_value = {
+        request.py_request_id: request for request in in_transfer
+    }
+    return executor
+
+
+def test_watchdog_predicate_fires_on_wedged_ctx_transfer():
+    request = _make_ctx_only_request()
+    request.py_kv_transfer_timed_out = True
+    executor = _make_watchdog_executor(in_transfer=[request])
+
+    assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is True
+
+
+def test_watchdog_predicate_fires_on_wedged_gen_transfer():
+    request = _make_timeout_request()
+    executor = _make_watchdog_executor(active=[request])
+
+    assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is True
+
+
+def test_watchdog_predicate_ignores_a_healthy_idle_server():
+    """An idle server with nothing past its deadline must never be killed."""
+    request = _make_ctx_only_request()
+    assert request.py_kv_transfer_timed_out is False
+    executor = _make_watchdog_executor(in_transfer=[request], active=[request])
+
+    assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is False
+
+
+def test_watchdog_predicate_ignores_a_completely_idle_server():
+    executor = _make_watchdog_executor()
+
+    assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is False
+
+
+def test_watchdog_predicate_requires_an_empty_batch():
+    """A loop that is still scheduling work is making progress, not wedged."""
+    request = _make_ctx_only_request()
+    request.py_kv_transfer_timed_out = True
+    executor = _make_watchdog_executor(num_scheduled_requests=4, in_transfer=[request])
+
+    assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is False
+
+
+def test_watchdog_predicate_is_inert_without_a_transceiver():
+    """Non-disagg jobs must be untouched by this mechanism."""
+    executor = _make_watchdog_executor()
+    executor.kv_cache_transceiver = None
+
+    assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is False

--- a/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
+++ b/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import sys
+import time
 from types import SimpleNamespace
 from unittest.mock import Mock, call
 
@@ -807,65 +808,106 @@ def test_empty_pass_runs_the_timeout_check_the_pp_loop_used_to_skip():
     executor._process_iter_stats.assert_not_called()
 
 
-def _executed_batch_empty_pass_guards():
-    """Return the guard expressions of the empty-pass calls in _executor_loop_pp."""
-    import ast
-    import inspect
-    import textwrap
-
-    tree = ast.parse(textwrap.dedent(inspect.getsource(PyExecutor._executor_loop_pp)))
-    guards = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.If):
-            continue
-        for inner in ast.walk(node):
-            if (
-                isinstance(inner, ast.Call)
-                and isinstance(inner.func, ast.Attribute)
-                and inner.func.attr == "_handle_executed_batch"
-                and len(inner.args) == 1
-                and isinstance(inner.args[0], ast.Constant)
-                and inner.args[0].value is None
-            ):
-                guards.append(node.test)
-    return guards
-
-
-def test_pp_loop_makes_one_empty_pass_when_the_pipeline_is_drained():
-    """The drained PP loop must still make a single pass through the tail."""
-    guards = _executed_batch_empty_pass_guards()
-
-    assert len(guards) == 1, (
-        "expected exactly one guarded _handle_executed_batch(None) empty pass in "
-        f"_executor_loop_pp, found {len(guards)}"
+def _make_dispatch_executor(rank, queued_batches, has_transceiver=True):
+    executor = object.__new__(PyExecutor)
+    executor.dist = SimpleNamespace(rank=rank)
+    executor.unhandled_batch_counter = 0
+    executor.kv_cache_transceiver = Mock() if has_transceiver else None
+    executor.executed_batch_response_queue = SimpleNamespace(
+        get=Mock(side_effect=list(queued_batches))
     )
+    executor._handle_executed_batch = Mock()
+    return executor
 
 
-def test_empty_pass_is_guarded_only_by_the_broadcast_consensus_value():
-    """Rank symmetry: the guard may depend on nothing rank-local.
+@pytest.mark.parametrize("executed_batch_num", [0, 1, 2])
+def test_executed_batch_dispatch_is_rank_symmetric(executed_batch_num):
+    """The tail must run the same number of times on every rank role.
 
-    ``executed_batch_num`` is the ring-broadcast consensus value and is identical
-    on every rank, so guarding on it alone means the empty pass -- and the
-    ``tp_allgather`` collectives inside the tail -- is taken by all ranks or by
-    none. Any rank-local term here (``self.dist.rank``, ``executed_batches``,
-    ``unhandled_batch_counter``, ...) would desync the collectives and deadlock
-    every PP job, disagg or not.
+    ``_handle_executed_batch`` enters ``tp_allgather`` via
+    ``_handle_kv_transfer_timeouts_synced`` and ``_flush_iter_stats_synced``, so
+    the call count must be a pure function of the ring-broadcast consensus
+    value ``executed_batch_num`` -- identical on rank 0 and on every other rank.
+    A desync here deadlocks every PP job, disagg or not.
     """
-    import ast
+    batches = [object() for _ in range(executed_batch_num)]
 
-    (guard,) = _executed_batch_empty_pass_guards()
+    rank0 = _make_dispatch_executor(0, [])
+    PyExecutor._dispatch_executed_batches(rank0, executed_batch_num, batches)
 
-    names = {node.id for node in ast.walk(guard) if isinstance(node, ast.Name)}
-    attributes = {node.attr for node in ast.walk(guard) if isinstance(node, ast.Attribute)}
+    other = _make_dispatch_executor(3, batches)
+    PyExecutor._dispatch_executed_batches(other, executed_batch_num, [])
 
-    assert names == {"executed_batch_num"}, f"guard reads rank-local names: {names}"
-    assert not attributes, f"guard reads rank-local attributes: {attributes}"
+    rank0_calls = rank0._handle_executed_batch.call_count
+    other_calls = other._handle_executed_batch.call_count
+
+    assert rank0_calls == other_calls, (
+        f"rank 0 ran the tail {rank0_calls}x but a non-zero rank ran it "
+        f"{other_calls}x for executed_batch_num={executed_batch_num}"
+    )
+    assert rank0_calls == max(executed_batch_num, 1)
+    # The consensus count is still decremented identically on both roles.
+    assert rank0.unhandled_batch_counter == other.unhandled_batch_counter
+    assert rank0.unhandled_batch_counter == -executed_batch_num
 
 
-def _make_watchdog_executor(num_scheduled_requests=0, in_transfer=(), active=()):
+@pytest.mark.parametrize("rank", [0, 3])
+def test_drained_pipeline_makes_exactly_one_empty_pass(rank):
+    """A drained pipeline must still reach the tail once, with no real batch."""
+    executor = _make_dispatch_executor(rank, [])
+
+    PyExecutor._dispatch_executed_batches(executor, 0, [])
+
+    executor._handle_executed_batch.assert_called_once_with(None)
+
+
+@pytest.mark.parametrize("executed_batch_num", [1, 2])
+def test_non_drained_pipeline_makes_no_empty_pass(executed_batch_num):
+    """No double-call: the empty pass fires only when the tail ran zero times."""
+    batches = [object() for _ in range(executed_batch_num)]
+    executor = _make_dispatch_executor(0, [])
+
+    PyExecutor._dispatch_executed_batches(executor, executed_batch_num, batches)
+
+    assert executor._handle_executed_batch.call_args_list == [call(b) for b in batches]
+
+
+@pytest.mark.parametrize("rank", [0, 3])
+def test_non_disagg_pipeline_takes_no_empty_pass(rank):
+    """Non-disagg PP jobs must keep taking zero collectives when drained.
+
+    ``_handle_kv_transfer_timeouts_synced`` gates only on attention-DP, with no
+    transceiver check, so an unconditional empty pass would add a
+    ``tp_allgather`` to every drained iteration of *any* ADP+PP job. Drained
+    iterations are a recurring steady state when
+    ``pp_async_broadcast_sample_state`` is on, so that is hot-path cost for
+    jobs this fix has nothing to do with.
+    """
+    executor = _make_dispatch_executor(rank, [], has_transceiver=False)
+
+    PyExecutor._dispatch_executed_batches(executor, 0, [])
+
+    executor._handle_executed_batch.assert_not_called()
+
+
+_TIMEOUT_MS = 60_000
+_HANG_TIMEOUT_S = 300
+
+
+def _make_watchdog_executor(
+    num_scheduled_requests=0,
+    in_transfer=(),
+    active=(),
+    timeout_ms=_TIMEOUT_MS,
+):
     executor = object.__new__(PyExecutor)
     executor.num_scheduled_requests = num_scheduled_requests
+    executor.iter_counter = 0
+    executor._wedged_kv_transfer_iter = -1
+    executor._wedged_kv_transfer_result = False
+    executor.hang_detector = SimpleNamespace(timeout=_HANG_TIMEOUT_S)
     executor.kv_cache_transceiver = Mock()
+    executor.kv_cache_transceiver.kv_transfer_timeout_ms = timeout_ms
     executor.active_requests = list(active)
     executor.async_transfer_manager = Mock()
     executor.async_transfer_manager.requests_in_transfer.return_value = {
@@ -874,25 +916,48 @@ def _make_watchdog_executor(num_scheduled_requests=0, in_transfer=(), active=())
     return executor
 
 
+def _make_wedged_request(elapsed_s, request_id=11, timed_out=True):
+    request = _make_ctx_only_request(request_id=request_id)
+    request.py_kv_transfer_timed_out = timed_out
+    request.py_kv_transfer_start_time = time.monotonic() - elapsed_s
+    return request
+
+
 def test_watchdog_predicate_fires_on_wedged_ctx_transfer():
-    request = _make_ctx_only_request()
-    request.py_kv_transfer_timed_out = True
+    request = _make_wedged_request(elapsed_s=_HANG_TIMEOUT_S + 120)
     executor = _make_watchdog_executor(in_transfer=[request])
 
     assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is True
 
 
 def test_watchdog_predicate_fires_on_wedged_gen_transfer():
-    request = _make_timeout_request()
+    request = _make_wedged_request(elapsed_s=_HANG_TIMEOUT_S + 120)
     executor = _make_watchdog_executor(active=[request])
 
     assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is True
 
 
+def test_watchdog_predicate_spares_a_slow_but_live_transfer():
+    """The whole point of the give-up margin.
+
+    ``kv_transfer_timeout_ms`` defaults to 60s and only means "start trying to
+    cancel". On main a transfer that blows it but cannot be cancelled is left
+    alone and allowed to finish. Killing every rank via ``MPI_Abort`` for a
+    transfer that is merely slow would be a new outage class, so a flagged
+    transfer keeps a full ``hang_detection_timeout`` of grace.
+    """
+    request = _make_wedged_request(elapsed_s=_HANG_TIMEOUT_S - 60)
+
+    for executor in (
+        _make_watchdog_executor(in_transfer=[request]),
+        _make_watchdog_executor(active=[request]),
+    ):
+        assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is False
+
+
 def test_watchdog_predicate_ignores_a_healthy_idle_server():
-    """An idle server with nothing past its deadline must never be killed."""
-    request = _make_ctx_only_request()
-    assert request.py_kv_transfer_timed_out is False
+    """An idle server with nothing flagged must never be killed."""
+    request = _make_wedged_request(elapsed_s=100_000, timed_out=False)
     executor = _make_watchdog_executor(in_transfer=[request], active=[request])
 
     assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is False
@@ -906,8 +971,7 @@ def test_watchdog_predicate_ignores_a_completely_idle_server():
 
 def test_watchdog_predicate_requires_an_empty_batch():
     """A loop that is still scheduling work is making progress, not wedged."""
-    request = _make_ctx_only_request()
-    request.py_kv_transfer_timed_out = True
+    request = _make_wedged_request(elapsed_s=_HANG_TIMEOUT_S + 120)
     executor = _make_watchdog_executor(num_scheduled_requests=4, in_transfer=[request])
 
     assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is False
@@ -919,3 +983,26 @@ def test_watchdog_predicate_is_inert_without_a_transceiver():
     executor.kv_cache_transceiver = None
 
     assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is False
+
+
+def test_watchdog_predicate_is_inert_without_a_configured_timeout():
+    executor = _make_watchdog_executor(
+        in_transfer=[_make_wedged_request(elapsed_s=100_000)], timeout_ms=None
+    )
+
+    assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is False
+
+
+def test_watchdog_predicate_is_evaluated_once_per_iteration():
+    """It runs on every checkpoint() and pause(); the walks touch C++ bindings."""
+    request = _make_wedged_request(elapsed_s=_HANG_TIMEOUT_S + 120)
+    executor = _make_watchdog_executor(in_transfer=[request])
+    walks = executor.async_transfer_manager.requests_in_transfer
+
+    for _ in range(4):
+        assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is True
+    assert walks.call_count == 1
+
+    executor.iter_counter += 1
+    assert PyExecutor._is_wedged_on_timed_out_kv_transfer(executor) is True
+    assert walks.call_count == 2

--- a/tests/unittest/_torch/executor/test_hang_detector_kill.py
+++ b/tests/unittest/_torch/executor/test_hang_detector_kill.py
@@ -117,3 +117,101 @@ def test_propagate_hard_kill_self_sigkills_without_mpi():
         f"expected self-SIGKILL (-9), got {proc.returncode}; "
         f"stderr={proc.stderr.decode(errors='replace')[-500:]}"
     )
+
+
+def _wait_until_detected(hd, budget_s):
+    deadline = time.monotonic() + budget_s
+    while time.monotonic() < deadline and not hd.detected():
+        time.sleep(0.02)
+    return hd.detected()
+
+
+def test_suppressor_freezes_deadline_across_spinning_checkpoints():
+    """A hot loop that checkpoints every iteration still dies once suppressed.
+
+    This is the disagg livelock in miniature: the executor loop spins with an
+    empty batch and re-arms the watchdog thousands of times a second. With the
+    suppressor asserted the pending detection is left to run down instead of
+    being pushed forward, so the detector fires despite the checkpoint storm.
+    """
+    fired = []
+    hd = HangDetector(timeout=2, on_detected=lambda: fired.append(time.monotonic()))
+    with hd:
+        hd.checkpoint()  # arm before suppression begins
+        hd.set_rearm_suppressor(lambda: True)
+        start = time.monotonic()
+        while time.monotonic() - start < 3.0 and not hd.detected():
+            hd.checkpoint()
+            time.sleep(0.001)
+        assert hd.detected(), "suppressed checkpoints must not keep pushing the deadline out"
+        assert fired, "on_detected must run"
+
+
+def test_suppressed_pause_does_not_rearm():
+    """``pause()`` must not undo suppression on exit.
+
+    ``RequestBroadcaster.broadcast`` pause-wraps a collective on *every*
+    iteration, and ``pause.__exit__`` re-arms unconditionally. Gating only the
+    loop-top ``checkpoint()`` would therefore leave the watchdog re-armed ~1250
+    times a second by this path alone.
+    """
+    hd = HangDetector(timeout=2, on_detected=lambda: None)
+    with hd:
+        hd.checkpoint()
+        hd.set_rearm_suppressor(lambda: True)
+        start = time.monotonic()
+        while time.monotonic() - start < 3.0 and not hd.detected():
+            with hd.pause():
+                pass
+            time.sleep(0.001)
+        assert hd.detected(), "pause() must not re-arm the detector while suppressed"
+
+
+def test_suppressor_never_disables_an_unarmed_detector():
+    """Suppression can only ever *cause* a kill, never suppress one.
+
+    When nothing is armed yet there is no deadline to preserve, so the normal
+    arming path must still run even though the predicate holds.
+    """
+    hd = HangDetector(timeout=2, on_detected=lambda: None)
+    with hd:
+        hd.set_rearm_suppressor(lambda: True)
+        assert not hd.is_armed()
+        hd.checkpoint()
+        assert hd.is_armed(), "an unarmed detector must always be armed by checkpoint()"
+        assert _wait_until_detected(hd, 4.0), "the armed detection must still fire"
+
+
+def test_unsuppressed_checkpoint_still_resets_timer():
+    """A healthy idle server must never be killed by this mechanism."""
+    hd = HangDetector(timeout=2, on_detected=lambda: None)
+    with hd:
+        hd.set_rearm_suppressor(lambda: False)
+        hd.checkpoint()
+        start = time.monotonic()
+        while time.monotonic() - start < 3.0:
+            hd.checkpoint()
+            with hd.pause():
+                pass
+            time.sleep(0.001)
+        assert not hd.detected(), "an unsuppressed checkpoint must keep resetting the timer"
+
+
+def test_failing_suppressor_falls_back_to_normal_rearm(monkeypatch):
+    """A broken predicate must not wedge or kill the executor loop."""
+    logged = []
+    monkeypatch.setattr(hang_detector_module, "_best_effort_log_error", logged.append)
+
+    def boom():
+        raise RuntimeError("predicate blew up")
+
+    hd = HangDetector(timeout=2, on_detected=lambda: None)
+    with hd:
+        hd.checkpoint()
+        hd.set_rearm_suppressor(boom)
+        start = time.monotonic()
+        while time.monotonic() - start < 3.0:
+            hd.checkpoint()
+            time.sleep(0.001)
+        assert not hd.detected(), "a failing predicate must fall back to re-arming"
+        assert any("re-arm suppressor failed" in message for message in logged)


### PR DESCRIPTION
## Summary

When a disaggregated KV transfer wedges, the CTX server runs to the **10,800 s harness timeout** instead of dying at its own `kv_transfer_timeout_ms`. This is the largest hang cluster in CI (disagg perf-sanity). Two independent defects produce that single symptom; both are fixed here.

## Defect 1 — on CTX (`_executor_loop_pp`), the timeout check never runs

`handle_executed_batches` iterates `executed_batch_num` times, which is **0** once nothing is queued. `_handle_executed_batch` is then never called, taking out its ungated tail — including `_check_kv_transfer_timeout` — so `py_kv_transfer_timed_out` is never even set. Unlike `_executor_loop` and `_executor_loop_overlap`, the PP loop has no ungated timeout drain.

**Fix:** when `executed_batch_num == 0` **and a transceiver is configured**, make one `_handle_executed_batch(None)` pass. The Stage 3.3 dispatch moved out of the `handle_executed_batches` closure into `_dispatch_executed_batches` so both rank roles can be driven directly in tests.

*Rank symmetry:* `executed_batch_num` is the ring-broadcast consensus value, identical on every rank, so the branch is taken by all ranks or by none and the `tp_allgather` collectives in `_handle_kv_transfer_timeouts_synced` / `_flush_iter_stats_synced` stay in lockstep. `kv_cache_transceiver` is built from rank-uniform `LlmArgs`, so the added conjunct preserves that. `_handle_executed_batch` itself is **unchanged**, and the extra call happens exactly when the dispatch loops make zero calls, so nothing is double-called.

*Why the transceiver conjunct matters:* `_handle_kv_transfer_timeouts_synced` gates only on attention-DP, with **no** transceiver check. Without it, every ADP+PP job — disagg or not — would take a `tp_allgather` on each drained iteration where `main` took none, and drained iterations are a **recurring steady state** when `pp_async_broadcast_sample_state` is on (the default), not just fill/drain.

*Recovery is attempted, and refused:* once the empty pass sets the flag, `_check_disagg_ctx_cache_transfer_status` — reached every iteration via `_check_disagg_transfer_progress_when_idle`, independently of `executed_batch_num` — starts attempting `_request_kv_transfer_cancellation` on the wedged request. The transceiver refuses (see *Out of scope*), so the attempt fails every iteration and the kill is what actually resolves the job. An earlier revision of this description claimed that function was unreachable from the drained path; that was **wrong** and is corrected here.

## Defect 2 — even once flagged, nothing acts on it

`hang_detector.checkpoint()` is the first statement in all three executor loops and unconditionally re-arms the watchdog, so a 0.8 ms empty-batch spin re-arms it ~1,250x/s and the hang is never detected.

**Fix:** `HangDetector` grows an optional **re-arm suppressor**. While the predicate holds, `checkpoint()` leaves the pending detection to run down instead of pushing it forward. `pause()` honours it too — **this matters:** `RequestBroadcaster.broadcast` pause-wraps a collective on *every* iteration and `pause.__exit__` re-arms unconditionally, so gating only the loop-top `checkpoint()` would leave the watchdog re-armed ~1,250x/s by that path alone.

### The predicate keys on give-up state, not deadline-missed state

`py_kv_transfer_timed_out` alone is **not** a safe trigger despite its name. `kv_transfer_timeout_ms` **defaults to 60 s** and is a *start-trying-to-cancel* threshold: on `main` a transfer that blows it but that the transceiver refuses to cancel is left alone and **allowed to complete** (`if not is_cancelled: continue`). Suppressing on the flag alone would `MPI_Abort` every rank — taking the healthy generation side and every other in-flight request with it — for a transfer that was merely slow, and a legitimate 128k-context transfer can run well past 60 s. That would be a new outage class for served deployments, categorically different from the existing detector which requires the loop to make *no progress at all*.

So the trigger is the flag **plus** a further `hang_detection_timeout` of grace: only a transfer that has burned `kv_transfer_timeout_ms + hang_detection_timeout` without finishing or being cancellable counts as wedged.

The truer signal would be *"cancellation was attempted and refused"*. That signal is **reachable but not recorded**: `_disagg_timed_out_ctx_cancelled_ids` tracks only *successful* cancellations under in-flight-cancel mode, and nothing tracks refusals. Adding a refusal set is small, but it puts new mutable state on a live disagg path in an already high-risk change, so it is deferred — see *Follow-ups*. Elapsed time is the v1 proxy.

### Kill latency

Worst case is `kv_transfer_timeout_ms + 3 x hang_detection_timeout` ≈ **960 s** with defaults (60 s + 300 s give-up grace + up to 2x300 s to fire). The extra `hang_detection_timeout` is real: if the wedge begins inside an *unsuppressed* `pause()`, `__exit__` finds `is_armed()` False and re-arms a full fresh timeout. Still **~11x** better than 10,800 s.

### Suppression can only ever *cause* a kill, never suppress one

Structural, not incidental:

- the suppressed path **never cancels** a pending detection — `checkpoint()` returns before `cancel_task()`, and `pause()` returns before it too;
- `_suppress_rearm()` returns False whenever `is_armed()` is False, so an unarmed detector is **always** armed normally;
- a predicate that raises is caught, logged, and treated as False.

## Out of scope

Releasing the wedged request itself. With `TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL` off (the default in both Python and C++), `dataTransceiver` refuses to cancel an active transfer *by design*, so `cancel_request()` returns False and the legacy release path is unreachable. That is owned by the disagg/cache-transceiver team. This PR makes the job **die loudly and fast** rather than burn a CI slot for 3 hours.

## Known residual: the proxy can kill a slow-but-succeeding transfer

With defaults a transfer that would have succeeded at `kv_transfer_timeout_ms + hang_detection_timeout + ε` (360 s) is still killed, and this description notes a 128k transfer can legitimately reach 600 s. Deployments that raise `kv_transfer_timeout_ms` to 600 s are unaffected. Accepted for v1 on three grounds:

1. **The `num_scheduled_requests == 0` conjunct does most of the safety work.** The kill can only land on a server that is simultaneously over-deadline *and* scheduling nothing; a busy server short-circuits on the first line. The cost of a false positive is restarting a server that was doing nothing.
2. **Blast radius is one job, not the deployment.** In disagg the GEN server is a separate process and survives.
3. **60 s is a declared contract, not an unexamined default.** `llm_args.py`: *"Requests exceeding this timeout **will be cancelled**."* The implementation never delivered that. This enforces a documented policy rather than inventing one.

**Honest caveat:** the enforcement does not match the declared contract. The field promises the *request* is cancelled; what is delivered is the *process* aborted. No operator reading that description would infer the second. That is documentation debt this PR does not pay off.

**No opt-in gate, deliberately.** Default-off would leave production with a livelocked rank spinning forever and no timeout at all (production has no 10,800 s harness), so given (1) and (2) the restart is the better production outcome — and the CI benefit would evaporate the first config refresh that drops the env var.

## Follow-ups (not in this PR)

- **Record the cancellation refusal** in the `if not is_cancelled: continue` branch and key the predicate on it — direct proof of a wedge instead of a time proxy, removing the residual above.
- **Make `hang_detection_timeout` reachable from `TorchLlmArgs`.** It is currently a `PyExecutor.__init__` kwarg nothing ever passes, so the grace margin is not independently tunable: an operator wanting more grace must raise `kv_transfer_timeout_ms`, which also delays the cancellation attempt. Worth extending the `kv_transfer_timeout_ms` description to state the composite policy at the same time.
- **A per-transfer progress signal** would let the predicate require *no progress across the grace window* — immune to the residual entirely. Note this is **not** a small follow-up: `CacheTransceiver::getStatusDump` (already registered as a hang-detector status provider) returns an opaque human-readable string, and its `StatusSnapshot` carries only per-category *counts* (`timedOutSenders`, `completedSenders`, …) with no bytes-transferred or progress field. New C++ instrumentation plus a structured accessor would be required.

## Test plan

CPU-only unit tests, added to two files **already registered** in the test DB (`unittest/_torch/executor` is listed as a directory in `l0_h100`/`l0_b300`/`l0_dgx_b300`/`l0_gb300_multi_gpus`; `test_hang_detector_kill.py` is listed per-file in `l0_sanity_check`), so no test-list change is needed.

- **Rank symmetry, behaviourally:** `_dispatch_executed_batches` is driven for rank 0 and a non-zero rank across `executed_batch_num` in {0,1,2}, asserting equal `_handle_executed_batch` call counts equal to `max(n,1)`, plus equal `unhandled_batch_counter`. Also: exactly one empty pass when drained, none when not drained, and **none at all without a transceiver**.
- **Predicate:** fires on wedged CTX/GEN past give-up; **spares a slow-but-live transfer** inside the grace window; ignores a healthy idle server, a completely idle server, a still-scheduling loop, a job with no transceiver, and one with no configured timeout; evaluated **once per iteration**.
- **HangDetector:** deadline stays frozen across a checkpoint storm; a suppressed `pause()` does not re-arm; an unarmed detector is never disabled; an unsuppressed checkpoint still resets the timer; a failing predicate falls back to normal re-arming.

**Verified:** all new tests pass with the fix, **23 fail without it**. Mutation-tested — removing the transceiver conjunct, the give-up margin, the memoisation, or rank symmetry each fails **only** its intended test. Full `tests/unittest/_torch/executor/`: **1148 passed, 0 failed** (10 errors are missing `LLM_MODELS_ROOT`).

## GPU validation (4xH200, job 3387549)

**Rank symmetry is now measured, not derived.** This was the claim where a wrong answer deadlocks every PP job.

- **Non-disagg inertness (PP=2 x TP=2, ADP).** Both arms `rc=0`, outputs **byte-identical** across all 3 generate waves. The transceiver conjunct makes the change provably inert outside disagg.
- **The decisive run: CTX TP=2 x PP=2 with ADP on (4 ranks)**, which makes `_handle_kv_transfer_timeouts_synced`'s `tp_allgather` a **real 2-way collective** on the empty pass. The empty-pass counter sequence is **identical across all four ranks** — every rank logs the same `(count, iter)` multiset `{1@0, 1@0, 2@2, 3@4, 4@6, 5@8}`, the doubled first entry being the memory-profiling dry-run executor plus the real one, uniformly on every rank. No deadlock, no `MPI_Abort`, no `Hang detected`, no tracebacks in any of the 12 logs (the only string matching a "deadlock" grep is the benign startup line *"Create new MPI comm ... to avoid deadlock."*). Block reuse was on, so `_disagg_pp_termination_handler` was armed and its invocation-indexed PP ring tolerated the extra invocation.
- Incidentally this also confirms the STEP 0 premise on hardware: a CTX transfer logged `py_kv_transfer_start_time` armed (`transfer_flags=[(id, False, 261735.53)]`) while still in flight.

### 🔴 Two boundary conditions, measured

**1. If the CTX receives no further requests after a wedge, nothing fires.** An idle CTX computes `idle = (total_num_active_requests == 0) and not waiting_queue` and, on the MPI path, passes `timeout=None` into `get_from_request_queue` **inside `hang_detector.pause()`** (`py_executor.py:4984`, `request_utils.py:518`) — so the loop stops iterating *and* the watchdog is disarmed. The empty pass only helps **while the loop keeps iterating**. Observed directly: with a frozen gen worker and no traffic, the empty pass fired twice (`n=1 iter=0`, `n=2 iter=2`, both ranks) and then stopped — no timeout log, no kill, 450 s.

**2. The two predicate conditions are hard to co-satisfy synthetically.** `num_scheduled_requests == 0` requires a drained loop, but the flag only gets set while iterations happen; the validator kept landing on one side or the other.

**So the fix's efficacy is NOT demonstrated on hardware.** What is demonstrated is that it is safe: rank-symmetric, inert outside disagg, byte-identical outputs. The evidence that it *fires* in the real case remains the production log — CTX spinning at 0.8 ms/iter with `num_scheduled_requests = 0` for ~10.9 M iterations, i.e. both conditions simultaneously and continuously, which is precisely the state the synthetic injections could not reproduce. That is an argument, not a measurement.

**Why the traffic run did not establish the kill** — informative rather than a failure: with keepalive traffic the timeout check ran and set the flag 56 times, but `_check_disagg_ctx_cache_transfer_status` **successfully cancelled** each transfer and released it, so nothing survived to the grace deadline. The injection produced **cancellable** timeouts; the predicate targets the **uncancellable** wedge. That is exactly the "cancellation attempted and refused" distinction, and it strengthens the case for recording the refusal (first follow-up above).

### Validation caveats

- **The C++ side was never exercised.** No source build: the two changed Python files were overlaid onto a cached `1.3.0rc23` image, verified byte-identical to git and applied identically to both A/B arms. rc23 predates the base commit's nanobind `get_status_dump`, which was shimmed with a `getattr` fallback — a **base-commit** diagnostic, not this change.
- `hang_detection_timeout` confirmed **on hardware** to be plumbed nowhere (no `LlmArgs` field, no env var), reinforcing the follow-up above.
- **Untested:** PP depth > 2, multi-node, Blackwell, and the real disagg CI tests (no pytest in the release image).

This should not merge on this evidence alone without a maintainer accepting boundary condition 1.

**Unrelated CI risk worth knowing:** `test_kv_cache_manager_v2.py::test_per_conversation_policy_ignores_overlapping_request` SIGABRTs in the copy engine on some hardware (reproduces identically on unpatched `main`). It lives in the same directory these tests' CI registration depends on, so if it ever aborts on an H100/B300 runner it takes the pytest process down and these tests never report.
